### PR TITLE
fix: normalize copied example command format in sFTP upload agent panel

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -1573,7 +1573,10 @@ export default class BackendAiAppLauncher extends BackendAIPage {
   _copySSHConnectionExample(divSelector) {
     const divElement = this.shadowRoot?.querySelector(divSelector);
     if (divElement) {
-      const textToCopy = divElement.textContent.trim();
+      const textToCopy = divElement.textContent
+        .replace(/[\r\n\t]+/g, ' ')
+        .replace(/\s\s+/g, ' ')
+        .trim();
 
       if (textToCopy.length === 0) {
         this.notification.text = _text(


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
### This PR Resolves lablup/giftbox#669

### Why the bug occurred?
When extracting the text of an `example command element`, the command was not copied correctly because there was no logic to remove line breaks in the element text. 

### What's changed
Changed extracting the text of an element to extract the command as a single line, removing any useless spaces or newlines.



**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
