### PR TITLE
change the password icon

### DIFF
--- a/src/components/backend-ai-registry-list.ts
+++ b/src/components/backend-ai-registry-list.ts
@@ -106,7 +106,7 @@ class BackendAIRegistryList extends BackendAIPage {
         }
 
         wl-textfield#add-registry-password {
-          --input-font-family: sans-serif, Roboto, Noto;
+          --input-font-family: Noto, sans-serif, Roboto;
         }
 
         wl-label.helper-text {

--- a/src/components/backend-ai-registry-list.ts
+++ b/src/components/backend-ai-registry-list.ts
@@ -105,6 +105,10 @@ class BackendAIRegistryList extends BackendAIPage {
           --input-label-space: 20px;
         }
 
+        wl-textfield#add-registry-password {
+          --input-font-family: sans-serif, Roboto, Noto;
+        }
+
         wl-label.helper-text {
           --label-color: #b00020;
           --label-font-family: Roboto, Noto, sans-serif;


### PR DESCRIPTION
the password masking on the "Add Registry" dialog is a triangle because the Roboto font does not support the circle icon. 
So, I added a font style to add-registry-password.

this PR closes #993 