### PR TITLE
feat: the project select supports model store type for admin

### DIFF
--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -255,6 +255,7 @@ export const useCurrentUserRole = () => {
     },
     {
       suspense: false,
+      staleTime: Infinity,
     },
   );
   const userRole = roleData?.user.role;

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -310,6 +310,7 @@ type BackendAIConfig = {
   maskUserInfo: boolean;
   singleSignOnVendors: string[];
   ssoRealmName: string;
+  supportModelStore: boolean;
   enableContainerCommit: boolean;
   appDownloadUrl: string;
   systemSSHImage: string;

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -490,7 +490,8 @@
     "Image": "Bild",
     "All": "Alle",
     "InProgress": "In Arbeit",
-    "Session": "Sitzung"
+    "Session": "Sitzung",
+    "General": "Allgemein"
   },
   "credential": {
     "Permission": "Genehmigung",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -490,7 +490,8 @@
     "Image": "Εικόνα",
     "All": "Όλα",
     "InProgress": "Σε εξέλιξη",
-    "Session": "Σύνοδος"
+    "Session": "Σύνοδος",
+    "General": "Γενικά"
   },
   "credential": {
     "Permission": "Αδεια",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -593,7 +593,8 @@
     "Image": "Image",
     "All": "All",
     "InProgress": "In progress",
-    "Session": "Session"
+    "Session": "Session",
+    "General": "General"
   },
   "credential": {
     "Permission": "Permission",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -509,7 +509,8 @@
     "Image": "Imagen",
     "All": "Todos",
     "InProgress": "En curso",
-    "Session": "Sesión"
+    "Session": "Sesión",
+    "General": "General"
   },
   "import": {
     "CleanUpImportTask": "Tarea de importación de limpieza...",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -509,7 +509,8 @@
     "Image": "Kuva",
     "All": "Kaikki",
     "InProgress": "Käynnissä",
-    "Session": "Istunto"
+    "Session": "Istunto",
+    "General": "Yleistä"
   },
   "import": {
     "CleanUpImportTask": "Tuontitehtävän siivous...",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -490,7 +490,8 @@
     "Image": "Image",
     "All": "Tous",
     "InProgress": "En cours",
-    "Session": "Session"
+    "Session": "Session",
+    "General": "Général"
   },
   "credential": {
     "Permission": "Autorisation",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -491,7 +491,8 @@
     "Image": "Gambar",
     "All": "Semua",
     "InProgress": "Sedang Berlangsung",
-    "Session": "Sesi"
+    "Session": "Sesi",
+    "General": "Umum"
   },
   "credential": {
     "Permission": "Izin",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -490,7 +490,8 @@
     "Image": "Immagine",
     "All": "Tutti",
     "InProgress": "In corso",
-    "Session": "Sessione"
+    "Session": "Sessione",
+    "General": "Generale"
   },
   "credential": {
     "Permission": "Autorizzazione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -490,7 +490,8 @@
     "Image": "画像",
     "All": "全体",
     "InProgress": "進行中",
-    "Session": "セッション"
+    "Session": "セッション",
+    "General": "一般"
   },
   "credential": {
     "Permission": "許可",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -580,7 +580,8 @@
     "Image": "이미지",
     "All": "전체",
     "InProgress": "진행중",
-    "Session": "세션"
+    "Session": "세션",
+    "General": "일반"
   },
   "credential": {
     "Permission": "권한",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -491,7 +491,8 @@
     "Image": "Зураг",
     "All": "бүхэлд нь",
     "InProgress": "Ажиллаж байна",
-    "Session": "Сессия"
+    "Session": "Сессия",
+    "General": "Генерал"
   },
   "credential": {
     "Permission": "Зөвшөөрөл",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -490,7 +490,8 @@
     "Image": "Gambar",
     "All": "keseluruhan",
     "InProgress": "Prosiding",
-    "Session": "Sesi"
+    "Session": "Sesi",
+    "General": "Umum"
   },
   "credential": {
     "Permission": "Kebenaran",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -490,7 +490,8 @@
     "Image": "Obraz",
     "All": "Wszystkie",
     "InProgress": "W toku",
-    "Session": "Sesja"
+    "Session": "Sesja",
+    "General": "Ogólne"
   },
   "credential": {
     "Permission": "Pozwolenie",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -490,7 +490,8 @@
     "Image": "Imagem",
     "All": "Todos",
     "InProgress": "Em curso",
-    "Session": "Sessão"
+    "Session": "Sessão",
+    "General": "Geral"
   },
   "credential": {
     "Permission": "Permissão",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -490,7 +490,8 @@
     "Image": "Imagem",
     "All": "Todos",
     "InProgress": "Em curso",
-    "Session": "Sessão"
+    "Session": "Sessão",
+    "General": "Geral"
   },
   "credential": {
     "Permission": "Permissão",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -490,7 +490,8 @@
     "Image": "Изображение",
     "All": "Все",
     "InProgress": "В процессе",
-    "Session": "Сессия"
+    "Session": "Сессия",
+    "General": "Общие сведения"
   },
   "credential": {
     "Permission": "Разрешение",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -490,7 +490,8 @@
     "Image": "Resim",
     "All": "Tümü",
     "InProgress": "Devam Ediyor",
-    "Session": "Oturum"
+    "Session": "Oturum",
+    "General": "Genel"
   },
   "credential": {
     "Permission": "izin",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -490,7 +490,8 @@
     "Image": "Hình ảnh",
     "All": "toàn bộ",
     "InProgress": "Đang tiến hành",
-    "Session": "Phiên họp"
+    "Session": "Phiên họp",
+    "General": "Tổng quan"
   },
   "credential": {
     "Permission": "Sự cho phép",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -490,7 +490,8 @@
     "Image": "图像",
     "All": "全部",
     "InProgress": "进行中",
-    "Session": "会话"
+    "Session": "会话",
+    "General": "一般情况"
   },
   "credential": {
     "Permission": "允许",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -490,7 +490,8 @@
     "Image": "影像",
     "All": "全部",
     "InProgress": "进行中",
-    "Session": "會話"
+    "Session": "會話",
+    "General": "一般情况"
   },
   "credential": {
     "Permission": "允許",


### PR DESCRIPTION
### TL;DR
Added new hooks and updated components in ProjectSelect to include new features.

### What changed?
- Updated queries in ProjectSelectorQuery
- Implemented filtering and grouping for projects in ProjectSelect
- Added type for supportModelStore to BackendAIConfig
- Updated i18n files with new translations for 'General' key

### How to test?
You can see these changes when passing [this condition]([url](https://github.com/lablup/backend.ai-webui/blob/bcde6ad0a6ebe31a6654444c5f9eea919595890b/react/src/components/ProjectSelect.tsx#L77-L78))
You can see the model-type project after setting `supportModelStore` of `config.toml` and loggin as admin or superadmin.


### Why make this change?
The changes were made to enhance the functionality and user experience of the ProjectSelect component. For managing the model store vfolders, the admin needs to select the current project as the model type project in order to view the vfolders for the model store.

---

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/39a62bcd-e8d3-4459-ab2b-05cb93b1737c.png)


<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
