### PR TITLE
fix: monkeypatch style manipulation according to the number of list-items in environment

### DIFF
--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -351,7 +351,6 @@ export default class BackendAILogin extends BackendAIPage {
     this.endpoints = globalThis.backendaioptions.get('endpoints', []);
   }
 
-  
 
   /**
    * Change the signin mode with SESSION or API

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1126,7 +1126,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       this._toggleScheduleTime(!this.useScheduledTime);
 
       // monkeypatch for mwc-list-item width adjustment
-      const scrollEnabledNum = 7;
+      const scrollEnabledNum = 11;
       const environmentListItems = this.shadowRoot.querySelectorAll('mwc-select#environment > mwc-list-item');
       if (this.languages.length > scrollEnabledNum) {
         environmentListItems.forEach((element) => element.style.paddingRight = `0`);

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -571,10 +571,6 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
           --mdc-select-min-width: 190px;
         }
 
-        mwc-select > mwc-list-item {
-          width: 370px; // default width
-        }
-
         mwc-textfield {
           width: 100%;
           font-family: var(--general-font-family);
@@ -1124,15 +1120,6 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       await this._refreshResourcePolicy();
       this.requestUpdate();
       this._toggleScheduleTime(!this.useScheduledTime);
-
-      // monkeypatch for mwc-list-item width adjustment
-      const scrollEnabledNum = 11;
-      const environmentListItems = this.shadowRoot.querySelectorAll('mwc-select#environment > mwc-list-item');
-      if (this.languages.length > scrollEnabledNum) {
-        environmentListItems.forEach((element) => element.style.paddingRight = `0`);
-      } else {
-        environmentListItems.forEach((element) => element.style.paddingRight = `15px`);
-      }
       this.shadowRoot.querySelector('#new-session-dialog').show();
     }
   }

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -557,6 +557,9 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
           --mdc-list-item__primary-text: {
             height: 20px;
           };
+          /* Need to be set when fixedMenuPosition attribute is enabled */
+          --mdc-menu-max-width: 400px;
+          --mdc-menu-min-width: 400px;
         }
 
         mwc-select#owner-group,
@@ -1121,6 +1124,15 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       await this._refreshResourcePolicy();
       this.requestUpdate();
       this._toggleScheduleTime(!this.useScheduledTime);
+
+      // monkeypatch for mwc-list-item width adjustment
+      const scrollEnabledNum = 7;
+      const environmentListItems = this.shadowRoot.querySelectorAll('mwc-select#environment > mwc-list-item');
+      if (this.languages.length > scrollEnabledNum) {
+        environmentListItems.forEach((element) => element.style.paddingRight = `0`);
+      } else {
+        environmentListItems.forEach((element) => element.style.paddingRight = `15px`);
+      }
       this.shadowRoot.querySelector('#new-session-dialog').show();
     }
   }
@@ -2942,14 +2954,12 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                   <mwc-list-item id="${item.name}" value="${item.name}" graphic="icon">
                     <img slot="graphic" alt="language icon" src="resources/icons/${item.icon}"
                          style="width:24px;height:24px;"/>
-                    <div class="horizontal justified center flex layout" style="width:340px;">
+                    <div class="horizontal justified center flex layout" style="width:325px;">
                       <div style="padding-right:5px;">${item.basename}</div>
