### PR TITLE
feat: Link FastTrack button to frontend server

### DIFF
--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -86,6 +86,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: String }) connection_mode = 'SESSION' as ConnectionMode;
   @property({ type: String }) systemSSHImage = '';
   @property({ type: String }) fasttrackEndpoint = '';
+  @property({ type: Boolean }) hideSideMenuFastTrackButton = false;
   @property({ type: Number }) login_attempt_limit = 500;
   @property({ type: Number }) login_block_time = 180;
   @property({ type: String }) user;
@@ -939,8 +940,18 @@ export default class BackendAILogin extends BackendAIPage {
     this.fasttrackEndpoint = this._getConfigValueByExists(pipelineConfig, {
       valueType: 'string',
       defaultValue: '',
-      value: pipelineConfig?.endpoint,
+      value: pipelineConfig?.frontendEndpoint,
     } as ConfigValueObject) as string;
+
+    // Enable hide button flag
+    this.hideSideMenuFastTrackButton = this._getConfigValueByExists(
+      pipelineConfig,
+      {
+        valueType: 'boolean',
+        defaultValue: false,
+        value: pipelineConfig?.hideSideMenuButton,
+      } as ConfigValueObject,
+    ) as boolean;
   }
 
   /**
@@ -1731,6 +1742,8 @@ export default class BackendAILogin extends BackendAIPage {
         globalThis.backendaiclient._config.systemSSHImage = this.systemSSHImage;
         globalThis.backendaiclient._config.fasttrackEndpoint =
           this.fasttrackEndpoint;
+        globalThis.backendaiclient._config.hideSideMenuFastTrackButton =
+          this.hideSideMenuFastTrackButton;
         globalThis.backendaiclient._config.hideAgents = this.hideAgents;
         globalThis.backendaiclient._config.enable2FA = this.enable2FA;
         globalThis.backendaiclient._config.force2FA = this.force2FA;

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -103,6 +103,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   @property({ type: Array }) groups = [];
   @property({ type: Object }) plugins = Object();
   @property({ type: String }) fasttrackEndpoint = '';
+  @property({ type: Boolean }) isHideSideMenuFastTrackButton = false;
   @property({ type: String }) _page = '';
   @property({ type: String }) _lazyPage = '';
   @property({ type: Object }) _pageParams = {};
@@ -481,9 +482,15 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
     }
     if (
       typeof config.pipeline !== 'undefined' &&
-      'endpoint' in config.pipeline
+      'frontendEndpoint' in config.pipeline
     ) {
-      this.fasttrackEndpoint = config.pipeline.endpoint;
+      this.fasttrackEndpoint = config.pipeline.frontendEndpoint;
+    }
+    if (
+      typeof config.pipeline !== 'undefined' &&
+      'hideSideMenuButton' in config.pipeline
+    ) {
+      this.isHideSideMenuFastTrackButton = config.pipeline.hideSideMenuButton;
     }
     if (typeof config.plugin !== 'undefined') {
       // Store plugin informations
@@ -1236,7 +1243,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
         _text('webui.menu.AgentSummary'),
       );
     }
-    if (this.fasttrackEndpoint !== '') {
+    if (!this.isHideSideMenuFastTrackButton && this.fasttrackEndpoint !== '') {
       this._createPopover('fasttrack-menu-icon', _text('webui.menu.FastTrack'));
     }
   }
@@ -1530,6 +1537,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
               <span class="full-menu">${_t('webui.menu.Statistics')}</span>
             </mwc-list-item>
             ${
+              !this.isHideSideMenuFastTrackButton &&
               this.fasttrackEndpoint !== ''
                 ? html`
                     <a href="${this.fasttrackEndpoint}" target="_blank">


### PR DESCRIPTION
This PR is a counterpart to lablup/backend.ai#1692

This PR updates the `FastTrack` button to use `pipeline.frontendEndpoint`(frontend server) rather than `pipeline.endpoint`(API server) to redirect users to the right service.

Required manager version: >= 23.09.**6**

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
