### PR TITLE
fix: touchup description for ssh sftp session

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -294,7 +294,7 @@
     "AllowedClientIps": "Allowed client IPs",
     "CommaSeparated": "comma-separated",
     "TryPreferredPort": "Try preferred port",
-    "SFTPDescription": "Use your favorite SSH/SFTP application to connect.",
+    "SFTPDescription": "You can upload files quickly and securely through an SSH/SFTP client. If you haven't uploaded your SSH key pair beforehand, please click the "SSH Key Download" button to save your SSH key first. You can then use that key to execute commands such as SFTP, SCP, and Rsync. On the "Session - Upload Session" page, you can manage the list of sessions for file uploads. It is recommended to delete sessions after they have been used, as there is a limit on the number of sessions. Sessions that are not used for uploading files within a certain period of time may be automatically deleted.",
     "ConnectionInformation": "Connection Information",
     "DownloadSSHKey": "Download SSH key file (id_container)",
     "VNCconnection": "VNC connection",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -294,7 +294,8 @@
     "AllowedClientIps": "Allowed client IPs",
     "CommaSeparated": "comma-separated",
     "TryPreferredPort": "Try preferred port",
-    "SFTPDescription": "You can upload files quickly and securely through an SSH/SFTP client. If you haven't uploaded your SSH key pair beforehand, please click the "SSH Key Download" button to save your SSH key first. You can then use that key to execute commands such as SFTP, SCP, and Rsync. On the "Session - Upload Session" page, you can manage the list of sessions for file uploads. It is recommended to delete sessions after they have been used, as there is a limit on the number of sessions. Sessions that are not used for uploading files within a certain period of time may be automatically deleted.",
+    "SFTPDescription": "You can upload files quickly and securely through an SSH/SFTP client. If you haven't uploaded your SSH key pair beforehand, please click the \"SSH Key Download\" button to save your SSH key first. You can then use that key to execute commands such as SFTP, SCP, and Rsync. On the \"Session - Upload Session\" page, you can manage the list of sessions for file uploads.",
+    "SFTPExtraNotification": "It is recommended to delete sessions after they have been used, as there is a limit on the number of sessions. Sessions that are not used for uploading files within a certain period of time may be automatically deleted.",
     "ConnectionInformation": "Connection Information",
     "DownloadSSHKey": "Download SSH key file (id_container)",
     "VNCconnection": "VNC connection",
@@ -374,6 +375,7 @@
     "GracePeriodDesc": "Utilization idle checker will be activated after this initial grace time. During this time, sessions are not terminated even if utilization is low.",
     "UtilizationThresholdDesc": "Threshold criteria of each compute resource. When one or more resource of a compute session does not exceed the configured threshold criteria for a certain time, the session will be garbage collected (terminated). For example, if you set 1% of CUDA utilization threshold, compute sessions that show less than 1% CUDA GPU utilization, for a certain duration of time, will be destroyed. Resources with empty values are excluded from the garbage collection criteria.",
     "ConnectionExample": "Connection Example",
+    "ConnectionNotice": "Notice",
     "System": "Upload Sessions"
   },
   "button": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -296,6 +296,8 @@
     "TryPreferredPort": "Try preferred port",
     "SFTPDescription": "You can upload files quickly and securely through an SSH/SFTP client. If you haven't uploaded your SSH key pair beforehand, please click the \"SSH Key Download\" button to save your SSH key first. You can then use that key to execute commands such as SFTP, SCP, and Rsync. On the \"Session - Upload Session\" page, you can manage the list of sessions for file uploads.",
     "SFTPExtraNotification": "It is recommended to delete sessions after they have been used, as there is a limit on the number of sessions. Sessions that are not used for uploading files within a certain period of time may be automatically deleted.",
+    "Readmore": "Read More...",
+    "Readless": "Read less",
     "ConnectionInformation": "Connection Information",
     "DownloadSSHKey": "Download SSH key file (id_container)",
     "VNCconnection": "VNC connection",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -368,7 +368,10 @@
     "ConnectionExample": "__NOT_TRANSLATED__",
     "System": "__NOT_TRANSLATED__",
     "SFTPExtraNotification": "__NOT_TRANSLATED__",
-    "ConnectionNotice": "__NOT_TRANSLATED__"
+    "ConnectionNotice": "__NOT_TRANSLATED__",
+    "ReadMore": "__NOT_TRANSLATED__",
+    "Readless": "__NOT_TRANSLATED__",
+    "Readmore": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Annuler",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -366,7 +366,9 @@
     "UtilizationThresholdDesc": "__NOT_TRANSLATED__",
     "ExpiresAfter": "__NOT_TRANSLATED__",
     "ConnectionExample": "__NOT_TRANSLATED__",
