### PR TITLE
feature: show tooltips on every icon in controls tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend.ai-webui",
-  "version": "22.09.14",
+  "version": "23.03.0a1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend.ai-webui",
-      "version": "22.09.14",
+      "version": "23.03.0a1",
       "hasInstallScript": true,
       "license": "LGPL-3.0-or-later",
       "dependencies": {
@@ -35,6 +35,7 @@
         "@vaadin/item": "^24.0.0",
         "@vaadin/progress-bar": "^24.0.0",
         "@vaadin/text-field": "^24.0.0",
+        "@vaadin/tooltip": "^24.0.0",
         "@vanillawc/wc-codemirror": "^2.1.0",
         "@webcomponents/webcomponentsjs": "^2.7.0",
         "bufferutil": "^4.0.7",
@@ -5361,6 +5362,19 @@
         "@vaadin/field-base": "~24.0.0",
         "@vaadin/input-container": "~24.0.0",
         "@vaadin/item": "~24.0.0",
+        "@vaadin/overlay": "~24.0.0",
+        "@vaadin/vaadin-lumo-styles": "~24.0.0",
+        "@vaadin/vaadin-material-styles": "~24.0.0",
+        "@vaadin/vaadin-themable-mixin": "~24.0.0"
+      }
+    },
+    "node_modules/@vaadin/tooltip": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/tooltip/-/tooltip-24.0.0.tgz",
+      "integrity": "sha512-IOVGunNpgd8UKU/LLyNTXronDpJbjz9a8Wc6hpg7QLXj1f763X5b3+gLYjMLBjoLx86p34bI25j7RWNZle2Lng==",
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.0.0",
         "@vaadin/overlay": "~24.0.0",
         "@vaadin/vaadin-lumo-styles": "~24.0.0",
         "@vaadin/vaadin-material-styles": "~24.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@vaadin/item": "^24.0.0",
     "@vaadin/progress-bar": "^24.0.0",
     "@vaadin/text-field": "^24.0.0",
+    "@vaadin/tooltip": "^24.0.0",
     "@vanillawc/wc-codemirror": "^2.1.0",
     "@webcomponents/webcomponentsjs": "^2.7.0",
     "bufferutil": "^4.0.7",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -336,7 +336,12 @@
     "Inference": "Inference",
     "UseSubdomain": "UseSubdomain",
     "BypassAuthentication": "Bypass authentication",
