### PR TITLE
fix: do not disable the gpu resource slider when the min and max value of it is the same

### DIFF
--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1920,7 +1920,8 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
           this.shadowRoot.querySelector('#cluster-size').disabled = false;
         }
       }
-      if (this.cuda_device_metric.min == this.cuda_device_metric.max) {
+      if (this.cuda_device_metric.min == this.cuda_device_metric.max &&
+          this.cuda_device_metric.max < 1) {
         this.shadowRoot.querySelector('#gpu-resource').disabled = true;
       }
       if (this.concurrency_limit <= 1) {


### PR DESCRIPTION
This resolves https://github.com/lablup/backend.ai-webui/issues/1191.