### PR TITLE
style: label wrapping, font resizing and numeric token formatting in login panel

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -257,7 +257,7 @@ ${Object.entries(token)
       return '';
     } else {
       return typeof value === 'number'
-        ? `--token-${key}: ${value?.toString() ?? ''}px;`
+        ? `--token-${key}: ${value}px;`
         : `--token-${key}: ${value?.toString() ?? ''};`;
     }
   })

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -256,7 +256,9 @@ ${Object.entries(token)
     if (key.charAt(0) === key.charAt(0).toUpperCase()) {
       return '';
     } else {
-      return `--token-${key}: ${value?.toString() ?? ''};`;
+      return typeof value === 'number'
+        ? `--token-${key}: ${value?.toString() ?? ''}px;`
+        : `--token-${key}: ${value?.toString() ?? ''};`;
     }
   })
   .join('\n')}

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -242,6 +242,7 @@ export default class BackendAILogin extends BackendAIPage {
         mwc-button[outlined] {
           background-image: none;
           --mdc-button-outline-width: 2px;
+          --mdc-typography-button-font-size: 12px;
         }
 
         h3 small {
@@ -2029,21 +2030,23 @@ export default class BackendAILogin extends BackendAIPage {
           </div>
         </div>
         <div slot="content" class="login-panel intro centered">
-          <h3
+          <div
             class="horizontal center layout"
-            style="margin: 0 25px;font-weight:700;min-height:40px; padding-bottom:10px;"
+            style="margin: 0 25px;font-weight:700;min-height:40px; padding-bottom:10px; justify-content: space-between;"
           >
-            <div>
+            <h3
+              style="flex: 1; white-space: normal; overflow-wrap: break-word; word-break: break-word; margin-right: 10px;"
+            >
               ${this.connection_mode === 'SESSION'
                 ? _t('login.LoginWithE-mailorUsername')
                 : _t('login.LoginWithIAM')}
-            </div>
-            <div class="flex"></div>
+            </h3>
             ${this.change_signin_support
               ? html`
                   <div
                     id="change-signin-area"
                     class="vertical center-justified layout"
+                    style="flex: 1; text-align: right;"
                   >
                     <div id="change-signin-message">
                       ${_t('login.LoginAnotherway')}
@@ -2059,7 +2062,7 @@ export default class BackendAILogin extends BackendAIPage {
                   </div>
                 `
               : html``}
-          </h3>
+          </div>
           <div class="login-form">
             <div id="waiting-animation" class="horizontal layout wrap">
               <div class="sk-folding-cube">
@@ -2280,7 +2283,11 @@ export default class BackendAILogin extends BackendAIPage {
                       ></mwc-button>
                     `
                   : html``}
-                <div id="additional-action-area" class="layout horizontal">
+                <div
+                  id="additional-action-area"
+                  class="layout horizontal"
+                  style="align-items: flex-end;"
+                >
                   ${this.signup_support
                     ? html`
                         <div

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -245,10 +245,6 @@ export default class BackendAILogin extends BackendAIPage {
           --mdc-typography-button-font-size: 12px;
         }
 
-        h3 small {
-          --button-font-size: 12px;
-        }
-
         .title-img {
           height: 35px;
           padding: 15px 0 15px 5px;
@@ -256,7 +252,7 @@ export default class BackendAILogin extends BackendAIPage {
 
         #change-signin-area > #change-signin-message {
           font-size: 12px;
-          margin: 5px 10px;
+          margin: 5px 0px;
           text-align: center;
           font-weight: 400;
         }

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -233,6 +233,7 @@ export default class BackendAILogin extends BackendAIPage {
 
         mwc-button {
           background-image: none;
+          --mdc-typography-button-font-size: var(--token-fontSizeSM, 12px);
         }
 
         mwc-button[unelevated] {
@@ -242,7 +243,6 @@ export default class BackendAILogin extends BackendAIPage {
         mwc-button[outlined] {
           background-image: none;
           --mdc-button-outline-width: 2px;
-          --mdc-typography-button-font-size: 12px;
         }
 
         .title-img {


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR Resolves #2323 

### Features
- Make modal's label text automatically wrap when it gets long.
- Adjust the font size of the MWC button.
- If the value type of antd token value is numeric, append 'px' after it. (e.g. fontSize)

<img width="420" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/28584164/a5dbd505-1972-4d0e-a6a9-cef0ce83bbde">


**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
