### PR TITLE
fix: include cancel handler in ServiceLauncherModal

### DIFF
--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -84,7 +84,8 @@ interface ServiceCreateType {
   config: ServiceCreateConfigType;
 }
 
-interface ServiceLauncherProps extends Omit<BAIModalProps, 'onOK'> {
+interface ServiceLauncherProps
+  extends Omit<BAIModalProps, 'onOk' | 'onCancel'> {
   endpointFrgmt?: ServiceLauncherModalFragment$key | null;
   extraP?: boolean;
   onRequestClose: (success?: boolean) => void;
@@ -476,6 +477,7 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
         </Flex>
       )}
       confirmLoading={mutationToCreateService.isLoading}
+      onCancel={handleCancel}
       {...modalProps}
     >
       <Suspense fallback={<FlexActivityIndicator />}>

--- a/react/src/pages/RoutingListPage.tsx
+++ b/react/src/pages/RoutingListPage.tsx
@@ -548,9 +548,6 @@ const RoutingListPage: React.FC<RoutingListPageProps> = () => {
       <ServiceLauncherModal
         endpointFrgmt={endpoint}
         open={isOpenServiceLauncherModal}
-        onCancel={() => {
-          setIsOpenServiceLauncherModal(!isOpenServiceLauncherModal);
-        }}
         onRequestClose={(success) => {
           setIsOpenServiceLauncherModal(!isOpenServiceLauncherModal);
           if (success) {

--- a/react/src/pages/ServingListPage.tsx
+++ b/react/src/pages/ServingListPage.tsx
@@ -557,11 +557,8 @@ const ServingListPage: React.FC<PropsWithChildren> = ({ children }) => {
       <ServiceLauncherModal
         open={isOpenServiceLauncher}
         endpointFrgmt={editingModelService || null}
-        onCancel={() => {
-          setEditingModelService(null);
-          setIsOpenServiceLauncher(!isOpenServiceLauncher);
-        }}
         onRequestClose={(success) => {
+          setEditingModelService(null);
           setIsOpenServiceLauncher(!isOpenServiceLauncher);
           if (success) {
             startRefetchTransition(() => {


### PR DESCRIPTION
### TL;DR

This pull request introduces a change to the `onCancel` handling in the `ServiceLauncherModal` to resolve the issue of the modify service modal popping up when clicking the start service button.

### What changed?
In the `ServiceListPage`, the `onRequestClose` method is called to set the `editingModelService` to null and remove the `onCancel` prop. 

In the `ServiceLauncherModal`, the `onCancel` behavior has been changed to call `onRequestClose` when triggered.

### How to test?

1.  Navigate to the serving page.
2. Click the gear icon in the Control column and close the modal with the close button at the bottom (not the x button).
3. Click Create new service button.
4. The create modal should appear.


---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
resolves https://github.com/lablup/backend.ai-webui/issues/2378

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup) : 10.100.64.15
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
