### PR TITLE
fix: session launcher's environment variable editor dialog button is broken in Korean

### DIFF
--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -4053,12 +4053,14 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
               id="delete-all-button"
               slot="footer"
               icon="delete"
+              style="width:100px"
               label="${_text('button.Reset')}"
               @click="${()=>this._clearRows()}"></mwc-button>
           <mwc-button
               unelevated
               slot="footer"
               icon="check"
+              style="width:100px"
               label="${_text('button.Save')}"
               @click="${()=>this.modifyEnv()}"></mwc-button>
         </div>

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -4053,14 +4053,12 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
               id="delete-all-button"
               slot="footer"
               icon="delete"
-              style="width:100px"
               label="${_text('button.Reset')}"
               @click="${()=>this._clearRows()}"></mwc-button>
           <mwc-button
               unelevated
               slot="footer"
               icon="check"
-              style="width:100px"
               label="${_text('button.Save')}"
               @click="${()=>this.modifyEnv()}"></mwc-button>
         </div>


### PR DESCRIPTION
This PR resolves #1664 
In Korean language UI, OK button on the session launcher's environment variable editor dialog was broken. This PR resolves the problem by fixing the button width. 