### PR TITLE
Fix: hide `max_vfolder_count` setting according to the api version

### DIFF
--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -1,3 +1,5 @@
+# PR #1688 79ef241dff642618d97e8d087c2a4d36e19fb27b
+
 schema {
   query: Queries
   mutation: Mutations

--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -1,21 +1,37 @@
-# PR #1680 27ab15e5297862f0bf2717b6b0b98d99eb609e26
-
 schema {
   query: Queries
   mutation: Mutations
 }
 
-"""All available GraphQL queries."""
+"""
+All available GraphQL queries.
+"""
 type Queries {
   node(
-    """The ID of the object"""
+    """
+    The ID of the object
+    """
     id: ID!
   ): Node
   agent(agent_id: String!): Agent
-  agent_list(limit: Int!, offset: Int!, filter: String, order: String, scaling_group: String, status: String): AgentList
+  agent_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    scaling_group: String
+    status: String
+  ): AgentList
   agents(scaling_group: String, status: String): [Agent]
   agent_summary(agent_id: String!): AgentSummary
-  agent_summary_list(limit: Int!, offset: Int!, filter: String, order: String, scaling_group: String, status: String): AgentSummaryList
+  agent_summary_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    scaling_group: String
+    status: String
+  ): AgentSummaryList
   domain(name: String): Domain
   domains(is_active: Boolean): [Domain]
   group(id: UUID!, domain_name: String): Group
@@ -25,11 +41,33 @@ type Queries {
   images(is_installed: Boolean, is_operation: Boolean): [Image]
   user(domain_name: String, email: String): User
   user_from_uuid(domain_name: String, user_id: ID): User
-  users(domain_name: String, group_id: UUID, is_active: Boolean, status: String): [User]
-  user_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: UUID, is_active: Boolean, status: String): UserList
+  users(
+    domain_name: String
+    group_id: UUID
+    is_active: Boolean
+    status: String
+  ): [User]
+  user_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: UUID
+    is_active: Boolean
+    status: String
+  ): UserList
   keypair(domain_name: String, access_key: String): KeyPair
   keypairs(domain_name: String, email: String, is_active: Boolean): [KeyPair]
-  keypair_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, email: String, is_active: Boolean): KeyPairList
+  keypair_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    email: String
+    is_active: Boolean
+  ): KeyPairList
   keypair_resource_policy(name: String): KeyPairResourcePolicy
   user_resource_policy(name: String): UserResourcePolicy
   project_resource_policy(name: String!): ProjectResourcePolicy
@@ -41,38 +79,141 @@ type Queries {
   scaling_group(name: String): ScalingGroup
   scaling_groups(name: String, is_active: Boolean): [ScalingGroup]
   scaling_groups_for_domain(domain: String!, is_active: Boolean): [ScalingGroup]
-  scaling_groups_for_user_group(user_group: String!, is_active: Boolean): [ScalingGroup]
-  scaling_groups_for_keypair(access_key: String!, is_active: Boolean): [ScalingGroup]
+  scaling_groups_for_user_group(
+    user_group: String!
+    is_active: Boolean
+  ): [ScalingGroup]
+  scaling_groups_for_keypair(
+    access_key: String!
+    is_active: Boolean
+  ): [ScalingGroup]
   storage_volume(id: String): StorageVolume
-  storage_volume_list(limit: Int!, offset: Int!, filter: String, order: String): StorageVolumeList
+  storage_volume_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+  ): StorageVolumeList
   vfolder(id: String): VirtualFolder
-  vfolder_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: UUID, access_key: String): VirtualFolderList
-  vfolder_permission_list(limit: Int!, offset: Int!, filter: String, order: String): VirtualFolderPermissionList
-  vfolder_own_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList
-  vfolder_invited_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList
-  vfolder_project_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList
-  vfolders(domain_name: String, group_id: String, access_key: String): [VirtualFolder]
+  vfolder_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: UUID
+    access_key: String
+  ): VirtualFolderList
+  vfolder_permission_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+  ): VirtualFolderPermissionList
+  vfolder_own_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    access_key: String
+  ): VirtualFolderList
+  vfolder_invited_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    access_key: String
+  ): VirtualFolderList
+  vfolder_project_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    access_key: String
+  ): VirtualFolderList
+  vfolders(
+    domain_name: String
+    group_id: String
+    access_key: String
+  ): [VirtualFolder]
   compute_session(id: UUID!): ComputeSession
   compute_container(id: UUID!): ComputeContainer
