### PR TITLE
fix: serving dialog popup generates error when unexpected image metadata is loaded without icon URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       }
     };
     globalThis.packageVersion = "23.09.0-alpha.3";
-    globalThis.buildVersion = "230731.220712";
+    globalThis.buildVersion = "230731.230711";
 </script>
   <!-- DO NOT CHANGE BELOW LINE -->
   <!-- REACT_BUNDLE_INJECTING FOR DEV-->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend.ai-webui",
-  "version": "23.09.0-alpha.2",
+  "version": "23.09.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend.ai-webui",
-      "version": "23.09.0-alpha.2",
+      "version": "23.09.0-alpha.3",
       "hasInstallScript": true,
       "license": "LGPL-3.0-or-later",
       "dependencies": {

--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -209,7 +209,7 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
           >
             <ResourceGroupSelect autoSelectDefault />
           </Form.Item>
-          <Form.Item name="openToPublic" label="Open To Public">
+          <Form.Item name="openToPublic" label="Open To Public" valuePropName="checked">
             <Switch></Switch>
           </Form.Item>
           <Form.Item

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -109,7 +109,9 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
     >
       {_.map(filteredVFolders, (vfolder) => {
         return (
-          <Select.Option value={vfolder?.name}>{vfolder?.name}</Select.Option>
+          <Select.Option key={vfolder?.id} value={vfolder?.name}>
+            {vfolder?.name}
+          </Select.Option>
         );
       })}
     </Select>

--- a/react/src/hooks/index.ts
+++ b/react/src/hooks/index.ts
@@ -182,8 +182,8 @@ export const useBackendaiImageMetaData = () => {
         const { key } = getImageMeta(imageName);
         return (
           path +
-          (metadata?.imageInfo[key].icon !== undefined
-            ? metadata?.imageInfo[key].icon
+          (metadata?.imageInfo[key]?.icon !== undefined
+            ? metadata?.imageInfo[key]?.icon
             : "default.png")
         );
       },

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -930,11 +930,11 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
    * Add tool tips by create popovers.
    */
   async addTooltips() {
-    this._createPopover('#summary-menu-icon', _text('webui.menu.Summary'));
-    this._createPopover('#sessions-menu-icon', _text('webui.menu.Sessions'));
-    this._createPopover('#serving-menu-icon', _text('webui.menu.Serving'));
-    this._createPopover('#data-menu-icon', _text('webui.menu.Data&Storage'));
-    this._createPopover('#import-menu-icon', _text('webui.menu.Import&Run'));
+    this._createPopover('summary-menu-icon', _text('webui.menu.Summary'));
+    this._createPopover('sessions-menu-icon', _text('webui.menu.Sessions'));
+    this._createPopover('serving-menu-icon', _text('webui.menu.Serving'));
+    this._createPopover('data-menu-icon', _text('webui.menu.Data&Storage'));
+    this._createPopover('import-menu-icon', _text('webui.menu.Import&Run'));
 
     // temporally blcok pipeline menu
     // this._createPopover('#pipeline-menu-icon', _text('webui.menu.Pipeline'));

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "23.09.0-alpha.3", "build": "230731.220712", "revision": "eb823bec" }
+{ "package": "23.09.0-alpha.3", "build": "230731.230711", "revision": "b8475223" }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a8d59c1</samp>

### Summary
🛠️🚀📦

<!--
1.  🛠️ - This emoji represents a bug fix or a minor improvement, and can be used for the first and third changes.
2.  🚀 - This emoji represents a new feature or a performance enhancement, and can be used for the second change, which prevents a potential error and improves the user experience.
3.  📦 - This emoji represents a new release or a version update, and can be used for the fourth change, which updates the version information of the web UI.
-->
This pull request updates the web UI build version and fixes some bugs related to image metadata, menu tooltips, and CSS selectors. It also updates the `version.json` file with the latest revision hash.

> _`build` and `version`_
> _updated for web UI_
> _autumn bugs are fixed_

### Walkthrough
*  Update the web UI version and check for updates with the new build version in `index.html` ([link](https://github.com/lablup/backend.ai-webui/pull/1825/files?diff=unified&w=0#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L33-R33))
*  Fix a potential null reference error when getting the image icon and description in the useBackendaiImageMetaData hook in `react/src/hooks/index.ts` ([link](https://github.com/lablup/backend.ai-webui/pull/1825/files?diff=unified&w=0#diff-0ab640cf893a25e0e4bfc1bc0fdc0e27b9a51363651add905e4a7d88d287f4faL185-R186))
*  Remove the hash sign from the id selectors in the addTooltips method in `src/components/backend-ai-webui.ts` to show the main menu tooltips correctly ([link](https://github.com/lablup/backend.ai-webui/pull/1825/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL933-R937))
*  Update the package, build, and revision information in `version.json` to match the new build and git hash ([link](https://github.com/lablup/backend.ai-webui/pull/1825/files?diff=unified&w=0#diff-093664cc0c7cf4a76165141e93265eeb139f655bbee8105ed3ee2534a612354cL1-R1))

