### PR TITLE
feat: ensure that the logo is always on top at sider.

### DIFF
--- a/react/src/components/BAISider.tsx
+++ b/react/src/components/BAISider.tsx
@@ -9,6 +9,7 @@ export interface BAISiderProps extends SiderProps {
   logo?: React.ReactNode;
   logoTitleCollapsed?: React.ReactNode;
   logoTitle?: React.ReactNode;
+  fixedLogo?: boolean;
   bottomText?: React.ReactNode;
 }
 
@@ -19,6 +20,7 @@ const BAISider: React.FC<BAISiderProps> = ({
   logoCollapsed,
   logoTitle,
   logoTitleCollapsed,
+  fixedLogo,
   bottomText,
   ...otherProps
 }) => {
@@ -117,7 +119,10 @@ const BAISider: React.FC<BAISiderProps> = ({
             </Typography.Text>
           </div>
         </Flex>
-        <div className="siderContents" style={{ overflowY: 'auto' }}>
+        <div
+          className="siderContents"
+          style={{ overflowY: fixedLogo ? 'auto' : undefined }}
+        >
           {children}
           {bottomText && (
             <>

--- a/react/src/components/BAISider.tsx
+++ b/react/src/components/BAISider.tsx
@@ -52,6 +52,9 @@ const BAISider: React.FC<BAISiderProps> = ({
           .bai-sider .non-draggable {
             -webkit-app-region: no-drag;
           }
+          .bai-sider .siderContents::-webkit-scrollbar {
+            display: none;
+          }
         `}
       </style>
       <Sider
@@ -74,8 +77,8 @@ const BAISider: React.FC<BAISiderProps> = ({
           xs
             ? 0
             : _.isNumber(otherProps.collapsedWidth)
-            ? otherProps.collapsedWidth
-            : DEFAULT_COLLAPSED_WIDTH
+              ? otherProps.collapsedWidth
+              : DEFAULT_COLLAPSED_WIDTH
         }
         className="bai-sider"
       >
@@ -114,31 +117,33 @@ const BAISider: React.FC<BAISiderProps> = ({
             </Typography.Text>
           </div>
         </Flex>
-        {children}
-        {bottomText && (
-          <>
-            <Flex style={{ flex: 1 }} />
-            <Flex
-              justify="center"
-              direction="column"
-              style={{
-                width: '100%',
-                padding: 20,
-                textAlign: 'center',
-              }}
-            >
-              <Text
-                type="secondary"
+        <div className="siderContents" style={{ overflowY: 'auto' }}>
+          {children}
+          {bottomText && (
+            <>
+              <Flex style={{ flex: 1 }} />
+              <Flex
+                justify="center"
+                direction="column"
                 style={{
-                  fontSize: '12px',
-                  wordBreak: 'normal',
+                  width: '100%',
+                  padding: 20,
+                  textAlign: 'center',
                 }}
               >
-                {bottomText}
-              </Text>
-            </Flex>
-          </>
-        )}
+                <Text
+                  type="secondary"
+                  style={{
+                    fontSize: '12px',
+                    wordBreak: 'normal',
+                  }}
+                >
+                  {bottomText}
+                </Text>
+              </Flex>
+            </>
+          )}
+        </div>
       </Sider>
     </>
   );

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -199,6 +199,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
       logoTitleCollapsed={
         themeConfig?.logo?.logoTitleCollapsed || siteDescription || 'WebUI'
       }
+      fixedLogo
       bottomText={
         props.collapsed ? null : (
           <>
@@ -305,25 +306,27 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
                 },
               ]
             : currentUserRole === 'admin'
-            ? [
-                ...generalMenu,
-                {
-                  type: 'group',
-                  label: (
-                    <Flex
-                      style={{ borderBottom: `1px solid ${token.colorBorder}` }}
-                    >
-                      {!props.collapsed && (
-                        <Typography.Text type="secondary" ellipsis>
-                          {t('webui.menu.Administration')}
-                        </Typography.Text>
-                      )}
-                    </Flex>
-                  ),
-                  children: [...adminMenu],
-                },
-              ]
-            : [...generalMenu]
+              ? [
+                  ...generalMenu,
+                  {
+                    type: 'group',
+                    label: (
+                      <Flex
+                        style={{
+                          borderBottom: `1px solid ${token.colorBorder}`,
+                        }}
+                      >
+                        {!props.collapsed && (
+                          <Typography.Text type="secondary" ellipsis>
+                            {t('webui.menu.Administration')}
+                          </Typography.Text>
+                        )}
+                      </Flex>
+                    ),
+                    children: [...adminMenu],
+                  },
+                ]
+              : [...generalMenu]
         }
         /**
          * Etc menu


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

If layout is too small, sider's contents(logo, menuList, bottomText) is scrolled all.
User must scroll up to click logo to go summary page.
So I added scroll to sider's content to ensure that the logo is always on top.

Before
![스크린샷 2024-02-14 오후 3 27 26](https://github.com/lablup/backend.ai-webui/assets/28584221/881588d4-1e2d-4c56-a6ca-4a0553732f26)

After
![스크린샷 2024-02-14 오후 5 11 45](https://github.com/lablup/backend.ai-webui/assets/28584221/8f230b43-5975-4921-a433-f65bf19c8219)



**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
