### PR TITLE
add: bundle option to Makefile with auto-release bundle

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,7 +5,7 @@
 # file with configuration.  For more information, see:
 # https://github.com/actions/labeler/blob/master/README.md
 
-name: Build Desktop Applications
+name: Build and Release Packages
 on:
   release:
     types: [published]
@@ -23,7 +23,7 @@ jobs:
           node-version: 20
       - name: Install Dependencies
         run: npm install
-      - name: Package Applications
+      - name: Package Desktop Applications
         run: make all
         env:
           BAI_APP_SIGN: 1
@@ -32,6 +32,8 @@ jobs:
           BAI_APP_SIGN_IDENTITY: ${{ secrets.BAI_APP_SIGN_IDENTITY }}
           BAI_APP_SIGN_KEYCHAIN_B64: ${{ secrets.BAI_APP_SIGN_KEYCHAIN_B64 }}
           BAI_APP_SIGN_KEYCHAIN_PASSWORD: ${{ secrets.BAI_APP_SIGN_KEYCHAIN_PASSWORD }}
+      - name: Bundle static resources into zip package
+        run: make bundle
       - name: Upload application to latest release
         run: node upload-release.js app
         env:

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ all: dep
 	@make win_arm64
 	@make linux_x64
 	@make linux_arm64
+	@make bundle
 dep:
 	@if [ ! -f "./config.toml" ]; then \
 		cp config.toml.sample config.toml; \
@@ -144,6 +145,11 @@ ifeq ($(site),main)
 else
 	@mv ./app/backend.ai-desktop-$(arch)-$(BUILD_DATE).dmg ./app/backend.ai-desktop-$(BUILD_VERSION)-$(site)-$(os)-$(arch).dmg
 endif
+	@printf "$(YELLOW)Finished$(NC)\n"
+bundle: dep
+	@printf "$(GREEN)Bundling...$(NC)"
+	@cd build/rollup; zip -r -9 ../../app/backend.ai-webui-bundle-$(BUILD_DATE).zip . > /dev/null
+	@mv ./app/backend.ai-webui-bundle-$(BUILD_DATE).zip ./app/backend.ai-webui-bundle-$(BUILD_VERSION).zip
 	@printf "$(YELLOW)Finished$(NC)\n"
 mac: dep
 	@make mac_x64

--- a/README.md
+++ b/README.md
@@ -233,6 +233,13 @@ $ make compile
 
 Then bundled resource will be prepared in `build/rollup`. Basically, both app and web serving is based on static serving sources in the directory. However, to work as single page application, URL request fallback is needed.
 
+If you want to create the bundle zip file, 
+
+```console
+$ make bundle
+```
+will generate compiled static web bundle at `./app` directory. Then you can serve the web bundle via webservers.
+
 ### Serving with nginx
 
 If you need to serve with nginx, please install and setup `backend.ai-wsproxy` package for websocket proxy. Bundled websocket proxy is simplified version for single-user app.

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       }
     };
     globalThis.packageVersion = "24.03.0-alpha.3";
-    globalThis.buildVersion = "231113.221100";
+    globalThis.buildVersion = "231120.211106";
 </script>
   <!-- DO NOT CHANGE BELOW LINE -->
   <!-- REACT_BUNDLE_INJECTING FOR DEV-->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backend.ai-webui",
