### PR TITLE
fix: disable filebrowser button only when it is visible

### DIFF
--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1654,9 +1654,12 @@ export default class BackendAiStorageList extends BackendAIPage {
   _toggleFilebrowserButton() {
     let isfilebrowserSupported = (this.filebrowserSupportedImages.length > 0 && this._isResourceEnough()) ? true : false;
     let filebrowserIcon = this.shadowRoot.querySelector('#filebrowser-img');
-    this.shadowRoot.querySelector('#filebrowser-btn').disabled = !isfilebrowserSupported;
-    let filterClass = isfilebrowserSupported ? '' : 'apply-grayscale';
-    filebrowserIcon.setAttribute('class', filterClass);
+    let filebrowserBtn = this.shadowRoot.querySelector('#filebrowser-btn');
+    if (filebrowserIcon && filebrowserBtn) {
+      filebrowserBtn.disabled = !isfilebrowserSupported;
+      let filterClass = isfilebrowserSupported ? '' : 'apply-grayscale';
+      filebrowserIcon.setAttribute('class', filterClass);
+    }
   }
 
   /**


### PR DESCRIPTION
This PR is a hotfix for filebrowser related bug, which occurred by accessing and changing the property of the non-existing element.