### PR TITLE
Fix: css variable typo error on `mwc`

### DIFF
--- a/src/components/backend-ai-change-forgot-password-view.ts
+++ b/src/components/backend-ai-change-forgot-password-view.ts
@@ -59,7 +59,7 @@ export default class BackendAIChangeForgotPasswordView extends BackendAIPage {
           margin: auto 10px;
           background-image: none;
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
         }
       `
     ];

--- a/src/components/backend-ai-credential-list.ts
+++ b/src/components/backend-ai-credential-list.ts
@@ -153,7 +153,7 @@ export default class BackendAICredentialList extends BackendAIPage {
         mwc-button, mwc-button[unelevated], mwc-button[outlined] {
           background-image: none;
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
           --mdc-typography-font-family: var(--general-font-family);
         }
 

--- a/src/components/backend-ai-environment-list.ts
+++ b/src/components/backend-ai-environment-list.ts
@@ -227,13 +227,13 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
           --mdc-button-disabled-outline-color: var(--general-sidebar-color);
           --mdc-button-disabled-ink-color: var(--general-sidebar-color);
           --mdc-theme-primary: #38bd73;
-          --mdc-on-theme-primary: #38bd73;
+          --mdc-theme-on-primary: #38bd73;
         }
 
         mwc-button, mwc-button[unelevated] {
           background-image: none;
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
         }
 
         mwc-button[disabled] {

--- a/src/components/backend-ai-general-styles.ts
+++ b/src/components/backend-ai-general-styles.ts
@@ -504,7 +504,7 @@ export const BackendAiStyles = [
     mwc-button, mwc-button[unelevated] {
       background-image: none;
       --mdc-theme-primary: var(--general-button-background-color);
-      --mdc-on-theme-primary: var(--general-button-background-color);
+      --mdc-theme-on-primary: var(--general-button-color);
       --mdc-typography-font-family: var(--general-font-family);
     }
 

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -168,7 +168,7 @@ export default class BackendAILogin extends BackendAIPage {
         mwc-button {
           background-image: none;
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
         }
 
         mwc-button[unelevated] {
@@ -182,7 +182,7 @@ export default class BackendAILogin extends BackendAIPage {
           --mdc-button-disabled-outline-color: var(--general-button-background-color);
           --mdc-button-disabled-ink-color: var(--general-button-background-color);
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
         }
 
         h3 small {

--- a/src/components/backend-ai-maintenance-view.ts
+++ b/src/components/backend-ai-maintenance-view.ts
@@ -108,7 +108,7 @@ export default class BackendAiMaintenanceView extends BackendAIPage {
           --mdc-button-disabled-outline-color: var(--general-sidebar-color);
           --mdc-button-disabled-ink-color: var(--general-sidebar-color);
           --mdc-theme-primary: #38bd73;
-          --mdc-on-theme-primary: #38bd73;
+          --mdc-theme-on-primary: #38bd73;
         }
 
         lablup-activity-panel {

--- a/src/components/backend-ai-pipeline-view.ts
+++ b/src/components/backend-ai-pipeline-view.ts
@@ -89,12 +89,12 @@ export default class BackendAIPipelineView extends BackendAIPage {
           --mdc-button-disabled-outline-color: var(--general-sidebar-color);
           --mdc-button-disabled-ink-color: var(--general-sidebar-color);
           --mdc-theme-primary: var(--paper-light-blue-800, #efefef);
-          --mdc-on-theme-primary: var(--paper-light-blue-800, #efefef);
+          --mdc-theme-on-primary: var(--paper-light-blue-800, #efefef);
         }
 
         h3 mwc-button[outlined] {
           --mdc-theme-primary: #38bd73;
-          --mdc-on-theme-primary: #38bd73;
+          --mdc-theme-on-primary: #38bd73;
         }
 
         #edit-pipeline {

--- a/src/components/backend-ai-registry-list.ts
+++ b/src/components/backend-ai-registry-list.ts
@@ -144,7 +144,7 @@ class BackendAIRegistryList extends BackendAIPage {
         mwc-button, mwc-button[unelevated] {
           background-image: none;
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
           --mdc-typography-font-family: var(--general-font-family);
         }
       `];

--- a/src/components/backend-ai-resource-group-list.ts
+++ b/src/components/backend-ai-resource-group-list.ts
@@ -146,7 +146,7 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
           background-image: none;
           --mdc-button-outline-width: 2px;
           --mdc-theme-primary: #38bd73;
