### PR TITLE
fix: incomplete URL substring sanitization

### DIFF
--- a/src/components/backend-ai-import-view.ts
+++ b/src/components/backend-ai-import-view.ts
@@ -529,7 +529,7 @@ export default class BackendAIImport extends BackendAIPage {
     const group = ''; // user ownership
     const vhost_info = await globalThis.backendaiclient.vfolder.list_hosts();
     let host = vhost_info.default;
-    if (url.includes('github.com/')) {
+    if (new URL(url).hostname.endsWith('github.com')) {
       host = (
         this.shadowRoot?.querySelector('#github-add-folder-host') as Select
       ).value;
@@ -542,7 +542,7 @@ export default class BackendAIImport extends BackendAIPage {
     return globalThis.backendaiclient.vfolder
       .create(name, host, group, usageMode, permission)
       .then((value) => {
-        if (url.includes('github.com/')) {
+        if (new URL(url).hostname.endsWith('github.com')) {
           this.importNotebookMessage = _text('import.FolderName') + name;
         } else {
           this.importGitlabMessage = _text('import.FolderName') + name;
@@ -565,7 +565,7 @@ export default class BackendAIImport extends BackendAIPage {
     });
     if (vfolders.includes(name)) {
       this.notification.text = _text('import.FolderAlreadyExists');
-      if (url.includes('github.com/')) {
+      if (new URL(url).hostname.endsWith('github.com')) {
         this.importNotebookMessage = this.notification.text;
       } else {
         this.importGitlabMessage = this.notification.text;

--- a/src/components/backend-ai-import-view.ts
+++ b/src/components/backend-ai-import-view.ts
@@ -529,7 +529,7 @@ export default class BackendAIImport extends BackendAIPage {
     const group = ''; // user ownership
     const vhost_info = await globalThis.backendaiclient.vfolder.list_hosts();
     let host = vhost_info.default;
-    if (new URL(url).hostname.endsWith('github.com')) {
+    if (new URL(url).host === 'github.com') {
       host = (
         this.shadowRoot?.querySelector('#github-add-folder-host') as Select
       ).value;
@@ -542,7 +542,7 @@ export default class BackendAIImport extends BackendAIPage {
     return globalThis.backendaiclient.vfolder
       .create(name, host, group, usageMode, permission)
       .then((value) => {
-        if (new URL(url).hostname.endsWith('github.com')) {
+        if (new URL(url).host === 'github.com') {
           this.importNotebookMessage = _text('import.FolderName') + name;
         } else {
           this.importGitlabMessage = _text('import.FolderName') + name;
@@ -565,7 +565,7 @@ export default class BackendAIImport extends BackendAIPage {
     });
     if (vfolders.includes(name)) {
       this.notification.text = _text('import.FolderAlreadyExists');
-      if (new URL(url).hostname.endsWith('github.com')) {
+      if (new URL(url).host === 'github.com') {
         this.importNotebookMessage = this.notification.text;
       } else {
         this.importGitlabMessage = this.notification.text;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e4d8cea</samp>

### Summary
🛠️🌐📓

<!--
1.  🛠️ - This emoji represents fixing or improving something, and can be used to indicate that the code for importing notebooks from github urls has been enhanced and made more robust.
2.  🌐 - This emoji represents the internet or the web, and can be used to indicate that the feature involves working with urls and domains.
3.  📓 - This emoji represents a notebook, and can be used to indicate that the feature is related to the core functionality of the app, which is creating and editing notebooks.
-->
Improved the validation of github urls for importing notebooks in `backend-ai-import-view.ts`. Used the `URL` constructor and the `hostname` property to check the domain.

> _From the depths of github we summon the code_
> _With the URL constructor we forge the mode_
> _We validate the domain with the hostname property_
> _We unleash the power of notebook importability_

### Walkthrough
*  Use `URL` constructor and `hostname` property to check if url is from github.com ([link](https://github.com/lablup/backend.ai-webui/pull/1889/files?diff=unified&w=0#diff-bff65336524f666db43fece462096725a4a0f99ec7eb69836cc84130e5de2b63L532-R532), [link](https://github.com/lablup/backend.ai-webui/pull/1889/files?diff=unified&w=0#diff-bff65336524f666db43fece462096725a4a0f99ec7eb69836cc84130e5de2b63L545-R545), [link](https://github.com/lablup/backend.ai-webui/pull/1889/files?diff=unified&w=0#diff-bff65336524f666db43fece462096725a4a0f99ec7eb69836cc84130e5de2b63L568-R568))

