### PR TITLE
fix: unable to launch VSCode in web version

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -339,10 +339,10 @@
     "EnterValidSessionName": "EnterValidSessionName",
     "EnvironmentInfo": "Environment Info",
     "DownloadingSessionLogs": "Downloading session logs.",
-    "VSCodeRemoteConnection": "Connect Visual Studio Code Remote",
-    "VSCodeRemotePasswordTitle": "Visual Studio Code Remote Password",
-    "VSCodeRemoteDescription": "If you want to run Visual Studio Code Remote, need to enter a password",
-    "VSCodeRemoteNoticeSSHConfig": "You can add the following to the `$HOME/.ssh/config` file to seamlessly remote connection to the Visual Studio Code.",
+    "VSCodeRemoteConnection": "VSCode Remote Connection",
+    "VSCodeRemotePasswordTitle": "Visual Studio Code remote SSH password",
+    "VSCodeRemoteDescription": "You can launch your local Visual Studio Code application and connect to the remote compute session (via SSH) using the password below. Please copy the password before clicking the button.",
+    "VSCodeRemoteNoticeSSHConfig": "To set up a seamless connection for Visual Studio Code to the remote compute session, create or edit the $HOME/.ssh/config file and add the following block.",
     "ElapsedTime": "Elapsed Time",
     "Timeout": "Timeout",
     "TimeoutExceeded": "Time reached. Checking...",
@@ -1279,7 +1279,7 @@
     "Minutes": "m"
   },
   "DownloadSSHKey": "Download SSH Key",
-  "OpenVSCodeRemote": "open Visual Studio Code for Remote",
+  "OpenVSCodeRemote": "Open local Visual Studio Code",
   "license": {
     "Perpetual": "Perpetual",
     "Subscription": "Subscription",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -341,7 +341,7 @@
     "DownloadingSessionLogs": "Downloading session logs.",
     "VSCodeRemoteConnection": "VSCode Remote Connection",
     "VSCodeRemotePasswordTitle": "Visual Studio Code remote SSH password",
-    "VSCodeRemoteDescription": "You can launch your local Visual Studio Code application and connect to the remote compute session (via SSH) using the password below. Please copy the password before clicking the button.",
+    "VSCodeRemoteDescription": "You can launch your local Visual Studio Code application and connect to the remote compute session (via SSH) using the password below. Please copy the password before clicking the button. (NOTE: You have to install Visual Studio Code in your local machine.)",
     "VSCodeRemoteNoticeSSHConfig": "To set up a seamless connection for Visual Studio Code to the remote compute session, create or edit the $HOME/.ssh/config file and add the following block.",
     "ElapsedTime": "Elapsed Time",
     "Timeout": "Timeout",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -333,7 +333,7 @@
     "DownloadingSessionLogs": "세션 로그를 다운받습니다.",
     "VSCodeRemoteConnection": "VSCode 원격 연결",
     "VSCodeRemotePasswordTitle": "Visual Studio Code 원격 연결 SSH 패스워드",
-    "VSCodeRemoteDescription": "로컬 Visual Studio Code 앱을 띄운후 아래 비밀번호를 입력하여 연산 세션에 (SSH를 통해) 원격 연결하고 작업할 수 있습니다. 버튼을 클릭하기 전에 비밀번호를 복사하세요.",
+    "VSCodeRemoteDescription": "로컬 Visual Studio Code 앱을 띄운후 아래 비밀번호를 입력하여 연산 세션에 (SSH를 통해) 원격 연결하고 작업할 수 있습니다. 버튼을 클릭하기 전에 비밀번호를 복사하세요. (주의: Visual Studio Code 앱이 여러분의 로컬 머신에 설치되어 있어야 합니다.)",
     "VSCodeRemoteNoticeSSHConfig": "$HOME/.ssh/config 파일을 생성 또는 수정하여 아래 내용을 추가하면 Visual Studio Code에서 연산 세션으로의 원격 연결을 좀더 편리하게 할 수 있습니다.",
     "ElapsedTime": "경과 시간",
     "Timeout": "타임아웃",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -331,10 +331,10 @@
     "DescCommitSession": "다음 세션에 대응하는 컨테이너를 커밋하려고 합니다: ",
     "EnvironmentInfo": "환경 정보",
     "DownloadingSessionLogs": "세션 로그를 다운받습니다.",
-    "VSCodeRemoteConnection": "Visual Studio Code 원격 연결",
-    "VSCodeRemotePasswordTitle": "Visual Studio Code 원격 연결 패스워드",
-    "VSCodeRemoteDescription": "Visual Studioe Code 원격 연결로 작업합니다.",
-    "VSCodeRemoteNoticeSSHConfig": "`$HOME/.ssh/config` 파일에 아래와 같은 내용을 추가하여 Visual Studio Code 원격 연결을 원활하게 할 수 있습니다.",
+    "VSCodeRemoteConnection": "VSCode 원격 연결",
+    "VSCodeRemotePasswordTitle": "Visual Studio Code 원격 연결 SSH 패스워드",
+    "VSCodeRemoteDescription": "로컬 Visual Studio Code 앱을 띄운후 아래 비밀번호를 입력하여 연산 세션에 (SSH를 통해) 원격 연결하고 작업할 수 있습니다. 버튼을 클릭하기 전에 비밀번호를 복사하세요.",
+    "VSCodeRemoteNoticeSSHConfig": "$HOME/.ssh/config 파일을 생성 또는 수정하여 아래 내용을 추가하면 Visual Studio Code에서 연산 세션으로의 원격 연결을 좀더 편리하게 할 수 있습니다.",
     "ElapsedTime": "경과 시간",
     "Timeout": "타임아웃",
     "SessionLifetime": "세션 수명",
@@ -1339,7 +1339,7 @@
     "ValueRequired": "값이 필요합니다.",
     "InputTooShort": "입력값이 너무 짧습니다."
   },
