### PR TITLE
feature: hide vfolder sharing when invite others disabled

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -1137,7 +1137,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
                                .helper="(${_t('session.CommaSeparated')})"></mwc-textfield>
               </div>
             `}
-            <div class="horizontal layout center">
+            <div id="preferred-app-port-config-box" style="display:none" class="horizontal layout center">
               <mwc-checkbox id="chk-preferred-port" style="margin-right:0.5em;"></mwc-checkbox>
               ${_t('session.TryPreferredPort')}
               <mwc-textfield id="app-port" type="number" no-label-float value="10250"

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1657,10 +1657,20 @@ export default class BackendAiStorageList extends BackendAIPage {
    *
    */
   async _checkFilebrowserSupported() {
-    const response = await globalThis.backendaiclient.image.list(['name', 'tag', 'registry', 'digest', 'installed', 'labels { key value }', 'resource_limits { key min max }'], false, true);
+    const fields = [
+      'name', 'tag', 'registry', 'digest', 'installed',
+      'labels { key value }',
+      'resource_limits { key min max }',
+    ];
+    const response = await globalThis.backendaiclient.image.list(fields, true, true);
     const images = response.images;
-    // only filter both installed and filebrowser supported image from images
-    this.filebrowserSupportedImages = images.filter((image) => image['installed'] && image.labels.find((label) => label.key === 'ai.backend.service-ports' && label.value.toLowerCase().includes('filebrowser')));
+    // Filter filebrowser supported images.
+    this.filebrowserSupportedImages = images.filter((image) =>
+      image.labels.find((label) =>
+        label.key === 'ai.backend.service-ports' &&
+        label.value.toLowerCase().includes('filebrowser'),
+      ),
+    );
   }
 
   async _viewStateChanged(active) {

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1587,7 +1587,9 @@ export default class BackendAiStorageList extends BackendAIPage {
 
   async refreshFolderList() {
     this._triggerFolderListChanged();
-    this.folderListGrid.clearCache();
+    if (this.folderListGrid) {
+      this.folderListGrid.clearCache();
+    }
     return await this._refreshFolderList(true, 'refreshFolderList');
   }
 

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -2318,25 +2318,21 @@ class StorageProxy {
 
   /**
    * Get all fields related to allowed_vfolder_hosts according to the current user information
-   * 
-   * @param {string} domainName 
+   *
+   * @param {string} domainName
    * @param {string} projectId
-   * @param {string} resourcePolicyName 
+   * @param {string} resourcePolicyName
    * @returns {object} - get allowed_vfolder_hosts key-value on domain, group, resource policy of current user
    */
-  async getAllowedVFolderHostsByCurrentUserInfo(domainName = '',
-                                                projectId = '',
-                                                resourcePolicyName = '') {
-    let q = `query($domainName: String, $projectId: UUID!, $resourcePolicyName: String) {` +
-        ` domain(name: $domainName) { allowed_vfolder_hosts }` +
-        ` group(id: $projectId, domain_name: $domainName) { allowed_vfolder_hosts }` +
-        ` keypair_resource_policy(name: $resourcePolicyName) { allowed_vfolder_hosts }` +
-        `}`;
-    let v = {
-      'domainName': domainName,
-      'projectId': projectId,
-      'resourcePolicyName': resourcePolicyName,
-    };
+  async getAllowedVFolderHostsByCurrentUserInfo(domainName = '', projectId = '', resourcePolicyName = '') {
+    const q = `
+      query($domainName: String, $projectId: UUID!, $resourcePolicyName: String) {
+        domain(name: $domainName) { allowed_vfolder_hosts }
+        group(id: $projectId, domain_name: $domainName) { allowed_vfolder_hosts }
+        keypair_resource_policy(name: $resourcePolicyName) { allowed_vfolder_hosts }
+      }
+    `;
+    const v = { domainName, projectId, resourcePolicyName };
     return this.client.query(q, v);
   }
 

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -2315,6 +2315,31 @@ class StorageProxy {
       return this.client._wrapWithPromise(rqst);
     }
   }
+
+  /**
+   * Get all fields related to allowed_vfolder_hosts according to the current user information
+   * 
+   * @param {string} domainName 
+   * @param {string} projectId
+   * @param {string} resourcePolicyName 
+   * @returns {object} - get allowed_vfolder_hosts key-value on domain, group, resource policy of current user
+   */
+  async getAllowedVFolderHostsByCurrentUserInfo(domainName = '',
+                                                projectId = '',
+                                                resourcePolicyName = '') {
+    let q = `query($domainName: String, $projectId: UUID!, $resourcePolicyName: String) {` +
+        ` domain(name: $domainName) { allowed_vfolder_hosts }` +
+        ` group(id: $projectId, domain_name: $domainName) { allowed_vfolder_hosts }` +
+        ` keypair_resource_policy(name: $resourcePolicyName) { allowed_vfolder_hosts }` +
+        `}`;
+    let v = {
+      'domainName': domainName,
+      'projectId': projectId,
+      'resourcePolicyName': resourcePolicyName,
+    };
+    return this.client.query(q, v);
+  }
+
 }
 
 class Keypair {


### PR DESCRIPTION
## Description
This PR resolves #1629.

> NOTE: you may need to change `allowed_vfolder_hosts` values to test the visibility of icon-button related to `vfolder sharing`. They will show-up when `invite-others` are allowed at least in one of the policies(`domain`, `project(group)`, `keypair resource policy`).

## Screenshot(s)
<img width="1249" alt="Screenshot 2023-03-17 at 8 31 22 PM" src="https://user-images.githubusercontent.com/46954439/225893034-7d5623a0-1baa-43c3-9ddb-eada04bff723.png">
