### PR TITLE
fix: apply manual image name in session creating

### DIFF
--- a/src/components/backend-ai-session-launcher-legacy.ts
+++ b/src/components/backend-ai-session-launcher-legacy.ts
@@ -1117,7 +1117,7 @@ import {
       config['env'] = this.environ_values;
     }
     let kernelName: string;
-    if (this._debug && this.manualImageName.value !== '') {
+    if (this._debug || this.manualImageName.value !== '') {
       kernelName = this.manualImageName.value;
     } else {
       kernelName = this._generateKernelIndex(kernel, version);

--- a/src/components/backend-ai-session-launcher-legacy.ts
+++ b/src/components/backend-ai-session-launcher-legacy.ts
@@ -2614,7 +2614,7 @@ import {
             <mwc-list fullwidth multi id="vfolder"
               @selected="${() => this._updateSelectedFolder()}">
             ${this.vfolders.length === 0 ? html`
-              <mwc-list-item value="" disabled="true">${_t('session.launcher.NoFolderExists')}</mwc-list-item>
+              <mwc-list-item value="" ?disabled="${true}">${_t('session.launcher.NoFolderExists')}</mwc-list-item>
             `:html``}
             ${this.vfolders.map((item) => html`
               <mwc-check-list-item
@@ -2763,7 +2763,7 @@ import {
             `)}
             ${this.isEmpty(this.resource_templates_filtered) ? html`
               <mwc-list-item class="resource-button vertical center start layout" role="option"
-                             style="height:140px;width:350px;" type="button" aria-selected
+                             style="height:140px;width:350px;" type="button"
                              flat inverted outlined disabled>
                 <div>
                   <h4>${_t('session.launcher.NoSuitablePreset')}</h4>

--- a/src/components/backend-ai-session-launcher-legacy.ts
+++ b/src/components/backend-ai-session-launcher-legacy.ts
@@ -160,6 +160,7 @@ import {
   @property({type: Number}) max_cuda_device_per_container = 16;
   @property({type: Number}) max_cuda_shares_per_container = 16;
   @property({type: Number}) max_shm_per_container = 2;
+  @property({type: Boolean}) allow_manual_image_name_for_session = false;
   @property({type: Object}) resourceBroker;
   @property({type: Number}) cluster_size = 1;
   @property({type: String}) cluster_mode;
@@ -721,6 +722,13 @@ import {
         this.max_cuda_device_per_container = globalThis.backendaiclient._config.maxCUDADevicesPerContainer || 16;
         this.max_cuda_shares_per_container = globalThis.backendaiclient._config.maxCUDASharesPerContainer || 16;
         this.max_shm_per_container = globalThis.backendaiclient._config.maxShmPerContainer || 2;
+        if (globalThis.backendaiclient._config.allow_manual_image_name_for_session !== undefined &&
+          'allow_manual_image_name_for_session' in globalThis.backendaiclient._config &&
+          globalThis.backendaiclient._config.allow_manual_image_name_for_session !== '') {
+          this.allow_manual_image_name_for_session = globalThis.backendaiclient._config.allow_manual_image_name_for_session;
+        } else {
+          this.allow_manual_image_name_for_session = false;
+        }
         if (globalThis.backendaiclient.supports('multi-container')) {
           this.cluster_support = true;
         }
@@ -734,6 +742,13 @@ import {
       this.max_cuda_device_per_container = globalThis.backendaiclient._config.maxCUDADevicesPerContainer || 16;
       this.max_cuda_shares_per_container = globalThis.backendaiclient._config.maxCUDASharesPerContainer || 16;
       this.max_shm_per_container = globalThis.backendaiclient._config.maxShmPerContainer || 2;
+      if (globalThis.backendaiclient._config.allow_manual_image_name_for_session !== undefined &&
+        'allow_manual_image_name_for_session' in globalThis.backendaiclient._config &&
+        globalThis.backendaiclient._config.allow_manual_image_name_for_session !== '') {
+        this.allow_manual_image_name_for_session = globalThis.backendaiclient._config.allow_manual_image_name_for_session;
+      } else {
+        this.allow_manual_image_name_for_session = false;
+      }
       if (globalThis.backendaiclient.supports('multi-container')) {
         this.cluster_support = true;
       }
@@ -2464,6 +2479,22 @@ import {
     this.shadowRoot.querySelector('#' + id).hide();
   }
 
+  /**
+   * Disable Select UI about Environments and versions when event target value is not empty.
+   * 
+   */
+  _toggleEnvironmentSelectUI() {
+    const SelectedEnvironment = this.shadowRoot.querySelector('mwc-select#environment');
+    const SelectedVersions = this.shadowRoot.querySelector('mwc-select#version');
+    const isManualImageEnabled = this.manualImageName?.value ? true : false;
+    SelectedEnvironment.disabled = SelectedVersions.disabled = isManualImageEnabled;
+    // select none(-1) when manual image is enabled
+    const selectedIndex = isManualImageEnabled ? -1 : 1;
+    SelectedEnvironment.select(selectedIndex);
+    SelectedVersions.select(selectedIndex);
+  }
+
+
   render() {
     // language=HTML
     return html`
@@ -2535,9 +2566,11 @@ import {
               </mwc-list-item>
             `)}
             </mwc-select>
-            ${this._debug ? html`
+            ${this._debug || this.allow_manual_image_name_for_session ? html`
+            
             <mwc-textfield id="image-name" type="text" class="flex" value=""
-              label="${_t('session.launcher.ManualImageName')}"></mwc-textfield>
+              label="${_t('session.launcher.ManualImageName')}" @change=${(e) => this._toggleEnvironmentSelectUI()}></mwc-textfield>
+
             `:html``}
           </div>
           <div style="display:none;">

--- a/src/components/backend-ai-session-launcher-legacy.ts
+++ b/src/components/backend-ai-session-launcher-legacy.ts
@@ -1027,9 +1027,20 @@ import {
   _newSession() {
     const confirmationDialog = this.shadowRoot.querySelector('#launch-confirmation-dialog');
     confirmationDialog.hide();
-    const selectedItem = this.shadowRoot.querySelector('#environment').selected;
-    const kernel = selectedItem.id;
-    const version = this.shadowRoot.querySelector('#version').value;
+    let kernel;
+    let version;
+    if (this.manualImageName && this.manualImageName.value) {
+      const nameFragements = this.manualImageName.value.split(':');
+      version = nameFragements.splice(-1, 1)[0];
+      kernel = nameFragements.join(':');
+    } else {
+      // When the "Environment" dropdown is disabled after typing the image name manually,
+      // `selecteditem.id` is `null` and raises "id" exception when trying to launch the session.
+      // That's why we need if-else block here.
+      const selectedItem = this.shadowRoot.querySelector('#environment').selected;
+      kernel = selectedItem.id;
+      version = this.shadowRoot.querySelector('#version').value;
+    }
     let sessionName = this.shadowRoot.querySelector('#session-name').value;
     const isSessionNameValid = this.shadowRoot.querySelector('#session-name').checkValidity();
     const vfolder = this.selectedVfolders;

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1205,7 +1205,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       config['env'] = this.environ_values;
     }
     let kernelName: string;
-    if (this._debug && this.manualImageName.value !== '') {
+    if (this._debug || this.manualImageName.value !== '') {
       kernelName = this.manualImageName.value;
     } else {
       kernelName = this._generateKernelIndex(kernel, version);

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1112,9 +1112,9 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     let kernel;
     let version;
     if (this.manualImageName && this.manualImageName.value) {
-      const nameFragements = this.manualImageName.value.split(':');
-      version = nameFragements.splice(-1, 1)[0];
-      kernel = nameFragements.join(':');
+      const nameFragments = this.manualImageName.value.split(':');
+      version = nameFragments.splice(-1, 1)[0];
+      kernel = nameFragments.join(':');
     } else {
       // When the "Environment" dropdown is disabled after typing the image name manually,
       // `selecteditem.id` is `null` and raises "id" exception when trying to launch the session.
@@ -2841,7 +2841,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
               `)}
               ${this.isEmpty(this.resource_templates_filtered) ? html`
                 <mwc-list-item class="resource-button vertical center start layout" role="option"
-                              style="height:140px;width:350px;" type="button" aria-selected
+                              style="height:140px;width:350px;" type="button"
                               flat inverted outlined disabled>
                   <div>
                     <h4>${_t('session.launcher.NoSuitablePreset')}</h4>

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1109,9 +1109,20 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
   _newSession() {
     const confirmationDialog = this.shadowRoot.querySelector('#launch-confirmation-dialog');
     confirmationDialog.hide();
-    const selectedItem = this.shadowRoot.querySelector('#environment').selected;
-    const kernel = selectedItem.id;
-    const version = this.shadowRoot.querySelector('#version').value;
+    let kernel;
+    let version;
+    if (this.manualImageName && this.manualImageName.value) {
+      const nameFragements = this.manualImageName.value.split(':');
+      version = nameFragements.splice(-1, 1)[0];
+      kernel = nameFragements.join(':');
+    } else {
+      // When the "Environment" dropdown is disabled after typing the image name manually,
+      // `selecteditem.id` is `null` and raises "id" exception when trying to launch the session.
+      // That's why we need if-else block here.
+      const selectedItem = this.shadowRoot.querySelector('#environment').selected;
+      kernel = selectedItem.id;
+      version = this.shadowRoot.querySelector('#version').value;
+    }
     let sessionName = this.shadowRoot.querySelector('#session-name').value;
     const isSessionNameValid = this.shadowRoot.querySelector('#session-name').checkValidity();
     const vfolder = this.selectedVfolders;

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -515,7 +515,9 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
           --mdc-select-label-ink-color: rgba(0, 0, 0, 0.75);
           --mdc-select-dropdown-icon-color: rgba(255, 0, 0, 0.87);
           --mdc-select-focused-dropdown-icon-color: rgba(255, 0, 0, 0.42);
+          --mdc-select-disabled-ink-color	: rgba(0, 0, 0, 0.64);
           --mdc-select-disabled-dropdown-icon-color: rgba(255, 0, 0, 0.87);
+          --mdc-select-disabled-fill-color: rgba(244, 244, 244, 1);
           --mdc-select-idle-line-color: rgba(0, 0, 0, 0.42);
           --mdc-select-hover-line-color: rgba(255, 0, 0, 0.87);
           --mdc-select-outlined-idle-border-color: rgba(255, 0, 0, 0.42);
@@ -2596,6 +2598,21 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     return (currentIndex / progressLength).toFixed(2);
   }
 
+  /**
+   * Disable Select UI about Environments and versions when event target value is not empty.
+   * 
+   */
+  _toggleEnvironmentSelectUI() {
+    const SelectedEnvironment = this.shadowRoot.querySelector('mwc-select#environment');
+    const SelectedVersions = this.shadowRoot.querySelector('mwc-select#version');
+    const isManualImageEnabled = this.manualImageName?.value ? true : false;
+    SelectedEnvironment.disabled = SelectedVersions.disabled = isManualImageEnabled;
+    // select none(-1) when manual image is enabled
+    const selectedIndex = isManualImageEnabled ? -1 : 1;
+    SelectedEnvironment.select(selectedIndex);
+    SelectedVersions.select(selectedIndex);
+  }
+
   render() {
     // language=HTML
     return html`
@@ -2667,7 +2684,8 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
             </mwc-select>
             ${this._debug || this.allow_manual_image_name_for_session ? html`
             <mwc-textfield id="image-name" type="text" class="flex" value="" icon="assignment_turned_in"
-              label="${_t('session.launcher.ManualImageName')}"></mwc-textfield>
+              label="${_t('session.launcher.ManualImageName')}"
+              @change=${(e) => this._toggleEnvironmentSelectUI()}></mwc-textfield>
             `:html``}
             <mwc-textfield id="session-name" placeholder="${_t('session.launcher.SessionNameOptional')}"
                            pattern="[a-zA-Z0-9_-]{4,}" maxLength="64" icon="label"

--- a/src/components/lablup-progress-bar.ts
+++ b/src/components/lablup-progress-bar.ts
@@ -32,7 +32,7 @@ export default class LablupProgressBar extends LitElement {
   @property({type: Object}) progressBar;
   @property({type: Object}) frontDesc;
   @property({type: Object}) backDesc;
-  @property({type: Number}) progress = 0;
+  @property({type: String}) progress = '';
   @property({type: String}) description = ''
 
   static get styles(): CSSResultOrNative | CSSResultArray {

--- a/src/components/lablup-slider.ts
+++ b/src/components/lablup-slider.ts
@@ -36,11 +36,11 @@ export default class LablupSlider extends LitElement {
   @property({type: Number}) value;
   @property({type: Number}) max;
   @property({type: Number}) min;
-  @property({type: Boolean}) editable = null;
-  @property({type: Boolean}) pin = null;
-  @property({type: Boolean}) markers = null;
+  @property({type: Boolean}) editable = false;
+  @property({type: Boolean}) pin = false;
+  @property({type: Boolean}) markers = false;
   @property({type: Number}) marker_limit = 30;
-  @property({type: Boolean}) disabled = null;
+  @property({type: Boolean}) disabled = false;
   @property({type: Object}) textfield;
   @query('#slider', true) slider;
 


### PR DESCRIPTION
This PR resolves #1069.

Also for better user experiences, Environment and Version selection are disabled when the input field of the manual image is not empty.
![manual-image-input-field](https://user-images.githubusercontent.com/46954439/125915255-eac155b6-f962-4294-8e50-ec16c0b44de6.gif)
