### PR TITLE
docs: Modified to fit nvidia brand notation

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "Erlauben Sie dem Agenten, sich beim Manager zu registrieren. <br/> Nur verwenden, wenn der Backend.AI-Cluster an einem sicheren Ort verwaltet wird.",
     "Plugins": "Plugins",
     "CUDAGPUsupport": "CUDA-GPU-Unterstützung",
-    "DescCUDAGPUsupport": "NVidia CUDA-GPU-Unterstützung. <br/> Erfordert Backend.AI CUDA-Plugin.",
+    "DescCUDAGPUsupport": "NVIDIA CUDA-GPU-Unterstützung. <br/> Erfordert Backend.AI CUDA-Plugin.",
     "CUDAGPUdisabledByFGPUsupport": "Deaktiviert, weil das System das Fractional GPU-Plugin verwendet",
     "ROCMGPUsupport": "ROCm-GPU-Unterstützung",
     "DescROCMGPUsupport": "AMD ROCm-GPU-Unterstützung. <br/> Erfordert Backend.AI ROCm-Plugin.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "Επιτρέψτε στον πράκτορα να εγγραφεί στον διαχειριστή. <br/> Χρησιμοποιήστε μόνο εάν το σύμπλεγμα Backend.AI διαχειρίζεται σε ασφαλή τοποθεσία.",
     "Plugins": "Πρόσθετα",
     "CUDAGPUsupport": "Υποστήριξη CUDA GPU",
-    "DescCUDAGPUsupport": "Υποστήριξη NVidia CUDA GPU. <br/> Απαιτείται πρόσθετο Backend.AI CUDA.",
+    "DescCUDAGPUsupport": "Υποστήριξη NVIDIA CUDA GPU. <br/> Απαιτείται πρόσθετο Backend.AI CUDA.",
     "CUDAGPUdisabledByFGPUsupport": "Απενεργοποιήθηκε επειδή το σύστημα χρησιμοποιεί Fractional GPU plugin",
     "ROCMGPUsupport": "Υποστήριξη ROCm GPU",
     "DescROCMGPUsupport": "Υποστήριξη AMD ROCm GPU. <br/> Απαιτείται πρόσθετο Backend.AI ROCm.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1075,7 +1075,7 @@
     "DescAllowAgentSideRegistration": "Allow agent to register itself to manager.<br/>Use only if Backend.AI cluster is managed on secure location.",
     "Plugins": "Plugins",
     "CUDAGPUsupport": "CUDA GPU support",
-    "DescCUDAGPUsupport": "NVidia CUDA GPU support. <br/>Requires Backend.AI CUDA Plugin.",
+    "DescCUDAGPUsupport": "NVIDIA CUDA GPU support. <br/>Requires Backend.AI CUDA Plugin.",
     "CUDAGPUdisabledByFGPUsupport": "Disabled because system uses Fractional GPU plugin",
     "ROCMGPUsupport": "ROCm GPU support",
     "DescROCMGPUsupport": "AMD ROCm GPU support. <br/>Requires Backend.AI ROCm Plugin.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "Permitir que el agente se registre como administrador. <br/> Úselo solo si el clúster Backend.AI se administra en una ubicación segura.",
     "Plugins": "Complementos",
     "CUDAGPUsupport": "Compatibilidad con GPU CUDA",
-    "DescCUDAGPUsupport": "Soporte de GPU NVidia CUDA. <br/> Requiere el complemento Backend.AI CUDA.",
+    "DescCUDAGPUsupport": "Soporte de GPU NVIDIA CUDA. <br/> Requiere el complemento Backend.AI CUDA.",
     "CUDAGPUdisabledByFGPUsupport": "Deshabilitado porque el sistema usa el complemento de GPU fraccional",
     "ROCMGPUsupport": "Soporte de GPU ROCm",
     "DescROCMGPUsupport": "Compatibilidad con GPU AMD ROCm. <br/> Requiere el complemento Backend.AI ROCm.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "Salli agentin rekisteröidä itsensä johtajaan. <br/> Käytä vain, jos Backend.AI-klusteria hallitaan suojatussa paikassa.",
     "Plugins": "Laajennukset",
     "CUDAGPUsupport": "CUDA-näytönohjaimen tuki",
