### PR TITLE
fix: show session language description

### DIFF
--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2540,7 +2540,6 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     e.stopPropagation();
     const name = item.kernelname;
     if (name in this.resourceBroker.imageInfo && 'description' in this.resourceBroker.imageInfo[name]) {
-      // TODO define extended type for custom properties
       this._helpDescriptionTitle = this.resourceBroker.imageInfo[name].name;
       this._helpDescription = this.resourceBroker.imageInfo[name].description || _text('session.launcher.NoDescriptionFound');
       this._helpDescriptionIcon = item.icon;

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2541,9 +2541,9 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     const name = item.kernelname;
     if (name in this.resourceBroker.imageInfo && 'description' in this.resourceBroker.imageInfo[name]) {
       // TODO define extended type for custom properties
-      (this.helpDescriptionDialog as any)._helpDescriptionTitle = this.resourceBroker.imageInfo[name].name;
-      (this.helpDescriptionDialog as any)._helpDescription = this.resourceBroker.imageInfo[name].description;
-      (this.helpDescriptionDialog as any)._helpDescriptionIcon = item.icon;
+      this._helpDescriptionTitle = this.resourceBroker.imageInfo[name].name;
+      this._helpDescription = this.resourceBroker.imageInfo[name].description || _text('session.launcher.NoDescriptionFound');
+      this._helpDescriptionIcon = item.icon;
       this.helpDescriptionDialog.show();
     } else {
       if (name in this.imageInfo) {
@@ -2603,6 +2603,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     e.stopPropagation();
     this._helpDescriptionTitle = _text('session.launcher.EnvironmentVariableTitle');
     this._helpDescription = _text('session.launcher.DescSetEnv');
+    this._helpDescriptionIcon = '';
     this.helpDescriptionDialog.show();
   }
 


### PR DESCRIPTION
resolves #1488 
- fix: session language info disappears
- Reset `_helpDescriptionIcon` to prevent unrelated icons and descriptions from appearing together as shown below.
  <img width="394" alt="image" src="https://user-images.githubusercontent.com/28584164/199425101-a96d6cd7-6268-4d45-88f4-6400b57d0750.png">
