### PR TITLE
revert: "#2344 remove px when calculating margin of WebUIHeader wrapper"

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -158,7 +158,7 @@ function MainLayout() {
             >
               <div
                 style={{
-                  margin: `0 -${token.paddingContentHorizontalLG} 0 -${token.paddingContentHorizontalLG}`,
+                  margin: `0 -${token.paddingContentHorizontalLG}px 0 -${token.paddingContentHorizontalLG}px`,
                   position: 'sticky',
                   top: 0,
                   zIndex: HEADER_Z_INDEX_IN_MAIN_LAYOUT,


### PR DESCRIPTION

This reverts commit 8ab862887725094c59ce51de0a5fae767b9eaffe.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
