### PR TITLE
fix: parsing valid appConnectUrl

### DIFF
--- a/src/components/backend-ai-edu-applauncher.ts
+++ b/src/components/backend-ai-edu-applauncher.ts
@@ -528,7 +528,7 @@ export default class BackendAiEduApplauncher extends BackendAIPage {
             _text('session.applauncher.Prepared'),
           );
           setTimeout(() => {
-            globalThis.open(String(appConnectUrl) || resp.url, '_self');
+            globalThis.open(String(appConnectUrl.appConnectUrl) || resp.url, '_self');
             // globalThis.open(resp.url);
           });
         } else {


### PR DESCRIPTION
Since [_connectProxyWorker](https://github.com/lablup/backend.ai-webui/blob/baaf3cac6e7358b746535e3215d970873eb1a485/src/components/backend-ai-app-launcher.ts#L1065) returns object, the previous result of appConnectUrl is nested object.
This PR is parsing it properly.

follows https://github.com/lablup/backend.ai-webui/pull/2310

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
