### PR TITLE
fix: exception caused by mismatched selected resource group information.

### DIFF
--- a/react/src/components/ResourceGroupSelect.tsx
+++ b/react/src/components/ResourceGroupSelect.tsx
@@ -15,6 +15,7 @@ const ResourceGroupSelect: React.FC<ResourceGroupSelectProps> = ({
   projectId,
   autoSelectDefault,
   filter,
+  loading,
   ...selectProps
 }) => {
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
@@ -110,7 +111,7 @@ const ResourceGroupSelect: React.FC<ResourceGroupSelectProps> = ({
           });
         }
       }}
-      loading={isPendingLoading}
+      loading={isPendingLoading || loading}
       {...selectProps}
     >
       {_.map(resourceGroups, (resourceGroup, idx) => {

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -216,6 +216,7 @@ customElements.define(
       if (props.value !== value) {
         setValue(props.value || '');
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.value]);
 
     return (

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -210,6 +210,14 @@ customElements.define(
 customElements.define(
   'backend-ai-react-resource-group-select',
   reactToWebComponent((props) => {
+    const [value, setValue] = React.useState(props.value || '');
+
+    React.useEffect(() => {
+      if (props.value !== value) {
+        setValue(props.value || '');
+      }
+    }, [props.value]);
+
     return (
       <DefaultProviders {...props}>
         <Flex direction="column" align="stretch" style={{ minWidth: 200 }}>
@@ -220,8 +228,10 @@ customElements.define(
             >
               <ResourceGroupSelect
                 size="large"
-                value={props.value}
+                value={value}
+                loading={value !== props.value || value === ''}
                 onChange={(value) => {
+                  setValue(value);
                   props.dispatchEvent('change', value);
                 }}
               />

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -219,8 +219,8 @@ customElements.define(
               style={{ margin: 0 }}
             >
               <ResourceGroupSelect
-                autoSelectDefault
                 size="large"
+                value={props.value}
                 onChange={(value) => {
                   props.dispatchEvent('change', value);
                 }}

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -575,7 +575,10 @@ export default class BackendAiResourceBroker extends BackendAIPage {
           using: { cpu: 0, mem: 0 },
           remaining: { cpu: 0, mem: 0 },
         };
-      } else if (this.scaling_groups.length === 0) {
+      } else if (
+        this.scaling_groups.length === 0 ||
+        resourcePresetInfo.scaling_groups[this.scaling_group] === undefined
+      ) {
         this.aggregate_updating = false;
         return Promise.resolve(false);
       }

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -662,13 +662,15 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
       <div id="scaling-group-select-box" class="layout horizontal center-justified ${
         this.direction
       }">
-      <backend-ai-react-resource-group-select @change=${({ detail: value }) => {
-        this.updateScalingGroup(true, {
-          target: {
-            value,
-          },
-        });
-      }}/>
+      <backend-ai-react-resource-group-select 
+        value=${this.scaling_group}
+        @change=${({ detail: value }) => {
+          this.updateScalingGroup(true, {
+            target: {
+              value,
+            },
+          });
+        }}/>
       </div>
       <div class="layout ${this.direction}-card flex wrap">
         <div id="resource-gauges" class="layout ${this.direction} ${


### PR DESCRIPTION
resolve #2039 

How to reproduce the bug
- visit `summary` page
- select `resource group` on the resource monitor
- move to `session` page
- select `resource group` on the resource monitor
- move back to `summary page` 
You can see the `Problem occurred` notification at least once

After this PR, you can not see that notification.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

---

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 30430da</samp>

### Summary
🔄🐛🚀

<!--
1.  🔄 for the first and third changes, because they are refactoring changes that improve the functionality and consistency of the existing code without adding new features.
2.  🐛 for the second change, because it is a bug fix that prevents an error from occurring in a specific scenario.
3.  🚀 for the overall changes, because they improve the user experience and performance of the resource group selection feature.
-->
This pull request refactors the resource group selection feature to use a `value` prop for controlling the selected option and synchronizing it with the parent component's state. It also fixes a bug that caused an error when switching to a resource group without resource presets. The changes affect the `ResourceGroupSelect` component and its wrapper components in `index.tsx`, `backend-ai-resource-broker.ts`, and `backend-ai-resource-monitor.ts`.

> _`value` prop added_
> _resource group selection improved_
> _autumn of refactor_

### Walkthrough
*  Refactor resource group selection feature to use `value` prop for controlling the selected option and synchronizing with parent state ([link](https://github.com/lablup/backend.ai-webui/pull/2043/files?diff=unified&w=0#diff-8e8a93d52a7e6e8a4b91770c2de7cb6b500148e2855dc2f5bca6f97f8271bc06L222-R223), [link](https://github.com/lablup/backend.ai-webui/pull/2043/files?diff=unified&w=0#diff-4d539664e2e893cb51e426e86aacf30e0610ea77761ffab70b5565fdf2574cacL665-R673))
* Fix error when switching to a resource group without resource presets by checking if `scaling_group` property is defined in `resourcePresetInfo` object ([link](https://github.com/lablup/backend.ai-webui/pull/2043/files?diff=unified&w=0#diff-1f39f3adffae3b281a31ce9f4a28b3bb54d59485eccc246a49a9b877fcf1fd92L578-R581))

