### PR TITLE
add: hover tooltips on storage control icons

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -684,7 +684,9 @@
       "FolderUsing": "Using",
       "FolderQuota": "Capacity",
       "MaxFolderQuota": "Max Folder Quota",
-      "Serve": "Serve"
+      "Serve": "Model serving",
+      "CloneFolder": "Clone folder",
+      "LeaveFolder": "Leave folder"
     },
     "explorer": {
       "Delete": "Delete",
@@ -741,7 +743,13 @@
       "StartingSSH/SFTPSession": "Starting SFTP session...",
       "EmptyFilesAndFoldersAreNotUploaded": "Empty files and empty folders are not uploaded",
       "NumberOfSFTPSessionsExceededTitle": "Reached limit of running upload session count",
-      "NumberOfSFTPSessionsExceededBody": "You are running all available upload sessions you are allowed to create. Please terminated unused upload sessions before starting a new session."
+      "NumberOfSFTPSessionsExceededBody": "You are running all available upload sessions you are allowed to create. Please terminated unused upload sessions before starting a new session.",
+      "Serve": "Serve",
+      "FolderInfo": "Folder information",
+      "CloneFolder": "Clone this folder",
+      "Rename": "Rename folder",
+      "FolderOptionUpdate": "Update folder options",
+      "LeaveFolder": "Leave a folder"
     },
     "invitation": {
       "EnterEmail": "Enter email address",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -686,7 +686,9 @@
       "MaxFolderQuota": "Max Folder Quota",
       "Serve": "Model serving",
       "CloneFolder": "Clone folder",
-      "LeaveFolder": "Leave folder"
+      "LeaveFolder": "Leave folder",
+      "ShareFolder": "Share folder",
+      "ModifyPermissions": "Modify permissions"
     },
     "explorer": {
       "Delete": "Delete",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -618,7 +618,9 @@
       "Status": "__NOT_TRANSLATED__",
       "Serve": "__NOT_TRANSLATED__",
       "CloneFolder": "__NOT_TRANSLATED__",
-      "LeaveFolder": "__NOT_TRANSLATED__"
+      "LeaveFolder": "__NOT_TRANSLATED__",
+      "ShareFolder": "__NOT_TRANSLATED__",
+      "ModifyPermissions": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Effacer...",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -616,7 +616,9 @@
       "FolderInfo": "__NOT_TRANSLATED__",
       "OpenAFolder": "__NOT_TRANSLATED__",
       "Status": "__NOT_TRANSLATED__",
-      "Serve": "__NOT_TRANSLATED__"
+      "Serve": "__NOT_TRANSLATED__",
+      "CloneFolder": "__NOT_TRANSLATED__",
+      "LeaveFolder": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Effacer...",
@@ -673,7 +675,13 @@
       "EmptyFilesAndFoldersAreNotUploaded": "__NOT_TRANSLATED__",
       "FolderAlreadyExists": "__NOT_TRANSLATED__",
       "NumberOfSFTPSessionsExceededTitle": "__NOT_TRANSLATED__",
-      "NumberOfSFTPSessionsExceededBody": "__NOT_TRANSLATED__"
+      "NumberOfSFTPSessionsExceededBody": "__NOT_TRANSLATED__",
+      "Serve": "__NOT_TRANSLATED__",
+      "FolderInfo": "__NOT_TRANSLATED__",
+      "CloneFolder": "__NOT_TRANSLATED__",
+      "Rename": "__NOT_TRANSLATED__",
+      "FolderOptionUpdate": "__NOT_TRANSLATED__",
+      "LeaveFolder": "__NOT_TRANSLATED__"
     },
     "invitation": {
       "EnterEmail": "Entrer l'adresse e-mail",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -616,7 +616,9 @@
       "FolderInfo": "__NOT_TRANSLATED__",
       "OpenAFolder": "__NOT_TRANSLATED__",
       "Status": "__NOT_TRANSLATED__",
-      "Serve": "__NOT_TRANSLATED__"
+      "Serve": "__NOT_TRANSLATED__",
+      "CloneFolder": "__NOT_TRANSLATED__",
+      "LeaveFolder": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Menghapus...",
@@ -673,7 +675,13 @@
       "EmptyFilesAndFoldersAreNotUploaded": "__NOT_TRANSLATED__",
       "FolderAlreadyExists": "__NOT_TRANSLATED__",
       "NumberOfSFTPSessionsExceededTitle": "__NOT_TRANSLATED__",
-      "NumberOfSFTPSessionsExceededBody": "__NOT_TRANSLATED__"
+      "NumberOfSFTPSessionsExceededBody": "__NOT_TRANSLATED__",
+      "Serve": "__NOT_TRANSLATED__",
+      "FolderInfo": "__NOT_TRANSLATED__",
+      "CloneFolder": "__NOT_TRANSLATED__",
+      "Rename": "__NOT_TRANSLATED__",
+      "FolderOptionUpdate": "__NOT_TRANSLATED__",
+      "LeaveFolder": "__NOT_TRANSLATED__"
     },
     "invitation": {
       "EnterEmail": "Masukkan alamat email",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -618,7 +618,9 @@
       "Status": "__NOT_TRANSLATED__",
       "Serve": "__NOT_TRANSLATED__",
       "CloneFolder": "__NOT_TRANSLATED__",
-      "LeaveFolder": "__NOT_TRANSLATED__"
+      "LeaveFolder": "__NOT_TRANSLATED__",
+      "ShareFolder": "__NOT_TRANSLATED__",
+      "ModifyPermissions": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Menghapus...",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -679,7 +679,9 @@
       "MaxFolderQuota": "최대 할당 가능 용량",
       "Serve": "서비스",
       "CloneFolder": "폴더 클론",
-      "LeaveFolder": "초대된 폴더 나가기"
+      "LeaveFolder": "초대된 폴더 나가기",
+      "ShareFolder": "폴더 공유하기",
+      "ModifyPermissions": "권한 수정"
     },
     "explorer": {
       "Delete": "삭제",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -677,7 +677,9 @@
       "FolderUsing": "사용량",
       "FolderQuota": "가용량",
       "MaxFolderQuota": "최대 할당 가능 용량",
-      "Serve": "서비스"
+      "Serve": "서비스",
+      "CloneFolder": "폴더 클론",
+      "LeaveFolder": "초대된 폴더 나가기"
     },
     "explorer": {
       "Delete": "삭제",
@@ -734,7 +736,13 @@
       "StartingSSH/SFTPSession": "SFTP 서버 시작",
       "EmptyFilesAndFoldersAreNotUploaded": "빈 파일과 빈 폴더들은 업로드되지 않습니다.",
       "NumberOfSFTPSessionsExceededTitle": "생성 가능한 업로드 세션 갯수 한도에 도달했습니다.",
-      "NumberOfSFTPSessionsExceededBody": "설정된 업로드 세션 갯수를 초과하여 세션 생성을 시도하고 있습니다. 계속하기 전에 사용하지 않는 업로드 세션을 중지시키세요."
+      "NumberOfSFTPSessionsExceededBody": "설정된 업로드 세션 갯수를 초과하여 세션 생성을 시도하고 있습니다. 계속하기 전에 사용하지 않는 업로드 세션을 중지시키세요.",
+      "Serve": "모델 서빙",
+      "FolderInfo": "폴더 정보",
+      "CloneFolder": "폴더 클론",
+      "Rename": "이름 변경",
+      "FolderOptionUpdate": "폴더 옵션 변경",
+      "LeaveFolder": "초대된 폴더 나가기"
     },
     "invitation": {
       "EnterEmail": "이메일을 입력하세요",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -616,7 +616,9 @@
       "FolderInfo": "__NOT_TRANSLATED__",
       "OpenAFolder": "__NOT_TRANSLATED__",
       "Status": "__NOT_TRANSLATED__",
-      "Serve": "__NOT_TRANSLATED__"
+      "Serve": "__NOT_TRANSLATED__",
+      "CloneFolder": "__NOT_TRANSLATED__",
+      "LeaveFolder": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Устгах ...",
@@ -673,7 +675,13 @@
       "EmptyFilesAndFoldersAreNotUploaded": "__NOT_TRANSLATED__",
       "FolderAlreadyExists": "__NOT_TRANSLATED__",
       "NumberOfSFTPSessionsExceededTitle": "__NOT_TRANSLATED__",
-      "NumberOfSFTPSessionsExceededBody": "__NOT_TRANSLATED__"
+      "NumberOfSFTPSessionsExceededBody": "__NOT_TRANSLATED__",
+      "Serve": "__NOT_TRANSLATED__",
+      "FolderInfo": "__NOT_TRANSLATED__",
+      "CloneFolder": "__NOT_TRANSLATED__",
+      "Rename": "__NOT_TRANSLATED__",
+      "FolderOptionUpdate": "__NOT_TRANSLATED__",
+      "LeaveFolder": "__NOT_TRANSLATED__"
     },
     "invitation": {
       "EnterEmail": "Цахим хаягаа оруулна уу",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -618,7 +618,9 @@
       "Status": "__NOT_TRANSLATED__",
       "Serve": "__NOT_TRANSLATED__",
       "CloneFolder": "__NOT_TRANSLATED__",
-      "LeaveFolder": "__NOT_TRANSLATED__"
+      "LeaveFolder": "__NOT_TRANSLATED__",
+      "ShareFolder": "__NOT_TRANSLATED__",
+      "ModifyPermissions": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Устгах ...",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -616,7 +616,9 @@
       "FolderInfo": "__NOT_TRANSLATED__",
       "OpenAFolder": "__NOT_TRANSLATED__",
       "Status": "__NOT_TRANSLATED__",
-      "Serve": "__NOT_TRANSLATED__"
+      "Serve": "__NOT_TRANSLATED__",
+      "CloneFolder": "__NOT_TRANSLATED__",
+      "LeaveFolder": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Удалить...",
@@ -673,7 +675,13 @@
       "EmptyFilesAndFoldersAreNotUploaded": "__NOT_TRANSLATED__",
       "FolderAlreadyExists": "__NOT_TRANSLATED__",
       "NumberOfSFTPSessionsExceededTitle": "__NOT_TRANSLATED__",
-      "NumberOfSFTPSessionsExceededBody": "__NOT_TRANSLATED__"
+      "NumberOfSFTPSessionsExceededBody": "__NOT_TRANSLATED__",
+      "Serve": "__NOT_TRANSLATED__",
+      "FolderInfo": "__NOT_TRANSLATED__",
+      "CloneFolder": "__NOT_TRANSLATED__",
+      "Rename": "__NOT_TRANSLATED__",
+      "FolderOptionUpdate": "__NOT_TRANSLATED__",
+      "LeaveFolder": "__NOT_TRANSLATED__"
     },
     "invitation": {
       "EnterEmail": "Введите адрес электронной почты",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -618,7 +618,9 @@
       "Status": "__NOT_TRANSLATED__",
       "Serve": "__NOT_TRANSLATED__",
       "CloneFolder": "__NOT_TRANSLATED__",
-      "LeaveFolder": "__NOT_TRANSLATED__"
+      "LeaveFolder": "__NOT_TRANSLATED__",
+      "ShareFolder": "__NOT_TRANSLATED__",
+      "ModifyPermissions": "__NOT_TRANSLATED__"
     },
     "explorer": {
       "Delete": "Удалить...",

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1366,7 +1366,7 @@ export default class BackendAiStorageList extends BackendAIPage {
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-serve'}"
           ></mwc-icon-button>`: html``}
-          <vaadin-tooltip for="${rowData.item.id+'-serve'}" text="${_t('data.explorer.Serve')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.id+'-serve'}" text="${_t('data.folders.Serve')}" position="top-start"></vaadin-tooltip>
           <mwc-icon-button
             class="fg green controls-running"
             icon="info"
@@ -1375,7 +1375,7 @@ export default class BackendAiStorageList extends BackendAIPage {
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-folderinfo'}"
           ></mwc-icon-button>
-          <vaadin-tooltip for="${rowData.item.id+'-folderinfo'}" text="${_t('data.explorer.FolderInfo')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.id+'-folderinfo'}" text="${_t('data.folders.FolderInfo')}" position="top-start"></vaadin-tooltip>
           <!--${this._hasPermission(rowData.item, 'r') && this.enableStorageProxy ?
       html`
         <mwc-icon-button
@@ -1386,30 +1386,30 @@ export default class BackendAiStorageList extends BackendAIPage {
           @click="${() => { this._requestCloneFolder(rowData.item);}}"
           id="${rowData.item.id+'-clone'}"
           ></mwc-icon-button>
-          <vaadin-tooltip for="${rowData.item.id+'-clone'}" text="${_t('data.explorer.CloneFolder')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.id+'-clone'}" text="${_t('data.folders.CloneFolder')}" position="top-start"></vaadin-tooltip>
       ` : html``}-->
       ${rowData.item.is_owner ?
         html`
           <mwc-icon-button
             class="fg ${rowData.item.type == 'user' ? 'blue' : 'green'} controls-running"
             icon="share"
-            title=${_t('data.explorer.ShareFolder')}
+            title=${_t('data.folders.ShareFolder')}
             @click="${(e) => this._shareFolderDialog(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             style="display: ${isSharingAllowed ? '': 'none'}"
             id="${rowData.item.id+'-share'}"
           ></mwc-icon-button>
-          <vaadin-tooltip for="${rowData.item.id+'-share'}" text="${_t('data.explorer.ShareFolder')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.id+'-share'}" text="${_t('data.folders.ShareFolder')}" position="top-start"></vaadin-tooltip>
           <mwc-icon-button
             class="fg cyan controls-running"
             icon="perm_identity"
-            title=${_t('data.explorer.ModifyPermissions')}
+            title=${_t('data.folders.ModifyPermissions')}
             @click=${(e) => (this._modifyPermissionDialog(rowData.item.id))}
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             style="display: ${isSharingAllowed ? '': 'none'}"
             id="${rowData.item.id+'-modifypermission'}"
           ></mwc-icon-button>
-          <vaadin-tooltip for="${rowData.item.id+'-modifypermission'}" text="${_t('data.explorer.ModifyPermissions')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.id+'-modifypermission'}" text="${_t('data.folders.ModifyPermissions')}" position="top-start"></vaadin-tooltip>
           <mwc-icon-button
             class="fg ${rowData.item.type == 'user' ? 'blue' : 'green'} controls-running"
             icon="create"
@@ -1418,7 +1418,7 @@ export default class BackendAiStorageList extends BackendAIPage {
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-rename'}"
           ></mwc-icon-button>
-          <vaadin-tooltip for="${rowData.item.id+'-rename'}" text="${_t('data.explorer.Rename')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.id+'-rename'}" text="${_t('data.folders.Rename')}" position="top-start"></vaadin-tooltip>
           <mwc-icon-button
             class="fg blue controls-running"
             icon="settings"
@@ -1427,7 +1427,7 @@ export default class BackendAiStorageList extends BackendAIPage {
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-optionupdate'}"
           ></mwc-icon-button>
-          <vaadin-tooltip for="${rowData.item.id+'-optionupdate'}" text="${_t('data.explorer.FolderOptionUpdate')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.id+'-optionupdate'}" text="${_t('data.folders.FolderOptionUpdate')}" position="top-start"></vaadin-tooltip>
         ` : html``}
       ${rowData.item.is_owner ||
         this._hasPermission(rowData.item, 'd') ||
@@ -1441,7 +1441,7 @@ export default class BackendAiStorageList extends BackendAIPage {
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-delete'}"
           ></mwc-icon-button>
-          <vaadin-tooltip for="${rowData.item.id+'-delete'}" text="${_t('data.explorer.Delete')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.id+'-delete'}" text="${_t('data.folders.Delete')}" position="top-start"></vaadin-tooltip>
         ` : html``}
       ${(!rowData.item.is_owner && rowData.item.type == 'user') ?
         html`
@@ -1453,7 +1453,7 @@ export default class BackendAiStorageList extends BackendAIPage {
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-leavefolder'}"
           ></mwc-icon-button>
-          <vaadin-tooltip for="${rowData.item.id+'-leavefolder'}" text="${_t('data.explorer.LeaveFolder')}" position="top-start"></vaadin-tooltip>
+          <vaadin-tooltip for="${rowData.item.id+'-leavefolder'}" text="${_t('data.folders.LeaveFolder')}" position="top-start"></vaadin-tooltip>
         ` : html``}
         </div>
        `, root

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -28,6 +28,7 @@ import '@vaadin/grid/vaadin-grid-filter-column';
 import '@vaadin/grid/vaadin-grid-selection-column';
 import '@vaadin/progress-bar/vaadin-progress-bar';
 import '@vaadin/item/vaadin-item';
+import '@vaadin/tooltip';
 
 import 'weightless/button';
 import 'weightless/card';
@@ -1363,22 +1364,29 @@ export default class BackendAiStorageList extends BackendAIPage {
             title=${_t('data.folders.Serve')}
             @click="${(e) => this._inferModel(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
+            id="${rowData.item.id+'-serve'}"
           ></mwc-icon-button>`: html``}
+          <vaadin-tooltip for="${rowData.item.id+'-serve'}" text="${_t('data.explorer.Serve')}" position="top-start"></vaadin-tooltip>
           <mwc-icon-button
             class="fg green controls-running"
             icon="info"
             title=${_t('data.folders.FolderInfo')}
             @click="${(e) => this._infoFolder(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
+            id="${rowData.item.id+'-folderinfo'}"
           ></mwc-icon-button>
+          <vaadin-tooltip for="${rowData.item.id+'-folderinfo'}" text="${_t('data.explorer.FolderInfo')}" position="top-start"></vaadin-tooltip>
           <!--${this._hasPermission(rowData.item, 'r') && this.enableStorageProxy ?
       html`
         <mwc-icon-button
           class="fg blue controls-running"
           icon="content_copy"
+          title=${_t('data.folders.CloneFolder')}
           disabled
           @click="${() => { this._requestCloneFolder(rowData.item);}}"
+          id="${rowData.item.id+'-clone'}"
           ></mwc-icon-button>
+          <vaadin-tooltip for="${rowData.item.id+'-clone'}" text="${_t('data.explorer.CloneFolder')}" position="top-start"></vaadin-tooltip>
       ` : html``}-->
       ${rowData.item.is_owner ?
         html`
@@ -1389,7 +1397,9 @@ export default class BackendAiStorageList extends BackendAIPage {
             @click="${(e) => this._shareFolderDialog(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             style="display: ${isSharingAllowed ? '': 'none'}"
+            id="${rowData.item.id+'-share'}"
           ></mwc-icon-button>
+          <vaadin-tooltip for="${rowData.item.id+'-share'}" text="${_t('data.explorer.ShareFolder')}" position="top-start"></vaadin-tooltip>
           <mwc-icon-button
             class="fg cyan controls-running"
             icon="perm_identity"
@@ -1397,21 +1407,28 @@ export default class BackendAiStorageList extends BackendAIPage {
             @click=${(e) => (this._modifyPermissionDialog(rowData.item.id))}
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             style="display: ${isSharingAllowed ? '': 'none'}"
+            id="${rowData.item.id+'-modifypermission'}"
           ></mwc-icon-button>
+          <vaadin-tooltip for="${rowData.item.id+'-modifypermission'}" text="${_t('data.explorer.ModifyPermissions')}" position="top-start"></vaadin-tooltip>
           <mwc-icon-button
             class="fg ${rowData.item.type == 'user' ? 'blue' : 'green'} controls-running"
             icon="create"
             title=${_t('data.folders.Rename')}
             @click="${(e) => this._renameFolderDialog(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
+            id="${rowData.item.id+'-rename'}"
           ></mwc-icon-button>
+          <vaadin-tooltip for="${rowData.item.id+'-rename'}" text="${_t('data.explorer.Rename')}" position="top-start"></vaadin-tooltip>
           <mwc-icon-button
             class="fg blue controls-running"
             icon="settings"
             title=${_t('data.folders.FolderOptionUpdate')}
             @click="${(e) => this._modifyFolderOptionDialog(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
-          ></mwc-icon-button>` : html``}
+            id="${rowData.item.id+'-optionupdate'}"
+          ></mwc-icon-button>
+          <vaadin-tooltip for="${rowData.item.id+'-optionupdate'}" text="${_t('data.explorer.FolderOptionUpdate')}" position="top-start"></vaadin-tooltip>
+        ` : html``}
       ${rowData.item.is_owner ||
         this._hasPermission(rowData.item, 'd') ||
         (rowData.item.type === 'group' && this.is_admin) ?
@@ -1422,15 +1439,22 @@ export default class BackendAiStorageList extends BackendAIPage {
             title=${_t('data.folders.Delete')}
             @click="${(e) => this._deleteFolderDialog(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
-          ></mwc-icon-button>` : html``}
+            id="${rowData.item.id+'-delete'}"
+          ></mwc-icon-button>
+          <vaadin-tooltip for="${rowData.item.id+'-delete'}" text="${_t('data.explorer.Delete')}" position="top-start"></vaadin-tooltip>
+        ` : html``}
       ${(!rowData.item.is_owner && rowData.item.type == 'user') ?
         html`
           <mwc-icon-button
             class="fg red controls-running"
             icon="remove_circle"
+            title=${_t('data.folders.LeaveFolder')}
             @click="${(e) => this._leaveInvitedFolderDialog(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
-          ></mwc-icon-button>` : html``}
+            id="${rowData.item.id+'-leavefolder'}"
+          ></mwc-icon-button>
+          <vaadin-tooltip for="${rowData.item.id+'-leavefolder'}" text="${_t('data.explorer.LeaveFolder')}" position="top-start"></vaadin-tooltip>
+        ` : html``}
         </div>
        `, root
     );

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1361,7 +1361,6 @@ export default class BackendAiStorageList extends BackendAIPage {
           <mwc-icon-button
             class="fg green controls-running"
             icon="play_arrow"
-            title=${_t('data.folders.Serve')}
             @click="${(e) => this._inferModel(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-serve'}"
@@ -1370,7 +1369,6 @@ export default class BackendAiStorageList extends BackendAIPage {
           <mwc-icon-button
             class="fg green controls-running"
             icon="info"
-            title=${_t('data.folders.FolderInfo')}
             @click="${(e) => this._infoFolder(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-folderinfo'}"
@@ -1381,7 +1379,6 @@ export default class BackendAiStorageList extends BackendAIPage {
         <mwc-icon-button
           class="fg blue controls-running"
           icon="content_copy"
-          title=${_t('data.folders.CloneFolder')}
           disabled
           @click="${() => { this._requestCloneFolder(rowData.item);}}"
           id="${rowData.item.id+'-clone'}"
@@ -1393,7 +1390,6 @@ export default class BackendAiStorageList extends BackendAIPage {
           <mwc-icon-button
             class="fg ${rowData.item.type == 'user' ? 'blue' : 'green'} controls-running"
             icon="share"
-            title=${_t('data.folders.ShareFolder')}
             @click="${(e) => this._shareFolderDialog(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             style="display: ${isSharingAllowed ? '': 'none'}"
@@ -1403,7 +1399,6 @@ export default class BackendAiStorageList extends BackendAIPage {
           <mwc-icon-button
             class="fg cyan controls-running"
             icon="perm_identity"
-            title=${_t('data.folders.ModifyPermissions')}
             @click=${(e) => (this._modifyPermissionDialog(rowData.item.id))}
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             style="display: ${isSharingAllowed ? '': 'none'}"
@@ -1413,7 +1408,6 @@ export default class BackendAiStorageList extends BackendAIPage {
           <mwc-icon-button
             class="fg ${rowData.item.type == 'user' ? 'blue' : 'green'} controls-running"
             icon="create"
-            title=${_t('data.folders.Rename')}
             @click="${(e) => this._renameFolderDialog(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-rename'}"
@@ -1422,7 +1416,6 @@ export default class BackendAiStorageList extends BackendAIPage {
           <mwc-icon-button
             class="fg blue controls-running"
             icon="settings"
-            title=${_t('data.folders.FolderOptionUpdate')}
             @click="${(e) => this._modifyFolderOptionDialog(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-optionupdate'}"
@@ -1436,7 +1429,6 @@ export default class BackendAiStorageList extends BackendAIPage {
           <mwc-icon-button
             class="fg red controls-running"
             icon="delete"
-            title=${_t('data.folders.Delete')}
             @click="${(e) => this._deleteFolderDialog(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-delete'}"
@@ -1448,7 +1440,6 @@ export default class BackendAiStorageList extends BackendAIPage {
           <mwc-icon-button
             class="fg red controls-running"
             icon="remove_circle"
-            title=${_t('data.folders.LeaveFolder')}
             @click="${(e) => this._leaveInvitedFolderDialog(e)}"
             ?disabled="${this._checkProcessingStatus(rowData.item.status)}"
             id="${rowData.item.id+'-leavefolder'}"

--- a/src/components/lablup-slider.ts
+++ b/src/components/lablup-slider.ts
@@ -26,7 +26,7 @@ import {BackendAiStyles} from './backend-ai-general-styles';
 
  <lablup-slider></lablup-slider>
 
-@group Backend.AI Web UI
+ @group Backend.AI Web UI
  @element lablup-slider
  */
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 33758f7</samp>

### Summary
🆕🌐💡

<!--
1.  🆕 - This emoji can be used to indicate that new features and buttons are added to the data explorer component, such as serving models, cloning and renaming folders, and updating folder options.
2.  🌐 - This emoji can be used to indicate that translation files are updated for various languages, such as French, Indonesian, Korean, Mongolian, and Russian. The emoji represents the globe and can signify internationalization or localization efforts.
3.  💡 - This emoji can be used to indicate that tooltips and titles are added to the data explorer buttons in the `backend-ai-storage-list` component. The emoji represents a light bulb and can signify helpful hints or information.
-->
This pull request enhances the data explorer component of the web UI with new features and actions for folders and models, such as serving, cloning, and renaming. It also updates the translation files for different languages with new keys and values for the data explorer labels and tooltips. The `backend-ai-storage-list` component is modified to use the translation texts and the folder ids for the button tooltips and titles.


### Walkthrough
*  Add new buttons and tooltips for data explorer component ([link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-b810064a5174ba45c2487b7e92a6aaacd7349f7f637602afd38ad22bc49ba9b0R31), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-b810064a5174ba45c2487b7e92a6aaacd7349f7f637602afd38ad22bc49ba9b0L1366-R1369), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-b810064a5174ba45c2487b7e92a6aaacd7349f7f637602afd38ad22bc49ba9b0L1373-R1378), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-b810064a5174ba45c2487b7e92a6aaacd7349f7f637602afd38ad22bc49ba9b0L1379-R1389), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-b810064a5174ba45c2487b7e92a6aaacd7349f7f637602afd38ad22bc49ba9b0L1392-R1402), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-b810064a5174ba45c2487b7e92a6aaacd7349f7f637602afd38ad22bc49ba9b0L1400-R1412), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-b810064a5174ba45c2487b7e92a6aaacd7349f7f637602afd38ad22bc49ba9b0L1407-R1421), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-b810064a5174ba45c2487b7e92a6aaacd7349f7f637602afd38ad22bc49ba9b0L1414-R1431), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-b810064a5174ba45c2487b7e92a6aaacd7349f7f637602afd38ad22bc49ba9b0L1425-R1445), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-b810064a5174ba45c2487b7e92a6aaacd7349f7f637602afd38ad22bc49ba9b0L1431-R1457))
* Add new translation keys for data explorer component ([link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-5295c72e8e9f81f41ad24071df9b7dba8bf9672ff8d5c37d587f374166008f44L687-R689), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-5295c72e8e9f81f41ad24071df9b7dba8bf9672ff8d5c37d587f374166008f44L744-R752), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-cb28ed7aa2d69a36b056c5fc48c220ac0634c320118dd903ffa7b508e6656f24L619-R621), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-cb28ed7aa2d69a36b056c5fc48c220ac0634c320118dd903ffa7b508e6656f24L676-R684), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-efa18d69e25ee4acbf51802e5b7d487d283299cbcbbc319388b175bcf1a0426bL619-R621), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-efa18d69e25ee4acbf51802e5b7d487d283299cbcbbc319388b175bcf1a0426bL676-R684), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-42a74440ee50b3644e615a3a3c71a4a6ae54dff82f52b5eccf3aaf22b4811b1cL680-R682), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-42a74440ee50b3644e615a3a3c71a4a6ae54dff82f52b5eccf3aaf22b4811b1cL737-R745), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-0e2edcc06e27c33466506878abd4fcbad53e695960932b8de70aedcb6f9fe301L619-R621), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-0e2edcc06e27c33466506878abd4fcbad53e695960932b8de70aedcb6f9fe301L676-R684), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-00509cee1359d9305e94d87843979c41295c5768c2e4b0b7f07519c341fd7ff7L619-R621), [link](https://github.com/lablup/backend.ai-webui/pull/1788/files?diff=unified&w=0#diff-00509cee1359d9305e94d87843979c41295c5768c2e4b0b7f07519c341fd7ff7L676-R684))


This PR resolves #1384
