### PR TITLE
fix: UI with multiple types of accelerators

### DIFF
--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -349,6 +349,10 @@ export default class BackendAiResourceBroker extends BackendAIPage {
    *
    */
   async _refreshResourcePolicy() {
+    if (!globalThis.backendaiclient) {
+      // To prevent a silent failure when the client is not ready in aggregating resources.
+      return Promise.resolve(false);
+    }
     if (Date.now() - this.lastResourcePolicyQueryTime < 2000) {
       return Promise.resolve(false);
     }
@@ -482,7 +486,7 @@ export default class BackendAiResourceBroker extends BackendAIPage {
    * @param {string} from - set the value for debugging purpose.
    */
   async _aggregateCurrentResource(from = '') {
-    if (this.aggregate_updating) {
+    if (!globalThis.backendaiclient || this.aggregate_updating) {
       return Promise.resolve(false);
     }
     if (Date.now() - this.lastQueryTime < 1000) {

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -517,6 +517,15 @@ export default class BackendAiResourceBroker extends BackendAIPage {
         const sgs = await globalThis.backendaiclient.scalingGroup.list(
           this.current_user_group,
         );
+        // TODO: Delete these codes after backend.ai support scaling groups filtering.
+        // ================================ START ====================================
+        if (sgs && sgs.scaling_groups && sgs.scaling_groups.length > 0) {
+          const sftpResourceGroups = await this._sftpScalingGroups();
+          sgs.scaling_groups = sgs.scaling_groups.filter(
+            (item) => !sftpResourceGroups?.includes(item.name),
+          );
+        }
+        // ================================ END ====================================
         // Make empty scaling group item if there is no scaling groups.
         this.scaling_groups =
           sgs.scaling_groups.length > 0 ? sgs.scaling_groups : [{ name: '' }];

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -496,12 +496,14 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
     ) as Switch;
     if (document.body.clientWidth > 750 && this.direction == 'horizontal') {
       legend.style.display = 'flex';
+      legend.style.marginTop = '0';
       Array.from(this.resourceGauge.children).forEach((elem) => {
         (elem as HTMLElement).style.display = 'flex';
       });
     } else {
       if (toggleButton.selected) {
         legend.style.display = 'flex';
+        legend.style.marginTop = '0';
         if (document.body.clientWidth < 750) {
           this.resourceGauge.style.left = '20px';
           this.resourceGauge.style.right = '20px';

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -532,7 +532,16 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
     }
     return this.resourceBroker
       ._refreshResourcePolicy()
-      .then(() => {
+      .then((resolvedValue) => {
+        if (resolvedValue === false) {
+          setTimeout(() => {
+            // Retry to get the concurrency_max after a while if resource broker
+            // is not ready. When the timeout is 2000, it delays the display of
+            // other resource's allocation status. I don't know why, but I just
+            // set it to 2500.
+            this._refreshResourcePolicy();
+          }, 2500);
+        }
         this.concurrency_used = this.resourceBroker.concurrency_used;
         // this.userResourceLimit = this.resourceBroker.userResourceLimit;
         this.concurrency_max =

--- a/src/components/backend-ai-resource-panel.ts
+++ b/src/components/backend-ai-resource-panel.ts
@@ -186,7 +186,6 @@ export default class BackendAIResourcePanel extends BackendAIPage {
         .resource {
           margin-bottom: 10px;
           margin-left: 5px;
-          height: 46px;
         }
 
         .resource-line {
@@ -631,245 +630,277 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                           >
                             <div class="gauge-name">GPU/NPU</div>
                           </div>
-                          ${this.cuda_gpu_total
-                            ? html`
-                                <div
-                                  class="layout vertical start-justified wrap"
-                                >
-                                  <lablup-progress-bar
-                                    id="gpu-usage-bar"
-                                    class="start"
-                                    progress="${this.cuda_gpu_used /
-                                    this.cuda_gpu_total}"
-                                    description="${this.cuda_gpu_used} / ${this
-                                      .cuda_gpu_total} CUDA GPUs ${_t(
-                                      'summary.reserved',
-                                    )}."
-                                  ></lablup-progress-bar>
-                                  <lablup-progress-bar
-                                    id="gpu-usage-bar-2"
-                                    class="end"
-                                    progress="0"
-                                    description="${_t(
-                                      'summary.FractionalGPUScalingEnabled',
-                                    )}."
-                                  ></lablup-progress-bar>
-                                </div>
-                                <div
-                                  class="layout vertical center center-justified"
-                                >
-                                  <span class="percentage start-bar">
-                                    ${this.cuda_gpu_used !== 0
-                                      ? (
-                                          (this.cuda_gpu_used /
-                                            this.cuda_gpu_total) *
-                                          100
-                                        ).toFixed(1)
-                                      : 0}%
-                                  </span>
-                                  <span class="percentage end-bar">&nbsp;</span>
-                                </div>
-                              `
-                            : html``}
-                          ${this.cuda_fgpu_total
-                            ? html`
-                                <div
-                                  class="layout vertical start-justified wrap"
-                                >
-                                  <lablup-progress-bar
-                                    id="fgpu-usage-bar"
-                                    class="start"
-                                    progress="${this.cuda_fgpu_used /
-                                    this.cuda_fgpu_total}"
-                                    description="${this.cuda_fgpu_used} / ${this
-                                      .cuda_fgpu_total} CUDA FGPUs ${_t(
-                                      'summary.reserved',
-                                    )}."
-                                  ></lablup-progress-bar>
-                                  <lablup-progress-bar
-                                    id="fgpu-usage-bar-2"
-                                    class="end"
-                                    progress="0"
-                                    description="${_t(
-                                      'summary.FractionalGPUScalingEnabled',
-                                    )}."
-                                  ></lablup-progress-bar>
-                                </div>
-                                <div
-                                  class="layout vertical center center-justified"
-                                >
-                                  <span class="percentage start-bar">
-                                    ${this.cuda_fgpu_used !== 0
-                                      ? (
-                                          (this.cuda_fgpu_used /
-                                            this.cuda_fgpu_total) *
-                                          100
-                                        ).toFixed(1)
-                                      : 0}%
-                                  </span>
-                                  <span class="percentage end-bar">&nbsp;</span>
-                                </div>
-                              `
-                            : html``}
-                          ${this.rocm_gpu_total
-                            ? html`
-                                <div
-                                  class="layout vertical start-justified wrap"
-                                >
-                                  <lablup-progress-bar
-                                    id="rocm-gpu-usage-bar"
-                                    class="start"
-                                    progress="${this.rocm_gpu_used / 100.0}"
-                                    description="${this.rocm_gpu_used} / ${this
-                                      .rocm_gpu_total} ROCm GPUs ${_t(
-                                      'summary.reserved',
-                                    )}."
-                                  ></lablup-progress-bar>
-                                  <lablup-progress-bar
-                                    id="rocm-gpu-usage-bar-2"
-                                    class="end"
-                                    progress="0"
-                                    description="${_t(
-                                      'summary.ROCMGPUEnabled',
-                                    )}."
-                                  ></lablup-progress-bar>
-                                </div>
-                                <div
-                                  class="layout vertical center center-justified"
-                                >
-                                  <span class="percentage start-bar">
-                                    ${this.rocm_gpu_used.toFixed(1) + '%'}
-                                  </span>
-                                  <span class="percentage end-bar">&nbsp;</span>
-                                </div>
-                              `
-                            : html``}
-                          ${this.tpu_total
-                            ? html`
-                                <div
-                                  class="layout vertical start-justified wrap"
-                                >
-                                  <lablup-progress-bar
-                                    id="tpu-usage-bar"
-                                    class="start"
-                                    progress="${this.tpu_used / 100.0}"
-                                    description="${this.tpu_used} / ${this
-                                      .tpu_total} TPUs ${_t(
-                                      'summary.reserved',
-                                    )}."
-                                  ></lablup-progress-bar>
-                                  <lablup-progress-bar
-                                    id="tpu-usage-bar-2"
-                                    class="end"
-                                    progress="0"
-                                    description="${_t('summary.TPUEnabled')}."
-                                  ></lablup-progress-bar>
-                                </div>
-                                <div
-                                  class="layout vertical center center-justified"
-                                >
-                                  <span class="percentage start-bar">
-                                    ${this.tpu_used.toFixed(1) + '%'}
-                                  </span>
-                                  <span class="percentage end-bar"></span>
-                                </div>
-                              `
-                            : html``}
-                          ${this.ipu_total
-                            ? html`
-                                <div
-                                  class="layout vertical start-justified wrap"
-                                >
-                                  <lablup-progress-bar
-                                    id="ipu-usage-bar"
-                                    class="start"
-                                    progress="${this.ipu_used / 100.0}"
-                                    description="${this.ipu_used} / ${this
-                                      .ipu_total} IPUs ${_t(
-                                      'summary.reserved',
-                                    )}."
-                                  ></lablup-progress-bar>
-                                  <lablup-progress-bar
-                                    id="ipu-usage-bar-2"
-                                    class="end"
-                                    progress="0"
-                                    description="${_t('summary.IPUEnabled')}."
-                                  ></lablup-progress-bar>
-                                </div>
-                                <div
-                                  class="layout vertical center center-justified"
-                                >
-                                  <span class="percentage start-bar">
-                                    ${this.ipu_used.toFixed(1) + '%'}
-                                  </span>
-                                  <span class="percentage end-bar"></span>
-                                </div>
-                              `
-                            : html``}
-                          ${this.atom_total
-                            ? html`
-                                <div
-                                  class="layout vertical start-justified wrap"
-                                >
-                                  <lablup-progress-bar
-                                    id="atom-usage-bar"
-                                    class="start"
-                                    progress="${this.atom_used / 100.0}"
-                                    description="${this.atom_used} / ${this
-                                      .atom_total} ATOMs ${_t(
-                                      'summary.reserved',
-                                    )}."
-                                  ></lablup-progress-bar>
-                                  <lablup-progress-bar
-                                    id="atom-usage-bar-2"
-                                    class="end"
-                                    progress="0"
-                                    description="${_t('summary.ATOMEnabled')}."
-                                  ></lablup-progress-bar>
-                                </div>
-                                <div
-                                  class="layout vertical center center-justified"
-                                >
-                                  <span class="percentage start-bar">
-                                    ${this.atom_used.toFixed(1) + '%'}
-                                  </span>
-                                  <span class="percentage end-bar"></span>
-                                </div>
-                              `
-                            : html``}
-                          ${this.warboy_total
-                            ? html`
-                                <div
-                                  class="layout vertical start-justified wrap"
-                                >
-                                  <lablup-progress-bar
-                                    id="warboy-usage-bar"
-                                    class="start"
-                                    progress="${this.warboy_used / 100.0}"
-                                    description="${this.warboy_used} / ${this
-                                      .warboy_total} Warboys ${_t(
-                                      'summary.reserved',
-                                    )}."
-                                  ></lablup-progress-bar>
-                                  <lablup-progress-bar
-                                    id="warboy-usage-bar-2"
-                                    class="end"
-                                    progress="0"
-                                    description="${_t(
-                                      'summary.WarboyEnabled',
-                                    )}."
-                                  ></lablup-progress-bar>
-                                </div>
-                                <div
-                                  class="layout vertical center center-justified"
-                                >
-                                  <span class="percentage start-bar">
-                                    ${this.warboy_used.toFixed(1) + '%'}
-                                  </span>
-                                  <span class="percentage end-bar"></span>
-                                </div>
-                              `
-                            : html``}
+                          <div class="layout vertical">
+                            ${this.cuda_gpu_total
+                              ? html`
+                                  <div class="layout horizontal">
+                                    <div
+                                      class="layout vertical start-justified wrap"
+                                    >
+                                      <lablup-progress-bar
+                                        id="gpu-usage-bar"
+                                        class="start"
+                                        progress="${this.cuda_gpu_used /
+                                        this.cuda_gpu_total}"
+                                        description="${this
+                                          .cuda_gpu_used} / ${this
+                                          .cuda_gpu_total} CUDA GPUs ${_t(
+                                          'summary.reserved',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                      <lablup-progress-bar
+                                        id="gpu-usage-bar-2"
+                                        class="end"
+                                        progress="0"
+                                        description="${_t(
+                                          'summary.FractionalGPUScalingEnabled',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                    </div>
+                                    <div
+                                      class="layout vertical center center-justified"
+                                    >
+                                      <span class="percentage start-bar">
+                                        ${this.cuda_gpu_used !== 0
+                                          ? (
+                                              (this.cuda_gpu_used /
+                                                this.cuda_gpu_total) *
+                                              100
+                                            ).toFixed(1)
+                                          : 0}%
+                                      </span>
+                                      <span class="percentage end-bar">
+                                        &nbsp;
+                                      </span>
+                                    </div>
+                                  </div>
+                                `
+                              : html``}
+                            ${this.cuda_fgpu_total
+                              ? html`
+                                  <div class="layout horizontal">
+                                    <div
+                                      class="layout vertical start-justified wrap"
+                                    >
+                                      <lablup-progress-bar
+                                        id="fgpu-usage-bar"
+                                        class="start"
+                                        progress="${this.cuda_fgpu_used /
+                                        this.cuda_fgpu_total}"
+                                        description="${this
+                                          .cuda_fgpu_used} / ${this
+                                          .cuda_fgpu_total} CUDA FGPUs ${_t(
+                                          'summary.reserved',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                      <lablup-progress-bar
+                                        id="fgpu-usage-bar-2"
+                                        class="end"
+                                        progress="0"
+                                        description="${_t(
+                                          'summary.FractionalGPUScalingEnabled',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                    </div>
+                                    <div
+                                      class="layout vertical center center-justified"
+                                    >
+                                      <span class="percentage start-bar">
+                                        ${this.cuda_fgpu_used !== 0
+                                          ? (
+                                              (this.cuda_fgpu_used /
+                                                this.cuda_fgpu_total) *
+                                              100
+                                            ).toFixed(1)
+                                          : 0}%
+                                      </span>
+                                      <span class="percentage end-bar">
+                                        &nbsp;
+                                      </span>
+                                    </div>
+                                  </div>
+                                `
+                              : html``}
+                            ${this.rocm_gpu_total
+                              ? html`
+                                  <div class="layout horizontal">
+                                    <div
+                                      class="layout vertical start-justified wrap"
+                                    >
+                                      <lablup-progress-bar
+                                        id="rocm-gpu-usage-bar"
+                                        class="start"
+                                        progress="${this.rocm_gpu_used / 100.0}"
+                                        description="${this
+                                          .rocm_gpu_used} / ${this
+                                          .rocm_gpu_total} ROCm GPUs ${_t(
+                                          'summary.reserved',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                      <lablup-progress-bar
+                                        id="rocm-gpu-usage-bar-2"
+                                        class="end"
+                                        progress="0"
+                                        description="${_t(
+                                          'summary.ROCMGPUEnabled',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                    </div>
+                                    <div
+                                      class="layout vertical center center-justified"
+                                    >
+                                      <span class="percentage start-bar">
+                                        ${this.rocm_gpu_used.toFixed(1) + '%'}
+                                      </span>
+                                      <span class="percentage end-bar">
+                                        &nbsp;
+                                      </span>
+                                    </div>
+                                  </div>
+                                `
+                              : html``}
+                            ${this.tpu_total
+                              ? html`
+                                  <div class="layout horizontal">
+                                    <div
+                                      class="layout vertical start-justified wrap"
+                                    >
+                                      <lablup-progress-bar
+                                        id="tpu-usage-bar"
+                                        class="start"
+                                        progress="${this.tpu_used / 100.0}"
+                                        description="${this.tpu_used} / ${this
+                                          .tpu_total} TPUs ${_t(
+                                          'summary.reserved',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                      <lablup-progress-bar
+                                        id="tpu-usage-bar-2"
+                                        class="end"
+                                        progress="0"
+                                        description="${_t(
+                                          'summary.TPUEnabled',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                    </div>
+                                    <div
+                                      class="layout vertical center center-justified"
+                                    >
+                                      <span class="percentage start-bar">
+                                        ${this.tpu_used.toFixed(1) + '%'}
+                                      </span>
+                                      <span class="percentage end-bar"></span>
+                                    </div>
+                                  </div>
+                                `
+                              : html``}
+                            ${this.ipu_total
+                              ? html`
+                                  <div class="layout horizontal">
+                                    <div
+                                      class="layout vertical start-justified wrap"
+                                    >
+                                      <lablup-progress-bar
+                                        id="ipu-usage-bar"
+                                        class="start"
+                                        progress="${this.ipu_used / 100.0}"
+                                        description="${this.ipu_used} / ${this
+                                          .ipu_total} IPUs ${_t(
+                                          'summary.reserved',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                      <lablup-progress-bar
+                                        id="ipu-usage-bar-2"
+                                        class="end"
+                                        progress="0"
+                                        description="${_t(
+                                          'summary.IPUEnabled',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                    </div>
+                                    <div
+                                      class="layout vertical center center-justified"
+                                    >
+                                      <span class="percentage start-bar">
+                                        ${this.ipu_used.toFixed(1) + '%'}
+                                      </span>
+                                      <span class="percentage end-bar"></span>
+                                    </div>
+                                  </div>
+                                `
+                              : html``}
+                            ${this.atom_total
+                              ? html`
+                                  <div class="layout horizontal">
+                                    <div
+                                      class="layout vertical start-justified wrap"
+                                    >
+                                      <lablup-progress-bar
+                                        id="atom-usage-bar"
+                                        class="start"
+                                        progress="${this.atom_used / 100.0}"
+                                        description="${this.atom_used} / ${this
+                                          .atom_total} ATOMs ${_t(
+                                          'summary.reserved',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                      <lablup-progress-bar
+                                        id="atom-usage-bar-2"
+                                        class="end"
+                                        progress="0"
+                                        description="${_t(
+                                          'summary.ATOMEnabled',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                    </div>
+                                    <div
+                                      class="layout vertical center center-justified"
+                                    >
+                                      <span class="percentage start-bar">
+                                        ${this.atom_used.toFixed(1) + '%'}
+                                      </span>
+                                      <span class="percentage end-bar"></span>
+                                    </div>
+                                  </div>
+                                `
+                              : html``}
+                            ${this.warboy_total
+                              ? html`
+                                  <div class="layout horizontal">
+                                    <div
+                                      class="layout vertical start-justified wrap"
+                                    >
+                                      <lablup-progress-bar
+                                        id="warboy-usage-bar"
+                                        class="start"
+                                        progress="${this.warboy_used / 100.0}"
+                                        description="${this
+                                          .warboy_used} / ${this
+                                          .warboy_total} Warboys ${_t(
+                                          'summary.reserved',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                      <lablup-progress-bar
+                                        id="warboy-usage-bar-2"
+                                        class="end"
+                                        progress="0"
+                                        description="${_t(
+                                          'summary.WarboyEnabled',
+                                        )}."
+                                      ></lablup-progress-bar>
+                                    </div>
+                                    <div
+                                      class="layout vertical center center-justified"
+                                    >
+                                      <span class="percentage start-bar">
+                                        ${this.warboy_used.toFixed(1) + '%'}
+                                      </span>
+                                      <span class="percentage end-bar"></span>
+                                    </div>
+                                  </div>
+                                `
+                              : html``}
+                          </div>
                         </div>
                       `
                     : html``}


### PR DESCRIPTION
Some fixes for UI with multiple types of accelerators. The changes are far from optimal solutions, but rather points out that they require changes. Please check if the updates are compatible with other environments.

**Broken accelerator allocation bar layout in the summary page**
<img width="1020" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/7539358/0529200e-ba63-4db5-8dec-c40bbc138f16">

**Broken resource monitor texts**
<img width="807" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/7539358/fbcecadd-58de-47b9-8946-8095b4c0bdf5">

**Hide sFTP upload resource group from session launcher dialog**
<img width="814" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/7539358/78d039ec-9934-4871-91b3-c208d6e58c26">

**User's max session concurrency is displayed after 20 seconds**
<img width="576" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/7539358/638315d6-37d5-4a8e-be64-17d6a7ba7f86">