### PR TITLE
fix: Manual image name is not required in Session launcher

### DIFF
--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1366,7 +1366,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       config['env']['OPENBLAS_NUM_THREADS'] = openBLASCoreValue ? Math.max(0, parseInt(openBLASCoreValue)).toString() : '1';
     }
     let kernelName: string;
-    if (this._debug || ( this.manualImageName && this.manualImageName.value !== '')) {
+    if ((this._debug && this.manualImageName.value !== '') || ( this.manualImageName && this.manualImageName.value !== '')) {
       kernelName = this.manualImageName.value;
     } else {
       kernelName = this._generateKernelIndex(kernel, version);


### PR DESCRIPTION
## Fix
* An error occurred because manualImageName.value is used as kernalname even though manualimagename field is empty in debug mode.
So I modified the manual image name field to be used as a kernal name only when it is not empty.
* In Session launcher, manual image name is not required but optional (in debug mode or when allowManualImageNameForSession is true)

resolve #1365 
