### PR TITLE
fix: modify compatible manager version of trash bin

### DIFF
--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -675,13 +675,10 @@ class Client {
     if (this.isManagerVersionCompatibleWith('23.09.9')) {
       this._features['modify-endpoint'] = true;
     }
-    // TODO: remove this after 24.03.0 release
-    if (this.isManagerVersionCompatibleWith('24.03.0.*')) {
-      this._features['vfolder-trash-bin'] = true;
-    }
     if (this.isManagerVersionCompatibleWith('24.03.0')) {
       this._features['max-vfolder-count-in-user-resource-policy'] = true;
       this._features['model-store'] = true;
+      this._features['vfolder-trash-bin'] = true;
     }
   }
 


### PR DESCRIPTION
follows #2204 
fix the compatible manager version since the core has been updated to 24.03.

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version: 24.03
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
