### PR TITLE
hotfix: remove wrong parsing number logic in initial configuration

### DIFF
--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -465,6 +465,11 @@ export default class BackendAILogin extends BackendAIPage {
     }
   }
 
+  /**
+   * Refresh global value used in Backend.Ai WebUI read from config file with keys
+   *
+   * @param {object} config
+   */
   refreshWithConfig(config) {
     if (typeof config.plugin === 'undefined' || typeof config.plugin.login === 'undefined' || config.plugin.login === '') {
       this._enableUserInput();
@@ -790,8 +795,6 @@ export default class BackendAILogin extends BackendAIPage {
  }
 
   /**
-=======
->>>>>>> fc0cf224f12c74fd2830f99581a1241cd0c878fe
    * Open loginPanel.
    * */
   open() {

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -640,7 +640,7 @@ export default class BackendAILogin extends BackendAIPage {
      {
        valueType: 'string',
        defaultValue: '',
-       value: parseInt(generalConfig?.defaultSessionEnvironment),
+       value: generalConfig?.defaultSessionEnvironment,
      } as ConfigValueObject) as string;
 
    // Default session environment value
@@ -648,7 +648,7 @@ export default class BackendAILogin extends BackendAIPage {
      {
        valueType: 'string',
        defaultValue: 'cr.backend.ai/stable/python', // 'index.docker.io/lablup/python:3.8-ubuntu18.04'
-       value: parseInt(generalConfig?.defaultImportEnvironment),
+       value: generalConfig?.defaultImportEnvironment,
      } as ConfigValueObject) as string;
 
    // Mask user info flag
@@ -665,7 +665,7 @@ export default class BackendAILogin extends BackendAIPage {
        valueType: 'array',
        defaultValue: [] as string[],
        // sanitize whitespace on user-input after splitting
-       value: (generalConfig?.singleSignOnVendors  ?? '').split(',').map(el => el.trim()),
+       value: (generalConfig?.singleSignOnVendors) ? generalConfig?.singleSignOnVendors.split(',').map(el => el.trim()) : [],
      } as ConfigValueObject) as string[];
 
    // Enable container commit flag
@@ -790,7 +790,7 @@ export default class BackendAILogin extends BackendAIPage {
        valueType: 'array',
        defaultValue: [] as string[],
        // sanitize whitespace on user-input after splitting
-       value: (environmentsConfig?.allowlist ?? '').split(',').map(el => el.trim()),
+       value: (environmentsConfig?.allowlist) ? environmentsConfig?.allowlist.split(',').map(el => el.trim()) : [],
      } as ConfigValueObject) as string[];
  }
 


### PR DESCRIPTION
## Description
This PR fixes human error based on calling the number parsing function(e.g. `ParseInt`, `ParseFloat`, etc.) on wrong data.

Also, there was an issue with sanitizing the whitespace when reading from configuration values with commas(`,`), which are regarded as an array. when there are no values (undefined or null or empty string), It was treated as an empty string(`''`). But when appending `split(',')` function at the end, it changed to `['']`, which is different from an empty array(`[]`). Therefore I added extra conditional logic to set an empty array when the value is nullish.