### PR TITLE
fix: the ant.d tooltip is covered in modal with mwc drawer

### DIFF
--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -130,7 +130,7 @@ const DefaultProviders: React.FC<DefaultProvidersProps> = ({
                   <ConfigProvider
                     // @ts-ignore
                     getPopupContainer={(triggerNode) => {
-                      return shadowRoot;
+                      return triggerNode?.parentNode || shadowRoot;
                     }}
                     //TODO: apply other supported locales
                     locale={'ko' === lang ? ko_KR : en_US}

--- a/react/src/fix_antd.css
+++ b/react/src/fix_antd.css
@@ -52,7 +52,13 @@
   }
 }
 
+/* fix: fixed column shadow display outside of a table wrapper */
 .ant-table-wrapper {
   border-radius: 8px 8px 0 0;
   overflow: hidden;
+}
+
+/* fix: the tooltip does not appear in the `<Form.Item tooltip={'something'}` when the popup container is a parent node of the trigger node. */
+.ant-form-item-label {
+  overflow: unset !important;
 }


### PR DESCRIPTION
resolve #1923 
How to test:
- Open the service launcher modal.
- Change the browser window size to narrow (like the screen below, the modal has to be displayed over the the sider of mwc-drawer)
- Hover over the `?` icon next to the CPU label."

After:
<img width="623" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/dec3fc97-de61-44ee-9c86-4e34c771ccb3">
