### PR TITLE
fix: expand space between resources displaying and fix decimal points

### DIFF
--- a/src/components/backend-ai-credential-list.ts
+++ b/src/components/backend-ai-credential-list.ts
@@ -134,7 +134,7 @@ export default class BackendAICredentialList extends BackendAIPage {
         }
 
         div.configuration {
-          width: 70px !important;
+          width: 100px !important;
         }
 
         div.configuration mwc-icon {
@@ -287,6 +287,7 @@ export default class BackendAICredentialList extends BackendAIPage {
           ['cpu', 'mem', 'cuda_shares', 'cuda_device', 'rocm_device', 'tpu_device'].forEach((slot) => {
             keypair['total_resource_slots'][slot] = this._markIfUnlimited(keypair['total_resource_slots'][slot]);
           });
+          keypair['max_vfolder_size'] = this._markIfUnlimited(BackendAICredentialList.bytesToGiB(keypair['max_vfolder_size']));
         }
       });
       this.keypairs = keypairs;
@@ -833,6 +834,11 @@ export default class BackendAICredentialList extends BackendAIPage {
     if (rateLimit <= 0 ) {
       this.rateLimit.value = '1';
     }
+  }
+
+  static bytesToGiB(num, digits=1) {
+    if (!num) return num;
+    return (num / 2 ** 30).toFixed(digits);
   }
 
   /**

--- a/src/components/backend-ai-resource-policy-list.ts
+++ b/src/components/backend-ai-resource-policy-list.ts
@@ -138,7 +138,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
         }
 
         div.configuration {
-          width: 70px !important;
+          width: 100px !important;
         }
 
         div.configuration wl-icon {
@@ -403,6 +403,24 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
     );
   }
 
+  _displayResourcesByResourceUnit(value = 0, enableUnitConvert = false, resourceName = '') {
+    let decimalPoint = 0;
+    const resourceValue = this._markIfUnlimited(value, enableUnitConvert);
+    resourceName = resourceName.toLowerCase();
+    switch (resourceName) {
+      case 'cpu':
+      case 'cuda_device':
+      case 'max_vfolder_count':
+        decimalPoint = 0;
+        break;
+      case 'mem':
+      case 'cuda_shares':
+      case 'max_vfolder_size':
+        decimalPoint = 1;
+    }
+    return ['∞', '-'].includes(resourceValue) ? resourceValue : Number(resourceValue).toFixed(decimalPoint);
+  }
+
   /**
    * Render a resource.
    *
@@ -416,12 +434,12 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
         <div class="layout horizontal wrap center">
           <div class="layout horizontal configuration">
             <wl-icon class="fg green indicator">developer_board</wl-icon>
-            <span>${this._markIfUnlimited(rowData.item.total_resource_slots.cpu)}</span>
+            <span>${this._displayResourcesByResourceUnit(rowData.item.total_resource_slots.cpu, false ,'cpu')}</span>
             <span class="indicator">cores</span>
           </div>
           <div class="layout horizontal configuration">
             <wl-icon class="fg green indicator">memory</wl-icon>
-            <span>${this._markIfUnlimited(rowData.item.total_resource_slots.mem)}</span>
+            <span>${this._displayResourcesByResourceUnit(rowData.item.total_resource_slots.mem, false ,'mem')}</span>
             <span class="indicator">GB</span>
           </div>
         </div>
@@ -430,7 +448,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
     html`
           <div class="layout horizontal configuration">
             <wl-icon class="fg green indicator">view_module</wl-icon>
-            <span>${this._markIfUnlimited(rowData.item.total_resource_slots.cuda_device)}</span>
+            <span>${this._displayResourcesByResourceUnit(rowData.item.total_resource_slots.cuda_device, false, 'cuda_device')}</span>
             <span class="indicator">GPU</span>
           </div>
 ` : html``}
@@ -438,7 +456,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
     html`
           <div class="layout horizontal configuration">
             <wl-icon class="fg green indicator">view_module</wl-icon>
-            <span>${this._markIfUnlimited(rowData.item.total_resource_slots.cuda_shares)}</span>
+            <span>${this._displayResourcesByResourceUnit(rowData.item.total_resource_slots.cuda_shares, false,'cuda_shares')}</span>
             <span class="indicator">fGPU</span>
           </div>
 ` : html``}
@@ -446,12 +464,12 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
         <div class="layout horizontal wrap center">
           <div class="layout horizontal configuration">
             <wl-icon class="fg green indicator">cloud_queue</wl-icon>
-            <span>${this._markIfUnlimited(rowData.item.max_vfolder_size, true)}</span>
+            <span>${this._displayResourcesByResourceUnit(rowData.item.max_vfolder_size, true, 'max_vfolder_size')}</span>
             <span class="indicator">GB</span>
           </div>
           <div class="layout horizontal configuration">
             <wl-icon class="fg green indicator">folder</wl-icon>
-            <span>${this._markIfUnlimited(rowData.item.max_vfolder_count)}</span>
+            <span>${this._displayResourcesByResourceUnit(rowData.item.max_vfolder_count, false, 'max_vfolder_count')}</span>
             <span class="indicator">Folders</span>
           </div>
         </div>


### PR DESCRIPTION
This PR resolves #1602.
Also, I found a similar issue occurred in resource column field at resource policies tab, so I add some touch-up code there, too.

## Screenshot(s)
### before
* Credentials Tab
<img width="1175" alt="Screenshot 2023-02-20 at 7 22 25 PM" src="https://user-images.githubusercontent.com/46954439/220079068-2350f9b8-47b5-42f4-8bb2-a68a8cea2471.png">

* Resource Policies Tab
<img width="1175" alt="Screenshot 2023-02-20 at 7 22 28 PM" src="https://user-images.githubusercontent.com/46954439/220079242-41e782cb-5504-4caa-bc05-e587c209b57e.png">


### after
* Credentials Tab
<img width="1175" alt="Screenshot 2023-02-20 at 7 21 35 PM" src="https://user-images.githubusercontent.com/46954439/220079277-e1ca83db-33cd-45c6-8447-2ba262e2dc91.png">

* Resource Policies Tab
<img width="1175" alt="Screenshot 2023-02-20 at 7 21 39 PM" src="https://user-images.githubusercontent.com/46954439/220079331-3513e5d7-b508-4433-b156-a2a10238fe95.png">
