### PR TITLE
feat: update year of copyright

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
           </ul>
           <ul>
             <li>Powered by open-source software</li>
-            <li class="copyright">Copyright &copy; 2015-2023 Lablup Inc.</li>
+            <li class="copyright">Copyright &copy; 2015-2024 Lablup Inc.</li>
           </ul>
         </div>
         <div class="sk-folding-cube">

--- a/main.js
+++ b/main.js
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 const {app, Menu, shell, BrowserWindow, protocol, session, clipboard, dialog, ipcMain} = require('electron');
 process.env.electronPath = app.getAppPath();

--- a/react/src/components/KeypairInfoModal.tsx
+++ b/react/src/components/KeypairInfoModal.tsx
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';

--- a/react/src/components/UserProfileSettingModal.tsx
+++ b/react/src/components/UserProfileSettingModal.tsx
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';

--- a/resources/templates/under_construction.html
+++ b/resources/templates/under_construction.html
@@ -219,7 +219,7 @@
     <h1 class="title">We’ll be back soon!</h1>
     <p>Sorry for the inconvenience but we’re performing some maintenance at the moment.</p>
     <p>If you need to you can always contact us, otherwise we’ll be back online shortly!</p>
-    <div class="copyright">Copyright &copy; 2015-2023 Lablup Inc.</div>
+    <div class="copyright">Copyright &copy; 2015-2024 Lablup Inc.</div>
   </div>
   <div class="sk-folding-cube">
     <div class="sk-cube1 sk-cube"></div>

--- a/src/backend-ai-app.ts
+++ b/src/backend-ai-app.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 export const UPDATE_PAGE = 'UPDATE_PAGE';
 export const UPDATE_OFFLINE = 'UPDATE_OFFLINE';

--- a/src/components/backend-ai-agent-list.ts
+++ b/src/components/backend-ai-agent-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-agent-summary-list.ts
+++ b/src/components/backend-ai-agent-summary-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
-Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
 */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-agent-summary-view.ts
+++ b/src/components/backend-ai-agent-summary-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
-Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
 */
 import './backend-ai-agent-summary-list';
 import { BackendAiStyles } from './backend-ai-general-styles';

