### PR TITLE
feat: apply ellipsis into notification

### DIFF
--- a/react/src/components/BAINotificationItem.tsx
+++ b/react/src/components/BAINotificationItem.tsx
@@ -5,7 +5,6 @@ import {
   ClockCircleOutlined,
   CloseCircleOutlined,
 } from '@ant-design/icons';
-import { useControllableValue } from 'ahooks';
 import { Card, List, Progress, Typography, theme } from 'antd';
 import dayjs from 'dayjs';
 import _ from 'lodash';
@@ -24,9 +23,7 @@ const BAINotificationItem: React.FC<{
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const [showExtraDescription, setShowExtraDescription] = useState(false);
-  const [ellipsis, setEllipsis] = useControllableValue({
-    defaultValue: allowEllipsis,
-  });
+  const [ellipsis, setEllipsis] = useState(allowEllipsis ?? false);
   return (
     <List.Item>
       <Flex direction="column" align="stretch" gap={'xxs'}>
@@ -63,7 +60,7 @@ const BAINotificationItem: React.FC<{
             }}
             ellipsis={ellipsis ? { rows: 3 } : false}
             onClick={() => {
-              setEllipsis(!ellipsis);
+              !allowEllipsis && setEllipsis(!ellipsis);
             }}
           >
             {notification.message}
@@ -74,7 +71,7 @@ const BAINotificationItem: React.FC<{
           <Typography.Paragraph
             ellipsis={ellipsis ? { rows: 3 } : false}
             onClick={() => {
-              setEllipsis(!ellipsis);
+              !allowEllipsis && setEllipsis(!ellipsis);
             }}
           >
             {notification.description}
@@ -114,7 +111,7 @@ const BAINotificationItem: React.FC<{
               copyable
               ellipsis={ellipsis ? { rows: 3 } : false}
               onClick={() => {
-                setEllipsis(!ellipsis);
+                !allowEllipsis && setEllipsis(!ellipsis);
               }}
             >
               {notification.extraDescription}

--- a/react/src/components/BAINotificationItem.tsx
+++ b/react/src/components/BAINotificationItem.tsx
@@ -5,6 +5,7 @@ import {
   ClockCircleOutlined,
   CloseCircleOutlined,
 } from '@ant-design/icons';
+import { useControllableValue } from 'ahooks';
 import { Card, List, Progress, Typography, theme } from 'antd';
 import dayjs from 'dayjs';
 import _ from 'lodash';
@@ -18,10 +19,14 @@ const BAINotificationItem: React.FC<{
     notification: NotificationState,
   ) => void;
   showDate?: boolean;
-}> = ({ notification, onClickAction, showDate }) => {
+  allowEllipsis?: boolean;
+}> = ({ notification, onClickAction, showDate, allowEllipsis }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const [showExtraDescription, setShowExtraDescription] = useState(false);
+  const [ellipsis, setEllipsis] = useControllableValue({
+    defaultValue: allowEllipsis,
+  });
   return (
     <List.Item>
       <Flex direction="column" align="stretch" gap={'xxs'}>
@@ -52,17 +57,28 @@ const BAINotificationItem: React.FC<{
               <CheckCircleOutlined style={{ color: token.colorSuccess }} />
             ) : null}
           </Flex>
-          <Typography.Text
+          <Typography.Paragraph
             style={{
               fontWeight: 500,
             }}
+            ellipsis={ellipsis ? { rows: 3 } : false}
+            onClick={() => {
+              setEllipsis(!ellipsis);
+            }}
           >
             {notification.message}
-          </Typography.Text>
+          </Typography.Paragraph>
         </Flex>
 
         <Flex direction="row" align="end" gap={'xxs'} justify="between">
-          <Typography.Text>{notification.description}</Typography.Text>
+          <Typography.Paragraph
+            ellipsis={ellipsis ? { rows: 3 } : false}
+            onClick={() => {
+              setEllipsis(!ellipsis);
+            }}
+          >
+            {notification.description}
+          </Typography.Paragraph>
           {notification.to ? (
             <Flex>
               <Typography.Link
@@ -93,9 +109,16 @@ const BAINotificationItem: React.FC<{
         </Flex>
         {notification.extraDescription && showExtraDescription ? (
           <Card size="small">
-            <Typography.Text type="secondary" copyable>
+            <Typography.Paragraph
+              type="secondary"
+              copyable
+              ellipsis={ellipsis ? { rows: 3 } : false}
+              onClick={() => {
+                setEllipsis(!ellipsis);
+              }}
+            >
               {notification.extraDescription}
-            </Typography.Text>
+            </Typography.Paragraph>
           </Card>
         ) : null}
 

--- a/react/src/components/BAINotificationItem.tsx
+++ b/react/src/components/BAINotificationItem.tsx
@@ -18,12 +18,10 @@ const BAINotificationItem: React.FC<{
     notification: NotificationState,
   ) => void;
   showDate?: boolean;
-  allowEllipsis?: boolean;
-}> = ({ notification, onClickAction, showDate, allowEllipsis }) => {
+}> = ({ notification, onClickAction, showDate }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const [showExtraDescription, setShowExtraDescription] = useState(false);
-  const [ellipsis, setEllipsis] = useState(allowEllipsis ?? false);
   return (
     <List.Item>
       <Flex direction="column" align="stretch" gap={'xxs'}>
@@ -58,22 +56,14 @@ const BAINotificationItem: React.FC<{
             style={{
               fontWeight: 500,
             }}
-            ellipsis={ellipsis ? { rows: 3 } : false}
-            onClick={() => {
-              !allowEllipsis && setEllipsis(!ellipsis);
-            }}
+            ellipsis={{ rows: 3 }}
           >
             {notification.message}
           </Typography.Paragraph>
         </Flex>
 
         <Flex direction="row" align="end" gap={'xxs'} justify="between">
-          <Typography.Paragraph
-            ellipsis={ellipsis ? { rows: 3 } : false}
-            onClick={() => {
-              !allowEllipsis && setEllipsis(!ellipsis);
-            }}
-          >
+          <Typography.Paragraph ellipsis={{ rows: 3, expandable: true }}>
             {notification.description}
           </Typography.Paragraph>
           {notification.to ? (
@@ -106,16 +96,9 @@ const BAINotificationItem: React.FC<{
         </Flex>
         {notification.extraDescription && showExtraDescription ? (
           <Card size="small">
-            <Typography.Paragraph
-              type="secondary"
-              copyable
-              ellipsis={ellipsis ? { rows: 3 } : false}
-              onClick={() => {
-                !allowEllipsis && setEllipsis(!ellipsis);
-              }}
-            >
+            <Typography.Text type="secondary" copyable>
               {notification.extraDescription}
-            </Typography.Paragraph>
+            </Typography.Text>
           </Card>
         ) : null}
 

--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -142,6 +142,7 @@ export const useBAINotification = () => {
                   }
                   destroyNotification(newNotification.key);
                 }}
+                allowEllipsis
               />
             ),
             onClose() {

--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -142,7 +142,6 @@ export const useBAINotification = () => {
                   }
                   destroyNotification(newNotification.key);
                 }}
-                allowEllipsis
               />
             ),
             onClose() {


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR resolves #2196 

feature :
- Added allowEllipsis prop to control ellipsis property. (allowEllipsis (boolean))
- Users can use the ellipsis feature by clicking on the text.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
