### PR TITLE
fix: Incorrect warning message is output when allocating a size small…

### DIFF
--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1194,7 +1194,7 @@
     "ResourcePolicyAlreadyExist": "같은 이름의 자원 정책이 이미 있습니다.",
     "ScalingGroupAlreadyExist": "같은 이름의 자원 그룹이 이미 있습니다.",
     "ResourceLimitExceed": "자원 제한을 초과했습니다. 가용 자원량을 확인하세요.",
-    "SmallerResourceThenImageRequires": "요청한 자원가 이미지가 요구하는 자원보다 적습니다. 자원를 보다 크게 해서 시도해보세요.",
+    "SmallerResourceThenImageRequires": "요청한 자원이 이미지가 요구하는 자원보다 적습니다. 자원를 보다 크게 해서 시도해보세요.",
     "LoginSucceededManagerNotResponding": "로그인은 성공하였으나 매니저 서버가 응답하지 않습니다.",
     "UserNameAlreadyExist": "이미 사용하고 있는 사용자명입니다.",
     "ResourcePolicyStillReferenced": "이 자원 정책을 사용하고 있는 자격 증명이 있습니다.",


### PR DESCRIPTION
…er than the size of the image you are trying to create

Modify the json SmallerResourceThenImageRequires value "자원가" to
"자원이" in resources/i18n/ko.json

fix #1398