### PR TITLE
feat: support i18n ally extension for VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,7 @@ typings/
 # next.js build output
 .next
 
-.vscode
+.vscode/*
 .DS_Store
 public
 build
@@ -76,7 +76,7 @@ app
 
 # IDEA
 .idea
-.vscode
+.vscode/*
 
 # webui config
 config.ini
@@ -123,3 +123,7 @@ tags
 #plugins
 src/plugins
 src/plugins/*
+
+
+# 
+!.vscode/i18n-ally-*

--- a/.vscode/i18n-ally-custom-framework.yml
+++ b/.vscode/i18n-ally-custom-framework.yml
@@ -1,0 +1,30 @@
+# .vscode/i18n-ally-custom-framework.yml
+
+# An array of strings which contain Language Ids defined by VS Code
+# You can check avaliable language ids here: https://code.visualstudio.com/docs/languages/overview#_language-id
+languageIds:
+  - javascript
+  - typescript
+  - javascriptreact
+  - typescriptreact
+
+# An array of RegExes to find the key usage. **The key should be captured in the first match group**.
+# You should unescape RegEx strings in order to fit in the YAML file
+# To help with this, you can use https://www.freeformatter.com/json-escape.html
+usageMatchRegex:
+  # The following example shows how to detect `t("your.i18n.keys")`
+  # the `{key}` will be placed by a proper keypath matching regex,
+  # you can ignore it and use your own matching rules as well
+  - "[^\\w\\d]_t\\(['\"`]({key})['\"`]"
+
+
+# An array of strings containing refactor templates.
+# The "$1" will be replaced by the keypath specified.
+# Optional: uncomment the following two lines to use
+
+# refactorTemplates:
+#  - i18n.get("$1")
+
+
+# If set to true, only enables this custom framework (will disable all built-in frameworks)
+monopoly: false


### PR DESCRIPTION
## Description
This PR adds two `.yaml` files to the `.vscode` directory, which include settings for the [i18n-ally extension](https://marketplace.visualstudio.com/items?itemName=Lokalise.i18n-ally) for VS Code.

To use this feature, follow these steps:

1. Install the [i18n-ally extension](https://marketplace.visualstudio.com/items?itemName=Lokalise.i18n-ally).
2. Open the VS Code settings (Mac: `cmd` + `,`) and search for `ally`. Then, make the following changes:
   - `I18n-ally: Dir Structure`: `auto`
   - `I18n-ally: Enabled Frameworks`: `react`, `custom`
   - (optional) `I18n-ally: Display Language`: If you set this to `ko`, you can see Korean instead of English (which is the default).
   - (optional) `I18n-ally: Annotation In Place`: you can change the annotation in place. please check the snapshot below.

This extension has several good features, such as a statistics translation feature and a review system. You can find details on extension page.

 ## Before & After
| before | after |
| ------ | ----- |
|  <img width="796" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/02fd2145-6861-44a0-b9eb-f8cb8ed266b8">  |  <img width="711" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/2d7d03cc-6ea4-40e4-a85c-452400b4fecc"> |

When `I18n-ally: Display Language` is `ko`:
<img width="745" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/465052da-f88f-4f24-a91c-7a47b4c0fe85">

After checked `I18n-ally: Annotation In Place`:
<img width="631" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/df76c973-9942-43cf-84b7-8838cc1c0f08">


### other features
<img width="379" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/35c49a78-5fcd-44a8-a901-b304bb39cc15">


