### PR TITLE
fix: automatically set the height of `list-wrapper`, which wraps grids, to avoid the height mismatch between the two elements

### DIFF
--- a/src/components/backend-ai-general-styles.ts
+++ b/src/components/backend-ai-general-styles.ts
@@ -881,7 +881,7 @@ export const BackendAiStyles = [
     }
 
     div.list-wrapper {
-      height: calc(100vh - 235px);
+      height: auto;
     }
 
     div.blank-box {


### PR DESCRIPTION
## Description
This PR resolves #1434.

## Screenshots
- before
![shrink-and-expand-problem](https://user-images.githubusercontent.com/46954439/185962007-99daaaff-8112-4c6f-bef9-494773eb2fc6.gif)

- after
![shrink-and-expand-problem-solved](https://user-images.githubusercontent.com/46954439/185962019-37f70437-ca2b-4e71-ac80-cc567d57847e.gif)
