### PR TITLE
feat: display vfolder in Service detail page

### DIFF
--- a/react/relay.config.js
+++ b/react/relay.config.js
@@ -26,4 +26,7 @@ module.exports = {
   featureFlags: {
     enable_relay_resolver_transform: true,
   },
+  customScalars: {
+    UUID: 'string'
+  }
 };

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -24,7 +24,12 @@ import { BrowserRouter, useNavigate } from 'react-router-dom';
 interface WebComponentContextType {
   value?: ReactWebComponentProps['value'];
   dispatchEvent: ReactWebComponentProps['dispatchEvent'];
-  moveTo: (path: string) => void;
+  moveTo: (
+    path: string,
+    params?: {
+      [key in string]?: boolean | string | number;
+    },
+  ) => void;
 }
 
 const WebComponentContext = React.createContext<WebComponentContextType>(null!);
@@ -105,10 +110,10 @@ const DefaultProviders: React.FC<DefaultProvidersProps> = ({
     return {
       value,
       dispatchEvent,
-      moveTo: (path: string) => {
-        dispatchEvent('moveTo', { path });
+      moveTo: (path, params) => {
+        dispatchEvent('moveTo', { path, params: params });
       },
-    };
+    } as WebComponentContextType;
   }, [value, dispatchEvent]);
   return (
     <>

--- a/react/src/components/VFolderLazyView.tsx
+++ b/react/src/components/VFolderLazyView.tsx
@@ -2,7 +2,6 @@ import { useBaiSignedRequestWithPromise } from '../helper';
 import { useCurrentProjectValue } from '../hooks';
 import { useTanQuery } from '../hooks/reactQueryAlias';
 import { useWebComponentInfo } from './DefaultProviders';
-import Flex from './Flex';
 import { VFolder } from './VFolderSelect';
 import { FolderOutlined } from '@ant-design/icons';
 import { Typography } from 'antd';
@@ -19,7 +18,7 @@ const VFolderLazyView: React.FC<VFolderLazyViewProps> = ({
   const currentProject = useCurrentProjectValue();
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
 
-  const { moveTo, dispatchEvent } = useWebComponentInfo();
+  const { moveTo } = useWebComponentInfo();
   const { data: vFolders } = useTanQuery({
     queryKey: ['VFolderSelectQuery'],
     queryFn: () => {

--- a/react/src/components/VFolderLazyView.tsx
+++ b/react/src/components/VFolderLazyView.tsx
@@ -1,0 +1,56 @@
+import { useBaiSignedRequestWithPromise } from '../helper';
+import { useCurrentProjectValue } from '../hooks';
+import { useTanQuery } from '../hooks/reactQueryAlias';
+import { useWebComponentInfo } from './DefaultProviders';
+import Flex from './Flex';
+import { VFolder } from './VFolderSelect';
+import { FolderOutlined } from '@ant-design/icons';
+import { Typography } from 'antd';
+import React from 'react';
+
+interface VFolderLazyViewProps {
+  uuid: string;
+  clickable?: boolean;
+}
+const VFolderLazyView: React.FC<VFolderLazyViewProps> = ({
+  uuid,
+  clickable,
+}) => {
+  const currentProject = useCurrentProjectValue();
+  const baiRequestWithPromise = useBaiSignedRequestWithPromise();
+
+  const { moveTo, dispatchEvent } = useWebComponentInfo();
+  const { data: vFolders } = useTanQuery({
+    queryKey: ['VFolderSelectQuery'],
+    queryFn: () => {
+      return baiRequestWithPromise({
+        method: 'GET',
+        url: `/folders?group_id=${currentProject.id}`,
+      }) as Promise<VFolder[]>;
+    },
+    staleTime: 1000,
+    suspense: true,
+  });
+  const vFolder = vFolders?.find(
+    // `id` of `/folders` API is not UUID, but UUID without `-`
+    (vFolder) => vFolder.id === uuid.replaceAll('-', ''),
+  );
+  return (
+    vFolder &&
+    (clickable ? (
+      <Typography.Link
+        onClick={() => {
+          moveTo('/data', { folder: vFolder.name });
+        }}
+      >
+        <FolderOutlined /> {vFolder.name}
+      </Typography.Link>
+    ) : (
+      <div>
+        <FolderOutlined /> {vFolder.name}
+      </div>
+    ))
+  );
+};
+
+export default VFolderLazyView;

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -5,7 +5,7 @@ import { Select, SelectProps } from 'antd';
 import _ from 'lodash';
 import React, { startTransition, useEffect } from 'react';
 
-type VFolder = {
+export type VFolder = {
   name: string;
   id: string;
   quota_scope_id: string;

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -331,7 +331,7 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
               )}
             </Flex>
           </Descriptions.Item>
-          <Descriptions.Item label="Image">
+          <Descriptions.Item label={t('modelService.Image')}>
             {endpoint?.image && (
               <Flex direction="row" gap={'xs'}>
                 <ImageMetaIcon image={endpoint.image} />

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -337,20 +337,20 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
               )}
             </Flex>
           </Descriptions.Item>
-          <Descriptions.Item label={t('modelService.Image')}>
+          <Descriptions.Item label={t('session.launcher.ModelStorage')}>
+            <Suspense fallback={<Spin indicator={<LoadingOutlined spin />} />}>
+              {endpoint?.model && (
+                <VFolderLazyView uuid={endpoint?.model} clickable={false} />
+              )}
+            </Suspense>
+          </Descriptions.Item>
+          <Descriptions.Item label={t('modelService.Image')} span={2}>
             {endpoint?.image && (
               <Flex direction="row" gap={'xs'}>
                 <ImageMetaIcon image={endpoint.image} />
                 <CopyableCodeText>{endpoint.image}</CopyableCodeText>
               </Flex>
             )}
-          </Descriptions.Item>
-          <Descriptions.Item label={t('session.launcher.ModelStorage')}>
-            <Suspense fallback={<Spin indicator={<LoadingOutlined spin />} />}>
-              {endpoint?.model && (
-                <VFolderLazyView uuid={endpoint?.model} clickable />
-              )}
-            </Suspense>
           </Descriptions.Item>
         </Descriptions>
       </Card>

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -2,10 +2,12 @@ import CopyableCodeText from '../components/CopyableCodeText';
 import EndpointStatusTag from '../components/EndpointStatusTag';
 import EndpointTokenGenerationModal from '../components/EndpointTokenGenerationModal';
 import Flex from '../components/Flex';
+import FlexActivityIndicator from '../components/FlexActivityIndicator';
 import ImageMetaIcon from '../components/ImageMetaIcon';
 import ModelServiceSettingModal from '../components/ModelServiceSettingModal';
 import ResourceNumber, { ResourceTypeKey } from '../components/ResourceNumber';
 import ServingRouteErrorModal from '../components/ServingRouteErrorModal';
+import VFolderLazyView from '../components/VFolderLazyView';
 import { ServingRouteErrorModalFragment$key } from '../components/__generated__/ServingRouteErrorModalFragment.graphql';
 import { baiSignedRequestWithPromise } from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
@@ -17,6 +19,7 @@ import {
 import {
   CheckOutlined,
   CloseOutlined,
+  LoadingOutlined,
   PlusOutlined,
   QuestionCircleOutlined,
   ReloadOutlined,
@@ -28,7 +31,9 @@ import {
   Button,
   Card,
   Descriptions,
+  Grid,
   Popover,
+  Spin,
   Table,
   Tag,
   Tooltip,
@@ -38,7 +43,7 @@ import {
 import graphql from 'babel-plugin-relay/macro';
 import { default as dayjs } from 'dayjs';
 import _ from 'lodash';
-import React, { useState, useTransition } from 'react';
+import React, { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyLoadQuery } from 'react-relay';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -123,6 +128,8 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
               ...ServingRouteErrorModalFragment
             }
             retries
+            model
+            model_mount_destiation
             resource_group
             resource_slots
             resource_opts
@@ -159,7 +166,7 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
         tokenListOffset:
           (paginationState.current - 1) * paginationState.pageSize,
         tokenListLimit: paginationState.pageSize,
-        endpointId: serviceId,
+        endpointId: serviceId || '',
       },
       {
         fetchPolicy:
@@ -167,7 +174,6 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
         fetchKey,
       },
     );
-
   const mutationToClearError = useTanMutation(() => {
     if (!endpoint) return;
     return baiSignedRequestWithPromise({
@@ -339,6 +345,13 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
               </Flex>
             )}
           </Descriptions.Item>
+          <Descriptions.Item label={t('session.launcher.ModelStorage')}>
+            <Suspense fallback={<Spin indicator={<LoadingOutlined spin />} />}>
+              {endpoint?.model && (
+                <VFolderLazyView uuid={endpoint?.model} clickable />
+              )}
+            </Suspense>
+          </Descriptions.Item>
         </Descriptions>
       </Card>
       <Card
@@ -456,7 +469,9 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
                           type="text"
                           icon={<QuestionCircleOutlined />}
                           style={{ color: token.colorTextSecondary }}
-                          onClick={() => openSessionErrorModal(session)}
+                          onClick={() =>
+                            session && openSessionErrorModal(session)
+                          }
                         />
                       </Popover>
                     )}

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -2,7 +2,6 @@ import CopyableCodeText from '../components/CopyableCodeText';
 import EndpointStatusTag from '../components/EndpointStatusTag';
 import EndpointTokenGenerationModal from '../components/EndpointTokenGenerationModal';
 import Flex from '../components/Flex';
-import FlexActivityIndicator from '../components/FlexActivityIndicator';
 import ImageMetaIcon from '../components/ImageMetaIcon';
 import ModelServiceSettingModal from '../components/ModelServiceSettingModal';
 import ResourceNumber, { ResourceTypeKey } from '../components/ResourceNumber';
@@ -31,7 +30,6 @@ import {
   Button,
   Card,
   Descriptions,
-  Grid,
   Popover,
   Spin,
   Table,
@@ -342,6 +340,7 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
               {endpoint?.model && (
                 <VFolderLazyView uuid={endpoint?.model} clickable={false} />
               )}
+              ㄱ
             </Suspense>
           </Descriptions.Item>
           <Descriptions.Item label={t('modelService.Image')} span={2}>

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -340,7 +340,6 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
               {endpoint?.model && (
                 <VFolderLazyView uuid={endpoint?.model} clickable={false} />
               )}
-              ㄱ
             </Suspense>
           </Descriptions.Item>
           <Descriptions.Item label={t('modelService.Image')} span={2}>

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -357,7 +357,7 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
       >
         <Table
           scroll={{ x: 'max-content' }}
-          rowKey={'endpoint_id'}
+          rowKey={'token'}
           columns={[
             {
               title: '#',

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -281,7 +281,7 @@
       "PreOpenPortPanelTitle": "Preopen ports to set (optional)",
       "PreOpenPortRange": "Preopen ports are only available from 1024 to 65535.",
       "MinMemory": "The minimum memory capacity for the currently selected runtime environment is {{size}}iB.",
-      "ModelStorage": "ModelStorage"
+      "ModelStorage": "Model Storage"
     },
     "Preparing": "Preparing...",
     "PreparingSession": "Preparing session...",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -280,7 +280,8 @@
       "PreOpenPortConfigurationDone": "Preopen ports configured successfully.",
       "PreOpenPortPanelTitle": "Preopen ports to set (optional)",
       "PreOpenPortRange": "Preopen ports are only available from 1024 to 65535.",
-      "MinMemory": "The minimum memory capacity for the currently selected runtime environment is {{size}}iB."
+      "MinMemory": "The minimum memory capacity for the currently selected runtime environment is {{size}}iB.",
+      "ModelStorage": "ModelStorage"
     },
     "Preparing": "Preparing...",
     "PreparingSession": "Preparing session...",
@@ -453,7 +454,8 @@
     "TokenExpiredDateError": "The token expiration time must be after the current time",
     "ServiceNameRule": "Only allow 4 to 64 characters of alphanumeric, underscore(_), hyphen(-), and period(.) and it must end with an alphanumeric character.",
     "FormValidationFailed": "Form validation failed",
-    "resources": "Resources"
+    "resources": "Resources",
+    "Image": "Image"
   },
   "button": {
     "Cancel": "Cancel",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -266,7 +266,8 @@
       "PrePortConfigWillDisappear": "__NOT_TRANSLATED__",
       "PreOpenPortPanelTitle": "__NOT_TRANSLATED__",
       "PreOpenPortRange": "__NOT_TRANSLATED__",
-      "MinMemory": "__NOT_TRANSLATED__"
+      "MinMemory": "__NOT_TRANSLATED__",
+      "ModelStorage": "__NOT_TRANSLATED__"
     },
     "Preparing": "En train de préparer...",
     "PreparingSession": "Séance de préparation...",
@@ -1519,7 +1520,8 @@
     "TokenExpiredDateError": "__NOT_TRANSLATED__",
     "FormValidationFailed": "__NOT_TRANSLATED__",
     "ServiceNameRule": "__NOT_TRANSLATED__",
-    "resources": "__NOT_TRANSLATED__"
+    "resources": "__NOT_TRANSLATED__",
+    "Image": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "__NOT_TRANSLATED__",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -266,7 +266,8 @@
       "PrePortConfigWillDisappear": "__NOT_TRANSLATED__",
       "PreOpenPortPanelTitle": "__NOT_TRANSLATED__",
       "PreOpenPortRange": "__NOT_TRANSLATED__",
-      "MinMemory": "__NOT_TRANSLATED__"
+      "MinMemory": "__NOT_TRANSLATED__",
+      "ModelStorage": "__NOT_TRANSLATED__"
     },
     "Preparing": "Mempersiapkan...",
     "PreparingSession": "Mempersiapkan sesi...",
@@ -1519,7 +1520,8 @@
     "TokenExpiredDateError": "__NOT_TRANSLATED__",
     "FormValidationFailed": "__NOT_TRANSLATED__",
     "ServiceNameRule": "__NOT_TRANSLATED__",
-    "resources": "__NOT_TRANSLATED__"
+    "resources": "__NOT_TRANSLATED__",
+    "Image": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "__NOT_TRANSLATED__",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -257,6 +257,7 @@
       "InferenceMode": "Inference",
       "ImageDoesNotProvideModelPath": "모델 경로를 지정하지 않은 컨테이너 이미지입니다. 수정이 필요합니다.",
       "ModelStorageToMount": "마운트할 모델 스토리지 폴더",
+      "ModelStorage": "모델 스토리지 폴더",
       "AIAccelerator": "AI 가속기",
       "DescAIAccelerator": "<p>AI 가속기 (GPU 및 NPU)는 기계 학습과 관련된 행렬 / 벡터 계산에 적합합니다. AI 가속기는 훈련 및 인퍼런스 알고리즘을 몇 배나 가속화하여 기계 학습 워크로드의 실행 시간을 몇 주에서 며칠로 줄입니다.</p>",
       "PreOpenPortTitle": "사전 개방 포트",
@@ -441,7 +442,8 @@
     "TokenExpiredDateError": "토큰 만료 시간은 현재 시간 이후여야 합니다.",
     "ServiceNameRule": "4~64자의 영문, 숫자, 밑줄(_), 하이픈(-), 마침표(.)만 허용하며, 영문으로 영문이나 숫자로 끝나야합니다.",
     "FormValidationFailed": "양식 유효성 검사 실패",
-    "resources": "자원"
+    "resources": "자원",
+    "Image": "이미지"
   },
   "button": {
     "Cancel": "취소",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -266,7 +266,8 @@
       "PrePortConfigWillDisappear": "__NOT_TRANSLATED__",
       "PreOpenPortPanelTitle": "__NOT_TRANSLATED__",
       "PreOpenPortRange": "__NOT_TRANSLATED__",
-      "MinMemory": "__NOT_TRANSLATED__"
+      "MinMemory": "__NOT_TRANSLATED__",
+      "ModelStorage": "__NOT_TRANSLATED__"
     },
     "Preparing": "Бэлтгэж байна ...",
     "PreparingSession": "Session бэлтгэж байна ...",
@@ -1519,7 +1520,8 @@
     "TokenExpiredDateError": "__NOT_TRANSLATED__",
     "FormValidationFailed": "__NOT_TRANSLATED__",
     "ServiceNameRule": "__NOT_TRANSLATED__",
-    "resources": "__NOT_TRANSLATED__"
+    "resources": "__NOT_TRANSLATED__",
+    "Image": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "__NOT_TRANSLATED__",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -266,7 +266,8 @@
       "PrePortConfigWillDisappear": "__NOT_TRANSLATED__",
       "PreOpenPortPanelTitle": "__NOT_TRANSLATED__",
       "PreOpenPortRange": "__NOT_TRANSLATED__",
-      "MinMemory": "__NOT_TRANSLATED__"
+      "MinMemory": "__NOT_TRANSLATED__",
+      "ModelStorage": "__NOT_TRANSLATED__"
     },
     "Preparing": "Подготовка ...",
     "PreparingSession": "Подготовка сеанса ...",
@@ -1519,7 +1520,8 @@
     "TokenExpiredDateError": "__NOT_TRANSLATED__",
     "FormValidationFailed": "__NOT_TRANSLATED__",
     "ServiceNameRule": "__NOT_TRANSLATED__",
-    "resources": "__NOT_TRANSLATED__"
+    "resources": "__NOT_TRANSLATED__",
+    "Image": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "__NOT_TRANSLATED__",

--- a/src/components/backend-ai-serving-list.ts
+++ b/src/components/backend-ai-serving-list.ts
@@ -2,10 +2,12 @@
  @license
 Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
 */
+import { navigate } from '../backend-ai-app';
 import {
   IronFlex,
   IronFlexAlignment,
 } from '../plastics/layout/iron-flex-layout-classes';
+import { store } from '../store';
 import { BackendAiStyles } from './backend-ai-general-styles';
 import { BackendAIPage } from './backend-ai-page';
 import '@material/mwc-circular-progress';
@@ -47,7 +49,18 @@ export default class BackendAIServingList extends BackendAIPage {
   render() {
     // language=HTML
     return html`
-      <backend-ai-react-serving-list></backend-ai-react-serving-list>
+      <backend-ai-react-serving-list
+        @moveTo="${(e: CustomEvent) => {
+          const path = e.detail.path;
+          const params = e.detail.params;
+          globalThis.history.pushState(
+            {},
+            '',
+            path + '?folder=' + params.folder,
+          );
+          store.dispatch(navigate(decodeURIComponent(path), params));
+        }}"
+      ></backend-ai-react-serving-list>
     `;
   }
 }


### PR DESCRIPTION
After:
<img width="1185" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/837ceb5f-9e59-4276-a4ea-871376d3eca4">

This PR doesn't include the open the folder by clicking on the Service detail page.

---

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 884164a</samp>

### Summary
🛠️📁🌐

<!--
1.  🛠️ - This emoji represents the changes related to the relay.config.js file, the VFolder type, and the moveTo function, which are all technical improvements or fixes that enhance the functionality or performance of the web UI.
2. 📁 - This emoji represents the changes related to the VFolderLazyView.tsx component, the model storage folder information, and the navigation to the data page with a specific virtual folder, which are all features that involve displaying or accessing virtual folders or data in the web UI.
3. 🌐 - This emoji represents the changes related to the translation keys and values for the ModelStorage and Image labels, which are all localization updates that support different languages in the web UI.
-->
This pull request adds a feature to show and navigate to the model storage folders for each model service in the web UI. It updates the GraphQL schema, the relay configuration, the web component context, and the routing list page to support this feature. It also adds new translation keys and values for the service detail labels in various languages.

> _`relay.config.js`_
> _Custom scalars for GraphQL_
> _Autumn leaves falling_

### Walkthrough
*  Add a customScalars field to the relay config file to handle the UUID scalar type in the GraphQL schema ([link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-78a5d0314616c9bfa2e49b1fb473aba3a9418108d13ff3085c5785cc3d8355e3R29-R31))
*  Export the VFolder type from VFolderSelect.tsx and add a new component VFolderLazyView.tsx to render a virtual folder name with an optional link to the data page using react-query and suspense ([link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-37a0a7c2be6ca99e2f4289ab07f658bc6af9db215c5a77d516d26659070a9717R1-R55), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-d191efffefe30deea0936aba97b2645040e05e1276691079ca15866550abbdefL8-R8))
*  Modify the WebComponentContextType interface and the moveTo function in DefaultProviders.tsx to accept an optional params argument for passing additional parameters to the moveTo event handler ([link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-1ec6f89edfe2d9ae74244de78c2c81173269c809f471dd0195a10bc02420f860L27-R32), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-1ec6f89edfe2d9ae74244de78c2c81173269c809f471dd0195a10bc02420f860L108-R116))
*  Import the VFolderLazyView component, the LoadingOutlined icon, the Spin component, and the Suspense component in RoutingListPage.tsx to show the model storage folder information for each model service in the service detail panel ([link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-b95c8773f0011bade5e876018f34889f34d54b495ccdabe90c2d81a7ca5334e8R9), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-b95c8773f0011bade5e876018f34889f34d54b495ccdabe90c2d81a7ca5334e8R21), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-b95c8773f0011bade5e876018f34889f34d54b495ccdabe90c2d81a7ca5334e8R34), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-b95c8773f0011bade5e876018f34889f34d54b495ccdabe90c2d81a7ca5334e8L41-R44))
*  Add the model and model_mount_destination fields to the modelServiceQuery in RoutingListPage.tsx and add a fallback value for the endpointId variable ([link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-b95c8773f0011bade5e876018f34889f34d54b495ccdabe90c2d81a7ca5334e8R129-R130), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-b95c8773f0011bade5e876018f34889f34d54b495ccdabe90c2d81a7ca5334e8L162-R167))
*  Add a new Descriptions.Item component in RoutingListPage.tsx to render the model storage folder name using the VFolderLazyView component inside a Suspense component and modify the label and span props of the existing Descriptions.Item component that renders the image name ([link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-b95c8773f0011bade5e876018f34889f34d54b495ccdabe90c2d81a7ca5334e8L334-R346))
*  Replace the endpoint_id field with the token field as the rowKey prop of the Table component in RoutingListPage.tsx to avoid potential errors or duplicates when rendering the table rows ([link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-b95c8773f0011bade5e876018f34889f34d54b495ccdabe90c2d81a7ca5334e8L360-R372))
*  Add a null check for the session variable in RoutingListPage.tsx to avoid calling the openSessionErrorModal function with a null or undefined value ([link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-b95c8773f0011bade5e876018f34889f34d54b495ccdabe90c2d81a7ca5334e8L459-R473))
*  Import the navigate function, the store, and the globalThis in backend-ai-serving-list.ts and add a moveTo event listener to the backend-ai-react-serving-list component to handle the moveTo event from the VFolderLazyView component and navigate to the data page with the selected virtual folder ([link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-41a34aa9c45062d3addaba2d47b5ed1e2de7237d854b55fe7f4771db12d6b43cL5-R10), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-41a34aa9c45062d3addaba2d47b5ed1e2de7237d854b55fe7f4771db12d6b43cL50-R63))
*  Add new translation keys and values for the ModelStorage and Image labels in en.json, fr.json, id.json, ko.json, mn.json, and ru.json and mark the values as __NOT_TRANSLATED__ for the languages other than English and Korean ([link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-5295c72e8e9f81f41ad24071df9b7dba8bf9672ff8d5c37d587f374166008f44L283-R284), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-5295c72e8e9f81f41ad24071df9b7dba8bf9672ff8d5c37d587f374166008f44L456-R458), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-cb28ed7aa2d69a36b056c5fc48c220ac0634c320118dd903ffa7b508e6656f24L269-R270), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-cb28ed7aa2d69a36b056c5fc48c220ac0634c320118dd903ffa7b508e6656f24L1522-R1524), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-efa18d69e25ee4acbf51802e5b7d487d283299cbcbbc319388b175bcf1a0426bL269-R270), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-efa18d69e25ee4acbf51802e5b7d487d283299cbcbbc319388b175bcf1a0426bL1522-R1524), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-42a74440ee50b3644e615a3a3c71a4a6ae54dff82f52b5eccf3aaf22b4811b1cR260), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-42a74440ee50b3644e615a3a3c71a4a6ae54dff82f52b5eccf3aaf22b4811b1cL444-R446), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-0e2edcc06e27c33466506878abd4fcbad53e695960932b8de70aedcb6f9fe301L269-R270), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-0e2edcc06e27c33466506878abd4fcbad53e695960932b8de70aedcb6f9fe301L1522-R1524), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-00509cee1359d9305e94d87843979c41295c5768c2e4b0b7f07519c341fd7ff7L269-R270), [link](https://github.com/lablup/backend.ai-webui/pull/1924/files?diff=unified&w=0#diff-00509cee1359d9305e94d87843979c41295c5768c2e4b0b7f07519c341fd7ff7L1522-R1524))

