### PR TITLE
feat: VFolderPermissionTag component

### DIFF
--- a/react/src/components/VFolderPermissionTag.tsx
+++ b/react/src/components/VFolderPermissionTag.tsx
@@ -1,0 +1,63 @@
+import DoubleTag, { DoubleTagObjectValue } from './DoubleTag';
+import {
+  VFolderPermissionTag_VFolder$data,
+  VFolderPermissionTag_VFolder$key,
+} from './__generated__/VFolderPermissionTag_VFolder.graphql';
+import graphql from 'babel-plugin-relay/macro';
+import _ from 'lodash';
+import React from 'react';
+import { useFragment } from 'react-relay';
+
+const hasPermission = (permission: string | undefined, perm: string) => {
+  if (permission?.includes(perm)) {
+    return true;
+  }
+  if (permission?.includes('w') && perm === 'r') {
+    return true;
+  }
+  return false;
+};
+
+type VFolderPermissionTagProps =
+  | {
+      vFolderFrgmt?: never;
+      permission: string;
+    }
+  | {
+      vFolderFrgmt: VFolderPermissionTag_VFolder$key;
+      permission?: never;
+    };
+
+const VFolderPermissionTag: React.FC<VFolderPermissionTagProps> = ({
+  vFolderFrgmt = null,
+  permission,
+}) => {
+  const vFolder = useFragment(
+    graphql`
+      fragment VFolderPermissionTag_VFolder on VirtualFolder {
+        permission
+      }
+    `,
+    vFolderFrgmt,
+  );
+  const tagValues: DoubleTagObjectValue[] = _.chain({
+    r: 'green',
+    w: 'blue',
+    d: 'red',
+  })
+    .map((color, perm) => {
+      if (hasPermission(vFolder?.permission || permission, perm)) {
+        return {
+          label: perm.toUpperCase(),
+          color,
+        };
+      }
+      return undefined;
+    })
+    .compact()
+    .value();
+
+  return <DoubleTag values={tagValues} />;
+};
+
+export default VFolderPermissionTag;

--- a/react/src/components/VFolderPermissionTag.tsx
+++ b/react/src/components/VFolderPermissionTag.tsx
@@ -1,8 +1,5 @@
 import DoubleTag, { DoubleTagObjectValue } from './DoubleTag';
-import {
-  VFolderPermissionTag_VFolder$data,
-  VFolderPermissionTag_VFolder$key,
-} from './__generated__/VFolderPermissionTag_VFolder.graphql';
+import { VFolderPermissionTag_VFolder$key } from './__generated__/VFolderPermissionTag_VFolder.graphql';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React from 'react';

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -5,6 +5,7 @@ import { useShadowRoot } from './DefaultProviders';
 import DoubleTag, { DoubleTagObjectValue } from './DoubleTag';
 import Flex from './Flex';
 import TextHighlighter from './TextHighlighter';
+import VFolderPermissionTag from './VFolderPermissionTag';
 import { VFolder } from './VFolderSelect';
 import {
   QuestionCircleOutlined,
@@ -163,16 +164,6 @@ const VFolderTable: React.FC<Props> = ({
           ),
         );
       });
-  };
-
-  const hasPermission = (vFolder: VFolder, perm: string) => {
-    if (vFolder.permission.includes(perm)) {
-      return true;
-    }
-    if (vFolder.permission.includes('w') && perm === 'r') {
-      return true;
-    }
-    return false;
   };
 
   const mapAliasToPath = (name: VFolderKey, input?: string) => {
@@ -369,24 +360,7 @@ const VFolderTable: React.FC<Props> = ({
       dataIndex: 'permission',
       sorter: (a, b) => a.permission.localeCompare(b.permission),
       render: (value, row) => {
-        const tagValues: DoubleTagObjectValue[] = _.chain({
-          r: 'green',
-          w: 'blue',
-          d: 'red',
-        })
-          .map((color, perm) => {
-            if (hasPermission(row, perm)) {
-              return {
-                label: perm.toUpperCase(),
-                color,
-              };
-            }
-            return undefined;
-          })
-          .compact()
-          .value();
-
-        return <DoubleTag values={tagValues} />;
+        return <VFolderPermissionTag permission={row.permission} />;
       },
     },
     {

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -2,7 +2,6 @@ import { useBaiSignedRequestWithPromise } from '../helper';
 import { useCurrentProjectValue, useUpdatableState } from '../hooks';
 import { useTanQuery } from '../hooks/reactQueryAlias';
 import { useShadowRoot } from './DefaultProviders';
-import DoubleTag, { DoubleTagObjectValue } from './DoubleTag';
 import Flex from './Flex';
 import TextHighlighter from './TextHighlighter';
 import VFolderPermissionTag from './VFolderPermissionTag';


### PR DESCRIPTION
This component can display vFolder permissions by using a permission string or GraphQL fragment.
<img width="97" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/dae8739d-c636-4479-a621-2131b787fec5">

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
