### PR TITLE
feat: notify update password

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -53,7 +53,8 @@
       "Experiments": "Experiments",
       "Menu": "Menu",
       "Run": "Run",
-      "UserName": "User Name"
+      "UserName": "User Name",
+      "PleaseChangeYourPassword": "Please change your password."
     },
     "LOGINREQUIRED": "LOGIN REQUIRED",
     "YouAreOffline": "You are now offline",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -53,7 +53,8 @@
       "Experiments": "Expériences",
       "Menu": "Menu",
       "Run": "Exécuter",
-      "UserName": "Nom d'utilisateur"
+      "UserName": "Nom d'utilisateur",
+      "PleaseChangeYourPassword": "__NOT_TRANSLATED__"
     },
     "LOGINREQUIRED": "CONNEXION REQUISE",
     "YouAreOffline": "Vous êtes maintenant hors ligne",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -53,7 +53,8 @@
       "Experiments": "Eksperimen",
       "Menu": "Menu",
       "Run": "Jalankan",
-      "UserName": "Nama Pengguna"
+      "UserName": "Nama Pengguna",
+      "PleaseChangeYourPassword": "__NOT_TRANSLATED__"
     },
     "LOGINREQUIRED": "LOGIN DIBUTUHKAN",
     "YouAreOffline": "Anda sekarang offline",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -53,7 +53,8 @@
       "Experiments": "실험",
       "Menu": "메뉴",
       "Run": "실행",
-      "UserName": "사용자"
+      "UserName": "사용자",
+      "PleaseChangeYourPassword": "비밀번호를 변경해주세요."
     },
     "LOGINREQUIRED": "로그인이 필요합니다",
     "YouAreOffline": "오프라인 상태가 되었습니다",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -53,7 +53,8 @@
       "Experiments": "Туршилт",
       "Menu": "Цэс",
       "Run": "Ажиллуулах",
-      "UserName": "Хэрэглэгчийн нэр"
+      "UserName": "Хэрэглэгчийн нэр",
+      "PleaseChangeYourPassword": "__NOT_TRANSLATED__"
     },
     "LOGINREQUIRED": "НЭВТРЭХ ШААРДЛАГАТАЙ",
     "YouAreOffline": "Та одоо офлайн байна",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -53,7 +53,8 @@
       "Experiments": "Эксперименты",
       "Menu": "Меню",
       "Run": "Запустить",
-      "UserName": "Имя пользователя"
+      "UserName": "Имя пользователя",
+      "PleaseChangeYourPassword": "__NOT_TRANSLATED__"
     },
     "LOGINREQUIRED": "ТРЕБУЕТСЯ ВХОД",
     "YouAreOffline": "Вы сейчас не в сети",

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -965,7 +965,7 @@ export default class BackendAILogin extends BackendAIPage {
       const resource_policy = response['keypair'].resource_policy;
       globalThis.backendaiclient.resource_policy = resource_policy;
       this.user = response['keypair'].user;
-      const fields = ['username', 'email', 'full_name', 'is_active', 'role', 'domain_name', 'groups {name, id}'];
+      const fields = ['username', 'email', 'full_name', 'is_active', 'role', 'domain_name', 'groups {name, id}', 'need_password_change'];
       const q = `query { user{ ${fields.join(' ')} } }`;
       const v = {'uuid': this.user};
       return globalThis.backendaiclient.query(q, v);
@@ -981,6 +981,7 @@ export default class BackendAILogin extends BackendAIPage {
       globalThis.backendaiclient.full_name = response['user'].full_name;
       globalThis.backendaiclient.is_admin = false;
       globalThis.backendaiclient.is_superadmin = false;
+      globalThis.backendaiclient.need_password_change = response['user'].need_password_change;
 
       if (['superadmin', 'admin'].includes(role)) {
         globalThis.backendaiclient.is_admin = true;

--- a/src/components/backend-ai-webui-styles.ts
+++ b/src/components/backend-ai-webui-styles.ts
@@ -549,7 +549,7 @@ export const BackendAIWebUIStyles = [
     }
 
     #password-change-request {
-      background-color: var(--paper-green-400);
+      background-color: var(--paper-orange-400);
       color: white;
       font-size: 14px;
       height: 28px;

--- a/src/components/backend-ai-webui-styles.ts
+++ b/src/components/backend-ai-webui-styles.ts
@@ -548,6 +548,20 @@ export const BackendAIWebUIStyles = [
       color: var(--general-sidebar-navbar-footer-color);
     }
 
+    #password-change-request {
+      background-color: var(--paper-green-400);
+      color: white;
+      font-size: 14px;
+      height: 28px;
+      position: absolute;
+      right: 0;
+      width: 100vw;
+    }
+
+    #password-change-request > mwc-icon-button > i {
+      font-size: 14px;
+    }
+
     @supports ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
       #main-toolbar {
         /*-webkit-backdrop-filter: saturate(180%) blur(20px);

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -96,6 +96,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   @property({type: Boolean}) is_admin = false;
   @property({type: Boolean}) is_superadmin = false;
   @property({type: Boolean}) allow_signout = false;
+  @property({type: Boolean}) needPasswordChange = false;
   @property({type: String}) proxy_url = '';
   @property({type: String}) connection_mode = 'API';
   @property({type: String}) connection_server = '';
@@ -387,6 +388,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
     (this.shadowRoot.getElementById('sign-button') as any).icon = 'exit_to_app';
     this.loggedAccount.access_key = globalThis.backendaiclient._config.accessKey;
     this.isUserInfoMaskEnabled = globalThis.backendaiclient._config.maskUserInfo;
+    this.needPasswordChange = globalThis.backendaiclient.need_password_change;
     globalThis.backendaiclient.proxyURL = this.proxy_url;
     if (typeof globalThis.backendaiclient !== 'undefined' && globalThis.backendaiclient != null &&
       typeof globalThis.backendaiclient.is_admin !== 'undefined' && globalThis.backendaiclient.is_admin === true) {
@@ -1271,6 +1273,11 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
     }
   }
 
+  _hidePasswordChangeRequest() {
+    const passwordChangeRequest = this.shadowRoot.querySelector('#password-change-request');
+    passwordChangeRequest.style.display = 'none';
+  }
+
   protected render() {
     // language=HTML
     return html`
@@ -1507,6 +1514,12 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
                         </mwc-icon-button>
                       </div>
                     </div>
+                  </div>
+                  <div id="password-change-request" class="horizontal layout center end-justified" style="display:${this.needPasswordChange ? 'flex' : 'none'};">
+                    <span>${_t('webui.menu.PleaseChangeYourPassword')}</span>
+                    <mwc-icon-button @click="${() => this._hidePasswordChangeRequest()}">
+                      <i class="fa fa-times"></i>
+                    </mwc-icon-button>
                   </div>
                 </div>
               </mwc-top-app-bar-fixed>


### PR DESCRIPTION
this resolves #1183 

- User will see the password update request message in every page of the header bar when `need_password_change` is true.
- User can close the message, but if refresh the page, then the message will show up again.
- If the user changes the password and refresh, this message disappear.

[Screenshot]
<img width="1508" alt="image" src="https://user-images.githubusercontent.com/28584164/166396673-a009e13e-561f-453d-a27e-2739f4952f67.png">