### PR TITLE
fix: change default translated string to `''`

### DIFF
--- a/i18n.config.js
+++ b/i18n.config.js
@@ -24,8 +24,8 @@ module.exports = {
         // Return key as the default value for English language
         return key;
       }
-      // Return the string '__NOT_TRANSLATED__' for other languages
-      return '__NOT_TRANSLATED__';
+      // Return the string '' for other languages
+      return '';
     },
     resource: {
       loadPath: 'resources/i18n/{{lng}}.json',


### PR DESCRIPTION
Set default translated string to `''` so that making easier to translate using Ally i18n extension.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
