### PR TITLE
feature: split copy to clipboard in sftp session connection dialog

### DIFF
--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -281,7 +281,7 @@
     "AllowedClientIps": "Allowed client IPs",
     "CommaSeparated": "comma-separated",
     "TryPreferredPort": "Try preferred port",
-    "SFTPDescription": "You can upload files quickly and securely through an SSH/SFTP client. If you haven't uploaded your SSH key pair beforehand, please click the \"SSH Key Download\" button to save your SSH key first. You can then use that key to execute commands such as SFTP, SCP, and Rsync. On the \"Session - Upload Session\" page, you can manage the list of sessions for file uploads.",
+    "SFTPDescription": "You can upload files quickly and securely through an SSH/SFTP client. If you haven't uploaded your SSH key pair beforehand, please click the \"DOWNLOAD SSH KEY\" button to save your SSH key first. You can then use that key to execute commands such as SFTP, SCP, and Rsync. On the \"Session - Upload Session\" page, you can manage the list of sessions for file uploads.",
     "SFTPExtraNotification": "It is recommended to delete sessions after they have been used, as there is a limit on the number of sessions. Sessions that are not used for uploading files within a certain period of time may be automatically deleted.",
     "Readmore": "Read More...",
     "Readless": "Read less",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -264,7 +264,7 @@
     "AllowedClientIps": "허용된 클라이언트 IP",
     "CommaSeparated": "콤마로 구분",
     "TryPreferredPort": "선호 포트",
-    "SFTPDescription": "SSH/SFTP 클라이언트를 통해 빠르고 안정적으로 파일을 업로드할 수 있습니다. 미리 SSH 키페어를 업로드하지 않으셨다면, \"SSH키 다운로드\" 버튼을 클릭하여 SSH 키를 먼저 저장하십시오. 그 키를 이용해서 sftp, scp, rsync 등의 명령을 사용할 수 있습니다. 세션 - 업로드 세션페이지에서 파일 업로드를 위한 세션 리스트를 관리할 수 있습니다.",
+    "SFTPDescription": "SSH/SFTP 클라이언트를 통해 빠르고 안정적으로 파일을 업로드할 수 있습니다. 미리 SSH 키페어를 업로드하지 않으셨다면, \"SSH 키 다운로드\" 버튼을 클릭하여 SSH 키를 먼저 저장하십시오. 그 키를 이용해서 sftp, scp, rsync 등의 명령을 사용할 수 있습니다. 세션 - 업로드 세션페이지에서 파일 업로드를 위한 세션 리스트를 관리할 수 있습니다.",
     "ConnectionInformation": "연결 정보",
     "VNCconnection": "VNC 연결",
     "CheckAgainDialog": "이 선택은 취소할 수 없습니다. 정말 진행하시겠습니까?",

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -56,6 +56,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
   @property({ type: String }) sshPort = '';
   @property({ type: Number }) vncPort = 0;
   @property({ type: Number }) xrdpPort = 0;
+  @property({ type: String }) mountedVfolderName = '';
   @property({ type: Number }) vscodeDesktopPort = 0;
   @property({ type: String }) tensorboardPath = '';
   @property({ type: String }) endpointURL = '';
@@ -126,6 +127,10 @@ export default class BackendAiAppLauncher extends BackendAIPage {
 
         mwc-icon-button {
           color: var(--general-button-background-color);
+        }
+
+        mwc-icon-button.sftp-session-connection-copy {
+          --mdc-icon-size: 20px;
         }
 
         #ssh-dialog {
@@ -265,6 +270,10 @@ export default class BackendAiAppLauncher extends BackendAIPage {
 
         .ssh-connection-example {
           display: flex;
+          background-color: rgba(230, 230, 230, 1);
+          padding: 10px;
+          border-radius: 5px;
+          margin-bottom: 5px;
         }
 
         #current-ssh-connection-example {
@@ -316,6 +325,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           this._readSSHKey(e.detail.sessionUuid);
           this.sshPort = e.detail.port;
           this.sshHost = e.detail.host;
+          this.mountedVfolderName = e.detail.mounted;
           this._openSSHDialog();
         }
       },
