### PR TITLE
hotfix: neo session launcher on cloud

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -179,6 +179,12 @@ const ImageEnvironmentSelectFormItems: React.FC<
       nextImage = nextEnvironment?.images[0];
     }
 
+    const customizedImageTag = _.find(
+      nextImage?.labels,
+      (item) =>
+        item !== null && item?.key === 'ai.backend.customized-image.name',
+    )?.value;
+
     if (nextImage) {
       if (
         !matchedEnvironmentByVersion &&
@@ -191,6 +197,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
             version: undefined,
             image: undefined,
             manual: version,
+            customizedTag: customizedImageTag ?? undefined,
           },
         });
       } else {
@@ -199,6 +206,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
             environment: nextEnvironment.environmentName,
             version: getImageFullName(nextImage),
             image: nextImage,
+            customizedTag: customizedImageTag ?? undefined,
           },
         });
       }
@@ -632,10 +640,6 @@ const ImageEnvironmentSelectFormItems: React.FC<
                               },
                             ]}
                           />,
-                        );
-                        form.setFieldValue(
-                          ['environments', 'customizedTag'],
-                          tag,
                         );
                       }
                     }

--- a/react/src/components/SessionKernelTag.tsx
+++ b/react/src/components/SessionKernelTag.tsx
@@ -1,6 +1,5 @@
 import { useBackendAIImageMetaData } from '../hooks';
 import DoubleTag from './DoubleTag';
-import Flex from './Flex';
 import { Tag } from 'antd';
 import React from 'react';
 

--- a/react/src/components/SessionKernelTag.tsx
+++ b/react/src/components/SessionKernelTag.tsx
@@ -1,4 +1,7 @@
 import { useBackendAIImageMetaData } from '../hooks';
