### PR TITLE
remove remaining session limit validation error

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -1114,29 +1114,16 @@ const ResourceAllocationFormItems: React.FC<
                       required: true,
                     },
                     {
-                      warningOnly:
-                        baiClient._config?.always_enqueue_compute_session,
+                      warningOnly: true,
                       validator: async (rule, value: number) => {
                         if (
                           sessionSliderLimitAndRemaining &&
                           value > sessionSliderLimitAndRemaining.remaining
                         ) {
                           return Promise.reject(
-                            baiClient._config?.always_enqueue_compute_session
-                              ? t(
-                                  'session.launcher.EnqueueComputeSessionWarning',
-                                  {
-                                    amount:
-                                      sessionSliderLimitAndRemaining.remaining,
-                                  },
-                                )
-                              : t(
-                                  'session.launcher.ErrorCanNotExceedRemaining',
-                                  {
-                                    amount:
-                                      sessionSliderLimitAndRemaining.remaining,
-                                  },
-                                ),
+                            t('session.launcher.EnqueueComputeSessionWarning', {
+                              amount: sessionSliderLimitAndRemaining.remaining,
+                            }),
                           );
                         } else {
                           return Promise.resolve();

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -485,6 +485,7 @@ const SessionLauncherPage = () => {
               resolved: t('eduapi.ComputeSessionPrepared'),
             },
           },
+          duration: 0,
           message: t('general.Session') + ': ' + sessionName,
           open: true,
         });


### PR DESCRIPTION
## Before 
Before this PR, if there is no remaining session count related to the session limit and no `always_enqueue_compute_session`, the form item displays an error, and the user is not allowed to create a (pending) session. 

## After
- However, after this PR, the user can create a (pending) session even if there is no remaining session count, regardless of the `always_enqueue_compute_session` setting. **This behavior is the same as the classic session launcher.**
<img width="686" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/c967abf2-950f-4360-89e8-50a7231b9943">

- [the session preparing notification remains on until the promise is re…](https://github.com/lablup/backend.ai-webui/pull/2312/commits/58366b4fecdca7f0737feb15eeeffe4668a0a1c4)

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
