### PR TITLE
style: remove `px` when calculating margin of WebUIHeader wrapper

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -255,8 +255,6 @@ ${Object.entries(token)
     // Skip Component specific tokens
     if (key.charAt(0) === key.charAt(0).toUpperCase()) {
       return '';
-    } else if (typeof value === 'number') {
-      return `--token-${key}: ${value}px;`;
     } else {
       return typeof value === 'number'
         ? `--token-${key}: ${value}px;`

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -158,7 +158,7 @@ function MainLayout() {
             >
               <div
                 style={{
-                  margin: `0 -${token.paddingContentHorizontalLG}px 0 -${token.paddingContentHorizontalLG}px`,
+                  margin: `0 -${token.paddingContentHorizontalLG} 0 -${token.paddingContentHorizontalLG}`,
                   position: 'sticky',
                   top: 0,
                   zIndex: HEADER_Z_INDEX_IN_MAIN_LAYOUT,
@@ -255,6 +255,8 @@ ${Object.entries(token)
     // Skip Component specific tokens
     if (key.charAt(0) === key.charAt(0).toUpperCase()) {
       return '';
+    } else if (typeof value === 'number') {
+      return `--token-${key}: ${value}px;`;
     } else {
       return `--token-${key}: ${value?.toString() ?? ''};`;
     }


### PR DESCRIPTION
`--token-xxx` has already px from #2338, I removed the duplicated definition.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