+import DoubleTag from './DoubleTag';
+import Flex from './Flex';
+import { Tag } from 'antd';
 import React from 'react';
 
 const SessionKernelTag: React.FC<{
@@ -7,80 +10,34 @@ const SessionKernelTag: React.FC<{
   border?: boolean;
 }> = ({ image, style = {} }, bordered) => {
   image = image || '';
-  const [, { getImageAliasName, getBaseVersion, getBaseImage }] =
-    useBackendAIImageMetaData();
-
-  // const sessionTags = useMemo(() => {
-  //   const tags = [];
-  //   if (meta && image) {
-  //     const specs = image.split("/");
-  //     const name = (specs[2] || specs[1]).split(":")[0];
-  //     if (name in meta.kernel_labels) {
-  //       tags.push(meta.kernel_labels[name]);
-  //     } else {
-  //       const imageParts = image.split("/");
-  //       // const registry = imageParts[0]; // hide registry (ip of docker registry is exposed)
-  //       let namespace;
-  //       let langName;
-  //       if (imageParts.length === 3) {
-  //         namespace = imageParts[1];
-  //         langName = imageParts[2];
-  //       } else if (imageParts.length > 3) {
-  //         namespace = imageParts.slice(2, imageParts.length - 1).join("/");
-  //         langName = imageParts[imageParts.length - 1];
-  //       } else {
-  //         namespace = "";
-  //         langName = imageParts[1];
-  //       }
-  //       langName = langName.split(":")[0];
-  //       langName = namespace ? namespace + "/" + langName : langName;
-  //       tags.push([
-  //         { category: "Env", tag: `${langName}`, color: "lightgrey" },
-  //       ]);
-  //     }
-  //   }
-  //   return tags;
-  // }, [image, meta?.kernel_labels, image]);
-
-  // const specs = image.split("/");
-  // console.log(image, sessionTags);
-  // const _tag = specs[specs.length - 1].split(':')[1];
-  // const _tags = tag.split('-');
-  // const baseversion = _tags[0];
-  // const baseimage = _tags[1];
-
-  // if (_tags[1] !== undefined) {
-  //   sessions[objectKey].baseversion = tags[0];
-  //   sessions[objectKey].baseimage = tags[1];
-  //   sessions[objectKey].additional_reqs = tags.slice(1, tags.length).map((tag) => tag.toUpperCase());
-  // } else if (sessions[objectKey].tag !== undefined) {
-  //   sessions[objectKey].baseversion = sessions[objectKey].tag;
-  // } else {
-  //   sessions[objectKey].baseversion = tag;
-  // }
-
-  // const tag
+  const [
+    ,
+    {
+      getImageAliasName,
+      getBaseVersion,
+      getBaseImage,
+      getArchitecture,
+      tagAlias,
+    },
+  ] = useBackendAIImageMetaData();
 
   return (
     <>
-      <div>{getImageAliasName(image)}</div>
-      <div>{getBaseVersion(image)}</div>
-      <div>{getBaseImage(image)}</div>
+      <DoubleTag
+        values={[
+          {
+            label: tagAlias(getImageAliasName(image)),
+            color: 'blue',
+          },
+          {
+            label: getBaseVersion(image),
+            color: 'green',
+          },
+        ]}
+      />
+      <Tag color="green">{tagAlias(getBaseImage(image))}</Tag>
+      <Tag color="green">{tagAlias(getArchitecture(image))}</Tag>
     </>
-    // <>
-    //   {_.map(sessionTags, (tag, i) =>
-    //     _.map(tag, ({ category, color, tag }) => {
-    //       if (category === "Env") {
-    //         category = tag;
-    //       }
-    //       // if (category && rowData.item.baseversion) {
-    //       //   item.tag = rowData.item.baseversion;
-    //       // }
-    //       return category;
-    //     })
-    //   )}
-    //   {/* {JSON.stringify(meta?.kernel_labels)} */}
-    // </>
   );
 };
 

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -262,6 +262,13 @@ export const useBackendAIImageMetaData = () => {
         return tags[1];
       },
       getImageMeta,
+      getArchitecture: (imageName: string) => {
+        let [, architecture] = imageName ? imageName.split('@') : ['', ''];
+        return architecture;
+      },
+      tagAlias: (tag: string) => {
+        return metadata?.tagAlias[tag] || tag;
+      },
     },
   ] as const;
 };

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1304,9 +1304,8 @@ const SessionLauncherPage = () => {
                     >
                       <Flex direction="column" align="stretch">
                         {_.some(
-                          form.getFieldValue('resource').resource,
+                          form.getFieldValue('resource')?.resource,
                           (v, key) => {
-                            //                         console.log(form.getFieldError(['resource', 'shmem']));
                             return (
                               form.getFieldWarning(['resource', key]).length > 0
                             );

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -20,6 +20,7 @@ import ResourceAllocationFormItems, {
   ResourceAllocationFormValue,
 } from '../components/ResourceAllocationFormItems';
 import ResourceNumber from '../components/ResourceNumber';
+import SessionKernelTag from '../components/SessionKernelTag';
 import SessionNameFormItem, {
   SessionNameFormItemValue,
 } from '../components/SessionNameFormItem';
@@ -1213,11 +1214,28 @@ const SessionLauncherPage = () => {
                               }
                             />
                             {/* {form.getFieldValue('environments').image} */}
-                            <div>
-                              <Typography.Text copyable code>
-                                {form.getFieldValue('environments')?.version ||
-                                  form.getFieldValue('environments')?.manual}
-                              </Typography.Text>
+                            <Flex direction="row">
+                              {form.getFieldValue('environments')?.manual ? (
+                                <Typography.Text copyable code>
+                                  form.getFieldValue('environments')?.manual
+                                </Typography.Text>
+                              ) : (
+                                <>
+                                  <SessionKernelTag
+                                    image={
+                                      form.getFieldValue('environments')
+                                        ?.version
+                                    }
+                                  />
+                                  <Typography.Text
+                                    copyable={{
+                                      text: form.getFieldValue('environments')
+                                        ?.version,
+                                    }}
+                                  />
+                                </>
+                              )}
+
                               {form.getFieldValue('environments')
                                 ?.customizedTag ? (
                                 <DoubleTag
@@ -1235,7 +1253,7 @@ const SessionLauncherPage = () => {
                                   ]}
                                 />
                               ) : null}
-                            </div>
+                            </Flex>
                           </Flex>
                         </Descriptions.Item>
                         {form.getFieldValue('envvars')?.length > 0 && (

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1227,6 +1227,23 @@ const SessionLauncherPage = () => {
                                         ?.version
                                     }
                                   />
+                                  {form.getFieldValue('environments')
+                                    ?.customizedTag ? (
+                                    <DoubleTag
+                                      values={[
+                                        {
+                                          label: 'Customized',
+                                          color: 'cyan',
+                                        },
+                                        {
+                                          label:
+                                            form.getFieldValue('environments')
+                                              ?.customizedTag,
+                                          color: 'cyan',
+                                        },
+                                      ]}
+                                    />
+                                  ) : null}
                                   <Typography.Text
                                     copyable={{
                                       text: form.getFieldValue('environments')
@@ -1235,24 +1252,6 @@ const SessionLauncherPage = () => {
                                   />
                                 </>
                               )}
-
-                              {form.getFieldValue('environments')
-                                ?.customizedTag ? (
-                                <DoubleTag
-                                  values={[
-                                    {
-                                      label: 'Customized',
-                                      color: 'cyan',
-                                    },
-                                    {
-                                      label:
-                                        form.getFieldValue('environments')
-                                          ?.customizedTag,
-                                      color: 'cyan',
-                                    },
-                                  ]}
-                                />
-                              ) : null}
                             </Flex>
                           </Flex>
                         </Descriptions.Item>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -263,7 +263,7 @@
       "StartTimeDoesNotApply": "Wenn die Startzeit nicht festgelegt ist, gilt sie nicht.",
       "MiniumAllocation": "Mindestanforderungen",
       "MiniumAllocationTooltip": "Wählen Sie als Mindestanforderung für die ausgewählte Betriebsumgebung",
-      "PreviousLauncher": "Vorherige",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Sie verwenden den \"{{launcher}}\"-Sitzungsstarter.",
       "SkipToConfirmAndLaunch": "Zur Bewertung springen",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -263,7 +263,7 @@
       "OnlyAllowsDiscreteNumberByClusterSize": "Μόνο ακέραιος επιτρέπεται όταν το μέγεθος του συμπλέγματος δεν είναι μικρότερο από 2.",
       "MiniumAllocation": "Ελάχιστες απαιτήσεις",
       "MiniumAllocationTooltip": "Επιλέξτε ως ελάχιστη απαίτηση για το επιλεγμένο περιβάλλον λειτουργίας",
-      "PreviousLauncher": "Προηγούμενο",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Χρησιμοποιείτε τον εκκινητή συνόδου \"{{launcher}}\".",
       "SkipToConfirmAndLaunch": "Skip to review",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -276,7 +276,7 @@
       "StartTimeDoesNotApply": "If the start time is not set, it doesn't apply.",
       "MiniumAllocation": "Minimum requirements",
       "MiniumAllocationTooltip": "Select as the minimum requirement for the selected running environment",
-      "PreviousLauncher": "Previous",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "You are using the \"{{launcher}}\" session launcher.",
       "SkipToConfirmAndLaunch": "Skip to review",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1157,7 +1157,7 @@
       "StartTimeDoesNotApply": "Si no se establece la hora de inicio, no se aplica.",
       "MiniumAllocation": "Requisitos mínimos",
       "MiniumAllocationTooltip": "Seleccione como requisito mínimo para el entorno de ejecución seleccionado",
-      "PreviousLauncher": "Anterior",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Estás utilizando el lanzador de sesiones \"{{launcher}}\".",
       "SkipToConfirmAndLaunch": "Ir a la reseña",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1155,7 +1155,7 @@
       "StartTimeDoesNotApply": "Jos aloitusaikaa ei ole asetettu, se ei ole voimassa.",
       "MiniumAllocation": "Vähimmäisvaatimukset",
       "MiniumAllocationTooltip": "Valitse valitun käyttöympäristön vähimmäisvaatimukseksi seuraavat tiedot",
-      "PreviousLauncher": "Edellinen",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Käytät \"{{launcher}}\"-istunnon käynnistintä.",
       "SkipToConfirmAndLaunch": "Siirry arvosteluun",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -263,7 +263,7 @@
       "StartTimeDoesNotApply": "Si l'heure de début n'est pas définie, elle ne s'applique pas.",
       "MiniumAllocation": "Exigences minimales",
       "MiniumAllocationTooltip": "Choisir comme exigence minimale pour l'environnement d'exécution sélectionné",
-      "PreviousLauncher": "Précédent",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Vous utilisez le lanceur de session \"{{launcher}}\".",
       "SkipToConfirmAndLaunch": "Sauter à l'examen",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -266,7 +266,8 @@
       "PreOpenPortMaxCountLimit_0": "__NOT_TRANSLATED__",
       "OnlyAllowsDiscreteNumberByClusterSize": "Hanya bilangan bulat yang diperbolehkan jika ukuran cluster tidak kurang dari 2.",
       "StartAfter": "Mulai setelah:",
-      "StartTimeDoesNotApply": "Jika waktu mulai tidak ditetapkan, maka tidak berlaku."
+      "StartTimeDoesNotApply": "Jika waktu mulai tidak ditetapkan, maka tidak berlaku.",
+      "PreviousLauncher": "Classic"
     },
     "Preparing": "Mempersiapkan...",
     "PreparingSession": "Mempersiapkan sesi...",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -263,7 +263,7 @@
       "StartTimeDoesNotApply": "Se l'ora di inizio non è impostata, non si applica.",
       "MiniumAllocation": "Requisiti minimi",
       "MiniumAllocationTooltip": "Selezionare come requisito minimo per l'ambiente di esecuzione selezionato",
-      "PreviousLauncher": "Precedente",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Si sta utilizzando il lanciatore di sessione \"{{launcher}}\".",
       "SkipToConfirmAndLaunch": "Vai alla recensione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -263,7 +263,7 @@
       "StartTimeDoesNotApply": "開始時間が設定されていない場合は適用されません。",
       "MiniumAllocation": "最低条件",
       "MiniumAllocationTooltip": "選択した実行環境の最小要件として選択する。",
-      "PreviousLauncher": "前へ",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "あなたは「{{launcher}}」セッション・ランチャーを使用しています。",
       "SkipToConfirmAndLaunch": "レビューへスキップ",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -268,7 +268,7 @@
       "MiniumAllocation": "최소 요구사항 할당",
       "MiniumAllocationTooltip": "선택한 실행환경에서 요구되는 최소 요구사항으로 선택",
       "NeoSwitchDescription": "현재 \"{{launcher}}\" 세션 런처를 사용중입니다.",
-      "PreviousLauncher": "기존",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "EnvironmentVariableValueRequired": "값을 입력해주세요."
     },

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -263,7 +263,7 @@
       "StartTimeDoesNotApply": "Jika masa mula tidak ditetapkan, ia tidak terpakai.",
       "MiniumAllocation": "Keperluan minimum",
       "MiniumAllocationTooltip": "Pilih sebagai keperluan minimum untuk persekitaran berjalan yang dipilih",
-      "PreviousLauncher": "Sebelumnya",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Anda menggunakan pelancar sesi \"{{launcher}}\".",
       "SkipToConfirmAndLaunch": "Langkau ke semakan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -265,7 +265,7 @@
       "StartTimeDoesNotApply": "Jeśli godzina rozpoczęcia nie jest ustawiona, nie ma ona zastosowania.",
       "MiniumAllocation": "Minimalne wymagania",
       "MiniumAllocationTooltip": "Wybierz jako minimalne wymaganie dla wybranego środowiska uruchomieniowego",
-      "PreviousLauncher": "Poprzedni",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Używasz programu uruchamiającego sesję \"{{launcher}}\".",
       "SkipToConfirmAndLaunch": "Przejdź do recenzji",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -263,7 +263,7 @@
       "StartTimeDoesNotApply": "Se a hora de início não estiver definida, ela não se aplica.",
       "MiniumAllocation": "Requisitos mínimos",
       "MiniumAllocationTooltip": "Selecionar como requisito mínimo para o ambiente de execução selecionado",
-      "PreviousLauncher": "Anterior",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Está a utilizar o iniciador de sessão \"{{launcher}}\".",
       "SkipToConfirmAndLaunch": "Saltar para a revisão",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -263,7 +263,7 @@
       "StartTimeDoesNotApply": "Se a hora de início não estiver definida, ela não se aplica.",
       "MiniumAllocation": "Requisitos mínimos",
       "MiniumAllocationTooltip": "Selecionar como requisito mínimo para o ambiente de execução selecionado",
-      "PreviousLauncher": "Anterior",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Está a utilizar o iniciador de sessão \"{{launcher}}\".",
       "SkipToConfirmAndLaunch": "Saltar para a revisão",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -265,7 +265,7 @@
       "StartTimeDoesNotApply": "Если время начала не установлено, оно не применяется.",
       "MiniumAllocation": "Минимальные требования",
       "MiniumAllocationTooltip": "Выберите минимальное требование для выбранной среды выполнения",
-      "PreviousLauncher": "Предыдущий",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Вы используете программу запуска сессии \"{{launcher}}\".",
       "SkipToConfirmAndLaunch": "Перейти к обзору",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -263,7 +263,7 @@
       "StartTimeDoesNotApply": "Başlangıç ​​zamanı ayarlanmamışsa geçerli değildir.",
       "MiniumAllocation": "Minimum gereksinimler",
       "MiniumAllocationTooltip": "Seçilen çalışma ortamı için minimum gereksinim olarak seçin",
-      "PreviousLauncher": "Önceki",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "\"{{launcher}}\" oturum başlatıcısını kullanıyorsunuz.",
       "SkipToConfirmAndLaunch": "İncelemeye geç",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -263,7 +263,7 @@
       "StartTimeDoesNotApply": "Nếu thời gian bắt đầu không được đặt, nó sẽ không được áp dụng.",
       "MiniumAllocation": "Yêu cầu tối thiểu",
       "MiniumAllocationTooltip": "Chọn làm yêu cầu tối thiểu cho môi trường chạy đã chọn",
-      "PreviousLauncher": "Trước",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "Bạn đang sử dụng trình khởi chạy phiên \"{{launcher}}\".",
       "SkipToConfirmAndLaunch": "Bỏ qua để xem xét",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -263,7 +263,7 @@
       "StartTimeDoesNotApply": "如果未设置开始时间，则不适用。",
       "MiniumAllocation": "最低要求",
       "MiniumAllocationTooltip": "选择所选运行环境的最低要求",
-      "PreviousLauncher": "上一页",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "您正在使用\"{{launcher}}\"会话启动器。",
       "SkipToConfirmAndLaunch": "跳过评论",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -263,7 +263,7 @@
       "StartTimeDoesNotApply": "如果未設定開始時間，則不適用。",
       "MiniumAllocation": "最低要求",
       "MiniumAllocationTooltip": "选择所选运行环境的最低要求",
-      "PreviousLauncher": "上一页",
+      "PreviousLauncher": "Classic",
       "NeoLauncher": "NEO",
       "NeoSwitchDescription": "您正在使用\"{{launcher}}\"会话启动器。",
       "SkipToConfirmAndLaunch": "跳过评论",

--- a/src/components/backend-ai-edu-applauncher.ts
+++ b/src/components/backend-ai-edu-applauncher.ts
@@ -528,7 +528,7 @@ export default class BackendAiEduApplauncher extends BackendAIPage {
             _text('session.applauncher.Prepared'),
           );
           setTimeout(() => {
-            globalThis.open(appConnectUrl || resp.url, '_self');
+            globalThis.open(String(appConnectUrl) || resp.url, '_self');
             // globalThis.open(resp.url);
           });
         } else {

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -2028,13 +2028,17 @@ export default class BackendAILogin extends BackendAIPage {
                 `}
           </div>
         </div>
-        <div slot="content">
-          <div class="horizontal flex center around-justified layout wrap">
-            <h3 style="width:150px;">
+        <div slot="content" class="login-panel intro centered">
+          <h3
+            class="horizontal center layout"
+            style="margin: 0 25px;font-weight:700;min-height:40px; padding-bottom:10px;"
+          >
+            <div>
               ${this.connection_mode === 'SESSION'
                 ? _t('login.LoginWithE-mailorUsername')
                 : _t('login.LoginWithIAM')}
-            </h3>
+            </div>
+            <div class="flex"></div>
             ${this.change_signin_support
               ? html`
                   <div
@@ -2055,7 +2059,7 @@ export default class BackendAILogin extends BackendAIPage {
                   </div>
                 `
               : html``}
-          </div>
+          </h3>
           <div class="login-form">
             <div id="waiting-animation" class="horizontal layout wrap">
               <div class="sk-folding-cube">

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -86,9 +86,9 @@ type CommitSessionInfo = {
 /**
  * Type of commit session info
  */
-type SessionToImageInfo = CommitSessionInfo & {
-  name: string;
-};
+// type SessionToImageInfo = CommitSessionInfo & {
+//   name: string;
+// };
 
 /**
  * Type of commit session status


### PR DESCRIPTION
This PR:
- changes the previous session launcher name from "Previous" to "Classic" 
<img width="460" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/ffc5b637-ae84-4168-af42-3cab62f9bed5">

- uses human-readable tags for images in Neo session launcher's final step

| Before | After |
|--------|--------|
| <img width="372" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/ef6f2fe1-5907-42fd-b957-dd2fae747009">|  <img width="664" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/67b42ab5-0878-4c16-a138-84144aaae3a5"> | 

- disables presets based on the current image's accelerator limits

After

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