@@ -1748,27 +1758,44 @@ export default class BackendAiAppLauncher extends BackendAIPage {
             </div>
             <div><span>Port:</span> ${this.sshPort}</div>
             <h4>${_t('session.ConnectionExample')}</h4>
-            <div class="monospace ssh-connection-example">
-              <div id="current-ssh-connection-example">
-                sftp -i ./id_container -P ${this.sshPort} work@${
-                  this.sshHost
-                } -o StringHostKeyChecking=no -o UserKnownHostsFile=/dev/null<br/>
-                scp -i ./id_container -P ${
-                  this.sshPort
-                } -rp /path/to/source work@${this.sshHost}:~/<vfolder-name><br/>
-                rsync -av -e "ssh -i ./id_container" /path/to/source/ work@${
-                  this.sshHost
-                }:~/<vfolder-name>/<br/>
-              </div>
-              <mwc-icon-button
-                id="current-ssh-connection-example-copy-button"
-                icon="content_copy"
-                @click="${() =>
-                  this._copySSHConnectionExample(
-                    '#current-ssh-connection-example',
-                  )}">
-              </mwc-icon-button>
-            </div>
+                <div class="horizontal layout flex monospace ssh-connection-example">
+                <span id="sftp-string">
+                  sftp -i ./id_container -P ${this.sshPort} work@${
+                    this.sshHost
+                  } -o StringHostKeyChecking=no -o UserKnownHostsFile=/dev/null<br/>
+                </span>
+                <mwc-icon-button
+                class="sftp-session-connection-copy"
+                icon="content_copy" @click="${() =>
+                  this._copySSHConnectionExample('#sftp-string')}">
+                </mwc-icon-button>
+                </div>
+                <div class="horizontal layout flex monospace ssh-connection-example">
+                <span id="scp-string">
+                  scp -i ./id_container -P ${
+                    this.sshPort
+                  } -rp /path/to/source work@${this.sshHost}:~/${
+                    this.mountedVfolderName
+                  }<br/>
+                </span>
+                <mwc-icon-button
+                class="sftp-session-connection-copy"
+                icon="content_copy" @click="${() =>
+                  this._copySSHConnectionExample('#scp-string')}">
+                </mwc-icon-button>
+                </div>
+                <div class="horizontal layout flex monospace ssh-connection-example">
+                <span id="rsync-string">
+                  rsync -av -e "ssh -i ./id_container" /path/to/source/ work@${
+                    this.sshHost
+                  }:~/${this.mountedVfolderName}/<br/>
+                </span>
+                <mwc-icon-button
+                class="sftp-session-connection-copy"
+                icon="content_copy" @click="${() =>
+                  this._copySSHConnectionExample('#rsync-string')}">
+                </mwc-icon-button>
+                </div>
           </section>
         </div>
         <div slot="footer" class="horizontal center-justified flex layout">

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -276,13 +276,6 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           margin-bottom: 5px;
         }
 
-        #current-ssh-connection-example {
-          color: #ffffff;
-          background-color: #242424;
-          padding: 15px;
-          margin: 0 5px 0 0;
-        }
-
         @media screen and (max-width: 810px) {
           #terminal-guide {
             --component-width: calc(100% - 50px);
@@ -1762,7 +1755,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
                 <span id="sftp-string">
                   sftp -i ./id_container -P ${this.sshPort} work@${
                     this.sshHost
-                  } -o StringHostKeyChecking=no -o UserKnownHostsFile=/dev/null<br/>
+                  } -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null<br/>
                 </span>
                 <mwc-icon-button
                 class="sftp-session-connection-copy"
@@ -1772,7 +1765,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
                 </div>
                 <div class="horizontal layout flex monospace ssh-connection-example">
                 <span id="scp-string">
