### PR TITLE
fix: model service owner always represented as logged in user

### DIFF
--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -1,4 +1,3 @@
-# PR 1749
 schema {
   query: Queries
   mutation: Mutations
@@ -415,9 +414,9 @@ type User implements Item {
   sudo_session_enabled: Boolean
 
   """
-  Added in 24.03.0. Work as default access key of the user. User's main_access_key is changable but not deletable.
+  Added in 24.03.0. Used as the default authentication credential for password-based logins and sets the user's total resource usage limit. User's main_access_key cannot be deleted, and only super-admin can replace main_access_key.
   """
-  main_access_key: String 
+  main_access_key: String
   groups: [UserGroup]
 }
 
@@ -726,8 +725,20 @@ type Endpoint implements Item {
   url: String
   model: UUID
   model_mount_destiation: String
-  created_user: UUID
-  session_owner: UUID
+  created_user: UUID @deprecated(reason: "Deprecated since 23.09.8; use `created_user_id`")
+
+  """Added at 23.09.8"""
+  created_user_email: String
+
+  """Added at 23.09.8"""
+  created_user_id: UUID
+  session_owner: UUID @deprecated(reason: "Deprecated since 23.09.8; use `session_owner_id`")
+
+  """Added at 23.09.8"""
+  session_owner_email: String
+
+  """Added at 23.09.8"""
+  session_owner_id: UUID
   tag: String
   startup_command: String
   bootstrap_script: String

--- a/react/src/components/EndpointOwnerInfo.tsx
+++ b/react/src/components/EndpointOwnerInfo.tsx
@@ -1,0 +1,56 @@
+import { useSuspendedBackendaiClient } from '../hooks';
+import { EndpointOwnerInfoFragment$key } from './__generated__/EndpointOwnerInfoFragment.graphql';
+import { QuestionCircleOutlined } from '@ant-design/icons';
+import { Button, Tooltip, theme } from 'antd';
+import graphql from 'babel-plugin-relay/macro';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useFragment } from 'react-relay';
+
+interface EndpointOwnerInfoProps {
+  endpointFrgmt: EndpointOwnerInfoFragment$key | null;
+}
+const EndpointOwnerInfo: React.FC<EndpointOwnerInfoProps> = ({
+  endpointFrgmt,
+}) => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const baiClient = useSuspendedBackendaiClient();
+
+  const endpoint = useFragment(
+    graphql`
+      fragment EndpointOwnerInfoFragment on Endpoint {
+        id
+        created_user_email @since(version: "23.09.8")
+        session_owner_email @since(version: "23.09.8")
+      }
+    `,
+    endpointFrgmt,
+  );
+
+  if (!baiClient.supports('model-serving-endpoint-user-info'))
+    return baiClient.email || '';
+  if (endpoint?.created_user_email === endpoint?.session_owner_email)
+    return endpoint?.session_owner_email || '';
+  else
+    return (
+      <>
+        {endpoint?.session_owner_email || ''}
+        <Tooltip
+          title={t('modelService.ServiceDelegatedFrom', {
+            createdUser: endpoint?.created_user_email || '',
+            sessionOwner: endpoint?.session_owner_email || '',
+          })}
+        >
+          <Button
+            size="small"
+            type="text"
+            icon={<QuestionCircleOutlined />}
+            style={{ color: token.colorTextSecondary }}
+          />
+        </Tooltip>
+      </>
+    );
+};
+
+export default EndpointOwnerInfo;

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -126,8 +126,6 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
             resource_group
             resource_slots
             resource_opts
-            created_user_email
-            session_owner_email
             routings {
               routing_id
               session

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -227,7 +227,13 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
           </Tooltip>
         </>
       );
-  }, [endpoint?.created_user_email, endpoint?.session_owner_email]);
+  }, [
+    endpoint?.created_user_email,
+    endpoint?.session_owner_email,
+    baiClient,
+    t,
+    token.colorTextSecondary,
+  ]);
 
   const resource_opts = JSON.parse(endpoint?.resource_opts || '{}');
   return (

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -1,4 +1,5 @@
 import CopyableCodeText from '../components/CopyableCodeText';
+import EndpointOwnerInfo from '../components/EndpointOwnerInfo';
 import EndpointStatusTag from '../components/EndpointStatusTag';
 import EndpointTokenGenerationModal from '../components/EndpointTokenGenerationModal';
 import Flex from '../components/Flex';
@@ -134,6 +135,7 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
               endpoint
               status
             }
+            ...EndpointOwnerInfoFragment
             ...EndpointStatusTagFragment
             ...ModelServiceSettingModal_endpoint
           }
@@ -202,38 +204,6 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
     }
     return color;
   };
