### PR TITLE
fix: side menu icon button ripple to disappear after click

### DIFF
--- a/src/components/backend-ai-webui-styles.ts
+++ b/src/components/backend-ai-webui-styles.ts
@@ -441,6 +441,7 @@ export const BackendAIWebUIStyles = [
     mwc-icon-button.side-menu {
       --mdc-icon-button-size: 44px;
       --mdc-theme-text-disabled-on-light: var(--paper-grey-800);
+      --mdc-ripple-focus-opacity: 0;
     }
 
     #sidebar-navbar-footer mwc-icon-button {

--- a/src/components/backend-ai-webui-styles.ts
+++ b/src/components/backend-ai-webui-styles.ts
@@ -444,6 +444,10 @@ export const BackendAIWebUIStyles = [
       --mdc-ripple-focus-opacity: 0;
     }
 
+    mwc-icon-button#mini-ui-toggle-button {
+      --mdc-ripple-focus-opacity: 0;
+    }
+
     #sidebar-navbar-footer mwc-icon-button {
       --mdc-theme-text-disabled-on-light: var(--paper-grey-800);
     }


### PR DESCRIPTION
## Description
The **Material Web Component**'s **`<icon-button />`** has default ripple component its inside. The problem is the background focus ripple after clicked button is show by default but it does not disappear even user click button's outside after `display: block` -> `display: none`. I think this is mwc's wrong behavior. So I changed background focus not to disappear by default.

## Fixes

- remove remaining ripple from menu drawer's icon button

### Screenshots

**before**
<img width="487" alt="image" src="https://user-images.githubusercontent.com/5039744/178263369-6f4ae7db-748c-47db-adf5-e4e0224e066f.png">
> icon button's background focus ripple remained

**after**
<img width="490" alt="image" src="https://user-images.githubusercontent.com/5039744/178263238-ed3e35ec-c950-4844-a3a3-f2ed66f00126.png">
> icon button's background focus ripple does not appear

---
related issue: #1352 