### PR TITLE
fix: regression of imageInfo initialization for categorizing environments by label in metadata

### DIFF
--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -153,6 +153,7 @@ export default class BackendAiResourceBroker extends BackendAIPage {
     this.icons = globalThis.backendaimetadata.icons;
     this.imageTagAlias = globalThis.backendaimetadata.imageTagAlias;
     this.imageTagReplace = globalThis.backendaimetadata.imageTagReplace;
+    this.imageInfo = globalThis.backendaimetadata.imageInfo;
     document.addEventListener(
       'backend-ai-metadata-image-loaded',
       () => {
@@ -160,6 +161,7 @@ export default class BackendAiResourceBroker extends BackendAIPage {
         this.icons = globalThis.backendaimetadata.icons;
         this.imageTagAlias = globalThis.backendaimetadata.imageTagAlias;
         this.imageTagReplace = globalThis.backendaimetadata.imageTagReplace;
+        this.imageInfo = globalThis.backendaimetadata.imageInfo;
       },
       { once: true },
     );


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
This PR fixes regression issue of missing categories in "environment select UI" inside session-launcher.
All of image except custom image, which is without description in metadata, should be grouped with the title defined in
[metadata.json](https://github.com/lablup/backend.ai-webui/blob/main/resources/image_metadata.json).
For more details, please look through the code below.

https://github.com/lablup/backend.ai-webui/blob/fe8209a0b6e060f4e03b6f5b1aef7c173033c1de/src/components/backend-ai-resource-broker.ts#L1096-L1108

| After | before |
|------|--------|
| <img width="341" alt="Screenshot 2024-03-22 at 3 33 51 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/12c4b93b-4cd1-42e4-a1d3-2f75f46efb54"> | <img width="341" alt="Screenshot 2024-03-22 at 3 34 08 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/f6d9b3b1-6ff3-4f5c-aeb0-9eb79c0de554"> |


**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [] Test case(s) to demonstrate the difference of before/after
