### PR TITLE
fix: mapping `servicePorts` instead string array when get services.

### DIFF
--- a/src/components/backend-ai-edu-applauncher.ts
+++ b/src/components/backend-ai-edu-applauncher.ts
@@ -367,7 +367,8 @@ export default class BackendAiEduApplauncher extends BackendAIPage {
         const _sess = sessions.compute_session_list.items[i];
         const sessionImage = _sess.image;
         const servicePorts = JSON.parse(_sess.service_ports || '{}');
-        const services = Object.keys(servicePorts).map((s) => s.name) || [];
+        const services =
+          Object.keys(servicePorts).map((s) => servicePorts[s].name) || [];
         const sessionStatus = _sess.status;
         if (
           sessionImage != requestedSessionTemplate.template.spec.kernel.image


### PR DESCRIPTION
follows #2147 
Mapping `servicePorts` instead string array when get services.

Before
```js
const servicePorts = JSON.parse(_sess.service_ports || '{}');
const services = Object.keys(servicePorts).map((s) => s.name) || [];
```
After
```js
const services = Object.keys(servicePorts).map((s) => servicePorts[s].name) || [];
```


**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minimum required manager version: 23.09
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
