### PR TITLE
fix: empty filtered scaling groups generates error

### DIFF
--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -293,8 +293,10 @@ export default class BackendAiResourceBroker extends BackendAIPage {
             (item) => !sftpResourceGroups?.includes(item.name),
           );
         }
-
-        this.scaling_groups = sgs ?? [{ name: '' }];
+        sgs = sgs ?? [];
+        if (Array.isArray(sgs) && sgs.length === 0) {
+          this.scaling_groups = [{ name: '' }];
+        }
         // ================================ END ======================================
 
         // Make empty scaling group item if there is no scaling groups.


### PR DESCRIPTION
This PR fixes error when filtered scaling groups are empty, scaling group name call generates error. 
e.g. When SFTP scaling group is not set

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1b2bf53</samp>

### Summary
🐛🛠️🚧

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change.
2.  🛠️ - This emoji represents a tool or a fix, which is also relevant for this change as it improves the functionality of the scaling group selector component.
3.  🚧 - This emoji represents construction or work in progress, which could also apply to this change as it is part of a larger feature or improvement.
-->
Fix a bug in `backend-ai-resource-broker.ts` that caused errors when the scaling_groups API response was null or undefined. Ensure that the scaling_groups property is always an array with a default empty object.

> _`scaling_groups` fixed_
> _No more nulls or undefined_
> _Autumn bugs swept away_

### Walkthrough
* Fix a bug where scaling_groups property could be null ([link](https://github.com/lablup/backend.ai-webui/pull/1982/files?diff=unified&w=0#diff-1f39f3adffae3b281a31ce9f4a28b3bb54d59485eccc246a49a9b877fcf1fd92L296-R299))

