### PR TITLE
fix: add blockedMenuItem again

### DIFF
--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -103,7 +103,6 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   @property({ type: Array }) groups = [];
   @property({ type: Object }) plugins = Object();
   @property({ type: String }) fasttrackEndpoint = '';
-  @property({ type: Boolean }) isHideSideMenuFastTrackButton = false;
   @property({ type: String }) _page = '';
   @property({ type: String }) _lazyPage = '';
   @property({ type: Object }) _pageParams = {};
@@ -132,6 +131,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
     'id',
   ];
   @property({ type: Array }) blockedMenuItem;
+  @property({ type: Array }) inactiveMenuItem;
   @property({ type: Number }) minibarWidth = 88;
   @property({ type: Number }) sidebarWidth = 250;
   @property({ type: Number }) sidepanelWidth = 250;
@@ -198,6 +198,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   constructor() {
     super();
     this.blockedMenuItem = [];
+    this.inactiveMenuItem = [];
   }
 
   static get styles(): CSSResultGroup {
@@ -446,7 +447,16 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
       this.edition = config.license.edition;
     }
     if (typeof config.menu !== 'undefined' && 'blocklist' in config.menu) {
-      this.blockedMenuItem = config.menu.blocklist.split(',');
+      this.blockedMenuItem = config.menu.blocklist
+        .split(',')
+        .map((x: string) => x.trim());
+      // Remove summary from accidentally added in config.menu.blocklist
+      this.blockedMenuItem.filter((menuTitle) => menuTitle !== 'summary');
+    }
+    if (typeof config.menu !== 'undefined' && 'inactivelist' in config.menu) {
+      this.inactiveMenuItem = config.menu.inactivelist
+        .split(',')
+        .map((x: string) => x.trim());
     }
     if (
       typeof config.general !== 'undefined' &&
@@ -486,14 +496,8 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
     ) {
       this.fasttrackEndpoint = config.pipeline.frontendEndpoint;
     }
-    if (
-      typeof config.pipeline !== 'undefined' &&
-      'hideSideMenuButton' in config.pipeline
-    ) {
-      this.isHideSideMenuFastTrackButton = config.pipeline.hideSideMenuButton;
-    }
     if (typeof config.plugin !== 'undefined') {
-      // Store plugin informations
+      // Store plugin information
       if ('login' in config.plugin) {
         this.plugins['login'] = config.plugin.login;
       }
@@ -622,7 +626,8 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
         .filter((item) => !item.available)
         .map((item) => item.page)
         .includes(this._page) ||
-      this.blockedMenuItem.includes(this._page)
+      this.blockedMenuItem.includes(this._page) ||
+      this.inactiveMenuItem.includes(this._page)
     ) {
       this._page = 'error';
       globalThis.history.pushState({}, '', '/error');
@@ -1040,9 +1045,6 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
     ) {
       this.notification.text = _text('webui.CleanUpNow');
       this.notification.show();
-      // if (globalThis.backendaiclient._config.connectionMode === 'SESSION' && this._usePipeline) {
-      //   await Promise.all([globalThis.backendaiclient.pipeline.logout(), globalThis.backendaiclient.logout()]);
-      // }
       if (globalThis.backendaiclient._config.connectionMode === 'SESSION') {
         await globalThis.backendaiclient.logout();
       }
@@ -1243,7 +1245,10 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
         _text('webui.menu.AgentSummary'),
       );
     }
-    if (!this.isHideSideMenuFastTrackButton && this.fasttrackEndpoint !== '') {
+    if (
+      !this.blockedMenuItem.includes('pipeline') &&
+      this.fasttrackEndpoint !== ''
+    ) {
       this._createPopover('fasttrack-menu-icon', _text('webui.menu.FastTrack'));
     }
   }
