### PR TITLE
fix: empty filter layout of `BAIPropertyFiilter`

### DIFF
--- a/react/src/components/BAIPropertyFilter.tsx
+++ b/react/src/components/BAIPropertyFilter.tsx
@@ -149,43 +149,45 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
           {...otherProps}
         />
       </Flex>
-      <Flex
-        direction="row"
-        gap={'xs'}
-        wrap="wrap"
-        style={{ alignSelf: 'stretch' }}
-      >
-        {_.map(list, (item, index) => {
-          return (
-            <Tag
-              key={getKey(index)}
-              closable
-              onClose={() => {
-                remove(index);
-              }}
-              style={{ margin: 0 }}
-            >
-              {item.propertyLabel}: {trimFilterValue(item.value)}
-            </Tag>
-          );
-        })}
-        {list.length > 1 && (
-          <Tooltip title={t('propertyFilter.ResetFilter')}>
-            <Button
-              size="small"
-              icon={
-                <CloseCircleOutlined
-                  style={{ color: token.colorTextSecondary }}
-                />
-              }
-              type="text"
-              onClick={() => {
-                resetList([]);
-              }}
-            />
-          </Tooltip>
-        )}
-      </Flex>
+      {list.length > 0 && (
+        <Flex
+          direction="row"
+          gap={'xs'}
+          wrap="wrap"
+          style={{ alignSelf: 'stretch' }}
+        >
+          {_.map(list, (item, index) => {
+            return (
+              <Tag
+                key={getKey(index)}
+                closable
+                onClose={() => {
+                  remove(index);
+                }}
+                style={{ margin: 0 }}
+              >
+                {item.propertyLabel}: {trimFilterValue(item.value)}
+              </Tag>
+            );
+          })}
+          {list.length > 1 && (
+            <Tooltip title={t('propertyFilter.ResetFilter')}>
+              <Button
+                size="small"
+                icon={
+                  <CloseCircleOutlined
+                    style={{ color: token.colorTextSecondary }}
+                  />
+                }
+                type="text"
+                onClick={() => {
+                  resetList([]);
+                }}
+              />
+            </Tooltip>
+          )}
+        </Flex>
+      )}
     </Flex>
   );
 };


### PR DESCRIPTION
This PR removes the empty space (red line on the screenshot) when BAIPropertyFilter has no filter.

You can check this "Resources" menu(`/agent`).

| Before | After |
| -- | -- |
|  ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/04878b5f-1116-4daa-99cd-13b02bfca6db.png)   |  ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/5b4b427b-243f-49eb-9e96-a208c4809fec.png)   |

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
