### PR TITLE
feat: add disk column on agent tab and display the total capacity of the storage

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -371,7 +371,8 @@
     "BackendType": "Backend Type",
     "Capabilities": "Capabilities",
     "NoAgentToDisplay": "No Agents to display",
-    "NoNetworkSignal": "No network signals."
+    "NoNetworkSignal": "No network signals.",
+    "DiskPerc": "Disk %"
   },
   "general": {
     "cores": "cores",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -374,7 +374,8 @@
     "NoAgentToDisplay": "__NOT_TRANSLATED__",
     "Utilization": "__NOT_TRANSLATED__",
     "NoAvailableLiveStat": "__NOT_TRANSLATED__",
-    "Allocation": "__NOT_TRANSLATED__"
+    "Allocation": "__NOT_TRANSLATED__",
+    "DiskPerc": "__NOT_TRANSLATED__"
   },
   "general": {
     "cores": "cœurs",
@@ -473,7 +474,8 @@
     "NoUserToDisplay": "__NOT_TRANSLATED__",
     "RateLimitInputRequired": "__NOT_TRANSLATED__",
     "InvalidRateLimitValue": "__NOT_TRANSLATED__",
-    "WarningLessRateLimit": "__NOT_TRANSLATED__"
+    "WarningLessRateLimit": "__NOT_TRANSLATED__",
+    "KeypairDetail": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Dossiers",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -374,7 +374,8 @@
     "NoAgentToDisplay": "__NOT_TRANSLATED__",
     "Utilization": "__NOT_TRANSLATED__",
     "NoAvailableLiveStat": "__NOT_TRANSLATED__",
-    "Allocation": "__NOT_TRANSLATED__"
+    "Allocation": "__NOT_TRANSLATED__",
+    "DiskPerc": "__NOT_TRANSLATED__"
   },
   "general": {
     "cores": "core",
@@ -473,7 +474,8 @@
     "NoUserToDisplay": "__NOT_TRANSLATED__",
     "RateLimitInputRequired": "__NOT_TRANSLATED__",
     "InvalidRateLimitValue": "__NOT_TRANSLATED__",
-    "WarningLessRateLimit": "__NOT_TRANSLATED__"
+    "WarningLessRateLimit": "__NOT_TRANSLATED__",
+    "KeypairDetail": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Folder",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -373,7 +373,8 @@
     "Architecture": "아키텍쳐",
     "Utilization": "사용량",
     "NoAvailableLiveStat": "표시할 사용량 없음",
-    "Allocation": "할당 정보"
+    "Allocation": "할당 정보",
+    "DiskPerc": "디스크 %"
   },
   "general": {
     "cores": "코어",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -374,7 +374,8 @@
     "NoAgentToDisplay": "__NOT_TRANSLATED__",
     "Utilization": "__NOT_TRANSLATED__",
     "NoAvailableLiveStat": "__NOT_TRANSLATED__",
-    "Allocation": "__NOT_TRANSLATED__"
+    "Allocation": "__NOT_TRANSLATED__",
+    "DiskPerc": "__NOT_TRANSLATED__"
   },
   "general": {
     "cores": "цөм",
@@ -473,7 +474,8 @@
     "NoUserToDisplay": "__NOT_TRANSLATED__",
     "RateLimitInputRequired": "__NOT_TRANSLATED__",
     "InvalidRateLimitValue": "__NOT_TRANSLATED__",
-    "WarningLessRateLimit": "__NOT_TRANSLATED__"
+    "WarningLessRateLimit": "__NOT_TRANSLATED__",
+    "KeypairDetail": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Фолдерууд",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -374,7 +374,8 @@
     "NoAgentToDisplay": "__NOT_TRANSLATED__",
     "Utilization": "__NOT_TRANSLATED__",
     "NoAvailableLiveStat": "__NOT_TRANSLATED__",
-    "Allocation": "__NOT_TRANSLATED__"
+    "Allocation": "__NOT_TRANSLATED__",
+    "DiskPerc": "__NOT_TRANSLATED__"
   },
   "general": {
     "cores": "ядра",
@@ -473,7 +474,8 @@
     "NoUserToDisplay": "__NOT_TRANSLATED__",
     "RateLimitInputRequired": "__NOT_TRANSLATED__",
     "InvalidRateLimitValue": "__NOT_TRANSLATED__",
-    "WarningLessRateLimit": "__NOT_TRANSLATED__"
+    "WarningLessRateLimit": "__NOT_TRANSLATED__",
+    "KeypairDetail": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Папки",

--- a/src/components/backend-ai-agent-list.ts
+++ b/src/components/backend-ai-agent-list.ts
@@ -82,6 +82,7 @@ export default class BackendAIAgentList extends BackendAIPage {
   @property({type: Object}) _boundContactDateRenderer = this.contactDateRenderer.bind(this);
   @property({type: Object}) _boundResourceRenderer = this.resourceRenderer.bind(this);
   @property({type: Object}) _boundUtilizationRenderer = this.utilizationRenderer.bind(this);
+  @property({type: Object}) _boundDiskRenderer = this.diskRenderer.bind(this);
   @property({type: Object}) _boundStatusRenderer = this.statusRenderer.bind(this);
   @property({type: Object}) _boundControlRenderer = this.controlRenderer.bind(this);
   @property({type: Object}) _boundSchedulableRenderer = this.schedulableRenderer.bind(this);
@@ -853,6 +854,39 @@ export default class BackendAIAgentList extends BackendAIPage {
   }
 
   /**
+   * Render a disk occupancy.
+   *
+   * @param {DOMelement} root
+   * @param {object} column (<vaadin-grid-column> element)
+   * @param {object} rowData
+   */
+  diskRenderer(root, column?, rowData?) {
+    let pct;
+    if (rowData.item.live_stat && rowData.item.live_stat.node && rowData.item.live_stat.node.disk) {
+      pct = parseFloat(rowData.item.live_stat.node.disk.pct || 0).toFixed(1);
+    }
+    render(
+      html`
+        ${pct ? html`
+          <div class="flex-column indicator">
+            ${pct > 80 ? html`
+              <lablup-progress-bar class="utilization" progress="${pct / 100 || 0}"
+                                   description="${pct} %"
+                                   style="--progress-bar-background:var(--paper-red-500)"></lablup-progress-bar>
+            `: html`
+              <lablup-progress-bar class="utilization" progress="${pct / 100 || 0}"
+                                   description="${pct} %"></lablup-progress-bar>
+            `}
+            <div style="margin-top:3px;">${globalThis.backendaiutils._humanReadableFileSize(rowData.item.live_stat.node.disk.current)} / ${globalThis.backendaiutils._humanReadableFileSize(rowData.item.live_stat.node.disk.capacity)}</div>
+          </div>
+        `: html`
+          <span>-</span>
+        `}
+      `, root
+    );
+  }
+
+  /**
    * Render a heartbeat status.
    *
    * @param {DOMelement} root
@@ -1147,6 +1181,8 @@ export default class BackendAIAgentList extends BackendAIPage {
           <vaadin-grid-column resizable width="150px" header="${_t('agent.Utilization')}"
                               .renderer="${this._boundUtilizationRenderer}">
           </vaadin-grid-column>
+          <vaadin-grid-column resizable header="${_t('agent.DiskPerc')}"
+                              .renderer="${this._boundDiskRenderer}"></vaadin-grid-column>
           <vaadin-grid-sort-column resizable auto-width flex-grow="0" path="scaling_group"
                               header="${_t('general.ResourceGroup')}"></vaadin-grid-sort-column>
           <vaadin-grid-column width="160px" flex-grow="0" resizable header="${_t('agent.Status')}"

--- a/src/components/backend-ai-agent-list.ts
+++ b/src/components/backend-ai-agent-list.ts
@@ -868,16 +868,17 @@ export default class BackendAIAgentList extends BackendAIPage {
     render(
       html`
         ${pct ? html`
-          <div class="flex-column indicator">
+          <div class="indicator layout vertical center">
             ${pct > 80 ? html`
               <lablup-progress-bar class="utilization" progress="${pct / 100 || 0}"
                                    description="${pct} %"
-                                   style="--progress-bar-background:var(--paper-red-500)"></lablup-progress-bar>
+                                   style="margin-left:0;--progress-bar-background:var(--paper-red-500)"></lablup-progress-bar>
             `: html`
               <lablup-progress-bar class="utilization" progress="${pct / 100 || 0}"
-                                   description="${pct} %"></lablup-progress-bar>
+                                   description="${pct} %"
+                                   style="margin-left:0;"></lablup-progress-bar>
             `}
-            <div style="margin-top:3px;">${globalThis.backendaiutils._humanReadableFileSize(rowData.item.live_stat.node.disk.current)} / ${globalThis.backendaiutils._humanReadableFileSize(rowData.item.live_stat.node.disk.capacity)}</div>
+            <div style="margin-top:10px;">${globalThis.backendaiutils._humanReadableFileSize(rowData.item.live_stat.node.disk.current)} / ${globalThis.backendaiutils._humanReadableFileSize(rowData.item.live_stat.node.disk.capacity)}</div>
           </div>
         `: html`
           <span>-</span>

--- a/src/components/backend-ai-storage-proxy-list.ts
+++ b/src/components/backend-ai-storage-proxy-list.ts
@@ -388,9 +388,12 @@ export default class BackendAIStorageProxyList extends BackendAIPage {
               <span class="indicator" style="padding-left:5px;">${_t('session.Usage')}</span>
             </div>
             <span class="flex"></span>
-            <lablup-progress-bar id="volume-usage-bar" progress="${usageRatio}"
-                                 buffer="${totalBuffer}"
-                                 description="${usagePercent}%"></lablup-progress-bar>
+            <div class="layout vertical center">
+              <lablup-progress-bar id="volume-usage-bar" progress="${usageRatio}"
+                                   buffer="${totalBuffer}"
+                                   description="${usagePercent}%"></lablup-progress-bar>
+              <div class="indicator" style="margin-top:3px;">${globalThis.backendaiutils._humanReadableFileSize(usage.used_bytes)} / ${globalThis.backendaiutils._humanReadableFileSize(usage.capacity_bytes)}</div>
+            </div>
           </div>
         </div>
       `, root


### PR DESCRIPTION
resolves https://github.com/lablup/giftbox/issues/6

agent tab (add disk column)
<img width="301" alt="image" src="https://user-images.githubusercontent.com/28584164/215696352-2bf91bd1-a73a-4200-b1aa-c605169da197.png">
storage tab (display the capacity value)
<img width="419" alt="image" src="https://user-images.githubusercontent.com/28584164/215685111-827ade54-695a-4bea-a31d-04dc670de154.png">