### PR TITLE
fix: revive clone feature

### DIFF
--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -549,13 +549,15 @@ export default class BackendAIData extends BackendAIPage {
             : html``}
           ${this.enableStorageProxy
             ? html`
-                <!--<div class="horizontal layout flex wrap center justified">
-              <p style="color:rgba(0, 0, 0, 0.6);">
-                ${_t('data.folders.Cloneable')}
-              </p>
-              <mwc-switch id="add-folder-cloneable" style="margin-right:10px;">
-              </mwc-switch>
-            </div>-->
+                <div class="horizontal layout flex wrap center justified">
+                  <p style="color:rgba(0, 0, 0, 0.6);">
+                    ${_t('data.folders.Cloneable')}
+                  </p>
+                  <mwc-switch
+                    id="add-folder-cloneable"
+                    style="margin-right:10px;"
+                  ></mwc-switch>
+                </div>
               `
             : html``}
           <div style="font-size:11px;">

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -26,8 +26,10 @@ import '@material/mwc-formfield';
 import '@material/mwc-icon-button';
 import '@material/mwc-list';
 import '@material/mwc-radio';
+// need to import explicitly
 import { Radio } from '@material/mwc-radio';
 import { Select } from '@material/mwc-select';
+import '@material/mwc-switch';
 import { Switch } from '@material/mwc-switch';
 import '@material/mwc-textfield';
 import { TextField } from '@material/mwc-textfield';

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -691,12 +691,13 @@ export default class BackendAiStorageList extends BackendAIPage {
           ></vaadin-grid-column>
           ${this.enableStorageProxy
             ? html`
-                <!--<vaadin-grid-column
-                auto-width flex-grow="0" resizable header="${_t(
-                  'data.folders.Cloneable',
-                )}"
-                .renderer="${this
-                  ._boundCloneableRenderer}"></vaadin-grid-column>-->
+                <vaadin-grid-column
+                  auto-width
+                  flex-grow="0"
+                  resizable
+                  header="${_t('data.folders.Cloneable')}"
+                  .renderer="${this._boundCloneableRenderer}"
+                ></vaadin-grid-column>
               `
             : html``}
           <vaadin-grid-column
@@ -773,13 +774,15 @@ export default class BackendAiStorageList extends BackendAIPage {
           </mwc-select>
           ${this.enableStorageProxy
             ? html`
-                <!--<div class="horizontal layout flex wrap center justified">
-            <p style="color:rgba(0, 0, 0, 0.6);">
-              ${_t('data.folders.Cloneable')}
-            </p>
-            <mwc-switch id="update-folder-cloneable" style="margin-right:10px;">
-            </mwc-switch>
-          </div>-->
+                <div class="horizontal layout flex wrap center justified">
+                  <p style="color:rgba(0, 0, 0, 0.6);">
+                    ${_t('data.folders.Cloneable')}
+                  </p>
+                  <mwc-switch
+                    id="update-folder-cloneable"
+                    style="margin-right:10px;"
+                  ></mwc-switch>
+                </div>
               `
             : html``}
         </div>
@@ -1878,13 +1881,12 @@ export default class BackendAiStorageList extends BackendAIPage {
             text="${_t('data.folders.FolderInfo')}"
             position="top-start"
           ></vaadin-tooltip>
-          <!--${this._hasPermission(rowData.item, 'r') &&
-          this.enableStorageProxy
+          ${this._hasPermission(rowData.item, 'r') && this.enableStorageProxy
             ? html`
                 <mwc-icon-button
                   class="fg blue controls-running"
                   icon="content_copy"
-                  disabled
+                  ?disabled=${!rowData.item.cloneable}
                   @click="${() => {
                     this._requestCloneFolder(rowData.item);
                   }}"
@@ -1896,7 +1898,7 @@ export default class BackendAiStorageList extends BackendAIPage {
                   position="top-start"
                 ></vaadin-tooltip>
               `
-            : html``}-->
+            : html``}
           ${rowData.item.is_owner
             ? html`
                 <mwc-icon-button
@@ -2860,9 +2862,10 @@ export default class BackendAiStorageList extends BackendAIPage {
    * @param {HTMLElement} selectedItem - selected Vfolder to clone
    */
   _requestCloneFolder(selectedItem) {
-    // temporary diable cloning folder until the logic of cloning large size of virtual folder is optimized
-    /* const event = new CustomEvent('backend-ai-vfolder-cloning', {'detail': selectedItem});
-    document.dispatchEvent(event); */
+    const event = new CustomEvent('backend-ai-vfolder-cloning', {
+      detail: selectedItem,
+    });
+    document.dispatchEvent(event);
   }
 
   /**


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR revives "clone" feature which was commented out due to timing issue on large vfolder cloning ( > 10GB), which seems to be resolved already.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

### Tests
- [ ] You can see Cloneable icon for each vfolder in Cloneable column, for each row. (check icon will show up only when the vfolder is cloneable.)
- [ ] You can change cloneable flag in "Update folder option", which can be triggered when you click "gear" icon in Control column.
- [ ] When you try to clone vfolder which has more than 10GB size for total, It do take time but eventually cloning operation will be finished succesfully.