### PR TITLE
feature: add sorting filter in new column `created_at` in serving list

### DIFF
--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -111,6 +111,7 @@ type ComputeContainer implements Item {
   occupied_slots: JSONString
   live_stat: JSONString
   last_stat: JSONString
+  preopen_ports: [Int]
 }
 
 type ComputeContainerList implements PaginatedList {
@@ -390,6 +391,8 @@ type Endpoint implements Item {
   cluster_mode: String
   cluster_size: Int
   open_to_public: Boolean
+  created_at: DateTime!
+  terminated_at: DateTime
   routings: [Routing]
   retries: Int
   status: String
@@ -398,6 +401,22 @@ type Endpoint implements Item {
 
 type EndpointList implements PaginatedList {
   items: [Endpoint]!
+  total_count: Int!
+}
+
+type EndpointToken implements Item {
+  id: ID
+  token: String!
+  endpoint_id: UUID!
+  domain: String!
+  project: String!
+  session_owner: UUID!
+  created_at: DateTime!
+  valid_until: DateTime
+}
+
+type EndpointTokenList implements PaginatedList {
+  items: [EndpointToken]!
   total_count: Int!
 }
 
@@ -767,9 +786,9 @@ type Mutations {
   rescan_images(registry: String): RescanImages
   preload_image(references: [String]!, target_agents: [String]!): PreloadImage
   unload_image(references: [String]!, target_agents: [String]!): UnloadImage
-  modify_image(architecture: String = "x86_64", props: ModifyImageInput!, target: String!): ModifyImage
-  forget_image(architecture: String = "x86_64", reference: String!): ForgetImage
-  alias_image(alias: String!, architecture: String = "x86_64", target: String!): AliasImage
+  modify_image(architecture: String = "aarch64", props: ModifyImageInput!, target: String!): ModifyImage
+  forget_image(architecture: String = "aarch64", reference: String!): ForgetImage
+  alias_image(alias: String!, architecture: String = "aarch64", target: String!): AliasImage
   dealias_image(alias: String!): DealiasImage
   clear_images(registry: String): ClearImages
   create_keypair_resource_policy(name: String!, props: CreateKeyPairResourcePolicyInput!): CreateKeyPairResourcePolicy
@@ -851,7 +870,7 @@ type Queries {
   group(id: UUID!, domain_name: String): Group
   groups_by_name(name: String!, domain_name: String): [Group]
   groups(domain_name: String, is_active: Boolean): [Group]
-  image(reference: String!, architecture: String = "x86_64"): Image
+  image(reference: String!, architecture: String = "aarch64"): Image
   images(is_installed: Boolean, is_operation: Boolean): [Image]
   user(domain_name: String, email: String): User
   user_from_uuid(domain_name: String, user_id: ID): User
@@ -877,6 +896,9 @@ type Queries {
   storage_volume_list(limit: Int!, offset: Int!, filter: String, order: String): StorageVolumeList
   vfolder_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: UUID, access_key: String): VirtualFolderList
   vfolder_permission_list(limit: Int!, offset: Int!, filter: String, order: String): VirtualFolderPermissionList
+  vfolder_own_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList
+  vfolder_invited_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList
+  vfolder_project_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList
   vfolders(domain_name: String, group_id: String, access_key: String): [VirtualFolder]
   compute_session(id: UUID!): ComputeSession
   compute_container(id: UUID!): ComputeContainer
@@ -889,6 +911,8 @@ type Queries {
   endpoint_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: String, access_key: String, project: UUID): EndpointList
   routing(routing_id: UUID!): Routing
   routing_list(limit: Int!, offset: Int!, filter: String, order: String, endpoint_id: UUID): RoutingList
+  endpoint_token(token: String!): EndpointToken
+  endpoint_token_list(limit: Int!, offset: Int!, filter: String, order: String, endpoint_id: UUID): EndpointTokenList
   quota_scope(storage_host_name: String!, quota_scope_id: String!): QuotaScope
 }
 
@@ -940,6 +964,7 @@ type Routing implements Item {
   session: UUID
   status: String
   traffic_ratio: Float
+  created_at: DateTime
 }
 
 type RoutingList implements PaginatedList {
@@ -1096,4 +1121,3 @@ type VirtualFolderPermissionList implements PaginatedList {
   items: [VirtualFolderPermission]!
   total_count: Int!
 }
-

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -30,6 +30,7 @@
         "react-router-dom": "^6.15.0",
         "react-scripts": "5.0.1",
         "typescript": "^5.1.6",
+        "use-query-params": "^2.2.1",
         "web-vitals": "^3.4.0"
       },
       "devDependencies": {
@@ -18199,6 +18200,11 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/serialize-query-params": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.2.tgz",
+      "integrity": "sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q=="
+    },
     "node_modules/serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
@@ -19627,6 +19633,28 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-query-params": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-2.2.1.tgz",
+      "integrity": "sha512-i6alcyLB8w9i3ZK3caNftdb+UnbfBRNPDnc89CNQWkGRmDrm/gfydHvMBfVsQJRq3NoHOM2dt/ceBWG2397v1Q==",
+      "dependencies": {
+        "serialize-query-params": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@reach/router": "^1.2.1",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-router-dom": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@reach/router": {
+          "optional": true
+        },
+        "react-router-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {
@@ -33914,6 +33942,11 @@
         "randombytes": "^2.1.0"
       }
     },
+    "serialize-query-params": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-2.0.2.tgz",
+      "integrity": "sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q=="
+    },
     "serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
@@ -34970,6 +35003,14 @@
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "use-query-params": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-2.2.1.tgz",
+      "integrity": "sha512-i6alcyLB8w9i3ZK3caNftdb+UnbfBRNPDnc89CNQWkGRmDrm/gfydHvMBfVsQJRq3NoHOM2dt/ceBWG2397v1Q==",
+      "requires": {
+        "serialize-query-params": "^2.0.2"
       }
     },
     "util-deprecate": {

--- a/react/package.json
+++ b/react/package.json
@@ -25,6 +25,7 @@
     "react-router-dom": "^6.15.0",
     "react-scripts": "5.0.1",
     "typescript": "^5.1.6",
+    "use-query-params": "^2.2.1",
     "web-vitals": "^3.4.0"
   },
   "scripts": {

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -87,6 +87,16 @@ export const _humanReadableBinarySize = (
   );
 };
 
