### PR TITLE
style: make endpoint resizable and unify heights of vaadin-grid

### DIFF
--- a/src/components/backend-ai-agent-list.ts
+++ b/src/components/backend-ai-agent-list.ts
@@ -876,7 +876,7 @@ export default class BackendAIAgentList extends BackendAIPage {
                    .items="${this.agents}">
         <vaadin-grid-column width="40px" flex-grow="0" header="#" text-align="center"
                             .renderer="${this._indexRenderer}"></vaadin-grid-column>
-        <vaadin-grid-column width="80px" header="${_t('agent.Endpoint')}" .renderer="${this._boundEndpointRenderer}">
+        <vaadin-grid-column resizable width="80px" header="${_t('agent.Endpoint')}" .renderer="${this._boundEndpointRenderer}">
         </vaadin-grid-column>
         <vaadin-grid-column width="100px" resizable header="${_t('agent.Region')}"
                             .renderer="${this._boundRegionRenderer}">

--- a/src/components/backend-ai-scaling-group-list.ts
+++ b/src/components/backend-ai-scaling-group-list.ts
@@ -71,6 +71,12 @@ export default class BackendAIScalingGroupList extends BackendAIPage {
       IronFlexAlignment,
       // language=CSS
       css`
+        vaadin-grid {
+          border: 0;
+          font-size: 14px;
+          height: var(--list-height, calc(100vh - 246px));
+        }
+
         h4 {
           font-weight: 200;
           font-size: 14px;

--- a/src/components/backend-ai-storage-proxy-list.ts
+++ b/src/components/backend-ai-storage-proxy-list.ts
@@ -454,7 +454,7 @@ export default class BackendAIStorageProxyList extends BackendAIPage {
                    .items="${this.storages}">
         <vaadin-grid-column width="40px" flex-grow="0" header="#" text-align="center"
                             .renderer="${this._indexRenderer}"></vaadin-grid-column>
-        <vaadin-grid-column width="80px" header="${_t('agent.Endpoint')}" .renderer="${this._boundEndpointRenderer}">
+        <vaadin-grid-column resizable width="80px" header="${_t('agent.Endpoint')}" .renderer="${this._boundEndpointRenderer}">
         </vaadin-grid-column>
         <vaadin-grid-column width="100px" resizable header="${_t('agent.BackendType')}"
                             .renderer="${this._boundTypeRenderer}">


### PR DESCRIPTION
- all endpoints in the agent page can be checked by adding the resizable attribute.
- Match `vaadin-grid` height in resource group tab to `vaadin-grid` in same page, different tab.

[Screenshot]
**Before**
![image](https://user-images.githubusercontent.com/28584164/154009089-8be5b1bb-1e39-46d4-a493-e287d7ec860d.png)
![image](https://user-images.githubusercontent.com/28584164/154009107-9c4b6af4-8d4b-4e9f-a806-d4654975b311.png)

**After**
![image](https://user-images.githubusercontent.com/28584164/154008867-b91a1bc1-ad55-472a-92d3-0372c6583da3.png)
👆 resizable endpoint

![image](https://user-images.githubusercontent.com/28584164/154008902-0b106719-12a3-436a-8c11-7df9738bb701.png)
