### PR TITLE
fix: hide inference app from app launcher

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -487,8 +487,14 @@ export default class BackendAiAppLauncher extends BackendAIPage {
     }
     this.preOpenedPortList = [];
     const preOpenAppNameList = servicePorts
-      ?.filter((item) => item.protocol === 'preopen')
+      ?.filter(
+        (item) => item.protocol === 'preopen' && item.is_inference === false,
+      )
       .map((item) => item.name);
+    const inferenceAppNameList = servicePorts
+      ?.filter((item) => item.is_inference === true)
+      .map((item) => item.name);
+
     preOpenAppNameList?.forEach((elm) => {
       this.preOpenedPortList.push({
         name: elm,
@@ -498,8 +504,11 @@ export default class BackendAiAppLauncher extends BackendAIPage {
       });
     });
     const filteredAppServices =
-      appServices?.filter((item) => !preOpenAppNameList?.includes(item)) ??
-      appServices;
+      appServices?.filter(
+        (item) =>
+          !preOpenAppNameList?.includes(item) &&
+          !inferenceAppNameList?.includes(item),
+      ) ?? appServices;
     this.appSupportList = [];
     if (!filteredAppServices?.includes('ttyd')) {
       this.appSupportList.push({


### PR DESCRIPTION
This PR updates app launcher's icon display logic to hide inference app being shown at the UI. App launcher is meant to display interactive apps only, so printing out inference apps here can make confusion to the user. To test this PR you have to create a model service session, move on to sessions tab and click app launcher icon.

**Checklist:** (if applicable)

- [X] Minimum required manager version
- [X] Specific setting for review (eg., KB link, endpoint or how to setup)
