### PR TITLE
fix: apply ellipsis when username or userid exceeds total width of user dropdown menu

### DIFF
--- a/src/components/backend-ai-user-dropdown-menu.ts
+++ b/src/components/backend-ai-user-dropdown-menu.ts
@@ -5,7 +5,7 @@
 
 
 import {customElement, property, query} from 'lit/decorators.js';
-import {LitElement, html, CSSResultGroup} from 'lit';
+import {css, LitElement, html, CSSResultGroup} from 'lit';
 import {translate as _t} from 'lit-translate';
 import '@material/mwc-select';
 import '@material/mwc-icon-button';
@@ -73,7 +73,21 @@ export default class BackendAiUserDropdownMenu extends LitElement {
       IronFlex,
       IronFlexAlignment,
       IronFlexFactors,
-      IronPositioning
+      IronPositioning,
+      css`
+        span.dropdown-menu-name {
+          display: inline-block;
+          text-overflow: ellipsis;
+          overflow: hidden;
+          white-space: nowrap;
+          max-width: 135px;
+        }
+
+        #dropdown-area {
+          position: relative;
+          right: 50px;
+        }
+      `,
     ];
   }
   firstUpdated() {
@@ -106,8 +120,8 @@ export default class BackendAiUserDropdownMenu extends LitElement {
    * @return {string} Name from full name or user ID
    */
   _getUsername() {
-    let name = this.fullName ? this.fullName : this.userId;
-    // mask username only when the configuration is enabled
+    let name = (this.fullName.replace(/\s+/g, "").length > 0) ? this.fullName : this.userId;
+      // mask username only when the configuration is enabled
     if (this.isUserInfoMaskEnabled) {
       const maskStartIdx = 2;
       const emailPattern = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
@@ -482,7 +496,7 @@ export default class BackendAiUserDropdownMenu extends LitElement {
     return html`
       <link rel="stylesheet" href="resources/custom.css">
       <div class="horizontal flex center layout">
-        <div class="vertical layout center" style="position:relative;right:50px;">
+        <div class="vertical layout center" id="dropdown-area">
           <mwc-menu id="dropdown-menu" class="user-menu">
             ${this.domain !== 'default' && this.domain !== '' ? html`
             <mwc-list-item class="horizontal layout start center" disabled style="border-bottom:1px solid #ccc;pointer-events:none;">
@@ -491,7 +505,7 @@ export default class BackendAiUserDropdownMenu extends LitElement {
             ` : html``}
             <mwc-list-item class="horizontal layout start center" style="pointer-events:none;">
                 <mwc-icon class="dropdown-menu">perm_identity</mwc-icon>
-                <span class="dropdown-menu-name">${this._getUsername()}</span>
+                 <span class="dropdown-menu-name">${this._getUsername()}</span>
             </mwc-list-item>
             <mwc-list-item class="horizontal layout start center" disabled style="border-bottom:1px solid #ccc;pointer-events:none;">
                 <mwc-icon class="dropdown-menu">email</mwc-icon>


### PR DESCRIPTION
This PR resolves #1621.

### Screenshot(s)
* applying long user-id(email)
* applying full name of user info filled with whitespace (display user-id instead)
<img width="355" alt="Screenshot 2023-03-08 at 2 51 57 PM" src="https://user-images.githubusercontent.com/46954439/223630864-e0cace1c-634b-4b68-9612-017b62cc5003.png">

|   | Before|After|
|---|---|---|
|long user-id|<img width="200" alt="Screenshot 2023-03-08 at 2 55 28 PM" src="https://user-images.githubusercontent.com/46954439/223631004-c0c1b347-9207-4c44-8943-4b7df5f843e7.png">|<img width="200" alt="Screenshot 2023-03-08 at 2 47 25 PM" src="https://user-images.githubusercontent.com/46954439/223630925-390fbc83-a48f-420d-ab90-71ff1e01da24.png">|
|fullname filled with whitespace|<img width="582" alt="Screenshot 2023-03-08 at 3 02 45 PM" src="https://user-images.githubusercontent.com/46954439/223632342-584f9af6-23fe-4520-a5cf-a02e85388617.png">|<img width="582" alt="Screenshot 2023-03-08 at 3 01 35 PM" src="https://user-images.githubusercontent.com/46954439/223632331-b8f160f9-cb31-4477-a7d9-6bc81d35ab0c.png">|


