### PR TITLE
Fix: Make the text of the config button horizontally

### DIFF
--- a/src/components/backend-ai-settings-view.ts
+++ b/src/components/backend-ai-settings-view.ts
@@ -142,6 +142,7 @@ export default class BackendAiSettingsView extends BackendAIPage {
         .setting-button {
           float: right;
           width: 35px;
+          white-space: nowrap;
         }
 
         .setting-desc-pulldown {


### PR DESCRIPTION
Fix: Make the text of the config button horizontally.

Is your feature request related to a problem? Please describe.
On the configurations page, when the system language setting is Korean, the text of the config button looks vertical. Make the text of the config button horizontally whatever the language environment it is.

I fix to make the text of the config button horizontally.