### PR TITLE
fix: set the popup container to shadowRoot always

### DIFF
--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -127,9 +127,6 @@ const DefaultProviders: React.FC<DefaultProvidersProps> = ({
                   <ConfigProvider
                     // @ts-ignore
                     getPopupContainer={(triggerNode) => {
-                      if (triggerNode?.parentNode) {
-                        return triggerNode.parentNode;
-                      }
                       return shadowRoot;
                     }}
                     //TODO: apply other supported locales

--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -1,6 +1,6 @@
 import { Card, Form, Input, Modal, ModalProps, theme, Switch } from "antd";
 import React, { Suspense } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useSuspendedBackendaiClient } from "../hooks";
 import SliderInputItem from "./SliderInputFormItem";
 import ImageEnvironmentSelectFormItems, {
@@ -276,8 +276,7 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
                     <SliderInputItem
                       name={"cpu"}
                       label={t("session.launcher.CPU")}
-                      // tooltip={t("session.launcher.DescCPU")}
-
+                      tooltip={<Trans i18nKey={"session.launcher.DescCPU"} />}
                       min={parseInt(
                         _.find(
                           currentImage?.resource_limits,
@@ -303,7 +302,9 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
                     <SliderInputItem
                       name={"mem"}
                       label={t("session.launcher.Memory")}
-                      // tooltip={t("session.launcher.DescMemory")}
+                      tooltip={
+                        <Trans i18nKey={"session.launcher.DescMemory"} />
+                      }
                       max={30}
                       inputNumberProps={{
                         addonAfter: "GB",
@@ -319,7 +320,9 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
                     <SliderInputItem
                       name={"shmem"}
                       label={t("session.launcher.SharedMemory")}
-                      // tooltip={t("session.launcher.DescSharedMemory")}
+                      tooltip={
+                        <Trans i18nKey={"session.launcher.DescSharedMemory"} />
+                      }
                       max={30}
                       step={0.1}
                       inputNumberProps={{
@@ -336,7 +339,9 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
                       style={{ marginBottom: 0 }}
                       name={"gpu"}
                       label={t("session.launcher.AIAccelerator")}
-                      // tooltip={t("session.launcher.DescAIAccelerator")}
+                      tooltip={
+                        <Trans i18nKey={"session.launcher.DescAIAccelerator"} />
+                      }
                       max={30}
                       step={0.1}
                       inputNumberProps={{


### PR DESCRIPTION
before: 
<img width="477" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/c0f93c39-c91e-499f-ad1e-32235f00b06f">

after: 
<img width="813" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/354d01e5-9d57-435f-b64d-fa9f59dc6131">
