### PR TITLE
fix: typo error

### DIFF
--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -5794,10 +5794,10 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
                         </h4>
                         ${this.environ.map(
                           (item) => html`
-                            <nwc-textfield
+                            <mwc-textfield
                               disabled
                               value="${item.value}"
-                            ></nwc-textfield>
+                            ></mwc-textfield>
                           `,
                         )}
                       </div>


### PR DESCRIPTION
## Description
Due to the typo error, it is not available to check the env value when creating a new session.

## How to check:
> you can check throw the Amplified Hosting :)
- click the start session button from summary / session page.
- set `Environment Variable`
- click `CONFIRM AND LAUNCH` button.
- check the set envs are displayed well in the `Environment variables to set (optional)` part.

## Screenshot
| Before | After |
|--------|--------|
| ![image](https://github.com/lablup/backend.ai-webui/assets/28584164/6a3bfe78-9430-4a1b-a0b5-fd20159d6ccc) | ![image](https://github.com/lablup/backend.ai-webui/assets/28584164/79eaa57a-4711-4cb2-898d-812683e22601) |



**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
