### PR TITLE
fix: remove image naming checking when selecting sftp image

### DIFF
--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -3813,9 +3813,7 @@ export default class BackendAiStorageList extends BackendAIPage {
     const imageResource: Record<string, unknown> = {};
     const configSSHImage = globalThis.backendaiclient._config.systemSSHImage;
     const images = this.systemRoleSupportedImages.filter(
-      (image: any) =>
-        image['name'].toLowerCase().includes('sftp-upload') &&
-        image['installed'],
+      (image: any) => image['installed'],
     );
     // TODO: use lablup/openssh-server image
     // select one image to launch system role supported session


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

resolves https://github.com/lablup/backend.ai-webui/issues/2006
## What's changed
By removing unnecessary logic that checks whether the image name contains `sftp-upload` or not, I have modified the fallback image to be properly selected even if `systemSSHImage` is not specified.

 (image: any) =>
        **~~image['name'].toLowerCase().includes('sftp-upload') &&~~**
        image['installed'],

## How to test
> Need sftp setting farm (`system` role  image, isolated storagy proxy node, sftp_scaling_groups, etc.): 10.82.230.101

- [ ] Test 1
1.  Remove the `systemSSHImage` option.
2. Open the ssh/sftp image by clicking the ssh icon on the folder dialog.
3. Check upload session is created without error.

- [ ] Test 2
1. Set `systemSSHImage` option.
2. Launch upload session in the same way as above.
3. Check the requested session image is the same as the set image.


**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after