-    "DescCUDAGPUsupport": "NVidia CUDA -näytönohjaimen tuki. <br/> Vaatii Backend.AI CUDA -laajennuksen.",
+    "DescCUDAGPUsupport": "NVIDIA CUDA -näytönohjaimen tuki. <br/> Vaatii Backend.AI CUDA -laajennuksen.",
     "CUDAGPUdisabledByFGPUsupport": "Pois käytöstä, koska järjestelmä käyttää murto-osan GPU-laajennusta",
     "ROCMGPUsupport": "ROCm-näytönohjaimen tuki",
     "DescROCMGPUsupport": "AMD ROCm -näytönohjaimen tuki. <br/> Vaatii Backend.AI ROCm -laajennuksen.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1067,7 +1067,7 @@
     "DescAllowAgentSideRegistration": "Autoriser l'agent à s'inscrire auprès du gestionnaire. <br/> À utiliser uniquement si le cluster Backend.AI est géré sur un emplacement sécurisé.",
     "Plugins": "Plugins",
     "CUDAGPUsupport": "Prise en charge du processeur graphique CUDA",
-    "DescCUDAGPUsupport": "Prise en charge du GPU NVidia CUDA. <br/> Nécessite le plugin Backend.AI CUDA.",
+    "DescCUDAGPUsupport": "Prise en charge du GPU NVIDIA CUDA. <br/> Nécessite le plugin Backend.AI CUDA.",
     "CUDAGPUdisabledByFGPUsupport": "Désactivé car le système utilise le plug-in Fractional GPU",
     "ROCMGPUsupport": "Prise en charge du GPU ROCm",
     "DescROCMGPUsupport": "Prise en charge du GPU AMD ROCm. <br/> Nécessite le plugin Backend.AI ROCm.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1067,7 +1067,7 @@
     "DescAllowAgentSideRegistration": "Izinkan agen untuk mendaftarkan dirinya ke manajer. <br/>Gunakan hanya jika klaster Backend.AI dikelola di lokasi yang aman.",
     "Plugins": "Plugin",
     "CUDAGPUsupport": "Dukungan GPU CUDA",
-    "DescCUDAGPUsupport": "Dukungan GPU NVidia CUDA. <br/>Membutuhkan Plugin CUDA Backend.AI.",
+    "DescCUDAGPUsupport": "Dukungan GPU NVIDIA CUDA. <br/>Membutuhkan Plugin CUDA Backend.AI.",
     "CUDAGPUdisabledByFGPUsupport": "Dinonaktifkan karena sistem menggunakan plugin GPU Pecahan",
     "ROCMGPUsupport": "Dukungan GPU ROCm",
     "DescROCMGPUsupport": "Dukungan AMD ROCm GPU. <br/>Membutuhkan Plugin Backend.AI ROCm.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "Consenti all'agente di registrarsi al gestore. <br/> Utilizzare solo se il cluster Backend.AI è gestito in una posizione sicura.",
     "Plugins": "Plugin",
     "CUDAGPUsupport": "Supporto GPU CUDA",
-    "DescCUDAGPUsupport": "Supporto per GPU NVidia CUDA. <br/> Richiede il plug-in CUDA di backend.AI.",
+    "DescCUDAGPUsupport": "Supporto per GPU NVIDIA CUDA. <br/> Richiede il plug-in CUDA di backend.AI.",
     "CUDAGPUdisabledByFGPUsupport": "Disabilitato perché il sistema utilizza il plug-in Fractional GPU",
     "ROCMGPUsupport": "Supporto GPU ROCm",
     "DescROCMGPUsupport": "Supporto per GPU AMD ROCm. <br/> Richiede il plug-in ROCm Backend.AI.",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "エージェントが自分自身をマネージャーに登録できるようにします。 <br/>Backend.AIクラスターが安全な場所で管理されている場合にのみ使用します。",
     "Plugins": "プラグイン",
     "CUDAGPUsupport": "CUDAGPUサポート",
