### PR TITLE
feat: add passwordless sudo user management UI

### DIFF
--- a/react/src/components/UserInfoModal.tsx
+++ b/react/src/components/UserInfoModal.tsx
@@ -31,6 +31,9 @@ const UserInfoModal: React.FC<Props> = ({ ...baiModalProps }) => {
   const { open, userEmail } = parsedValue;
 
   const baiClient = useSuspendedBackendaiClient();
+  const sudoSessionEnabledSupported = baiClient?.supports(
+    'sudo-session-enabled',
+  );
   let totpSupported = false;
   let {
     data: isManagerSupportingTOTP,
@@ -49,7 +52,11 @@ const UserInfoModal: React.FC<Props> = ({ ...baiModalProps }) => {
 
   const { user } = useLazyLoadQuery<UserInfoModalQuery>(
     graphql`
-      query UserInfoModalQuery($email: String, $isTOTPSupported: Boolean!) {
+      query UserInfoModalQuery(
+        $email: String
+        $isNotSupportSudoSessionEnabled: Boolean!
+        $isTOTPSupported: Boolean!
+      ) {
         user(email: $email) {
           email
           username
@@ -63,12 +70,18 @@ const UserInfoModal: React.FC<Props> = ({ ...baiModalProps }) => {
             id
             name
           }
+          # TODO: reflect https://github.com/lablup/backend.ai-webui/pull/1999
+          # support from 23.09.0b1
+          # https://github.com/lablup/backend.ai/pull/1530
+          sudo_session_enabled
+            @skipOnClient(if: $isNotSupportSudoSessionEnabled)
           totp_activated @include(if: $isTOTPSupported)
         }
       }
     `,
     {
       email: userEmail,
+      isNotSupportSudoSessionEnabled: !sudoSessionEnabledSupported,
       isTOTPSupported: totpSupported ?? false,
     },
   );
@@ -125,6 +138,11 @@ const UserInfoModal: React.FC<Props> = ({ ...baiModalProps }) => {
         <Descriptions.Item label={t('credential.DescRequirePasswordChange')}>
           {user?.need_password_change ? t('button.Yes') : t('button.No')}
         </Descriptions.Item>
+        {sudoSessionEnabledSupported && (
+          <Descriptions.Item label={t('credential.EnableSudoSession')}>
+            {user?.sudo_session_enabled ? t('button.Yes') : t('button.No')}
+          </Descriptions.Item>
+        )}
         {totpSupported && (
           <Descriptions.Item label={t('webui.menu.TotpActivated')}>
             <Spin spinning={isLoadingManagerSupportingTOTP}>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "Schlüsselpaar Detail",
     "SignoutSeccessfullyFinished": "Die Abmeldung ist erfolgreich abgeschlossen",
     "Status": "Status",
-    "NoUserToDisplay": "Keine Benutzer zum Anzeigen"
+    "NoUserToDisplay": "Keine Benutzer zum Anzeigen",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Ordner",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "Λεπτομέρεια ζεύγους κλειδιών",
     "SignoutSeccessfullyFinished": "Η αποσύνδεση ολοκληρώθηκε επιτυχώς",
     "Status": "Κατάσταση",
-    "NoUserToDisplay": "Δεν υπάρχουν χρήστες για εμφάνιση"
+    "NoUserToDisplay": "Δεν υπάρχουν χρήστες για εμφάνιση",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Φάκελοι",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -597,7 +597,8 @@
     "KeypairDetail": "Keypair Detail",
     "AdminCanOnlyRemoveTotp": "Only disabling 2FA of other users is possible.",
     "KeySeccessfullyDeleted": "KeyPair is seccessfully deleted.",
-    "SignoutSeccessfullyFinished": "Signout is seccessfully finished"
+    "SignoutSeccessfullyFinished": "Signout is seccessfully finished",
+    "EnableSudoSession": "Enable sudo session"
   },
   "data": {
     "Folders": "Folders",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -204,7 +204,8 @@
       "PleaseSelectOptions": "Por favor, seleccione al menos una opción o más.",
       "PolicyName": "Nombre de la póliza Obligatorio.",
       "ValidationFailed": "Validación fallida"
-    }
+    },
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Allowslettersnumbersand-_": "Permite letras, números y -_",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -204,7 +204,8 @@
       "PleaseSelectOptions": "Valitse vähintään yksi tai useampi vaihtoehto.",
       "PolicyName": "Vakuutuksen nimi Pakollinen.",
       "ValidationFailed": "Validointi epäonnistui"
-    }
+    },
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Allowslettersnumbersand-_": "Sallii kirjaimet, numerot ja -_",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -505,7 +505,8 @@
     "AdminCanOnlyRemoveTotp": "Seule la désactivation du 2FA des autres utilisateurs est possible.",
     "KeySeccessfullyDeleted": "La paire de clés est supprimée successivement.",
     "SignoutSeccessfullyFinished": "La signature est terminée en toute sécurité",
-    "ModifyUserDetail": "Modifier les détails de l'utilisateur"
+    "ModifyUserDetail": "Modifier les détails de l'utilisateur",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Dossiers",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -505,7 +505,8 @@
     "AdminCanOnlyRemoveTotp": "Hanya menonaktifkan 2FA pengguna lain yang dapat dilakukan.",
     "KeySeccessfullyDeleted": "KeyPair dihapus dengan aman.",
     "SignoutSeccessfullyFinished": "Keluar dengan aman selesai",
-    "ModifyUserDetail": "Ubah Detail Pengguna"
+    "ModifyUserDetail": "Ubah Detail Pengguna",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Folder",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "Dettaglio coppia di chiavi",
     "SignoutSeccessfullyFinished": "Il signout è terminato in modo sicuro",
     "Status": "Stato",
-    "NoUserToDisplay": "Nessun utente da visualizzare"
+    "NoUserToDisplay": "Nessun utente da visualizzare",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "cartelle",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "キーフェア情報",
     "SignoutSeccessfullyFinished": "ユーザーアカウントが正常に削除されました。",
     "Status": "状態",
-    "NoUserToDisplay": "ユーザー情報がありません。"
+    "NoUserToDisplay": "ユーザー情報がありません。",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "フォルダー",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -586,7 +586,8 @@
     "AdminCanOnlyRemoveTotp": "다른 사용자의 이중 인증은 해제만 가능합니다.",
     "KeySeccessfullyDeleted": "키페어가 정상적으로 삭제되었습니다.",
     "SignoutSeccessfullyFinished": "사용자 계정이 성공적으로 삭제되었습니다.",
-    "ModifyUserDetail": "사용자 상세 정보 수정"
+    "ModifyUserDetail": "사용자 상세 정보 수정",
+    "EnableSudoSession": "sudo 세션 허용"
   },
   "data": {
     "Folders": "폴더",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -505,7 +505,8 @@
     "AdminCanOnlyRemoveTotp": "Зөвхөн бусад хэрэглэгчдийн 2FA-г идэвхгүй болгох боломжтой.",
     "KeySeccessfullyDeleted": "KeyPair амжилттай устгагдсан.",
     "SignoutSeccessfullyFinished": "Гарах ажиллагаа амжилттай дууслаа",
-    "ModifyUserDetail": "Хэрэглэгчийн мэдээллийг өөрчлөх"
+    "ModifyUserDetail": "Хэрэглэгчийн мэдээллийг өөрчлөх",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Фолдерууд",
@@ -898,7 +899,8 @@
     "PleaseSelectOption": "Нэг сонголтыг сонгоно уу.",
     "RegistrySuccessfullyModified": "Бүртгэл амжилттай өөрчлөгдсөн.",
     "ModifyRegistry": "Бүртгэлийг өөрчлөх",
-    "NoRegistryToDisplay": "Харуулах бүртгэл байхгүй"
+    "NoRegistryToDisplay": "Харуулах бүртгэл байхгүй",
+    "ConfirmNoUserName": "__NOT_TRANSLATED__"
   },
   "resourceGroup": {
     "ResourceGroups": "Нөөцийн бүлгүүд",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "Butiran pasangan kekunci",
     "SignoutSeccessfullyFinished": "Log keluar telah selesai dengan selamat",
     "Status": "Status",
-    "NoUserToDisplay": "Tiada Pengguna untuk dipaparkan"
+    "NoUserToDisplay": "Tiada Pengguna untuk dipaparkan",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Folder",
@@ -898,7 +899,8 @@
     "PleaseSelectOption": "Sila pilih satu pilihan.",
     "RegistrySuccessfullyModified": "Pendaftaran berjaya diubah suai.",
     "NoRegistryToDisplay": "Tiada Pendaftaran untuk dipaparkan",
-    "ModifyRegistry": "Ubah suai Pendaftaran"
+    "ModifyRegistry": "Ubah suai Pendaftaran",
+    "ConfirmNoUserName": "__NOT_TRANSLATED__"
   },
   "resourceGroup": {
     "ResourceGroups": "Kumpulan Sumber",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "Szczegóły pary kluczy",
     "SignoutSeccessfullyFinished": "Wylogowanie zostało pomyślnie zakończone",
     "Status": "Status",
-    "NoUserToDisplay": "Brak użytkowników do wyświetlenia"
+    "NoUserToDisplay": "Brak użytkowników do wyświetlenia",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Lornetka składana",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "Detalhe do par de chaves",
     "SignoutSeccessfullyFinished": "O registo foi concluído com êxito",
     "Status": "Estado",
-    "NoUserToDisplay": "Nenhum utilizador a apresentar"
+    "NoUserToDisplay": "Nenhum utilizador a apresentar",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Pastas",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "Detalhe do par de chaves",
     "SignoutSeccessfullyFinished": "O registo foi concluído com êxito",
     "Status": "Estado",
-    "NoUserToDisplay": "Nenhum utilizador a apresentar"
+    "NoUserToDisplay": "Nenhum utilizador a apresentar",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Pastas",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -505,7 +505,8 @@
     "AdminCanOnlyRemoveTotp": "Возможно только отключение 2FA для других пользователей.",
     "KeySeccessfullyDeleted": "Пара ключей удалена без последствий.",
     "SignoutSeccessfullyFinished": "Выход из системы завершен",
-    "ModifyUserDetail": "Изменение сведений о пользователе"
+    "ModifyUserDetail": "Изменение сведений о пользователе",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Папки",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "Anahtar Çifti Detayı",
     "SignoutSeccessfullyFinished": "Çıkış işlemi başarıyla tamamlandı",
     "Status": "Durum",
-    "NoUserToDisplay": "Görüntülenecek Kullanıcı Yok"
+    "NoUserToDisplay": "Görüntülenecek Kullanıcı Yok",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "klasörler",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "Chi tiết bàn phím",
     "SignoutSeccessfullyFinished": "Đăng xuất đã hoàn tất thành công",
     "Status": "Trạng thái",
-    "NoUserToDisplay": "Không có người dùng để hiển thị"
+    "NoUserToDisplay": "Không có người dùng để hiển thị",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "Thư mục",
@@ -898,7 +899,8 @@
     "PleaseSelectOption": "Làm ơn chọn một giải pháp.",
     "RegistrySuccessfullyModified": "Đã sửa đổi sổ đăng ký thành công.",
     "NoRegistryToDisplay": "Không có đăng ký để hiển thị",
-    "ModifyRegistry": "Sửa đổi sổ đăng ký"
+    "ModifyRegistry": "Sửa đổi sổ đăng ký",
+    "ConfirmNoUserName": "__NOT_TRANSLATED__"
   },
   "resourceGroup": {
     "ResourceGroups": "Nhóm tài nguyên",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "配对密钥详情",
     "SignoutSeccessfullyFinished": "签出已顺利完成",
     "Status": "现状",
-    "NoUserToDisplay": "无用户显示"
+    "NoUserToDisplay": "无用户显示",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "文件夹",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -505,7 +505,8 @@
     "KeypairDetail": "配对密钥详情",
     "SignoutSeccessfullyFinished": "签出已顺利完成",
     "Status": "现状",
-    "NoUserToDisplay": "无用户显示"
+    "NoUserToDisplay": "无用户显示",
+    "EnableSudoSession": "__NOT_TRANSLATED__"
   },
   "data": {
     "Folders": "文件夾",

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -660,7 +660,7 @@ class Client {
     if (this.isManagerVersionCompatibleWith('23.03.11')) {
       this._features['model-serving'] = true;
     }
-    if (this.isManagerVersionCompatibleWith('23.09.0b1')) {
+    if (this.isManagerVersionCompatibleWith('23.09.0')) {
       this._features['sudo-session-enabled'] = true;
     }
     if (this.isManagerVersionCompatibleWith('23.09.2')) {

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -660,6 +660,9 @@ class Client {
     if (this.isManagerVersionCompatibleWith('23.03.11')) {
       this._features['model-serving'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('23.09.0b1')) {
+      this._features['sudo-session-enabled'] = true;
+    }
     if (this.isManagerVersionCompatibleWith('23.09.2')) {
       this._features['container-registry-gql'] = true;
     }


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
resolves #1978 

## What's changed
- Query `sudo_session_enabled`
![image](https://github.com/lablup/backend.ai-webui/assets/28584164/83f722fc-f954-41c3-9528-fd8e26ef6ae5)
- Setting `sudo_session_enabled`
![image](https://github.com/lablup/backend.ai-webui/assets/28584164/6dcff9a1-fe02-4e00-90e1-bba567cf33e1)

## How to test
- Minimum manager version: `23.09.0b1`.
- Go to Users (credential) page -> check the user info and setting dialog.
- Checklist
  - [ ] Can query `sudo_session_enabled` in the user info, user setting dialog.


**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after
