### PR TITLE
fix: font-size of the session launcher button

### DIFF
--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -867,6 +867,9 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
             opacity: 1;
           }
         }
+        #launch-button {
+          font-size: 14px;
+        }
       `,
     ];
   }


### PR DESCRIPTION
The font-size of session launcher button is increased after #2193 .

![image](https://github.com/lablup/backend.ai-webui/assets/621215/bac8ab02-279c-4b99-a5e0-f454fc7cbded)

Afte this PR
<img width="430" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/baca9b9e-b602-4dc7-8e92-e6fab2177dd1">

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