@@ -1319,8 +1324,8 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   protected render() {
     // language=HTML
     return html`
-      <link rel="stylesheet" href="resources/fonts/font-awesome-all.min.css">
-      <link rel="stylesheet" href="resources/custom.css">
+      <link rel="stylesheet" href="resources/fonts/font-awesome-all.min.css" />
+      <link rel="stylesheet" href="resources/custom.css" />
       <div id="loading-curtain" class="loading-background">
         <div id="loading-drag-area" class="loading-background-drag-area"></div>
       </div>
@@ -1386,16 +1391,22 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
             }" @click="${() =>
               this._moveTo(
                 '/summary',
-              )}" ?disabled="${this.blockedMenuItem.includes('summary')}">
+              )}" ?disabled="${this.inactiveMenuItem.includes(
+              'summary',
+            )}" class="${
+              this.blockedMenuItem.includes('summary') ? 'hidden' : ''
+            }">
               <i class="fas fa-th-large" slot="graphic" id="summary-menu-icon"></i>
               <span class="full-menu">${_t('webui.menu.Summary')}</span>
             </mwc-list-item>
             <mwc-list-item graphic="icon" ?selected="${
               this._page === 'job'
             }" @click="${() =>
-              this._moveTo('/job')}" ?disabled="${this.blockedMenuItem.includes(
-              'job',
-            )}">
+              this._moveTo(
+                '/job',
+              )}" ?disabled="${this.inactiveMenuItem.includes('job')}" class="${
+              this.blockedMenuItem.includes('job') ? 'hidden' : ''
+            }">
               <i class="fas fa-list-alt" slot="graphic" id="sessions-menu-icon"></i>
               <span class="full-menu">${_t('webui.menu.Sessions')}</span>
             </mwc-list-item>
@@ -1404,7 +1415,11 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
             }" @click="${() =>
               this._moveTo(
                 '/session',
-              )}" ?disabled="${this.blockedMenuItem.includes('session')}">
+              )}" ?disabled="${this.inactiveMenuItem.includes(
+              'session',
+            )}" class="${
+              this.blockedMenuItem.includes('session') ? 'hidden' : ''
+            }">
               <i class="fas fa-list-alt" slot="graphic" id="sessions-menu-icon"></i>
               <span class="full-menu">${_t(
                 'webui.menu.Sessions',
@@ -1417,7 +1432,10 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
                       graphic="icon"
                       ?selected="${this._page === 'serving'}"
                       @click="${() => this._moveTo('/serving')}"
-                      ?disabled="${this.blockedMenuItem.includes('serving')}"
+                      ?disabled="${this.inactiveMenuItem.includes('serving')}"
+                      class="${this.blockedMenuItem.includes('serving')
+                        ? 'hidden'
+                        : ''}"
                     >
                       <i
                         class="fa fa-rocket"
@@ -1436,7 +1454,12 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
                       graphic="icon"
                       ?selected="${this._page === 'experiment'}"
                       @click="${() => this._moveTo('/experiment')}"
-                      ?disabled="${this.blockedMenuItem.includes('experiment')}"
+                      ?disabled="${this.inactiveMenuItem.includes(
+                        'experiment',
+                      )}"
+                      class="${this.blockedMenuItem.includes('experiment')
+                        ? 'hidden'
+                        : ''}"
                     >
                       <i class="fas fa-flask" slot="graphic"></i>
                       <span class="full-menu">
@@ -1451,7 +1474,11 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
               }" @click="${() =>
                 this._moveTo(
                   '/import',
-                )}" ?disabled="${this.blockedMenuItem.includes('import')}">
+                )}" ?disabled="${this.inactiveMenuItem.includes('import')}"
+                class="${
+                  this.blockedMenuItem.includes('import') ? 'hidden' : ''
+                }"
+              >
                 <i class="fas fa-play" slot="graphic" id="import-menu-icon"></i>
                 <span class="full-menu">${_t('webui.menu.Import&Run')}</span>
               </mwc-list-item>
@@ -1460,7 +1487,9 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
             }" @click="${() =>
               this._moveTo(
                 '/data',
-              )}" ?disabled="${this.blockedMenuItem.includes('data')}">
+              )}" ?disabled="${this.inactiveMenuItem.includes('data')}"
+              class="${this.blockedMenuItem.includes('data') ? 'hidden' : ''}
+            >
               <i class="fas fa-cloud-upload-alt" slot="graphic" id="data-menu-icon"></i>
               <span class="full-menu">${_t('webui.menu.Data&Storage')}</span>
             </mwc-list-item>
@@ -1471,7 +1500,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
                       graphic="icon"
                       ?selected="${this._page === 'pipeline'}"
                       @click="${() => this._moveTo('/pipeline')}"
-                      ?disabled="${this.blockedMenuItem.includes('pipeline')}"
+                      ?disabled="${this.inactiveMenuItem.includes('pipeline')}"
                       style="display:none;"
                     >
                       <i
@@ -1487,7 +1516,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
                       graphic="icon"
                       ?selected="${this._page === 'pipeline-job'}"
                       @click="${() => this._moveTo('/pipeline-job')}"
-                      ?disabled="${this.blockedMenuItem.includes(
+                      ?disabled="${this.inactiveMenuItem.includes(
                         'pipeline-job',
                       )}"
                       style="display:none;"
@@ -1512,9 +1541,12 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
                       graphic="icon"
                       ?selected="${this._page === 'agent-summary'}"
                       @click="${() => this._moveTo('/agent-summary')}"
-                      ?disabled="${this.blockedMenuItem.includes(
+                      ?disabled="${this.inactiveMenuItem.includes(
                         'agent-summary',
                       )}"
+                      class="${this.blockedMenuItem.includes('agent-summary')
+                        ? 'hidden'
+                        : ''}"
                     >
                       <i
                         class="fas fa-server"
@@ -1532,12 +1564,16 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
             }" @click="${() =>
               this._moveTo(
                 '/statistics',
-              )}" ?disabled="${this.blockedMenuItem.includes('statistics')}">
+              )}" ?disabled="${this.inactiveMenuItem.includes('statistics')}"
+              class="${
+                this.blockedMenuItem.includes('statistics') ? 'hidden' : ''
+              }">
+            >
               <i class="fas fa-chart-bar" slot="graphic" id="statistics-menu-icon"></i>
               <span class="full-menu">${_t('webui.menu.Statistics')}</span>
             </mwc-list-item>
             ${
-              !this.isHideSideMenuFastTrackButton &&
+              !this.blockedMenuItem.includes('pipeline') &&
               this.fasttrackEndpoint !== ''
                 ? html`
                     <a href="${this.fasttrackEndpoint}" target="_blank">
@@ -1619,31 +1655,31 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
                   `
                 : html``
             }
-                ${
-                  'page' in this.plugins
-                    ? this.plugins['page']
-                        .filter((item) =>
-                          this.plugins['menuitem-admin'].includes(item.url),
-                        )
-                        .map(
-                          (item) => html`
-                            <mwc-list-item
-                              graphic="icon"
-                              ?selected="${this._page === item.url}"
-                              @click="${() => this._moveTo('/' + item.url)}"
-                              ?disabled="${!this.is_admin}"
-                            >
-                              <i
-                                class="fas fa-puzzle-piece"
-                                slot="graphic"
-                                id="${item}-menu-icon"
-                              ></i>
-                              <span class="full-menu">${item.menuitem}</span>
-                            </mwc-list-item>
-                          `,
-                        )
-                    : html``
-                }
+            ${
+              'page' in this.plugins
+                ? this.plugins['page']
+                    .filter((item) =>
+                      this.plugins['menuitem-admin'].includes(item.url),
+                    )
+                    .map(
+                      (item) => html`
+                        <mwc-list-item
+                          graphic="icon"
+                          ?selected="${this._page === item.url}"
+                          @click="${() => this._moveTo('/' + item.url)}"
+                          ?disabled="${!this.is_admin}"
+                        >
+                          <i
+                            class="fas fa-puzzle-piece"
+                            slot="graphic"
+                            id="${item}-menu-icon"
+                          ></i>
+                          <span class="full-menu">${item.menuitem}</span>
+                        </mwc-list-item>
+                      `,
+                    )
+                : html``
+            }
             ${
               this.is_superadmin
                 ? html`

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -1568,7 +1568,6 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
               class="${
                 this.blockedMenuItem.includes('statistics') ? 'hidden' : ''
               }">
