### PR TITLE
feat(wsproxy): Add dotenv support and parse env-vars more carefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-
-# backend.ai-webui
+# Backend.AI Web UI
 
 [![GitHub version](https://badge.fury.io/gh/lablup%2Fbackend.ai-webui.svg)](https://badge.fury.io/gh/lablup%2Fbackend.ai-webui)
 
@@ -440,10 +439,16 @@ Note: Packaging macOS disk image requires electron-installer-dmg to make macOS d
 
 Note: There are two Electron configuration files, `main.js` and `main.electron-packager.js`. Local Electron run uses `main.js`, not `main.electron-packager.js` that is used for real Electron app.
 
-```
-$ make dep # Compile with app dependencies
+```console
+$ make dep            # Compile with app dependencies
 $ npm run electron:d  # OR, ./node_modules/electron/cli.js .
 ```
+
+The electron app reads the configuration from `./build/electron-app/app/config.toml`, which is copied from the root `config.toml` file during `make clean && make dep`.
+
+If you configure `[server].webServerURL`, the electron app will replace the web contents (including `config.toml`) with the server-provided ones.
+The server may be either a `npm run server:d` instance or a `./py -m ai.backend.web.server` daemon from the mono-repo.
+This is known as the "web shell" mode and allows live edits of the web UI while running it inside the electron app.
 
 ### Localization
 Locale resources are JSON files located in `resources/i18n`.

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ $ npm run electron:d  # OR, ./node_modules/electron/cli.js .
 
 The electron app reads the configuration from `./build/electron-app/app/config.toml`, which is copied from the root `config.toml` file during `make clean && make dep`.
 
-If you configure `[server].webServerURL`, the electron app will replace the web contents (including `config.toml`) with the server-provided ones.
+If you configure `[server].webServerURL`, the electron app will load the web contents (including `config.toml`) from the designated server.
 The server may be either a `npm run server:d` instance or a `./py -m ai.backend.web.server` daemon from the mono-repo.
 This is known as the "web shell" mode and allows live edits of the web UI while running it inside the electron app.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "crypto-browserify": "^3.12.0",
         "crypto-es": "^1.2.7",
         "date-fns": "^2.28.0",
+        "dotenv": "^16.0.1",
         "https-proxy-agent": "^5.0.1",
         "lit": "^2.2.3",
         "lit-translate": "^2.0.1",
@@ -7564,6 +7565,14 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ds-store": {
@@ -25607,6 +25616,11 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
     "ds-store": {
       "version": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "crypto-browserify": "^3.12.0",
     "crypto-es": "^1.2.7",
     "date-fns": "^2.28.0",
+    "dotenv": "^16.0.1",
     "https-proxy-agent": "^5.0.1",
     "lit": "^2.2.3",
     "lit-translate": "^2.0.1",

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -497,7 +497,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         'Accept': 'application/json',
         'Content-Type': 'application/json'
       },
-      uri: proxyURL + 'conf'
+      uri: new URL('conf', proxyURL).href;
     };
     this.indicator.set(20, _text('session.launcher.SettingUpProxyForApp'));
     const response = await this.sendRequest(rqst);

--- a/src/wsproxy/local_proxy.js
+++ b/src/wsproxy/local_proxy.js
@@ -1,7 +1,9 @@
-const DEBUG = process.env.DEBUG || false;
+require('dotenv').config();
+
+const DEBUG = (process.env.DEBUG === 'true');
 const proxyListenIP = process.env.PROXYLISTENIP || '127.0.0.1';
 const proxyBaseHost = process.env.PROXYBASEHOST || 'localhost';
-const proxyBasePort = process.env.PROXYBASEPORT || 5050;
+const proxyBasePort = parseInt(process.env.PROXYBASEPORT || 5050);
 const ProxyManager = require('./manager.js');
 const logger = require('./lib/logger')(__filename);
 

--- a/src/wsproxy/manager.js
+++ b/src/wsproxy/manager.js
@@ -129,7 +129,7 @@ class Manager extends EventEmitter {
       let args = req.query.args ? JSON.parse(decodeURI(req.query.args)) : {};
       let envs = req.query.envs ? JSON.parse(decodeURI(req.query.envs)) : {};
       let gateway;
-      let ip = "127.0.0.1"; //FIXME: Update needed
+      let ip = this.listen_ip;
       //let port = undefined;
       if (this.proxies.hasOwnProperty(p)) {
         gateway = this.proxies[p];
@@ -172,7 +172,7 @@ class Manager extends EventEmitter {
         }
       }
 
-      let proxy_target = "http://localhost:" + port;
+      let proxy_target = "http://" + this.proxyBaseHost + ":" + port;
       if (app == 'sftp') {
         logger.debug('proxy target: ' + proxy_target);
         res.send({"code": 200, "proxy": proxy_target, "url": this.baseURL + "/sftp?port=" + port + "&dummy=1"});
@@ -248,8 +248,11 @@ class Manager extends EventEmitter {
 
     this.app.get('/sftp', (req, res) => {
       let port = req.query.port;
-      let url = "sftp://upload@127.0.0.1:" + port;
-      res.send(htmldeco("Connect with your own SFTP", "host: 127.0.0.1<br/>port: " + port + "<br/>username:upload<br/>URL : <a href=\"" + url + "\">" + url + "</a>"));
+      let url = "sftp://upload@" + this.proxyBaseHost + ":" + port;
+      res.send(htmldeco(
+        "Connect with your own SFTP",
+        "host: " + this.proxyBaseHost + "<br/>port: " + port + "<br/>username:upload<br/>URL : <a href=\"" + url + "\">" + url + "</a>"
+      ));
     });
 
     this.app.get('/redirect', (req, res) => {

--- a/src/wsproxy/manager.js
+++ b/src/wsproxy/manager.js
@@ -255,9 +255,9 @@ class Manager extends EventEmitter {
     this.app.get('/redirect', (req, res) => {
       let port = req.query.port;
       let path = req.query.redirect || "";
-      path.replace("<proxy-host>", this.listen_ip);
+      path.replace("<proxy-host>", this.proxyBaseHost);
       path.replace("<port-number>", port);
-      res.redirect("http://" + this.listen_ip + ":" + port + path)
+      res.redirect("http://" + this.proxyBaseHost + ":" + port + path)
     });
   }
 


### PR DESCRIPTION
* Add `dotenv` as a dependency
* Perform more careful (type-aware) env-var parsing in the local wsproxy
* Fix misuse of `proxyListenIP` and replace them with `proxyBaseHost` -- confirmed working on VM-based dev setup
  - We need to carefully and explicitly distinguish the binding IP address and the hostname sent to the clients, as they may be completely different in remote development setups.

Related: lablup/backend.ai#501

Example:
<img width="570" alt="image" src="https://user-images.githubusercontent.com/555156/178213304-210778ee-f6c1-495c-a3b9-48822901483e.png">
