### PR TITLE
feat: auto mounted vFolder in Neo session launcher

### DIFF
--- a/react/src/components/VFolderTableFormItem.tsx
+++ b/react/src/components/VFolderTableFormItem.tsx
@@ -56,6 +56,7 @@ const VFolderTableFromItem: React.FC<VFolderTableFromItemProps> = ({
         <Input />
         {/* <Flex>{form.getFieldValue('vfoldersAliasMap')}</Flex> */}
       </Form.Item>
+      <Form.Item hidden name="autoMountedFolderNames" />
       <Form.Item
         name={'mounts'}
         {...formItemProps}
@@ -73,6 +74,10 @@ const VFolderTableFromItem: React.FC<VFolderTableFromItemProps> = ({
           // TODO: implement pagination
           pagination={false}
           filter={filter}
+          showAutoMountedFoldersSection
+          onChangeAutoMountedFolders={(names) => {
+            form.setFieldValue('autoMountedFolderNames', names);
+          }}
         />
       </Form.Item>
     </>

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -207,6 +207,7 @@ const SessionLauncherPage = () => {
             form.getFieldsValue(),
             ['environments.image'],
             ['environments.customizedTag'],
+            ['autoMountedFolderNames'],
           ),
         },
         'replaceIn',
@@ -1442,53 +1443,72 @@ const SessionLauncherPage = () => {
                         );
                       }}
                     >
-                      {form.getFieldValue('mounts')?.length > 0 ? (
-                        <Table
-                          rowKey="name"
-                          size="small"
-                          pagination={false}
-                          columns={[
-                            {
-                              dataIndex: 'name',
-                              title: t('data.folders.Name'),
-                            },
-                            {
-                              dataIndex: 'alias',
-                              title: t('session.launcher.FolderAlias'),
-                              render: (value, record) => {
-                                return _.isEmpty(value) ? (
-                                  <Typography.Text
-                                    type="secondary"
-                                    style={{
-                                      opacity: 0.7,
-                                    }}
-                                  >
-                                    {`/home/work/${record.name}`}
-                                  </Typography.Text>
-                                ) : (
-                                  value
-                                );
+                      {/* {console.log(_.sum([form.getFieldValue('mounts')?.length, form.getFieldValue('autoMountedFolderNames')]))} */}
+                      {/* {_.sum([form.getFieldValue('mounts')?.length, form.getFieldValue('autoMountedFolderNames').length]) > 0 ? ( */}
+                      <Flex direction="column" align="stretch" gap={'xs'}>
+                        {form.getFieldValue('mounts')?.length > 0 ? (
+                          <Table
+                            rowKey="name"
+                            size="small"
+                            pagination={false}
+                            columns={[
+                              {
+                                dataIndex: 'name',
+                                title: t('data.folders.Name'),
                               },
-                            },
-                          ]}
-                          dataSource={_.map(
-                            form.getFieldValue('mounts'),
-                            (v) => {
-                              return {
-                                name: v,
-                                alias:
-                                  form.getFieldValue('vfoldersAliasMap')?.[v],
-                              };
-                            },
-                          )}
-                        ></Table>
-                      ) : (
-                        <Alert
-                          type="warning"
-                          showIcon
-                          message={t('session.launcher.NoFolderMounted')}
-                        />
-                      )}
+                              {
+                                dataIndex: 'alias',
+                                title: t('session.launcher.FolderAlias'),
+                                render: (value, record) => {
+                                  return _.isEmpty(value) ? (
+                                    <Typography.Text
+                                      type="secondary"
+                                      style={{
+                                        opacity: 0.7,
+                                      }}
+                                    >
+                                      {`/home/work/${record.name}`}
+                                    </Typography.Text>
+                                  ) : (
+                                    value
+                                  );
+                                },
+                              },
+                            ]}
+                            dataSource={_.map(
+                              form.getFieldValue('mounts'),
+                              (v) => {
+                                return {
+                                  name: v,
+                                  alias:
+                                    form.getFieldValue('vfoldersAliasMap')?.[v],
+                                };
+                              },
+                            )}
+                          ></Table>
+                        ) : (
+                          <Alert
+                            type="warning"
+                            showIcon
+                            message={t('session.launcher.NoFolderMounted')}
+                          />
+                        )}
+                        {form.getFieldValue('autoMountedFolderNames')?.length >
+                        0 ? (
+                          <Descriptions size="small">
+                            <Descriptions.Item
+                              label={t('data.AutomountFolders')}
+                            >
+                              {_.map(
+                                form.getFieldValue('autoMountedFolderNames'),
+                                (name) => {
+                                  return <Tag>{name}</Tag>;
+                                },
+                              )}
+                            </Descriptions.Item>
+                          </Descriptions>
+                        ) : null}
+                      </Flex>
                     </BAICard>
                     <BAICard
                       title="Network"


### PR DESCRIPTION
### TL;DR

This PR adds functionality to show auto-mounted folders in the VFolderTable and resolve [#2371](https://github.com/lablup/backend.ai-webui/issues/2371)

### What changed?

- Added logic to display auto-mounted folders in the VFolderTable component

### How to test?

1. Run the application
2. Navigate to the VFolderTable component
3. Verify the auto-mounted folders section is displayed

### Why make this change?

The change was made to enhance the user experience by providing visibility into auto-mounted folders in the VFolderTable.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
