### PR TITLE
fix: remove warnings/errors and unused logs in the browser console

### DIFF
--- a/react/src/RelayEnvironment.ts
+++ b/react/src/RelayEnvironment.ts
@@ -36,15 +36,12 @@ const fetchFn: FetchFunction = async (
     reqBody,
   );
 
-  console.log('##############');
-  console.log(reqBody);
   const result =
     //@ts-ignore
     (await globalThis.backendaiclient
       ?._wrapWithPromise(reqInfo, false, null, 10000, 0)
       .catch((err: any) => {
-        console.log('######@@@@@@@@@@@@@');
-        console.log(err);
+        // console.log(err);
       })) || {};
 
   return result;

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -283,68 +283,97 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
           style={{
             backgroundColor: token.colorBgBase,
           }}
-        >
-          <Descriptions.Item label={t('modelService.EndpointName')}>
-            <Typography.Text copyable>{endpoint?.name}</Typography.Text>
-          </Descriptions.Item>
-          <Descriptions.Item label={t('modelService.Status')}>
-            <EndpointStatusTag endpointFrgmt={endpoint} />
-          </Descriptions.Item>
-          <Descriptions.Item label={t('modelService.EndpointId')}>
-            {endpoint?.endpoint_id}
-          </Descriptions.Item>
-          <Descriptions.Item label={t('modelService.SessionOwner')}>
-            {baiClient.email || ''}
-          </Descriptions.Item>
-          <Descriptions.Item label={t('modelService.DesiredSessionCount')}>
-            {endpoint?.desired_session_count}
-          </Descriptions.Item>
-          <Descriptions.Item label={t('modelService.ServiceEndpoint')}>
-            {endpoint?.url ? (
-              <Typography.Text copyable>{endpoint?.url}</Typography.Text>
-            ) : (
-              <Tag>{t('modelService.NoServiceEndpoint')}</Tag>
-            )}
-          </Descriptions.Item>
-          <Descriptions.Item label={t('modelService.OpenToPublic')}>
-            {endpoint?.open_to_public ? <CheckOutlined /> : <CloseOutlined />}
-          </Descriptions.Item>
-          <Descriptions.Item label={t('modelService.resources')} span={2}>
-            <Flex direction="row" wrap="wrap" gap={'md'}>
-              <Tooltip title={t('session.ResourceGroup')}>
-                <Tag>{endpoint?.resource_group}</Tag>
-              </Tooltip>
-              {_.map(
-                JSON.parse(endpoint?.resource_slots || '{}'),
-                (value: string, type: ResourceTypeKey) => {
-                  return (
-                    <ResourceNumber
-                      key={type}
-                      type={type}
-                      value={value}
-                      opts={resource_opts}
-                    />
-                  );
-                },
-              )}
-            </Flex>
-          </Descriptions.Item>
-          <Descriptions.Item label={t('session.launcher.ModelStorage')}>
-            <Suspense fallback={<Spin indicator={<LoadingOutlined spin />} />}>
-              {endpoint?.model && (
-                <VFolderLazyView uuid={endpoint?.model} clickable={false} />
-              )}
-            </Suspense>
-          </Descriptions.Item>
-          <Descriptions.Item label={t('modelService.Image')} span={2}>
-            {endpoint?.image && (
-              <Flex direction="row" gap={'xs'}>
-                <ImageMetaIcon image={endpoint.image} />
-                <CopyableCodeText>{endpoint.image}</CopyableCodeText>
-              </Flex>
-            )}
-          </Descriptions.Item>
-        </Descriptions>
+          items={[
+            {
+              label: t('modelService.EndpointName'),
+              children: (
+                <Typography.Text copyable>{endpoint?.name}</Typography.Text>
+              ),
+            },
+            {
+              label: t('modelService.Status'),
+              children: <EndpointStatusTag endpointFrgmt={endpoint} />,
+            },
+            {
+              label: t('modelService.EndpointId'),
+              children: endpoint?.endpoint_id,
+            },
+            {
+              label: t('modelService.SessionOwner'),
+              children: baiClient.email || '',
+            },
+            {
+              label: t('modelService.DesiredSessionCount'),
+              children: endpoint?.desired_session_count,
+            },
+            {
+              label: t('modelService.ServiceEndpoint'),
+              children: endpoint?.url ? (
+                <Typography.Text copyable>{endpoint?.url}</Typography.Text>
+              ) : (
+                <Tag>{t('modelService.NoServiceEndpoint')}</Tag>
+              ),
+            },
+            {
+              label: t('modelService.OpenToPublic'),
+              children: endpoint?.open_to_public ? (
+                <CheckOutlined />
+              ) : (
+                <CloseOutlined />
+              ),
+            },
+            {
+              label: t('modelService.resources'),
+              children: (
+                <Flex direction="row" wrap="wrap" gap={'md'}>
+                  <Tooltip title={t('session.ResourceGroup')}>
+                    <Tag>{endpoint?.resource_group}</Tag>
+                  </Tooltip>
+                  {_.map(
+                    JSON.parse(endpoint?.resource_slots || '{}'),
+                    (value: string, type: ResourceTypeKey) => {
+                      return (
+                        <ResourceNumber
+                          key={type}
+                          type={type}
+                          value={value}
+                          opts={resource_opts}
+                        />
+                      );
+                    },
+                  )}
+                </Flex>
+              ),
+              span: {
+                xl: 2,
+              },
+            },
+            {
+              label: t('session.launcher.ModelStorage'),
+              children: (
+                <Suspense
+                  fallback={<Spin indicator={<LoadingOutlined spin />} />}
+                >
+                  {endpoint?.model && (
+                    <VFolderLazyView uuid={endpoint?.model} clickable={false} />
+                  )}
+                </Suspense>
+              ),
+            },
+            {
+              label: t('modelService.Image'),
+              children: endpoint?.image && (
+                <Flex direction="row" gap={'xs'}>
+                  <ImageMetaIcon image={endpoint.image} />
+                  <CopyableCodeText>{endpoint.image}</CopyableCodeText>
+                </Flex>
+              ),
+              span: {
+                xl: 2,
+              },
+            },
+          ]}
+        ></Descriptions>
       </Card>
       <Card
         title={t('modelService.GeneratedTokens')}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 621b8d6</samp>

