### PR TITLE
Fix/draggable header for electron

### DIFF
--- a/react/src/components/MainLayout/WebUIHeader.css
+++ b/react/src/components/MainLayout/WebUIHeader.css
@@ -1,4 +1,4 @@
-.webui-header-container.draggable,
+.webui-header-container,
 .webui-header-container .draggable {
   -webkit-app-region: drag;
 }

--- a/react/src/components/MainLayout/WebUIHeader.tsx
+++ b/react/src/components/MainLayout/WebUIHeader.tsx
@@ -5,7 +5,8 @@ import Flex, { FlexProps } from '../Flex';
 import ProjectSelect from '../ProjectSelect';
 import UserDropdownMenu from '../UserDropdownMenu';
 import WEBUIHelpButton from '../WEBUIHelpButton';
-import './WebUIHeader.css';
+// @ts-ignore
+import rawCss from './WebUIHeader.css?raw';
 import { MenuOutlined } from '@ant-design/icons';
 import { theme, Button, Typography, Grid } from 'antd';
 import _ from 'lodash';
@@ -51,8 +52,9 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({
         boxShadow: scrolled ? '0 5px 6px -6px rgba(0, 0, 0, 0.1)' : 'none',
         transition: 'background-color 0.2s ease-in-out',
       }}
-      className={'webui-header-container draggable'}
+      className={'webui-header-container'}
     >
+      <style>{rawCss}</style>
       <Flex direction="row" gap={'sm'}>
         <Button
           icon={<MenuOutlined />}

--- a/react/src/components/WEBUINotificationDrawer.tsx
+++ b/react/src/components/WEBUINotificationDrawer.tsx
@@ -43,6 +43,7 @@ const WEBUINotificationDrawer: React.FC<Props> = ({ ...drawerProps }) => {
       width={DRAWER_WIDTH}
       title={t('notification.Notifications')}
       mask={false}
+      className="webui-notification-drawer"
       styles={{
         // mask: { backgroundColor: 'transparent' },
         body: {
@@ -51,7 +52,8 @@ const WEBUINotificationDrawer: React.FC<Props> = ({ ...drawerProps }) => {
           paddingRight: token.paddingContentHorizontalSM,
         },
         header: {
-          padding: 15,
+          // @ts-ignore
+          '-webkit-app-region': 'drag',
         },
         wrapper: {
           padding: 0,
@@ -84,6 +86,14 @@ const WEBUINotificationDrawer: React.FC<Props> = ({ ...drawerProps }) => {
       }
       {...drawerProps}
     >
+      <style>
+        {`
+          .ant-drawer-header-title .ant-drawer-close,
+          .ant-drawer-header .ant-drawer-extra{
+            -webkit-app-region: no-drag;
+          }
+        `}
+      </style>
       <List
         itemLayout="vertical"
         dataSource={

--- a/src/components/lablup-notification.ts
+++ b/src/components/lablup-notification.ts
@@ -2,9 +2,7 @@
  @license
  Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
  */
-import { navigate } from '../backend-ai-app';
 import '../plastics/mwc/mwc-snackbar';
-import { store } from '../store';
 import { BackendAiStyles } from './backend-ai-general-styles';
 import '@material/mwc-icon-button';
 import { css, CSSResultGroup, html, LitElement } from 'lit';


### PR DESCRIPTION
After #2121, there is a bug related to the draggable area to move an Electron app window.

The blue box area is the draggable area, except for the red box area.
<img width="1312" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/84d96a70-689d-42b0-bb41-6adeb1ead054">

Please build an app using `make` command (below command for `make mac_arm64`) and test the draggable area.
```
make clean
make mac_arm64
```


<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
