### PR TITLE
fix: unable to terminate a compute session when wsproxy address is not properly

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1462,12 +1462,8 @@ export default class BackendAISessionList extends BackendAIPage {
     });
   }
 
-  _requestDestroySession(sessionId, accessKey, forced, err = null) {
+  _requestDestroySession(sessionId, accessKey, forced) {
     globalThis.backendaiclient.destroy(sessionId, accessKey, forced).then((req) => {
-      if (err) {
-        this.notification.text = PainKiller.relieve(err["title"]);
-        this.notification.show(true, err);
-      }
       setTimeout(async () => {
         this.terminationQueue = [];
         // await this.refreshList(true, false); // Will be called from session-view from the event below
@@ -1493,11 +1489,10 @@ export default class BackendAISessionList extends BackendAIPage {
     return this._terminateApp(sessionId).then(() => {
       this._requestDestroySession(sessionId, accessKey, forced);
     }).catch((err) => {
-      console.log(err);
       if (err && err.message) {
-        if (err.statusCode == 500) {
+        if (err.statusCode == 404) {
           // Even if wsproxy address is invalid, session must be deleted.
-          this._requestDestroySession(sessionId, accessKey, forced, err = err);
+          this._requestDestroySession(sessionId, accessKey, forced);
         } else {
           this.notification.text = PainKiller.relieve(err.title);
           this.notification.detail = err.message;

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "23.09.0-alpha.2", "build": "230724.180758", "revision": "51141ead" }
+{ "package": "23.09.0-alpha.2", "build": "230728.070732", "revision": "6b7603b4" }


### PR DESCRIPTION
There was a bug that the session was not deleted when the wsproxy address of the scaling group was invalid.

This PR is related to this PR in backend.ai repository. [#1423](https://github.com/lablup/backend.ai/pull/1423)

In order to prevent side effects caused by server-side code modification, it was modified to handle exceptions in the web UI-side code.