### PR TITLE
bugfix: session rename translation (ko)

### DIFF
--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -226,11 +226,7 @@
       "(Automatic)": "(자동설정)",
       "NumOpenMPthreads": "OpenMP 쓰레드 수",
       "NumOpenBLASthreads": "OpenBLAS 쓰레드 수",
-      "SwitchOpenMPoptimization": "OpenMP 자동 최적화 사용",
-      "SessionRenamed": "세션 이름이 변경되었습니다",
-      "SessionNameRequired": "세션 이름을 입력해주세요",
-      "EnterValidSessionName": "올바른 세션 이름을 입력해주세요",
-      "SessionNameAlreadyExist": "같은 이름의 세션이 이미 있습니다"
+      "SwitchOpenMPoptimization": "OpenMP 자동 최적화 사용"
     },
     "Preparing": "준비중...",
     "PreparingSession": "세션 준비중...",
@@ -292,7 +288,11 @@
     "XRDPconnection": "RDP 연결",
     "UseYourFavoriteMSTSCApp": "선호하는 MS 리모트 데스크탑 클라이언트를 사용해 연결하세요",
     "OnlyOneFolderAttached": "하나의 폴더만 연결되어 있습니다.",
-    "NoLogMsgAvailable": "현재 표시할 수 있는 로그 메시지가 없습니다."
+    "NoLogMsgAvailable": "현재 표시할 수 있는 로그 메시지가 없습니다.",
+    "SessionRenamed": "세션 이름이 변경되었습니다",
+    "SessionNameRequired": "세션 이름을 입력해주세요",
+    "EnterValidSessionName": "올바른 세션 이름을 입력해주세요",
+    "SessionNameAlreadyExist": "같은 이름의 세션이 이미 있습니다"
   },
   "button": {
     "Cancel": "취소",


### PR DESCRIPTION
- The Korean version translation related to the session rename does not work properly because it is under `session.launcher`
- It resolves #1229 
- this PR follows up #1181 