-                      <div class="flex"></div>
                       <div class="horizontal layout end-justified center flex">
                         ${item.tags ? item.tags.map((item) => html`
-                          <lablup-shields slot="meta" style="margin-right:5px;" color="${item.color}"
-                                          description="${item.tag}"></lablup-shields>
-                          <span style="display:none">(${item.tag})</span>
+                          <lablup-shields style="margin-right:5px;" color="${item.color}"
+                                          description=""></lablup-shields>
                         `) : ''}
                         <mwc-icon-button icon="info"
                                          class="fg blue info"

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2825,8 +2825,8 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
 
   /**
    * Toggle scheduling time interval according to `isActive` parameter
-   * 
-   * @param {Boolean} isActive 
+   *
+   * @param {Boolean} isActive
    */
 
   _toggleScheduleTime(isActive = false) {

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1219,7 +1219,7 @@ export default class BackendAiSessionList extends BackendAIPage {
 
   /**
    * Show tooltip when mouseenter the corresponding element
-   * 
+   *
    * @param {string} elementId
    */
   _showTooltip(elementId = '') {
@@ -1231,7 +1231,7 @@ export default class BackendAiSessionList extends BackendAIPage {
 
   /**
    * Hide tooltip when mouseleave the corresponding element
-   * 
+   *
    * @param {string} elementId
    */
   _hideTooltip(elementId = '') {
@@ -1473,7 +1473,7 @@ export default class BackendAiSessionList extends BackendAIPage {
 
   /**
    * Render session type - batch or interactive
-   * 
+   *
    * @param {Element} root - the row details content DOM element
    * @param {Element} column - the column element that controls the state of the host element
    * @param {Object} rowData - the object with the properties related with the rendered item
@@ -1637,7 +1637,7 @@ export default class BackendAiSessionList extends BackendAIPage {
             <mwc-icon-button class="fg red controls-running"
                                icon="power_settings_new" @click="${(e) => this._openTerminateSessionDialog(e)}"></mwc-icon-button>
           ` : html``}
-          ${(this._isRunning && !this._isPreparing(rowData.item.status) || this._APIMajorVersion > 4)  && !this._isPending(rowData.item.status) ? html`
+          ${(this._isRunning && !this._isPreparing(rowData.item.status) || this._APIMajorVersion > 4) && !this._isPending(rowData.item.status) ? html`
             <mwc-icon-button class="fg blue controls-running" icon="assignment"
                                @click="${(e) => this._showLogs(e)}"></mwc-icon-button>
           ` : html`
@@ -2008,8 +2008,8 @@ export default class BackendAiSessionList extends BackendAIPage {
         </vaadin-grid-filter-column>
         ${this._isIntegratedCondition ? html`
           <vaadin-grid-filter-column path="type" width="120px" flex-grow="0" text-align="center" header="${_t('session.launcher.SessionType')}" resizable .renderer="${this._boundSessionTypeRenderer}"></vaadin-grid-filter-column>
-        `
-        : html``}
+        ` :
+    html``}
         <vaadin-grid-filter-column path="status" auto-width header="${_t('session.Status')}" resizable
                                    .renderer="${this._boundStatusRenderer}">
         </vaadin-grid-filter-column>

--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -231,7 +231,7 @@ export default class BackendAiSignup extends BackendAIPage {
     this._toggleInputField(true);
     let inputFields: Array<string> = ['#id_user_email', '#id_token', '#id_password1', '#id_password2'];
     if (this.allowSignupWithoutConfirmation) {
-      inputFields = inputFields.filter((el: string) => el !== '#id_token')
+      inputFields = inputFields.filter((el: string) => el !== '#id_token');
     }
     inputFields.forEach((el: string) => {
       this.shadowRoot.querySelector(el).value = '';
@@ -242,7 +242,7 @@ export default class BackendAiSignup extends BackendAIPage {
   _toggleInputField(isActive: boolean) {
     let inputFields: Array<string> = ['#id_user_name', '#id_token', '#signup-button'];
     if (this.allowSignupWithoutConfirmation) {
-      inputFields = inputFields.filter((el: string) => el !== '#id_token')
+      inputFields = inputFields.filter((el: string) => el !== '#id_token');
     }
     inputFields.forEach((el: string) => {
       if (isActive) {
@@ -256,7 +256,7 @@ export default class BackendAiSignup extends BackendAIPage {
   _signup() {
     let inputFields: Array<string> = ['#id_user_email', '#id_token', '#id_password1', '#id_password2'];
     if (this.allowSignupWithoutConfirmation) {
-      inputFields = inputFields.filter((el: string) => el !== '#id_token')
+      inputFields = inputFields.filter((el: string) => el !== '#id_token');
     }
     const inputFieldsValidity: Array<boolean> = inputFields.map((el: string) => {
       this.shadowRoot.querySelector(el).reportValidity();
@@ -299,7 +299,7 @@ export default class BackendAiSignup extends BackendAIPage {
       setTimeout(() => {
         this.signupPanel.hide();
         this._clearUserInput();
-        if(!this.allowSignupWithoutConfirmation) {
+        if (!this.allowSignupWithoutConfirmation) {
           this.shadowRoot.querySelector('#email-sent-dialog').show();
         }
       }, 1000);
@@ -433,8 +433,8 @@ export default class BackendAiSignup extends BackendAIPage {
     return html`
       <backend-ai-dialog id="signup-panel" fixed blockscrolling persistent disablefocustrap>
         <span slot="title">${this.allowSignupWithoutConfirmation ? html`
-          ${_t('signup.Signup')}` : 
-            html`${_t('signup.SignupBETA')}
+          ${_t('signup.Signup')}` :
+    html`${_t('signup.SignupBETA')}
           `}
         </span>
         <div slot="content" class="vertical flex layout">

--- a/src/components/lablup-codemirror.ts
+++ b/src/components/lablup-codemirror.ts
@@ -86,7 +86,7 @@ export default class LablupCodemirror extends LitElement {
    * */
   focus() {
     globalThis.setTimeout(() => this.editor.focus(), 100);
-    }
+  }
 
   /**
    * Get the editor's contents.


### PR DESCRIPTION
## Description
This PR will resolve overflowing list-items in the environment selection UI in session launcher.

## Before
When items in the supported environment list exceed 7 or more, the scrollbar triggers extra width for each item(environment) and causes overflow.
<img width="445" alt="environment-selection-overflow" src="https://user-images.githubusercontent.com/46954439/150771907-a83582fc-cc0b-4010-a215-e3759a6c609f.png">



## After
Width of each item in the supported environment list stays still regardless of scrollbar.
- When the number of item in supported environment list exceeds more than 10
<img width="445" alt="environment-selection-overflow-resolved" src="https://user-images.githubusercontent.com/46954439/150767841-e27d1e86-2a78-435b-90f0-0d59b3558e24.png">


> ⚠️ &nbsp; NOTE: `mwc-list-item` and `mwc-select` element internally use their own hierarchy, so it doesn't allow flexible custom layouts. Therefore I need to use arbitrary code to circumvent the overflow problem.