### PR TITLE
feature: hide sftp resource group

### DIFF
--- a/graphql.config.js
+++ b/graphql.config.js
@@ -2,7 +2,7 @@ module.exports = {
   schema: [
     // To update graphql schema, run `./backend.ai mgr gql show` and copy the output to schema.graphql
     "./react/data/schema.graphql",
-    "./react/data/relay-and-local-directives-for-graphql-config.graphql"
+    // "./react/data/relay-and-local-directives-for-graphql-config.graphql"
   ],
   documents: ["./react/src/**/*.{graphql,ts,tsx}"],
 };

--- a/react/src/components/ResourceGroupSelect.tsx
+++ b/react/src/components/ResourceGroupSelect.tsx
@@ -5,13 +5,13 @@ import { Select, SelectProps } from 'antd';
 import _ from 'lodash';
 import React, { useEffect, useTransition } from 'react';
 
-interface ResourceGroupSelectorProps extends SelectProps {
+interface ResourceGroupSelectProps extends SelectProps {
   projectId?: string;
   autoSelectDefault?: boolean;
   filter?: (projectName: string) => boolean;
 }
 
-const ResourceGroupSelector: React.FC<ResourceGroupSelectorProps> = ({
+const ResourceGroupSelect: React.FC<ResourceGroupSelectProps> = ({
   projectId,
   autoSelectDefault,
   filter,
@@ -22,7 +22,7 @@ const ResourceGroupSelector: React.FC<ResourceGroupSelectorProps> = ({
   const [key, checkUpdate] = useUpdatableState('first');
 
   const [isPendingLoading, startLoadingTransition] = useTransition();
-  const { data: resourceGroupSelectorQueryResult } = useTanQuery<
+  const { data: resourceGroupSelectQueryResult } = useTanQuery<
     [
       {
         scaling_groups: {
@@ -45,7 +45,7 @@ const ResourceGroupSelector: React.FC<ResourceGroupSelectorProps> = ({
       },
     ]
   >({
-    queryKey: ['ResourceGroupSelectorQuery', key, currentProject.name],
+    queryKey: ['ResourceGroupSelectQuery', key, currentProject.name],
     queryFn: () => {
       return Promise.all([
         baiRequestWithPromise({
@@ -62,12 +62,12 @@ const ResourceGroupSelector: React.FC<ResourceGroupSelectorProps> = ({
   });
 
   const sftpResourceGroups = _.flatMap(
-    resourceGroupSelectorQueryResult?.[1].volume_info,
+    resourceGroupSelectQueryResult?.[1].volume_info,
     (item) => item?.sftp_scaling_groups ?? [],
   );
 
   const resourceGroups = _.filter(
-    resourceGroupSelectorQueryResult?.[0].scaling_groups,
+    resourceGroupSelectQueryResult?.[0].scaling_groups,
     (item) => {
       if (_.includes(sftpResourceGroups, item.name)) {
         return false;
@@ -124,4 +124,4 @@ const ResourceGroupSelector: React.FC<ResourceGroupSelectorProps> = ({
   );
 };
 
-export default ResourceGroupSelector;
+export default ResourceGroupSelect;

--- a/react/src/components/ResourceGroupSelect.tsx
+++ b/react/src/components/ResourceGroupSelect.tsx
@@ -2,10 +2,8 @@ import { useBaiSignedRequestWithPromise } from '../helper';
 import { useCurrentProjectValue, useUpdatableState } from '../hooks';
 import { useTanQuery } from '../hooks/reactQueryAlias';
 import { Select, SelectProps } from 'antd';
-import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
-import React, { startTransition, useEffect } from 'react';
-import { useLazyLoadQuery } from 'react-relay';
+import React, { useEffect, useTransition } from 'react';
 
 interface ResourceGroupSelectorProps extends SelectProps {
   projectId?: string;
@@ -23,10 +21,8 @@ const ResourceGroupSelector: React.FC<ResourceGroupSelectorProps> = ({
   const currentProject = useCurrentProjectValue();
   const [key, checkUpdate] = useUpdatableState('first');
 
-  const {
-    data: resourceGroupSelectorQueryResult,
-    isLoading: resourceGroupLoading,
-  } = useTanQuery<
+  const [isPendingLoading, startLoadingTransition] = useTransition();
+  const { data: resourceGroupSelectorQueryResult } = useTanQuery<
     [
       {
         scaling_groups: {
@@ -109,11 +105,12 @@ const ResourceGroupSelector: React.FC<ResourceGroupSelectorProps> = ({
       defaultValue={autoSelectDefault ? autoSelectedOption : undefined}
       onDropdownVisibleChange={(open) => {
         if (open) {
-          startTransition(() => {
+          startLoadingTransition(() => {
             checkUpdate();
           });
         }
       }}
+      loading={isPendingLoading}
       {...selectProps}
     >
       {_.map(resourceGroups, (resourceGroup, idx) => {

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -1,6 +1,10 @@
 import BAIErrorBoundary from './components/BAIErrorBoundary';
+import Flex from './components/Flex';
+import ResourceGroupSelector from './components/ResourceGroupSelect';
 import { loadCustomThemeConfig } from './helper/customThemeConfig';
 import reactToWebComponent from './helper/react-to-webcomponent';
+import { Form } from 'antd';
+import { t } from 'i18next';
 import React, { Suspense } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
@@ -196,6 +200,32 @@ customElements.define(
             props.dispatchEvent('close', null);
           }}
         />
+      </DefaultProviders>
+    );
+  }),
+);
+
+customElements.define(
+  'backend-ai-react-resource-group-select',
+  reactToWebComponent((props) => {
+    return (
+      <DefaultProviders {...props}>
+        <Flex direction="column" align="stretch" style={{ minWidth: 200 }}>
+          <Form layout="vertical">
+            <Form.Item
+              label={t('session.launcher.ResourceGroup')}
+              style={{ margin: 0 }}
+            >
+              <ResourceGroupSelector
+                autoSelectDefault
+                size="large"
+                onChange={(value) => {
+                  props.dispatchEvent('change', value);
+                }}
+              />
+            </Form.Item>
+          </Form>
+        </Flex>
       </DefaultProviders>
     );
   }),

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -1,6 +1,6 @@
 import BAIErrorBoundary from './components/BAIErrorBoundary';
 import Flex from './components/Flex';
-import ResourceGroupSelector from './components/ResourceGroupSelect';
+import ResourceGroupSelect from './components/ResourceGroupSelect';
 import { loadCustomThemeConfig } from './helper/customThemeConfig';
 import reactToWebComponent from './helper/react-to-webcomponent';
 import { Form } from 'antd';
@@ -216,7 +216,7 @@ customElements.define(
               label={t('session.launcher.ResourceGroup')}
               style={{ margin: 0 }}
             >
-              <ResourceGroupSelector
+              <ResourceGroupSelect
                 autoSelectDefault
                 size="large"
                 onChange={(value) => {

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -285,18 +285,21 @@ export default class BackendAiResourceBroker extends BackendAIPage {
         let sgs = await globalThis.backendaiclient.scalingGroup.list(
           this.current_user_group,
         );
-        // TODO: delete these codes after backend.ai support scaling groups filtering.
-        const sftpScalingGroups = await this._sftpScalingGroups();
+        // TODO: Delete these codes after backend.ai support scaling groups filtering.
+        // ================================ START ====================================
+        const sftpResourceGroups = await this._sftpScalingGroups();
         if (sgs.scaling_groups.length > 0) {
           sgs = sgs.scaling_groups.filter(
-            (item) => !sftpScalingGroups?.includes(item.name),
+            (item) => !sftpResourceGroups?.includes(item.name),
           );
         }
+
+        this.scaling_groups = sgs ?? [{ name: '' }];
+        // ================================ END ======================================
 
         // Make empty scaling group item if there is no scaling groups.
         // this.scaling_groups =
         //   sgs.scaling_groups.length > 0 ? sgs.scaling_groups : [{ name: '' }];
-        this.scaling_groups = sgs ?? [{ name: '' }];
         this.scaling_group = this.scaling_groups[0].name;
       }
 

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -257,6 +257,15 @@ export default class BackendAiResourceBroker extends BackendAIPage {
     }
   }
 
+  async _sftpScalingGroups() {
+    const hosts = await globalThis.backendaiclient?.vfolder?.list_hosts(
+      globalThis.backendaiclient?.current_group_id(),
+    );
+    return Object.values(hosts.volume_info).map(
+      (item: any) => item?.sftp_scaling_groups.join(', '),
+    );
+  }
+
   /**
    * Update all variables on the broker.
    *
@@ -273,12 +282,21 @@ export default class BackendAiResourceBroker extends BackendAIPage {
           this.current_user_group = globalThis.backendaiclient.current_group;
         }
         // const currentGroup = globalThis.backendaiclient.current_group || null;
-        const sgs = await globalThis.backendaiclient.scalingGroup.list(
+        let sgs = await globalThis.backendaiclient.scalingGroup.list(
           this.current_user_group,
         );
+        // TODO: delete these codes after backend.ai support scaling groups filtering.
+        const sftpScalingGroups = await this._sftpScalingGroups();
+        if (sgs.scaling_groups.length > 0) {
+          sgs = sgs.scaling_groups.filter(
+            (item) => !sftpScalingGroups?.includes(item.name),
+          );
+        }
+
         // Make empty scaling group item if there is no scaling groups.
-        this.scaling_groups =
-          sgs.scaling_groups.length > 0 ? sgs.scaling_groups : [{ name: '' }];
+        // this.scaling_groups =
+        //   sgs.scaling_groups.length > 0 ? sgs.scaling_groups : [{ name: '' }];
+        this.scaling_groups = sgs ?? [{ name: '' }];
         this.scaling_group = this.scaling_groups[0].name;
       }
 

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -994,7 +994,7 @@ export default class BackendAiResourceBroker extends BackendAIPage {
       // clamp to roundUpNumber if the number of decimal place exceeds
       if (
         !Number.isInteger(Number(resourceValue)) &&
-        resourceValue.split('.')[1].length > roundUpNumber
+        resourceValue.split('.')[1]?.length > roundUpNumber
       ) {
         resourceValue = (Math.round(Number(resourceValue) * 100) / 100).toFixed(
           2,


### PR DESCRIPTION
- hide sftp resource group from `ResourceGroupSelect` and `backend-ai-resource-broker`.
- user cannot check the sftp resource group from resource monitor and resource group selector of creating model service modal.
- `ResourceGroupSelect`: replace resource group list with graphql 