### PR TITLE
fix: preventing sharing of auto-mounted folders

### DIFF
--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1953,9 +1953,10 @@ export default class BackendAiStorageList extends BackendAIPage {
    * @param {Object} rowData - the object with the properties related with the rendered item
    * */
   controlFolderListRenderer(root, column?, rowData?) {
-    const isSharingAllowed = (
-      this._unionedAllowedPermissionByVolume[rowData.item.host] ?? []
-    ).includes('invite-others');
+    const isSharingAllowed =
+      (
+        this._unionedAllowedPermissionByVolume[rowData.item.host] ?? []
+      ).includes('invite-others') && !rowData.item.name.startsWith('.');
     render(
       // language=HTML
       html`


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR Resolves #2373 Issue.

### Feature
`auto mounted folder` is a folder that name begins with '.' in the folder name. I added folder name validation to the `isSharingAllowed` validation logic in the control button lander logic.

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
