### PR TITLE
fix: add omitted html tag in folder explorer

### DIFF
--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -330,9 +330,9 @@ export default class BackendAiStorageList extends BackendAIPage {
           ); /* 88px is width for mini-ui icon of drawer menu */
         }
 
-        #folder-explorer-dialog vaadin-grid vaadin-grid-column {
+        /* #folder-explorer-dialog vaadin-grid vaadin-grid-column {
           height: 32px !important;
-        }
+        }*/
 
         #folder-explorer-dialog vaadin-grid mwc-icon-button {
           --mdc-icon-size: 24px;
@@ -654,21 +654,19 @@ export default class BackendAiStorageList extends BackendAIPage {
             .renderer="${this._boundStatusRenderer}"
             header="${_t('data.folders.Status')}"
           ></lablup-grid-sort-filter-column>
-          ${
-            this.directoryBasedUsage
-              ? html`
-                  <vaadin-grid-sort-column
-                    id="folder-quota-column"
-                    path="max_size"
-                    width="95px"
-                    flex-grow="0"
-                    resizable
-                    header="${_t('data.folders.FolderQuota')}"
-                    .renderer="${this._boundQuotaRenderer}"
-                  ></vaadin-grid-sort-column>
-                `
-              : html``
-          }
+          ${this.directoryBasedUsage
+            ? html`
+                <vaadin-grid-sort-column
+                  id="folder-quota-column"
+                  path="max_size"
+                  width="95px"
+                  flex-grow="0"
+                  resizable
+                  header="${_t('data.folders.FolderQuota')}"
+                  .renderer="${this._boundQuotaRenderer}"
+                ></vaadin-grid-sort-column>
+              `
+            : html``}
           <lablup-grid-sort-filter-column
             path="ownership_type"
             width="70px"
@@ -691,25 +689,22 @@ export default class BackendAiStorageList extends BackendAIPage {
             header="${_t('data.folders.Owner')}"
             .renderer="${this._boundOwnerRenderer}"
           ></vaadin-grid-column>
-          ${
-            this.enableStorageProxy
-              ? html`
-            <!--<vaadin-grid-column
+          ${this.enableStorageProxy
+            ? html`
+                <!--<vaadin-grid-column
                 auto-width flex-grow="0" resizable header="${_t(
                   'data.folders.Cloneable',
                 )}"
-                .renderer="${
-                  this._boundCloneableRenderer
-                }"></vaadin-grid-column>`
-              : html``
-          }
-          <vaadin-grid-column
+                .renderer="${this
+                  ._boundCloneableRenderer}"></vaadin-grid-column>-->
+              `
+            : html``}
+          <!--<vaadin-grid-column
             auto-width
             resizable
             header="${_t('data.folders.Control')}"
             .renderer="${this._boundControlFolderListRenderer}"
-          ></vaadin-grid-column>
-          -->
+          ></vaadin-grid-column>-->
         </vaadin-grid>
         <backend-ai-list-status
           id="list-status"
@@ -723,12 +718,10 @@ export default class BackendAiStorageList extends BackendAIPage {
           <div
             class="vertical layout"
             id="modify-quota-controls"
-            style="display:${
-              this.directoryBasedUsage &&
-              this._checkFolderSupportSizeQuota(this.folderInfo.host)
-                ? 'flex'
-                : 'none'
-            }"
+            style="display:${this.directoryBasedUsage &&
+            this._checkFolderSupportSizeQuota(this.folderInfo.host)
+              ? 'flex'
+              : 'none'}"
           >
             <div class="horizontal layout center justified">
               <mwc-textfield
@@ -778,19 +771,17 @@ export default class BackendAiStorageList extends BackendAIPage {
               `,
             )}
           </mwc-select>
-          ${
-            this.enableStorageProxy
-              ? html`
-                  <!--<div class="horizontal layout flex wrap center justified">
+          ${this.enableStorageProxy
+            ? html`
+                <!--<div class="horizontal layout flex wrap center justified">
             <p style="color:rgba(0, 0, 0, 0.6);">
               ${_t('data.folders.Cloneable')}
             </p>
             <mwc-switch id="update-folder-cloneable" style="margin-right:10px;">
             </mwc-switch>
           </div>-->
-                `
-              : html``
-          }
+              `
+            : html``}
         </div>
         <div slot="footer" class="horizontal center-justified flex layout">
           <mwc-button
