### PR TITLE
fix: unable to open app launcher dialog

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -31,7 +31,7 @@ import {IronFlex, IronFlexAlignment} from '../plastics/layout/iron-flex-layout-c
 
 @customElement('backend-ai-app-launcher')
 export default class BackendAiAppLauncher extends BackendAIPage {
-  @property({type: Boolean, reflect: true}) active = false;
+  @property({type: Boolean, reflect: true}) active = true;
   @property({type: String}) condition = 'running';
   @property({type: Object}) jobs = Object();
   @property({type: Object}) controls = Object();


### PR DESCRIPTION
Setting `active = false` for this component blocks the opening of app
launcher diloag.
