### PR TITLE
add: import weightless textfield to summary view

### DIFF
--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -14,6 +14,7 @@ import './lablup-loading-spinner';
 
 import 'weightless/card';
 import 'weightless/icon';
+import 'weightless/textfield';
 
 import '@material/mwc-button';
 import '@material/mwc-linear-progress/mwc-linear-progress';


### PR DESCRIPTION
Unable to set environment because weightless/textfield was not imported.
<img width="448" alt="image" src="https://user-images.githubusercontent.com/28584164/165060867-839daec8-287e-43c2-b066-6cb4fb8dec8f.png">
