### PR TITLE
fix: display credential-list when `keypair`button in `summary` page is clicked

### DIFF
--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -1177,32 +1177,15 @@ export default class BackendAICredentialView extends BackendAIPage {
   }
 
   async _runAction() {
-    const regex = /action=/; // If there is a new action, add it with |action after it.
-    const isActionExist = regex.test(location.search);
-
-    if (isActionExist) {
-      const action = location.search.split('action=')[1];
-
-      switch (action) {
-        case 'add':
-          this._showTab(
-            this.shadowRoot?.querySelector('mwc-tab[title=credential-lists]'),
-          );
-          this.shadowRoot
-            ?.querySelector('mwc-tab-bar.main-bar')
-            ?.setAttribute('activeindex', '1');
-          await this._launchKeyPairDialog();
-          break;
-        case 'manage':
-          this._showTab(
-            this.shadowRoot?.querySelector('mwc-tab[title=credential-lists]'),
-          );
-          this.shadowRoot
-            ?.querySelector('mwc-tab-bar.main-bar')
-            ?.setAttribute('activeindex', '1');
-          break;
-      }
+    if (location.search.includes('add')) {
+      await this._launchKeyPairDialog();
     }
+    this._showTab(
+      this.shadowRoot?.querySelector('mwc-tab[title=credential-lists]'),
+    );
+    this.shadowRoot
+      ?.querySelector('mwc-tab-bar.main-bar')
+      ?.setAttribute('activeindex', '1');
   }
 
   render() {

--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -1185,9 +1185,22 @@ export default class BackendAICredentialView extends BackendAIPage {
 
       switch (action) {
         case 'add':
+          this._showTab(
+            this.shadowRoot?.querySelector('mwc-tab[title=credential-lists]'),
+          );
+          this.shadowRoot
+            ?.querySelector('mwc-tab-bar.main-bar')
+            ?.setAttribute('activeindex', '1');
           await this._launchKeyPairDialog();
           break;
       }
+    } else if (location.search.includes('manage')) {
+      this._showTab(
+        this.shadowRoot?.querySelector('mwc-tab[title=credential-lists]'),
+      );
+      this.shadowRoot
+        ?.querySelector('mwc-tab-bar.main-bar')
+        ?.setAttribute('activeindex', '1');
     }
   }
 
@@ -1198,7 +1211,7 @@ export default class BackendAICredentialView extends BackendAIPage {
       <lablup-activity-panel noheader narrow autowidth>
         <div slot="message">
           <h3 class="tab horizontal wrap layout">
-           <mwc-tab-bar>
+           <mwc-tab-bar class="main-bar">
             <mwc-tab title="user-lists" label="${_t('credential.Users')}"
                 @click="${(e) => this._showTab(e.target)}"></mwc-tab>
             <mwc-tab title="credential-lists" label="${_t(

--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -1177,7 +1177,7 @@ export default class BackendAICredentialView extends BackendAIPage {
   }
 
   async _runAction() {
-    const regex = /action=(add)$/; // If there is a new action, add it with |action after it.
+    const regex = /action=/; // If there is a new action, add it with |action after it.
     const isActionExist = regex.test(location.search);
 
     if (isActionExist) {
@@ -1193,14 +1193,15 @@ export default class BackendAICredentialView extends BackendAIPage {
             ?.setAttribute('activeindex', '1');
           await this._launchKeyPairDialog();
           break;
+        case 'manage':
+          this._showTab(
+            this.shadowRoot?.querySelector('mwc-tab[title=credential-lists]'),
+          );
+          this.shadowRoot
+            ?.querySelector('mwc-tab-bar.main-bar')
+            ?.setAttribute('activeindex', '1');
+          break;
       }
-    } else if (location.search.includes('manage')) {
-      this._showTab(
-        this.shadowRoot?.querySelector('mwc-tab[title=credential-lists]'),
-      );
-      this.shadowRoot
-        ?.querySelector('mwc-tab-bar.main-bar')
-        ?.setAttribute('activeindex', '1');
     }
   }
 

--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -573,7 +573,7 @@ export default class BackendAISummary extends BackendAIPage {
                       </button>
                       <button
                         @click="${() => {
-                          this._moveTo('/credential');
+                          this._moveTo('/credential', '?action=manage');
                         }}"
                         class="vertical center center-justified layout start-menu-items link-button"
                         style="border-left:1px solid #ccc;"

--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -573,7 +573,7 @@ export default class BackendAISummary extends BackendAIPage {
                       </button>
                       <button
                         @click="${() => {
-                          this._moveTo('/credential', '?action=manage');
+                          this._moveTo('/credential');
                         }}"
                         class="vertical center center-justified layout start-menu-items link-button"
                         style="border-left:1px solid #ccc;"


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR resolves https://github.com/lablup/backend.ai-webui/issues/2175
 
![스크린샷 2024-01-31 오후 12 00 52](https://github.com/lablup/backend.ai-webui/assets/28584221/bba90ca9-a6f4-41e7-ad81-bd6d6104debb)
![스크린샷 2024-01-31 오후 12 01 03](https://github.com/lablup/backend.ai-webui/assets/28584221/fd425152-8c94-4de5-9c6c-94259892af18)

After this PR, it is need to implement antd's tab instead of using mwc-tab and add routing each tab.

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
