### PR TITLE
Hotfix: Temporally disable terminate and container commit on running session

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1851,7 +1851,7 @@ export default class BackendAiSessionList extends BackendAIPage {
             </mwc-icon-button>
           ` : html``}
           ${(this._isRunning && !this._isPreparing(rowData.item.status)) || this._isError(rowData.item.status) ? html`
-            <mwc-icon-button class="fg red controls-running" ?disabled=${!this._isPending(rowData.item.status) && rowData.item?.commit_status === 'duplicated'}
+            <mwc-icon-button class="fg red controls-running" ?disabled=${!this._isPending(rowData.item.status) && rowData.item?.commit_status as CommitSessionStatus === 'ongoing'}
                                icon="power_settings_new" @click="${(e) => this._openTerminateSessionDialog(e)}"></mwc-icon-button>
           ` : html``}
           ${(this._isRunning && !this._isPreparing(rowData.item.status) || this._APIMajorVersion > 4) && !this._isPending(rowData.item.status) ? html`
@@ -1868,7 +1868,7 @@ export default class BackendAiSessionList extends BackendAIPage {
                              ?disabled=${this._isPending(rowData.item.status) ||
                                          this._isPreparing(rowData.item.status) ||
                                          this._isError(rowData.item.status) ||
-                                         rowData.item.commit_status === 'duplicated'}
+                                         rowData.item.commit_status as CommitSessionStatus === 'ongoing'}
                              icon="archive" @click="${(e) => this._openCommitSessionDialog(e)}"></mwc-icon-button>
           ` : html``}
         </div>

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -604,7 +604,7 @@ export default class BackendAiSessionList extends BackendAIPage {
     }
     const group_id = globalThis.backendaiclient.current_group_id();
 
-    if (this._isContainerCommitEnabled) {
+    if (this._isContainerCommitEnabled && status.includes('RUNNING')) {
       fields.push('commit_status');
     }
 

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -428,6 +428,10 @@ export default class BackendAiSessionList extends BackendAIPage {
     return status === 'PENDING';
   }
 
+  _isFinished(status) {
+    return ['TERMINATED', 'CANCELLED', 'TERMINATING'].includes(status);
+  }
+
   firstUpdated() {
     this.spinner = this.shadowRoot.querySelector('#loading-spinner');
     this._grid = this.shadowRoot.querySelector('#list-grid');
@@ -1868,6 +1872,7 @@ export default class BackendAiSessionList extends BackendAIPage {
                              ?disabled=${this._isPending(rowData.item.status) ||
                                          this._isPreparing(rowData.item.status) ||
                                          this._isError(rowData.item.status) ||
+                                         this._isFinished(rowData.item.status) ||
                                          rowData.item.commit_status as CommitSessionStatus === 'ongoing'}
                              icon="archive" @click="${(e) => this._openCommitSessionDialog(e)}"></mwc-icon-button>
           ` : html``}


### PR DESCRIPTION
### Description
This PR fixes and applies minor updates which haven't been applied via #1412 by accident.
1. Regression of disabling container commit request icon button in certain situations:
   - when container commit is ongoing
   - when the corresponding session is terminated
2. Only add `commit_status` when requesting and receiving the session list for `RUNNING` tab, not in all tabs.

### Screenshots
- FINISHED tab which lists TERMINATED Sessions
   ![Screen Shot 2022-08-19 at 12 24 55 AM](https://user-images.githubusercontent.com/46954439/185433473-3db0a8b7-26c8-40b1-967a-3d7e5c64bec0.png)
   
- When container commit operation is available; no container commit operation is on-going
   ![Screen Shot 2022-08-19 at 12 25 07 AM](https://user-images.githubusercontent.com/46954439/185433494-f64105ed-b854-423f-9e33-1ebb615d2e8a.png)
- When container commit operation is in progress
   ![Screen Shot 2022-08-19 at 12 25 13 AM](https://user-images.githubusercontent.com/46954439/185433506-25c985d2-6f3d-4c2f-972e-5a46d74323cf.png)
