### PR TITLE
fix:  main layout header appears behind fixed column table

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -2,13 +2,14 @@ import BAIContentWithDrawerArea from '../BAIContentWithDrawerArea';
 import BAISider from '../BAISider';
 import Flex from '../Flex';
 import { DRAWER_WIDTH } from '../WEBUINotificationDrawer';
-import WebUIHeader from './WebUIHeader';
+import WebUIHeader, { HEADER_HEIGHT } from './WebUIHeader';
 import WebUISider from './WebUISider';
 import { useLocalStorageState } from 'ahooks';
 import { App, Layout, theme } from 'antd';
 import { Suspense, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useNavigate, Outlet } from 'react-router-dom';
 
+export const HEADER_Z_INDEX_IN_MAIN_LAYOUT = 5;
 export type PluginPage = {
   name: string;
   url: string;
@@ -29,9 +30,8 @@ function MainLayout() {
   const [compactSidebarActive] = useLocalStorageState<boolean | undefined>(
     'backendaiwebui.settings.user.compact_sidebar',
   );
-  const [sideCollapsed, setSideCollapsed] = useState<boolean>(
-    !!compactSidebarActive,
-  );
+  const [sideCollapsed, setSideCollapsed] =
+    useState<boolean>(!!compactSidebarActive);
 
   // const currentDomainName = useCurrentDomainValue();
   const { token } = theme.useToken();
@@ -121,7 +121,7 @@ function MainLayout() {
                   margin: `0 -${token.paddingContentHorizontalLG}px 0 -${token.paddingContentHorizontalLG}px`,
                   position: 'sticky',
                   top: 0,
-                  zIndex: 1,
+                  zIndex: HEADER_Z_INDEX_IN_MAIN_LAYOUT,
                 }}
               >
                 <WebUIHeader

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -2,7 +2,7 @@ import BAIContentWithDrawerArea from '../BAIContentWithDrawerArea';
 import BAISider from '../BAISider';
 import Flex from '../Flex';
 import { DRAWER_WIDTH } from '../WEBUINotificationDrawer';
-import WebUIHeader, { HEADER_HEIGHT } from './WebUIHeader';
+import WebUIHeader from './WebUIHeader';
 import WebUISider from './WebUISider';
 import { useLocalStorageState } from 'ahooks';
 import { App, Layout, theme } from 'antd';


### PR DESCRIPTION
(cherry picked from commit fa84a860dae37fc3fd3e16a2155abca92e441fba)

This PR resolves UI bug where main layout header appears behind fixed column.

How to reproduce this bug:
- Go to the page that has a fixed header table, such as `/session/start?step=2` and `/serving`.
- Reduce the browser window size until it has a scroll bar.
- Scroll to the bottom until the table header overlaps the table content.
<img width="690" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/f50df37c-82a0-4dbc-98dd-177f2fddc4e0">

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
