### PR TITLE
feature: re-arrange my account dialog

### DIFF
--- a/react/src/components/KeypairInfoModal.tsx
+++ b/react/src/components/KeypairInfoModal.tsx
@@ -8,7 +8,7 @@ import { useTanQuery } from '../hooks/reactQueryAlias';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
 import { KeypairInfoModalQuery } from './__generated__/KeypairInfoModalQuery.graphql';
-import { Button, theme, Table, Typography, Tag } from 'antd';
+import { Button, Table, Typography, Tag } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/KeypairInfoModal.tsx
+++ b/react/src/components/KeypairInfoModal.tsx
@@ -25,23 +25,18 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
   const { t } = useTranslation();
   const [userInfo] = useCurrentUserInfo();
   const baiClient = useSuspendedBackendaiClient();
-
-  const { data: keypairs } = useTanQuery<
-    {
-      secret_key: string;
-      access_key: string;
-    }[]
-  >(
-    'baiClient.keypair.list',
-    () => {
+  const { data: keypairs } = useTanQuery({
+    queryKey: ['baiClient.keypair.list', baiModalProps.open], // refetch on open state
+    queryFn: () => {
       return baiClient.keypair
         .list(userInfo.email, ['access_key', 'secret_key', 'is_active'], true)
         .then((res: any) => res.keypairs);
     },
-    {
-      suspense: true,
-    },
-  );
+    suspense: true,
+    staleTime: 0,
+    cacheTime: 0,
+  });
+
   const supportMainAccessKey = baiClient?.supports('main-access-key');
 
   const { user } = useLazyLoadQuery<KeypairInfoModalQuery>(

--- a/react/src/components/KeypairInfoModal.tsx
+++ b/react/src/components/KeypairInfoModal.tsx
@@ -23,7 +23,6 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
   ...baiModalProps
 }) => {
   const { t } = useTranslation();
-  const { token } = theme.useToken();
   const [userInfo] = useCurrentUserInfo();
   const baiClient = useSuspendedBackendaiClient();
 

--- a/react/src/components/KeypairInfoModal.tsx
+++ b/react/src/components/KeypairInfoModal.tsx
@@ -60,6 +60,7 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
       centered
       onCancel={onRequestClose}
       destroyOnClose
+      width={'auto'}
       footer={[
         <Button
           onClick={() => {
@@ -83,6 +84,7 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
               return index;
             },
             showSorterTooltip: false,
+            rowScope: 'row',
           },
           {
             title: t('general.AccessKey'),
@@ -90,12 +92,12 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
             fixed: 'left',
             render: (value) => (
               <Flex direction="column" align="start">
-                <Typography.Text ellipsis copyable style={{ width: 150 }}>
+                <Typography.Text ellipsis copyable>
                   {value}
                 </Typography.Text>
-                {supportMainAccessKey && value === user?.main_access_key ? (
+                {supportMainAccessKey && value === user?.main_access_key && (
                   <Tag color="red">{t('credential.MainAccessKey')}</Tag>
-                ) : null}
+                )}
               </Flex>
             ),
           },
@@ -104,7 +106,7 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
             dataIndex: 'secret_key',
             fixed: 'left',
             render: (value) => (
-              <Typography.Text ellipsis copyable style={{ width: 150 }}>
+              <Typography.Text ellipsis copyable>
                 {value}
               </Typography.Text>
             ),

--- a/react/src/components/KeypairInfoModal.tsx
+++ b/react/src/components/KeypairInfoModal.tsx
@@ -1,0 +1,101 @@
+/**
+ @license
+ Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ */
+import { useSuspendedBackendaiClient } from '../hooks';
+import { useCurrentUserInfo } from '../hooks/backendai';
+import { useTanQuery } from '../hooks/reactQueryAlias';
+import BAIModal, { BAIModalProps } from './BAIModal';
+import { Button, theme, Table, Typography } from 'antd';
+import _ from 'lodash';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface KeypairInfoModalProps extends BAIModalProps {
+  onRequestClose: () => void;
+}
+
+const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
+  onRequestClose,
+  ...baiModalProps
+}) => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const [userInfo] = useCurrentUserInfo();
+  const baiClient = useSuspendedBackendaiClient();
+
+  const { data: keypairs } = useTanQuery<
+    {
+      secret_key: string;
+      access_key: string;
+    }[]
+  >(
+    'baiClient.keypair.list',
+    () => {
+      return baiClient.keypair
+        .list(userInfo.email, ['access_key', 'secret_key', 'is_active'], true)
+        .then((res: any) => res.keypairs);
+    },
+    {
+      suspense: true,
+    },
+  );
+
+  return (
+    <BAIModal
+      {...baiModalProps}
+      title={t('usersettings.MyKeypairInfo')}
+      centered
+      onCancel={onRequestClose}
+      destroyOnClose
+      footer={[
+        <Button
+          onClick={() => {
+            onRequestClose();
+          }}
+        >
+          {t('button.Close')}
+        </Button>,
+      ]}
+    >
+      <Table
+        scroll={{ x: 'max-content' }}
+        rowKey={'access_key'}
+        dataSource={keypairs}
+        columns={[
+          {
+            title: '#',
+            fixed: 'left',
+            render: (id, record, index) => {
+              ++index;
+              return index;
+            },
+            showSorterTooltip: false,
+          },
+          {
+            title: t('general.AccessKey'),
+            dataIndex: 'access_key',
+            fixed: 'left',
+            render: (value) => (
+              <Typography.Text ellipsis copyable style={{ width: 150 }}>
+                {value}
+              </Typography.Text>
+            ),
+          },
+          {
+            title: t('general.SecretKey'),
+            dataIndex: 'secret_key',
+            fixed: 'left',
+            render: (value) => (
+              <Typography.Text ellipsis copyable style={{ width: 150 }}>
+                {value}
+              </Typography.Text>
+            ),
+          },
+        ]}
+      ></Table>
+    </BAIModal>
+  );
+};
+
+export default KeypairInfoModal;

