### PR TITLE
feat: set `maxHeight` to BAIModal

### DIFF
--- a/react/src/components/BAIModal.css
+++ b/react/src/components/BAIModal.css
@@ -1,24 +1,3 @@
-.ant-modal.bai-modal .ant-modal-content {
-  padding: var(--general-modal-content-padding, 0);
-}
-.ant-modal.bai-modal .ant-modal-body {
-  padding: var(--general-modal-body-padding, 0 24px);
-}
-
-.ant-modal.bai-modal .ant-modal-footer {
-  padding: var(--general-modal-footer-padding, 0 20px 24px 20px);
-}
-
-.ant-modal.bai-modal .ant-modal-header {
-  border-bottom: 1px solid var(--token-colorBorder, rgb(221, 221, 221));
-  border-width: 100%;
-  justify-content: space-between;
-  display: flex;
-  align-items: center;
-  height: var(--general-modal-header-height, 69px);
-  padding: var(--general-modal-header-padding, 10px 20px);
-}
-
 div > div.ant-modal-wrap.draggable.ant-modal-centered {
   overflow: hidden;
 }

--- a/react/src/components/BAIModal.tsx
+++ b/react/src/components/BAIModal.tsx
@@ -49,8 +49,33 @@ const BAIModal: React.FC<BAIModalProps> = ({ styles, ...modalProps }) => {
         styles={{
           ...styles,
           header: {
-            marginBottom: token.marginSM,
+            marginBottom: 0,
+            borderBottom: `1px solid var(--token-colorBorder, ${token.colorBorder})`,
+            borderWidth: '100%',
+            justifyContent: 'space-between',
+            display: 'flex',
+            alignItems: 'center',
+            height: 'var(--general-modal-header-height, 69px)',
+            padding: 'var(--general-modal-header-padding, 10px 20px)',
             ...styles?.header,
+          },
+          body: {
+            padding: `var(--general-modal-body-padding, 0 24px)`,
+            maxHeight: 'calc(100vh - 69px - 57px - 48px)',
+            overflow: 'auto',
+            paddingTop: token.paddingMD,
+            paddingBottom: token.paddingMD,
+          },
+          content: {
+            padding: `var(--general-modal-content-padding, 0)`,
+          },
+          footer: {
+            borderTop: '1px solid',
+            borderColor: token.colorBorder,
+            padding: token.paddingSM,
+            paddingLeft: token.paddingMD,
+            paddingRight: token.paddingMD,
+            marginTop: 0,
           },
         }}
         title={


### PR DESCRIPTION
### TL;DR

The styles applied to the BAIModal component have been refactored.

| Before | After |
|--------|--------|
|  <img width="715" alt="image" src="https://github.com/lablup/backend.ai-webui/assets/621215/8372437f-95d7-474c-affa-43992575643a">  |  ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/3357767a-ed7a-4316-83f4-d4dbcfc18f10.png) | 

### What changed?

Now, BAIModal has `max-height`. BAIModal body has a scroll when contend is too long.
 Also the declared styles in BAIModal.css file were removed and directly applied to BAIModal.tsx instead. Added new styles properties for content, footer, and body.

### How to test?

To test this change, do a visual inspection of the rendering of the BAIModal component in the UI and compare with the previous version.

### Why make this change?

This change allows for more flexibility when styling BAIModal, as these styles are now managed within the component itself instead of relying on a separate CSS file.

---



<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
