### PR TITLE
Fix: allocate resource according to selected resource preset

### DIFF
--- a/src/components/backend-ai-resource-policy-list.ts
+++ b/src/components/backend-ai-resource-policy-list.ts
@@ -31,6 +31,11 @@ import {default as PainKiller} from './backend-ai-painkiller';
 import {BackendAiStyles} from './backend-ai-general-styles';
 import {IronFlex, IronFlexAlignment} from '../plastics/layout/iron-flex-layout-classes';
 
+class BigNumber {
+  static getValue() {
+    return 1000000;
+  }
+}
 @customElement('backend-ai-resource-policy-list')
 export default class BackendAIResourcePolicyList extends BackendAIPage {
   @property({type: Boolean}) visible = false;
@@ -245,7 +250,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
           <div class="horizontal justified layout distancing">
             <div class="vertical left layout">
                 <wl-label>${_t('resourcePolicy.ContainerPerSession')}</wl-label>
-                <mwc-textfield class="discrete" id="container-per-session-limit" type="number" min="0" max="100"
+                <mwc-textfield class="discrete" id="container-per-session-limit" type="number" min="1" max="100"
                     @change="${(e) => this._validateResourceInput(e)}"></mwc-textfield>
                 <wl-label class="unlimited">
                   <wl-checkbox @change="${(e) => this._toggleCheckbox(e)}" style="border-width: 1px;"></wl-checkbox>
@@ -263,7 +268,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
               </div>
               <div class="vertical left layout">
                   <wl-label>${_t('resourcePolicy.ConcurrentJobs')}</wl-label>
-                  <mwc-textfield class="discrete" id="concurrency-limit" type="number" min="0" max="100"
+                  <mwc-textfield class="discrete" id="concurrency-limit" type="number" min="1" max="100"
                       @change="${(e) => this._validateResourceInput(e)}"></mwc-textfield>
                   <wl-label class="unlimited">
                     <wl-checkbox @change="${(e) => this._toggleCheckbox(e)}" style="border-width: 1px;"></wl-checkbox>
@@ -396,7 +401,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
   concurrencyRenderer(root, column?, rowData?) {
     render(
       html`
-        <div>${rowData.item.max_concurrent_sessions === 1000000 ? '∞' : rowData.item.max_concurrent_sessions}</div>
+        <div>${[0, BigNumber.getValue()].includes(rowData.item.max_concurrent_sessions) ? '∞' : rowData.item.max_concurrent_sessions}</div>
     `, root
     );
   }
@@ -434,7 +439,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
     render(
       // language=HTML
       html`
-      <div>${rowData.item.max_containers_per_session}</div>
+      <div>${[0, BigNumber.getValue()].includes(rowData.item.max_containers_per_session) ? '∞' : rowData.item.max_containers_per_session}</div>
       `, root
     );
   }
@@ -611,10 +616,9 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
     total_resource_slots['mem'] = this.ram_resource['value'] + 'g';
     total_resource_slots['cuda.device'] = parseInt(this.gpu_resource['value']);
     total_resource_slots['cuda.shares'] = parseFloat(this.fgpu_resource['value']);
-
-    this.concurrency_limit['value'] = this.concurrency_limit['value'] === '' ? 1000000 : parseInt(this.concurrency_limit['value']);
+    this.concurrency_limit['value'] = ['', 0].includes(this.concurrency_limit['value']) ? BigNumber.getValue() : parseInt(this.concurrency_limit['value']);
     this.idle_timeout['value'] = this.idle_timeout['value'] === '' ? 0 : parseInt(this.idle_timeout['value']);
-    this.container_per_session_limit['value'] = this.container_per_session_limit['value'] === '' ? 0 : parseInt(this.container_per_session_limit['value']);
+    this.container_per_session_limit['value'] = ['', 0].includes(this.container_per_session_limit['value']) ? BigNumber.getValue() : parseInt(this.container_per_session_limit['value']);
     this.vfolder_capacity['value'] = this.vfolder_capacity['value'] === '' ? 0 : parseFloat(this.vfolder_capacity['value']);
     this.vfolder_max_limit['value'] = this.vfolder_max_limit['value'] === '' ? 0 : parseInt(this.vfolder_max_limit['value']);
 
@@ -706,7 +710,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
     TextEl.disabled = checked;
     if (!TextEl.disabled) {
       if (TextEl.value === '') {
-        TextEl.value = 0;
+        TextEl.value = TextEl.min ?? 0;
       }
     }
   }
