### PR TITLE
fix: we need to await before getting wsproxy version value

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -524,7 +524,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
 
     const scalingGroupId = kInfo.compute_session.scaling_group;
     // Apply v1 when executing in electron mode
-    let wsproxyVersion = (globalThis.isElectron) ? 'v1' : await globalThis.backendaiclient.scalingGroup.getWsproxyVersion(scalingGroupId).version;
+    const wsproxyVersion = (globalThis.isElectron) ? 'v1' : (await globalThis.backendaiclient.scalingGroup.getWsproxyVersion(scalingGroupId)).version;
     let uri = (wsproxyVersion == 'v1') ? await this._resolveV1ProxyUri(sessionUuid, app) : await this._resolveV2ProxyUri(sessionUuid, app, port, envs, args);
     if (!uri) {
       return Promise.resolve(false);


### PR DESCRIPTION
This closes https://github.com/lablup/backend.ai-webui/issues/1154.