### PR TITLE
docs: change the usage branch name of submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ To download and deploy web UI from pre-built source, do the following in `backen
 git submodule init
 git submodule update
 cd src/ai/backend/web/static
-git checkout master
+git checkout main
 git fetch
 git pull
 ```


### PR DESCRIPTION
Modify the docs to use the main branch instead of the currently deprecated master branch in the repository of the submodule backend.ai-app