### PR TITLE
fix: utilization values in idle checker pop-up are not updated after the initial rendering

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -2505,7 +2505,7 @@ export default class BackendAISessionList extends BackendAIPage {
       let button;
       if (key === 'utilization') {
         button = html`
-            <button
+          <button
             class="idle-check-key"
             style="color:#42a5f5;"
             @mouseenter="${(e) => this._createUtilizationIdleCheckDropdown(e, rowData.item.idle_checks?.utilization?.extra?.resources)}"
@@ -2516,7 +2516,7 @@ export default class BackendAISessionList extends BackendAIPage {
         `;
       } else {
         button = html`
-            <button
+          <button
             class="idle-check-key"
             style="color:#222222;"
           >

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -2506,7 +2506,6 @@ export default class BackendAISessionList extends BackendAIPage {
       if (key === 'utilization') {
         button = html`
             <button
-            id="${key}"
             class="idle-check-key"
             style="color:#42a5f5;"
             @mouseenter="${(e) => this._createUtilizationIdleCheckDropdown(e, rowData.item.idle_checks?.utilization?.extra?.resources)}"
@@ -2518,7 +2517,6 @@ export default class BackendAISessionList extends BackendAIPage {
       } else {
         button = html`
             <button
-            id="${key}"
             class="idle-check-key"
             style="color:#222222;"
           >

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1879,8 +1879,6 @@ export default class BackendAISessionList extends BackendAIPage {
    * @param {Object} utilizationExtra - idle_checks.utilization.extra
    */
   _createUtilizationIdleCheckDropdown(e, utilizationExtra) {
-    this._removeUtilizationIdleCheckDropdown();
-
     const menuDiv: HTMLElement = e.target;
     const menu = document.createElement('mwc-menu') as Menu;
     menu.anchor = menuDiv;
@@ -2504,17 +2502,36 @@ export default class BackendAISessionList extends BackendAIPage {
         );
       }
 
+      let button;
+      if (key === 'utilization') {
+        button = html`
+            <button
+            id="${key}"
+            class="idle-check-key"
+            style="color:#42a5f5;"
+            @mouseenter="${(e) => this._createUtilizationIdleCheckDropdown(e, rowData.item.idle_checks?.utilization?.extra?.resources)}"
+            @mouseleave="${() => this._removeUtilizationIdleCheckDropdown()}"
+          >
+            ${_text('session.' + this.idleChecksTable[key])}
+          </button>
+        `;
+      } else {
+        button = html`
+            <button
+            id="${key}"
+            class="idle-check-key"
+            style="color:#222222;"
+          >
+            ${_text('session.' + this.idleChecksTable[key])}
+          </button>
+        `;
+      }
+
       if (key in this.idleChecksTable) {
         return html`
           <div class="layout vertical" style="padding:3px auto;">
             <div style="margin:4px;">
-              <button
-                id="${key}"
-                class="idle-check-key"
-                style="color:${key === 'utilization' ? '#42a5f5' : '#222222'}"
-              >
-                ${_text('session.' + this.idleChecksTable[key])}
-              </button>
+              ${button}
               <br/>
               <strong style="color:${remainingColor}">${remaining}</strong>
               <div class="idle-type">${_text('session.' + this.idleChecksTable[remainingTimeType])}</div>
@@ -2528,10 +2545,6 @@ export default class BackendAISessionList extends BackendAIPage {
 
     const contentTemplate = html`${contentTemplates}`;
     render(contentTemplate, root);
-
-    const utilization = root.querySelector('#utilization');
-    utilization?.addEventListener('mouseenter', (e) => this._createUtilizationIdleCheckDropdown(e, rowData.item.idle_checks?.utilization?.extra?.resources));
-    utilization?.addEventListener('mouseleave', () => this._removeUtilizationIdleCheckDropdown());
   }
 
   /**

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1879,8 +1879,7 @@ export default class BackendAISessionList extends BackendAIPage {
    * @param {Object} utilizationExtra - idle_checks.utilization.extra
    */
   _createUtilizationIdleCheckDropdown(e, utilizationExtra) {
-    // Prevent re-rendering
-    if (document.getElementsByClassName('util-dropdown-menu').length > 0) return;
+    this._removeUtilizationIdleCheckDropdown();
 
     const menuDiv: HTMLElement = e.target;
     const menu = document.createElement('mwc-menu') as Menu;


### PR DESCRIPTION
duplicate renderings in the idle checker column occur invalid utilization of idle checker values. When filtering the session list, there is a problem with taking advantage of the idle checker value of the session that was at the top of the list before filtering.