### PR TITLE
update: fix '자원를' to '자원을' for smaller resource text

### DIFF
--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1418,7 +1418,7 @@
     "ResourcePolicyAlreadyExist": "같은 이름의 자원 정책이 이미 있습니다.",
     "ScalingGroupAlreadyExist": "같은 이름의 자원 그룹이 이미 있습니다.",
     "ResourceLimitExceed": "자원 제한을 초과했습니다. 가용 자원량을 확인하세요.",
-    "SmallerResourceThenImageRequires": "요청한 자원이 이미지가 요구하는 자원보다 적습니다. 자원를 보다 크게 해서 시도해보세요.",
+    "SmallerResourceThenImageRequires": "요청한 자원이 이미지가 요구하는 자원보다 적습니다. 자원을 보다 크게 해서 시도해보세요.",
     "LoginSucceededManagerNotResponding": "로그인은 성공하였으나 매니저 서버가 응답하지 않습니다.",
     "UserNameAlreadyExist": "이미 사용하고 있는 사용자명입니다.",
     "ResourcePolicyStillReferenced": "이 자원 정책을 사용하고 있는 자격 증명이 있습니다.",


### PR DESCRIPTION
Fix typo on "Smaller Resource Then Image Requires" text

<img width="1427" alt="img" src="https://github.com/lablup/backend.ai-webui/assets/48766355/846243a4-577e-4fd5-953f-7b955c254c76">