-            >
               <i class="fas fa-chart-bar" slot="graphic" id="statistics-menu-icon"></i>
               <span class="full-menu">${_t('webui.menu.Statistics')}</span>
             </mwc-list-item>

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -450,8 +450,6 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
       this.blockedMenuItem = config.menu.blocklist
         .split(',')
         .map((x: string) => x.trim());
-      // Remove summary from accidentally added in config.menu.blocklist
-      this.blockedMenuItem.filter((menuTitle) => menuTitle !== 'summary');
     }
     if (typeof config.menu !== 'undefined' && 'inactivelist' in config.menu) {
       this.inactiveMenuItem = config.menu.inactivelist
@@ -1391,11 +1389,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
             }" @click="${() =>
               this._moveTo(
                 '/summary',
-              )}" ?disabled="${this.inactiveMenuItem.includes(
-              'summary',
-            )}" class="${
-              this.blockedMenuItem.includes('summary') ? 'hidden' : ''
-            }">
+              )}" ?disabled="${this.inactiveMenuItem.includes('summary')}">
               <i class="fas fa-th-large" slot="graphic" id="summary-menu-icon"></i>
               <span class="full-menu">${_t('webui.menu.Summary')}</span>
             </mwc-list-item>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ba1fbbe</samp>

### Summary
:wrench::bug::lock:

