### PR TITLE
fix: Correct hyphen usage in input validator regex

### DIFF
--- a/react/src/components/SessionListColums/SessionInfoCell.tsx
+++ b/react/src/components/SessionListColums/SessionInfoCell.tsx
@@ -105,7 +105,7 @@ const SessionInfoCell: React.FC<{
                   max: 64,
                 },
                 {
-                  pattern: /^(?:[a-zA-Z0-9][a-zA-Z0-9._\-]{2,}[a-zA-Z0-9])?$/,
+                  pattern: /^(?:[a-zA-Z0-9][-a-zA-Z0-9._]{2,}[a-zA-Z0-9])?$/,
                   message: t(
                     'session.Validation.EnterValidSessionName',
                   ).toString(),

--- a/react/src/components/SessionListColums/SessionInfoCell.tsx
+++ b/react/src/components/SessionListColums/SessionInfoCell.tsx
@@ -105,7 +105,7 @@ const SessionInfoCell: React.FC<{
                   max: 64,
                 },
                 {
-                  pattern: /^(?:[a-zA-Z0-9][a-zA-Z0-9._-]{2,}[a-zA-Z0-9])?$/,
+                  pattern: /^(?:[a-zA-Z0-9][a-zA-Z0-9._\-]{2,}[a-zA-Z0-9])?$/,
                   message: t(
                     'session.Validation.EnterValidSessionName',
                   ).toString(),

--- a/react/src/components/SessionNameFormItem.tsx
+++ b/react/src/components/SessionNameFormItem.tsx
@@ -22,7 +22,7 @@ const SessionNameFormItem: React.FC<SessionNameFormItemProps> = ({
           message: t('session.Validation.SessionNameTooLong64'),
         },
         {
-          pattern: /^(?:[a-zA-Z0-9][a-zA-Z0-9._\-]{2,}[a-zA-Z0-9])?$/,
+          pattern: /^(?:[a-zA-Z0-9][-a-zA-Z0-9._]{2,}[a-zA-Z0-9])?$/,
           message: t(
             'session.Validation.PleaseFollowSessionNameRule',
           ).toString(),

--- a/react/src/components/SessionNameFormItem.tsx
+++ b/react/src/components/SessionNameFormItem.tsx
@@ -22,7 +22,7 @@ const SessionNameFormItem: React.FC<SessionNameFormItemProps> = ({
           message: t('session.Validation.SessionNameTooLong64'),
         },
         {
-          pattern: /^(?:[a-zA-Z0-9][a-zA-Z0-9._-]{2,}[a-zA-Z0-9])?$/,
+          pattern: /^(?:[a-zA-Z0-9][a-zA-Z0-9._\-]{2,}[a-zA-Z0-9])?$/,
           message: t(
             'session.Validation.PleaseFollowSessionNameRule',
           ).toString(),


### PR DESCRIPTION
Place the hyphen (`-`) in the input element's regex pattern at the start of the character class to prevent it from being misinterpreted as a range indicator, which raises the following error in the browser's inspector console.
![image](https://github.com/lablup/backend.ai-webui/assets/7539358/5f6902e1-bff0-4297-9c45-4daac7296804)