-
-  const sessionOwnerElement = React.useMemo(() => {
-    if (!baiClient.supports('model-serving-endpoint-user-info'))
-      return baiClient.email || '';
-    if (endpoint?.created_user_email === endpoint?.session_owner_email)
-      return endpoint?.session_owner_email || '';
-    else
-      return (
-        <>
-          {endpoint?.session_owner_email || ''}
-          <Tooltip
-            title={t('modelService.ServiceDelegatedFrom', {
-              createdUser: endpoint?.created_user_email || '',
-              sessionOwner: endpoint?.session_owner_email || '',
-            })}
-          >
-            <Button
-              size="small"
-              type="text"
-              icon={<QuestionCircleOutlined />}
-              style={{ color: token.colorTextSecondary }}
-            />
-          </Tooltip>
-        </>
-      );
-  }, [
-    endpoint?.created_user_email,
-    endpoint?.session_owner_email,
-    baiClient,
-    t,
-    token.colorTextSecondary,
-  ]);
 
   const resource_opts = JSON.parse(endpoint?.resource_opts || '{}');
   return (
@@ -334,7 +304,7 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
             },
             {
               label: t('modelService.SessionOwner'),
-              children: sessionOwnerElement,
+              children: <EndpointOwnerInfo endpointFrgmt={endpoint} />,
             },
             {
               label: t('modelService.DesiredSessionCount'),

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -126,8 +126,8 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
             resource_group
             resource_slots
             resource_opts
-            created_user_email @since(version: "23.09.8")
-            session_owner_email @since(version: "23.09.8")
+            created_user_email
+            session_owner_email
             routings {
               routing_id
               session

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -125,6 +125,8 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
             resource_group
             resource_slots
             resource_opts
+            created_user_email @since(version: "23.09.8")
+            session_owner_email @since(version: "23.09.8")
             routings {
               routing_id
               session
@@ -200,6 +202,32 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
     }
     return color;
   };
+
+  const sessionOwnerElement = React.useMemo(() => {
+    if (!baiClient.supports('model-serving-endpoint-user-info'))
+      return baiClient.email || '';
+    if (endpoint?.created_user_email === endpoint?.session_owner_email)
+      return endpoint?.session_owner_email || '';
+    else
+      return (
+        <>
+          {endpoint?.session_owner_email || ''}
+          <Tooltip
+            title={t('modelService.ServiceDelegatedFrom', {
+              createdUser: endpoint?.created_user_email || '',
+              sessionOwner: endpoint?.session_owner_email || '',
+            })}
+          >
+            <Button
+              size="small"
+              type="text"
+              icon={<QuestionCircleOutlined />}
+              style={{ color: token.colorTextSecondary }}
+            />
+          </Tooltip>
+        </>
+      );
+  }, [endpoint?.created_user_email, endpoint?.session_owner_email]);
 
   const resource_opts = JSON.parse(endpoint?.resource_opts || '{}');
   return (
@@ -300,7 +328,7 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
             },
             {
               label: t('modelService.SessionOwner'),
-              children: baiClient.email || '',
+              children: sessionOwnerElement,
             },
             {
               label: t('modelService.DesiredSessionCount'),

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -178,6 +178,7 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
       ? [
           {
             title: t('modelService.Owner'),
+            // created_user_email is refered by EndpointOwnerInfoFragment
             dataIndex: 'created_user_email',
             key: 'session_owner',
             render: (_: string, endpoint_info: Endpoint) => (
@@ -283,8 +284,6 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
               url
               open_to_public
               created_at @since(version: "23.09.0")
-              created_user_email
-              session_owner_email
               desired_session_count @required(action: NONE)
               routings {
                 routing_id

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -1,4 +1,5 @@
 import BAIModal from '../components/BAIModal';
+import EndpointOwnerInfo from '../components/EndpointOwnerInfo';
 import EndpointStatusTag from '../components/EndpointStatusTag';
 import Flex from '../components/Flex';
 import ModelServiceSettingModal from '../components/ModelServiceSettingModal';
@@ -177,9 +178,11 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
       ? [
           {
             title: t('modelService.Owner'),
-            dataIndex: 'created_user',
+            dataIndex: 'created_user_email',
             key: 'session_owner',
-            render: (created_user: string) => created_user,
+            render: (_: string, endpoint_info: Endpoint) => (
+              <EndpointOwnerInfo endpointFrgmt={endpoint_info} />
+            ),
           },
         ]
       : []),
@@ -280,7 +283,8 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
               url
               open_to_public
               created_at @since(version: "23.09.0")
-              created_user
+              created_user_email @since(version: "23.09.8")
+              session_owner_email @since(version: "23.09.8")
               desired_session_count @required(action: NONE)
               routings {
                 routing_id
@@ -290,6 +294,7 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
                 status
               }
               ...ModelServiceSettingModal_endpoint
+              ...EndpointOwnerInfoFragment
               ...EndpointStatusTagFragment
             }
           }

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -283,8 +283,8 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
               url
               open_to_public
               created_at @since(version: "23.09.0")
-              created_user_email @since(version: "23.09.8")
-              session_owner_email @since(version: "23.09.8")
+              created_user_email
+              session_owner_email
               desired_session_count @required(action: NONE)
               routings {
                 routing_id

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "Der Variablenname muss mit einem Buchstaben oder Unterstrich beginnen und darf nur Buchstaben, Zahlen und Unterstriche enthalten.",
       "EnvironmentVariableDuplicateName": "Ein Variablenname, der bereits existiert.",
       "Template": "Sitzungsvorlage",
-      "EnableAutomaticShmem": "Automatischer gemeinsamer Speicher"
+      "EnableAutomaticShmem": "Automatischer gemeinsamer Speicher",
+      "PreOpenPortMaxCountLimit_plural": "__NOT_TRANSLATED__"
     },
     "Preparing": "Vorbereitung...",
     "PreparingSession": "Sitzung vorbereiten...",
@@ -1397,7 +1398,8 @@
     "Active/Total": "Aktiv/Gesamt",
     "Public": "Öffentlich",
     "YouAreAboutToTerminate": "Sie stehen kurz vor der Beendigung",
-    "Owner": "Eigentümer"
+    "Owner": "Eigentümer",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "Es ist ein Fehler aufgetreten.",

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1399,7 +1399,7 @@
     "Public": "Öffentlich",
     "YouAreAboutToTerminate": "Sie stehen kurz vor der Beendigung",
     "Owner": "Eigentümer",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Der Modelldienst wird von {{ createdUser }} erstellt, aber das Eigentum an der Sitzung wird an {{ sessionOwner }} delegiert."
   },
   "ErrorBoundary": {
     "title": "Es ist ein Fehler aufgetreten.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "Το όνομα της μεταβλητής πρέπει να αρχίζει με γράμμα ή υπογράμμιση και μπορεί να περιέχει μόνο γράμματα, αριθμούς και υπογράμμιση.",
       "EnvironmentVariableDuplicateName": "Ένα όνομα μεταβλητής που υπάρχει ήδη.",
       "Template": "Πρότυπο συνεδρίας",
-      "EnableAutomaticShmem": "Αυτόματη κοινή μνήμη"
+      "EnableAutomaticShmem": "Αυτόματη κοινή μνήμη",
+      "PreOpenPortMaxCountLimit_plural": "__NOT_TRANSLATED__"
     },
     "Preparing": "Προετοιμασία ...",
     "PreparingSession": "Προετοιμασία συνεδρίας ...",
@@ -1397,7 +1398,8 @@
     "Active/Total": "Ενεργό/Σύνολο",
     "Public": "Δημόσιο",
     "YouAreAboutToTerminate": "Πρόκειται να τερματίσετε",
-    "Owner": "Ιδιοκτήτης"
+    "Owner": "Ιδιοκτήτης",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "Εμφανίστηκε σφάλμα.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1399,7 +1399,7 @@
     "Public": "Δημόσιο",
     "YouAreAboutToTerminate": "Πρόκειται να τερματίσετε",
     "Owner": "Ιδιοκτήτης",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Το μοντέλο υπηρεσίας δημιουργείται από τον {{ createdUser }}, αλλά η ιδιοκτησία της συνεδρίας θα ανατεθεί στον {{ sessionOwner }}"
   },
   "ErrorBoundary": {
     "title": "Εμφανίστηκε σφάλμα.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -266,7 +266,8 @@
       "EnvironmentVariableNamePatternError": "Variable name must start with a letter or underscore, and can only contain letters, numbers, and underscores.",
       "EnvironmentVariableDuplicateName": "A variable name that already exists.",
       "Template": "Session Template",
-      "EnableAutomaticShmem": "Automatic shared memory"
+      "EnableAutomaticShmem": "Automatic shared memory",
+      "PreOpenPortMaxCountLimit_plural": "PreOpenPortMaxCountLimit"
     },
     "Preparing": "Preparing...",
     "PreparingSession": "Preparing session...",
@@ -432,7 +433,8 @@
     "FormValidationFailed": "Form validation failed",
     "resources": "Resources",
     "Image": "Image",
-    "Owner": "Owner"
+    "Owner": "Owner",
+    "ServiceDelegatedFrom": "Model service is created by {{ createdUser }} but the session ownership will be delegated to {{ sessionOwner }}"
   },
   "button": {
     "Cancel": "Cancel",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -718,7 +718,7 @@
     "YouAreAboutToTerminate": "Está a punto de terminar",
     "resources": "Recursos",
     "Owner": "Dueño",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "El servicio modelo es creado por {{ createdUser }} pero la propiedad de la sesión será delegada a {{ sessionOwner }}"
   },
   "notification": {
     "Initializing": "Inicializando...",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -717,7 +717,8 @@
     "TrafficRatio": "Ratio de tráfico",
     "YouAreAboutToTerminate": "Está a punto de terminar",
     "resources": "Recursos",
-    "Owner": "Dueño"
+    "Owner": "Dueño",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "notification": {
     "Initializing": "Inicializando...",
@@ -1132,7 +1133,8 @@
       "EnvironmentVariableNamePatternError": "El nombre de la variable debe empezar por una letra o un guión bajo, y sólo puede contener letras, números y guiones bajos.",
       "EnvironmentVariableDuplicateName": "Un nombre de variable que ya existe.",
       "Template": "Plantilla de sesión",
-      "EnableAutomaticShmem": "Memoria compartida automática"
+      "EnableAutomaticShmem": "Memoria compartida automática",
+      "PreOpenPortMaxCountLimit_plural": "__NOT_TRANSLATED__"
     },
     "ExpiresAfter": "Tiempo restante",
     "CPU": "CPU",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -718,7 +718,7 @@
     "YouAreAboutToTerminate": "Olet lopettamassa",
     "resources": "Resurssit",
     "Owner": "Omistaja",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Mallipalvelun luo {{ createdUser }}, mutta istunnon omistusoikeus siirretään {{ sessionOwner }}:lle."
   },
   "notification": {
     "Initializing": "Aloitetaan...",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -717,7 +717,8 @@
     "TrafficRatio": "Liikennesuhde",
     "YouAreAboutToTerminate": "Olet lopettamassa",
     "resources": "Resurssit",
-    "Owner": "Omistaja"
+    "Owner": "Omistaja",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "notification": {
     "Initializing": "Aloitetaan...",
@@ -1132,7 +1133,8 @@
       "EnvironmentVariableDuplicateName": "Muuttujan nimi, joka on jo olemassa.",
       "ErrorCanNotExceedRemaining": "Ei voida asettaa suuremmaksi kuin jäljellä olevat resurssit ({{amount}}).",
       "EnableAutomaticShmem": "Automaattinen jaettu muisti",
-      "Template": "Istuntomalli"
+      "Template": "Istuntomalli",
+      "PreOpenPortMaxCountLimit_plural": "__NOT_TRANSLATED__"
     },
     "ExpiresAfter": "Jäljellä oleva aika",
     "CPU": "CPU",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "Le nom de la variable doit commencer par une lettre ou un trait de soulignement et ne peut contenir que des lettres, des chiffres et des traits de soulignement.",
       "EnvironmentVariableDuplicateName": "Un nom de variable qui existe déjà.",
       "Template": "Modèle de session",
-      "EnableAutomaticShmem": "Mémoire partagée automatique"
+      "EnableAutomaticShmem": "Mémoire partagée automatique",
+      "PreOpenPortMaxCountLimit_plural": "__NOT_TRANSLATED__"
     },
     "Preparing": "En train de préparer...",
     "PreparingSession": "Séance de préparation...",
