### PR TITLE
fix: remove ROCm icon from resource monitor

### DIFF
--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -843,10 +843,6 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     <div
                       class="layout vertical center center-justified resource-name"
                     >
-                      <img
-                        class="resource-type-icon fg green"
-                        src="/resources/icons/ROCm.png"
-                      />
                       <span class="gauge-name">
                         ROCm
                         <br />


### PR DESCRIPTION
This PR removes undesired ROCm icon from `backend-ai-resource-monitor` component.

<img width="1427" alt="스크린샷 2024-01-29 오후 2 54 45" src="https://github.com/lablup/backend.ai-webui/assets/14137676/b71bb9cd-17cc-40cc-b283-999766a83449">

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
