### PR TITLE
feature: show total resource group amount in resource monitor gauge

### DIFF
--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -110,6 +110,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({type: Boolean}) maxShmPerContainer = 2;
   @property({type: Boolean}) maxFileUploadSize = -1;
   @property({type: Boolean}) maskUserInfo = false;
+  @property({type: Boolean}) hideAgents = false;
   @property({type: Array}) singleSignOnVendors: string[] = [];
   @property({type: Array}) allow_image_list;
   @property({type: Array}) endpoints;
@@ -703,6 +704,14 @@ export default class BackendAILogin extends BackendAIPage {
         defaultValue: 'https://github.com/lablup/backend.ai-webui/releases/download',
         value: (generalConfig?.appDownloadUrl),
       } as ConfigValueObject) as string;
+
+    // Enable hide agent flag
+    this.hideAgents = this._getConfigValueByExists(generalConfig,
+      {
+        valueType: 'boolean',
+        defaultValue: true,
+        value: (generalConfig?.hideAgents),
+      } as ConfigValueObject) as boolean;
 
     // Enable pipeline flag
     // FIXME: temporally disable pipeline feature in manual
@@ -1417,6 +1426,7 @@ export default class BackendAILogin extends BackendAIPage {
       globalThis.backendaiclient._config.singleSignOnVendors = this.singleSignOnVendors;
       globalThis.backendaiclient._config.enableContainerCommit = this._enableContainerCommit;
       globalThis.backendaiclient._config.appDownloadUrl = this.appDownloadUrl;
+      globalThis.backendaiclient._config.hideAgents = this.hideAgents;
       globalThis.backendaiclient.ready = true;
       if (this.endpoints.indexOf(globalThis.backendaiclient._config.endpoint as any) === -1) {
         this.endpoints.push(globalThis.backendaiclient._config.endpoint as any);

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -110,7 +110,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({type: Boolean}) maxShmPerContainer = 2;
   @property({type: Boolean}) maxFileUploadSize = -1;
   @property({type: Boolean}) maskUserInfo = false;
-  @property({type: Boolean}) hideAgents = false;
+  @property({type: Boolean}) hideAgents = true;
   @property({type: Array}) singleSignOnVendors: string[] = [];
   @property({type: Array}) allow_image_list;
   @property({type: Array}) endpoints;

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -604,12 +604,6 @@ export default class BackendAiResourceBroker extends BackendAIPage {
 
       this.total_slot = total_slot;
       if (!globalThis.backendaiclient._config.hideAgents) {
-        let initialResourceSlots = {
-          cpu: 0,
-          mem: 0,
-          cuda_device: 0,
-          cuda_shares: 0
-        };
         const status = 'ALIVE';
         const limit = 20;
         const offset = 0;
@@ -646,7 +640,7 @@ export default class BackendAiResourceBroker extends BackendAIPage {
               acc[key] += curr[key];
             });
             return acc;
-          }, initialResourceSlots);
+          }, { cpu: 0, mem: 0, cuda_device: 0, cuda_shares: 0 });
         this.total_resource_group_slot.mem = this.total_resource_group_slot.mem?.toFixed(2);
         if ('cuda_shares' in this.total_resource_group_slot) {
           this.total_resource_group_slot.cuda_shares = this.total_resource_group_slot.cuda_shares.toFixed(1);

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -471,7 +471,7 @@ export default class BackendAiResourceBroker extends BackendAIPage {
       const scaling_group_resource_remaining = response.scaling_groups[this.scaling_group].remaining;
 
       const keypair_resource_limit = response.keypair_limits;
-      
+
 
       if ('cpu' in keypair_resource_limit) {
         total_resource_group_slot['cpu'] = Number(scaling_group_resource_remaining.cpu) + Number(scaling_group_resource_using.cpu);
@@ -604,6 +604,12 @@ export default class BackendAiResourceBroker extends BackendAIPage {
 
       this.total_slot = total_slot;
       if (!globalThis.backendaiclient._config.hideAgents) {
+        let initialResourceSlots = {
+          cpu: 0,
+          mem: 0,
+          cuda_device: 0,
+          cuda_shares: 0
+        };
         const status = 'ALIVE';
         const limit = 20;
         const offset = 0;
@@ -612,7 +618,7 @@ export default class BackendAiResourceBroker extends BackendAIPage {
         const agentSummaryList = await globalThis.backendaiclient.agentSummary.list(status, fields, limit, offset, timeout);
         this.total_resource_group_slot = agentSummaryList.agent_summary_list.items
           .filter((agent) => agent.scaling_group == this.scaling_group).map((agent) => {
-            const availableSlots = JSON.parse(agent.available_slots)
+            const availableSlots = JSON.parse(agent.available_slots);
             if ('cpu' in availableSlots) {
               availableSlots['cpu'] = parseInt(availableSlots['cpu'] ?? 0);
             } else {
@@ -624,12 +630,12 @@ export default class BackendAiResourceBroker extends BackendAIPage {
               availableSlots['mem'] = 0;
             }
             if ('cuda.device' in availableSlots) {
-              availableSlots['cuda_device'] = parseInt(availableSlots['cuda.device'])
+              availableSlots['cuda_device'] = parseInt(availableSlots['cuda.device']);
             } else {
               availableSlots['cuda_device'] = 0;
             }
             if ('cuda.shares' in availableSlots) {
-              availableSlots['cuda_shares'] = parseInt(availableSlots['cuda.shares'])
+              availableSlots['cuda_shares'] = parseInt(availableSlots['cuda.shares']);
             } else {
               availableSlots['cuda_shares'] = 0;
             }
@@ -639,8 +645,8 @@ export default class BackendAiResourceBroker extends BackendAIPage {
             Object.keys(curr).forEach((key) => {
               acc[key] += curr[key];
             });
-          return acc;
-        });
+            return acc;
+          }, initialResourceSlots);
         this.total_resource_group_slot.mem = this.total_resource_group_slot.mem.toFixed(2);
         if ('cuda_shares' in this.total_resource_group_slot) {
           this.total_resource_group_slot.cuda_shares = this.total_resource_group_slot.cuda_shares.toFixed(1);

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -647,7 +647,7 @@ export default class BackendAiResourceBroker extends BackendAIPage {
             });
             return acc;
           }, initialResourceSlots);
-        this.total_resource_group_slot.mem = this.total_resource_group_slot.mem.toFixed(2);
+        this.total_resource_group_slot.mem = this.total_resource_group_slot.mem?.toFixed(2);
         if ('cuda_shares' in this.total_resource_group_slot) {
           this.total_resource_group_slot.cuda_shares = this.total_resource_group_slot.cuda_shares.toFixed(1);
         }


### PR DESCRIPTION
This PR resolves #1592.

### How to test
> you need more than one account to test this in your environment.
> For convenience's sake, I'll call them as account A and account B.
> Also, you need to set `hideAgents` option in configuration file(webUI, webserver, manager) to false. (you may need to restart some process.)

1. Login to account A.
2. Create a session with the maximum resources that you can allocate on behalf of account A.
3. Login to account B.
4. See each gauge in resource monitor.

### Screenshot(s)
|      | Before | After |
| ---| --- | --- |
|resource monitor of account A | <img width="378" alt="Screenshot 2023-02-17 at 10 59 25 AM" src="https://user-images.githubusercontent.com/46954439/219530262-8b223247-39c7-4d78-81bd-1e483868626b.png"> | <img width="378" alt="Screenshot 2023-02-17 at 10 55 15 AM" src="https://user-images.githubusercontent.com/46954439/219530700-fd6ccf80-8c96-4341-bc64-9ed6241b274e.png"> |
|resource monitor of account B | <img width="378" alt="Screenshot 2023-02-17 at 10 59 33 AM" src="https://user-images.githubusercontent.com/46954439/219530291-46b90ba7-2858-441a-848b-3ac77b5165a7.png"> | <img width="378" alt="Screenshot 2023-02-17 at 10 55 01 AM" src="https://user-images.githubusercontent.com/46954439/219530710-b2fd29fe-e539-475d-8516-d37cb47987c1.png"> |



