### PR TITLE
fix: use user-accessible API for getting storage backend information

### DIFF
--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -697,23 +697,9 @@ export default class BackendAIData extends BackendAIPage {
     this.openDialog('add-folder-dialog');
   }
 
-  _getStorageProxyBackendInformation() {
-    globalThis.backendaiclient.storageproxy.list(
-      ['id', 'backend', 'capabilities']
-    ).then((resp) => {
-      const results = resp.storage_volume_list.items;
-      const storageInfo = {};
-      results.forEach((s) => {
-        storageInfo[s.id] = s;
-      });
-      this.storageProxyInfo = storageInfo;
-    }).catch((err) => {
-      if (err && err.message) {
-        this.notification.text = PainKiller.relieve(err.title);
-        this.notification.detail = err.message;
-        this.notification.show(true, err);
-      }
-    });
+  async _getStorageProxyBackendInformation() {
+    const vhostInfo = await globalThis.backendaiclient.vfolder.list_hosts();
+    this.storageProxyInfo = vhostInfo.volume_info || {};
   }
 
   openDialog(id) {

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1417,30 +1417,16 @@ export default class BackendAiStorageList extends BackendAIPage {
     );
   }
 
-  _getStorageProxyBackendInformation() {
-    globalThis.backendaiclient.storageproxy.list(
-      ['id', 'backend', 'capabilities']
-    ).then((resp) => {
-      const results = resp.storage_volume_list.items;
-      const storageInfo = {};
-      results.forEach((s) => {
-        storageInfo[s.id] = s;
-      });
-      this.storageProxyInfo = storageInfo;
-    }).catch((err) => {
-      if (err && err.message) {
-        this.notification.text = PainKiller.relieve(err.title);
-        this.notification.detail = err.message;
-        this.notification.show(true, err);
-      }
-    });
+  async _getStorageProxyBackendInformation() {
+    const vhostInfo = await globalThis.backendaiclient.vfolder.list_hosts();
+    this.storageProxyInfo = vhostInfo.volume_info || {};
   }
 
   _checkFolderSupportSizeQuota(host: string) {
     if (!host) {
       return false;
     }
-    const backend = this.storageProxyInfo[host].backend;
+    const backend = this.storageProxyInfo[host]?.backend;
     return this.quotaSupportStorageBackends.includes(backend) ? true : false;
   }
 


### PR DESCRIPTION
This resolves https://github.com/lablup/backend.ai-webui/issues/1158.

This PR needs manger's [PR to allow users to get/set vfolder quota](https://github.com/lablup/backend.ai-manager/pull/492).