### PR TITLE
fix: Electron live debug mode using `LIVE_DEBUG` and `LIVE_DEBUG_ENDPOINT`

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,7 +14,6 @@ if (isDev()) { // Dev mode from Makefile
   process.env.serveMode = 'prod'; // Prod OR debug
   debugMode = false;
 }
-process.env.liveDebugMode = false; // Special flag for live server debug.
 const url = require('url');
 const path = require('path');
 const toml = require('markty-toml');
@@ -340,14 +339,12 @@ function createWindow() {
     }
   });
   // and load the index.html of the app.
-  if (process.env.liveDebugMode === true) {
+  if (process.env.LIVE_DEBUG === '1') {
+    const endpoint = process.env.LIVE_DEBUG_ENDPOINT || 'http://127.0.0.1:9081';
+
     // Load HTML into new Window (dynamic serving for develop)
-    console.log("Running on live debug mode...");
-    mainWindow.loadURL(url.format({
-      pathname: '127.0.0.1:9081',
-      protocol: 'http',
-      slashes: true
-    }));
+    console.log(`Running on live debug(${endpoint}) mode...`);
+    mainWindow.loadURL(endpoint);
   } else {
     // Load HTML into new Window (file-based serving)
     nfs.readFile(path.join(es6Path, 'config.toml'), 'utf-8', (err, data) => {


### PR DESCRIPTION
This PR introduces 
- `LIVE_DEBUG`: Set to `1` if you want to live debug mode for Electron. The default value is `undefined`
- `LIVE_DEBUG_ENDPOINT`: This variable allows developers to dynamically specify the endpoint URL that the application should connect to during live debugging. The default value is `http://127.0.0.1:9081`

### Example
```
LIVE_DEBUG=1 npm run electron:d
```
```
LIVE_DEBUG=1 LIVE_DEBUG_ENDPOINT=http://warboy-15-local.backend.ai:9081 npm run electron:d
``` 

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
