### PR TITLE
feat: Quota Scope ID in data page's storage status panel

### DIFF
--- a/react/src/components/StorageStatusPanel.tsx
+++ b/react/src/components/StorageStatusPanel.tsx
@@ -291,7 +291,7 @@ const StorageStatusPanel: React.FC<{
       key: 'userQuotaScopeId',
       label: t('data.userQuotaScopeId'),
       children: (
-        <Typography.Text>
+        <Typography.Text copyable>
           {addQuotaScopeTypePrefix('user', user?.id || '')}
         </Typography.Text>
       ),

--- a/react/src/components/StorageStatusPanel.tsx
+++ b/react/src/components/StorageStatusPanel.tsx
@@ -170,11 +170,12 @@ const StorageStatusPanel: React.FC<{
       ? ((createdCount / maxVfolderCount) * 100)?.toFixed(2)
       : 0
   ) as number;
-
-  return (
-    <Card size="small" title={t('data.StorageStatus')}>
-      <Descriptions bordered column={columnSetting} size="small">
-        <Descriptions.Item label={t('data.NumberOfFolders')}>
+  const descriptionItem: DescriptionsProps['items'] = [
+    {
+      key: '1',
+      label: t('data.NumberOfFolders'),
+      children: (
+        <>
           <Progress
             size={[200, 15]}
             percent={numberOfFolderPercent}
@@ -208,17 +209,21 @@ const StorageStatusPanel: React.FC<{
               {invitedCount}
             </Flex>
           </Flex>
-        </Descriptions.Item>
-        <Descriptions.Item
-          label={
-            <div>
-              {t('data.QuotaPerStorageVolume')}
-              <Tooltip title={t('data.HostDetails')}>
-                <Button type="link" icon={<InfoCircleOutlined />} />
-              </Tooltip>
-            </div>
-          }
-        >
+        </>
+      ),
+    },
+    {
+      key: '2',
+      label: (
+        <div>
+          {t('data.QuotaPerStorageVolume')}
+          <Tooltip title={t('data.HostDetails')}>
+            <Button type="link" icon={<InfoCircleOutlined />} />
+          </Tooltip>
+        </div>
+      ),
+      children: (
+        <>
           <Flex
             wrap="wrap"
             justify="between"
@@ -279,13 +284,24 @@ const StorageStatusPanel: React.FC<{
               style={{ margin: '25px auto' }}
             />
           )}
-        </Descriptions.Item>
-        {user?.id && (
-          <Descriptions.Item label="User ID" span={4}>
-            <Typography.Text copyable>{user?.id}</Typography.Text>
-          </Descriptions.Item>
-        )}
-      </Descriptions>
+        </>
+      ),
+    },
+    {
+      key: '3',
+      label: t('data.userQuotaScopeId'),
+      children: <Typography.Text copyable>{user?.id}</Typography.Text>,
+    },
+  ];
+
+  return (
+    <Card size="small" title={t('data.StorageStatus')}>
+      <Descriptions
+        bordered
+        column={columnSetting}
+        size="small"
+        items={descriptionItem}
+      />
     </Card>
   );
 };

--- a/react/src/components/StorageStatusPanel.tsx
+++ b/react/src/components/StorageStatusPanel.tsx
@@ -43,8 +43,8 @@ const StorageStatusPanel: React.FC<{
   const deferredFetchKey = useDeferredValue(fetchKey);
 
   const columnSetting: DescriptionsProps['column'] = {
-    xxl: 4,
-    xl: 4,
+    xxl: 2,
+    xl: 2,
     lg: 2,
     md: 1,
     sm: 1,
@@ -280,6 +280,11 @@ const StorageStatusPanel: React.FC<{
             />
           )}
         </Descriptions.Item>
+        {user?.id && (
+          <Descriptions.Item label="User ID" span={4}>
+            <Typography.Text copyable>{user?.id}</Typography.Text>
+          </Descriptions.Item>
+        )}
       </Descriptions>
     </Card>
   );

--- a/react/src/components/StorageStatusPanel.tsx
+++ b/react/src/components/StorageStatusPanel.tsx
@@ -170,9 +170,9 @@ const StorageStatusPanel: React.FC<{
       ? ((createdCount / maxVfolderCount) * 100)?.toFixed(2)
       : 0
   ) as number;
-  const descriptionItem: DescriptionsProps['items'] = [
+  const descriptionItems: DescriptionsProps['items'] = [
     {
-      key: '1',
+      key: 'totalFolders',
       label: t('data.NumberOfFolders'),
       children: (
         <>
@@ -213,7 +213,7 @@ const StorageStatusPanel: React.FC<{
       ),
     },
     {
-      key: '2',
+      key: 'quotaPerStorageVolume',
       label: (
         <div>
           {t('data.QuotaPerStorageVolume')}
@@ -288,9 +288,13 @@ const StorageStatusPanel: React.FC<{
       ),
     },
     {
-      key: '3',
+      key: 'userQuotaScopeId',
       label: t('data.userQuotaScopeId'),
-      children: <Typography.Text copyable>{user?.id}</Typography.Text>,
+      children: (
+        <Typography.Text>
+          {addQuotaScopeTypePrefix('user', user?.id || '')}
+        </Typography.Text>
+      ),
     },
   ];
 
@@ -300,7 +304,7 @@ const StorageStatusPanel: React.FC<{
         bordered
         column={columnSetting}
         size="small"
-        items={descriptionItem}
+        items={descriptionItems}
       />
     </Card>
   );

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -708,7 +708,7 @@
     "New": "Neu",
     "Add": "hinzufügen",
     "CloningIsOnlyPossibleSameHost": "Derzeit ist das Klonen nur auf demselben Host möglich.",
-    "userQuotaScopeId": "Benutzer-UUID"
+    "userQuotaScopeId": "Kontingentumfang-ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -708,7 +708,7 @@
     "New": "Neu",
     "Add": "hinzufügen",
     "CloningIsOnlyPossibleSameHost": "Derzeit ist das Klonen nur auf demselben Host möglich.",
-    "userQuotaScopeId": "Kontingentumfang-ID"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -707,7 +707,8 @@
     "ModelStore": "Modellladen",
     "New": "Neu",
     "Add": "hinzufügen",
-    "CloningIsOnlyPossibleSameHost": "Derzeit ist das Klonen nur auf demselben Host möglich."
+    "CloningIsOnlyPossibleSameHost": "Derzeit ist das Klonen nur auf demselben Host möglich.",
+    "userQuotaScopeId": "Benutzer-UUID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -708,7 +708,7 @@
     "New": "Νέος",
     "Add": "Προσθέστε",
     "CloningIsOnlyPossibleSameHost": "Προς το παρόν, η κλωνοποίηση είναι δυνατή μόνο στον ίδιο κεντρικό υπολογιστή.",
-    "userQuotaScopeId": "Αναγνωριστικό πεδίου ποσοστώσεων"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -707,7 +707,8 @@
     "ModelStore": "Κατάστημα μοντέλων",
     "New": "Νέος",
     "Add": "Προσθέστε",
-    "CloningIsOnlyPossibleSameHost": "Προς το παρόν, η κλωνοποίηση είναι δυνατή μόνο στον ίδιο κεντρικό υπολογιστή."
+    "CloningIsOnlyPossibleSameHost": "Προς το παρόν, η κλωνοποίηση είναι δυνατή μόνο στον ίδιο κεντρικό υπολογιστή.",
+    "userQuotaScopeId": "UUID χρήστη"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -708,7 +708,7 @@
     "New": "Νέος",
     "Add": "Προσθέστε",
     "CloningIsOnlyPossibleSameHost": "Προς το παρόν, η κλωνοποίηση είναι δυνατή μόνο στον ίδιο κεντρικό υπολογιστή.",
-    "userQuotaScopeId": "UUID χρήστη"
+    "userQuotaScopeId": "Αναγνωριστικό πεδίου ποσοστώσεων"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -808,7 +808,8 @@
     "ModelStore": "Model Store",
     "New": "New",
     "Add": "Add",
-    "CloningIsOnlyPossibleSameHost": "Currently, cloning is only possible on the same host."
+    "CloningIsOnlyPossibleSameHost": "Currently, cloning is only possible on the same host.",
+    "userQuotaScopeId": "User UUID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -809,7 +809,7 @@
     "New": "New",
     "Add": "Add",
     "CloningIsOnlyPossibleSameHost": "Currently, cloning is only possible on the same host.",
-    "userQuotaScopeId": "User UUID"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -379,7 +379,8 @@
     "ModelStore": "Tienda de modelos",
     "New": "Nuevo",
     "Add": "Añadir",
-    "CloningIsOnlyPossibleSameHost": "Actualmente, la clonación sólo es posible en el mismo host."
+    "CloningIsOnlyPossibleSameHost": "Actualmente, la clonación sólo es posible en el mismo host.",
+    "userQuotaScopeId": "UUID de usuario"
   },
   "dialog": {
     "ErrorOccurred": "Se ha producido un error",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -380,7 +380,7 @@
     "New": "Nuevo",
     "Add": "Añadir",
     "CloningIsOnlyPossibleSameHost": "Actualmente, la clonación sólo es posible en el mismo host.",
-    "userQuotaScopeId": "UUID de usuario"
+    "userQuotaScopeId": "ID de alcance de cuota"
   },
   "dialog": {
     "ErrorOccurred": "Se ha producido un error",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -380,7 +380,7 @@
     "New": "Nuevo",
     "Add": "Añadir",
     "CloningIsOnlyPossibleSameHost": "Actualmente, la clonación sólo es posible en el mismo host.",
-    "userQuotaScopeId": "ID de alcance de cuota"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "ErrorOccurred": "Se ha producido un error",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -380,7 +380,7 @@
     "Add": "Lisätä",
     "CloningIsOnlyPossibleSameHost": "Tällä hetkellä kloonaus on mahdollista vain samassa isännässä.",
     "New": "Uusi",
-    "userQuotaScopeId": "Käyttäjän UUID"
+    "userQuotaScopeId": "Kiintiön laajuuden tunnus"
   },
   "dialog": {
     "ErrorOccurred": "Tapahtunut virhe",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -379,7 +379,8 @@
     "ModelStore": "Mallikauppa",
     "Add": "Lisätä",
     "CloningIsOnlyPossibleSameHost": "Tällä hetkellä kloonaus on mahdollista vain samassa isännässä.",
-    "New": "Uusi"
+    "New": "Uusi",
+    "userQuotaScopeId": "Käyttäjän UUID"
   },
   "dialog": {
     "ErrorOccurred": "Tapahtunut virhe",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -380,7 +380,7 @@
     "Add": "Lisätä",
     "CloningIsOnlyPossibleSameHost": "Tällä hetkellä kloonaus on mahdollista vain samassa isännässä.",
     "New": "Uusi",
-    "userQuotaScopeId": "Kiintiön laajuuden tunnus"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "ErrorOccurred": "Tapahtunut virhe",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -708,7 +708,7 @@
     "New": "Nouveau",
     "Add": "Ajouter",
     "CloningIsOnlyPossibleSameHost": "Actuellement, le clonage n'est possible que sur le même hôte.",
-    "userQuotaScopeId": "UUID de l'utilisateur"
+    "userQuotaScopeId": "ID de portée du quota"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -707,7 +707,8 @@
     "ModelStore": "Magasin de modèles",
     "New": "Nouveau",
     "Add": "Ajouter",
-    "CloningIsOnlyPossibleSameHost": "Actuellement, le clonage n'est possible que sur le même hôte."
+    "CloningIsOnlyPossibleSameHost": "Actuellement, le clonage n'est possible que sur le même hôte.",
+    "userQuotaScopeId": "UUID de l'utilisateur"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -708,7 +708,7 @@
     "New": "Nouveau",
     "Add": "Ajouter",
     "CloningIsOnlyPossibleSameHost": "Actuellement, le clonage n'est possible que sur le même hôte.",
-    "userQuotaScopeId": "ID de portée du quota"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -708,7 +708,7 @@
     "New": "Baru",
     "Add": "Menambahkan",
     "CloningIsOnlyPossibleSameHost": "Saat ini, kloning hanya dapat dilakukan pada host yang sama.",
-    "userQuotaScopeId": "UUID pengguna"
+    "userQuotaScopeId": "ID Cakupan Kuota"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -707,7 +707,8 @@
     "ModelStore": "Toko Model",
     "New": "Baru",
     "Add": "Menambahkan",
-    "CloningIsOnlyPossibleSameHost": "Saat ini, kloning hanya dapat dilakukan pada host yang sama."
+    "CloningIsOnlyPossibleSameHost": "Saat ini, kloning hanya dapat dilakukan pada host yang sama.",
+    "userQuotaScopeId": "UUID pengguna"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -708,7 +708,7 @@
     "New": "Baru",
     "Add": "Menambahkan",
     "CloningIsOnlyPossibleSameHost": "Saat ini, kloning hanya dapat dilakukan pada host yang sama.",
-    "userQuotaScopeId": "ID Cakupan Kuota"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -708,7 +708,7 @@
     "New": "Nuovo",
     "Add": "Aggiungi",
     "CloningIsOnlyPossibleSameHost": "Attualmente la clonazione è possibile solo sullo stesso host.",
-    "userQuotaScopeId": "ID ambito quota"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -708,7 +708,7 @@
     "New": "Nuovo",
     "Add": "Aggiungi",
     "CloningIsOnlyPossibleSameHost": "Attualmente la clonazione è possibile solo sullo stesso host.",
-    "userQuotaScopeId": "UUID dell'utente"
+    "userQuotaScopeId": "ID ambito quota"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -707,7 +707,8 @@
     "ModelStore": "Negozio di modelli",
     "New": "Nuovo",
     "Add": "Aggiungi",
-    "CloningIsOnlyPossibleSameHost": "Attualmente la clonazione è possibile solo sullo stesso host."
+    "CloningIsOnlyPossibleSameHost": "Attualmente la clonazione è possibile solo sullo stesso host.",
+    "userQuotaScopeId": "UUID dell'utente"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -707,7 +707,8 @@
     "ModelStore": "模型店",
     "New": "新しい",
     "Add": "追加",
-    "CloningIsOnlyPossibleSameHost": "現在、クローン作成は同じホスト上でのみ可能です。"
+    "CloningIsOnlyPossibleSameHost": "現在、クローン作成は同じホスト上でのみ可能です。",
+    "userQuotaScopeId": "ユーザーUUID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -708,7 +708,7 @@
     "New": "新しい",
     "Add": "追加",
     "CloningIsOnlyPossibleSameHost": "現在、クローン作成は同じホスト上でのみ可能です。",
-    "userQuotaScopeId": "ユーザーUUID"
+    "userQuotaScopeId": "クォータスコープID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -708,7 +708,7 @@
     "New": "新しい",
     "Add": "追加",
     "CloningIsOnlyPossibleSameHost": "現在、クローン作成は同じホスト上でのみ可能です。",
-    "userQuotaScopeId": "クォータスコープID"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -796,7 +796,8 @@
     "ModelStore": "모델 스토어",
     "New": "새로운",
     "Add": "추가",
-    "CloningIsOnlyPossibleSameHost": "현재 폴더 복사는 동일한 호스트간에만 가능합니다."
+    "CloningIsOnlyPossibleSameHost": "현재 폴더 복사는 동일한 호스트간에만 가능합니다.",
+    "userQuotaScopeId": "사용자 UUID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -797,7 +797,7 @@
     "New": "새로운",
     "Add": "추가",
     "CloningIsOnlyPossibleSameHost": "현재 폴더 복사는 동일한 호스트간에만 가능합니다.",
-    "userQuotaScopeId": "할당량 범위 ID"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -797,7 +797,7 @@
     "New": "새로운",
     "Add": "추가",
     "CloningIsOnlyPossibleSameHost": "현재 폴더 복사는 동일한 호스트간에만 가능합니다.",
-    "userQuotaScopeId": "사용자 UUID"
+    "userQuotaScopeId": "할당량 범위 ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -707,7 +707,8 @@
     "ModelStore": "Загварын дэлгүүр",
     "New": "Шинэ",
     "Add": "Нэмэх",
-    "CloningIsOnlyPossibleSameHost": "Одоогоор зөвхөн нэг хост дээр клон хийх боломжтой."
+    "CloningIsOnlyPossibleSameHost": "Одоогоор зөвхөн нэг хост дээр клон хийх боломжтой.",
+    "userQuotaScopeId": "Хэрэглэгч UUID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -708,7 +708,7 @@
     "New": "Шинэ",
     "Add": "Нэмэх",
     "CloningIsOnlyPossibleSameHost": "Одоогоор зөвхөн нэг хост дээр клон хийх боломжтой.",
-    "userQuotaScopeId": "Хэрэглэгч UUID"
+    "userQuotaScopeId": "Квотын хамрах хүрээ ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -708,7 +708,7 @@
     "New": "Шинэ",
     "Add": "Нэмэх",
     "CloningIsOnlyPossibleSameHost": "Одоогоор зөвхөн нэг хост дээр клон хийх боломжтой.",
-    "userQuotaScopeId": "Квотын хамрах хүрээ ID"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -708,7 +708,7 @@
     "New": "Baru",
     "Add": "Tambah",
     "CloningIsOnlyPossibleSameHost": "Pada masa ini, pengklonan hanya boleh dilakukan pada hos yang sama.",
-    "userQuotaScopeId": "UUID pengguna"
+    "userQuotaScopeId": "ID Skop Kuota"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -708,7 +708,7 @@
     "New": "Baru",
     "Add": "Tambah",
     "CloningIsOnlyPossibleSameHost": "Pada masa ini, pengklonan hanya boleh dilakukan pada hos yang sama.",
-    "userQuotaScopeId": "ID Skop Kuota"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -707,7 +707,8 @@
     "ModelStore": "Kedai Model",
     "New": "Baru",
     "Add": "Tambah",
-    "CloningIsOnlyPossibleSameHost": "Pada masa ini, pengklonan hanya boleh dilakukan pada hos yang sama."
+    "CloningIsOnlyPossibleSameHost": "Pada masa ini, pengklonan hanya boleh dilakukan pada hos yang sama.",
+    "userQuotaScopeId": "UUID pengguna"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -710,7 +710,7 @@
     "New": "Nowy",
     "Add": "Dodaj",
     "CloningIsOnlyPossibleSameHost": "Obecnie klonowanie jest możliwe tylko na tym samym hoście.",
-    "userQuotaScopeId": "UUID użytkownika"
+    "userQuotaScopeId": "Identyfikator zakresu przydziału"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -709,7 +709,8 @@
     "ModelStore": "Sklep modelarski",
     "New": "Nowy",
     "Add": "Dodaj",
-    "CloningIsOnlyPossibleSameHost": "Obecnie klonowanie jest możliwe tylko na tym samym hoście."
+    "CloningIsOnlyPossibleSameHost": "Obecnie klonowanie jest możliwe tylko na tym samym hoście.",
+    "userQuotaScopeId": "UUID użytkownika"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -710,7 +710,7 @@
     "New": "Nowy",
     "Add": "Dodaj",
     "CloningIsOnlyPossibleSameHost": "Obecnie klonowanie jest możliwe tylko na tym samym hoście.",
-    "userQuotaScopeId": "Identyfikator zakresu przydziału"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -708,7 +708,7 @@
     "New": "Novo",
     "Add": "Adicionar",
     "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host.",
-    "userQuotaScopeId": "ID do escopo da cota"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -707,7 +707,8 @@
     "ModelStore": "Loja de modelos",
     "New": "Novo",
     "Add": "Adicionar",
-    "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host."
+    "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host.",
+    "userQuotaScopeId": "UUID do usuário"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -708,7 +708,7 @@
     "New": "Novo",
     "Add": "Adicionar",
     "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host.",
-    "userQuotaScopeId": "UUID do usuário"
+    "userQuotaScopeId": "ID do escopo da cota"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -708,7 +708,7 @@
     "New": "Novo",
     "Add": "Adicionar",
     "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host.",
-    "userQuotaScopeId": "ID do escopo da cota"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -707,7 +707,8 @@
     "ModelStore": "Loja de modelos",
     "New": "Novo",
     "Add": "Adicionar",
-    "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host."
+    "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host.",
+    "userQuotaScopeId": "UUID do usuário"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -708,7 +708,7 @@
     "New": "Novo",
     "Add": "Adicionar",
     "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host.",
-    "userQuotaScopeId": "UUID do usuário"
+    "userQuotaScopeId": "ID do escopo da cota"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -710,7 +710,7 @@
     "New": "Новый",
     "Add": "Добавить",
     "CloningIsOnlyPossibleSameHost": "В настоящее время клонирование возможно только на том же хосте.",
-    "userQuotaScopeId": "Идентификатор области квоты"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -710,7 +710,7 @@
     "New": "Новый",
     "Add": "Добавить",
     "CloningIsOnlyPossibleSameHost": "В настоящее время клонирование возможно только на том же хосте.",
-    "userQuotaScopeId": "UUID пользователя"
+    "userQuotaScopeId": "Идентификатор области квоты"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -709,7 +709,8 @@
     "ModelStore": "Модельный магазин",
     "New": "Новый",
     "Add": "Добавить",
-    "CloningIsOnlyPossibleSameHost": "В настоящее время клонирование возможно только на том же хосте."
+    "CloningIsOnlyPossibleSameHost": "В настоящее время клонирование возможно только на том же хосте.",
+    "userQuotaScopeId": "UUID пользователя"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -708,7 +708,7 @@
     "New": "Yeni",
     "Add": "Ekle",
     "CloningIsOnlyPossibleSameHost": "Şu anda klonlama yalnızca aynı ana bilgisayarda mümkündür.",
-    "userQuotaScopeId": "Kota Kapsam Kimliği"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -708,7 +708,7 @@
     "New": "Yeni",
     "Add": "Ekle",
     "CloningIsOnlyPossibleSameHost": "Şu anda klonlama yalnızca aynı ana bilgisayarda mümkündür.",
-    "userQuotaScopeId": "Kullanıcı UUID'si"
+    "userQuotaScopeId": "Kota Kapsam Kimliği"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -707,7 +707,8 @@
     "ModelStore": "Model Mağazası",
     "New": "Yeni",
     "Add": "Ekle",
-    "CloningIsOnlyPossibleSameHost": "Şu anda klonlama yalnızca aynı ana bilgisayarda mümkündür."
+    "CloningIsOnlyPossibleSameHost": "Şu anda klonlama yalnızca aynı ana bilgisayarda mümkündür.",
+    "userQuotaScopeId": "Kullanıcı UUID'si"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -707,7 +707,8 @@
     "ModelStore": "Cửa hàng mô hình",
     "New": "Mới",
     "Add": "Thêm vào",
-    "CloningIsOnlyPossibleSameHost": "Hiện tại, việc nhân bản chỉ có thể thực hiện được trên cùng một máy chủ."
+    "CloningIsOnlyPossibleSameHost": "Hiện tại, việc nhân bản chỉ có thể thực hiện được trên cùng một máy chủ.",
+    "userQuotaScopeId": "UUID người dùng"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -708,7 +708,7 @@
     "New": "Mới",
     "Add": "Thêm vào",
     "CloningIsOnlyPossibleSameHost": "Hiện tại, việc nhân bản chỉ có thể thực hiện được trên cùng một máy chủ.",
-    "userQuotaScopeId": "UUID người dùng"
+    "userQuotaScopeId": "ID phạm vi hạn ngạch"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -708,7 +708,7 @@
     "New": "Mới",
     "Add": "Thêm vào",
     "CloningIsOnlyPossibleSameHost": "Hiện tại, việc nhân bản chỉ có thể thực hiện được trên cùng một máy chủ.",
-    "userQuotaScopeId": "ID phạm vi hạn ngạch"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -708,7 +708,7 @@
     "New": "新的",
     "Add": "添加",
     "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主机上进行。",
-    "userQuotaScopeId": "用户UUID"
+    "userQuotaScopeId": "配额范围 ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -708,7 +708,7 @@
     "New": "新的",
     "Add": "添加",
     "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主机上进行。",
-    "userQuotaScopeId": "配额范围 ID"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -707,7 +707,8 @@
     "ModelStore": "模型店",
     "New": "新的",
     "Add": "添加",
-    "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主机上进行。"
+    "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主机上进行。",
+    "userQuotaScopeId": "用户UUID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -708,7 +708,7 @@
     "New": "新的",
     "Add": "添加",
     "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主機上進行。",
-    "userQuotaScopeId": "配額範圍 ID"
+    "userQuotaScopeId": "Quota Scope ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -708,7 +708,7 @@
     "New": "新的",
     "Add": "添加",
     "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主機上進行。",
-    "userQuotaScopeId": "用戶UUID"
+    "userQuotaScopeId": "配額範圍 ID"
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -707,7 +707,8 @@
     "ModelStore": "模型店",
     "New": "新的",
     "Add": "添加",
-    "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主機上進行。"
+    "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主機上進行。",
+    "userQuotaScopeId": "用戶UUID"
   },
   "dialog": {
     "warning": {


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR Resolves #2251 issue. 

### Feature
- show quota scope id (user id) in storage status panel.
- change antd's descriptions column because 2 line representation is visually better than 3 line representation.
(I've tried showing text at the bottom of the card without using descriptions.item, but it doesn't feel consistent.)
- modify the way render descriptions items that is appropriate for the current antd version. The old way was used in versions 5.8.0 and earlier.

<img width="1241" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/51399982/2fd8353c-5a7a-405e-8b62-d6d426bd2283">

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
