### PR TITLE
feat: `allow_manual_image_name_for_session` option in ServiceLauncher

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -13,16 +13,7 @@ import {
   ImageEnvironmentSelectFormItemsQuery,
   ImageEnvironmentSelectFormItemsQuery$data,
 } from './__generated__/ImageEnvironmentSelectFormItemsQuery.graphql';
-import {
-  Divider,
-  Form,
-  Input,
-  RefSelectProps,
-  Select,
-  Switch,
-  Tag,
-  theme,
-} from 'antd';
+import { Divider, Form, Input, RefSelectProps, Select, Tag, theme } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -1,4 +1,7 @@
-import { useBackendAIImageMetaData } from '../hooks';
+import {
+  useBackendAIImageMetaData,
+  useSuspendedBackendaiClient,
+} from '../hooks';
 import { useThemeMode } from '../hooks/useThemeMode';
 import DoubleTag from './DoubleTag';
 import Flex from './Flex';
@@ -36,6 +39,7 @@ export type ImageEnvironmentFormInput = {
     environment: string;
     version: string;
     image: Image | undefined;
+    manual?: string;
   };
 };
 
@@ -81,7 +85,8 @@ const ImageEnvironmentSelectFormItems: React.FC<
   ImageEnvironmentSelectFormItemsProps
 > = ({ filter, showPrivate }) => {
   const form = Form.useFormInstance<ImageEnvironmentFormInput>();
-  Form.useWatch('environments', { form, preserve: true });
+  const environments = Form.useWatch('environments', { form, preserve: true });
+  const baiClient = useSuspendedBackendaiClient();
 
   const [environmentSearch, setEnvironmentSearch] = useState('');
   const [versionSearch, setVersionSearch] = useState('');
@@ -291,6 +296,10 @@ const ImageEnvironmentSelectFormItems: React.FC<
               });
             }
           }}
+          disabled={
+            baiClient._config.allow_manual_image_name_for_session &&
+            !_.isEmpty(environments?.manual)
+          }
         >
           {fullNameMatchedImage ? (
             <Select.Option
@@ -476,6 +485,10 @@ const ImageEnvironmentSelectFormItems: React.FC<
                     {menu}
                   </>
                 )}
+                disabled={
+                  baiClient._config.allow_manual_image_name_for_session &&
+                  !_.isEmpty(environments?.manual)
+                }
               >
                 {_.map(
                   _.uniqBy(selectedEnvironmentGroup?.images, 'digest'),
@@ -570,6 +583,17 @@ const ImageEnvironmentSelectFormItems: React.FC<
             </Form.Item>
           );
         }}
+      </Form.Item>
+      <Form.Item
+        label={t('session.launcher.ManualImageName')}
+        name={['environments', 'manual']}
+        style={{
+          display: baiClient._config.allow_manual_image_name_for_session
+            ? 'block'
+            : 'none',
+        }}
+      >
+        <Input allowClear />
       </Form.Item>
       <Form.Item noStyle hidden name={['environments', 'image']}>
         <Input />

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -13,7 +13,16 @@ import {
   ImageEnvironmentSelectFormItemsQuery,
   ImageEnvironmentSelectFormItemsQuery$data,
 } from './__generated__/ImageEnvironmentSelectFormItemsQuery.graphql';
-import { Divider, Form, Input, RefSelectProps, Select, Tag, theme } from 'antd';
+import {
+  Divider,
+  Form,
+  Input,
+  RefSelectProps,
+  Select,
+  Switch,
+  Tag,
+  theme,
+} from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -134,6 +143,9 @@ const ImageEnvironmentSelectFormItems: React.FC<
   // If not initial value, select first value
   // auto select when relative field is changed
   useEffect(() => {
+    if (!_.isEmpty(environments?.manual)) {
+      return;
+    }
     // if not initial value, select first value
     const nextEnvironmentName =
       form.getFieldValue('environments')?.environment ||
@@ -172,7 +184,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form.getFieldValue('environments')?.environment]);
+  }, [environments?.environment, environments?.manual]);
 
   const imageGroups: ImageGroup[] = useMemo(
     () =>
@@ -272,7 +284,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
         label={`${t('session.launcher.Environments')} / ${t(
           'session.launcher.Version',
         )}`}
-        rules={[{ required: true }]}
+        rules={[{ required: _.isEmpty(environments?.manual) }]}
         style={{ marginBottom: 10 }}
       >
         <Select
@@ -449,7 +461,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
             <Form.Item
               className="image-environment-select-form-item"
               name={['environments', 'version']}
-              rules={[{ required: true }]}
+              rules={[{ required: _.isEmpty(environments?.manual) }]}
             >
               <Select
                 ref={versionSelectRef}
@@ -593,7 +605,20 @@ const ImageEnvironmentSelectFormItems: React.FC<
             : 'none',
         }}
       >
