### PR TITLE
hotfix: enable non-accelerator preset when accelerator image

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -197,12 +197,16 @@ const ResourceAllocationFormItems: React.FC<
       },
     ).map((preset) => preset.name);
 
-    return _.intersection(
-      baiClient._config?.always_enqueue_compute_session
+    return currentImageAcceleratorLimits.length > 0
+      ? baiClient._config?.always_enqueue_compute_session
         ? bySliderLimit
-        : byPresetInfo,
-      byImageAcceleratorLimits,
-    );
+        : byPresetInfo
+      : _.intersection(
+          baiClient._config?.always_enqueue_compute_session
+            ? bySliderLimit
+            : byPresetInfo,
+          byImageAcceleratorLimits,
+        );
   }, [
     baiClient._config?.always_enqueue_compute_session,
     checkPresetInfo?.presets,


### PR DESCRIPTION
- If there is no accelerator requirement in the image:
  - Exclude accelerators presets.
  - Disable the accelerator input field.
  
- If there is an accelerator requirement in the image:
  - (After this PR) **Show non-accelerator presets also.** 
  - Enable the accelerator input field.
  
 <!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
