### PR TITLE
Omit `onOk` from `BAIModalProps` instead of `onOK`

### DIFF
--- a/react/src/components/EndpointTokenGenerationModal.tsx
+++ b/react/src/components/EndpointTokenGenerationModal.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 // import { graphql, useFragment } from "react-relay";
 
 interface EndpointTokenGenerationModalProps
-  extends Omit<BAIModalProps, 'onOK' | 'onClose'> {
+  extends Omit<BAIModalProps, 'onOk' | 'onClose'> {
   endpoint_id: string;
   onRequestClose: (success?: boolean) => void;
 }


### PR DESCRIPTION
### TL;DR

This change fixes the inconsistency in the props of EndpointTokenGenerationModal.tsx.

### What changed?

Property 'onOK' is corrected to 'onOk' in EndpointTokenGenerationModal.tsx.

### How to test?

Pull the changes, and verify the property in the EndpointTokenGenerationModal.tsx component.

### Why make this change?

The change was necessary to align with the correct property name and prevent potential prop related issues.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
