### PR TITLE
style: add css variable to vaadin grid for plugin page

### DIFF
--- a/src/components/backend-ai-storage-proxy-list.ts
+++ b/src/components/backend-ai-storage-proxy-list.ts
@@ -83,7 +83,7 @@ export default class BackendAIStorageProxyList extends BackendAIPage {
         vaadin-grid {
           border: 0;
           font-size: 14px;
-          height: calc(100vh - 182px);
+          height: var(--list-height, calc(100vh - 182px));
         }
 
         mwc-icon {


### PR DESCRIPTION
For plugin pages that use `backend-ai-storage-proxy-list.ts`, the grid size is too large. So I added CSS variable to `vaadin-grid`. The `--list-height` is already used in many plugin pages.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
