### PR TITLE
fix: prevent delete in shared vfolder by permission

### DIFF
--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -2154,7 +2154,9 @@ export default class BackendAiStorageList extends BackendAIPage {
             text="${_t('data.folders.FolderInfo')}"
             position="top-start"
           ></vaadin-tooltip>
-          ${rowData.item.is_owner || rowData.item.permission === 'wd'
+          ${rowData.item.is_owner ||
+          this._hasPermission(rowData.item, 'd') ||
+          (rowData.item.type === 'group' && this.is_admin)
             ? html`
                 <mwc-icon-button
                   class="fg blue controls-running"

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -2154,32 +2154,36 @@ export default class BackendAiStorageList extends BackendAIPage {
             text="${_t('data.folders.FolderInfo')}"
             position="top-start"
           ></vaadin-tooltip>
-          <mwc-icon-button
-            class="fg blue controls-running"
-            icon="redo"
-            ?disabled=${rowData.item.status !== 'delete-pending'}
-            @click="${(e) => this._restoreFolder(e)}"
-            id="${rowData.item.id + '-restore'}"
-          ></mwc-icon-button>
-          <vaadin-tooltip
-            for="${rowData.item.id + '-restore'}"
-            text="${_t('data.folders.Restore')}"
-            position="top-start"
-          ></vaadin-tooltip>
-          <mwc-icon-button
-            class="fg red controls-running"
-            icon="delete_forever"
-            ?disabled=${rowData.item.status !== 'delete-pending'}
-            @click="${(e) => {
-              this.openDeleteFromTrashBinDialog(e);
-            }}"
-            id="${rowData.item.id + '-delete-forever'}"
-          ></mwc-icon-button>
-          <vaadin-tooltip
-            for="${rowData.item.id + '-delete-forever'}"
-            text="${_t('data.folders.DeleteForever')}"
-            position="top-start"
-          ></vaadin-tooltip>
+          ${rowData.item.is_owner || rowData.item.permission === 'wd'
+            ? html`
+                <mwc-icon-button
+                  class="fg blue controls-running"
+                  icon="redo"
+                  ?disabled=${rowData.item.status !== 'delete-pending'}
+                  @click="${(e) => this._restoreFolder(e)}"
+                  id="${rowData.item.id + '-restore'}"
+                ></mwc-icon-button>
+                <vaadin-tooltip
+                  for="${rowData.item.id + '-restore'}"
+                  text="${_t('data.folders.Restore')}"
+                  position="top-start"
+                ></vaadin-tooltip>
+                <mwc-icon-button
+                  class="fg red controls-running"
+                  icon="delete_forever"
+                  ?disabled=${rowData.item.status !== 'delete-pending'}
+                  @click="${(e) => {
+                    this.openDeleteFromTrashBinDialog(e);
+                  }}"
+                  id="${rowData.item.id + '-delete-forever'}"
+                ></mwc-icon-button>
+                <vaadin-tooltip
+                  for="${rowData.item.id + '-delete-forever'}"
+                  text="${_t('data.folders.DeleteForever')}"
+                  position="top-start"
+                ></vaadin-tooltip>
+              `
+            : html``}
         </div>
       `,
       root,


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR Resolves #2362 Issue.

### Feature
- Prevent delete/restore by users without delete permission.

### How to test
1. Share vfolders to other users with different permissions.
2. After the sharing is successful, log in as the owner user and move the folders to the trash bin.
3. log in as the shared user account, and make sure that the permanent delete and restore features are enabled according to your permissions. (Only accounts with the delete permission can be permanently deleted and restored.)

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
