### PR TITLE
feature: Response style for `ImageEnvironmentSelectFormItems`

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.css
+++ b/react/src/components/ImageEnvironmentSelectFormItems.css
@@ -1,0 +1,42 @@
+/* Change the image and tags of the select option when the selection is opened  */
+div.image-environment-select-form-item
+  div.ant-select-open
+  span.ant-select-selection-item
+  div
+  img,
+div.image-environment-select-form-item
+  div.ant-select-open
+  span.ant-select-selection-item
+  div
+  span.ant-tag {
+  opacity: 0.5;
+}
+
+div.image-environment-select-form-item
+  div.ant-select-item-option-content
+  div.tag-wrap {
+  /* flex: 1 !important; */
+  flex-wrap: wrap !important;
+}
+
+div.image-environment-select-form-item
+  span.ant-select-selection-item
+  div.tag-wrap {
+  overflow: hidden;
+}
+
+div.image-environment-select-form-item
+  span.ant-select-selection-item
+  div.tag-wrap::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 10px; /* Width of the transparent gradient area */
+  background: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0),
+    rgba(255, 255, 255, 1)
+  );
+}

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -4,6 +4,8 @@ import {
 } from '../hooks';
 import DoubleTag from './DoubleTag';
 import Flex from './Flex';
+// @ts-ignore
+import cssRaw from './ImageEnvironmentSelectFormItems.css?raw';
 import ImageMetaIcon from './ImageMetaIcon';
 import TextHighlighter from './TextHighlighter';
 import {
@@ -252,7 +254,9 @@ const ImageEnvironmentSelectFormItems: React.FC<
 
   return (
     <>
+      <style>{cssRaw}</style>
       <Form.Item
+        className="image-environment-select-form-item"
         name={['environments', 'environment']}
         label={`${t('session.launcher.Environments')} / ${t(
           'session.launcher.Version',
@@ -263,12 +267,12 @@ const ImageEnvironmentSelectFormItems: React.FC<
         <Select
           ref={envSelectRef}
           showSearch
+          className="image-environment-select"
+          // open={true}
           // autoClearSearchValue
-          labelInValue={false}
           searchValue={environmentSearch}
           onSearch={setEnvironmentSearch}
           defaultActiveFirstOption={true}
-          optionLabelProp="label"
           optionFilterProp="filterValue"
           onChange={(value) => {
             if (fullNameMatchedImage) {
@@ -364,23 +368,6 @@ const ImageEnvironmentSelectFormItems: React.FC<
                           '\t' +
                           extraFilterValues.join('\t')
                         }
-                        label={
-                          <Flex
-                            direction="row"
-                            align="center"
-                            gap="xs"
-                            style={{ display: 'inline-flex' }}
-                          >
-                            <ImageMetaIcon
-                              image={getImageFullName(firstImage) || ''}
-                              style={{
-                                width: 15,
-                                height: 15,
-                              }}
-                            />
-                            {environmentGroup.displayName}
-                          </Flex>
-                        }
                       >
                         <Flex direction="row" justify="between">
                           <Flex direction="row" align="center" gap="xs">
@@ -395,8 +382,19 @@ const ImageEnvironmentSelectFormItems: React.FC<
                               {environmentGroup.displayName}
                             </TextHighlighter>
                           </Flex>
-                          {environmentPrefixTag}
-                          {tagsFromMetaImageInfoLabel}
+                          <Flex
+                            direction="row"
+                            // set specific class name to handle flex wrap using css
+                            className="tag-wrap"
+                            // style={{ flex: 1 }}
+                            style={{
+                              marginLeft: token.marginXS,
+                              flexShrink: 1,
+                            }}
+                          >
+                            {environmentPrefixTag}
+                            {tagsFromMetaImageInfoLabel}
+                          </Flex>
                         </Flex>
                       </Select.Option>
                     );
@@ -432,6 +430,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
           });
           return (
             <Form.Item
+              className="image-environment-select-form-item"
               name={['environments', 'version']}
               rules={[{ required: true }]}
             >
@@ -448,7 +447,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
                 onSearch={setVersionSearch}
                 // autoClearSearchValue
                 optionFilterProp="filterValue"
-                optionLabelProp="label"
+                // optionLabelProp="label"
                 dropdownRender={(menu) => (
                   <>
                     <Flex
@@ -495,16 +494,8 @@ const ImageEnvironmentSelectFormItems: React.FC<
 
                     const extraFilterValues: string[] = [];
                     const requirementTags =
-                      requirements.length > 0 ? (
-                        <Flex
-                          direction="row"
-                          wrap="wrap"
-                          style={{
-                            flex: 1,
-                          }}
-                          gap={'xxs'}
-                        >
-                          {_.map(requirements, (requirement, idx) => (
+                      requirements.length > 0
+                        ? _.map(requirements, (requirement, idx) => (
                             <DoubleTag
                               key={idx}
                               values={
@@ -523,11 +514,8 @@ const ImageEnvironmentSelectFormItems: React.FC<
                                   }) || requirements
                               }
                             />
-                          ))}
-                        </Flex>
-                      ) : (
-                        '-'
-                      );
+                          ))
+                        : '-';
                     return (
                       <Select.Option
                         key={image?.digest}
@@ -538,29 +526,32 @@ const ImageEnvironmentSelectFormItems: React.FC<
                           image?.architecture,
                           ...extraFilterValues,
                         ].join('\t')}
-                        label={[
-                          version,
-                          tagAlias,
-                          image?.architecture,
-                          requirements.length > 0
-                            ? requirements.join(', ')
-                            : '-',
-                        ].join(' | ')}
                       >
-                        <Flex direction="row">
-                          <TextHighlighter keyword={versionSearch}>
-                            {version}
-                          </TextHighlighter>
-                          <Divider type="vertical" />
-                          <TextHighlighter keyword={versionSearch}>
-                            {tagAlias}
-                          </TextHighlighter>
-                          <Divider type="vertical" />
-                          <TextHighlighter keyword={versionSearch}>
-                            {image?.architecture}
-                          </TextHighlighter>
-                          <Divider type="vertical" />
-                          {requirementTags}
+                        <Flex direction="row" justify="between">
+                          <Flex direction="row">
+                            <TextHighlighter keyword={versionSearch}>
+                              {version}
+                            </TextHighlighter>
+                            <Divider type="vertical" />
+                            <TextHighlighter keyword={versionSearch}>
+                              {tagAlias}
+                            </TextHighlighter>
+                            <Divider type="vertical" />
+                            <TextHighlighter keyword={versionSearch}>
+                              {image?.architecture}
+                            </TextHighlighter>
+                          </Flex>
+                          <Flex
+                            direction="row"
+                            // set specific class name to handle flex wrap using css
+                            className="tag-wrap"
+                            style={{
+                              marginLeft: token.marginXS,
+                              flexShrink: 1,
+                            }}
+                          >
+                            {requirementTags}
+                          </Flex>
                         </Flex>
                       </Select.Option>
                     );

--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -474,6 +474,7 @@ const ResourceAllocationFormItems: React.FC<
       >
         <ResourceGroupSelect
           autoSelectDefault
+          showSearch
           loading={isPendingCheckResets}
           onChange={(v) => {
             startCheckRestsTransition(() => {


### PR DESCRIPTION
## Changes
- Display Tag on Select
- Add a gradient to the end of the Tags when width is small
  | Before | After |
  |--------|--------|
  | <img width="378" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/53a9a0c0-4c24-4be3-aa20-5e2d28a414e3"> | <img width="364" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/6dd6452a-814e-4455-a943-faa81401c0e2"> |
  | Cell | Cell | 
- Add opacity to image and tag when `Select` is opened (check a PyTorch icon below)

  | Before | After |
  |--------|--------|
  | <img width="348" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/c49912a0-89d0-4635-a0d5-635ab5c28b99"> | <img width="352" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/f7fa60fa-da56-41b3-81c0-217e4a64e80a"> |



<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after
