### PR TITLE
test: Flex component rendering test & snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "npx eslint src -c ./.eslintrc.json --quiet --ext .js,.ts; exit 0",
     "lint-fix": "npx eslint src -c ./.eslintrc.json  --quiet --ext .js,.ts --fix;exit 0",
     "test": "npx testcafe chrome ./tests/*.js",
+    "test:react" : "npm test --prefix ./react test",
     "wsproxy": "node ./src/wsproxy/local_proxy.js",
     "build": "rm -rf build/rollup && npm run patchLib && mkdir -p build/rollup/src/components && npm run copyindex && npm run copywc && npm run copywa && npm run copyresource && npm run copyconfig && npx rollup -c rollup.config.ts --configPlugin typescript && npm run --prefix ./react build:copy",
     "build:react-only": "npm run --prefix ./react build",

--- a/react/src/components/DomainSelector.test.tsx
+++ b/react/src/components/DomainSelector.test.tsx
@@ -8,8 +8,6 @@ import {
   MockPayloadGenerator,
 } from "relay-test-utils";
 import { RelayEnvironmentProvider } from "react-relay";
-import ReactTestRenderer from "react-test-renderer";
-// import App from "./App";
 
 jest.mock("react-i18next", () => ({
   // this mock makes sure any components using the translate hook can use it without a warning being shown

--- a/react/src/components/Flex.test.tsx
+++ b/react/src/components/Flex.test.tsx
@@ -1,15 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import Flex from "./Flex";
-import renderer from "react-test-renderer";
 
 describe("Flex", () => {
   test("default render", async () => {
-    const flex = renderer.create(<Flex />);
-    expect(flex.toJSON()).toMatchSnapshot();
+    const { baseElement } = render(<Flex />);
+    expect(baseElement).toMatchSnapshot();
   });
-
   test("render with custom props", async () => {
-    const customFlex = renderer.create(
+    const { baseElement } = render(
       <Flex
         direction="column"
         wrap="wrap-reverse"
@@ -19,6 +17,27 @@ describe("Flex", () => {
         style={{ backgroundColor: "blue" }}
       />
     );
-    expect(customFlex.toJSON()).toMatchSnapshot();
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  test("render with children", async () => {
+    const { baseElement } = render(
+      <Flex>
+        <div data-testid="firstChildComponent">
+          <h1> First Child </h1>
+          <div data-testid="nestedChildComponent">
+            <h1> Nested Child </h1>
+          </div>
+        </div>
+        <div data-testid="secondChildComponent">
+          <h1> Second Child </h1>
+        </div>
+      </Flex>
+    );
+    expect(screen.getByTestId("firstChildComponent")).toBeInTheDocument();
+    expect(screen.getByTestId("secondChildComponent")).toBeInTheDocument();
+    expect(screen.getByTestId("nestedChildComponent")).toBeInTheDocument();
+
+    expect(baseElement).toMatchSnapshot();
   });
 });

--- a/react/src/components/Flex.test.tsx
+++ b/react/src/components/Flex.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import Flex from "./Flex";
+import renderer from "react-test-renderer";
+
+describe("Flex", () => {
+  test("default render", async () => {
+    const flex = renderer.create(<Flex />);
+    expect(flex.toJSON()).toMatchSnapshot();
+  });
+
+  test("render with custom props", async () => {
+    const customFlex = renderer.create(
+      <Flex
+        direction="column"
+        wrap="wrap-reverse"
+        justify="center"
+        align="start"
+        gap="sm"
+        style={{ backgroundColor: "blue" }}
+      />
+    );
+    expect(customFlex.toJSON()).toMatchSnapshot();
+  });
+});

--- a/react/src/components/__snapshots__/Flex.test.tsx.snap
+++ b/react/src/components/__snapshots__/Flex.test.tsx.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Flex default render 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "transparent",
+      "border": "0 solid black",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexBasis": "auto",
+      "flexDirection": "row",
+      "flexShrink": 0,
+      "flexWrap": "nowrap",
+      "gap": 0,
+      "justifyContent": "flex-start",
+      "listStyle": "none",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+    }
+  }
+/>
+`;
+
+exports[`Flex render with custom props 1`] = `
+<div
+  style={
+    Object {
+      "alignItems": "flex-start",
+      "backgroundColor": "blue",
+      "border": "0 solid black",
+      "boxSizing": "border-box",
+      "display": "flex",
+      "flexBasis": "auto",
+      "flexDirection": "column",
+      "flexShrink": 0,
+      "flexWrap": "wrap-reverse",
+      "gap": 12,
+      "justifyContent": "center",
+      "listStyle": "none",
+      "margin": 0,
+      "minHeight": 0,
+      "minWidth": 0,
+      "padding": 0,
+      "position": "relative",
+      "textDecoration": "none",
+    }
+  }
+/>
+`;

--- a/react/src/components/__snapshots__/Flex.test.tsx.snap
+++ b/react/src/components/__snapshots__/Flex.test.tsx.snap
@@ -1,55 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Flex default render 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "center",
-      "backgroundColor": "transparent",
-      "border": "0 solid black",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "flexBasis": "auto",
-      "flexDirection": "row",
-      "flexShrink": 0,
-      "flexWrap": "nowrap",
-      "gap": 0,
-      "justifyContent": "flex-start",
-      "listStyle": "none",
-      "margin": 0,
-      "minHeight": 0,
-      "minWidth": 0,
-      "padding": 0,
-      "position": "relative",
-      "textDecoration": "none",
-    }
-  }
-/>
+<body>
+  <div>
+    <div
+      style="align-items: center; background-color: transparent; border: 0px solid black; box-sizing: border-box; display: flex; flex-basis: auto; flex-direction: row; flex-shrink: 0; list-style: none; margin: 0px; min-height: 0; min-width: 0; padding: 0px; position: relative; text-decoration: none; gap: 0; flex-wrap: nowrap; justify-content: flex-start;"
+    />
+  </div>
+</body>
+`;
+
+exports[`Flex render with children 1`] = `
+<body>
+  <div>
+    <div
+      style="align-items: center; background-color: transparent; border: 0px solid black; box-sizing: border-box; display: flex; flex-basis: auto; flex-direction: row; flex-shrink: 0; list-style: none; margin: 0px; min-height: 0; min-width: 0; padding: 0px; position: relative; text-decoration: none; gap: 0; flex-wrap: nowrap; justify-content: flex-start;"
+    >
+      <div
+        data-testid="firstChildComponent"
+      >
+        <h1>
+           First Child 
+        </h1>
+        <div
+          data-testid="nestedChildComponent"
+        >
+          <h1>
+             Nested Child 
+          </h1>
+        </div>
+      </div>
+      <div
+        data-testid="secondChildComponent"
+      >
+        <h1>
+           Second Child 
+        </h1>
+      </div>
+    </div>
+  </div>
+</body>
 `;
 
 exports[`Flex render with custom props 1`] = `
-<div
-  style={
-    Object {
-      "alignItems": "flex-start",
-      "backgroundColor": "blue",
-      "border": "0 solid black",
-      "boxSizing": "border-box",
-      "display": "flex",
-      "flexBasis": "auto",
-      "flexDirection": "column",
-      "flexShrink": 0,
-      "flexWrap": "wrap-reverse",
-      "gap": 12,
-      "justifyContent": "center",
-      "listStyle": "none",
-      "margin": 0,
-      "minHeight": 0,
-      "minWidth": 0,
-      "padding": 0,
-      "position": "relative",
-      "textDecoration": "none",
-    }
-  }
-/>
+<body>
+  <div>
+    <div
+      style="align-items: flex-start; background-color: blue; border: 0px solid black; box-sizing: border-box; display: flex; flex-basis: auto; flex-direction: column; flex-shrink: 0; list-style: none; margin: 0px; min-height: 0; min-width: 0; padding: 0px; position: relative; text-decoration: none; gap: 12px; flex-wrap: wrap-reverse; justify-content: center;"
+    />
+  </div>
+</body>
 `;


### PR DESCRIPTION
I'd like to resolve the issue: test codes of react components

Before starting the tasks, I hope to check if I am doing properly.

---

I found two test methods of rendering components: using either "@testing-library/react" or "react-test-renderer"

I think it would be ok that using "react-test-renderer" just for rendering a specific component because my main goal is to leave its snapshot.("react-test-renderer" has good utilities for snapshots)

On the other hand, when I have to make some codes for testing user's interaction or relay-test(graphql reqeust and response) in the component, I will choose "@testing-library/react" with other mocking libraries.

So, can I mix these ways for testing? Aren't there any side effects?