### PR TITLE
feat: add overlay network settings dialog and increase code flexibility

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -885,7 +885,7 @@
     "SessionCreationRetriesDescription": "If the session creation fails, the session creation is retried for the value specified in here. If the session cannot be created within the trials, the request will be ignored and Backend.AI will process the next request.",
     "FifoOnly": "Currently, changes are only possible when the scheduler is FIFO.",
     "InputRequired": "This field is required.",
-    "InputRange0to1000": "Enter values between 0 to 1000.",
+    "OutOfRange": "Out of range.",
     "SchedulerRequired": "Scheduler is required.",
     "InvalidValue": "Please put the correct input value.",
     "EnvConfigWillDisappear": "Any unsaved environment variable and value will be disappeared.",
@@ -904,7 +904,12 @@
       "digest": "Digest",
       "tag": "Tag",
       "none": "None"
-    }
+    },
+    "OverlayNetwork": "Overlay Network",
+    "OverlayNetworkConfiguration": "Configuration to use when creating overlay networks.",
+    "OverlayNetworkSettings": "Overlay Network settings",
+    "OverlayNetworkSettingsDescription": "An overlay network is a computer network that is layered on top of another network. The overlay network creates a distributed network among multiple Docker daemon hosts of the Backend.AI manager.",
+    "MTUDescription": "Maximum transmission unit, the size of the largest packet that a network protocol can transmit."
   },
   "notification": {
     "SuccessfullyUpdated": "Successfully Updated",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -885,7 +885,7 @@
     "SessionCreationRetriesDescription": "세션 생성이 실패한 경우 지정한 횟수만큼 세션 생성을 재시도합니다. 만약 지정한 횟수 안에 세션 생성을 하지 못하는 경우 해당 요청을 무시하고 다음 요청을 처리합니다.",
     "FifoOnly": "현재는 스케줄러가 FIFO일 때만 변경 가능합니다.",
     "InputRequired": "필수 입력입니다.",
-    "InputRange0to1000": "0 에서 1000 사이 정수 값만 입력해주세요.",
+    "OutOfRange": "입력 범위를 벗어났습니다.",
     "SchedulerRequired": "스케줄러는 필수 선택입니다.",
     "InvalidValue": "올바른 입력값을 넣어주세요.",
     "EnvConfigWillDisappear": "저장되지 않은 환경 변수 설정값은 사라집니다.",
@@ -904,7 +904,12 @@
       "digest": "해시값",
       "tag": "태그",
       "none": "사용안함"
-    }
+    },
+    "OverlayNetwork": "오버레이 네트워크",
+    "OverlayNetworkConfiguration": "오버레이 네트워크 설정을 변경합니다.",
+    "OverlayNetworkSettings": "오버레이 네트워크 설정",
+    "OverlayNetworkSettingsDescription": "오버레이 네트워크는 물리 네트워크 위에 성립되는 가상의 컴퓨터 네트워크입니다. 오버레이 네트워크는 Backend.AI 매니저의 여러 Docker 데몬 호스트 간에 분산 네트워크를 생성합니다.",
+    "MTUDescription": "최대 전송 단위 - 해당 레이어가 전송할 수 있는 최대 프로토콜 데이터 단위의 크기입니다."
   },
   "notification": {
     "SuccessfullyUpdated": "성공적으로 수정되었습니다.",

--- a/src/components/backend-ai-settings-view.ts
+++ b/src/components/backend-ai-settings-view.ts
@@ -427,7 +427,6 @@ export default class BackendAiSettingsView extends BackendAIPage {
               <span slot="title">${_t('settings.SessionCreationRetries')}</span>
               <mwc-icon-button icon="info" @click="${(e) => this._showConfigDescription(e, 'retries')}" style="pointer-events:auto;"></mwc-icon-button>
               <mwc-textfield  id="num-retries"
-                              outlined
                               required
                               autoValidate
                               validationMessage="${_t('settings.InputRequired')}"
@@ -470,7 +469,6 @@ export default class BackendAiSettingsView extends BackendAIPage {
               <mwc-textfield id="mtu"
                              class="network-option"
                              value="${this.options.network.mtu}"
-                             outlined
                              required
                              autoValidate
                              validationMessage="${_t('settings.InputRequired')}"

--- a/src/components/backend-ai-settings-view.ts
+++ b/src/components/backend-ai-settings-view.ts
@@ -43,7 +43,8 @@ export default class BackendAiSettingsView extends BackendAIPage {
   @property({type: Object}) images = Object();
   @property({type: Object}) options = Object();
   @property({type: Object}) schedulerOptions = Object();
-  @property({type: Object}) schedulerOptionsAndId = Object();
+  @property({type: Object}) networkOptions = Object();
+  @property({type: Object}) optionsAndId = Object();
   @property({type: Object}) notification = Object();
   @property({type: Array}) imagePullingBehavior = [
     {name: _text('settings.image.digest'), behavior: 'digest'},
@@ -55,10 +56,8 @@ export default class BackendAiSettingsView extends BackendAIPage {
   @property({type: String}) selectedSchedulerType = '';
   @property({type: String}) _helpDescriptionTitle = '';
   @property({type: String}) _helpDescription = '';
-  @property({type: Object}) numRetriesRange = {
-    'min': 0,
-    'max': 1000
-  }
+  @property({type: Object}) optionRange = Object();
+
   constructor() {
     super();
     this.options = {
@@ -67,14 +66,27 @@ export default class BackendAiSettingsView extends BackendAIPage {
       cuda_fgpu: false,
       rocm_gpu: false,
       tpu: false,
-      scheduler: 'fifo',
+      schedulerType: 'fifo',
+      scheduler: {
+        num_retries_to_skip: '0',
+      },
+      network: {
+        mtu: '',
+      }
     };
-    this.schedulerOptions = {
-      num_retries_to_skip: '0'
+    this.optionRange = {
+      numRetries: {
+        min: 0,
+        max: 1000
+      },
+      mtu: {
+        min: 0
+      },
     };
-    // Stores scheduler option keys and id.
-    this.schedulerOptionsAndId = [
-      {option: 'num_retries_to_skip', id: 'num-retries'}
+    // Save the key and ID of the options.
+    this.optionsAndId = [
+      {option: 'num_retries_to_skip', id: 'num-retries'},
+      {option: 'mtu', id: 'mtu'},
     ];
   }
 
@@ -156,7 +168,7 @@ export default class BackendAiSettingsView extends BackendAIPage {
           --component-width: 350px;
         }
 
-        #env-dialog {
+        #scheduler-env-dialog {
           --component-max-height: 800px;
           --component-width: 400px;
         }
@@ -282,19 +294,36 @@ export default class BackendAiSettingsView extends BackendAIPage {
               </p>
             </div>
             <div style="margin:auto 16px;">
-                <h3 class="horizontal center layout">
+              <h3 class="horizontal center layout">
                 <span>${_t('settings.Scaling')}</span>
                 <span class="flex"></span>
               </h3>
-              <div class="horizontal wrap layout">
-                <div class="horizontal layout wrap setting-item">
-                  <div class="vertical center-justified layout setting-desc-shrink">
-                    <div class="title">${_t('settings.AllowAgentSideRegistration')}</div>
-                    <div class="description-shrink">${_tr('settings.DescAllowAgentSideRegistration')}
+              <div class="vertical wrap layout">
+                <div class="horizontal layout wrap start start-justified">
+                  <div class="horizontal layout setting-item">
+                    <div class="vertical center-justified layout setting-desc-shrink">
+                      <div class="title">${_t('settings.AllowAgentSideRegistration')}</div>
+                      <div class="description-shrink">${_tr('settings.DescAllowAgentSideRegistration')}
+                      </div>
+                    </div>
+                    <div class="vertical center-justified layout setting-button">
+                      <mwc-switch id="allow-agent-registration-switch" checked disabled></mwc-switch>
                     </div>
                   </div>
-                  <div class="vertical center-justified layout setting-button">
-                    <mwc-switch id="allow-agent-registration-switch" checked disabled></mwc-switch>
+                  <div class="horizontal layout setting-item">
+                    <div class="vertical center-justified layout setting-desc-shrink">
+                      <div class="title">${_t('settings.OverlayNetwork')}</div>
+                      <div class="description-shrink">${_tr('settings.OverlayNetworkConfiguration')}
+                      </div>
+                    </div>
+                    <div class="vertical center-justified layout">
+                      <mwc-button
+                        unelevated
+                        icon="rule"
+                        label="${_t('settings.Config')}"
+                        style="float: right;"
+                        @click="${() => this._openDialogWithConfirmation('overlay-network-env-dialog')}"></mwc-button>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -338,7 +367,7 @@ export default class BackendAiSettingsView extends BackendAIPage {
                         icon="rule"
                         label="${_t('settings.Config')}"
                         style="float: right;"
-                        @click="${()=>this._showEnvDialog()}"></mwc-button>
+                        @click="${()=>this._openDialogWithConfirmation('scheduler-env-dialog')}"></mwc-button>
                     </div>
                   </div>
                 </div>
@@ -372,12 +401,12 @@ export default class BackendAiSettingsView extends BackendAIPage {
             </div>
           </div>
         </lablup-activity-panel>
-        <backend-ai-dialog id="env-dialog" fixed backdrop persistent closeWithConfirmation>
+        <backend-ai-dialog id="scheduler-env-dialog" class="env-dialog" fixed backdrop persistent closeWithConfirmation>
           <span slot="title" class="horizontal layout center">${_tr('settings.ConfigPerJobSchduler')}</span>
           <span slot="action">
             <mwc-icon-button icon="info" @click="${(e) => this._showConfigDescription(e, 'default')}" style="pointer-events:auto;"></mwc-icon-button>
           </span>
-          <div slot="content" id="env-container" class="vertical layout centered" style="width: 100%;">
+          <div slot="content" id="scheduler-env-container" class="vertical layout centered env-container" style="width: 100%;">
             <mwc-select
               id="scheduler-switch"
               required
@@ -401,8 +430,8 @@ export default class BackendAiSettingsView extends BackendAIPage {
                               validationMessage="${_t('settings.InputRequired')}"
                               type="number"
                               pattern="[0-9]+"
-                              min="${this.numRetriesRange.min}"
-                              max="${this.numRetriesRange.max}"
+                              min="${this.optionRange.numRetries.min}"
+                              max="${this.optionRange.numRetries.max}"
                               style="margin-top: 18px"
                               @change="${(e) => this._validateInput(e)}"
                               @input="${(e) => this._customizeValidationMessage(e)}"></mwc-textfield>
@@ -413,7 +442,7 @@ export default class BackendAiSettingsView extends BackendAIPage {
               id="config-cancel-button"
               style="width:auto;margin-right:10px;"
               icon="delete"
-              @click="${() => this._clearOptions()}"
+              @click="${() => this._clearOptions('scheduler-env-container')}"
               label="${_t('button.DeleteAll')}"></mwc-button>
             <mwc-button
               unelevated
@@ -421,6 +450,48 @@ export default class BackendAiSettingsView extends BackendAIPage {
               style="width:auto;"
               icon="check"
               @click="${() => this.saveAndCloseDialog()}"
+              label="${_t('button.Save')}"></mwc-button>
+          </div>
+        </backend-ai-dialog>
+        <backend-ai-dialog id="overlay-network-env-dialog" class="env-dialog" fixed backdrop persistent closeWithConfirmation>
+          <span slot="title" class="horizontal layout center">${_tr('settings.OverlayNetworkSettings')}</span>
+          <span slot="action">
+            <mwc-icon-button icon="info" @click="${(e) => this._showConfigDescription(e, 'overlayNetwork')}" style="pointer-events:auto;"></mwc-icon-button>
+          </span>
+          <div slot="content" id="overlay-network-env-container" class="vertical layout centered env-container" style="width: 100%;">
+            <div class="horizontal center layout flex row justified">
+              <div class="horizontal center layout">
+                <span slot="title">MTU</span>
+                <mwc-icon-button icon="info" @click="${(e) => this._showConfigDescription(e, 'mtu')}" style="pointer-events:auto;"></mwc-icon-button>
+              </div>
+              <mwc-textfield id="mtu"
+                             class="network-option"
+                             value="${this.options.network.mtu}"
+                             outlined
+                             required
+                             autoValidate
+                             validationMessage="${_t('settings.InputRequired')}"
+                             type="number"
+                             pattern="[0-9]+"
+                             min="${this.optionRange.mtu.min}"
+                             style="margin-top:18px;min-width:240px;"
+                             @change="${(e) => this._validateInput(e)}"
+                             @input="${(e) => this._customizeValidationMessage(e)}"></mwc-textfield>
+            </div>
+          </div>
+          <div slot="footer" class="horizontal end-justified flex layout">
+            <mwc-button
+              id="config-cancel-button"
+              style="width:auto;margin-right:10px;"
+              icon="delete"
+              @click="${() => this._clearOptions('overlay-network-env-container')}"
+              label="${_t('button.DeleteAll')}"></mwc-button>
+            <mwc-button
+              unelevated
+              id="config-save-button"
+              style="width:auto;"
+              icon="check"
+              @click="${() => this.saveAndCloseOverlayNetworkDialog()}"
               label="${_t('button.Save')}"></mwc-button>
           </div>
         </backend-ai-dialog>
@@ -464,17 +535,29 @@ export default class BackendAiSettingsView extends BackendAIPage {
       this.updateSettings();
     }
     // if user wants to modify the scheduler options and close the dialog, open the confirm dialog.
-    const envDialog = this.shadowRoot.querySelector('#env-dialog');
-    envDialog.addEventListener('dialog-closing-confirm', (e) => {
-      const container = this.shadowRoot.querySelector('#env-container');
+    const schedulerEnvDialog = this.shadowRoot.querySelector('#scheduler-env-dialog');
+    schedulerEnvDialog.addEventListener('dialog-closing-confirm', (e) => {
+      const container = this.shadowRoot.querySelector('#scheduler-env-container');
       const rows = container.querySelectorAll('mwc-textfield');
       for (const row of rows) {
-        if (this.schedulerOptions[this._findOptionById(row.id)] !== row.value && this.selectedSchedulerType !== '') {
+        if (this.options.scheduler[this._findOptionById(row.id)] !== row.value && this.selectedSchedulerType !== '') {
           this.openDialog('env-config-confirmation');
           break;
         } else {
-          this.closeDialog('env-config-confirmation');
-          this._hideEnvDialog();
+          this._closeDialogWithConfirmation('scheduler-env-dialog');
+        }
+      }
+    });
+    const networkEnvDialog = this.shadowRoot.querySelector('#overlay-network-env-dialog');
+    networkEnvDialog.addEventListener('dialog-closing-confirm', (e) => {
+      const container = this.shadowRoot.querySelector('#overlay-network-env-container');
+      const rows = container.querySelectorAll('mwc-textfield');
+      for (const row of rows) {
+        if (this.options.network[this._findOptionById(row.id)] !== row.value) {
+          this.openDialog('env-config-confirmation');
+          break;
+        } else {
+          this._closeDialogWithConfirmation('overlay-network-env-dialog');
         }
       }
     });
@@ -487,7 +570,7 @@ export default class BackendAiSettingsView extends BackendAIPage {
   }
 
   /**
-   * Image pulling behavior, scheduler, and resource slots setting update
+   * Image pulling behavior, scheduler, network, and resource slots setting update
    * */
   updateSettings() {
     globalThis.backendaiclient.setting.get('docker/image/auto_pull').then((response) => {
@@ -500,15 +583,25 @@ export default class BackendAiSettingsView extends BackendAIPage {
       }
       this.update(this.options);
     });
-    for (const [key] of Object.entries(this.schedulerOptions)) {
+    for (const [key] of Object.entries(this.options.scheduler)) {
       globalThis.backendaiclient.setting.get(`plugins/scheduler/${this.selectedSchedulerType}/${key}`).then((response) => {
         if (response['result'] === null) {
-          this.schedulerOptions[key] = '0';
+          this.options.scheduler[key] = '0';
         } else {
-          this.schedulerOptions[key] = response['result'];
+          this.options.scheduler[key] = response['result'];
         }
       });
-      this.update(this.schedulerOptions);
+      this.update(this.options);
+    }
+    for (const [key] of Object.entries(this.options.network)) {
+      globalThis.backendaiclient.setting.get(`network/overlay/${key}`).then((response) => {
+        if (response['result'] === null) {
+          this.options.network[key] = response['result'] = '';
+        } else {
+          this.options.network[key] = response['result'];
+        }
+      });
+      this.update(this.options);
     }
     globalThis.backendaiclient.get_resource_slots().then((response) => {
       if ('cuda.device' in response) {
@@ -551,42 +644,43 @@ export default class BackendAiSettingsView extends BackendAIPage {
   /**
    * find id in html by scheduler option key.
    *
-   * @param {object} option - scheduler option key
-   * @return {string} - id of scheduler
+   * @param {object} option - option name
+   * @return {string} - id
    */
   _findIdByOption(option) {
-    return this.schedulerOptionsAndId.find((elm) => elm.option === option).id;
+    return this.optionsAndId.find((elm) => elm.option === option).id;
   }
 
   /**
    * find scheduler option key by id in html.
    *
-   * @param {string} id - id of scheduler
-   * @return {object} - options in scheduler
+   * @param {string} id - id of option
+   * @return {object} - option name
    */
   _findOptionById(id) {
-    return this.schedulerOptionsAndId.find((elm) => elm.id === id).option;
+    return this.optionsAndId.find((elm) => elm.id === id).option;
   }
 
   /**
    * Clear option values from environment container.
+   * @param {string} id - id of option
    */
-  _clearOptions() {
-    const container = this.shadowRoot.querySelector('#env-container');
+  _clearOptions(id) {
+    const container = this.shadowRoot.querySelector('#' + id);
     // initialize options (textfield values)
     container.querySelectorAll('mwc-textfield').forEach((tf) => {
       tf.value = '';
     });
   }
 
-  _showEnvDialog() {
-    const envDialog = this.shadowRoot.querySelector('#env-dialog');
+  _openDialogWithConfirmation(id) {
+    const envDialog = this.shadowRoot.querySelector('#' + id);
     envDialog.closeWithConfirmation = true;
     envDialog.show();
   }
 
-  _hideEnvDialog() {
-    const envDialog = this.shadowRoot.querySelector('#env-dialog');
+  _closeDialogWithConfirmation(id) {
+    const envDialog = this.shadowRoot.querySelector('#' + id);
     envDialog.closeWithConfirmation = false;
     envDialog.hide();
   }
@@ -595,23 +689,40 @@ export default class BackendAiSettingsView extends BackendAIPage {
    * Close confirmation dialog and environment variable dialog and reset the option values.
    */
   closeAndResetEnvInput() {
-    const schedulerSwitch = this.shadowRoot.querySelector('#scheduler-switch');
-    schedulerSwitch.value = null;
-    this._clearOptions();
-    this.closeDialog('env-config-confirmation');
-    this._hideEnvDialog();
+    const envDialogs = this.shadowRoot.querySelectorAll('.env-dialog');
+    for (const envDialog of envDialogs) {
+      if (envDialog.open) {
+        const envContainer = envDialog.querySelector('.env-container');
+        this._clearOptions(envContainer.id);
+        this.closeDialog('env-config-confirmation');
+        this._closeDialogWithConfirmation(envDialog.id);
+        if (envDialog.id === 'scheduler-env-dialog') {
+          const schedulerSwitch = this.shadowRoot.querySelector('#scheduler-switch');
+          schedulerSwitch.value = null;
+        }
+        break;
+      }
+    }
   }
 
   _showConfigDescription(e, item) {
     e.stopPropagation();
     const schedulerConfigDescription = {
       'default': {
-        'title': _tr('settings.ConfigPerJobSchduler'),
+        'title': _text('settings.ConfigPerJobSchduler'),
         'desc': _text('settings.ConfigPerJobSchdulerDescription')
       },
       'retries': {
         'title': _text('settings.SessionCreationRetries'),
         'desc': _text('settings.SessionCreationRetriesDescription') + '\n' + _text('settings.FifoOnly')
+      },
+      'overlayNetwork': {
+        'title': _text('settings.OverlayNetworkSettings'),
+        'desc': _text('settings.OverlayNetworkSettingsDescription')
+      },
+      'mtu': {
+        'title': 'MTU',
+        'desc': _text('settings.MTUDescription')
       }
     };
     if (item in schedulerConfigDescription) {
@@ -654,11 +765,10 @@ export default class BackendAiSettingsView extends BackendAIPage {
           .then((response) => {
             this.notification.text = _text('notification.SuccessfullyUpdated');
             this.notification.show();
-            this.options['scheduler'] = this.selectedSchedulerType;
-            this.schedulerOptions = {...this.schedulerOptions, ...options};
+            this.options['schedulerType'] = this.selectedSchedulerType;
+            this.options.scheduler = {...this.options.scheduler, ...options};
             this.update(this.options);
-            this.update(this.schedulerOptions);
-            this._hideEnvDialog();
+            this._closeDialogWithConfirmation('scheduler-env-dialog');
           })
           .catch((err) => {
             this.notification.text = PainKiller.relieve('Couldn\'t update scheduler setting.');
@@ -673,6 +783,36 @@ export default class BackendAiSettingsView extends BackendAIPage {
     }
   }
 
+  saveAndCloseOverlayNetworkDialog() {
+    const networkOptions = [...this.shadowRoot.querySelectorAll('.network-option')];
+    if (networkOptions.filter((elem) => elem.reportValidity()).length < networkOptions.length) {
+      return;
+    }
+    const options = {};
+    for (const networkOption of networkOptions) {
+      const key = this._findOptionById(networkOption.id);
+      const value = networkOption.value;
+      if (value !== '' || value.length !== 0 || value != undefined) {
+        options[key] = value;
+      } else {
+        return;
+      }
+    }
+    globalThis.backendaiclient.setting.set(`network/overlay`, options)
+      .then((response) => {
+        this.notification.text = _text('notification.SuccessfullyUpdated');
+        this.notification.show();
+        this.options.network = {...this.options.network, ...options};
+        this.update(this.options);
+        this._closeDialogWithConfirmation('overlay-network-env-dialog');
+      })
+      .catch((err) => {
+        this.notification.text = PainKiller.relieve('Couldn\'t update scheduler setting.');
+        this.notification.detail = err;
+        this.notification.show(true, err);
+      });
+  }
+
   /**
    * Change this.selectedSchedulerType value and the scheduler options
    *
@@ -681,7 +821,7 @@ export default class BackendAiSettingsView extends BackendAIPage {
   changeSelectedScheduleType(e) {
     this.selectedSchedulerType = e.target.value;
     this.updateSettings();
-    for (const [key] of Object.entries(this.schedulerOptions)) {
+    for (const [key] of Object.entries(this.options.scheduler)) {
       globalThis.backendaiclient.setting.get(`plugins/scheduler/${this.selectedSchedulerType}/${key}`).then((response) => {
         if (response['result'] === null) {
           this.shadowRoot.querySelector('#' + this._findIdByOption(key)).value = '0';
@@ -701,7 +841,9 @@ export default class BackendAiSettingsView extends BackendAIPage {
     const textfield = e.target.closest('mwc-textfield');
     if (textfield.value) {
       textfield.value = Math.round(textfield.value);
-      textfield.value = globalThis.backendaiclient.utils.clamp(textfield.value, textfield.min, textfield.max);
+      if (textfield.min && textfield.max) {
+        textfield.value = globalThis.backendaiclient.utils.clamp(textfield.value, textfield.min, textfield.max);
+      }
     }
   }
 
@@ -721,7 +863,7 @@ export default class BackendAiSettingsView extends BackendAIPage {
             customError: !nativeValidity.valid
           };
         } else if (nativeValidity.rangeOverflow || nativeValidity.rangeUnderflow) {
-          textfield.validationMessage = _text('settings.InputRange0to1000');
+          textfield.validationMessage = _text('settings.OutOfRange');
           return {
             valid: nativeValidity.valid,
             customError: !nativeValidity.valid

--- a/src/components/backend-ai-settings-view.ts
+++ b/src/components/backend-ai-settings-view.ts
@@ -534,13 +534,14 @@ export default class BackendAiSettingsView extends BackendAIPage {
     } else { // already connected
       this.updateSettings();
     }
+    const {scheduler, network} = this.options;
     // if user wants to modify the scheduler options and close the dialog, open the confirm dialog.
     const schedulerEnvDialog = this.shadowRoot.querySelector('#scheduler-env-dialog');
     schedulerEnvDialog.addEventListener('dialog-closing-confirm', (e) => {
       const container = this.shadowRoot.querySelector('#scheduler-env-container');
       const rows = container.querySelectorAll('mwc-textfield');
       for (const row of rows) {
-        if (this.options.scheduler[this._findOptionById(row.id)] !== row.value && this.selectedSchedulerType !== '') {
+        if (scheduler[this._findOptionById(row.id)] !== row.value && this.selectedSchedulerType !== '') {
           this.openDialog('env-config-confirmation');
           break;
         } else {
@@ -553,7 +554,7 @@ export default class BackendAiSettingsView extends BackendAIPage {
       const container = this.shadowRoot.querySelector('#overlay-network-env-container');
       const rows = container.querySelectorAll('mwc-textfield');
       for (const row of rows) {
-        if (this.options.network[this._findOptionById(row.id)] !== row.value) {
+        if (network[this._findOptionById(row.id)] !== row.value) {
           this.openDialog('env-config-confirmation');
           break;
         } else {
@@ -765,7 +766,7 @@ export default class BackendAiSettingsView extends BackendAIPage {
           .then((response) => {
             this.notification.text = _text('notification.SuccessfullyUpdated');
             this.notification.show();
-            this.options['schedulerType'] = this.selectedSchedulerType;
+            this.options.schedulerType = this.selectedSchedulerType;
             this.options.scheduler = {...this.options.scheduler, ...options};
             this.update(this.options);
             this._closeDialogWithConfirmation('scheduler-env-dialog');
@@ -792,7 +793,7 @@ export default class BackendAiSettingsView extends BackendAIPage {
     for (const networkOption of networkOptions) {
       const key = this._findOptionById(networkOption.id);
       const value = networkOption.value;
-      if (value !== '' || value.length !== 0 || value != undefined) {
+      if (value !== '' || value !== null || value !== undefined) {
         options[key] = value;
       } else {
         return;


### PR DESCRIPTION
- Add overlay network setting dialog on the setting page.
- When clicking the `Config` button, you can change the MTU option.
- For code reusability, I changed some properties and functions like `schedulerOptionsAndId`,`_showEnvDialog()`.

Internal Ticket: OP#1458
Related PR: [manager#475](https://github.com/lablup/backend.ai-manager/pull/475) 