### PR TITLE
fix: remove `max_vfolder_count` from keypair resource policy

### DIFF
--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -207,8 +207,6 @@ input CreateKeyPairResourcePolicyInput {
   max_concurrent_sessions: Int!
   max_containers_per_session: Int!
   idle_timeout: BigInt!
-  max_vfolder_count: Int!
-  max_vfolder_size: BigInt!
   allowed_vfolder_hosts: JSONString
 }
 
@@ -219,7 +217,8 @@ type CreateProjectResourcePolicy {
 }
 
 input CreateProjectResourcePolicyInput {
-  max_vfolder_size: BigInt!
+  max_vfolder_count: BigInt!
+  max_quota_scope_size: BigInt!
 }
 
 type CreateResourcePreset {
@@ -265,7 +264,8 @@ type CreateUserResourcePolicy {
 }
 
 input CreateUserResourcePolicyInput {
-  max_vfolder_size: BigInt!
+  max_vfolder_count: BigInt!
+  max_quota_scope_size: BigInt!
 }
 
 scalar DateTime
@@ -516,7 +516,10 @@ type KeyPair implements Item {
   compute_sessions(status: String): [ComputeSession]
   concurrency_used: Int
   user_info: UserInfo
-  concurrency_limit: Int @deprecated(reason: "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field.")
+  concurrency_limit: Int
+    @deprecated(
+      reason: "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field."
+    )
 }
 
 input KeyPairInput {
@@ -541,8 +544,6 @@ type KeyPairResourcePolicy {
   max_concurrent_sessions: Int
   max_containers_per_session: Int
   idle_timeout: BigInt
-  max_vfolder_count: Int
-  max_vfolder_size: BigInt
   allowed_vfolder_hosts: JSONString
 }
 
@@ -693,8 +694,6 @@ input ModifyKeyPairResourcePolicyInput {
   max_concurrent_sessions: Int
   max_containers_per_session: Int
   idle_timeout: BigInt
-  max_vfolder_count: Int
-  max_vfolder_size: BigInt
   allowed_vfolder_hosts: JSONString
 }
 
@@ -704,7 +703,8 @@ type ModifyProjectResourcePolicy {
 }
 
 input ModifyProjectResourcePolicyInput {
-  max_vfolder_size: BigInt!
+  max_vfolder_count: BigInt!
+  max_quota_scope_size: BigInt!
 }
 
 type ModifyResourcePreset {
@@ -763,7 +763,8 @@ type ModifyUserResourcePolicy {
 }
 
 input ModifyUserResourcePolicyInput {
-  max_vfolder_size: BigInt!
+  max_vfolder_count: BigInt!
+  max_quota_scope_size: BigInt!
 }
 
 type Mutations {
@@ -786,36 +787,106 @@ type Mutations {
   rescan_images(registry: String): RescanImages
   preload_image(references: [String]!, target_agents: [String]!): PreloadImage
   unload_image(references: [String]!, target_agents: [String]!): UnloadImage
-  modify_image(architecture: String = "aarch64", props: ModifyImageInput!, target: String!): ModifyImage
-  forget_image(architecture: String = "aarch64", reference: String!): ForgetImage
-  alias_image(alias: String!, architecture: String = "aarch64", target: String!): AliasImage
+  modify_image(
+    architecture: String = "aarch64"
+    props: ModifyImageInput!
+    target: String!
+  ): ModifyImage
+  forget_image(
+    architecture: String = "aarch64"
+    reference: String!
+  ): ForgetImage
+  alias_image(
+    alias: String!
+    architecture: String = "aarch64"
+    target: String!
+  ): AliasImage
   dealias_image(alias: String!): DealiasImage
   clear_images(registry: String): ClearImages
-  create_keypair_resource_policy(name: String!, props: CreateKeyPairResourcePolicyInput!): CreateKeyPairResourcePolicy
-  modify_keypair_resource_policy(name: String!, props: ModifyKeyPairResourcePolicyInput!): ModifyKeyPairResourcePolicy
+  create_keypair_resource_policy(
+    name: String!
+    props: CreateKeyPairResourcePolicyInput!
+  ): CreateKeyPairResourcePolicy
+  modify_keypair_resource_policy(
+    name: String!
+    props: ModifyKeyPairResourcePolicyInput!
+  ): ModifyKeyPairResourcePolicy
   delete_keypair_resource_policy(name: String!): DeleteKeyPairResourcePolicy
-  create_user_resource_policy(name: String!, props: CreateUserResourcePolicyInput!): CreateUserResourcePolicy
-  modify_user_resource_policy(name: String!, props: ModifyUserResourcePolicyInput!): ModifyUserResourcePolicy
+  create_user_resource_policy(
+    name: String!
+    props: CreateUserResourcePolicyInput!
+  ): CreateUserResourcePolicy
+  modify_user_resource_policy(
+    name: String!
+    props: ModifyUserResourcePolicyInput!
+  ): ModifyUserResourcePolicy
   delete_user_resource_policy(name: String!): DeleteUserResourcePolicy
-  create_project_resource_policy(name: String!, props: CreateProjectResourcePolicyInput!): CreateProjectResourcePolicy
-  modify_project_resource_policy(name: String!, props: ModifyProjectResourcePolicyInput!): ModifyProjectResourcePolicy
+  create_project_resource_policy(
+    name: String!
+    props: CreateProjectResourcePolicyInput!
+  ): CreateProjectResourcePolicy
+  modify_project_resource_policy(
+    name: String!
+    props: ModifyProjectResourcePolicyInput!
+  ): ModifyProjectResourcePolicy
   delete_project_resource_policy(name: String!): DeleteProjectResourcePolicy
-  create_resource_preset(name: String!, props: CreateResourcePresetInput!): CreateResourcePreset
-  modify_resource_preset(name: String!, props: ModifyResourcePresetInput!): ModifyResourcePreset
+  create_resource_preset(
+    name: String!
+    props: CreateResourcePresetInput!
+  ): CreateResourcePreset
+  modify_resource_preset(
+    name: String!
+    props: ModifyResourcePresetInput!
+  ): ModifyResourcePreset
   delete_resource_preset(name: String!): DeleteResourcePreset
-  create_scaling_group(name: String!, props: CreateScalingGroupInput!): CreateScalingGroup
-  modify_scaling_group(name: String!, props: ModifyScalingGroupInput!): ModifyScalingGroup
+  create_scaling_group(
+    name: String!
+    props: CreateScalingGroupInput!
+  ): CreateScalingGroup
+  modify_scaling_group(
+    name: String!
+    props: ModifyScalingGroupInput!
+  ): ModifyScalingGroup
   delete_scaling_group(name: String!): DeleteScalingGroup
-  associate_scaling_group_with_domain(domain: String!, scaling_group: String!): AssociateScalingGroupWithDomain
-  associate_scaling_group_with_user_group(scaling_group: String!, user_group: UUID!): AssociateScalingGroupWithUserGroup
-  associate_scaling_group_with_keypair(access_key: String!, scaling_group: String!): AssociateScalingGroupWithKeyPair
-  disassociate_scaling_group_with_domain(domain: String!, scaling_group: String!): DisassociateScalingGroupWithDomain
-  disassociate_scaling_group_with_user_group(scaling_group: String!, user_group: UUID!): DisassociateScalingGroupWithUserGroup
-  disassociate_scaling_group_with_keypair(access_key: String!, scaling_group: String!): DisassociateScalingGroupWithKeyPair
-  disassociate_all_scaling_groups_with_domain(domain: String!): DisassociateAllScalingGroupsWithDomain
-  disassociate_all_scaling_groups_with_group(user_group: UUID!): DisassociateAllScalingGroupsWithGroup
-  set_quota_scope(props: QuotaScopeInput!, quota_scope_id: String!, storage_host_name: String!): SetQuotaScope
-  unset_quota_scope(quota_scope_id: String!, storage_host_name: String!): UnsetQuotaScope
+  associate_scaling_group_with_domain(
+    domain: String!
+    scaling_group: String!
+  ): AssociateScalingGroupWithDomain
+  associate_scaling_group_with_user_group(
+    scaling_group: String!
+    user_group: UUID!
+  ): AssociateScalingGroupWithUserGroup
+  associate_scaling_group_with_keypair(
+    access_key: String!
+    scaling_group: String!
+  ): AssociateScalingGroupWithKeyPair
+  disassociate_scaling_group_with_domain(
+    domain: String!
+    scaling_group: String!
+  ): DisassociateScalingGroupWithDomain
+  disassociate_scaling_group_with_user_group(
+    scaling_group: String!
+    user_group: UUID!
+  ): DisassociateScalingGroupWithUserGroup
+  disassociate_scaling_group_with_keypair(
+    access_key: String!
+    scaling_group: String!
+  ): DisassociateScalingGroupWithKeyPair
+  disassociate_all_scaling_groups_with_domain(
+    domain: String!
+  ): DisassociateAllScalingGroupsWithDomain
+  disassociate_all_scaling_groups_with_group(
+    user_group: UUID!
+  ): DisassociateAllScalingGroupsWithGroup
+  set_quota_scope(
+    props: QuotaScopeInput!
+    quota_scope_id: String!
+    storage_host_name: String!
+  ): SetQuotaScope
+  unset_quota_scope(
+    quota_scope_id: String!
+    storage_host_name: String!
+  ): UnsetQuotaScope
 }
 
 interface PaginatedList {
@@ -837,7 +908,9 @@ type ProjectResourcePolicy {
   id: ID!
   name: String!
   created_at: DateTime!
-  max_vfolder_size: BigInt
+  max_vfolder_count: BigInt
+  max_vfolder_size: BigInt # aliased field
+  max_quota_scope_size: BigInt
 }
 
 type PurgeDomain {
@@ -861,10 +934,24 @@ input PurgeUserInput {
 
 type Queries {
   agent(agent_id: String!): Agent
-  agent_list(limit: Int!, offset: Int!, filter: String, order: String, scaling_group: String, status: String): AgentList
+  agent_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    scaling_group: String
+    status: String
+  ): AgentList
   agents(scaling_group: String, status: String): [Agent]
   agent_summary(agent_id: String!): AgentSummary
-  agent_summary_list(limit: Int!, offset: Int!, filter: String, order: String, scaling_group: String, status: String): AgentSummaryList
+  agent_summary_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    scaling_group: String
+    status: String
+  ): AgentSummaryList
   domain(name: String): Domain
   domains(is_active: Boolean): [Domain]
   group(id: UUID!, domain_name: String): Group
@@ -874,11 +961,33 @@ type Queries {
   images(is_installed: Boolean, is_operation: Boolean): [Image]
   user(domain_name: String, email: String): User
   user_from_uuid(domain_name: String, user_id: ID): User
-  users(domain_name: String, group_id: UUID, is_active: Boolean, status: String): [User]
-  user_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: UUID, is_active: Boolean, status: String): UserList
+  users(
+    domain_name: String
+    group_id: UUID
+    is_active: Boolean
+    status: String
+  ): [User]
+  user_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: UUID
+    is_active: Boolean
+    status: String
+  ): UserList
   keypair(domain_name: String, access_key: String): KeyPair
   keypairs(domain_name: String, email: String, is_active: Boolean): [KeyPair]
-  keypair_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, email: String, is_active: Boolean): KeyPairList
+  keypair_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    email: String
+    is_active: Boolean
+  ): KeyPairList
   keypair_resource_policy(name: String): KeyPairResourcePolicy
   user_resource_policy(name: String): UserResourcePolicy
   project_resource_policy(name: String!): ProjectResourcePolicy
@@ -890,29 +999,128 @@ type Queries {
   scaling_group(name: String): ScalingGroup
   scaling_groups(name: String, is_active: Boolean): [ScalingGroup]
   scaling_groups_for_domain(domain: String!, is_active: Boolean): [ScalingGroup]
-  scaling_groups_for_user_group(user_group: String!, is_active: Boolean): [ScalingGroup]
-  scaling_groups_for_keypair(access_key: String!, is_active: Boolean): [ScalingGroup]
+  scaling_groups_for_user_group(
+    user_group: String!
+    is_active: Boolean
+  ): [ScalingGroup]
+  scaling_groups_for_keypair(
+    access_key: String!
+    is_active: Boolean
+  ): [ScalingGroup]
   storage_volume(id: String): StorageVolume
-  storage_volume_list(limit: Int!, offset: Int!, filter: String, order: String): StorageVolumeList
-  vfolder_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: UUID, access_key: String): VirtualFolderList
-  vfolder_permission_list(limit: Int!, offset: Int!, filter: String, order: String): VirtualFolderPermissionList
-  vfolder_own_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList
-  vfolder_invited_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList
-  vfolder_project_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList
-  vfolders(domain_name: String, group_id: String, access_key: String): [VirtualFolder]
+  storage_volume_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+  ): StorageVolumeList
+  vfolder_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: UUID
+    access_key: String
+  ): VirtualFolderList
+  vfolder_permission_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+  ): VirtualFolderPermissionList
+  vfolder_own_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    access_key: String
+  ): VirtualFolderList
+  vfolder_invited_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    access_key: String
+  ): VirtualFolderList
+  vfolder_project_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    access_key: String
+  ): VirtualFolderList
+  vfolders(
+    domain_name: String
+    group_id: String
+    access_key: String
+  ): [VirtualFolder]
   compute_session(id: UUID!): ComputeSession
   compute_container(id: UUID!): ComputeContainer
