### PR TITLE
feat: apply filter to png icon when theme is darkmode

### DIFF
--- a/src/components/backend-ai-agent-list.ts
+++ b/src/components/backend-ai-agent-list.ts
@@ -203,6 +203,17 @@ export default class BackendAIAgentList extends BackendAIPage {
   }
 
   /**
+   * re-bind the renderer function when the them(light, dark) is changed
+   */
+
+  updated(changedProperties) {
+    if (changedProperties.has('isDarkMode')) {
+      this._boundRegionRenderer = this.regionRenderer.bind(this);
+      this.requestUpdate();
+    }
+  }
+
+  /**
    * Change state to 'ALIVE' when backend.ai client connected.
    *
    * @param {Boolean} active - The component will work if active is true.
@@ -890,8 +901,11 @@ export default class BackendAIAgentList extends BackendAIPage {
       html`
         <div class="horizontal start-justified center layout wrap">
           <img
+            class="platform-icon"
             src="/resources/icons/${icon}.png"
-            style="width:32px;height:32px;"
+            style="width:32px;height:32px;${this.isDarkMode && icon === 'local'
+              ? 'filter:invert(1);'
+              : ''}"
           />
           <lablup-shields
             app="${location}"

--- a/src/components/backend-ai-agent-list.ts
+++ b/src/components/backend-ai-agent-list.ts
@@ -203,17 +203,6 @@ export default class BackendAIAgentList extends BackendAIPage {
   }
 
   /**
-   * re-bind the renderer function when the them(light, dark) is changed
-   */
-
-  updated(changedProperties) {
-    if (changedProperties.has('isDarkMode')) {
-      this._boundRegionRenderer = this.regionRenderer.bind(this);
-      this.requestUpdate();
-    }
-  }
-
-  /**
    * Change state to 'ALIVE' when backend.ai client connected.
    *
    * @param {Boolean} active - The component will work if active is true.
@@ -1886,7 +1875,9 @@ export default class BackendAIAgentList extends BackendAIPage {
             auto-width
             resizable
             header="${_t('agent.Region')}"
-            .renderer="${this._boundRegionRenderer}"
+            .renderer="${(root, column, rowData) => {
+              return this.regionRenderer(root, column, rowData);
+            }}"
           ></vaadin-grid-column>
           <vaadin-grid-sort-column
             auto-width

--- a/src/plastics/lablup-shields/lablup-shields.ts
+++ b/src/plastics/lablup-shields/lablup-shields.ts
@@ -84,7 +84,6 @@ export default class LablupShields extends LitElement {
         }
         .app,
         .desc {
-          word-break: break-all;
           white-space: normal;
           height: fit-content;
           width: var(--lablup-shield-component-width, auto);


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
### This PR Resolves #2296 #2297 Issues

### Feature
- Change the color of the local icon on resource pages to white when in dark mode
- Fixed the regionRenderer function to rebind when isDarkMode is updated via the update lifecycle
- Remove the word-break attribute from text inside a shield

| Light Mode| Dark Mode| 
|---|---|
|![image](https://github.com/lablup/backend.ai-webui/assets/51399982/250ad7db-f05a-4aa6-8f89-628779e53ad1)|![image](https://github.com/lablup/backend.ai-webui/assets/51399982/c86e6154-389f-4836-96ca-b90105ea2c27)|
<img width="101" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/51399982/0cecb21b-e6e6-4f80-892c-3718f1041967">


**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
