### PR TITLE
fix: regression of built-in app in session execution when app itself is refreshed in Windows Desktop app

### DIFF
--- a/main.js
+++ b/main.js
@@ -250,7 +250,7 @@ app.once('ready', function() {
                 protocol: 'file',
                 slashes: true
               }));
-              mainContent.executeJavaScript(`window.__local_proxy = '${proxyUrl}'`);
+              mainContent.executeJavaScript(`window.__local_proxy = {}; window.__local_proxy.url = '${proxyUrl}';`);
               console.log('Re-connected to proxy: ' + proxyUrl);
             }
           },

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -644,7 +644,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
       param['secret_key'] = globalThis.backendaiclient._config.secretKey;
     }
     param['api_version'] = globalThis.backendaiclient.APIMajorVersion;
-    if (globalThis.isElectron && globalThis.__local_proxy.url === undefined) {
+    if (globalThis.isElectron && window.__local_proxy.url === undefined) {
       this.indicator.end();
       this.notification.text = _text('session.launcher.ProxyNotReady');
       this.notification.show();


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR fixes bug when built-in app in session execution fails when refreshes app itself inside Desktop application especially in Windows environment.
- Manager version: `23.09.10rc2`~

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [X] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
