### PR TITLE
update: stand-alone local proxy packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,6 @@ mac_intel: dep mac_load_keychain
 ifdef BAI_APP_SIGN_KEYCHAIN
 	security default-keychain -s login.keychain
 endif
-	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-x64
-	npx pkg ./src/wsproxy/local_proxy.js --targets node18-macos-x64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-intel --compress Brotli
 	rm -rf ./app/backend.ai-desktop-macos-intel
 	cd app; mv "Backend.AI Desktop-darwin-x64" backend.ai-desktop-macos-intel;
 	npx electron-installer-dmg './app/backend.ai-desktop-macos-intel/Backend.AI Desktop.app' ./app/backend.ai-desktop-intel-$(BUILD_DATE) --overwrite --icon=manifest/backend-ai.icns --title=Backend.AI
@@ -106,14 +104,16 @@ ifeq ($(site),main)
 else
 	mv ./app/backend.ai-desktop-intel-$(BUILD_DATE).dmg ./app/backend.ai-desktop-$(BUILD_VERSION)-$(site)-macos-intel.dmg
 endif
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-x64
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-macos-x64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-intel --compress Brotli
+	rm -rf ./app/backend.ai-local-proxy; cp ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-intel ./app/backend.ai-local-proxy
+	cd app; zip -r -9 ./backend.ai-local-proxy-$(BUILD_VERSION)-macos-intel.zip "./backend.ai-local-proxy"
 mac_apple: dep mac_load_keychain
 	cp ./configs/$(site).toml ./build/electron-app/app/config.toml
 	BAI_APP_SIGN_KEYCHAIN="${BAI_APP_SIGN_KEYCHAIN}" node ./app-packager.js darwin arm64
 ifdef BAI_APP_SIGN_KEYCHAIN
 	security default-keychain -s login.keychain
 endif
-	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-apple
-	npx pkg ./src/wsproxy/local_proxy.js --targets node18-macos-arm64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-apple --compress Brotli
 	rm -rf ./app/backend.ai-desktop-macos-apple
 	cd app; mv "Backend.AI Desktop-darwin-arm64" backend.ai-desktop-macos-apple;
 	npx electron-installer-dmg './app/backend.ai-desktop-macos-apple/Backend.AI Desktop.app' ./app/backend.ai-desktop-apple-$(BUILD_DATE) --overwrite --icon=manifest/backend-ai.icns --title=Backend.AI
@@ -122,52 +122,64 @@ ifeq ($(site),main)
 else
 	mv ./app/backend.ai-desktop-apple-$(BUILD_DATE).dmg ./app/backend.ai-desktop-$(BUILD_VERSION)-$(site)-macos-apple.dmg
 endif
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-apple
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-macos-arm64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-apple --compress Brotli
+	rm -rf ./app/backend.ai-local-proxy; cp ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-apple ./app/backend.ai-local-proxy
+	cd app; zip -r -9 ./backend.ai-local-proxy-$(BUILD_VERSION)-macos-apple.zip "./backend.ai-local-proxy"
 win: win_intel win_arm64
 win_intel: dep
 	cp ./configs/$(site).toml ./build/electron-app/app/config.toml
 	node ./app-packager.js win x64
-	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win-x64
-	npx pkg ./src/wsproxy/local_proxy.js --targets node18-win-x64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win32-x64 --compress Brotli
 	cd app; zip ./backend.ai-desktop-win32-x64-$(BUILD_DATE).zip -r "./Backend.AI Desktop-win32-x64"
 ifeq ($(site),main)
 	mv ./app/backend.ai-desktop-win32-x64-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(BUILD_VERSION)-win32-x64.zip
 else
 	mv ./app/backend.ai-desktop-win32-x64-$(BUILD_DATE).zip ./app/backend.ai-desktop-x64-$(BUILD_VERSION)-$(site).zip
 endif
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win-x64.exe
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-win-x64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win32-x64.exe --compress Brotli
+	rm -rf ./app/backend.ai-local-proxy; cp ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win-x64 ./app/backend.ai-local-proxy.exe
+	cd app; zip -r -9 ./backend.ai-local-proxy-$(BUILD_VERSION)-win-x64.zip "./backend.ai-local-proxy.exe"
 win_arm64: dep
 	cp ./configs/$(site).toml ./build/electron-app/app/config.toml
 	node ./app-packager.js win arm64
-	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win-arm64
-	npx pkg ./src/wsproxy/local_proxy.js --targets node18-win-arm64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win32-arm64 --compress Brotli
 	cd app; zip ./backend.ai-desktop-win32-arm64-$(BUILD_DATE).zip -r "./Backend.AI Desktop-win32-arm64"
 ifeq ($(site),main)
 	mv ./app/backend.ai-desktop-win32-arm64-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(BUILD_VERSION)-win32-arm64.zip
 else
 	mv ./app/backend.ai-desktop-win32-arm64-$(BUILD_DATE).zip ./app/backend.ai-desktop-arm64-$(BUILD_VERSION)-$(site).zip
 endif
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win-arm64.exe
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-win-arm64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win32-arm64.exe --compress Brotli
+	rm -rf ./app/backend.ai-local-proxy; cp ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win-x64 ./app/backend.ai-local-proxy.exe
+	cd app; zip -r -9 ./backend.ai-local-proxy-$(BUILD_VERSION)-win-arm64.zip "./backend.ai-local-proxy.exe"
 linux: linux_intel linux_arm64
 linux_intel: dep
 	cp ./configs/$(site).toml ./build/electron-app/app/config.toml
 	node ./app-packager.js linux x64
