### PR TITLE
feat: add config option that can hide custom resource allocation

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -27,6 +27,7 @@ appDownloadUrl = ""                     # URL to download the electron app. If b
 systemSSHImage = ""                     # This image is used to launch ssh session from the filebrowser dialog to support fast uploading.
 directoryBasedUsage = false             # If true, display the amount of usage per directory such as folder capacity, and number of files and directories.
 maxCountForPreopenPorts = 10            # The maximum allowed number of preopen ports. If you set this option to 0, the feature of preopen ports is disabled.
+allowCustomResourceAllocation = true    # If true, display the custom allocation on the session launcher.
 
 [wsproxy]
 proxyURL = "[Proxy URL]"

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -129,6 +129,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: Boolean }) needToResetPassword = false;
   @property({ type: Boolean }) directoryBasedUsage = false;
   @property({ type: Number }) maxCountForPreopenPorts = 10;
+  @property({ type: Boolean }) allowCustomResourceAllocation = true;
   private _enableContainerCommit = false;
   private _enablePipeline = false;
   @query('#login-panel')
@@ -823,6 +824,15 @@ export default class BackendAILogin extends BackendAIPage {
       defaultValue: this.maxCountForPreopenPorts, // default value has been already assigned in property declaration
       value: parseInt(generalConfig?.maxCountForPreopenPorts),
     } as ConfigValueObject) as number;
+
+    this.allowCustomResourceAllocation = this._getConfigValueByExists(
+      generalConfig,
+      {
+        valueType: 'boolean',
+        defaultValue: true,
+        value: generalConfig?.allowCustomResourceAllocation,
+      } as ConfigValueObject,
+    ) as boolean;
   }
 
   /**
@@ -1738,6 +1748,8 @@ export default class BackendAILogin extends BackendAIPage {
           this.directoryBasedUsage;
         globalThis.backendaiclient._config.maxCountForPreopenPorts =
           this.maxCountForPreopenPorts;
+        globalThis.backendaiclient._config.allowCustomResourceAllocation =
+          this.allowCustomResourceAllocation;
         globalThis.backendaiclient.ready = true;
         if (
           this.endpoints.indexOf(

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -229,6 +229,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
   );
   @property({ type: Boolean }) isExceedMaxCountForPreopenPorts = false;
   @property({ type: Number }) maxCountForPreopenPorts = 10;
+  @property({ type: Boolean }) allowCustomResourceAllocation = true;
 
   @query('#image-name') manualImageName;
   @query('#version') version_selector!: Select;
@@ -1006,6 +1007,8 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
           }
           this.maxCountForPreopenPorts =
             globalThis.backendaiclient._config.maxCountForPreopenPorts;
+          this.allowCustomResourceAllocation =
+            globalThis.backendaiclient._config.allowCustomResourceAllocation;
           this.is_connected = true;
           this._debug = globalThis.backendaiwebui.debug;
           this._enableLaunchButton();
@@ -1051,6 +1054,8 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       }
       this.maxCountForPreopenPorts =
         globalThis.backendaiclient._config.maxCountForPreopenPorts;
+      this.allowCustomResourceAllocation =
+        globalThis.backendaiclient._config.allowCustomResourceAllocation;
       this.is_connected = true;
       this._debug = globalThis.backendaiwebui.debug;
       this._enableLaunchButton();
@@ -5182,7 +5187,12 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                   : html``}
               </mwc-select>
             </div>
-            <lablup-expansion name="resource-group">
+            <lablup-expansion
+              name="resource-group"
+              style="display:${this.allowCustomResourceAllocation
+                ? 'block'
+                : 'none'}"
+            >
               <span slot="title">
                 ${_t('session.launcher.CustomAllocation')}
               </span>


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
resolves #1997 

How to test:
1. add `allowCustomResourceAllocation` option to config.toml
2. Check the custom allocation is hidden when `allowCustomResourceAllocation` is false.

Hide custom allocation if `allowCustomResourceAllocation` is false.
<img width="427" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/28584164/b26bac1d-fcd3-4d47-bf87-38472d8c482f">


**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after
