### PR TITLE
update: change NPU device limit per node to 8

### DIFF
--- a/src/components/backend-ai-session-launcher-neo.ts
+++ b/src/components/backend-ai-session-launcher-neo.ts
@@ -981,10 +981,10 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
           this.max_ipu_device_per_container =
             globalThis.backendaiclient._config.maxIPUDevicesPerContainer || 8;
           this.max_atom_device_per_container =
-            globalThis.backendaiclient._config.maxATOMDevicesPerContainer || 4;
+            globalThis.backendaiclient._config.maxATOMDevicesPerContainer || 8;
           this.max_warboy_device_per_container =
             globalThis.backendaiclient._config.maxWarboyDevicesPerContainer ||
-            4;
+            8;
           this.max_shm_per_container =
             globalThis.backendaiclient._config.maxShmPerContainer || 8;
           if (
@@ -1027,9 +1027,9 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       this.max_ipu_device_per_container =
         globalThis.backendaiclient._config.maxIPUDevicesPerContainer || 8;
       this.max_atom_device_per_container =
-        globalThis.backendaiclient._config.maxATOMDevicesPerContainer || 4;
+        globalThis.backendaiclient._config.maxATOMDevicesPerContainer || 8;
       this.max_warboy_device_per_container =
-        globalThis.backendaiclient._config.maxWarboyDevicesPerContainer || 4;
+        globalThis.backendaiclient._config.maxWarboyDevicesPerContainer || 8;
       this.max_shm_per_container =
         globalThis.backendaiclient._config.maxShmPerContainer || 8;
       if (

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -983,10 +983,10 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
           this.max_ipu_device_per_container =
             globalThis.backendaiclient._config.maxIPUDevicesPerContainer || 8;
           this.max_atom_device_per_container =
-            globalThis.backendaiclient._config.maxATOMDevicesPerContainer || 4;
+            globalThis.backendaiclient._config.maxATOMDevicesPerContainer || 8;
           this.max_warboy_device_per_container =
             globalThis.backendaiclient._config.maxWarboyDevicesPerContainer ||
-            4;
+            8;
           this.max_shm_per_container =
             globalThis.backendaiclient._config.maxShmPerContainer || 8;
           if (
@@ -1031,9 +1031,9 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       this.max_ipu_device_per_container =
         globalThis.backendaiclient._config.maxIPUDevicesPerContainer || 8;
       this.max_atom_device_per_container =
-        globalThis.backendaiclient._config.maxATOMDevicesPerContainer || 4;
+        globalThis.backendaiclient._config.maxATOMDevicesPerContainer || 8;
       this.max_warboy_device_per_container =
-        globalThis.backendaiclient._config.maxWarboyDevicesPerContainer || 4;
+        globalThis.backendaiclient._config.maxWarboyDevicesPerContainer || 8;
       this.max_shm_per_container =
         globalThis.backendaiclient._config.maxShmPerContainer || 8;
       if (


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1d16c74</samp>

### Summary
🚀🔄🎨

<!--
1.  🚀 for increasing the default maximum number of ATOM and Warboy devices per container.
2.  🔄 for updating the `backend-ai-session-launcher` component to match the new session launcher UI.
3.  🎨 for improving the user experience of launching sessions with different device types.
-->
Increased the default device limits and harmonized the device options for session launchers. This pull request modifies the `backend-ai-session-launcher-neo` and `backend-ai-session-launcher` components to improve the usability and consistency of the web UI.

### Walkthrough
*  Increase the default values of the maximum number of ATOM and Warboy devices per container from 4 to 8 in both the original and the new version of the session launcher UI ([link](https://github.com/lablup/backend.ai-webui/pull/2014/files?diff=unified&w=0#diff-d8e9f0c6088f86086891a29f0c9bec1d7a03e25983ba8962772125c4cb41c5bbL984-R987), [link](https://github.com/lablup/backend.ai-webui/pull/2014/files?diff=unified&w=0#diff-d8e9f0c6088f86086891a29f0c9bec1d7a03e25983ba8962772125c4cb41c5bbL1030-R1032), [link](https://github.com/lablup/backend.ai-webui/pull/2014/files?diff=unified&w=0#diff-ba6f5c1817ab368d2abef6c7543a522c8ae23002c3f0389fd20d897f25d31b3eL986-R989), [link](https://github.com/lablup/backend.ai-webui/pull/2014/files?diff=unified&w=0#diff-ba6f5c1817ab368d2abef6c7543a522c8ae23002c3f0389fd20d897f25d31b3eL1034-R1036))