@@ -1446,7 +1447,8 @@
     "ServiceNameRule": "Seuls 4 à 24 caractères alphanumériques, le trait de soulignement (_), le trait d'union (-) et le point (.) sont autorisés et le texte doit se terminer par un caractère alphanumérique.",
     "resources": "Ressources",
     "Image": "Image",
-    "Owner": "Propriétaire"
+    "Owner": "Propriétaire",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "Une erreur s'est produite.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1448,7 +1448,7 @@
     "resources": "Ressources",
     "Image": "Image",
     "Owner": "Propriétaire",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Le service modèle est créé par {{ createdUser }} mais la propriété de la session sera déléguée à {{ sessionOwner }}."
   },
   "ErrorBoundary": {
     "title": "Une erreur s'est produite.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "Nama variabel harus dimulai dengan huruf atau garis bawah, dan hanya boleh terdiri dari huruf, angka, dan garis bawah.",
       "EnvironmentVariableDuplicateName": "Nama variabel yang sudah ada.",
       "Template": "Templat Sesi",
-      "EnableAutomaticShmem": "Memori bersama otomatis"
+      "EnableAutomaticShmem": "Memori bersama otomatis",
+      "PreOpenPortMaxCountLimit_0": "__NOT_TRANSLATED__"
     },
     "Preparing": "Mempersiapkan...",
     "PreparingSession": "Mempersiapkan sesi...",