-    "System": "__NOT_TRANSLATED__"
+    "System": "__NOT_TRANSLATED__",
+    "SFTPExtraNotification": "__NOT_TRANSLATED__",
+    "ConnectionNotice": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Annuler",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -366,7 +366,9 @@
     "UtilizationThresholdDesc": "__NOT_TRANSLATED__",
     "ExpiresAfter": "__NOT_TRANSLATED__",
     "ConnectionExample": "__NOT_TRANSLATED__",
-    "System": "__NOT_TRANSLATED__"
+    "System": "__NOT_TRANSLATED__",
+    "SFTPExtraNotification": "__NOT_TRANSLATED__",
+    "ConnectionNotice": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Batalkan",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -368,7 +368,10 @@
     "ConnectionExample": "__NOT_TRANSLATED__",
     "System": "__NOT_TRANSLATED__",
     "SFTPExtraNotification": "__NOT_TRANSLATED__",
-    "ConnectionNotice": "__NOT_TRANSLATED__"
+    "ConnectionNotice": "__NOT_TRANSLATED__",
+    "ReadMore": "__NOT_TRANSLATED__",
+    "Readless": "__NOT_TRANSLATED__",
+    "Readmore": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Batalkan",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -278,7 +278,7 @@
     "AllowedClientIps": "허용된 클라이언트 IP",
     "CommaSeparated": "콤마로 구분",
     "TryPreferredPort": "선호 포트",
-    "SFTPDescription": "SSH/SFTP 클라이언트를 통해 빠르고 안정적으로 파일을 업로드할 수 있습니다. 미리 SSH 키페어를 업로드하지 않으셨다면, \"SSH키 다운로드\" 버튼을 클릭하여 SSH 키를 먼저 저장하십시오. 그 키를 이용해서 sftp, scp, rsync 등의 명령을 사용할 수 있습니다. 세션 - 업로드 세션페이지에서 파일 업로드를 위한 세션 리스트를 관리할 수 있습니다. 개수 제한이 있으므로 다 사용한 후에는 삭제하는 것이 좋습니다. 일정 시간 업로드를 하지 않는 세션은 자동으로 삭제될 수 있습니다.",
+    "SFTPDescription": "SSH/SFTP 클라이언트를 통해 빠르고 안정적으로 파일을 업로드할 수 있습니다. 미리 SSH 키페어를 업로드하지 않으셨다면, \"SSH키 다운로드\" 버튼을 클릭하여 SSH 키를 먼저 저장하십시오. 그 키를 이용해서 sftp, scp, rsync 등의 명령을 사용할 수 있습니다. 세션 - 업로드 세션페이지에서 파일 업로드를 위한 세션 리스트를 관리할 수 있습니다.",
     "ConnectionInformation": "연결 정보",
     "DownloadSSHKey": "SSH 키 파일 다운로드 (id_container)",
     "VNCconnection": "VNC 연결",
@@ -367,7 +367,9 @@
     "UtilizationThresholdDesc": "연산 세션의 자원 사용량 기준입니다. 연산 세션의 자원 사용량이 일정 시간 동안 설정된 기준값을 넘지 못하면, 그 세션은 자동으로 삭제됩니다. 예를 들어, CUDA 사용률 기준을 1%로 설정했다면, 일정 시간 동안 1% 미만의 CUDA GPU 사용률을 보이는 연산 세션이 삭제됩니다. 값이 설정되지 않는 자원은 자동 삭제 기준에서 제외됩니다.",
     "ExpiresAfter": "남은 시간",
     "ConnectionExample": "접속 예제",
