### PR TITLE
fix: modify husky config to format both lit and react components

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+npm run format-fix-all

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint-fix": "npx eslint src -c ./.eslintrc.json  --quiet --ext .js,.ts --fix;exit 0",
     "format": "npx prettier --check 'src/**/*.{js, ts}'",
     "format-fix": "npx prettier --write 'src/**/*.{js, ts}'",
+    "format-fix-all": "prettier --write 'src/**/*.{js, ts}' 'react/src/**/*.{js,jsx,ts,tsx}'",
     "test": "npx testcafe chrome ./tests/*.js",
     "jest": "jest",
     "test:react": "npm test --prefix ./react test",
@@ -170,17 +171,9 @@
   "vaadin": {
     "disableUsageStatistics": true
   },
-  "lint-staged": {
-    "react/src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
-      "prettier --write"
-    ],
-    "src/**/*.{jsx,ts,tsx,json,css,scss,md}": [
-      "prettier --write"
-    ]
-  },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "npm run format-fix-all"
     }
   },
   "jest": {

--- a/react/src/components/ResourcePolicyCard.tsx
+++ b/react/src/components/ResourcePolicyCard.tsx
@@ -208,11 +208,11 @@ const ResourcePolicyCard: React.FC<Props> = ({
                     )
                   : '-'
                 : user_resource_policy &&
-                  user_resource_policy?.max_quota_scope_size !== -1
-                ? humanReadableDecimalSize(
-                    user_resource_policy?.max_quota_scope_size,
-                  )
-                : '-'}
+                    user_resource_policy?.max_quota_scope_size !== -1
+                  ? humanReadableDecimalSize(
+                      user_resource_policy?.max_quota_scope_size,
+                    )
+                  : '-'}
             </Descriptions.Item>
           </Descriptions>
         ) : null}

--- a/react/src/pages/ModelStoreListPage.tsx
+++ b/react/src/pages/ModelStoreListPage.tsx
@@ -185,8 +185,8 @@ const ModelStoreListPage: React.FC = () => {
                 info?.title?.toLowerCase().includes(searchLower) ||
                 info?.task?.toLowerCase().includes(searchLower) ||
                 info?.category?.toLowerCase().includes(searchLower) ||
-                info?.label?.some(
-                  (label) => label?.toLowerCase().includes(searchLower),
+                info?.label?.some((label) =>
+                  label?.toLowerCase().includes(searchLower),
                 ) ||
                 false;
             }


### PR DESCRIPTION
Original pre-commit doesn't affect the react components.
Fix the pre-commit command to format both lit(web) components and react components.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