-  compute_session_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: String, access_key: String, status: String): ComputeSessionList
-  compute_container_list(limit: Int!, offset: Int!, filter: String, order: String, session_id: ID!, role: String): ComputeContainerList
-  legacy_compute_session_list(limit: Int!, offset: Int!, order_key: String, order_asc: Boolean, domain_name: String, group_id: String, access_key: String, status: String): LegacyComputeSessionList
-  legacy_compute_session(sess_id: String!, domain_name: String, access_key: String): LegacyComputeSession
+  compute_session_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: String
+    access_key: String
+    status: String
+  ): ComputeSessionList
+  compute_container_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    session_id: ID!
+    role: String
+  ): ComputeContainerList
+  legacy_compute_session_list(
+    limit: Int!
+    offset: Int!
+    order_key: String
+    order_asc: Boolean
+    domain_name: String
+    group_id: String
+    access_key: String
+    status: String
+  ): LegacyComputeSessionList
+  legacy_compute_session(
+    sess_id: String!
+    domain_name: String
+    access_key: String
+  ): LegacyComputeSession
   vfolder_host_permissions: PredefinedAtomicPermission
   endpoint(endpoint_id: UUID!): Endpoint
-  endpoint_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: String, access_key: String, project: UUID): EndpointList
+  endpoint_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: String
+    access_key: String
+    project: UUID
+  ): EndpointList
   routing(routing_id: UUID!): Routing
