### PR TITLE
fix: rename to mode_card

### DIFF
--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -88,10 +88,10 @@ type Queries {
   container_registries: [ContainerRegistry]
 
   """Added in 24.03.0."""
-  model_info(id: String!): ModelInfo
+  model_metadata(id: String!): ModelMetadata
 
   """Added in 24.03.0."""
-  model_infos(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ModelInfoConnection
+  model_metadatas(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ModelMetadataConnection
 }
 
 """
@@ -827,7 +827,7 @@ type ContainerRegistryConfig {
   ssl_verify: Boolean
 }
 
-type ModelInfo implements AsyncNode {
+type ModelMetadata implements AsyncNode {
   """The ID of the object"""
   id: ID!
   name: String
@@ -859,21 +859,21 @@ type ModelInfo implements AsyncNode {
   readme_filetype: String
 }
 
-type ModelInfoConnection {
+type ModelMetadataConnection {
   """Pagination data for this connection."""
   pageInfo: PageInfo!
 
   """Contains the nodes in this connection."""
-  edges: [ModelInfoEdge]!
+  edges: [ModelMetadataEdge]!
 
   """Total count of the GQL nodes of the query."""
   count: Int
 }
 
-"""A Relay edge containing a `ModelInfo` and its cursor."""
-type ModelInfoEdge {
+"""A Relay edge containing a `ModelMetadata` and its cursor."""
+type ModelMetadataEdge {
   """The item at the end of the edge"""
-  node: ModelInfo
+  node: ModelMetadata
 
   """A cursor for use in pagination"""
   cursor: String!

--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -88,10 +88,10 @@ type Queries {
   container_registries: [ContainerRegistry]
 
   """Added in 24.03.0."""
-  model_metadata(id: String!): ModelMetadata
+  model_card(id: String!): ModelCard
 
   """Added in 24.03.0."""
-  model_metadatas(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ModelMetadataConnection
+  model_cards(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ModelCardConnection
 }
 
 """
@@ -827,7 +827,7 @@ type ContainerRegistryConfig {
   ssl_verify: Boolean
 }
 
-type ModelMetadata implements AsyncNode {
+type ModelCard implements AsyncNode {
   """The ID of the object"""
   id: ID!
   name: String
@@ -859,21 +859,21 @@ type ModelMetadata implements AsyncNode {
   readme_filetype: String
 }
 
-type ModelMetadataConnection {
+type ModelCardConnection {
   """Pagination data for this connection."""
   pageInfo: PageInfo!
 
   """Contains the nodes in this connection."""
-  edges: [ModelMetadataEdge]!
+  edges: [ModelCardEdge]!
 
   """Total count of the GQL nodes of the query."""
   count: Int
 }
 
-"""A Relay edge containing a `ModelMetadata` and its cursor."""
-type ModelMetadataEdge {
+"""A Relay edge containing a `ModelCard` and its cursor."""
+type ModelCardEdge {
   """The item at the end of the edge"""
-  node: ModelMetadata
+  node: ModelCard
 
   """A cursor for use in pagination"""
   cursor: String!

--- a/react/src/components/ModelCardModal.tsx
+++ b/react/src/components/ModelCardModal.tsx
@@ -49,7 +49,7 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
   const [metadata] = useBackendaiImageMetaData();
   const model_info = useFragment(
     graphql`
-      fragment ModelCardModalFragment on ModelInfo {
+      fragment ModelCardModalFragment on ModelMetadata {
         id
         name
         author

--- a/react/src/components/ModelCardModal.tsx
+++ b/react/src/components/ModelCardModal.tsx
@@ -47,9 +47,9 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
 
   const screen = Grid.useBreakpoint();
   const [metadata] = useBackendaiImageMetaData();
-  const model_info = useFragment(
+  const model_card = useFragment(
     graphql`
-      fragment ModelCardModalFragment on ModelMetadata {
+      fragment ModelCardModalFragment on ModelCard {
         id
         name
         author
@@ -80,7 +80,7 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
   return (
     <BAIModal
       {...props}
-      title={model_info?.title || model_info?.name}
+      title={model_card?.title || model_card?.name}
       centered
       onCancel={onRequestClose}
       destroyOnClose
@@ -109,18 +109,18 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
           style={{ flex: 1 }}
           wrap="wrap"
         >
-          {model_info?.category && (
+          {model_card?.category && (
             <Tag bordered={false} style={{ marginRight: 0 }}>
-              {model_info?.category}
+              {model_card?.category}
             </Tag>
           )}
-          {model_info?.task && (
+          {model_card?.task && (
             <Tag bordered={false} color="success" style={{ marginRight: 0 }}>
-              {model_info?.task}
+              {model_card?.task}
             </Tag>
           )}
-          {model_info?.label &&
-            _.map(model_info?.label, (label) => (
+          {model_card?.label &&
+            _.map(model_card?.label, (label) => (
               <Tag
                 key={label}
                 bordered={false}
@@ -130,14 +130,14 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
                 {label}
               </Tag>
             ))}
-          {model_info?.license && (
+          {model_card?.license && (
             <Tag
               icon={<BankOutlined />}
               bordered={false}
               color="geekblue"
               style={{ marginRight: 0 }}
             >
-              {model_info?.license}
+              {model_card?.license}
             </Tag>
           )}
         </Flex>
@@ -156,12 +156,12 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
             ghost
             icon={<CopyOutlined />}
             size="small"
-            disabled={!model_info?.vfolder?.cloneable}
+            disabled={!model_card?.vfolder?.cloneable}
             onClick={() => {
               // const event = new CustomEvent('backend-ai-vfolder-cloning', {
               //   detail: {
               //     // TODO: change this to vfolder name
-              //     name: model_info?.name,
+              //     name: mode_card?.name,
               //   },
               // });
               // onRequestClose();
@@ -189,7 +189,7 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
                 overflow: 'auto',
               }}
             >
-              <Paragraph>{model_info?.description}</Paragraph>
+              <Paragraph>{model_card?.description}</Paragraph>
             </Card>
             <Descriptions
               style={{ marginTop: token.marginMD }}
@@ -201,17 +201,17 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
                 {
                   key: 'author',
                   label: t('modelStore.Author'),
-                  children: model_info?.author,
+                  children: model_card?.author,
                 },
                 {
                   key: 'version',
                   label: t('modelStore.Version'),
-                  children: model_info?.version,
+                  children: model_card?.version,
                 },
                 {
                   key: 'architecture',
                   label: t('environment.Architecture'),
-                  children: model_info?.architecture,
+                  children: model_card?.architecture,
                 },
                 {
                   key: 'frameworks',
@@ -219,7 +219,7 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
                   children: (
                     <Flex direction="row" gap={'xs'}>
                       {_.map(
-                        _.castArray(model_info?.framework),
+                        _.castArray(model_card?.framework),
                         (framework) => {
                           const targetImageKey = framework?.replace(
                             /\s*\d+\s*$/,
@@ -252,21 +252,21 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
                 {
                   key: 'created',
                   label: t('modelStore.Created'),
-                  children: dayjs(model_info?.created_at).format('lll'),
+                  children: dayjs(model_card?.created_at).format('lll'),
                 },
                 {
                   key: 'last_modified',
                   label: t('modelStore.LastModified'),
-                  children: dayjs(model_info?.modified_at).format('lll'),
+                  children: dayjs(model_card?.modified_at).format('lll'),
                 },
                 {
                   key: 'min_resource',
                   label: t('modelStore.MinResource'),
                   children: (
                     <Flex gap="xs">
-                      {model_info?.min_resource &&
+                      {model_card?.min_resource &&
                         _.map(
-                          JSON.parse(model_info?.min_resource),
+                          JSON.parse(model_card?.min_resource),
                           (value, type) => {
                             return (
                               <ResourceNumber
@@ -302,14 +302,14 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
               // maxHeight: 650
             }}
           >
-            <Markdown>{model_info?.readme || ''}</Markdown>
+            <Markdown>{model_card?.readme || ''}</Markdown>
           </Card>
         </Col>
       </Row>
       <Suspense>
         <ModelCloneModal
-          sourceFolderName={model_info?.vfolder?.name || ''}
-          sourceFolderHost={model_info?.vfolder?.host || ''}
+          sourceFolderName={model_card?.vfolder?.name || ''}
+          sourceFolderHost={model_card?.vfolder?.host || ''}
           title={t('modelStore.CloneAsFolder')}
           open={visibleCloneModal}
           onOk={() => {

--- a/react/src/pages/ModelStoreListPage.tsx
+++ b/react/src/pages/ModelStoreListPage.tsx
@@ -27,10 +27,10 @@ const ModelStoreListPage: React.FC = () => {
 
   const [isPendingRefetching, startRefetchingTransition] = useTransition();
 
-  const { model_infos } = useLazyLoadQuery<ModelStoreListPageQuery>(
+  const { model_metadatas } = useLazyLoadQuery<ModelStoreListPageQuery>(
     graphql`
       query ModelStoreListPageQuery($filter: String) {
-        model_infos(filter: $filter) {
+        model_metadatas(filter: $filter) {
           edges {
             cursor
             node {
@@ -77,7 +77,7 @@ const ModelStoreListPage: React.FC = () => {
     fields.forEach((field) => (result[field] = []));
 
     // Traverse the JSON object
-    model_infos?.edges.forEach((edge) => {
+    model_metadatas?.edges.forEach((edge) => {
       fields.forEach((field) => {
         // Check if the field exists in the node
         if (edge?.node?.[field]) {
@@ -90,7 +90,7 @@ const ModelStoreListPage: React.FC = () => {
       });
     });
     return result;
-  }, [model_infos?.edges]);
+  }, [model_metadatas?.edges]);
   return (
     <Flex
       direction="column"
@@ -175,7 +175,7 @@ const ModelStoreListPage: React.FC = () => {
       </Flex>
       <List
         grid={{ gutter: 16, xs: 1, sm: 2, md: 2, lg: 3, xl: 4, xxl: 5 }}
-        dataSource={model_infos?.edges
+        dataSource={model_metadatas?.edges
           ?.map((edge) => edge?.node)
           .filter((info) => {
             let passSearchFilter = true;

--- a/react/src/pages/ModelStoreListPage.tsx
+++ b/react/src/pages/ModelStoreListPage.tsx
@@ -27,10 +27,10 @@ const ModelStoreListPage: React.FC = () => {
 
   const [isPendingRefetching, startRefetchingTransition] = useTransition();
 
-  const { model_metadatas } = useLazyLoadQuery<ModelStoreListPageQuery>(
+  const { model_cards } = useLazyLoadQuery<ModelStoreListPageQuery>(
     graphql`
       query ModelStoreListPageQuery($filter: String) {
-        model_metadatas(filter: $filter) {
+        model_cards(filter: $filter) {
           edges {
             cursor
             node {
@@ -77,7 +77,7 @@ const ModelStoreListPage: React.FC = () => {
     fields.forEach((field) => (result[field] = []));
 
     // Traverse the JSON object
-    model_metadatas?.edges.forEach((edge) => {
+    model_cards?.edges.forEach((edge) => {
       fields.forEach((field) => {
         // Check if the field exists in the node
         if (edge?.node?.[field]) {
@@ -90,7 +90,7 @@ const ModelStoreListPage: React.FC = () => {
       });
     });
     return result;
-  }, [model_metadatas?.edges]);
+  }, [model_cards?.edges]);
   return (
     <Flex
       direction="column"
@@ -175,7 +175,7 @@ const ModelStoreListPage: React.FC = () => {
       </Flex>
       <List
         grid={{ gutter: 16, xs: 1, sm: 2, md: 2, lg: 3, xl: 4, xxl: 5 }}
-        dataSource={model_metadatas?.edges
+        dataSource={model_cards?.edges
           ?.map((edge) => edge?.node)
           .filter((info) => {
             let passSearchFilter = true;

--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -411,13 +411,17 @@ export default class BackendAIData extends BackendAIPage {
                   </div>
                 `
               : html``}
-            <backend-ai-react-model-store-list
-              id="model-store-folder-lists"
-              class="tab-content"
-              style="display:none;"
-              ?active="${this.active === true &&
-              this._activeTab === 'modelStore'}"
-            ></backend-ai-react-model-store-list>
+            ${this.supportModelStore
+              ? html`
+                  <backend-ai-react-model-store-list
+                    id="model-store-folder-lists"
+                    class="tab-content"
+                    style="display:none;"
+                    ?active="${this.active === true &&
+                    this._activeTab === 'modelStore'}"
+                  ></backend-ai-react-model-store-list>
+                `
+              : html``}
           </div>
         </lablup-activity-panel>
       </div>


### PR DESCRIPTION
This PR 
- follows up on changes to the GraphQL Schema, which involve renaming from model_info to model_card.
- prevent sending a model metadata GraphQL query if the manager doesn't support the model store.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
