### PR TITLE
feat: toggle token email confirmation option

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -10,7 +10,7 @@ signupSupport = false
 allowSignout = false
 allowAnonymousChangePassword = false
 allowProjectResourceMonitor = true
-useManualSignUp = false
+allowSignupWithoutConfirmation = false
 autoLogout = false
 debug = false
 

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -10,6 +10,7 @@ signupSupport = false
 allowSignout = false
 allowAnonymousChangePassword = false
 allowProjectResourceMonitor = true
+useManualSignUp = false
 autoLogout = false
 debug = false
 

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -84,7 +84,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({type: Boolean}) allow_signout = false;
   @property({type: Boolean}) allow_project_resource_monitor = false;
   @property({type: Boolean}) allow_manual_image_name_for_session = false;
-  @property({type: Boolean}) isManualSignup = false;
+  @property({type: Boolean}) allowSignupWithoutConfirmation = false;
   @property({type: Boolean}) openPortToPublic = false;
   @property({type: Boolean}) maxCPUCoresPerContainer = 64;
   @property({type: Boolean}) maxMemoryPerContainer = 16;
@@ -494,10 +494,10 @@ export default class BackendAILogin extends BackendAIPage {
       (this.shadowRoot.querySelector('#id_api_endpoint') as any).disabled = true;
       (this.shadowRoot.querySelector('#id_api_endpoint_humanized') as any).disabled = true;
     }
