### PR TITLE
hotfix: rename `volumeInfo` property to `storageProxyInfo`

### DIFF
--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -96,7 +96,7 @@ export default class BackendAIData extends BackendAIPage {
   @property({type: Number}) capacity;
   @property({type: String}) cloneFolderName = '';
   @property({type: Array}) quotaSupportStorageBackends = ['xfs', 'weka', 'spectrumscale'];
-  @property({type: Object}) volumeInfo = Object();
+  @property({type: Object}) storageProxyInfo = Object();
   @property({type: String}) folderType = 'user';
   @query('#add-folder-name') addFolderNameInput!: TextField;
   @query('#clone-folder-name') cloneFolderNameInput!: TextField;
@@ -677,10 +677,10 @@ export default class BackendAIData extends BackendAIPage {
     };
     if (typeof globalThis.backendaiclient === 'undefined' || globalThis.backendaiclient === null || globalThis.backendaiclient.ready === false) {
       document.addEventListener('backend-ai-connected', () => {
-        this._getVolumeInformation();
+        this._getStorageProxyInformation();
       }, true);
     } else { // already connected
-      this._getVolumeInformation();
+      this._getStorageProxyInformation();
     }
     document.addEventListener('backend-ai-folder-list-changed', () => {
       // this.shadowRoot.querySelector('#storage-status').updateChart();
@@ -715,7 +715,7 @@ export default class BackendAIData extends BackendAIPage {
         this.usageModes.push('Model');
       }
       this.apiMajorVersion = globalThis.backendaiclient.APIMajorVersion;
-      this._getVolumeInformation();
+      this._getStorageProxyInformation();
       if (globalThis.backendaiclient.isAPIVersionCompatibleWith('v4.20191215')) {
         this._vfolderInnatePermissionSupport = true;
       }
@@ -827,9 +827,9 @@ export default class BackendAIData extends BackendAIPage {
     this.openDialog('add-folder-dialog');
   }
 
-  async _getVolumeInformation() {
+  async _getStorageProxyInformation() {
     const vhostInfo = await globalThis.backendaiclient.vfolder.list_hosts();
-    this.volumeInfo = vhostInfo.volume_info || {};
+    this.storageProxyInfo = vhostInfo.volume_info || {};
   }
 
   openDialog(id: string) {


### PR DESCRIPTION
follows https://github.com/lablup/backend.ai-webui/pull/1640
`storageProxyInfo` is not defined as a property. So below errors occurs.
And `volumeInfo` actually acts `storageProxyInfo`. So I rename `volumeInfo` property to `storageProxyInfo` and renamed the related function.
<img width="654" alt="image" src="https://user-images.githubusercontent.com/28584164/226875655-52a90d57-d1d7-48ee-bbad-122d6f10925d.png">
<img width="1223" alt="image" src="https://user-images.githubusercontent.com/28584164/226875606-8d2ac76d-326f-4a91-b0b6-cd0652d87288.png">