-    "DescCUDAGPUsupport": "NVidia CUDAGPUのサポート。 <br/> Backend.AICUDAプラグインが必要です。",
+    "DescCUDAGPUsupport": "NVIDIA CUDAGPUのサポート。 <br/> Backend.AICUDAプラグインが必要です。",
     "CUDAGPUdisabledByFGPUsupport": "システムがフラクショナルGPUプラグインを使用しているため無効になっています",
     "ROCMGPUsupport": "ROCmGPUサポート",
     "DescROCMGPUsupport": "AMD ROCmGPUのサポート。 <br/> Backend.AIROCmプラグインが必要です。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1068,7 +1068,7 @@
     "DescAllowAgentSideRegistration": "매니저에 에이전트 자신을 등록하도록 허용합니다.<br/>Backend.AI 클러스터가 보안환경에서 동작 및 관리되고 있을 때만 사용하세요.",
     "Plugins": "플러그인",
     "CUDAGPUsupport": "CUDA GPU 지원",
-    "DescCUDAGPUsupport": "NVidia CUDA GPU 지원을 추가합니다. <br/>Backend.AI CUDA 플러그인이 필요합니다.",
+    "DescCUDAGPUsupport": "NVIDIA CUDA GPU 지원을 추가합니다. <br/>Backend.AI CUDA 플러그인이 필요합니다.",
     "CUDAGPUdisabledByFGPUsupport": "시스템이 Fractional GPU 플러그인을 사용하고 있어 비활성화되었습니다.",
     "ROCMGPUsupport": "ROCm GPU 지원",
     "DescROCMGPUsupport": "AMD ROCm GPU 지원을 추가합니다. <br/>Backend.AI ROCm 플러그인이 필요합니다.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1067,7 +1067,7 @@
     "DescAllowAgentSideRegistration": "Агентэд өөрийгөө менежерт бүртгүүлэхийг зөвшөөрөх. <br/> Зөвхөн Backend.AI кластерийг аюулгүй байршилд удирдаж байгаа тохиолдолд л ашиглана уу.",
     "Plugins": "Залгаасууд",
     "CUDAGPUsupport": "CUDA GPU дэмжлэг",
-    "DescCUDAGPUsupport": "NVidia CUDA GPU дэмжлэг. <br/> Backend.AI CUDA залгаас шаарддаг.",
+    "DescCUDAGPUsupport": "NVIDIA CUDA GPU дэмжлэг. <br/> Backend.AI CUDA залгаас шаарддаг.",
     "CUDAGPUdisabledByFGPUsupport": "Систем нь бутархай GPU залгаас ашигладаг тул идэвхгүй болгосон",
     "ROCMGPUsupport": "ROCm GPU дэмжлэг",
     "DescROCMGPUsupport": "AMD ROCm GPU дэмжлэг. <br/> Backend шаардлагатай. AI ROCm залгаас.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "Benarkan ejen mendaftarkan dirinya kepada pengurus. <br/> Gunakan hanya jika kluster Backend.AI diuruskan di lokasi yang selamat.",
     "Plugins": "Pemalam",
     "CUDAGPUsupport": "Sokongan GPU CUDA",
-    "DescCUDAGPUsupport": "Sokongan GPU NVidia CUDA. <br/> Memerlukan Backend.AI CUDA Plugin.",
+    "DescCUDAGPUsupport": "Sokongan GPU NVIDIA CUDA. <br/> Memerlukan Backend.AI CUDA Plugin.",
     "CUDAGPUdisabledByFGPUsupport": "Dinyahdayakan kerana sistem menggunakan pemalam GPU pecahan",
     "ROCMGPUsupport": "Sokongan GPU ROCm",
     "DescROCMGPUsupport": "Sokongan GPU AMD ROCm. <br/> Memerlukan Backend.AI ROCm Plugin.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "Zezwól agentowi na zarejestrowanie się w menedżerze. <br/> Używaj tylko wtedy, gdy klaster Backend.AI jest zarządzany w bezpiecznej lokalizacji.",
     "Plugins": "Wtyczki",
     "CUDAGPUsupport": "Obsługa procesorów graficznych CUDA",
