### PR TITLE
feat: show idle check information based on only applied configurations#361

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -364,7 +364,7 @@
     "UtilizationThreshold": "Utilization Threshold",
     "ExpiresAfter": "Expires After",
     "GracePeriod": "Grace Period",
-    "IdleChecksDesc": "Backend.AI supports three types of inactivity (idleness) criteria for automatic garbage collection of compute sessions.",
+    "IdleChecksDesc": "Backend.AI supports inactivity (idleness) criteria for automatic garbage collection of compute sessions.",
     "MaxSessionLifetimeDesc": "Force-terminate sessions after this time from creation. It prevents the session from running infinitely.",
     "NetworkIdleTimeoutDesc": "Force-terminate sessions that do not exchange data with the user (browser or web app) after this time. Traffic between the user and the compute session continuously occurs when the user interacts with an app, like terminal or Jupyter, by keyboard input, Jupyter cell creation, etc. Jupyter cell creation, etc. If there is no interaction for a certain period, the condition of garbage collection will be met. Even if there is a process executing a job in the compute session, it is subject to termination if there is no user interaction.",
     "UtilizationIdleTimeoutDesc": "Force-terminate sessions based only on the utilization of resources allocated to them.",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -351,7 +351,7 @@
     "Utilization": "사용률",
     "Threshold": "수거 기준값",
     "IdleChecks": "유휴 상태 검사",
