### PR TITLE
Refactor: querySelector with leading Number id string(#1321)

### DIFF
--- a/src/components/backend-ai-environment-list.ts
+++ b/src/components/backend-ai-environment-list.ts
@@ -385,7 +385,7 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
     this.installImageDialog.hide();
     this.selectedImages.forEach( async (image: any) => {
       // make image installing status visible
-      const selectedImageLabel = '#' + image.registry.replace(/\./gi, '-') + '-' + image.name.replace('/', '-') + '-' + image.tag.replace(/\./gi, '-');
+      const selectedImageLabel = '[id=\"' + image.registry.replace(/\./gi, '-') + '-' + image.name.replace('/', '-') + '-' + image.tag.replace(/\./gi, '-') + '\"]';
       this._grid.querySelector(selectedImageLabel).setAttribute('style', 'display:block;');
       const imageName = image['registry'] + '/' + image['name'] + ':' + image['tag'];
       let isGPURequired = false;


### PR DESCRIPTION
Refactor: querySelector with leading Number id string(#1321)

Changed the querySelector's value to explicitly stating id values `querySelector("[id='1']")`

example) id value: `10-20-30-10...blahblah`
If the first character of an identifier is numeric, you’ll need to escape it based on its Unicode code point.
However, If you don't change string to Unicode code point,
you would have to do this: `querySelector("[id='1']")`

Ref: Using querySelector with IDs that are numbers
https://stackoverflow.com/questions/20306204/using-queryselector-with-ids-that-are-numbers