### PR TITLE
misc: change color of main access key tag to green

### DIFF
--- a/react/src/components/KeypairInfoModal.tsx
+++ b/react/src/components/KeypairInfoModal.tsx
@@ -104,7 +104,7 @@ const KeypairInfoModal: React.FC<KeypairInfoModalProps> = ({
                   {value}
                 </Typography.Text>
                 {supportMainAccessKey && value === user?.main_access_key && (
-                  <Tag color="red">{t('credential.MainAccessKey')}</Tag>
+                  <Tag color="#457b3b">{t('credential.MainAccessKey')}</Tag>
                 )}
               </Flex>
             ),

--- a/src/components/backend-ai-credential-list.ts
+++ b/src/components/backend-ai-credential-list.ts
@@ -802,7 +802,7 @@ export default class BackendAICredentialList extends BackendAIPage {
             ? html`
                 <lablup-shields
                   app=""
-                  color="red"
+                  color="darkgreen"
                   description="${_t('credential.MainAccessKey')}"
                   ui="flat"
                 ></lablup-shields>


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR fixes cosmetic issue; showing main access key tag with appropriate color, instead of red color as if looks like expired.

### Screenshot(s)
* After
<img width="772" alt="Screenshot 2024-05-09 at 4 25 24 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/186b0e7c-70b2-456e-8ff6-e07c3838366b">
<img width="577" alt="Screenshot 2024-05-09 at 4 25 38 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/03871f68-8286-4d34-88c9-3bc5004d578c">

* Before
<img width="706" alt="Screenshot 2024-05-10 at 12 59 04 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/951d4e41-340e-4bbc-800b-a384323e4aed">
<img width="572" alt="Screenshot 2024-05-10 at 12 59 16 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/d007bbf1-166a-4db7-8d7f-62b0694e9c30">

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