-	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-x64
-	npx pkg ./src/wsproxy/local_proxy.js --targets node18-linux-x64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-x64 --compress Brotli
 	cd app; zip -r -9 ./backend.ai-desktop-linux-x64-$(BUILD_DATE).zip "./Backend.AI Desktop-linux-x64"
 ifeq ($(site),main)
 	mv ./app/backend.ai-desktop-linux-x64-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(BUILD_VERSION)-linux-x64.zip
 else
 	mv ./app/backend.ai-desktop-linux-x64-$(BUILD_DATE).zip ./app/backend.ai-desktop-linux-x64-$(BUILD_VERSION)-$(site).zip
 endif
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-x64
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-linux-x64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-x64 --compress Brotli
+	rm -rf ./app/backend.ai-local-proxy; cp ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-x64 ./app/backend.ai-local-proxy
+	cd app; zip -r -9 ./backend.ai-local-proxy-$(BUILD_VERSION)-linux-x64.zip "./backend.ai-local-proxy"
 linux_arm64: dep
 	cp ./configs/$(site).toml ./build/electron-app/app/config.toml
 	node ./app-packager.js linux arm64
-	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-arm64
-	npx pkg ./src/wsproxy/local_proxy.js --targets node18-linux-arm64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-arm64 --compress Brotli
 	cd app; zip -r -9 ./backend.ai-desktop-linux-arm64-$(BUILD_DATE).zip "./Backend.AI Desktop-linux-arm64"
 ifeq ($(site),main)
 	mv ./app/backend.ai-desktop-linux-arm64-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(BUILD_VERSION)-linux-arm64.zip
 else
 	mv ./app/backend.ai-desktop-linux-arm64-$(BUILD_DATE).zip ./app/backend.ai-desktop-linux-arm64-$(BUILD_VERSION)-$(site).zip
 endif
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-arm64
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-linux-arm64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-arm64 --compress Brotli
+	rm -rf ./app/backend.ai-local-proxy; cp ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-arm64 ./app/backend.ai-local-proxy
+	cd app; zip -r -9 ./backend.ai-local-proxy-$(BUILD_VERSION)-linux-arm64.zip "./backend.ai-local-proxy"
 build_docker: compile
 	docker build -t backend.ai-webui:$(BUILD_DATE) .
 pack:

--- a/Makefile
+++ b/Makefile
@@ -130,38 +130,38 @@ mac_x64: os := macos
 mac_x64: arch := x64
 mac_x64: local_proxy_postfix :=
 mac_x64: dep mac_load_keychain compile_localproxy package_dmg
-	@echo "Building for macOS x64"
+	@echo "Build finished: macOS x64"
 mac_arm64: os := macos
 mac_arm64: arch := arm64
 mac_arm64: local_proxy_postfix :=
 mac_arm64: dep mac_load_keychain compile_localproxy package_dmg
-	@echo "Building for macOS arm64"
+	@echo "Build finished: macOS arm64"
 win: win_x64 win_arm64
 win_x64: os := win
 win_x64: os_api := win32
 win_x64: arch := x64
 win_x64: local_proxy_postfix := .exe
 win_x64: dep compile_localproxy package_zip
-	@echo "Building for Windows x64"
+	@echo "Build finished: Windows x64"
 win_arm64: os := win
 win_arm64: os_api := win32
 win_arm64: arch := arm64
 win_arm64: local_proxy_postfix := .exe
 win_arm64: dep compile_localproxy package_zip
-	@echo "Building for Windows arm64"
+	@echo "Build finished: Windows arm64"
 linux: linux_x64 linux_arm64
 linux_x64: os := linux
 linux_x64: os_api := linux
 linux_x64: arch := x64
 linux_x64: local_proxy_postfix :=
 linux_x64: dep compile_localproxy package_zip
-	@echo "Building for Linux x64"
+	@echo "Build finished: Linux x64"
 linux_arm64: os := linux
 linux_arm64: os_api := linux
 linux_arm64: arch := arm64
 linux_arm64: local_proxy_postfix :=
 linux_arm64: dep compile_localproxy package_zip
-	@echo "Building for Linux arm64"
+	@echo "Build finished: Linux arm64"
 build_docker: compile
 	docker build -t backend.ai-webui:$(BUILD_DATE) .
 i18n:

--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,11 @@ mac_intel: dep mac_load_keychain
 ifdef BAI_APP_SIGN_KEYCHAIN
 	security default-keychain -s login.keychain
 endif
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-x64
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-macos-x64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-intel --compress Brotli
 	rm -rf ./app/backend.ai-desktop-macos-intel
 	cd app; mv "Backend.AI Desktop-darwin-x64" backend.ai-desktop-macos-intel;
