### PR TITLE
fix: display cuda mem info if cuda util exist

### DIFF
--- a/src/components/backend-ai-agent-list.ts
+++ b/src/components/backend-ai-agent-list.ts
@@ -863,10 +863,10 @@ export default class BackendAIAgentList extends BackendAIPage {
                   <lablup-progress-bar class="utilization" progress="${liveStat.cuda_util?.ratio}" description="${(liveStat.cuda_util?.ratio * 100).toFixed(1)} %"></lablup-progress-bar>
                 </div>
               ` : html``}
-              ${liveStat.cuda_mem ? html`
+              ${liveStat.cuda_util ? html`
                 <div class="layout horizontal justified flex progress-bar-section">
                   <span style="margin-right:5px;">GPU(mem)</span>
-                  <lablup-progress-bar class="utilization" progress="${liveStat.cuda_mem?.ratio}" description="${BackendAIAgentList.bytesToGiB(liveStat.cuda_mem?.current)}/${BackendAIAgentList.bytesToGiB(liveStat.cuda_mem?.capacity)} GiB"></lablup-progress-bar>
+                  <lablup-progress-bar class="utilization" progress="${liveStat.cuda_mem?.ratio || 0}" description="${BackendAIAgentList.bytesToGiB(liveStat.cuda_mem?.current)}/${BackendAIAgentList.bytesToGiB(liveStat.cuda_mem?.capacity)} GiB"></lablup-progress-bar>
                 </div>
               ` : html``}
             </div>

--- a/src/components/backend-ai-agent-list.ts
+++ b/src/components/backend-ai-agent-list.ts
@@ -862,8 +862,6 @@ export default class BackendAIAgentList extends BackendAIPage {
                   <span style="margin-right:5px;">GPU(util)</span>
                   <lablup-progress-bar class="utilization" progress="${liveStat.cuda_util?.ratio}" description="${(liveStat.cuda_util?.ratio * 100).toFixed(1)} %"></lablup-progress-bar>
                 </div>
-              ` : html``}
-              ${liveStat.cuda_util ? html`
                 <div class="layout horizontal justified flex progress-bar-section">
                   <span style="margin-right:5px;">GPU(mem)</span>
                   <lablup-progress-bar class="utilization" progress="${liveStat.cuda_mem?.ratio || 0}" description="${BackendAIAgentList.bytesToGiB(liveStat.cuda_mem?.current)}/${BackendAIAgentList.bytesToGiB(liveStat.cuda_mem?.capacity)} GiB"></lablup-progress-bar>

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -704,7 +704,7 @@ export default class BackendAiSessionList extends BackendAIPage {
             } else {
               sessions[objectKey].tpu_util = 0;
             }
-   if (liveStat && liveStat.cuda_mem) {
+            if (liveStat && liveStat.cuda_mem) {
               sessions[objectKey].cuda_mem_ratio = liveStat.cuda_mem.pct;
             } else {
               sessions[objectKey].cuda_mem_ratio = null;
@@ -2087,22 +2087,22 @@ export default class BackendAiSessionList extends BackendAIPage {
               ></lablup-progress-bar>
             </div>
           </div>` : html``}
+          ${rowData.item.cuda_fgpu_slot || rowData.item.rocm_gpu_slot ? html`
+          <div class="horizontal start-justified center layout">
+            <div class="usage-items">GPU(mem)</div>
+            <div class="horizontal start-justified center layout">
+              <lablup-progress-bar class="usage"
+                progress="${rowData.item.cuda_mem_ratio}"
+                description=""
+              ></lablup-progress-bar>
+            </div>
+          </div>` : html``}
           ${rowData.item.tpu_slot && parseFloat(rowData.item.tpu_slot) > 0 ? html`
           <div class="horizontal start-justified center layout">
             <div class="usage-items">TPU(util)</div>
             <div class="horizontal start-justified center layout">
               <lablup-progress-bar class="usage"
                 progress="${rowData.item.tpu_util / (rowData.item.tpu_slot * 100)}"
-                description=""
-              ></lablup-progress-bar>
-            </div>
-          </div>` : html``}
-          ${rowData.item.cuda_mem_ratio ? html`
-          <div class="horizontal start-justified center layout">
-            <div class="usage-items">GPU(mem)</div>
-            <div class="horizontal start-justified center layout">
-              <lablup-progress-bar class="usage"
-                progress="${rowData.item.cuda_mem_ratio}"
                 description=""
               ></lablup-progress-bar>
             </div>


### PR DESCRIPTION
- style: display cuda mem info just below the cuda util
- follows https://github.com/lablup/backend.ai-webui/pull/1572