### PR TITLE
fix: use `max_resoure_policy` of `user_resource_policy` since 23.09.4

### DIFF
--- a/react/src/components/StorageStatusPanel.tsx
+++ b/react/src/components/StorageStatusPanel.tsx
@@ -133,7 +133,7 @@ const StorageStatusPanel: React.FC<{
         $storage_host_name: String!
         $skipQuotaScope: Boolean!
       ) {
-        user_resource_policy(name: $user_RP_name) @since(version: "23.09.1") {
+        user_resource_policy(name: $user_RP_name) @since(version: "23.09.4") {
           max_vfolder_count
         }
         # project_resource_policy(name: $project_RP_name) @since(version: "23.09.1") {


### PR DESCRIPTION
[Teams thread](https://teams.microsoft.com/l/message/19:3c0acc0825024daeb2211f55c4e7f4aa@thread.skype/1712390047229?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=74ae2c4d-ec4d-4fdf-b2c2-f5041d1e8631&parentMessageId=1711969419442&teamName=devops&channelName=Backend.AI%20Talks&createdTime=1712390047229)

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