@@ -1446,7 +1447,8 @@
     "ServiceNameRule": "Hanya mengizinkan 4 hingga 24 karakter alfanumerik, garis bawah (_), tanda hubung (-), dan titik (.) dan harus diakhiri dengan karakter alfanumerik.",
     "resources": "Sumber daya",
     "Image": "Gambar",
-    "Owner": "Pemilik"
+    "Owner": "Pemilik",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "Telah terjadi kesalahan.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1448,7 +1448,7 @@
     "resources": "Sumber daya",
     "Image": "Gambar",
     "Owner": "Pemilik",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Layanan model dibuat oleh {{ createdUser }} namun kepemilikan sesi akan didelegasikan ke {{ sessionOwner }}"
   },
   "ErrorBoundary": {
     "title": "Telah terjadi kesalahan.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "Il nome della variabile deve iniziare con una lettera o un trattino basso e può contenere solo lettere, numeri e trattini bassi.",
       "EnvironmentVariableDuplicateName": "Un nome di variabile già esistente.",
       "Template": "Modello di sessione",
-      "EnableAutomaticShmem": "Memoria condivisa automatica"
+      "EnableAutomaticShmem": "Memoria condivisa automatica",
+      "PreOpenPortMaxCountLimit_plural": "__NOT_TRANSLATED__"
     },
     "Preparing": "Preparazione...",
     "PreparingSession": "Preparazione della sessione...",
