### PR TITLE
refactor/add more sort columns for multiple pages

### DIFF
--- a/src/components/backend-ai-credential-list.ts
+++ b/src/components/backend-ai-credential-list.ts
@@ -23,6 +23,7 @@ import '@material/mwc-list/mwc-list-item';
 
 import BackendAIDialog from './backend-ai-dialog';
 import './backend-ai-list-status';
+import './lablup-grid-sort-filter-column';
 import '../plastics/lablup-shields/lablup-shields';
 
 import {default as PainKiller} from './backend-ai-painkiller';
@@ -872,10 +873,10 @@ export default class BackendAICredentialList extends BackendAIPage {
                      id="keypair-grid" .items="${this.keypairs}">
           <vaadin-grid-column width="40px" flex-grow="0" header="#" text-align="center"
                               .renderer="${this._indexRenderer.bind(this)}"></vaadin-grid-column>
-          <vaadin-grid-filter-column path="user_id" auto-width header="${_t('credential.UserID')}" resizable
-                                     .renderer="${this._boundUserIdRenderer}"></vaadin-grid-filter-column>
-          <vaadin-grid-filter-column path="access_key" auto-width header="${_t('general.AccessKey')}" resizable
-                                     .renderer="${this._boundAccessKeyRenderer}"></vaadin-grid-filter-column>
+          <lablup-grid-sort-filter-column path="user_id" auto-width header="${_t('credential.UserID')}" resizable
+                                     .renderer="${this._boundUserIdRenderer}"></lablup-grid-sort-filter-column>
+          <lablup-grid-sort-filter-column path="access_key" auto-width header="${_t('general.AccessKey')}" resizable
+                                     .renderer="${this._boundAccessKeyRenderer}"></lablup-grid-sort-filter-column>
           <vaadin-grid-sort-column resizable header="${_t('credential.Permission')}" path="admin"
                                    .renderer="${this._boundPermissionRenderer}"></vaadin-grid-sort-column>
           <vaadin-grid-sort-column auto-width resizable header="${_t('credential.KeyAge')}" path="created_at"

--- a/src/components/backend-ai-environment-list.ts
+++ b/src/components/backend-ai-environment-list.ts
@@ -17,8 +17,9 @@ import {
   IronPositioning
 } from '../plastics/layout/iron-flex-layout-classes';
 import '../plastics/lablup-shields/lablup-shields';
-import './lablup-loading-spinner';
 import './backend-ai-dialog';
+import './lablup-grid-sort-filter-column';
+import './lablup-loading-spinner';
 
 import '@vaadin/vaadin-grid/vaadin-grid';
 import '@vaadin/vaadin-grid/vaadin-grid-selection-column';
@@ -1206,22 +1207,22 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
           </vaadin-grid-selection-column>
           <vaadin-grid-sort-column path="installed" flex-grow="0" header="${_t('environment.Status')}" .renderer="${this._boundInstallRenderer}">
           </vaadin-grid-sort-column>
-          <vaadin-grid-filter-column path="registry" width="80px" resizable
-              header="${_t('environment.Registry')}"></vaadin-grid-filter-column>
-          <vaadin-grid-filter-column path="architecture" width="80px" resizable
-              header="${_t('environment.Architecture')}"></vaadin-grid-filter-column>
-          <vaadin-grid-filter-column path="namespace" width="60px" resizable
-              header="${_t('environment.Namespace')}"></vaadin-grid-filter-column>
-          <vaadin-grid-filter-column path="lang" resizable
-              header="${_t('environment.Language')}"></vaadin-grid-filter-column>
-          <vaadin-grid-filter-column path="baseversion" resizable
-              header="${_t('environment.Version')}"></vaadin-grid-filter-column>
-          <vaadin-grid-column resizable width="110px" header="${_t('environment.Base')}" .renderer="${this._boundBaseImageRenderer}">
-          </vaadin-grid-column>
-          <vaadin-grid-column width="50px" resizable header="${_t('environment.Constraint')}" .renderer="${this._boundConstraintRenderer}">
-          </vaadin-grid-column>
-          <vaadin-grid-filter-column path="digest" resizable header="${_t('environment.Digest')}" .renderer="${this._boundDigestRenderer}">
-          </vaadin-grid-filter-column>
+          <lablup-grid-sort-filter-column path="registry" width="80px" resizable
+              header="${_t('environment.Registry')}"></lablup-grid-sort-filter-column>
+          <lablup-grid-sort-filter-column path="architecture" width="80px" resizable
+              header="${_t('environment.Architecture')}"></lablup-grid-sort-filter-column>
+          <lablup-grid-sort-filter-column path="namespace" width="60px" resizable
+              header="${_t('environment.Namespace')}"></lablup-grid-sort-filter-column>
+          <lablup-grid-sort-filter-column path="lang" resizable
+              header="${_t('environment.Language')}"></lablup-grid-sort-filter-column>
+          <lablup-grid-sort-filter-column path="baseversion" resizable
+              header="${_t('environment.Version')}"></lablup-grid-sort-filter-column>
+          <vaadin-grid-sort-filter-column path="baseimage" resizable width="110px" header="${_t('environment.Base')}" .renderer="${this._boundBaseImageRenderer}">
+          </lablup-grid-sort-filter-column>
+          <lablup-grid-sort-filter-column path="additional_req" width="50px" resizable header="${_t('environment.Constraint')}" .renderer="${this._boundConstraintRenderer}">
+          </lablup-grid-sort-filter-column>
+          <lablup-grid-sort-filter-column path="digest" resizable header="${_t('environment.Digest')}" .renderer="${this._boundDigestRenderer}">
+          </lablup-grid-sort-filter-column>
           <vaadin-grid-column width="150px" flex-grow="0" resizable header="${_t('environment.ResourceLimit')}" .renderer="${this._boundRequirementsRenderer}">
           </vaadin-grid-column>
           <vaadin-grid-column resizable header="${_t('general.Control')}" .renderer=${this._boundControlsRenderer}>

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -30,10 +30,11 @@ import {Menu} from '@material/mwc-menu';
 import '@material/mwc-textfield/mwc-textfield';
 
 import {default as PainKiller} from './backend-ai-painkiller';
-import './backend-ai-list-status';
-import '../plastics/lablup-shields/lablup-shields';
-import './lablup-progress-bar';
 import './backend-ai-dialog';
+import './backend-ai-list-status';
+import './lablup-grid-sort-filter-column';
+import './lablup-progress-bar';
+import '../plastics/lablup-shields/lablup-shields';
 
 import {BackendAiStyles} from './backend-ai-general-styles';
 import {BackendAIPage} from './backend-ai-page';
@@ -2385,17 +2386,17 @@ export default class BackendAiSessionList extends BackendAIPage {
           ` : html``}
           <vaadin-grid-column frozen width="40px" flex-grow="0" header="#" .renderer="${this._indexRenderer}"></vaadin-grid-column>
           ${this.is_admin ? html`
-            <vaadin-grid-filter-column frozen path="${this._connectionMode === 'API' ? 'access_key' : 'user_email'}"
+            <lablup-grid-sort-filter-column frozen path="${this._connectionMode === 'API' ? 'access_key' : 'user_email'}"
                                       header="${this._connectionMode === 'API' ? 'API Key' : 'User ID'}" resizable
                                       .renderer="${this._boundUserInfoRenderer}">
-            </vaadin-grid-filter-column>
+            </lablup-grid-sort-filter-column>
           ` : html``}
-          <vaadin-grid-filter-column frozen path="${this.sessionNameField}" auto-width header="${_t('session.SessionInfo')}" resizable
+          <lablup-grid-sort-filter-column frozen path="${this.sessionNameField}" auto-width header="${_t('session.SessionInfo')}" resizable
                                      .renderer="${this._boundSessionInfoRenderer}">
-          </vaadin-grid-filter-column>
-          <vaadin-grid-filter-column width="120px" path="status" header="${_t('session.Status')}" resizable
+          </lablup-grid-sort-filter-column>
+          <lablup-grid-sort-filter-column width="120px" path="status" header="${_t('session.Status')}" resizable
                                      .renderer="${this._boundStatusRenderer}">
-          </vaadin-grid-filter-column>
+          </lablup-grid-sort-filter-column>
           <vaadin-grid-column width=${this._isContainerCommitEnabled ? '260px': '210px'} flex-grow="0" resizable header="${_t('general.Control')}"
                               .renderer="${this._boundControlRenderer}"></vaadin-grid-column>
           <vaadin-grid-column auto-width flex-grow="0" resizable header="${_t('session.Configuration')}"
@@ -2406,16 +2407,16 @@ export default class BackendAiSessionList extends BackendAIPage {
           <vaadin-grid-sort-column resizable auto-width flex-grow="0" header="${_t('session.Reservation')}"
                                    path="created_at" .renderer="${this._boundReservationRenderer}">
           </vaadin-grid-sort-column>
-          <vaadin-grid-filter-column width="110px" path="architecture" header="${_t('session.Architecture')}" resizable
+          <lablup-grid-sort-filter-column width="110px" path="architecture" header="${_t('session.Architecture')}" resizable
                                      .renderer="${this._boundArchitectureRenderer}">
-          </vaadin-grid-filter-column>
+          </lablup-grid-sort-filter-column>
           ${this._isIntegratedCondition ? html`
-            <vaadin-grid-filter-column path="type" width="120px" flex-grow="0" text-align="center" header="${_t('session.launcher.SessionType')}" resizable .renderer="${this._boundSessionTypeRenderer}"></vaadin-grid-filter-column>
+            <lablup-grid-sort-filter-column path="type" width="120px" flex-grow="0" text-align="center" header="${_t('session.launcher.SessionType')}" resizable .renderer="${this._boundSessionTypeRenderer}"></lablup-grid-sort-filter-column>
         ` : html``}
           ${this.is_superadmin ? html`
-            <vaadin-grid-column auto-width flex-grow="0" resizable header="${_t('session.Agent')}"
+            <lablup-grid-sort-filter-column path="agent" auto-width flex-grow="0" resizable header="${_t('session.Agent')}"
                                 .renderer="${this._boundAgentRenderer}">
-            </vaadin-grid-column>
+            </lablup-grid-sort-filter-column>
                 ` : html``}
           </vaadin-grid>
           <backend-ai-list-status id="list-status" statusCondition="${this.listCondition}" message="${_text('session.NoSessionToDisplay')}"></backend-ai-list-status>

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -8,8 +8,9 @@ import {css, CSSResultGroup, html, render} from 'lit';
 import {customElement, property, query} from 'lit/decorators.js';
 import {BackendAIPage} from './backend-ai-page';
 
-import './backend-ai-list-status';
 import './backend-ai-dialog';
+import './backend-ai-list-status';
+import './lablup-grid-sort-filter-column';
 
 import {Button} from '@material/mwc-button';
 import '@material/mwc-formfield';
@@ -592,14 +593,14 @@ export default class BackendAiStorageList extends BackendAIPage {
         <vaadin-grid class="folderlist" theme="row-stripes column-borders wrap-cell-content compact" column-reordering-allowed aria-label="Folder list" .items="${this.folders}">
           <vaadin-grid-column width="40px" flex-grow="0" resizable header="#" text-align="center" .renderer="${this._boundIndexRenderer}">
           </vaadin-grid-column>
-          <vaadin-grid-filter-column path="name" width="80px" resizable .renderer="${this._boundFolderListRenderer}"
-              header="${_t('data.folders.Name')}"></vaadin-grid-filter-column>
-          <vaadin-grid-column width="135px" flex-grow="0" resizable header="ID" .renderer="${this._boundIDRenderer}">
-          </vaadin-grid-column>
-          <vaadin-grid-filter-column path="host" width="105px" flex-grow="0" resizable
-              header="${_t('data.folders.Location')}"></vaadin-grid-filter-column>
-          <vaadin-grid-column auto-width flex-grow="0" resizable header="${_t('data.folders.FolderQuota')}" .renderer="${this._boundQuotaRenderer}"></vaadin-grid-column>
-          <vaadin-grid-column width="55px" flex-grow="0" resizable header="${_t('data.folders.Type')}" .renderer="${this._boundTypeRenderer}"></vaadin-grid-column>
+          <lablup-grid-sort-filter-column path="name" width="80px" resizable .renderer="${this._boundFolderListRenderer}"
+              header="${_t('data.folders.Name')}"></lablup-grid-sort-filter-column>
+          <lablup-grid-sort-filter-column path="id" width="130px" flex-grow="0" resizable header="ID" .renderer="${this._boundIDRenderer}">
+          </lablup-grid-sort-filter-column>
+          <lablup-grid-sort-filter-column path="host" width="105px" flex-grow="0" resizable
+              header="${_t('data.folders.Location')}"></lablup-grid-sort-filter-column>
+          <vaadin-grid-sort-column path="max_size" width="95px" flex-grow="0" resizable header="${_t('data.folders.FolderQuota')}" .renderer="${this._boundQuotaRenderer}"></vaadin-grid-sort-column>
+          <lablup-grid-sort-filter-column path="ownership_type" width="70px" flex-grow="0" resizable header="${_t('data.folders.Type')}" .renderer="${this._boundTypeRenderer}"></lablup-grid-sort-filter-column>
           <vaadin-grid-column width="95px" flex-grow="0" resizable header="${_t('data.folders.Permission')}" .renderer="${this._boundPermissionViewRenderer}"></vaadin-grid-column>
           <vaadin-grid-column auto-width flex-grow="0" resizable header="${_t('data.folders.Owner')}" .renderer="${this._boundOwnerRenderer}"></vaadin-grid-column>
           ${this.enableStorageProxy ? html`

--- a/src/components/backend-ai-user-list.ts
+++ b/src/components/backend-ai-user-list.ts
@@ -8,8 +8,9 @@ import {customElement, property, query} from 'lit/decorators.js';
 
 import {BackendAIPage} from './backend-ai-page';
 
-import './backend-ai-list-status';
 import './backend-ai-dialog';
+import './backend-ai-list-status';
+import './lablup-grid-sort-filter-column';
 
 import '@vaadin/vaadin-grid/vaadin-grid';
 import '@vaadin/vaadin-grid/vaadin-grid-filter-column';
@@ -660,13 +661,13 @@ export default class BackendAIUserList extends BackendAIPage {
                     aria-label="User list" id="user-grid" .items="${this.users}">
           <vaadin-grid-column width="40px" flex-grow="0" header="#" text-align="center"
                               .renderer="${this._indexRenderer.bind(this)}"></vaadin-grid-column>
-          <vaadin-grid-filter-column auto-width path="email" header="${_t('credential.UserID')}" resizable
-                              .renderer="${this._userIdRenderer.bind(this)}"></vaadin-grid-filter-column>
-          <vaadin-grid-filter-column auto-width path="username" header="${_t('credential.Name')}" resizable
-                              .renderer="${this._userNameRenderer}"></vaadin-grid-filter-column>
+          <lablup-grid-sort-filter-column auto-width path="email" header="${_t('credential.UserID')}" resizable
+                              .renderer="${this._userIdRenderer.bind(this)}"></lablup-grid-sort-filter-column>
+          <lablup-grid-sort-filter-column auto-width path="username" header="${_t('credential.Name')}" resizable
+                              .renderer="${this._userNameRenderer}"></lablup-grid-sort-filter-column>
           ${this.condition !== 'active' ? html`
-            <vaadin-grid-filter-column auto-width path="status" header="${_t('credential.Status')}" resizable
-                              .renderer="${this._userStatusRenderer}"></vaadin-grid-filter-column>` : html``}
+            <lablup-grid-sort-filter-column auto-width path="status" header="${_t('credential.Status')}" resizable
+                              .renderer="${this._userStatusRenderer}"></lablup-grid-sort-filter-column>` : html``}
           <vaadin-grid-column resizable header="${_t('general.Control')}"
               .renderer="${this._boundControlRenderer}"></vaadin-grid-column>
         </vaadin-grid>

--- a/src/components/lablup-grid-sort-filter-column.ts
+++ b/src/components/lablup-grid-sort-filter-column.ts
@@ -109,7 +109,6 @@ class LablupGridSortFilterColumn extends GridColumn {
       return;
     }
     this.direction = e.detail.value;
-    console.log('__onDirectionChanged', this.direction);
   }
 
   __getHeader(header, path) {

--- a/src/components/lablup-grid-sort-filter-column.ts
+++ b/src/components/lablup-grid-sort-filter-column.ts
@@ -1,0 +1,127 @@
+/* eslint "require-jsdoc": ["error", {
+  "require": {
+    "MethodDefinition": false,
+    "ClassDeclaration": true,
+  }
+}]*/
+import '@vaadin/vaadin-grid/vaadin-grid-filter';
+import '@vaadin/vaadin-grid/vaadin-grid-sorter';
+import { GridColumn } from '@vaadin/vaadin-grid/vaadin-grid-column';
+
+/**
+ * Codemirror component.
+ */
+class LablupGridSortFilterColumn extends GridColumn {
+  private __boundOnFilterValueChanged: (e: any) => void;
+  private _generateHeader: any;
+  __boundOnDirectionChanged: (e: any) => void;
+  direction: any;
+  _filterValue: any;
+
+  static get properties() {
+    return {
+      path: { type: String },
+      /**
+       * Text to display as the label of the column filter text-field.
+       */
+      header: { type: String },
+      /**
+       * How to sort the data.
+       * Possible values are `asc` to use an ascending algorithm, `desc` to sort the data in
+       * descending direction, or `null` for not sorting the data.
+       * @type {GridSorterDirection | undefined}
+       */
+      direction: { type: String, notify: true },
+    };
+  }
+
+  static get observers() {
+    return [
+      '_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header, _filterValue)',
+      '_onHeaderRendererOrBindingChanged(_headerRenderer, _headerCell, path, header, direction)',
+    ];
+  }
+
+  constructor() {
+    super();
+    this.__boundOnFilterValueChanged = this.__onFilterValueChanged.bind(this);
+    this.__boundOnDirectionChanged = this.__onDirectionChanged.bind(this);
+  }
+
+  _defaultHeaderRenderer(root, _column) {
+    let header = root.firstElementChild;
+    let sorter = header ? header.firstElementChild : undefined;
+    let filter = header ? header.lastElementChild : undefined;
+    let textField = filter ? filter.firstElementChild : undefined;
+
+    if (!header) {
+      header = document.createElement('div');
+      header.setAttribute('style', 'display: flex; flex-direction: column');
+
+      // Create sorter header
+      sorter = document.createElement('vaadin-grid-sorter');
+      sorter.addEventListener('direction-changed', this.__boundOnDirectionChanged);
+      header.appendChild(sorter);
+
+      // Create filter header
+      filter = document.createElement('vaadin-grid-filter');
+      textField = document.createElement('vaadin-text-field');
+      textField.setAttribute('slot', 'filter');
+      textField.setAttribute('theme', 'small');
+      textField.setAttribute('style', 'max-width: 100%;');
+      textField.setAttribute('focus-target', '');
+      textField.addEventListener('value-changed', this.__boundOnFilterValueChanged);
+      filter.appendChild(textField);
+      header.appendChild(filter);
+
+      root.appendChild(header);
+    }
+
+    // Sorter header properties
+    sorter.path = this.path;
+    sorter.__rendererDirection = this.direction;
+    sorter.direction = this.direction;
+    sorter.textContent = this.__getHeader(this.header, this.path);
+
+    // Filter header properties
+    filter.path = this.path;
+    filter.value = this._filterValue;
+    textField.__rendererValue = this._filterValue;
+    textField.value = this._filterValue;
+    // textField.label = this.__getHeader(this.header, this.path);
+  }
+
+  _computeHeaderRenderer() {
+    return this._defaultHeaderRenderer;
+  }
+
+  __onFilterValueChanged(e) {
+    // Skip if the value is changed by the renderer.
+    if (e.detail.value === e.target.__rendererValue) {
+      return;
+    }
+    this._filterValue = e.detail.value;
+  }
+
+  __onDirectionChanged(e) {
+    // Skip if the direction is changed by the renderer.
+    if (e.detail.value === e.target.__rendererDirection) {
+      return;
+    }
+    this.direction = e.detail.value;
+    console.log('__onDirectionChanged', this.direction);
+  }
+
+  __getHeader(header, path) {
+    if (header) {
+      return header;
+    }
+    if (path) {
+      return this._generateHeader(path);
+    }
+  }
+}
+
+customElements.define('lablup-grid-sort-filter-column', LablupGridSortFilterColumn);
+
+export { LablupGridSortFilterColumn };


### PR DESCRIPTION
- Add new custom element: `lablup-grid-sort-filter-column` to add a `vaadin-grid` column which simultaneously support sorting and filtering.
- Add sorting features to
  - Sessions page : user id, session name, status, architecture, session type agent
  - Data & Storage : name, id, location (host), capacity, type
  - Users : user id, name, status (for inactive tab)
  - Credentials : user id, access key
  - Images : registry, architecture, namespace, language, version, constraint, digest

Resolves #1560.