### PR TITLE
ci: pr auto author assign

### DIFF
--- a/.github/workflows/auto_author_assign.yml
+++ b/.github/workflows/auto_author_assign.yml
@@ -1,0 +1,14 @@
+name: 'Auto Author Assign'
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.4.0


### PR DESCRIPTION
Most prs are assigned by the author, but there are some that are missing.
Automate this through github actions