-    "System": "업로드 세션"
+    "System": "업로드 세션",
+    "SFTPExtraNotification": "개수 제한이 있으므로 다 사용한 후에는 삭제하는 것이 좋습니다. 일정 시간 업로드를 하지 않는 세션은 자동으로 삭제될 수 있습니다.",
+    "ConnectionNotice": "주의"
   },
   "button": {
     "Cancel": "취소",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -369,7 +369,9 @@
     "ConnectionExample": "접속 예제",
     "System": "업로드 세션",
     "SFTPExtraNotification": "개수 제한이 있으므로 다 사용한 후에는 삭제하는 것이 좋습니다. 일정 시간 업로드를 하지 않는 세션은 자동으로 삭제될 수 있습니다.",
-    "ConnectionNotice": "주의"
+    "ConnectionNotice": "주의",
+    "Readmore": "더 알아보기...",
+    "Readless": "내용 접기"
   },
   "button": {
     "Cancel": "취소",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -278,7 +278,7 @@
     "AllowedClientIps": "허용된 클라이언트 IP",
     "CommaSeparated": "콤마로 구분",
     "TryPreferredPort": "선호 포트",
-    "SFTPDescription": "SSH/SFTP 클라이언트를 이용해서 접속하세요.",
+    "SFTPDescription": "SSH/SFTP 클라이언트를 통해 빠르고 안정적으로 파일을 업로드할 수 있습니다. 미리 SSH 키페어를 업로드하지 않으셨다면, \"SSH키 다운로드\" 버튼을 클릭하여 SSH 키를 먼저 저장하십시오. 그 키를 이용해서 sftp, scp, rsync 등의 명령을 사용할 수 있습니다. 세션 - 업로드 세션페이지에서 파일 업로드를 위한 세션 리스트를 관리할 수 있습니다. 개수 제한이 있으므로 다 사용한 후에는 삭제하는 것이 좋습니다. 일정 시간 업로드를 하지 않는 세션은 자동으로 삭제될 수 있습니다.",
     "ConnectionInformation": "연결 정보",
     "DownloadSSHKey": "SSH 키 파일 다운로드 (id_container)",
     "VNCconnection": "VNC 연결",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -368,7 +368,10 @@
     "ConnectionExample": "__NOT_TRANSLATED__",
     "System": "__NOT_TRANSLATED__",
     "SFTPExtraNotification": "__NOT_TRANSLATED__",
-    "ConnectionNotice": "__NOT_TRANSLATED__"
+    "ConnectionNotice": "__NOT_TRANSLATED__",
+    "ReadMore": "__NOT_TRANSLATED__",
+    "Readless": "__NOT_TRANSLATED__",
+    "Readmore": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Цуцлах",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -366,7 +366,9 @@
     "UtilizationThresholdDesc": "__NOT_TRANSLATED__",
     "ExpiresAfter": "__NOT_TRANSLATED__",
     "ConnectionExample": "__NOT_TRANSLATED__",
-    "System": "__NOT_TRANSLATED__"
+    "System": "__NOT_TRANSLATED__",
+    "SFTPExtraNotification": "__NOT_TRANSLATED__",
+    "ConnectionNotice": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Цуцлах",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -366,7 +366,9 @@
     "UtilizationThresholdDesc": "__NOT_TRANSLATED__",
     "ExpiresAfter": "__NOT_TRANSLATED__",
     "ConnectionExample": "__NOT_TRANSLATED__",
-    "System": "__NOT_TRANSLATED__"
+    "System": "__NOT_TRANSLATED__",
+    "SFTPExtraNotification": "__NOT_TRANSLATED__",
+    "ConnectionNotice": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Отмена",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -368,7 +368,10 @@
     "ConnectionExample": "__NOT_TRANSLATED__",
     "System": "__NOT_TRANSLATED__",
     "SFTPExtraNotification": "__NOT_TRANSLATED__",
-    "ConnectionNotice": "__NOT_TRANSLATED__"
+    "ConnectionNotice": "__NOT_TRANSLATED__",
+    "ReadMore": "__NOT_TRANSLATED__",
+    "Readless": "__NOT_TRANSLATED__",
+    "Readmore": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "Отмена",

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -1343,8 +1343,8 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           <section class="vertical layout wrap start start-justified">
             <div id="expandable-desc">
               <div style="padding:15px 0;">${_t('session.SFTPDescription')}</div>
-              <div style="background-color:var(--paper-blue-400);">
-                <div style="background-color:var(--paper-blue-700);padding:5px 15px">
+              <div style="background-color:var(--paper-blue-200);">
+                <div style="background-color:var(--paper-blue-400);padding:5px 15px">
                   <span style="font-weight:700;">${_t('session.ConnectionNotice')}</span>
                 </div>
               <div style="padding:15px;">${_tr('session.SFTPExtraNotification')}</div>

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -164,6 +164,28 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           margin: 0 10px;
         }
 
+        #collapsible-btn {
+          background: none;
+          border: none;
+          padding: 10px 0px;
+          cursor: pointer;
+          font-size: 0.9rem;
+          font-family: Ubuntu;
+          color: #0000EE;
+          font-weight: 500;
+        }
+
+        #collapsible-btn:hover {
+          color: var(--general-button-background-color);
+        }
+
+        #expandable-desc {
+          // default height for 3line ellpsis
+          height: auto;
+          max-height: 83px;
+          overflow-y: hidden;
+        }
+
         .slide {
           display: flex;
           align-items: center;
@@ -1199,6 +1221,15 @@ export default class BackendAiAppLauncher extends BackendAIPage {
     }
   }
 