--- a/src/components/backend-ai-agent-view.ts
+++ b/src/components/backend-ai-agent-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import './backend-ai-agent-list';
 import { BackendAiStyles } from './backend-ai-general-styles';

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/backend-ai-change-forgot-password-view.ts
+++ b/src/components/backend-ai-change-forgot-password-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { Client, ClientConfig } from '../lib/backend.ai-client-esm';
 import {

--- a/src/components/backend-ai-chart.ts
+++ b/src/components/backend-ai-chart.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/chart-js';
 import {

--- a/src/components/backend-ai-common-utils.ts
+++ b/src/components/backend-ai-common-utils.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { BackendAIPage } from './backend-ai-page';
 import { html } from 'lit';

--- a/src/components/backend-ai-credential-list.ts
+++ b/src/components/backend-ai-credential-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-dialog.ts
+++ b/src/components/backend-ai-dialog.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 // import {get as _text, registerTranslateConfig, translate as _t, use as setLanguage} from "lit-translate";
 import {

--- a/src/components/backend-ai-edu-applauncher.ts
+++ b/src/components/backend-ai-edu-applauncher.ts
@@ -1,6 +1,6 @@
 /**
 @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { Client, ClientConfig } from '../lib/backend.ai-client-esm';
 import {

--- a/src/components/backend-ai-email-verification-view.ts
+++ b/src/components/backend-ai-email-verification-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { Client, ClientConfig } from '../lib/backend.ai-client-esm';
 import {

--- a/src/components/backend-ai-environment-list.ts
+++ b/src/components/backend-ai-environment-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-environment-view.ts
+++ b/src/components/backend-ai-environment-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/backend-ai-error-view.ts
+++ b/src/components/backend-ai-error-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { navigate } from '../backend-ai-app';
 import {

--- a/src/components/backend-ai-help-button.ts
+++ b/src/components/backend-ai-help-button.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 // import {get as _text, registerTranslateConfig, translate as _t, use as setLanguage} from "lit-translate";
 import { BackendAIPage } from './backend-ai-page';

--- a/src/components/backend-ai-import-view.ts
+++ b/src/components/backend-ai-import-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-indicator-pool.ts
+++ b/src/components/backend-ai-indicator-pool.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import './backend-ai-indicator';
 import { CSSResultGroup, html, LitElement } from 'lit';

--- a/src/components/backend-ai-indicator.ts
+++ b/src/components/backend-ai-indicator.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import './backend-ai-dialog';
 import { BackendAiStyles } from './backend-ai-general-styles';

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 // import * as aiSDK from '../lib/backend.ai-client-es6';
 import * as ai from '../lib/backend.ai-client-esm';

--- a/src/components/backend-ai-maintenance-view.ts
+++ b/src/components/backend-ai-maintenance-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/backend-ai-message.ts
+++ b/src/components/backend-ai-message.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { LitElement } from 'lit';
 

--- a/src/components/backend-ai-metadata-store.ts
+++ b/src/components/backend-ai-metadata-store.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { BackendAIPage } from './backend-ai-page';
 import { html } from 'lit';

--- a/src/components/backend-ai-multi-select.ts
+++ b/src/components/backend-ai-multi-select.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-offline-indicator.ts
+++ b/src/components/backend-ai-offline-indicator.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { css, CSSResultGroup, html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';

--- a/src/components/backend-ai-permission-denied-view.ts
+++ b/src/components/backend-ai-permission-denied-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { navigate } from '../backend-ai-app';
 import {

--- a/src/components/backend-ai-project-switcher.ts
+++ b/src/components/backend-ai-project-switcher.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/backend-ai-registry-list.ts
+++ b/src/components/backend-ai-registry-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-release-check.ts
+++ b/src/components/backend-ai-release-check.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { CSSResultGroup, html, LitElement } from 'lit';
 import { get as _text } from 'lit-translate';

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { BackendAIPage } from './backend-ai-page';
 import { CSSResultGroup, html } from 'lit';

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-resource-panel.ts
+++ b/src/components/backend-ai-resource-panel.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-piechart/lablup-piechart';
 import '../plastics/lablup-shields/lablup-shields';

--- a/src/components/backend-ai-resource-policy-list.ts
+++ b/src/components/backend-ai-resource-policy-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
-Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
 */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-resource-preset-list.ts
+++ b/src/components/backend-ai-resource-preset-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-serving-view.ts
+++ b/src/components/backend-ai-serving-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
-Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
 */
 import { navigate } from '../backend-ai-app';
 import {

--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { default as AnsiUp } from '../lib/ansiup';
 import '../plastics/lablup-shields/lablup-shields';

--- a/src/components/backend-ai-session-view-next.ts
+++ b/src/components/backend-ai-session-view-next.ts
@@ -1,6 +1,6 @@
 /**
  @license
-Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
 */
 import { navigate } from '../backend-ai-app';
 import {

--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import JsonToCsv from '../lib/json_to_csv';
 import {

--- a/src/components/backend-ai-settings-store.ts
+++ b/src/components/backend-ai-settings-store.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { BackendAIPage } from './backend-ai-page';
 import { html } from 'lit';

--- a/src/components/backend-ai-settings-view.ts
+++ b/src/components/backend-ai-settings-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/backend-ai-sidepanel-notification.ts
+++ b/src/components/backend-ai-sidepanel-notification.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/backend-ai-sidepanel-task.ts
+++ b/src/components/backend-ai-sidepanel-task.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/backend-ai-signup.ts
+++ b/src/components/backend-ai-signup.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { Client, ClientConfig } from '../lib/backend.ai-client-esm';
 import {

--- a/src/components/backend-ai-splash.ts
+++ b/src/components/backend-ai-splash.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import './backend-ai-dialog';
 import BackendAIDialog from './backend-ai-dialog';
@@ -178,7 +178,7 @@ export default class BackendAISplash extends LitElement {
           </ul>
           <ul>
             <li>Powered by <a target="_blank" href="https://github.com/lablup/backend.ai/blob/main/LICENSE">open-source software</a></li>
-            <li class="copyright">Copyright &copy; 2015-2023 Lablup Inc.</li>
+            <li class="copyright">Copyright &copy; 2015-2024 Lablup Inc.</li>
             <li class="release-note">
               <a target="_blank" href="https://github.com/lablup/backend.ai-webui/releases/tag/v${
                 this.version

--- a/src/components/backend-ai-statistics-view.ts
+++ b/src/components/backend-ai-statistics-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/backend-ai-storage-host-settings-view.ts
+++ b/src/components/backend-ai-storage-host-settings-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
-Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
 */
 import { navigate } from '../backend-ai-app';
 import {

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import tus from '../lib/tus';
 import '../plastics/lablup-shields/lablup-shields';

--- a/src/components/backend-ai-storage-proxy-list.ts
+++ b/src/components/backend-ai-storage-proxy-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { navigate } from '../backend-ai-app';
 import '../plastics/lablup-shields/lablup-shields';

--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { navigate } from '../backend-ai-app';
 import '../plastics/lablup-piechart/lablup-piechart';

--- a/src/components/backend-ai-tasker.ts
+++ b/src/components/backend-ai-tasker.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { css, CSSResultGroup, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';

--- a/src/components/backend-ai-usage-list.ts
+++ b/src/components/backend-ai-usage-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/backend-ai-user-list.ts
+++ b/src/components/backend-ai-user-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../plastics/lablup-shields/lablup-shields';
 import {

--- a/src/components/backend-ai-usersettings-general-list.ts
+++ b/src/components/backend-ai-usersettings-general-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/backend-ai-usersettings-view.ts
+++ b/src/components/backend-ai-usersettings-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { navigate, updateOffline } from '../backend-ai-app';
 // import '../lib/backend.ai-client-esm';

--- a/src/components/lablup-activity-panel.ts
+++ b/src/components/lablup-activity-panel.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/lablup-expansion.ts
+++ b/src/components/lablup-expansion.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/lablup-loading-dots.ts
+++ b/src/components/lablup-loading-dots.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { css, CSSResultGroup, html, LitElement } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';

--- a/src/components/lablup-loading-spinner.ts
+++ b/src/components/lablup-loading-spinner.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '@material/mwc-circular-progress';
 import { css, CSSResultGroup, html, LitElement } from 'lit';

--- a/src/components/lablup-notification.ts
+++ b/src/components/lablup-notification.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { BackendAiStyles } from './backend-ai-general-styles';
 import '@material/mwc-icon-button';

--- a/src/components/lablup-progress-bar.ts
+++ b/src/components/lablup-progress-bar.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/lablup-slider.ts
+++ b/src/components/lablup-slider.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/components/lablup-terms-of-service.ts
+++ b/src/components/lablup-terms-of-service.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/pipeline/components/pipeline-job-list.ts
+++ b/src/pipeline/components/pipeline-job-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../../components/backend-ai-dialog';
 import { BackendAiStyles } from '../../components/backend-ai-general-styles';

--- a/src/pipeline/components/pipeline-job-view.ts
+++ b/src/pipeline/components/pipeline-job-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../../components/backend-ai-dialog';
 import { BackendAiStyles } from '../../components/backend-ai-general-styles';

--- a/src/pipeline/components/pipeline-list.ts
+++ b/src/pipeline/components/pipeline-list.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../../components/backend-ai-dialog';
 import { BackendAiStyles } from '../../components/backend-ai-general-styles';

--- a/src/pipeline/components/pipeline-view.ts
+++ b/src/pipeline/components/pipeline-view.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import '../../components/backend-ai-dialog';
 import { BackendAiStyles } from '../../components/backend-ai-general-styles';

--- a/src/pipeline/lib/pipeline-configuration-form.ts
+++ b/src/pipeline/lib/pipeline-configuration-form.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { BackendAiStyles } from '../../components/backend-ai-general-styles';
 import '../../components/lablup-codemirror';

--- a/src/pipeline/lib/pipeline-flow.ts
+++ b/src/pipeline/lib/pipeline-flow.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/pipeline/lib/pipeline-utils.ts
+++ b/src/pipeline/lib/pipeline-utils.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   PipelineEnvironment,

--- a/src/plastics/chart-js.ts
+++ b/src/plastics/chart-js.ts
@@ -1,6 +1,6 @@
 /*
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 //import Chart from '../lib/Chart.min';
 import Chart from 'chart.js/auto';

--- a/src/plastics/lablup-piechart/lablup-piechart.ts
+++ b/src/plastics/lablup-piechart/lablup-piechart.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/plastics/lablup-shields/lablup-shields.ts
+++ b/src/plastics/lablup-shields/lablup-shields.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   IronFlex,

--- a/src/plastics/mwc/archive/mwc-drawer.ts
+++ b/src/plastics/mwc/archive/mwc-drawer.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright 2015-2023 Lablup Inc.
+ Copyright 2015-2024 Lablup Inc.
 
  Original code by 2018 Google Inc. All Rights Reserved.
 

--- a/src/plastics/mwc/archive/mwc-top-app-bar-fixed.ts
+++ b/src/plastics/mwc/archive/mwc-top-app-bar-fixed.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright 2015-2023 Lablup Inc.
+ Copyright 2015-2024 Lablup Inc.
 
  Original code by 2018 Google Inc. All Rights Reserved.
 

--- a/src/reducers/app.ts
+++ b/src/reducers/app.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import {
   CLOSE_SNACKBAR,

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2023 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import app from './reducers/app';
 import { lazyReducerEnhancer } from 'pwa-helpers/lazy-reducer-enhancer';


### PR DESCRIPTION
Including the about backend.ai, change the year of copyright from 2015-202**3** to 2015-202**4**
![image](https://github.com/lablup/backend.ai-webui/assets/28584164/f96ff0ac-6915-41fc-b785-5ec68bb2bc7a)

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