<!--
1.  :wrench: - This emoji represents a tool or a configuration change, which is suitable for the addition of the new properties and the removal of the old one.
2.  :bug: - This emoji represents a bug fix, which is suitable for the fixes of the HTML tags, the pipeline logic, and the code indentation.
3.  :lock: - This emoji represents a security or privacy improvement, which is suitable for the enhancement of the blocked menu item feature, which prevents unauthorized access to certain pages.
-->
This pull request enhances the side menu customization and fixes some HTML and logic bugs in the `backend-ai-webui` component. It introduces two new properties, `inactiveMenuItem` and `blockedMenuItem`, to hide or disable menu items based on the config file. It also corrects some tag names, pipeline conditions, and indentation issues in the `src/components/backend-ai-webui.ts` file.

> _Oh we're the webui crew and we've got a job to do_
> _We're changing the side menu to make it more flexible and true_
> _We're dropping `isHideSideMenuFastTrackButton` and adding `inactiveMenuItem` and `blockedMenuItem`_
> _So heave away, me hearties, heave away on the count of three_

### Walkthrough
*  Remove `isHideSideMenuFastTrackButton` property and logic from `backend-ai-webui` component, as it is replaced by `blockedMenuItem` property ([link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL106), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1246-R1251), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1535-R1576))
* Add `inactiveMenuItem` property and logic to `backend-ai-webui` component, to disable but not hide certain menu items based on configuration file ([link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabR134), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabR201), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL625-R630), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1389-R1398), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1396-R1409), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1407-R1422), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1420-R1438), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1439-R1462), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1454-R1481), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1463-R1492), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1474-R1503), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1490-R1519), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1515-R1549), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1535-R1576))
* Modify `blocklist` logic to trim whitespace and filter out `summary` item from configuration file, and use `blockedMenuItem` property to hide certain menu items ([link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL449-R460), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1389-R1398), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1396-R1409), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1407-R1422), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1420-R1438), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1439-R1462), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1454-R1481), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1463-R1492), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1515-R1549), [link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1535-R1576))
* Remove `hideSideMenuButton` logic and fix typo in comment ([link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL489-R500))
* Remove commented out code for pipeline session logout ([link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1043-L1045))
* Add slash at the end of link tags for font and custom CSS files ([link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1322-R1328))
* Fix indentation of plugin menu items rendering code ([link](https://github.com/lablup/backend.ai-webui/pull/2049/files?diff=unified&w=0#diff-c970ee927d9c8e6050388af9c74159ccfd53cdff999e3e89f836009010c01aabL1622-R1683))


