### PR TITLE
refactor: show path dialog only when clicking the icon

### DIFF
--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2062,7 +2062,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     this._helpDescription = _text('session.launcher.DescFolderAlias');
     this._helpDescriptionIcon = '';
     const pathDialog = this.shadowRoot.querySelector('#help-description');
-    setTimeout(() => this.setPathContent(pathDialog, this.helpDescTagCount(this._helpDescription)));
+    // setTimeout(() => this.setPathContent(pathDialog, this.helpDescTagCount(this._helpDescription)));
     pathDialog.show();
   }
 
@@ -2857,12 +2857,12 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     nextButton.style.visibility = this.currentIndex == this.progressLength ? 'hidden' : 'visible';
     this.shadowRoot.querySelector('#launch-button-msg').textContent = this.progressLength == this.currentIndex ? _text('session.launcher.Launch') : _text('session.launcher.ConfirmAndLaunch');
 
-    if (this.currentIndex == 2) {
-      const isVisible = localStorage.getItem('backendaiwebui.pathguide');
-      if (!isVisible || isVisible === 'true') {
-        this._showPathDescription();
-      }
-    }
+    // if (this.currentIndex == 2) {
+    //   const isVisible = localStorage.getItem('backendaiwebui.pathguide');
+    //   if (!isVisible || isVisible === 'true') {
+    //     this._showPathDescription();
+    //   }
+    // }
 
     // monkeypatch for grid items in accessible vfolder list in Safari or Firefox
     this._grid?.clearCache();


### PR DESCRIPTION
For better user experience, show Path & Alias only when the user clicks the info icon.
I also hide the checkbox by commenting out the `setPathContent` function.
[Before]
<img width="411" alt="image" src="https://user-images.githubusercontent.com/28584164/161686087-c9aebcb6-d368-4c58-aa91-683fc2c20b2e.png">
[After]
<img width="415" alt="image" src="https://user-images.githubusercontent.com/28584164/161685923-a73418e8-8cfe-4ccf-a946-533339cd205c.png">
