### PR TITLE
add: storage host that supports directory based quota setting

### DIFF
--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -90,7 +90,7 @@ export default class BackendAIData extends BackendAIPage {
   @property({type: Number}) totalCount;
   @property({type: Number}) capacity;
   @property({type: String}) cloneFolderName = '';
-  @property({type: Array}) quotaSupportStorageBackends = ['xfs'];
+  @property({type: Array}) quotaSupportStorageBackends = ['xfs', 'weka'];
   @property({type: Object}) storageProxyInfo = Object();
 
   constructor() {

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -130,7 +130,7 @@ export default class BackendAiStorageList extends BackendAIPage {
   };
   @property({type: Array}) filebrowserSupportedImages = [];
   @property({type: Object}) storageProxyInfo = Object();
-  @property({type: Array}) quotaSupportStorageBackends = ['xfs'];
+  @property({type: Array}) quotaSupportStorageBackends = ['xfs', 'weka'];
   @property({type: Object}) quotaUnit = {
     MiB: Math.pow(2, 20),
     GiB: Math.pow(2, 30),


### PR DESCRIPTION
## Description
This PR adds a storage host that supports directory-based quota (e.g. [Weka.io](https://docs.weka.io/fs/quota-management#directory-quotas))

Also, for further implementation goal is to make quota setting to "optional", not "mandatory".

related PR: #1328.