@@ -907,20 +898,18 @@ export default class BackendAiStorageList extends BackendAIPage {
               <div class="big indicator">${this.folderInfo.host}</div>
               <span>${_t('data.folders.Location')}</span>
             </div>
-            ${
-              this.directoryBasedUsage
-                ? html`
-                    <div class="vertical layout center info-indicator">
-                      <div class="big indicator">
-                        ${this.folderInfo.numFiles < 0
-                          ? 'many'
-                          : this.folderInfo.numFiles}
-                      </div>
-                      <span>${_t('data.folders.NumberOfFiles')}</span>
+            ${this.directoryBasedUsage
+              ? html`
+                  <div class="vertical layout center info-indicator">
+                    <div class="big indicator">
+                      ${this.folderInfo.numFiles < 0
+                        ? 'many'
+                        : this.folderInfo.numFiles}
                     </div>
-                  `
-                : html``
-            }
+                    <span>${_t('data.folders.NumberOfFiles')}</span>
+                  </div>
+                `
+              : html``}
           </div>
           <mwc-list>
             <mwc-list-item twoline>
@@ -929,135 +918,123 @@ export default class BackendAiStorageList extends BackendAIPage {
                 ${this.folderInfo.id}
               </span>
             </mwc-list-item>
-            ${
-              this.folderInfo.is_owner
-                ? html`
-                    <mwc-list-item twoline>
-                      <span>
-                        <strong>${_t('data.folders.Ownership')}</strong>
-                      </span>
-                      <span slot="secondary">
-                        ${_t('data.folders.DescYouAreFolderOwner')}
-                      </span>
-                    </mwc-list-item>
-                  `
-                : html``
-            }
-            ${
-              this.folderInfo.usage_mode !== 'undefined'
-                ? html`
-                    <mwc-list-item twoline>
-                      <span><strong>${_t('data.UsageMode')}</strong></span>
-                      <span slot="secondary">
-                        ${this.folderInfo.usage_mode}
-                      </span>
-                    </mwc-list-item>
-                  `
-                : html``
-            }
-            ${
-              this.folderInfo.permission
-                ? html`
-                    <mwc-list-item twoline>
-                      <span>
-                        <strong>${_t('data.folders.Permission')}</strong>
-                      </span>
-                      <div slot="secondary" class="horizontal layout">
-                        ${this._hasPermission(this.folderInfo, 'r')
-                          ? html`
-                              <lablup-shields
-                                app=""
-                                color="green"
-                                description="R"
-                                ui="flat"
-                              ></lablup-shields>
-                            `
-                          : html``}
-                        ${this._hasPermission(this.folderInfo, 'w')
-                          ? html`
-                              <lablup-shields
-                                app=""
-                                color="blue"
-                                description="W"
-                                ui="flat"
-                              ></lablup-shields>
-                            `
-                          : html``}
-                        ${this._hasPermission(this.folderInfo, 'd')
-                          ? html`
-                              <lablup-shields
-                                app=""
-                                color="red"
-                                description="D"
-                                ui="flat"
-                              ></lablup-shields>
-                            `
-                          : html``}
-                      </div>
-                    </mwc-list-item>
-                  `
-                : html``
-            }
-            ${
-              this.enableStorageProxy
-                ? html`
-                    <mwc-list-item twoline>
-                      <span>
-                        <strong>${_t('data.folders.Cloneable')}</strong>
-                      </span>
-                      <span class="monospace" slot="secondary">
-                        ${this.folderInfo.cloneable
-                          ? html`
-                              <mwc-icon class="cloneable" style="color:green;">
-                                check_circle
-                              </mwc-icon>
-                            `
-                          : html`
-                              <mwc-icon class="cloneable" style="color:red;">
-                                block
-                              </mwc-icon>
-                            `}
-                      </span>
-                    </mwc-list-item>
-                  `
-                : html``
-            }
-            ${
-              this.directoryBasedUsage &&
-              this._checkFolderSupportSizeQuota(this.folderInfo.host)
-                ? html`
-                    <mwc-list-item twoline>
-                      <span>
-                        <strong>${_t('data.folders.FolderUsage')}</strong>
-                      </span>
-                      <span class="monospace" slot="secondary">
-                        ${_t('data.folders.FolderUsing')}:
-                        ${this.folderInfo.used_bytes >= 0
-                          ? globalThis.backendaiutils._humanReadableFileSize(
-                              this.folderInfo.used_bytes,
-                            )
-                          : 'Undefined'}
-                        / ${_t('data.folders.FolderQuota')}:
-                        ${this.folderInfo.max_size >= 0
-                          ? globalThis.backendaiutils._humanReadableFileSize(
-                              this.folderInfo.max_size * this.quotaUnit.MiB,
-                            )
-                          : 'Undefined'}
-                        ${this.folderInfo.used_bytes >= 0 &&
-                        this.folderInfo.max_size >= 0
-                          ? html`
-                              <vaadin-progress-bar
-                                value="${this.folderInfo.used_bytes /
-                                this.folderInfo.max_size /
-                                2 ** 20}"
-                              ></vaadin-progress-bar>
-                            `
-                          : html``}
-                      </span>
-                    </mwc-list-item>
-                  `
-                : html``
-            }
+            ${this.folderInfo.is_owner
+              ? html`
+                  <mwc-list-item twoline>
+                    <span>
+                      <strong>${_t('data.folders.Ownership')}</strong>
+                    </span>
+                    <span slot="secondary">
+                      ${_t('data.folders.DescYouAreFolderOwner')}
+                    </span>
+                  </mwc-list-item>
+                `
+              : html``}
+            ${this.folderInfo.usage_mode !== 'undefined'
+              ? html`
+                  <mwc-list-item twoline>
+                    <span><strong>${_t('data.UsageMode')}</strong></span>
+                    <span slot="secondary">${this.folderInfo.usage_mode}</span>
+                  </mwc-list-item>
+                `
+              : html``}
+            ${this.folderInfo.permission
+              ? html`
+                  <mwc-list-item twoline>
+                    <span>
+                      <strong>${_t('data.folders.Permission')}</strong>
+                    </span>
+                    <div slot="secondary" class="horizontal layout">
+                      ${this._hasPermission(this.folderInfo, 'r')
+                        ? html`
+                            <lablup-shields
+                              app=""
+                              color="green"
+                              description="R"
+                              ui="flat"
+                            ></lablup-shields>
+                          `
+                        : html``}
+                      ${this._hasPermission(this.folderInfo, 'w')
+                        ? html`
+                            <lablup-shields
+                              app=""
+                              color="blue"
+                              description="W"
+                              ui="flat"
+                            ></lablup-shields>
+                          `
+                        : html``}
+                      ${this._hasPermission(this.folderInfo, 'd')
+                        ? html`
+                            <lablup-shields
+                              app=""
+                              color="red"
+                              description="D"
+                              ui="flat"
+                            ></lablup-shields>
+                          `
+                        : html``}
+                    </div>
+                  </mwc-list-item>
+                `
+              : html``}
+            ${this.enableStorageProxy
+              ? html`
+                  <mwc-list-item twoline>
+                    <span>
+                      <strong>${_t('data.folders.Cloneable')}</strong>
+                    </span>
+                    <span class="monospace" slot="secondary">
+                      ${this.folderInfo.cloneable
+                        ? html`
+                            <mwc-icon class="cloneable" style="color:green;">
+                              check_circle
+                            </mwc-icon>
+                          `
+                        : html`
+                            <mwc-icon class="cloneable" style="color:red;">
+                              block
+                            </mwc-icon>
+                          `}
+                    </span>
+                  </mwc-list-item>
+                `
+              : html``}
+            ${this.directoryBasedUsage &&
+            this._checkFolderSupportSizeQuota(this.folderInfo.host)
+              ? html`
+                  <mwc-list-item twoline>
+                    <span>
+                      <strong>${_t('data.folders.FolderUsage')}</strong>
+                    </span>
+                    <span class="monospace" slot="secondary">
+                      ${_t('data.folders.FolderUsing')}:
+                      ${this.folderInfo.used_bytes >= 0
+                        ? globalThis.backendaiutils._humanReadableFileSize(
+                            this.folderInfo.used_bytes,
+                          )
+                        : 'Undefined'}
+                      / ${_t('data.folders.FolderQuota')}:
+                      ${this.folderInfo.max_size >= 0
+                        ? globalThis.backendaiutils._humanReadableFileSize(
+                            this.folderInfo.max_size * this.quotaUnit.MiB,
+                          )
+                        : 'Undefined'}
+                      ${this.folderInfo.used_bytes >= 0 &&
+                      this.folderInfo.max_size >= 0
+                        ? html`
+                            <vaadin-progress-bar
+                              value="${this.folderInfo.used_bytes /
+                              this.folderInfo.max_size /
+                              2 ** 20}"
+                            ></vaadin-progress-bar>
+                          `
+                        : html``}
+                    </span>
+                  </mwc-list-item>
+                `
+              : html``}
           </mwc-list>
         </div>
       </backend-ai-dialog>