-    "IdleChecksDesc": "연산 세션을 자동 삭제하는 세 가지 기준을 제공합니다.",
+    "IdleChecksDesc": "연산 세션을 자동 삭제하는 기준을 제공합니다.",
     "MaxSessionLifetime": "최대 세션 수명 시간",
     "MaxSessionLifetimeDesc": "세션 생성 후 이 시간이 지나면 세션을 강제 종료합니다. 세션이 무한으로 실행되는 것을 막을 수 있습니다.",
     "NetworkIdleTimeout": "네트워크 트래픽 기반 유휴 시간",

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -2788,10 +2788,12 @@ export default class BackendAISessionList extends BackendAIPage {
           <vaadin-grid-sort-column resizable width="180px" flex-grow="0" header="${_t('session.Reservation')}"
                                    path="created_at" .renderer="${this._boundReservationRenderer}">
           </vaadin-grid-sort-column>
-          <vaadin-grid-column resizable auto-width flex-grow="0"
-                              .headerRenderer="${this._boundIdleChecksHeaderderer}"
-                              .renderer="${this._boundIdleChecksRenderer}">
-          </vaadin-grid-column>
+          ${globalThis.backendaiclient.supports('idle-checks') && this.activeIdleCheckList.size > 0 ? html`
+            <vaadin-grid-column resizable auto-width flex-grow="0"
+                                .headerRenderer="${this._boundIdleChecksHeaderderer}"
+                                .renderer="${this._boundIdleChecksRenderer}">
+            </vaadin-grid-column>
+          ` : html``}
           <lablup-grid-sort-filter-column width="110px" path="architecture" header="${_t('session.Architecture')}" resizable
                                      .renderer="${this._boundArchitectureRenderer}">
           </lablup-grid-sort-filter-column>

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -135,6 +135,7 @@ export default class BackendAISessionList extends BackendAIPage {
   @property({type: String}) _helpDescription = '';
   @property({type: String}) _helpDescriptionTitle = '';
   @property({type: String}) _helpDescriptionIcon = '';
+  @property({type: Set}) activeIdleCheckList;
   @property({type: Proxy}) statusColorTable = new Proxy({
     'idle-timeout': 'green',
     'user-requested': 'green',
@@ -202,6 +203,7 @@ export default class BackendAISessionList extends BackendAIPage {
     super();
     this._selected_items = [];
     this.terminationQueue = [];
+    this.activeIdleCheckList = new Set();
   }
 
   static get styles(): CSSResultGroup {
@@ -358,7 +360,7 @@ export default class BackendAISessionList extends BackendAIPage {
         }
 
         #help-description {
-          --component-width: 70vw;
+          --component-max-width: 70vw;
         }
 
         #help-description p, #help-description strong {
@@ -709,12 +711,15 @@ export default class BackendAISessionList extends BackendAIPage {
             }
             if (idleChecks && idleChecks.network_timeout && idleChecks.network_timeout.remaining) {
               sessions[objectKey].idle_checks.network_timeout.remaining = BackendAISessionList.secondsToDHMS(idleChecks.network_timeout.remaining);
+              this.activeIdleCheckList?.add('network_timeout');
             }
             if (idleChecks && idleChecks.session_lifetime && idleChecks.session_lifetime.remaining) {
               sessions[objectKey].idle_checks.session_lifetime.remaining = BackendAISessionList.secondsToDHMS(idleChecks.session_lifetime.remaining);
+              this.activeIdleCheckList?.add('session_lifetime');
             }
             if (idleChecks && idleChecks.utilization && idleChecks.utilization.remaining) {
               sessions[objectKey].idle_checks.utilization.remaining = BackendAISessionList.secondsToDHMS(idleChecks.utilization.remaining);
+              this.activeIdleCheckList?.add('utilization');
             }
           }
           if (sessions[objectKey].containers && sessions[objectKey].containers.length > 0) {
@@ -1532,7 +1537,6 @@ export default class BackendAISessionList extends BackendAIPage {
 
   _renderStatusDetail() {
     const tmpSessionStatus = JSON.parse(this.selectedSessionStatus.data);
-    console.log(this.selectedSessionStatus)
     tmpSessionStatus.reserved_time = this.selectedSessionStatus.reserved_time;
     const statusDetailEl = this.shadowRoot?.querySelector('#status-detail') as HTMLDivElement;
     const statusDialogContent: Array<TemplateResult> = [];
@@ -1540,7 +1544,7 @@ export default class BackendAISessionList extends BackendAIPage {
     <div class="vertical layout justified start">
       <h3 style="width:100%;padding-left:15px;border-bottom:1px solid #ccc;">${_text('session.Status')}</h3>
       <lablup-shields color="${this.statusColorTable[this.selectedSessionStatus.info]}"
-          description="${this.selectedSessionStatus.info}" ui="round" style="padding-left:15px;"></lablup-shields>
+          description="${this.selectedSessionStatus.info}" ui="round" style="padding-left:10px;padding-right:10px;"></lablup-shields>
     </div>`);
 
     if (tmpSessionStatus.hasOwnProperty('kernel') || tmpSessionStatus.hasOwnProperty('session')) {
@@ -1814,22 +1818,28 @@ export default class BackendAISessionList extends BackendAIPage {
     this._helpDescriptionTitle = _text('session.IdleChecks');
     this._helpDescription = `
       <p>${_text('session.IdleChecksDesc')}</p>
-      <strong>${_text('session.MaxSessionLifetime')}</strong>
-      <p>${_text('session.MaxSessionLifetimeDesc')}</p>
-      <strong>${_text('session.NetworkIdleTimeout')}</strong>
-      <p>${_text('session.NetworkIdleTimeoutDesc')}</p>
-      <strong>${_text('session.UtilizationIdleTimeout')}</strong>
-      <p>${_text('session.UtilizationIdleTimeoutDesc')}</p>
-      <div style="margin:10px 5% 20px 5%;">
-        <li>
-          <span style="font-weight:500">${_text('session.GracePeriod')}</span>
-          <div style="padding-left:20px;">${_text('session.GracePeriodDesc')}</div>
-        </li>
-        <li>
-          <span style="font-weight:500">${_text('session.UtilizationThreshold')}</span>
-          <div style="padding-left:20px;">${_text('session.UtilizationThresholdDesc')}</div>
-        </li>
-      </div>
+      ${this.activeIdleCheckList?.has('session_lifetime') ? `
+        <strong>${_text('session.MaxSessionLifetime')}</strong>
+        <p>${_text('session.MaxSessionLifetimeDesc')}</p>
+        ` : ``}
+      ${this.activeIdleCheckList?.has('network_timeout') ? `
+        <strong>${_text('session.NetworkIdleTimeout')}</strong>
+        <p>${_text('session.NetworkIdleTimeoutDesc')}</p>
+      ` : ``}
+      ${this.activeIdleCheckList?.has('utilization') ? `
+        <strong>${_text('session.UtilizationIdleTimeout')}</strong>
+        <p>${_text('session.UtilizationIdleTimeoutDesc')}</p>
+        <div style="margin:10px 5% 20px 5%;">
+          <li>
+            <span style="font-weight:500">${_text('session.GracePeriod')}</span>
+            <div style="padding-left:20px;">${_text('session.GracePeriodDesc')}</div>
+          </li>
+          <li>
+            <span style="font-weight:500">${_text('session.UtilizationThreshold')}</span>
+            <div style="padding-left:20px;">${_text('session.UtilizationThresholdDesc')}</div>
+          </li>
+        </div>
+      ` : ``}
     `;
     this.helpDescriptionDialog.show();
   }


### PR DESCRIPTION
Since the policy of the session can be known, only the description of the set Idle checker is visible.
resolves https://github.com/lablup/giftbox/issues/361

+ Updated)
Hide idle checker column if manager doesn't support idle checks or no configuration

Example
![image](https://github.com/lablup/backend.ai-webui/assets/28584164/c1a4e706-d953-4ebf-bca5-cbe77b0c8ffb)
![image](https://github.com/lablup/backend.ai-webui/assets/28584164/66e30816-6dd9-4b17-aac4-c3366e35b1f2)