@@ -1397,7 +1398,8 @@
     "Active/Total": "Attivo/Totale",
     "Public": "Pubblico",
     "YouAreAboutToTerminate": "State per terminare",
-    "Owner": "Proprietario"
+    "Owner": "Proprietario",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "Si è verificato un errore.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1399,7 +1399,7 @@
     "Public": "Pubblico",
     "YouAreAboutToTerminate": "State per terminare",
     "Owner": "Proprietario",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Il servizio modello è creato da {{ createdUser }}, ma la proprietà della sessione sarà delegata a {{ sessionOwner }}."
   },
   "ErrorBoundary": {
     "title": "Si è verificato un errore.",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1399,7 +1399,7 @@
     "YouAreAboutToTerminate": "以下のサービスを削除しようとします：",
     "Image": "イメージ",
     "Owner": "所有者",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "モデルサービスは{{ createdUser }}によって作成されますが、セッションの所有権は{{ sessionOwner }}に委譲されます。"
   },
   "ErrorBoundary": {
     "title": "エラーが発生しました。",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "変数名は文字またはアンダースコアで始まり、文字、数字、アンダースコアのみを含むことができます。",
       "EnvironmentVariableDuplicateName": "既に存在する変数名です。",
       "Template": "セッションテンプレート",
-      "EnableAutomaticShmem": "自動共有メモリー"
+      "EnableAutomaticShmem": "自動共有メモリー",
+      "PreOpenPortMaxCountLimit_0": "__NOT_TRANSLATED__"
     },
     "Preparing": "準備...",
     "PreparingSession": "セッションの準備...",
@@ -1397,7 +1398,8 @@
     "Public": "公開",
     "YouAreAboutToTerminate": "以下のサービスを削除しようとします：",
     "Image": "イメージ",
-    "Owner": "所有者"
+    "Owner": "所有者",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "エラーが発生しました。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -255,7 +255,8 @@
       "EnterEnvironmentVariable": "변수 이름 입력해주세요.",
       "EnvironmentVariableNamePatternError": "변수 이름은 문자 또는 밑줄로 시작해야 하며 문자, 숫자, 밑줄만 포함할 수 있습니다.",
       "EnvironmentVariableDuplicateName": "이미 존재하는 변수명입니다.",
-      "EnableAutomaticShmem": "자동 공유메모리 설정"
+      "EnableAutomaticShmem": "자동 공유메모리 설정",
+      "PreOpenPortMaxCountLimit_0": "__NOT_TRANSLATED__"
     },
     "Preparing": "준비중...",
     "PreparingSession": "세션 준비중...",
@@ -421,7 +422,8 @@
     "FormValidationFailed": "양식 유효성 검사 실패",
     "resources": "자원",
     "Image": "이미지",
-    "Owner": "소유자"
+    "Owner": "소유자",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "button": {
     "Cancel": "취소",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -423,7 +423,7 @@
     "resources": "자원",
     "Image": "이미지",
     "Owner": "소유자",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "모델 서비스는 {{ createdUser }}에 의해 생성되지만 세션 소유권은 {{ sessionOwner }}에 위임됩니다."
   },
   "button": {
     "Cancel": "취소",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "Хувьсагчийн нэр үсэг эсвэл доогуур зураасаар эхлэх ёстой бөгөөд зөвхөн үсэг, тоо, доогуур зураас агуулсан байж болно.",
       "EnvironmentVariableDuplicateName": "Энэ хувьсагчийн нэр аль хэдийн байна.",
       "Template": "Сеанс загвар",
-      "EnableAutomaticShmem": "Автомат хуваалцсан санах ой"
+      "EnableAutomaticShmem": "Автомат хуваалцсан санах ой",
+      "PreOpenPortMaxCountLimit_plural": "__NOT_TRANSLATED__"
     },
     "Preparing": "Бэлтгэж байна ...",
     "PreparingSession": "Session бэлтгэж байна ...",
@@ -1446,7 +1447,8 @@
     "ServiceNameRule": "Зөвхөн 4-24 үсэг тоо, доогуур зураас(_), зураас(-), цэг(.) оруулахыг зөвшөөрөх ба энэ нь үсэг, тоон тэмдэгтээр төгсөх ёстой.",
     "resources": "Нөөц",
     "Image": "Зураг",
