### PR TITLE
feat/refactor-keypair-resource-policy-page

### DIFF
--- a/react/src/components/FormItemWithUnlimited.tsx
+++ b/react/src/components/FormItemWithUnlimited.tsx
@@ -1,7 +1,6 @@
 import Flex from './Flex';
 import { Form, Checkbox } from 'antd';
 import { CheckboxChangeEvent } from 'antd/es/checkbox';
-import { FormInstance } from 'antd/es/form';
 import { NamePath } from 'antd/es/form/interface';
 import _ from 'lodash';
 import React, { cloneElement, useEffect, useState } from 'react';
@@ -23,14 +22,6 @@ const FormItemWithUnlimited: React.FC<FormItemWithUnlimitedProps> = ({
   const { t } = useTranslation();
   const [isUnlimited, setIsUnlimited] = useState<boolean>(false);
   const form = Form.useFormInstance();
-  // // Reset unlimited fields to undefined when the form is initialized.
-  // useEffect(() => {
-  //   const fieldValue = form.getFieldValue(name);
-  //   if (fieldValue === unlimitedValue) {
-  //     form.setFieldValue(name, undefined);
-  //   }
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, []);
 
   // Detect changes in form value to update the isUnlimited state.
   useEffect(() => {
@@ -44,6 +35,7 @@ const FormItemWithUnlimited: React.FC<FormItemWithUnlimitedProps> = ({
         disabled: isUnlimited,
       } as React.Attributes & { disabled?: boolean })
     : children;
+
   const childrenWithUndefinedValue =
     isUnlimited && React.isValidElement(children)
       ? cloneElement(children, {

--- a/react/src/components/FormItemWithUnlimited.tsx
+++ b/react/src/components/FormItemWithUnlimited.tsx
@@ -3,14 +3,18 @@ import { Form, Checkbox } from 'antd';
 import { CheckboxChangeEvent } from 'antd/es/checkbox';
 import { NamePath } from 'antd/es/form/interface';
 import _ from 'lodash';
-import React, { cloneElement, useEffect, useState } from 'react';
+import React, {
+  cloneElement,
+  PropsWithChildren,
+  useEffect,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 
-interface FormItemWithUnlimitedProps {
+interface FormItemWithUnlimitedProps extends PropsWithChildren {
   name: NamePath;
   unlimitedValue?: number | string;
   label?: string;
-  children?: React.ReactNode;
 }
 
 const FormItemWithUnlimited: React.FC<FormItemWithUnlimitedProps> = ({

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -1,6 +1,9 @@
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import Flex from './Flex';
-import KeypairResourcePolicySettingModal from './KeypairResourcePolicySettingModal';
+import KeypairResourcePolicySettingModal, {
+  UNLIMITED_MAX_CONCURRENT_SESSIONS,
+  UNLIMITED_MAX_CONTAINERS_PER_SESSIONS,
+} from './KeypairResourcePolicySettingModal';
 import ResourceNumber from './ResourceNumber';
 import TableColumnsSettingModal from './TableColumnsSettingModal';
 import { KeypairResourcePolicyListMutation } from './__generated__/KeypairResourcePolicyListMutation.graphql';
@@ -125,7 +128,8 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         a?.max_concurrent_sessions && b?.max_concurrent_sessions
           ? a.max_concurrent_sessions - b.max_concurrent_sessions
           : 1,
-      render: (text) => (text ? text : '∞'),
+      render: (text) =>
+        text === UNLIMITED_MAX_CONCURRENT_SESSIONS ? '∞' : text,
     },
     {
       title: t('resourcePolicy.ClusterSize'),
@@ -135,7 +139,8 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         a?.max_containers_per_session && b?.max_containers_per_session
           ? a.max_containers_per_session - b.max_containers_per_session
           : 1,
-      render: (text) => (text ? text : '∞'),
+      render: (text) =>
+        text === UNLIMITED_MAX_CONTAINERS_PER_SESSIONS ? '∞' : text,
     },
     {
       title: t('resourcePolicy.IdleTimeout'),

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -1,3 +1,4 @@
+import { localeCompare } from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import Flex from './Flex';
 import KeypairResourcePolicySettingModal, {
@@ -97,7 +98,7 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
       dataIndex: 'name',
       key: 'name',
       fixed: 'left',
-      sorter: (a, b) => (a?.name && b?.name ? a.name.localeCompare(b.name) : 0),
+      sorter: (a, b) => localeCompare(a?.name, b?.name),
     },
     {
       title: t('resourcePolicy.Resources'),
@@ -311,6 +312,7 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         rowKey="name"
         scroll={{ x: 'max-content' }}
         pagination={false}
+        showSorterTooltip={false}
       />
       <Flex
         justify="end"

--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -120,11 +120,23 @@ const KeypairResourcePolicySettingModal: React.FC<
       )?.numberUnit;
     }
 
+    let unlimitedValues = {};
+    if (keypairResourcePolicy === null) {
+      // Initialize unlimited values as a default
+      unlimitedValues = {
+        max_session_lifetime: 0,
+        max_concurrent_sessions: UNLIMITED_MAX_CONCURRENT_SESSIONS,
+        max_containers_per_session: UNLIMITED_MAX_CONTAINERS_PER_SESSIONS,
+        idle_timeout: 0,
+      };
+    }
+
     return {
       parsedTotalResourceSlots,
       allowedVfolderHostNames: _.keys(
         JSON.parse(keypairResourcePolicy?.allowed_vfolder_hosts || '{}'),
       ),
+      ...unlimitedValues,
       ...keypairResourcePolicy,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -297,22 +297,22 @@ const KeypairResourcePolicySettingModal: React.FC<
                   name={['parsedTotalResourceSlots', 'cpu']}
                   unlimitedValue={undefined}
                   label={resourceSlotsDetails?.cpu.description}
-                  children={
-                    <InputNumber
-                      min={0}
-                      max={512}
-                      addonAfter={resourceSlotsDetails?.cpu.display_unit}
-                    />
-                  }
-                />
+                >
+                  <InputNumber
+                    min={0}
+                    max={512}
+                    addonAfter={resourceSlotsDetails?.cpu.display_unit}
+                  />
+                </FormItemWithUnlimited>
               </Col>
               <Col span={12}>
                 <FormItemWithUnlimited
                   name={['parsedTotalResourceSlots', 'mem']}
                   unlimitedValue={undefined}
                   label={resourceSlotsDetails?.mem.description}
-                  children={<DynamicUnitInputNumber />}
-                />
+                >
+                  <DynamicUnitInputNumber />
+                </FormItemWithUnlimited>
               </Col>
             </Row>
             <Row gutter={16} align="bottom">
@@ -321,33 +321,31 @@ const KeypairResourcePolicySettingModal: React.FC<
                   name={['parsedTotalResourceSlots', 'cuda.device']}
                   unlimitedValue={undefined}
                   label={resourceSlotsDetails?.['cuda.device'].description}
-                  children={
-                    <InputNumber
-                      min={0}
-                      max={64}
-                      addonAfter={
-                        resourceSlotsDetails?.['cuda.device'].display_unit
-                      }
-                    />
-                  }
-                />
+                >
+                  <InputNumber
+                    min={0}
+                    max={64}
+                    addonAfter={
+                      resourceSlotsDetails?.['cuda.device'].display_unit
+                    }
+                  />
+                </FormItemWithUnlimited>
               </Col>
               <Col span={12}>
                 <FormItemWithUnlimited
                   name={['parsedTotalResourceSlots', 'cuda.shares']}
                   unlimitedValue={undefined}
                   label={resourceSlotsDetails?.['cuda.shares'].description}
-                  children={
-                    <InputNumber
-                      min={0}
-                      max={256}
-                      step={0.1}
-                      addonAfter={
-                        resourceSlotsDetails?.['cuda.shares'].display_unit
-                      }
-                    />
-                  }
-                />
+                >
+                  <InputNumber
+                    min={0}
+                    max={256}
+                    step={0.1}
+                    addonAfter={
+                      resourceSlotsDetails?.['cuda.shares'].display_unit
+                    }
+                  />
+                </FormItemWithUnlimited>
               </Col>
             </Row>
           </Card>
@@ -360,20 +358,18 @@ const KeypairResourcePolicySettingModal: React.FC<
                   name={'max_containers_per_session'}
                   unlimitedValue={UNLIMITED_MAX_CONCURRENT_SESSIONS}
                   label={t('resourcePolicy.ContainerPerSession')}
-                  children={
-                    <InputNumber min={0} max={100} style={{ width: '100%' }} />
-                  }
-                />
+                >
+                  <InputNumber min={0} max={100} style={{ width: '100%' }} />
+                </FormItemWithUnlimited>
               </Col>
               <Col span={12}>
                 <FormItemWithUnlimited
                   name={'max_session_lifetime'}
                   unlimitedValue={0}
                   label={t('resourcePolicy.MaxSessionLifetime')}
-                  children={
-                    <InputNumber min={0} max={100} style={{ width: '100%' }} />
-                  }
-                />
+                >
+                  <InputNumber min={0} max={100} style={{ width: '100%' }} />
+                </FormItemWithUnlimited>
               </Col>
             </Row>
             <Row gutter={16}>
@@ -382,24 +378,22 @@ const KeypairResourcePolicySettingModal: React.FC<
                   name={'max_concurrent_sessions'}
                   unlimitedValue={UNLIMITED_MAX_CONTAINERS_PER_SESSIONS}
                   label={t('resourcePolicy.ConcurrentJobs')}
-                  children={
-                    <InputNumber min={0} max={100} style={{ width: '100%' }} />
-                  }
-                />
+                >
+                  <InputNumber min={0} max={100} style={{ width: '100%' }} />
+                </FormItemWithUnlimited>
               </Col>
               <Col span={12}>
                 <FormItemWithUnlimited
                   name={'idle_timeout'}
                   unlimitedValue={0}
                   label={t('resourcePolicy.IdleTimeoutSec')}
-                  children={
-                    <InputNumber
-                      min={0}
-                      max={15552000}
-                      style={{ width: '100%' }}
-                    />
-                  }
-                />
+                >
+                  <InputNumber
+                    min={0}
+                    max={15552000}
+                    style={{ width: '100%' }}
+                  />
+                </FormItemWithUnlimited>
               </Col>
             </Row>
           </Card>


### PR DESCRIPTION
resolves [feedback](https://app.graphite.dev/github/pr/lablup/backend.ai-webui/2357/feat-add-new-resource-policy-page-keypair-user-project#comment-PRRC_kwDOCRTcws5fzxrU) from @yomybaby 

### TL;DR

Update FormItemWithUnlimited.tsx and KeypairResourcePolicyList.tsx, KeypairResourcePolicySettingModal.tsx.

### What changed?

- Refactored FormItemWithUnlimited.tsx to simplify logic and improve structure.
- Updated KeypairResourcePolicyList.tsx to display '∞' for unlimited values.
- Modified KeypairResourcePolicySettingModal.tsx to define unlimited constants and update field inputs.

### How to test?

Manual testing of the UI components and behavior is required.

### Why make this change?

To enhance code readability, simplify complex logic, and improve user experience.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
