### PR TITLE
fix setting page's config button horizontally

### DIFF
--- a/src/components/backend-ai-settings-view.ts
+++ b/src/components/backend-ai-settings-view.ts
@@ -204,6 +204,10 @@ export default class BackendAiSettingsView extends BackendAIPage {
         mwc-textfield#num-retries {
           width: 10rem;
         }
+
+        mwc-button {
+          word-break: keep-all;
+        }
         @media screen and (max-width: 750px) {
           .setting-desc, .setting-desc-shrink {
             width: 275px;


### PR DESCRIPTION
fix setting page's config button horizontally

In Korean case, If you resize the width of the setting page,
sometimes the config button is displayed vertically.

I solved the issue using the CSS's `word-break` feature.
close https://github.com/lablup/backend.ai-webui/issues/1110