### PR TITLE
fix: unkown scailing group error when user change the project

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -428,6 +428,7 @@ const ResourceAllocationFormItems: React.FC<
             startCheckRestsTransition(() => {
               // update manually to handle granular pending status management
               form.setFieldValue('resourceGroup', v);
+              form.validateFields(['resourceGroup']).catch(() => {});
             });
           }}
         />

--- a/react/src/components/ResourceGroupSelect.tsx
+++ b/react/src/components/ResourceGroupSelect.tsx
@@ -36,6 +36,9 @@ const ResourceGroupSelect: React.FC<ResourceGroupSelectProps> = ({
       ),
     );
 
+  const [controllableValue, setControllableValue] =
+    useControllableValue(selectProps);
+
   const [isPendingLoading, startLoadingTransition] = useTransition();
   const { data: resourceGroupSelectQueryResult } = useTanQuery<
     [
@@ -94,6 +97,14 @@ const ResourceGroupSelect: React.FC<ResourceGroupSelectProps> = ({
     },
   );
 
+  useEffect(() => {
+    if (
+      controllableValue &&
+      !_.some(resourceGroups, (item) => item.name === controllableValue)
+    ) {
+      setControllableValue(undefined);
+    }
+  }, [resourceGroups, selectProps.value]);
   const autoSelectedResourceGroup =
     _.find(resourceGroups, (item) => item.name === 'default') ||
     resourceGroups[0];
@@ -110,7 +121,7 @@ const ResourceGroupSelect: React.FC<ResourceGroupSelectProps> = ({
       autoSelectedOption &&
       autoSelectedOption.value !== selectProps.value
     ) {
-      selectProps.onChange?.(autoSelectedOption.value, autoSelectedOption);
+      setControllableValue(autoSelectedOption.value, autoSelectedOption);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoSelectDefault]);
@@ -150,6 +161,8 @@ const ResourceGroupSelect: React.FC<ResourceGroupSelectProps> = ({
         );
       }}
       {...selectProps}
+      value={controllableValue}
+      onChange={setControllableValue}
     />
   );
 };

--- a/react/src/components/ResourceGroupSelect.tsx
+++ b/react/src/components/ResourceGroupSelect.tsx
@@ -104,7 +104,7 @@ const ResourceGroupSelect: React.FC<ResourceGroupSelectProps> = ({
     ) {
       setControllableValue(undefined);
     }
-  }, [resourceGroups, selectProps.value]);
+  }, [resourceGroups, controllableValue, setControllableValue]);
   const autoSelectedResourceGroup =
     _.find(resourceGroups, (item) => item.name === 'default') ||
     resourceGroups[0];

--- a/react/src/hooks/useResourceLimitAndRemaining.tsx
+++ b/react/src/hooks/useResourceLimitAndRemaining.tsx
@@ -101,10 +101,12 @@ export const useResourceLimitAndRemaining = ({
     queryKey: ['check-resets', currentProjectName, currentResourceGroup],
     queryFn: () => {
       if (currentResourceGroup) {
-        return baiClient.resourcePreset.check({
-          group: currentProjectName,
-          scaling_group: currentResourceGroup,
-        });
+        return baiClient.resourcePreset
+          .check({
+            group: currentProjectName,
+            scaling_group: currentResourceGroup,
+          })
+          .catch(() => {});
       } else {
         return;
       }

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1198,16 +1198,13 @@ const SessionLauncherPage = () => {
                         );
                       }}
                     >
-                      <Descriptions size="small" column={2}>
+                      <Descriptions size="small" column={1}>
                         <Descriptions.Item
                           label={t('session.launcher.Project')}
                         >
                           {currentProject.name}
                         </Descriptions.Item>
-                        <Descriptions.Item label={t('general.ResourceGroup')}>
-                          {form.getFieldValue('resourceGroup')}
-                        </Descriptions.Item>
-                        <Descriptions.Item label={t('general.Image')} span={2}>
+                        <Descriptions.Item label={t('general.Image')}>
                           <Flex direction="row" gap="xs" style={{ flex: 1 }}>
                             <ImageMetaIcon
                               image={
@@ -1299,7 +1296,9 @@ const SessionLauncherPage = () => {
                           return (
                             form.getFieldError(['resource', key]).length > 0
                           );
-                        }) || form.getFieldError(['num_of_sessions']).length > 0
+                        }) ||
+                        form.getFieldError(['num_of_sessions']).length > 0 ||
+                        form.getFieldError('resourceGroup').length > 0
                           ? 'error'
                           : // : _.some(form.getFieldValue('resource'), (v, key) => {
                             //     //                         console.log(form.getFieldError(['resource', 'shmem']));
@@ -1340,6 +1339,16 @@ const SessionLauncherPage = () => {
                         )}
 
                         <Descriptions column={2}>
+                          <Descriptions.Item
+                            label={t('general.ResourceGroup')}
+                            span={2}
+                          >
+                            {form.getFieldValue('resourceGroup') || (
+                              <Typography.Text type="secondary">
+                                {t('general.None')}
+                              </Typography.Text>
+                            )}
+                          </Descriptions.Item>
                           <Descriptions.Item
                             label={t(
                               'session.launcher.ResourceAllocationPerContainer',


### PR DESCRIPTION
This PR includes the following changes:
- Ignore the `/resource-preset` response error.
- Clear the value of `ResourceGroupSelect` when the value is not in the options.
- Validate and handle validation errors for no resource group.
- change the position of the resource item in the Neo Session Launcher preview step.



| Before | After |
|--------|--------|
| <img width="655" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/18113b7a-7fc6-4f62-94dd-5c4abe4fbb72"> | <img width="652" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/afb897e1-5485-484d-9b76-c2f73de70076"> | 

This PR affects the pages that use `ResourceGroupSelect` and `ResourceAllocationFormItems`, such as the Neo Session Launcher, Service Launcher, and Resource Monitor.


<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
