### PR TITLE
fix: omit the mark if it is greater than the max

### DIFF
--- a/react/src/components/DynamicUnitInputNumberWithSlider.tsx
+++ b/react/src/components/DynamicUnitInputNumberWithSlider.tsx
@@ -171,7 +171,11 @@ const DynamicUnitInputNumberWithSlider: React.FC<
                   },
                 }),
               // extra: remaining mark code should be located before max mark code to prevent overlapping when it is same value
-              ...extraMarks,
+              ..._.omitBy(extraMarks, (option, key) => {
+                return _.isNumber(maxGiB?.number)
+                  ? _.parseInt(key) > (maxGiB?.number as number)
+                  : false;
+              }),
               ...(maxGiB?.number && {
                 [maxGiB.number]: {
                   style: {

--- a/react/src/components/InputNumberWithSlider.tsx
+++ b/react/src/components/InputNumberWithSlider.tsx
@@ -2,6 +2,7 @@ import Flex from './Flex';
 import { useControllableValue } from 'ahooks';
 import { InputNumber, Slider, InputNumberProps, SliderSingleProps } from 'antd';
 import { SliderRangeProps } from 'antd/es/slider';
+import _ from 'lodash';
 import React, { useEffect } from 'react';
 
 type OmitControlledProps<T> = Omit<T, 'value' | 'onChange'>;
@@ -67,6 +68,10 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
             }
           }}
           {...sliderProps}
+          // remove marks that are greater than max
+          marks={_.omitBy(sliderProps?.marks, (option, key) => {
+            return _.isNumber(max) ? _.parseInt(key) > max : false;
+          })}
         />
       </Flex>
     </Flex>


### PR DESCRIPTION
### Bug
- The sliders of `InputNumberWithSilder` and `DynamicUnitInputNumberWithSlider` display the mark outside the slider when the mark value is greater than the max of the slider.
<img width="1478" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/05bab4f4-7489-410b-98ee-32ab9bd3356d">

### How to reproduce:
Open the service launcher modal in a local dev environment, you can see this bug on the slider for cluster size.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
