### PR TITLE
fix: wrapping notice-ticker to fit in the layout with bigger font-size

### DIFF
--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -562,7 +562,7 @@ export default class BackendAISummary extends BackendAIPage {
         ${this.announcement != '' ? html`
           <div class="notice-ticker horizontal layout wrap flex">
             <lablup-shields app="" color="red" description="Notice" ui="round"></lablup-shields>
-            <span style="">${this._stripHTMLTags(this.announcement)}</span>
+            <span>${this._stripHTMLTags(this.announcement)}</span>
           </div>
         ` : html``}
         <div class="horizontal wrap layout">

--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -200,8 +200,15 @@ export default class BackendAISummary extends BackendAIPage {
           margin-top: 10px;
           font-size: 13px;
           font-weight: 400;
-          height: 35px;
+          height: auto;
+          max-width: 1000px;
           overflow-y: scroll;
+        }
+
+        .notice-ticker > span {
+          display: inline-block;
+          white-space: pre-line;
+          font-size: 1rem;
         }
 
         .notice-ticker lablup-shields {
@@ -326,9 +333,16 @@ export default class BackendAISummary extends BackendAIPage {
           --card-background-color: var(--general-sidepanel-color);
         }
 
+        @media screen and (max-width: 899px) {
+          .notice-ticker {
+            justify-content: left !important;
+          }
+        }
+
         @media screen and (max-width: 850px) {
           .notice-ticker {
             margin-left: 0px;
+            width: auto;
           }
 
           .notice-ticker > span {
@@ -544,11 +558,11 @@ export default class BackendAISummary extends BackendAIPage {
     // language=HTML
     return html`
       <link rel="stylesheet" href="/resources/fonts/font-awesome-all.min.css">
-      <div class="item" elevation="1">
+      <div class="item" elevation="1" class="vertical layout center wrap flex">
         ${this.announcement != '' ? html`
-          <div class="notice-ticker horizontal center layout wrap flex">
+          <div class="notice-ticker horizontal layout wrap flex">
             <lablup-shields app="" color="red" description="Notice" ui="round"></lablup-shields>
-            <span>${this._stripHTMLTags(this.announcement)}</span>
+            <span style="">${this._stripHTMLTags(this.announcement)}</span>
           </div>
         ` : html``}
         <div class="horizontal wrap layout">


### PR DESCRIPTION
This PR resolves #1557.

### Screenshot(s)
- before
<img width="1532" alt="Screenshot 2023-01-27 at 8 09 16 PM" src="https://user-images.githubusercontent.com/46954439/215072692-21963c4e-30b5-4d4b-a1e6-31b8bfbdde4c.png">

- after
<img width="1365" alt="Screenshot 2023-01-27 at 8 08 29 PM" src="https://user-images.githubusercontent.com/46954439/215072806-476de4df-9965-44d8-9fdf-cad173de4830.png">
<img width="686" alt="Screenshot 2023-01-27 at 8 08 48 PM" src="https://user-images.githubusercontent.com/46954439/215072727-a28283eb-2d26-4982-9ecb-fdafb76e47c7.png">
