### PR TITLE
feature: 2fa management

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -487,7 +487,8 @@
     "KeypairCreated": "Keypair successfully created.",
     "UserNotFound": "Credential creation failed, since the following user ID could't be found : ",
     "UserIDRequired": "User ID is required.",
-    "KeypairDetail": "Keypair Detail"
+    "KeypairDetail": "Keypair Detail",
+    "AdminCanOnlyRemoveTotp": "Admin can only disable the use of two-factor authentication."
   },
   "data": {
     "Folders": "Folders",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -488,7 +488,7 @@
     "UserNotFound": "Credential creation failed, since the following user ID could't be found : ",
     "UserIDRequired": "User ID is required.",
     "KeypairDetail": "Keypair Detail",
-    "AdminCanOnlyRemoveTotp": "Admin can only disable the use of two-factor authentication."
+    "AdminCanOnlyRemoveTotp": "Only disabling 2FA authentication of other users is possible."
   },
   "data": {
     "Folders": "Folders",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -480,7 +480,8 @@
     "RateLimitInputRequired": "__NOT_TRANSLATED__",
     "InvalidRateLimitValue": "__NOT_TRANSLATED__",
     "WarningLessRateLimit": "__NOT_TRANSLATED__",
-    "KeypairDetail": "__NOT_TRANSLATED__"
+    "KeypairDetail": "__NOT_TRANSLATED__",
+    "AdminCanOnlyRemoveTotp": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Dossiers",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -480,7 +480,8 @@
     "RateLimitInputRequired": "__NOT_TRANSLATED__",
     "InvalidRateLimitValue": "__NOT_TRANSLATED__",
     "WarningLessRateLimit": "__NOT_TRANSLATED__",
-    "KeypairDetail": "__NOT_TRANSLATED__"
+    "KeypairDetail": "__NOT_TRANSLATED__",
+    "AdminCanOnlyRemoveTotp": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Folder",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -479,7 +479,8 @@
     "KeypairCreated": "키페어가 성공적으로 생성되었습니다.",
     "UserNotFound": "다음 사용자 계정을 찾을 수 없어 자격 증명 생성에 실패하였습니다. : ",
     "UserIDRequired": "사용자 계정(email)은 필수 입력입니다.",
-    "KeypairDetail": "키페어 정보"
+    "KeypairDetail": "키페어 정보",
+    "AdminCanOnlyRemoveTotp": "관리자는 이중 인증 사용 비활성화만 가능합니다."
   },
   "data": {
     "Folders": "폴더",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -480,7 +480,7 @@
     "UserNotFound": "다음 사용자 계정을 찾을 수 없어 자격 증명 생성에 실패하였습니다. : ",
     "UserIDRequired": "사용자 계정(email)은 필수 입력입니다.",
     "KeypairDetail": "키페어 정보",
-    "AdminCanOnlyRemoveTotp": "관리자는 이중 인증 사용 비활성화만 가능합니다."
+    "AdminCanOnlyRemoveTotp": "다른 사용자의 이중 인증은 해제만 가능합니다."
   },
   "data": {
     "Folders": "폴더",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -480,7 +480,8 @@
     "RateLimitInputRequired": "__NOT_TRANSLATED__",
     "InvalidRateLimitValue": "__NOT_TRANSLATED__",
     "WarningLessRateLimit": "__NOT_TRANSLATED__",
-    "KeypairDetail": "__NOT_TRANSLATED__"
+    "KeypairDetail": "__NOT_TRANSLATED__",
+    "AdminCanOnlyRemoveTotp": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Фолдерууд",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -480,7 +480,8 @@
     "RateLimitInputRequired": "__NOT_TRANSLATED__",
     "InvalidRateLimitValue": "__NOT_TRANSLATED__",
     "WarningLessRateLimit": "__NOT_TRANSLATED__",
-    "KeypairDetail": "__NOT_TRANSLATED__"
+    "KeypairDetail": "__NOT_TRANSLATED__",
+    "AdminCanOnlyRemoveTotp": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Папки",

--- a/src/components/backend-ai-user-dropdown-menu.ts
+++ b/src/components/backend-ai-user-dropdown-menu.ts
@@ -145,17 +145,17 @@ export default class BackendAiUserDropdownMenu extends LitElement {
   async _showTotpActivated() {
     this.totpSupported = await globalThis.backendaiclient.managerSupportsTotp();
     if (this.totpSupported) {
-      const user_info = await globalThis.backendaiclient.user.get(
+      const userInfo = await globalThis.backendaiclient.user.get(
         globalThis.backendaiclient.email, ['totp_activated']
       );
-      this.totpActivated = user_info.user.totp_activated;
+      this.totpActivated = userInfo.user.totp_activated;
     }
   }
 
   _getKeypairInfo(user_id) {
     const fields = ['access_key', 'secret_key'];
-    const is_active = true;
-    return globalThis.backendaiclient.keypair.list(user_id, fields, is_active);
+    const isActive = true;
+    return globalThis.backendaiclient.keypair.list(user_id, fields, isActive);
   }
 
   async _showKeypairInfo() {

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -794,8 +794,14 @@ class Client {
     return this._wrapWithPromise(rqst);
   }
 
-  async remove_totp() {
-    let rqst = this.newSignedRequest('DELETE', '/totp', {}, null);
+  async remove_totp(email=null) {
+    let rqstUrl = '/totp';
+    if (email) {
+      const params = {email: email};
+      const q = new URLSearchParams(params).toString();
+      rqstUrl += `?${q}`;
+    }
+    let rqst = this.newSignedRequest('DELETE', rqstUrl, {}, null);
     return this._wrapWithPromise(rqst);
   }
 

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -612,9 +612,9 @@ class Client {
     let rqst = this.newSignedRequest('GET', `/totp`, null, null);
     try {
       await this._wrapWithPromise(rqst);
-      return true
+      return true;
     } catch (e) {
-      return false
+      return false;
     }
   }
 


### PR DESCRIPTION
resolves #1598 

---
## How to test
1. clone [backend.ai-totp-plugin](https://github.com/lablup/backend.ai-totp-plugin) to backend.ai/plugins.
2. install totp plugin
  `./py -m pip install -e plugins/backend.ai-totp-plugin`
3. checkout backend.ai's branch to `feature/totp-created-at-column` (related PR: https://github.com/lablup/backend.ai/pull/1072)
4. upgrade db `./py -m alembic upgrade head` (maybe you need twice. the header should be `3efd66393bd0`)
---
## Checklist
- Is correct the 2fa enabled column data?
- Is correct the value of 2fa in the info dialog?
- Is possible to remove the 2fa in the edit dialog?
- Is possible to set my own 2fa in the setting dialog on the credential page?
---
## Screenshots
- add 2fa status
  <img width="1222" alt="image" src="https://user-images.githubusercontent.com/28584164/219931618-78b8b103-b4cc-4fae-90fb-ec3c8c633a8e.png">
- add 2fa column to info dialog
  <img width="395" alt="image" src="https://user-images.githubusercontent.com/28584164/219931629-1f76170f-9fd2-4a1e-ade0-5e45edcf5a49.png">
- remove users' totp (superadmin, admin only)
  <img width="365" alt="image" src="https://user-images.githubusercontent.com/28584164/219931663-93bbde04-9ca4-4e66-a0cd-e9273a756485.png">
- cannot activate 
  <img width="501" alt="image" src="https://user-images.githubusercontent.com/28584164/219939961-38fec0a6-cae9-4cd4-bb07-ed970e6e8f53.png">  
- but it can activate own account
  <img width="501" alt="image" src="https://user-images.githubusercontent.com/28584164/219940190-d77d4795-825f-4dbf-95b0-05c3702be60d.png">

