### PR TITLE
hotfix: regression of image info display in serving page

### DIFF
--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -224,7 +224,11 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
     return color;
   };
 
-  const fullImageString = `${endpoint?.image_object?.registry}/${endpoint?.image_object?.name}:${endpoint?.image_object?.tag}@${endpoint?.image_object?.architecture}`;
+  const fullImageString: string = (
+    baiClient.supports('modify-endpoint')
+      ? `${endpoint?.image_object?.registry}/${endpoint?.image_object?.name}:${endpoint?.image_object?.tag}@${endpoint?.image_object?.architecture}`
+      : endpoint?.image
+  ) as string;
 
   const resource_opts = JSON.parse(endpoint?.resource_opts || '{}');
   return (
@@ -387,7 +391,9 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
             },
             {
               label: t('modelService.Image'),
-              children: endpoint?.image_object && (
+              children: (baiClient.supports('modify-endpoint')
+                ? endpoint?.image_object
+                : endpoint?.image) && (
                 <Flex direction="row" gap={'xs'}>
                   <ImageMetaIcon image={fullImageString} />
                   <CopyableCodeText>{fullImageString}</CopyableCodeText>

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -113,7 +113,26 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
             name
             status
             endpoint_id
-            image
+            image_object @since(version: "23.09.9") {
+              name
+              humanized_name
+              tag
+              registry
+              architecture
+              is_local
+              digest
+              resource_limits {
+                key
+                min
+                max
+              }
+              labels {
+                key
+                value
+              }
+              size_bytes
+              supported_accelerators
+            }
             desired_session_count
             url
             open_to_public
@@ -203,6 +222,8 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
     }
     return color;
   };
+
+  const fullImageString = `${endpoint?.image_object?.registry}/${endpoint?.image_object?.name}:${endpoint?.image_object?.tag}-${endpoint?.image_object?.architecture}`;
 
   const resource_opts = JSON.parse(endpoint?.resource_opts || '{}');
   return (
@@ -365,10 +386,10 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
             },
             {
               label: t('modelService.Image'),
-              children: endpoint?.image && (
+              children: endpoint?.image_object && (
                 <Flex direction="row" gap={'xs'}>
-                  <ImageMetaIcon image={endpoint.image} />
-                  <CopyableCodeText>{endpoint.image}</CopyableCodeText>
+                  <ImageMetaIcon image={fullImageString} />
+                  <CopyableCodeText>{fullImageString}</CopyableCodeText>
                 </Flex>
               ),
               span: {

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -113,6 +113,7 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
             name
             status
             endpoint_id
+            image
             image_object @since(version: "23.09.9") {
               name
               humanized_name

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -113,7 +113,7 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
             name
             status
             endpoint_id
-            image
+            image @deprecatedSince(version: "23.09.9")
             image_object @since(version: "23.09.9") {
               name
               humanized_name

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -223,7 +223,7 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
     return color;
   };
 
-  const fullImageString = `${endpoint?.image_object?.registry}/${endpoint?.image_object?.name}:${endpoint?.image_object?.tag}-${endpoint?.image_object?.architecture}`;
+  const fullImageString = `${endpoint?.image_object?.registry}/${endpoint?.image_object?.name}:${endpoint?.image_object?.tag}@${endpoint?.image_object?.architecture}`;
 
   const resource_opts = JSON.parse(endpoint?.resource_opts || '{}');
   return (

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -272,27 +272,6 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
             items {
               name
               endpoint_id
-              image
-              image_object @since(version: "23.09.9") {
-                name
-                humanized_name
-                tag
-                registry
-                architecture
-                is_local
-                digest
-                resource_limits {
-                  key
-                  min
-                  max
-                }
-                labels {
-                  key
-                  value
-                }
-                size_bytes
-                supported_accelerators
-              }
               model
               domain
               status

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -272,7 +272,26 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
             items {
               name
               endpoint_id
-              image
+              image_object @since(version: "23.09.9") {
+                name
+                humanized_name
+                tag
+                registry
+                architecture
+                is_local
+                digest
+                resource_limits {
+                  key
+                  min
+                  max
+                }
+                labels {
+                  key
+                  value
+                }
+                size_bytes
+                supported_accelerators
+              }
               model
               domain
               status

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -272,6 +272,7 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
             items {
               name
               endpoint_id
+              image
               image_object @since(version: "23.09.9") {
                 name
                 humanized_name

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1528,6 +1528,15 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       const nameFragments = this.manualImageName.value.split(':');
       version = nameFragments.splice(-1, 1)[0];
       kernel = nameFragments.join(':');
+      // extract architecture if exists
+      architecture = ['x86_64', 'aarch64'].includes(
+        this.manualImageName.value.split('-').pop(),
+      )
+        ? this.manualImageName.value.split('-').pop()
+        : undefined;
+      if (architecture) {
+        kernel = this.manualImageName.value.split('-').slice(0, -1).join('-');
+      }
       // TODO: Add support for selecting image architecture when starting kernel with manual image name
     } else {
       // When the "Environment" dropdown is disabled after typing the image name manually,
@@ -1664,7 +1673,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       (this._debug && this.manualImageName.value !== '') ||
       (this.manualImageName && this.manualImageName.value !== '')
     ) {
-      kernelName = this.manualImageName.value;
+      kernelName = architecture ? kernel : this.manualImageName.value;
     } else {
       kernelName = this._generateKernelIndex(kernel, version);
     }

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1530,12 +1530,12 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
       kernel = nameFragments.join(':');
       // extract architecture if exists
       architecture = ['x86_64', 'aarch64'].includes(
-        this.manualImageName.value.split('-').pop(),
+        this.manualImageName.value.split('@').pop(),
       )
-        ? this.manualImageName.value.split('-').pop()
+        ? this.manualImageName.value.split('@').pop()
         : undefined;
       if (architecture) {
-        kernel = this.manualImageName.value.split('-').slice(0, -1).join('-');
+        kernel = this.manualImageName.value.split('@')[0];
       }
       // TODO: Add support for selecting image architecture when starting kernel with manual image name
     } else {


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

This PR fixes two thing,
 - [x] Show full-image string in Routing page, as a regression of replacing deprecated `image` key in `endpoint` to `image_object`.
 - [x] Supports architecture on same image string (multiarch) by extracting from full-image string

- Core(manager) version: `23.9.9~`

How to test:
1. Go to Serving page
2. Click `Start service` button.
3. Service launcher modal pops up.
4. Create a service with two cases:
    - [x] Select from environment/version
    - [x] Input image string (`cr.backend.ai/multiarch/python:3.9-ubuntu20.04@aarch64`) in manual image input field
5. Click `Create` button.
6. Click Endpoint Name you just created from step 4.
7. See image info in Routing page.

| After | Before |
|------|--------|
| <img width="1229" alt="Screenshot 2024-03-06 at 12 02 14 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/112fdeee-f19d-4eec-93a8-881b13b1a7c0"> | <img width="1229" alt="Screenshot 2024-03-06 at 12 24 07 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/2dbcb7e8-5d54-48d6-bf2a-df1b18282f90"> |