### PR TITLE
fix: `ResourceGroup` typo error ( #1311 )

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -817,7 +817,7 @@
     "SelectDomain": "Select Domain",
     "ModifyResourceGroup": "Modify Resource Group",
     "TypeResourceGroupNameToDelete": "Type resource group name to delete",
-    "ResourceGroupName": "ResourceGroupName",
+    "ResourceGroupName": "Resource Group Name",
     "Active": "Active",
     "SelectScheduler": "Select Scheduler",
     "NochangesMade": "No changes made",
@@ -831,7 +831,7 @@
     "WsproxyAddress": "WSProxy Server Address",
     "SetSchedulerOptions": "Set Scheduler Options",
     "TimeoutSeconds": "Seconds",
-    "ResourceGroupDetail": "ResourceGroup Detail",
+    "ResourceGroupDetail": "Resource Group Detail",
     "RetriesToSkip": "Times"
   },
   "maintenance": {


### PR DESCRIPTION
https://github.com/lablup/backend.ai-webui/issues/1311
fix: `ResourceGroup` typo error
changed `ResourceGroup` to `Resource Group`