### PR TITLE
fix: touchup sftp connection example text

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -274,11 +274,9 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           padding: 10px;
           border-radius: 5px;
           margin-bottom: 5px;
-          max-width: 95%;
         }
 
         .ssh-connection-example > span {
-          max-width: 95%;
           word-break: break-word;
         }
 
@@ -1773,7 +1771,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
                 </div>
                 <div class="horizontal layout flex monospace ssh-connection-example">
                 <span id="scp-string">
-                  scp -i ./id_container -o StrictHostKeyChecking=no UserKnownHostsFile=/dev/null -P ${
+                  scp -i ./id_container -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P ${
                     this.sshPort
                   } -rp /path/to/source work@${this.sshHost}:~/${
                     this.mountedVfolderName
@@ -1787,9 +1785,11 @@ export default class BackendAiAppLauncher extends BackendAIPage {
                 </div>
                 <div class="horizontal layout flex monospace ssh-connection-example">
                 <span id="rsync-string">
-                  rsync -av -e "ssh -i ./id_container -o StrictHostKeyChecking=no UserKnownHostsFile=/dev/null" /path/to/source/ work@${
-                    this.sshHost
-                  }:~/${this.mountedVfolderName}/<br/>
+                  rsync -av -e "ssh -i ./id_container -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p ${
+                    this.sshPort
+                  }" /path/to/source/ work@${this.sshHost}:~/${
+                    this.mountedVfolderName
+                  }/<br/>
                 </span>
                 <mwc-icon-button
                 class="sftp-session-connection-copy"

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -274,6 +274,12 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           padding: 10px;
           border-radius: 5px;
           margin-bottom: 5px;
+          max-width: 95%;
+        }
+
+        .ssh-connection-example > span {
+          max-width: 95%;
+          word-break: break-word;
         }
 
         @media screen and (max-width: 810px) {

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -1753,9 +1753,11 @@ export default class BackendAiAppLauncher extends BackendAIPage {
             <h4>${_t('session.ConnectionExample')}</h4>
                 <div class="horizontal layout flex monospace ssh-connection-example">
                 <span id="sftp-string">
-                  sftp -i ./id_container -P ${this.sshPort} work@${
+                  sftp -i ./id_container -P ${
+                    this.sshPort
+                  } -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null work@${
                     this.sshHost
-                  } -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null<br/>
+                  }<br/>
                 </span>
                 <mwc-icon-button
                 class="sftp-session-connection-copy"


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
follows #1986 

## What's changed
Current SSH/SFTP connection command example does not work on MacOS. To fix this problem, I modified the example so that the host input goes to the end of the sentence and added missed options such as `-o`, and `-p <port>`.

+) style: added `break-word` to avoid overlapping.

| Before | After |
|--------|--------|
| sftp -i ./id_container -P ${this.sshPort} **work@${this.sshHost}** -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null | sftp -i ./id_container -P ${this.sshPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null **work@${this.sshPort}** |
|scp -i ./id_container -o StrictHostKeyChecking=no UserKnownHostsFile=/dev/null -P ${this.sshPort} -rp /path/to/source work@${this.sshHost}:~/${this.mountedVfolderName}|scp -i ./id_container -o StrictHostKeyChecking=no **-o** UserKnownHostsFile=/dev/null -P ${this.sshPort} -rp /path/to/source work@${this.sshHost}:~/${this.mountedVfolderName}|
|rsync -av -e "ssh -i ./id_container -o StrictHostKeyChecking=no UserKnownHostsFile=/dev/null" /path/to/source/ work@${this.sshHost}:~/${this.mountedVfolderName}|rsync -av -e "ssh -i ./id_container -o StrictHostKeyChecking=no **-o** UserKnownHostsFile=/dev/null **-p ${this.sshPort}**" /path/to/source/ work@${this.sshHost}:~/${this.mountedVfolderName}|

<img width="391" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/28584164/99c85b8c-c9c4-4580-a8fb-058591e360b6">


## How to test
- Test machine: 10.82.230.101
- Checklist: 
  - [ ] Does sftp, scp, rsync work well?
    - ref: https://webui.docs.backend.ai/en/latest/sftp_to_container/sftp_to_container.html#ssh-sftp-connection-to-a-compute-session
  - [ ] Isn't an example code block's UI broken even if the mounted folder's name is long?

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after
