### PR TITLE
feat: add the flag to hide 2fa

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -21,6 +21,7 @@ maskUserInfo = false                    # If true, then account information in h
 #singleSignOnVendors = "saml"           # Comma-separated list of vendors that support single sign-on.
 enableContainerCommit = false           # If true, then user can request container commit corres ponding to the session in running status
 hideAgents = true                       # If false, show the `Agent Summary` menu in the sidebar.
+hide2FA = true                          # If false, users can use 2FA.
 appDownloadUrl = ""                     # URL to download the electron app. If blank, https://github.com/lablup/backend.ai-webui/releases/download will be used.
 
 [wsproxy]

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -21,7 +21,7 @@ maskUserInfo = false                    # If true, then account information in h
 #singleSignOnVendors = "saml"           # Comma-separated list of vendors that support single sign-on.
 enableContainerCommit = false           # If true, then user can request container commit corres ponding to the session in running status
 hideAgents = true                       # If false, show the `Agent Summary` menu in the sidebar.
-hide2FA = true                          # If false, users can use 2FA.
+hide2FA = true                          # If false and users installed the backend.ai-totp-plugin, users can use 2FA.
 appDownloadUrl = ""                     # URL to download the electron app. If blank, https://github.com/lablup/backend.ai-webui/releases/download will be used.
 
 [wsproxy]

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -488,7 +488,7 @@
     "UserNotFound": "Credential creation failed, since the following user ID could't be found : ",
     "UserIDRequired": "User ID is required.",
     "KeypairDetail": "Keypair Detail",
-    "AdminCanOnlyRemoveTotp": "Only disabling 2FA authentication of other users is possible."
+    "AdminCanOnlyRemoveTotp": "Only disabling 2FA of other users is possible."
   },
   "data": {
     "Folders": "Folders",

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -111,6 +111,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({type: Boolean}) maxFileUploadSize = -1;
   @property({type: Boolean}) maskUserInfo = false;
   @property({type: Boolean}) hideAgents = true;
+  @property({type: Boolean}) hide2FA = true;
   @property({type: Array}) singleSignOnVendors: string[] = [];
   @property({type: Array}) allow_image_list;
   @property({type: Array}) endpoints;
@@ -714,6 +715,14 @@ export default class BackendAILogin extends BackendAIPage {
         valueType: 'boolean',
         defaultValue: true,
         value: (generalConfig?.hideAgents),
+      } as ConfigValueObject) as boolean;
+
+    // Enable hide 2FA flag
+    this.hide2FA = this._getConfigValueByExists(generalConfig,
+      {
+        valueType: 'boolean',
+        defaultValue: true,
+        value: (generalConfig?.hide2FA),
       } as ConfigValueObject) as boolean;
 
     // Enable pipeline flag
@@ -1434,6 +1443,7 @@ export default class BackendAILogin extends BackendAIPage {
       globalThis.backendaiclient._config.enableContainerCommit = this._enableContainerCommit;
       globalThis.backendaiclient._config.appDownloadUrl = this.appDownloadUrl;
       globalThis.backendaiclient._config.hideAgents = this.hideAgents;
+      globalThis.backendaiclient._config.hide2FA = this.hide2FA;
       globalThis.backendaiclient.ready = true;
       if (this.endpoints.indexOf(globalThis.backendaiclient._config.endpoint as any) === -1) {
         this.endpoints.push(globalThis.backendaiclient._config.endpoint as any);

--- a/src/components/backend-ai-user-dropdown-menu.ts
+++ b/src/components/backend-ai-user-dropdown-menu.ts
@@ -605,7 +605,7 @@ export default class BackendAiUserDropdownMenu extends LitElement {
                                     @click="${(e) => this._togglePasswordVisibility(e.target)}">
           </mwc-icon-button-toggle>
         </div>
-        ${this.totpSupported ? html`
+        ${this.totpSupported === true ? html`
           <div class="horizontal flex layout">
             <p style="flex-grow: 1;margin-left: 15px;">
               ${_t('webui.menu.TotpActivated')}

--- a/src/components/backend-ai-user-list.ts
+++ b/src/components/backend-ai-user-list.ts
@@ -791,7 +791,7 @@ export default class BackendAIUserList extends BackendAIPage {
                               .renderer="${this._userIdRenderer.bind(this)}"></lablup-grid-sort-filter-column>
           <lablup-grid-sort-filter-column auto-width path="username" header="${_t('credential.Name')}" resizable
                               .renderer="${this._userNameRenderer}"></lablup-grid-sort-filter-column>
-          ${this.totpSupported ? html`
+          ${this.totpSupported === true ? html`
             <vaadin-grid-sort-column auto-width flex-grow="0" path="totp_activated" header="${_t('webui.menu.TotpActivated')}" resizable
                               .renderer="${this._totpActivatedRenderer.bind(this)}"></vaadin-grid-sort-column>
           `: html``}
@@ -897,7 +897,7 @@ export default class BackendAIUserList extends BackendAIPage {
                       id="need_password_change"
                       ?selected=${this.userInfo.need_password_change}></mwc-switch>
                 </div>
-                ${this.totpSupported ? html`
+                ${this.totpSupported === true ? html`
                   <div class="horizontal layout center">
                     <p class="label">${_text('webui.menu.TotpActivated')}</p>
                     <mwc-switch
@@ -915,7 +915,7 @@ export default class BackendAIUserList extends BackendAIPage {
                     disabled
                     label="${_text('credential.DescRequirePasswordChange')}"
                     value="${this.userInfo.need_password_change ? `${_text('button.Yes')}` : `${_text('button.No')}`}"></mwc-textfield>
-                ${this.totpSupported ? html`
+                ${this.totpSupported === true ? html`
                   <mwc-textfield
                       disabled
                       label="${_text('webui.menu.TotpActivated')}"

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -610,6 +610,9 @@ class Client {
   }
 
   async isManagerSupportingTOTP() {
+    if (this._config.hide2FA) {
+      return false;
+    }
     let rqst = this.newSignedRequest('GET', `/totp`, null, null);
     try {
       await this._wrapWithPromise(rqst);


### PR DESCRIPTION
resolves https://github.com/lablup/giftbox/issues/200

If the `hide2FA` flag is true, users can hide 2FA-related columns and don't call the totp API 