### PR TITLE
feat: add sticky title option to `backend-ai-dialog`

### DIFF
--- a/src/components/backend-ai-dialog.ts
+++ b/src/components/backend-ai-dialog.ts
@@ -43,6 +43,7 @@ export default class BackendAiDialog extends LitElement {
   @property({type: String}) type = 'normal';
   @property({type: Boolean}) closeWithConfirmation = false;
   @property({type: String}) escapeKeyAction = 'close';
+  @property({type: Boolean}) stickyTitle = false;
 
   @query('#dialog') protected dialog;
 
@@ -116,6 +117,16 @@ export default class BackendAiDialog extends LitElement {
           height: 20px;
           border-bottom: 1px solid #DDD !important;
         }
+
+        .sticky {
+          position: sticky;
+          position: -webkit-sticky;
+          position: -moz-sticky;
+          position: -ms-sticky;
+          position: -o-sticky;
+          top: 0;
+          z-index: 10;
+        }
       `];
   }
 
@@ -123,6 +134,9 @@ export default class BackendAiDialog extends LitElement {
     this.open = this.dialog.open;
     if (this.persistent) {
       this.dialog.scrimClickAction = '';
+    }
+    if (this.stickyTitle) {
+      (this.shadowRoot?.querySelector('h3') as HTMLElement).classList.add('sticky');
     }
     this.dialog.addEventListener('opened', () => {
       this.open = this.dialog.open;


### PR DESCRIPTION
If the dialog length is long, users have to scroll up to close the dialog. So I added the `stickyTitle` option to `backend-ai-dialog`. With this option, the user can always see the dialog's title and close the dialog without scrolling.