### Summary
🔧🚀🖥️

<!--
1.  🔧 - This emoji represents a wrench or a tool, and can be used to indicate a refactoring or improvement of existing code. This emoji is suitable for the first change, which refactors the `Descriptions` component to simplify the code and enhance the layout.
2. 🚀 - This emoji represents a rocket or a launch, and can be used to indicate a performance or speed improvement of the code. This emoji is suitable for the second change, which removes or comments out some console logging statements to improve the performance and security of the web UI.
3. 🖥️ - This emoji represents a desktop computer or a monitor, and can be used to indicate a change related to the web UI or the frontend. This emoji is suitable for both changes, since they both affect the web UI of the model service endpoint. Alternatively, one could use 🌐 for the web or 📱 for responsiveness.
-->
This pull request improves the web UI by removing unnecessary console logging in `RelayEnvironment.ts` and refactoring the `Descriptions` component in `RoutingListPage.tsx`. These changes enhance the performance, security, readability, and responsiveness of the web UI.

> _Oh we are the coders of the `RoutingListPage`_
> _We make it look simple and easy to engage_
> _We refactor `Descriptions` with `items` and `span`_
> _And we heave away the console logs on the count of three_

### Walkthrough
*  Simplify and adjust the layout of the `Descriptions` component in the `RoutingListPage` component ([link](https://github.com/lablup/backend.ai-webui/pull/1961/files?diff=unified&w=0#diff-b95c8773f0011bade5e876018f34889f34d54b495ccdabe90c2d81a7ca5334e8L286-R376))
*  Remove or comment out the console logging of the request body and the error in the `fetchFn` function in `RelayEnvironment.ts` ([link](https://github.com/lablup/backend.ai-webui/pull/1961/files?diff=unified&w=0#diff-e1757ecad7e9cf3ff6f03bb9ab94ca5fb3693ed22cfdccada07d28f46c46028aL39-L40), [link](https://github.com/lablup/backend.ai-webui/pull/1961/files?diff=unified&w=0#diff-e1757ecad7e9cf3ff6f03bb9ab94ca5fb3693ed22cfdccada07d28f46c46028aL46-R44))

