### PR TITLE
docs: Update outdated Makefile command for building macOS apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,8 +391,8 @@ Electron building is automated using `Makefile`.
 ```console
 $ make clean      # clean prebuilt codes
 $ make mac        # build macOS app (both Intel/Apple)
-$ make mac_intel  # build macOS app (Intel x64)
-$ make mac_apple  # build macOS app (Apple Silicon)
+$ make mac_x64    # build macOS app (Intel x64)
+$ make mac_arm64  # build macOS app (Apple Silicon)
 $ make win        # build win64 app
 $ make linux      # build linux app
 $ make all        # build win64/macos/linux app
@@ -416,12 +416,12 @@ NOTE: Sometimes Apple silicon version compiled on Intel machine does not work.
 
 ##### Intel x64
 ```console
-$ make mac_intel
+$ make mac_x64
 ```
 
 ##### Apple Silicon (Apple M1 and above)
 ```console
-$ make mac_apple
+$ make mac_arm64
 ```
 
 ##### Building app with Code Signing (all platforms)

--- a/src/lib/backend.ai-client-node.ts
+++ b/src/lib/backend.ai-client-node.ts
@@ -3715,8 +3715,8 @@ class Maintenance {
    * @param {string} task_id - background task id.
    */
   attach_background_task(task_id: string) {
-    var urlStr = '/events/background-task?task_id=' + task_id;
-    let req = this.client.newSignedRequest('GET', urlStr, null);
+    const urlStr = '/events/background-task?task_id=' + task_id;
+    const req = this.client.newSignedRequest('GET', urlStr, null);
     return new EventSource(req.uri, { withCredentials: true });
   }
 


### PR DESCRIPTION
This PR is a follow-up to #2013.

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