-    "Owner": "Эзэмшигч"
+    "Owner": "Эзэмшигч",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "Алдаа гарсан байна.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1448,7 +1448,7 @@
     "resources": "Нөөц",
     "Image": "Зураг",
     "Owner": "Эзэмшигч",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Загвар үйлчилгээг {{ createdUser }} үүсгэсэн боловч сессийн эрхийг {{ sessionOwner }}-д шилжүүлнэ."
   },
   "ErrorBoundary": {
     "title": "Алдаа гарсан байна.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableDuplicateName": "Nama pembolehubah ini sudah wujud.",
       "Template": "Templat Sesi",
       "EnableAutomaticShmem": "Memori dikongsi automatik",
-      "PreOpenPortMaxCountLimit": "Anda boleh menyediakan kepada {{count}} port pra-buka."
+      "PreOpenPortMaxCountLimit": "Anda boleh menyediakan kepada {{count}} port pra-buka.",
+      "PreOpenPortMaxCountLimit_0": "__NOT_TRANSLATED__"
     },
     "Preparing": "Menyiapkan ...",
     "PreparingSession": "Menyiapkan sesi ...",
@@ -1437,7 +1438,8 @@
     "Active/Total": "Aktif/Jumlah",
     "Public": "Awam",
     "YouAreAboutToTerminate": "Anda akan menamatkan perkhidmatan",
-    "Owner": "Pemilik"
+    "Owner": "Pemilik",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "totp": {
     "TotpSetupCompleted": "Didayakan 2FA",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1439,7 +1439,7 @@
     "Public": "Awam",
     "YouAreAboutToTerminate": "Anda akan menamatkan perkhidmatan",
     "Owner": "Pemilik",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Perkhidmatan model dicipta oleh {{ createdUser }} tetapi pemilikan sesi akan diwakilkan kepada {{ sessionOwner }}"
   },
   "totp": {
     "TotpSetupCompleted": "Didayakan 2FA",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1401,7 +1401,7 @@
     "Public": "Publiczny",
     "YouAreAboutToTerminate": "Zamierzasz zakończyć",
     "Owner": "Właściciel",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Usługa modelu jest tworzona przez {{ createdUser }}, ale własność sesji będzie delegowana do {{ sessionOwner }}."
   },
   "ErrorBoundary": {
     "title": "Wystąpił błąd.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -255,7 +255,10 @@
       "EnvironmentVariableNamePatternError": "Nazwa zmiennej musi zaczynać się od litery lub podkreślenia i może zawierać tylko litery, cyfry i podkreślenia.",
       "EnvironmentVariableDuplicateName": "Nazwa zmiennej, która już istnieje.",
       "Template": "Szablon sesji",
-      "EnableAutomaticShmem": "Automatyczna pamięć współdzielona"
+      "EnableAutomaticShmem": "Automatyczna pamięć współdzielona",
+      "PreOpenPortMaxCountLimit_0": "__NOT_TRANSLATED__",
+      "PreOpenPortMaxCountLimit_1": "__NOT_TRANSLATED__",
+      "PreOpenPortMaxCountLimit_2": "__NOT_TRANSLATED__"
     },
     "Preparing": "Przygotowuję...",
     "PreparingSession": "Przygotowuję sesję...",
@@ -1397,7 +1400,8 @@
     "Active/Total": "Aktywny/Ogółem",
     "Public": "Publiczny",
     "YouAreAboutToTerminate": "Zamierzasz zakończyć",
-    "Owner": "Właściciel"
+    "Owner": "Właściciel",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "Wystąpił błąd.",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "O nome da variável deve começar com uma letra ou um sublinhado e só pode conter letras, números e sublinhados.",
       "EnvironmentVariableDuplicateName": "Um nome de variável que já existe.",
       "Template": "Modelo de sessão",
-      "EnableAutomaticShmem": "Memória partilhada automática"
+      "EnableAutomaticShmem": "Memória partilhada automática",
+      "PreOpenPortMaxCountLimit_plural": "__NOT_TRANSLATED__"
     },
     "Preparing": "Preparando...",
     "PreparingSession": "Preparando sessão ...",
@@ -1437,7 +1438,8 @@
     "Active/Total": "Ativo/Total",
     "Public": "Público",
     "YouAreAboutToTerminate": "Está prestes a terminar",
-    "Owner": "Proprietário"
+    "Owner": "Proprietário",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "totp": {
     "TotpSetupCompleted": "Ativado 2FA",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1439,7 +1439,7 @@
     "Public": "Público",
     "YouAreAboutToTerminate": "Está prestes a terminar",
     "Owner": "Proprietário",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "O serviço de modelo é criado por {{ createdUser }} mas a propriedade da sessão será delegada a {{ sessionOwner }}"
   },
   "totp": {
     "TotpSetupCompleted": "Ativado 2FA",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1439,7 +1439,7 @@
     "YouAreAboutToTerminate": "Está prestes a terminar",
     "Image": "Imagem",
     "Owner": "Proprietário",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "O serviço de modelo é criado por {{ createdUser }} mas a propriedade da sessão será delegada a {{ sessionOwner }}"
   },
   "totp": {
     "TotpSetupCompleted": "Ativado 2FA",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "O nome da variável deve começar com uma letra ou um sublinhado e só pode conter letras, números e sublinhados.",
       "EnvironmentVariableDuplicateName": "Um nome de variável que já existe.",
       "Template": "Modelo de sessão",
-      "EnableAutomaticShmem": "Memória partilhada automática"
+      "EnableAutomaticShmem": "Memória partilhada automática",
+      "PreOpenPortMaxCountLimit_plural": "__NOT_TRANSLATED__"
     },
     "Preparing": "Preparando...",
     "PreparingSession": "Preparando sessão ...",
