### PR TITLE
fix: Modal header buttons are not clickable in the top area of Electron

### DIFF
--- a/react/src/components/BAIModal.css
+++ b/react/src/components/BAIModal.css
@@ -27,4 +27,5 @@ div > div.ant-modal-wrap.draggable.ant-modal-centered {
   width: var(--general-modal-header-width, 26px);
   height: var(--general-modal-header-height, 26px);
   top: 22px;
+  -webkit-app-region: no-drag;
 }

--- a/react/src/components/BAIModal.tsx
+++ b/react/src/components/BAIModal.tsx
@@ -59,6 +59,8 @@ const BAIModal: React.FC<BAIModalProps> = ({ styles, ...modalProps }) => {
               style={{
                 cursor: modalProps.draggable ? 'move' : '',
                 display: !modalProps.draggable ? 'none' : '',
+                // @ts-ignore
+                '-webkit-app-region': 'no-drag',
               }}
               onMouseOver={() => {
                 if (disabled) {


### PR DESCRIPTION
### TL;DR

This pull request prevents BAIModal from being draggable from its content.

### What changed?

Two lines of code have been added, one to BAIModal.css and one to BAIModal.tsx. 

The changes make the contents of the BAIModal un-draggable by adding the 'no-drag' value to the '-webkit-app-region' attribute. This prevents the modal from being dragged when clicked inside the content area.

### How to test?

To test these changes, open a ServiceLauncherModal and attempt to drag the modal by clicking within the content area in Electron app. It should not move.

### Why make this change?

This change improves the user experience by preventing unwanted behavior when interacting with BAIModals.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
