### PR TITLE
fix: Change WARBOY resource display icon to FuriosaAI

### DIFF
--- a/resources/device_metadata.json
+++ b/resources/device_metadata.json
@@ -97,7 +97,7 @@
         "binary": false,
         "round_length": 0
       },
-      "display_icon": "rebel"
+      "display_icon": "furiosa"
     }
   }
 }


### PR DESCRIPTION
This PR changes a typo in `display_icon` field from WARBOY device metadata.

Refs
- lablup/backend.ai#1546