@@ -730,7 +734,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
 
     if (textfield.value <= 0) {
       // concurrency job and container-per-session limit must be upper than 0.
-      textfield.value = ((textfield.id === 'concurrency-limit') || (textfield.id === 'container-per-session-limit')) ? 1 : 0;
+      textfield.value = (['concurrency-limit', 'container-per-session-limit'].includes(textfield.id)) ? 1 : 0;
     }
 
     if (!textfield.valid) {
@@ -744,7 +748,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
   }
 
   _updateUnlimitedValue(value) {
-    return ['-', 0, '0', 'Unlimited', Infinity, 'Infinity'].includes(value) ? '' : value;
+    return ['-', 0, '0', 'Unlimited', Infinity, 'Infinity', BigNumber.getValue()].includes(value) ? '' : value;
   }
 
   /**
@@ -765,10 +769,10 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
   _updateInputStatus(resource) {
     const textfield = resource;
     const checkbox = textfield.closest('div').querySelector('wl-checkbox');
-    if (textfield.value === '' || textfield.value === '0') {
+    if (textfield.value === '' || textfield.value === 0) {
       textfield.disabled = true;
       checkbox.checked = true;
-    } else if (textfield.id === 'concurrency-limit' && textfield.value === '1000000') {
+    } else if (['concurrency-limit', 'container-per-session-limit'].includes(textfield.id) && textfield.value === BigNumber.getValue()) {
       textfield.disabled = true;
       checkbox.checked = true;
     } else {

--- a/src/components/backend-ai-resource-policy-list.ts
+++ b/src/components/backend-ai-resource-policy-list.ts
@@ -250,7 +250,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
           <div class="horizontal justified layout distancing">
             <div class="vertical left layout">
                 <wl-label>${_t('resourcePolicy.ContainerPerSession')}</wl-label>
-                <mwc-textfield class="discrete" id="container-per-session-limit" type="number" min="1" max="100"
+                <mwc-textfield class="discrete" id="container-per-session-limit" type="number" min="0" max="100"
                     @change="${(e) => this._validateResourceInput(e)}"></mwc-textfield>
                 <wl-label class="unlimited">
                   <wl-checkbox @change="${(e) => this._toggleCheckbox(e)}" style="border-width: 1px;"></wl-checkbox>
@@ -268,7 +268,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
               </div>
               <div class="vertical left layout">
                   <wl-label>${_t('resourcePolicy.ConcurrentJobs')}</wl-label>
-                  <mwc-textfield class="discrete" id="concurrency-limit" type="number" min="1" max="100"
+                  <mwc-textfield class="discrete" id="concurrency-limit" type="number" min="0" max="100"
                       @change="${(e) => this._validateResourceInput(e)}"></mwc-textfield>
                   <wl-label class="unlimited">
                     <wl-checkbox @change="${(e) => this._toggleCheckbox(e)}" style="border-width: 1px;"></wl-checkbox>
@@ -730,11 +730,6 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
 
     if (textfield.classList.contains('discrete')) {
       textfield.value = Math.round(textfield.value);
-    }
-
-    if (textfield.value <= 0) {
-      // concurrency job and container-per-session limit must be upper than 0.
-      textfield.value = (['concurrency-limit', 'container-per-session-limit'].includes(textfield.id)) ? 1 : 0;
     }
 
     if (!textfield.valid) {

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2566,16 +2566,19 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
   _updateShmemLimit() {
     const shmemEl = this.shadowRoot.querySelector('#shmem-resource');
     const currentMemLimit = parseFloat(this.shadowRoot.querySelector('#mem-resource').value);
-    let shmem_value = shmemEl.value;
+    let shmemValue = shmemEl.value;
     // this.shmem_metric.max = Math.min(this.max_shm_per_container, currentMemLimit);
     // clamp the max value to the smaller of the current memory value or the configuration file value.
     // shmemEl.max = this.shmem_metric.max;
-    if (parseFloat(shmem_value) > currentMemLimit) {
-      shmem_value = currentMemLimit;
-      this.shmem_request = shmem_value;
-      shmemEl.value = shmem_value;
+    if (parseFloat(shmemValue) > currentMemLimit) {
+      shmemValue = currentMemLimit;
+      this.shmem_request = shmemValue;
+      shmemEl.value = shmemValue;
+      shmemEl.max = shmemValue;
       this.notification.text = _text('session.launcher.SharedMemorySettingIsReduced');
       this.notification.show();
+    } else if (this.max_shm_per_container > shmemValue) {
+      shmemEl.max = this.max_shm_per_container;
     }
   }
 

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -46,7 +46,6 @@ import {
   IronFlexFactors,
   IronPositioning
 } from '../plastics/layout/iron-flex-layout-classes';
-import { isThisHour } from 'date-fns';
 
 /**
  Backend AI Session Launcher Carousel
@@ -828,7 +827,21 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     this.shadowRoot.querySelectorAll('wl-expansion').forEach((element) => {
       element.addEventListener('keydown', (event) => {
         event.stopPropagation();
-      }, true);
+        event.cancelBubble = true;
+        if (event && event.key === 'Tab' && event.target?.tagName === 'LABLUP-SLIDER') {
+          const sliderList = [...this.shadowRoot.querySelectorAll('lablup-slider')];
+          sliderList.forEach((elem, idx) => {
+            const nextIdx = (event.shiftKey) ? idx - 1 : idx + 1;
+            if (event?.target?.id === elem.id) {
+              setTimeout(() => {
+                if (nextIdx > -1 && nextIdx < sliderList.length) {
+                  sliderList[nextIdx].textfield.focus();
+                }
+              }, 0);
+            }
+          });
+        }
+      });
     });
 
     this.resourceGauge = this.shadowRoot.querySelector('#resource-gauges');
@@ -3436,6 +3449,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                 ${this.cluster_mode_list.map((item) => html`
                   <mwc-list-item
                       class="cluster-mode-dropdown"
+                      ?selected="${item === this.cluster_mode}"
                       id="${item}"
                       value="${item}">
                     <div class="horizontal layout center" style="width:100%;">

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2187,10 +2187,10 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
   }
 
   /**
-    * Set Cluster size when the cluster mode is 'multi-node'
-    *
-    * @param {Event} e
-    */
+   * Set Cluster size when the cluster mode is 'multi-node'
+   *
+   * @param {Event} e
+   */
   _setClusterSize(e) {
     this.cluster_size = e.target.value > 0 ? Math.round(e.target.value) : 0;
     this.shadowRoot.querySelector('#cluster-size').value = this.cluster_size;
@@ -2208,11 +2208,11 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
   }
 
   /**
-  * Set session count limit to value
-  *
-  * @param {Number} maxValue - max value to limit session in multi-container mode
-  *
-  */
+   * Set session count limit to value
+   *
+   * @param {Number} maxValue - max value to limit session in multi-container mode
+   *
+   */
   _setSessionLimit(maxValue = 1) {
     const sessionSlider = this.shadowRoot.querySelector('#session-resource');
     if (maxValue > 0) {

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -18,6 +18,7 @@ import '@material/mwc-list/mwc-list-item';
 import '@material/mwc-list/mwc-check-list-item';
 import '@material/mwc-select';
 import '@material/mwc-switch';
+import '@material/mwc-slider';
 import '@material/mwc-textfield/mwc-textfield';
 
 import '@vaadin/vaadin-grid/vaadin-grid';
@@ -292,6 +293,10 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
           font-weight: 500;
           height: 20px;
           padding: 5px;
+        }
+
+        mwc-slider {
+          width: 200px;
         }
 
         div.vfolder-list,
@@ -2472,6 +2477,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
   _applyResourceValueChanges(e, isResourceClicked = true) {
     const value = e.target.value;
     const id = e.target.id.split('-')[0];
+    console.log('changed:', value)
     switch (id) {
     case 'cpu':
       this.cpu_request = value;
@@ -3350,7 +3356,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                   </mwc-list-item>
                   <li divider role="separator"></li>
                   <mwc-list-item class="slider-list-item">
-                    <lablup-slider id="cpu-resource" class="cpu"
+                  <lablup-slider id="cpu-resource" class="cpu" step="1"
                                    pin snaps expand editable markers
                                    @change="${(e) => this._applyResourceValueChanges(e)}"
                                    marker_limit="${this.marker_limit}"
@@ -3451,7 +3457,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                   <li divider role="separator"></li>
                   <mwc-list-item class="slider-list-item">
                     <lablup-slider id="cluster-size" class="cluster"
-                                   pin snaps expand editable markers
+                                   pin snaps expand editable markers step="1"
                                    marker_limit="${this.marker_limit}"
                                    min="${this.cluster_metric.min}" max="${this.cluster_metric.max}"
                                    value="${this.cluster_size}"

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2588,7 +2588,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       this.notification.text = _text('session.launcher.SharedMemorySettingIsReduced');
       this.notification.show();
     } else if (this.max_shm_per_container > shmemValue) {
-      shmemEl.max = this.max_shm_per_container;
+      shmemEl.max = currentMemLimit > this.max_shm_per_container ? this.max_shm_per_container : currentMemLimit;
     }
   }
 

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2241,7 +2241,6 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       this.shmem_request = shmem ? shmem : 0.0625; // 64MB as default. Enough for single core CPU.
       // this.shmem_metric.preferred = this.shmem_request;
     }
