### PR TITLE
feat: add support for header based authentication on wsproxy

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -60,6 +60,8 @@ export default class BackendAiAppLauncher extends BackendAIPage {
   @query('#app-port') appPort!: TextField;
   @query('#chk-open-to-public') checkOpenToPublic!: Checkbox;
   @query('#chk-preferred-port') checkPreferredPort!: Checkbox;
+  @query('#force-use-v1-proxy') forceUseV1Proxy!: Checkbox;
+  @query('#force-use-v2-proxy') forceUseV2Proxy!: Checkbox;
   @query('#app-launch-confirmation-dialog') appLaunchConfirmationDialog!: BackendAIDialog;
   @query('#ssh-dialog') sshDialog!: BackendAIDialog;
   @query('#tensorboard-dialog') tensorboardDialog!: BackendAIDialog;
@@ -351,6 +353,11 @@ export default class BackendAiAppLauncher extends BackendAIPage {
    * @return {string} wsproxy version
    */
   async _getWSProxyVersion(sessionUuid) {
+    if (globalThis.backendaiwebui.debug === true) {
+      if (this.forceUseV1Proxy.checked) return 'v1'
+      else if (this.forceUseV2Proxy.checked) return 'v2';
+    }
+
     const kInfo = await globalThis.backendaiclient.computeSession.get(['scaling_group'], sessionUuid);
     const scalingGroupId = kInfo.compute_session.scaling_group;
     const groupId = globalThis.backendaiclient.current_group_id();
@@ -481,7 +488,13 @@ export default class BackendAiAppLauncher extends BackendAIPage {
     };
     if (globalThis.backendaiclient._config.connectionMode === 'SESSION') {
       param['mode'] = 'SESSION';
-      param['session'] = globalThis.backendaiclient._config._session_id;
+      if (globalThis.backendaiclient._loginSessionId) {
+        param['auth_mode'] = 'header';
+        param['session'] = globalThis.backendaiclient._loginSessionId;
+      } else {
+        param['auth_mode'] = 'cookie';
+        param['session'] = globalThis.backendaiclient._config._session_id;
+      }
     } else {
       param['mode'] = 'API';
       param['access_key'] = globalThis.backendaiclient._config.accessKey;
@@ -1090,6 +1103,14 @@ export default class BackendAiAppLauncher extends BackendAIPage {
               <mwc-textfield id="app-port" type="number" no-label-float value="10250"
                              min="1025" max="65534" style="margin-left:1em;width:90px;"
                              @change="${(e) => this._adjustPreferredAppPortNumber(e)}"></mwc-textfield>
+            </div>
+            <div class="horizontal layout center">
+            ${globalThis.backendaiwebui.debug === true ? html`
+              <mwc-checkbox id="force-use-v1-proxy" style="margin-right:0.5em;"></mwc-checkbox>
+              Force use of V1
+              <mwc-checkbox id="force-use-v2-proxy" style="margin-right:0.5em;"></mwc-checkbox>
+              Force use of V2
+            `: ``}
             </div>
           </div>
         </div>

--- a/src/wsproxy/lib/console-appproxy.js
+++ b/src/wsproxy/lib/console-appproxy.js
@@ -42,8 +42,13 @@ module.exports = (proxy = class Proxy {
     let requestBody = '';
     let hdrs = {
       "Content-Type": "application/json",
-      "Cookie" : "AIOHTTP_SESSION=" + this._env.session
     };
+    logger.debug(`authenticating with manager by ${this._env.auth_mode} mode`)
+    if (this._env.auth_mode === "cookie") {
+      hdrs.Cookie = "AIOHTTP_SESSION=" + this._env.session;
+    } else {
+      hdrs['X-BackendAI-SessionID'] = this._env.session;
+    }
     return hdrs;
   }
 

--- a/src/wsproxy/manager.js
+++ b/src/wsproxy/manager.js
@@ -76,6 +76,7 @@ class Manager extends EventEmitter {
       if (req.body.mode && req.body.mode === "SESSION") {
         cf['mode'] = "SESSION";
         cf['session'] = req.body.session;
+        cf['auth_mode'] = req.body.auth_mode;
         cf['endpoint'] = cf['endpoint'] + "/func";
       } else {
         cf['mode'] = "API";


### PR DESCRIPTION
This PR is a follow-up of #1521, allowing wsproxy also to communicate with webserver by using header based authentication instead of traditional cookie based mode.