### PR TITLE
fix: `initialValues` props of `<Form/>` under Modal doesn't work in Electron

### DIFF
--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -2,10 +2,18 @@ import BAIModal, { BAIModalProps } from './BAIModal';
 import { ContainerRegistryEditorModalCreateMutation } from './__generated__/ContainerRegistryEditorModalCreateMutation.graphql';
 import { ContainerRegistryEditorModalFragment$key } from './__generated__/ContainerRegistryEditorModalFragment.graphql';
 import { ContainerRegistryEditorModalModifyMutation } from './__generated__/ContainerRegistryEditorModalModifyMutation.graphql';
-import { message, Form, Input, Select, Modal, Checkbox } from 'antd';
+import {
+  message,
+  Form,
+  Input,
+  Select,
+  Modal,
+  Checkbox,
+  FormInstance,
+} from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFragment, useMutation } from 'react-relay';
 
@@ -24,7 +32,7 @@ const ContainerRegistryEditorModal: React.FC<
   ...modalProps
 }) => {
   const { t } = useTranslation();
-  const [form] = Form.useForm();
+  const formRef = useRef<FormInstance>(null);
 
   const [messageAPI, contextHolder] = message.useMessage();
   const [modal, modalContextHolder] = Modal.useModal();
@@ -92,8 +100,8 @@ const ContainerRegistryEditorModal: React.FC<
     `);
 
   const handleSave = async () => {
-    return form
-      .validateFields()
+    return formRef.current
+      ?.validateFields()
       .then((values) => {
         const mutationVariables = {
           hostname: values.hostname,
@@ -159,8 +167,8 @@ const ContainerRegistryEditorModal: React.FC<
       okText={containerRegistry ? t('button.Save') : t('button.Add')}
       confirmLoading={isInflightCreateRegistry || isInflightModifyRegistry}
       onOk={() => {
-        form
-          .validateFields()
+        formRef.current
+          ?.validateFields()
           .then((values) => {
             if (
               _.includes(values.config?.type, 'harbor') &&
@@ -189,7 +197,7 @@ const ContainerRegistryEditorModal: React.FC<
       {contextHolder}
       {modalContextHolder}
       <Form
-        form={form}
+        ref={formRef}
         layout="vertical"
         requiredMark="optional"
         initialValues={
@@ -272,17 +280,15 @@ const ContainerRegistryEditorModal: React.FC<
             _.isEmpty(next.config?.password)
           }
         >
-          {() => {
-            form.validateFields([['config', 'username']]);
+          {({ validateFields, getFieldValue }) => {
+            validateFields([['config', 'username']]);
             return (
               <Form.Item
                 name={['config', 'username']}
                 label={t('registry.Username')}
                 rules={[
                   {
-                    required: !_.isEmpty(
-                      form.getFieldValue(['config', 'password']),
-                    ),
+                    required: !_.isEmpty(getFieldValue(['config', 'password'])),
                   },
                 ]}
               >
@@ -299,12 +305,12 @@ const ContainerRegistryEditorModal: React.FC<
               prev.isChangedPassword !== next.isChangedPassword
             }
           >
-            {() => (
+            {({ getFieldValue }) => (
               <Form.Item noStyle name={['config', 'password']}>
                 <Input.Password
                   disabled={
                     !_.isEmpty(containerRegistry) &&
-                    !form.getFieldValue('isChangedPassword')
+                    !getFieldValue('isChangedPassword')
                   }
                 />
               </Form.Item>
@@ -315,7 +321,7 @@ const ContainerRegistryEditorModal: React.FC<
               <Checkbox
                 onChange={(e) => {
                   if (!e.target.checked) {
-                    form.setFieldValue(['config', 'password'], '');
+                    formRef.current?.setFieldValue(['config', 'password'], '');
                   }
                 }}
               >
@@ -358,9 +364,9 @@ const ContainerRegistryEditorModal: React.FC<
           }
           noStyle
         >
-          {() => {
+          {({ getFieldValue }) => {
             return (
-              form.getFieldValue(['config', 'type']) !== 'docker' && (
+              getFieldValue(['config', 'type']) !== 'docker' && (
                 <Form.Item
                   name={['config', 'project']}
                   label={t('registry.ProjectName')}

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -230,6 +230,7 @@ const ContainerRegistryList = () => {
         </Tooltip>
       </Flex>
       <Table
+        rowKey={(record) => record.id}
         scroll={{ x: 'max-content' }}
         pagination={false}
         columns={[

--- a/react/src/components/EndpointTokenGenerationModal.tsx
+++ b/react/src/components/EndpointTokenGenerationModal.tsx
@@ -3,9 +3,9 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
-import { Alert, DatePicker, Form, message } from 'antd';
+import { Alert, DatePicker, Form, FormInstance, message } from 'antd';
 import dayjs from 'dayjs';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // import { graphql, useFragment } from "react-relay";
@@ -25,7 +25,7 @@ const EndpointTokenGenerationModal: React.FC<
 > = ({ onRequestClose, onCancel, endpoint_id, ...baiModalProps }) => {
   const { t } = useTranslation();
   const baiClient = useSuspendedBackendaiClient();
-  const [form] = Form.useForm();
+  const formRef = useRef<FormInstance>(null);
 
   const mutationToGenerateToken = useTanMutation<
     unknown,
@@ -49,7 +49,7 @@ const EndpointTokenGenerationModal: React.FC<
 
   // Apply any operation after clicking OK button
   const handleOk = (e: React.MouseEvent<HTMLElement>) => {
-    form.validateFields().then((values) => {
+    formRef.current?.validateFields().then((values) => {
       const validUntil = values.datetime.unix();
       mutationToGenerateToken.mutate(
         {
@@ -91,6 +91,7 @@ const EndpointTokenGenerationModal: React.FC<
       title={t('modelService.GenerateNewToken')}
     >
       <Form
+        ref={formRef}
         preserve={false}
         labelCol={{ span: 10 }}
         initialValues={{
@@ -98,7 +99,6 @@ const EndpointTokenGenerationModal: React.FC<
         }}
         validateTrigger={['onChange', 'onBlur']}
         style={{ maxWidth: 500 }}
-        form={form}
       >
         <Flex direction="column" gap="sm" align="stretch">
           <Alert

--- a/react/src/components/ModelCloneModal.tsx
+++ b/react/src/components/ModelCloneModal.tsx
@@ -4,7 +4,16 @@ import { usePainKiller } from '../hooks/usePainKiller';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
 import StorageSelector from './StorageSelector';
-import { Alert, Form, Input, Select, Switch, message } from 'antd';
+import {
+  Alert,
+  Form,
+  FormInstance,
+  Input,
+  Select,
+  Switch,
+  message,
+} from 'antd';
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface ModelCloneModalProps extends BAIModalProps {
@@ -18,7 +27,7 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
 }) => {
   const { t } = useTranslation();
   const baiClient = useSuspendedBackendaiClient();
-  const [form] = Form.useForm();
+  const formRef = useRef<FormInstance>(null);
   const painKiller = usePainKiller();
 
   // const { data: allowed_vfolder_types } = useTanQuery({
@@ -42,8 +51,8 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
       okText={t('button.Clone')}
       confirmLoading={mutationToClone.isLoading}
       onOk={() => {
-        form
-          .validateFields()
+        formRef.current
+          ?.validateFields()
           .then((values) => {
             mutationToClone.mutate(
               {
@@ -73,7 +82,7 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
       <Flex direction="column" align="stretch" gap="sm">
         <Alert showIcon type="info" message={t('modelStore.CloneInfo')} />
         <Form
-          form={form}
+          ref={formRef}
           layout="vertical"
           requiredMark="optional"
           initialValues={{

--- a/react/src/components/ModelServiceSettingModal.tsx
+++ b/react/src/components/ModelServiceSettingModal.tsx
@@ -4,9 +4,9 @@ import { useTanMutation } from '../hooks/reactQueryAlias';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
 import { ModelServiceSettingModal_endpoint$key } from './__generated__/ModelServiceSettingModal_endpoint.graphql';
-import { Form, InputNumber, theme } from 'antd';
+import { Form, FormInstance, InputNumber, theme } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFragment } from 'react-relay';
 
@@ -27,7 +27,7 @@ const ModelServiceSettingModal: React.FC<Props> = ({
   const { token } = theme.useToken();
   const baiClient = useSuspendedBackendaiClient();
   const { t } = useTranslation();
-  const [form] = Form.useForm();
+  const formRef = useRef<FormInstance>(null);
 
   const endpoint = useFragment(
     graphql`
@@ -55,8 +55,8 @@ const ModelServiceSettingModal: React.FC<Props> = ({
 
   // Apply any operation after clicking OK button
   const handleOk = (e: React.MouseEvent<HTMLElement>) => {
-    form
-      .validateFields()
+    formRef.current
+      ?.validateFields()
       .then((values) => {
         mutationToUpdateService.mutate(values, {
           onSuccess: () => {
@@ -96,7 +96,7 @@ const ModelServiceSettingModal: React.FC<Props> = ({
     >
       <Flex direction="row" align="stretch" justify="around">
         <Form
-          form={form}
+          ref={formRef}
           preserve={false}
           validateTrigger={['onChange', 'onBlur']}
           initialValues={{

--- a/react/src/components/ProjectResourcePolicySettingModal.tsx
+++ b/react/src/components/ProjectResourcePolicySettingModal.tsx
@@ -3,9 +3,9 @@ import BAIModal, { BAIModalProps } from './BAIModal';
 import { ProjectResourcePolicySettingModalFragment$key } from './__generated__/ProjectResourcePolicySettingModalFragment.graphql';
 // import { ProjectResourcePolicySettingModalCreateMutation } from "./__generated__/ProjectResourcePolicySettingModalCreateMutation.graphql";
 import { ProjectResourcePolicySettingModalModifyMutation } from './__generated__/ProjectResourcePolicySettingModalModifyMutation.graphql';
-import { Form, Input, message, Alert } from 'antd';
+import { Form, Input, message, Alert, FormInstance } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFragment, useMutation } from 'react-relay';
 
@@ -21,7 +21,7 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
 
-  const [form] = Form.useForm();
+  const formRef = useRef<FormInstance>(null);
 
   const projectResourcePolicyInfo = useFragment(
     graphql`
@@ -69,7 +69,7 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
   `);
 
   const _onOk = (e: React.MouseEvent<HTMLElement>) => {
-    form.validateFields().then((values) => {
+    formRef.current?.validateFields().then((values) => {
       if (
         projectResourcePolicyInfo?.name &&
         projectResourcePolicyInfo?.max_quota_scope_size
@@ -143,7 +143,7 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
         style={{ marginTop: 20, marginBottom: 25 }}
       />
       <Form
-        form={form}
+        ref={formRef}
         preserve={false}
         labelCol={{ span: 6 }}
         wrapperCol={{ span: 20 }}

--- a/react/src/components/QuotaSettingModal.tsx
+++ b/react/src/components/QuotaSettingModal.tsx
@@ -2,9 +2,9 @@ import { GBToBytes, bytesToGB } from '../helper';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { QuotaSettingModalFragment$key } from './__generated__/QuotaSettingModalFragment.graphql';
 import { QuotaSettingModalSetMutation } from './__generated__/QuotaSettingModalSetMutation.graphql';
-import { Form, Input, message } from 'antd';
+import { Form, FormInstance, Input, message } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFragment, useMutation } from 'react-relay';
 
@@ -20,7 +20,7 @@ const QuotaSettingModal: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
 
-  const [form] = Form.useForm();
+  const formRef = useRef<FormInstance>(null);
 
   const quotaScope = useFragment(
     graphql`
@@ -61,7 +61,7 @@ const QuotaSettingModal: React.FC<Props> = ({
     `);
 
   const _onOk = (e: React.MouseEvent<HTMLElement>) => {
-    form.validateFields().then((values) => {
+    formRef.current?.validateFields().then((values) => {
       commitSetQuotaScope({
         variables: {
           quota_scope_id: quotaScope?.quota_scope_id || '',
@@ -101,7 +101,7 @@ const QuotaSettingModal: React.FC<Props> = ({
       title={t('storageHost.quotaSettings.QuotaSettings')}
     >
       <Form
-        form={form}
+        ref={formRef}
         preserve={false}
         labelCol={{ span: 6 }}
         wrapperCol={{ span: 20 }}

--- a/react/src/components/SessionListColums/SessionInfoCell.tsx
+++ b/react/src/components/SessionListColums/SessionInfoCell.tsx
@@ -6,9 +6,9 @@ import { useTanMutation } from '../../hooks/reactQueryAlias';
 import Flex from '../Flex';
 import { SessionInfoCellFragment$key } from './__generated__/SessionInfoCellFragment.graphql';
 import { EditOutlined } from '@ant-design/icons';
-import { Button, Form, Input, Typography, theme } from 'antd';
+import { Button, Form, FormInstance, Input, Typography, theme } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFragment } from 'react-relay';
 
@@ -59,7 +59,7 @@ const SessionInfoCell: React.FC<{
     },
   });
 
-  const [form] = Form.useForm();
+  const formRef = useRef<FormInstance>(null);
   const { t } = useTranslation();
 
   const [editing, setEditing] = useState(false);
@@ -70,8 +70,8 @@ const SessionInfoCell: React.FC<{
     baiClient.email === session.user_email;
 
   const save = () => {
-    form
-      .validateFields()
+    formRef.current
+      ?.validateFields()
       .then(({ name }) => {
         setEditing(false);
         setOptimisticName(name);
@@ -92,7 +92,7 @@ const SessionInfoCell: React.FC<{
   // sessions[objectKey].icon = this._getKernelIcon(session.image);
   //         sessions[objectKey].sessionTags = this._getKernelInfo(session.image);
   return (
-    <Form form={form}>
+    <Form ref={formRef}>
       {editing ? (
         <Form.Item
           style={{ margin: 0 }}
@@ -145,7 +145,7 @@ const SessionInfoCell: React.FC<{
               icon={<EditOutlined />}
               style={{ color: token.colorLink }}
               onClick={() => {
-                form.setFieldsValue({
+                formRef.current?.setFieldsValue({
                   name: session.name,
                 });
                 setEditing(true);

--- a/react/src/components/SignoutModal.tsx
+++ b/react/src/components/SignoutModal.tsx
@@ -1,8 +1,8 @@
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import BAIModal, { BAIModalProps } from './BAIModal';
-import { Form, Input, message, Alert } from 'antd';
-import React from 'react';
+import { Form, Input, message, Alert, FormInstance } from 'antd';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface SignoutModalProps extends BAIModalProps {
@@ -15,7 +15,7 @@ const SignoutModal: React.FC<SignoutModalProps> = ({
   onRequestClose,
   ...modalProps
 }) => {
-  const [form] = Form.useForm();
+  const formRef = useRef<FormInstance>(null);
   const { t } = useTranslation();
   const [messageApi, contextHolder] = message.useMessage();
   const baiClient = useSuspendedBackendaiClient();
@@ -25,8 +25,8 @@ const SignoutModal: React.FC<SignoutModalProps> = ({
     },
   });
   const handleOk = () => {
-    form
-      .validateFields()
+    formRef.current
+      ?.validateFields()
       .then((values) => {
         signoutMutation.mutate(
           {
@@ -66,7 +66,7 @@ const SignoutModal: React.FC<SignoutModalProps> = ({
         {...modalProps}
       >
         <Form
-          form={form}
+          ref={formRef}
           layout="vertical"
           labelCol={{ span: 6 }}
           disabled={signoutMutation.isLoading}

--- a/react/src/components/TableColumnsSettingModal.tsx
+++ b/react/src/components/TableColumnsSettingModal.tsx
@@ -2,8 +2,9 @@ import BAIModal, { BAIModalProps } from './BAIModal';
 import { SearchOutlined } from '@ant-design/icons';
 import { Checkbox, Input, theme, Form } from 'antd';
 import { ColumnsType } from 'antd/es/table';
+import { FormInstance } from 'antd/lib';
 import _ from 'lodash';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface FormValues {
@@ -25,7 +26,7 @@ const TableColumnsSettingModal: React.FC<TableColumnsSettingProps> = ({
   displayedColumnKeys,
   ...modalProps
 }) => {
-  const [form] = Form.useForm<FormValues>();
+  const formRef = useRef<FormInstance>(null);
   const { t } = useTranslation();
   const { token } = theme.useToken();
 
@@ -64,8 +65,8 @@ const TableColumnsSettingModal: React.FC<TableColumnsSettingProps> = ({
       destroyOnClose
       centered
       onOk={() => {
-        form
-          .validateFields()
+        formRef.current
+          ?.validateFields()
           .then((values) => {
             onRequestClose(values);
           })
@@ -77,7 +78,7 @@ const TableColumnsSettingModal: React.FC<TableColumnsSettingProps> = ({
       {...modalProps}
     >
       <Form
-        form={form}
+        ref={formRef}
         preserve={false}
         initialValues={{
           selectedColumnKeys:

--- a/react/src/components/UserResourcePolicySettingModal.tsx
+++ b/react/src/components/UserResourcePolicySettingModal.tsx
@@ -3,9 +3,9 @@ import BAIModal, { BAIModalProps } from './BAIModal';
 import { UserResourcePolicySettingModalFragment$key } from './__generated__/UserResourcePolicySettingModalFragment.graphql';
 // import { UserResourcePolicySettingModalCreateMutation } from "./__generated__/UserResourcePolicySettingModalCreateMutation.graphql";
 import { UserResourcePolicySettingModalModifyMutation } from './__generated__/UserResourcePolicySettingModalModifyMutation.graphql';
-import { Form, Input, message, Alert } from 'antd';
+import { Form, Input, message, Alert, FormInstance } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFragment, useMutation } from 'react-relay';
 
@@ -22,7 +22,7 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
 
-  const [form] = Form.useForm();
+  const formRef = useRef<FormInstance>(null);
 
   const userResourcePolicyInfo = useFragment(
     graphql`
@@ -72,7 +72,7 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
   `);
 
   const _onOk = (e: React.MouseEvent<HTMLElement>) => {
-    form.validateFields().then((values) => {
+    formRef.current?.validateFields().then((values) => {
       if (userResourcePolicyInfo?.name) {
         commitModifyUserResourcePolicy({
           variables: {
@@ -144,7 +144,7 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
         style={{ marginTop: 20, marginBottom: 25 }}
       />
       <Form
-        form={form}
+        ref={formRef}
         preserve={false}
         labelCol={{ span: 6 }}
         wrapperCol={{ span: 20 }}


### PR DESCRIPTION
This bug was found during the review of #2121.

The `initialValues` props don't work in the specific case below:
- In Electron, the modal has the `<Form/>` with `initialValues` prop. This is the case even when `destroyOnClose` of Modal and `preserve=false` of Form are set.

This PR has the following changes:
- Use `ref` of Form instead of `form` if available. (FYI, `Form.useWatch` cannot be used with `ref` because `ref` can be null)
- Set the row key to the table of ContainerRegistryList

### How to test
- Please check the electron environment and browser environment. For the election environment, you can build `make clean` and `make mac_arm64` (other [platforms](https://github.com/lablup/backend.ai-webui/blob/main/Makefile#L54-L60) are available.)
- Please check the modals that have been changed.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
