### PR TITLE
fix: Clamp resource value in session launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ proxyListenIP = "[Websocket proxy configuration IP.]"
 [resources]
 openPortToPublic = true # Show option to open app proxy port to anyone.
 maxCPUCoresPerContainer = 256 # Maximum CPU per container.
+maxMemoryPerContainer = 16 # Maximum memory per container.
 maxCUDADevicesPerContainer = 16  # Maximum CUDA devices per container.
+maxCUDASharesPerContainer = 8  # Maximum CUDA shares per container.
 maxShmPerContainer = 1 # Maximum shared memory per container.
 maxFileUploadSize = 4294967296 # Maximum size of single file upload. Set to -1 for unlimited upload.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ proxyListenIP = "[Websocket proxy configuration IP.]"
 [resources]
 openPortToPublic = true # Show option to open app proxy port to anyone.
 maxCPUCoresPerContainer = 256 # Maximum CPU per container.
-maxMemoryPerContainer = 16 # Maximum memory per container.
+maxMemoryPerContainer = 64 # Maximum memory per container.
 maxCUDADevicesPerContainer = 16  # Maximum CUDA devices per container.
 maxCUDASharesPerContainer = 8  # Maximum CUDA shares per container.
 maxShmPerContainer = 1 # Maximum shared memory per container.

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -23,7 +23,7 @@ disableCertCheck = true
 [resources]
 openPortToPublic = false # Show option to open app proxy port to anyone.
 maxCPUCoresPerContainer = 256 # Maximum CPU per container.
-maxMemoryPerContainer = 16 # Maximum memory per container.
+maxMemoryPerContainer = 64 # Maximum memory per container.
 maxCUDADevicesPerContainer = 8  # Maximum CUDA devices per container.
 maxCUDASharesPerContainer = 8  # Maximum CUDA shares per container.
 maxShmPerContainer = 4 # Maximum shared memory per container.

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -23,6 +23,7 @@ disableCertCheck = true
 [resources]
 openPortToPublic = false # Show option to open app proxy port to anyone.
 maxCPUCoresPerContainer = 256 # Maximum CPU per container.
+maxMemoryPerContainer = 16 # Maximum memory per container.
 maxCUDADevicesPerContainer = 8  # Maximum CUDA devices per container.
 maxCUDASharesPerContainer = 8  # Maximum CUDA shares per container.
 maxShmPerContainer = 4 # Maximum shared memory per container.

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -84,6 +84,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({type: Boolean}) allow_project_resource_monitor = false;
   @property({type: Boolean}) openPortToPublic = false;
   @property({type: Boolean}) maxCPUCoresPerContainer = 64;
+  @property({type: Boolean}) maxMemoryPerContainer = 16;
   @property({type: Number}) maxCUDADevicesPerContainer = 16;
   @property({type: Number}) maxCUDASharesPerContainer = 16;
   @property({type: Boolean}) maxShmPerContainer = 2;
