### PR TITLE
fix: resolve resource allocation related errors in session launchers when there are multiple AI accelerators.

### DIFF
--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -390,7 +390,7 @@ export default class BackendAiResourceBroker extends BackendAIPage {
               (this.gpu_modes as Array<string>).push(k);
             }
 
-            // Set gpu device as largest among available slots
+            // Set gpu device as the largest one among available slots
             if (
               k in results &&
               this.available_slot.hasOwnProperty(v) &&

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -972,9 +972,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     >
                       <span class="gauge-name">IPU</span>
                     </div>
-                    <div
-                      class="layout vertical center-justified wrap short-indicator"
-                    >
+                    <div class="layout vertical center-justified wrap">
                       <lablup-progress-bar
                         id="ipu-usage-bar"
                         class="start"

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -924,9 +924,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     >
                       <span class="gauge-name">TPU</span>
                     </div>
-                    <div
-                      class="layout vertical center-justified wrap short-indicator"
-                    >
+                    <div class="layout vertical center-justified wrap">
                       <lablup-progress-bar
                         id="tpu-usage-bar"
                         class="start"
@@ -1018,9 +1016,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     >
                       <span class="gauge-name">ATOM</span>
                     </div>
-                    <div
-                      class="layout vertical center-justified wrap short-indicator"
-                    >
+                    <div class="layout vertical center-justified wrap">
                       <lablup-progress-bar
                         id="atom-usage-bar"
                         class="start"
@@ -1066,9 +1062,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     >
                       <span class="gauge-name">Warboy</span>
                     </div>
-                    <div
-                      class="layout vertical center-justified wrap short-indicator"
-                    >
+                    <div class="layout vertical center-justified wrap">
                       <lablup-progress-bar
                         id="warboy-usage-bar"
                         class="start"

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -3171,8 +3171,8 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     let gpu_type;
     let gpu_value;
     if (
-      typeof cuda_device !== 'undefined' ||
-      typeof cuda_shares !== 'undefined'
+      (typeof cuda_device !== 'undefined' && Number(cuda_device) > 0) ||
+      (typeof cuda_shares !== 'undefined' && Number(cuda_shares) > 0)
     ) {
       if (typeof cuda_device === 'undefined') {
         // FGPU
@@ -3182,19 +3182,22 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
         gpu_type = 'cuda.device';
         gpu_value = cuda_device;
       }
-    } else if (typeof rocm_device !== 'undefined') {
+    } else if (typeof rocm_device !== 'undefined' && Number(rocm_device) > 0) {
       gpu_type = 'rocm.device';
       gpu_value = rocm_device;
-    } else if (typeof tpu_device !== 'undefined') {
+    } else if (typeof tpu_device !== 'undefined' && Number(tpu_device) > 0) {
       gpu_type = 'tpu.device';
       gpu_value = tpu_device;
-    } else if (typeof ipu_device !== 'undefined') {
+    } else if (typeof ipu_device !== 'undefined' && Number(ipu_device) > 0) {
       gpu_type = 'ipu.device';
       gpu_value = ipu_device;
-    } else if (typeof atom_device !== 'undefined') {
+    } else if (typeof atom_device !== 'undefined' && Number(atom_device) > 0) {
       gpu_type = 'atom.device';
       gpu_value = atom_device;
-    } else if (typeof warboy_device !== 'undefined') {
+    } else if (
+      typeof warboy_device !== 'undefined' &&
+      Number(warboy_device) > 0
+    ) {
       gpu_type = 'warboy.device';
       gpu_value = warboy_device;
     } else {

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1212,7 +1212,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       if (forceUpdate === true) {
         await this._refreshResourcePolicy();
       } else {
-        this.updateResourceAllocationPane('session dialog');
+        await this.updateResourceAllocationPane('session dialog');
       }
     }
   }

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -3514,6 +3514,13 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
     (this.resourceTemplatesSelect as any).selectedText = _text(
       'session.launcher.CustomResourceApplied',
     );
+
+    this._updateResourceIndicator(
+      this.cpu_request,
+      this.mem_request,
+      this.gpu_mode,
+      this.gpu_request,
+    );
   }
 
   /**

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -5016,7 +5016,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                 icon="storage"
                 required
                 fixedMenuPosition
-                @selected="${(e) => this.updateScalingGroup(false, e)}"
+                @selected="${(e) => this.updateScalingGroup(true, e)}"
               >
                 ${this.scaling_groups.map(
                   (item) => html`

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -3074,7 +3074,7 @@ ${rowData.item[this.sessionNameField]}</pre
               ${rowData.item.ipu_slot
                 ? html`
                     <mwc-icon class="fg green indicator">view_module</mwc-icon>
-                    <span>${rowData.item.tpu_slot}</span>
+                    <span>${rowData.item.ipu_slot}</span>
                     <span class="indicator">IPU</span>
                   `
                 : html``}


### PR DESCRIPTION
resolve https://github.com/lablup/giftbox/issues/521
- fix: typo error so that displaying the allocated IPU
<img width="229" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/28584164/70942d00-3c84-44e2-9d2c-7d1e4e07a1e6">

- When the user changed the resource group, the custom allocation items were updated to indicate the accelerators supported by the resource group.
- Resolved the mismatch between the selected resource preset and custom allocation and the requested resources when there are multiple accelerators.
- style: fix the broken UI of resource gauge (IPU)

| Before | After |
|--------|--------|
| <img width="327" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/28584164/196beda4-7206-45b4-82e0-591cc2ca313e"> | <img width="274" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/28584164/f6753229-6f72-47c4-ad88-7d5d046f7177"> | 

> **Note**
The required resources are different based on the container image. For example, `python-pytorch` image needs IPU, but `ngc-pytorch` image needs GPU. So when you want to create a session with `python-pytorch` image, use the `ipu` resource group to use AI accelerator.