-          --mdc-on-theme-primary: #38bd73;
+          --mdc-theme-on-primary: #38bd73;
         }
 
         mwc-textarea {

--- a/src/components/backend-ai-resource-policy-list.ts
+++ b/src/components/backend-ai-resource-policy-list.ts
@@ -171,7 +171,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
         mwc-button, mwc-button[unelevated] {
           background-image: none;
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
           --mdc-typography-font-family: var(--general-font-family);
         }
 

--- a/src/components/backend-ai-resource-preset-list.ts
+++ b/src/components/backend-ai-resource-preset-list.ts
@@ -97,7 +97,7 @@ class BackendAiResourcePresetList extends BackendAIPage {
         mwc-button, mwc-button[unelevated] {
           background-image: none;
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
           --mdc-typography-font-family: var(--general-font-family);
         }
 

--- a/src/components/backend-ai-session-launcher-legacy.ts
+++ b/src/components/backend-ai-session-launcher-legacy.ts
@@ -525,7 +525,7 @@ export default class BackendAiSessionLauncherLegacy extends BackendAIPage {
         mwc-button[disabled] {
           background-image: none;
           --mdc-theme-primary: #ddd;
-          --mdc-on-theme-primary: var(--general-sidebar-topbar-background-color);
+          --mdc-theme-on-primary: var(--general-sidebar-topbar-background-color);
         }
 
         #environment {

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -595,7 +595,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
         mwc-button[disabled] {
           background-image: none;
           --mdc-theme-primary: #ddd;
-          --mdc-on-theme-primary: var(--general-sidebar-topbar-background-color);
+          --mdc-theme-on-primary: var(--general-sidebar-topbar-background-color);
         }
 
         mwc-checkbox {

--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -105,7 +105,7 @@ export default class BackendAiSignup extends BackendAIPage {
           mwc-button {
             background-image: none;
             --mdc-theme-primary: var(--general-button-background-color);
-            --mdc-on-theme-primary: var(--general-button-background-color);
+            --mdc-theme-on-primary: var(--general-button-color);
           }
 
           mwc-button[unelevated] {
@@ -119,7 +119,7 @@ export default class BackendAiSignup extends BackendAIPage {
             --mdc-button-disabled-outline-color: var(--general-button-background-color);
             --mdc-button-disabled-ink-color: var(--general-button-background-color);
             --mdc-theme-primary: var(--general-button-background-color);
-            --mdc-on-theme-primary: var(--general-button-background-color);
+            --mdc-theme-on-primary: var(--general-button-color);
           }
 
           mwc-checkbox {

--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -156,7 +156,7 @@ export default class BackendAISummary extends BackendAIPage {
         mwc-button, mwc-button[unelevated], mwc-button[outlined] {
           background-image: none;
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
           --mdc-typography-font-family: var(--general-font-family);
         }
 

--- a/src/components/backend-ai-user-list.ts
+++ b/src/components/backend-ai-user-list.ts
@@ -171,7 +171,7 @@ export default class BackendAIUserList extends BackendAIPage {
         mwc-button, mwc-button[unelevated], mwc-button[outlined] {
           background-image: none;
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
           --mdc-typography-font-family: var(--general-font-family);
         }
 

--- a/src/components/backend-ai-usersettings-general-list.ts
+++ b/src/components/backend-ai-usersettings-general-list.ts
@@ -205,19 +205,19 @@ export default class BackendAiUsersettingsGeneralList extends BackendAIPage {
           --mdc-button-disabled-outline-color: var(--general-button-background-color);
           --mdc-button-disabled-ink-color: var(--general-button-background-color);
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
         }
 
         mwc-button {
           margin: auto 10px;
           background-image: none;
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
         }
 
         mwc-button[unelevated] {
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
         }
 
         mwc-button.shell-button {

--- a/src/components/backend-ai-usersettings-view.ts
+++ b/src/components/backend-ai-usersettings-view.ts
@@ -139,7 +139,7 @@ export default class BackendAiUserSettingsView extends BackendAIPage {
         mwc-button {
           background-image: none;
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
         }
 
         mwc-button[unelevated] {
@@ -153,7 +153,7 @@ export default class BackendAiUserSettingsView extends BackendAIPage {
           --mdc-button-disabled-outline-color: var(--general-button-background-color);
           --mdc-button-disabled-ink-color: var(--general-button-background-color);
           --mdc-theme-primary: var(--general-button-background-color);
-          --mdc-on-theme-primary: var(--general-button-background-color);
+          --mdc-theme-on-primary: var(--general-button-color);
         }
 
         mwc-button.log {

--- a/src/components/backend-ai-webui-styles.ts
+++ b/src/components/backend-ai-webui-styles.ts
@@ -203,12 +203,12 @@ export const BackendAIWebUIStyles = [
       margin: auto 10px;
       background-image: none;
       --mdc-theme-primary: var(--general-button-background-color);
-      --mdc-on-theme-primary: var(--general-button-background-color);
+      --mdc-theme-on-primary: var(--general-button-color);
     }
 
-    mwc-button[unelevate--mdc-theme-primary] {
+    mwc-button[unelevated] {
       --mdc-theme-primary: var(--general-button-background-color);
-      --mdc-on-theme-primary: var(--general-button-background-color);
+      --mdc-theme-on-primary: var(--general-button-color);
     }
 
     .page {


### PR DESCRIPTION
This PR fixes a minor typo error of CSS variable used in [mwc(material web component)](https://github.com/material-components/material-web).
Before: `--mdc-on-theme-primary`(X)
After: `--mdc-theme-on-primary` (O)