### PR TITLE
style: adjust the License Key button size

### DIFF
--- a/src/components/backend-ai-information-view.ts
+++ b/src/components/backend-ai-information-view.ts
@@ -283,7 +283,7 @@ export default class BackendAiInformationView extends BackendAIPage {
                 <div class="description">${_t('information.DescLicenseKey')}
                 </div>
               </div>
-              <div class="horizontal center end-justified layout setting-label monospace indicator">
+              <div class="horizontal center end-justified layout setting-label">
                 <p class="label">${this.license_key}</p>
               </div>
             </div>


### PR DESCRIPTION
### This PR Fixes https://github.com/lablup/backend.ai-webui/issues/1475

### Changes
Adjust the License Key button size to be the same as the other buttons.

### Before
<img width="884" alt="image" src="https://user-images.githubusercontent.com/67859819/190161629-56a05232-7ee0-4ae9-9ba1-fce6694c87a7.png">
<img width="920" alt="image" src="https://user-images.githubusercontent.com/67859819/190161267-0c15b885-874b-4ac3-8c41-18957413f878.png">

### After
<img width="890" alt="image" src="https://user-images.githubusercontent.com/67859819/190161541-39ad80d0-4cb9-4f2d-9a5c-398984b59ffb.png">
<img width="875" alt="image" src="https://user-images.githubusercontent.com/67859819/190161401-1e8d06c4-b385-4380-b3f7-7a31b09dfa12.png">
