### PR TITLE
add: a draft for updated sliderInputItem with selectable AI accelerator

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -322,7 +322,9 @@ const ImageEnvironmentSelectFormItems: React.FC<
                     ) {
                       extraFilterValues.push(environmentGroup.prefix);
                       environmentPrefixTag = (
-                        <Tag color="purple">{environmentGroup.prefix}</Tag>
+                        <Tag color="purple" key={environmentGroup.prefix}>
+                          {environmentGroup.prefix}
+                        </Tag>
                       );
                     }
 
@@ -336,8 +338,11 @@ const ImageEnvironmentSelectFormItems: React.FC<
                         ) {
                           extraFilterValues.push(label.tag);
                           return (
-                            <Tag color={label.color}>
-                              <TextHighlighter keyword={environmentSearch}>
+                            <Tag color={label.color} key={label.tag}>
+                              <TextHighlighter
+                                keyword={environmentSearch}
+                                key={label.tag}
+                              >
                                 {label.tag}
                               </TextHighlighter>
                             </Tag>
@@ -499,7 +504,10 @@ const ImageEnvironmentSelectFormItems: React.FC<
                                   .map((str) => {
                                     extraFilterValues.push(str);
                                     return (
-                                      <TextHighlighter keyword={versionSearch}>
+                                      <TextHighlighter
+                                        keyword={versionSearch}
+                                        key={str}
+                                      >
                                         {str}
                                       </TextHighlighter>
                                     );

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -401,7 +401,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
       <Form.Item
         noStyle
         shouldUpdate={(prev, cur) =>
-          prev.environments?.environments !== cur.environments?.environment
+          prev.environments?.environment !== cur.environments?.environment
         }
       >
         {({ getFieldValue }) => {

--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -113,6 +113,49 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
     });
   }, [currentImage]);
 
+  const getLimitByAccelerator = (acceleratorName: string) => {
+    // FIXME: temporally add hard-coded number when config is undefined
+    const defaultAIAcceleratorMaxLimit = 8;
+    switch (acceleratorName) {
+      case 'cuda.device':
+      default:
+        return (
+          baiClient._config.maxCUDADevicesPerContainer ||
+          defaultAIAcceleratorMaxLimit
+        );
+      case 'cuda.shares':
+        return (
+          baiClient._config.maxCUDASharesPerContainer ||
+          defaultAIAcceleratorMaxLimit
+        );
+      case 'rocm.device':
+        return (
+          baiClient._config.maxROCMDevicesPerContainer ||
+          defaultAIAcceleratorMaxLimit
+        );
+      case 'tpu.device':
+        return (
+          baiClient._config.maxTPUDevicesPerContainer ||
+          defaultAIAcceleratorMaxLimit
+        );
+      case 'ipu.device':
+        return (
+          baiClient._config.maxIPUDevicesPerContainer ||
+          defaultAIAcceleratorMaxLimit
+        );
+      case 'atom.device':
+        return (
+          baiClient._config.maxATOMDevicesPerContainer ||
+          defaultAIAcceleratorMaxLimit
+        );
+      case 'warboy.device':
+        return (
+          baiClient._config.maxWarboyDevicesPerContainer ||
+          defaultAIAcceleratorMaxLimit
+        );
+    }
+  };
+
   const mutationToCreateService = useTanMutation<
     unknown,
     {
@@ -420,8 +463,7 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
             <Form.Item
               noStyle
               shouldUpdate={(prev, cur) =>
-                prev.environments?.environments !==
-                cur.environments?.environment
+                prev.environments?.environment !== cur.environments?.environment
               }
             >
               {() => {
@@ -438,7 +480,7 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
                         0: 0,
                       },
                     }}
-                    max={30}
+                    max={getLimitByAccelerator(currentImageAcceleratorTypeName)}
                     step={
                       _.endsWith(currentAcceleratorType, 'shares') ? 0.1 : 1
                     }

--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -522,7 +522,6 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
                 return (
                   <SliderInputItem
                     name={['resource', 'accelerator']}
-                    initialValue={0}
                     label={t(`session.launcher.AIAccelerator`)}
                     tooltip={
                       <Trans i18nKey={'session.launcher.DescAIAccelerator'} />

--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -28,6 +28,11 @@ interface ServiceCreateConfigResourceType {
   mem: string;
   'cuda.device'?: number | string;
   'cuda.shares'?: number | string;
+  'rocm.device'?: number | string;
+  'tpu.device'?: number | string;
+  'ipu.device'?: number | string;
+  'atom.device'?: number | string;
+  'warboy.device'?: number | string;
 }
 
 interface ServiceCreateConfigType {
@@ -63,7 +68,8 @@ interface ServiceLauncherProps
 }
 interface ServiceLauncherFormInput extends ImageEnvironmentFormInput {
   serviceName: string;
-  gpu: number;
+  // gpu: number;
+  resource: AIAccelerator;
   cpu: number;
   mem: number;
   shmem: number;
@@ -71,6 +77,16 @@ interface ServiceLauncherFormInput extends ImageEnvironmentFormInput {
   vFolderName: string;
   desiredRoutingCount: number;
   openToPublic: boolean;
+}
+
+interface AIAccelerator {
+  accelerator: number;
+  acceleratorType: SelectUIType;
+}
+
+interface SelectUIType {
+  value: string;
+  label: string;
 }
 
 const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
@@ -277,7 +293,10 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
           initialValues={
             {
               cpu: 1,
-              gpu: 0,
+              // gpu: 0,
+              resource: {
+                accelerator: 0,
+              },
               mem: 0.25,
               shmem: 0,
               desiredRoutingCount: 1,

--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -526,11 +526,14 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
                     tooltip={
                       <Trans i18nKey={'session.launcher.DescAIAccelerator'} />
                     }
-                    sliderProps={{
-                      marks: {
-                        0: 0,
-                      },
-                    }}
+                    sliderProps={
+                      {
+                        // FIXME: temporally comment out min value
+                        // marks: {
+                        //   0: 0,
+                        // },
+                      }
+                    }
                     min={0}
                     max={
                       getLimitByAccelerator(currentImageAcceleratorTypeName).max

--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -131,6 +131,7 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
       value: currentImageAcceleratorTypeName,
       label: ACCELERATOR_UNIT_MAP[currentImageAcceleratorTypeName] || 'UNIT',
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentImage]);
 
   const getLimitByAccelerator = (acceleratorName: string) => {
@@ -168,7 +169,7 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
       _.filter(
         currentImageAcceleratorLimits,
         (supportedAcceleratorInfo) =>
-          supportedAcceleratorInfo?.key == currentImageAcceleratorTypeName,
+          supportedAcceleratorInfo?.key === currentImageAcceleratorTypeName,
       )[0]?.min as string,
     );
     return {

--- a/react/src/components/SliderInputFormItem.tsx
+++ b/react/src/components/SliderInputFormItem.tsx
@@ -18,6 +18,7 @@ interface SliderInputProps extends Omit<FormItemProps, 'name'> {
   name: NamePath;
   inputNumberProps?: InputNumberProps;
   sliderProps?: SliderSingleProps | SliderRangeProps;
+  disabled?: boolean;
 }
 const SliderInputItem: React.FC<SliderInputProps> = ({
   name,
@@ -29,6 +30,7 @@ const SliderInputItem: React.FC<SliderInputProps> = ({
   inputNumberProps,
   sliderProps,
   initialValue,
+  disabled,
   ...formItemProps
 }) => {
   return (
@@ -41,7 +43,13 @@ const SliderInputItem: React.FC<SliderInputProps> = ({
             rules={rules}
             initialValue={initialValue}
           >
-            <Slider max={max} min={min} step={step} {...sliderProps} />
+            <Slider
+              max={max}
+              min={min}
+              step={step}
+              disabled={disabled}
+              {...sliderProps}
+            />
           </Form.Item>
         </Flex>
         <Flex style={{ flex: 2 }}>
@@ -53,6 +61,7 @@ const SliderInputItem: React.FC<SliderInputProps> = ({
               onStep={(value, info) => {
                 console.log(value, info);
               }}
+              disabled={disabled}
               {...inputNumberProps}
             />
           </Form.Item>

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -24,6 +24,11 @@ export const useResourceSlots = () => {
     mem?: string;
     'cuda.shares'?: string;
     'cuda.device'?: string;
+    'rocm.device'?: string;
+    'tpu.device'?: string;
+    'ipu.device'?: string;
+    'atom.device'?: string;
+    'warboy.device'?: string;
   }>({
     queryKey: ['useResourceSlots', key],
     queryFn: () => {


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR provides multiple supported AI accelerator on service launcher modal, which formerly supported CUDA only.
After merging this PR, user can create a service with any AI accelerator that supported by both environment(image) and resource group.

## Before:
<img width="551" alt="Screenshot 2023-11-08 at 5 39 53 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/066f7fe8-f8ae-42c2-93b2-a0878f1886c1">


## After:
| Warboy supported environment | FGPU supported environment |
|---------------------------------|-------------------------------|
| <img width="551" alt="Screenshot 2023-11-08 at 5 40 20 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/777d598f-5007-4d67-84bc-a9264bab4334"> | <img width="551" alt="Screenshot 2023-11-08 at 5 40 14 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/23d16091-35a0-4e47-bca9-abfecb76e921"> |


### How to test

You can find the test environment setting via [here](https://github.com/orgs/lablup/projects/24/views/10?pane=issue&itemId=43982640). 

> ⚠️ NOTE: the maximum value is currently managed by config, so please test according to test condition. adjusting max value will be handled as another issue.

- [ ] Check whether you can create service according to following conditions:
   > common conditions:
   > - Service Name: anything-## (## is number)
   >   - Resource Group: default
   >   - Open To Public: enabled
   >   - Model storage to mount: KoAlpaca-5.8B-8bit
   >   - Desired Routing Count: 1
   >   - CPU: 1 Core
   >   - Memory: 2 GiB
   >   - Shared Memory: 1.00 GiB
   - [ ] condition 1(Using Warboy as AI accelerator):
         - Environments / Version: `baidev/furiosa-server` / `3.10 | Ubuntu 22.04 | x86_63 | -`
         - AI Accelerator: 1 Warboy
   - [ ] condition 2(Using FGPU as AI accelerator):
         - Environments / Version: `PyTorch (NGC)` / `23.08 | PyTorch 2.1 | x86_64 | py310, cuda12.2`
         - AI Accelerator: 1.5 FGPU
   - [ ] condition 3 (Doesn't use any AI accelerator):
         - Environments / Version: `Python` / `3.9 | Ubuntu 20.04 | x86_64 | -`
         - AI Accelerator: disabled
- [ ] Check whether Unit of AI accelerator changes when environment changes.
   - [ ] If Environment string includes "furiosa", then AI Accelerator only enables "Warboy" and disable others.
   - [ ] If Environment is set to simple python kernel (e.g. `Python` / `3.9 | Ubuntu 20.04 | x86_64 | -`) then AI Accelerator field will be disabled.
   - [ ] If Environment is set to PyTorch (NGC), then AI Accelerator only enables "FGPU" and disable others.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after