@@ -1073,56 +1050,54 @@ export default class BackendAiStorageList extends BackendAIPage {
           class="horizontal layout space-between folder-action-buttons center"
         >
           <div class="flex"></div>
-          ${
-            this.isWritable
-              ? html`
+          ${this.isWritable
+            ? html`
+                <mwc-button
+                  outlined
+                  class="multiple-action-buttons fg red"
+                  icon="delete"
+                  @click="${() => this._openDeleteMultipleFileDialog()}"
+                  style="display:none;"
+                >
+                  <span>${_t('data.explorer.Delete')}</span>
+                </mwc-button>
+                <div id="add-btn-cover">
                   <mwc-button
-                    outlined
-                    class="multiple-action-buttons fg red"
-                    icon="delete"
-                    @click="${() => this._openDeleteMultipleFileDialog()}"
-                    style="display:none;"
+                    id="add-btn"
+                    icon="upload_file"
+                    ?disabled=${!this.isWritable}
+                    @click="${(e) => this._uploadBtnClick(e)}"
                   >
-                    <span>${_t('data.explorer.Delete')}</span>
+                    <span>${_t('data.explorer.UploadFiles')}</span>
                   </mwc-button>
-                  <div id="add-btn-cover">
-                    <mwc-button
-                      id="add-btn"
-                      icon="upload_file"
-                      ?disabled=${!this.isWritable}
-                      @click="${(e) => this._uploadBtnClick(e)}"
-                    >
-                      <span>${_t('data.explorer.UploadFiles')}</span>
-                    </mwc-button>
-                  </div>
-                  <div>
-                    <mwc-button
-                      id="add-folder-btn"
-                      icon="drive_folder_upload"
-                      ?disabled=${!this.isWritable}
-                      @click="${(e) => this._uploadBtnClick(e)}"
-                    >
-                      <span>${_t('data.explorer.UploadFolder')}</span>
-                    </mwc-button>
-                  </div>
-                  <div id="mkdir-cover">
-                    <mwc-button
-                      id="mkdir"
-                      class="tooltip"
-                      icon="create_new_folder"
-                      ?disabled=${!this.isWritable}
-                      @click="${() => this._mkdirDialog()}"
-                    >
-                      <span>${_t('data.explorer.NewFolder')}</span>
-                    </mwc-button>
-                  </div>
-                `
-              : html`
-                  <mwc-button id="readonly-btn" disabled>
-                    <span>${_t('data.explorer.ReadonlyFolder')}</span>
+                </div>
+                <div>
+                  <mwc-button
+                    id="add-folder-btn"
+                    icon="drive_folder_upload"
+                    ?disabled=${!this.isWritable}
+                    @click="${(e) => this._uploadBtnClick(e)}"
+                  >
+                    <span>${_t('data.explorer.UploadFolder')}</span>
                   </mwc-button>
-                `
-          }
+                </div>
+                <div id="mkdir-cover">
+                  <mwc-button
+                    id="mkdir"
+                    class="tooltip"
+                    icon="create_new_folder"
+                    ?disabled=${!this.isWritable}
+                    @click="${() => this._mkdirDialog()}"
+                  >
+                    <span>${_t('data.explorer.NewFolder')}</span>
+                  </mwc-button>
+                </div>
+              `
+            : html`
+                <mwc-button id="readonly-btn" disabled>
+                  <span>${_t('data.explorer.ReadonlyFolder')}</span>
+                </mwc-button>
+              `}
           <div id="filebrowser-btn-cover">
             <mwc-button
               id="filebrowser-btn"
@@ -1153,39 +1128,37 @@ export default class BackendAiStorageList extends BackendAIPage {
         </div>
         <div slot="content">
           <div class="breadcrumb">
-            ${
-              this.explorer.breadcrumb
-                ? html`
-                    <ul>
-                      ${this.explorer.breadcrumb.map(
-                        (item) => html`
-                          <li>
-                            ${item === '.'
-                              ? html`
-                                  <mwc-icon-button
-                                    icon="folder_open"
-                                    dest="${item}"
-                                    @click="${(e) => this._gotoFolder(e)}"
-                                  ></mwc-icon-button>
-                                `
-                              : html`
-                                  <a
-                                    outlined
-                                    class="goto"
-                                    path="item"
-                                    @click="${(e) => this._gotoFolder(e)}"
-                                    dest="${item}"
-                                  >
-                                    ${item}
-                                  </a>
-                                `}
-                          </li>
-                        `,
-                      )}
-                    </ul>
-                  `
-                : html``
-            }
+            ${this.explorer.breadcrumb
+              ? html`
+                  <ul>
+                    ${this.explorer.breadcrumb.map(
+                      (item) => html`
+                        <li>
+                          ${item === '.'
+                            ? html`
+                                <mwc-icon-button
+                                  icon="folder_open"
+                                  dest="${item}"
+                                  @click="${(e) => this._gotoFolder(e)}"
+                                ></mwc-icon-button>
+                              `
+                            : html`
+                                <a
+                                  outlined
+                                  class="goto"
+                                  path="item"
+                                  @click="${(e) => this._gotoFolder(e)}"
+                                  dest="${item}"
+                                >
+                                  ${item}
+                                </a>
+                              `}
+                        </li>
+                      `,
+                    )}
+                  </ul>
+                `
+              : html``}
           </div>
           <div id="dropzone"><p>drag</p></div>
           <input
@@ -1205,45 +1178,43 @@ export default class BackendAiStorageList extends BackendAIPage {
             directory
             multiple
           />
-          ${
-            this.uploadFilesExist
-              ? html`
-                  <div class="horizontal layout start-justified">
-                    <mwc-button
-                      icon="cancel"
-                      id="cancel_upload"
-                      @click="${() => this._cancelUpload()}"
-                    >
-                      ${_t('data.explorer.StopUploading')}
-                    </mwc-button>
+          ${this.uploadFilesExist
+            ? html`
+                <div class="horizontal layout start-justified">
+                  <mwc-button
+                    icon="cancel"
+                    id="cancel_upload"
+                    @click="${() => this._cancelUpload()}"
+                  >
+                    ${_t('data.explorer.StopUploading')}
+                  </mwc-button>
+                </div>
+                <div class="horizontal layout center progress-item flex">
+                  ${this.currentUploadFile?.complete
+                    ? html`
+                        <mwc-icon>check</mwc-icon>
+                      `
+                    : html``}
+                  <div
+                    class="vertical layout progress-item"
+                    style="width:100%;"
+                  >
+                    <span>${this.currentUploadFile?.name}</span>
+                    <vaadin-progress-bar
+                      value="${this.currentUploadFile?.progress}"
+                    ></vaadin-progress-bar>
+                    <span>${this.currentUploadFile?.caption}</span>
                   </div>
-                  <div class="horizontal layout center progress-item flex">
-                    ${this.currentUploadFile?.complete
-                      ? html`
-                          <mwc-icon>check</mwc-icon>
-                        `
-                      : html``}
-                    <div
-                      class="vertical layout progress-item"
-                      style="width:100%;"
-                    >
-                      <span>${this.currentUploadFile?.name}</span>
-                      <vaadin-progress-bar
-                        value="${this.currentUploadFile?.progress}"
-                      ></vaadin-progress-bar>
-                      <span>${this.currentUploadFile?.caption}</span>
-                    </div>
-                  </div>
-                  <!-- <vaadin-grid class="progress" theme="row-stripes compact" aria-label="uploadFiles" .items="${this
-                    .uploadFiles}" height-by-rows>
+                </div>
+                <!-- <vaadin-grid class="progress" theme="row-stripes compact" aria-label="uploadFiles" .items="${this
+                  .uploadFiles}" height-by-rows>
             <vaadin-grid-column width="100px" flex-grow="0" .renderer="${this
-                    ._boundUploadListRenderer}"></vaadin-grid-column>
+                  ._boundUploadListRenderer}"></vaadin-grid-column>
             <vaadin-grid-column .renderer="${this