-    "App": "App"
+    "App": "App",
+    "SeeAppDialog": "See App Dialog",
+    "ExecuteTerminalApp": "Execute Terminal App",
+    "TerminateSession": "Terminate Session",
+    "SeeContainerLogs": "See Container Logs",
+    "RequestContainerCommit": "Request Container Commit"
   },
   "button": {
     "Cancel": "Cancel",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -329,7 +329,12 @@
     "Inference": "__NOT_TRANSLATED__",
     "UseSubdomain": "__NOT_TRANSLATED__",
     "BypassAuthentication": "__NOT_TRANSLATED__",
-    "App": "__NOT_TRANSLATED__"
+    "App": "__NOT_TRANSLATED__",
+    "SeeAppDialog": "__NOT_TRANSLATED__",
+    "ExecuteTerminalApp": "__NOT_TRANSLATED__",
+    "TerminateSession": "__NOT_TRANSLATED__",
+    "SeeContainerLogs": "__NOT_TRANSLATED__",
+    "RequestContainerCommit": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Annuler",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -329,7 +329,12 @@
     "Inference": "__NOT_TRANSLATED__",
     "UseSubdomain": "__NOT_TRANSLATED__",
     "BypassAuthentication": "__NOT_TRANSLATED__",
-    "App": "__NOT_TRANSLATED__"
+    "App": "__NOT_TRANSLATED__",
+    "SeeAppDialog": "__NOT_TRANSLATED__",
+    "ExecuteTerminalApp": "__NOT_TRANSLATED__",
+    "TerminateSession": "__NOT_TRANSLATED__",
+    "SeeContainerLogs": "__NOT_TRANSLATED__",
+    "RequestContainerCommit": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Batalkan",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -328,7 +328,12 @@
     "Inference": "INFERENCE",
     "UseSubdomain": "서브도메인 주소 입력",
     "BypassAuthentication": "인증 바이패스",
-    "App": "__NOT_TRANSLATED__"
+    "App": "앱",
+    "SeeAppDialog": "앱 다이얼로그 보기",
+    "ExecuteTerminalApp": "터미널 앱 실행하기",
+    "TerminateSession": "세션 종료하기",
+    "SeeContainerLogs": "컨테이너 로그 보기",
+    "RequestContainerCommit": "컨테이너 커밋하기"
   },
   "button": {
     "Cancel": "취소",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -329,7 +329,12 @@
     "Inference": "__NOT_TRANSLATED__",
     "UseSubdomain": "__NOT_TRANSLATED__",
     "BypassAuthentication": "__NOT_TRANSLATED__",
-    "App": "__NOT_TRANSLATED__"
+    "App": "__NOT_TRANSLATED__",
+    "SeeAppDialog": "__NOT_TRANSLATED__",
+    "ExecuteTerminalApp": "__NOT_TRANSLATED__",
+    "TerminateSession": "__NOT_TRANSLATED__",
+    "SeeContainerLogs": "__NOT_TRANSLATED__",
+    "RequestContainerCommit": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Цуцлах",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -329,7 +329,12 @@
     "Inference": "__NOT_TRANSLATED__",
     "UseSubdomain": "__NOT_TRANSLATED__",
     "BypassAuthentication": "__NOT_TRANSLATED__",
-    "App": "__NOT_TRANSLATED__"
+    "App": "__NOT_TRANSLATED__",
+    "SeeAppDialog": "__NOT_TRANSLATED__",
+    "ExecuteTerminalApp": "__NOT_TRANSLATED__",
+    "TerminateSession": "__NOT_TRANSLATED__",
+    "SeeContainerLogs": "__NOT_TRANSLATED__",
+    "RequestContainerCommit": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Отмена",

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -12,15 +12,14 @@ import '@vaadin/grid/vaadin-grid-selection-column';
 import '@vaadin/grid/vaadin-grid-sort-column';
 import '@vaadin/grid/vaadin-grid-filter-column';
 import '@vaadin/icons/vaadin-icons';
+import '@vaadin/tooltip';
 
 import {default as AnsiUp} from '../lib/ansiup';
 import 'weightless/button';
 import {Checkbox} from 'weightless/checkbox';
 import 'weightless/expansion';
 import 'weightless/icon';
-import 'weightless/tooltip';
 import {Textfield} from 'weightless/textfield';
-import {Tooltip} from 'weightless/tooltip/tooltip';
 
 import '@material/mwc-icon-button';
 import '@material/mwc-icon-button-toggle';
@@ -241,14 +240,6 @@ export default class BackendAiSessionList extends BackendAIPage {
           --button-fab-size: 32px;
           --button-padding: 3px;
           margin-right: 5px;
-        }
-
-        wl-tooltip.log-disabled-msg {
-          position: absolute;
-          top: 80%;
-          left: 100%;
-          transform: translate(-50%, -50%);
-          z-index: 1; /* used for overlay */
         }
 
         img.indicator-icon {
@@ -1479,30 +1470,6 @@ export default class BackendAiSessionList extends BackendAIPage {
     while (menu[0]) menu[0].parentNode.removeChild(menu[0]);
   }
 
-  /**
-   * Show tooltip when mouseenter the corresponding element
-   *
-   * @param {string} elementId
-   */
-  _showTooltip(elementId = '') {
-    if (elementId) {
-      const tooltip = this.shadowRoot?.querySelector(`#${elementId}`) as Tooltip;
-      tooltip.open = true;
-    }
-  }
-
-  /**
-   * Hide tooltip when mouseleave the corresponding element
-   *
-   * @param {string} elementId
-   */
-  _hideTooltip(elementId = '') {
-    if (elementId) {
-      const tooltip = this.shadowRoot?.querySelector(`#${elementId}`) as Tooltip;
-      tooltip.open = false;
-    }
-  }
-
   _renderStatusDetail() {
     const tmpSessionStatus = JSON.parse(this.selectedSessionStatus.data);
     tmpSessionStatus.reserved_time = this.selectedSessionStatus.reserved_time;
@@ -1909,12 +1876,19 @@ export default class BackendAiSessionList extends BackendAIPage {
              .kernel-image="${rowData.item.kernel_image}"
              .app-services="${rowData.item.app_services}"
              .app-services-option="${rowData.item.app_services_option}">
+          <vaadin-tooltip for="${rowData.item.session_id+'apps'}" text="${_t('session.SeeAppDialog')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.session_id+'terminal'}" text="${_t('session.ExecuteTerminalApp')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.session_id+'power'}" text="${_t('session.TerminateSession')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.session_id+'assignment'}" text="${_t('session.SeeContainerLogs')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.session_id+'archive'}" text="${_t('session.RequestContainerCommit')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.session_id+'nologs'}" text="${_t('session.NoLogMsgAvailable')}" position="top-start"></vaadin-tooltip>
           ${rowData.item.appSupport ? html`
             <mwc-icon-button class="fg controls-running green"
+                               id="${rowData.item.session_id+'apps'}"
                                @click="${(e) => this._showAppLauncher(e)}"
-                               ?disabled="${!mySession || rowData.item.type === 'BATCH'}"
                                icon="apps"></mwc-icon-button>
             <mwc-icon-button class="fg controls-running"
+                               id="${rowData.item.session_id+'terminal'}"
                                ?disabled="${!mySession}"
                                @click="${(e) => this._runTerminal(e)}">
               <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
@@ -1936,20 +1910,18 @@ export default class BackendAiSessionList extends BackendAIPage {
             </mwc-icon-button>
           ` : html``}
           ${(this._isRunning && !this._isPreparing(rowData.item.status)) || this._isError(rowData.item.status) ? html`
-            <mwc-icon-button class="fg red controls-running" ?disabled=${!this._isPending(rowData.item.status) && rowData.item?.commit_status as CommitSessionStatus === 'ongoing'}
+            <mwc-icon-button class="fg red controls-running" id="${rowData.item.session_id+'power'}" ?disabled=${!this._isPending(rowData.item.status) && rowData.item?.commit_status as CommitSessionStatus === 'ongoing'}
                                icon="power_settings_new" @click="${(e) => this._openTerminateSessionDialog(e)}"></mwc-icon-button>
           ` : html``}
           ${(this._isRunning && !this._isPreparing(rowData.item.status) || this._APIMajorVersion > 4) && !this._isPending(rowData.item.status) ? html`
-            <mwc-icon-button class="fg blue controls-running" icon="assignment"
+            <mwc-icon-button class="fg blue controls-running" id="${rowData.item.session_id+'assignment'}" icon="assignment"
                                @click="${(e) => this._showLogs(e)}"></mwc-icon-button>
           ` : html`
-            <div @mouseenter="${() => this._showTooltip('tooltip-'+rowData.item.session_id)}" @mouseleave="${() => this._hideTooltip('tooltip-'+rowData.item.session_id)}">
-              <mwc-icon-button fab flat inverted disabled class="fg controls-running" icon="assignment"></mwc-icon-button>
-            </div>
-            <wl-tooltip class="log-disabled-msg" id="tooltip-${rowData.item.session_id}">${_t('session.NoLogMsgAvailable')}</wl-tooltip>
+            <mwc-icon-button fab flat inverted disabled class="fg controls-running" id="${rowData.item.session_id+'nologs'}" icon="assignment"></mwc-icon-button>
           `}
           ${this._isContainerCommitEnabled ? html`
             <mwc-icon-button class="fg blue controls-running"
+                             id="${rowData.item.session_id+'archive'}"
                              ?disabled=${this._isPending(rowData.item.status) ||
                                          this._isPreparing(rowData.item.status) ||
                                          this._isError(rowData.item.status) ||

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1864,7 +1864,6 @@ export default class BackendAiSessionList extends BackendAIPage {
    * @param {Object} rowData - the object with the properties related with the rendered item
    * */
   controlRenderer(root, column?, rowData?) {
-    console.log(rowData)
     let mySession = true;
     mySession = (this._connectionMode === 'API' && rowData.item.access_key === globalThis.backendaiclient._config._accessKey) ||
       (rowData.item.user_email === globalThis.backendaiclient.email);

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1864,6 +1864,7 @@ export default class BackendAiSessionList extends BackendAIPage {
    * @param {Object} rowData - the object with the properties related with the rendered item
    * */
   controlRenderer(root, column?, rowData?) {
+    console.log(rowData)
     let mySession = true;
     mySession = (this._connectionMode === 'API' && rowData.item.access_key === globalThis.backendaiclient._config._accessKey) ||
       (rowData.item.user_email === globalThis.backendaiclient.email);
@@ -1876,19 +1877,19 @@ export default class BackendAiSessionList extends BackendAIPage {
              .kernel-image="${rowData.item.kernel_image}"
              .app-services="${rowData.item.app_services}"
              .app-services-option="${rowData.item.app_services_option}">
-          <vaadin-tooltip for="${rowData.item.session_id+'apps'}" text="${_t('session.SeeAppDialog')}" position="top-start"></vaadin-tooltip>
-          <vaadin-tooltip for="${rowData.item.session_id+'terminal'}" text="${_t('session.ExecuteTerminalApp')}" position="top-start"></vaadin-tooltip>
-          <vaadin-tooltip for="${rowData.item.session_id+'power'}" text="${_t('session.TerminateSession')}" position="top-start"></vaadin-tooltip>
-          <vaadin-tooltip for="${rowData.item.session_id+'assignment'}" text="${_t('session.SeeContainerLogs')}" position="top-start"></vaadin-tooltip>
-          <vaadin-tooltip for="${rowData.item.session_id+'archive'}" text="${_t('session.RequestContainerCommit')}" position="top-start"></vaadin-tooltip>
-          <vaadin-tooltip for="${rowData.item.session_id+'nologs'}" text="${_t('session.NoLogMsgAvailable')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.index+'-apps'}" text="${_t('session.SeeAppDialog')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.index+'-terminal'}" text="${_t('session.ExecuteTerminalApp')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.index+'-power'}" text="${_t('session.TerminateSession')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.index+'-assignment'}" text="${_t('session.SeeContainerLogs')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.index+'-archive'}" text="${_t('session.RequestContainerCommit')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.index+'-nologs'}" text="${_t('session.NoLogMsgAvailable')}" position="top-start"></vaadin-tooltip>
           ${rowData.item.appSupport ? html`
             <mwc-icon-button class="fg controls-running green"
-                               id="${rowData.item.session_id+'apps'}"
+                               id="${rowData.index+'-apps'}"
                                @click="${(e) => this._showAppLauncher(e)}"
                                icon="apps"></mwc-icon-button>
             <mwc-icon-button class="fg controls-running"
-                               id="${rowData.item.session_id+'terminal'}"
+                               id="${rowData.index+'-terminal'}"
                                ?disabled="${!mySession}"
                                @click="${(e) => this._runTerminal(e)}">
               <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
@@ -1910,18 +1911,18 @@ export default class BackendAiSessionList extends BackendAIPage {
             </mwc-icon-button>
           ` : html``}
           ${(this._isRunning && !this._isPreparing(rowData.item.status)) || this._isError(rowData.item.status) ? html`
-            <mwc-icon-button class="fg red controls-running" id="${rowData.item.session_id+'power'}" ?disabled=${!this._isPending(rowData.item.status) && rowData.item?.commit_status as CommitSessionStatus === 'ongoing'}
+            <mwc-icon-button class="fg red controls-running" id="${rowData.index+'-power'}" ?disabled=${!this._isPending(rowData.item.status) && rowData.item?.commit_status as CommitSessionStatus === 'ongoing'}
                                icon="power_settings_new" @click="${(e) => this._openTerminateSessionDialog(e)}"></mwc-icon-button>
           ` : html``}
           ${(this._isRunning && !this._isPreparing(rowData.item.status) || this._APIMajorVersion > 4) && !this._isPending(rowData.item.status) ? html`
-            <mwc-icon-button class="fg blue controls-running" id="${rowData.item.session_id+'assignment'}" icon="assignment"
+            <mwc-icon-button class="fg blue controls-running" id="${rowData.index+'-assignment'}" icon="assignment"
                                @click="${(e) => this._showLogs(e)}"></mwc-icon-button>
           ` : html`
-            <mwc-icon-button fab flat inverted disabled class="fg controls-running" id="${rowData.item.session_id+'nologs'}" icon="assignment"></mwc-icon-button>
+            <mwc-icon-button fab flat inverted disabled class="fg controls-running" id="${rowData.index+'-nologs'}" icon="assignment"></mwc-icon-button>
           `}
           ${this._isContainerCommitEnabled ? html`
             <mwc-icon-button class="fg blue controls-running"
-                             id="${rowData.item.session_id+'archive'}"
+                             id="${rowData.index+'-archive'}"
                              ?disabled=${this._isPending(rowData.item.status) ||
                                          this._isPreparing(rowData.item.status) ||
                                          this._isError(rowData.item.status) ||

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -786,6 +786,7 @@ export default class BackendAiSessionList extends BackendAIPage {
 
       this.compute_sessions = sessions;
       this._grid.recalculateColumnWidths();
+      // this._grid.clearCache();
       this.requestUpdate();
       let refreshTime;
       this.refreshing = false;
@@ -1876,17 +1877,13 @@ export default class BackendAiSessionList extends BackendAIPage {
              .kernel-image="${rowData.item.kernel_image}"
              .app-services="${rowData.item.app_services}"
              .app-services-option="${rowData.item.app_services_option}">
-          <vaadin-tooltip for="${rowData.index+'-apps'}" text="${_t('session.SeeAppDialog')}" position="top-start"></vaadin-tooltip>
-          <vaadin-tooltip for="${rowData.index+'-terminal'}" text="${_t('session.ExecuteTerminalApp')}" position="top-start"></vaadin-tooltip>
-          <vaadin-tooltip for="${rowData.index+'-power'}" text="${_t('session.TerminateSession')}" position="top-start"></vaadin-tooltip>
-          <vaadin-tooltip for="${rowData.index+'-assignment'}" text="${_t('session.SeeContainerLogs')}" position="top-start"></vaadin-tooltip>
-          <vaadin-tooltip for="${rowData.index+'-archive'}" text="${_t('session.RequestContainerCommit')}" position="top-start"></vaadin-tooltip>
-          <vaadin-tooltip for="${rowData.index+'-nologs'}" text="${_t('session.NoLogMsgAvailable')}" position="top-start"></vaadin-tooltip>
           ${rowData.item.appSupport ? html`
             <mwc-icon-button class="fg controls-running green"
                                id="${rowData.index+'-apps'}"
                                @click="${(e) => this._showAppLauncher(e)}"
-                               icon="apps"></mwc-icon-button>
+                               icon="apps">
+            </mwc-icon-button>
+            <vaadin-tooltip for="${rowData.index+'-apps'}" text="${_t('session.SeeAppDialog')}" position="top-start"></vaadin-tooltip>
             <mwc-icon-button class="fg controls-running"
                                id="${rowData.index+'-terminal'}"
                                ?disabled="${!mySession}"
@@ -1908,16 +1905,20 @@ export default class BackendAiSessionList extends BackendAIPage {
               </g>
             </svg>
             </mwc-icon-button>
+            <vaadin-tooltip for="${rowData.index+'-terminal'}" text="${_t('session.ExecuteTerminalApp')}" position="top-start"></vaadin-tooltip>
           ` : html``}
           ${(this._isRunning && !this._isPreparing(rowData.item.status)) || this._isError(rowData.item.status) ? html`
             <mwc-icon-button class="fg red controls-running" id="${rowData.index+'-power'}" ?disabled=${!this._isPending(rowData.item.status) && rowData.item?.commit_status as CommitSessionStatus === 'ongoing'}
                                icon="power_settings_new" @click="${(e) => this._openTerminateSessionDialog(e)}"></mwc-icon-button>
+            <vaadin-tooltip for="${rowData.index+'-power'}" text="${_t('session.TerminateSession')}" position="top-start"></vaadin-tooltip>
           ` : html``}
           ${(this._isRunning && !this._isPreparing(rowData.item.status) || this._APIMajorVersion > 4) && !this._isPending(rowData.item.status) ? html`
             <mwc-icon-button class="fg blue controls-running" id="${rowData.index+'-assignment'}" icon="assignment"
                                @click="${(e) => this._showLogs(e)}"></mwc-icon-button>
+            <vaadin-tooltip for="${rowData.index+'-assignment'}" text="${_t('session.SeeContainerLogs')}" position="top-start"></vaadin-tooltip>
           ` : html`
             <mwc-icon-button fab flat inverted disabled class="fg controls-running" id="${rowData.index+'-nologs'}" icon="assignment"></mwc-icon-button>
+            <vaadin-tooltip for="${rowData.index+'-archive'}" text="${_t('session.RequestContainerCommit')}" position="top-start"></vaadin-tooltip>
           `}
           ${this._isContainerCommitEnabled ? html`
             <mwc-icon-button class="fg blue controls-running"
@@ -1929,6 +1930,7 @@ export default class BackendAiSessionList extends BackendAIPage {
                                          rowData.item.type as SessionType === 'BATCH' ||
                                          rowData.item.commit_status as CommitSessionStatus === 'ongoing'}
                              icon="archive" @click="${(e) => this._openCommitSessionDialog(e)}"></mwc-icon-button>
+            <vaadin-tooltip for="${rowData.index+'-nologs'}" text="${_t('session.NoLogMsgAvailable')}" position="top-start"></vaadin-tooltip>
           ` : html``}
         </div>
       `, root


### PR DESCRIPTION
## Description
This PR resolves #1632.
Also, I replaced `wl-tooltip` with `vaadin-tooltip` to provide a better user experience by unifying the tooltip component.

> NOTE:
> IMO, when any element is set to "disabled", it shall not receive or invoke an event unless it's necessary for a specific situation. Therefore I didn't add any "workaround" code on "icons" with disabled status.

## Screenshot(s)
* Before
<img width="823" alt="Screenshot 2023-03-17 at 3 50 47 PM" src="https://user-images.githubusercontent.com/46954439/225833532-dc7fc637-aa29-49c3-a177-17c34f2cd317.png">

* After
<img width="823" alt="Screenshot 2023-03-17 at 3 42 55 PM" src="https://user-images.githubusercontent.com/46954439/225833552-098b3149-3e63-48a4-ace9-745915803561.png">
