### PR TITLE
fix: SFTP scaling group session refusing to be created

### DIFF
--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -2900,6 +2900,7 @@ export default class BackendAiStorageList extends BackendAIPage {
     imageResource['mem'] = '256m';
     imageResource['domain'] = globalThis.backendaiclient._config.domainName;
     imageResource['scaling_group'] = this.volumeInfo[this.vhost]?.sftp_scaling_groups[0];
+    imageResource['group_name'] = globalThis.backendaiclient.current_group;
     const indicator = await this.indicator.start('indeterminate');
     return (async () => {
       try {


### PR DESCRIPTION
This PR fixes SFTP scaling group session not being created when user is not a member of `default` project.