### PR TITLE
fix: apply AI accelerator allocation when selecting resource preset in neo session launcher

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -83,7 +83,6 @@ const ResourceAllocationFormItems: React.FC<
 
   const baiClient = useSuspendedBackendaiClient();
   const [resourceSlots] = useResourceSlots();
-  const acceleratorSlots = _.omit(resourceSlots, ['cpu', 'mem', 'shmem']);
 
   const [{ keypairResourcePolicy, sessionLimitAndRemaining }] =
     useCurrentKeyPairResourcePolicyLazyLoadQuery();
@@ -105,6 +104,17 @@ const ResourceAllocationFormItems: React.FC<
       currentResourceGroup: currentResourceGroup,
       currentImage: currentImage,
     });
+
+  const acceleratorSlots = _.omitBy(resourceSlots, (value, key) => {
+    if (['cpu', 'mem', 'shmem'].includes(key)) return true;
+
+    if (
+      !resourceLimits.accelerators[key]?.max ||
+      resourceLimits.accelerators[key]?.max === 0
+    )
+      return true;
+    return false;
+  });
 
   const currentImageAcceleratorLimits = _.filter(
     currentImage?.resource_limits,

--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -319,12 +319,29 @@ const ResourceAllocationFormItems: React.FC<
     const slots = _.pick(preset?.resource_slots, _.keys(resourceSlots));
     const mem = iSizeToSize((slots?.mem || 0) + 'b', 'g', 2)?.numberUnit;
     const acceleratorObj = _.omit(slots, ['cpu', 'mem', 'shmem']);
+
+    // Select the first matched AI accelerator type and value
+    const firstMatchedAcceleratorType = _.find(
+      _.keys(acceleratorSlots),
+      (value) => acceleratorObj[value] !== undefined,
+    );
+
+    let acceleratorSetting: {
+      acceleratorType?: string;
+      accelerator: number;
+    } = {
+      accelerator: 0,
+    };
+    if (firstMatchedAcceleratorType) {
+      acceleratorSetting = {
+        acceleratorType: firstMatchedAcceleratorType,
+        accelerator: Number(acceleratorObj[firstMatchedAcceleratorType] || 0),
+      };
+    }
     form.setFieldsValue({
       resource: {
         // ...slots,
-        // FIXME: temporary apply the first AI accelerator type and value
-        acceleratorType: Object.keys(acceleratorObj)[0],
-        accelerator: Number(Object.values(acceleratorObj)[0]),
+        ...acceleratorSetting,
         // transform to GB based on preset values
         mem,
         shmem: iSizeToSize((preset?.shared_memory || 0) + 'b', 'g', 2)

--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -308,9 +308,13 @@ const ResourceAllocationFormItems: React.FC<
     );
     const slots = _.pick(preset?.resource_slots, _.keys(resourceSlots));
     const mem = iSizeToSize((slots?.mem || 0) + 'b', 'g', 2)?.numberUnit;
+    const acceleratorObj = _.omit(slots, ['cpu', 'mem', 'shmem']);
     form.setFieldsValue({
       resource: {
-        ...slots,
+        // ...slots,
+        // FIXME: temporary apply the first AI accelerator type and value
+        acceleratorType: Object.keys(acceleratorObj)[0],
+        accelerator: Number(Object.values(acceleratorObj)[0]),
         // transform to GB based on preset values
         mem,
         shmem: iSizeToSize((preset?.shared_memory || 0) + 'b', 'g', 2)

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1303,13 +1303,15 @@ const SessionLauncherPage = () => {
                       }}
                     >
                       <Flex direction="column" align="stretch">
-                        {_.some(form.getFieldValue('resource'), (v, key) => {
-                          //                         console.log(form.getFieldError(['resource', 'shmem']));
-                          // console.log(form.getFieldValue(['resource']));
-                          return (
-                            form.getFieldWarning(['resource', key]).length > 0
-                          );
-                        }) && (
+                        {_.some(
+                          form.getFieldValue('resource').resource,
+                          (v, key) => {
+                            //                         console.log(form.getFieldError(['resource', 'shmem']));
+                            return (
+                              form.getFieldWarning(['resource', key]).length > 0
+                            );
+                          },
+                        ) && (
                           <Alert
                             type="warning"
                             showIcon


### PR DESCRIPTION
This PR resolves AI accelerator doesn't move when user selects resoruce preset from the list in neo session launcher and :
- [omit resource slot type which has no slots](https://github.com/lablup/backend.ai-webui/pull/2308/commits/3282e41ae3f4e2b087281115e19a7b4f27499dfd)
- [When applying a preset, use the first matched accelerator type](https://github.com/lablup/backend.ai-webui/pull/2308/commits/848271b305ebc9e2615877939ce814cf76a66a6b)


https://github.com/lablup/backend.ai-webui/assets/46954439/8b200a32-88e3-4b84-a4c5-c4b57db44d7b

<img width="1016" alt="Screenshot 2024-04-05 at 6 32 05 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/eed76b9e-5554-42af-a100-8999ba0f797c">


<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