--- a/react/src/components/UserProfileSettingModal.css
+++ b/react/src/components/UserProfileSettingModal.css
@@ -1,4 +1,0 @@
-.disabled_style_readonly,
-.disabled_style_readonly input {
-  background-color: #f5f5f5;
-}

--- a/react/src/components/UserProfileSettingModal.tsx
+++ b/react/src/components/UserProfileSettingModal.tsx
@@ -12,18 +12,8 @@ import TOTPActivateModal from './TOTPActivateModal';
 import { UserProfileSettingModalQuery } from './__generated__/UserProfileSettingModalQuery.graphql';
 import { ExclamationCircleFilled } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import {
-  Modal,
-  ModalProps,
-  Input,
-  Form,
-  Select,
-  message,
-  Switch,
-  Divider,
-} from 'antd';
+import { Modal, ModalProps, Input, Form, message, Switch } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
-import _ from 'lodash';
 import React, { useDeferredValue } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyLoadQuery } from 'react-relay';

--- a/react/src/components/UserProfileSettingModal.tsx
+++ b/react/src/components/UserProfileSettingModal.tsx
@@ -9,11 +9,19 @@ import BAIModal from './BAIModal';
 import { passwordPattern } from './ResetPasswordRequired';
 import TOTPActivateModal from './TOTPActivateModal';
 // @ts-ignore
-import customCSS from './UserProfileSettingModal.css?raw';
 import { UserProfileSettingModalQuery } from './__generated__/UserProfileSettingModalQuery.graphql';
 import { ExclamationCircleFilled } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { Modal, ModalProps, Input, Form, Select, message, Switch } from 'antd';
