### PR TITLE
fix: CUDA utilization was displayed as `Infinity`

### DIFF
--- a/src/components/backend-ai-agent-list.ts
+++ b/src/components/backend-ai-agent-list.ts
@@ -811,7 +811,16 @@ export default class BackendAIAgentList extends BackendAIPage {
         });
         liveStat.cuda_util!.capacity = parseFloat(rowData.item.live_stat.node.cuda_util.capacity ?? 0);
         liveStat.cuda_util!.current = parseFloat(rowData.item.live_stat.node.cuda_util.current);
-        liveStat.cuda_util!.ratio = (liveStat.cuda_util!.current / liveStat.cuda_util!.capacity ?? 100) || 0;
+        // NOTE: cuda_util.capacity is reported as 0 from the server. In that case,
+        //       we manually set it to 100 to properly display the GPU utilization.
+        // liveStat.cuda_util!.ratio = (liveStat.cuda_util!.current / liveStat.cuda_util!.capacity ?? 100) || 0;
+        let cudaUtilCapacity;
+        if (liveStat.cuda_util!.capacity || liveStat.cuda_util!.capacity === 0) {
+          cudaUtilCapacity = 100;
+        } else {
+          cudaUtilCapacity = liveStat.cuda_util!.capacity;
+        }
+        liveStat.cuda_util!.ratio = (liveStat.cuda_util!.current / cudaUtilCapacity) || 0;
       }
       if (rowData.item.live_stat && rowData.item.live_stat.node && rowData.item.live_stat.devices) {
         const numCores = Object.keys(rowData.item.live_stat.devices.cpu_util).length;


### PR DESCRIPTION
Server reports the `cuda_util.capacity` to 0. In this case, the GPU
utilization per node is displayed as `Infinity`.
