### PR TITLE
fix: `_viewStateChanged` is called for same `active` value in `attributeChangedCallback`

### DIFF
--- a/src/components/backend-ai-page.ts
+++ b/src/components/backend-ai-page.ts
@@ -91,12 +91,16 @@ export class BackendAIPage extends LitElement {
     oldval: string | null,
     newval: string | null,
   ): void {
-    if (name == 'active' && newval !== null) {
-      this.active = true;
-      this._viewStateChanged(true);
-    } else if (name === 'active') {
-      this.active = false;
-      this._viewStateChanged(false);
+    if (name === 'active') {
+      if (oldval === newval) {
+        return;
+      } else if (newval !== null) {
+        this.active = true;
+        this._viewStateChanged(true);
+      } else {
+        this.active = false;
+        this._viewStateChanged(false);
+      }
     }
     super.attributeChangedCallback(name, oldval, newval);
   }


### PR DESCRIPTION
This PR avoid calling `_viewStateChanged` for same `active` value in `attributeChangedCallback`.

Before the PR, every component extending the BackendAIPage component runs `_viewStateChanged` twice with the same active value, leading to multiple duplicated remote requests.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
