### PR TITLE
hotfix: touchup container commit feature

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -324,7 +324,7 @@
     "Architecture": "Architektur",
     "SessionType": "SessionType",
     "Validation": {
-      "EnterValidSessionName": "Gültigen Sitzungsnamen eingeben",
+      "EnterValidSessionName": "Bitte geben Sie eine Kombination aus mindestens 4 Buchstaben, Zahlen, Bindestrichen oder Unterstrichen ein.",
       "SessionNameRequired": "Sitzungsname ist erforderlich",
       "SluggedStrings": "Geschliffene Zeichenfolgen (>3 Zeichen)",
       "SessionNameAlreadyExist": "Sitzungsname existiert bereits",
@@ -437,7 +437,8 @@
     "Clone": "Klonen",
     "Config": "Konfigurieren Sie",
     "Next": "Weiter",
-    "Previous": "Vorherige"
+    "Previous": "Vorherige",
+    "PushToImage": "Push-Sitzung auf benutzerdefiniertes Bild"
   },
   "agent": {
     "Endpoint": "Endpunkt",
@@ -1522,7 +1523,8 @@
   },
   "OpenVSCodeRemote": "Lokalen Visual Studio Code öffnen",
   "inputLimit": {
-    "4to64chars": "(4~64 Zeichen)"
+    "4to64chars": "(4~64 Zeichen)",
+    "4to32chars": "(4~32 Zeichen)"
   },
   "modelStore": {
     "Description": "Beschreibung",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -324,7 +324,7 @@
     "Architecture": "Αρχιτεκτονική",
     "SessionType": "SessionType",
     "Validation": {
-      "EnterValidSessionName": "Εισάγετε έγκυρο όνομα συνεδρίας",
+      "EnterValidSessionName": "Εισαγάγετε έναν συνδυασμό τουλάχιστον 4 γραμμάτων αλφαβήτου ή αριθμών ή παύλας ή υπογράμμισης.",
       "SessionNameRequired": "Το όνομα συνεδρίας είναι υποχρεωτικό",
       "SluggedStrings": "Στιγμιότυπα αλφαριθμητικά (>3 χαρακτήρες)",
       "SessionNameAlreadyExist": "Το όνομα συνεδρίας υπάρχει ήδη",
@@ -437,7 +437,8 @@
     "Clone": "Κλώνος",
     "Config": "Διαμόρφωση",
     "Next": "Επόμενο",
-    "Previous": "Προηγούμενο"
+    "Previous": "Προηγούμενο",
+    "PushToImage": "Σπρώξτε τη συνεδρία σε προσαρμοσμένη εικόνα"
   },
   "agent": {
     "Endpoint": "Τελικό σημείο",
@@ -1522,7 +1523,8 @@
   },
   "OpenVSCodeRemote": "Ανοίξτε τον τοπικό κώδικα του Visual Studio",
   "inputLimit": {
-    "4to64chars": "(4~64 χαρακτήρες)"
+    "4to64chars": "(4~64 χαρακτήρες)",
+    "4to32chars": "(4~32 χαρακτήρες)"
   },
   "modelStore": {
     "Description": "Περιγραφή",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -361,7 +361,7 @@
     "Validation": {
       "SessionNameRequired": "Session name is required",
       "SluggedStrings": "Slugged strings (>3 chars)",
-      "EnterValidSessionName": "Enter valid session name",
+      "EnterValidSessionName": "Please enter a combination of at least 4 alphabet letters, or numbers, or hyphen, or underscore.",
       "SessionNameAlreadyExist": "Session name already exists",
       "SessionNameTooLong64": "Please enter 64 characters or less.",
       "PleaseFollowSessionNameRule": "Please enter a combination of at least 4 letters, numbers, '.', '_', and '-'.",
@@ -504,7 +504,8 @@
     "Clone": "Clone",
     "Config": "Config",
     "Next": "Next",
-    "Previous": "Previous"
+    "Previous": "Previous",
+    "PushToImage": "Push session to customized image"
   },
   "agent": {
     "Endpoint": "Endpoint",
@@ -1513,6 +1514,7 @@
     "2048chars": "(maximum 2048 chars)"
   },
   "inputLimit": {
+    "4to32chars": "(4~32 chars)",
     "4to64chars": "(4~64 chars)"
   },
   "explorer": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -133,7 +133,8 @@
     "Clone": "Clon",
     "Config": "Configurar",
     "Next": "Siguiente",
-    "Previous": "Anterior"
+    "Previous": "Anterior",
+    "PushToImage": "Enviar sesión a una imagen personalizada"
   },
   "credential": {
     "AccessKeyOptional": "Clave de acceso (opcional)",
@@ -556,7 +557,8 @@
     "UsesSSL": "Utiliza SSL"
   },
   "inputLimit": {
-    "4to64chars": "(4~64 caracteres)"
+    "4to64chars": "(4~64 caracteres)",
+    "4to32chars": "(4~32 caracteres)"
   },
   "language": {
     "English": "English",
@@ -988,7 +990,7 @@
     "VSCodeRemoteNoticeSSHConfig": "Para configurar una conexión transparente para Visual Studio Code con la sesión de computación remota, cree o edite el archivo $HOME/.ssh/config y añada el siguiente bloque.",
     "VSCodeRemotePasswordTitle": "Contraseña SSH remota de Visual Studio Code",
     "Validation": {
-      "EnterValidSessionName": "Introduzca un nombre de sesión válido",
+      "EnterValidSessionName": "Ingrese una combinación de al menos 4 letras del alfabeto, números, guiones o guiones bajos.",
       "SessionNameAlreadyExist": "El nombre de la sesión ya existe",
       "SessionNameRequired": "El nombre de la sesión es obligatorio",
       "SluggedStrings": "Cadenas babosas (>3 caracteres)",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -133,7 +133,8 @@
     "Download": "ladata",
     "Config": "Config",
     "Next": "Seuraava",
-    "Previous": "Edellinen"
+    "Previous": "Edellinen",
+    "PushToImage": "Työnnä istunto mukautettuun kuvaan"
   },
   "credential": {
     "AccessKeyOptional": "Pääsyavain (valinnainen)",
@@ -556,7 +557,8 @@
     "UsesSSL": "Käyttää SSL:ää"
   },
   "inputLimit": {
-    "4to64chars": "(4~64 merkkiä)"
+    "4to64chars": "(4~64 merkkiä)",
+    "4to32chars": "(4-32 merkkiä)"
   },
   "language": {
     "English": "English",
@@ -986,7 +988,7 @@
     "VSCodeRemoteNoticeSSHConfig": "Jos haluat luoda saumattoman yhteyden Visual Studio Code -ohjelmistolle etälaskentaistuntoon, luo tai muokkaa $HOME/.ssh/config-tiedostoa ja lisää seuraava lohko.",
     "VSCodeRemotePasswordTitle": "Visual Studio Code SSH-etäsalasana",
     "Validation": {
-      "EnterValidSessionName": "Syötä kelvollinen istunnon nimi",
+      "EnterValidSessionName": "Anna vähintään neljän aakkosten kirjaimen tai numeron tai yhdysviivan tai alaviivan yhdistelmä.",
       "SessionNameAlreadyExist": "Istunnon nimi on jo olemassa",
       "SessionNameRequired": "Istunnon nimi vaaditaan",
       "SluggedStrings": "Slugged-merkkijonot (>3 merkkiä)",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -335,7 +335,7 @@
     "Architecture": "Architecture",
     "Validation": {
       "SessionNameRequired": "Le nom de la session est obligatoire",
-      "EnterValidSessionName": "Saisir un nom de session valide",
+      "EnterValidSessionName": "Veuillez saisir une combinaison d'au moins 4 lettres de l'alphabet, ou chiffres, ou trait d'union, ou trait de soulignement.",
       "SessionNameAlreadyExist": "Le nom de la session existe déjà",
       "SluggedStrings": "Chaînes de caractères tronquées (>3 chars)",
       "SessionNameTooLong64": "Veuillez saisir 64 caractères ou moins.",
@@ -437,7 +437,8 @@
     "Clone": "Clone",
     "Config": "Config",
     "Next": "Suivant",
-    "Previous": "Précédent"
+    "Previous": "Précédent",
+    "PushToImage": "Pousser la session vers une image personnalisée"
   },
   "agent": {
     "Endpoint": "Point de terminaison",
@@ -1427,7 +1428,8 @@
     "RequireOTP": "Écrivez OTP."
   },
   "inputLimit": {
-    "4to64chars": "(4~64 caractères)"
+    "4to64chars": "(4~64 caractères)",
+    "4to32chars": "(4 ~ 32 caractères)"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -336,7 +336,7 @@
       "SessionNameShouldEndWith": "Nama tersebut harus diakhiri dengan huruf alfabet, angka, atau '_'.",
       "SessionNameInvalidCharacter": "Bagian tengah nama hanya boleh berisi huruf alfabet, angka, dan '_'.",
       "SessionNameRequired": "Nama sesi harus diisi",
-      "EnterValidSessionName": "Masukkan nama sesi yang valid",
+      "EnterValidSessionName": "Silakan masukkan kombinasi minimal 4 huruf alfabet, atau angka, atau tanda hubung, atau garis bawah.",
       "SessionNameAlreadyExist": "Nama sesi sudah ada",
       "SluggedStrings": "String yang disumbat (>3 karakter)",
       "SessionNameTooLong64": "Silakan masukkan 64 karakter atau kurang.",
@@ -433,7 +433,8 @@
     "Clone": "Clone",
     "Config": "Konfigurasi",
     "Next": "Berikutnya",
-    "Previous": "Sebelumnya"
+    "Previous": "Sebelumnya",
+    "PushToImage": "Sesi dorong ke gambar yang disesuaikan"
   },
   "agent": {
     "Endpoint": "Titik akhir",
@@ -1421,7 +1422,8 @@
     "RequireOTP": "Tulis OTP."
   },
   "inputLimit": {
-    "4to64chars": "(4 ~ 64 karakter)"
+    "4to64chars": "(4 ~ 64 karakter)",
+    "4to32chars": "(4~32 karakter)"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -324,7 +324,7 @@
     "Architecture": "Architettura",
     "SessionType": "Tipo di sessione",
     "Validation": {
-      "EnterValidSessionName": "Inserire un nome di sessione valido",
+      "EnterValidSessionName": "Inserisci una combinazione di almeno 4 lettere dell'alfabeto, numeri, trattini o trattini bassi.",
       "SessionNameRequired": "Il nome della sessione è obbligatorio",
       "SluggedStrings": "Stringhe con slugged (>3 caratteri)",
       "SessionNameAlreadyExist": "Il nome della sessione esiste già",
@@ -437,7 +437,8 @@
     "Clone": "Clone",
     "Config": "Configurazione",
     "Next": "Avanti",
-    "Previous": "Precedente"
+    "Previous": "Precedente",
+    "PushToImage": "Push della sessione all'immagine personalizzata"
   },
   "agent": {
     "Endpoint": "Endpoint",
@@ -1522,7 +1523,8 @@
   },
   "OpenVSCodeRemote": "Aprire il codice locale di Visual Studio",
   "inputLimit": {
-    "4to64chars": "(4~64 caratteri)"
+    "4to64chars": "(4~64 caratteri)",
+    "4to32chars": "(4~32 caratteri)"
   },
   "modelStore": {
     "Description": "Descrizione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -324,7 +324,7 @@
     "Architecture": "アーキテクチャ",
     "SessionType": "セッションタイプ",
     "Validation": {
-      "EnterValidSessionName": "正しいセッション名を入力してください",
+      "EnterValidSessionName": "アルファベット、数字、ハイフン、アンダースコアを 4 文字以上組み合わせて入力してください。",
       "SessionNameRequired": "セッション名を入力してください",
       "SluggedStrings": "最低4文字以上の固有の文字列で入力してください。",
       "SessionNameAlreadyExist": "同じ名前のセッションが既にあります",
@@ -437,7 +437,8 @@
     "Clone": "クローン",
     "Config": "コンフィグ",
     "Next": "次のページ",
-    "Previous": "前へ"
+    "Previous": "前へ",
+    "PushToImage": "セッションをカスタマイズされたイメージにプッシュする"
   },
   "agent": {
     "Endpoint": "終点",
@@ -1522,7 +1523,8 @@
   },
   "OpenVSCodeRemote": "ローカルVisual Studio Codeを開く",
   "inputLimit": {
-    "4to64chars": "(4～64文字)"
+    "4to64chars": "(4～64文字)",
+    "4to32chars": "(4~32文字)"
   },
   "modelStore": {
     "Description": "説明",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -339,7 +339,7 @@
     "Validation": {
       "SessionNameRequired": "세션 이름을 입력해주세요",
       "SluggedStrings": "최소 4자 이상의 고유문자열로 입력해주세요",
-      "EnterValidSessionName": "올바른 세션 이름을 입력해주세요",
+      "EnterValidSessionName": "영문, 숫자, 하이픈, 밑줄 4자 이상 조합하여 입력해주세요.",
       "SessionNameAlreadyExist": "같은 이름의 세션이 이미 있습니다",
       "SessionNameTooLong64": "64자 이하로 입력해주세요.",
       "PleaseFollowSessionNameRule": "최소 4자 이상의 문자, 숫자, '.', '_', '-' 조합으로 입력해주세요.",
@@ -492,7 +492,8 @@
     "Clone": "복사",
     "Config": "설정",
     "Next": "다음",
-    "Previous": "이전"
+    "Previous": "이전",
+    "PushToImage": "세션을 사용자 정의된 이미지로 푸시"
   },
   "agent": {
     "Endpoint": "엔드포인트",
@@ -1499,7 +1500,8 @@
     "2048chars": "(최대 길이 2048자)"
   },
   "inputLimit": {
-    "4to64chars": "(4~64자)"
+    "4to64chars": "(4~64자)",
+    "4to32chars": "(4~32자)"
   },
   "explorer": {
     "ValueRequired": "값이 필요합니다.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -324,7 +324,7 @@
     "Architecture": "Архитектур",
     "Validation": {
       "SessionNameRequired": "Сеансын нэрийг оруулах шаардлагатай",
-      "EnterValidSessionName": "Хүчинтэй сессийн нэрийг оруулна уу",
+      "EnterValidSessionName": "Дор хаяж 4 цагаан толгойн үсэг, тоо, зураас, доогуур зураасын хослолыг оруулна уу.",
       "SessionNameAlreadyExist": "Сешн нэр аль хэдийн байна",
       "SluggedStrings": "Залгисан мөрүүд (>3 тэмдэгт)",
       "SessionNameTooLong64": "64 ба түүнээс бага тэмдэгт оруулна уу.",
@@ -1540,7 +1540,7 @@
     "SearchTableColumn": "Хүснэгтийн багануудыг хайх"
   },
   "setting": {
-    "SearchPlaceholder": "Хайлтын нэр томъёог оруулна уу"
+    "SearchPlaceholder": "Хайлтын нэр томъёог оруулна уу",
     "HyperaccelLPUsupport": "Hyperaccel LPU",
     "DescHyperaccelLPUsupport": "Hyperaccel LPU хурдасгуурыг ашигла.",
     "RequireHyperaccelLPUPlugin": "Backend.AI Hyperaccel LPU Plugin шаардлагатай."

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -324,7 +324,7 @@
     "Architecture": "Seni bina",
     "SessionType": "Jenis Sesi",
     "Validation": {
-      "EnterValidSessionName": "Masukkan nama sesi yang sah",
+      "EnterValidSessionName": "Sila masukkan gabungan sekurang-kurangnya 4 huruf abjad, atau nombor, atau sempang, atau garis bawah.",
       "SessionNameRequired": "Nama sesi diperlukan",
       "SluggedStrings": "Rentetan slugged (>3 aksara)",
       "SessionNameAlreadyExist": "Nama sesi sudah wujud",
@@ -437,7 +437,8 @@
     "Clone": "Klon",
     "Config": "Konfigurasi",
     "Next": "Seterusnya",
-    "Previous": "Sebelumnya"
+    "Previous": "Sebelumnya",
+    "PushToImage": "Sesi tolak ke imej tersuai"
   },
   "agent": {
     "Endpoint": "Titik Akhir",
@@ -1503,7 +1504,8 @@
   },
   "OpenVSCodeRemote": "Buka Kod Visual Studio tempatan",
   "inputLimit": {
-    "4to64chars": "(4~64 aksara)"
+    "4to64chars": "(4~64 aksara)",
+    "4to32chars": "(4~32 aksara)"
   },
   "modelStore": {
     "Description": "Penerangan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -326,7 +326,7 @@
     "Architecture": "Architektura",
     "SessionType": "SessionType",
     "Validation": {
-      "EnterValidSessionName": "Wprowadź prawidłową nazwę sesji",
+      "EnterValidSessionName": "Wprowadź kombinację co najmniej 4 liter alfabetu, cyfr, łącznika lub podkreślenia.",
       "SessionNameRequired": "Nazwa sesji jest wymagana",
       "SluggedStrings": "Ucięte ciągi znaków (>3 znaki)",
       "SessionNameAlreadyExist": "Nazwa sesji już istnieje",
@@ -439,7 +439,8 @@
     "Clone": "Klon",
     "Config": "Konfiguracja",
     "Next": "Następny",
-    "Previous": "Poprzedni"
+    "Previous": "Poprzedni",
+    "PushToImage": "Prześlij sesję do spersonalizowanego obrazu"
   },
   "agent": {
     "Endpoint": "Punkt końcowy",
@@ -1524,7 +1525,8 @@
   },
   "OpenVSCodeRemote": "Otwórz lokalny kod Visual Studio",
   "inputLimit": {
-    "4to64chars": "(4~64 znaki)"
+    "4to64chars": "(4~64 znaki)",
+    "4to32chars": "(4~32 znaki)"
   },
   "modelStore": {
     "Description": "Opis",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -324,7 +324,7 @@
     "Architecture": "Arquitetura",
     "SessionType": "Tipo de sessão",
     "Validation": {
-      "EnterValidSessionName": "Introduzir um nome de sessão válido",
+      "EnterValidSessionName": "Insira uma combinação de pelo menos quatro letras do alfabeto, ou números, ou hífen, ou sublinhado.",
       "SessionNameRequired": "O nome da sessão é obrigatório",
       "SluggedStrings": "Cadeias de caracteres com slugged (>3 caracteres)",
       "SessionNameAlreadyExist": "O nome da sessão já existe",
@@ -437,7 +437,8 @@
     "Clone": "Clone",
     "Config": "Configuração",
     "Next": "Seguinte",
-    "Previous": "Anterior"
+    "Previous": "Anterior",
+    "PushToImage": "Enviar sessão para imagem personalizada"
   },
   "agent": {
     "Endpoint": "Endpoint",
@@ -1522,7 +1523,8 @@
   },
   "OpenVSCodeRemote": "Abrir o código local do Visual Studio",
   "inputLimit": {
-    "4to64chars": "(4~64 caracteres)"
+    "4to64chars": "(4~64 caracteres)",
+    "4to32chars": "(4~32 caracteres)"
   },
   "modelStore": {
     "Description": "Descrição",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -324,7 +324,7 @@
     "Architecture": "Arquitetura",
     "SessionType": "Tipo de sessão",
     "Validation": {
-      "EnterValidSessionName": "Introduzir um nome de sessão válido",
+      "EnterValidSessionName": "Insira uma combinação de pelo menos quatro letras do alfabeto, ou números, ou hífen, ou sublinhado.",
       "SessionNameRequired": "O nome da sessão é obrigatório",
       "SluggedStrings": "Cadeias de caracteres com slugged (>3 caracteres)",
       "SessionNameAlreadyExist": "O nome da sessão já existe",
@@ -437,7 +437,8 @@
     "Clone": "Clone",
     "Config": "Configuração",
     "Next": "Seguinte",
-    "Previous": "Anterior"
+    "Previous": "Anterior",
+    "PushToImage": "Enviar sessão para imagem personalizada"
   },
   "agent": {
     "Endpoint": "Endpoint",
@@ -1522,7 +1523,8 @@
   },
   "OpenVSCodeRemote": "Abrir o código local do Visual Studio",
   "inputLimit": {
-    "4to64chars": "(4~64 caracteres)"
+    "4to64chars": "(4~64 caracteres)",
+    "4to32chars": "(4~32 caracteres)"
   },
   "modelStore": {
     "Description": "Descrição",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -337,7 +337,7 @@
     "Architecture": "Архитектура",
     "Validation": {
       "SessionNameRequired": "Имя сессии является обязательным",
-      "EnterValidSessionName": "Введите действительное имя сессии",
+      "EnterValidSessionName": "Введите комбинацию как минимум из 4 букв алфавита, цифр, дефиса или подчеркивания.",
       "SessionNameAlreadyExist": "Имя сессии уже существует",
       "SluggedStrings": "Строки с засечками (>3 символов)",
       "SessionNameTooLong64": "Введите не более 64 символов.",
@@ -439,7 +439,8 @@
     "Clone": "Клон",
     "Config": "Конфигурация",
     "Next": "Следующий",
-    "Previous": "Предыдущий"
+    "Previous": "Предыдущий",
+    "PushToImage": "Отправить сеанс на настроенное изображение"
   },
   "agent": {
     "Endpoint": "Конечная точка",
@@ -1429,7 +1430,8 @@
     "RequireOTP": "Напишите ОТП."
   },
   "inputLimit": {
-    "4to64chars": "(4~64 символа)"
+    "4to64chars": "(4~64 символа)",
+    "4to32chars": "(4~32 символа)"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -324,7 +324,7 @@
     "Architecture": "Mimarlık",
     "SessionType": "OturumTürü",
     "Validation": {
-      "EnterValidSessionName": "Geçerli oturum adını girin",
+      "EnterValidSessionName": "Lütfen en az 4 alfabe harfi veya rakamı, kısa çizgi veya alt çizgiden oluşan bir kombinasyon girin.",
       "SessionNameRequired": "Oturum adı gereklidir",
       "SluggedStrings": "Kesikli dizeler (>3 karakter)",
       "SessionNameAlreadyExist": "Oturum adı zaten mevcut",
@@ -437,7 +437,8 @@
     "Clone": "Klon",
     "Config": "Konfigürasyon",
     "Next": "Sonraki",
-    "Previous": "Önceki"
+    "Previous": "Önceki",
+    "PushToImage": "Oturumu özelleştirilmiş resme aktarın"
   },
   "agent": {
     "Endpoint": "uç nokta",
@@ -1522,7 +1523,8 @@
   },
   "OpenVSCodeRemote": "Yerel Visual Studio Kodunu açın",
   "inputLimit": {
-    "4to64chars": "(4~64 karakter)"
+    "4to64chars": "(4~64 karakter)",
+    "4to32chars": "(4~32 karakter)"
   },
   "modelStore": {
     "Description": "Tanım",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -324,7 +324,7 @@
     "Architecture": "Ngành kiến ​​​​trúc",
     "SessionType": "Loại phiên",
     "Validation": {
-      "EnterValidSessionName": "Nhập tên phiên hợp lệ",
+      "EnterValidSessionName": "Vui lòng nhập kết hợp ít nhất 4 chữ cái trong bảng chữ cái, hoặc số, hoặc dấu gạch ngang hoặc dấu gạch dưới.",
       "SessionNameRequired": "Tên phiên là bắt buộc",
       "SluggedStrings": "Chuỗi bị trượt (>3 ký tự)",
       "SessionNameAlreadyExist": "Tên phiên đã tồn tại",
@@ -437,7 +437,8 @@
     "Clone": "Dòng vô tính",
     "Config": "Cấu hình",
     "Next": "Kế tiếp",
-    "Previous": "Trước"
+    "Previous": "Trước",
+    "PushToImage": "Đẩy phiên sang hình ảnh tùy chỉnh"
   },
   "agent": {
     "Endpoint": "Điểm cuối",
@@ -1522,7 +1523,8 @@
   },
   "OpenVSCodeRemote": "Mở mã Visual Studio cục bộ",
   "inputLimit": {
-    "4to64chars": "(4~64 ký tự)"
+    "4to64chars": "(4~64 ký tự)",
+    "4to32chars": "(4~32 ký tự)"
   },
   "modelStore": {
     "Description": "Sự miêu tả",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -324,7 +324,7 @@
     "Architecture": "建筑学",
     "SessionType": "会话类型",
     "Validation": {
-      "EnterValidSessionName": "输入有效的会话名称",
+      "EnterValidSessionName": "请输入至少 4 个字母、数字、连字符或下划线的组合。",
       "SessionNameRequired": "会话名称为必填项",
       "SluggedStrings": "多字符串（>3 字符）",
       "SessionNameAlreadyExist": "会话名称已存在",
@@ -437,7 +437,8 @@
     "Clone": "克隆",
     "Config": "配置",
     "Next": "下一页",
-    "Previous": "上一页"
+    "Previous": "上一页",
+    "PushToImage": "将会话推送到自定义镜像"
   },
   "agent": {
     "Endpoint": "端点",
@@ -1522,7 +1523,8 @@
   },
   "OpenVSCodeRemote": "打开本地 Visual Studio 代码",
   "inputLimit": {
-    "4to64chars": "（4 至 64 个字符）"
+    "4to64chars": "（4 至 64 个字符）",
+    "4to32chars": "(4~32个字符)"
   },
   "modelStore": {
     "Description": "描述",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -324,7 +324,7 @@
     "Architecture": "建筑学",
     "SessionType": "会话类型",
     "Validation": {
-      "EnterValidSessionName": "输入有效的会话名称",
+      "EnterValidSessionName": "請輸入至少 4 個字母、數字、連字號或底線的組合。",
       "SessionNameRequired": "会话名称为必填项",
       "SluggedStrings": "多字符串（>3 字符）",
       "SessionNameAlreadyExist": "会话名称已存在",
@@ -437,7 +437,8 @@
     "Clone": "克隆",
     "Config": "配置",
     "Next": "下一页",
-    "Previous": "上一页"
+    "Previous": "上一页",
+    "PushToImage": "將會話推送到自訂鏡像"
   },
   "agent": {
     "Endpoint": "端點",
@@ -1522,7 +1523,8 @@
   },
   "OpenVSCodeRemote": "打开本地 Visual Studio 代码",
   "inputLimit": {
-    "4to64chars": "（4 至 64 个字符）"
+    "4to64chars": "（4 至 64 个字符）",
+    "4to32chars": "(4~32個字元)"
   },
   "modelStore": {
     "Description": "描述",

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1832,6 +1832,10 @@ export default class BackendAISessionList extends BackendAIPage {
     this.commitSessionDialog.sessionName = sessionName;
     this.commitSessionDialog.sessionId = sessionId;
     this.commitSessionDialog.kernelImage = kernelImage;
+    // Reset image name field;
+    (
+      this.shadowRoot?.querySelector('#new-image-name-field') as TextField
+    ).value = '';
     this.commitSessionDialog.show();
   }
 

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -3188,7 +3188,10 @@ ${rowData.item[this.sessionNameField]}</pre
                   this._isFinished(rowData.item.status) ||
                   (rowData.item.type as SessionType) === 'BATCH' ||
                   (rowData.item.commit_status as CommitSessionStatus) ===
-                    'ongoing'}
+                    'ongoing' ||
+                  // FIXME: temporally disable container commit feature
+                  // when the session is not created by logined user
+                  rowData.item.user_email !== globalThis.backendaiclient.email}
                   icon="archive"
                   @click="${(e) => this._openCommitSessionDialog(e)}"
                 ></mwc-icon-button>

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -311,6 +311,10 @@ export default class BackendAISessionList extends BackendAIPage {
           padding: 0;
         }
 
+        mwc-checkbox.list-check {
+          margin: 6px 0 0 0;
+        }
+
         mwc-icon {
           margin-right: 5px;
         }
@@ -453,6 +457,16 @@ export default class BackendAISessionList extends BackendAIPage {
         .error-description {
           font-size: 0.8rem;
           word-break: break-word;
+        }
+
+        h4.commit-session-title {
+          margin-bottom: 0;
+        }
+
+        span.commit-session-subheading {
+          font-size: smaller;
+          font-family: monospace;
+          color: rgba(0, 0, 0, 0.6);
         }
 
         mwc-button.multiple-action-button {
@@ -4001,108 +4015,111 @@ ${rowData.item[this.sessionNameField]}</pre
       <backend-ai-dialog id="commit-session-dialog" fixed backdrop>
         <span slot="title">${_t('session.CommitSession')}</span>
         <div slot="content" class="vertical layout center flex">
-          <span style="font-size:14px;margin:auto 20px;">
+          <span style="font-size:14px;">
             ${_t('session.DescCommitSession')}
           </span>
-          <mwc-list style="width:100%">
-            <mwc-list-item twoline noninteractive class="commit-session-info">
-              <span class="subheading">${_t('session.SessionName')}</span>
-              <span class="monospace" slot="secondary">
-                ${commitSessionInfo?.session?.name
-                  ? commitSessionInfo.session.name
-                  : '-'}
-              </span>
-            </mwc-list-item>
-            <mwc-list-item twoline noninteractive class="commit-session-info">
-              <span class="subheading">${_t('session.SessionId')}</span>
-              <span class="monospace" slot="secondary">
-                ${commitSessionInfo?.session?.id
-                  ? commitSessionInfo.session.id
-                  : '-'}
-              </span>
-            </mwc-list-item>
-            <mwc-list-item twoline noninteractive class="commit-session-info">
-              <span class="subheading">
-                <strong>${_t('session.EnvironmentAndVersion')}</strong>
-              </span>
-              <span class="monospace" slot="secondary">
-                ${commitSessionInfo
-                  ? html`
-                      <lablup-shields
-                        app="${commitSessionInfo.environment === ''
-                          ? '-'
-                          : commitSessionInfo.environment}"
-                        color="blue"
-                        description="${commitSessionInfo.version === ''
-                          ? '-'
-                          : commitSessionInfo.version}"
-                        ui="round"
-                        class="right-below-margin"
-                      ></lablup-shields>
-                    `
-                  : html``}
-              </span>
-            </mwc-list-item>
-            <mwc-list-item twoline noninteractive class="commit-session-info">
-              <span class="subheading">${_t('session.Tags')}</span>
-              <span class="monospace horizontal layout" slot="secondary">
-                ${commitSessionInfo
-                  ? commitSessionInfo?.tags?.map(
-                      (tag) => html`
-                        <lablup-shields
-                          app=""
-                          color="green"
-                          description="${tag}"
-                          ui="round"
-                          class="right-below-margin"
-                        ></lablup-shields>
-                      `,
-                    )
-                  : html`
+          <div class="vertical flex start layout" style="width:100%;">
+            <h4 class="commit-session-title">${_t('session.SessionName')}</h4>
+            <span class="commit-session-subheading">
+              ${commitSessionInfo?.session?.name
+                ? commitSessionInfo.session.name
+                : '-'}
+            </span>
+          </div>
+          <div class="vertical flex start layout" style="width:100%;">
+            <h4 class="commit-session-title">${_t('session.SessionId')}</h4>
+            <span class="commit-session-subheading">
+              ${commitSessionInfo?.session?.id
+                ? commitSessionInfo.session.id
+                : '-'}
+            </span>
+          </div>
+          <div class="vertical flex start layout" style="width:100%;">
+            <h4 class="commit-session-title">
+              ${_t('session.EnvironmentAndVersion')}
+            </h4>
+            <span class="commit-session-subheading">
+              ${commitSessionInfo
+                ? html`
+                    <lablup-shields
+                      app="${commitSessionInfo.environment === ''
+                        ? '-'
+                        : commitSessionInfo.environment}"
+                      color="blue"
+                      description="${commitSessionInfo.version === ''
+                        ? '-'
+                        : commitSessionInfo.version}"
+                      ui="round"
+                      class="right-below-margin"
+                    ></lablup-shields>
+                  `
+                : html``}
+            </span>
+          </div>
+          <div class="vertical flex start layout" style="width:100%;">
+            <h4 class="commit-session-title">${_t('session.Tags')}</h4>
+            <div class="horizontal wrap layout">
+              ${commitSessionInfo
+                ? commitSessionInfo?.tags?.map(
+                    (tag) => html`
                       <lablup-shields
                         app=""
                         color="green"
-                        description="-"
+                        description="${tag}"
                         ui="round"
-                        style="right-below-margin"
+                        class="right-below-margin"
                       ></lablup-shields>
-                    `}
-              </span>
-            </mwc-list-item>
-            <mwc-list-item twoline class="commit-session-info">
-              <span class="subheading">
-                ${_t('session.ConvertSessionToImage')}
-              </span>
-              <div class="horizontal layout center">
-                <mwc-checkbox
-                  class="list-check"
-                  ?checked="${this.pushImageInsteadOfCommiting}"
-                  @click="${() =>
-                    (this.pushImageInsteadOfCommiting =
-                      !this.pushImageInsteadOfCommiting)}"
-                ></mwc-checkbox>
-                <mwc-textfield
-                  id="new-image-name-field"
-                  required
-                  autoValidate
-                  pattern="^[a-zA-Z0-9.-_]+$"
-                  minLength="4"
-                  maxLength="32"
-                  ?disabled="${!this.pushImageInsteadOfCommiting}"
-                  validationMessage="${_text(
-                    'session.Validation.EnterValidSessionName',
-                  )}"
-                  style="margin-top:8px;"
-                  @change="${this._updateImagifyAvailabilityStatus}"
-                ></mwc-textfield>
-              </div>
-            </mwc-list-item>
-          </mwc-list>
+                    `,
+                  )
+                : html`
+                    <lablup-shields
+                      app=""
+                      color="green"
+                      description="-"
+                      ui="round"
+                      style="right-below-margin"
+                    ></lablup-shields>
+                  `}
+            </div>
+          </div>
+          <div class="vertical flex start layout" style="width:100%;">
+            <h4 class="commit-session-title">
+              ${_t('session.ConvertSessionToImage')}
+            </h4>
+            <div class="horizontal layout flex" style="width:100%">
+              <mwc-checkbox
+                class="list-check"
+                ?checked="${this.pushImageInsteadOfCommiting}"
+                @click="${() => {
+                  this.pushImageInsteadOfCommiting =
+                    !this.pushImageInsteadOfCommiting;
+                }}"
+              ></mwc-checkbox>
+              <mwc-textfield
+                id="new-image-name-field"
+                required
+                autoValidate
+                pattern="^[a-zA-Z0-9-_]+$"
+                minLength="4"
+                maxLength="32"
+                placeholder="${_t('inputLimit.4to32chars')}"
+                ?disabled="${!this.pushImageInsteadOfCommiting}"
+                validationMessage="${_text(
+                  'session.Validation.EnterValidSessionName',
+                )}"
+                style="margin-top:8px;width:100%;"
+                @change="${this._updateImagifyAvailabilityStatus}"
+              ></mwc-textfield>
+            </div>
+          </div>
         </div>
         <div slot="footer" class="horizontal end-justified flex layout">
           <mwc-button
             unelevated
             class="ok"
+            style="font-size: ${this.pushImageInsteadOfCommiting
+              ? 'smaller'
+              : 'inherit'}"
             ?disabled="${commitSessionInfo?.environment === '' ||
             (this.pushImageInsteadOfCommiting && !this.canStartImagifying)}"
             @click=${(e) => {
@@ -4112,7 +4129,9 @@ ${rowData.item[this.sessionNameField]}</pre
                 this._requestCommitSession(commitSessionInfo);
               }
             }}
-            label="${_t('button.Commit')}"
+            label="${this.pushImageInsteadOfCommiting
+              ? _t('button.PushToImage')
+              : _t('button.Commit')}"
           ></mwc-button>
         </div>
       </backend-ai-dialog>


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

* Core version: 24.03.0 or later

This PR mainly fixes cosmetic issues in container commit dialog:
- [x] Change button label from `Commit` to `Push session to customized image` when checkbox in "Convert session to image" session is checked
- [x] Add placeholder(4~32 chars) and proper validation msg in the input-field of "Convert session to image" section
- [x] (FIXME) Temporally disable `container commit` icon when session is not created by user*
       (For now, even if superadmin role tries to do container commit or push session to image, the server throws "No such session" response.)

### Screenshot(s)
| After | Before |
|------|--------|
| <img width="373" alt="Screenshot 2024-04-06 at 4 54 06 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/d94fda64-2af8-468c-9cd2-7189765bf005"> | <img width="376" alt="Screenshot 2024-04-06 at 5 15 23 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/961aa70f-95a4-4307-b8b6-67ce681e08cb">
 |

* After 
   <img width="1273" alt="Screenshot 2024-04-06 at 5 19 19 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/10f6d131-a163-4f6a-b018-c8dd6842fd35">
* Before
   <img width="1277" alt="Screenshot 2024-04-06 at 5 14 46 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/5cbc34a1-fc7b-4795-abd9-47268708e832">





**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
