### PR TITLE
feat: show all resource templates when `alwaysEnqueueComputeSession` is true

### DIFF
--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -661,8 +661,10 @@ export default class BackendAiResourceBroker extends BackendAIPage {
           item.allocatable = true;
           for (const [slotKey, slotName] of Object.entries(slotList)) {
             if (slotKey in item.resource_slots && slotName in total_resource_group_slot) {
-              if (item.resource_slots[slotKey] <= total_resource_group_slot[slotName]) {
-                item[slotName] = item.resource_slots[slotKey];
+              const resourceSlot = slotKey === 'mem' ? globalThis.backendaiclient.utils.changeBinaryUnit(item.resource_slots.mem, 'g') : item.resource_slots[slotKey];
+              const totalResourceGroupSlot = total_resource_group_slot[slotName];
+              if (resourceSlot <= totalResourceGroupSlot) {
+                item[slotName] = resourceSlot;
               } else {
                 item.allocatable = false;
                 break;

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1884,12 +1884,11 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
           const cpu_metric = {...item};
           cpu_metric.min = parseInt(cpu_metric.min);
           if (enqueue_session) {
-            available_slot['cpu'] = Infinity;
-            available_slot['mem'] = Infinity;
-            available_slot['cuda_device'] = Infinity;
-            available_slot['cuda_shares'] = Infinity;
-            available_slot['rocm_device'] = Infinity;
-            available_slot['tpu_device'] = Infinity;
+            ['cpu', 'mem', 'cuda_device', 'cuda_shares', 'rocm_device', 'tpu_device'].forEach((slot) => {
+              if (slot in this.total_resource_group_slot) {
+                available_slot[slot] = this.total_resource_group_slot[slot];
+              }
+            });
           }
 
           if ('cpu' in this.userResourceLimit) {


### PR DESCRIPTION
resolve #1523 

- show all of the preset lists (resource templates) when `alwaysEnqueueComputeSession` is true.
- set allocatable resource limit according to `total_resource_group_slot` when `alwaysEnqueueComputeSession` is true to prevent automatically canceling the creation of a new session because of the lack of resources.
   - reference image
    <img width="344" alt="image" src="https://user-images.githubusercontent.com/28584164/207210916-d060afec-290e-4034-9f8c-105b276a7ff5.png">
