### PR TITLE
fix: set supported language codes to allow all i18n languages

### DIFF
--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -124,10 +124,24 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   @property({ type: Array }) supportLanguageCodes = [
     'en',
     'ko',
-    'ru',
+    'de',
+    'el',
+    'es',
+    'fi',
     'fr',
-    'mn',
     'id',
+    'it',
+    'ja',
+    'mn',
+    'ms',
+    'pl',
+    'pt',
+    'pt-BR',
+    'ru',
+    'tr',
+    'vi',
+    'zh-CN',
+    'zh-TW',
   ];
   @property({ type: Array }) blockedMenuItem;
   @property({ type: Array }) inactiveMenuItem;
@@ -411,6 +425,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
       this.lang = 'en';
     }
     globalThis.backendaioptions.set('current_language', this.lang);
+    globalThis.backendaioptions.set('language', this.lang);
     await setLanguage(this.lang);
     this.hasLoadedStrings = true;
     // this._initClient();


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
### This PR Resolves #2326 Issue. 

### Feature
- Fixed webui to follow the previously set language even if the connection happen again
- Added allow language without deleting validation logic to handle possible exceptions.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