@@ -1437,7 +1438,8 @@
     "Public": "Público",
     "YouAreAboutToTerminate": "Está prestes a terminar",
     "Image": "Imagem",
-    "Owner": "Proprietário"
+    "Owner": "Proprietário",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "totp": {
     "TotpSetupCompleted": "Ativado 2FA",
@@ -1479,7 +1481,8 @@
     "Task": "Tarefa",
     "CloneAsFolder": "Clonar como Pasta",
     "CloneSuccess": "O pedido de clone foi enviado com sucesso.",
-    "category": "Categoria"
+    "category": "Categoria",
+    "CloneInfo": "__NOT_TRANSLATED__"
   },
   "table": {
     "SettingTable": "Configuração de mesa",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -255,7 +255,10 @@
       "EnvironmentVariableNamePatternError": "Имя переменной должно начинаться с буквы или символа подчеркивания и может содержать только буквы, цифры и символы подчеркивания.",
       "EnvironmentVariableDuplicateName": "Имя переменной, которая уже существует.",
       "Template": "Шаблон сессии",
-      "EnableAutomaticShmem": "Автоматическая разделяемая память"
+      "EnableAutomaticShmem": "Автоматическая разделяемая память",
+      "PreOpenPortMaxCountLimit_0": "__NOT_TRANSLATED__",
+      "PreOpenPortMaxCountLimit_1": "__NOT_TRANSLATED__",
+      "PreOpenPortMaxCountLimit_2": "__NOT_TRANSLATED__"
     },
     "Preparing": "Подготовка ...",
     "PreparingSession": "Подготовка сеанса ...",
@@ -1446,7 +1449,8 @@
     "ServiceNameRule": "Допускается только от 4 до 24 буквенно-цифровых символов, символов подчеркивания (_), дефиса (-) и точки(.), и он должен заканчиваться буквенно-цифровым символом.",
     "resources": "Ресурсы",
     "Image": "Изображение",
-    "Owner": "Владелец"
+    "Owner": "Владелец",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "Произошла ошибка.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1450,7 +1450,7 @@
     "resources": "Ресурсы",
     "Image": "Изображение",
     "Owner": "Владелец",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Сервис модели создается {{ createdUser }}, но право владения сессией будет передано {{ sessionOwner }}."
   },
   "ErrorBoundary": {
     "title": "Произошла ошибка.",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1399,7 +1399,7 @@
     "Public": "Kamu",
     "YouAreAboutToTerminate": "Sonlandırmak üzeresiniz",
     "Owner": "Mal sahibi",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Model hizmeti {{ createdUser }} tarafından oluşturulur ancak oturum sahipliği {{ sessionOwner }}'a devredilir."
   },
   "ErrorBoundary": {
     "title": "Bir hata oluştu.",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "Değişken adı bir harf veya alt çizgi ile başlamalıdır ve yalnızca harfler, sayılar ve alt çizgiler içerebilir.",
       "EnvironmentVariableDuplicateName": "Zaten var olan bir değişken adı.",
       "Template": "Oturum Şablonu",
-      "EnableAutomaticShmem": "Otomatik paylaşılan bellek"
+      "EnableAutomaticShmem": "Otomatik paylaşılan bellek",
+      "PreOpenPortMaxCountLimit_plural": "__NOT_TRANSLATED__"
     },
     "Preparing": "hazırlanıyor...",
     "PreparingSession": "Oturum hazırlanıyor...",
@@ -1397,7 +1398,8 @@
     "Active/Total": "Aktif/Toplam",
     "Public": "Kamu",
     "YouAreAboutToTerminate": "Sonlandırmak üzeresiniz",
-    "Owner": "Mal sahibi"
+    "Owner": "Mal sahibi",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "ErrorBoundary": {
     "title": "Bir hata oluştu.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableDuplicateName": "Tên biến này đã tồn tại.",
       "Template": "Mẫu phiên",
       "EnableAutomaticShmem": "Bộ nhớ chia sẻ tự động",
-      "PreOpenPortMaxCountLimit": "Bạn có thể thiết lập tối đa {{count}} cổng mở trước."
+      "PreOpenPortMaxCountLimit": "Bạn có thể thiết lập tối đa {{count}} cổng mở trước.",
+      "PreOpenPortMaxCountLimit_0": "__NOT_TRANSLATED__"
     },
     "Preparing": "Đang chuẩn bị ...",
     "PreparingSession": "Đang chuẩn bị phiên ...",
