### PR TITLE
fix: use `defaultSessionEnvironment` as a initial `environments.environment`

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -172,7 +172,20 @@ const ImageEnvironmentSelectFormItems: React.FC<
     if (matchedEnvironmentByVersion) {
       nextEnvironment = matchedEnvironmentByVersion;
       nextImage = matchedImageByVersion;
-    } else {
+    } else if (form.getFieldValue(['environments', 'environment'])) {
+      _.find(imageGroups, (group) => {
+        nextEnvironment = _.find(group.environmentGroups, (environment) => {
+          return (
+            environment.environmentName ===
+            form.getFieldValue(['environments', 'environment'])
+          );
+        });
+        nextImage = nextEnvironment?.images[0];
+        return !!nextEnvironment;
+      });
+    }
+
+    if (!nextEnvironment || !nextImage) {
       nextEnvironment = imageGroups[0]?.environmentGroups[0];
       nextImage = nextEnvironment?.images[0];
     }
@@ -242,7 +255,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
                   // metadata?.imageInfo[
                   //   getImageMeta(getImageFullName(image) || "").key
                   // ]?.name || image?.name
-                  image?.name
+                  image?.registry + ':' + image?.name
                 );
               })
               .map((images, environmentName) => {

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -171,7 +171,7 @@ const SessionLauncherPage = () => {
     // set default_session_environment only if set
     ...(baiClient._config?.default_session_environment && {
       environments: {
-        version: baiClient._config?.default_session_environment,
+        environment: baiClient._config?.default_session_environment,
       },
     }),
     ...RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,


### PR DESCRIPTION
This PR follows up on #2337 and resolves #2336.

After this PR, the `defaultSessionEnvironment` will be used as the initial `environments.environment` form value for Neo Session Launcher.


<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
