### PR TITLE
feature: set password to `undefined` when no change is desired.

### DIFF
--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -60,6 +60,7 @@ const ContainerRegistryEditorModal: React.FC<
               type
               project
               username
+              password
               ssl_verify
             }
           }
@@ -82,6 +83,7 @@ const ContainerRegistryEditorModal: React.FC<
               type
               project
               username
+              password
               ssl_verify
             }
           }
@@ -105,9 +107,11 @@ const ContainerRegistryEditorModal: React.FC<
             username: _.isEmpty(values.config.username)
               ? null
               : values.config.username,
-            password: _.isEmpty(values.config.password)
-              ? null
-              : values.config.password,
+            password: values.isChangedPassword
+              ? _.isEmpty(values.config.password)
+                ? null // unset
+                : values.config.password
+              : undefined, // no change
           },
         };
         if (containerRegistry) {

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -61,6 +61,7 @@ const ContainerRegistryList = () => {
               type
               project
               username
+              password
               ssl_verify
             }
           }
@@ -261,9 +262,10 @@ const ContainerRegistryList = () => {
             title: t('registry.Username'),
             dataIndex: ['config', 'username'],
           },
-          // {
-          // title: t('registry.Password')
-          // },
+          {
+            title: t('registry.Password'),
+            dataIndex: ['config', 'password'],
+          },
           {
             title: t('general.Enabled'),
             render: (value, record) => {


### PR DESCRIPTION
After https://github.com/lablup/backend.ai/pull/1670 merged, you can test.

There are two changes
- Set the password to `undefined` when no change is desired.
  - <img width="514" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/1ebca27b-87dc-421d-88cc-e86fdcf3e3c5">
- display the masked password if the password is set.  
  - <img width="572" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/d55a3b34-72bc-4aa3-b568-0bd97e842367">

How to test
- Create a registry with a username and password
  - [ ] You can see the `****` in the password column of the created registry.
- Click the "Edit" button in the registry. Check "비밀번호 변경" and leave the password field blank. Finally, click "Save".
  - [ ]  You can see the empty password column of the registry. 

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