-    this.shmem_metric.max = button.mem; // resource preset value of shared memory must be smaller than memory
     this._updateResourceIndicator(cpu, mem, gpu_type, gpu_value);
   }
 

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -3355,8 +3355,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                   <mwc-list-item class="slider-list-item">
                     <lablup-slider id="cpu-resource" class="cpu"
                                    pin snaps expand editable markers
-                                   @click="${(e) => this._applyResourceValueChanges(e)}"
-                                   @focusout="${(e) => this._applyResourceValueChanges(e)}"
+                                   @change="${(e) => this._applyResourceValueChanges(e)}"
                                    marker_limit="${this.marker_limit}"
                                    suffix="${_text('session.launcher.Core')}"
                                    min="${this.cpu_metric.min}" max="${this.cpu_metric.max}"
@@ -3373,13 +3372,12 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                   <mwc-list-item  class="slider-list-item">
                     <lablup-slider id="mem-resource" class="mem"
                                    pin snaps expand step=0.05 editable markers
-                                   @click="${(e) => {
+                                   @change="${(e) => {
     this._applyResourceValueChanges(e);
   }}"
                                    @changed="${() => {
     this._updateShmemLimit();
   }}"
-                                   @focusout="${(e) => this._applyResourceValueChanges(e)}"
                                    marker_limit="${this.marker_limit}" suffix="GB"
                                    min="${this.mem_metric.min}" max="${this.mem_metric.max}"
                                    value="${this.mem_request}"></lablup-slider>
