### PR TITLE
feature: update existing components for neo session launcher

### DIFF
--- a/react/src/components/DoubleTag.tsx
+++ b/react/src/components/DoubleTag.tsx
@@ -38,7 +38,7 @@ const DoubleTag: React.FC<{
             style={
               _.last(objectValues) === objValue
                 ? undefined
-                : { margin: 0, marginRight: -1, zIndex: 1 }
+                : { margin: 0, marginRight: -1 }
             }
             color={objValue.color}
           >

--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -31,12 +31,12 @@ const ResourceAllocationFormItems = () => {
               resource: {
                 ...slots,
                 // transform to GB based on preset values
-                mem: iSizeToSize((slots?.mem || 0) + 'b', 'g', 2).number,
+                mem: iSizeToSize((slots?.mem || 0) + 'b', 'g', 2)?.number,
                 shmem: iSizeToSize(
                   (options?.preset?.shared_memory || 0) + 'b',
                   'g',
                   2,
-                ).number,
+                )?.number,
               },
             });
           }}

--- a/react/src/components/ResourceNumber.tsx
+++ b/react/src/components/ResourceNumber.tsx
@@ -35,6 +35,7 @@ interface Props {
   extra?: ReactElement;
   opts?: ResourceOpts;
   value: string;
+  hideTooltip?: boolean;
 }
 
 type ResourceTypeInfo<V> = {
@@ -45,6 +46,7 @@ const ResourceNumber: React.FC<Props> = ({
   value: amount,
   extra,
   opts,
+  hideTooltip = false,
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
@@ -56,24 +58,24 @@ const ResourceNumber: React.FC<Props> = ({
 
   return (
     <Flex direction="row" gap="xxs">
-      <ResourceTypeIcon type={type} />
+      <ResourceTypeIcon type={type} showTooltip={!hideTooltip} />
       <Typography.Text>
         {units[type] === 'GiB'
-          ? iSizeToSize(amount + 'b', 'g', 2).numberFixed
+          ? Number(iSizeToSize(amount + 'b', 'g', 3)?.numberFixed).toString()
           : units[type] === 'FGPU'
           ? parseFloat(amount).toFixed(2)
           : amount}
       </Typography.Text>
       <Typography.Text type="secondary">{units[type]}</Typography.Text>
-      {type === 'mem' && opts?.shmem && (
+      {type === 'mem' && opts?.shmem && opts?.shmem > 0 ? (
         <Typography.Text
           type="secondary"
           style={{ fontSize: token.fontSizeSM }}
         >
-          (SHM: {iSizeToSize(opts.shmem + 'b', 'g', 2).numberFixed}
+          (SHM: {iSizeToSize(opts.shmem + 'b', 'g', 2)?.numberFixed}
           GiB)
         </Typography.Text>
-      )}
+      ) : null}
       {extra}
     </Flex>
   );
@@ -132,29 +134,30 @@ export const ResourceTypeIcon: React.FC<AccTypeIconProps> = ({
     'warboy.device': ['/resources/icons/furiosa.svg', 'Warboy'],
   };
 
-  return (
-    <Tooltip
-      title={
-        showTooltip ? `${type} (${resourceTypeIconSrcMap[type][1]})` : undefined
-      }
-    >
-      {typeof resourceTypeIconSrcMap[type]?.[0] === 'string' ? (
-        <img
-          {...props}
-          style={{
-            height: size,
-            ...(props.style || {}),
-          }}
-          // @ts-ignore
-          src={resourceTypeIconSrcMap[type]?.[0] || ''}
-          alt={type}
-        />
-      ) : (
-        <div style={{ width: 16, height: 16 }}>
-          {resourceTypeIconSrcMap[type]?.[0] || type}
-        </div>
-      )}
-    </Tooltip>
+  const content =
+    typeof resourceTypeIconSrcMap[type]?.[0] === 'string' ? (
+      <img
+        {...props}
+        style={{
+          height: size,
+          alignSelf: 'center',
+          ...(props.style || {}),
+        }}
+        // @ts-ignore
+        src={resourceTypeIconSrcMap[type]?.[0] || ''}
+        alt={type}
+      />
+    ) : (
+      <Flex style={{ width: 16, height: 16 }}>
+        {resourceTypeIconSrcMap[type]?.[0] || type}
+      </Flex>
+    );
+
+  return showTooltip ? (
+    // <Tooltip title={showTooltip ? `${type} (${resourceTypeIconSrcMap[type][1]})` : undefined}>
+    <Tooltip title={type}>{content}</Tooltip>
+  ) : (
+    <Flex style={{ pointerEvents: 'none' }}>{content}</Flex>
   );
 };
 

--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -475,11 +475,14 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
                               'G',
                             );
 
-                            if (sizeGInfo.number > value) {
+                            if (
+                              sizeGInfo?.number &&
+                              sizeGInfo?.number > value
+                            ) {
                               return Promise.reject(
                                 new Error(
                                   t('session.launcher.MinMemory', {
-                                    size: sizeGInfo.numberUnit,
+                                    size: sizeGInfo?.numberUnit,
                                   }),
                                 ),
                               );

--- a/react/src/components/SliderInputFormItem.tsx
+++ b/react/src/components/SliderInputFormItem.tsx
@@ -42,6 +42,7 @@ const SliderInputItem: React.FC<SliderInputProps> = ({
             noStyle
             rules={rules}
             initialValue={initialValue}
+            label={formItemProps.label}
           >
             <Slider
               max={max}
@@ -52,8 +53,17 @@ const SliderInputItem: React.FC<SliderInputProps> = ({
             />
           </Form.Item>
         </Flex>
-        <Flex style={{ flex: 2 }}>
-          <Form.Item name={name} noStyle initialValue={initialValue}>
+        <Flex
+          style={{ flex: 2, minWidth: 130 }}
+          align="stretch"
+          direction="column"
+        >
+          <Form.Item
+            name={name}
+            noStyle
+            initialValue={initialValue}
+            label={formItemProps.label}
+          >
             <InputNumber
               max={max}
               min={min}

--- a/react/src/components/SliderInputFormItem.tsx
+++ b/react/src/components/SliderInputFormItem.tsx
@@ -61,6 +61,7 @@ const SliderInputItem: React.FC<SliderInputProps> = ({
           <Form.Item
             name={name}
             noStyle
+            rules={rules}
             initialValue={initialValue}
             label={formItemProps.label}
           >

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -1,4 +1,4 @@
-import { iSizeToSize } from './index';
+import { compareNumberWithUnits, iSizeToSize } from './index';
 
 describe('iSizeToSize', () => {
   it('should convert iSize to Size with default fixed value', () => {
@@ -64,5 +64,11 @@ describe('iSizeToSize', () => {
       unit: 'K',
       numberUnit: '1.00K',
     });
+  });
+});
+
+describe('compareNumberWithUnits', () => {
+  it('should compare two numbers with units', () => {
+    expect(compareNumberWithUnits('256m', '9007199254740991')).toBeLessThan(0);
   });
 });

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -133,7 +133,7 @@ export const bytesToGB = (
 };
 
 export function iSizeToSize(
-  sizeWithUnit: string,
+  sizeWithUnit: string | undefined,
   targetSizeUnit?:
     | 'B'
     | 'K'
@@ -150,12 +150,17 @@ export function iSizeToSize(
     | 'p'
     | 'e',
   fixed: number = 2,
-): {
-  number: number;
-  numberFixed: string;
-  unit: string;
-  numberUnit: string;
-} {
+):
+  | {
+      number: number;
+      numberFixed: string;
+      unit: string;
+      numberUnit: string;
+    }
+  | undefined {
+  if (sizeWithUnit === undefined) {
+    return undefined;
+  }
   const sizes = ['B', 'K', 'M', 'G', 'T', 'P', 'E'];
   const sizeUnit = sizeWithUnit.slice(-1).toUpperCase();
   const sizeValue = parseFloat(sizeWithUnit.slice(0, -1));

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -162,11 +162,10 @@ export function iSizeToSize(
     return undefined;
   }
   const sizes = ['B', 'K', 'M', 'G', 'T', 'P', 'E'];
-  const sizeUnit = sizeWithUnit.slice(-1).toUpperCase();
-  const sizeValue = parseFloat(sizeWithUnit.slice(0, -1));
-  const sizeIndex = sizes.indexOf(sizeUnit);
+  const [sizeValue, sizeUnit] = parseUnit(sizeWithUnit);
+  const sizeIndex = sizes.indexOf(sizeUnit.toUpperCase());
   if (sizeIndex === -1 || isNaN(sizeValue)) {
-    throw new Error('Invalid size format');
+    throw new Error('Invalid size format,' + sizeWithUnit);
   }
   const bytes = sizeValue * Math.pow(1024, sizeIndex);
   const targetIndex = targetSizeUnit
@@ -180,6 +179,21 @@ export function iSizeToSize(
     unit: sizes[targetIndex],
     numberUnit: `${numberFixed}${sizes[targetIndex]}`,
   };
+}
+
+export function compareNumberWithUnits(size1: string, size2: string) {
+  const [number1, unit1] = parseUnit(size1);
+  const [number2, unit2] = parseUnit(size2);
+  // console.log(size1, size2);
+  // console.log(number1, unit1, number2, unit2);
+  if (unit1 === unit2) {
+    return number1 - number2;
+  }
+  if (number1 === 0 && number2 === 0) {
+    return 0;
+  }
+  // @ts-ignore
+  return iSizeToSize(size1, 'g')?.number - iSizeToSize(size2, 'g')?.number;
 }
 
 export type QuotaScopeType = 'project' | 'user';
@@ -224,4 +238,15 @@ export function filterNonNullItems<T extends { [key: string]: any }>(
     return [];
   }
   return arr.filter((item): item is T => item !== null) as T[];
+}
+
+export function parseUnit(str: string): [number, string] {
+  const match = str?.match(/^(\d+(?:\.\d+)?)([a-zA-Z]*)$/);
+  if (!match) {
+    // If the input doesn't match the pattern, assume it's in bytes
+    return [parseFloat(str), 'b'];
+  }
+  const num = parseFloat(match[1]);
+  const unit = match[2];
+  return [num, unit.toLowerCase() || 'b'];
 }

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -674,8 +674,8 @@ const SessionLauncherPage = () => {
                                     type={type}
                                     value={
                                       type === 'mem'
-                                        ? iSizeToSize(value + 'g', 'b').number +
-                                          ''
+                                        ? iSizeToSize(value + 'g', 'b')
+                                            ?.number + ''
                                         : value
                                     }
                                     opts={{
@@ -685,7 +685,7 @@ const SessionLauncherPage = () => {
                                             form.getFieldValue('resource')
                                               .shmem + 'g',
                                             'b',
-                                          ).number
+                                          )?.number
                                         : undefined,
                                     }}
                                   />


### PR DESCRIPTION
This PR includes several changes to existing components for the neo session launcher.
All changes are from #1953, which affect existing components.

## Changes
- `iSizeToSize` function
  - `react/src/helper/index.tsx`
  - Used in `ServiceLauncerModal`
- `DoubleTag` component: cosmetic touch
  - `react/src/components/DoubleTag.tsx` 
  - Used in 
    - `ImageEnvironmentSelectFormItem` in ServiceLauncherModal
    - `Information Page`
- `ImageEnvironmentSelectFormItem` component: 
  - `react/src/components/ImageEnvironmentSelectFormItems.tsx`
  - changes
    - fix: set image in `onChange` of version select
- `ResourceNumber` component:
  - `react/src/components/ResourceNumber.tsx`
  - changes 
    - feat: `hideTooltip` props
    - change fixed number (2->3)
    - show `shmem` info when `> 0`
  - Used in
    - `RountingListPage`
- `ServiceLauncherModa` component
  - `react/src/components/ServiceLauncherModal.tsx`
  - Add optional chaining to `sizeGInfo.number`
- `SliderInputItem` component
  - `react/src/components/SliderInputFormItem.tsx`
  - fix: add rule for `InputNumber` also
  - Include a `label` for auto-generated validation messages, even for `noStyle` items.
  
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

---
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4bc5d0b</samp>

### Summary
🐛🌟📊

<!--
1.  🐛 - This emoji represents the bug fix for the `zIndex` style property and the memory input value condition.
2.  🌟 - This emoji represents the enhancement for the image selection form and its environment variables.
3.  📊 - This emoji represents the improvement for the resource numbers and tooltips, the slider and input number, and the number with units handling and comparison.
-->
This pull request improves the user interface and functionality of the web console for selecting and launching sessions and services. It adds features and fixes bugs related to the image and environment variable selection, the resource number display and validation, and the comparison of numbers with units. It also adds unit tests and modifies some styles and props of the components involved. The files affected are `ImageEnvironmentSelectFormItems.tsx`, `ResourceNumber.tsx`, `SliderInputFormItem.tsx`, `index.test.tsx`, `index.tsx`, `DoubleTag.tsx`, and `ServiceLauncherModal.tsx`.

> _Sing, O Muse, of the skillful coder who refined the form_
> _Of choosing images and variables, with many a feature born_
> _Of keen logic and design, such as the `DoubleTag` bright_
> _That no longer overlaps the menu, like a star that dims its light_

### Walkthrough
*  Add `compareNumberWithUnits` function to compare two numbers with units and test its functionality ([link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-0a8608ef16d58318fb19a92e170b6ed1db5e41fbc9f440eaee5b0bb643fc4394R184-R198), [link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-f54f81ae836608673741c9c7e13ec0dd5a4e41c2aedbda7192ee527959a93333R69-R74), [link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-0a8608ef16d58318fb19a92e170b6ed1db5e41fbc9f440eaee5b0bb643fc4394R242-R252))
*  Modify `iSizeToSize` function to accept `undefined` input and use `parseUnit` function to extract number and unit ([link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-0a8608ef16d58318fb19a92e170b6ed1db5e41fbc9f440eaee5b0bb643fc4394L136-R136), [link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-0a8608ef16d58318fb19a92e170b6ed1db5e41fbc9f440eaee5b0bb643fc4394L153-R168))
*  Add `hideTooltip` prop to `ResourceNumber` component to control tooltip visibility and improve SHM text and byte conversion logic ([link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-f9ddf3960d76b6da46525ff9a3b36fcd64f75e8852319e1c50d40066d6fa8d33R38), [link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-f9ddf3960d76b6da46525ff9a3b36fcd64f75e8852319e1c50d40066d6fa8d33R49), [link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-f9ddf3960d76b6da46525ff9a3b36fcd64f75e8852319e1c50d40066d6fa8d33L59-R64), [link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-f9ddf3960d76b6da46525ff9a3b36fcd64f75e8852319e1c50d40066d6fa8d33L68-R78))
*  Add `showTooltip` prop to `ResourceTypeIcon` component to wrap icon with `Tooltip` or `Flex` component and simplify tooltip title ([link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-f9ddf3960d76b6da46525ff9a3b36fcd64f75e8852319e1c50d40066d6fa8d33L135-R160))
*  Add `preserve` option to `Form.useWatch` hook in `ImageEnvironmentSelectFormItems` component to prevent form values from being reset ([link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-0c3eda30e966d59fcc7f298b411bdf4671271d6ff721e2395f9985d638a98e37L78-R88))
*  Add `onChange` handler to `Select` component for image version in `ImageEnvironmentSelectFormItems` component to update form value ([link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-0c3eda30e966d59fcc7f298b411bdf4671271d6ff721e2395f9985d638a98e37L436-R445))
*  Add `TextHighlighter` component to `environmentPrefixTag` element in `ImageEnvironmentSelectFormItems` component to highlight matching text ([link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-0c3eda30e966d59fcc7f298b411bdf4671271d6ff721e2395f9985d638a98e37L325-R330))
*  Add `label` prop to `Form.Item` component for slider and input number in `SliderInputFormItem` component and adjust layout ([link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-ad35cbb0fd105ed9005d70d66ba6684d4b05f528884698bb2562642431f84774R45), [link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-ad35cbb0fd105ed9005d70d66ba6684d4b05f528884698bb2562642431f84774L55-R67))
*  Remove `zIndex` style property from `DoubleTag` component to fix tag overlap bug ([link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-463d993a4d8752e78427abdcd400b131ca6e3bb205434169a3b17c61a8637b7cL41-R41))
*  Modify condition for rejecting memory input value in `ServiceLauncherModal` component to avoid error ([link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-14075520518ef75d88c4d5df326da07601b2eb8721afadb0d0c9629306b63284L478-R485))
*  Move `isPrivateImage` function to top of `ImageEnvironmentSelectFormItems` component for readability and reusability ([link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-0c3eda30e966d59fcc7f298b411bdf4671271d6ff721e2395f9985d638a98e37R70-R79), [link](https://github.com/lablup/backend.ai-webui/pull/2023/files?diff=unified&w=0#diff-0c3eda30e966d59fcc7f298b411bdf4671271d6ff721e2395f9985d638a98e37L165-L172))