-  routing_list(limit: Int!, offset: Int!, filter: String, order: String, endpoint_id: UUID): RoutingList
+  routing_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    endpoint_id: UUID
+  ): RoutingList
   endpoint_token(token: String!): EndpointToken
-  endpoint_token_list(limit: Int!, offset: Int!, filter: String, order: String, endpoint_id: UUID): EndpointTokenList
+  endpoint_token_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    endpoint_id: UUID
+  ): EndpointTokenList
   quota_scope(storage_host_name: String!, quota_scope_id: String!): QuotaScope
 }
 
@@ -1076,7 +1284,9 @@ type UserResourcePolicy {
   id: ID!
   name: String!
   created_at: DateTime!
-  max_vfolder_size: BigInt
+  max_vfolder_count: BigInt
+  max_vfolder_size: BigInt # aliased field
+  max_quota_scope_size: BigInt
 }
 
 type VirtualFolder implements Item {

--- a/react/src/components/ProjectResourcePolicySettingModal.tsx
+++ b/react/src/components/ProjectResourcePolicySettingModal.tsx
@@ -29,7 +29,7 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
         id
         name
         created_at
-        max_vfolder_size
+        max_quota_scope_size
       }
     `,
     resourcePolicyFrgmt,
@@ -47,7 +47,7 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
   //       ok
   //       msg
   //       resource_policy {
-  //         max_vfolder_size
+  //         max_quota_scope_size
   //       }
   //     }
   //   }
@@ -72,13 +72,14 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
     form.validateFields().then((values) => {
       if (
         projectResourcePolicyInfo?.name &&
-        projectResourcePolicyInfo?.max_vfolder_size
+        projectResourcePolicyInfo?.max_quota_scope_size
       ) {
         commitModifyProjectResourcePolicy({
           variables: {
             name: projectResourcePolicyInfo?.name,
             props: {
-              max_vfolder_size: GBToBytes(values?.max_vfolder_size),
+              max_vfolder_count: values?.max_vfolder_count,
+              max_quota_scope_size: GBToBytes(values?.max_quota_scope_size),
             },
           },
           onCompleted(response) {
@@ -103,7 +104,7 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
         //       // Create a project resource policy with the same name as the project name
         //       name: projectResourcePolicy || "",
         //       props: {
-        //         max_vfolder_size: GBToBytes(values?.max_vfolder_size),
+        //         max_quota_scope_size: GBToBytes(values?.max_quota_scope_size),
         //       },
         //     },
         //     onCompleted(response) {
@@ -151,14 +152,14 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
           id: projectResourcePolicyInfo?.id,
           name: projectResourcePolicyInfo?.name,
           created_at: projectResourcePolicyInfo?.created_at,
-          max_vfolder_size:
-            projectResourcePolicyInfo?.max_vfolder_size === -1
+          max_quota_scope_size:
+            projectResourcePolicyInfo?.max_quota_scope_size === -1
               ? null
-              : bytesToGB(projectResourcePolicyInfo?.max_vfolder_size),
+              : bytesToGB(projectResourcePolicyInfo?.max_quota_scope_size),
         }}
       >
         <Form.Item
-          name="max_vfolder_size"
+          name="max_quota_scope_size"
           label={t('storageHost.MaxFolderSize')}
           rules={[
             {

--- a/react/src/components/ResourcePolicyCard.tsx
+++ b/react/src/components/ResourcePolicyCard.tsx
@@ -56,7 +56,7 @@ const ResourcePolicyCard: React.FC<Props> = ({
       fragment ResourcePolicyCard_project_resource_policy on ProjectResourcePolicy {
         id
         name
-        max_vfolder_size
+        max_quota_scope_size
         ...ProjectResourcePolicySettingModalFragment
       }
     `,
