### PR TITLE
fix: add title to show what the Control icons do

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -508,6 +508,8 @@
       "CloneAFolder": "Clone a folder",
       "LeaveAFolder": "Leave a folder",
       "DeleteAFolder": "Delete a folder",
+      "OpenAFolder": "Open a folder",
+      "FolderInfo": "Info",
       "TypeFolderNameToDelete": "Type folder name to delete",
       "TypeFolderNameToLeave": "Type folder name to leave",
       "Delete": "Delete",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -315,7 +315,8 @@
     "CommitFinished": "__NOT_TRANSLATED__",
     "CommitFailed": "__NOT_TRANSLATED__",
     "DescCommitSession": "__NOT_TRANSLATED__",
-    "Message": "Message"
+    "Message": "Message",
+    "EnvironmentInfo": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Annuler",
@@ -542,7 +543,9 @@
       "MaxFolderQuota": "__NOT_TRANSLATED__",
       "FolderUsage": "__NOT_TRANSLATED__",
       "FolderUsing": "__NOT_TRANSLATED__",
-      "NoFolderToDisplay": "__NOT_TRANSLATED__"
+      "NoFolderToDisplay": "__NOT_TRANSLATED__",
+      "FolderInfo": "__NOT_TRANSLATED__",
+      "OpenAFolder": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Effacer...",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -543,7 +543,9 @@
       "MaxFolderQuota": "__NOT_TRANSLATED__",
       "FolderUsage": "__NOT_TRANSLATED__",
       "FolderUsing": "__NOT_TRANSLATED__",
-      "NoFolderToDisplay": "__NOT_TRANSLATED__"
+      "NoFolderToDisplay": "__NOT_TRANSLATED__",
+      "FolderInfo": "__NOT_TRANSLATED__",
+      "OpenAFolder": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Menghapus...",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -510,6 +510,8 @@
       "CloneAFolder": "폴더 복사",
       "LeaveAFolder": "초대된 폴더 나가기",
       "DeleteAFolder": "폴더 삭제",
+      "OpenAFolder": "폴더 열기",
+      "FolderInfo": "폴더 정보",
       "TypeFolderNameToDelete": "삭제 확인을 위해 폴더 이름을 입력하세요",
       "TypeFolderNameToLeave": "연결 해제 확인을 위해 폴더 이름을 입력하세요",
       "Delete": "삭제",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -543,7 +543,9 @@
       "MaxFolderQuota": "__NOT_TRANSLATED__",
       "FolderUsage": "__NOT_TRANSLATED__",
       "FolderUsing": "__NOT_TRANSLATED__",
-      "NoFolderToDisplay": "__NOT_TRANSLATED__"
+      "NoFolderToDisplay": "__NOT_TRANSLATED__",
+      "FolderInfo": "__NOT_TRANSLATED__",
+      "OpenAFolder": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Устгах ...",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -543,7 +543,9 @@
       "MaxFolderQuota": "__NOT_TRANSLATED__",
       "FolderUsage": "__NOT_TRANSLATED__",
       "FolderUsing": "__NOT_TRANSLATED__",
-      "NoFolderToDisplay": "__NOT_TRANSLATED__"
+      "NoFolderToDisplay": "__NOT_TRANSLATED__",
+      "FolderInfo": "__NOT_TRANSLATED__",
+      "OpenAFolder": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Удалить...",

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1244,6 +1244,7 @@ export default class BackendAiStorageList extends BackendAIPage {
           <mwc-icon-button
             class="fg green controls-running"
             icon="info"
+            title=${_t('data.folders.FolderInfo')}
             @click="${(e) => this._infoFolder(e)}"
           ></mwc-icon-button>
 
@@ -1252,6 +1253,7 @@ export default class BackendAiStorageList extends BackendAIPage {
               <mwc-icon-button
                 class="fg blue controls-running"
                 icon="folder_open"
+                title=${_t('data.folders.OpenAFolder')}
                 @click="${(e) =>
     this._folderExplorer(e, (this._hasPermission(rowData.item, 'w') ||
                 rowData.item.is_owner ||
@@ -1275,6 +1277,7 @@ export default class BackendAiStorageList extends BackendAIPage {
               <mwc-icon-button
                 class="fg ${rowData.item.type == 'user' ? 'blue' : 'green'} controls-running"
                 icon="share"
+                title=${_t('data.explorer.ShareFolder')}
                 @click="${(e) => this._shareFolderDialog(e)}"
               ></mwc-icon-button>
             ` :
@@ -1286,6 +1289,7 @@ export default class BackendAiStorageList extends BackendAIPage {
               <mwc-icon-button
                 class="fg cyan controls-running"
                 icon="perm_identity"
+                title=${_t('data.explorer.ModifyPermissions')}
                 @click=${(e) => (this._modifyPermissionDialog(rowData.item.id))}
               ></mwc-icon-button>
             ` :
@@ -1296,6 +1300,7 @@ export default class BackendAiStorageList extends BackendAIPage {
               <mwc-icon-button
                 class="fg ${rowData.item.type == 'user' ? 'blue' : 'green'} controls-running"
                 icon="create"
+                title=${_t('data.folders.Rename')}
                 @click="${(e) => this._renameFolderDialog(e)}"
               ></mwc-icon-button>
             ` :
@@ -1306,6 +1311,7 @@ export default class BackendAiStorageList extends BackendAIPage {
               <mwc-icon-button
                 class="fg blue controls-running"
                 icon="settings"
+                title=${_t('data.folders.FolderOptionUpdate')}
                 @click="${(e) => this._modifyFolderOptionDialog(e)}"
               ></mwc-icon-button>
             ` :
@@ -1316,6 +1322,7 @@ export default class BackendAiStorageList extends BackendAIPage {
               <mwc-icon-button
                 class="fg red controls-running"
                 icon="delete"
+                title=${_t('data.folders.Delete')}
                 @click="${(e) => this._deleteFolderDialog(e)}"
               ></mwc-icon-button>
             ` :


### PR DESCRIPTION
## Related Issue
#1384 

<br/>

## Implementation
Previously, it wasn't able to get the information before clicking the Control icon.
So, add title attribute to show what the Control icons do.

<br/>

## Screenshot

https://user-images.githubusercontent.com/50884017/188849124-2a0cb21a-6d80-4bc3-9a7f-f1dce176def8.mov

It showed nothing when I screenshot, so I upload the recording.

<br/>

## Discussion Required
Refer to language converter(ko.json) 
if it exists, I used it, but if it does not exist, write it in English