### PR TITLE
add: event-driven metadata reload

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -273,11 +273,14 @@ export default class BackendAiAppLauncher extends BackendAIPage {
   }
 
   firstUpdated() {
-    this._initializeAppTemplate();
-    this.refreshTimer = null;
     this.imageInfo = globalThis.backendaimetadata.imageInfo;
     this.kernel_labels = globalThis.backendaimetadata.kernel_labels;
-
+    document.addEventListener('backend-ai-metadata-image-loaded', () => {
+      this.imageInfo = globalThis.backendaimetadata.imageInfo;
+      this.kernel_labels = globalThis.backendaimetadata.kernel_labels;
+    }, {once: true});
+    this._initializeAppTemplate();
+    this.refreshTimer = null;
     // add WebTerminalGuide UI dynamically
     this._createTerminalGuide();
     // add DonotShowOption dynamically

--- a/src/components/backend-ai-metadata-store.ts
+++ b/src/components/backend-ai-metadata-store.ts
@@ -36,8 +36,8 @@ export default class BackendAIMetadataStore extends BackendAIPage {
   firstUpdated() {
   }
 
-  readImageMetadata() {
-    fetch('resources/image_metadata.json').then(
+  async readImageMetadata() {
+    return fetch('resources/image_metadata.json').then(
       (response) => response.json()
     ).then(
       (json) => {
@@ -70,6 +70,11 @@ export default class BackendAIMetadataStore extends BackendAIPage {
         }
         this.imageTagAlias = json.tagAlias;
         this.imageTagReplace = json.tagReplace;
+      }
+    ).then(
+      () => {
+        const event: CustomEvent = new CustomEvent('backend-ai-metadata-image-loaded', {'detail': ''});
+        document.dispatchEvent(event);
       }
     );
   }

--- a/src/components/backend-ai-metadata-store.ts
+++ b/src/components/backend-ai-metadata-store.ts
@@ -91,6 +91,11 @@ export default class BackendAIMetadataStore extends BackendAIPage {
           }
         }
       }
+    ).then(
+      () => {
+        const event: CustomEvent = new CustomEvent('backend-ai-metadata-device-loaded', {'detail': ''});
+        document.dispatchEvent(event);
+      }
     );
   }
 

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -152,6 +152,12 @@ export default class BackendAiResourceBroker extends BackendAIPage {
     this.icons = globalThis.backendaimetadata.icons;
     this.imageTagAlias = globalThis.backendaimetadata.imageTagAlias;
     this.imageTagReplace = globalThis.backendaimetadata.imageTagReplace;
+    document.addEventListener('backend-ai-metadata-image-loaded', () => {
+      this.tags = globalThis.backendaimetadata.tags;
+      this.icons = globalThis.backendaimetadata.icons;
+      this.imageTagAlias = globalThis.backendaimetadata.imageTagAlias;
+      this.imageTagReplace = globalThis.backendaimetadata.imageTagReplace;
+    }, {once: true});
     if (typeof globalThis.backendaiclient === 'undefined' || globalThis.backendaiclient === null || globalThis.backendaiclient.ready === false) {
       document.addEventListener('backend-ai-connected', () => {
         this._refreshImageList();

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -504,10 +504,15 @@ export default class BackendAISessionList extends BackendAIPage {
   }
 
   firstUpdated() {
-    this.refreshTimer = null;
     this.imageInfo = globalThis.backendaimetadata.imageInfo;
     this.kernel_icons = globalThis.backendaimetadata.icons;
     this.kernel_labels = globalThis.backendaimetadata.kernel_labels;
+    document.addEventListener('backend-ai-metadata-image-loaded', () => {
+      this.imageInfo = globalThis.backendaimetadata.imageInfo;
+      this.kernel_icons = globalThis.backendaimetadata.icons;
+      this.kernel_labels = globalThis.backendaimetadata.kernel_labels;
+    }, {once: true});
+    this.refreshTimer = null;
     this.notification = globalThis.lablupNotification;
     this.indicator = globalThis.lablupIndicator;
     document.addEventListener('backend-ai-group-changed', (e) => this.refreshList(true, false));


### PR DESCRIPTION
## Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c912067</samp>

This pull request makes the image metadata loading asynchronous and adds custom events to synchronize the components that depend on it. This improves the web UI performance and accuracy for displaying images, labels, icons, and presets.


## Changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c912067</samp>

* Ensure that the app launcher has the correct image and label information by moving and adding assignments and event listeners ([link](https://github.com/lablup/backend.ai-webui/pull/1693/files?diff=unified&w=0#diff-8bfdd81f6977f0f8e05c0ba087d666df8c36729464b9b50adad2acba20077326L276-R283))
* Make the `readImageMetadata` method async and dispatch custom events when the image and device metadata are loaded ([link](https://github.com/lablup/backend.ai-webui/pull/1693/files?diff=unified&w=0#diff-7eda865744d0e74582fb6bcf7886b56dccbeb6929ed02b57465f2326aabf9a6aL39-R40), [link](https://github.com/lablup/backend.ai-webui/pull/1693/files?diff=unified&w=0#diff-7eda865744d0e74582fb6bcf7886b56dccbeb6929ed02b57465f2326aabf9a6aR74-R78), [link](https://github.com/lablup/backend.ai-webui/pull/1693/files?diff=unified&w=0#diff-7eda865744d0e74582fb6bcf7886b56dccbeb6929ed02b57465f2326aabf9a6aR94-R98))
* Update the resource broker properties related to the image metadata when the `backend-ai-metadata-image-loaded` event is fired ([link](https://github.com/lablup/backend.ai-webui/pull/1693/files?diff=unified&w=0#diff-1f39f3adffae3b281a31ce9f4a28b3bb54d59485eccc246a49a9b877fcf1fd92R155-R160))
* Update the session list properties related to the image metadata when the `backend-ai-metadata-image-loaded` event is fired ([link](https://github.com/lablup/backend.ai-webui/pull/1693/files?diff=unified&w=0#diff-4d843242713270c38dd580c57115bfd4160a27e2b9922086d2bbb83efe5d1895L507-R515))
