### PR TITLE
fix: remove comment applied in controls column in vfolder list

### DIFF
--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -699,12 +699,12 @@ export default class BackendAiStorageList extends BackendAIPage {
                   ._boundCloneableRenderer}"></vaadin-grid-column>-->
               `
             : html``}
-          <!--<vaadin-grid-column
+          <vaadin-grid-column
             auto-width
             resizable
             header="${_t('data.folders.Control')}"
             .renderer="${this._boundControlFolderListRenderer}"
-          ></vaadin-grid-column>-->
+          ></vaadin-grid-column>
         </vaadin-grid>
         <backend-ai-list-status
           id="list-status"


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
This PR is regression of missing Controls columns in vfolder list came from commenting out wrong HTML tags.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

### Screenshot(s)
| After | Before |
|------|--------|
| <img width="1358" alt="Screenshot 2023-11-29 at 2 08 21 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/00d58fae-c6a1-4ace-b8d1-b268c363d83e"> | <img width="1358" alt="Screenshot 2023-11-29 at 2 08 34 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/fceda96a-6a95-4cfc-b3e7-09f66b7204f9"> |
