### PR TITLE
fix:activated and disabled mwc-switch's color is shown shadow color

### DIFF
--- a/src/components/backend-ai-general-styles.ts
+++ b/src/components/backend-ai-general-styles.ts
@@ -410,6 +410,15 @@ export const BackendAiStyles = [
       );
     }
 
+    mwc-switch[disabled] {
+      --mdc-switch-disabled-selected-handle-color: var(
+        --general-switch-on-color
+      );
+      --mdc-switch-disabled-selected-track-color: var(
+        --general-switch-on-color
+      ) !important;
+    }
+
     div.card p {
       padding: 10px;
     }


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR resolves https://github.com/lablup/backend.ai-webui/issues/2090

Now the activated and disabled mwc-switch is shown shadow colors.

<img width="900" alt="스크린샷 2023-12-10 오전 1 11 45" src="https://github.com/lablup/backend.ai-webui/assets/28584221/575089ae-68bd-40fa-9c6e-51ab374fff44">


**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