-  compute_session_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: String, access_key: String, status: String): ComputeSessionList
-  compute_container_list(limit: Int!, offset: Int!, filter: String, order: String, session_id: ID!, role: String): ComputeContainerList
-  legacy_compute_session_list(limit: Int!, offset: Int!, order_key: String, order_asc: Boolean, domain_name: String, group_id: String, access_key: String, status: String): LegacyComputeSessionList
-  legacy_compute_session(sess_id: String!, domain_name: String, access_key: String): LegacyComputeSession
+  compute_session_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: String
+    access_key: String
+    status: String
+  ): ComputeSessionList
+  compute_container_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    session_id: ID!
+    role: String
+  ): ComputeContainerList
+  legacy_compute_session_list(
+    limit: Int!
+    offset: Int!
+    order_key: String
+    order_asc: Boolean
+    domain_name: String
+    group_id: String
+    access_key: String
+    status: String
+  ): LegacyComputeSessionList
+  legacy_compute_session(
+    sess_id: String!
+    domain_name: String
+    access_key: String
+  ): LegacyComputeSession
   vfolder_host_permissions: PredefinedAtomicPermission
   endpoint(endpoint_id: UUID!): Endpoint
-  endpoint_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: String, access_key: String, project: UUID): EndpointList
+  endpoint_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: String
+    access_key: String
+    project: UUID
+  ): EndpointList
   routing(routing_id: UUID!): Routing
-  routing_list(limit: Int!, offset: Int!, filter: String, order: String, endpoint_id: UUID): RoutingList
+  routing_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    endpoint_id: UUID
+  ): RoutingList
   endpoint_token(token: String!): EndpointToken
-  endpoint_token_list(limit: Int!, offset: Int!, filter: String, order: String, endpoint_id: UUID): EndpointTokenList
+  endpoint_token_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    endpoint_id: UUID
+  ): EndpointTokenList
   quota_scope(storage_host_name: String!, quota_scope_id: String!): QuotaScope
   container_registry(hostname: String!): ContainerRegistry
   container_registries: [ContainerRegistry]
 }
 
-"""An object with an ID"""
+"""
+An object with an ID
+"""
 interface Node {
-  """The ID of the object"""
+  """
+  The ID of the object
+  """
   id: ID!
 }
 
@@ -176,7 +317,9 @@ interface PaginatedList {
   total_count: Int!
 }
 