+/**
+ * Change date of any type to human readable date time.
+ *
+ * @param {Date} d   - string or DateTime object to convert
+ * @return {Date}   - Formatted date / time to be human-readable text.
+ */
+export const _humanReadableTime = (date: string) => {
+  return new Date(date).toUTCString();
+}
+
 export const GBToBytes = (value = 0) => {
   const gigabyte = Math.pow(10, 9);
   return Math.round(gigabyte * value);
@@ -115,4 +125,8 @@ export const usageIndicatorColor = (percentage: number) => {
     : percentage < 90
     ? 'rgb(223, 179, 23)'
     : '#ef5350';
+};
+
+export const offset_to_cursor = (offset: number): string => {
+  return window.btoa(`arrayconnection:${offset}`);
 };

--- a/react/src/helper/types.tsx
+++ b/react/src/helper/types.tsx
@@ -1,0 +1,5 @@
+import { useLazyLoadQuery } from "react-relay";
+
+export type LazyLoadQueryOptions = ArgumentTypes<typeof useLazyLoadQuery>[2];
+
+export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/react/src/hooks/reactPaginationQueryOptions.tsx
+++ b/react/src/hooks/reactPaginationQueryOptions.tsx
@@ -1,0 +1,177 @@
+import { offset_to_cursor } from "../helper";
+import { LazyLoadQueryOptions } from "../helper/types";
+import { SorterResult } from "antd/lib/table/interface";
+import _ from "lodash";
+import { useState } from "react";
+import {
+  fetchQuery,
+  GraphQLTaggedNode,
+  useRelayEnvironment,
+} from "react-relay";
+import {
+  ArrayParam,
+  NumberParam,
+  ObjectParam,
+  useQueryParams,
+} from "use-query-params";
+
+export type SorterInterface = Pick<SorterResult<any>, "field" | "order">;
+
+export const antdSorterResultToOrder = (
+  sorter: SorterInterface | SorterInterface[]
+) => {
+  const sorterArray = _.castArray(sorter).filter((s) => s.field);
+
+  return _.filter(
+    _.map(sorterArray, (s) =>
+      _.isNull(s.order)
+        ? undefined
+        : `${_.snakeCase(s.field as string).toUpperCase()}_${
+            s.order === "ascend" ? "ASC" : "DESC"
+          }`
+    )
+  );
+};
+
+export const orderToAntdSorterResult = (order: string[]) => {
+  return _.map(order, (o) => {
+    const names = o.split("_");
+    const orderKey = names.pop();
+    const field = _.camelCase(names.join("_"));
+    return {
+      field,
+      order: (orderKey === "ASC" ? "ascend" : "descend") as
+        | "ascend"
+        | "descend"
+        | null,
+    };
+  });
+};
+
+export const getSortOrderByName = (order: string[], name: string) => {
+  const sorterResult = orderToAntdSorterResult(order);
+  const sorter = _.find(sorterResult, (s) => s.field === name);
+  return sorter?.order;
+};
+
+export const useRelayPaginationQueryOptions = <
+  // Q, N,
+  O,
+  F
+>({
+  query,
+  defaultVariables,
+  getVariables = ({ page, pageSize, order, filter }) => {
+    return {
+      first: pageSize,
+      after: page > 1 ? offset_to_cursor((page - 1) * pageSize - 1) : undefined,
+      order: order,
+      filter: filter,
+    };
+  },
+}: {
+  query: GraphQLTaggedNode;
+  defaultVariables: {
+    page: number;
+    pageSize: number;
+    order: O[];
+    filter?: F;
+    // sorter?: SorterResult<N>[];
+  };
+  getVariables?: (params: {
+    page: number;
+    pageSize: number;
+    order: O[];
+    filter?: F;
+  }) => any;
+}) => {
+  const [isPending, setIsPending] = useState(false);
+
+  const [params, setParams] = useQueryParams({
+    page: NumberParam,
+    pageSize: NumberParam,
+    order: ArrayParam,
+    filter: ObjectParam,
+  });
+
+  const page = params.page || defaultVariables.page;
+  const pageSize = params.pageSize || defaultVariables.pageSize;
+  //TODO: not use as
+  const order = (params.order || defaultVariables.order) as O[];
+  const filter = (params.filter || defaultVariables.filter) as F;
+
+  const relayEnvironment = useRelayEnvironment();
+
+  const [refreshedQueryOptions, setRefreshedQueryOptions] =
+    useState<LazyLoadQueryOptions>({
+      fetchKey: 0,
+      fetchPolicy: "store-and-network",
+    });
+
+  const prevLocationRef = window.location.href;
+  const refresh = (
+    newPage: number = defaultVariables.page,
+    newPageSize: number = defaultVariables.pageSize,
+    // sorter: SorterResult<N>[],
+    newOrder: O[] = defaultVariables.order,
+    newFilter: F | undefined = defaultVariables.filter,
+    options?: {
+      withoutPendingStatus: boolean;
+    }
+  ) => {
+    if (options?.withoutPendingStatus !== true) {
+      setIsPending(true);
+    }
+    fetchQuery<any>(
+      relayEnvironment,
+      query,
+      getVariables({
+        page: newPage,
+        pageSize: newPageSize,
+        order: newOrder,
+        filter: newFilter,
+      })
+    ).subscribe({
+      complete: () => {
+        if (window.location.href !== prevLocationRef) return;
+        setIsPending(false);
+        setParams({
+          page: newPage,
+          pageSize: newPageSize,
+          // eslint-disable-next-line
+          order: newOrder as [], // TODO: not use as []
+          // eslint-disable-next-line
+          filter: newFilter as {}, // TODO: not use as {}
+        });
+        setRefreshedQueryOptions((prev) => ({
+          ...prev,
+          fetchPolicy: "store-only",
+          fetchKey: new Date().toISOString(),
+        }));
+      },
+    });
+  };
+
+  const variables = getVariables({
+    page,
+    pageSize,
+    order,
+    filter,
+  });
+
+  return [
+    {
+      refreshedQueryOptions,
+      page,
+      pageSize,
+      order,
+      isPending,
+      variables,
+      filter,
+      after: page > 1 ? offset_to_cursor((page - 1) * pageSize - 1) : undefined,
+    },
+    {
+      refresh,
+    },
+  ] as const;
+};

--- a/react/src/hooks/reactPaginationQueryOptions.tsx
+++ b/react/src/hooks/reactPaginationQueryOptions.tsx
@@ -1,4 +1,4 @@
-import { offset_to_cursor } from "../helper";
+// import { offset_to_cursor } from "../helper";
 import { LazyLoadQueryOptions } from "../helper/types";
 import { SorterResult } from "antd/lib/table/interface";
 import _ from "lodash";
@@ -64,7 +64,7 @@ export const useRelayPaginationQueryOptions = <
   getVariables = ({ page, pageSize, order, filter }) => {
     return {
       first: pageSize,
-      after: page > 1 ? offset_to_cursor((page - 1) * pageSize - 1) : undefined,
+    //   after: page > 1 ? offset_to_cursor((page - 1) * pageSize - 1) : undefined,
       order: order,
       filter: filter,
     };
@@ -168,7 +168,7 @@ export const useRelayPaginationQueryOptions = <
       isPending,
       variables,
       filter,
-      after: page > 1 ? offset_to_cursor((page - 1) * pageSize - 1) : undefined,
+    //   after: page > 1 ? offset_to_cursor((page - 1) * pageSize - 1) : undefined,
     },
     {
       refresh,

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -340,13 +340,7 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
                   render: (created_at) => {
                     return _humanReadableTime(created_at);
                   },
-                  sorter: true,
-                  sortDirections: ["ascend", "descend"],
-                  // TODO: pagination query order
-                  // sortOrder: getSortOrderByName(
-                  //   paginationStates.order,
-                  //   "statusChanged"
-                  // ),
+                  sorter: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
                 },
                 {
                   title: t('modelService.DesiredSessionCount'),

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -9,7 +9,7 @@ import {
   useSuspendedBackendaiClient,
   useUpdatableState,
 } from '../hooks';
-import { getSortOrderByName } from '../hooks/reactPaginationQueryOptions';
+// import { getSortOrderByName } from '../hooks/reactPaginationQueryOptions';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import {
   ServingListPageQuery,
@@ -340,6 +340,7 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
                   render: (created_at) => {
                     return _humanReadableTime(created_at);
                   },
+                  defaultSortOrder: 'descend',
                   sorter: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
                 },
                 {

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -9,6 +9,7 @@ import {
   useSuspendedBackendaiClient,
   useUpdatableState,
 } from '../hooks';
+import { default as dayjs } from 'dayjs';
 // import { getSortOrderByName } from '../hooks/reactPaginationQueryOptions';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import {
@@ -338,10 +339,15 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
                   title: t('modelService.CreatedAt'),
                   dataIndex: 'created_at',
                   render: (created_at) => {
-                    return _humanReadableTime(created_at);
+                    return dayjs(created_at).format('YYYY/MM/DD HH:MM:ss');
                   },
                   defaultSortOrder: 'descend',
-                  sorter: (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+                  sortDirections: ['descend', 'ascend', 'descend'],
+                  sorter: (a, b) => {
+                    const date1 = dayjs(a.created_at);
+                    const date2 = dayjs(b.created_at);
+                    return date1.diff(date2);
+                  },
                 },
                 {
                   title: t('modelService.DesiredSessionCount'),

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -3,12 +3,13 @@ import EndpointStatusTag from '../components/EndpointStatusTag';
 import Flex from '../components/Flex';
 import ModelServiceSettingModal from '../components/ModelServiceSettingModal';
 import ServiceLauncherModal from '../components/ServiceLauncherModal';
-import { baiSignedRequestWithPromise } from '../helper';
+import { baiSignedRequestWithPromise, _humanReadableTime } from '../helper';
 import {
   useCurrentProjectValue,
   useSuspendedBackendaiClient,
   useUpdatableState,
 } from '../hooks';
+import { getSortOrderByName } from '../hooks/reactPaginationQueryOptions';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import {
   ServingListPageQuery,
@@ -85,6 +86,7 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
   }, 7000);
 
   const { endpoint_list: modelServiceList } =
+  // TODO: need to convert LazyLoadQuery to pagination query with option
     useLazyLoadQuery<ServingListPageQuery>(
       graphql`
         query ServingListPageQuery(
@@ -110,6 +112,8 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
               resource_slots
               url
               open_to_public
+              created_at
+              created_user
               desired_session_count @required(action: NONE)
               routings {
                 routing_id
@@ -329,6 +333,20 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
                   render: (text, row) => (
                     <EndpointStatusTag endpointFrgmt={row} />
                   ),
+                },
+                {
+                  title: t('modelService.CreatedAt'),
+                  dataIndex: 'created_at',
+                  render: (created_at) => {
+                    return _humanReadableTime(created_at);
+                  },
+                  sorter: true,
+                  sortDirections: ["ascend", "descend"],
+                  // TODO: pagination query order
+                  // sortOrder: getSortOrderByName(
+                  //   paginationStates.order,
+                  //   "statusChanged"
+                  // ),
                 },
                 {
                   title: t('modelService.DesiredSessionCount'),

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -3,7 +3,7 @@ import EndpointStatusTag from '../components/EndpointStatusTag';
 import Flex from '../components/Flex';
 import ModelServiceSettingModal from '../components/ModelServiceSettingModal';
 import ServiceLauncherModal from '../components/ServiceLauncherModal';
-import { baiSignedRequestWithPromise, _humanReadableTime } from '../helper';
+import { baiSignedRequestWithPromise } from '../helper';
 import {
   useCurrentProjectValue,
   useSuspendedBackendaiClient,

--- a/react/src/react-app-env.d.ts
+++ b/react/src/react-app-env.d.ts
@@ -6,3 +6,7 @@ declare module 'babel-plugin-relay/macro' {
 
 type ArrayElement<ArrayType extends readonly unknown[]> =
   ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+
+type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any
+  ? A
+  : never;

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -423,6 +423,7 @@
     "OnlyAllowsNonNegativeIntegers": "Only allows non-negative integers",
     "RoutingInfo": "Routing Info",
     "ServiceInfo": "Service Info",
+    "CreatedAt": "Created At",
     "StartService": "Start Service",
     "SessionOwner": "Session Owner",
     "ServiceEndpoint": "Service Endpoint",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -739,7 +739,9 @@
     "ProjectFolder": "__NOT_TRANSLATED__",
     "QuotaPerStorageVolume": "__NOT_TRANSLATED__",
     "HostDetails": "__NOT_TRANSLATED__",
-    "Used": "__NOT_TRANSLATED__"
+    "Used": "__NOT_TRANSLATED__",
+    "Pipeline": "__NOT_TRANSLATED__",
+    "DialogDataFolder": "__NOT_TRANSLATED__"
   },
   "dialog": {
     "warning": {
@@ -1498,6 +1500,7 @@
     "YouAreAboutToTerminate": "__NOT_TRANSLATED__",
     "FailedToStartService": "__NOT_TRANSLATED__",
     "ServingRouteErrorModalTitle": "__NOT_TRANSLATED__",
-    "ClearErrors": "__NOT_TRANSLATED__"
+    "ClearErrors": "__NOT_TRANSLATED__",
+    "CreatedAt": "__NOT_TRANSLATED__"
   }
 }

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -739,7 +739,9 @@
     "ProjectFolder": "__NOT_TRANSLATED__",
     "QuotaPerStorageVolume": "__NOT_TRANSLATED__",
     "HostDetails": "__NOT_TRANSLATED__",
-    "Used": "__NOT_TRANSLATED__"
+    "Used": "__NOT_TRANSLATED__",
+    "Pipeline": "__NOT_TRANSLATED__",
+    "DialogDataFolder": "__NOT_TRANSLATED__"
   },
   "dialog": {
     "warning": {
@@ -1498,6 +1500,7 @@
     "YouAreAboutToTerminate": "__NOT_TRANSLATED__",
     "FailedToStartService": "__NOT_TRANSLATED__",
     "ServingRouteErrorModalTitle": "__NOT_TRANSLATED__",
-    "ClearErrors": "__NOT_TRANSLATED__"
+    "ClearErrors": "__NOT_TRANSLATED__",
+    "CreatedAt": "__NOT_TRANSLATED__"
   }
 }

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -423,7 +423,8 @@
     "YouAreAboutToTerminate": "아래의 서비스를 삭제하려고 합니다: ",
     "ClearErrors": "오류 지우고 재시도",
     "ServingRouteErrorModalTitle": "서빙 라우트 에러",
-    "FailedToStartService": "서비스를 생성하지 못했습니다."
+    "FailedToStartService": "서비스를 생성하지 못했습니다.",
+    "CreatedAt": "생성 시각"
   },
   "button": {
     "Cancel": "취소",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -739,7 +739,9 @@
     "ProjectFolder": "__NOT_TRANSLATED__",
     "QuotaPerStorageVolume": "__NOT_TRANSLATED__",
     "HostDetails": "__NOT_TRANSLATED__",
-    "Used": "__NOT_TRANSLATED__"
+    "Used": "__NOT_TRANSLATED__",
+    "Pipeline": "__NOT_TRANSLATED__",
+    "DialogDataFolder": "__NOT_TRANSLATED__"
   },
   "dialog": {
     "warning": {
@@ -1498,6 +1500,7 @@
     "YouAreAboutToTerminate": "__NOT_TRANSLATED__",
     "FailedToStartService": "__NOT_TRANSLATED__",
     "ServingRouteErrorModalTitle": "__NOT_TRANSLATED__",
-    "ClearErrors": "__NOT_TRANSLATED__"
+    "ClearErrors": "__NOT_TRANSLATED__",
+    "CreatedAt": "__NOT_TRANSLATED__"
   }
 }

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -739,7 +739,9 @@
     "ProjectFolder": "__NOT_TRANSLATED__",
     "QuotaPerStorageVolume": "__NOT_TRANSLATED__",
     "HostDetails": "__NOT_TRANSLATED__",
-    "Used": "__NOT_TRANSLATED__"
+    "Used": "__NOT_TRANSLATED__",
+    "Pipeline": "__NOT_TRANSLATED__",
+    "DialogDataFolder": "__NOT_TRANSLATED__"
   },
   "dialog": {
     "warning": {
@@ -1498,6 +1500,7 @@
     "YouAreAboutToTerminate": "__NOT_TRANSLATED__",
     "FailedToStartService": "__NOT_TRANSLATED__",
     "ServingRouteErrorModalTitle": "__NOT_TRANSLATED__",
-    "ClearErrors": "__NOT_TRANSLATED__"
+    "ClearErrors": "__NOT_TRANSLATED__",
+    "CreatedAt": "__NOT_TRANSLATED__"
   }
 }


### PR DESCRIPTION
This PR resolves #1887.

> ⚠️ NOTE: ~~pagination filter goes to `created_at` as a default.~~
> There's a bit changed in `package.json` and `package-lock.json`. You need to update installed node packages in `src/react` by `npm i` before reviewing the code and UI whether it works properly or not.
> We need to implement pagination right after implementing monitoring by access-control(e.g. admin user can see all of the services that user(s) have been created) as a future feature.


## Before
<img width="1108" alt="Screenshot 2023-08-25 at 8 12 50 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/1110fd0e-0eab-45bf-849f-1b970b53e3d7">


## After
<img width="1162" alt="Screenshot 2023-08-28 at 4 20 59 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/8ccb28fe-3093-42a0-9818-6238f04ad9f5">