### PR TITLE
fix: override webserver configs only in the Electron app

### DIFF
--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -604,7 +604,7 @@ export default class BackendAILogin extends BackendAIPage {
           'general.apiEndpoint',
           'general.apiEndpointText',
           'general.siteDescription',
-          'wsproxy.proxyURL',
+          'wsproxy',
         ];
         const webserverConfigURL = new URL('./config.toml', this.api_endpoint).href;
         webuiEl._parseConfig(webserverConfigURL, true).then((config) => {

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -604,7 +604,8 @@ export default class BackendAILogin extends BackendAIPage {
           'general.apiEndpoint',
           'general.apiEndpointText',
           'general.siteDescription',
-        ]
+          'wsproxy.proxyURL',
+        ];
         const webserverConfigURL = new URL('./config.toml', this.api_endpoint).href;
         webuiEl._parseConfig(webserverConfigURL, true).then((config) => {
           fieldsToExclude.forEach((key) => {
@@ -632,7 +633,9 @@ export default class BackendAILogin extends BackendAIPage {
     }
     this.api_endpoint = this.api_endpoint.trim();
     if (this.connection_mode === 'SESSION') {
-      this._loadConfigFromWebServer();
+      if (globalThis.isElectron) {
+        this._loadConfigFromWebServer();
+      }
       this._connectUsingSession(showError);
     } else if (this.connection_mode === 'API') {
       // this.block(_text('login.PleaseWait'), _text('login.ConnectingToCluster'));
@@ -651,7 +654,9 @@ export default class BackendAILogin extends BackendAIPage {
     }
     this.api_endpoint = this.api_endpoint.trim();
     if (this.connection_mode === 'SESSION') {
-      this._loadConfigFromWebServer();
+      if (globalThis.isElectron) {
+        this._loadConfigFromWebServer();
+      }
       return this._checkLoginUsingSession();
     } else if (this.connection_mode === 'API') {
       return Promise.resolve(false);


### PR DESCRIPTION
This is a follow-up of https://github.com/lablup/backend.ai-webui/pull/1300.