### PR TITLE
fix: remove comments on config values

### DIFF
--- a/react/src/components/AnnouncementAlert.tsx
+++ b/react/src/components/AnnouncementAlert.tsx
@@ -21,8 +21,8 @@ const AnnouncementAlert: React.FC<Props> = ({ style, ...otherProps }) => {
     <Alert
       banner
       style={{
-        // alignItems: 'flex-start',
         // overflow: 'auto',
+        alignItems: 'center',
         ...style,
       }}
       // icon={

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -467,13 +467,16 @@ export default class BackendAILogin extends BackendAIPage {
   }
 
   private _getConfigValueByExists(parentsKey, valueObj: ConfigValueObject) {
+    const uncommentedValue =
+      typeof valueObj.value === 'string' && valueObj.value.includes('#')
+        ? valueObj.value.split('#')[0].trim()
+        : '';
     const defaultConditions: boolean =
       parentsKey === undefined ||
       valueObj.value === undefined ||
       typeof valueObj.value === 'undefined' ||
-      valueObj.value === '' ||
-      valueObj.value === '""' ||
-      valueObj.value === null;
+      ['', '""', null].includes(uncommentedValue);
+
     let extraConditions;
     switch (typeof valueObj.defaultValue) {
       case 'number':


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
### This PR Resolves #2382 Issue. (and minor fix on summary page's alert margin)

### Why the bug occurred
Inside the config.toml file, a description of each value is included as a comment. These comments were being read together to prevent the default value from being used even when no value was provided. 

### Feature
- Remove comments when reading config.toml values
- Adjust the alert margin at the top of the summary page

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
