### PR TITLE
fix: check isNaN before set value of DynamicUnitInputNumber

### DIFF
--- a/react/src/components/DynamicUnitInputNumber.tsx
+++ b/react/src/components/DynamicUnitInputNumber.tsx
@@ -72,6 +72,14 @@ const DynamicUnitInputNumber: React.FC<DynamicUnitInputNumberProps> = ({
       onBlur={() => {
         if (_.isNumber(roundStep) && roundStep > 0) {
           const decimalCount = roundStep.toString().split('.')[1]?.length || 0;
+          if (
+            isNaN(
+              Math.round(_.toNumber(ref.current?.value || '0') / roundStep) *
+                roundStep,
+            )
+          ) {
+            return;
+          }
           setValue(
             `${(
               Math.round(_.toNumber(ref.current?.value || '0') / roundStep) *


### PR DESCRIPTION
When you input `mem` like this:
<img width="410" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/8c87a013-d3ac-4637-b3bd-903897fed1ec">

You can see the error like this:
<img width="573" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/9cc5909d-9f91-4215-9651-e8f7eb7908cd">



<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
