### PR TITLE
fix: version label overlapping

### DIFF
--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -3450,7 +3450,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                     <div style="width:110px;">${_t('session.launcher.Base')}</div>
                     <div style="width:90px;">${_t('session.launcher.Architecture')}</div>
                   <div style="width:110px;">${_t('session.launcher.Requirements')}</div>
-                </h5>   
+                </h5>
                 ${this.versions.map(({version, architecture}) => html`
                   <mwc-list-item id="${version}" architecture="${architecture}" value="${version}" style="min-height:35px;height:auto;">
                       <span style="display:none">${version}</span>
@@ -3462,7 +3462,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                                         description="${item.tag}"
                                         class="horizontal layout center center-justified">
                         </lablup-shields>
-                      `)} 
+                      `)}
                     </div>
                   </mwc-list-item>
                 `)}

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -3442,28 +3442,31 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
             </mwc-select>
             <mwc-select id="version" icon="architecture" label="${_text('session.launcher.Version')}" required fixedMenuPosition>
               <mwc-list-item selected style="display:none!important"></mwc-list-item>
-              <h5 style="font-size:12px;padding: 0 10px 3px 15px;margin:0; border-bottom:1px solid #ccc;"
-                  role="separator" disabled="true" class="horizontal layout">
-                  <div style="width:60px;">${_t('session.launcher.Version')}</div>
-                  <div style="width:110px;">${_t('session.launcher.Base')}</div>
-                  <div style="width:90px;">${_t('session.launcher.Architecture')}</div>
-                <div style="width:110px;">${_t('session.launcher.Requirements')}</div>
-              </h5>
-              ${this.versions.map(({version, architecture}) => html`
-                <mwc-list-item id="${version}" architecture="${architecture}" value="${version}" style="min-height:35px;height:auto;">
-                    <span style="display:none">${version}</span>
-                    <div class="horizontal layout end-justified">
-                    ${this._getVersionInfo(version || '', architecture).map((item) => html`
-                      <lablup-shields style="width:${item.size}!important;"
-                                      color="${item.color}"
-                                      app="${typeof item.app != 'undefined' && item.app != '' && item.app != ' ' ? item.app : ''}"
-                                      description="${item.tag}"
-                                      class="horizontal layout center center-justified">
-                      </lablup-shields>
-                    `)}
-                  </div>
-                </mwc-list-item>
-              `)}
+              ${this.versions[0] === 'Not Selected' && this.versions.length === 1 ? 
+              html`` : html`
+                <h5 style="font-size:12px;padding: 0 10px 3px 15px;margin:0; border-bottom:1px solid #ccc;"
+                    role="separator" disabled="true" class="horizontal layout">
+                    <div style="width:60px;">${_t('session.launcher.Version')}</div>
+                    <div style="width:110px;">${_t('session.launcher.Base')}</div>
+                    <div style="width:90px;">${_t('session.launcher.Architecture')}</div>
+                  <div style="width:110px;">${_t('session.launcher.Requirements')}</div>
+                </h5>   
+                ${this.versions.map(({version, architecture}) => html`
+                  <mwc-list-item id="${version}" architecture="${architecture}" value="${version}" style="min-height:35px;height:auto;">
+                      <span style="display:none">${version}</span>
+                      <div class="horizontal layout end-justified">
+                      ${this._getVersionInfo(version || '', architecture).map((item) => html`
+                        <lablup-shields style="width:${item.size}!important;"
+                                        color="${item.color}"
+                                        app="${typeof item.app != 'undefined' && item.app != '' && item.app != ' ' ? item.app : ''}"
+                                        description="${item.tag}"
+                                        class="horizontal layout center center-justified">
+                        </lablup-shields>
+                      `)} 
+                    </div>
+                  </mwc-list-item>
+                `)}
+              `}
             </mwc-select>
             ${this._debug || this.allow_manual_image_name_for_session ? html`
               <mwc-textfield id="image-name" type="text" class="flex" value="" icon="assignment_turned_in"

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1734,7 +1734,9 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     const res = this._getVersionInfo(version, architecture);
     const resultArray: string[] = [];
     res.forEach((item) => {
-      resultArray.push(item.tag);
+      if (item.tag !== '' && item.tag !== null){
+        resultArray.push(item.tag);
+      }
     });
     // TODO remove protected field access
     (this.version_selector as any).selectedText = resultArray.join(' / ');


### PR DESCRIPTION
This PR resolves [#1809](https://github.com/lablup/backend.ai-webui/issues/1809#issue-1820069285)

**Before PR**
<img width="420" alt="image" src="https://github.com/lablup/backend.ai-webui-ossca-2023/assets/89445100/17b5461f-3ecc-433d-9ce8-1f707c87b023">
<img width="432" alt="image" src="https://github.com/lablup/backend.ai-webui-ossca-2023/assets/89445100/041e2caa-004b-45b4-b871-833cea701ceb">

**After PR**
<img width="429" alt="image" src="https://github.com/lablup/backend.ai-webui-ossca-2023/assets/89445100/38d8db56-9c2f-46b1-bd25-e12fc2d85e15">
<img width="443" alt="image" src="https://github.com/lablup/backend.ai-webui-ossca-2023/assets/89445100/39d56bdd-442c-4dcf-9234-73b7e8a1b3ea">

The element `'Not Selected'` of the default `version` array is pushed to the `info` array of the `_getVersionInfo()` function and displayed in the `version` list.

I've made the wrong tags invisible (they still exist in `info` array), would it be better to fix them so that the function `_getVersionInfo()` doesn't include them in the `info` array at all?
