### PR TITLE
fix: parse unicode strings for some items in the toml config

### DIFF
--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -443,6 +443,14 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   }
 
   _parseConfig(fileName, returning = false): Promise<void> {
+    const _preprocessToml = (config) => {
+      if (config.general?.apiEndpointText) {
+        config.general.apiEndpointText = JSON.parse(`"${config.general.apiEndpointText}"`);
+      }
+      if (config.general?.siteDescription) {
+        config.general.siteDescription = JSON.parse(`"${config.general.siteDescription}"`);
+      }
+    };
     return fetch(fileName)
       .then((res) => {
         if (res.status == 200) {
@@ -452,10 +460,11 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
       })
       .then((res) => {
         const tomlConfig = toml(res);
+        _preprocessToml(tomlConfig)
         if (returning) {
           return tomlConfig;
         } else {
-          this.config = toml(res);
+          this.config = tomlConfig;
         }
       }).catch((err) => {
         console.log('Configuration file missing.');

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -444,10 +444,10 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
 
   _parseConfig(fileName, returning = false): Promise<void> {
     const _preprocessToml = (config) => {
-      if (config.general?.apiEndpointText) {
+      if (config?.general?.apiEndpointText) {
         config.general.apiEndpointText = JSON.parse(`"${config.general.apiEndpointText}"`);
       }
-      if (config.general?.siteDescription) {
+      if (config?.general?.siteDescription) {
         config.general.siteDescription = JSON.parse(`"${config.general.siteDescription}"`);
       }
     };

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -468,6 +468,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
         }
       }).catch((err) => {
         console.log('Configuration file missing.');
+        console.error(err);
       });
   }
 


### PR DESCRIPTION
Recent server PR https://github.com/lablup/backend.ai/pull/599 introduces bare unicode for some text items in composing the toml config file. For example, if an admin sets a string `JPark's Test Node` for `api.text` item in `webserver.conf`, the the resulting text would be `JPark\u0027s Test Node`.

<img width="426" alt="image" src="https://user-images.githubusercontent.com/7539358/181178744-1bd32a53-b36a-4aad-8887-6c9ef3ad7ebc.png">

This PR manually handles this case by parsing the unicode text in loading the config.

Affected config items:
- `config.general.apiEndpointText`
- `config.general.siteDescription`
