### PR TITLE
feat: add support for setting `inference` as allowed session type

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -929,7 +929,8 @@
     "TimeoutSeconds": "Seconds",
     "ResourceGroupDetail": "Resource Group Detail",
     "RetriesToSkip": "Times",
-    "NoGroupToDisplay": "NoGroupToDisplay"
+    "NoGroupToDisplay": "NoGroupToDisplay",
+    "AllowedSessionTypes": "Allowed session types"
   },
   "maintenance": {
     "General": "General",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -921,7 +921,8 @@
     "TimeoutSeconds": "Seconds",
     "ResourceGroupDetail": "Détail du groupe de ressources",
     "RetriesToSkip": "__NOT_TRANSLATED__",
-    "NoGroupToDisplay": "__NOT_TRANSLATED__"
+    "NoGroupToDisplay": "__NOT_TRANSLATED__",
+    "AllowedSessionTypes": "__NOT_TRANSLATED__"
   },
   "maintenance": {
     "General": "Général",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -921,7 +921,8 @@
     "TimeoutSeconds": "Detik",
     "ResourceGroupDetail": "Detail Grup Sumber Daya",
     "RetriesToSkip": "__NOT_TRANSLATED__",
-    "NoGroupToDisplay": "__NOT_TRANSLATED__"
+    "NoGroupToDisplay": "__NOT_TRANSLATED__",
+    "AllowedSessionTypes": "__NOT_TRANSLATED__"
   },
   "maintenance": {
     "General": "Umum",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -921,7 +921,8 @@
     "TimeoutSeconds": "초",
     "ResourceGroupDetail": "자원 그룹 세부 정보",
     "RetriesToSkip": "회",
-    "NoGroupToDisplay": "그룹이 없습니다."
+    "NoGroupToDisplay": "그룹이 없습니다.",
+    "AllowedSessionTypes": "허용된 세션 타입"
   },
   "maintenance": {
     "General": "일반",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -921,7 +921,8 @@
     "TimeoutSeconds": "Секунд",
     "ResourceGroupDetail": "Нөөцийн бүлгийн дэлгэрэнгүй",
     "RetriesToSkip": "__NOT_TRANSLATED__",
-    "NoGroupToDisplay": "__NOT_TRANSLATED__"
+    "NoGroupToDisplay": "__NOT_TRANSLATED__",
+    "AllowedSessionTypes": "__NOT_TRANSLATED__"
   },
   "maintenance": {
     "General": "Ерөнхий",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -921,7 +921,8 @@
     "TimeoutSeconds": "Секунды",
     "ResourceGroupDetail": "Сведения о группе ресурсов",
     "RetriesToSkip": "__NOT_TRANSLATED__",
-    "NoGroupToDisplay": "__NOT_TRANSLATED__"
+    "NoGroupToDisplay": "__NOT_TRANSLATED__",
+    "AllowedSessionTypes": "__NOT_TRANSLATED__"
   },
   "maintenance": {
     "General": "Общий",

--- a/src/components/backend-ai-resource-group-list.ts
+++ b/src/components/backend-ai-resource-group-list.ts
@@ -542,8 +542,8 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
    * */
   _initializeCreateSchedulerOpts() {
     const schedulerOptsInputForms = this.shadowRoot?.querySelector('#scheduler-options-input-form') as Expansion;
-
     this.allowedSessionTypesSelect.items = this.allowedSessionTypes;
+    this.allowedSessionTypesSelect.selectedItemList = [];
     schedulerOptsInputForms.checked = false;
     if (this.timeoutInput?.value) {
       this.timeoutInput.value = '';
@@ -885,32 +885,32 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
                   <div role="listbox">
                     ${this.enableSchedulerOpts ? html`
                       ${Object.entries(JSON.parse(this.resourceGroupInfo?.scheduler_opts)).map(([key, value]: any) => {
-    if (key === 'allowed_session_types') {
-      return html`
-                                  <vaadin-item>
-                                    <div><strong>allowed session types</strong></div>
-                                    <div class="scheduler-option-value">${value.join(', ')}</div>
-                                  </vaadin-item>`;
-    } else if (key === 'pending_timeout') {
-      return html`
-      <vaadin-item>
-      <div><strong>pending timeout</strong></div>
-      <div class="scheduler-option-value">${value + ' ' + _text('resourceGroup.TimeoutSeconds')}</div>
-    </vaadin-item>`;
-    } else if (key === 'config') {
-      if (value['num_retries_to_skip']) {
-        return html`
-        <vaadin-item>
-        <div><strong># retries to skip pending session</strong></div>
-        <div class="scheduler-option-value">${value['num_retries_to_skip'] + ' ' + _text('resourceGroup.RetriesToSkip')}</div>
-      </vaadin-item>`;
-      } else {
-        return '';
-      }
-    } else {
-      return '';
-    }
-  })}
+                        if (key === 'allowed_session_types') {
+                          return html`
+                                                      <vaadin-item>
+                                                        <div><strong>allowed session types</strong></div>
+                                                        <div class="scheduler-option-value">${value.join(', ')}</div>
+                                                      </vaadin-item>`;
+                        } else if (key === 'pending_timeout') {
+                          return html`
+                          <vaadin-item>
+                          <div><strong>pending timeout</strong></div>
+                          <div class="scheduler-option-value">${value + ' ' + _text('resourceGroup.TimeoutSeconds')}</div>
+                        </vaadin-item>`;
+                        } else if (key === 'config') {
+                          if (value['num_retries_to_skip']) {
+                            return html`
+                            <vaadin-item>
+                            <div><strong># retries to skip pending session</strong></div>
+                            <div class="scheduler-option-value">${value['num_retries_to_skip'] + ' ' + _text('resourceGroup.RetriesToSkip')}</div>
+                          </vaadin-item>`;
+                          } else {
+                            return '';
+                          }
+                        } else {
+                          return '';
+                        }
+                      })}
                     ` : html``}
                   </div>
                 </div>

--- a/src/components/backend-ai-resource-group-list.ts
+++ b/src/components/backend-ai-resource-group-list.ts
@@ -70,7 +70,9 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
   @property({type: Object}) allowedSessionTypesObjects = {
     'interactive': 'interactive',
     'batch': 'batch',
-    'both': 'both (interactive, batch)'
+    'inference': 'inference',
+    'general': 'general (interactive, batch)',
+    'all': 'all (interactive, batch, inference)'
   };
   @property({type: Boolean}) enableSchedulerOpts = false;
   @property({type: Boolean}) enableWSProxyAddr = false;
@@ -539,7 +541,7 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
   _initializeCreateSchedulerOpts() {
     const schedulerOptsInputForms = this.shadowRoot?.querySelector('#scheduler-options-input-form') as Expansion;
 
-    this.allowedSessionTypesSelect.value= 'both';
+    this.allowedSessionTypesSelect.value= 'general';
     schedulerOptsInputForms.checked = false;
     if (this.timeoutInput?.value) {
       this.timeoutInput.value = '';
@@ -557,8 +559,10 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
    * */
   _initializeModifySchedulerOpts(name = '', value: any) {
     if ('allowed_session_types' === name) {
-      if (value.includes('interactive') && value.includes('batch')) {
-        this.allowedSessionTypesSelect.value = 'both';
+      if (value.includes('interactive') && value.includes('batch') && value.includes('inference')) {
+        this.allowedSessionTypesSelect.value = 'all';
+      } else if (value.includes('interactive') && value.includes('batch')) {
+        this.allowedSessionTypesSelect.value = 'general';
       } else {
         this.allowedSessionTypesSelect.value = value[0];
       }
@@ -612,8 +616,9 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
    * */
   _saveSchedulerOpts() {
     this.schedulerOpts = {};
-
-    if (this.allowedSessionTypesSelect.value === 'both') {
+    if (this.allowedSessionTypesSelect.value === 'all') {
+      this.schedulerOpts['allowed_session_types'] = ['interactive', 'batch', 'inference'];
+    } else if (this.allowedSessionTypesSelect.value === 'general') {
       this.schedulerOpts['allowed_session_types'] = ['interactive', 'batch'];
     } else {
       this.schedulerOpts['allowed_session_types'] = [this.allowedSessionTypesSelect.value];

--- a/src/components/backend-ai-resource-group-list.ts
+++ b/src/components/backend-ai-resource-group-list.ts
@@ -5,7 +5,7 @@
 
 import {get as _text, translate as _t} from 'lit-translate';
 import {css, CSSResultGroup, html, render} from 'lit';
-import {customElement, property, query} from 'lit/decorators.js';
+import {customElement, property, query, state} from 'lit/decorators.js';
 import {BackendAIPage} from './backend-ai-page';
 
 import '@vaadin/grid/vaadin-grid';
@@ -33,6 +33,7 @@ import '@material/mwc-textarea/mwc-textarea';
 import '@material/mwc-textfield/mwc-textfield';
 
 import './backend-ai-dialog';
+import './backend-ai-multi-select';
 import {default as PainKiller} from './backend-ai-painkiller';
 import {BackendAiStyles} from './backend-ai-general-styles';
 import {IronFlex, IronFlexAlignment} from '../plastics/layout/iron-flex-layout-classes';
@@ -67,13 +68,14 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
   @property({type: Array}) resourceGroups;
   @property({type: Array}) schedulerTypes;
   @property({type: Object}) schedulerOpts;
-  @property({type: Object}) allowedSessionTypesObjects = {
-    'interactive': 'interactive',
-    'batch': 'batch',
-    'inference': 'inference',
-    'general': 'general (interactive, batch)',
-    'all': 'all (interactive, batch, inference)'
-  };
+  @state() private allowedSessionTypes = ['interactive', 'batch', 'inference'];
+  // {
+  //   'interactive': 'interactive',
+  //   'batch': 'batch',
+  //   'inference': 'inference',
+  //   'general': 'general (interactive, batch)',
+  //   'all': 'all (interactive, batch, inference)'
+  // };
   @property({type: Boolean}) enableSchedulerOpts = false;
   @property({type: Boolean}) enableWSProxyAddr = false;
   @property({type: Number}) functionCount = 0;
@@ -83,7 +85,7 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
   @query('#resource-group-scheduler') resourceGroupSchedulerSelect!: Select;
   @query('#resource-group-active') resourceGroupActiveSwitch!: Switch;
   @query('#resource-group-wsproxy-address') resourceGroupWSProxyaddressInput!: TextField;
-  @query('#allowed-session-types') allowedSessionTypesSelect!: Select;
+  @query('#allowed-session-types') private allowedSessionTypesSelect;
   @query('#num-retries-to-skip') numberOfRetriesToSkip!: TextField;
   @query('#pending-timeout') timeoutInput!: TextField;
   @query('#delete-resource-group') deleteResourceGroupInput!: TextField;
@@ -541,7 +543,7 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
   _initializeCreateSchedulerOpts() {
     const schedulerOptsInputForms = this.shadowRoot?.querySelector('#scheduler-options-input-form') as Expansion;
 
-    this.allowedSessionTypesSelect.value= 'general';
+    this.allowedSessionTypesSelect.items = this.allowedSessionTypes;
     schedulerOptsInputForms.checked = false;
     if (this.timeoutInput?.value) {
       this.timeoutInput.value = '';
@@ -558,20 +560,21 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
    * @param {Any} value - scheduler option value in selected resource group(scaling group)
    * */
   _initializeModifySchedulerOpts(name = '', value: any) {
-    if ('allowed_session_types' === name) {
-      if (value.includes('interactive') && value.includes('batch') && value.includes('inference')) {
-        this.allowedSessionTypesSelect.value = 'all';
-      } else if (value.includes('interactive') && value.includes('batch')) {
-        this.allowedSessionTypesSelect.value = 'general';
-      } else {
-        this.allowedSessionTypesSelect.value = value[0];
-      }
-    } else if ('pending_timeout' === name) {
-      this.timeoutInput.value = value;
-    } else if ('config' === name) {
-      this, this.numberOfRetriesToSkip.value = value['num_retries_to_skip'] ?? '';
-    } else {
-      // other scheduler options
+    switch(name) {
+      case 'allowed_session_types':
+        this.allowedSessionTypesSelect.items = this.allowedSessionTypes;
+        this.allowedSessionTypesSelect.selectedItemList = value;
+        break;
+      case 'pending_timeout':
+        this.timeoutInput.value = value;
+        break;
+      case 'config':
+        this.numberOfRetriesToSkip.value = value['num_retries_to_skip'] ?? '';
+
+        break;
+      default:
+        // other scheduler options;
+        break;
     }
   }
 
@@ -582,7 +585,6 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
    * */
   _verifyCreateSchedulerOpts() {
     const validityCheckResult = [
-      this.allowedSessionTypesSelect,
       this.timeoutInput,
       this.numberOfRetriesToSkip
     ].filter((fn) => !fn.checkValidity());
@@ -600,7 +602,6 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
    * */
   _verifyModifySchedulerOpts() {
     const validityCheckResult = [
-      this.allowedSessionTypesSelect,
       this.timeoutInput,
       this.numberOfRetriesToSkip
     ].filter((fn) => !fn.checkValidity());
@@ -616,13 +617,7 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
    * */
   _saveSchedulerOpts() {
     this.schedulerOpts = {};
-    if (this.allowedSessionTypesSelect.value === 'all') {
-      this.schedulerOpts['allowed_session_types'] = ['interactive', 'batch', 'inference'];
-    } else if (this.allowedSessionTypesSelect.value === 'general') {
-      this.schedulerOpts['allowed_session_types'] = ['interactive', 'batch'];
-    } else {
-      this.schedulerOpts['allowed_session_types'] = [this.allowedSessionTypesSelect.value];
-    }
+    this.schedulerOpts['allowed_session_types'] = this.allowedSessionTypesSelect.selectedItemList;
     if (this.timeoutInput.value !== '') {
       this.schedulerOpts['pending_timeout'] = this.timeoutInput.value;
     }
@@ -771,36 +766,37 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
           ${this.enableSchedulerOpts ? html`
             <wl-expansion id="scheduler-options-input-form">
               <span slot="title">${_t('resourceGroup.SchedulerOptions')}</span>
-              <mwc-select id="allowed-session-types" label="allowed session types" required>
-                ${Object.entries(this.allowedSessionTypesObjects).map(([key, value]) => {
-    return html`<mwc-list-item value="${key}">${value}</mwc-list-item>`;
-  })
-}
-              </mwc-select>
-              <mwc-textfield
-                type="number"
-                value="0"
-                id="pending-timeout"
-                label="pending timeout"
-                placeholder="0"
-                suffix="${_t('resourceGroup.TimeoutSeconds')}"
-                validationMessage="${_t('settings.InvalidValue')}"
-                autoValidate
-                min="0"
-                value="${this.resourceGroupInfo?.scheduler_opts?.pending_timeout ?? ''}"
-              ></mwc-textfield>
-              <mwc-textfield
-                  type="number"
-                  value="0"
-                  id="num-retries-to-skip"
-                  label="# retries to skip pending session"
-                  placeholder="0"
-                  suffix="${_t('resourceGroup.RetriesToSkip')}"
-                  validationMessage="${_t('settings.InvalidValue')}"
-                  autoValidate
-                  min="0"
-                  value="${this.resourceGroupInfo?.scheduler_opts?.config?.num_retries_to_skip ?? ''}"
+              <div class="vertical layout flex">
+                <backend-ai-multi-select
+                    open-up
+                    id="allowed-session-types"
+                    label="${_t('resourceGroup.AllowedSessionTypes')}"
+                    style="width:100%;"></backend-ai-multi-select>
+                <mwc-textfield
+                    type="number"
+                    value="0"
+                    id="pending-timeout"
+                    label="pending timeout"
+                    placeholder="0"
+                    suffix="${_t('resourceGroup.TimeoutSeconds')}"
+                    validationMessage="${_t('settings.InvalidValue')}"
+                    autoValidate
+                    min="0"
+                    value="${this.resourceGroupInfo?.scheduler_opts?.pending_timeout ?? ''}"
                 ></mwc-textfield>
+                <mwc-textfield
+                    type="number"
+                    value="0"
+                    id="num-retries-to-skip"
+                    label="# retries to skip pending session"
+                    placeholder="0"
+                    suffix="${_t('resourceGroup.RetriesToSkip')}"
+                    validationMessage="${_t('settings.InvalidValue')}"
+                    autoValidate
+                    min="0"
+                    value="${this.resourceGroupInfo?.scheduler_opts?.config?.num_retries_to_skip ?? ''}"
+                  ></mwc-textfield>
+              </div>
             </wl-expansion>
             ` : html``}
         </div>


### PR DESCRIPTION
This commit updates resource group list page to allow adding `inference` session type as allowed session type of scaling group.

### Screenshot(s)
| Before | After |
| --- | --- |
|<img width="272" alt="Screenshot 2023-03-30 at 1 15 43 PM" src="https://user-images.githubusercontent.com/46954439/228727853-b89a2f33-244a-4ea2-90f4-b7900e0cf750.png">|<img width="272" alt="Screenshot 2023-03-30 at 1 15 10 PM" src="https://user-images.githubusercontent.com/46954439/228727839-778247c4-3834-4406-aae2-d95f53f12017.png">|