### PR TITLE
fix: Image name exceptions of `ImageEnvironmentSelectFormItem`

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -199,20 +199,31 @@ const ImageEnvironmentSelectFormItems: React.FC<
                   image?.name
                 );
               })
-              .map((images, environmentName) => ({
-                environmentName,
-                displayName:
-                  metadata?.imageInfo[environmentName.split('/')?.[1]]?.name ||
+              .map((images, environmentName) => {
+                const imageKey = environmentName.split('/')?.[1];
+                const displayName =
+                  imageKey && metadata?.imageInfo[imageKey]?.name;
+
+                return {
                   environmentName,
-                prefix: environmentName.split('/')?.[0],
-                images: images.sort((a, b) =>
-                  compareVersions(
-                    // latest version comes first
-                    b?.tag?.split('-')?.[0] ?? '',
-                    a?.tag?.split('-')?.[0] ?? '',
+                  displayName:
+                    displayName ||
+                    (_.last(environmentName.split('/')) as string),
+                  prefix: _.chain(environmentName)
+                    .split('/')
+                    .dropRight(1)
+                    .join('/')
+                    .value(),
+                  images: images.sort((a, b) =>
+                    compareVersions(
+                      // latest version comes first
+                      b?.tag?.split('-')?.[0] ?? '',
+                      a?.tag?.split('-')?.[0] ?? '',
+                    ),
                   ),
-                ),
-              }))
+                };
+              })
+
               .sortBy((item) => item.displayName)
               .value(),
           };