-"""A schema for normal users."""
+"""
+A schema for normal users.
+"""
 type AgentSummary implements Item {
   id: ID
   status: String
@@ -309,7 +452,10 @@ type KeyPair implements Item {
   compute_sessions(status: String): [ComputeSession]
   concurrency_used: Int
   user_info: UserInfo
-  concurrency_limit: Int @deprecated(reason: "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field.")
+  concurrency_limit: Int
+    @deprecated(
+      reason: "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field."
+    )
 }
 
 type VirtualFolder implements Item {
@@ -418,10 +564,14 @@ type UserResourcePolicy {
   name: String!
   created_at: DateTime!
 
-  """Added since 24.03.1. Limitation of the number of user vfolders."""
+  """
+  Added since 24.03.1. Limitation of the number of user vfolders.
+  """
   max_vfolder_count: Int
 
-  """Added since 24.03.1. Limitation of the quota size of user vfolders."""
+  """
+  Added since 24.03.1. Limitation of the quota size of user vfolders.
+  """
   max_quota_scope_size: BigInt
   max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.1.")
 }
@@ -431,10 +581,14 @@ type ProjectResourcePolicy {
   name: String!
   created_at: DateTime!
 
-  """Added since 24.03.1. Limitation of the number of project vfolders."""
+  """
+  Added since 24.03.1. Limitation of the number of project vfolders.
+  """
   max_vfolder_count: Int
 
-  """Added since 24.03.1. Limitation of the quota size of project vfolders."""
+  """
+  Added since 24.03.1. Limitation of the quota size of project vfolders.
+  """
   max_quota_scope_size: BigInt
   max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.1.")
 }
@@ -510,7 +664,9 @@ type LegacyComputeSessionList implements PaginatedList {
   total_count: Int!
 }
 
-"""Represents a main session."""
+"""
+Represents a main session.
+"""
 type LegacyComputeSession implements Item {
   id: ID
   tag: String
@@ -662,7 +818,9 @@ type QuotaDetails {
 }
 
 type ContainerRegistry implements Node {
-  """The ID of the object"""
+  """
+  The ID of the object
+  """
   id: ID!
   hostname: String
   config: ContainerRegistryConfig
@@ -677,18 +835,22 @@ type ContainerRegistryConfig {
   ssl_verify: Boolean
 }
 
-"""All available GraphQL mutations."""
+"""
+All available GraphQL mutations.
+"""
 type Mutations {
   modify_agent(id: String!, props: ModifyAgentInput!): ModifyAgent
   create_domain(name: String!, props: DomainInput!): CreateDomain
   modify_domain(name: String!, props: ModifyDomainInput!): ModifyDomain
 
-  """Instead of deleting the domain, just mark it as inactive."""
+  """
+  Instead of deleting the domain, just mark it as inactive.
+  """
   delete_domain(name: String!): DeleteDomain
 
   """
   Completely delete domain from DB.
-  
+
   Domain-bound kernels will also be all deleted.
   To purge domain, there should be no users and groups in the target domain.
   """
@@ -696,12 +858,14 @@ type Mutations {
   create_group(name: String!, props: GroupInput!): CreateGroup
   modify_group(gid: UUID!, props: ModifyGroupInput!): ModifyGroup
 
-  """Instead of deleting the group, just mark it as inactive."""
+  """
+  Instead of deleting the group, just mark it as inactive.
+  """
   delete_group(gid: UUID!): DeleteGroup
 
   """
   Completely deletes a group from DB.
-  
+
   Group's vfolders and their data will also be lost
   as well as the kernels run from the group.
   There is no migration of the ownership for group folders.
@@ -712,23 +876,23 @@ type Mutations {
 
   """
   Instead of really deleting user, just mark the account as deleted status.
-  
+
   All related keypairs will also be inactivated.
   """
   delete_user(email: String!): DeleteUser
 
   """
   Delete user as well as all user-related DB informations such as keypairs, kernels, etc.
-  
+
   If target user has virtual folders, they can be purged together or migrated to the superadmin.
-  
+
   vFolder treatment policy:
     User-type:
     - vfolder is not shared: delete
     - vfolder is shared:
       + if purge_shared_vfolder is True: delete
       + else: change vfolder's owner to requested admin
-  
+
   This action cannot be undone.
   """
   purge_user(email: String!, props: PurgeUserInput!): PurgeUser
@@ -738,38 +902,114 @@ type Mutations {
   rescan_images(registry: String): RescanImages
   preload_image(references: [String]!, target_agents: [String]!): PreloadImage
   unload_image(references: [String]!, target_agents: [String]!): UnloadImage
-  modify_image(architecture: String = "aarch64", props: ModifyImageInput!, target: String!): ModifyImage
-  forget_image(architecture: String = "aarch64", reference: String!): ForgetImage
-  alias_image(alias: String!, architecture: String = "aarch64", target: String!): AliasImage
+  modify_image(
+    architecture: String = "aarch64"
+    props: ModifyImageInput!
+    target: String!
+  ): ModifyImage
+  forget_image(
+    architecture: String = "aarch64"
+    reference: String!
+  ): ForgetImage
+  alias_image(
+    alias: String!
+    architecture: String = "aarch64"
+    target: String!
+  ): AliasImage
   dealias_image(alias: String!): DealiasImage
   clear_images(registry: String): ClearImages
-  create_keypair_resource_policy(name: String!, props: CreateKeyPairResourcePolicyInput!): CreateKeyPairResourcePolicy
-  modify_keypair_resource_policy(name: String!, props: ModifyKeyPairResourcePolicyInput!): ModifyKeyPairResourcePolicy
+  create_keypair_resource_policy(
+    name: String!
+    props: CreateKeyPairResourcePolicyInput!
+  ): CreateKeyPairResourcePolicy
+  modify_keypair_resource_policy(
+    name: String!
+    props: ModifyKeyPairResourcePolicyInput!
+  ): ModifyKeyPairResourcePolicy
   delete_keypair_resource_policy(name: String!): DeleteKeyPairResourcePolicy
-  create_user_resource_policy(name: String!, props: CreateUserResourcePolicyInput!): CreateUserResourcePolicy
-  modify_user_resource_policy(name: String!, props: ModifyUserResourcePolicyInput!): ModifyUserResourcePolicy
+  create_user_resource_policy(
+    name: String!
+    props: CreateUserResourcePolicyInput!
+  ): CreateUserResourcePolicy
+  modify_user_resource_policy(
+    name: String!
+    props: ModifyUserResourcePolicyInput!
+  ): ModifyUserResourcePolicy
   delete_user_resource_policy(name: String!): DeleteUserResourcePolicy
-  create_project_resource_policy(name: String!, props: CreateProjectResourcePolicyInput!): CreateProjectResourcePolicy
-  modify_project_resource_policy(name: String!, props: ModifyProjectResourcePolicyInput!): ModifyProjectResourcePolicy
+  create_project_resource_policy(
+    name: String!
+    props: CreateProjectResourcePolicyInput!
+  ): CreateProjectResourcePolicy
+  modify_project_resource_policy(
+    name: String!
+    props: ModifyProjectResourcePolicyInput!
+  ): ModifyProjectResourcePolicy
   delete_project_resource_policy(name: String!): DeleteProjectResourcePolicy
-  create_resource_preset(name: String!, props: CreateResourcePresetInput!): CreateResourcePreset
-  modify_resource_preset(name: String!, props: ModifyResourcePresetInput!): ModifyResourcePreset
+  create_resource_preset(
+    name: String!
+    props: CreateResourcePresetInput!
+  ): CreateResourcePreset
+  modify_resource_preset(
+    name: String!
+    props: ModifyResourcePresetInput!
+  ): ModifyResourcePreset
   delete_resource_preset(name: String!): DeleteResourcePreset
-  create_scaling_group(name: String!, props: CreateScalingGroupInput!): CreateScalingGroup
-  modify_scaling_group(name: String!, props: ModifyScalingGroupInput!): ModifyScalingGroup
+  create_scaling_group(
+    name: String!
+    props: CreateScalingGroupInput!
+  ): CreateScalingGroup
+  modify_scaling_group(
+    name: String!
+    props: ModifyScalingGroupInput!
+  ): ModifyScalingGroup
   delete_scaling_group(name: String!): DeleteScalingGroup
-  associate_scaling_group_with_domain(domain: String!, scaling_group: String!): AssociateScalingGroupWithDomain
-  associate_scaling_group_with_user_group(scaling_group: String!, user_group: UUID!): AssociateScalingGroupWithUserGroup
-  associate_scaling_group_with_keypair(access_key: String!, scaling_group: String!): AssociateScalingGroupWithKeyPair
-  disassociate_scaling_group_with_domain(domain: String!, scaling_group: String!): DisassociateScalingGroupWithDomain
-  disassociate_scaling_group_with_user_group(scaling_group: String!, user_group: UUID!): DisassociateScalingGroupWithUserGroup
-  disassociate_scaling_group_with_keypair(access_key: String!, scaling_group: String!): DisassociateScalingGroupWithKeyPair
-  disassociate_all_scaling_groups_with_domain(domain: String!): DisassociateAllScalingGroupsWithDomain
-  disassociate_all_scaling_groups_with_group(user_group: UUID!): DisassociateAllScalingGroupsWithGroup
-  set_quota_scope(props: QuotaScopeInput!, quota_scope_id: String!, storage_host_name: String!): SetQuotaScope
-  unset_quota_scope(quota_scope_id: String!, storage_host_name: String!): UnsetQuotaScope
-  create_container_registry(hostname: String!, props: CreateContainerRegistryInput!): CreateContainerRegistry
-  modify_container_registry(hostname: String!, props: ModifyContainerRegistryInput!): ModifyContainerRegistry
+  associate_scaling_group_with_domain(
+    domain: String!
+    scaling_group: String!
+  ): AssociateScalingGroupWithDomain
+  associate_scaling_group_with_user_group(
+    scaling_group: String!
+    user_group: UUID!
+  ): AssociateScalingGroupWithUserGroup
+  associate_scaling_group_with_keypair(
+    access_key: String!
+    scaling_group: String!
+  ): AssociateScalingGroupWithKeyPair
+  disassociate_scaling_group_with_domain(
+    domain: String!
+    scaling_group: String!
+  ): DisassociateScalingGroupWithDomain
+  disassociate_scaling_group_with_user_group(
+    scaling_group: String!
+    user_group: UUID!
+  ): DisassociateScalingGroupWithUserGroup
+  disassociate_scaling_group_with_keypair(
+    access_key: String!
+    scaling_group: String!
+  ): DisassociateScalingGroupWithKeyPair
+  disassociate_all_scaling_groups_with_domain(
+    domain: String!
+  ): DisassociateAllScalingGroupsWithDomain
+  disassociate_all_scaling_groups_with_group(
+    user_group: UUID!
+  ): DisassociateAllScalingGroupsWithGroup
+  set_quota_scope(
+    props: QuotaScopeInput!
+    quota_scope_id: String!
+    storage_host_name: String!
+  ): SetQuotaScope
+  unset_quota_scope(
+    quota_scope_id: String!
+    storage_host_name: String!
+  ): UnsetQuotaScope
+  create_container_registry(
+    hostname: String!
+    props: CreateContainerRegistryInput!
+  ): CreateContainerRegistry
+  modify_container_registry(
+    hostname: String!
+    props: ModifyContainerRegistryInput!
+  ): ModifyContainerRegistry
   delete_container_registry(hostname: String!): DeleteContainerRegistry
 }
 
@@ -814,7 +1054,9 @@ input ModifyDomainInput {
   integration_id: String
 }
 
-"""Instead of deleting the domain, just mark it as inactive."""
+"""
+Instead of deleting the domain, just mark it as inactive.
+"""
 type DeleteDomain {
   ok: Boolean
   msg: String
@@ -866,7 +1108,9 @@ input ModifyGroupInput {
   resource_policy: String
 }
 
-"""Instead of deleting the group, just mark it as inactive."""
+"""
+Instead of deleting the group, just mark it as inactive.
+"""
 type DeleteGroup {
   ok: Boolean
   msg: String
@@ -1072,9 +1316,10 @@ type CreateKeyPairResourcePolicy {
 
 input CreateKeyPairResourcePolicyInput {
   default_for_unspecified: String!
-  total_resource_slots: JSONString!
-  max_session_lifetime: Int! = 0
+  total_resource_slots: JSONString = "{}"
+  max_session_lifetime: Int = 0
   max_concurrent_sessions: Int!
+  max_concurrent_sftp_sessions: Int = 1
   max_containers_per_session: Int!
   idle_timeout: BigInt!
   allowed_vfolder_hosts: JSONString
@@ -1093,6 +1338,7 @@ input ModifyKeyPairResourcePolicyInput {
   total_resource_slots: JSONString
   max_session_lifetime: Int
   max_concurrent_sessions: Int
+  max_concurrent_sftp_sessions: Int
   max_containers_per_session: Int
   idle_timeout: BigInt
   allowed_vfolder_hosts: JSONString
@@ -1113,10 +1359,14 @@ type CreateUserResourcePolicy {
 }
 
 input CreateUserResourcePolicyInput {
-  """Added since 24.03.1. Limitation of the number of user vfolders."""
+  """
+  Added since 24.03.1. Limitation of the number of user vfolders.
+  """
   max_vfolder_count: Int
 
-  """Added since 24.03.1. Limitation of the quota size of user vfolders."""
+  """
+  Added since 24.03.1. Limitation of the quota size of user vfolders.
+  """
   max_quota_scope_size: BigInt
 }
 
@@ -1126,10 +1376,14 @@ type ModifyUserResourcePolicy {
 }
 
 input ModifyUserResourcePolicyInput {
-  """Added since 24.03.1. Limitation of the number of user vfolders."""
+  """
+  Added since 24.03.1. Limitation of the number of user vfolders.
+  """
   max_vfolder_count: Int
 
-  """Added since 24.03.1. Limitation of the quota size of user vfolders."""
+  """
+  Added since 24.03.1. Limitation of the quota size of user vfolders.
+  """
   max_quota_scope_size: BigInt
 }
 
@@ -1145,10 +1399,14 @@ type CreateProjectResourcePolicy {
 }
 
 input CreateProjectResourcePolicyInput {
-  """Added since 24.03.1. Limitation of the number of project vfolders."""
+  """
+  Added since 24.03.1. Limitation of the number of project vfolders.
+  """
   max_vfolder_count: Int
 
-  """Added since 24.03.1. Limitation of the quota size of project vfolders."""
+  """
+  Added since 24.03.1. Limitation of the quota size of project vfolders.
+  """
   max_quota_scope_size: BigInt
 }
 
@@ -1158,10 +1416,14 @@ type ModifyProjectResourcePolicy {
 }
 
 input ModifyProjectResourcePolicyInput {
-  """Added since 24.03.1. Limitation of the number of project vfolders."""
+  """
+  Added since 24.03.1. Limitation of the number of project vfolders.
+  """
   max_vfolder_count: Int
 
-  """Added since 24.03.1. Limitation of the quota size of project vfolders."""
+  """
+  Added since 24.03.1. Limitation of the quota size of project vfolders.
+  """
   max_quota_scope_size: BigInt
 }
 
@@ -1308,8 +1570,8 @@ type ModifyContainerRegistry {
 }
 
 input ModifyContainerRegistryInput {
-  url: String!
-  type: String!
+  url: String
+  type: String
   project: [String]
   username: String
   password: String

--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -1475,14 +1475,25 @@ export default class BackendAICredentialView extends BackendAIPage {
             <backend-ai-multi-select open-up id="allowed-vfolder-hosts" label="${_t(
               'resourcePolicy.AllowedHosts',
             )}" style="width:100%;"></backend-ai-multi-select>
-            <div class="horizontal layout justified" style="width:100%;">
-              <div class="vertical layout flex">
-                <mwc-textfield label="${_t(
-                  'credential.Max#',
-                )}" class="discrete" id="vfolder-count-limit" type="number" min="0" max="50"
-                    @change="${(e) =>
-                      this._validateResourceInput(e)}"></mwc-textfield>
-              </div>
+            <div
+              class="horizontal layout justified"
+              style=${
+                globalThis.backendaiclient.supports(
+                  'max-vfolder-count-in-user-resource-policy',
+                )
+                  ? 'display:none;'
+                  : 'width:100%;'
+              }
+            >
+              <mwc-textfield
+                label="${_t('credential.Max#')}"
+                class="discrete"
+                id="vfolder-count-limit"
+                type="number"
+                min="0"
+                max="50"
+                @change="${(e) => this._validateResourceInput(e)}"
+              ></mwc-textfield>
             </div>
           </div>
         </div>

--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -106,6 +106,7 @@ export default class BackendAICredentialView extends BackendAIPage {
   @state() private all_vfolder_hosts;
   @state() private default_vfolder_host = '';
   @state() private vfolderPermissions;
+  @state() private isSupportMaxVfolderCountInUserResourcePolicy = false;
 
   constructor() {
     super();
@@ -348,6 +349,10 @@ export default class BackendAICredentialView extends BackendAIPage {
           globalThis.backendaiclient.supports(
             'fine-grained-storage-permissions',
           );
+        this.isSupportMaxVfolderCountInUserResourcePolicy =
+          globalThis.backendaiclient.supports(
+            'max-vfolder-count-in-user-resource-policy',
+          );
         this._preparePage();
         if (this.enableParsingStoragePermissions) {
           this._getVfolderPermissions();
@@ -359,6 +364,10 @@ export default class BackendAICredentialView extends BackendAIPage {
         globalThis.backendaiclient.supports('session-lifetime');
       this.enableParsingStoragePermissions =
         globalThis.backendaiclient.supports('fine-grained-storage-permissions');
+      this.isSupportMaxVfolderCountInUserResourcePolicy =
+        globalThis.backendaiclient.supports(
+          'max-vfolder-count-in-user-resource-policy',
+        );
       this._preparePage();
       if (this.enableParsingStoragePermissions) {
         this._getVfolderPermissions();
@@ -1478,9 +1487,7 @@ export default class BackendAICredentialView extends BackendAIPage {
             <div
               class="horizontal layout justified"
               style=${
-                globalThis.backendaiclient.supports(
-                  'max-vfolder-count-in-user-resource-policy',
-                )
+                this.isSupportMaxVfolderCountInUserResourcePolicy
                   ? 'display:none;'
                   : 'width:100%;'
               }

--- a/src/components/backend-ai-resource-policy-list.ts
+++ b/src/components/backend-ai-resource-policy-list.ts
@@ -81,6 +81,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
   @state() private allowed_vfolder_hosts;
   @state() private is_super_admin = false;
   @state() private vfolderPermissions;
+  @state() private isSupportMaxVfolderCountInUserResourcePolicy = false;
 
   constructor() {
     super();
@@ -447,9 +448,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
             ></backend-ai-multi-select>
             <div
               class="horizontal layout justified"
-              style=${globalThis.backendaiclient.supports(
-                'max-vfolder-count-in-user-resource-policy',
-              )
+              style=${this.isSupportMaxVfolderCountInUserResourcePolicy
                 ? 'display:none;'
                 : 'width:100%;'}
             >
@@ -620,9 +619,7 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
               `
             : html``}
         </div>
-        ${globalThis.backendaiclient.supports(
-          'max-vfolder-count-in-user-resource-policy',
-        )
+        ${this.isSupportMaxVfolderCountInUserResourcePolicy
           ? html``
           : html`
               <div class="layout horizontal wrap center">
@@ -801,6 +798,10 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
             globalThis.backendaiclient.supports(
               'fine-grained-storage-permissions',
             );
+          this.isSupportMaxVfolderCountInUserResourcePolicy =
+            globalThis.backendaiclient.supports(
+              'max-vfolder-count-in-user-resource-policy',
+            );
           this.is_super_admin = globalThis.backendaiclient.is_superadmin;
           this._refreshPolicyData();
           if (this.enableParsingStoragePermissions) {
@@ -815,6 +816,10 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
         globalThis.backendaiclient.supports('session-lifetime');
       this.enableParsingStoragePermissions =
         globalThis.backendaiclient.supports('fine-grained-storage-permissions');
+      this.isSupportMaxVfolderCountInUserResourcePolicy =
+        globalThis.backendaiclient.supports(
+          'max-vfolder-count-in-user-resource-policy',
+        );
       this.is_super_admin = globalThis.backendaiclient.is_superadmin;
       this._refreshPolicyData();
       if (this.enableParsingStoragePermissions) {
@@ -1092,16 +1097,12 @@ export default class BackendAIResourcePolicyList extends BackendAIPage {
       max_concurrent_sessions: parseInt(this.concurrencyLimit.value),
       max_containers_per_session: parseInt(this.containerPerSessionLimit.value),
       idle_timeout: this.idleTimeout.value,
-
+      max_vfolder_count: 0,
       allowed_vfolder_hosts: vfolder_hosts,
     };
 
-    if (
-      !globalThis.backendaiclient.supports(
-        'max-vfolder-count-in-user-resource-policy',
-      )
-    ) {
-      input.max_vfolder_count = this.vfolderCountLimitInput.value;
+    if (!this.isSupportMaxVfolderCountInUserResourcePolicy) {
+      input.max_vfolder_count = parseInt(this.vfolderCountLimitInput.value);
     }
 
     if (this.enableSessionLifetime) {


### PR DESCRIPTION
follows https://github.com/lablup/backend.ai-webui/pull/2011

## Problem
Updating `max_vfolder_count` in keypair is allowed only up to API 23 version or lower.
But the `max_vfolder_count` setting UI is always shown on the resource policy modification dialog.


## What's changed
- If the core version is greater than 23, hide the `max_vfolder_count` setting UI in the Modify Resource Policy dialog.
- Update schema.

## How to check
1. Go to the Users - Resource Policies page.
2. Check the `Max. # of folder` setting UI is displayed when only the API version is 23 or lower.
3. 23.09 endpoint: http://10.82.230.94:8090

## Checklist
- [ ] Main branch(greater than 23): `Max. # of folder` UI disappears on the create and update resource policy dialog.
- [ ] 23 or lower: `Max. # of folder` UI appears.



**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
