### PR TITLE
feat: display allocated shared memory in session config column

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -127,6 +127,7 @@ export default class BackendAISessionList extends BackendAIPage {
   @property({type: String}) _connectionMode = 'API';
   @property({type: Object}) notification = Object();
   @property({type: Boolean}) enableScalingGroup = false;
+  @property({type: Boolean}) isDisplayingAllocatedShmemEnabled = false;
   @property({type: String}) listCondition: StatusCondition = 'loading';
   @property({type: Object}) refreshTimer = Object();
   @property({type: Object}) kernel_labels = Object();
@@ -548,6 +549,7 @@ export default class BackendAISessionList extends BackendAIPage {
         this.is_superadmin = globalThis.backendaiclient.is_superadmin;
         this._connectionMode = globalThis.backendaiclient._config._connectionMode;
         this.enableScalingGroup = globalThis.backendaiclient.supports('scaling-group');
+        this.isDisplayingAllocatedShmemEnabled = globalThis.backendaiclient.supports('display-allocated-shmem');
         this._APIMajorVersion = globalThis.backendaiclient.APIMajorVersion;
         this.isUserInfoMaskEnabled = globalThis.backendaiclient._config.maskUserInfo;
         // check whether image commit supported via both configuration variable and version(22.09)
@@ -571,6 +573,7 @@ export default class BackendAISessionList extends BackendAIPage {
       this.is_superadmin = globalThis.backendaiclient.is_superadmin;
       this._connectionMode = globalThis.backendaiclient._config._connectionMode;
       this.enableScalingGroup = globalThis.backendaiclient.supports('scaling-group');
+      this.isDisplayingAllocatedShmemEnabled = globalThis.backendaiclient.supports('display-allocated-shmem');
       this._APIMajorVersion = globalThis.backendaiclient.APIMajorVersion;
       this.isUserInfoMaskEnabled = globalThis.backendaiclient._config.maskUserInfo;
       // check whether image commit supported via both configuration variable and version(22.09)
@@ -2240,7 +2243,11 @@ export default class BackendAISessionList extends BackendAIPage {
             <wl-icon class="fg green indicator">memory</wl-icon>
             <span>${rowData.item.mem_slot}</span>
             <span class="indicator">GiB</span>
-            <span class="indicator">${`(SHM: `+this._aggregateSharedMemory(JSON.parse(rowData.item.resource_opts))+`GiB)`}</span>
+            ${this.isDisplayingAllocatedShmemEnabled ? html`
+              <span class="indicator">
+                ${`(SHM: `+this._aggregateSharedMemory(JSON.parse(rowData.item.resource_opts))+`GiB)`}
+              </span>
+            ` : html``}
           </div>
           <div class="layout horizontal center configuration">
             ${rowData.item.cuda_gpu_slot ? html`

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -2240,11 +2240,7 @@ export default class BackendAISessionList extends BackendAIPage {
             <wl-icon class="fg green indicator">memory</wl-icon>
             <span>${rowData.item.mem_slot}</span>
             <span class="indicator">GiB</span>
-          </div>
-          <div class="layout horizontal center configuration">
-            <wl-icon class="fg green indicator">bento</wl-icon>
-            <span>${this._aggregateSharedMemory(JSON.parse(rowData.item.resource_opts))}</span>
-            <span class="indicator">GiB</span>
+            <span class="indicator">${`(SHM: `+this._aggregateSharedMemory(JSON.parse(rowData.item.resource_opts))+`GiB)`}</span>
           </div>
           <div class="layout horizontal center configuration">
             ${rowData.item.cuda_gpu_slot ? html`
@@ -2822,7 +2818,7 @@ export default class BackendAISessionList extends BackendAIPage {
           </lablup-grid-sort-filter-column>
           <vaadin-grid-column width=${this._isContainerCommitEnabled ? '260px': '210px'} flex-grow="0" resizable header="${_t('general.Control')}"
                               .renderer="${this._boundControlRenderer}"></vaadin-grid-column>
-          <vaadin-grid-column auto-width flex-grow="0" resizable header="${_t('session.Configuration')}"
+          <vaadin-grid-column width="200px" flex-grow="0" resizable header="${_t('session.Configuration')}"
                               .renderer="${this._boundConfigRenderer}"></vaadin-grid-column>
           <vaadin-grid-column width="140px" flex-grow="0" resizable header="${_t('session.Usage')}"
                               .renderer="${this._boundUsageRenderer}">

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -596,6 +596,7 @@ class Client {
     if (this.isManagerVersionCompatibleWith('23.03')) {
       this._features['inference-workload'] = true;
       this._features['local-vscode-remote-connection'] = true;
+      this._features['display-allocated-shmem'] = true;
     }
   }
 


### PR DESCRIPTION
This PR adds a simple user interface for "shared memory" allocated in each session.
Please note that shared memory also follows the policy; which aggregates all allocated amounts of the same resources in each container on multi-container conditions; as the other resources do.
related PR: [backend.ai#1282](https://github.com/lablup/backend.ai/pull/1282)

### Screenshot(s)
* Before
<img width="1125" alt="Screenshot 2023-05-18 at 9 32 54 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/aba4ab3e-e005-452c-9955-0dc97ab39d64">

* After
<img width="1125" alt="Screenshot 2023-05-18 at 9 31 46 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/a6ad9d3d-671f-416d-b129-c341332407f7">