@@ -1437,7 +1438,8 @@
     "Active/Total": "Đang hoạt động/Tổng cộng",
     "Public": "Công cộng",
     "YouAreAboutToTerminate": "Bạn sắp chấm dứt",
-    "Owner": "Người sở hữu"
+    "Owner": "Người sở hữu",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "totp": {
     "TotpSetupCompleted": "Đã bật 2FA",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1439,7 +1439,7 @@
     "Public": "Công cộng",
     "YouAreAboutToTerminate": "Bạn sắp chấm dứt",
     "Owner": "Người sở hữu",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "Dịch vụ mô hình được tạo bởi {{ createUser }} nhưng quyền sở hữu phiên sẽ được ủy quyền cho {{ sessionOwner }}"
   },
   "totp": {
     "TotpSetupCompleted": "Đã bật 2FA",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "变量名必须以字母或下划线开头，且只能包含字母、数字和下划线。",
       "EnvironmentVariableDuplicateName": "已经存在的变量名。",
       "Template": "会议模板",
-      "EnableAutomaticShmem": "自动共享内存"
+      "EnableAutomaticShmem": "自动共享内存",
+      "PreOpenPortMaxCountLimit_0": "__NOT_TRANSLATED__"
     },
     "Preparing": "正在准备...",
     "PreparingSession": "正在准备会议...",
@@ -1437,7 +1438,8 @@
     "Public": "公众",
     "YouAreAboutToTerminate": "您即将终止",
     "Image": "图片",
-    "Owner": "所有者"
+    "Owner": "所有者",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "totp": {
     "TotpSetupCompleted": "已启用 2FA",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1439,7 +1439,7 @@
     "YouAreAboutToTerminate": "您即将终止",
     "Image": "图片",
     "Owner": "所有者",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "模型服务由 {{ createdUser }} 创建，但会话所有权将委托给 {{ sessionOwner }}"
   },
   "totp": {
     "TotpSetupCompleted": "已启用 2FA",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -255,7 +255,8 @@
       "EnvironmentVariableNamePatternError": "变量名必须以字母或下划线开头，且只能包含字母、数字和下划线。",
       "EnvironmentVariableDuplicateName": "已经存在的变量名。",
       "Template": "会议模板",
-      "EnableAutomaticShmem": "自动共享内存"
+      "EnableAutomaticShmem": "自动共享内存",
+      "PreOpenPortMaxCountLimit_0": "__NOT_TRANSLATED__"
     },
     "Preparing": "正在準備...",
     "PreparingSession": "正在準備會議...",
@@ -1437,7 +1438,8 @@
     "Public": "公众",
     "YouAreAboutToTerminate": "您即将终止",
     "Image": "图片",
-    "Owner": "擁有者"
+    "Owner": "擁有者",
+    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
   },
   "totp": {
     "TotpSetupCompleted": "已启用 2FA",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1439,7 +1439,7 @@
     "YouAreAboutToTerminate": "您即将终止",
     "Image": "图片",
     "Owner": "擁有者",
-    "ServiceDelegatedFrom": "__NOT_TRANSLATED__"
+    "ServiceDelegatedFrom": "模型服务由 {{ createdUser }} 创建，但会话所有权将委托给 {{ sessionOwner }}"
   },
   "totp": {
     "TotpSetupCompleted": "已启用 2FA",

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -669,6 +669,9 @@ class Client {
     if (this.isManagerVersionCompatibleWith('23.09.7')) {
       this._features['main-access-key'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('23.09.8')) {
+      this._features['model-serving-endpoint-user-info'] = true;
+    }
     if (this.isManagerVersionCompatibleWith('24.03.0')) {
       this._features['max-vfolder-count-in-user-resource-policy'] = true;
       this._features['model-store'] = true;


### PR DESCRIPTION
This PR resolves owner of model session always being shown as the email of current logged in user, by pulling out user information from the new GQL fields introduced at lablup/backend.ai#1831. Previous approach can cause confusion to the system admin, as they are possible to also take a look at the status of model service created by other users. 
<img width="1437" alt="Screenshot 2024-01-10 at 12 04 47 PM" src="https://github.com/lablup/backend.ai-webui/assets/2904494/165b5595-392d-4871-9744-049759ee677e">
Now this displays the true information correctly.
<img width="1421" alt="Screenshot 2024-01-10 at 12 02 01 PM" src="https://github.com/lablup/backend.ai-webui/assets/2904494/fdf6cdae-8290-423f-a4db-4a54810d6fb6">
Whenever there's a difference between model service creator and actual model session owner, by hovering the cursor over question mark webui will show a tooltip mentioning about these facts. 
Testing this PR will require a Backend.AI server with lablup/backend.ai#1831 patch applied.

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [x] Minimum required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
