### PR TITLE
feat: update legacy key(`ram`) from device metadata

### DIFF
--- a/resources/device_metadata.json
+++ b/resources/device_metadata.json
@@ -11,7 +11,7 @@
       },
       "display_icon": "cpu"
     },
-    "ram": {
+    "mem": {
       "slot_name": "ram",
       "description": "Memory",
       "human_readable_name": "RAM",


### PR DESCRIPTION
This PR updates a legacy key `ram` to `mem`, following the manager.

https://github.com/lablup/backend.ai/blob/dc6b85868fe5cb8b5aea5ba58c62d579fd38d101/src/ai/backend/manager/api/etcd.py#L36-L43
