### PR TITLE
fix: Change '/session' path to be used as sider's selectedKey 'job'

### DIFF
--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -309,6 +309,9 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
           location.pathname.split('/')[1] || 'summary',
           // TODO: After matching first path of 'storage-settings' and 'agent', remove this code
           location.pathname.split('/')[1] === 'storage-settings' ? 'agent' : '',
+          // TODO: After 'SessionListPage' is completed and used as the main page, remove this code
+          //       and change 'job' key to 'session'
+          location.pathname.split('/')[1] === 'session' ? 'job' : '',
         ]}
         items={
           // TODO: add plugin menu


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR Resolves #2372 Issue

### Why the bug occurred?
The sider selection key value for the session page of the component's initial render is 'job'. Since `neo session launcher` uses 'session/start' as the query path, it needs to be changed to recognize it as the 'job' key. 

### Feature 
If the first query path is 'session', change it to 'job' so that it can be recognized as the key of the sider.


**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
