### PR TITLE
Fix/user signup without confirmation

### DIFF
--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -308,7 +308,10 @@ export default class BackendAiSignup extends BackendAIPage {
     if (inputFieldsValidity.includes(false)) {
       return;
     }
-    const token = this.tokenInput.value;
+    let token;
+    if (!this.allowSignupWithoutConfirmation) {
+      token = this.tokenInput.value;
+    }
     const user_email = this.userEmailInput.value;
     const user_name = this.userNameInput.value;
     const password = this.passwordInput.value;

--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -265,7 +265,14 @@ export default class BackendAiSignup extends BackendAIPage {
   }
 
   _toggleInputField(isActive: boolean) {
-    let inputFields = [this.userNameInput, this.tokenInput, this.signupButton];
+    let inputFields = [
+      this.userEmailInput,
+      this.userNameInput,
+      this.tokenInput,
+      this.passwordInput,
+      this.passwordConfirmInput,
+      this.signupButton,
+    ];
     if (this.allowSignupWithoutConfirmation) {
       inputFields = inputFields.filter((el) => el !== this.tokenInput);
     }

--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -55,12 +55,15 @@ export default class BackendAiSignup extends BackendAIPage {
   @property({ type: String }) TOSlanguage = 'en';
   @property({ type: String }) preloadedToken;
   @property({ type: Boolean }) allowSignupWithoutConfirmation;
+  @property({ type: HTMLSpanElement }) signupButtonMessage = html`
+    <span id="signup-button-message">${_text('signup.Signup')}</span>
+  `;
+  @query('#signup-button') signupButton!: Button;
   @query('#id_user_email') userEmailInput!: TextField;
   @query('#id_user_name') userNameInput!: TextField;
   @query('#id_token') tokenInput!: TextField;
   @query('#id_password1') passwordInput!: TextField;
   @query('#id_password2') passwordConfirmInput!: TextField;
-  @query('#signup-button') signupButton!: Button;
   @query('#signup-panel') signupPanel!: BackendAIDialog;
   @query('#block-panel') blockPanel!: BackendAIDialog;
   @query('#email-sent-dialog') emailSentDialog!: BackendAIDialog;
@@ -257,11 +260,9 @@ export default class BackendAiSignup extends BackendAIPage {
     if (this.preloadedToken !== undefined) {
       this.tokenInput.value = this.preloadedToken;
     }
-    (
-      this.shadowRoot?.querySelector(
-        '#signup-button-message',
-      ) as HTMLSpanElement
-    ).innerHTML = _text('signup.Signup');
+    this.signupButtonMessage = html`
+      <span id="signup-button-message">${_text('signup.Signup')}</span>
+    `;
   }
 
   _toggleInputField(isActive: boolean) {
@@ -339,11 +340,11 @@ export default class BackendAiSignup extends BackendAIPage {
       ._wrapWithPromise(rqst)
       .then((response) => {
         this._toggleInputField(false);
-        (
-          this.shadowRoot?.querySelector(
-            '#signup-button-message',
-          ) as HTMLSpanElement
-        ).innerHTML = _text('signup.SignupSucceeded');
+        this.signupButtonMessage = html`
+          <span id="signup-button-message">
+            ${_text('signup.SignupSucceeded')}
+          </span>
+        `;
         this.notification.text = _text('signup.SignupSucceeded');
         this.notification.show();
         setTimeout(() => {
@@ -623,7 +624,7 @@ export default class BackendAiSignup extends BackendAIPage {
             icon="check"
             @click="${() => this._signup()}"
           >
-            <span id="signup-button-message">${_text('signup.Signup')}</span>
+            ${this.signupButtonMessage}
           </mwc-button>
         </div>
       </backend-ai-dialog>

--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -247,6 +247,7 @@ export default class BackendAiSignup extends BackendAIPage {
     this._toggleInputField(true);
     let inputFields = [
       this.userEmailInput,
+      this.userNameInput,
       this.tokenInput,
       this.passwordInput,
       this.passwordConfirmInput,


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR resolves issue https://github.com/lablup/backend.ai-webui/issues/2032
- Add condition that token is not set when allowSignupWithoutConfirmation is set true
- Add EmailInput, passwordInput, passwordConfirmInput can't set during signup
  -> Previously, only userNameInput, tokenInput, signupInput is disabled
- Removed innerHTML
- userNameInput clear value after signup

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
