### PR TITLE
ci: Add auto-label-in-issue action

### DIFF
--- a/.github/workflows/auto-label-in-issue.yaml
+++ b/.github/workflows/auto-label-in-issue.yaml
@@ -1,0 +1,14 @@
+name: 'Auto Label in Issue'
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lablup/auto-label-in-issue@1.4.0


### PR DESCRIPTION
This project is an open source project and uses many labels for pr and issue management.
However, managing labels is time consuming and needs to be automated.
If there is an issue linked to pr, add an action that automatically adds the label added to the issue to pr.