@@ -3394,8 +3392,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                 <mwc-list-item class="slider-list-item">
                   <lablup-slider id="shmem-resource" class="mem"
                                  pin snaps step="0.0125" editable markers
-                                 @click="${(e) => this._applyResourceValueChanges(e)}"
-                                 @focusout="${(e) => this._applyResourceValueChanges(e)}"
+                                 @change="${(e) => this._applyResourceValueChanges(e)}"
                                  marker_limit="${this.marker_limit}" suffix="GB"
                                  min="0.0625" max="${this.shmem_metric.max}"
                                  value="${this.shmem_request}"></lablup-slider>
@@ -3410,8 +3407,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                   <mwc-list-item class="slider-list-item">
                   <lablup-slider id="gpu-resource" class="gpu"
                                  pin snaps editable markers step="${this.gpu_step}"
-                                 @click="${(e) => this._applyResourceValueChanges(e)}"
-                                 @focusout="${(e) => this._applyResourceValueChanges(e)}"
+                                 @change="${(e) => this._applyResourceValueChanges(e)}"
                                  marker_limit="${this.marker_limit}" suffix="GPU"
                                  min="0.0" max="${this.cuda_device_metric.max}"
                                  value="${this.gpu_request}"></lablup-slider>
@@ -3426,8 +3422,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                   <mwc-list-item class="slider-list-item">
                   <lablup-slider id="session-resource" class="session"
                                  pin snaps editable markers step="1"
-                                 @click="${(e) => this._applyResourceValueChanges(e)}"
-                                 @focusout="${(e) => this._applyResourceValueChanges(e)}"
+                                 @change="${(e) => this._applyResourceValueChanges(e)}"
                                  marker_limit="${this.marker_limit}" suffix="#"
                                  min="1" max="${this.concurrency_limit}"
                                  value="${this.session_request}"></lablup-slider>
@@ -3466,8 +3461,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                                    marker_limit="${this.marker_limit}"
                                    min="${this.cluster_metric.min}" max="${this.cluster_metric.max}"
                                    value="${this.cluster_size}"
-                                   @click="${(e) => this._applyResourceValueChanges(e, false)}"
-                                   @focusout="${(e) => this._applyResourceValueChanges(e, false)}"
+                                   @change="${(e) => this._applyResourceValueChanges(e, false)}"
                                    suffix="${this.cluster_mode === 'single-node' ? _text('session.launcher.Container') : _text('session.launcher.Node')}"></lablup-slider>
                   </mwc-list-item>
                 </mwc-list>

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2017,6 +2017,12 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
         this.shadowRoot.querySelector('#session-resource').value = 1;
         this.shadowRoot.querySelector('#session-resource').disabled = true;
       }
+      if (this.max_containers_per_session <= 1 && this.cluster_mode === 'single-node') {
+        this.shadowRoot.querySelector('#cluster-size').min = 1;
+        this.shadowRoot.querySelector('#cluster-size').max = 2;
+        this.shadowRoot.querySelector('#cluster-size').value = 1;
+        this.shadowRoot.querySelector('#cluster-size').disabled = true;
+      }
       this.metric_updating = false;
     }
   }
@@ -3543,22 +3549,22 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                 <div class="horizontal layout">
                   <div class="vertical layout center center-justified resource-allocated">
                     <p>${_t('session.launcher.CPU')}</p>
