### PR TITLE
feat: Do not allow batch session startup command to have an empty string.

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -833,7 +833,8 @@
     "warning": {
       "CannotBeUndone": "WARNING: this cannot be undone!",
       "LogDeletion": "Are you sure you want to delete all of the log messages?",
-      "WillBeAppliedToNewSessions": "This update will be applied to new sessions."
+      "WillBeAppliedToNewSessions": "This update will be applied to new sessions.",
+      "Required": "Required"
     },
     "ask": {
       "DoYouWantToProceed": "Do you want to proceed?"

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -742,7 +742,8 @@
     "warning": {
       "CannotBeUndone": "ATTENTION : cela ne peut pas être annulé !",
       "LogDeletion": "Voulez-vous vraiment supprimer tous les messages du journal ?",
-      "WillBeAppliedToNewSessions": "Cette mise à jour sera appliquée aux nouvelles sessions."
+      "WillBeAppliedToNewSessions": "Cette mise à jour sera appliquée aux nouvelles sessions.",
+      "Required": "__NOT_TRANSLATED__"
     },
     "ask": {
       "DoYouWantToProceed": "Voulez-vous poursuivre?"

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -742,7 +742,8 @@
     "warning": {
       "CannotBeUndone": "PERINGATAN: ini tidak dapat dibatalkan!",
       "LogDeletion": "Anda yakin ingin menghapus semua pesan log?",
-      "WillBeAppliedToNewSessions": "Pembaruan ini akan diterapkan ke sesi baru."
+      "WillBeAppliedToNewSessions": "Pembaruan ini akan diterapkan ke sesi baru.",
+      "Required": "__NOT_TRANSLATED__"
     },
     "ask": {
       "DoYouWantToProceed": "Apakah Anda ingin lanjut?"

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -822,7 +822,8 @@
     "warning": {
       "CannotBeUndone": "주의: 이 동작은 취소할 수 없습니다!",
       "LogDeletion": "정말로 모든 로그를 삭제하시겠습니까?",
-      "WillBeAppliedToNewSessions": "이 변경사항은 새 세션부터 적용됩니다."
+      "WillBeAppliedToNewSessions": "이 변경사항은 새 세션부터 적용됩니다.",
+      "Required": "필수 입력입니다."
     },
     "ask": {
       "DoYouWantToProceed": "계속 진행하시겠습니까?"

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -742,7 +742,8 @@
     "warning": {
       "CannotBeUndone": "АНХААРУУЛГА: үүнийг буцаах боломжгүй!",
       "LogDeletion": "Бүртгэлийн бүх мессежийг устгахдаа итгэлтэй байна уу?",
-      "WillBeAppliedToNewSessions": "Энэхүү шинэчлэлтийг шинэ Sessionүүдэд ашиглах болно."
+      "WillBeAppliedToNewSessions": "Энэхүү шинэчлэлтийг шинэ Sessionүүдэд ашиглах болно.",
+      "Required": "__NOT_TRANSLATED__"
     },
     "ask": {
       "DoYouWantToProceed": "Та үргэлжлүүлэхийг хүсч байна уу?"

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -742,7 +742,8 @@
     "warning": {
       "CannotBeUndone": "ВНИМАНИЕ: это нельзя отменить!",
       "LogDeletion": "Вы уверены, что хотите удалить все сообщения журнала?",
-      "WillBeAppliedToNewSessions": "Это обновление будет применено к новым сеансам."
+      "WillBeAppliedToNewSessions": "Это обновление будет применено к новым сеансам.",
+      "Required": "__NOT_TRANSLATED__"
     },
     "ask": {
       "DoYouWantToProceed": "Вы хотите продолжить?"

--- a/src/components/backend-ai-general-styles.ts
+++ b/src/components/backend-ai-general-styles.ts
@@ -75,6 +75,7 @@ export const BackendAiStyles = [
       --general-progress-bar-using: linear-gradient(to left, #18aa7c, #60bb43),
       linear-gradient(to left, #722cd7, #5c7cfa);
       --lumo-font-family: var(--general-font-family);
+      --general-warning-text: var(--paper-red-400);
     }
 
     body {

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -3678,7 +3678,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
               <div class="horizontal layout start-justified">
                 <div style="width:370px;font-size:12px;">${_t('session.launcher.StartUpCommand')}*</div>
               </div>
-              <lablup-codemirror id="command-editor" mode="shell" required helperText="${_t('dialog.warning.Required')}"></lablup-codemirror>
+              <lablup-codemirror id="command-editor" mode="shell" required validationMessage="${_t('dialog.warning.Required')}"></lablup-codemirror>
               <div class="horizontal center layout justified" style="margin: 10px auto;">
                 <div style="width:330px;font-size:12px;">${_t('session.launcher.ScheduleTime')}</div>
                 <mwc-switch id="use-scheduled-time" @click="${() => this._toggleScheduleTimeDisplay()}"></mwc-switch>

--- a/src/components/lablup-codemirror.ts
+++ b/src/components/lablup-codemirror.ts
@@ -42,9 +42,9 @@ export default class LablupCodemirror extends LitElement {
   @property({type: Boolean}) readonly = false;
   @property({type: Boolean}) useLineWrapping = false;
   @property({type: Boolean}) required = false;
-  @property({type: String}) helperText = '';
-  @property({type: String}) helperTextIcon = 'warning';
-  @query('#helper-text') helperTextEl!: HTMLDivElement;
+  @property({type: String}) validationMessage = '';
+  @property({type: String}) validationMessageIcon = 'warning';
+  @query('#validation-message') validationMessageEl!: HTMLDivElement;
   @query('#codemirror-editor') editorEl!: WCCodeMirror;
 
   constructor() {
@@ -123,15 +123,23 @@ export default class LablupCodemirror extends LitElement {
   _validateInput() {
     if (this.required) {
       if (this.getValue() === '') {
-        this.helperTextEl.style.display = 'flex';
+        this.showValidationMessage();
         this.editorEl.style.border = '2px solid red';
         return false;
       } else {
-        this.helperTextEl.style.display = 'none';
+        this.hideValidationMessage();
         this.editorEl.style.border = 'none';
       }
     }
     return true;
+  }
+
+  showValidationMessage() {
+    this.validationMessageEl.style.display = 'flex';
+  }
+
+  hideValidationMessage() {
+    this.validationMessageEl.style.display = 'none';
   }
 
   static get styles(): CSSResultGroup | undefined {
@@ -148,15 +156,15 @@ export default class LablupCodemirror extends LitElement {
           font-size: 15px;
         }
 
-        #helper-text {
-          font-size: var(--helper-text-font-size, 12px);
-          color: var(--helper-text-color, var(--general-warning-text));
-          width: var(--helper-text-width, 100%);
-          font-weight: var(--helper-text-font-weight, bold);
+        #validation-message {
+          font-size: var(--validation-message-font-size, 12px);
+          color: var(--validation-message-color, var(--general-warning-text));
+          width: var(--validation-message-width, 100%);
+          font-weight: var(--validation-message-font-weight, bold);
         }
 
-        #helper-text mwc-icon {
-          font-size: var(--helper-text-font-size, 12px);
+        #validation-message mwc-icon {
+          font-size: var(--validation-message-font-size, 12px);
           margin-right: 2px;
         }
       `,
@@ -170,9 +178,9 @@ export default class LablupCodemirror extends LitElement {
         <wc-codemirror id="codemirror-editor" mode="${this.mode}" theme="monokai" ?readonly="${this.readonly}" @input="${() => this._validateInput()}">
           <link rel="stylesheet" href="node_modules/@vanillawc/wc-codemirror/theme/monokai.css">
         </wc-codemirror>
-        <div id="helper-text" class="horizontal layout center" style="display:none;">
-          <mwc-icon>${this.helperTextIcon}</mwc-icon>
-          <span>${this.helperText}</span>
+        <div id="validation-message" class="horizontal layout center" style="display:none;">
+          <mwc-icon>${this.validationMessageIcon}</mwc-icon>
+          <span>${this.validationMessage}</span>
         </div>
       </div>
     `;


### PR DESCRIPTION
By adding validation to the `lablup-codemirror`, it was prevented from moving on to the next step without entering the startup command in the batch session.
<img width="416" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/28584164/1d95ecf5-3986-4d17-a09a-7834a8655b7d">