-  "version": "24.03.0-alpha.2",
+  "version": "24.03.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backend.ai-webui",
-      "version": "24.03.0-alpha.2",
+      "version": "24.03.0-alpha.3",
       "hasInstallScript": true,
       "license": "LGPL-3.0-or-later",
       "dependencies": {

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -1766,7 +1766,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
               </div>
               <address class="full-menu">
                 <small class="sidebar-footer">Lablup Inc.</small>
-                <small class="sidebar-footer" style="font-size:9px;">24.03.0-alpha.3.231113</small>
+                <small class="sidebar-footer" style="font-size:9px;">24.03.0-alpha.3.231120</small>
               </address>
               <div id="sidebar-navbar-footer" class="vertical start end-justified layout" style="margin-left:16px;">
                 <backend-ai-help-button active style="margin-left:4px;"></backend-ai-help-button>
@@ -1804,7 +1804,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
             </div>
             <address class="full-menu">
               <small class="sidebar-footer">Lablup Inc.</small>
-              <small class="sidebar-footer" style="font-size:9px;">24.03.0-alpha.3.231113</small>
+              <small class="sidebar-footer" style="font-size:9px;">24.03.0-alpha.3.231120</small>
             </address>
             <div id="sidebar-navbar-footer" class="vertical start end-justified layout" style="margin-left:16px;">
               <backend-ai-help-button active style="margin-left:4px;"></backend-ai-help-button>

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "24.03.0-alpha.3", "build": "231113.221100", "revision": "bdd3cf9c" }
+{ "package": "24.03.0-alpha.3", "build": "231120.211106", "revision": "1965b97a" }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d934787</samp>

### Summary
📦🕒📝

<!--
1.  📦 - This emoji represents the creation of a zip bundle of the web UI, which is a new feature that allows for easier distribution and deployment of the web UI. It also reflects the update of the package version in the `version.json` file and the GitHub workflow.
2.  🕒 - This emoji represents the update of the build version in the `index.html` file and the web UI footer, which reflects the latest date and time of the build. It also indicates that the web UI is constantly being updated and improved.
3.  📝 - This emoji represents the addition of a new section to the `README.md` file, which explains how to use the `make bundle` command and how to serve the web UI via webservers. It also reflects the update of the revision value in the `version.json` file, which indicates the latest commit hash.
-->
This pull request adds a new feature to create a zip bundle of the web UI resources, which can be used for static site deployment or embedding. It also updates the web UI version information and documentation accordingly.

> _We build the web of doom, we zip the source of power_
> _We update the version, we unleash the alpha hour_
> _We serve the static site, we embed the UI_
> _We make the bundle, we make the bundle fly_

### Walkthrough
* Change the name and the run step of the GitHub workflow for building and releasing packages ([link](https://github.com/lablup/backend.ai-webui/pull/2034/files?diff=unified&w=0#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L8-R8), [link](https://github.com/lablup/backend.ai-webui/pull/2034/files?diff=unified&w=0#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52L26-R26))
* Add a new run step to bundle the web resources into a zip file using the `make bundle` command ([link](https://github.com/lablup/backend.ai-webui/pull/2034/files?diff=unified&w=0#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R35-R36))
* Update the `buildVersion` variable in the `index.html` file with the latest build date and time ([link](https://github.com/lablup/backend.ai-webui/pull/2034/files?diff=unified&w=0#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L33-R33))
* Add a new line to the `all` target in the `Makefile` to invoke the `bundle` target after packaging the desktop applications ([link](https://github.com/lablup/backend.ai-webui/pull/2034/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R59))
* Add a new target `bundle` to the `Makefile`, which uses the `zip` command to compress the web resources and moves the zip file to the `app` directory ([link](https://github.com/lablup/backend.ai-webui/pull/2034/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R149-R153))
* Add a new section "Preparing bundled source" to the `README.md` file, which explains how to use the `make bundle` command and how to serve the zip file via webservers ([link](https://github.com/lablup/backend.ai-webui/pull/2034/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R242))
* Update the version string in the `sidebar-footer` elements in the `src/components/backend-ai-webui.ts` file with the latest package and build version ([link](https://github.com/lablup/backend.ai-webui/pull/2034/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1769-R1769), [link](https://github.com/lablup/backend.ai-webui/pull/2034/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1807-R1807))
* Update the `version.json` file with the latest package, build, and revision values ([link](https://github.com/lablup/backend.ai-webui/pull/2034/files?diff=unified&w=0#diff-093664cc0c7cf4a76165141e93265eeb139f655bbee8105ed3ee2534a612354cL1-R1))



