### PR TITLE
fix: preserve the preset of session launcher using query parameters.

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -224,7 +224,11 @@ const ResourceAllocationFormItems: React.FC<
       )
     ) {
     } else {
-      if (allocatablePresetNames[0]) {
+      if (
+        allocatablePresetNames.includes(form.getFieldValue('allocationPreset'))
+      ) {
+        // if the current preset is available in the current resource group, do nothing.
+      } else if (allocatablePresetNames[0]) {
         const autoSelectedPreset = _.sortBy(allocatablePresetNames, 'name')[0];
         form.setFieldsValue({
           allocationPreset: autoSelectedPreset,


### PR DESCRIPTION
How to test:
- Select a preset in Neo session launcher.
- Refresh the browser.

Expected behavior:
- After refreshing, the preset should not change.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
