### PR TITLE
fix: vFolder form item validation in Neo session launcher

### DIFF
--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -404,7 +404,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
           }}
         />
       </Flex>
-      <Form form={internalForm}>
+      <Form form={internalForm} component={false}>
         <Table
           // size="small"
           scroll={{ x: 'max-content' }}

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -59,6 +59,8 @@ export interface VFolderTableProps extends Omit<TableProps<VFolder>, 'rowKey'> {
   rowKey: string | number;
 }
 
+export const vFolderAliasNameRegExp = /^[a-zA-Z0-9_/-]*$/;
+
 const VFolderTable: React.FC<VFolderTableProps> = ({
   filter,
   showAliasInput = false,
@@ -248,7 +250,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
                         {
                           // required: true,
                           type: 'string',
-                          pattern: /^[a-zA-Z0-9_/-]*$/,
+                          pattern: vFolderAliasNameRegExp,
                           message: t('session.launcher.FolderAliasInvalid'),
                         },
                         {

--- a/react/src/components/VFolderTableFormItem.tsx
+++ b/react/src/components/VFolderTableFormItem.tsx
@@ -1,4 +1,8 @@
-import VFolderTable, { AliasMap, VFolderTableProps } from './VFolderTable';
+import VFolderTable, {
+  AliasMap,
+  VFolderTableProps,
+  vFolderAliasNameRegExp,
+} from './VFolderTable';
 import { Form, FormItemProps, Input } from 'antd';
 import _ from 'lodash';
 import React from 'react';
@@ -40,6 +44,9 @@ const VFolderTableFromItem: React.FC<VFolderTableFromItemProps> = ({
                 return Promise.reject(
                   t('session.launcher.FolderAliasOverlapping'),
                 );
+              }
+              if (_.some(arr, (alias) => !vFolderAliasNameRegExp.test(alias))) {
+                return Promise.reject(t('session.launcher.FolderAliasInvalid'));
               }
               return Promise.resolve();
             },

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -1,3 +1,4 @@
+import { useEventNotStable } from './useEventNotStable';
 import _ from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
@@ -48,9 +49,9 @@ export const useBackendAIConnectedState = () => {
 export const useDateISOState = (initialValue?: string) => {
   const [value, setValue] = useState(initialValue || new Date().toISOString());
 
-  const update = (newValue?: string) => {
+  const update = useEventNotStable((newValue?: string) => {
     setValue(newValue || new Date().toISOString());
-  };
+  });
   return [value, update] as const;
 };
 

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -315,18 +315,6 @@ const SessionLauncherPage = () => {
     (item) => item.errors.length > 0,
   );
 
-  // console.log(form.getFieldError(['resource', 'shmem']));
-  // console.log(form.getFieldValue(['resource']));
-
-  const moveToPreview = () => {
-    form
-      .validateFields()
-      .catch((e) => {})
-      .finally(() => {
-        setCurrentStep(steps.length - 1);
-      });
-  };
-
   const [, setLastValidateErrorTime] = useUpdatableState('first'); // Force an update when a validation error occurs.
   useEffect(() => {
     if (currentStep === steps.length - 1) {
@@ -456,27 +444,7 @@ const SessionLauncherPage = () => {
                 return res;
               })
               .catch((err: any) => {
-                console.log(err);
                 throw err;
-                // console.log(err);
-                // if (err && err.message) {
-                //   if ('statusCode' in err && err.statusCode === 408) {
-                //     this.notification.text = _text(
-                //       'session.launcher.sessionStillPreparing',
-                //     );
-                //   } else {
-                //     if (err.description) {
-                //       this.notification.text = PainKiller.relieve(err.description);
-                //     } else {
-                //       this.notification.text = PainKiller.relieve(err.message);
-                //     }
-                //   }
-                //   this.notification.detail = err.message;
-                //   this.notification.show(true, err);
-                // } else if (err && err.title) {
-                //   this.notification.text = PainKiller.relieve(err.title);
-                //   this.notification.show(true, err);
-                // }
               });
           },
         );

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -31,6 +31,7 @@ import { compareNumberWithUnits, iSizeToSize } from '../helper';
 import {
   useCurrentProjectValue,
   useSuspendedBackendaiClient,
+  useUpdatableState,
   useWebUINavigate,
 } from '../hooks';
 import { useSetBAINotification } from '../hooks/useBAINotification';
@@ -1068,7 +1069,10 @@ const SessionLauncherPage = () => {
                 >
                   <VFolderTableFromItem
                     filter={(vfolder) => {
-                      return vfolder.status === 'ready';
+                      return (
+                        vfolder.status === 'ready' &&
+                        !vfolder.name?.startsWith('.')
+                      );
                     }}
                   />
                   {/* <VFolderTable /> */}

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1564,24 +1564,6 @@ const SessionLauncherPage = () => {
 
                 <Flex direction="row" justify="between">
                   <Flex gap={'sm'}>
-                    {/* <Popconfirm
-                    title={t('session.CheckAgainDialog')}
-                    placement="topLeft"
-                    okButtonProps={{
-                      danger: true,
-                    }}
-                    okText={t('button.Reset')}
-                    onConfirm={() => {
-                      // @ts-ignore
-                      form.resetFields({
-
-                      });
-                    }}
-                  >
-                    <Button ghost danger>
-                      {t('button.Reset')}
-                    </Button>
-                  </Popconfirm> */}
                     <Popconfirm
                       title={t('button.Reset')}
                       description={t('session.launcher.ResetFormConfirm')}

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -327,6 +327,13 @@ const SessionLauncherPage = () => {
       });
   };
 
+  const [, setLastValidateErrorTime] = useUpdatableState('first'); // Force an update when a validation error occurs.
+  useEffect(() => {
+    if (currentStep === steps.length - 1) {
+      form.validateFields().catch((e) => setLastValidateErrorTime());
+    }
+  }, [currentStep, form, setLastValidateErrorTime, steps.length]);
+
   const startSession = () => {
     // TODO: support inference mode, support import mode
 
@@ -1657,7 +1664,11 @@ const SessionLauncherPage = () => {
                       </Button>
                     )}
                     {currentStep !== steps.length - 1 && (
-                      <Button onClick={moveToPreview}>
+                      <Button
+                        onClick={() => {
+                          setCurrentStep(steps.length - 1);
+                        }}
+                      >
                         {t('session.launcher.SkipToConfirmAndLaunch')}
                         <DoubleRightOutlined />
                       </Button>
@@ -1676,12 +1687,7 @@ const SessionLauncherPage = () => {
               direction="vertical"
               current={currentStep}
               onChange={(nextCurrent) => {
-                // handle "skip to review" step specifically, because validation
-                if (nextCurrent === steps.length - 1) {
-                  moveToPreview();
-                } else {
-                  setCurrentStep(nextCurrent);
-                }
+                setCurrentStep(nextCurrent);
               }}
               items={_.map(steps, (s, idx) => ({
                 ...s,


### PR DESCRIPTION
This PR contains changes related to vFolder validation in the Neo session launcher. Please review the commits one by one.
- remove console.log warning about `<form> cannot appear as a descendant of <form>`
- add missing name rule for vFolder alias map for preview step
- [exclude auto-mounted vFolders from the vFolder list in Neo session launcer](https://github.com/lablup/backend.ai-webui/commit/d6c8308bb8d032d5ff7ed4076027196cd63650d9)
- validate form after step changed using `useEffect` and set the last validation error time to re-render.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
