### PR TITLE
fix: inconsistent login style

### DIFF
--- a/src/components/backend-ai-dialog.ts
+++ b/src/components/backend-ai-dialog.ts
@@ -201,7 +201,9 @@ export default class BackendAiDialog extends LitElement {
                     style="padding:0;" class="${this.type}">
         <div elevation="1" class="card" style="margin: 0;padding:0;">
           <h3 class="horizontal justified layout" style="font-weight:bold">
-            <span class="vertical center-justified layout"><slot name="title"></slot></span>
+            <span class="vertical center-justified layout">
+              <slot name="title"></slot>
+            </span>
             <div class="flex"></div>
             <slot name="action"></slot>
             ${this.noclosebutton ? html`` : html`
@@ -217,7 +219,7 @@ export default class BackendAiDialog extends LitElement {
           </div>
         </div>
       </mwc-dialog>
-      `;
+    `;
   }
 }
 

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -1337,7 +1337,7 @@ export default class BackendAILogin extends BackendAIPage {
                 ${this.singleSignOnVendors.includes('saml') ? html`
                   <mwc-button fullwidth id="sso-login-saml-button"
                       label="${_t('login.SingleSignOn.LoginWithSAML')}"
-                      @click="${() => this.client.login_with_saml()}"
+                      @click="${() => this.client?.login_with_saml()}"
                   ></mwc-button>
                 ` : html``}
                 <div id="additional-action-area" class="layout horizontal">

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -7,14 +7,10 @@ import {get as _text, translate as _t} from 'lit-translate';
 import {css, CSSResultGroup, html} from 'lit';
 import {customElement, property, query} from 'lit/decorators.js';
 
-import 'weightless/button';
-import 'weightless/icon';
-import 'weightless/card';
-
 import '@material/mwc-button';
 import '@material/mwc-icon';
-import '@material/mwc-list/mwc-list-item';
 import {IconButton} from '@material/mwc-icon-button';
+import '@material/mwc-list/mwc-list-item';
 import {Menu} from '@material/mwc-menu';
 import '@material/mwc-select';
 import {TextField} from '@material/mwc-textfield';

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -149,6 +149,8 @@ export default class BackendAILogin extends BackendAIPage {
         }
 
         .endpoint-text {
+          --mdc-text-field-idle-line-color: rgba(0, 0, 0, 0);
+          --mdc-text-field-hover-line-color:rgba(0, 0, 0, 0);
           --mdc-text-field-disabled-line-color: rgba(0, 0, 0, 0.0);
         }
 
@@ -204,6 +206,39 @@ export default class BackendAILogin extends BackendAIPage {
           padding: 0;
         }
 
+        .title-img {
+          height: 35px;
+          padding: 15px 0 15px 5px;
+        }
+
+        #change-signin-area > #change-signin-message {
+          font-size: 12px;
+          margin: 5px 10px;
+          text-align: center;
+          font-weight: 400;
+        }
+
+        #session-login-form.block {
+          display: block;
+        }
+
+        #session-login-form.none {
+          display: none;
+        }
+
+        #api-login-form.block {
+          display: block;
+        }
+
+        #api-login-form.none {
+          display: none;
+        }
+
+        #endpoint-button {
+          padding-left: 3px;
+          background-color: rgb(250, 250, 250);
+        }
+
         .login-input {
           background-color: #FAFAFA;
           border-bottom: 1px solid #ccc;
@@ -231,6 +266,34 @@ export default class BackendAILogin extends BackendAIPage {
 
         .login-form {
           position: relative;
+        }
+
+        #additional-action-area {
+          margin-top: 2em;
+        }
+
+        #additional-action-area > #signup-area {
+          width: 100%;
+        }
+
+        #signup-area > #signup-message {
+          font-size: 12px;
+          margin: 0 10px;
+          text-align: center;
+        }
+
+        #additional-action-area > span {
+          min-width: 1em;
+        }
+
+        #change-password-area {
+          width: 100%;
+        }
+
+        #change-password-area > #change-password-message {
+          font-size: 12px;
+          margin:0 10px;
+          text-align: center;
         }
 
         .waiting-animation {
@@ -1174,20 +1237,17 @@ export default class BackendAILogin extends BackendAIPage {
         <div slot="title">
           <div id="login-title-area"></div>
           <div class="horizontal center layout">
-            <img src="manifest/backend.ai-text.svg" style="height:35px;padding:15px 0 15px 5px;" />
-            <div class="flex"></div>
+            <img class="title-img" src="manifest/backend.ai-text.svg" alt="backend.ai" />
           </div>
         </div>
-        <div slot="content" class="login-panel intro centered" style="margin: 0;">
+        <div slot="content" class="login-panel intro centered">
           <h3 class="horizontal center layout" style="margin: 0 25px;font-weight:700;min-height:40px;">
             <div>${this.connection_mode == 'SESSION' ? _t('login.LoginWithE-mail') : _t('login.LoginWithIAM')}</div>
             <div class="flex"></div>
             ${this.change_signin_support ? html`
-                <div class="vertical center-justified layout">
-                  <div style="font-size:12px;margin:5px 10px;text-align:center;font-weight:400;">${_t('login.LoginAnotherway')}</div>
-                  <mwc-button
-                      class="change-login-mode-button"
-                      outlined
+                <div id="change-signin-area" class="vertical center-justified layout">
+                  <div id="change-signin-message">${_t('login.LoginAnotherway')}</div>
+                  <mwc-button outlined class="change-login-mode-button"
                       label="${this.connection_mode == 'SESSION' ? _t('login.ClickToUseIAM') : _t('login.ClickToUseID')}"
                       @click="${() => this._changeSigninMode()}">
                   </mwc-button>
@@ -1204,80 +1264,93 @@ export default class BackendAILogin extends BackendAIPage {
               </div>
               <div id="loading-message">Waiting...</div>
             </div>
-            <form id="session-login-form" style="${this.connection_mode == 'SESSION' ? `display:block;` : `display:none;`}">
+            <form id="session-login-form" class="${this.connection_mode === 'SESSION' ? 'block' : 'none'}">
               <fieldset>
                 <div class="horizontal layout start-justified center login-input">
                   <mwc-icon>email</mwc-icon>
                   <input type="email" id="id_user_id" maxlength="64" autocomplete="username"
-                              label="${_t('login.E-mail')}" placeholder="${_t('login.E-mail')}" icon="email" value="${this.user_id}" @keyup="${this._submitIfEnter}"></input>
+                      label="${_t('login.E-mail')}" placeholder="${_t('login.E-mail')}" icon="email"
+                      value="${this.user_id}"
+                      @keyup="${this._submitIfEnter}" />
                 </div>
                 <div class="horizontal layout start-justified center login-input">
                   <mwc-icon>vpn_key</mwc-icon>
                   <input type="password" id="id_password" autocomplete="current-password"
-                              label="${_t('login.Password')}" placeholder="${_t('login.Password')}" icon="vpn_key" value="${this.password}" @keyup="${this._submitIfEnter}"></input>
+                      label="${_t('login.Password')}" placeholder="${_t('login.Password')}" icon="vpn_key"
+                      value="${this.password}"
+                      @keyup="${this._submitIfEnter}" />
                 </div>
               </fieldset>
             </form>
-            <form id="api-login-form" style="${this.connection_mode == 'SESSION' ? `display:none;` : `display:block;`}">
+            <form id="api-login-form" class="${this.connection_mode === 'SESSION' ? 'none' : 'block'}">
               <fieldset>
                 <mwc-textfield type="text" id="id_api_key" maxLength="20"
-                            label="${_t('login.APIKey')}" icon="lock" value="${this.api_key}" @keyup="${this._submitIfEnter}"></mwc-textfield>
+                    label="${_t('login.APIKey')}" icon="lock"
+                    value="${this.api_key}"
+                    @keyup="${this._submitIfEnter}">
+                </mwc-textfield>
                 <mwc-textfield type="password" id="id_secret_key" maxLength="40"
-                            label="${_t('login.SecretKey')}" icon="vpn_key" value="${this.secret_key}" @keyup="${this._submitIfEnter}" ></mwc-textfield>
+                    label="${_t('login.SecretKey')}" icon="vpn_key"
+                    value="${this.secret_key}"
+                    @keyup="${this._submitIfEnter}">
+                </mwc-textfield>
               </fieldset>
             </form>
             <form>
               <fieldset>
                 <div class="horizontal layout" id="id_api_endpoint_container" style="display:none;">
-                  <mwc-icon-button id="endpoint-button" icon="cloud_queue" style="padding-left: 3px; background-color: rgb(250, 250, 250);" @click="${() => this._toggleEndpoint()}"></mwc-icon-button>
+                  <mwc-icon-button id="endpoint-button" icon="cloud_queue"
+                      @click="${() => this._toggleEndpoint()}">
+                  </mwc-icon-button>
                   <mwc-menu id="endpoint-list" @selected="${() => this._updateEndpoint()}">
                     <mwc-list-item disabled>${_t('login.EndpointHistory')}</mwc-list-item>
                     ${this.endpoints.length === 0 ? html`
-                    <mwc-list-item value="">${_t('login.NoEndpointSaved')}</mwc-list-item>
+                      <mwc-list-item value="">${_t('login.NoEndpointSaved')}</mwc-list-item>
                     ` : html``}
 
-                    ${this.endpoints.map((item) =>
-    html`<mwc-list-item value="${item}">
-                      <div class="horizontal justified center flex layout" style="width:365px;">
-                        <span>${item}</span><span class="flex"></span>
-                        <mwc-icon-button icon="delete" @click="${() => this._deleteEndpoint(item)}" class="endpoint-control-button"></mwc-icon-button>
-                      </div>
-                    </mwc-list-item>`)}
+                    ${this.endpoints.map((item) => html`
+                      <mwc-list-item value="${item}">
+                        <div class="horizontal justified center flex layout" style="width:365px;">
+                          <span>${item}</span><span class="flex"></span>
+                          <mwc-icon-button class="endpoint-control-button" icon="delete"
+                              @click="${() => this._deleteEndpoint(item)}">
+                          </mwc-icon-button>
+                        </div>
+                      </mwc-list-item>
+                    `)}
                   </mwc-menu>
-                  <mwc-textfield class="endpoint-text" type="text" id="id_api_endpoint" maxLength="2048"
-                              style="--mdc-text-field-idle-line-color:rgba(255,255,255,0);--mdc-text-field-hover-line-color:rgba(255,255,255,0);"
-                              label="${_t('login.Endpoint')}" value="${this.api_endpoint}" @keyup="${this._submitIfEnter}"></mwc-textfield>
+                  <mwc-textfield class="endpoint-text" type="text" id="id_api_endpoint"
+                      maxLength="2048" label="${_t('login.Endpoint')}"
+                      value="${this.api_endpoint}"
+                      @keyup="${this._submitIfEnter}">
+                  </mwc-textfield>
                 </div>
-                <mwc-textfield class="endpoint-text" type="text" id="id_api_endpoint_humanized" maxLength="2048"
-                            style="display:none;--mdc-text-field-idle-line-color:rgba(255,255,255,0);--mdc-text-field-hover-line-color:rgba(255,255,255,0);"
-                            label="${_t('login.Endpoint')}" icon="cloud" value=""></mwc-textfield>
-                <mwc-button
-                      unelevated
-                      id="login-button"
-                      icon="check"
-                      fullwidth
-                      label="${_t('login.Login')}"
-                      @click="${() => this._login()}"></mwc-button>
-                <div class="layout horizontal" style="margin-top:2em;">
+                <mwc-textfield class="endpoint-text" type="text" id="id_api_endpoint_humanized"
+                    maxLength="2048" style="display:none;"
+                    label="${_t('login.Endpoint')}" icon="cloud" value="">
+                </mwc-textfield>
+                <mwc-button unelevated fullwidth id="login-button" icon="check"
+                    label="${_t('login.Login')}"
+                    @click="${() => this._login()}">
+                </mwc-button>
+                <div id="additional-action-area" class="layout horizontal">
                   ${this.signup_support ? html`
-                    <div class="vertical center-justified layout" style="width:100%;">
-                      <div style="font-size:12px; margin:0 10px; text-align:center;">${_t('login.NotAUser')}</div>
-                      <mwc-button
-                          outlined
-                          label="${_t('login.SignUp')}"
-                          @click="${() => this._showSignupDialog()}"></mwc-button>
+                    <div id="signup-area" class="vertical center-justified layout">
+                      <div id="signup-message">${_t('login.NotAUser')}</div>
+                      <mwc-button outlined label="${_t('login.SignUp')}"
+                          @click="${() => this._showSignupDialog()}">
+                      </mwc-button>
                     </div>
                   `: html``}
                   ${this.signup_support && this.allowAnonymousChangePassword ? html`
-                    <span class="flex" style="min-width:1em;"></span>
+                    <span class="flex"></span>
                   `: html``}
                   ${this.allowAnonymousChangePassword ? html`
-                    <div class="vertical center-justified layout" style="width:100%;">
-                      <div style="font-size:12px; margin:0 10px; text-align:center;">${_t('login.ForgotPassword')}</div>
-                      <mwc-button
-                          outlined
-                          label="${_t('login.ChangePassword')}"
-                          @click="${() => this._showChangePasswordEmailDialog()}"></mwc-button>
+                    <div id="change-password-area" class="vertical center-justified layout">
+                      <div id="change-password-message">${_t('login.ForgotPassword')}</div>
+                      <mwc-button outlined label="${_t('login.ChangePassword')}"
+                          @click="${() => this._showChangePasswordEmailDialog()}">
+                      </mwc-button>
                     </div>
                   ` : html``}
                 </div>
@@ -1292,19 +1365,20 @@ export default class BackendAILogin extends BackendAIPage {
           <section>
             <div class="warning">${_t('login.DescConfirmLeave')}</div>
           </section>
-          <mwc-textfield type="email" name="signout_user_id" id="id_signout_user_id" maxLength="64"
-              label="E-mail" value="" @keyup="${this._signoutIfEnter}"></mwc-textfield>
-          <mwc-textfield type="password" name="signout_password" id="id_signout_password" maxLength="64"
-              label="Password" value="" @keyup="${this._signoutIfEnter}"></mwc-textfield>
+          <mwc-textfield type="email" name="signout_user_id" id="id_signout_user_id"
+              maxLength="64" label="E-mail" value=""
+              @keyup="${this._signoutIfEnter}">
+          </mwc-textfield>
+          <mwc-textfield type="password" name="signout_password" id="id_signout_password"
+              maxLength="64" label="Password" value=""
+              @keyup="${this._signoutIfEnter}">
+          </mwc-textfield>
         </div>
         <div slot="footer" class="horizontal center-justified flex layout">
-          <mwc-button
-              outlined
-              fullwidth
-              id="signout-button"
-              icon="check"
-              label="${_t('login.LeaveService')}"
-              @click="${() => this._signout()}"></mwc-button>
+          <mwc-button outlined fullwidth id="signout-button"
+              icon="check" label="${_t('login.LeaveService')}"
+              @click="${() => this._signout()}">
+          </mwc-button>
         </div>
       </backend-ai-dialog>
       <backend-ai-dialog id="change-password-confirm-dialog" fixed backdrop blockscrolling persistent disablefocustrap>
@@ -1333,14 +1407,15 @@ export default class BackendAILogin extends BackendAIPage {
             <span slot="title" id="work-title">${this.blockType}</span>
           ` : html``}
           <div slot="content" style="text-align:center;padding-top:15px;">
-          ${this.blockMessage}
+            ${this.blockMessage}
           </div>
           <div slot="footer" class="horizontal center-justified flex layout">
-          <mwc-button
+            <mwc-button
               outlined
               fullwidth
               label="${_t('login.CancelLogin')}"
-              @click="${(e) => this._cancelLogin(e)}"></mwc-button>
+              @click="${(e) => this._cancelLogin(e)}">
+            </mwc-button>
           </div>
         ` : html``}
       </backend-ai-dialog>
@@ -1348,6 +1423,7 @@ export default class BackendAILogin extends BackendAIPage {
     `;
   }
 }
+
 declare global {
   interface HTMLElementTagNameMap {
     'backend-ai-login': BackendAILogin;

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -428,7 +428,7 @@ export default class BackendAILogin extends BackendAIPage {
    * */
   _changeSigninMode() {
     if (this.change_signin_support === true) {
-      if (this.connection_mode == 'SESSION') {
+      if (this.connection_mode === 'SESSION') {
         this.connection_mode = 'API';
         localStorage.setItem('backendaiwebui.connection_mode', 'API');
       } else {
@@ -467,38 +467,38 @@ export default class BackendAILogin extends BackendAIPage {
       globalThis.backendaiwebui.debug = true;
       console.log('Debug flag is set to true');
     }
-    if (typeof config.general === 'undefined' || typeof config.general.signupSupport === 'undefined' || config.general.signupSupport === '' || config.general.signupSupport == false) {
+    if (typeof config.general === 'undefined' || typeof config.general.signupSupport === 'undefined' || config.general.signupSupport === '' || config.general.signupSupport === false) {
       this.signup_support = false;
     } else {
       this.signup_support = true;
       (this.shadowRoot?.querySelector('#signup-dialog') as HTMLElementTagNameMap['backend-ai-signup']).active = true;
     }
-    if (typeof config.general === 'undefined' || typeof config.general.allowAnonymousChangePassword === 'undefined' || config.general.allowAnonymousChangePassword === '' || config.general.allowAnonymousChangePassword == false) {
+    if (typeof config.general === 'undefined' || typeof config.general.allowAnonymousChangePassword === 'undefined' || config.general.allowAnonymousChangePassword === '' || config.general.allowAnonymousChangePassword === false) {
       this.allowAnonymousChangePassword = false;
     } else {
       this.allowAnonymousChangePassword = true;
     }
-    if (typeof config.general === 'undefined' || typeof config.general.allowChangeSigninMode === 'undefined' || config.general.allowChangeSigninMode === '' || config.general.allowChangeSigninMode == false) {
+    if (typeof config.general === 'undefined' || typeof config.general.allowChangeSigninMode === 'undefined' || config.general.allowChangeSigninMode === '' || config.general.allowChangeSigninMode === false) {
       this.change_signin_support = false;
     } else {
       this.change_signin_support = true;
     }
-    if (typeof config.general === 'undefined' || typeof config.general.allowProjectResourceMonitor === 'undefined' || config.general.allowProjectResourceMonitor === '' || config.general.allowProjectResourceMonitor == false) {
+    if (typeof config.general === 'undefined' || typeof config.general.allowProjectResourceMonitor === 'undefined' || config.general.allowProjectResourceMonitor === '' || config.general.allowProjectResourceMonitor === false) {
       this.allow_project_resource_monitor = false;
     } else {
       this.allow_project_resource_monitor = true;
     }
-    if (typeof config.general === 'undefined' || typeof config.general.allowManualImageNameForSession === 'undefined' || config.general.allowManualImageNameForSession === '' || config.general.allowManualImageNameForSession == false) {
+    if (typeof config.general === 'undefined' || typeof config.general.allowManualImageNameForSession === 'undefined' || config.general.allowManualImageNameForSession === '' || config.general.allowManualImageNameForSession === false) {
       this.allow_manual_image_name_for_session = false;
     } else {
       this.allow_manual_image_name_for_session = true;
     }
-    if (typeof config.general === 'undefined' || typeof config.general.alwaysEnqueueComputeSession === 'undefined' || config.general.alwaysEnqueueComputeSession === '' || config.general.alwaysEnqueueComputeSession == false) {
+    if (typeof config.general === 'undefined' || typeof config.general.alwaysEnqueueComputeSession === 'undefined' || config.general.alwaysEnqueueComputeSession === '' || config.general.alwaysEnqueueComputeSession === false) {
       this.always_enqueue_compute_session = false;
     } else {
       this.always_enqueue_compute_session = true;
     }
-    if (typeof config.resources === 'undefined' || typeof config.resources.openPortToPublic === 'undefined' || config.resources.openPortToPublic === '' || config.resources.openPortToPublic == false) {
+    if (typeof config.resources === 'undefined' || typeof config.resources.openPortToPublic === 'undefined' || config.resources.openPortToPublic === '' || config.resources.openPortToPublic === false) {
       this.openPortToPublic = false;
     } else {
       this.openPortToPublic = true;
@@ -533,7 +533,7 @@ export default class BackendAILogin extends BackendAIPage {
     } else {
       this.maxFileUploadSize = parseInt(config.resources.maxFileUploadSize);
     }
-    if (typeof config.general === 'undefined' || typeof config.general.allowSignout === 'undefined' || config.general.allowSignout === '' || config.general.allowSignout == false) {
+    if (typeof config.general === 'undefined' || typeof config.general.allowSignout === 'undefined' || config.general.allowSignout === '' || config.general.allowSignout === false) {
       this.allow_signout = false;
     } else {
       this.allow_signout = true;
@@ -568,7 +568,7 @@ export default class BackendAILogin extends BackendAIPage {
       this.apiEndpointInput.disabled = true;
       this.apiEndpointHumanizedInput.disabled = true;
     }
-    if (typeof config.general === 'undefined' || typeof config.general.allowSignupWithoutConfirmation === 'undefined' || config.general.allowSignupWithoutConfirmation === '' || config.general.allowSignupWithoutConfirmation == false) {
+    if (typeof config.general === 'undefined' || typeof config.general.allowSignupWithoutConfirmation === 'undefined' || config.general.allowSignupWithoutConfirmation === '' || config.general.allowSignupWithoutConfirmation === false) {
       this.allowSignupWithoutConfirmation = false;
     } else {
       this.allowSignupWithoutConfirmation = true;
@@ -595,7 +595,7 @@ export default class BackendAILogin extends BackendAIPage {
       this.maskUserInfo = config.general.maskUserInfo;
     }
     const connection_mode: string | null = localStorage.getItem('backendaiwebui.connection_mode');
-    if (globalThis.isElectron && connection_mode !== null && connection_mode != '' && connection_mode != '""') {
+    if (globalThis.isElectron && connection_mode !== null && connection_mode !== '' && connection_mode !== '""') {
       if (connection_mode === 'SESSION') {
         this.connection_mode = 'SESSION';
       } else {
@@ -661,7 +661,7 @@ export default class BackendAILogin extends BackendAIPage {
     this.blockPanel.hide();
   }
 
-  _trimChar(str, char) {
+  _trimChar(str: string) {
     return str.replace(/^\|+|\|+$/g, '');
   }
 
@@ -700,8 +700,8 @@ export default class BackendAILogin extends BackendAIPage {
    * */
   login(showError = true) {
     if (this.api_endpoint === '') {
-      const api_endpoint: any = localStorage.getItem('backendaiwebui.api_endpoint');
-      if (api_endpoint != null) {
+      const api_endpoint = localStorage.getItem('backendaiwebui.api_endpoint');
+      if (api_endpoint !== null) {
         this.api_endpoint = api_endpoint.replace(/^"+|"+$/g, '');
       }
     }
@@ -722,7 +722,7 @@ export default class BackendAILogin extends BackendAIPage {
   async check_login(showError = true) {
     if (this.api_endpoint === '') {
       const api_endpoint: any = localStorage.getItem('backendaiwebui.api_endpoint');
-      if (api_endpoint != null) {
+      if (api_endpoint !== null) {
         this.api_endpoint = api_endpoint.replace(/^"+|"+$/g, '');
       }
     }
@@ -825,18 +825,18 @@ export default class BackendAILogin extends BackendAIPage {
   }
 
   _validate_data(value) {
-    if (value != undefined && value != null && value != '') {
+    if (value !== undefined && value !== null && value !== '') {
       return true;
     }
     return false;
   }
 
   _submitIfEnter(e) {
-    if (e.keyCode == 13) this._login();
+    if (e.keyCode === 13) this._login();
   }
 
   _signoutIfEnter(e) {
-    if (e.keyCode == 13) this._signout();
+    if (e.keyCode === 13) this._signout();
   }
 
   _signout() {
@@ -938,13 +938,13 @@ export default class BackendAILogin extends BackendAIPage {
         this.client.login().then((response) => {
           if (response === false) {
             this.open();
-            if (this.user_id != '' && this.password != '') {
+            if (this.user_id !== '' && this.password !== '') {
               this.notification.text = PainKiller.relieve('Login information mismatch. Please check your login information.');
               this.notification.show();
             }
           } else if (response.fail_reason) {
             this.open();
-            if (this.user_id != '' && this.password != '') {
+            if (this.user_id !== '' && this.password !== '') {
               this.notification.text = PainKiller.relieve(response.fail_reason);
               this.notification.show();
             }
@@ -1242,13 +1242,13 @@ export default class BackendAILogin extends BackendAIPage {
         </div>
         <div slot="content" class="login-panel intro centered">
           <h3 class="horizontal center layout" style="margin: 0 25px;font-weight:700;min-height:40px;">
-            <div>${this.connection_mode == 'SESSION' ? _t('login.LoginWithE-mail') : _t('login.LoginWithIAM')}</div>
+            <div>${this.connection_mode === 'SESSION' ? _t('login.LoginWithE-mail') : _t('login.LoginWithIAM')}</div>
             <div class="flex"></div>
             ${this.change_signin_support ? html`
                 <div id="change-signin-area" class="vertical center-justified layout">
                   <div id="change-signin-message">${_t('login.LoginAnotherway')}</div>
                   <mwc-button outlined class="change-login-mode-button"
-                      label="${this.connection_mode == 'SESSION' ? _t('login.ClickToUseIAM') : _t('login.ClickToUseID')}"
+                      label="${this.connection_mode === 'SESSION' ? _t('login.ClickToUseIAM') : _t('login.ClickToUseID')}"
                       @click="${() => this._changeSigninMode()}">
                   </mwc-button>
                 </div>
@@ -1398,7 +1398,7 @@ export default class BackendAILogin extends BackendAIPage {
         </div>
       </backend-ai-dialog>
       <backend-ai-dialog id="block-panel" fixed blockscrolling persistent escapeKeyAction>
-        ${this.blockMessage != '' ? html`
+        ${this.blockMessage !== '' ? html`
           ${this.blockType !== '' ? html`
             <span slot="title" id="work-title">${this.blockType}</span>
           ` : html``}

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -875,7 +875,7 @@ export default class BackendAILogin extends BackendAIPage {
       this.password = this.passwordInput.value;
 
       // show error message when id or password input is empty
-      if (this.user_id === '' || this.user_id === 'undefined' || this.password === '' || this.password === 'undefined') {
+      if (!this.user_id || this.user_id === 'undefined' || !this.password || this.password === 'undefined') {
         this.notification.text = _text('login.PleaseInputLoginInfo');
         this.notification.show();
         this._enableUserInput();
@@ -885,7 +885,14 @@ export default class BackendAILogin extends BackendAIPage {
     } else {
       this.api_key = (this.shadowRoot?.querySelector('#id_api_key') as TextField).value;
       this.secret_key = (this.shadowRoot?.querySelector('#id_secret_key') as TextField).value;
-      this._connectUsingAPI(true);
+
+      if (!this.api_key || this.api_key === 'undefined' || !this.secret_key || this.secret_key === 'undefined') {
+        this.notification.text = _text('login.PleaseInputLoginInfo');
+        this.notification.show();
+        this._enableUserInput();
+      } else {
+        this._connectUsingAPI(true);
+      }
     }
   }
 

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -5,7 +5,7 @@
 
 import {get as _text, translate as _t} from 'lit-translate';
 import {css, CSSResultGroup, html} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, property, query} from 'lit/decorators.js';
 
 import 'weightless/button';
 import 'weightless/icon';
@@ -14,10 +14,10 @@ import 'weightless/card';
 import '@material/mwc-button';
 import '@material/mwc-icon';
 import '@material/mwc-list/mwc-list-item';
-import '@material/mwc-icon-button';
-import '@material/mwc-menu';
+import {IconButton} from '@material/mwc-icon-button';
+import {Menu} from '@material/mwc-menu';
 import '@material/mwc-select';
-import '@material/mwc-textfield';
+import {TextField} from '@material/mwc-textfield';
 
 import '../plastics/lablup-shields/lablup-shields';
 import './backend-ai-dialog';
@@ -55,6 +55,8 @@ declare global {
  */
 @customElement('backend-ai-login')
 export default class BackendAILogin extends BackendAIPage {
+  shadowRoot!: ShadowRoot | null;
+
   @property({type: String}) api_key = '';
   @property({type: String}) secret_key = '';
   @property({type: String}) user_id = '';
@@ -72,9 +74,6 @@ export default class BackendAILogin extends BackendAIPage {
   @property({type: String}) user;
   @property({type: String}) email;
   @property({type: Object}) config = Object();
-  @property({type: Object}) loginPanel;
-  @property({type: Object}) signoutPanel;
-  @property({type: Object}) blockPanel;
   @property({type: Boolean}) is_connected = false;
   @property({type: Object}) clientConfig;
   @property({type: Object}) client;
@@ -100,6 +99,14 @@ export default class BackendAILogin extends BackendAIPage {
   @property({type: Array}) endpoints;
   @property({type: Object}) logoutTimerBeforeOneMin;
   @property({type: Object}) logoutTimer;
+  @query('#login-panel') loginPanel!: HTMLElementTagNameMap['backend-ai-dialog'];
+  @query('#signout-panel') signoutPanel!: HTMLElementTagNameMap['backend-ai-dialog'];
+  @query('#block-panel') blockPanel!: HTMLElementTagNameMap['backend-ai-dialog'];
+  @query('#id_api_endpoint_container') apiEndpointContainer!: HTMLDivElement;
+  @query('#id_api_endpoint') apiEndpointInput!: TextField;
+  @query('#id_api_endpoint_humanized') apiEndpointHumanizedInput!: TextField;
+  @query('#id_user_id') userIdInput!: HTMLInputElement;
+  @query('#id_password') passwordInput!: HTMLInputElement;
 
   constructor() {
     super();
@@ -107,7 +114,7 @@ export default class BackendAILogin extends BackendAIPage {
     this.endpoints = [];
   }
 
-  static get styles(): CSSResultGroup | undefined {
+  static get styles(): CSSResultGroup {
     return [
       BackendAiStyles,
       IronFlex,
@@ -348,9 +355,6 @@ export default class BackendAILogin extends BackendAIPage {
   }
 
   firstUpdated() {
-    this.loginPanel = this.shadowRoot.querySelector('#login-panel');
-    this.signoutPanel = this.shadowRoot.querySelector('#signout-panel');
-    this.blockPanel = this.shadowRoot.querySelector('#block-panel');
     this.notification = globalThis.lablupNotification;
     this.endpoints = globalThis.backendaioptions.get('endpoints', []);
   }
@@ -404,7 +408,7 @@ export default class BackendAILogin extends BackendAIPage {
       this.signup_support = false;
     } else {
       this.signup_support = true;
-      (this.shadowRoot.querySelector('#signup-dialog') as any).active = true;
+      (this.shadowRoot?.querySelector('#signup-dialog') as HTMLElementTagNameMap['backend-ai-signup']).active = true;
     }
     if (typeof config.general === 'undefined' || typeof config.general.allowAnonymousChangePassword === 'undefined' || config.general.allowAnonymousChangePassword === '' || config.general.allowAnonymousChangePassword == false) {
       this.allowAnonymousChangePassword = false;
@@ -485,21 +489,21 @@ export default class BackendAILogin extends BackendAIPage {
       this.proxy_url = config.wsproxy.proxyURL;
     }
     if (typeof config.general === 'undefined' || typeof config.general.apiEndpoint === 'undefined' || config.general.apiEndpoint === '') {
-      (this.shadowRoot.querySelector('#id_api_endpoint_container') as any).style.display = 'flex';
-      (this.shadowRoot.querySelector('#id_api_endpoint_humanized') as any).style.display = 'none';
+      this.apiEndpointContainer.style.display = 'flex';
+      this.apiEndpointHumanizedInput.style.display = 'none';
     } else {
       this.api_endpoint = config.general.apiEndpoint;
       if (typeof config.general === 'undefined' || typeof config.general.apiEndpointText === 'undefined' || config.general.apiEndpointText === '') {
-        (this.shadowRoot.querySelector('#id_api_endpoint_container') as any).style.display = 'flex';
-        (this.shadowRoot.querySelector('#id_api_endpoint_humanized') as any).style.display = 'none';
-        (this.shadowRoot.querySelector('#endpoint-button') as any).disabled = 'true';
+        this.apiEndpointContainer.style.display = 'flex';
+        this.apiEndpointHumanizedInput.style.display = 'none';
+        (this.shadowRoot?.querySelector('#endpoint-button') as IconButton).disabled = true;
       } else {
-        (this.shadowRoot.querySelector('#id_api_endpoint_container') as any).style.display = 'none';
-        (this.shadowRoot.querySelector('#id_api_endpoint_humanized') as any).style.display = 'block';
-        (this.shadowRoot.querySelector('#id_api_endpoint_humanized') as any).value = config.general.apiEndpointText;
+        this.apiEndpointContainer.style.display = 'none';
+        this.apiEndpointHumanizedInput.style.display = 'block';
+        this.apiEndpointHumanizedInput.value = config.general.apiEndpointText;
       }
-      (this.shadowRoot.querySelector('#id_api_endpoint') as any).disabled = true;
-      (this.shadowRoot.querySelector('#id_api_endpoint_humanized') as any).disabled = true;
+      this.apiEndpointInput.disabled = true;
+      this.apiEndpointHumanizedInput.disabled = true;
     }
     if (typeof config.general === 'undefined' || typeof config.general.allowSignupWithoutConfirmation === 'undefined' || config.general.allowSignupWithoutConfirmation === '' || config.general.allowSignupWithoutConfirmation == false) {
       this.allowSignupWithoutConfirmation = false;
@@ -720,18 +724,18 @@ export default class BackendAILogin extends BackendAIPage {
       this.notification.show();
       return;
     }
-    const signupDialog = this.shadowRoot.querySelector('#signup-dialog');
+    const signupDialog = this.shadowRoot?.querySelector('#signup-dialog') as HTMLElementTagNameMap['backend-ai-signup'];
     signupDialog.endpoint = this.api_endpoint;
     signupDialog.allowSignupWithoutConfirmation = this.allowSignupWithoutConfirmation;
     signupDialog.open();
   }
 
   _showChangePasswordEmailDialog() {
-    this.shadowRoot.querySelector('#change-password-confirm-dialog').show();
+    (this.shadowRoot?.querySelector('#change-password-confirm-dialog') as HTMLElementTagNameMap['backend-ai-dialog']).show();
   }
 
   async _sendChangePasswordEmail() {
-    const emailEl = this.shadowRoot.querySelector('#password-change-email');
+    const emailEl = this.shadowRoot?.querySelector('#password-change-email') as TextField;
     if (!emailEl.value || !emailEl.validity.valid) return;
     try {
       // Create an anonymous client.
@@ -742,7 +746,7 @@ export default class BackendAILogin extends BackendAIPage {
       );
 
       await client.cloud.send_password_change_email(emailEl.value);
-      this.shadowRoot.querySelector('#change-password-confirm-dialog').hide();
+      (this.shadowRoot?.querySelector('#change-password-confirm-dialog') as HTMLElementTagNameMap['backend-ai-dialog']).hide();
       this.notification.text = _text('signup.EmailSent');
       this.notification.show();
     } catch (e) {
@@ -773,8 +777,8 @@ export default class BackendAILogin extends BackendAIPage {
   }
 
   _signout() {
-    const user_id = (this.shadowRoot.querySelector('#id_signout_user_id') as any).value;
-    const password = (this.shadowRoot.querySelector('#id_signout_password') as any).value;
+    const user_id = (this.shadowRoot?.querySelector('#id_signout_user_id') as TextField).value;
+    const password = (this.shadowRoot?.querySelector('#id_signout_password') as TextField).value;
     this.client.signout(user_id, password).then((response) => {
       this.notification.text = _text('login.SignoutFinished');
       this.notification.show();
@@ -815,7 +819,7 @@ export default class BackendAILogin extends BackendAIPage {
       globalThis.backendaioptions.set('login_attempt', loginAttempt + 1, 'general');
     }
 
-    this.api_endpoint = (this.shadowRoot.querySelector('#id_api_endpoint') as any).value;
+    this.api_endpoint = this.apiEndpointInput.value;
     this.api_endpoint = this.api_endpoint.replace(/\/+$/, '');
     if (this.api_endpoint === '') {
       this.notification.text = _text('login.APIEndpointEmpty');
@@ -824,8 +828,8 @@ export default class BackendAILogin extends BackendAIPage {
     }
     if (this.connection_mode === 'SESSION') {
       this._disableUserInput();
-      this.user_id = (this.shadowRoot.querySelector('#id_user_id') as any).value;
-      this.password = (this.shadowRoot.querySelector('#id_password') as any).value;
+      this.user_id = this.userIdInput.value;
+      this.password = this.passwordInput.value;
 
       // show error message when id or password input is empty
       if (this.user_id === '' || this.user_id === 'undefined' || this.password === '' || this.password === 'undefined') {
@@ -837,8 +841,8 @@ export default class BackendAILogin extends BackendAIPage {
       }
     } else {
       this._disableUserInput();
-      this.api_key = (this.shadowRoot.querySelector('#id_api_key') as any).value;
-      this.secret_key = (this.shadowRoot.querySelector('#id_secret_key') as any).value;
+      this.api_key = (this.shadowRoot?.querySelector('#id_api_key') as TextField).value;
+      this.secret_key = (this.shadowRoot?.querySelector('#id_secret_key') as TextField).value;
       this._connectUsingAPI(true);
     }
   }
@@ -1123,15 +1127,17 @@ export default class BackendAILogin extends BackendAIPage {
   }
 
   _toggleEndpoint() {
-    const endpoint_list = this.shadowRoot.querySelector('#endpoint-list');
-    const endpoint_button = this.shadowRoot.querySelector('#endpoint-button');
+    const endpoint_list = this.shadowRoot?.querySelector('#endpoint-list') as Menu;
+    const endpoint_button = this.shadowRoot?.querySelector('#endpoint-button') as IconButton;
     endpoint_list.anchor = endpoint_button;
     endpoint_list.open = !endpoint_list.open;
   }
 
   _updateEndpoint() {
-    const endpoint_list = this.shadowRoot.querySelector('#endpoint-list');
-    this.api_endpoint = endpoint_list.selected.value;
+    const endpoint_list = this.shadowRoot?.querySelector('#endpoint-list') as Menu;
+    if (endpoint_list.selected && !(endpoint_list.selected instanceof Array)) {
+      this.api_endpoint = endpoint_list.selected.value;
+    }
   }
 
   _deleteEndpoint(endpoint) {
@@ -1145,21 +1151,19 @@ export default class BackendAILogin extends BackendAIPage {
 
   _disableUserInput() {
     if (this.connection_mode === 'SESSION') {
-      this.shadowRoot.querySelector('#id_user_id').disabled = true;
-      this.shadowRoot.querySelector('#id_password').disabled = true;
+      this.userIdInput.disabled = true;
+      this.passwordInput.disabled = true;
     } else {
-      this.shadowRoot.querySelector('#id_user_id').disabled = true;
-      this.shadowRoot.querySelector('#id_password').disabled = true;
+      this.userIdInput.disabled = true;
+      this.passwordInput.disabled = true;
     }
-    this.shadowRoot.querySelector('.waiting-animation').style.display = 'flex';
+    (this.shadowRoot?.querySelector('.waiting-animation') as HTMLDivElement).style.display = 'flex';
   }
 
   _enableUserInput() {
-    this.shadowRoot.querySelector('#id_user_id').disabled = false;
-    this.shadowRoot.querySelector('#id_password').disabled = false;
-    this.shadowRoot.querySelector('#id_user_id').disabled = false;
-    this.shadowRoot.querySelector('#id_password').disabled = false;
-    this.shadowRoot.querySelector('.waiting-animation').style.display = 'none';
+    this.userIdInput.disabled = false;
+    this.passwordInput.disabled = false;
+    (this.shadowRoot?.querySelector('.waiting-animation') as HTMLDivElement).style.display = 'none';
   }
 
   render() {

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -1003,6 +1003,10 @@ export default class BackendAILogin extends BackendAIPage {
     this.client.ready = false;
     return this.client.get_manager_version().then((response) => {
       return this._connectGQL(showError);
+    }).catch((err) => {
+      // FIXME need error handling logic and message prompt
+      console.log(err);
+      this._enableUserInput();
     });
   }
 

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -71,8 +71,8 @@ export default class BackendAILogin extends BackendAIPage {
   @property({type: String}) email;
   @property({type: Object}) config = Object();
   @property({type: Boolean}) is_connected = false;
-  @property({type: Object}) clientConfig;
-  @property({type: Object}) client;
+  @property({type: Object}) clientConfig: ai.ClientConfig | undefined;
+  @property({type: Object}) client: ai.Client | undefined;
   @property({type: Object}) notification;
   @property({type: Object}) user_groups;
   @property({type: Boolean}) signup_support = false;
@@ -746,7 +746,7 @@ export default class BackendAILogin extends BackendAIPage {
       `Backend.AI Console.`,
     );
     return this.client.get_manager_version().then(async ()=>{
-      const isLogon = await this.client.check_login();
+      const isLogon = await this.client?.check_login();
       return Promise.resolve(isLogon);
     });
   }
@@ -757,7 +757,7 @@ export default class BackendAILogin extends BackendAIPage {
    * @param {boolean} showError
    * */
   async _logoutSession(showError = true) {
-    return this.client.logout();
+    return this.client?.logout();
   }
 
   signout() {
@@ -822,7 +822,7 @@ export default class BackendAILogin extends BackendAIPage {
   private _signout() {
     const user_id = (this.shadowRoot?.querySelector('#id_signout_user_id') as TextField).value;
     const password = (this.shadowRoot?.querySelector('#id_signout_password') as TextField).value;
-    this.client.signout(user_id, password).then((response) => {
+    this.client?.signout(user_id, password).then((response) => {
       this.notification.text = _text('login.SignoutFinished');
       this.notification.show();
       const event = new CustomEvent('backend-ai-logout', {'detail': ''});
@@ -911,17 +911,18 @@ export default class BackendAILogin extends BackendAIPage {
       `Backend.AI Console.`,
     );
     return this.client.get_manager_version().then(async () => {
-      const isLogon = await this.client.check_login();
+      const isLogon = await this.client?.check_login();
       if (isLogon === false) { // Not authenticated yet.
         this.block(_text('login.PleaseWait'), _text('login.ConnectingToCluster'));
 
-        this.client.login().then((response) => {
+        this.client?.login().then((response) => {
           if (response === false) {
             this.open();
             if (this.user_id !== '' && this.password !== '') {
               this.notification.text = PainKiller.relieve('Login information mismatch. Please check your login information.');
               this.notification.show();
             }
+            return Promise.reject();
           } else if (response.fail_reason) {
             this.open();
             if (this.user_id !== '' && this.password !== '') {
@@ -1048,7 +1049,7 @@ export default class BackendAILogin extends BackendAIPage {
     const fields = ['user_id', 'resource_policy', 'user'];
     const q = `query { keypair { ${fields.join(' ')} } }`;
     const v = {};
-    return this.client.query(q, v).then((response) => {
+    return this.client?.query(q, v).then((response) => {
       this.is_connected = true;
       globalThis.backendaiclient = this.client;
       const resource_policy = response['keypair'].resource_policy;
@@ -1158,7 +1159,7 @@ export default class BackendAILogin extends BackendAIPage {
         // When authorization failed, it is highly likely that session cookie
         // is used which tried to use non-existent API keypairs
         console.log('automatic logout ...');
-        this.client.logout();
+        this.client?.logout();
       }
       this._enableUserInput();
     });

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -922,13 +922,14 @@ export default class BackendAILogin extends BackendAIPage {
               this.notification.text = PainKiller.relieve('Login information mismatch. Please check your login information.');
               this.notification.show();
             }
-            return Promise.reject();
+            return Promise.resolve(false);
           } else if (response.fail_reason) {
             this.open();
             if (this.user_id !== '' && this.password !== '') {
               this.notification.text = PainKiller.relieve(response.fail_reason);
               this.notification.show();
             }
+            return Promise.resolve(false);
           } else {
             this.is_connected = true;
             return this._connectGQL();
@@ -951,7 +952,6 @@ export default class BackendAILogin extends BackendAIPage {
               } else {
                 this.notification.text = PainKiller.relieve('Login failed. Check login information.');
               }
-              console.log(err);
             }
             this.notification.show();
           }

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -1266,20 +1266,16 @@ export default class BackendAILogin extends BackendAIPage {
             </div>
             <form id="session-login-form" class="${this.connection_mode === 'SESSION' ? 'block' : 'none'}">
               <fieldset>
-                <div class="horizontal layout start-justified center login-input">
-                  <mwc-icon>email</mwc-icon>
-                  <input type="email" id="id_user_id" maxlength="64" autocomplete="username"
-                      label="${_t('login.E-mail')}" placeholder="${_t('login.E-mail')}" icon="email"
+                  <mwc-textfield type="email" id="id_user_id" maxlength="64" autocomplete="username"
+                      label="${_t('login.E-mail')}" icon="email"
                       value="${this.user_id}"
-                      @keyup="${this._submitIfEnter}" />
-                </div>
-                <div class="horizontal layout start-justified center login-input">
-                  <mwc-icon>vpn_key</mwc-icon>
-                  <input type="password" id="id_password" autocomplete="current-password"
-                      label="${_t('login.Password')}" placeholder="${_t('login.Password')}" icon="vpn_key"
+                      @keyup="${this._submitIfEnter}">
+                  </mwc-textfield>
+                  <mwc-textfield type="password" id="id_password" autocomplete="current-password"
+                      label="${_t('login.Password')}" icon="vpn_key"
                       value="${this.password}"
-                      @keyup="${this._submitIfEnter}" />
-                </div>
+                      @keyup="${this._submitIfEnter}">
+                  </mwc-textfield>
               </fieldset>
             </form>
             <form id="api-login-form" class="${this.connection_mode === 'SESSION' ? 'none' : 'block'}">

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -417,7 +417,7 @@ export default class BackendAILogin extends BackendAIPage {
   /**
    * Change the signin mode with SESSION or API
    * */
-  _changeSigninMode() {
+  private _changeSigninMode() {
     if (this.change_signin_support === true) {
       if (this.connection_mode === 'SESSION') {
         this.connection_mode = 'API';
@@ -652,7 +652,7 @@ export default class BackendAILogin extends BackendAIPage {
     this.blockPanel.hide();
   }
 
-  _trimChar(str: string) {
+  private _trimChar(str: string) {
     return str.replace(/^\|+|\|+$/g, '');
   }
 
@@ -660,7 +660,7 @@ export default class BackendAILogin extends BackendAIPage {
    * Load configuration file from the WebServer when using Session mode.
    *
    * */
-  _loadConfigFromWebServer() {
+  private _loadConfigFromWebServer() {
     if (!window.location.href.startsWith(this.api_endpoint)) {
       // Override configs with Webserver's config.
       const webuiEl = document.querySelector('backend-ai-webui');
@@ -735,7 +735,7 @@ export default class BackendAILogin extends BackendAIPage {
    *
    * @param {boolean} showError
    * */
-  async _checkLoginUsingSession(showError = true) {
+  private async _checkLoginUsingSession(showError = true) {
     if (this.api_endpoint === '') {
       return Promise.resolve(false);
     }
@@ -771,7 +771,7 @@ export default class BackendAILogin extends BackendAIPage {
   /**
    * Show signup dialog. And notify message if API Endpoint is empty.
    * */
-  _showSignupDialog() {
+  private _showSignupDialog() {
     this.api_endpoint = this.api_endpoint.trim();
     if (this.api_endpoint === '') {
       this.notification.text = _text('error.APIEndpointIsEmpty');
@@ -784,11 +784,11 @@ export default class BackendAILogin extends BackendAIPage {
     signupDialog.open();
   }
 
-  _showChangePasswordEmailDialog() {
+  private _showChangePasswordEmailDialog() {
     (this.shadowRoot?.querySelector('#change-password-confirm-dialog') as HTMLElementTagNameMap['backend-ai-dialog']).show();
   }
 
-  async _sendChangePasswordEmail() {
+  private async _sendChangePasswordEmail() {
     const emailEl = this.shadowRoot?.querySelector('#password-change-email') as TextField;
     if (!emailEl.value || !emailEl.validity.valid) return;
     try {
@@ -810,27 +810,27 @@ export default class BackendAILogin extends BackendAIPage {
     }
   }
 
-  _cancelLogin(e) {
+  private _cancelLogin(e) {
     this._hideDialog(e);
     this.open();
   }
 
-  _validate_data(value) {
+  private _validate_data(value) {
     if (value !== undefined && value !== null && value !== '') {
       return true;
     }
     return false;
   }
 
-  _submitIfEnter(e) {
+  private _submitIfEnter(e) {
     if (e.keyCode === 13) this._login();
   }
 
-  _signoutIfEnter(e) {
+  private _signoutIfEnter(e) {
     if (e.keyCode === 13) this._signout();
   }
 
-  _signout() {
+  private _signout() {
     const user_id = (this.shadowRoot?.querySelector('#id_signout_user_id') as TextField).value;
     const password = (this.shadowRoot?.querySelector('#id_signout_password') as TextField).value;
     this.client.signout(user_id, password).then((response) => {
@@ -856,7 +856,7 @@ export default class BackendAILogin extends BackendAIPage {
     });
   }
 
-  _login() {
+  private _login() {
     const loginAttempt = globalThis.backendaioptions.get('login_attempt', 0, 'general');
     const lastLogin = globalThis.backendaioptions.get('last_login', Math.floor(Date.now() / 1000), 'general');
     const currentTime = Math.floor(Date.now() / 1000);
@@ -990,7 +990,7 @@ export default class BackendAILogin extends BackendAIPage {
    *
    * @param {boolean} showError
    * */
-  _connectUsingAPI(showError = true) {
+  private _connectUsingAPI(showError = true) {
     this.clientConfig = new ai.backend.ClientConfig(
       this.api_key,
       this.secret_key,
@@ -1011,7 +1011,7 @@ export default class BackendAILogin extends BackendAIPage {
    *
    * @param {boolean} showError
    * */
-  _connectGQL(showError = true) {
+  private _connectGQL(showError = true) {
     // Test connection
     if (this.loginPanel.open !== true) {
       this.block();
@@ -1053,7 +1053,7 @@ export default class BackendAILogin extends BackendAIPage {
    *
    * @return {Void}
    * */
-  _connectViaGQL() {
+  private _connectViaGQL() {
     const fields = ['user_id', 'resource_policy', 'user'];
     const q = `query { keypair { ${fields.join(' ')} } }`;
     const v = {};
@@ -1180,21 +1180,21 @@ export default class BackendAILogin extends BackendAIPage {
     localStorage.removeItem('backendaiwebui.login.password');
   }
 
-  _toggleEndpoint() {
+  private _toggleEndpoint() {
     const endpoint_list = this.shadowRoot?.querySelector('#endpoint-list') as Menu;
     const endpoint_button = this.shadowRoot?.querySelector('#endpoint-button') as IconButton;
     endpoint_list.anchor = endpoint_button;
     endpoint_list.open = !endpoint_list.open;
   }
 
-  _updateEndpoint() {
+  private _updateEndpoint() {
     const endpoint_list = this.shadowRoot?.querySelector('#endpoint-list') as Menu;
     if (endpoint_list.selected && !(endpoint_list.selected instanceof Array)) {
       this.api_endpoint = endpoint_list.selected.value;
     }
   }
 
-  _deleteEndpoint(endpoint) {
+  private _deleteEndpoint(endpoint) {
     const idx = this.endpoints.indexOf(endpoint);
     if (idx > -1) {
       this.endpoints.splice(idx, 1);
@@ -1203,7 +1203,7 @@ export default class BackendAILogin extends BackendAIPage {
     this.requestUpdate();
   }
 
-  _disableUserInput() {
+  private _disableUserInput() {
     if (this.connection_mode === 'SESSION') {
       this.userIdInput.disabled = true;
       this.passwordInput.disabled = true;
@@ -1214,13 +1214,13 @@ export default class BackendAILogin extends BackendAIPage {
     (this.shadowRoot?.querySelector('.waiting-animation') as HTMLDivElement).style.display = 'flex';
   }
 
-  _enableUserInput() {
+  private _enableUserInput() {
     this.userIdInput.disabled = false;
     this.passwordInput.disabled = false;
     (this.shadowRoot?.querySelector('.waiting-animation') as HTMLDivElement).style.display = 'none';
   }
 
-  render() {
+  protected render() {
     // language=HTML
     return html`
       <link rel="stylesheet" href="resources/custom.css">

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -652,10 +652,6 @@ export default class BackendAILogin extends BackendAIPage {
     this.blockPanel.hide();
   }
 
-  private _trimChar(str: string) {
-    return str.replace(/^\|+|\|+$/g, '');
-  }
-
   /**
    * Load configuration file from the WebServer when using Session mode.
    *
@@ -813,13 +809,6 @@ export default class BackendAILogin extends BackendAIPage {
   private _cancelLogin(e) {
     this._hideDialog(e);
     this.open();
-  }
-
-  private _validate_data(value) {
-    if (value !== undefined && value !== null && value !== '') {
-      return true;
-    }
-    return false;
   }
 
   private _submitIfEnter(e) {

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -197,11 +197,6 @@ export default class BackendAILogin extends BackendAIPage {
           --button-font-size: 12px;
         }
 
-        wl-icon {
-          --icon-size: 16px;
-          padding: 0;
-        }
-
         .title-img {
           height: 35px;
           padding: 15px 0 15px 5px;

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -101,8 +101,10 @@ export default class BackendAILogin extends BackendAIPage {
   @query('#id_api_endpoint_container') apiEndpointContainer!: HTMLDivElement;
   @query('#id_api_endpoint') apiEndpointInput!: TextField;
   @query('#id_api_endpoint_humanized') apiEndpointHumanizedInput!: TextField;
-  @query('#id_user_id') userIdInput!: HTMLInputElement;
-  @query('#id_password') passwordInput!: HTMLInputElement;
+  @query('#id_user_id') userIdInput!: TextField;
+  @query('#id_password') passwordInput!: TextField;
+  @query('#id_api_key') apiKeyInput!: TextField;
+  @query('#id_secret_key') secretKeyInput!: TextField;
 
   constructor() {
     super();
@@ -883,8 +885,8 @@ export default class BackendAILogin extends BackendAIPage {
         this._connectUsingSession(true);
       }
     } else {
-      this.api_key = (this.shadowRoot?.querySelector('#id_api_key') as TextField).value;
-      this.secret_key = (this.shadowRoot?.querySelector('#id_secret_key') as TextField).value;
+      this.api_key = this.apiKeyInput.value;
+      this.secret_key = this.secretKeyInput.value;
 
       if (!this.api_key || this.api_key === 'undefined' || !this.secret_key || this.secret_key === 'undefined') {
         this.notification.text = _text('login.PleaseInputLoginInfo');
@@ -1207,8 +1209,8 @@ export default class BackendAILogin extends BackendAIPage {
       this.userIdInput.disabled = true;
       this.passwordInput.disabled = true;
     } else {
-      this.userIdInput.disabled = true;
-      this.passwordInput.disabled = true;
+      this.apiKeyInput.disabled = true;
+      this.secretKeyInput.disabled = true;
     }
     (this.shadowRoot?.querySelector('.waiting-animation') as HTMLDivElement).style.display = 'flex';
   }
@@ -1216,6 +1218,8 @@ export default class BackendAILogin extends BackendAIPage {
   private _enableUserInput() {
     this.userIdInput.disabled = false;
     this.passwordInput.disabled = false;
+    this.apiKeyInput.disabled = false;
+    this.secretKeyInput.disabled = false;
     (this.shadowRoot?.querySelector('.waiting-animation') as HTMLDivElement).style.display = 'none';
   }
 


### PR DESCRIPTION
## Description

The login page has some issue related between SESSION and IAM login type. I cherry picked commit that patches login page typing from #1359

### 1. UI issue

I fixed the SESSION and IAM login form to use same component (mwc-textfield).

**(after)**
| SESSION | IAM |
|------|-------|
| <img width="475" alt="image" src="https://user-images.githubusercontent.com/5039744/184501005-caafde4d-1c8c-4244-95fe-9440ec7c19c8.png"> | <img width="463" alt="image" src="https://user-images.githubusercontent.com/5039744/184501010-a04611a4-7f92-49e3-a356-024d64ba2034.png"> |

**(before)**
| E-mail | IAM |
|--|--|
| ![image](https://user-images.githubusercontent.com/5039744/184501661-05416b07-2529-49e1-9fac-2ff090e0e961.png)  | ![image](https://user-images.githubusercontent.com/5039744/184501708-62da1a24-f68d-4847-8cfa-af78a3be8446.png) |


### 2. loading

I fixed IAM login behavior.

- attemption with empty api and secret key causes infinite loading
  - check input value existence and prevent attemption if it is empty.
- enable user input if IAM login failed
- refactor and improve login method returns

### To Do

- add IAM login error handling

## Changes

- remove inline-style from html template
  - apply id and class based styles
  - improve template readability
- apply mwc-textfield to SESSION login user input
- enhance compare operator (`==` -> `===`, `!=` -> `!==`)
- remove weightless imports and related styles (because it is no longer used)
- specify type for client, clientConfig property
- fix disable / enable user input method to control appropriate element

This fixes #1410 