### PR TITLE
fix: let base64 encode convert padding with byte triplet condition

### DIFF
--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -1472,10 +1472,19 @@ class Client {
     let i = 0;
     while (i < strBytes.length) {
       const byte1 = strBytes[i++];
-      const byte2 = i < strBytes.length ? strBytes[i++] : 0;
-      const byte3 = i < strBytes.length ? strBytes[i++] : 0;
-      const triplet = (byte1 << 16) + (byte2 << 8) + byte3;
-      strBase64 += charset.charAt((triplet >> 18) & 0x3F) + charset.charAt((triplet >> 12) & 0x3F) + charset.charAt((triplet >> 6) & 0x3F) + charset.charAt(triplet & 0x3F);
+      const byte2 = (i < strBytes.length) ? strBytes[i++] : -1;
+      const byte3 = (i < strBytes.length) ? strBytes[i++] : -1;
+      const triplet = (
+        (byte1 << 16) +
+        ((byte2 != -1 ? byte2 : 0) << 8) +
+        (byte3 != -1 ? byte3 : 0)
+      );
+      strBase64 += (
+        charset.charAt((triplet >> 18) & 0x3F) +
+        charset.charAt((triplet >> 12) & 0x3F) +
+        charset.charAt(byte2 != -1 ? (triplet >> 6) & 0x3F : 64) +
+        charset.charAt(byte3 != -1 ? triplet & 0x3F : 64)
+      );
     }
     return strBase64;
   }


### PR DESCRIPTION
This PR ensures the endpoint conversion to base64 with compatible forma with `btoa` and byte-wise server-side base64 parser. 