### PR TITLE
fix: `onChangeAliasMap` is triggered on every render

### DIFF
--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -168,7 +168,9 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
 
   useEffect(() => {
     handleAliasUpdate();
-  }, [selectedRowKeys, handleAliasUpdate]);
+    // `selectedRowKeys` can be changed by parents at any time, so we need to check whether `selectedRowKeys` has changed using JSON.stringify
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(selectedRowKeys), handleAliasUpdate]);
 
   const shadowRoot = useShadowRoot();
 


### PR DESCRIPTION
This PR resolves #2368.
This is a side effect of https://github.com/lablup/backend.ai-webui/pull/2359

Before this PR, `VFolderTable` was triggering `onChangeSelectedRowKeys` on every render if the parent component passed `selectedRowKeys` as a new instance of an array. `VFolderTable` should consider this scenario.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
