### PR TITLE
fix:modiy condition of registry user config validation

### DIFF
--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -165,7 +165,10 @@ const ContainerRegistryEditorModal: React.FC<
             if (
               _.includes(values.config?.type, 'harbor') &&
               (_.isEmpty(values.config.username) ||
-                _.isEmpty(values.config.password))
+                (containerRegistry
+                  ? values.isChangedPassword &&
+                    _.isEmpty(values.config.password)
+                  : _.isEmpty(values.config.password)))
             ) {
               modal.confirm({
                 title: t('button.Confirm'),

--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -162,7 +162,10 @@ const ContainerRegistryEditorModal: React.FC<
         form
           .validateFields()
           .then((values) => {
-            if (_.includes(values.config?.type, 'harbor')) {
+            if (
+              !values.config.username ||
+              (values.isChangedPassword && !values.config.password)
+            ) {
               modal.confirm({
                 title: t('button.Confirm'),
                 content: t('registry.ConfirmNoUserName'),

--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -163,8 +163,9 @@ const ContainerRegistryEditorModal: React.FC<
           .validateFields()
           .then((values) => {
             if (
-              !values.config.username ||
-              (values.isChangedPassword && !values.config.password)
+              _.includes(values.config?.type, 'harbor') &&
+              (_.isEmpty(values.config.username) ||
+                _.isEmpty(values.config.password))
             ) {
               modal.confirm({
                 title: t('button.Confirm'),


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR resolves https://github.com/lablup/backend.ai-webui/issues/2089

Modal.confirm is pop up when user isn't set username or check isChangePassword but user isn't write password

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
