### PR TITLE
fix: reflect changed desktop app download link by architecture

### DIFF
--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -101,7 +101,7 @@ export default class BackendAISummary extends BackendAIPage {
       },
       MacOS: {
         os: 'macos',
-        architecture: ['intel', 'apple'],
+        architecture: ['arm64', 'x64'],
         extension: 'dmg',
       },
       Windows: {

--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -105,7 +105,7 @@ export default class BackendAISummary extends BackendAIPage {
         extension: 'dmg',
       },
       Windows: {
-        os: 'win32',
+        os: 'win',
         architecture: ['arm64', 'x64'],
         extension: 'zip',
       },


### PR DESCRIPTION
<!--
copilot:all
-->

### Summary
🐛🍎🔄

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change. The bug fix emoji is commonly used to indicate that a problem or error was resolved in the code.
2.  🍎 - This emoji represents the MacOS platform, which is the specific target of this change. The apple emoji is often used to refer to MacOS or Apple products in general, and it can also convey a sense of quality or innovation.
3.  🔄 - This emoji represents a change or update, which is the nature of this change. The arrows emoji can signify that something was replaced, modified, or refreshed in the code, and it can also imply a sense of improvement or enhancement.
-->
Fixed a bug in `backend-ai-summary-view.ts` that caused incorrect MacOS installer downloads. Updated the `supportedPlatforms` property to use the standard `x64` and `arm64` architecture names.

### Walkthrough
*  Fix MacOS installer download bug by updating supported platforms ([link](https://github.com/lablup/backend.ai-webui/pull/2065/files?diff=unified&w=0#diff-a965143d9a6bbce8cee70617131d5b16de916fa5929e10fbd9eb1856b90dcc3cL104-R104))

