### PR TITLE
hotfix: regression of showing project list according to allowed group in user info

### DIFF
--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -63,17 +63,6 @@ const ProjectSelector: React.FC<Props> = ({
     user?.groups?.map((group) => group?.id).includes(project?.id),
   );
 
-  useEffect(() => {
-    if (
-      autoClearSearchValue &&
-      !value &&
-      accessibleProjects?.length &&
-      accessibleProjects?.length > 0
-    ) {
-      alert(accessibleProjects[0]?.id);
-      setValue(accessibleProjects[0]?.id);
-    }
-  });
   return (
     <Select
       onChange={(value, option) => {

--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -1,4 +1,5 @@
 import { useSuspendedBackendaiClient } from '../hooks';
+import { useCurrentUserInfo } from '../hooks/backendai';
 import { ProjectSelectorQuery } from './__generated__/ProjectSelectorQuery.graphql';
 import { useControllableValue } from 'ahooks';
 import { Select, SelectProps } from 'antd';
@@ -28,7 +29,7 @@ const ProjectSelector: React.FC<Props> = ({
   ...selectProps
 }) => {
   const { t } = useTranslation();
-  const baiClient = useSuspendedBackendaiClient();
+  const [currentUser] = useCurrentUserInfo();
 
   const [value, setValue] = useControllableValue(selectProps);
   const { projects, user } = useLazyLoadQuery<ProjectSelectorQuery>(
@@ -50,7 +51,7 @@ const ProjectSelector: React.FC<Props> = ({
     `,
     {
       domain_name: domain,
-      email: baiClient?.email, // use current user email
+      email: currentUser.email,
     },
     {
       fetchPolicy: 'store-and-network',

--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -1,11 +1,10 @@
-import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { ProjectSelectorQuery } from './__generated__/ProjectSelectorQuery.graphql';
 import { useControllableValue } from 'ahooks';
 import { Select, SelectProps } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyLoadQuery } from 'react-relay';
 


### PR DESCRIPTION


<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

- Core Version: `23.09` or newer

This PR resolves showing only available "project(a.k.a. group)" list according to user info, not only for user role, but also in superadmin.
Please check out the previous version of the code
- [Getting allowed group list from user](https://github.com/lablup/backend.ai-webui/blob/16974db484321c6e9bd25dc2e1fceb2dc44ecff4/src/components/backend-ai-login.ts#L1689-L1733)
- [Filtering in Client-side to only allow accessible group from allowed group list](https://github.com/lablup/backend.ai-webui/blob/16974db484321c6e9bd25dc2e1fceb2dc44ecff4/src/components/backend-ai-login.ts#L1760-L1777)

### Screenshot(s)
> ⚠️ NOTE: Current admin user is only accessible to "default" project(group).

<img width="606" alt="Screenshot 2024-04-15 at 7 38 45 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/e22dca56-d24d-4ab9-8a91-edac61c709f5">

| After | Before |
|------|--------|
| <img width="457" alt="Screenshot 2024-04-15 at 7 39 48 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/23ca50fe-d6a9-447a-8740-c7a00b00d2f5"> | <img width="457" alt="Screenshot 2024-04-15 at 7 40 01 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/ce654edb-b9a6-4d12-a9dd-9406ecc37925"> |



**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after
