### PR TITLE
feat: add branding config to theme.json

### DIFF
--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -280,7 +280,9 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
               </Flex>
             </div>
             <address>
-              <small className="sidebar-footer">Lablup Inc.</small>
+              <small className="sidebar-footer">
+                {themeConfig?.branding?.companyName || 'Lablup Inc.'}
+              </small>
               &nbsp;
               <small
                 className="sidebar-footer"

--- a/react/src/helper/customThemeConfig.ts
+++ b/react/src/helper/customThemeConfig.ts
@@ -15,11 +15,16 @@ type LogoConfig = {
 type SiderConfig = {
   theme?: 'light' | 'dark';
 };
+type BrandingConfig = {
+  companyName?: string;
+  brandName?: string;
+};
 let _customTheme: {
   light: ThemeConfig;
   dark: ThemeConfig;
   logo: LogoConfig;
   sider?: SiderConfig;
+  branding?: BrandingConfig;
 };
 
 export const loadCustomThemeConfig = () => {

--- a/resources/theme.json
+++ b/resources/theme.json
@@ -54,5 +54,9 @@
     "href": "/summary"
   },
   "sider": {
+  },
+  "branding": {
+    "companyName": "Lablup Inc.",
+    "brandName": "Backend.AI"
   }
 }

--- a/resources/theme.schema.json
+++ b/resources/theme.schema.json
@@ -54,6 +54,13 @@
       "properties": {
         "theme": { "type": ["string"], "enum": ["dark","light","auto"], "default":"auto", "description": "The theme of the sider. If it's set to 'dark' or 'light', the entered theme will be applied to the sider regardless of the site's dark mode status." }
       }
+    },
+    "branding": {
+      "type": "object",
+      "properties": {
+        "companyName": { "type": "string", "description": "The name of the company or organization." },
+        "brandName": { "type": "string", "description": "The name of the brand or product." }
+      }
     }
   },
   "required": ["$schema", "light", "dark", "logo", "sider"]

--- a/scripts/replace-with-brand-name.sh
+++ b/scripts/replace-with-brand-name.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# get the brand name from resources/theme.json
+brandName=$(jq -r '.branding.brandName' resources/theme.json)
+echo "brandName: $brandName"
+
+# loop through all json files in resources/i18n
+for file in resources/i18n/*.json; do
+  echo "Processing $file..."
+  # create a temporary file
+  tmp=$(mktemp)
+
+  # replace "Backend.AI" with brandName in a case-insensitive manner
+  # 'walk(if type == "string" then ... else . end)' traverses all strings and replaces if the condition is met
+  jq --arg brandName "$brandName" '
+    walk(if type == "string" then
+      gsub("(?i)Backend\\.AI"; $brandName)
+    else .
+    end)' "$file" > "$tmp" && mv "$tmp" "$file"
+  
+done
+
+echo "All files processed."


### PR DESCRIPTION
related: https://github.com/lablup/backend.ai-webui/issues/2327
- add `branding` option to `theme.json`.
- the `companyName` will change the bottom text of the sidebar.
	<img width="186" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/28584164/ecd688e3-38bc-4b0d-860c-4c455b8fc49a">

- `brandName` will be used to change all brand names (default: Backend.AI) in i18n at once.

## Checklist for reviewers
- [ ] Change `companyName` of the `theme.json` and check the company name is reflected in the sidebar's bottom text.
- [ ] Change `brandName` of the `theme.json` and check the `Backend.AI` string is replace with it. (reflected to i18n json files)
	- How to check: run `./scripts/replace-with-brand-name.sh` in webui root directory.

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version: 23.09
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