@@ -67,7 +67,7 @@ const ResourcePolicyCard: React.FC<Props> = ({
       fragment ResourcePolicyCard_user_resource_policy on UserResourcePolicy {
         id
         name
-        max_vfolder_size
+        max_quota_scope_size
         ...UserResourcePolicySettingModalFragment
       }
     `,
@@ -116,7 +116,8 @@ const ResourcePolicyCard: React.FC<Props> = ({
             variables: {
               name: project_resource_policy.name,
               props: {
-                max_vfolder_size: -1,
+                max_vfolder_count: 0,
+                max_quota_scope_size: -1,
               },
             },
             onCompleted(response) {
@@ -138,7 +139,8 @@ const ResourcePolicyCard: React.FC<Props> = ({
             variables: {
               name: user_resource_policy.name,
               props: {
-                max_vfolder_size: -1,
+                max_vfolder_count: 0,
+                max_quota_scope_size: -1,
               },
             },
             onCompleted(response) {
@@ -200,15 +202,15 @@ const ResourcePolicyCard: React.FC<Props> = ({
             <Descriptions.Item label={t('storageHost.MaxFolderSize')}>
               {project_resource_policy
                 ? project_resource_policy &&
-                  project_resource_policy?.max_vfolder_size !== -1
+                  project_resource_policy?.max_quota_scope_size !== -1
                   ? humanReadableDecimalSize(
-                      project_resource_policy?.max_vfolder_size,
+                      project_resource_policy?.max_quota_scope_size,
                     )
                   : '-'
                 : user_resource_policy &&
-                  user_resource_policy?.max_vfolder_size !== -1
+                  user_resource_policy?.max_quota_scope_size !== -1
                 ? humanReadableDecimalSize(
-                    user_resource_policy?.max_vfolder_size,
+                    user_resource_policy?.max_quota_scope_size,
                   )
                 : '-'}
             </Descriptions.Item>

--- a/react/src/components/StorageStatusPanel.tsx
+++ b/react/src/components/StorageStatusPanel.tsx
@@ -68,16 +68,12 @@ const StorageStatusPanel: React.FC<{
   ).length;
 
   // TODO: Add resolver to enable subquery and modify to call useLazyLoadQuery only once.
-  const { keypair, user } = useLazyLoadQuery<StorageStatusPanelKeypairQuery>(
+  const { user } = useLazyLoadQuery<StorageStatusPanelKeypairQuery>(
     graphql`
       query StorageStatusPanelKeypairQuery(
         $domain_name: String
-        $access_key: String
         $email: String
       ) {
-        keypair(domain_name: $domain_name, access_key: $access_key) {
-          resource_policy
-        }
         user(domain_name: $domain_name, email: $email) {
           id
         }
@@ -85,22 +81,21 @@ const StorageStatusPanel: React.FC<{
     `,
     {
       domain_name: useCurrentDomainValue(),
-      access_key: baiClient?._config.accessKey,
       email: baiClient?.email,
     },
   );
 
-  const { keypair_resource_policy, project_quota_scope, user_quota_scope } =
+  const { user_resource_policy, project_quota_scope, user_quota_scope } =
     useLazyLoadQuery<StorageStatusPanelQuery>(
       graphql`
         query StorageStatusPanelQuery(
-          $keypair_resource_policy_name: String
+          $name: String
           $project_quota_scope_id: String!
           $user_quota_scope_id: String!
           $storage_host_name: String!
           $skipQuotaScope: Boolean!
         ) {
-          keypair_resource_policy(name: $keypair_resource_policy_name) {
+          user_resource_policy(name: $name) {
             max_vfolder_count
           }
           project_quota_scope: quota_scope(
@@ -118,7 +113,6 @@ const StorageStatusPanel: React.FC<{
         }
       `,
       {
-        keypair_resource_policy_name: keypair?.resource_policy,
         project_quota_scope_id: addQuotaScopeTypePrefix(
           'project',
           currentProject?.id,
@@ -132,7 +126,7 @@ const StorageStatusPanel: React.FC<{
       },
     );
 
-  const maxVfolderCount = keypair_resource_policy?.max_vfolder_count || 0;
+  const maxVfolderCount = user_resource_policy?.max_vfolder_count || 0;
   const numberOfFolderPercent = (
     maxVfolderCount > 0
       ? ((createdCount / maxVfolderCount) * 100)?.toFixed(2)
@@ -163,7 +157,7 @@ const StorageStatusPanel: React.FC<{
             <Typography.Text type="secondary">
               {t('data.Limit')}:
             </Typography.Text>
-            {maxVfolderCount}
+            {maxVfolderCount === 0 ? '-' : maxVfolderCount}
           </Flex>
           <Divider style={{ margin: '12px auto' }} />
           <Flex direction="row" wrap="wrap" justify="between">

--- a/react/src/components/UserResourcePolicySettingModal.tsx
+++ b/react/src/components/UserResourcePolicySettingModal.tsx
@@ -30,7 +30,8 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
         id
         name
         created_at
-        max_vfolder_size
+        max_vfolder_count
+        max_quota_scope_size
       }
     `,
     resourcePolicyFrgmt,
@@ -48,7 +49,8 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
   //       ok
   //       msg
   //       resource_policy {
-  //         max_vfolder_size
+  //         max_vfolder_count
+  //         max_quota_scope_size
   //       }
   //     }
   //   }
@@ -76,7 +78,8 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
           variables: {
             name: userResourcePolicyInfo?.name,
             props: {
-              max_vfolder_size: GBToBytes(values?.max_vfolder_size),
+              max_vfolder_count: values?.max_vfolder_count,
+              max_quota_scope_size: GBToBytes(values?.max_quota_scope_size),
             },
           },
           onCompleted(response) {
@@ -101,7 +104,8 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
         //     // Create a user resource policy with the same name as the user name
         //     name: userResourcePolicy || "",
         //     props: {
-        //       max_vfolder_size: GBToBytes(values?.max_vfolder_size),
+        //       max_vfolder_count: values?.max_vfolder_count,
+        //       max_quota_scope_size: GBToBytes(values?.max_vfolmax_quota_scope_sizeder_count),
         //     },
         //   },
         //   onCompleted(response) {
@@ -149,14 +153,14 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
           id: userResourcePolicyInfo?.id,
           name: userResourcePolicyInfo?.name,
           created_at: userResourcePolicyInfo?.created_at,
-          max_vfolder_size:
-            userResourcePolicyInfo?.max_vfolder_size === -1
+          max_quota_scope_size:
+            userResourcePolicyInfo?.max_quota_scope_size === -1
               ? null
-              : bytesToGB(userResourcePolicyInfo?.max_vfolder_size),
+              : bytesToGB(userResourcePolicyInfo?.max_quota_scope_size),
         }}
       >
         <Form.Item
-          name="max_vfolder_size"
+          name="max_quota_scope_size"
           label={t('storageHost.MaxFolderSize')}
           rules={[
             {

--- a/src/components/backend-ai-credential-list.ts
+++ b/src/components/backend-ai-credential-list.ts
@@ -847,11 +847,6 @@ export default class BackendAICredentialList extends BackendAIPage {
             <span>${rowData.item.max_vfolder_size}</span>
             <span class="indicator">GB</span>
           </div>
-          <div class="layout horizontal configuration">
-            <mwc-icon class="fg green">folder</mwc-icon>
-            <span>${rowData.item.max_vfolder_count}</span>
-            <span class="indicator">${_t('general.Folders')}</span>
-          </div>
         </div>
       `,
       root,

--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -63,8 +63,6 @@ export default class BackendAICredentialView extends BackendAIPage {
   @property({ type: Object }) concurrency_limit = {};
   @property({ type: Object }) idle_timeout = {};
   @property({ type: Object }) session_lifetime = {};
-  @property({ type: Object }) vfolder_capacity = {};
-  @property({ type: Object }) vfolder_max_limit = {};
   @property({ type: Object }) container_per_session_limit = {};
   @property({ type: Array }) rate_metric = [
     1000, 2000, 3000, 4000, 5000, 10000, 50000,
@@ -313,11 +311,9 @@ export default class BackendAICredentialView extends BackendAIPage {
     this._updateInputStatus(this.concurrency_limit);
     this._updateInputStatus(this.idle_timeout);
     this._updateInputStatus(this.container_per_session_limit);
-    this._updateInputStatus(this.vfolder_capacity);
     if (this.enableSessionLifetime) {
       this._updateInputStatus(this.session_lifetime);
     }
-    this.vfolder_max_limit['value'] = 10;
     this._defaultFileName = this._getDefaultCSVFileName();
     await this._runAction();
   }
@@ -572,8 +568,6 @@ export default class BackendAICredentialView extends BackendAIPage {
     this._validateUserInput(this.concurrency_limit);
     this._validateUserInput(this.idle_timeout);
     this._validateUserInput(this.container_per_session_limit);
-    this._validateUserInput(this.vfolder_capacity);
-    this._validateUserInput(this.vfolder_max_limit);
 
     total_resource_slots['cpu'] = this.cpu_resource['value'];
     total_resource_slots['mem'] = this.ram_resource['value'] + 'g';
@@ -594,14 +588,6 @@ export default class BackendAICredentialView extends BackendAIPage {
       this.container_per_session_limit['value'] === ''
         ? 0
         : parseInt(this.container_per_session_limit['value']);
-    this.vfolder_capacity['value'] =
-      this.vfolder_capacity['value'] === ''
-        ? 0
-        : parseFloat(this.vfolder_capacity['value']);
-    this.vfolder_max_limit['value'] =
-      this.vfolder_max_limit['value'] === ''
-        ? 0
-        : parseInt(this.vfolder_max_limit['value']);
 
     Object.keys(total_resource_slots).map((resource) => {
       if (isNaN(parseFloat(total_resource_slots[resource]))) {
@@ -614,10 +600,6 @@ export default class BackendAICredentialView extends BackendAIPage {
       max_concurrent_sessions: this.concurrency_limit['value'],
       max_containers_per_session: this.container_per_session_limit['value'],
       idle_timeout: this.idle_timeout['value'],
-      max_vfolder_count: this.vfolder_max_limit['value'],
-      max_vfolder_size: BackendAICredentialView.gBToBytes(
-        this.vfolder_capacity['value'],
-      ),
       allowed_vfolder_hosts: vfolder_hosts,
     };
     if (this.enableSessionLifetime) {
@@ -1035,12 +1017,6 @@ export default class BackendAICredentialView extends BackendAIPage {
     ) as TextField;
     this.container_per_session_limit = this.shadowRoot?.querySelector(
       '#container-per-session-limit',
-    ) as TextField;
-    this.vfolder_capacity = this.shadowRoot?.querySelector(
-      '#vfolder-capacity-limit',
-    ) as TextField;
-    this.vfolder_max_limit = this.shadowRoot?.querySelector(
-      '#vfolder-count-limit',
     ) as TextField;
     if (this.enableSessionLifetime) {
       this.session_lifetime = this.shadowRoot?.querySelector(
@@ -1486,28 +1462,6 @@ export default class BackendAICredentialView extends BackendAIPage {
             <backend-ai-multi-select open-up id="allowed-vfolder-hosts" label="${_t(
               'resourcePolicy.AllowedHosts',
             )}" style="width:100%;"></backend-ai-multi-select>
-            <div class="horizontal layout justified" style="width:100%;">
-              <div class="vertical layout flex popup-right-margin">
-                <mwc-textfield label="${_t(
-                  'resourcePolicy.Capacity',
-                )}(GB)" id="vfolder-capacity-limit" type="number" min="0" max="1024" step="0.1"
-                    @change="${(e) =>
-                      this._validateResourceInput(e)}"></mwc-textfield>
-                <mwc-formfield label="${_t(
-                  'resourcePolicy.Unlimited',
-                )}" class="unlimited">
-                    <mwc-checkbox @change="${(e) =>
-                      this._toggleCheckbox(e)}"></mwc-checkbox>
-                </mwc-formfield>
-              </div>
-              <div class="vertical layout flex popup-left-margin">
-                <mwc-textfield label="${_t(
-                  'credential.Max#',
-                )}" class="discrete" id="vfolder-count-limit" type="number" min="0" max="50"
-                    @change="${(e) =>
-                      this._validateResourceInput(e)}"></mwc-textfield>
-              </div>
-            </div>
           </div>
         </div>
         <div slot="footer" class="horizontal center-justified flex layout distancing">

--- a/src/components/backend-ai-resource-policy-list.ts
+++ b/src/components/backend-ai-resource-policy-list.ts
@@ -63,8 +63,6 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
   @property({ type: Object }) _boundStorageNodesRenderer =
     this.storageNodesRenderer.bind(this);
   @query('#dropdown-area') dropdownArea!: HTMLDivElement;
-  @query('#vfolder-count-limit') vfolderCountLimitInput!: TextField;
-  @query('#vfolder-capacity-limit') vfolderCapacityLimit!: TextField;
   @query('#cpu-resource') cpuResource!: TextField;
   @query('#ram-resource') ramResource!: TextField;
   @query('#gpu-resource') gpuResource!: TextField;
@@ -446,38 +444,6 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
               label="${_t('resourcePolicy.AllowedHosts')}"
               style="width:100%;"
             ></backend-ai-multi-select>
-            <div class="horizontal layout justified" style="width:100%;">
-              <div class="vertical layout flex popup-right-margin">
-                <mwc-textfield
-                  label="${_t('resourcePolicy.Capacity')}(GB)"
-                  id="vfolder-capacity-limit"
-                  type="number"
-                  min="0"
-                  max="1024"
-                  step="0.1"
-                  @change="${(e) => this._validateResourceInput(e)}"
-                ></mwc-textfield>
-                <mwc-formfield
-                  label="${_t('resourcePolicy.Unlimited')}"
-                  class="unlimited"
-                >
-                  <mwc-checkbox
-                    @change="${(e) => this._toggleCheckbox(e)}"
-                  ></mwc-checkbox>
-                </mwc-formfield>
-              </div>
-              <div class="vertical layout flex popup-left-margin">
-                <mwc-textfield
-                  label="${_t('credential.Max#')}"
-                  class="discrete"
-                  id="vfolder-count-limit"
-                  type="number"
-                  min="0"
-                  max="50"
-                  @change="${(e) => this._validateResourceInput(e)}"
-                ></mwc-textfield>
-              </div>
-            </div>
           </div>
         </div>
         <div
@@ -556,12 +522,10 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
     switch (resourceName) {
       case 'cpu':
       case 'cuda_device':
-      case 'max_vfolder_count':
         decimalPoint = 0;
         break;
       case 'mem':
       case 'cuda_shares':
-      case 'max_vfolder_size':
         decimalPoint = 1;
     }
     return ['∞', '-'].includes(resourceValue)
@@ -635,30 +599,6 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
                 </div>
               `
             : html``}
-        </div>
-        <div class="layout horizontal wrap center">
-          <div class="layout horizontal configuration">
-            <mwc-icon class="fg green indicator">cloud_queue</mwc-icon>
-            <span>
-              ${this._displayResourcesByResourceUnit(
-                rowData.item.max_vfolder_size,
-                true,
-                'max_vfolder_size',
-              )}
-            </span>
-            <span class="indicator">GB</span>
-          </div>
-          <div class="layout horizontal configuration">
-            <mwc-icon class="fg green indicator">folder</mwc-icon>
-            <span>
-              ${this._displayResourcesByResourceUnit(
-                rowData.item.max_vfolder_count,
-                false,
-                'max_vfolder_count',
-              )}
-            </span>
-            <span class="indicator">Folders</span>
-          </div>
         </div>
       `,
       root,
@@ -916,9 +856,6 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
     this.containerPerSessionLimit.value = this._updateUnlimitedValue(
       resourcePolicy.max_containers_per_session,
     );
-    this.vfolderCapacityLimit.value = this._updateUnlimitedValue(
-      resourcePolicy.max_vfolder_size,
-    );
 
     if (this.enableSessionLifetime) {
       this.sessionLifetime.value = this._updateUnlimitedValue(
@@ -934,13 +871,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
     this._updateInputStatus(this.concurrencyLimit);
     this._updateInputStatus(this.idleTimeout);
     this._updateInputStatus(this.containerPerSessionLimit);
-    this._updateInputStatus(this.vfolderCapacityLimit);
 
-    this.vfolderCountLimitInput.value = resourcePolicy.max_vfolder_count;
-    this.vfolderCapacityLimit.value = BackendAIResourcePolicyList.bytesToGB(
-      resourcePolicy.max_vfolder_size,
-      1,
-    );
     this.allowed_vfolder_hosts = allowedStorageHosts;
   }
 
@@ -1087,8 +1018,6 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
     this._validateUserInput(this.concurrencyLimit);
     this._validateUserInput(this.idleTimeout);
     this._validateUserInput(this.containerPerSessionLimit);
-    this._validateUserInput(this.vfolderCapacityLimit);
-    this._validateUserInput(this.vfolderCountLimitInput);
 
     total_resource_slots['cpu'] = this.cpuResource.value;
     total_resource_slots['mem'] = this.ramResource.value + 'g';
@@ -1104,14 +1033,6 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
     )
       ? BigNumber.getValue().toString()
       : this.containerPerSessionLimit.value;
-    this.vfolderCapacityLimit.value =
-      this.vfolderCapacityLimit.value === ''
-        ? '0'
-        : this.vfolderCapacityLimit.value;
-    this.vfolderCountLimitInput.value =
-      this.vfolderCountLimitInput.value === ''
-        ? '0'
-        : this.vfolderCountLimitInput.value;
 
     Object.keys(total_resource_slots).map((resource) => {
       if (isNaN(parseFloat(total_resource_slots[resource]))) {
@@ -1125,10 +1046,6 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
       max_concurrent_sessions: this.concurrencyLimit.value,
       max_containers_per_session: this.containerPerSessionLimit.value,
       idle_timeout: this.idleTimeout.value,
-      max_vfolder_count: this.vfolderCountLimitInput.value,
-      max_vfolder_size: BackendAIResourcePolicyList.gBToBytes(
-        Number(this.vfolderCapacityLimit.value),
-      ),
       allowed_vfolder_hosts: vfolder_hosts,
     };
 

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -2892,23 +2892,19 @@ export default class BackendAiStorageList extends BackendAIPage {
       'resource_policy',
     ]);
     const policyName = res.keypair.resource_policy;
-    const resource_policy = await globalThis.backendaiclient.resourcePolicy.get(
-      policyName,
-      ['max_vfolder_count', 'max_vfolder_size'],
-    );
-    const max_vfolder_size =
-      resource_policy.keypair_resource_policy.max_vfolder_size;
+    const resource_policy =
+      await globalThis.backendaiclient.resourcePolicy.get(policyName);
     // default unit starts with MB.
-    [this.maxSize.value, this.maxSize.unit] = globalThis.backendaiutils
-      ._humanReadableFileSize(max_vfolder_size)
-      .split(' ');
-    if (['Bytes', 'KB', 'MB'].includes(this.maxSize.unit)) {
-      this.maxSize.value =
-        this.maxSize.value < 1 ? 1 : Math.round(this.maxSize.value);
-      this.maxSize.unit = 'MB';
-    } else {
-      this.maxSize.value = Math.round(this.maxSize.value * 10) / 10;
-    }
+    // [this.maxSize.value, this.maxSize.unit] = globalThis.backendaiutils
+    //   ._humanReadableFileSize(max_vfolder_size)
+    //   .split(' ');
+    // if (['Bytes', 'KB', 'MB'].includes(this.maxSize.unit)) {
+    //   this.maxSize.value =
+    //     this.maxSize.value < 1 ? 1 : Math.round(this.maxSize.value);
+    //   this.maxSize.unit = 'MB';
+    // } else {
+    //   this.maxSize.value = Math.round(this.maxSize.value * 10) / 10;
+    // }
   }
 
   /**

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -3164,8 +3164,6 @@ class ResourcePolicy {
       'total_resource_slots',
       'max_concurrent_sessions',
       'max_containers_per_session',
-      'max_vfolder_count',
-      'max_vfolder_size',
       'allowed_vfolder_hosts',
       'idle_timeout',
     ],
@@ -3199,8 +3197,6 @@ class ResourcePolicy {
    *   'max_concurrent_sessions': concurrency_limit,
    *   'max_containers_per_session': containers_per_session_limit,
    *   'idle_timeout': idle_timeout,
-   *   'max_vfolder_count': vfolder_count_limit,
-   *   'max_vfolder_size': vfolder_capacity_limit,
    *   'allowed_vfolder_hosts': vfolder_hosts,
    *   'max_session_lifetime': max_session_lifetime
    * };
@@ -3213,8 +3209,6 @@ class ResourcePolicy {
       'total_resource_slots',
       'max_concurrent_sessions',
       'max_containers_per_session',
-      'max_vfolder_count',
-      'max_vfolder_size',
       'allowed_vfolder_hosts',
       'idle_timeout',
     ];
@@ -3249,8 +3243,6 @@ class ResourcePolicy {
    *   {int} 'max_concurrent_sessions': concurrency_limit,
    *   {int} 'max_containers_per_session': containers_per_session_limit,
    *   {bigint} 'idle_timeout': idle_timeout,
-   *   {int} 'max_vfolder_count': vfolder_count_limit,
-   *   {bigint} 'max_vfolder_size': vfolder_capacity_limit,
    *   {[string]} 'allowed_vfolder_hosts': vfolder_hosts,
    *   {int} 'max_session_lifetime': max_session_lifetime
    * };


### PR DESCRIPTION
resolves #1970 
related PR: https://github.com/lablup/backend.ai/pull/1417
`max_vfolder_count` management UI will be handled by #1971 

- I just removed the keypair's `max_vfolder_count` related info to avoid errors that occur when trying to query vfolder list or CRUD `keypair_resource_policy`.
- Update schema