### PR TITLE
fix: vFolder field has incorrect value in editing

### DIFF
--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -18,6 +18,7 @@ import ImageEnvironmentSelectFormItems, {
   ImageEnvironmentFormInput,
 } from './ImageEnvironmentSelectFormItems';
 import InputNumberWithSlider from './InputNumberWithSlider';
+import VFolderLazyView from './VFolderLazyView';
 import VFolderSelect from './VFolderSelect';
 import { ServiceLauncherModalFragment$key } from './__generated__/ServiceLauncherModalFragment.graphql';
 import { ServiceLauncherModalModifyMutation } from './__generated__/ServiceLauncherModalModifyMutation.graphql';
@@ -31,6 +32,7 @@ import {
   Button,
   Space,
   FormInstance,
+  Skeleton,
 } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
@@ -120,6 +122,7 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
         cluster_mode
         cluster_size
         open_to_public
+        model
         image_object @since(version: "23.09.9") {
           name
           humanized_name
@@ -280,6 +283,7 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
           cluster_mode
           cluster_size
           open_to_public
+          model
           image_object @since(version: "23.09.9") {
             name
             humanized_name
@@ -554,21 +558,34 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
                 <Switch disabled={endpoint ? true : false}></Switch>
               </Form.Item>
               {/* <VFolderTableFromItem /> */}
-              <Form.Item
-                name={'vFolderName'}
-                label={t('session.launcher.ModelStorageToMount')}
-                rules={[
-                  {
-                    required: true,
-                  },
-                ]}
-              >
-                <VFolderSelect
-                  filter={(vf) => vf.usage_mode === 'model'}
-                  autoSelectDefault
-                  disabled={endpoint ? true : false}
-                />
-              </Form.Item>
+              {!endpoint ? (
+                <Form.Item
+                  name={'vFolderName'}
+                  label={t('session.launcher.ModelStorageToMount')}
+                  rules={[
+                    {
+                      required: true,
+                    },
+                  ]}
+                >
+                  <VFolderSelect
+                    filter={(vf) => vf.usage_mode === 'model'}
+                    autoSelectDefault
+                    disabled={endpoint ? true : false}
+                  />
+                </Form.Item>
+              ) : (
+                endpoint?.model && (
+                  <Form.Item
+                    label={t('session.launcher.ModelStorageToMount')}
+                    required
+                  >
+                    <Suspense fallback={<Skeleton.Input active />}>
+                      <VFolderLazyView uuid={endpoint?.model} />
+                    </Suspense>
+                  </Form.Item>
+                )
+              )}
             </>
           )}
           <Form.Item


### PR DESCRIPTION
In Service endpoint editing,
- The vFolder field value is always the first option.

This PR 
- displays the correct value as read-only.
- uses `VFolderLazyView` and show Skeleton when `VFolderLazyView` is suspended.


| Before | After |
|--------|--------|
| <img width="508" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/031f7c3f-6854-4cd7-8c46-7831d8e00e98"> | <img width="531" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/2a01c397-671c-4308-a038-3e781a3b3e64"> | 

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