-                    ._boundUploadProgressRenderer}"></vaadin-grid-column>
+                  ._boundUploadProgressRenderer}"></vaadin-grid-column>
           </vaadin-grid> -->
-                `
-              : html``
-          }
+              `
+            : html``}
           <vaadin-grid
             id="file-list-grid"
             class="explorer"
@@ -1275,9 +1246,13 @@ export default class BackendAiStorageList extends BackendAIPage {
               path="ctime"
               .renderer="${this._boundCreatedTimeRenderer}"
             ></vaadin-grid-sort-column>
-            <vaadin-grid-sort-column auto-width resizable header="${_t(
-              'data.explorer.Size',
-            )}" path="size" .renderer="${this._boundSizeRenderer}">
+            <vaadin-grid-sort-column
+              auto-width
+              resizable
+              header="${_t('data.explorer.Size')}"
+              path="size"
+              .renderer="${this._boundSizeRenderer}"
+            ></vaadin-grid-sort-column>
             <vaadin-grid-column
               resizable
               auto-width
@@ -1490,34 +1465,30 @@ export default class BackendAiStorageList extends BackendAIPage {
             fullwidth
             @click="${(e) => this._keepFileExtension()}"
           >
-            ${
-              globalThis.backendaioptions.get('language') !== 'ko'
-                ? html`
-                    ${_text('data.explorer.KeepFileExtension') +
-                    this.oldFileExtension}
-                  `
-                : html`
-                    ${this.oldFileExtension +
-                    _text('data.explorer.KeepFileExtension')}
-                  `
-            }
+            ${globalThis.backendaioptions.get('language') !== 'ko'
+              ? html`
+                  ${_text('data.explorer.KeepFileExtension') +
+                  this.oldFileExtension}
+                `
+              : html`
+                  ${this.oldFileExtension +
+                  _text('data.explorer.KeepFileExtension')}
+                `}
           </mwc-button>
           <mwc-button unelevated fullwidth @click="${() => this._renameFile()}">
-            ${
-              globalThis.backendaioptions.get('language') !== 'ko'
-                ? html`
-                    ${this.newFileExtension
-                      ? _text('data.explorer.UseNewFileExtension') +
-                        this.newFileExtension
-                      : _text('data.explorer.RemoveFileExtension')}
-                  `
-                : html`
-                    ${this.newFileExtension
-                      ? this.newFileExtension +
-                        _text('data.explorer.UseNewFileExtension')
-                      : _text('data.explorer.RemoveFileExtension')}
-                  `
-            }
+            ${globalThis.backendaioptions.get('language') !== 'ko'
+              ? html`
+                  ${this.newFileExtension
+                    ? _text('data.explorer.UseNewFileExtension') +
+                      this.newFileExtension
+                    : _text('data.explorer.RemoveFileExtension')}
+                `
+              : html`
+                  ${this.newFileExtension
+                    ? this.newFileExtension +
+                      _text('data.explorer.UseNewFileExtension')
+                    : _text('data.explorer.RemoveFileExtension')}
+                `}
           </mwc-button>
         </div>
       </backend-ai-dialog>
@@ -2254,7 +2225,6 @@ export default class BackendAiStorageList extends BackendAIPage {
    * @param {Object} rowData - the object with the properties related with the rendered item
    * */
   sizeRenderer(root, column?, rowData?) {
-    console.log(rowData.item);
     render(
       // language=HTML
       html`


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
This PR is regression of missing Controls columns in vfolder list came from commenting out wrong HTML tags.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

### Screenshot(s)
| After | Before |
|------|--------|
| <img width="1358" alt="Screenshot 2023-11-29 at 2 08 21 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/00d58fae-c6a1-4ace-b8d1-b268c363d83e"> | <img width="1358" alt="Screenshot 2023-11-29 at 2 08 34 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/fceda96a-6a95-4cfc-b3e7-09f66b7204f9"> |
