### PR TITLE
fix: send preferred port when only checked

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -784,7 +784,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         }
       }
       const userPort = parseInt(this.appPort.value);
-      if (this.checkPreferredPort && userPort) {
+      if (this.checkPreferredPort.checked && userPort) {
         port = userPort;
       }
       this._open_wsproxy(sessionUuid, appName, port, envs, args)


### PR DESCRIPTION
It solves the problem of sending port information together without checking the preferred port when launching the session app in the WebUI.