### PR TITLE
fix: add helper dialog for endpoint

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1065,6 +1065,8 @@
     "ClickToUseID": "Click To Use ID",
     "EndpointHistory": "Endpoint History",
     "NoEndpointSaved": "No endpoint saved.",
+    "EndpointInfo": "About Endpoint",
+    "DescEndpoint": "<p>In API ENDPOINT, the URL of Backend.AI Webserver, which relays the request to the Manager, should be entered.</p><p>e.g., http://127.0.0.1:8090/</p>",
     "CancelLogin": "Cancel Login",
     "SignoutFinished": "Signout finished.",
     "APIEndpointEmpty": "API Endpoint is empty. Please specify API endpoint to login.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1086,7 +1086,9 @@
     "TooManyAttempt": "Il y a eu trop de tentatives de connexion. Les tentatives de connexion sont bloquées depuis un certain temps.",
     "SingleSignOn": {
       "LoginWithSAML": "__NOT_TRANSLATED__"
-    }
+    },
+    "EndpointInfo": "__NOT_TRANSLATED__",
+    "DescEndpoint": "__NOT_TRANSLATED__"
   },
   "signup": {
     "SignupBETA": "Inscription (invitation bêta uniquement)",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1086,7 +1086,9 @@
     "TooManyAttempt": "Ada terlalu banyak upaya login. Upaya login telah diblokir untuk sementara waktu.",
     "SingleSignOn": {
       "LoginWithSAML": "__NOT_TRANSLATED__"
-    }
+    },
+    "EndpointInfo": "__NOT_TRANSLATED__",
+    "DescEndpoint": "__NOT_TRANSLATED__"
   },
   "signup": {
     "SignupBETA": "Pendaftaran (khusus undangan Beta)",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1067,6 +1067,8 @@
     "ClickToUseID": "ID 사용",
     "EndpointHistory": "엔드포인트 기록",
     "NoEndpointSaved": "저장된 엔드포인트가 없습니다.",
+    "EndpointInfo": "엔드포인트 안내",
+    "DescEndpoint": "<p>엔트포인트에는 Manager로의 연결을 중계하는 Backend.AI Webserver가 작동하고 있는 URL을 작성해주시면 됩니다.</p><p>e.g., http://127.0.0.1:8090/</p>",
     "CancelLogin": "로그인 취소",
     "SignoutFinished": "탈퇴가 완료되었습니다.",
     "APIEndpointEmpty": "API Endpoint 가 지정되지 않았습니다. 로그인을 위해 앤드포인트를 지정하세요.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1086,7 +1086,9 @@
     "TooManyAttempt": "Хэт олон нэвтрэх оролдлого хийсэн. Нэвтрэх оролдлогыг хэсэг хугацаанд хаасан байна.",
     "SingleSignOn": {
       "LoginWithSAML": "__NOT_TRANSLATED__"
-    }
+    },
+    "EndpointInfo": "__NOT_TRANSLATED__",
+    "DescEndpoint": "__NOT_TRANSLATED__"
   },
   "signup": {
     "SignupBETA": "Бүртгүүлэх (зөвхөн бета урилга)",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1086,7 +1086,9 @@
     "TooManyAttempt": "Слишком много попыток входа в систему. Попытки входа в систему на время заблокированы.",
     "SingleSignOn": {
       "LoginWithSAML": "__NOT_TRANSLATED__"
-    }
+    },
+    "EndpointInfo": "__NOT_TRANSLATED__",
+    "DescEndpoint": "__NOT_TRANSLATED__"
   },
   "signup": {
     "SignupBETA": "Регистрация (только приглашение в бета-версию)",

--- a/src/components/backend-ai-general-styles.ts
+++ b/src/components/backend-ai-general-styles.ts
@@ -642,6 +642,11 @@ export const BackendAiStyles = [
       color: #222222;
     }
 
+    .fg.grey {
+      color: var(--paper-grey-600) !important;
+      --mdc-theme-on-primary: var(--paper-grey-600) !important;
+    }
+
     .fg.blue {
       color: var(--paper-light-blue-400) !important;
       --mdc-theme-on-primary: var(--paper-light-blue-400) !important;

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -6,6 +6,7 @@
 import {get as _text, translate as _t} from 'lit-translate';
 import {css, CSSResultGroup, html} from 'lit';
 import {customElement, property, query} from 'lit/decorators.js';
+import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
 import '@material/mwc-button';
 import '@material/mwc-icon';
@@ -112,6 +113,8 @@ export default class BackendAILogin extends BackendAIPage {
   @property({type: Array}) endpoints;
   @property({type: Object}) logoutTimerBeforeOneMin;
   @property({type: Object}) logoutTimer;
+  @property({type: String}) _helpDescription = '';
+  @property({type: String}) _helpDescriptionTitle = '';
   private _enableContainerCommit = false;
   private _enablePipeline = false;
   @query('#login-panel') loginPanel!: HTMLElementTagNameMap['backend-ai-dialog'];
@@ -124,6 +127,7 @@ export default class BackendAILogin extends BackendAIPage {
   @query('#id_password') passwordInput!: TextField;
   @query('#id_api_key') apiKeyInput!: TextField;
   @query('#id_secret_key') secretKeyInput!: TextField;
+  @query('#help-description') helpDescriptionDialog!: BackendAIDialog;
 
   constructor() {
     super();
@@ -249,6 +253,14 @@ export default class BackendAILogin extends BackendAIPage {
         #endpoint-button {
           padding-left: 3px;
           background-color: rgb(250, 250, 250);
+        }
+
+        #help-description {
+          --component-width: 350px;
+        }
+
+        #help-description p {
+          padding: 5px !important;
         }
 
         .login-input {
@@ -1491,6 +1503,15 @@ export default class BackendAILogin extends BackendAIPage {
     (this.shadowRoot?.querySelector('.waiting-animation') as HTMLDivElement).style.display = 'none';
   }
 
+  private _showEndpointDescription(e?) {
+    if (e != undefined) {
+      e.stopPropagation();
+    }
+    this._helpDescriptionTitle = _text('login.EndpointInfo');
+    this._helpDescription = _text('login.DescEndpoint');
+    this.helpDescriptionDialog.show();
+  }
+
   protected render() {
     // language=HTML
     return html`
@@ -1582,6 +1603,7 @@ export default class BackendAILogin extends BackendAIPage {
                       value="${this.api_endpoint}"
                       @keyup="${this._submitIfEnter}">
                   </mwc-textfield>
+                  <mwc-icon-button icon="info" class="fg grey info" @click="${(e) => this._showEndpointDescription(e)}"></mwc-icon-button>
                 </div>
                 <mwc-textfield class="endpoint-text" type="text" id="id_api_endpoint_humanized"
                     maxLength="2048" style="display:none;"
@@ -1684,6 +1706,12 @@ export default class BackendAILogin extends BackendAIPage {
             </mwc-button>
           </div>
         ` : html``}
+      </backend-ai-dialog>
+      <backend-ai-dialog id="help-description" fixed backdrop>
+        <span slot="title">${this._helpDescriptionTitle}</span>
+        <div slot="content" class="horizontal layout center" style="margin:10px;">
+          <div style="font-size:14px;">${unsafeHTML(this._helpDescription)}</div>
+        </div>
       </backend-ai-dialog>
       <backend-ai-signup id="signup-dialog"></backend-ai-signup>
     `;


### PR DESCRIPTION
## Related Issue
#1468  

<br/>

## Implementation
Previously, it's hard to know what endpoint means.
So, add an info icon and helper dialog about endpoint.

<br/>

## Screenshot
Added the info icon next to endpoint text field in the login page. (@Sujin-Kim1 suggested grey color) <img width="1133" alt="image" src="https://user-images.githubusercontent.com/50884017/189901362-a34c531e-30c6-4c61-9ec3-bdb44bf0bc94.png">


When clicking the info icon button, the helper dialog appears. 
It contains the meaning and examples of endpoints. <img width="1133" alt="image" src="https://user-images.githubusercontent.com/50884017/189902814-e6e5be02-e71b-48ed-9e8e-9511e31d7282.png">

I added descriptions in English and Korean according to [Backend.AI Web-UI User Guide](https://webui.docs.backend.ai/en/latest/login/login.html). <img width="1133" alt="image" src="https://user-images.githubusercontent.com/50884017/189902572-68ec4c63-db7e-4ba8-8614-47088c775a28.png">


<br/>

## Discussion Required
nothing

<br/>