### PR TITLE
hotfix: support displaying error when multi-node session creation failed

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1332,11 +1332,12 @@ export default class BackendAiSessionList extends BackendAIPage {
       const sanitizeErrMsg = (msg) => {
         return msg ? msg.match(/'(.*?)'/g)[0].replace(/'/g, '') : '';
       };
+      const errorList = tmpSessionStatus.error.collection ?? [tmpSessionStatus.error];
       statusDetailEl.innerHTML += `
       <div class="vertical layout start flex" style="width:100%;">
         <div style="width:100%;">
           <h3 style="width:100%;padding-left:15px;border-bottom:1px solid #ccc;">${_text('session.StatusDetail')}</h3>
-            ${tmpSessionStatus.error.collection.map((item) => {
+            ${errorList.map((item) => {
     return `
               <div style="border-radius: 4px;background-color:var(--paper-grey-300);padding:10px;margin:10px;">
                 <div class="vertical layout start">


### PR DESCRIPTION
## Description
This PR will resolve errors that originated from multi-node session creation.

## Before
Some of the error msg didn't have a key `collection`, therefore accessing the `collection` key triggered error.

## After
Now users can see error msg regardless of the hierarchy of error msg.
**Screenshot:**
<img width="393" alt="error-msg-of-multi-node-session-creation" src="https://user-images.githubusercontent.com/46954439/149725036-73c4d00b-8584-4fc5-9068-c5952e83c644.png">
