### PR TITLE
fix: default environment as a initial value of the service launcher

### DIFF
--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -529,6 +529,12 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
               : {
                   desiredRoutingCount: 1,
                   ...RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
+                  ...(baiClient._config?.default_session_environment && {
+                    environments: {
+                      environment:
+                        baiClient._config?.default_session_environment,
+                    },
+                  }),
                 }
           }
           requiredMark="optional"


### PR DESCRIPTION
This PR is related to https://github.com/lablup/backend.ai-webui/pull/2345 and sets a default environment as the initial value of the service launcher.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
