### PR TITLE
add: automatic Windows / Linux builds on GitHub action

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,7 +5,7 @@
 # file with configuration.  For more information, see:
 # https://github.com/actions/labeler/blob/master/README.md
 
-name: Build macOS Desktop Application
+name: Build Desktop Applications
 on:
   release:
     types: [published]
@@ -24,7 +24,7 @@ jobs:
       - name: Install Dependencies
         run: npm install
       - name: Package Applications
-        run: make mac
+        run: make all
         env:
           BAI_APP_SIGN: 1
           BAI_APP_SIGN_APPLE_ID: ${{ secrets.BAI_APP_SIGN_APPLE_ID }}

--- a/upload-release.js
+++ b/upload-release.js
@@ -47,13 +47,13 @@ const getUploadURL = async (releaseId) => {
 
 const main = async () => {
     if (process.argv.length !== 3) {
-        console.error('usage: node upload-release.js <folder containing DMG files>')
+        console.error('usage: node upload-release.js <folder containing DMG/ZIP files>')
         process.exit(1)
     }
     const folder = process.argv[2]
     let DMGs = []
     try {
-        DMGs = (await fs.promises.readdir(folder)).filter((s) => !s.startsWith('.') && s.endsWith('.dmg'))
+        DMGs = (await fs.promises.readdir(folder)).filter((s) => !s.startsWith('.') && (s.endsWith('.dmg') || s.endsWith('.zip')))
     } catch (e) {
         console.error(e.message)
         process.exit(1)


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f8f5fac</samp>

### Summary
🖥️🌐🗜️

<!--
1.  🖥️ - This emoji represents desktop applications or computers in general, and can be used to indicate the workflow for building desktop applications.
2.  🌐 - This emoji represents the world wide web or the internet, and can be used to indicate the support for multiple platforms or the upload-release.js script.
3.  🗜️ - This emoji represents compression or ZIP files, and can be used to indicate the extension of the script to support ZIP files for macOS releases.
-->
This pull request adds support for packaging and uploading desktop applications for multiple platforms using GitHub Actions. It modifies the `.github/workflows/package.yml` workflow and the `upload-release.js` script to handle macOS, Windows, and Linux releases.

> _We build the apps of doom and despair_
> _For every platform we don't care_
> _We upload the releases with a script_
> _ZIP or DMG, we don't slip_

### Walkthrough
*  Rename and modify workflow to build desktop applications for multiple platforms ([link](https://github.com/lablup/backend.ai-webui/pull/1910/files?diff=unified&w=0#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L8-R8), [link](https://github.com/lablup/backend.ai-webui/pull/1910/files?diff=unified&w=0#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L27-R27))
*  Update and extend upload-release.js script to handle ZIP files as well as DMG files ([link](https://github.com/lablup/backend.ai-webui/pull/1910/files?diff=unified&w=0#diff-b1a807762ac5788cb5080a98cc96f86ad96a87b4980c283a3b229a9505d1ae28L50-R50), [link](https://github.com/lablup/backend.ai-webui/pull/1910/files?diff=unified&w=0#diff-b1a807762ac5788cb5080a98cc96f86ad96a87b4980c283a3b229a9505d1ae28L56-R56))