-    "DescCUDAGPUsupport": "Obsługa procesorów graficznych NVidia CUDA. <br/> Wymaga wtyczki Backend.AI CUDA.",
+    "DescCUDAGPUsupport": "Obsługa procesorów graficznych NVIDIA CUDA. <br/> Wymaga wtyczki Backend.AI CUDA.",
     "CUDAGPUdisabledByFGPUsupport": "Wyłączone, ponieważ system używa ułamkowej wtyczki GPU",
     "ROCMGPUsupport": "Obsługa ROCm GPU",
     "DescROCMGPUsupport": "Obsługa procesorów graficznych AMD ROCm. <br/> Wymaga wtyczki Backend.AI ROCm.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "Permitir que o agente se registre no gerente. <br/> Use apenas se o cluster Backend.AI for gerenciado em local seguro.",
     "Plugins": "Plugins",
     "CUDAGPUsupport": "Suporte para GPU CUDA",
-    "DescCUDAGPUsupport": "Suporte para GPU NVidia CUDA. <br/> Requer Backend.AI CUDA Plugin.",
+    "DescCUDAGPUsupport": "Suporte para GPU NVIDIA CUDA. <br/> Requer Backend.AI CUDA Plugin.",
     "CUDAGPUdisabledByFGPUsupport": "Desativado porque o sistema usa o plugin de GPU fracionário",
     "ROCMGPUsupport": "Suporte para GPU ROCm",
     "DescROCMGPUsupport": "Suporte a GPU AMD ROCm. <br/> Requer Backend.AI ROCm Plugin.",

--- a/resources/i18n/pt_BR.json
+++ b/resources/i18n/pt_BR.json
@@ -860,7 +860,7 @@
     "DescAllowAgentSideRegistration": "Permitir que o agente se registre no gerente. <br/> Use apenas se o cluster Backend.AI for gerenciado em local seguro.",
     "Plugins": "Plugins",
     "CUDAGPUsupport": "Suporte para GPU CUDA",
-    "DescCUDAGPUsupport": "Suporte para GPU NVidia CUDA. <br/> Requer Backend.AI CUDA Plugin.",
+    "DescCUDAGPUsupport": "Suporte para GPU NVIDIA CUDA. <br/> Requer Backend.AI CUDA Plugin.",
     "CUDAGPUdisabledByFGPUsupport": "Desativado porque o sistema usa o plugin de GPU fracionário",
     "ROCMGPUsupport": "Suporte para GPU ROCm",
     "DescROCMGPUsupport": "Suporte a GPU AMD ROCm. <br/> Requer Backend.AI ROCm Plugin.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1067,7 +1067,7 @@
     "DescAllowAgentSideRegistration": "Разрешить агенту зарегистрироваться в качестве менеджера. <br/> Используйте, только если кластер Backend.AI управляется в безопасном месте.",
     "Plugins": "Плагины",
     "CUDAGPUsupport": "Поддержка CUDA GPU",
-    "DescCUDAGPUsupport": "Поддержка графического процессора NVidia CUDA. <br/> Требуется подключаемый модуль Backend.AI CUDA.",
+    "DescCUDAGPUsupport": "Поддержка графического процессора NVIDIA CUDA. <br/> Требуется подключаемый модуль Backend.AI CUDA.",
     "CUDAGPUdisabledByFGPUsupport": "Отключено, поскольку в системе используется плагин Fractional GPU.",
     "ROCMGPUsupport": "Поддержка графического процессора ROCm",
     "DescROCMGPUsupport": "Поддержка графического процессора AMD ROCm. <br/> Требуется подключаемый модуль Backend.AI ROCm.",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "Aracının kendisini yöneticiye kaydetmesine izin verin. <br/> Yalnızca Backend.AI kümesi güvenli konumda yönetiliyorsa kullanın.",
     "Plugins": "Eklentiler",
     "CUDAGPUsupport": "CUDA GPU desteği",
