### PR TITLE
ci: Manage actions version with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    allow:
+      - dependency-name: actions/*
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"


### PR DESCRIPTION
Manage the version of github actions with dependabot.
First, only actions officially provided by the github actions team are applied first.

In the case of other external actions, there may be unknown update history, so I think it is necessary to check.