### PR TITLE
fix: resource-monitor is shown at out of layout

### DIFF
--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -162,7 +162,7 @@ customElements.define(
           direction="column"
           gap="sm"
           align="stretch"
-          style={{ minWidth: 200 }}
+          style={{ minWidth: 200, maxWidth: 310 }}
         >
           {t('session.launcher.ResourceGroup')}
           <ResourceGroupSelect

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -658,7 +658,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
     // language=HTML
     return html`
       <link rel="stylesheet" href="resources/custom.css" />
-      <div class="layout ${this.direction} justified flex">
+      <div class="layout ${this.direction} justified flex wrap">
         <div
           id="scaling-group-select-box"
           class="layout horizontal center-justified ${this.direction}"


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR resolves resource-monitor's layout issue that is occurred after merging https://github.com/lablup/backend.ai-webui/pull/2166

How to reproduce this bug:

- make long resource group name
- Go to the session page(/job)
- Reduce the browser window size as possible.

Before
![스크린샷 2024-02-13 오후 5 23 09](https://github.com/lablup/backend.ai-webui/assets/28584221/3c807121-02fe-4ea5-bfe7-a53c10b0d86a)

After
![스크린샷 2024-02-13 오후 5 43 39](https://github.com/lablup/backend.ai-webui/assets/28584221/8f7ed62a-e9e9-4628-8191-a3c3ecc74b81)



**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