+import {
+  Modal,
+  ModalProps,
+  Input,
+  Form,
+  Select,
+  message,
+  Switch,
+  Divider,
+} from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React, { useDeferredValue } from 'react';
@@ -29,8 +37,6 @@ type UserProfileFormValues = {
   originalPassword?: string;
   newPasswordConfirm?: string;
   newPassword?: string;
-  access_key?: string;
-  secret_key?: string;
   totp_activated: boolean;
 };
 
@@ -81,23 +87,6 @@ const UserProfileSettingModal: React.FC<Props> = ({
     {
       fetchPolicy: 'network-only',
       fetchKey: deferredMergedFetchKey,
-    },
-  );
-
-  const { data: keyPairs } = useTanQuery<
-    {
-      secret_key: string;
-      access_key: string;
-    }[]
-  >(
-    'baiClient.keypair.list',
-    () => {
-      return baiClient.keypair
-        .list(userInfo.email, ['access_key', 'secret_key'], true)
-        .then((res: any) => res.keypairs);
-    },
-    {
-      suspense: true,
     },
   );
 
@@ -164,7 +153,6 @@ const UserProfileSettingModal: React.FC<Props> = ({
 
   return (
     <>
-      <style>{customCSS}</style>
       <BAIModal
         {...baiModalProps}
         okText={t('webui.menu.Update')}
@@ -185,7 +173,6 @@ const UserProfileSettingModal: React.FC<Props> = ({
           initialValues={{
             full_name: userInfo.full_name,
             totp_activated: user?.totp_activated || false,
-            access_key: keyPairs?.[0].access_key,
           }}
           preserve={false}
         >
@@ -206,29 +193,6 @@ const UserProfileSettingModal: React.FC<Props> = ({
             ]}
           >
             <Input />
-          </Form.Item>
-          <Form.Item name="access_key" label={t('general.AccessKey')}>
-            <Select
-              options={_.map(keyPairs, (keyPair) => ({
-                value: keyPair.access_key,
-              }))}
-              // onSelect={onSelectAccessKey}
-            ></Select>
-          </Form.Item>
-          <Form.Item
-            label={t('general.SecretKey')}
-            shouldUpdate={(prev, next) => prev.access_key !== next.access_key}
-          >
-            {({ getFieldValue }) => (
-              <Input.Password
-                value={
-                  _.find(keyPairs, ['access_key', getFieldValue('access_key')])
-                    ?.secret_key
-                }
-                className="disabled_style_readonly"
-                readOnly
-              />
-            )}
           </Form.Item>
           <Form.Item
             name="originalPassword"

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -56,6 +56,9 @@ const SessionLauncherPage = React.lazy(
 const ContainerRegistryList = React.lazy(
   () => import('./components/ContainerRegistryList'),
 );
+const KeypairInfoModal = React.lazy(
+  () => import('./components/KeypairInfoModal'),
+);
 
 customElements.define(
   'backend-ai-react-information',
@@ -266,6 +269,22 @@ customElements.define(
         <Suspense fallback={<FlexActivityIndicator />}>
           <ModelStoreListPage />
         </Suspense>
+      </DefaultProviders>
+    );
+  }),
+);
+
+customElements.define(
+  'backend-ai-react-keypair-info-modal',
+  reactToWebComponent((props) => {
+    return (
+      <DefaultProviders {...props}>
+        <KeypairInfoModal
+          open={props.value === 'true'}
+          onRequestClose={() => {
+            props.dispatchEvent('close', null);
+          }}
+        />
       </DefaultProviders>
     );
   }),

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "Melden Sie sich automatisch ab, wenn alle angemeldeten Seiten geschlossen sind, mit Ausnahme von sitzungsbasierten Seiten für Apps (z. B. Jupyter Notebook, Webterminal usw.)",
     "SSHKeypairEnterManuallyFinished": "SSH-Keypair wurde erfolgreich registriert.",
     "BootstrapScriptDescription": "Das Bootstrap-Skript wird nur einmal nach der Erstellung der Sitzung ausgeführt",
-    "SSHKeypairEnterManually": "SSH-Schlüsselpaar"
+    "SSHKeypairEnterManually": "SSH-Schlüsselpaar",
+    "MyKeypairInfo": "Meine Schlüsselpaarinformationen",
+    "DescMyKeypairInfo": "Siehe meine Schlüsselpaarinformationen"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Erweiterte Web-Terminal-Nutzung: Terminal-Inhalte kopieren",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "Αποσυνδεθείτε αυτόματα εάν όλες οι συνδεδεμένες σελίδες είναι κλειστές εκτός από τις σελίδες που προέρχονται από περίοδο σύνδεσης για εφαρμογές (π.χ. jupyter notebook, web terminal κ.λπ.)",
     "SSHKeypairEnterManuallyFinished": "Το ζεύγος κλειδιών SSH καταχωρήθηκε με επιτυχία.",
     "BootstrapScriptDescription": "Το σενάριο Bootstrap θα εκτελεστεί μόνο μία φορά μετά τη δημιουργία συνεδρίας",
-    "SSHKeypairEnterManually": "Ζεύγος κλειδιών SSH"
+    "SSHKeypairEnterManually": "Ζεύγος κλειδιών SSH",
+    "MyKeypairInfo": "Πληροφορίες για το ζεύγος κλειδιών μου",
+    "DescMyKeypairInfo": "Δείτε τις πληροφορίες του ζεύγους κλειδιών μου"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Σύνθετη χρήση τερματικού Web: Αντιγραφή περιεχομένου τερματικού",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -896,6 +896,8 @@
     "BetaFeatures": "Beta Features",
     "DescBetaFeatures": "Use beta features for Web UI.<br />Beta features may be unstable. Some beta features may not be adopted as official feature.",
     "DescNoBetaFeatures": "No beta feature available now. :)",
+    "MyKeypairInfo": "My Keypair Information",
+    "DescMyKeypairInfo": "See my keypair information",
     "BootstrapScriptDescription": "Bootstrap script will be executed only once after session creation",
     "EditBootstrapScript": "Edit Bootstrap Script",
     "EditUserConfigScript": "Edit User Config Script",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1363,7 +1363,9 @@
     "SSHKeypairManagement": "Gestión de pares de claves SSH",
     "SessionTerminationDialog": "La finalización de la sesión no se puede deshacer. ¿Desea finalizar la sesión?",
     "ShellEnvironments": "Entornos de conchas",
-    "UseCompactSidebar": "Utilizar la barra lateral compacta por defecto"
+    "UseCompactSidebar": "Utilizar la barra lateral compacta por defecto",
+    "MyKeypairInfo": "Información de mi par de claves",
+    "DescMyKeypairInfo": "Ver la información de mi par de claves"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Uso avanzado del terminal web: Copiar el contenido del terminal",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1406,7 +1406,9 @@
     "ClearSSHKeypairInput": "__NOT_TRANSLATED__",
     "SSHKeypairEnterManually": "__NOT_TRANSLATED__",
     "General": "__NOT_TRANSLATED__",
-    "Logs": "__NOT_TRANSLATED__"
+    "Logs": "__NOT_TRANSLATED__",
+    "MyKeypairInfo": "Avainparini tiedot",
+    "DescMyKeypairInfo": "Katso avainparini tiedot"
   },
   "sidepanel": {
     "Notification": "__NOT_TRANSLATED__",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "Déconnectez-vous automatiquement si toutes les pages connectées sont fermées, à l'exception des pages d'origine de session pour les applications (par exemple, bloc-notes jupyter, terminal Web, etc.)",
     "BootstrapScriptDescription": "Le script Bootstrap ne sera exécuté qu'une seule fois après la création de la session.",
     "SSHKeypairEnterManually": "Couple de clés SSH",
-    "SSHKeypairEnterManuallyFinished": "La paire de clés SSH a été enregistrée avec succès."
+    "SSHKeypairEnterManuallyFinished": "La paire de clés SSH a été enregistrée avec succès.",
+    "MyKeypairInfo": "Informations sur ma paire de clés",
+    "DescMyKeypairInfo": "Voir les informations de ma paire de clés"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Utilisation avancée du terminal Web : copier le contenu du terminal",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "Keluar secara otomatis jika semua halaman yang masuk ditutup kecuali halaman yang berasal dari sesi untuk aplikasi (mis. Jupyter notebook, terminal web, dll.)",
     "BootstrapScriptDescription": "Skrip bootstrap akan dieksekusi hanya sekali setelah pembuatan sesi",
     "SSHKeypairEnterManually": "SSH Keypair",
-    "SSHKeypairEnterManuallyFinished": "SSH Keypair telah berhasil didaftarkan."
+    "SSHKeypairEnterManuallyFinished": "SSH Keypair telah berhasil didaftarkan.",
+    "MyKeypairInfo": "Informasi Pasangan Kunci Saya",
+    "DescMyKeypairInfo": "Lihat informasi keypair saya"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Penggunaan Terminal Web Tingkat Lanjut: Salin konten terminal",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "Disconnettersi automaticamente se tutte le pagine di accesso vengono chiuse eccetto le pagine originate dalla sessione per le app (ad es.",
     "SSHKeypairEnterManuallyFinished": "La coppia di chiavi SSH è stata registrata con successo.",
     "BootstrapScriptDescription": "Lo script Bootstrap verrà eseguito solo una volta dopo la creazione della sessione.",
-    "SSHKeypairEnterManually": "Coppia di chiavi SSH"
+    "SSHKeypairEnterManually": "Coppia di chiavi SSH",
+    "MyKeypairInfo": "Informazioni sulla mia coppia di chiavi",
+    "DescMyKeypairInfo": "Vedi le informazioni sulla mia coppia di chiavi"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Utilizzo avanzato del terminale Web: copia il contenuto del terminale",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "アプリのセッション開始ページ（jupyterノートブック、Webターミナルなど）を除き、ログインしたすべてのページが閉じている場合は、自動的にログアウトします。",
     "SSHKeypairEnterManuallyFinished": "SSHキーフェア登録が正常に完了しました。",
     "BootstrapScriptDescription": "ブートストラップスクリプトはセッション作成後一度だけ実行されます。",
-    "SSHKeypairEnterManually": "SSHキーペア入力"
+    "SSHKeypairEnterManually": "SSHキーペア入力",
+    "MyKeypairInfo": "私のキーペア情報",
+    "DescMyKeypairInfo": "私のキーペア情報を参照してください"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "高度なWeb端末の使用法：端末の内容をコピーする",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -921,7 +921,9 @@
     "Edit_ShellScriptTitle_2": " 셀 스크립트 수정하기",
     "AutoLogout": "자동 로그아웃",
     "DescAutoLogout": "세션 내 앱을 실행하기 위해 생성된 페이지를 제외한 모든 Backend.AI 웹 UI 페이지가 닫힐 경우 자동으로 로그아웃됩니다.",
-    "SSHKeypairEnterManuallyFinished": "SSH 키페어 등록이 성공적으로 완료되었습니다."
+    "SSHKeypairEnterManuallyFinished": "SSH 키페어 등록이 성공적으로 완료되었습니다.",
+    "MyKeypairInfo": "내 키페어 정보",
+    "DescMyKeypairInfo": "내 키페어 정보 보기"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "웹 터미널 고급 사용법: 터미널 내용 복사하기",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "Аппликешнд зориулж суулгасан хуудсуудаас бусад нэвтэрсэн бүх хуудсыг хаасан тохиолдолд автоматаар гарах болно (ж.нь. Jupyter Notebook, вэб терминал гэх мэт).",
     "BootstrapScriptDescription": "Ачаалагч скрипт нь сесс үүсгэсний дараа зөвхөн нэг удаа хийгдэх болно",
     "SSHKeypairEnterManually": "SSH товчлуурын хослол",
-    "SSHKeypairEnterManuallyFinished": "SSH Keypair амжилттай бүртгэгдлээ."
+    "SSHKeypairEnterManuallyFinished": "SSH Keypair амжилттай бүртгэгдлээ.",
+    "MyKeypairInfo": "Миний товчлуурын мэдээлэл",
+    "DescMyKeypairInfo": "Миний товчлуурын мэдээллийг харна уу"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Дэвшилтэт вэб терминалын хэрэглээ: Терминалын агуулгыг хуулах",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -839,7 +839,9 @@
     "DescAutoLogout": "Log keluar secara automatik jika semua halaman log masuk ditutup kecuali halaman yang berasal dari sesi untuk aplikasi (mis. Notebook jupyter, terminal web, dll.)",
     "SSHKeypairEnterManuallyFinished": "SSH Keypair telah berjaya didaftarkan.",
     "BootstrapScriptDescription": "Skrip Bootstrap akan dilaksanakan sekali sahaja selepas penciptaan sesi",
-    "SSHKeypairEnterManually": "SSH Keypair"
+    "SSHKeypairEnterManually": "SSH Keypair",
+    "MyKeypairInfo": "Maklumat Pasangan Kunci Saya",
+    "DescMyKeypairInfo": "Lihat maklumat pasangan kunci saya"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Penggunaan Terminal Web Lanjutan: Salin kandungan terminal",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -842,7 +842,9 @@
     "DescAutoLogout": "Wyloguj się automatycznie, jeśli wszystkie zalogowane strony są zamknięte, z wyjątkiem stron pochodzących z sesji dla aplikacji (np. notatnik jupyter, terminal internetowy itp.)",
     "SSHKeypairEnterManuallyFinished": "Para kluczy SSH została pomyślnie zarejestrowana.",
     "BootstrapScriptDescription": "Skrypt Bootstrap zostanie wykonany tylko raz po utworzeniu sesji.",
-    "SSHKeypairEnterManually": "Para kluczy SSH"
+    "SSHKeypairEnterManually": "Para kluczy SSH",
+    "MyKeypairInfo": "Informacje o mojej parze kluczy",
+    "DescMyKeypairInfo": "Zobacz informacje o mojej parze kluczy"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Zaawansowane korzystanie z terminala internetowego: Skopiuj zawartość terminala",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "Saia automaticamente se todas as páginas logadas forem fechadas, exceto as páginas originadas da sessão para aplicativos (por exemplo, notebook jupyter, terminal da web, etc.)",
     "SSHKeypairEnterManuallyFinished": "O par de chaves SSH foi registado com sucesso.",
     "BootstrapScriptDescription": "O script bootstrap será executado apenas uma vez após a criação da sessão",
-    "SSHKeypairEnterManually": "Par de chaves SSH"
+    "SSHKeypairEnterManually": "Par de chaves SSH",
+    "MyKeypairInfo": "Minhas informações de par de chaves",
+    "DescMyKeypairInfo": "Ver as informações do meu par de chaves"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Uso avançado do terminal da Web: Copiar o conteúdo do terminal",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "Saia automaticamente se todas as páginas logadas forem fechadas, exceto as páginas originadas da sessão para aplicativos (por exemplo, notebook jupyter, terminal da web, etc.)",
     "SSHKeypairEnterManuallyFinished": "O par de chaves SSH foi registado com sucesso.",
     "BootstrapScriptDescription": "O script bootstrap será executado apenas uma vez após a criação da sessão",
-    "SSHKeypairEnterManually": "Par de chaves SSH"
+    "SSHKeypairEnterManually": "Par de chaves SSH",
+    "MyKeypairInfo": "Minhas informações de par de chaves",
+    "DescMyKeypairInfo": "Ver as informações do meu par de chaves"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Uso avançado do terminal da Web: Copiar o conteúdo do terminal",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -842,7 +842,9 @@
     "DescAutoLogout": "Автоматический выход из системы, если все зарегистрированные страницы закрыты, кроме страниц, созданных в сеансе для приложений (например, блокнот jupyter, веб-терминал и т. Д.)",
     "BootstrapScriptDescription": "Bootstrap-скрипт будет выполняться только один раз после создания сессии",
     "SSHKeypairEnterManually": "Пара ключей SSH",
-    "SSHKeypairEnterManuallyFinished": "Пара ключей SSH успешно зарегистрирована."
+    "SSHKeypairEnterManuallyFinished": "Пара ключей SSH успешно зарегистрирована.",
+    "MyKeypairInfo": "Информация о моей паре ключей",
+    "DescMyKeypairInfo": "Посмотреть информацию о моей паре ключей"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Расширенное использование веб-терминала: копирование содержимого терминала",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "Uygulamalar için oturum kaynaklı sayfalar (örneğin jupyter notebook, web terminal, vb.)",
     "SSHKeypairEnterManuallyFinished": "SSH Anahtar Çifti başarıyla kaydedildi.",
     "BootstrapScriptDescription": "Bootstrap komut dosyası oturum oluşturulduktan sonra yalnızca bir kez çalıştırılacaktır",
-    "SSHKeypairEnterManually": "SSH Anahtar Çifti"
+    "SSHKeypairEnterManually": "SSH Anahtar Çifti",
+    "MyKeypairInfo": "Anahtar Çifti Bilgilerim",
+    "DescMyKeypairInfo": "Anahtar çifti bilgilerimi görün"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Gelişmiş Web Terminali Kullanımı: Terminal içeriğini kopyalayın",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -839,7 +839,9 @@
     "DescAutoLogout": "Tự động đăng xuất nếu tất cả các trang đã đăng nhập đều bị đóng ngoại trừ các trang gốc phiên cho ứng dụng (ví dụ: sổ ghi chép jupyter, thiết bị đầu cuối web, v.v.)",
     "SSHKeypairEnterManuallyFinished": "Cặp khóa SSH đã được đăng ký thành công.",
     "BootstrapScriptDescription": "Tập lệnh Bootstrap sẽ chỉ được thực thi một lần sau khi tạo phiên",
-    "SSHKeypairEnterManually": "Cặp khóa SSH"
+    "SSHKeypairEnterManually": "Cặp khóa SSH",
+    "MyKeypairInfo": "Thông tin về cặp khóa của tôi",
+    "DescMyKeypairInfo": "Xem thông tin cặp khóa của tôi"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Sử dụng đầu cuối web nâng cao: Sao chép nội dung đầu cuối",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "如果所有登录页面都关闭，除了应用程序的会话发起页面（例如 jupyter 笔记本、网络终端等），则自动注销",
     "SSHKeypairEnterManuallyFinished": "SSH 密钥对已成功注册。",
     "BootstrapScriptDescription": "Bootstrap 脚本只会在会话创建后执行一次",
-    "SSHKeypairEnterManually": "SSH 密钥对"
+    "SSHKeypairEnterManually": "SSH 密钥对",
+    "MyKeypairInfo": "我的密钥对信息",
+    "DescMyKeypairInfo": "查看我的密钥对信息"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "高级 Web 终端使用：复制终端内容",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -840,7 +840,9 @@
     "DescAutoLogout": "如果所有登錄頁面都關閉，除了應用程序的會話發起頁面（例如 jupyter 筆記本、網絡終端等），則自動註銷",
     "SSHKeypairEnterManuallyFinished": "SSH 密钥对已成功注册。",
     "BootstrapScriptDescription": "Bootstrap 脚本只会在会话创建后执行一次",
-    "SSHKeypairEnterManually": "SSH 密钥对"
+    "SSHKeypairEnterManually": "SSH 密钥对",
+    "MyKeypairInfo": "我的密鑰對訊息",
+    "DescMyKeypairInfo": "查看我的密鑰對訊息"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "高級 Web 終端使用：複製終端內容",

--- a/src/components/backend-ai-usersettings-general-list.ts
+++ b/src/components/backend-ai-usersettings-general-list.ts
@@ -103,7 +103,7 @@ export default class BackendAiUsersettingsGeneralList extends BackendAIPage {
   @query('#ssh-keypair-form-dialog') sshKeypairFormDialog!: BackendAIDialog;
   @query('#entered-ssh-public-key') enteredSSHPublicKeyInput!: TextArea;
   @query('#entered-ssh-private-key') enteredSSHPrivateKeyInput!: TextArea;
-
+  @property({ type: Boolean }) isOpenMyKeypairInfoDialog = false;
   @query('#ui-language') languageSelect!: Select;
   @query('#delete-rcfile') deleteRcfileButton!: Button;
 
@@ -960,6 +960,10 @@ export default class BackendAiUsersettingsGeneralList extends BackendAIPage {
     this._hideSSHKeypairGenerationDialog();
   }
 
+  _openMyKeypairDialog() {
+    this.isOpenMyKeypairInfoDialog = true;
+  }
+
   _discardCurrentEditorChange() {
     this._updateSelectedRcFileName(this.rcfile);
     this._hideCurrentEditorChangeDialog();
@@ -1199,6 +1203,21 @@ export default class BackendAiUsersettingsGeneralList extends BackendAIPage {
                 false,
               )}"
             ></mwc-switch>
+          </div>
+        </div>
+        <div class="horizontal layout wrap setting-item">
+          <div class="vertical start start-justified layout setting-desc">
+            <div class="title">${_t('usersettings.MyKeypairInfo')}</div>
+            <div class="description">
+              ${_tr('usersettings.DescMyKeypairInfo')}
+            </div>
+          </div>
+          <div class="vertical center-justified layout flex end">
+            <mwc-icon-button
+              id="ssh-keypair-details"
+              icon="more"
+              @click="${this._openMyKeypairDialog}"
+            ></mwc-icon-button>
           </div>
         </div>
         ${this.beta_feature_panel
@@ -1542,6 +1561,12 @@ export default class BackendAiUsersettingsGeneralList extends BackendAIPage {
           ></mwc-button>
         </div>
       </backend-ai-dialog>
+      <backend-ai-react-keypair-info-modal
+        value="${this.isOpenMyKeypairInfoDialog ? 'true' : 'false'}"
+        @close="${() => {
+          this.isOpenMyKeypairInfoDialog = false;
+        }}"
+      ></backend-ai-react-keypair-info-modal>
     `;
   }
 }


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

* related: #2083 

- required Core version: `24.03.0` or newer version
   - You need to upgrade alembic version to the latest by executing the following command in Core directory: 
      ```
       ./py -m alembic upgrade head
      ```

In this PR, keypair in user account information has been moved to user settings menu, since keypair is not maintained by user, but only for admin, which may confuses user if the fields is remaining in user account modal. 
Therefore, there are two things to check during this PR review:
- [x] Check access key and secret key is removed from user information(so called "My Account" modal)
- [x] Check the new menu "My keypair Info" in user settings menu
- [x] Check all the keypairs of current user in "My keypair info modal"
- [x] Check the main access key tag is attached correctly.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after


### Screenshot(s)
<img width="488" alt="Screenshot 2023-12-07 at 6 41 56 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/4d2e1709-e4a1-4fe9-bdbc-47e8ac8d746a">
<img width="1252" alt="Screenshot 2023-12-07 at 6 41 41 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/dab0d647-9888-4d8b-8e14-4d50274259ff">
<img width="489" alt="Screenshot 2023-12-07 at 7 36 14 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/cd50f155-902a-447e-8b57-ed5722358ce9">