-  "OpenVSCodeRemote": "원격으로 Visual Studio Code 열기",
+  "OpenVSCodeRemote": "로컬 Visual Studio Code 열기",
   "totp": {
     "OTP": "이중 인증",
     "TotpRemoved": "이중 인증이 비활성화 되었습니다.",

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -760,7 +760,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         if (port === '0' || port === 0) { // setting store does not accept null.
           port = null;
         }
-        sendAppName = 'vscode-desktop';
+        sendAppName = 'sshd';
       }
       this._open_wsproxy(sessionUuid, sendAppName, port, envs, args)
         .then(async (response) => {
@@ -884,7 +884,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         if (port === '0' || port === 0) { // setting store does not accept null.
           port = null;
         }
-        sendAppName = 'vscode-desktop';
+        sendAppName = 'sshd';
       }
       const userPort = (this.appPort === null || this.appPort === undefined) ? defaultPreferredPortNumber : parseInt(this.appPort?.value);
       if (this.checkPreferredPort !== null && this.checkPreferredPort?.checked && userPort) {

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -499,7 +499,12 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         }
       }
     });
-    if (globalThis.isElectron && !appServices.includes('vscode-desktop')) {
+
+    if (
+      globalThis.backendaiclient.supports('local-vscode-remote-connection') &&
+      globalThis.isElectron &&
+      !appServices.includes('vscode-desktop')
+    ) {
       const insertAfterIndex = this.appSupportList.findIndex((item) => item.name === 'vscode');
       this.appSupportList.splice(insertAfterIndex + 1, 0, {
         name: 'vscode-desktop',

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -117,7 +117,8 @@ export default class BackendAiAppLauncher extends BackendAIPage {
 
         .app-icon {
           margin-left: 15px;
-          margin-right: 5px;
+          margin-right: 15px;
+          margin-bottom: 20px;
         }
 
         .app-icon .label {

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -117,8 +117,8 @@ export default class BackendAiAppLauncher extends BackendAIPage {
 
         .app-icon {
           margin-left: 15px;
-          margin-right: 15px;
-          margin-bottom: 20px;
+          margin-right: 5px;
+          margin-bottom: 15px;
         }
 
         .app-icon .label {

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -627,8 +627,9 @@ export default class BackendAiAppLauncher extends BackendAIPage {
     if (servicePortInfo === undefined) {
       this.indicator.end();
       this.notification.text = _text('session.CreationFailed'); // TODO: Change text
-
-      this.notification.show();
+      if (app !== 'vscode-desktop') {
+        this.notification.show();
+      }
       return Promise.resolve(false);
     }
 
@@ -866,10 +867,6 @@ export default class BackendAiAppLauncher extends BackendAIPage {
       if (!isVisible || isVisible === 'true') {
         this._openTerminalGuideDialog();
       }
-    }
-    if (appName === 'vscode-desktop') {
-      this._openVSCodeDesktopDialog();
-      return;
     }
 
     if (typeof globalThis.backendaiwsproxy === 'undefined' || globalThis.backendaiwsproxy === null) {

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -240,7 +240,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         }
 
         .vscode-desktop-password {
-          min-height: 100px;
+          min-height: 80px;
           overflow-y: scroll;
           white-space: pre-wrap;
           word-wrap: break-word;
@@ -728,7 +728,12 @@ export default class BackendAiAppLauncher extends BackendAIPage {
       this._openTensorboardDialog();
       return;
     }
-
+    if (appName === 'ttyd') {
+      const isVisible = localStorage.getItem('backendaiwebui.terminalguide');
+      if (!isVisible || isVisible === 'true') {
+        this._openTerminalGuideDialog();
+      }
+    }
     if (appName === 'vscode-desktop') {
       this._openVSCodeDesktopDialog();
       return;
@@ -857,6 +862,10 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         this._openTerminalGuideDialog();
       }
     }
+    if (appName === 'vscode-desktop') {
+      this._openVSCodeDesktopDialog();
+      return;
+    }
 
     if (typeof globalThis.backendaiwsproxy === 'undefined' || globalThis.backendaiwsproxy === null) {
       this._hideAppLauncher();
@@ -946,7 +955,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
     const file = '/home/work/.password';
     const blob = await globalThis.backendaiclient.download_single(sessionUuid, file);
     const rawText = await blob.text();
-    vscodePasswordEl.value=rawText;
+    vscodePasswordEl.value = rawText;
   }
 
   /**
@@ -1371,29 +1380,31 @@ export default class BackendAiAppLauncher extends BackendAIPage {
       </backend-ai-dialog>
       <backend-ai-dialog id="vscode-desktop-dialog" fixed backdrop>
         <span slot="title">${_t('session.VSCodeRemoteConnection')}</span>
-        <div slot="content" style="padding:15px 0;">
-          <div style="padding:15px 0;">${_t('session.VSCodeRemoteDescription')}</div>
+        <div slot="content">
+          <div>${_t('session.VSCodeRemoteDescription')}</div>
           <section class="vertical layout wrap start start-justified">
-            <h4>${_t('session.ConnectionInformation')}</h4>
+            <h3>${_t('session.ConnectionInformation')}</h4>
             <div slot="content">
               <span>${_t('session.VSCodeRemotePasswordTitle')}:</span>
               <mwc-textfield
                 readonly
                 class="vscode-desktop-password"
-                id="vscode-desktop-password"></mwc-textfield>
+                id="vscode-desktop-password"
+              ></mwc-textfield>
               <mwc-icon-button
                 id="copy-vscode-password-button"
                 icon="content_copy"
-                @click="${() => this._copyVSCodePassword('#vscode-desktop-password')}"></mwc-icon-button>
+                @click="${() => this._copyVSCodePassword('#vscode-desktop-password')}"
+              ></mwc-icon-button>
             </div>
             <div class="horizontal wrap layout note" style="background-color:#FFFBE7;width:100%;padding:10px 0px;">
+              <p style="margin:auto 10px;">${_t('session.VSCodeRemoteNoticeSSHConfig')}</p>
               <p style="margin:auto 10px;">
-                ${_t('session.VSCodeRemoteNoticeSSHConfig')}
-              </p>
-              <p style="margin:auto 10px;">
-              <pre>Host 127.0.0.1
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null</pre>
+                <pre style="white-space:pre-line; margin:10px 10px 0 10px">
+                  Host 127.0.0.1
+                  &nbsp;&nbsp;StrictHostKeyChecking no
+                  &nbsp;&nbsp;UserKnownHostsFile /dev/null
+                </pre>
               </p>
             </div>
           </section>

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -48,7 +48,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
   @property({type: Number}) sshPort = 0;
   @property({type: Number}) vncPort = 0;
   @property({type: Number}) xrdpPort = 0;
-  @property({type: Number}) vscodePort = 0;
+  @property({type: Number}) vscodeDesktopPort = 0;
   @property({type: String}) tensorboardPath = '';
   @property({type: String}) endpointURL = '';
   @property({type: Boolean}) isPathConfigured = false;
@@ -73,7 +73,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
   @query('#terminal-guide') terminalGuideDialog!: BackendAIDialog;
   @query('#vnc-dialog') vncDialog!: BackendAIDialog;
   @query('#xrdp-dialog') xrdpDialog!: BackendAIDialog;
-  @query('#vscode-dialog') vscodeDialog!: BackendAIDialog;
+  @query('#vscode-desktop-dialog') vscodeDesktopDialog!: BackendAIDialog;
 
   constructor() {
     super();
@@ -141,7 +141,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           --component-width: 400px;
         }
 
-        #vscode-dialog {
+        #vscode-desktop-dialog {
           --component-width: 450px;
         }
 
@@ -232,14 +232,14 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           display: inline-block;
         }
 
-        mwc-textfield#vscode-password {
+        mwc-textfield#vscode-desktop-password {
           width: 360px;
           --mdc-text-field-fill-color: transparent;
           --mdc-theme-primary: var(--general-textfield-selected-color);
           --mdc-typography-font-family: var(--general-font-family);
         }
 
-        .vscode-password {
+        .vscode-desktop-password {
           min-height: 100px;
           overflow-y: scroll;
           white-space: pre-wrap;
@@ -247,7 +247,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           scrollbar-width: none; /* firefox */
         }
 
-        wl-button.vscode-password {
+        wl-button.vscode-desktop-password {
           display: inline-block;
           margin: 10px;
         }
@@ -259,7 +259,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           max-height: 15px !important;
         }
 
-        wl-icon#vscode-password-icon {
+        wl-icon#vscode-desktop-password-icon {
           color: var(--paper-indigo-700);
         }
 
@@ -499,13 +499,14 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         }
       }
     });
-    if (globalThis.isElectron && !appServices.includes('vscode')) {
-      this.appSupportList.push({ // Force push vscode
-        'name': 'vscode',
-        'title': 'VS Code',
-        'category': '2.Development',
-        'redirect': '',
-        'src': './resources/icons/vscode.svg'
+    if (globalThis.isElectron && !appServices.includes('vscode-desktop')) {
+      const insertAfterIndex = this.appSupportList.findIndex((item) => item.name === 'vscode');
+      this.appSupportList.splice(insertAfterIndex + 1, 0, {
+        name: 'vscode-desktop',
+        title: 'Visual Studio Code (Desktop)',
+        category: '2.Development',
+        redirect: '',
+        src: './resources/icons/vscode.svg'
       });
     }
     this.openPortToPublic = globalThis.backendaiclient._config.openPortToPublic;
@@ -728,8 +729,8 @@ export default class BackendAiAppLauncher extends BackendAIPage {
       return;
     }
 
-    if (appName === 'vscode') {
-      this._openVSCodeDialog();
+    if (appName === 'vscode-desktop') {
+      this._openVSCodeDesktopDialog();
       return;
     }
 
@@ -743,12 +744,12 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           port = null;
         }
       }
-      if (globalThis.isElectron && appName === 'vscode') {
+      if (globalThis.isElectron && appName === 'vscode-desktop') {
         port = globalThis.backendaioptions.get('custom_ssh_port', 0);
         if (port === '0' || port === 0) { // setting store does not accept null.
           port = null;
         }
-        sendAppName = 'sshd';
+        sendAppName = 'vscode-desktop';
       }
       this._open_wsproxy(sessionUuid, sendAppName, port, envs, args)
         .then(async (response) => {
@@ -867,12 +868,12 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           port = null;
         }
       }
-      if (globalThis.isElectron && appName === 'vscode') {
+      if (globalThis.isElectron && appName === 'vscode-desktop') {
         port = globalThis.backendaioptions.get('custom_ssh_port', 0);
         if (port === '0' || port === 0) { // setting store does not accept null.
           port = null;
         }
-        sendAppName = 'sshd';
+        sendAppName = 'vscode-desktop';
       }
       const userPort = (this.appPort === null || this.appPort === undefined) ? defaultPreferredPortNumber : parseInt(this.appPort?.value);
       if (this.checkPreferredPort !== null && this.checkPreferredPort?.checked && userPort) {
@@ -897,11 +898,11 @@ export default class BackendAiAppLauncher extends BackendAIPage {
             this.indicator.set(100, _text('session.applauncher.Prepared'));
             this.xrdpPort = response.port;
             this._openXRDPDialog();
-          } else if (appName === 'vscode') {
+          } else if (appName === 'vscode-desktop') {
             this.indicator.set(100, _text('session.applauncher.Prepared'));
-            this.vscodePort = response.port;
+            this.vscodeDesktopPort = response.port;
             this._readTempPasswd(sessionUuid);
-            this._openVSCodeDialog();
+            this._openVSCodeDesktopDialog();
             setTimeout(() => {
               this.indicator.end();
             }, 1000);
@@ -941,7 +942,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
    * @param {string} sessionUuid
    */
   async _readTempPasswd(sessionUuid) {
-    const vscodePasswordEl = this.shadowRoot?.querySelector('#vscode-password') as HTMLInputElement;
+    const vscodePasswordEl = this.shadowRoot?.querySelector('#vscode-desktop-password') as HTMLInputElement;
     const file = '/home/work/.password';
     const blob = await globalThis.backendaiclient.download_single(sessionUuid, file);
     const rawText = await blob.text();
@@ -1062,8 +1063,8 @@ export default class BackendAiAppLauncher extends BackendAIPage {
   /**
    * Open a VS Code dialog.
    */
-  _openVSCodeDialog() {
-    this.vscodeDialog.show();
+  _openVSCodeDesktopDialog() {
+    this.vscodeDesktopDialog.show();
   }
 
   /**
@@ -1178,7 +1179,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
    *
    * @param {string} vscodePassword - ssh(remote VS Code) access password
    * */
-   _copyVSCodePassword(vscodePassword: string) {
+  _copyVSCodePassword(vscodePassword: string) {
     if (vscodePassword !== '') {
       const copyText = (this.shadowRoot?.querySelector(vscodePassword) as any).value;
       if (copyText.length == 0) {
@@ -1368,7 +1369,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         <div slot="content"></div>
         <div slot="footer"></div>
       </backend-ai-dialog>
-      <backend-ai-dialog id="vscode-dialog" fixed backdrop>
+      <backend-ai-dialog id="vscode-desktop-dialog" fixed backdrop>
         <span slot="title">${_t('session.VSCodeRemoteConnection')}</span>
         <div slot="content" style="padding:15px 0;">
           <div style="padding:15px 0;">${_t('session.VSCodeRemoteDescription')}</div>
@@ -1378,12 +1379,12 @@ export default class BackendAiAppLauncher extends BackendAIPage {
               <span>${_t('session.VSCodeRemotePasswordTitle')}:</span>
               <mwc-textfield
                 readonly
-                class="vscode-password"
-                id="vscode-password"></mwc-textfield>
+                class="vscode-desktop-password"
+                id="vscode-desktop-password"></mwc-textfield>
               <mwc-icon-button
                 id="copy-vscode-password-button"
                 icon="content_copy"
-                @click="${() => this._copyVSCodePassword('#vscode-password')}"></mwc-icon-button>
+                @click="${() => this._copyVSCodePassword('#vscode-desktop-password')}"></mwc-icon-button>
             </div>
             <div class="horizontal wrap layout note" style="background-color:#FFFBE7;width:100%;padding:10px 0px;">
               <p style="margin:auto 10px;">
@@ -1398,7 +1399,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           </section>
         </div>
         <div slot="footer" class="horizontal center-justified flex layout">
-          <a id="vscode-link" style="margin-top:15px;width:100%;" href="vscode://vscode-remote/ssh-remote+work@127.0.0.1%3A${this.vscodePort}/home/work">
+          <a id="vscode-link" style="margin-top:15px;width:100%;" href="vscode://vscode-remote/ssh-remote+work@127.0.0.1%3A${this.vscodeDesktopPort}/home/work">
             <mwc-button unelevated fullwidth>${_t('OpenVSCodeRemote')}</mwc-button>
           </a>
         </div>

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -594,7 +594,7 @@ class Client {
     }
     if (this.isManagerVersionCompatibleWith('23.03')) {
       this._features['inference-workload'] = true;
-      this._features['local-vscode-remote-conneciton'] = true;
+      this._features['local-vscode-remote-connection'] = true;
     }
   }
 

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -594,6 +594,7 @@ class Client {
     }
     if (this.isManagerVersionCompatibleWith('23.03')) {
       this._features['inference-workload'] = true;
+      this._features['local-vscode-remote-conneciton'] = true;
     }
   }
 


### PR DESCRIPTION
### Fixes
- Unable to open the VSCode app in the web version.
  + Previous implementation always opens the VSCode Remote Connection dialog when the VSCode icon is clicked, even in the web version.
  + Separate `vscode-desktop` app from the legacy `vscode` app. The legacy code-server application is needed even in the Web UI desktop app. We cannot assume every user installs the Visual Studio Code application on their local machine. Even worse, in some cases, the users may not be allowed to install any application. So, in the desktop Web UI application, there will be two icons, one for the code-server and the other for the local VSCode.
    <img width="350" alt="image" src="https://user-images.githubusercontent.com/7539358/230776657-1778d54f-d33c-46db-95f7-1219458fc044.png">
- Do not expose the VSCode Desktop icon for the core version less than 23.03.
  + The core's [counterpart PR](https://github.com/lablup/backend.ai/pull/751) is for 23.03, but not backported to 22.09.
- Remove the annoying error message, unable to create a compute session, which is always displayed when the VSCode Remote Connection dialog opens up.

### Refactors
- Update dialog messages to help users understand better.
- Adjust dialog elements' margins to reduce the total height.
<img width="400" alt="image" src="https://user-images.githubusercontent.com/7539358/230776730-fa7f9988-2f6a-40b4-a20a-e6d8efb7b884.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/7539358/230776781-d64dbe0a-6ce4-48e4-aa39-dabd702e742d.png">

Follow up of https://github.com/lablup/backend.ai-webui/pull/1487