-        <Input allowClear />
+        <Input
+          allowClear
+          onChange={(value) => {
+            if (!_.isEmpty(value)) {
+              form.setFieldsValue({
+                environments: {
+                  environment: undefined,
+                  version: undefined,
+                  image: undefined,
+                },
+              });
+            }
+          }}
+        />
       </Form.Item>
       <Form.Item noStyle hidden name={['environments', 'image']}>
         <Input />

--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -755,7 +755,12 @@ const ResourceAllocationFormItems: React.FC<
                                   : undefined,
                             },
                           }}
-                          disabled={currentImageAcceleratorLimits.length === 0}
+                          disabled={
+                            currentImageAcceleratorLimits.length === 0 &&
+                            _.isEmpty(
+                              form.getFieldValue(['environments', 'manual']),
+                            )
+                          }
                           min={0}
                           max={
                             resourceLimits.accelerators[currentAcceleratorType]
@@ -777,7 +782,14 @@ const ResourceAllocationFormItems: React.FC<
                                 <Select
                                   tabIndex={-1}
                                   disabled={
-                                    currentImageAcceleratorLimits.length <= 0
+                                    currentImageAcceleratorLimits.length ===
+                                      0 &&
+                                    _.isEmpty(
+                                      form.getFieldValue([
+                                        'environments',
+                                        'manual',
+                                      ]),
+                                    )
                                   }
                                   suffixIcon={
                                     _.size(acceleratorSlots) > 1

--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -101,7 +101,12 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
     ServiceLauncherFormValue
   >({
     mutationFn: (values) => {
-      const image: string = `${values.environments.image?.registry}/${values.environments.image?.name}:${values.environments.image?.tag}`;
+      const image: string =
+        baiClient._config.allow_manual_image_name_for_session &&
+        values.environments?.manual &&
+        !_.isEmpty(values.environments.manual)
+          ? values.environments.manual
+          : `${values.environments.image?.registry}/${values.environments.image?.name}:${values.environments.image?.tag}`;
       const body: ServiceCreateType = {
         name: values.serviceName,
         desired_session_count: values.desiredRoutingCount,

--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -208,6 +208,7 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
             desiredRoutingCount: 1,
             ...RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
           }}
+          requiredMark="optional"
         >
           <Form.Item
             label={t('modelService.ServiceName')}


### PR DESCRIPTION
ref: https://github.com/lablup/giftbox/issues/569

This PR introduces the feature user can input the image name manually when `allow_manual_image_name_for_session` config is true.

How to test
- Set `allow_manual_image_name_for_session` of config.toml  to true
- Open service launcher, 
- Input image name manually
- Start service

If you need a test server that has a private image, please let me know.

Review Check List
- [x] You can see the manual input
  <img width="513" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/8f2fddae-cef5-4923-9c1f-189c217c8aae">
- [x] If manual name exists, environment/version form items are disabled (eg. `bai-repo:7080/library/python:3.9-ubuntu20.04`)
  <img width="501" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/a0024ae1-8c44-48cd-9268-093fafb2c52e">
- [x] After creating the service, you can see the image name that you input manually in the detail page(endpoint list).
  <img width="1182" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/95efcd01-5dcf-4e3f-abf3-f220bb487a82">

```[tasklist]
### Tasks
- [x] Add form item for manual name
- [x] Check the related views to display the selected image.
```

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
