### PR TITLE
Feature: num retries config in resource group

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -830,7 +830,8 @@
     "WsproxyAddress": "WSProxy Server Address",
     "SetSchedulerOptions": "Set Scheduler Options",
     "TimeoutSeconds": "Seconds",
-    "ResourceGroupDetail": "ResourceGroup Detail"
+    "ResourceGroupDetail": "ResourceGroup Detail",
+    "RetriesToSkip": "Times"
   },
   "maintenance": {
     "General": "General",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -833,7 +833,8 @@
     "WsproxyAddress": "__NOT_TRANSLATED__",
     "SetSchedulerOptions": "Définir les options du planificateur",
     "TimeoutSeconds": "Seconds",
-    "ResourceGroupDetail": "Détail du groupe de ressources"
+    "ResourceGroupDetail": "Détail du groupe de ressources",
+    "RetriesToSkip": "__NOT_TRANSLATED__"
   },
   "maintenance": {
     "General": "Général",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -833,7 +833,8 @@
     "WsproxyAddress": "__NOT_TRANSLATED__",
     "SetSchedulerOptions": "Setel Opsi Penjadwal",
     "TimeoutSeconds": "Detik",
-    "ResourceGroupDetail": "Detail Grup Sumber Daya"
+    "ResourceGroupDetail": "Detail Grup Sumber Daya",
+    "RetriesToSkip": "__NOT_TRANSLATED__"
   },
   "maintenance": {
     "General": "Umum",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -832,7 +832,8 @@
     "WsproxyAddress": "WSProxy 서버 주소",
     "SetSchedulerOptions": "스케쥴러 옵션 설정",
     "TimeoutSeconds": "초",
-    "ResourceGroupDetail": "자원 그룹 세부 정보"
+    "ResourceGroupDetail": "자원 그룹 세부 정보",
+    "RetriesToSkip": "회"
   },
   "maintenance": {
     "General": "일반",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -833,7 +833,8 @@
     "WsproxyAddress": "__NOT_TRANSLATED__",
     "SetSchedulerOptions": "Хуваарьлагчийн сонголтыг тохируулна уу",
     "TimeoutSeconds": "Секунд",
-    "ResourceGroupDetail": "Нөөцийн бүлгийн дэлгэрэнгүй"
+    "ResourceGroupDetail": "Нөөцийн бүлгийн дэлгэрэнгүй",
+    "RetriesToSkip": "__NOT_TRANSLATED__"
   },
   "maintenance": {
     "General": "Ерөнхий",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -833,7 +833,8 @@
     "WsproxyAddress": "__NOT_TRANSLATED__",
     "SetSchedulerOptions": "Установить параметры планировщика",
     "TimeoutSeconds": "Секунды",
-    "ResourceGroupDetail": "Сведения о группе ресурсов"
+    "ResourceGroupDetail": "Сведения о группе ресурсов",
+    "RetriesToSkip": "__NOT_TRANSLATED__"
   },
   "maintenance": {
     "General": "Общий",

--- a/src/components/backend-ai-resource-group-list.ts
+++ b/src/components/backend-ai-resource-group-list.ts
@@ -896,7 +896,7 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
       if (value['num_retries_to_skip']) {
         return html`
         <vaadin-item>
-        <div><strong># retries to skip</strong></div>
+        <div><strong># retries to skip pending session</strong></div>
         <div class="scheduler-option-value">${value['num_retries_to_skip'] + ' ' + _text('resourceGroup.RetriesToSkip')}</div>
       </vaadin-item>`;
       }

--- a/src/components/backend-ai-resource-group-list.ts
+++ b/src/components/backend-ai-resource-group-list.ts
@@ -784,7 +784,7 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
                   type="number"
                   value="0"
                   id="num-retries-to-skip"
-                  label="# retries to skip"
+                  label="# retries to skip pending session"
                   placeholder="0"
                   suffix="${_t('resourceGroup.RetriesToSkip')}"
                   validationMessage="${_t('settings.InvalidValue')}"

--- a/src/components/backend-ai-resource-group-list.ts
+++ b/src/components/backend-ai-resource-group-list.ts
@@ -526,12 +526,16 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
   _initializeCreateSchedulerOpts() {
     const allowedSessionTypes = this.shadowRoot.querySelector('#allowed-session-types');
     const pendingTimeout = this.shadowRoot.querySelector('#pending-timeout');
+    const numRetriesToSkip = this.shadowRoot.querySelector('#num-retries-to-skip');
     const schedulerOptsInputForms = this.shadowRoot.querySelector('#scheduler-options-input-form');
 
     allowedSessionTypes.value= 'both';
     schedulerOptsInputForms.checked = false;
     if (pendingTimeout?.value) {
       pendingTimeout.value = '';
+    }
+    if (numRetriesToSkip?.value) {
+      numRetriesToSkip.value = '';
     }
   }
 
@@ -544,6 +548,7 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
   _initializeModifySchedulerOpts(name = '', value: any) {
     const allowedSessionTypes = this.shadowRoot.querySelector('#allowed-session-types');
     const pendingTimeout = this.shadowRoot.querySelector('#pending-timeout');
+    const numRetriesToSkip = this.shadowRoot.querySelector('#num-retries-to-skip');
 
     if ('allowed_session_types' === name) {
       if (value.includes('interactive') && value.includes('batch')) {
@@ -553,6 +558,8 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
       }
     } else if ('pending_timeout' === name) {
       pendingTimeout.value = value;
+    } else if ('config' === name) {
+      numRetriesToSkip.value = value['num_retries_to_skip'] ?? '';
     } else {
       // other scheduler options
     }
@@ -566,8 +573,11 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
   _verifyCreateSchedulerOpts() {
     const allowedSessionTypes = this.shadowRoot.querySelector('#allowed-session-types');
     const pendingTimeout = this.shadowRoot.querySelector('#pending-timeout');
+    const numRetriesToSkip = this.shadowRoot.querySelector('#num-retries-to-skip');
 
-    if (allowedSessionTypes.checkValidity() === false || pendingTimeout.checkValidity() === false) {
+    const validityCheckResult = [allowedSessionTypes, pendingTimeout, numRetriesToSkip].filter((fn) => fn.checkValidity());
+
+    if (validityCheckResult.length > 0) {
       return false;
     }
     return true;
@@ -581,8 +591,11 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
   _verifyModifySchedulerOpts() {
     const allowedSessionTypes = this.shadowRoot.querySelector('#allowed-session-types');
     const pendingTimeout = this.shadowRoot.querySelector('#pending-timeout');
+    const numRetriesToSkip = this.shadowRoot.querySelector('#num-retries-to-skip');
 
-    if (allowedSessionTypes.checkValidity() === false || pendingTimeout.checkValidity() === false) {
+    const validityCheckResult = [allowedSessionTypes, pendingTimeout, numRetriesToSkip].filter((fn) => !fn.checkValidity());
+
+    if (validityCheckResult.length > 0) {
       return false;
     }
     return true;
@@ -595,6 +608,7 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
     this.schedulerOpts = {};
     const allowedSessionTypes = this.shadowRoot.querySelector('#allowed-session-types');
     const pendingTimeout = this.shadowRoot.querySelector('#pending-timeout');
+    const numRetriesToSkip = this.shadowRoot.querySelector('#num-retries-to-skip');
 
     if (allowedSessionTypes.value === 'both') {
       this.schedulerOpts['allowed_session_types'] = ['interactive', 'batch'];
@@ -603,6 +617,13 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
     }
     if (pendingTimeout.value !== '') {
       this.schedulerOpts['pending_timeout'] = pendingTimeout.value;
+    }
+    if (numRetriesToSkip.value !== '') {
+      Object.assign(this.schedulerOpts, {
+        config: {
+          num_retries_to_skip: numRetriesToSkip.value
+        }
+      });
     }
   }
 
@@ -703,9 +724,9 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
               `)}
             </mwc-select>
           ` : html`
-          <mwc-select id="resource-group-domain" label="${_t('resourceGroup.SelectDomain')}">
-            ${this.domains.map( (domain) => html`
-              <mwc-list-item value="${domain.name}">
+          <mwc-select required id="resource-group-domain" label="${_t('resourceGroup.SelectDomain')}">
+            ${this.domains.map((domain, idx) => html`
+              <mwc-list-item value="${domain.name}" ?selected=${idx === 0}>
                 ${domain.name}
               </mwc-list-item>
             `)}
@@ -759,6 +780,18 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
                 min="0"
                 value="${this.resourceGroupInfo?.scheduler_opts?.pending_timeout ?? ''}"
               ></mwc-textfield>
+              <mwc-textfield
+                  type="number"
+                  value="0"
+                  id="num-retries-to-skip"
+                  label="# retries to skip"
+                  placeholder="0"
+                  suffix="${_t('resourceGroup.RetriesToSkip')}"
+                  validationMessage="${_t('settings.InvalidValue')}"
+                  autoValidate
+                  min="0"
+                  value="${this.resourceGroupInfo?.scheduler_opts?.config?.num_retries_to_skip ?? ''}"
+                ></mwc-textfield>
             </wl-expansion>
             ` : html``}
         </div>
@@ -855,10 +888,18 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
                                   </vaadin-item>`;
     } else if (key === 'pending_timeout') {
       return html`
-                                  <vaadin-item>
-                                    <div><strong>pending timeout</strong></div>
-                                    <div class="scheduler-option-value">${value + ' ' + _text('resourceGroup.TimeoutSeconds')}</div>
-                                  </vaadin-item>`;
+      <vaadin-item>
+      <div><strong>pending timeout</strong></div>
+      <div class="scheduler-option-value">${value + ' ' + _text('resourceGroup.TimeoutSeconds')}</div>
+    </vaadin-item>`;
+    } else if (key === 'config') {
+      if (value['num_retries_to_skip']) {
+        return html`
+        <vaadin-item>
+        <div><strong># retries to skip</strong></div>
+        <div class="scheduler-option-value">${value['num_retries_to_skip'] + ' ' + _text('resourceGroup.RetriesToSkip')}</div>
+      </vaadin-item>`;
+      }
     } else {
       return '';
     }


### PR DESCRIPTION
## Description
This PR resolves configuring`num_retries_to_skip` value in resource group([scaling_groups in backend.ai-manager](https://github.com/lablup/backend.ai-manager/blob/e30c75bfd4b8eabb66ff20e5e731f3ba6cf3ff7d/src/ai/backend/manager/models/scaling_group.py#L96-L111)) in webUI.
Related: [manager#527](https://github.com/lablup/backend.ai-manager/pull/527)
> ⚠️ NOTE: 
> - If the value is empty, then It fallbacks to `num_retries_to_skip` value in default setting in etcd (manager).
> - If the intial value in default setting is "3" (ref: [sample.etcd.config.json](https://github.com/lablup/backend.ai-manager/blob/b2362d3871a7a594f89469be5f6a5cbe256613bc/config/sample.etcd.config.json#L44-L48)).
> - This feature is available from `22.03`.

## Before
- Create Resource Group Dialog
<img width="467" alt="Create-Resource-Group-before" src="https://user-images.githubusercontent.com/46954439/167396533-8e6314d2-756c-4c2f-9698-f340abf7281c.png">

- Modify Resource Group Dialog
<img width="467" alt="Modify-Resource-Group-before" src="https://user-images.githubusercontent.com/46954439/167396522-ab32cafb-49f1-4eec-9ddf-addfc0660806.png">

- Resource Group Detail Dialog
<img width="653" alt="Resource-Group-detail-before" src="https://user-images.githubusercontent.com/46954439/167396546-afdf7066-93d9-4880-a16b-f4f207251590.png">


## After
- Create Resource Group Dialog
<img width="467" alt="Create-Resource-Group" src="https://user-images.githubusercontent.com/46954439/167396482-bd704d33-4cf4-4f6b-a302-01bc8cdf43af.png">

- Modify Resource Group Dialog
<img width="467" alt="Modify-Resource-Group" src="https://user-images.githubusercontent.com/46954439/167396502-9a6f5e64-7a43-4938-86d7-89da526217f4.png">

- Resource Group Detail Dialog
<img width="653" alt="Resource-Group-detail" src="https://user-images.githubusercontent.com/46954439/167396566-bead1cc8-c4fd-4e77-b470-eb3198b37e53.png">

