### PR TITLE
fix: add scroll to session list tab in session tab

### DIFF
--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -472,7 +472,7 @@ export default class BackendAiSessionView extends BackendAIPage {
                 </div>
               ` : html``}
             <div class="horizontal layout flex end-justified" style="margin-right:20px;">
-              <backend-ai-session-launcher location="session" id="session-launcher" ?active="${this.active === true}" isSupportingFab></backend-ai-session-launcher>
+              <backend-ai-session-launcher location="session" id="session-launcher" ?active="${this.active === true}"></backend-ai-session-launcher>
             </div>
           </h3>
           <div id="running-lists" class="tab-content">

--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -148,7 +148,7 @@ export default class BackendAiSessionView extends BackendAIPage {
           --mdc-theme-primary: var(--paper-green-600);
         }
 
-        .hide_scrollbar::-webkit-scrollbar {
+        .hide-scrollbar::-webkit-scrollbar {
           display: none;
         }
 
@@ -446,7 +446,7 @@ export default class BackendAiSessionView extends BackendAIPage {
       <lablup-activity-panel elevation="1" autowidth narrow noheader>
         <div slot="message">
           <h3 class="tab horizontal center layout" style="margin-top:0;margin-bottom:0;">
-            <div class="scroll hide_scrollbar">
+            <div class="scroll hide-scrollbar">
               <div class="horizontal layout flex start-justified" style="width:70%;">
                 <mwc-tab-bar>
                   <mwc-tab title="running" label="${_t('session.Running')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>

--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -148,6 +148,10 @@ export default class BackendAiSessionView extends BackendAIPage {
           --mdc-theme-primary: var(--paper-green-600);
         }
 
+        .hide_scrollbar::-webkit-scrollbar {
+          display: none;
+        }
+
         backend-ai-resource-monitor {
           margin: 10px 50px;
         }
@@ -442,14 +446,17 @@ export default class BackendAiSessionView extends BackendAIPage {
       <lablup-activity-panel elevation="1" autowidth narrow noheader>
         <div slot="message">
           <h3 class="tab horizontal center layout" style="margin-top:0;margin-bottom:0;">
-            <div class="horizontal layout flex start-justified">
-            <mwc-tab-bar>
-              <mwc-tab title="running" label="${_t('session.Running')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>
-              <mwc-tab title="interactive" label="${_t('session.Interactive')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>
-              <mwc-tab title="batch" label="${_t('session.Batch')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>
-              <mwc-tab title="finished" label="${_t('session.Finished')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>
-              <mwc-tab title="others" label="${_t('session.Others')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>
-            </mwc-tab-bar>
+            <div class="scroll hide_scrollbar">
+              <div class="horizontal layout flex start-justified" style="width:70%;">
+                <mwc-tab-bar>
+                  <mwc-tab title="running" label="${_t('session.Running')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>
+                  <mwc-tab title="interactive" label="${_t('session.Interactive')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>
+                  <mwc-tab title="batch" label="${_t('session.Batch')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>
+                  <mwc-tab title="finished" label="${_t('session.Finished')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>
+                  <mwc-tab title="others" label="${_t('session.Others')}" @click="${(e) => this._showTab(e.target)}"></mwc-tab>
+                </mwc-tab-bar>
+              </div>
+            </div>
             ${this.is_admin ? html`
               <div style="position: relative;">
                 <mwc-icon-button id="dropdown-menu-button" icon="more_horiz" raised
@@ -464,9 +471,8 @@ export default class BackendAiSessionView extends BackendAIPage {
                   </mwc-menu>
                 </div>
               ` : html``}
-            </div>
             <div class="horizontal layout flex end-justified" style="margin-right:20px;">
-            <backend-ai-session-launcher location="session" id="session-launcher" ?active="${this.active === true}" isSupportingFab></backend-ai-session-launcher>
+              <backend-ai-session-launcher location="session" id="session-launcher" ?active="${this.active === true}" isSupportingFab></backend-ai-session-launcher>
             </div>
           </h3>
           <div id="running-lists" class="tab-content">


### PR DESCRIPTION
Resolve: lablup/backend.ai-webui #1198

- This bug is caused by inner block in 'session tab' h3 block is overflowed when window size is narrow.
- Add scroll to session list tab in session tab to prevent overflow

**test image**
![PR3](https://user-images.githubusercontent.com/43121372/150502376-33849481-25c2-45a3-87fc-3c67b1349cc5.png)
 