### PR TITLE
fix: TOS dialog doesn't show because of id mismatching

### DIFF
--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -66,7 +66,7 @@ export default class BackendAiSignup extends BackendAIPage {
   @query('#signup-panel') signupPanel!: BackendAIDialog;
   @query('#block-panel') blockPanel!: BackendAIDialog;
   @query('#email-sent-dialog') emailSentDialog!: BackendAIDialog;
-  @query('#block-panel') TOSdialog!: LablupTermsOfService;
+  @query('#terms-of-service') TOSdialog!: LablupTermsOfService;
 
   static get styles(): CSSResultGroup {
     return [


### PR DESCRIPTION
In the signup dialog, all of the Terms Of Service dialog doesn't show because of the id mismatching.