### PR TITLE
ci: display failed-tests annotation only in jest-coverage-report-action

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -35,3 +35,4 @@ jobs:
         package-manager: npm
         test-script: npm run test
         prnumber: ${{ steps.findPr.outputs.number }}
+        annotations: failed-tests


### PR DESCRIPTION
ref: https://github.com/ArtiomTr/jest-coverage-report-action?tab=readme-ov-file#change-annotations

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
