### PR TITLE
style: remove `whiteSpace` to fix the broken UI of the announcement.

### DIFF
--- a/react/src/components/AnnouncementAlert.tsx
+++ b/react/src/components/AnnouncementAlert.tsx
@@ -30,7 +30,23 @@ const AnnouncementAlert: React.FC = () => {
           </Tag>
         </>
       }
-      message={<Markdown>{announcement.message}</Markdown>}
+      message={
+        <Markdown
+          options={{
+            overrides: {
+              p: {
+                props: {
+                  style: {
+                    marginTop: 0,
+                  },
+                },
+              },
+            },
+          }}
+        >
+          {announcement.message}
+        </Markdown>
+      }
     />
   ) : (
     ''

--- a/react/src/components/AnnouncementAlert.tsx
+++ b/react/src/components/AnnouncementAlert.tsx
@@ -21,7 +21,6 @@ const AnnouncementAlert: React.FC = () => {
       style={{
         alignItems: 'flex-start',
         overflow: 'auto',
-        whiteSpace: 'pre-wrap',
       }}
       icon={
         //use <> because tag border is not displayed normally when Tag component is used only


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
follows https://github.com/lablup/backend.ai-webui/pull/2098
resolves #2124 
Before - include unexpected spaces
<img width="728" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/28584164/17f63679-f795-400e-bf0d-cb01f6ac516a">

After - removed unexpected spaces
<img width="730" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/28584164/45e01c21-8bc3-4a7b-8760-e849afea0c07">

## How to test
1. setup announcement with the control panel dashboard page.
``` Base system is upgraded to Enterprise R2/23.09. <lablup-shields app="status" color="green" description="Running" ui="round"></lablup-shields>```
2. refresh webui

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version: 23.09
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after
