### PR TITLE
feature: Improve edu-applauncher scalability for adding session templates

### DIFF
--- a/src/components/backend-ai-edu-applauncher.ts
+++ b/src/components/backend-ai-edu-applauncher.ts
@@ -367,7 +367,7 @@ export default class BackendAiEduApplauncher extends BackendAIPage {
         const _sess = sessions.compute_session_list.items[i];
         const sessionImage = _sess.image;
         const servicePorts = JSON.parse(_sess.service_ports || '{}');
-        const services = servicePorts.map((s) => s.name);
+        const services = Object.keys(servicePorts).map((s) => s.name) || [];
         const sessionStatus = _sess.status;
         if (
           sessionImage != requestedSessionTemplate.template.spec.kernel.image

--- a/src/components/backend-ai-environment-list.ts
+++ b/src/components/backend-ai-environment-list.ts
@@ -1785,7 +1785,7 @@ export default class BackendAIEnvironmentList extends BackendAIPage {
             <div>${_t('environment.Port')}</div>
             <div>${_t('environment.Action')}</div>
           </div>
-          ${this.servicePorts.map(
+          ${this.servicePorts?.map(
             (item, index) => html`
               <div class="row">
                 <mwc-textfield type="text" value=${item.app}></mwc-textfield>


### PR DESCRIPTION
resolves https://github.com/lablup/giftbox/issues/614
Follow-up #1993 

- Get `sessionTemplate` query string and launch a session with a session template with the given name
- Close edu-applauncher's indicator when any error raises
- remove `sleep` before launching rstudio image because the issue resolved

# How to test
[Follow this link
](https://lablup.sharepoint.com/:fl:/s/b334cd9f-0792-4007-b883-78ef6adfbd9b/EQDtlPsQToxBmeDOi1zljvkBOBxPK00g8cciC60spr_vbA?e=iqkT98&nav=cz0lMkZzaXRlcyUyRmIzMzRjZDlmLTA3OTItNDAwNy1iODgzLTc4ZWY2YWRmYmQ5YiZkPWIlMjFLZDR5eDFONkUwMnN5cG5Kd3dXTnhMbHFzYU12SDlkS2xLeTZHa29tcVUyUTBZcTdyUFJDVEpZdkxqVktWU2h3JmY9MDFLU1JMSFhZQTVXS1BXRUNPUlJBWlRZR09STk9PTERYWiZjPSUyRiZhPUxvb3BBcHAmcD0lNDBmbHVpZHglMkZsb29wLXBhZ2UtY29udGFpbmVyJng9JTdCJTIydyUyMiUzQSUyMlQwUlRVSHhzWVdKc2RYQXVjMmhoY21Wd2IybHVkQzVqYjIxOFlpRkxaRFI1ZURGT05rVXdNbk41Y0c1S2QzZFhUbmhNYkhGellVMTJTRGxrUzJ4TGVUWkhhMjl0Y1ZVeVVUQlpjVGR5VUZKRFZFcFpka3hxVmt0V1UyaDNmREF4UzFOU1RFaFlORFJHV1ZnelFVSkVNak0xUVZrMk4wSklOMDFUVTBkWVdFUSUzRCUyMiUyQyUyMmklMjIlM0ElMjI2ZmExZDIxMy04M2RmLTQyYzItYTYwYS1mNGYzYjVhMzZlZDYlMjIlN0Q%3D)
**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
