### PR TITLE
fix: display explicit message when a user tries to create a session with the same name of a running session

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -216,6 +216,7 @@
       "DuplicatedSessionName": "Duplicated session name not allowed",
       "SessionNameAllowCondition": "Session name should have 4-64 alphabets/numbers without any whitespaces.",
       "NoFolderExists": "No Folder Exists",
+      "SessionAlreadyExists": "Session name already exists",
       "sessionStillPreparing": "The session is still in preparation. After the session starts, tap the app icon to start the app.",
       "UnSelectAllVFolders": "UNSELECT ALL",
       "ResourceMonitorToggle": "See resource monitor",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -205,6 +205,7 @@
       "DuplicatedSessionName": "동일한 이름의 연산 세션이 있습니다",
       "SessionNameAllowCondition": "세션 이름은 공백없이 4-64자  사이의 영문/숫자만 입력 가능합니다.",
       "NoFolderExists": "폴더가 없습니다",
+      "SessionAlreadyExists": "같은 이름의 세션이 이미 존재합니다",
       "sessionStillPreparing": "세션이 아직 준비중입니다. 세션이 시작된 후 직접 앱 아이콘을 눌러 앱을 시작해주세요.",
       "UnSelectAllVFolders": "모두 선택 해제",
       "ResourceMonitorToggle": "자원 모니터 보기",

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1624,7 +1624,15 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
 
   _createKernel(kernelName: string, sessionName: string, architecture: string, config) {
     const task = globalThis.backendaiclient.createIfNotExists(kernelName, sessionName, config, 20000, architecture);
-    task.catch((err) => {
+    task.then((res) => {
+      // When session is already created with the same name, the status code
+      // is 200, but the response body has 'created' field as false. For better
+      // user experience, we show the notification message.
+      if (!res?.created) {
+        this.notification.text = _text('session.launcher.SessionAlreadyExists');
+        this.notification.show();
+      }
+    }).catch((err) => {
       // console.log(err);
       if (err && err.message) {
         if ('statusCode' in err && err.statusCode === 408) {


### PR DESCRIPTION
When a user tries to create a new compute session with the same name as another running session, it silently fails since the backend returns 200 OK. This is due to the query execution mode having to specify the session's name to reuse an already existing one to execute a related, but different code piece.

However, this confuses the Web UI users since there is no message indicating the session creation request was not successful. Even worse, some users may think the previous session is terminated, and a session with the same name is newly created.

So, this PR displays an explicit message when the `created: false` is delivered in the response body that the session with the same name already exists.