### PR TITLE
fix: broken `Select` UI by using inline-flex (since ant.d 5.9.1)

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -275,17 +275,20 @@ const ImageEnvironmentSelectFormItems: React.FC<
                         extraFilterValues.join('\t')
                       }
                       label={
-                        <Flex direction="row">
-                          <Flex direction="row" align="center" gap="xs">
-                            <ImageMetaIcon
-                              image={getImageFullName(firstImage) || ''}
-                              style={{
-                                width: 15,
-                                height: 15,
-                              }}
-                            />
-                            {environmentGroup.displayName}
-                          </Flex>
+                        <Flex
+                          direction="row"
+                          align="center"
+                          gap="xs"
+                          style={{ display: 'inline-flex' }}
+                        >
+                          <ImageMetaIcon
+                            image={getImageFullName(firstImage) || ''}
+                            style={{
+                              width: 15,
+                              height: 15,
+                            }}
+                          />
+                          {environmentGroup.displayName}
                         </Flex>
                       }
                     >


### PR DESCRIPTION
After updating Antd to version 5.9.1 via #1932 , the block type label of a Select UI has broken.

# Before
<img width="497" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/86c3d0d8-9498-4872-9c2f-95193d189bc3">

# After
<img width="494" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/67af8874-85ec-43e6-aa13-5d01d50d3258">
