### PR TITLE
fix: adjust support version check for main access key

### DIFF
--- a/react/src/components/KeypairInfoModal.tsx
+++ b/react/src/components/KeypairInfoModal.tsx
@@ -44,7 +44,7 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
       query KeypairInfoModalQuery($email: String) {
         user(email: $email) {
           email
-          main_access_key @since(version: "24.03.0")
+          main_access_key @since(version: "23.09.7")
         }
       }
     `,

--- a/react/src/components/UserInfoModal.tsx
+++ b/react/src/components/UserInfoModal.tsx
@@ -76,7 +76,7 @@ const UserInfoModal: React.FC<Props> = ({ ...baiModalProps }) => {
           sudo_session_enabled
             @skipOnClient(if: $isNotSupportSudoSessionEnabled)
           totp_activated @include(if: $isTOTPSupported)
-          main_access_key @since(version: "24.03.0")
+          main_access_key @since(version: "23.09.7")
         }
       }
     `,

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -666,10 +666,12 @@ class Client {
     if (this.isManagerVersionCompatibleWith('23.09.2')) {
       this._features['container-registry-gql'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('23.09.7')) {
+      this._features['main-access-key'] = true;
+    }
     if (this.isManagerVersionCompatibleWith('24.03.0')) {
       this._features['max-vfolder-count-in-user-resource-policy'] = true;
       this._features['model-store'] = true;
-      this._features['main-access-key'] = true;
     }
   }
 


### PR DESCRIPTION
> ⚠️ NOTE: Now(Dec 8, 2023 02:54PM KST), Backend.AI Core hasn't been released updated version of `23.09`.

- related: #2083, #2087, [backend.ai#1761](https://github.com/lablup/backend.ai/pull/1761)
- required Core version: 23.09.7 or newer version

Since `main_access_key` field has been added from `23.09.7` in Core, We need to apply it to version checking statement.



<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
