### PR TITLE
fix: remove the invalid redirect URL for vnc-web

### DIFF
--- a/resources/app_template.json
+++ b/resources/app_template.json
@@ -151,7 +151,7 @@
         "name": "vnc-web",
         "title": "VNC (Web)",
         "category": "6.Desktop Environment",
-        "redirect": "/vnc.html?host=<proxy-host>&port=<port-number>&password=backendai&autoconnect=true",
+        "redirect": "",
         "src": "./resources/icons/novnc.svg"
       }
     ],


### PR DESCRIPTION
When I try to launch a `vnc-web` application, Web-UI opens up the invalid redirect URL, which contains `<proxy-host>` and `<port-number>` like below:
![e4af8009-9477-418b-8b33-0cac71067529](https://user-images.githubusercontent.com/7539358/197331603-80436ae1-6f5a-4da9-a0c8-ac4dc79423f1.jpg)

This PR removes the URL since it is not working and prevent the loading of the `url_template` in service definition file.
