### PR TITLE
feat: set RegExpression for validating URL pattern

### DIFF
--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -254,9 +254,6 @@ const ContainerRegistryEditorModal: React.FC<
               required: true,
             },
             {
-              type: 'url',
-            },
-            {
               validator: (_, value) => {
                 if (
                   value &&
@@ -265,6 +262,14 @@ const ContainerRegistryEditorModal: React.FC<
                 ) {
                   return Promise.reject(t('registry.DescURLStartString'));
                 }
+                const pattern = new RegExp(
+                  '^(https?|ftp)://[a-zA-Z0-9-_.]+(:[0-9]{1,5})?(/[a-zA-Z0-9-_./]*)?$',
+                );
+
+                if (value && !pattern.test(value)) {
+                  return Promise.reject(t('registry.DescURLFormat'));
+                }
+
                 return Promise.resolve();
               },
             },

--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -255,21 +255,18 @@ const ContainerRegistryEditorModal: React.FC<
             },
             {
               validator: (_, value) => {
-                if (
-                  value &&
-                  !value.startsWith('http://') &&
-                  !value.startsWith('https://')
-                ) {
-                  return Promise.reject(t('registry.DescURLStartString'));
+                if (value) {
+                  if (
+                    !value.startsWith('http://') &&
+                    !value.startsWith('https://')
+                  )
+                    return Promise.reject(t('registry.DescURLStartString'));
+                  try {
+                    new URL(value);
+                  } catch (e) {
+                    return Promise.reject(t('registry.DescURLFormat'));
+                  }
                 }
-                const pattern = new RegExp(
-                  '^(https?|ftp)://[a-zA-Z0-9-_.]+(:[0-9]{1,5})?(/[a-zA-Z0-9-_./]*)?$',
-                );
-
-                if (value && !pattern.test(value)) {
-                  return Promise.reject(t('registry.DescURLFormat'));
-                }
-
                 return Promise.resolve();
               },
             },

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "Registry erfolgreich geändert.",
     "NoRegistryToDisplay": "Keine Registrierungen anzeigen",
     "ModifyRegistry": "Registry ändern",
-    "ConfirmNoUserName": "Benutzer und Passwort nicht angegeben, möchten Sie speichern?"
+    "ConfirmNoUserName": "Benutzer und Passwort nicht angegeben, möchten Sie speichern?",
+    "DescURLFormat": "Ungültiger URL-Typ"
   },
   "resourceGroup": {
     "ResourceGroups": "Ressourcengruppen",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "Το μητρώο τροποποιήθηκε επιτυχώς.",
     "NoRegistryToDisplay": "Δεν εμφανίζονται μητρώα",
     "ModifyRegistry": "Τροποποίηση μητρώου",
-    "ConfirmNoUserName": "Ο χρήστης και ο κωδικός πρόσβασης δεν έχουν καθοριστεί, θέλετε να αποθηκεύσετε;"
+    "ConfirmNoUserName": "Ο χρήστης και ο κωδικός πρόσβασης δεν έχουν καθοριστεί, θέλετε να αποθηκεύσετε;",
+    "DescURLFormat": "Μη έγκυρος τύπος URL"
   },
   "resourceGroup": {
     "ResourceGroups": "Ομάδες πόρων",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1031,7 +1031,8 @@
     "NoRegistryToDisplay": "No Registries to display",
     "RegistrySuccessfullyModified": "Registry successfully modified.",
     "PleaseSelectOption": "Please Select Option",
-    "ConfirmNoUserName": "User and password not specified, would you like to save?"
+    "ConfirmNoUserName": "User and password not specified, would you like to save?",
+    "DescURLFormat": "Invalid URL Type"
   },
   "resourceGroup": {
     "ResourceGroups": "Resource Groups",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -806,7 +806,8 @@
     "UpdatingRegistryInfo": "Actualización de la información del registro...",
     "Username": "Nombre de usuario",
     "UsernameOptional": "Nombre de usuario (opcional)",
-    "ConfirmNoUserName": "Usuario y contraseña no especificados, ¿desea guardar?"
+    "ConfirmNoUserName": "Usuario y contraseña no especificados, ¿desea guardar?",
+    "DescURLFormat": "Tipo de URL no válido"
   },
   "resourceGroup": {
     "Active": "Activo",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -806,7 +806,8 @@
     "UpdatingRegistryInfo": "Rekisteritietojen päivittäminen...",
     "Username": "Käyttäjätunnus",
     "UsernameOptional": "Käyttäjätunnus (valinnainen)",
-    "ConfirmNoUserName": "Käyttäjää ja salasanaa ei ole määritetty, haluatko tallentaa?"
+    "ConfirmNoUserName": "Käyttäjää ja salasanaa ei ole määritetty, haluatko tallentaa?",
+    "DescURLFormat": "Virheellinen URL-tyyppi"
   },
   "resourceGroup": {
     "Active": "Aktiivinen",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "Registre modifié avec succès.",
     "ModifyRegistry": "Modifier le registre",
     "NoRegistryToDisplay": "Aucun registre à afficher",
-    "ConfirmNoUserName": "L'utilisateur et le mot de passe ne sont pas spécifiés, voulez-vous sauvegarder ?"
+    "ConfirmNoUserName": "L'utilisateur et le mot de passe ne sont pas spécifiés, voulez-vous sauvegarder ?",
+    "DescURLFormat": "Type d'URL invalide"
   },
   "resourceGroup": {
     "ResourceGroups": "Groupes de ressources",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "Registry berhasil dimodifikasi.",
     "ModifyRegistry": "Memodifikasi Registri",
     "NoRegistryToDisplay": "Tidak ada Pendaftaran untuk ditampilkan",
-    "ConfirmNoUserName": "Pengguna dan kata sandi tidak ditentukan, apakah Anda ingin menyimpan?"
+    "ConfirmNoUserName": "Pengguna dan kata sandi tidak ditentukan, apakah Anda ingin menyimpan?",
+    "DescURLFormat": "Jenis URL tidak valid"
   },
   "resourceGroup": {
     "ResourceGroups": "Grup Sumber Daya",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "Registro modificato con successo.",
     "NoRegistryToDisplay": "Nessun registro da visualizzare",
     "ModifyRegistry": "Modificare il registro",
-    "ConfirmNoUserName": "Utente e password non specificati, si desidera salvare?"
+    "ConfirmNoUserName": "Utente e password non specificati, si desidera salvare?",
+    "DescURLFormat": "Tipo di URL non valido"
   },
   "resourceGroup": {
     "ResourceGroups": "Gruppi di risorse",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "レジストリが正常に修正されました。",
     "NoRegistryToDisplay": "レジストリ情報がありません。",
     "ModifyRegistry": "レジストリの修正",
-    "ConfirmNoUserName": "ユーザーとパスワードが指定されていません。"
+    "ConfirmNoUserName": "ユーザーとパスワードが指定されていません。",
+    "DescURLFormat": "無効な URL タイプ"
   },
   "resourceGroup": {
     "ResourceGroups": "リソースグループ",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1021,7 +1021,8 @@
     "NoRegistryToDisplay": "레지스트리 정보가 없습니다.",
     "RegistrySuccessfullyModified": "레지스트리가 성공적으로 수정되었습니다.",
     "PleaseSelectOption": "옵션을 선택하세요",
-    "ConfirmNoUserName": "사용자 및 비밀번호가 지정되지 않았습니다. 저장하시겠습니까?"
+    "ConfirmNoUserName": "사용자 및 비밀번호가 지정되지 않았습니다. 저장하시겠습니까?",
+    "DescURLFormat": "올바르지 않는 URL 타입입니다."
   },
   "resourceGroup": {
     "ResourceGroups": "자원 그룹",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "Бүртгэл амжилттай өөрчлөгдсөн.",
     "ModifyRegistry": "Бүртгэлийг өөрчлөх",
     "NoRegistryToDisplay": "Харуулах бүртгэл байхгүй",
-    "ConfirmNoUserName": "Хэрэглэгч болон нууц үгийг заагаагүй тул хадгалах уу?"
+    "ConfirmNoUserName": "Хэрэглэгч болон нууц үгийг заагаагүй тул хадгалах уу?",
+    "DescURLFormat": "Хүчингүй URL төрөл"
   },
   "resourceGroup": {
     "ResourceGroups": "Нөөцийн бүлгүүд",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "Pendaftaran berjaya diubah suai.",
     "NoRegistryToDisplay": "Tiada Pendaftaran untuk dipaparkan",
     "ModifyRegistry": "Ubah suai Pendaftaran",
-    "ConfirmNoUserName": "Pengguna dan kata laluan tidak dinyatakan, adakah anda ingin menyimpan?"
+    "ConfirmNoUserName": "Pengguna dan kata laluan tidak dinyatakan, adakah anda ingin menyimpan?",
+    "DescURLFormat": "Jenis URL tidak sah"
   },
   "resourceGroup": {
     "ResourceGroups": "Kumpulan Sumber",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -938,7 +938,8 @@
     "RegistrySuccessfullyModified": "Rejestr został pomyślnie zmodyfikowany.",
     "NoRegistryToDisplay": "Brak rejestrów do wyświetlenia",
     "ModifyRegistry": "Modyfikacja rejestru",
-    "ConfirmNoUserName": "Użytkownik i hasło nie zostały określone, czy chcesz zapisać?"
+    "ConfirmNoUserName": "Użytkownik i hasło nie zostały określone, czy chcesz zapisać?",
+    "DescURLFormat": "Nieprawidłowy typ adresu URL"
   },
   "resourceGroup": {
     "ResourceGroups": "Grupy zasobów",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "Registo modificado com sucesso.",
     "NoRegistryToDisplay": "Não há registos a apresentar",
     "ModifyRegistry": "Modificar o registo",
-    "ConfirmNoUserName": "Utilizador e palavra-passe não especificados, pretende guardar?"
+    "ConfirmNoUserName": "Utilizador e palavra-passe não especificados, pretende guardar?",
+    "DescURLFormat": "Tipo de URL inválido"
   },
   "resourceGroup": {
     "ResourceGroups": "Grupos de Recursos",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "Registo modificado com sucesso.",
     "NoRegistryToDisplay": "Não há registos a apresentar",
     "ModifyRegistry": "Modificar o registo",
-    "ConfirmNoUserName": "Utilizador e palavra-passe não especificados, pretende guardar?"
+    "ConfirmNoUserName": "Utilizador e palavra-passe não especificados, pretende guardar?",
+    "DescURLFormat": "Tipo de URL inválido"
   },
   "resourceGroup": {
     "ResourceGroups": "Grupos de Recursos",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -938,7 +938,8 @@
     "RegistrySuccessfullyModified": "Реестр успешно модифицирован.",
     "ModifyRegistry": "Изменение реестра",
     "NoRegistryToDisplay": "Отсутствие отображаемых реестров",
-    "ConfirmNoUserName": "Пользователь и пароль не указаны, хотите сохранить?"
+    "ConfirmNoUserName": "Пользователь и пароль не указаны, хотите сохранить?",
+    "DescURLFormat": "Неверный тип URL"
   },
   "resourceGroup": {
     "ResourceGroups": "Группы ресурсов",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "Kayıt defteri başarıyla değiştirildi.",
     "NoRegistryToDisplay": "Görüntülenecek Kayıt Yok",
     "ModifyRegistry": "Kayıt Defterini Değiştir",
-    "ConfirmNoUserName": "Kullanıcı ve şifre belirtilmemiş, kaydetmek ister misiniz?"
+    "ConfirmNoUserName": "Kullanıcı ve şifre belirtilmemiş, kaydetmek ister misiniz?",
+    "DescURLFormat": "Geçersiz URL Türü"
   },
   "resourceGroup": {
     "ResourceGroups": "Kaynak Grupları",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "Đã sửa đổi sổ đăng ký thành công.",
     "NoRegistryToDisplay": "Không có đăng ký để hiển thị",
     "ModifyRegistry": "Sửa đổi sổ đăng ký",
-    "ConfirmNoUserName": "Người dùng và mật khẩu không được chỉ định, bạn có muốn lưu không?"
+    "ConfirmNoUserName": "Người dùng và mật khẩu không được chỉ định, bạn có muốn lưu không?",
+    "DescURLFormat": "Loại URL không hợp lệ"
   },
   "resourceGroup": {
     "ResourceGroups": "Nhóm tài nguyên",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "注册表已成功修改。",
     "NoRegistryToDisplay": "无注册表显示",
     "ModifyRegistry": "修改注册表",
-    "ConfirmNoUserName": "未指定用户和密码，要保存吗？"
+    "ConfirmNoUserName": "未指定用户和密码，要保存吗？",
+    "DescURLFormat": "无效的 URL 类型"
   },
   "resourceGroup": {
     "ResourceGroups": "资源组",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -936,7 +936,8 @@
     "RegistrySuccessfullyModified": "注册表已成功修改。",
     "NoRegistryToDisplay": "无注册表显示",
     "ModifyRegistry": "修改注册表",
-    "ConfirmNoUserName": "未指定用户和密码，要保存吗？"
+    "ConfirmNoUserName": "未指定用户和密码，要保存吗？",
+    "DescURLFormat": "無效的 URL 類型"
   },
   "resourceGroup": {
     "ResourceGroups": "資源組",


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
### This PR resolves [#2190](https://github.com/lablup/backend.ai-webui/issues/2190)

### Main Idea
There are some chances that user could use customized hostname with port number, but antd input form validation on URL type doesn't work properly on these cases. URL validation need to accept the addresses like "bai-repo:####".

### Changes
1. use new URL for url validation
2. Set Error Message for Invalid type URL

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
