### PR TITLE
ci: Bump actions/labeler from 4 to 5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,9 +10,8 @@ area:ux:
 area:lib:
   - changed-files:
     - any-glob-to-any-file:
-      - src/plastics/**/*
-      - resources/lib/**/*
-      - resources/wsproxy/**/*
+      - src/lib/**/*
+      - src/wsproxy/**/*
 
 area:i18n:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,16 +1,25 @@
 maintenance:dependencies:
-  - scripts/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - scripts/**/*
 
 field:UI / UX:
-  - resources/fonts/*
-  - resources/icons/*
-  - resources/*.css
-  - src/plastics/**/*
-  - resources/i18n/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - resources/fonts/*
+      - resources/icons/*
+      - resources/*.css
+      - src/plastics/**/*
+      - resources/i18n/*
 
 field:library / SDK:
-  - resources/lib/**/*
-  - resources/wsproxy/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - src/plastics/**/*
+      - resources/lib/**/*
+      - resources/wsproxy/**/*
 
 field:localization:
-  - resources/i18n/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - resources/i18n/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,9 +1,4 @@
-maintenance:dependencies:
-  - changed-files:
-    - any-glob-to-any-file:
-      - scripts/**/*
-
-field:UI / UX:
+area:ux:
   - changed-files:
     - any-glob-to-any-file:
       - resources/fonts/*
@@ -12,14 +7,14 @@ field:UI / UX:
       - src/plastics/**/*
       - resources/i18n/*
 
-field:library / SDK:
+area:lib:
   - changed-files:
     - any-glob-to-any-file:
       - src/plastics/**/*
       - resources/lib/**/*
       - resources/wsproxy/**/*
 
-field:localization:
+area:i18n:
   - changed-files:
     - any-glob-to-any-file:
       - resources/i18n/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
     - name: size-label


### PR DESCRIPTION
As the labeler became version v5, its usage has changed.

```
any: match ALL globs against ANY changed path
all: match ALL globs against ALL changed paths
```

From the existing two rules that could be used,

```
any-glob-to-any-file: ANY glob must match against ANY changed file
any-glob-to-all-files: ANY glob must match against ALL changed files
all-globs-to-any-file: ALL globs must match against ANY changed file
all-globs-to-all-files: ALL globs must match against ALL changed files
```

It has been added so that it can be used in 4 ways.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
