### PR TITLE
fix: can't run app by clicking the app icon.

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -681,7 +681,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
    * @param {Event} e - Dispatches from the native input event each time the input changes.
    */
   async _runThisApp(e) {
-    const controller = e.target;
+    const controller = e.target.closest('mwc-icon-button');
     this.appController['app-name'] = controller['app-name'];
     const controls = controller.closest('#app-dialog');
     this.appController['session-uuid'] = controls.getAttribute('session-uuid');


### PR DESCRIPTION
- this resolves #1175 
- If you click the icon button, then the controller was set to the image, not `mwc-icon-button`.
- So I force to set the controller to `mwc-icon-button`.