### PR TITLE
add: read NPU limit per node configuration from config.toml

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -46,6 +46,11 @@ maxCPUCoresPerContainer = 256       # Maximum CPU per container.
 maxMemoryPerContainer = 64          # Maximum memory per container.
 maxCUDADevicesPerContainer = 8      # Maximum CUDA devices per container.
 maxCUDASharesPerContainer = 8       # Maximum CUDA shares per container.
+maxROCMDevicesPerContainer = 10     # Maximum ROCm devices per container.
+maxTPUDevicesPerContainer = 8       # Maximum TPU devices per container.
+maxIPUDevicesPerContainer = 8       # Maximum IPU devices per container.
+maxATOMDevicesPerContainer = 8      # Maximum ATOM devices per container.
+maxWarboyDevicesPerContainer = 8    # Maximum Warboy devices per container.
 maxShmPerContainer = 16             # Maximum shared memory per container.
 maxFileUploadSize = 4294967296      # Maximum size of single file upload. Set to -1 for unlimited upload.
 

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -111,6 +111,11 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: Boolean }) maxMemoryPerContainer = 16;
   @property({ type: Number }) maxCUDADevicesPerContainer = 16;
   @property({ type: Number }) maxCUDASharesPerContainer = 16;
+  @property({ type: Number }) maxROCMDevicesPerContainer = 10;
+  @property({ type: Number }) maxTPUDevicesPerContainer = 8;
+  @property({ type: Number }) maxIPUDevicesPerContainer = 8;
+  @property({ type: Number }) maxATOMDevicesPerContainer = 8;
+  @property({ type: Number }) maxWarboyDevicesPerContainer = 8;
   @property({ type: Boolean }) maxShmPerContainer = 2;
   @property({ type: Boolean }) maxFileUploadSize = -1;
   @property({ type: Boolean }) maskUserInfo = false;
@@ -914,7 +919,57 @@ export default class BackendAILogin extends BackendAIPage {
       } as ConfigValueObject,
     ) as number;
 
-    // Max CUDA shares per container number
+    // Max ROCm devices per container number
+    this.maxROCMDevicesPerContainer = this._getConfigValueByExists(
+      resourcesConfig,
+      {
+        valueType: 'number',
+        defaultValue: 10,
+        value: parseInt(resourcesConfig?.maxROCMDevicesPerContainer),
+      } as ConfigValueObject,
+    ) as number;
+
+    // Max TPU devices per container number
+    this.maxTPUDevicesPerContainer = this._getConfigValueByExists(
+      resourcesConfig,
+      {
+        valueType: 'number',
+        defaultValue: 8,
+        value: parseInt(resourcesConfig?.maxTPUDevicesPerContainer),
+      } as ConfigValueObject,
+    ) as number;
+
+    // Max IPU devices per container number
+    this.maxIPUDevicesPerContainer = this._getConfigValueByExists(
+      resourcesConfig,
+      {
+        valueType: 'number',
+        defaultValue: 8,
+        value: parseInt(resourcesConfig?.maxIPUDevicesPerContainer),
+      } as ConfigValueObject,
+    ) as number;
+
+    // Max ATOM devices per container number
+    this.maxATOMDevicesPerContainer = this._getConfigValueByExists(
+      resourcesConfig,
+      {
+        valueType: 'number',
+        defaultValue: 8,
+        value: parseInt(resourcesConfig?.maxATOMDevicesPerContainer),
+      } as ConfigValueObject,
+    ) as number;
+
+    // Max Warboy devices per container number
+    this.maxWarboyDevicesPerContainer = this._getConfigValueByExists(
+      resourcesConfig,
+      {
+        valueType: 'number',
+        defaultValue: 8,
+        value: parseInt(resourcesConfig?.maxWarboyDevicesPerContainer),
+      } as ConfigValueObject,
+    ) as number;
+
+    // Max shared memory per container number
     this.maxShmPerContainer = this._getConfigValueByExists(resourcesConfig, {
       valueType: 'number',
       defaultValue: 2,


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 58a6f05</samp>

### Summary
:gear::computer::lock:

<!--
1.  :gear: - This emoji represents configuration or settings, and can be used for the new configuration options for the maximum number of devices per container.
2.  :computer: - This emoji represents devices or hardware, and can be used for the changes related to the device types and properties for the containers.
3.  :lock: - This emoji represents security or restriction, and can be used for the changes related to the enforcement of the device limits for the user's containers.
-->
This pull request adds support for device limits per container in the `backend-ai-webui`. It modifies the `backend-ai-login` component and the `config.toml.sample` file to handle and display the new configuration options.


### Walkthrough
*  Add new configuration options for the maximum number of devices per container ([link](https://github.com/lablup/backend.ai-webui/pull/2015/files?diff=unified&w=0#diff-afc7c81ccfa8595a7b1c9b0199bc353d01316fd518c5295cdfbe8ebcc1556ee8R49-R53))
* Initialize and assign properties for the maximum number of devices per container in the backend-ai-login component ([link](https://github.com/lablup/backend.ai-webui/pull/2015/files?diff=unified&w=0#diff-efcecd6c9b6f3d9e866667b37775627d072d9cde0d40326edcba878e773fc109R114-R118), [link](https://github.com/lablup/backend.ai-webui/pull/2015/files?diff=unified&w=0#diff-efcecd6c9b6f3d9e866667b37775627d072d9cde0d40326edcba878e773fc109L917-R972))



**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
