### PR TITLE
fix: reload behavior of BAIErrorBoundary for Electron

### DIFF
--- a/react/src/components/BAIErrorBoundary.tsx
+++ b/react/src/components/BAIErrorBoundary.tsx
@@ -27,8 +27,13 @@ const BAIErrorBoundary: React.FC<BAIErrorBoundaryProps> = ({ ...props }) => {
                   type="primary"
                   key="console"
                   onClick={() => {
-                    // resetErrorBoundary();
-                    window.location.reload();
+                    // @ts-ignore
+                    if (globalThis.isElectron) {
+                      // @ts-ignore
+                      globalThis.location.href = globalThis.electronInitialHref;
+                    } else {
+                      globalThis.location.reload();
+                    }
                   }}
                   icon={<ReloadOutlined />}
                 >
@@ -72,7 +77,6 @@ const BAIErrorBoundary: React.FC<BAIErrorBoundaryProps> = ({ ...props }) => {
 };
 
 export default BAIErrorBoundary;
-
 export const ErrorView = () => {
   const { t } = useTranslation();
   return (
@@ -85,7 +89,13 @@ export const ErrorView = () => {
             type="primary"
             key="console"
             onClick={() => {
-              window.location.reload();
+              // @ts-ignore
+              if (globalThis.isElectron) {
+                // @ts-ignore
+                globalThis.location.href = globalThis.electronInitialHref;
+              } else {
+                globalThis.location.reload();
+              }
             }}
             icon={<ReloadOutlined />}
           >


### PR DESCRIPTION
### TL;DR

This pull request modifies the BAIErrorBoundary component's refresh functionality to be compatible with the Electron environment.

### What changed?

The PR updates the onClick handler of the refresh button in the Error View. When the refresh button is clicked, the application checks whether it's running in an Electron environment. If so, it refers to the 'electronInitialHref' for reloading; otherwise, it uses the standard location.reload().

### How to test?

You can test this by triggering an error on the page and clicking the refresh button, in both web browser and Electron environments.
- Example of triggering an error: 
  - Build electron app and launch
  - turn off the network of you machine
  - move the "Service" page and click "Start service"
  - You can see the Error Boundary fallback view

### Why make this change?

This change ensures that the correct refresh method is called depending upon the environment, thereby preventing potential errors or undesired behavior in Electron-based applications.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
