### PR TITLE
fix: increase item count 20 -> 100 for agent summary list query

### DIFF
--- a/src/components/backend-ai-agent-summary-list.ts
+++ b/src/components/backend-ai-agent-summary-list.ts
@@ -201,7 +201,10 @@ export default class BackendAIAgentSummaryList extends BackendAIPage {
       fields.push('schedulable');
     }
     const status = this.condition === 'running' ? 'ALIVE' : 'TERMINATED';
-    const limit = 20;
+    // TODO: Let's assume that the number of agents is less than 100 for
+    //       user-accessible resource group. This will meet our current need,
+    //       but we need to fix this when refactoring the resource indicator.
+    const limit = 100;
     const offset = 0;
     const timeout = 10 * 1000;
     globalThis.backendaiclient.agentSummary.list(status, fields, limit, offset, timeout).then((response) => {


### PR DESCRIPTION
If there are over 20 Agents in a reosurce group, #1593 will not work properly. this PR increases the fetch item count by 100.

:warning: Let's assume that the number of agents is less than 100 for user-accessible resource group. This will meet our immediate need, but we need to fix this when refactoring the resource indicator.