-    if (typeof config.general === 'undefined' || typeof config.general.useManualSignUp === 'undefined' || config.general.useManualSignUp === '' || config.general.useManualSignUp == false) {
-      this.isManualSignup = false;
+    if (typeof config.general === 'undefined' || typeof config.general.allowSignupWithoutConfirmation === 'undefined' || config.general.allowSignupWithoutConfirmation === '' || config.general.allowSignupWithoutConfirmation == false) {
+      this.allowSignupWithoutConfirmation = false;
     } else {
-      this.isManualSignup = true;
+      this.allowSignupWithoutConfirmation = true;
     }
 
     if (typeof config.general === 'undefined' || typeof config.general.defaultSessionEnvironment === 'undefined' || config.general.defaultSessionEnvironment === '') {
@@ -677,7 +677,7 @@ export default class BackendAILogin extends BackendAIPage {
     }
     const signupDialog = this.shadowRoot.querySelector('#signup-dialog');
     signupDialog.endpoint = this.api_endpoint;
-    signupDialog.isManualSignup = this.isManualSignup;
+    signupDialog.allowSignupWithoutConfirmation = this.allowSignupWithoutConfirmation;
     signupDialog.open();
   }
 

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -84,6 +84,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({type: Boolean}) allow_signout = false;
   @property({type: Boolean}) allow_project_resource_monitor = false;
   @property({type: Boolean}) allow_manual_image_name_for_session = false;
+  @property({type: Boolean}) isManualSignup = false;
   @property({type: Boolean}) openPortToPublic = false;
   @property({type: Boolean}) maxCPUCoresPerContainer = 64;
   @property({type: Boolean}) maxMemoryPerContainer = 16;
@@ -350,6 +351,8 @@ export default class BackendAILogin extends BackendAIPage {
     this.endpoints = globalThis.backendaioptions.get('endpoints', []);
   }
 
+  
+
   /**
    * Change the signin mode with SESSION or API
    * */
@@ -490,6 +493,11 @@ export default class BackendAILogin extends BackendAIPage {
       }
       (this.shadowRoot.querySelector('#id_api_endpoint') as any).disabled = true;
       (this.shadowRoot.querySelector('#id_api_endpoint_humanized') as any).disabled = true;
+    }
+    if (typeof config.general === 'undefined' || typeof config.general.useManualSignUp === 'undefined' || config.general.useManualSignUp === '' || config.general.useManualSignUp == false) {
+      this.isManualSignup = false;
+    } else {
+      this.isManualSignup = true;
     }
 
     if (typeof config.general === 'undefined' || typeof config.general.defaultSessionEnvironment === 'undefined' || config.general.defaultSessionEnvironment === '') {
@@ -667,9 +675,10 @@ export default class BackendAILogin extends BackendAIPage {
       this.notification.show();
       return;
     }
-    (this.shadowRoot.querySelector('#signup-dialog') as any).endpoint = this.api_endpoint;
-    // this.shadowRoot.querySelector('#signup-dialog').receiveAgreement();
-    (this.shadowRoot.querySelector('#signup-dialog') as any).open();
+    const signupDialog = this.shadowRoot.querySelector('#signup-dialog');
+    signupDialog.endpoint = this.api_endpoint;
+    signupDialog.isManualSignup = this.isManualSignup;
+    signupDialog.open();
   }
 
   _showChangePasswordEmailDialog() {

--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -53,7 +53,7 @@ export default class BackendAiSignup extends BackendAIPage {
   @property({type: Object}) client;
   @property({type: String}) TOSlanguage = 'en';
   @property({type: Object}) TOSdialog = Object();
-  @property({type: Boolean}) isManualSignup;
+  @property({type: Boolean}) allowSignupWithoutConfirmation;
 
   constructor() {
     super();
@@ -230,7 +230,7 @@ export default class BackendAiSignup extends BackendAIPage {
   _clearUserInput() {
     this._toggleInputField(true);
     let inputFields: Array<string> = ['#id_user_email', '#id_token', '#id_password1', '#id_password2'];
-    if (this.isManualSignup) {
+    if (this.allowSignupWithoutConfirmation) {
       inputFields = inputFields.filter((el: string) => el !== '#id_token')
     }
     inputFields.forEach((el: string) => {
@@ -241,7 +241,7 @@ export default class BackendAiSignup extends BackendAIPage {
 
   _toggleInputField(isActive: boolean) {
     let inputFields: Array<string> = ['#id_user_name', '#id_token', '#signup-button'];
-    if (this.isManualSignup) {
+    if (this.allowSignupWithoutConfirmation) {
       inputFields = inputFields.filter((el: string) => el !== '#id_token')
     }
     inputFields.forEach((el: string) => {
@@ -255,7 +255,7 @@ export default class BackendAiSignup extends BackendAIPage {
 
   _signup() {
     let inputFields: Array<string> = ['#id_user_email', '#id_token', '#id_password1', '#id_password2'];
-    if (this.isManualSignup) {
+    if (this.allowSignupWithoutConfirmation) {
       inputFields = inputFields.filter((el: string) => el !== '#id_token')
     }
     const inputFieldsValidity: Array<boolean> = inputFields.map((el: string) => {
@@ -286,7 +286,7 @@ export default class BackendAiSignup extends BackendAIPage {
       'password': password,
       'token': token
     };
-    if (this.isManualSignup) {
+    if (this.allowSignupWithoutConfirmation) {
       delete body[token];
     }
     this.init_client();
@@ -299,7 +299,7 @@ export default class BackendAiSignup extends BackendAIPage {
       setTimeout(() => {
         this.signupPanel.hide();
         this._clearUserInput();
-        if(!this.isManualSignup) {
+        if(!this.allowSignupWithoutConfirmation) {
           this.shadowRoot.querySelector('#email-sent-dialog').show();
         }
       }, 1000);
@@ -432,7 +432,7 @@ export default class BackendAiSignup extends BackendAIPage {
     // language=HTML
     return html`
       <backend-ai-dialog id="signup-panel" fixed blockscrolling persistent disablefocustrap>
-        <span slot="title">${this.isManualSignup ? html`
+        <span slot="title">${this.allowSignupWithoutConfirmation ? html`
           ${_t('signup.Signup')}` : 
             html`${_t('signup.SignupBETA')}
           `}
@@ -447,7 +447,7 @@ export default class BackendAiSignup extends BackendAIPage {
           <mwc-textfield type="text" name="user_name" id="id_user_name"
                        maxlength="64" placeholder="${_text('maxLength.64chars')}"
                        label="${_t('signup.UserName')}" value="${this.user_name}"></mwc-textfield>
-          ${this.isManualSignup ? html`` : html`
+          ${this.allowSignupWithoutConfirmation ? html`` : html`
             <mwc-textfield type="text" name="token" id="id_token"
                         maxlength="50"
                         label="${_t('signup.InvitationToken')}"

--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -53,6 +53,7 @@ export default class BackendAiSignup extends BackendAIPage {
   @property({type: Object}) client;
   @property({type: String}) TOSlanguage = 'en';
   @property({type: Object}) TOSdialog = Object();
+  @property({type: Boolean}) isManualSignup;
 
   constructor() {
     super();
@@ -228,27 +229,35 @@ export default class BackendAiSignup extends BackendAIPage {
 
   _clearUserInput() {
     this._toggleInputField(true);
-    const inputFields: Array<string> = ['#id_user_email', '#id_token', '#id_password1', '#id_password2'];
-    inputFields.map((el: string) => {
+    let inputFields: Array<string> = ['#id_user_email', '#id_token', '#id_password1', '#id_password2'];
+    if (this.isManualSignup) {
+      inputFields = inputFields.filter((el: string) => el !== '#id_token')
+    }
+    inputFields.forEach((el: string) => {
       this.shadowRoot.querySelector(el).value = '';
     });
     this.shadowRoot.querySelector('#signup-button-message').innerHTML = _text('signup.Signup');
   }
 
   _toggleInputField(isActive: boolean) {
-    if (isActive) {
-      this.shadowRoot.querySelector('#id_user_name').removeAttribute('disabled');
-      this.shadowRoot.querySelector('#id_token').removeAttribute('disabled');
-      this.shadowRoot.querySelector('#signup-button').removeAttribute('disabled');
-    } else {
-      this.shadowRoot.querySelector('#id_user_name').setAttribute('disabled', 'true');
-      this.shadowRoot.querySelector('#id_token').setAttribute('disabled', 'true');
-      this.shadowRoot.querySelector('#signup-button').setAttribute('disabled', 'true');
+    let inputFields: Array<string> = ['#id_user_name', '#id_token', '#signup-button'];
+    if (this.isManualSignup) {
+      inputFields = inputFields.filter((el: string) => el !== '#id_token')
     }
+    inputFields.forEach((el: string) => {
+      if (isActive) {
+        this.shadowRoot.querySelector(el).removeAttribute('disabled');
+      } else {
+        this.shadowRoot.querySelector(el).removeAttribute('disabled', 'true');
+      }
+    });
   }
 
   _signup() {
-    const inputFields: Array<string> = ['#id_user_email', '#id_token', '#id_password1', '#id_password2'];
+    let inputFields: Array<string> = ['#id_user_email', '#id_token', '#id_password1', '#id_password2'];
+    if (this.isManualSignup) {
+      inputFields = inputFields.filter((el: string) => el !== '#id_token')
+    }
     const inputFieldsValidity: Array<boolean> = inputFields.map((el: string) => {
       this.shadowRoot.querySelector(el).reportValidity();
       return this.shadowRoot.querySelector(el).checkValidity();
@@ -265,8 +274,7 @@ export default class BackendAiSignup extends BackendAIPage {
     if (inputFieldsValidity.includes(false)) {
       return;
     }
-
-    const token = (this.shadowRoot.querySelector('#id_token') as HTMLInputElement).value;
+    const token = (this.shadowRoot.querySelector('#id_token') as HTMLInputElement)?.value;
     const user_email = (this.shadowRoot.querySelector('#id_user_email') as HTMLInputElement).value;
     const user_name = (this.shadowRoot.querySelector('#id_user_name') as HTMLInputElement).value;
     const password = (this.shadowRoot.querySelector('#id_password1') as HTMLInputElement).value;
@@ -278,6 +286,9 @@ export default class BackendAiSignup extends BackendAIPage {
       'password': password,
       'token': token
     };
+    if (this.isManualSignup) {
+      delete body[token];
+    }
     this.init_client();
     const rqst = this.client.newSignedRequest('POST', `/auth/signup`, body);
     this.client._wrapWithPromise(rqst).then((response) => {
@@ -288,7 +299,9 @@ export default class BackendAiSignup extends BackendAIPage {
       setTimeout(() => {
         this.signupPanel.hide();
         this._clearUserInput();
-        this.shadowRoot.querySelector('#email-sent-dialog').show();
+        if(!this.isManualSignup) {
+          this.shadowRoot.querySelector('#email-sent-dialog').show();
+        }
       }, 1000);
     }).catch((e) => {
       if (e.message) {
@@ -419,7 +432,11 @@ export default class BackendAiSignup extends BackendAIPage {
     // language=HTML
     return html`
       <backend-ai-dialog id="signup-panel" fixed blockscrolling persistent disablefocustrap>
-        <span slot="title">${_t('signup.SignupBETA')}</span>
+        <span slot="title">${this.isManualSignup ? html`
+          ${_t('signup.Signup')}` : 
+            html`${_t('signup.SignupBETA')}
+          `}
+        </span>
         <div slot="content" class="vertical flex layout">
           <mwc-textfield type="email" name="user_email" id="id_user_email" autofocus
                        maxlength="64" placeholder="${_text('maxLength.64chars')}"
@@ -430,9 +447,12 @@ export default class BackendAiSignup extends BackendAIPage {
           <mwc-textfield type="text" name="user_name" id="id_user_name"
                        maxlength="64" placeholder="${_text('maxLength.64chars')}"
                        label="${_t('signup.UserName')}" value="${this.user_name}"></mwc-textfield>
-          <mwc-textfield type="text" name="token" id="id_token" maxlength="50"
-                       label="${_t('signup.InvitationToken')}"
-                       validationMessage="${_t('signup.TokenInputRequired')}" required></mwc-textfield>
+          ${this.isManualSignup ? html`` : html`
+            <mwc-textfield type="text" name="token" id="id_token"
+                        maxlength="50"
+                        label="${_t('signup.InvitationToken')}"
+                        validationMessage="${_t('signup.TokenInputRequired')}" required></mwc-textfield>
+          `}
           <div class="horizontal flex layout">
             <mwc-textfield type="password" name="password1" id="id_password1"
                         label="${_t('signup.Password')}" maxLength="64"


### PR DESCRIPTION
### Description
---------
This PR resolves #1185.
### Before
---------
No options about hiding unnecessary input fields and messages in signup dialog, such as "token" and "email sent msg".

### After
---------
Now `allowSignupWithoutConfirmation` stands for the visibility "token" input field and "emails sent msg".
if the value of `allowSignupWithoutConfirmation` in configuration file (`config.toml`) is `true`, then it will be regarded as "sign up without confirmation" as is, so signup dialog will not display "token" input field or "email sent msg" after registration.
