### PR TITLE
feat: add an auto selected volume in creating and cloning a data folder

### DIFF
--- a/resources/storage_metadata.json
+++ b/resources/storage_metadata.json
@@ -84,6 +84,11 @@
         "SpectrumScale",
         "GPFS"
       ]
+    },
+    "auto": {
+      "name": "Auto",
+      "description": "Automatically select the host with the least usage among the accessible folders for users. This prevents the folders from being concentrated on a single host.",
+      "icon": "local.png"
     }
   }
 }

--- a/resources/storage_metadata.json
+++ b/resources/storage_metadata.json
@@ -87,7 +87,7 @@
     },
     "auto": {
       "name": "Auto",
-      "description": "Automatically select the host with the least usage among the accessible folders for users. This prevents the folders from being concentrated on a single host.",
+      "description": "Choose the host with the lowest usage from the available host volumes for users. This ensures that usage is evenly distributed across multiple storage volumes, avoiding over-concentration on any single volume.",
       "icon": "local.png"
     }
   }

--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -980,12 +980,14 @@ export default class BackendAIData extends BackendAIPage {
 
   async _getAutoSelectedVhostIncludedList() {
     const vhostInfo = await globalThis.backendaiclient.vfolder.list_hosts();
-    vhostInfo.allowed.unshift(
-      `auto (${this._getAutoSelectedVhostName(vhostInfo)})`,
-    );
-    vhostInfo.volume_info[
-      `auto (${this._getAutoSelectedVhostName(vhostInfo)})`
-    ] = this._getAutoSelectedVhostInfo(vhostInfo);
+    if (vhostInfo.allowed.length > 1) {
+      vhostInfo.allowed.unshift(
+        `auto (${this._getAutoSelectedVhostName(vhostInfo)})`,
+      );
+      vhostInfo.volume_info[
+        `auto (${this._getAutoSelectedVhostName(vhostInfo)})`
+      ] = this._getAutoSelectedVhostInfo(vhostInfo);
+    }
     return vhostInfo;
   }
 
@@ -996,8 +998,13 @@ export default class BackendAIData extends BackendAIPage {
     const vhostInfo = await this._getAutoSelectedVhostIncludedList();
     this.addFolderNameInput.value = ''; // reset folder name
     this.vhosts = vhostInfo.allowed;
-    this.vhost = `auto (${this._getAutoSelectedVhostName(vhostInfo)})`;
-    this.selectedVhost = `auto (${this._getAutoSelectedVhostName(vhostInfo)})`;
+    if (this.vhosts.length > 1) {
+      this.vhost = this.selectedVhost = `auto (${this._getAutoSelectedVhostName(
+        vhostInfo,
+      )})`;
+    } else {
+      this.vhost = this.selectedVhost = vhostInfo.default;
+    }
     if (this.allowed_folder_type.includes('group')) {
       const group_info = await globalThis.backendaiclient.group.list();
       this.allowedGroups = group_info.groups;
@@ -1015,8 +1022,13 @@ export default class BackendAIData extends BackendAIPage {
     const vhostInfo = await this._getAutoSelectedVhostIncludedList();
     this.addFolderNameInput.value = ''; // reset folder name
     this.vhosts = vhostInfo.allowed;
-    this.vhost = `auto (${this._getAutoSelectedVhostName(vhostInfo)})`;
-    this.selectedVhost = `auto (${this._getAutoSelectedVhostName(vhostInfo)})`;
+    if (this.vhosts.length > 1) {
+      this.vhost = this.selectedVhost = `auto (${this._getAutoSelectedVhostName(
+        vhostInfo,
+      )})`;
+    } else {
+      this.vhost = this.selectedVhost = vhostInfo.default;
+    }
     if (this.allowed_folder_type.includes('group')) {
       const group_info = await globalThis.backendaiclient.group.list();
       this.allowedGroups = group_info.groups;

--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -980,8 +980,12 @@ export default class BackendAIData extends BackendAIPage {
 
   async _getAutoSelectedVhostIncludedList() {
     const vhostInfo = await globalThis.backendaiclient.vfolder.list_hosts();
-    vhostInfo.allowed.unshift('auto');
-    vhostInfo.volume_info.auto = this._getAutoSelectedVhostInfo(vhostInfo);
+    vhostInfo.allowed.unshift(
+      `auto (${this._getAutoSelectedVhostName(vhostInfo)})`,
+    );
+    vhostInfo.volume_info[
+      `auto (${this._getAutoSelectedVhostName(vhostInfo)})`
+    ] = this._getAutoSelectedVhostInfo(vhostInfo);
     return vhostInfo;
   }
 
@@ -992,8 +996,8 @@ export default class BackendAIData extends BackendAIPage {
     const vhostInfo = await this._getAutoSelectedVhostIncludedList();
     this.addFolderNameInput.value = ''; // reset folder name
     this.vhosts = vhostInfo.allowed;
-    this.vhost = 'auto';
-    this.selectedVhost = 'auto';
+    this.vhost = `auto (${this._getAutoSelectedVhostName(vhostInfo)})`;
+    this.selectedVhost = `auto (${this._getAutoSelectedVhostName(vhostInfo)})`;
     if (this.allowed_folder_type.includes('group')) {
       const group_info = await globalThis.backendaiclient.group.list();
       this.allowedGroups = group_info.groups;
@@ -1011,8 +1015,8 @@ export default class BackendAIData extends BackendAIPage {
     const vhostInfo = await this._getAutoSelectedVhostIncludedList();
     this.addFolderNameInput.value = ''; // reset folder name
     this.vhosts = vhostInfo.allowed;
-    this.vhost = 'auto';
-    this.selectedVhost = 'auto';
+    this.vhost = `auto (${this._getAutoSelectedVhostName(vhostInfo)})`;
+    this.selectedVhost = `auto (${this._getAutoSelectedVhostName(vhostInfo)})`;
     if (this.allowed_folder_type.includes('group')) {
       const group_info = await globalThis.backendaiclient.group.list();
       this.allowedGroups = group_info.groups;
@@ -1065,13 +1069,15 @@ export default class BackendAIData extends BackendAIPage {
   /**
    * Add folder with name, host, type, usage mode and permission.
    */
-  async _addFolder() {
+  _addFolder() {
     const name = this.addFolderNameInput.value;
     let host = (this.shadowRoot?.querySelector('#add-folder-host') as Select)
       .value;
-    if (host === 'auto') {
-      const vhostInfo = await globalThis.backendaiclient.vfolder.list_hosts();
-      host = this._getAutoSelectedVhostName(vhostInfo);
+    // Auto volume
+    const pattern = /^auto \((.+)\)$/;
+    const match = host.match(pattern);
+    if (match) {
+      host = match[1];
     }
     let ownershipType = (
       this.shadowRoot?.querySelector('#add-folder-type') as Select
@@ -1161,9 +1167,11 @@ export default class BackendAIData extends BackendAIPage {
     );
     let host = (this.shadowRoot?.querySelector('#clone-folder-host') as Select)
       .value;
-    if (host === 'auto') {
-      const vhostInfo = await globalThis.backendaiclient.vfolder.list_hosts();
-      host = this._getAutoSelectedVhostName(vhostInfo);
+    // Auto volume
+    const pattern = /^auto \((.+)\)$/;
+    const match = host.match(pattern);
+    if (match) {
+      host = match[1];
     }
     let ownershipType = (
       this.shadowRoot?.querySelector('#clone-folder-type') as Select


### PR DESCRIPTION
- resolves https://github.com/lablup/giftbox/issues/502
- Add 'auto' vhost when creating or cloning a data folder. (Auto volume is added only when there are multiple hosts.)
- The auto-selected folder is the lowest usage folder.
- If the usage percentage of the vhost is empty, set auto-selected vhost to the default folder.

## Screenshots
- create `autoSelectedVhostFolder` folder with auto host.
![image](https://github.com/lablup/backend.ai-webui/assets/28584164/6edaca5c-640b-468c-92b2-77f17a451dc0)
- The auto-selected folder is set to the ceph which is the lowest usage.
![image](https://github.com/lablup/backend.ai-webui/assets/28584164/38c2eed9-ba32-4b0e-8beb-b9e980b3411d)
- But after creating a new folder, the original host name (ceph) will be displayed on the storage list.
![image](https://github.com/lablup/backend.ai-webui/assets/28584164/4cae4f35-6108-45d9-9a95-8b7ef20ae5e3)
- Info description. The usage info will follow the original host's (ceph).
![image](https://github.com/lablup/backend.ai-webui/assets/28584164/a618f955-8ee6-47db-930c-575a5a4f7a3c)
