### PR TITLE
fix: show resource statistics about current resource group

### DIFF
--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -899,7 +899,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           <p style="font-size:12px;color:#242424;margin-right:10px;">
             ${_t('session.launcher.ResourceMonitorToggle')}
           </p>
-          <mwc-switch class="fg blue ${this.direction}" id="resource-gauge-switch-button"
+          <mwc-switch selected class="fg blue ${this.direction}" id="resource-gauge-switch-button"
             @click="${(e) => this._toggleResourceGauge(e)}">
           </mwc-switch>
         </div>

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -716,7 +716,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
   _toggleResourceGauge(e) {
     const legend = this.shadowRoot.querySelector('#resource-legend');
     if (e.target.selected) {
-      this.resourceGauge.style.display = 'flex';
+      this.resourceGauge.style.visibility = 'visible';
       if (legend) {
         legend.style.display = 'flex';
       }
@@ -725,7 +725,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
         this.resourceGauge.style.right = '20px';
       }
     } else {
-      this.resourceGauge.style.display = 'none';
+      this.resourceGauge.style.visibility = 'collapse';
       if (legend) {
         legend.style.display = 'none';
       }

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -366,7 +366,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
         .horizontal-card > #resource-gauges {
           display: grid !important;
           grid-auto-flow: row;
-          grid-template-columns: repeat(auto-fill, 420px);
+          grid-template-columns: repeat(auto-fill, 320px);
           justify-content: center;
         }
 

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -443,6 +443,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
 
   async updateScalingGroup(forceUpdate = false, e) {
     await this.resourceBroker.updateScalingGroup(forceUpdate, e.target.value);
+    
     if (this.active) {
       if (this.direction === 'vertical') {
         const scaling_group_selection_box = this.shadowRoot.querySelector('#scaling-group-select-box');
@@ -752,7 +753,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
       </div>
       ` : html``}
       <div class="layout ${this.direction}-card flex wrap">
-        <div id="resource-gauges" class="layout ${this.direction} ${this.direction}-panel resources flex wrap">
+        <div id="resource-gauges" class="layout horizontal ${this.direction}-panel resources flex wrap">
           <div class="layout horizontal center-justified monitor">
             <div class="layout vertical center center-justified resource-name">
               <div class="gauge-name">CPU</div>

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -367,7 +367,6 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           width: 250px;
         }
   
-
         @media screen and (min-width: 750px) {
           div#resource-gauges {
             display: flex !important;

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -904,6 +904,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           </mwc-switch>
         </div>
       </div>
+      ${this.direction === 'vertical' ? html`
       <div class="vertical start-justified layout ${this.direction}-card" id="resource-legend">
         <div class="layout horizontal center start-justified resource-legend-stack">
           <div class="resource-legend-icon start"></div>
@@ -913,7 +914,17 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           <div class="resource-legend-icon end"></div>
           <span class="resource-legend">${_t('session.launcher.UserResourceLimit')}</span>
         </div>
-      </div>
+      </div>` : html`
+      <div class="vertical start-justified layout ${this.direction}-card" id="resource-legend">
+        <div class="layout horizontal center end-justified resource-legend-stack">
+          <div class="resource-legend-icon start"></div>
+          <span class="resource-legend">${_t('session.launcher.CurrentResourceGroup')} (${this.scaling_group})</span>
+        </div>
+        <div class="layout horizontal center end-justified">
+          <div class="resource-legend-icon end"></div>
+          <span class="resource-legend">${_t('session.launcher.UserResourceLimit')}</span>
+        </div>
+      </div>`}
       ${this.direction === 'vertical' && this.project_resource_monitor === true &&
     (this.total_project_slot.cpu > 0 || this.total_project_slot.cpu === Infinity) ? html`
       <hr />

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -302,6 +302,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           margin-bottom: 10px;
         }
 
+        .resources.horizontal .monitor {
+          margin-bottom: 30px;
+        }
+
         mwc-select {
           width: 100%;
           font-family: var(--general-font-family);
@@ -359,6 +363,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
         }
 
         .horizontal-card > #resource-gauges > .monitor {
+          margin-top: 20px;
           width: 250px;
         }
 
@@ -501,7 +506,6 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
   }
 
   _updateScalingGroupSelector() {
-    if (this.direction === 'vertical') {
       const scaling_group_selection_box = this.shadowRoot.querySelector('#scaling-group-select-box'); // monitor SG selector
       // Detached from template to support live-update after creating new group (will need it)
       if (scaling_group_selection_box.hasChildNodes()) {
@@ -535,7 +539,6 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
       });
       // scaling_select.updateOptions();
       scaling_group_selection_box.appendChild(scaling_select);
-    }
   }
 
   /**
@@ -748,12 +751,9 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
   render() {
     // language=HTML
     return html`
-      ${this.direction === 'vertical' ? html`
-      <div id="scaling-group-select-box" class="layout horizontal start-justified">
-      </div>
-      ` : html``}
+      <div id="scaling-group-select-box" class="layout horizontal start-justified"></div>
       <div class="layout ${this.direction}-card flex wrap">
-        <div id="resource-gauges" class="layout horizontal ${this.direction}-panel resources flex wrap">
+        <div id="resource-gauges" class="layout ${this.direction} ${this.direction}-panel resources flex wrap">
           <div class="layout horizontal center-justified monitor">
             <div class="layout vertical center center-justified resource-name">
               <div class="gauge-name">CPU</div>
@@ -771,7 +771,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
               <span class="percentage end-bar">${this._numberWithPostfix(this.used_slot_percent.cpu, '%')}</span>
             </div>
           </div>
-          <div class="layout horizontal center-justified monitor" style="margin-right: 50px;">
+          <div class="layout horizontal center-justified monitor">
             <div class="layout vertical center center-justified resource-name">
               <span class="gauge-name">RAM</span>
             </div>
@@ -903,7 +903,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           </mwc-switch>
         </div>
       </div>
-      ${this.direction === 'vertical' ? html`
+      
       <div class="vertical start-justified layout ${this.direction}-card" id="resource-legend">
         <div class="layout horizontal center start-justified resource-legend-stack">
           <div class="resource-legend-icon start"></div>
@@ -914,7 +914,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           <span class="resource-legend">${_t('session.launcher.UserResourceLimit')}</span>
         </div>
       </div>
-      ` : html``}
+    
       ${this.direction === 'vertical' && this.project_resource_monitor === true &&
     (this.total_project_slot.cpu > 0 || this.total_project_slot.cpu === Infinity) ? html`
       <hr />

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -366,7 +366,12 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
         .horizontal-card > #resource-gauges > .monitor > .resource-name {
           width: 250px;
         }
-  
+        .horizontal-card > #resource-gauges {
+          display: grid !important;
+            grid-auto-flow: row;
+            grid-template-columns: repeat(auto-fill, 420px);
+        }
+
         @media screen and (min-width: 750px) {
           div#resource-gauges {
             display: flex !important;

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -448,7 +448,6 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
 
   async updateScalingGroup(forceUpdate = false, e) {
     await this.resourceBroker.updateScalingGroup(forceUpdate, e.target.value);
-    
     if (this.active) {
       if (this.direction === 'vertical') {
         const scaling_group_selection_box = this.shadowRoot.querySelector('#scaling-group-select-box');
@@ -881,7 +880,6 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           <div class="layout horizontal center-justified monitor">
             <div class="layout vertical center center-justified resource-name">
               <span class="gauge-name">${_t('session.launcher.Sessions')}</span>
-
             </div>
             <div class="layout vertical center-justified wrap">
               <lablup-progress-bar id="concurrency-usage-bar" class="start"
@@ -903,7 +901,6 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           </mwc-switch>
         </div>
       </div>
-      
       <div class="vertical start-justified layout ${this.direction}-card" id="resource-legend">
         <div class="layout horizontal center start-justified resource-legend-stack">
           <div class="resource-legend-icon start"></div>
@@ -914,7 +911,6 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           <span class="resource-legend">${_t('session.launcher.UserResourceLimit')}</span>
         </div>
       </div>
-    
       ${this.direction === 'vertical' && this.project_resource_monitor === true &&
     (this.total_project_slot.cpu > 0 || this.total_project_slot.cpu === Infinity) ? html`
       <hr />

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -362,14 +362,12 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
         .vertical-card > #resource-gauges > .monitor > .resource-name {
           width: 60px;
         }
-        
-        .horizontal-card > #resource-gauges > .monitor > .resource-name {
-          width: 250px;
-        }
+
         .horizontal-card > #resource-gauges {
           display: grid !important;
-            grid-auto-flow: row;
-            grid-template-columns: repeat(auto-fill, 420px);
+          grid-auto-flow: row;
+          grid-template-columns: repeat(auto-fill, 420px);
+          justify-content: center;
         }
 
         @media screen and (min-width: 750px) {

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -724,8 +724,14 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
         this.resourceGauge.style.left = '20px';
         this.resourceGauge.style.right = '20px';
       }
+      [...this.resourceGauge.children].forEach((elem) => {
+        elem.style.display = '';
+      });
     } else {
       this.resourceGauge.style.visibility = 'collapse';
+      [...this.resourceGauge.children].forEach((elem) => {
+        elem.style.display = 'none';
+      });
       if (legend) {
         legend.style.display = 'none';
       }

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -899,7 +899,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           <p style="font-size:12px;color:#242424;margin-right:10px;">
             ${_t('session.launcher.ResourceMonitorToggle')}
           </p>
-          <mwc-switch selected class="fg blue ${this.direction}" id="resource-gauge-switch-button"
+          <mwc-switch selected class="${this.direction}" id="resource-gauge-switch-button"
             @click="${(e) => this._toggleResourceGauge(e)}">
           </mwc-switch>
         </div>

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -771,7 +771,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
               <span class="percentage end-bar">${this._numberWithPostfix(this.used_slot_percent.cpu, '%')}</span>
             </div>
           </div>
-          <div class="layout horizontal center-justified monitor">
+          <div class="layout horizontal center-justified monitor" style="margin-right: 50px;">
             <div class="layout vertical center center-justified resource-name">
               <span class="gauge-name">RAM</span>
             </div>
@@ -881,6 +881,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           <div class="layout horizontal center-justified monitor">
             <div class="layout vertical center center-justified resource-name">
               <span class="gauge-name">${_t('session.launcher.Sessions')}</span>
+
             </div>
             <div class="layout vertical center-justified wrap">
               <lablup-progress-bar id="concurrency-usage-bar" class="start"

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -119,6 +119,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           padding-top: 20px;
           padding-left: 20px;
           background-color: #F6F6F6;
+          margin-bottom: 15px;
         }
 
         .vertical-panel #resource-gauges {
@@ -303,7 +304,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
         }
 
         .resources.horizontal .monitor {
-          margin-bottom: 30px;
+          margin-bottom: 10px;
         }
 
         mwc-select {
@@ -361,11 +362,11 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
         .vertical-card > #resource-gauges > .monitor > .resource-name {
           width: 60px;
         }
-
-        .horizontal-card > #resource-gauges > .monitor {
-          margin-top: 20px;
+        
+        .horizontal-card > #resource-gauges > .monitor > .resource-name {
           width: 250px;
         }
+  
 
         @media screen and (min-width: 750px) {
           div#resource-gauges {

--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -444,7 +444,7 @@ export default class BackendAiSessionView extends BackendAIPage {
     return html`
       <lablup-activity-panel title="${_t('summary.ResourceStatistics')}" elevation="1" autowidth>
         <div slot="message">
-          <backend-ai-resource-monitor location="session" id="resource-monitor" ?active="${this.active === true}" direction="vertical"></backend-ai-resource-monitor>
+          <backend-ai-resource-monitor location="session" id="resource-monitor" ?active="${this.active === true}" direction="horizontal"></backend-ai-resource-monitor>
         </div>
       </lablup-activity-panel>
       <lablup-activity-panel title="${_t('summary.Announcement')}" elevation="1" horizontalsize="2x" style="display:none;">

--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -444,7 +444,7 @@ export default class BackendAiSessionView extends BackendAIPage {
     return html`
       <lablup-activity-panel title="${_t('summary.ResourceStatistics')}" elevation="1" autowidth>
         <div slot="message">
-          <backend-ai-resource-monitor location="session" id="resource-monitor" ?active="${this.active === true}"></backend-ai-resource-monitor>
+          <backend-ai-resource-monitor location="session" id="resource-monitor" ?active="${this.active === true}" direction="vertical"></backend-ai-resource-monitor>
         </div>
       </lablup-activity-panel>
       <lablup-activity-panel title="${_t('summary.Announcement')}" elevation="1" horizontalsize="2x" style="display:none;">

--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -444,7 +444,7 @@ export default class BackendAiSessionView extends BackendAIPage {
     return html`
       <lablup-activity-panel title="${_t('summary.ResourceStatistics')}" elevation="1" autowidth>
         <div slot="message">
-          <backend-ai-resource-monitor location="session" id="resource-monitor" ?active="${this.active === true}" direction="horizontal"></backend-ai-resource-monitor>
+          <backend-ai-resource-monitor location="session" id="resource-monitor" ?active="${this.active === true}"></backend-ai-resource-monitor>
         </div>
       </lablup-activity-panel>
       <lablup-activity-panel title="${_t('summary.Announcement')}" elevation="1" horizontalsize="2x" style="display:none;">


### PR DESCRIPTION
## Fix
I just added a resource group selection to the summary page. (The design is the same as the Resource Group checkbox on the Session page.)
Now, you can view resources by selecting a resource group on the Summary page.

## Change
<table>
<tr>
<td><strong>Before</strong></td>
<td><strong>After</strong></td>
</tr>
<tr>
<td><img width="742" alt="before" src="https://user-images.githubusercontent.com/65989401/178208363-c1b2af95-05ff-4c45-9487-02a5067ffb92.png"></td>
<td><img width="1115" alt="after" src="https://user-images.githubusercontent.com/65989401/178208573-e7c1b8eb-2bd7-43fc-a3ad-dfb329aad461.png"></td>
</tr>
</table>
issue: #1124 