-    "DescCUDAGPUsupport": "NVidia CUDA GPU desteği. <br/> Backend.AI CUDA Eklentisi gerektirir.",
+    "DescCUDAGPUsupport": "NVIDIA CUDA GPU desteği. <br/> Backend.AI CUDA Eklentisi gerektirir.",
     "CUDAGPUdisabledByFGPUsupport": "Sistem Kesirli GPU eklentisi kullandığı için devre dışı bırakıldı",
     "ROCMGPUsupport": "ROCm GPU desteği",
     "DescROCMGPUsupport": "AMD ROCm GPU desteği. <br/> Backend.AI ROCm Eklentisi gerektirir.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "Cho phép đại lý tự đăng ký với người quản lý. <br/> Chỉ sử dụng nếu cụm Backend.AI được quản lý trên vị trí an toàn.",
     "Plugins": "bổ sung",
     "CUDAGPUsupport": "Hỗ trợ GPU CUDA",
-    "DescCUDAGPUsupport": "Hỗ trợ GPU NVidia CUDA. <br/> Yêu cầu Plugin Backend.AI CUDA.",
+    "DescCUDAGPUsupport": "Hỗ trợ GPU NVIDIA CUDA. <br/> Yêu cầu Plugin Backend.AI CUDA.",
     "CUDAGPUdisabledByFGPUsupport": "Bị vô hiệu hóa do hệ thống sử dụng plugin GPU Fractional",
     "ROCMGPUsupport": "Hỗ trợ GPU ROCm",
     "DescROCMGPUsupport": "Hỗ trợ GPU AMD ROCm. <br/> Yêu cầu Plugin Backend.AI ROCm.",

--- a/resources/i18n/zh_CN.json
+++ b/resources/i18n/zh_CN.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "允许代理将自己注册到经理。 <br/> 仅当 Backend.AI 集群在安全位置管理时使用。",
     "Plugins": "插件",
     "CUDAGPUsupport": "CUDA GPU 支持",
-    "DescCUDAGPUsupport": "NVidia CUDA GPU 支持。 <br/> 需要 Backend.AI CUDA 插件。",
+    "DescCUDAGPUsupport": "NVIDIA CUDA GPU 支持。 <br/> 需要 Backend.AI CUDA 插件。",
     "CUDAGPUdisabledByFGPUsupport": "已禁用，因为系统使用分数 GPU 插件",
     "ROCMGPUsupport": "ROCm GPU 支持",
     "DescROCMGPUsupport": "AMD ROCm GPU 支持。 <br/> 需要 Backend.AI ROCm 插件。",

--- a/resources/i18n/zh_TW.json
+++ b/resources/i18n/zh_TW.json
@@ -858,7 +858,7 @@
     "DescAllowAgentSideRegistration": "允許代理將自己註冊到經理。 <br/> 僅當 Backend.AI 集群在安全位置管理時使用。",
     "Plugins": "插件",
     "CUDAGPUsupport": "CUDA GPU 支持",
-    "DescCUDAGPUsupport": "NVidia CUDA GPU 支持。 <br/> 需要 Backend.AI CUDA 插件。",
+    "DescCUDAGPUsupport": "NVIDIA CUDA GPU 支持。 <br/> 需要 Backend.AI CUDA 插件。",
     "CUDAGPUdisabledByFGPUsupport": "已禁用，因為系統使用分數 GPU 插件",
     "ROCMGPUsupport": "ROCm GPU 支持",
     "DescROCMGPUsupport": "AMD ROCm GPU 支持。 <br/> 需要 Backend.AI ROCm 插件。",


### PR DESCRIPTION
When used as a logo, it is nVIDIA, and when written, NVIDIA seems to be the correct expression.
https://www.nvidia.com/en-us/about-nvidia/legal-info/logo-brand-usage/