### PR TITLE
bugfix: resize the web terminal guide according to window size

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -205,6 +205,12 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           padding: 0px 3px;
           display: inline-block;
         }
+        
+        @media screen and (max-width: 810px) {
+          #terminal-guide {
+            --component-width: calc(100% - 50px);
+          }
+        }
       `];
   }
 


### PR DESCRIPTION
Before fixing, the web terminal guide is cropped because the dialog size is fixed.
So I changed the size of the terminal guide dialog according to screen size.

this closes #988 