@@ -494,21 +505,20 @@ const ImageEnvironmentSelectFormItems: React.FC<
                         ? _.map(requirements, (requirement, idx) => (
                             <DoubleTag
                               key={idx}
-                              values={
-                                metadata?.tagAlias[requirement]
-                                  ?.split(':')
-                                  .map((str) => {
-                                    extraFilterValues.push(str);
-                                    return (
-                                      <TextHighlighter
-                                        keyword={versionSearch}
-                                        key={str}
-                                      >
-                                        {str}
-                                      </TextHighlighter>
-                                    );
-                                  }) || requirements
-                              }
+                              values={_.split(
+                                metadata?.tagAlias[requirement] || requirement,
+                                ':',
+                              ).map((str) => {
+                                extraFilterValues.push(str);
+                                return (
+                                  <TextHighlighter
+                                    keyword={versionSearch}
+                                    key={str}
+                                  >
+                                    {str}
+                                  </TextHighlighter>
+                                );
+                              })}
                             />
                           ))
                         : '-';

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -82,10 +82,6 @@ const isPrivateImage = (image: Image) => {
 const ImageEnvironmentSelectFormItems: React.FC<
   ImageEnvironmentSelectFormItemsProps
 > = ({ filter, showPrivate }) => {
-  // TODO: fix below without useSuspendedBackendaiClient
-  // Before fetching on relay environment, BAI client should be ready
-  useSuspendedBackendaiClient();
-
   const form = Form.useFormInstance<ImageEnvironmentFormInput>();
   Form.useWatch('environments', { form, preserve: true });
 

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -1,4 +1,4 @@
-import { useBackendaiImageMetaData } from '../hooks';
+import { useBackendAIImageMetaData } from '../hooks';
 import DoubleTag from './DoubleTag';
 import Flex from './Flex';
 // @ts-ignore
@@ -85,7 +85,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
   const [environmentSearch, setEnvironmentSearch] = useState('');
   const [versionSearch, setVersionSearch] = useState('');
   const { t } = useTranslation();
-  const [metadata, { getImageMeta }] = useBackendaiImageMetaData();
+  const [metadata, { getImageMeta }] = useBackendAIImageMetaData();
   const { token } = theme.useToken();
 
   const envSelectRef = useRef<RefSelectProps>(null);

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -1,7 +1,4 @@
-import {
-  useBackendaiImageMetaData,
-  useSuspendedBackendaiClient,
-} from '../hooks';
+import { useBackendaiImageMetaData } from '../hooks';
 import DoubleTag from './DoubleTag';
 import Flex from './Flex';
 // @ts-ignore

--- a/react/src/components/ImageMetaIcon.tsx
+++ b/react/src/components/ImageMetaIcon.tsx
@@ -1,4 +1,4 @@
-import { useBackendaiImageMetaData } from '../hooks';
+import { useBackendAIImageMetaData } from '../hooks';
 import React from 'react';
 
 const ImageMetaIcon: React.FC<{
@@ -7,7 +7,7 @@ const ImageMetaIcon: React.FC<{
   border?: boolean;
   alt?: string | null;
 }> = ({ image, style = {} }, bordered, alt = '') => {
-  const [, { getImageIcon }] = useBackendaiImageMetaData();
+  const [, { getImageIcon }] = useBackendAIImageMetaData();
 
   return (
     <img

--- a/react/src/components/ModelCardModal.tsx
+++ b/react/src/components/ModelCardModal.tsx
@@ -1,4 +1,4 @@
-import { useBackendaiImageMetaData } from '../hooks';
+import { useBackendAIImageMetaData } from '../hooks';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
 import ModelCloneModal from './ModelCloneModal';
@@ -46,7 +46,7 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
   const [visibleCloneModal, setVisibleCloneModal] = useState(false);
 
   const screen = Grid.useBreakpoint();
-  const [metadata] = useBackendaiImageMetaData();
+  const [metadata] = useBackendAIImageMetaData();
   const model_card = useFragment(
     graphql`
       fragment ModelCardModalFragment on ModelCard {

--- a/react/src/components/SessionKernelTag.tsx
+++ b/react/src/components/SessionKernelTag.tsx
@@ -1,4 +1,4 @@
-import { useBackendaiImageMetaData } from '../hooks';
+import { useBackendAIImageMetaData } from '../hooks';
 import React from 'react';
 
 const SessionKernelTag: React.FC<{
@@ -8,7 +8,7 @@ const SessionKernelTag: React.FC<{
 }> = ({ image, style = {} }, bordered) => {
   image = image || '';
   const [, { getImageAliasName, getBaseVersion, getBaseImage }] =
-    useBackendaiImageMetaData();
+    useBackendAIImageMetaData();
 
   // const sessionTags = useMemo(() => {
   //   const tags = [];

--- a/react/src/hooks/index.ts
+++ b/react/src/hooks/index.ts
@@ -182,6 +182,7 @@ export const useBackendaiImageMetaData = () => {
         ''
       ).split(':');
 
+      // remove architecture string and split by '-'
       const tags = tag.split('@')[0].split('-');
       return { key, tags };
     } catch (error) {

--- a/react/src/hooks/index.ts
+++ b/react/src/hooks/index.ts
@@ -138,7 +138,7 @@ interface ImageMetadata {
   }[];
 }
 
-export const useBackendaiImageMetaData = () => {
+export const useBackendAIImageMetaData = () => {
   const { data: metadata } = useQuery({
     queryKey: 'backendai-metadata-for-suspense',
     queryFn: () => {

--- a/react/src/hooks/index.ts
+++ b/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
 
@@ -166,7 +167,7 @@ export const useBackendaiImageMetaData = () => {
   const getImageMeta = (imageName: string) => {
     // cr.backend.ai/multiarch/python:3.9-ubuntu20.04
     // key = python, tags = [3.9, ubuntu20.04]
-    if (!imageName) {
+    if (_.isEmpty(imageName)) {
       return {
         key: '',
         tags: [],
@@ -174,10 +175,21 @@ export const useBackendaiImageMetaData = () => {
     }
     const specs = imageName.split('/');
 
-    const [key, tag] = (specs[2] || specs[1]).split(':');
-    const tags = tag.split('-');
+    try {
+      const [key, tag] = (
+        specs[specs.length - 1] ||
+        specs[specs.length - 2] ||
+        ''
+      ).split(':');
 
-    return { key, tags };
+      const tags = tag.split('@')[0].split('-');
+      return { key, tags };
+    } catch (error) {
+      return {
+        key: '',
+        tags: [],
+      };
+    }
   };
 
   return [


### PR DESCRIPTION
resolve https://github.com/lablup/giftbox/issues/578

This PR
- resolve parsing error when image name has more than two `/`. ([ref](https://github.com/lablup/backend.ai-webui/pull/2109/files#diff-0c3eda30e966d59fcc7f298b411bdf4671271d6ff721e2395f9985d638a98e37R199-R202))
    ```
    {
        "name": "abc/def/tranining",
        "humanized_name": "abc/def/tranining",
        "tag": "01-py3-abc-v1",
        "registry": "192.168.0.1:7080",
        "architecture": "x86_64",
    ```
- fix typo related requirement tag (use `requirement` instead of `requirements`, [ref](https://github.com/lablup/backend.ai-webui/pull/2109/files#diff-0c3eda30e966d59fcc7f298b411bdf4671271d6ff721e2395f9985d638a98e37R505-R518))
- remove unnecessary useSuspensedBackendaiClient (resovled by [#1999](https://github.com/lablup/backend.ai-webui/pull/1999/files#diff-e1757ecad7e9cf3ff6f03bb9ab94ca5fb3693ed22cfdccada07d28f46c46028aR22-R35) )
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
