### PR TITLE
fix: general setting page is empty after navigation from log tab

### DIFF
--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -6,8 +6,6 @@ import Card from 'antd/es/card/Card';
 import { useTranslation } from 'react-i18next';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
-type TabKey = 'general' | 'logs';
-
 const tabParam = withDefault(StringParam, 'general');
 
 const UserSettingPage = () => {
@@ -24,7 +22,7 @@ const UserSettingPage = () => {
             pathname: '/usersettings',
             search: `?tab=${key}`,
           },
-          // Pass the tab as a `params`` to update the tab in backend-ai-usersettings
+          // Pass the tab as a `params` to update the tab in backend-ai-usersettings
           {
             params: {
               tab: key,

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -1,5 +1,6 @@
 import ErrorLogList from '../components/ErrorLogList';
 import Flex from '../components/Flex';
+import { useWebUINavigate } from '../hooks';
 import { theme } from 'antd';
 import Card from 'antd/es/card/Card';
 import { useTranslation } from 'react-i18next';
@@ -12,11 +13,25 @@ const tabParam = withDefault(StringParam, 'general');
 const UserSettingPage = () => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+  const webUINavigate = useWebUINavigate();
+  const [curTabKey] = useQueryParam('tab', tabParam);
   return (
     <Card
       activeTabKey={curTabKey}
-      onTabChange={(key) => setCurTabKey(key as TabKey)}
+      onTabChange={(key) => {
+        webUINavigate(
+          {
+            pathname: '/usersettings',
+            search: `?tab=${key}`,
+          },
+          // Pass the tab as a `params`` to update the tab in backend-ai-usersettings
+          {
+            params: {
+              tab: key,
+            },
+          },
+        );
+      }}
       tabList={[
         {
           key: 'general',


### PR DESCRIPTION

###  How to Reproduce:
- Refresh the browser on the /summary page.
- Click the user dropdown in the top right corner.
- Click the "log / error" item.
- After navigating to the "Settings & Logs" page, click the "General" tab.

You will see that the tab content is blank.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
