### PR TITLE
feat: filter props of VFolderTableFormItem

### DIFF
--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -48,7 +48,7 @@ export interface AliasMap {
 
 type DataIndex = keyof VFolder;
 
-interface Props extends Omit<TableProps<VFolder>, 'rowKey'> {
+export interface VFolderTableProps extends Omit<TableProps<VFolder>, 'rowKey'> {
   showAliasInput?: boolean;
   selectedRowKeys?: VFolderKey[];
   onChangeSelectedRowKeys?: (selectedKeys: VFolderKey[]) => void;
@@ -59,7 +59,7 @@ interface Props extends Omit<TableProps<VFolder>, 'rowKey'> {
   rowKey: string | number;
 }
 
-const VFolderTable: React.FC<Props> = ({
+const VFolderTable: React.FC<VFolderTableProps> = ({
   filter,
   showAliasInput = false,
   selectedRowKeys: controlledSelectedRowKeys = [],

--- a/react/src/components/VFolderTableFormItem.tsx
+++ b/react/src/components/VFolderTableFormItem.tsx
@@ -1,10 +1,12 @@
-import VFolderTable, { AliasMap } from './VFolderTable';
+import VFolderTable, { AliasMap, VFolderTableProps } from './VFolderTable';
 import { Form, FormItemProps, Input } from 'antd';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-interface VFolderTableFromItemProps extends Omit<FormItemProps, 'name'> {}
+interface VFolderTableFromItemProps extends Omit<FormItemProps, 'name'> {
+  filter?: VFolderTableProps['filter'];
+}
 
 export interface VFolderTableFormValues {
   mounts: string[];
@@ -12,6 +14,7 @@ export interface VFolderTableFormValues {
 }
 
 const VFolderTableFromItem: React.FC<VFolderTableFromItemProps> = ({
+  filter,
   ...formItemProps
 }) => {
   const form = Form.useFormInstance();
@@ -62,6 +65,7 @@ const VFolderTableFromItem: React.FC<VFolderTableFromItemProps> = ({
           }}
           // TODO: implement pagination
           pagination={false}
+          filter={filter}
         />
       </Form.Item>
     </>

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -990,7 +990,11 @@ const SessionLauncherPage = () => {
                     display: currentStepKey === 'storage' ? 'block' : 'none',
                   }}
                 >
-                  <VFolderTableFromItem />
+                  <VFolderTableFromItem
+                    filter={(vfolder) => {
+                      return vfolder.status === 'ready';
+                    }}
+                  />
                   {/* <VFolderTable /> */}
                 </Card>
 


### PR DESCRIPTION
resolve #2171

This PR introduces `filter` props of `VFolderTableFormItem` and sets filter to neo session launcher vFolder form item to show only `ready` folders.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