+  _toggleCollapsibleArea(e) {
+    const btn = e.target;
+    const isFolded = (btn.textContent.replace(/\s/g, '') == _text('session.Readmore').replace(/\s/g, ''));
+    const collapsibleArea = (this.shadowRoot?.querySelector('#expandable-desc')) as HTMLElement;
+    // FIXME: temporally set maxHeight with hardcoded value
+    collapsibleArea.style.maxHeight = isFolded ? '100%': '83px';
+    btn.textContent = isFolded ? _text('session.Readless') : _text('session.Readmore');
+  }
+
   /**
    * Copy Remote VS Code password to clipboard
    *
@@ -1309,14 +1340,19 @@ export default class BackendAiAppLauncher extends BackendAIPage {
       <backend-ai-dialog id="ssh-dialog" fixed backdrop>
         <span slot="title">SSH / SFTP connection</span>
         <div slot="content">
-          <div style="padding:15px 0;">${_t('session.SFTPDescription')}</div>
           <section class="vertical layout wrap start start-justified">
-            <div style="background-color:var(--paper-orange-400);">
-              <div style="background-color:var(--paper-orange-700);padding:5px 15px">
-                <span style="font-weight:700;">${_t('session.ConnectionNotice')}</span>
+            <div id="expandable-desc">
+              <div style="padding:15px 0;">${_t('session.SFTPDescription')}</div>
+              <div style="background-color:var(--paper-blue-400);">
+                <div style="background-color:var(--paper-blue-700);padding:5px 15px">
+                  <span style="font-weight:700;">${_t('session.ConnectionNotice')}</span>
+                </div>
+              <div style="padding:15px;">${_tr('session.SFTPExtraNotification')}</div>
               </div>
-            <div style="padding:15px;">${_tr('session.SFTPExtraNotification')}</div>
             </div>
+            <button id="collapsible-btn" @click="${(e) => this._toggleCollapsibleArea(e)}">
+              ${_t('session.Readmore')}
+            </button>
             <h4>${_t('session.ConnectionInformation')}</h4>
             <div><span>User:</span> work</div>
             <div><span>SSH URL:</span> <a href="ssh://${this.sshHost}:${this.sshPort}">ssh://${this.sshHost}</a>

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -2,7 +2,7 @@
  @license
  Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
  */
-import {get as _text, translate as _t} from 'lit-translate';
+import {get as _text, translate as _t, translateUnsafeHTML as _tr} from 'lit-translate';
 import {css, CSSResultGroup, html} from 'lit';
 import {customElement, property, query} from 'lit/decorators.js';
 
@@ -113,7 +113,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         }
 
         #ssh-dialog {
-          --component-width: 330px;
+          --component-width: 375px;
         }
 
         .app-icon {
@@ -1311,6 +1311,12 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         <div slot="content">
           <div style="padding:15px 0;">${_t('session.SFTPDescription')}</div>
           <section class="vertical layout wrap start start-justified">
+            <div style="background-color:var(--paper-orange-400);">
+              <div style="background-color:var(--paper-orange-700);padding:5px 15px">
+                <span style="font-weight:700;">${_t('session.ConnectionNotice')}</span>
+              </div>
+            <div style="padding:15px;">${_tr('session.SFTPExtraNotification')}</div>
+            </div>
             <h4>${_t('session.ConnectionInformation')}</h4>
             <div><span>User:</span> work</div>
             <div><span>SSH URL:</span> <a href="ssh://${this.sshHost}:${this.sshPort}">ssh://${this.sshHost}</a>
@@ -1320,7 +1326,10 @@ export default class BackendAiAppLauncher extends BackendAIPage {
             <div><span>Port:</span> ${this.sshPort}</div>
             <h4>${_t('session.ConnectionExample')}</h4>
             <div class="monospace" style="background-color:#242424;padding:15px;">
-              <span style="color:#ffffff;">sftp -i ./id_container -P ${this.sshPort} work@${this.sshHost}</span>
+              <span style="color:#ffffff;">
+                sftp -i ./id_container -P ${this.sshPort} work@${this.sshHost}<br/>
+                scp -i ./id_container -P ${this.sshPort} -rp /path/to/source work@${this.sshHost}:~/<vfolder-name><br/>
+                rsync -av -e "ssh -i ./id_container" /path/to/source/ work@${this.sshHost}:~/<vfolder-name>/<br/>
             </div>
           </section>
         </div>


### PR DESCRIPTION
This PR resolves #1726.

### Screenshot(s)
* before
<img width="353" alt="Screenshot 2023-06-05 at 4 28 29 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/be532bc9-6ed1-4cf9-9698-b8e0d1b92cd3">


* after
> NOTE: By suggestion of @adrysn, I updated description area to be collapsible. you can expand/shrink by clicking `Read more.../Read less` button.

| Folded(Read more...) | Expanded(Read less)|
| ------------- | ------------- |
| <img width="404" alt="Screenshot 2023-06-07 at 5 53 30 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/cf084e5e-5f88-453a-abbd-de5822209092"> | <img width="404" alt="Screenshot 2023-06-07 at 6 21 36 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/15e72a9c-9e5e-474c-9a2f-590efddbaec0"> |