-	./node_modules/electron-installer-dmg/bin/electron-installer-dmg.js './app/backend.ai-desktop-macos-intel/Backend.AI Desktop.app' ./app/backend.ai-desktop-intel-$(BUILD_DATE) --overwrite --icon=manifest/backend-ai.icns --title=Backend.AI
+	npx electron-installer-dmg './app/backend.ai-desktop-macos-intel/Backend.AI Desktop.app' ./app/backend.ai-desktop-intel-$(BUILD_DATE) --overwrite --icon=manifest/backend-ai.icns --title=Backend.AI
 ifeq ($(site),main)
 	mv ./app/backend.ai-desktop-intel-$(BUILD_DATE).dmg ./app/backend.ai-desktop-$(BUILD_VERSION)-macos-intel.dmg
 else
@@ -110,9 +112,11 @@ mac_apple: dep mac_load_keychain
 ifdef BAI_APP_SIGN_KEYCHAIN
 	security default-keychain -s login.keychain
 endif
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-apple
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-macos-arm64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-macos-apple --compress Brotli
 	rm -rf ./app/backend.ai-desktop-macos-apple
 	cd app; mv "Backend.AI Desktop-darwin-arm64" backend.ai-desktop-macos-apple;
-	./node_modules/electron-installer-dmg/bin/electron-installer-dmg.js './app/backend.ai-desktop-macos-apple/Backend.AI Desktop.app' ./app/backend.ai-desktop-apple-$(BUILD_DATE) --overwrite --icon=manifest/backend-ai.icns --title=Backend.AI
+	npx electron-installer-dmg './app/backend.ai-desktop-macos-apple/Backend.AI Desktop.app' ./app/backend.ai-desktop-apple-$(BUILD_DATE) --overwrite --icon=manifest/backend-ai.icns --title=Backend.AI
 ifeq ($(site),main)
 	mv ./app/backend.ai-desktop-apple-$(BUILD_DATE).dmg ./app/backend.ai-desktop-$(BUILD_VERSION)-macos-apple.dmg
 else
@@ -122,6 +126,8 @@ win: win_intel win_arm64
 win_intel: dep
 	cp ./configs/$(site).toml ./build/electron-app/app/config.toml
 	node ./app-packager.js win x64
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win-x64
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-win-x64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win32-x64 --compress Brotli
 	cd app; zip ./backend.ai-desktop-win32-x64-$(BUILD_DATE).zip -r "./Backend.AI Desktop-win32-x64"
 ifeq ($(site),main)
 	mv ./app/backend.ai-desktop-win32-x64-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(BUILD_VERSION)-win32-x64.zip
@@ -131,6 +137,8 @@ endif
 win_arm64: dep
 	cp ./configs/$(site).toml ./build/electron-app/app/config.toml
 	node ./app-packager.js win arm64
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win-arm64
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-win-arm64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-win32-arm64 --compress Brotli
 	cd app; zip ./backend.ai-desktop-win32-arm64-$(BUILD_DATE).zip -r "./Backend.AI Desktop-win32-arm64"
 ifeq ($(site),main)
 	mv ./app/backend.ai-desktop-win32-arm64-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(BUILD_VERSION)-win32-arm64.zip
@@ -141,6 +149,8 @@ linux: linux_intel linux_arm64
 linux_intel: dep
 	cp ./configs/$(site).toml ./build/electron-app/app/config.toml
 	node ./app-packager.js linux x64
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-x64
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-linux-x64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-x64 --compress Brotli
 	cd app; zip -r -9 ./backend.ai-desktop-linux-x64-$(BUILD_DATE).zip "./Backend.AI Desktop-linux-x64"
 ifeq ($(site),main)
 	mv ./app/backend.ai-desktop-linux-x64-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(BUILD_VERSION)-linux-x64.zip
@@ -150,6 +160,8 @@ endif
 linux_arm64: dep
 	cp ./configs/$(site).toml ./build/electron-app/app/config.toml
 	node ./app-packager.js linux arm64
+	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-arm64
+	npx pkg ./src/wsproxy/local_proxy.js --targets node18-linux-arm64 --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-linux-arm64 --compress Brotli
 	cd app; zip -r -9 ./backend.ai-desktop-linux-arm64-$(BUILD_DATE).zip "./Backend.AI Desktop-linux-arm64"
 ifeq ($(site),main)
 	mv ./app/backend.ai-desktop-linux-arm64-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(BUILD_VERSION)-linux-arm64.zip

--- a/Makefile
+++ b/Makefile
@@ -11,40 +11,56 @@ KEYCHAIN_NAME := bai-build-$(shell uuidgen).keychain
 BAI_APP_SIGN_KEYCHAIN_FILE := $(shell mktemp -d)/keychain.p12
 BAI_APP_SIGN_KEYCHAIN =
 
