### PR TITLE
fix: change the size of the popup to fit the text

### DIFF
--- a/src/components/backend-ai-indicator.ts
+++ b/src/components/backend-ai-indicator.ts
@@ -39,7 +39,7 @@ export default class BackendAIIndicator extends LitElement {
           right: 20px;
           bottom: 20px;
           z-index: 9000;
-          --dialog-height: 80px;
+          --dialog-height: 100px;
           --dialog-width: 250px;
           --dialog-content-padding: 15px;
         }

--- a/src/components/backend-ai-indicator.ts
+++ b/src/components/backend-ai-indicator.ts
@@ -39,7 +39,7 @@ export default class BackendAIIndicator extends LitElement {
           right: 20px;
           bottom: 20px;
           z-index: 9000;
-          --dialog-height: 100px;
+          --dialog-height: auto;
           --dialog-width: 250px;
           --dialog-content-padding: 15px;
         }

--- a/src/components/backend-ai-indicator.ts
+++ b/src/components/backend-ai-indicator.ts
@@ -82,7 +82,7 @@ export default class BackendAIIndicator extends LitElement {
     // language=HTML
     return html`
       <wl-dialog id="app-progress-dialog" blockscrolling>
-        <wl-title level="5" id="app-progress-text" slot="header">${this.text}</wl-title>
+        <wl-title level="5" id="app-progress-text" slot="header" style="word-break: keep-all;">${this.text}</wl-title>
         <div slot="content">
         <wl-progress-bar .mode="${this.mode}" id="app-progress" .value="${this.value}"></wl-progress-bar>
         </div>


### PR DESCRIPTION
## Fix
I just increased the length of the dialog to prevent scrolling in the text.

## Change
<table>
<tr>
<td><strong>Before</strong></td>
<td><strong>After</strong></td>
</tr>

<tr>
<td><img width="245" alt="after" src="https://user-images.githubusercontent.com/65989401/179739359-f7defffc-0a6a-44ce-8e50-9e3aebce91e5.jpg"></td>
<td><img width="245" alt="after" src="https://user-images.githubusercontent.com/65989401/179738827-5227bcfe-4f21-4c13-b9d5-805cf1072bff.png"></td>
</tr>
</table>
resolve: #1349 