### PR TITLE
Fix: TOTP activation modal not opening for non-TOTP users with `forceTotp`

### DIFF
--- a/react/src/components/ForceTOTPChecker.tsx
+++ b/react/src/components/ForceTOTPChecker.tsx
@@ -1,0 +1,60 @@
+import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
+import { useTOTPSupported } from '../hooks/backendai';
+import TOTPActivateModal from './TOTPActivateModal';
+import { ForceTOTPCheckerQuery } from './__generated__/ForceTOTPCheckerQuery.graphql';
+import { useToggle } from 'ahooks';
+import graphql from 'babel-plugin-relay/macro';
+import { useLazyLoadQuery } from 'react-relay';
+
+const ForceTOTPChecker = () => {
+  const [isOpenTOTPActivateModal, { toggle: toggleTOTPActivateModal }] =
+    useToggle(false);
+  const { isTOTPSupported } = useTOTPSupported();
+  const [fetchKey, updateFetchKey] = useUpdatableState('first');
+  const baiClient = useSuspendedBackendaiClient();
+
+  const { user } = useLazyLoadQuery<ForceTOTPCheckerQuery>(
+    graphql`
+      query ForceTOTPCheckerQuery($email: String, $isNotSupportTotp: Boolean!) {
+        user(email: $email) {
+          totp_activated @skipOnClient(if: $isNotSupportTotp)
+          ...TOTPActivateModalFragment
+        }
+      }
+    `,
+    {
+      email: baiClient?.email ?? '',
+      isNotSupportTotp: !isTOTPSupported,
+    },
+    {
+      fetchKey,
+      fetchPolicy: 'network-only',
+    },
+  );
+  const open =
+    baiClient?.supports('force2FA') &&
+    baiClient?._config.force2FA &&
+    user?.totp_activated === false;
+  return (
+    !!isTOTPSupported && (
+      <TOTPActivateModal
+        userFrgmt={user}
+        closable={false}
+        cancelButtonProps={{
+          style: { display: 'none' },
+        }}
+        open={open}
+        onRequestClose={(success) => {
+          if (success) {
+            updateFetchKey();
+          } else {
+            // formRef.current?.setFieldValue('totp_activated', false);
+          }
+          toggleTOTPActivateModal();
+        }}
+      />
+    )
+  );
+};
+
+export default ForceTOTPChecker;

