### PR TITLE
fix: regression of listing connected agent with null-check on live_stat from response

### DIFF
--- a/src/components/backend-ai-agent-list.ts
+++ b/src/components/backend-ai-agent-list.ts
@@ -1225,7 +1225,7 @@ export default class BackendAIAgentList extends BackendAIPage {
         cpu_util: { capacity: 0, current: 0, ratio: 0 },
         mem_util: { capacity: 0, current: 0, ratio: 0 },
       };
-      if (rowData.item.live_stat && rowData.item.live_stat.node.cuda_util) {
+      if (rowData.item.live_stat?.node?.cuda_util) {
         liveStat = Object.assign(liveStat, {
           cuda_util: { capacity: 0, current: 0, ratio: 0 },
         });
@@ -1247,7 +1247,7 @@ export default class BackendAIAgentList extends BackendAIPage {
         // liveStat.cuda_util!.ratio = (liveStat.cuda_util!.current / cudaUtilCapacity) || 0;
         liveStat.cuda_util!.ratio = liveStat.cuda_util!.current / 100 || 0;
       }
-      if (rowData.item.live_stat && rowData.item.live_stat.node.cuda_mem) {
+      if (rowData.item.live_stat?.node?.cuda_mem) {
         liveStat = Object.assign(liveStat, {
           cuda_mem: { capacity: 0, current: 0, ratio: 0 },
         });

--- a/src/components/backend-ai-agent-list.ts
+++ b/src/components/backend-ai-agent-list.ts
@@ -1225,7 +1225,7 @@ export default class BackendAIAgentList extends BackendAIPage {
         cpu_util: { capacity: 0, current: 0, ratio: 0 },
         mem_util: { capacity: 0, current: 0, ratio: 0 },
       };
-      if (rowData.item.live_stat.node.cuda_util) {
+      if (rowData.item.live_stat && rowData.item.live_stat.node.cuda_util) {
         liveStat = Object.assign(liveStat, {
           cuda_util: { capacity: 0, current: 0, ratio: 0 },
         });
@@ -1247,7 +1247,7 @@ export default class BackendAIAgentList extends BackendAIPage {
         // liveStat.cuda_util!.ratio = (liveStat.cuda_util!.current / cudaUtilCapacity) || 0;
         liveStat.cuda_util!.ratio = liveStat.cuda_util!.current / 100 || 0;
       }
-      if (rowData.item.live_stat.node.cuda_mem) {
+      if (rowData.item.live_stat && rowData.item.live_stat.node.cuda_mem) {
         liveStat = Object.assign(liveStat, {
           cuda_mem: { capacity: 0, current: 0, ratio: 0 },
         });


### PR DESCRIPTION
Sometimes there has a chance of receiving NULL value in `live_stat` in agent status, but since now It's been treated as if always has value, which caused runtime-error. Therefore I added conditional statement so that parsing `live_stat` value is only available when it's not NULL.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