-                    <span>${this.cpu_request * (this.cluster_size <= 1 ? this.session_request : this.cluster_size)}</span>
+                    <span>${this.cpu_request * this.cluster_size * this.session_request}</span>
                     <p>Core</p>
                   </div>
                   <div class="vertical layout center center-justified resource-allocated">
                     <p>${_t('session.launcher.Memory')}</p>
-                    <span>${this._roundResourceAllocation(this.mem_request * (this.cluster_size <= 1 ? this.session_request : this.cluster_size), 1)}</span>
+                    <span>${this._roundResourceAllocation(this.mem_request * this.cluster_size * this.session_request, 1)}</span>
                     <p>GB</p>
                   </div>
                   <div class="vertical layout center center-justified resource-allocated">
                     <p>${_t('session.launcher.SharedMemoryAbbr')}</p>
-                    <span>${this._conditionalGBtoMB(this.shmem_request * (this.cluster_size <= 1 ? this.session_request : this.cluster_size))}</span>
-                    <p>${this._conditionalGBtoMBunit(this.shmem_request * (this.cluster_size <= 1 ? this.session_request : this.cluster_size))}</p>
+                    <span>${this._conditionalGBtoMB(this.shmem_request * this.cluster_size * this.session_request)}</span>
+                    <p>${this._conditionalGBtoMBunit(this.shmem_request * this.cluster_size * this.session_request)}</p>
                   </div>
                   <div class="vertical layout center center-justified resource-allocated">
                     <p>${_t('session.launcher.GPU')}</p>
-                    <span>${this.gpu_request * (this.cluster_size <= 1 ? this.session_request : this.cluster_size)}</span>
+                    <span>${this.gpu_request * this.cluster_size * this.session_request}</span>
                     <p>${_t('session.launcher.GPUSlot')}</p>
                   </div>
                 </div>

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2574,7 +2574,6 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       shmem_value = currentMemLimit;
       this.shmem_request = shmem_value;
       shmemEl.value = shmem_value;
-      shmemEl.max = shmem_value;
       this.notification.text = _text('session.launcher.SharedMemorySettingIsReduced');
       this.notification.show();
     }

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2537,13 +2537,15 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     const shmemEl = this.shadowRoot.querySelector('#shmem-resource');
     const currentMemLimit = parseFloat(this.shadowRoot.querySelector('#mem-resource').value);
     let shmem_value = shmemEl.value;
-    this.shmem_metric.max = Math.min(this.max_shm_per_container, currentMemLimit);
+    // this.shmem_metric.max = Math.min(this.max_shm_per_container, currentMemLimit);
     // clamp the max value to the smaller of the current memory value or the configuration file value.
-    shmemEl.max = this.shmem_metric.max;
-    if (parseFloat(shmem_value) > this.shmem_metric.max) {
-      shmem_value = this.shmem_metric.max;
+    // shmemEl.max = this.shmem_metric.max;
+    if (parseFloat(shmem_value) > currentMemLimit) {
+      shmem_value = currentMemLimit;
       this.shmem_request = shmem_value;
-      shmemEl.syncToSlider(); // explicitly call method of the slider component to avoid value mismatching
+      shmemEl.value = shmem_value;
+      this.notification.text = _text('session.launcher.SharedMemorySettingIsReduced');
+      this.notification.show();
     }
   }
 
@@ -3374,12 +3376,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                   <mwc-list-item  class="slider-list-item">
                     <lablup-slider id="mem-resource" class="mem"
                                    pin snaps expand step=0.05 editable markers
-                                   @change="${(e) => {
-    this._applyResourceValueChanges(e);
-  }}"
-                                   @changed="${() => {
-    this._updateShmemLimit();
-  }}"
+                                   @change="${(e) => {this._applyResourceValueChanges(e);}}"
                                    marker_limit="${this.marker_limit}" suffix="GB"
                                    min="${this.mem_metric.min}" max="${this.mem_metric.max}"
                                    value="${this.mem_request}"></lablup-slider>
@@ -3394,7 +3391,8 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                 <mwc-list-item class="slider-list-item">
                   <lablup-slider id="shmem-resource" class="mem"
                                  pin snaps step="0.0125" editable markers
