### PR TITLE
Feat: distinguish image tag for Custom Environments(#1255)

### DIFF
--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -840,14 +840,8 @@ export default class BackendAiResourceBroker extends BackendAIPage {
       if (specs.length == 2) {
         prefix = '';
         kernelName = specs[1];
-      } else {
-        prefix = '';
-        for (let i = 1; i < specs.length -1; i++) {
-          prefix += specs[i];
-          if (i != (specs.length-2)) {
-            prefix += '/';
-          }
-        }
+      } else if (specs.length > 2) {
+        prefix = specs.slice(1, specs.length-1).join('/');
         kernelName = specs[specs.length - 1];
       }
       let alias = this.aliases[item];

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -813,7 +813,9 @@ export default class BackendAiResourceBroker extends BackendAIPage {
   }
 
   _cap(text) {
-    text = text.replace(/^./, text[0].toUpperCase());
+    if (!text.includes('/')) {
+      text = text.replace(/^./, text[0].toUpperCase());
+    }
     return text;
   }
 
@@ -839,8 +841,14 @@ export default class BackendAiResourceBroker extends BackendAIPage {
         prefix = '';
         kernelName = specs[1];
       } else {
-        prefix = specs[1];
-        kernelName = specs[2];
+        prefix = '';
+        for (let i = 1; i < specs.length -1; i++) {
+          prefix += specs[i];
+          if (i != (specs.length-2)) {
+            prefix += '/';
+          }
+        }
+        kernelName = specs[specs.length - 1];
       }
       let alias = this.aliases[item];
       let basename;

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -769,6 +769,9 @@ export default class BackendAiSessionList extends BackendAIPage {
       if (imageParts.length === 3) {
         namespace = imageParts[1];
         langName = imageParts[2];
+      } else if (imageParts.length > 3) {
+        namespace = imageParts.slice(2, imageParts.length-1).join('/');
+        langName = imageParts[imageParts.length-1];
       } else {
         namespace = '';
         langName = imageParts[1];


### PR DESCRIPTION
distinguish image tag for Custom Environments (#1255)
If you register a custom gitlab docker url, The tag shows to get only uri path's first path name or namespace's first '/' splited string
Ex) <registry URL>/<namespace>/<project>/<image>
10.20.30.10:7055/root/test/r-base:4.1
shows custom Environemts' tag: root

However, custom image name uses the path's '/' splited last string.
So, custom image's tag used as <namespace> and <project> except for the last splited string in url path.

Ex1) 10.20.30.10:7055/root/test1/r-base:4.1 -> tag: root/test1
Ex2) 10.20.30.10:7055/root/test2/r-base:4.1 -> tag: root/test2

 #1255