### PR TITLE
fix: get `totpSupported` flag asynchronously

### DIFF
--- a/src/components/backend-ai-user-dropdown-menu.ts
+++ b/src/components/backend-ai-user-dropdown-menu.ts
@@ -144,7 +144,7 @@ export default class BackendAiUserDropdownMenu extends LitElement {
   }
 
   async _showTotpActivated() {
-    this.totpSupported = globalThis.backendaiclient?.supports('2FA');
+    this.totpSupported = await globalThis.backendaiclient?.supports('2FA');
     if (this.totpSupported) {
       const userInfo = await globalThis.backendaiclient?.user.get(
         globalThis.backendaiclient.email, ['totp_activated']
@@ -605,7 +605,7 @@ export default class BackendAiUserDropdownMenu extends LitElement {
                                     @click="${(e) => this._togglePasswordVisibility(e.target)}">
           </mwc-icon-button-toggle>
         </div>
-        ${this.totpSupported === true ? html`
+        ${this.totpSupported ? html`
           <div class="horizontal flex layout">
             <p style="flex-grow: 1;margin-left: 15px;">
               ${_t('webui.menu.TotpActivated')}

--- a/src/components/backend-ai-user-list.ts
+++ b/src/components/backend-ai-user-list.ts
@@ -256,14 +256,14 @@ export default class BackendAIUserList extends BackendAIPage {
     }
     // If disconnected
     if (typeof globalThis.backendaiclient === 'undefined' || globalThis.backendaiclient === null || globalThis.backendaiclient.ready === false) {
-      document.addEventListener('backend-ai-connected', () => {
-        this.totpSupported = globalThis.backendaiclient?.supports('2FA');
+      document.addEventListener('backend-ai-connected', async () => {
+        this.totpSupported = await globalThis.backendaiclient?.supports('2FA');
         this._refreshUserData();
         this.isAdmin = globalThis.backendaiclient.is_admin;
         this.isUserInfoMaskEnabled = globalThis.backendaiclient._config.maskUserInfo;
       }, true);
     } else { // already connected
-      this.totpSupported = globalThis.backendaiclient?.supports('2FA');
+      this.totpSupported = await globalThis.backendaiclient?.supports('2FA');
       this._refreshUserData();
       this.isAdmin = globalThis.backendaiclient.is_admin;
       this.isUserInfoMaskEnabled = globalThis.backendaiclient._config.maskUserInfo;
@@ -791,7 +791,7 @@ export default class BackendAIUserList extends BackendAIPage {
                               .renderer="${this._userIdRenderer.bind(this)}"></lablup-grid-sort-filter-column>
           <lablup-grid-sort-filter-column auto-width path="username" header="${_t('credential.Name')}" resizable
                               .renderer="${this._userNameRenderer}"></lablup-grid-sort-filter-column>
-          ${this.totpSupported === true ? html`
+          ${this.totpSupported ? html`
             <vaadin-grid-sort-column auto-width flex-grow="0" path="totp_activated" header="${_t('webui.menu.TotpActivated')}" resizable
                               .renderer="${this._totpActivatedRenderer.bind(this)}"></vaadin-grid-sort-column>
           `: html``}
@@ -897,7 +897,7 @@ export default class BackendAIUserList extends BackendAIPage {
                       id="need_password_change"
                       ?selected=${this.userInfo.need_password_change}></mwc-switch>
                 </div>
-                ${this.totpSupported === true ? html`
+                ${this.totpSupported ? html`
                   <div class="horizontal layout center">
                     <p class="label">${_text('webui.menu.TotpActivated')}</p>
                     <mwc-switch
@@ -915,7 +915,7 @@ export default class BackendAIUserList extends BackendAIPage {
                     disabled
                     label="${_text('credential.DescRequirePasswordChange')}"
                     value="${this.userInfo.need_password_change ? `${_text('button.Yes')}` : `${_text('button.No')}`}"></mwc-textfield>
-                ${this.totpSupported === true ? html`
+                ${this.totpSupported ? html`
                   <mwc-textfield
                       disabled
                       label="${_text('webui.menu.TotpActivated')}"


### PR DESCRIPTION
The logic of setting `totpSupported` option is incorrect, and I found a problem that the totp-related columns are not visible. Resolve the above error by getting the `totpSupported` option asynchronously.