--- a/react/src/components/ForceTOTPChecker.tsx
+++ b/react/src/components/ForceTOTPChecker.tsx
@@ -7,8 +7,7 @@ import graphql from 'babel-plugin-relay/macro';
 import { useLazyLoadQuery } from 'react-relay';
 
 const ForceTOTPChecker = () => {
-  const [isOpenTOTPActivateModal, { toggle: toggleTOTPActivateModal }] =
-    useToggle(false);
+  const [, { toggle: toggleTOTPActivateModal }] = useToggle(false);
   const { isTOTPSupported } = useTOTPSupported();
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
   const baiClient = useSuspendedBackendaiClient();

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -4,6 +4,7 @@ import { useThemeMode } from '../../hooks/useThemeMode';
 import BAIContentWithDrawerArea from '../BAIContentWithDrawerArea';
 import BAISider from '../BAISider';
 import Flex from '../Flex';
+import ForceTOTPChecker from '../ForceTOTPChecker';
 import PasswordChangeRequestAlert from '../PasswordChangeRequestAlert';
 import { DRAWER_WIDTH } from '../WEBUINotificationDrawer';
 import WebUIHeader from './WebUIHeader';
@@ -204,6 +205,9 @@ function MainLayout() {
                 style={{ marginBottom: token.paddingContentVerticalLG }}
                 closable
               />
+            </Suspense>
+            <Suspense>
+              <ForceTOTPChecker />
             </Suspense>
             <Suspense>
               <Outlet />

--- a/react/src/components/TOTPActivateModal.tsx
+++ b/react/src/components/TOTPActivateModal.tsx
@@ -61,8 +61,7 @@ const TOTPActivateModal: React.FC<Props> = ({
         : null;
     },
     suspense: false,
-    staleTime: 0,
-    cacheTime: 0,
+    staleTime: 1000,
   });
 
   const mutationToActivateTotp = useTanMutation({

--- a/react/src/components/UserDropdownMenu.tsx
+++ b/react/src/components/UserDropdownMenu.tsx
@@ -53,7 +53,7 @@ const UserDropdownMenu: React.FC = () => {
   const userRole = useCurrentUserRole();
 
   const webuiNavigate = useWebUINavigate();
-  const totpSupported = useTOTPSupported();
+  const { isTOTPSupported } = useTOTPSupported();
 
   const [isPendingRefreshModal, startRefreshModalTransition] = useTransition();
   const [
@@ -117,7 +117,7 @@ const UserDropdownMenu: React.FC = () => {
           loadUserProfileSettingQuery(
             {
               email: userInfo.email,
-              isNotSupportTotp: !totpSupported,
+              isNotSupportTotp: !isTOTPSupported,
             },
             {
               fetchPolicy: 'network-only',
@@ -213,7 +213,7 @@ const UserDropdownMenu: React.FC = () => {
       <Suspense>
         {userProfileSettingQueryRef && (
           <UserProfileSettingModal
-            totpSupported={totpSupported}
+            totpSupported={isTOTPSupported}
             queryRef={userProfileSettingQueryRef}
             open={isOpenUserSettingModal}
             onRequestClose={() => {
@@ -225,7 +225,7 @@ const UserDropdownMenu: React.FC = () => {
                 loadUserProfileSettingQuery(
                   {
                     email: userInfo.email,
-                    isNotSupportTotp: !totpSupported,
+                    isNotSupportTotp: !isTOTPSupported,
                   },
                   {
                     fetchPolicy: 'network-only',

--- a/react/src/components/UserInfoModal.tsx
+++ b/react/src/components/UserInfoModal.tsx
@@ -8,7 +8,6 @@ import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQuery } from 'react-query';
 import { useLazyLoadQuery } from 'react-relay';
 
 interface Props extends BAIModalProps {}

--- a/react/src/components/UserInfoModal.tsx
+++ b/react/src/components/UserInfoModal.tsx
@@ -1,4 +1,5 @@
 import { useSuspendedBackendaiClient } from '../hooks';
+import { useTOTPSupported } from '../hooks/backendai';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { useWebComponentInfo } from './DefaultProviders';
 import { UserInfoModalQuery } from './__generated__/UserInfoModalQuery.graphql';
@@ -34,21 +35,9 @@ const UserInfoModal: React.FC<Props> = ({ ...baiModalProps }) => {
   const sudoSessionEnabledSupported = baiClient?.supports(
     'sudo-session-enabled',
   );
-  let totpSupported = false;
-  let {
-    data: isManagerSupportingTOTP,
-    isLoading: isLoadingManagerSupportingTOTP,
-  } = useQuery(
-    'isManagerSupportingTOTP',
-    () => {
-      return baiClient.isManagerSupportingTOTP();
-    },
-    {
-      // for to render even this fail query failed
-      suspense: false,
-    },
-  );
-  totpSupported = baiClient?.supports('2FA') && isManagerSupportingTOTP;
+
+  const { isTOTPSupported, isLoading: isLoadingManagerSupportingTOTP } =
+    useTOTPSupported();
 
   const { user } = useLazyLoadQuery<UserInfoModalQuery>(
     graphql`
@@ -83,7 +72,7 @@ const UserInfoModal: React.FC<Props> = ({ ...baiModalProps }) => {
     {
       email: userEmail,
       isNotSupportSudoSessionEnabled: !sudoSessionEnabledSupported,
-      isTOTPSupported: totpSupported ?? false,
+      isTOTPSupported: isTOTPSupported ?? false,
     },
   );
 
@@ -147,7 +136,7 @@ const UserInfoModal: React.FC<Props> = ({ ...baiModalProps }) => {
             {user?.sudo_session_enabled ? t('button.Yes') : t('button.No')}
           </Descriptions.Item>
         )}
-        {totpSupported && (
+        {isTOTPSupported && (
           <Descriptions.Item label={t('webui.menu.TotpActivated')}>
             <Spin spinning={isLoadingManagerSupportingTOTP}>
               {user?.totp_activated ? t('button.Yes') : t('button.No')}

--- a/react/src/components/UserProfileSettingModal.tsx
+++ b/react/src/components/UserProfileSettingModal.tsx
@@ -58,18 +58,6 @@ const UserProfileSettingModal: React.FC<Props> = ({
   const [isOpenTOTPActivateModal, { toggle: toggleTOTPActivateModal }] =
     useToggle(false);
   const baiClient = useSuspendedBackendaiClient();
-
-  // const { data: isManagerSupportingTOTP } = useTanQuery(
-  //   'isManagerSupportingTOTP',
-  //   () => {
-  //     return baiClient.isManagerSupportingTOTP();
-  //   },
-  //   {
-  //     suspense: true,
-  //   },
-  // );
-  // const totpSupported = baiClient.supports('2FA') && isManagerSupportingTOTP;
-
   const [userInfo, userMutations] = useCurrentUserInfo();
   // const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
 

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -1,4 +1,5 @@
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
+import { useTOTPSupported } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { useWebComponentInfo } from './DefaultProviders';
@@ -85,22 +86,8 @@ const UserSettingModal: React.FC<Props> = ({
   const sudoSessionEnabledSupported = baiClient?.supports(
     'sudo-session-enabled',
   );
-  let totpSupported = false;
-  let {
-    data: isManagerSupportingTOTP,
-    isLoading: isLoadingManagerSupportingTOTP,
-  } = useQuery(
-    'isManagerSupportingTOTP',
-    () => {
-      return baiClient.isManagerSupportingTOTP();
-    },
-    {
-      // for to render even this fail query failed
-      suspense: false,
-    },
-  );
-  totpSupported = baiClient?.supports('2FA') && isManagerSupportingTOTP;
-
+  const { isTOTPSupported, isLoading: isLoadingManagerSupportingTOTP } =
+    useTOTPSupported();
   const { user, loggedInUser } = useLazyLoadQuery<UserSettingModalQuery>(
     graphql`
       query UserSettingModalQuery(
@@ -138,7 +125,7 @@ const UserSettingModal: React.FC<Props> = ({
     {
       email: userEmail,
       isNotSupportSudoSessionEnabled: !sudoSessionEnabledSupported,
-      isNotSupportTotp: !totpSupported,
+      isNotSupportTotp: !isTOTPSupported,
       loggedInUserEmail: baiClient?.email ?? '',
     },
     {
@@ -203,7 +190,7 @@ const UserSettingModal: React.FC<Props> = ({
         delete input?.sudo_session_enabled;
       }
       // TOTP setting
-      if (!totpSupported) {
+      if (!isTOTPSupported) {
         delete input?.totp_activated;
       }
 
@@ -212,7 +199,7 @@ const UserSettingModal: React.FC<Props> = ({
           email: values?.email || '',
           props: input,
           isNotSupportSudoSessionEnabled: !sudoSessionEnabledSupported,
-          isNotSupportTotp: !totpSupported,
+          isNotSupportTotp: !isTOTPSupported,
         },
         onCompleted(res) {
           if (res?.modify_user?.ok) {
@@ -342,7 +329,7 @@ const UserSettingModal: React.FC<Props> = ({
             <Switch />
           </Form.Item>
         )}
-        {!!totpSupported && (
+        {!!isTOTPSupported && (
           <Form.Item
             name="totp_activated"
             label={t('webui.menu.TotpActivated')}
@@ -401,7 +388,7 @@ const UserSettingModal: React.FC<Props> = ({
           </Form.Item>
         )}
       </Form>
-      {!!totpSupported && (
+      {!!isTOTPSupported && (
         <TOTPActivateModal
           userFrgmt={user}
           open={isOpenTOTPActivateModal}

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -25,7 +25,6 @@ import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React, { useDeferredValue, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQuery } from 'react-query';
 import { useMutation } from 'react-relay';
 import { useLazyLoadQuery } from 'react-relay';
 

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -232,7 +232,7 @@ export const useCurrentUserRole = () => {
 
 export const useTOTPSupported = () => {
   const baiClient = useSuspendedBackendaiClient();
-  const { data: isManagerSupportingTOTP } = useTanQuery<boolean>(
+  const { data: isManagerSupportingTOTP, isLoading } = useTanQuery<boolean>(
     'isManagerSupportingTOTP',
     () => {
       return baiClient.isManagerSupportingTOTP();
@@ -242,7 +242,7 @@ export const useTOTPSupported = () => {
       staleTime: 1000,
     },
   );
-  const isSupported = baiClient.supports('2FA') && isManagerSupportingTOTP;
+  const isTOTPSupported = baiClient.supports('2FA') && isManagerSupportingTOTP;
 
-  return isSupported;
+  return { isTOTPSupported, isLoading };
 };

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -239,6 +239,7 @@ export const useTOTPSupported = () => {
     },
     {
       suspense: false,
+      staleTime: 1000,
     },
   );
   const isSupported = baiClient.supports('2FA') && isManagerSupportingTOTP;


### PR DESCRIPTION
This PR introduces `ForceTOTPChecker` to open `TOTPActivateModal` for users who have not activated TOTP when the `forceTotp` configuration is true.
This part was missing during the transition to React.

<img width="812" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/ff496262-fd62-485c-97df-4363b74b18ce">

### How to test
- Install the TOTP plugin.
- Set the following config.toml variables:
  ```
  [general]
  enable2FA = true
  force2FA = true
  ```
- Try to log in using a user who has not activated TOTP.
- You will see the TOTPActivateModal (refer to the screenshot above) right after logging in.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
