### PR TITLE
fix: disable container commit when session is batch type

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -77,6 +77,12 @@ type CommitSessionInfo = {
  */
 type CommitSessionStatus = 'ready' | 'ongoing';
 
+/**
+ * Type of sesion type
+ * - INTERACTIVE: execute in prompt, terminate on-demand
+ * - BATCH: apply execution date and time, and automatically terminated when command is done
+ */
+type SessionType = "INTERACTIVE" | "BATCH";
 @customElement('backend-ai-session-list')
 export default class BackendAiSessionList extends BackendAIPage {
   public shadowRoot: any;
@@ -1885,6 +1891,7 @@ export default class BackendAiSessionList extends BackendAIPage {
                                          this._isPreparing(rowData.item.status) ||
                                          this._isError(rowData.item.status) ||
                                          this._isFinished(rowData.item.status) ||
+                                         rowData.item.type as SessionType === 'BATCH' ||
                                          rowData.item.commit_status as CommitSessionStatus === 'ongoing'}
                              icon="archive" @click="${(e) => this._openCommitSessionDialog(e)}"></mwc-icon-button>
           ` : html``}

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -756,13 +756,14 @@ export default class BackendAiSessionList extends BackendAIPage {
       }
       if (['batch', 'interactive'].includes(this.condition)) {
         const result = sessions.reduce((res, session) => {
-          res[session.type === 'BATCH' ? 'batch' : 'interactive'].push(session);
+          res[session.type === 'BATCH' as SessionType ? 'batch' : 'interactive'].push(session);
           return res;
         }, {batch: [], interactive: []});
         sessions = result[this.condition === 'batch' ? 'batch': 'interactive'];
       }
 
       this.compute_sessions = sessions;
+      this._grid.recalculateColumnWidths();
       this.requestUpdate();
       let refreshTime;
       this.refreshing = false;
@@ -1839,7 +1840,7 @@ export default class BackendAiSessionList extends BackendAIPage {
       (rowData.item.user_email === globalThis.backendaiclient.email);
     render(
       html`
-        <div id="controls" class="layout horizontal flex center"
+        <div id="controls" class="layout horizontal wrap center"
              .session-uuid="${rowData.item.session_id}"
              .session-name="${rowData.item[this.sessionNameField]}"
              .access-key="${rowData.item.access_key}"
@@ -2346,7 +2347,7 @@ export default class BackendAiSessionList extends BackendAIPage {
         </div>
       </div>
       <div class="list-wrapper">
-        <vaadin-grid id="list-grid" theme="row-stripes column-borders compact" aria-label="Session list"
+        <vaadin-grid id="list-grid" theme="row-stripes column-borders compact wrap-cell-content" aria-label="Session list"
           .items="${this.compute_sessions}" height-by-rows>
           ${this._isRunning ? html`
             <vaadin-grid-column frozen width="40px" flex-grow="0" text-align="center" .renderer="${this._boundCheckboxRenderer}">
@@ -2365,7 +2366,7 @@ export default class BackendAiSessionList extends BackendAIPage {
           <vaadin-grid-filter-column width="120px" path="status" header="${_t('session.Status')}" resizable
                                      .renderer="${this._boundStatusRenderer}">
           </vaadin-grid-filter-column>
-          <vaadin-grid-column width="260px" resizable header="${_t('general.Control')}"
+          <vaadin-grid-column width=${this._isContainerCommitEnabled ? "260px": "210px"} flex-grow="0" resizable header="${_t('general.Control')}"
                               .renderer="${this._boundControlRenderer}"></vaadin-grid-column>
           <vaadin-grid-column auto-width flex-grow="0" resizable header="${_t('session.Configuration')}"
                               .renderer="${this._boundConfigRenderer}"></vaadin-grid-column>

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -2347,7 +2347,7 @@ export default class BackendAiSessionList extends BackendAIPage {
         </div>
       </div>
       <div class="list-wrapper">
-        <vaadin-grid id="list-grid" theme="row-stripes column-borders compact wrap-cell-content" aria-label="Session list"
+        <vaadin-grid id="list-grid" theme="row-stripes column-borders compact" aria-label="Session list"
           .items="${this.compute_sessions}" height-by-rows>
           ${this._isRunning ? html`
             <vaadin-grid-column frozen width="40px" flex-grow="0" text-align="center" .renderer="${this._boundCheckboxRenderer}">


### PR DESCRIPTION
## Description
This PR fixes two things, disable container commit icon when the session is `BATCH` type and adjust the width of Controls column depending on whether the version and configuration support container commit.

## Screenshots

#### Before

![before-container-commit-icon-arrangement-fixed](https://user-images.githubusercontent.com/46954439/186574484-afa6679c-4d0f-4132-bb7b-7b5552dee757.gif)

#### After

![after-container-commit-icon-arrangement-fixed](https://user-images.githubusercontent.com/46954439/186574425-429e6113-123f-4161-b6e1-887cc2d1d659.gif)