-                                 @change="${(e) => this._applyResourceValueChanges(e)}"
+                                 @change="${(e) => {this._applyResourceValueChanges(e);}}}"
+                                 @changed="${() => {this._updateShmemLimit();}}"
                                  marker_limit="${this.marker_limit}" suffix="GB"
                                  min="0.0625" max="${this.shmem_metric.max}"
                                  value="${this.shmem_request}"></lablup-slider>

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2191,23 +2191,6 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
   }
 
   /**
-   * Set Cluster size when the cluster mode is 'multi-node'
-   *
-   * @param {Event} e
-   */
-  _setClusterSize(e) {
-    this.cluster_size = e.target.value > 0 ? Math.round(e.target.value) : 1;
-    this.shadowRoot.querySelector('#cluster-size').value = this.cluster_size;
-    if (globalThis.backendaiclient.supports('multi-container')) {
-      if (this.cluster_size > 1) {
-        this.gpu_step = 1;
-      } else {
-        this.gpu_step = this.resourceBroker.gpu_step;
-      }
-    }
-  }
-
-  /**
    * Choose resource template
    * - cpu, mem, cuda_device, cuda_shares, rocm_device, tpu_device, shmem
    *
@@ -2514,8 +2497,6 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     this.requestUpdate();
     if (isResourceClicked) { // resource allocation
       this._resourceTemplateToCustom();
-    } else { // cluster mode
-      this._setClusterSize(e);
     }
   }
 

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -405,16 +405,21 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
           padding: 0px 5px;
           background-color: var(--general-button-background-color);
           color: white;
+          line-height: 1.2em;
         }
 
         .cluster-allocated > div.horizontal > p {
           font-size: 1rem;
           margin: 0px;
+          line-height: 1.2em;
         }
 
         .cluster-allocated > p.small {
           font-size: 8px;
           margin: 0px;
+          margin-top: 0.5em;
+          text-align: center;
+          line-height: 1.2em;
         }
 
         .resource-allocated > span,

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -837,21 +837,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     this.shadowRoot.querySelectorAll('wl-expansion').forEach((element) => {
       element.addEventListener('keydown', (event) => {
         event.stopPropagation();
-        event.cancelBubble = true;
-        if (event && event.key === 'Tab' && event.target?.tagName === 'LABLUP-SLIDER') {
-          const sliderList = [...this.shadowRoot.querySelectorAll('lablup-slider')];
-          sliderList.forEach((elem, idx) => {
-            const nextIdx = (event.shiftKey) ? idx - 1 : idx + 1;
-            if (event?.target?.id === elem.id) {
-              setTimeout(() => {
-                if (nextIdx > -1 && nextIdx < sliderList.length) {
-                  sliderList[nextIdx].textfield.focus();
-                }
-              }, 0);
-            }
-          });
-        }
-      });
+      }, true);
     });
 
     this.resourceGauge = this.shadowRoot.querySelector('#resource-gauges');
@@ -3392,7 +3378,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
             <wl-expansion name="resource-group">
               <span slot="title">${_t('session.launcher.CustomAllocation')}</span>
               <div class="vertical layout">
-                <mwc-list multi>
+                <mwc-list multi rootTabbable>
                   <mwc-list-item hasMeta class="resource-type">
                     <div>CPU</div>
                     <mwc-icon-button slot="meta" icon="info" class="fg info"
@@ -3402,14 +3388,14 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                   </mwc-list-item>
                   <li divider role="separator"></li>
                   <mwc-list-item class="slider-list-item">
-                  <lablup-slider id="cpu-resource" class="cpu" step="1"
+                    <lablup-slider id="cpu-resource" class="cpu" step="1"
                                    pin snaps expand editable markers
                                    @change="${(e) => this._applyResourceValueChanges(e)}"
                                    marker_limit="${this.marker_limit}"
                                    suffix="${_text('session.launcher.Core')}"
                                    min="${this.cpu_metric.min}" max="${this.cpu_metric.max}"
                                    value="${this.cpu_request}"></lablup-slider>
-                  </mwc-list-item>
+                    </mwc-list-item>
                   <mwc-list-item hasMeta class="resource-type">
                     <div>RAM</div>
                     <mwc-icon-button slot="meta" icon="info" class="fg info"

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2866,7 +2866,9 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
 
     prevButton.style.visibility = this.currentIndex == 1 ? 'hidden' : 'visible';
     nextButton.style.visibility = this.currentIndex == this.progressLength ? 'hidden' : 'visible';
-    this.shadowRoot.querySelector('#launch-button-msg').textContent = this.progressLength == this.currentIndex ? _text('session.launcher.Launch') : _text('session.launcher.ConfirmAndLaunch');
+    if (!this.shadowRoot.querySelector('#launch-button').disabled) {
+      this.shadowRoot.querySelector('#launch-button-msg').textContent = this.progressLength == this.currentIndex ? _text('session.launcher.Launch') : _text('session.launcher.ConfirmAndLaunch');
+    }
 
     // if (this.currentIndex == 2) {
     //   const isVisible = localStorage.getItem('backendaiwebui.pathguide');

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2477,7 +2477,6 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
   _applyResourceValueChanges(e, isResourceClicked = true) {
     const value = e.target.value;
     const id = e.target.id.split('-')[0];
-    console.log('changed:', value)
     switch (id) {
     case 'cpu':
       this.cpu_request = value;
@@ -2543,6 +2542,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       shmem_value = currentMemLimit;
       this.shmem_request = shmem_value;
       shmemEl.value = shmem_value;
+      shmemEl.max = shmem_value;
       this.notification.text = _text('session.launcher.SharedMemorySettingIsReduced');
       this.notification.show();
     }
@@ -3375,7 +3375,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                   <mwc-list-item  class="slider-list-item">
                     <lablup-slider id="mem-resource" class="mem"
                                    pin snaps expand step=0.05 editable markers
-                                   @change="${(e) => {this._applyResourceValueChanges(e);}}"
+                                   @change="${(e) => {this._applyResourceValueChanges(e); this._updateShmemLimit()}}"
                                    marker_limit="${this.marker_limit}" suffix="GB"
                                    min="${this.mem_metric.min}" max="${this.mem_metric.max}"
                                    value="${this.mem_request}"></lablup-slider>
@@ -3390,8 +3390,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                 <mwc-list-item class="slider-list-item">
                   <lablup-slider id="shmem-resource" class="mem"
                                  pin snaps step="0.0125" editable markers
-                                 @change="${(e) => {this._applyResourceValueChanges(e);}}}"
-                                 @changed="${() => {this._updateShmemLimit();}}"
+                                 @change="${(e) => {this._applyResourceValueChanges(e); this._updateShmemLimit()}}"
                                  marker_limit="${this.marker_limit}" suffix="GB"
                                  min="0.0625" max="${this.shmem_metric.max}"
                                  value="${this.shmem_request}"></lablup-slider>

--- a/src/components/lablup-slider.ts
+++ b/src/components/lablup-slider.ts
@@ -130,7 +130,7 @@ export default class LablupSlider extends LitElement {
       if (propName === 'value') {
         setTimeout(() => {
           if (this.editable) {
-            if (oldVal && oldVal !== 0 && oldVal > this.min) {
+            if (!this.textfield.focused && oldVal && oldVal !== 0 && oldVal > this.min) {
               this.syncToText();
             }
             this.syncToSlider();

--- a/src/components/lablup-slider.ts
+++ b/src/components/lablup-slider.ts
@@ -130,7 +130,9 @@ export default class LablupSlider extends LitElement {
       if (propName === 'value') {
         setTimeout(() => {
           if (this.editable) {
-            this.syncToText();
+            if (oldVal && oldVal !== 0 && oldVal > this.min) {
+              this.syncToText();
+            }
             this.syncToSlider();
           }
           this.slider.layout();

--- a/src/components/lablup-slider.ts
+++ b/src/components/lablup-slider.ts
@@ -85,11 +85,10 @@ export default class LablupSlider extends LitElement {
                     ?markers="${this.markers}"
                     @change="${() => this.syncToText()}">
         </mwc-slider>
-        <mwc-textfield style="display:none" id="textfield" class="${this.id}" type="number"
+        <mwc-textfield id="textfield" class="${this.id}" type="number"
                       value="${this.value}" min="${this.min}" max="${this.max}" step="${this.step}"
                       prefix="${this.prefix}" suffix="${this.suffix}"
-                      ?disabled="${this.disabled}"
-                      @change="${() => this.syncToSlider()}">
+                      ?disabled="${this.disabled}">
         </mwc-textfield>
       </div>
     `;
@@ -99,8 +98,11 @@ export default class LablupSlider extends LitElement {
     if (this.editable) {
       this.textfield = this.shadowRoot.querySelector('#textfield');
       this.textfield.style.display = 'flex';
+      this.textfield.addEventListener('change', (e) => {
+        // FIX ME: the value itself doesn't change.
+        this.syncToSlider();
+      });
     }
-    this.updateStep();
     this.checkMarkerDisplay();
   }
 
@@ -130,9 +132,11 @@ export default class LablupSlider extends LitElement {
       if (propName === 'value') {
         setTimeout(() => {
           if (this.editable) {
-            if (!this.textfield.focused && oldVal && oldVal !== 0 && oldVal > this.min) {
-              this.syncToText();
-            }
+            // FIX ME: if you enable this code, knob moves but it will cause overflow.
+            // if (!this.textfield.focused && oldVal && oldVal !== 0 && oldVal > this.min) {
+            //   this.syncToText();
+            //   console.log('called!')
+            // }
             this.syncToSlider();
           }
           this.slider.layout();
@@ -176,6 +180,7 @@ export default class LablupSlider extends LitElement {
       this.textfield.value = this.min;
     }
     this.value = this.textfield.value;
+    this.slider.value = this.textfield.value;
     this.slider.step = this.step;
     // updated function will be automatically called.
   }
@@ -189,25 +194,6 @@ export default class LablupSlider extends LitElement {
         this.slider.removeAttribute('markers');
       }
     }
-    this.updateStep();
-  }
-
-  updateStep() {
-    // wl-textfield does not provide step property. The default step for number input
-    // is 1, so float numbers will invalidate the wl-textfield, which is a problem.
-    // So, we manually set the step property of wl-textfield's input field here.
-    const textfields = this.shadowRoot.querySelectorAll('wl-textfield');
-    setTimeout(() => {
-      textfields.forEach((el) => {
-        const step = el.getAttribute('step');
-        el.$formElement.step = step;
-      });
-    }, 100);
-    if (!this.step) {
-      this.step = 1.0;
-    }
-    this.slider.setAttribute('step', this.step);
-    this.slider.step = this.step;
   }
 }
 

--- a/src/components/lablup-slider.ts
+++ b/src/components/lablup-slider.ts
@@ -61,7 +61,7 @@ export default class LablupSlider extends LitElement {
           width: var(--textfield-min-width, 65px);
           height: 40px;
           margin-left: 10px;
-          --mdc-theme-primary: transparent;
+          // --mdc-theme-primary: transparent;
           --mdc-text-field-hover-line-color: transparent;
           --mdc-text-field-idle-line-color: transparent;
         }

--- a/src/components/lablup-slider.ts
+++ b/src/components/lablup-slider.ts
@@ -114,9 +114,10 @@ export default class LablupSlider extends LitElement {
 
   update(changedProperties: Map<any, any>) {
     if (Array.from(changedProperties.keys()).some((item) => ['value', 'min', 'max'].includes(item))) {
-      this.min = (this.min >= this.max) ? 0 : this.min;
-      if (this.min == this.max && this.max == 0) {
+      // this.min = (this.min >= this.max) ? 0 : this.min;
+      if (this.min == this.max) {
         this.max = this.max + 1;
+        this.value = this.min;
         this.disabled = true;
       }
     }
@@ -129,10 +130,11 @@ export default class LablupSlider extends LitElement {
       if (propName === 'value') {
         setTimeout(() => {
           if (this.editable) {
+            this.syncToText();
             this.syncToSlider();
           }
           this.slider.layout();
-        }, 500);
+        }, 100);
         const event = new CustomEvent('value-changed', {'detail': {}});
         this.dispatchEvent(event);
       }
@@ -172,7 +174,6 @@ export default class LablupSlider extends LitElement {
       this.textfield.value = this.min;
     }
     this.value = this.textfield.value;
-    this.slider.value = this.textfield.value;
     this.slider.step = this.step;
     // updated function will be automatically called.
   }


### PR DESCRIPTION
## Bug Description
There have been several annoying issues lingering on the resource allocation panel in session launcher, which degrades user experience. Please refer to the content below.
Issue 1. User cannot Input any value on textfield area of each resource section.
![Screen Recording 2022-04-20 at 12 53 44 AM mov](https://user-images.githubusercontent.com/46954439/164045173-9f68702c-77c0-4d69-94b3-62ec694062a1.gif)

Issue 2. Minimum value of each resource changes (e.g. the min value of cpu-resource was `1` but it changed to `0`)
![Screen Recording 2022-04-20 at 12 45 31 AM mov](https://user-images.githubusercontent.com/46954439/164044495-1d37c304-bb07-41d5-a666-dd0c57ac870d.gif)

Issue 3. Selected resource preset doesn't match actual allocation and knob in every slider doesn't move even resource preset is selected.
![Screen Shot 2022-04-20 at 12 46 02 AM](https://user-images.githubusercontent.com/46954439/164044295-d3f3c674-eed1-489f-884b-2fd340d513a5.png)

Issue 4. The number of containers in the total allocation section doesn't match the actual allocation.

Issue 5. If maximum number of container count in each session is zero, then it breaks the condition.

## Solution Description
- Only trigger value changes when the previous value is not null and it exceeds the minimum value.
- Set the minimum value of the resource to non-zero so that the user cannot accidentally allocate zero value on any resource. If there's no resource to allocate, then set the current value to min value, and disable the resource allocation section.
- Refactor the number of containers in the total allocation section to count not only cluster size but also the number of sessions to allocate.
- Set "0" value as an "infinite" value (Big number) in the resource policy setting dialog.

This resolves https://github.com/lablup/backend.ai-webui/issues/1292.