@@ -421,6 +422,11 @@ export default class BackendAILogin extends BackendAIPage {
       this.maxCPUCoresPerContainer = 64;
     } else {
       this.maxCPUCoresPerContainer = parseInt(config.resources.maxCPUCoresPerContainer);
+    }
+    if (typeof config.resources === 'undefined' || typeof config.resources.maxMemoryPerContainer === 'undefined' || isNaN(parseInt(config.resources.maxMemoryPerContainer))) {
+      this.maxMemoryPerContainer = 16;
+    } else {
+      this.maxMemoryPerContainer = parseInt(config.resources.maxMemoryPerContainer);
     }
     if (typeof config.resources === 'undefined' || typeof config.resources.maxCUDADevicesPerContainer === 'undefined' || isNaN(parseInt(config.resources.maxCUDADevicesPerContainer))) {
       this.maxCUDADevicesPerContainer = 16;
@@ -987,6 +993,7 @@ export default class BackendAILogin extends BackendAIPage {
       globalThis.backendaiclient._config.allow_project_resource_monitor = this.allow_project_resource_monitor;
       globalThis.backendaiclient._config.openPortToPublic = this.openPortToPublic;
       globalThis.backendaiclient._config.maxCPUCoresPerContainer = this.maxCPUCoresPerContainer;
+      globalThis.backendaiclient._config.maxMemoryPerContainer = this.maxMemoryPerContainer;
       globalThis.backendaiclient._config.maxCUDADevicesPerContainer = this.maxCUDADevicesPerContainer;
       globalThis.backendaiclient._config.maxCUDASharesPerContainer = this.maxCUDASharesPerContainer;
       globalThis.backendaiclient._config.maxShmPerContainer = this.maxShmPerContainer;

--- a/src/components/backend-ai-session-launcher-legacy.ts
+++ b/src/components/backend-ai-session-launcher-legacy.ts
@@ -156,6 +156,7 @@ import {
   @property({type: String}) _helpDescriptionTitle = '';
   @property({type: String}) _helpDescriptionIcon = '';
   @property({type: Number}) max_cpu_core_per_session = 64;
+  @property({type: Number}) max_mem_per_container = 16;
   @property({type: Number}) max_cuda_device_per_container = 16;
   @property({type: Number}) max_cuda_shares_per_container = 16;
   @property({type: Number}) max_shm_per_container = 2;
@@ -716,6 +717,7 @@ import {
     if (typeof globalThis.backendaiclient === 'undefined' || globalThis.backendaiclient === null || globalThis.backendaiclient.ready === false) {
       document.addEventListener('backend-ai-connected', () => {
         this.max_cpu_core_per_session = globalThis.backendaiclient._config.maxCPUCoresPerContainer || 64;
+        this.max_mem_per_container = globalThis.backendaiclient._config.maxMemoryPerContainer || 16;
         this.max_cuda_device_per_container = globalThis.backendaiclient._config.maxCUDADevicesPerContainer || 16;
         this.max_cuda_shares_per_container = globalThis.backendaiclient._config.maxCUDASharesPerContainer || 16;
         this.max_shm_per_container = globalThis.backendaiclient._config.maxShmPerContainer || 2;
@@ -728,6 +730,7 @@ import {
       }, {once: true});
     } else {
       this.max_cpu_core_per_session = globalThis.backendaiclient._config.maxCPUCoresPerContainer || 64;
+      this.max_mem_per_container = globalThis.backendaiclient._config.maxMemoryPerContainer || 16;
       this.max_cuda_device_per_container = globalThis.backendaiclient._config.maxCUDADevicesPerContainer || 16;
       this.max_cuda_shares_per_container = globalThis.backendaiclient._config.maxCUDASharesPerContainer || 16;
       this.max_shm_per_container = globalThis.backendaiclient._config.maxShmPerContainer || 2;
@@ -2107,6 +2110,7 @@ import {
 
   _resourceTemplateToCustom() {
     this.shadowRoot.querySelector('#resource-templates').selectedText = _text('session.launcher.CustomResourceApplied');
+    console.log(this.shmem_metric.max, this.max_shm_per_container);
   }
 
   /**
@@ -2176,9 +2180,9 @@ import {
   _updateShmemLimit() {
     const shmemEl = this.shadowRoot.querySelector('#shmem-resource');
     let shmem_value = shmemEl.value;
-    this.shmem_metric.max = parseFloat(this.shadowRoot.querySelector('#mem-resource').value);
+    this.shmem_metric.max = Math.min(this.max_shm_per_container, this.shmem_metric.max, parseFloat(this.shadowRoot.querySelector('#mem-resource').value));
     // clamp the max value to the smaller of the current memory value or the configuration file value.
-    this.shadowRoot.querySelector('#shmem-resource').max = Math.min(this.max_shm_per_container, this.shmem_metric.max);
+    shmemEl.max = this.shmem_metric.max;
     if (parseFloat(shmem_value) > this.shmem_metric.max) {
       shmem_value = this.shmem_metric.max;
       this.shmem_request = shmem_value;

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -163,6 +163,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
   @property({type: String}) _helpDescriptionTitle = '';
   @property({type: String}) _helpDescriptionIcon = '';
   @property({type: Number}) max_cpu_core_per_session = 64;
+  @property({type: Number}) max_mem_per_container = 16;
   @property({type: Number}) max_cuda_device_per_container = 16;
   @property({type: Number}) max_cuda_shares_per_container = 16;
   @property({type: Number}) max_shm_per_container = 2;
@@ -797,6 +798,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     if (typeof globalThis.backendaiclient === 'undefined' || globalThis.backendaiclient === null || globalThis.backendaiclient.ready === false) {
       document.addEventListener('backend-ai-connected', () => {
         this.max_cpu_core_per_session = globalThis.backendaiclient._config.maxCPUCoresPerContainer || 64;
+        this.max_mem_per_container = globalThis.backendaiclient._config.maxMemoryPerContainer || 16;
         this.max_cuda_device_per_container = globalThis.backendaiclient._config.maxCUDADevicesPerContainer || 16;
         this.max_cuda_shares_per_container = globalThis.backendaiclient._config.maxCUDASharesPerContainer || 16;
         this.max_shm_per_container = globalThis.backendaiclient._config.maxShmPerContainer || 2;
@@ -809,6 +811,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       }, {once: true});
     } else {
       this.max_cpu_core_per_session = globalThis.backendaiclient._config.maxCPUCoresPerContainer || 64;
+      this.max_mem_per_container = globalThis.backendaiclient._config.maxMemoryPerContainer || 16;
       this.max_cuda_device_per_container = globalThis.backendaiclient._config.maxCUDADevicesPerContainer || 16;
       this.max_cuda_shares_per_container = globalThis.backendaiclient._config.maxCUDASharesPerContainer || 16;
       this.max_shm_per_container = globalThis.backendaiclient._config.maxShmPerContainer || 2;
@@ -1744,13 +1747,13 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
             if (parseInt(image_mem_max) !== 0) {
               mem_metric.max = Math.min(parseFloat(image_mem_max), parseFloat(user_mem_max), available_slot['mem']);
             } else {
-              mem_metric.max = parseFloat(user_mem_max);
+              mem_metric.max = Math.min(parseFloat(user_mem_max), available_slot['mem'], this.max_mem_per_container);
             }
           } else {
             if (parseInt(mem_metric.max) !== 0 && mem_metric.max !== 'Infinity' && isNaN(mem_metric.max) !== true) {
               mem_metric.max = Math.min(parseFloat(globalThis.backendaiclient.utils.changeBinaryUnit(mem_metric.max, 'g', 'g')), available_slot['mem']);
             } else {
-              mem_metric.max = available_slot['mem']; // TODO: set to largest memory size
+              mem_metric.max = Math.min(available_slot['mem'], this.max_mem_per_container); // TODO: set to largest memory size
             }
           }
           if (mem_metric.min >= mem_metric.max) {
@@ -2247,9 +2250,9 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
   _updateShmemLimit() {
     const shmemEl = this.shadowRoot.querySelector('#shmem-resource');
     let shmem_value = shmemEl.value;
-    this.shmem_metric.max = parseFloat(this.shadowRoot.querySelector('#mem-resource').value);
+    this.shmem_metric.max = Math.min(this.max_shm_per_container, this.shmem_metric.max, parseFloat(this.shadowRoot.querySelector('#mem-resource').value));
     // clamp the max value to the smaller of the current memory value or the configuration file value.
-    this.shadowRoot.querySelector('#shmem-resource').max = Math.min(this.max_shm_per_container, this.shmem_metric.max);
+    shmemEl.max = this.shmem_metric.max;
     if (parseFloat(shmem_value) > this.shmem_metric.max) {
       shmem_value = this.shmem_metric.max;
       this.shmem_request = shmem_value;


### PR DESCRIPTION
This PR resolves two things.
- issue #1063 
- new config value for the maximum value of memory per container. (`maxMemoryPerContainer`)

Also, `maxMemoryPerContainer` will be added to README file and sample config file.