### PR TITLE
fix: session resource allocation doesn't match

### DIFF
--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1741,7 +1741,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       let shmem_metric: any = {
         'min': 0.0625,
         'max': 2,
-        'preferred': 0.125
+        'preferred': 0.0625
       };
       this.cuda_device_metric = {
         'min': 0,
@@ -3139,7 +3139,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                       <div style="width:50px;text-align:right;">${item.mem}GB</div>
                       <div style="width:60px;text-align:right;">${item.shmem ? html`
                             ${parseFloat(globalThis.backendaiclient.utils.changeBinaryUnit(item.shared_memory, 'g')).toFixed(2)} GB` :
-    html`128MB`}
+    html`64MB`}
                       </div>
                       <div style="width:80px;text-align:right;">
                         ${item.cuda_device && item.cuda_device > 0 ? html`${item.cuda_device} CUDA GPU` : html``}

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -3139,7 +3139,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                       <div style="width:50px;text-align:right;">${item.mem}GB</div>
                       <div style="width:60px;text-align:right;">${item.shmem ? html`
                             ${parseFloat(globalThis.backendaiclient.utils.changeBinaryUnit(item.shared_memory, 'g')).toFixed(2)} GB` :
-    html`64MB`}
+    html`128MB`}
                       </div>
                       <div style="width:80px;text-align:right;">
                         ${item.cuda_device && item.cuda_device > 0 ? html`${item.cuda_device} CUDA GPU` : html``}


### PR DESCRIPTION
Resolve: lablup/backend.ai-webui #1199

Original default shared memory setting code
![img1](https://user-images.githubusercontent.com/31719811/150753760-6dfdf3e2-2327-478b-ba14-fc5154dd91d3.PNG)
![img2](https://user-images.githubusercontent.com/31719811/150753822-0e74a6b1-2e1b-4ab6-9a95-4a5ddda82353.PNG)

Shared memory type value of this case is object.
![img5](https://user-images.githubusercontent.com/31719811/150754077-93d8b788-e3f7-47ff-9e70-d6acfc6daaeb.PNG)

This is fixing code, but it is not activated mostly because of no shared memory limit in most cases. 
![img3](https://user-images.githubusercontent.com/31719811/150755249-3b9f3397-ab0e-4c0e-af7b-1fed98fd8038.PNG)
![img4](https://user-images.githubusercontent.com/31719811/150754573-df442bfe-1ad4-4d05-9e17-e7a9a11cc691.PNG)

All session below don't have any shared memory limit
![img6](https://user-images.githubusercontent.com/31719811/150754766-fdeb8411-39bb-4d7a-8159-3e566a931bb9.PNG)

So I changed preferred value to 0.0625GB(64MB) which is enough for single core CPU.

