### PR TITLE
feat: allow user to force termination of sessions

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -2125,11 +2125,10 @@ export default class BackendAiSessionList extends BackendAIPage {
           <p>${_t('usersettings.SessionTerminationDialog')}</p>
         </div>
         <div slot="footer" class="horizontal end-justified flex layout">
-          ${this.is_admin ? html`
-            <wl-button class="warning fg red" inverted flat @click="${() => this._terminateSessionWithCheck(true)}">
-              ${_t('button.ForceTerminate')}
-            </wl-button>
-            <span class="flex"></span>` : html``}
+          <wl-button class="warning fg red" inverted flat @click="${() => this._terminateSessionWithCheck(true)}">
+            ${_t('button.ForceTerminate')}
+          </wl-button>
+          <span class="flex"></span>
           <wl-button class="cancel" inverted flat @click="${(e) => this._hideDialog(e)}">${_t('button.Cancel')}
           </wl-button>
           <wl-button class="ok" @click="${() => this._terminateSessionWithCheck()}">${_t('button.Okay')}</wl-button>
@@ -2141,11 +2140,10 @@ export default class BackendAiSessionList extends BackendAIPage {
           <p>${_t('usersettings.SessionTerminationDialog')}</p>
         </div>
         <div slot="footer" class="horizontal end-justified flex layout">
-          ${this.is_admin ? html`
-            <wl-button class="warning fg red" inverted flat
-                       @click="${() => this._terminateSelectedSessionsWithCheck(true)}">${_t('button.ForceTerminate')}
-            </wl-button>
-            <span class="flex"></span>` : html``}
+          <wl-button class="warning fg red" inverted flat
+                      @click="${() => this._terminateSelectedSessionsWithCheck(true)}">${_t('button.ForceTerminate')}
+          </wl-button>
+          <span class="flex"></span>
           <wl-button class="cancel" inverted flat @click="${(e) => this._hideDialog(e)}">${_t('button.Cancel')}
           </wl-button>
           <wl-button class="ok" @click="${() => this._terminateSelectedSessionsWithCheck()}">${_t('button.Okay')}


### PR DESCRIPTION
Allows the user to force-terminate the session to prevent the session from remaining in the PREPARING, TERMINATING status.

Related PR: https://github.com/lablup/backend.ai/pull/525