### PR TITLE
fix: `newPublicRequest` -> `newSignedRequest` when getting resource-slots

### DIFF
--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -839,9 +839,9 @@ class Client {
   async get_resource_slots() : Promise<any> {
     let rqst;
     if (this.isAPIVersionCompatibleWith('v4.20190601')) {
-      rqst = this.newPublicRequest('GET', '/config/resource-slots', null, '');
+      rqst = this.newSignedRequest('GET', '/config/resource-slots', null, '');
     } else {
-      rqst = this.newPublicRequest('GET', '/etcd/resource-slots', null, '');
+      rqst = this.newSignedRequest('GET', '/etcd/resource-slots', null, '');
     }
     return this._wrapWithPromise(rqst);
   }


### PR DESCRIPTION
Because of changes to throwing X-BackendAI-SessionID instead of cookies, it occurs a 401 error because the `newSignedRequest` or authentication header does not pass. To resolve this, change to use `newSignedRequest` when importing resource-slots.