### PR TITLE
fix: add the value of `wsproxy_addr` so that reflecting the setting value

### DIFF
--- a/src/components/backend-ai-resource-group-list.ts
+++ b/src/components/backend-ai-resource-group-list.ts
@@ -757,6 +757,7 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
                 type="url"
                 label="${_t('resourceGroup.WsproxyAddress')}"
                 placeholder="http://localhost:10200"
+                value="${this.resourceGroupInfo?.wsproxy_addr}"
               ></mwc-textfield>
             ` : html``}
           ${this.enableSchedulerOpts ? html`


### PR DESCRIPTION
Even if the user has set the `wsproxy_addr`, its value disappears in modify dialog.
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/28584164/169249692-4ad83a1f-788f-4b90-a1ba-3a9a2e9b1105.png">
<img width="384" alt="image" src="https://user-images.githubusercontent.com/28584164/169249739-5f19ac44-570d-4e08-99b1-2f1854f2d404.png">


[After]
<img width="373" alt="image" src="https://user-images.githubusercontent.com/28584164/169249957-a6294340-a28e-4cf9-8cd7-40b2566d8b35.png">
