### PR TITLE
fix: prevent esc key close login dialog

### DIFF
--- a/src/components/backend-ai-dialog.ts
+++ b/src/components/backend-ai-dialog.ts
@@ -166,9 +166,11 @@ export default class BackendAiDialog extends LitElement {
 
   /**
    * Hide a dialog.
+   *
+   * @param {Boolean} isRecur - check if this function is called by eventhandler.
    */
-  hide() {
-    if (this.closeWithConfirmation) {
+  hide(isRecur = false) {
+    if (this.closeWithConfirmation && !isRecur) {
       const closeEvent = new CustomEvent('dialog-closing-confirm', {detail: ''});
       this.dispatchEvent(closeEvent);
     } else {

--- a/src/components/backend-ai-dialog.ts
+++ b/src/components/backend-ai-dialog.ts
@@ -43,6 +43,7 @@ export default class BackendAiDialog extends LitElement {
   @property({type: Boolean}) open = false;
   @property({type: String}) type = 'normal';
   @property({type: Boolean}) closeWithConfirmation = false;
+  @property({type: String}) escapeKeyAction = 'close';
 
   @query('#dialog') protected dialog;
 
@@ -194,6 +195,7 @@ export default class BackendAiDialog extends LitElement {
                     ?backdrop="${this.backdrop}"
                     ?persistent="${this.persistent}"
                     ?scrollable="${this.scrollable}"
+                    escapeKeyAction="${this.escapeKeyAction}"
                     blockscrolling="${this.blockscrolling}"
                     hideActions="${this.hideActions}"
                     style="padding:0;" class="${this.type}">

--- a/src/components/backend-ai-dialog.ts
+++ b/src/components/backend-ai-dialog.ts
@@ -166,8 +166,6 @@ export default class BackendAiDialog extends LitElement {
 
   /**
    * Hide a dialog.
-   *
-   * @param {Boolean} isRecur - check if this function is called by eventhandler.
    */
   hide() {
     if (this.closeWithConfirmation) {

--- a/src/components/backend-ai-dialog.ts
+++ b/src/components/backend-ai-dialog.ts
@@ -169,8 +169,8 @@ export default class BackendAiDialog extends LitElement {
    *
    * @param {Boolean} isRecur - check if this function is called by eventhandler.
    */
-  hide(isRecur = false) {
-    if (this.closeWithConfirmation && !isRecur) {
+  hide() {
+    if (this.closeWithConfirmation) {
       const closeEvent = new CustomEvent('dialog-closing-confirm', {detail: ''});
       this.dispatchEvent(closeEvent);
     } else {

--- a/src/components/backend-ai-dialog.ts
+++ b/src/components/backend-ai-dialog.ts
@@ -43,7 +43,7 @@ export default class BackendAiDialog extends LitElement {
   @property({type: Boolean}) open = false;
   @property({type: String}) type = 'normal';
   @property({type: Boolean}) closeWithConfirmation = false;
-  @property({type: Boolean}) preventEscapeKeyClose = false;
+  @property({type: String}) escapeKeyAction = 'close';
 
   @query('#dialog') protected dialog;
 
@@ -125,7 +125,6 @@ export default class BackendAiDialog extends LitElement {
     if (this.persistent) {
       this.dialog.scrimClickAction = '';
     }
-    this.checkPreventEscapeKeyClose();
     this.dialog.addEventListener('opened', () => {
       this.open = this.dialog.open;
     });
@@ -162,19 +161,7 @@ export default class BackendAiDialog extends LitElement {
    * Open a dialog.
    */
   show() {
-    this.checkPreventEscapeKeyClose();
     this.dialog.show();
-  }
-
-  /**
-   * check preventEscapeKeyClose and apply it to current dialog
-   */
-  checkPreventEscapeKeyClose() {
-    if (this.preventEscapeKeyClose) {
-      this.dialog.escapeKeyAction = '';
-    } else {
-      this.dialog.escapeKeyAction = close;
-    }
   }
 
   /**
@@ -210,7 +197,7 @@ export default class BackendAiDialog extends LitElement {
                     ?backdrop="${this.backdrop}"
                     ?persistent="${this.persistent}"
                     ?scrollable="${this.scrollable}"
-                    ?preventEscapeKeyClose="${this.preventEscapeKeyClose}"
+                    escapeKeyAction="${this.escapeKeyAction}"
                     blockscrolling="${this.blockscrolling}"
                     hideActions="${this.hideActions}"
                     style="padding:0;" class="${this.type}">

--- a/src/components/backend-ai-dialog.ts
+++ b/src/components/backend-ai-dialog.ts
@@ -43,7 +43,7 @@ export default class BackendAiDialog extends LitElement {
   @property({type: Boolean}) open = false;
   @property({type: String}) type = 'normal';
   @property({type: Boolean}) closeWithConfirmation = false;
-  @property({type: String}) escapeKeyAction = 'close';
+  @property({type: Boolean}) preventEscapeKeyClose = false;
 
   @query('#dialog') protected dialog;
 
@@ -125,6 +125,7 @@ export default class BackendAiDialog extends LitElement {
     if (this.persistent) {
       this.dialog.scrimClickAction = '';
     }
+    this.checkPreventEscapeKeyClose();
     this.dialog.addEventListener('opened', () => {
       this.open = this.dialog.open;
     });
@@ -161,7 +162,19 @@ export default class BackendAiDialog extends LitElement {
    * Open a dialog.
    */
   show() {
+    this.checkPreventEscapeKeyClose();
     this.dialog.show();
+  }
+
+  /**
+   * check preventEscapeKeyClose and apply it to current dialog
+   */
+  checkPreventEscapeKeyClose() {
+    if (this.preventEscapeKeyClose) {
+      this.dialog.escapeKeyAction = '';
+    } else {
+      this.dialog.escapeKeyAction = close;
+    }
   }
 
   /**
@@ -197,7 +210,7 @@ export default class BackendAiDialog extends LitElement {
                     ?backdrop="${this.backdrop}"
                     ?persistent="${this.persistent}"
                     ?scrollable="${this.scrollable}"
-                    escapeKeyAction="${this.escapeKeyAction}"
+                    ?preventEscapeKeyClose="${this.preventEscapeKeyClose}"
                     blockscrolling="${this.blockscrolling}"
                     hideActions="${this.hideActions}"
                     style="padding:0;" class="${this.type}">

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -538,7 +538,6 @@ export default class BackendAILogin extends BackendAIPage {
    * Open loginPanel.
    * */
   open() {
-    this.login
     if (this.loginPanel.open !== true) {
       this.loginPanel.show();
     }

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -345,6 +345,9 @@ export default class BackendAILogin extends BackendAIPage {
 
   firstUpdated() {
     this.loginPanel = this.shadowRoot.querySelector('#login-panel');
+    setTimeout(() => {
+      this.loginPanel.escapeKeyAction = '';
+    }, 2000);
     this.signoutPanel = this.shadowRoot.querySelector('#signout-panel');
     this.blockPanel = this.shadowRoot.querySelector('#block-panel');
     this.blockPanel.addEventListener('dialog-closing-confirm', (e) => {

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -538,6 +538,7 @@ export default class BackendAILogin extends BackendAIPage {
    * Open loginPanel.
    * */
   open() {
+    this.login
     if (this.loginPanel.open !== true) {
       this.loginPanel.show();
     }
@@ -568,9 +569,9 @@ export default class BackendAILogin extends BackendAIPage {
     this.blockMessage = message;
     this.blockType = type;
     if (message === _text('login.PleaseWait') && type === _text('login.ConnectingToCluster')) {
-      this.blockPanel.addEventListener('dialog-closed', (e) => {
-        this._cancelLogin(e);
-      });
+      this.blockPanel.escapeKeyAction = '';
+    } else {
+      this.blockPanel.escapeKeyAction = 'close';
     }
     setTimeout(() => {
       if (this.blockPanel.open === false && this.is_connected === false && this.loginPanel.open === false) {

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -572,10 +572,10 @@ export default class BackendAILogin extends BackendAIPage {
     this.blockMessage = message;
     this.blockType = type;
     if (message === _text('login.PleaseWait') && type === _text('login.ConnectingToCluster')) {
-      this.blockPanel.preventEscapeKeyClose = true;
+      this.blockPanel.escapeKeyAction = '';
       this.blockPanel.closeWithConfirmation = true;
     } else {
-      this.blockPanel.preventEscapeKeyClose = false;
+      this.blockPanel.escapeKeyAction = 'close';
       this.blockPanel.closeWithConfirmation = false;
     }
     setTimeout(() => {
@@ -1128,7 +1128,7 @@ export default class BackendAILogin extends BackendAIPage {
     // language=HTML
     return html`
       <link rel="stylesheet" href="resources/custom.css">
-      <backend-ai-dialog id="login-panel" noclosebutton fixed blockscrolling persistent disablefocustrap preventEscapeKeyClose>
+      <backend-ai-dialog id="login-panel" noclosebutton fixed blockscrolling persistent disablefocustrap escapeKeyAction>
         <div slot="title">
           <div id="login-title-area"></div>
           <div class="horizontal center layout">

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -345,9 +345,6 @@ export default class BackendAILogin extends BackendAIPage {
 
   firstUpdated() {
     this.loginPanel = this.shadowRoot.querySelector('#login-panel');
-    setTimeout(() => {
-      this.loginPanel.escapeKeyAction = '';
-    }, 2000);
     this.signoutPanel = this.shadowRoot.querySelector('#signout-panel');
     this.blockPanel = this.shadowRoot.querySelector('#block-panel');
     this.blockPanel.addEventListener('dialog-closing-confirm', (e) => {
@@ -575,10 +572,10 @@ export default class BackendAILogin extends BackendAIPage {
     this.blockMessage = message;
     this.blockType = type;
     if (message === _text('login.PleaseWait') && type === _text('login.ConnectingToCluster')) {
-      this.blockPanel.escapeKeyAction = '';
+      this.blockPanel.preventEscapeKeyClose = true;
       this.blockPanel.closeWithConfirmation = true;
     } else {
-      this.blockPanel.escapeKeyAction = 'close';
+      this.blockPanel.preventEscapeKeyClose = false;
       this.blockPanel.closeWithConfirmation = false;
     }
     setTimeout(() => {
@@ -1131,7 +1128,7 @@ export default class BackendAILogin extends BackendAIPage {
     // language=HTML
     return html`
       <link rel="stylesheet" href="resources/custom.css">
-      <backend-ai-dialog id="login-panel" noclosebutton fixed blockscrolling persistent disablefocustrap>
+      <backend-ai-dialog id="login-panel" noclosebutton fixed blockscrolling persistent disablefocustrap preventEscapeKeyClose>
         <div slot="title">
           <div id="login-title-area"></div>
           <div class="horizontal center layout">

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -1274,7 +1274,7 @@ export default class BackendAILogin extends BackendAIPage {
               @click="${() => this._sendChangePasswordEmail()}"></mwc-button>
         </div>
       </backend-ai-dialog>
-      <backend-ai-dialog id="block-panel" fixed blockscrolling persistent>
+      <backend-ai-dialog id="block-panel" fixed blockscrolling persistent escapeKeyAction>
         ${this.blockMessage != '' ? html`
           ${this.blockType !== '' ? html`
             <span slot="title" id="work-title">${this.blockType}</span>

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -347,6 +347,10 @@ export default class BackendAILogin extends BackendAIPage {
     this.loginPanel = this.shadowRoot.querySelector('#login-panel');
     this.signoutPanel = this.shadowRoot.querySelector('#signout-panel');
     this.blockPanel = this.shadowRoot.querySelector('#block-panel');
+    this.blockPanel.addEventListener('dialog-closing-confirm', (e) => {
+      this.blockPanel.hide(true);
+      this.loginPanel.show();
+    });
     this.notification = globalThis.lablupNotification;
     this.endpoints = globalThis.backendaioptions.get('endpoints', []);
   }
@@ -569,8 +573,10 @@ export default class BackendAILogin extends BackendAIPage {
     this.blockType = type;
     if (message === _text('login.PleaseWait') && type === _text('login.ConnectingToCluster')) {
       this.blockPanel.escapeKeyAction = '';
+      this.blockPanel.closeWithConfirmation = true;
     } else {
       this.blockPanel.escapeKeyAction = 'close';
+      this.blockPanel.closeWithConfirmation = false;
     }
     setTimeout(() => {
       if (this.blockPanel.open === false && this.is_connected === false && this.loginPanel.open === false) {

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -571,13 +571,6 @@ export default class BackendAILogin extends BackendAIPage {
   block(message = '', type = '') {
     this.blockMessage = message;
     this.blockType = type;
-    if (message === _text('login.PleaseWait') && type === _text('login.ConnectingToCluster')) {
-      this.blockPanel.escapeKeyAction = '';
-      this.blockPanel.closeWithConfirmation = true;
-    } else {
-      this.blockPanel.escapeKeyAction = 'close';
-      this.blockPanel.closeWithConfirmation = false;
-    }
     setTimeout(() => {
       if (this.blockPanel.open === false && this.is_connected === false && this.loginPanel.open === false) {
         this.blockPanel.show();

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -567,6 +567,11 @@ export default class BackendAILogin extends BackendAIPage {
   block(message = '', type = '') {
     this.blockMessage = message;
     this.blockType = type;
+    if (message === _text('login.PleaseWait') && type === _text('login.ConnectingToCluster')) {
+      this.blockPanel.addEventListener('dialog-closed', (e) => {
+        this._cancelLogin(e);
+      });
+    }
     setTimeout(() => {
       if (this.blockPanel.open === false && this.is_connected === false && this.loginPanel.open === false) {
         this.blockPanel.show();

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -347,10 +347,6 @@ export default class BackendAILogin extends BackendAIPage {
     this.loginPanel = this.shadowRoot.querySelector('#login-panel');
     this.signoutPanel = this.shadowRoot.querySelector('#signout-panel');
     this.blockPanel = this.shadowRoot.querySelector('#block-panel');
-    this.blockPanel.addEventListener('dialog-closing-confirm', (e) => {
-      this.blockPanel.hide(true);
-      this.loginPanel.show();
-    });
     this.notification = globalThis.lablupNotification;
     this.endpoints = globalThis.backendaioptions.get('endpoints', []);
   }


### PR DESCRIPTION
Resolve: lablup/backend.ai-webui #1168 

- This bug caused by auto closing backend-ai-dialog when press esc button
- add 'escapeKeyAction' attribute to mwc-dialog in backend-ai-dialog
- change 'escapeKeyAction' attribute value from 'close'  to '' only when open cluster dialog

**Currently, If you press the esc key right after the 'login page' opens, you can see the 'cluster dialog'.**
![PR5_review0_1](https://user-images.githubusercontent.com/43121372/154623954-9f83cde6-281b-4b17-a5d9-4c80d4fd6e94.png)

