### PR TITLE
fix: created count in `StorageStatusPanel`

### DIFF
--- a/react/src/components/StorageStatusPanel.tsx
+++ b/react/src/components/StorageStatusPanel.tsx
@@ -31,12 +31,6 @@ import { useTranslation } from 'react-i18next';
 import { useQuery } from 'react-query';
 import { useLazyLoadQuery } from 'react-relay';
 
-export type DeadVFolderStatus =
-  | 'delete-pending'
-  | 'delete-ongoing'
-  | 'delete-complete'
-  | 'delete-error';
-
 const StorageStatusPanel: React.FC<{
   fetchKey: string;
 }> = ({ fetchKey }) => {
@@ -57,14 +51,12 @@ const StorageStatusPanel: React.FC<{
     sm: 1,
     xs: 1,
   };
-  const deadVFolderStatuses: DeadVFolderStatus[] = [
-    'delete-pending',
-    'delete-ongoing',
-    'delete-complete',
-    'delete-error',
-  ];
-  const isDeadVFolderStatus = (status: string) => {
-    return _.includes(deadVFolderStatuses, status);
+
+  const isExcludedCount = (status: string) => {
+    return _.includes(
+      ['delete-ongoing', 'delete-complete', 'delete-error'],
+      status,
+    );
   };
 
   const { data: vfolders } = useQuery(
@@ -77,17 +69,17 @@ const StorageStatusPanel: React.FC<{
     (item: any) =>
       item.is_owner &&
       item.ownership_type === 'user' &&
-      !isDeadVFolderStatus(item.status),
+      !isExcludedCount(item.status),
   ).length;
   const projectFolderCount = vfolders?.filter(
     (item: any) =>
-      item.ownership_type === 'group' && !isDeadVFolderStatus(item.status),
+      item.ownership_type === 'group' && !isExcludedCount(item.status),
   ).length;
   const invitedCount = vfolders?.filter(
     (item: any) =>
       !item.is_owner &&
       item.ownership_type === 'user' &&
-      !isDeadVFolderStatus(item.status),
+      !isExcludedCount(item.status),
   ).length;
 
   // TODO: Add resolver to enable subquery and modify to call useLazyLoadQuery only once.

--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -58,7 +58,7 @@ interface GroupData {
 @customElement('backend-ai-data-view')
 export default class BackendAIData extends BackendAIPage {
   @property({ type: String }) apiMajorVersion = '';
-  @property({ type: Date }) folderListFetchKey = new Date();
+  @property({ type: String }) folderListFetchKey = 'first';
   @property({ type: Boolean }) is_admin = false;
   @property({ type: Boolean }) enableStorageProxy = false;
   @property({ type: Boolean }) enableInferenceWorkload = false;
@@ -280,7 +280,7 @@ export default class BackendAIData extends BackendAIPage {
       <link rel="stylesheet" href="resources/custom.css" />
       <div class="vertical layout" style="gap:24px">
         <backend-ai-react-storage-status-panel
-          .value="${this.folderListFetchKey}"
+          value="${this.folderListFetchKey}"
         ></backend-ai-react-storage-status-panel>
         <lablup-activity-panel elevation="1" noheader narrow autowidth>
           <div slot="message">
@@ -887,7 +887,7 @@ export default class BackendAIData extends BackendAIPage {
       this._getStorageProxyInformation();
     }
     document.addEventListener('backend-ai-folder-list-changed', () => {
-      this.folderListFetchKey = new Date();
+      this.folderListFetchKey = new Date().toISOString();
     });
     document.addEventListener('backend-ai-vfolder-cloning', (e: any) => {
       if (e.detail) {


### PR DESCRIPTION
This PR fix the bug related to the count of created vFolders in `StorageStatusPanel`

Before this PR,
- the count does not include vfolders in the trash bin with 'delete-pending' status.
- the count is not updated right after creating/deleting(forever) vfolders.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
