### PR TITLE
fix: when user menu is clicked, credential tab is shown instead of user.

### DIFF
--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -1177,15 +1177,17 @@ export default class BackendAICredentialView extends BackendAIPage {
   }
 
   async _runAction() {
-    if (location.search.includes('add')) {
-      await this._launchKeyPairDialog();
+    if (location.search.includes('action')) {
+      if (location.search.includes('add')) {
+        await this._launchKeyPairDialog();
+      }
+      this._showTab(
+        this.shadowRoot?.querySelector('mwc-tab[title=credential-lists]'),
+      );
+      this.shadowRoot
+        ?.querySelector('mwc-tab-bar.main-bar')
+        ?.setAttribute('activeindex', '1');
     }
-    this._showTab(
-      this.shadowRoot?.querySelector('mwc-tab[title=credential-lists]'),
-    );
-    this.shadowRoot
-      ?.querySelector('mwc-tab-bar.main-bar')
-      ?.setAttribute('activeindex', '1');
   }
 
   render() {

--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -573,7 +573,7 @@ export default class BackendAISummary extends BackendAIPage {
                       </button>
                       <button
                         @click="${() => {
-                          this._moveTo('/credential');
+                          this._moveTo('/credential', '?action=manage');
                         }}"
                         class="vertical center center-justified layout start-menu-items link-button"
                         style="border-left:1px solid #ccc;"


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR resolve to fix `credential` in sidebar is shown keypair-list after merging https://github.com/lablup/backend.ai-webui/pull/2194

How to reproduce this bug:

- Login and go to the credential page to click `credential` in sidebar
- You can show keypair-list

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
