### PR TITLE
fix: add ErrorBoundary on main layout when error occurred during fetching TOTP checker

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -51,8 +51,10 @@ const router = createBrowserRouter([
           }
         }
       >
-        <MainLayout />
-        <RoutingEventHandler />
+        <BAIErrorBoundary>
+          <MainLayout />
+          <RoutingEventHandler />
+        </BAIErrorBoundary>
       </QueryParamProvider>
     ),
     handle: { labelKey: 'webui.menu.Summary' },

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,5 +1,5 @@
 import AnnouncementAlert from './components/AnnouncementAlert';
-import BAIErrorBoundary from './components/BAIErrorBoundary';
+import BAIErrorBoundary, { ErrorView } from './components/BAIErrorBoundary';
 import {
   DefaultProvidersForReactRoot,
   RoutingEventHandler,
@@ -41,6 +41,7 @@ const NeoSessionLauncherSwitchAlert = React.lazy(
 const router = createBrowserRouter([
   {
     path: '/',
+    errorElement: <ErrorView />,
     element: (
       <QueryParamProvider
         adapter={ReactRouter6Adapter}
@@ -51,10 +52,8 @@ const router = createBrowserRouter([
           }
         }
       >
-        <BAIErrorBoundary>
-          <MainLayout />
-          <RoutingEventHandler />
-        </BAIErrorBoundary>
+        <MainLayout />
+        <RoutingEventHandler />
       </QueryParamProvider>
     ),
     handle: { labelKey: 'webui.menu.Summary' },

--- a/react/src/components/BAIErrorBoundary.tsx
+++ b/react/src/components/BAIErrorBoundary.tsx
@@ -72,3 +72,27 @@ const BAIErrorBoundary: React.FC<BAIErrorBoundaryProps> = ({ ...props }) => {
 };
 
 export default BAIErrorBoundary;
+
+export const ErrorView = () => {
+  const { t } = useTranslation();
+  return (
+    <Result
+      status="warning"
+      title={t('ErrorBoundary.title')}
+      extra={
+        <Flex direction="column" gap="md">
+          <Button
+            type="primary"
+            key="console"
+            onClick={() => {
+              window.location.reload();
+            }}
+            icon={<ReloadOutlined />}
+          >
+            {t('ErrorBoundary.reloadPage')}
+          </Button>
+        </Flex>
+      }
+    ></Result>
+  );
+};

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -2,6 +2,7 @@ import { useCustomThemeConfig } from '../../helper/customThemeConfig';
 import { useBAISettingUserState } from '../../hooks/useBAISetting';
 import { useThemeMode } from '../../hooks/useThemeMode';
 import BAIContentWithDrawerArea from '../BAIContentWithDrawerArea';
+import BAIErrorBoundary from '../BAIErrorBoundary';
 import BAISider from '../BAISider';
 import Flex from '../Flex';
 import ForceTOTPChecker from '../ForceTOTPChecker';
@@ -149,31 +150,34 @@ function MainLayout() {
               overflow: 'auto',
             }}
           >
-            <Suspense
-              fallback={
-                <div>
-                  <Layout.Header style={{ visibility: 'hidden', height: 62 }} />
-                </div>
-              }
-            >
-              <div
-                style={{
-                  margin: `0 -${token.paddingContentHorizontalLG}px 0 -${token.paddingContentHorizontalLG}px`,
-                  position: 'sticky',
-                  top: 0,
-                  zIndex: HEADER_Z_INDEX_IN_MAIN_LAYOUT,
-                }}
+            <BAIErrorBoundary>
+              <Suspense
+                fallback={
+                  <div>
+                    <Layout.Header
+                      style={{ visibility: 'hidden', height: 62 }}
+                    />
+                  </div>
+                }
               >
-                <WebUIHeader
-                  onClickMenuIcon={() => setSideCollapsed((v) => !v)}
-                  containerElement={contentScrollFlexRef.current}
-                />
-              </div>
-            </Suspense>
-            {/* <Flex direction="column"> */}
+                <div
+                  style={{
+                    margin: `0 -${token.paddingContentHorizontalLG}px 0 -${token.paddingContentHorizontalLG}px`,
+                    position: 'sticky',
+                    top: 0,
+                    zIndex: HEADER_Z_INDEX_IN_MAIN_LAYOUT,
+                  }}
+                >
+                  <WebUIHeader
+                    onClickMenuIcon={() => setSideCollapsed((v) => !v)}
+                    containerElement={contentScrollFlexRef.current}
+                  />
+                </div>
+              </Suspense>
+              {/* <Flex direction="column"> */}
 
-            {/* TODO: Breadcrumb */}
-            {/* {location.pathname.split("/").length > 3 && (
+              {/* TODO: Breadcrumb */}
+              {/* {location.pathname.split("/").length > 3 && (
             <Breadcrumb
               items={matches.map((match, index) => {
                 return {
@@ -197,25 +201,26 @@ function MainLayout() {
               })}
             />
           )} */}
-            <Suspense>
-              <PasswordChangeRequestAlert
-                showIcon
-                icon={undefined}
-                banner={false}
-                style={{ marginBottom: token.paddingContentVerticalLG }}
-                closable
-              />
-            </Suspense>
-            <Suspense>
-              <ForceTOTPChecker />
-            </Suspense>
-            <Suspense>
-              <Outlet />
-            </Suspense>
-            {/* To match paddig to 16 (2+14) */}
-            {/* </Flex> */}
-            {/* @ts-ignore */}
-            <backend-ai-webui id="webui-shell" ref={webUIRef} />
+              <Suspense>
+                <PasswordChangeRequestAlert
+                  showIcon
+                  icon={undefined}
+                  banner={false}
+                  style={{ marginBottom: token.paddingContentVerticalLG }}
+                  closable
+                />
+              </Suspense>
+              <Suspense>
+                <ForceTOTPChecker />
+              </Suspense>
+              <Suspense>
+                <Outlet />
+              </Suspense>
+              {/* To match paddig to 16 (2+14) */}
+              {/* </Flex> */}
+              {/* @ts-ignore */}
+              <backend-ai-webui id="webui-shell" ref={webUIRef} />
+            </BAIErrorBoundary>
           </Flex>
         </BAIContentWithDrawerArea>
       </Layout>


### PR DESCRIPTION
This PR resolves error handling strategy to show "custom error boundary" rather than default error boundary page provided by react-router.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