-                  scp -i ./id_container -P ${
+                  scp -i ./id_container -o StrictHostKeyChecking=no -P ${
                     this.sshPort
                   } -rp /path/to/source work@${this.sshHost}:~/${
                     this.mountedVfolderName
@@ -1786,7 +1779,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
                 </div>
                 <div class="horizontal layout flex monospace ssh-connection-example">
                 <span id="rsync-string">
-                  rsync -av -e "ssh -i ./id_container" /path/to/source/ work@${
+                  rsync -av -e "ssh -i ./id_container -o StrictHostKeyChecking=no" /path/to/source/ work@${
                     this.sshHost
                   }:~/${this.mountedVfolderName}/<br/>
                 </span>

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -1765,7 +1765,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
                 </div>
                 <div class="horizontal layout flex monospace ssh-connection-example">
                 <span id="scp-string">
-                  scp -i ./id_container -o StrictHostKeyChecking=no -P ${
+                  scp -i ./id_container -o StrictHostKeyChecking=no UserKnownHostsFile=/dev/null -P ${
                     this.sshPort
                   } -rp /path/to/source work@${this.sshHost}:~/${
                     this.mountedVfolderName
@@ -1779,7 +1779,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
                 </div>
                 <div class="horizontal layout flex monospace ssh-connection-example">
                 <span id="rsync-string">
-                  rsync -av -e "ssh -i ./id_container -o StrictHostKeyChecking=no" /path/to/source/ work@${
+                  rsync -av -e "ssh -i ./id_container -o StrictHostKeyChecking=no UserKnownHostsFile=/dev/null" /path/to/source/ work@${
                     this.sshHost
                   }:~/${this.mountedVfolderName}/<br/>
                 </span>

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -2413,13 +2413,21 @@ ${item.traceback}</pre
     this.helpDescriptionDialog.show();
   }
 
-  async _openSFTPSessionConnectionInfoDialog(sessionId: string) {
+  async _openSFTPSessionConnectionInfoDialog(
+    sessionId: string,
+    mountedFolder: string,
+  ) {
     const directAccessInfo =
       await globalThis.backendaiclient.get_direct_access_info(sessionId);
     const host = directAccessInfo.public_host.replace(/^https?:\/\//, '');
     const port = directAccessInfo.sshd_ports;
     const event = new CustomEvent('read-ssh-key-and-launch-ssh-dialog', {
-      detail: { sessionUuid: sessionId, host: host, port: port },
+      detail: {
+        sessionUuid: sessionId,
+        host: host,
+        port: port,
+        mounted: mountedFolder,
+      },
     });
     document.dispatchEvent(event);
   }
@@ -2874,7 +2882,15 @@ ${rowData.item[this.sessionNameField]}</pre
                   class="fg green controls-running"
                   id="${rowData.index + '-sftp-connection-info'}"
                   @click="${() =>
-                    this._openSFTPSessionConnectionInfoDialog(rowData.item.id)}"
+                    this._openSFTPSessionConnectionInfoDialog(
+                      rowData.item.id,
+                      // send empty string when there's no explicitly mounted vfolder in sftp session (should not be happened)
+                      rowData.item.mounts.length > 0
+                        ? rowData.item.mounts.filter(
+                            (vfolder: string) => !vfolder.startsWith('.'),
+                          )[0]
+                        : '',
+                    )}"
                 >
                   <img src="/resources/icons/sftp.png" />
                 </mwc-icon-button>

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -3876,6 +3876,7 @@ export default class BackendAiStorageList extends BackendAIPage {
             sessionUuid: sessionResponse.sessionId,
             host: host,
             port: port,
+            mounted: this.explorer.id,
           },
         });
         document.dispatchEvent(event);


### PR DESCRIPTION
This PR is extension of #1984.
This PR mainly do...
- [x] Split `sftp` / `scp` / `rsync` command and provide Copy-to-clipboard respectively. 
- [x] Touch up codeblock box a little bit.
- [x] Add vfolder name into command instead of displaying `<vfolder-name>`.


### Screenshot(s)
| After | Before|
|------| -------|
| <img width="399" alt="Screenshot 2023-10-24 at 7 20 58 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/3d22bb9c-b327-4680-93b0-2c66a8b7a0d5"> | ![Screenshot 2023-10-24 at 5 22 32 PM](https://github.com/lablup/backend.ai-webui/assets/46954439/b63cd1d5-1d2b-41c6-8553-b17d8ca8f02d) |