### PR TITLE
hotfix: enable sftp-scaling-group feature from manager v22.03.3

### DIFF
--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -597,6 +597,8 @@ class Client {
       this._features['inference-workload'] = true;
       this._features['local-vscode-remote-connection'] = true;
       this._features['display-allocated-shmem'] = true;
+    }
+    if (this.isManagerVersionCompatibleWith('23.03.3')) {
       this._features['sftp-scaling-group'] = true;
     }
   }


### PR DESCRIPTION
The sftp-scaling-group feature was released in [manager v23.03.3](https://github.com/lablup/backend.ai/releases/tag/23.03.3).