+RED := \033[0;31m
+GREEN := \033[0;32m
+YELLOW := \033[1;33m
+BLUE := \033[1;34m
+MAGENTA := \033[1;35m
+CYAN := \033[1;36m
+WHITE := \033[1;37m
+BBLUE := \033[38;5;123m
+BWHITE := \033[38;5;231m
+BRED := \033[0;91m
+BGREEN := \033[0;92m
+BYELLOW := \033[1;93m
+NC := \033[0m
+
 test_web:
-	npm run server:d
+	@npm run server:d
 test_electron:
-	npx electron . --dev
+	@npx electron . --dev
 proxy:
-	node ./src/wsproxy/local_proxy.js
+	@node ./src/wsproxy/local_proxy.js
 run_tests:
-	npx testcafe chrome tests
+	@npx testcafe chrome tests
 versiontag:
-	echo '{ "package": "${BUILD_VERSION}", "build": "${BUILD_DATE}.${BUILD_TIME}", "revision": "${REVISION_INDEX}" }' > version.json
-	sed -i -E 's/globalThis.packageVersion = "\([^"]*\)"/globalThis.packageVersion = "${BUILD_VERSION}"/g' index.html
-	sed -i -E 's/"version": "\([^"]*\)"/"version": "${BUILD_VERSION}"/g' manifest.json
-	sed -i -E 's/"version": "\([^"]*\)"/"version": "${BUILD_VERSION}"/g' react/package.json
-	sed -i -E 's/globalThis.buildVersion = "\([^"]*\)"/globalThis.buildVersion = "${BUILD_DATE}\.${BUILD_TIME}"/g' index.html
-	sed -i -E 's/\<small class="sidebar-footer" style="font-size:9px;"\>\([^"]*\)\<\/small\>/\<small class="sidebar-footer" style="font-size:9px;"\>${BUILD_VERSION}.${BUILD_DATE}\<\/small\>/g' ./src/components/backend-ai-webui.ts
+	@printf "$(GREEN)Tagging version number / index...$(NC)\n"
+	@echo '{ "package": "${BUILD_VERSION}", "build": "${BUILD_DATE}.${BUILD_TIME}", "revision": "${REVISION_INDEX}" }' > version.json
+	@sed -i -E 's/globalThis.packageVersion = "\([^"]*\)"/globalThis.packageVersion = "${BUILD_VERSION}"/g' index.html
+	@sed -i -E 's/"version": "\([^"]*\)"/"version": "${BUILD_VERSION}"/g' manifest.json
+	@sed -i -E 's/"version": "\([^"]*\)"/"version": "${BUILD_VERSION}"/g' react/package.json
+	@sed -i -E 's/globalThis.buildVersion = "\([^"]*\)"/globalThis.buildVersion = "${BUILD_DATE}\.${BUILD_TIME}"/g' index.html
+	@sed -i -E 's/\<small class="sidebar-footer" style="font-size:9px;"\>\([^"]*\)\<\/small\>/\<small class="sidebar-footer" style="font-size:9px;"\>${BUILD_VERSION}.${BUILD_DATE}\<\/small\>/g' ./src/components/backend-ai-webui.ts
+	@printf "$(YELLOW)Finished$(NC)\n"
 compile_keepversion:
-	npm run build
+	@npm run build
 compile: versiontag
-	npm run build
+	@npm run build
 compile_wsproxy:
-	cd ./src/wsproxy; npx webpack --config webpack.config.js
+	@cd ./src/wsproxy; npx webpack --config webpack.config.js
 	#cd ./src/wsproxy; rollup -c rollup.config.ts
 all: dep
-	make mac_x64
-	make mac_arm64
-	make win_x64
-	make win_arm64
-	make linux_x64
-	make linux_arm64
+	@make mac_x64
+	@make mac_arm64
+	@make win_x64
+	@make win_arm64
+	@make linux_x64
+	@make linux_arm64
 dep:
-	if [ ! -f "./config.toml" ]; then \
+	@if [ ! -f "./config.toml" ]; then \
 		cp config.toml.sample config.toml; \
 	fi
-	if [ ! -d "./build/rollup/" ] || ! grep -q 'es6://static/js/main' react/build/index.html; then \
+	@if [ ! -d "./build/rollup/" ] || ! grep -q 'es6://static/js/main' react/build/index.html; then \
 		make compile; \
 		make compile_wsproxy; \
 		rm -rf build/electron-app; \
@@ -68,14 +84,14 @@ dep:
 		cp ./preload.js ./build/electron-app/preload.js; \
 	fi
 web:
-	if [ ! -d "./build/rollup/" ];then \
+	@if [ ! -d "./build/rollup/" ];then \
 		make compile; \
 	fi
-	mkdir -p ./deploy/$(site)
-	cd deploy/$(site); rm -rf ./*; mkdir webui
-	cp -Rp build/rollup/* deploy/$(site)/webui
-	cp ./configs/$(site).toml deploy/$(site)/webui/config.toml
-	if [ -f "./configs/$(site).css" ];then \
+	@mkdir -p ./deploy/$(site)
+	@cd deploy/$(site); rm -rf ./*; mkdir webui
+	@cp -Rp build/rollup/* deploy/$(site)/webui
+	@cp ./configs/$(site).toml deploy/$(site)/webui/config.toml
+	@if [ -f "./configs/$(site).css" ];then \
 		cp ./configs/$(site).css deploy/$(site)/webui/resources/custom.css; \
 	fi
 mac_load_keychain:
@@ -97,75 +113,79 @@ endif  # BAI_APP_SIGN_KEYCHAIN_PASSWORD
 endif  # BAI_APP_SIGN_KEYCHAIN_B64
 endif  # BAI_APP_SIGN_KEYCHAIN
 compile_localproxy:
-	rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-$(os)-$(arch)$(local_proxy_postfix)
-	npx pkg ./src/wsproxy/local_proxy.js --targets node18-$(os)-$(arch) --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-$(os)-$(arch)$(local_proxy_postfix) --compress Brotli
-	rm -rf ./app/backend.ai-local-proxy$(local_proxy_postfix); cp ./app/backend.ai-local-proxy-$(BUILD_VERSION)-$(os)-$(arch)$(local_proxy_postfix) ./app/backend.ai-local-proxy$(local_proxy_postfix)
-	cd app; zip -r -9 ./backend.ai-local-proxy-$(BUILD_VERSION)-$(os)-$(arch).zip "./backend.ai-local-proxy$(local_proxy_postfix)"
-	rm -rf ./app/backend.ai-local-proxy$(local_proxy_postfix)
+	@rm -rf ./app/backend.ai-local-proxy-$(BUILD_VERSION)-$(os)-$(arch)$(local_proxy_postfix)
+	@npx pkg ./src/wsproxy/local_proxy.js --targets node18-$(os)-$(arch) --output ./app/backend.ai-local-proxy-$(BUILD_VERSION)-$(os)-$(arch)$(local_proxy_postfix) --compress Brotli
+	@rm -rf ./app/backend.ai-local-proxy$(local_proxy_postfix); cp ./app/backend.ai-local-proxy-$(BUILD_VERSION)-$(os)-$(arch)$(local_proxy_postfix) ./app/backend.ai-local-proxy$(local_proxy_postfix)
+	@cd app; zip -r -9 ./backend.ai-local-proxy-$(BUILD_VERSION)-$(os)-$(arch).zip "./backend.ai-local-proxy$(local_proxy_postfix)"
+	@rm -rf ./app/backend.ai-local-proxy$(local_proxy_postfix)
 package_zip:
-	cp ./configs/$(site).toml ./build/electron-app/app/config.toml
-	node ./app-packager.js $(os) $(arch)
-	cd app; zip -r -9 ./backend.ai-desktop-$(os)-$(arch)-$(BUILD_DATE).zip "./Backend.AI Desktop-$(os_api)-$(arch)"
+	@printf "$(GREEN)Packaging as ZIP archive...$(NC)"
+	@cp ./configs/$(site).toml ./build/electron-app/app/config.toml
+	@node ./app-packager.js $(os) $(arch)
+	@cd app; zip -r -9 ./backend.ai-desktop-$(os)-$(arch)-$(BUILD_DATE).zip "./Backend.AI Desktop-$(os_api)-$(arch)"
 ifeq ($(site),main)
-	mv ./app/backend.ai-desktop-$(os)-$(arch)-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(BUILD_VERSION)-$(os)-$(arch).zip
+	@mv ./app/backend.ai-desktop-$(os)-$(arch)-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(BUILD_VERSION)-$(os)-$(arch).zip
 else
-	mv ./app/backend.ai-desktop-$(os)-$(arch)-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(os)-$(arch)-$(BUILD_VERSION)-$(site).zip
+	@mv ./app/backend.ai-desktop-$(os)-$(arch)-$(BUILD_DATE).zip ./app/backend.ai-desktop-$(os)-$(arch)-$(BUILD_VERSION)-$(site).zip
 endif
+	@printf "$(YELLOW)Finished$(NC)\n"
 package_dmg:
-	cp ./configs/$(site).toml ./build/electron-app/app/config.toml
-	BAI_APP_SIGN_KEYCHAIN="${BAI_APP_SIGN_KEYCHAIN}" node ./app-packager.js darwin $(arch)
+	@printf "$(GREEN)Packaging as DMG file...$(NC)"
+	@cp ./configs/$(site).toml ./build/electron-app/app/config.toml
+	@BAI_APP_SIGN_KEYCHAIN="${BAI_APP_SIGN_KEYCHAIN}" node ./app-packager.js darwin $(arch)
 ifdef BAI_APP_SIGN_KEYCHAIN
-	security default-keychain -s login.keychain
+	@security default-keychain -s login.keychain
 endif
-	rm -rf ./app/backend.ai-desktop-$(os)-$(arch)
-	cd app; mv "Backend.AI Desktop-darwin-$(arch)" backend.ai-desktop-$(os)-$(arch);
-	npx electron-installer-dmg './app/backend.ai-desktop-$(os)-$(arch)/Backend.AI Desktop.app' ./app/backend.ai-desktop-$(arch)-$(BUILD_DATE) --overwrite --icon=manifest/backend-ai.icns --title=Backend.AI
+	@rm -rf ./app/backend.ai-desktop-$(os)-$(arch)
+	@cd app; mv "Backend.AI Desktop-darwin-$(arch)" backend.ai-desktop-$(os)-$(arch);
+	@npx electron-installer-dmg './app/backend.ai-desktop-$(os)-$(arch)/Backend.AI Desktop.app' ./app/backend.ai-desktop-$(arch)-$(BUILD_DATE) --overwrite --icon=manifest/backend-ai.icns --title=Backend.AI
 ifeq ($(site),main)
-	mv ./app/backend.ai-desktop-$(arch)-$(BUILD_DATE).dmg ./app/backend.ai-desktop-$(BUILD_VERSION)-$(os)-$(arch).dmg
+	@mv ./app/backend.ai-desktop-$(arch)-$(BUILD_DATE).dmg ./app/backend.ai-desktop-$(BUILD_VERSION)-$(os)-$(arch).dmg
 else
-	mv ./app/backend.ai-desktop-$(arch)-$(BUILD_DATE).dmg ./app/backend.ai-desktop-$(BUILD_VERSION)-$(site)-$(os)-$(arch).dmg
+	@mv ./app/backend.ai-desktop-$(arch)-$(BUILD_DATE).dmg ./app/backend.ai-desktop-$(BUILD_VERSION)-$(site)-$(os)-$(arch).dmg
 endif
+	@printf "$(YELLOW)Finished$(NC)\n"
 mac: mac_x64 mac_arm64
 mac_x64: os := macos
 mac_x64: arch := x64
 mac_x64: local_proxy_postfix :=
 mac_x64: dep mac_load_keychain compile_localproxy package_dmg
-	@echo "Build finished: macOS x64"
+	@printf "$(GREEN)Build finished$(NC): macOS x64\n"
 mac_arm64: os := macos
 mac_arm64: arch := arm64
 mac_arm64: local_proxy_postfix :=
 mac_arm64: dep mac_load_keychain compile_localproxy package_dmg
-	@echo "Build finished: macOS arm64"
+	@printf "$(GREEN)Build finished$(NC): macOS arm64\n"
 win: win_x64 win_arm64
 win_x64: os := win
 win_x64: os_api := win32
 win_x64: arch := x64
 win_x64: local_proxy_postfix := .exe
 win_x64: dep compile_localproxy package_zip
-	@echo "Build finished: Windows x64"
+	@printf "$(GREEN)Build finished$(NC): Windows x64\n"
 win_arm64: os := win
 win_arm64: os_api := win32
 win_arm64: arch := arm64
 win_arm64: local_proxy_postfix := .exe
 win_arm64: dep compile_localproxy package_zip
-	@echo "Build finished: Windows arm64"
+	@printf "$(GREEN)Build finished$(NC): Windows arm64\n"
 linux: linux_x64 linux_arm64
 linux_x64: os := linux
 linux_x64: os_api := linux
 linux_x64: arch := x64
 linux_x64: local_proxy_postfix :=
 linux_x64: dep compile_localproxy package_zip
-	@echo "Build finished: Linux x64"
+	@printf "$(GREEN)Build finished$(NC): Linux x64\n"
 linux_arm64: os := linux
 linux_arm64: os_api := linux
 linux_arm64: arch := arm64
 linux_arm64: local_proxy_postfix :=
 linux_arm64: dep compile_localproxy package_zip
-	@echo "Build finished: Linux arm64"
+	@printf "$(GREEN)Build finished$(NC): Linux arm64\n"
 build_docker: compile
 	docker build -t backend.ai-webui:$(BUILD_DATE) .
 i18n:
-	 ./node_modules/i18next-scanner/bin/cli.js --config ./i18n.config.js
+	@npx i18next-scanner --config ./i18n.config.js
 clean:
-	cd app;	rm -rf ./backend*; rm -rf ./Backend*
-	cd build;rm -rf ./unbundle ./bundle ./rollup ./electron-app
+	@cd app;	rm -rf ./backend*; rm -rf ./Backend*
+	@cd build;rm -rf ./unbundle ./bundle ./rollup ./electron-app

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       }
     };
     globalThis.packageVersion = "24.03.0-alpha.2";
-    globalThis.buildVersion = "231106.151110";
+    globalThis.buildVersion = "231106.151130";
 </script>
   <!-- DO NOT CHANGE BELOW LINE -->
   <!-- REACT_BUNDLE_INJECTING FOR DEV-->

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       }
     };
     globalThis.packageVersion = "24.03.0-alpha.2";
-    globalThis.buildVersion = "231106.131151";
+    globalThis.buildVersion = "231106.141151";
 </script>
   <!-- DO NOT CHANGE BELOW LINE -->
   <!-- REACT_BUNDLE_INJECTING FOR DEV-->

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       }
     };
     globalThis.packageVersion = "24.03.0-alpha.2";
-    globalThis.buildVersion = "231106.131115";
+    globalThis.buildVersion = "231106.131151";
 </script>
   <!-- DO NOT CHANGE BELOW LINE -->
   <!-- REACT_BUNDLE_INJECTING FOR DEV-->

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       }
     };
     globalThis.packageVersion = "24.03.0-alpha.2";
-    globalThis.buildVersion = "231106.151130";
+    globalThis.buildVersion = "231106.161111";
 </script>
   <!-- DO NOT CHANGE BELOW LINE -->
   <!-- REACT_BUNDLE_INJECTING FOR DEV-->

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       }
     };
     globalThis.packageVersion = "24.03.0-alpha.2";
-    globalThis.buildVersion = "231106.161111";
+    globalThis.buildVersion = "231106.161132";
 </script>
   <!-- DO NOT CHANGE BELOW LINE -->
   <!-- REACT_BUNDLE_INJECTING FOR DEV-->

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       }
     };
     globalThis.packageVersion = "24.03.0-alpha.2";
-    globalThis.buildVersion = "231106.141151";
+    globalThis.buildVersion = "231106.151110";
 </script>
   <!-- DO NOT CHANGE BELOW LINE -->
   <!-- REACT_BUNDLE_INJECTING FOR DEV-->

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       }
     };
     globalThis.packageVersion = "24.03.0-alpha.2";
-    globalThis.buildVersion = "231101.201127";
+    globalThis.buildVersion = "231106.131115";
 </script>
   <!-- DO NOT CHANGE BELOW LINE -->
   <!-- REACT_BUNDLE_INJECTING FOR DEV-->

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
         "jsdoc": "^4.0.2",
         "lint-staged": "^14.0.1",
         "node-fetch": "^3.3.2",
+        "pkg": "^5.8.1",
         "prettier": "^3.0.3",
         "pwa-helpers": "^0.9.1",
         "redux": "^4.2.1",
@@ -7731,16 +7732,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cacheable-request/node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/cached-path-relative": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.1.0.tgz",
@@ -8012,6 +8003,12 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
     },
     "node_modules/chrome-remote-interface": {
       "version": "0.32.2",
@@ -9456,6 +9453,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-node": {
@@ -11196,17 +11202,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/execa/node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/execa/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -11251,6 +11246,15 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -11356,16 +11360,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/extract-zip/node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/falafel": {
@@ -11814,6 +11808,12 @@
         "from2": "^2.0.3"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -12148,6 +12148,12 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "dev": true
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "dev": true
     },
     "node_modules/glob": {
@@ -13190,6 +13196,22 @@
       "dev": true,
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/into-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
+      "integrity": "sha512-XHbaOAvP+uFKUFsOgoNPRjLkwB+I22JFPFe5OjTkQ0nwgj6+pSjb4NmB6VMxaPshLiOf+zcpOCBQuLwC1KHhZA==",
+      "dev": true,
+      "dependencies": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ip": {
@@ -15789,6 +15811,44 @@
       "integrity": "sha512-KU5tVjIdTGsMb92JlWwEZCGrvtI1ku9G9GuNbWdQT/Ici1ztFXX0L8lWpbbC3pISVMfBNL56wdqplHvva2XSlA==",
       "dev": true
     },
+    "node_modules/multistream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/multistream/-/multistream-4.1.0.tgz",
+      "integrity": "sha512-J1XDiAmmNpRCBfIWJv+n0ymC4ABcf/Pl+5YvC5B/D2f/2+8PtHvCNxMPKiQcZyi922Hq69J2YOpb1pTywfifyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "once": "^1.4.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/multistream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/murmur-32": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.2.0.tgz",
@@ -15918,6 +15978,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "dev": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -15949,6 +16015,51 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.51.0.tgz",
+      "integrity": "sha512-SQkEP4hmNWjlniS5zdnfIXTk1x7Ome85RDzHlTbBtzE97Gfwz/Ipw4v/Ryk20DWIy3yCNVLVlGKApCnmvYoJbA==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/node-dir": {
       "version": "0.1.17",
@@ -16325,6 +16436,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/p-is-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -16633,6 +16753,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pkg": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.8.1.tgz",
+      "integrity": "sha512-CjBWtFStCfIiT4Bde9QpJy0KeH19jCfwZRJqHFDFXfhUklCx8JoFmMj3wgnEYIwGmZVNkhsStPHEOnrtrQhEXA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "7.18.2",
+        "@babel/parser": "7.18.4",
+        "@babel/types": "7.19.0",
+        "chalk": "^4.1.2",
+        "fs-extra": "^9.1.0",
+        "globby": "^11.1.0",
+        "into-stream": "^6.0.0",
+        "is-core-module": "2.9.0",
+        "minimist": "^1.2.6",
+        "multistream": "^4.1.0",
+        "pkg-fetch": "3.4.2",
+        "prebuild-install": "7.1.1",
+        "resolve": "^1.22.0",
+        "stream-meter": "^1.0.4"
+      },
+      "bin": {
+        "pkg": "lib-es5/bin.js"
+      },
+      "peerDependencies": {
+        "node-notifier": ">=9.0.1"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -16696,6 +16849,231 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pkg-fetch": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.4.2.tgz",
+      "integrity": "sha512-0+uijmzYcnhC0hStDjm/cl2VYdrmVVBpe7Q8k9YBojxmR5tG8mvR9/nooQq3QSXiQqORDVOTY3XqMEqJVIzkHA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "fs-extra": "^9.1.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.6",
+        "progress": "^2.0.3",
+        "semver": "^7.3.5",
+        "tar-fs": "^2.1.1",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "pkg-fetch": "lib-es5/bin.js"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/pkg-fetch/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/pkg-fetch/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/pkg-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/pkg-fetch/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/pkg-up": {
       "version": "3.1.0",
@@ -16770,6 +17148,178 @@
         "node": ">=4"
       }
     },
+    "node_modules/pkg/node_modules/@babel/generator": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
+      "integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.18.2",
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/pkg/node_modules/@babel/parser": {
+      "version": "7.18.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.4.tgz",
+      "integrity": "sha512-FDge0dFazETFcxGw/EXzOkN8uJp0PC7Qbm+Pe9T+av2zlBpOgunFHkQPPn+eRuClU73JF+98D531UgayY89tow==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/pkg/node_modules/@babel/types": {
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
+      "integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.18.10",
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/pkg/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/pkg/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pkg/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/pkg/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/pkg/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/pkg/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pkg/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg/node_modules/is-core-module": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/pkg/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/pkg/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/plist": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.6.tgz",
@@ -16822,6 +17372,32 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -17124,6 +17700,16 @@
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
       "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA==",
       "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "1.4.1",
@@ -18620,6 +19206,31 @@
         }
       ]
     },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -18916,6 +19527,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/stream-meter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
+      "integrity": "sha512-4sOEtrbgFotXwnEuzzsQBYEV1elAeFSO8rSGeTwabuX1RRn/kEq9JVH7I0MRBhKVRR0sJkr0M0QCH7yOLf9fhQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^2.1.4"
       }
     },
     "node_modules/stream-read-all": {
@@ -19282,6 +19902,83 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/teex": {
@@ -19790,16 +20487,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/testcafe-browser-tools/node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/testcafe-browser-tools/node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -20261,16 +20948,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/testcafe/node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/testcafe/node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "jsdoc": "^4.0.2",
     "lint-staged": "^14.0.1",
     "node-fetch": "^3.3.2",
+    "pkg": "^5.8.1",
     "prettier": "^3.0.3",
     "pwa-helpers": "^0.9.1",
     "redux": "^4.2.1",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-ai-webui-react",
-  "version": "0.1.0",
+  "version": "24.03.0-alpha.2",
   "private": true,
   "dependencies": {
     "@ant-design/icons": "^5.2.6",

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -1758,7 +1758,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
               </div>
               <address class="full-menu">
                 <small class="sidebar-footer">Lablup Inc.</small>
-                <small class="sidebar-footer" style="font-size:9px;">24.03.0-alpha.2.231101</small>
+                <small class="sidebar-footer" style="font-size:9px;">24.03.0-alpha.2.231106</small>
               </address>
               <div id="sidebar-navbar-footer" class="vertical start end-justified layout" style="margin-left:16px;">
                 <backend-ai-help-button active style="margin-left:4px;"></backend-ai-help-button>
@@ -1796,7 +1796,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
             </div>
             <address class="full-menu">
               <small class="sidebar-footer">Lablup Inc.</small>
-              <small class="sidebar-footer" style="font-size:9px;">24.03.0-alpha.2.231101</small>
+              <small class="sidebar-footer" style="font-size:9px;">24.03.0-alpha.2.231106</small>
             </address>
             <div id="sidebar-navbar-footer" class="vertical start end-justified layout" style="margin-left:16px;">
               <backend-ai-help-button active style="margin-left:4px;"></backend-ai-help-button>

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "24.03.0-alpha.2", "build": "231106.131115", "revision": "a293e28d" }
+{ "package": "24.03.0-alpha.2", "build": "231106.131151", "revision": "97cec8bc" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "24.03.0-alpha.2", "build": "231106.141151", "revision": "931a96f2" }
+{ "package": "24.03.0-alpha.2", "build": "231106.151110", "revision": "9cc6df2c" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "24.03.0-alpha.2", "build": "231101.201127", "revision": "7a6f0cbd" }
+{ "package": "24.03.0-alpha.2", "build": "231106.131115", "revision": "a293e28d" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "24.03.0-alpha.2", "build": "231106.161111", "revision": "ef6590af" }
+{ "package": "24.03.0-alpha.2", "build": "231106.161132", "revision": "34171774" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "24.03.0-alpha.2", "build": "231106.151110", "revision": "9cc6df2c" }
+{ "package": "24.03.0-alpha.2", "build": "231106.151130", "revision": "e04fabb6" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "24.03.0-alpha.2", "build": "231106.151130", "revision": "e04fabb6" }
+{ "package": "24.03.0-alpha.2", "build": "231106.161111", "revision": "ef6590af" }

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "24.03.0-alpha.2", "build": "231106.131151", "revision": "97cec8bc" }
+{ "package": "24.03.0-alpha.2", "build": "231106.141151", "revision": "931a96f2" }


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
Add stand-alone binary for easy installation / runtime / setup

### How to build

> **Warning**
> You should run `make` without parallelization. Set `-j1` or `\make` if aliased.

```
npm i
\make mac_arm64
```
or
```
npm i
\make linux_arm64
```

In Linux, install `zip` first.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
