### PR TITLE
feat : change width Resource Statics panel

### DIFF
--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -431,15 +431,13 @@ export default class BackendAiSessionView extends BackendAIPage {
   render() {
     // language=HTML
     return html`
-      <div class="horizontal layout wrap">
-        <lablup-activity-panel title="${_t('summary.ResourceStatistics')}" elevation="1" autowidth>
-          <div slot="message">
-            <backend-ai-resource-monitor location="session" id="resource-monitor" ?active="${this.active === true}"></backend-ai-resource-monitor>
-          </div>
-        </lablup-activity-panel>
-        <lablup-activity-panel title="${_t('summary.Announcement')}" elevation="1" horizontalsize="2x" style="display:none;">
-        </lablup-activity-panel>
-      </div>
+      <lablup-activity-panel title="${_t('summary.ResourceStatistics')}" elevation="1" autowidth>
+        <div slot="message">
+          <backend-ai-resource-monitor location="session" id="resource-monitor" ?active="${this.active === true}"></backend-ai-resource-monitor>
+        </div>
+      </lablup-activity-panel>
+      <lablup-activity-panel title="${_t('summary.Announcement')}" elevation="1" horizontalsize="2x" style="display:none;">
+      </lablup-activity-panel>
       <lablup-activity-panel elevation="1" autowidth narrow noheader>
         <div slot="message">
           <h3 class="tab horizontal center layout" style="margin-top:0;margin-bottom:0;">


### PR DESCRIPTION
resolve #1113 

* cause
`width : auto;` is not work in flex container
<img width="392" alt="스크린샷 2021-08-29 오후 4 34 20" src="https://user-images.githubusercontent.com/68562176/131242501-6a78b005-b9ce-4f03-a663-a593633b0971.png">

* solution
1. add `style="width: 100%"` to `<lablup-activity-panel title="${_t('summary.ResourceStatistics')}" elevation="1" autowidth>`
ex)
`<lablup-activity-panel title="${_t('summary.ResourceStatistics')}" elevation="1" style="width">`
2. remove a div element which contains `<lablup-activity-panel title="${_t('summary.ResourceStatistics')}" elevation="1" autowidth>` with a class attribute with the value of "horizontal layout wrap"

* conclusion
I chose solution 2.
    * result
    screen width ≥ 1418px
        <img width="1440" alt="스크린샷 2021-08-29 오후 5 07 45" src="https://user-images.githubusercontent.com/68562176/131243401-4ece0022-e49a-4691-b50c-e03419817275.png">
    700px ≤ screen width < 1418px
        <img width="997" alt="스크린샷 2021-08-29 오후 5 14 13" src="https://user-images.githubusercontent.com/68562176/131243553-37cad57f-16b1-4969-8f4a-d4176879a68d.png">
    screen width < 700px
        <img width="527" alt="스크린샷 2021-08-29 오후 5 15 42" src="https://user-images.githubusercontent.com/68562176/131243584-eb1d632a-65b2-4872-9154-8be212d125ca.png">
        