### PR TITLE
ci: Add size label automation actions job

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -19,3 +19,7 @@ jobs:
     - uses: jsoref/labeler@v0-5.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+    - name: size-label
+      uses: "lablup/size-label-action@master"
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
The size label was added while the label was recently reorganized.
Automatically manage the corresponding size label through actions.