### PR TITLE
fix: Cannot set the maximum shared memory size via configuration

### DIFF
--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -783,7 +783,7 @@ export default class BackendAILogin extends BackendAIPage {
      {
        valueType: 'number',
        defaultValue: 2,
-       value: parseFloat(resourcesConfig?.maxShmPerContainerr),
+       value: parseFloat(resourcesConfig?.maxShmPerContainer),
      } as ConfigValueObject) as number;
 
     // Max File Upload size number


### PR DESCRIPTION
This PR fixes typo in configuration read logic, preventing to set the maximum shared memory size via configuration.