### PR TITLE
fix: `InputNumber` component does not update the value correctly at first

### DIFF
--- a/react/src/components/DynamicStepInputNumber.tsx
+++ b/react/src/components/DynamicStepInputNumber.tsx
@@ -1,3 +1,4 @@
+import { useUpdatableState } from '../hooks';
 import { useControllableValue } from 'ahooks';
 import { InputNumber, InputNumberProps } from 'antd';
 import _ from 'lodash';
@@ -25,9 +26,10 @@ const DynamicInputNumber: React.FC<DynamicInputNumberProps> = ({
   });
 
   // FIXME: this is a workaround to fix the issue that the value is not updated when the value is controlled
+  const [key, updateKey] = useUpdatableState('first');
   useEffect(() => {
     setTimeout(() => {
-      setValue(value);
+      updateKey(value);
     }, 0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -35,6 +37,7 @@ const DynamicInputNumber: React.FC<DynamicInputNumberProps> = ({
   return (
     <InputNumber
       {...inputNumberProps}
+      key={key}
       value={value}
       onChange={(newValue) => {
         // @ts-ignore

--- a/react/src/components/DynamicStepInputNumber.tsx
+++ b/react/src/components/DynamicStepInputNumber.tsx
@@ -1,7 +1,7 @@
 import { useControllableValue } from 'ahooks';
 import { InputNumber, InputNumberProps } from 'antd';
 import _ from 'lodash';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 export interface DynamicInputNumberProps
   extends Omit<InputNumberProps, 'step' | 'value' | 'onChange'> {
@@ -23,6 +23,14 @@ const DynamicInputNumber: React.FC<DynamicInputNumberProps> = ({
   const [value, setValue] = useControllableValue<number>(inputNumberProps, {
     defaultValue: dynamicSteps[0],
   });
+
+  // FIXME: this is a workaround to fix the issue that the value is not updated when the value is controlled
+  useEffect(() => {
+    setTimeout(() => {
+      setValue(value);
+    }, 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <InputNumber

--- a/react/src/components/DynamicUnitInputNumberWithSlider.tsx
+++ b/react/src/components/DynamicUnitInputNumberWithSlider.tsx
@@ -1,4 +1,5 @@
 import { compareNumberWithUnits, iSizeToSize } from '../helper';
+import { useUpdatableState } from '../hooks';
 import DynamicUnitInputNumber, {
   DynamicUnitInputNumberProps,
 } from './DynamicUnitInputNumber';
@@ -47,9 +48,10 @@ const DynamicUnitInputNumberWithSlider: React.FC<
   // console.log('##marks', marks);
 
   // FIXME: this is a workaround to fix the issue that the value is not updated when the value is controlled
+  const [key, updateKey] = useUpdatableState('first');
   useEffect(() => {
     setTimeout(() => {
-      setValue(value);
+      updateKey(value);
     }, 0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -63,6 +65,7 @@ const DynamicUnitInputNumberWithSlider: React.FC<
       >
         <DynamicUnitInputNumber
           {...otherProps}
+          key={key}
           min={min}
           max={max}
           units={units}

--- a/react/src/components/DynamicUnitInputNumberWithSlider.tsx
+++ b/react/src/components/DynamicUnitInputNumberWithSlider.tsx
@@ -51,6 +51,7 @@ const DynamicUnitInputNumberWithSlider: React.FC<
     setTimeout(() => {
       setValue(value);
     }, 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/react/src/components/DynamicUnitInputNumberWithSlider.tsx
+++ b/react/src/components/DynamicUnitInputNumberWithSlider.tsx
@@ -7,7 +7,7 @@ import { useControllableValue } from 'ahooks';
 import { Slider, theme } from 'antd';
 import { SliderMarks } from 'antd/es/slider';
 import _ from 'lodash';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 export interface DynamicUnitInputNumberWithSliderProps
   extends DynamicUnitInputNumberProps {
@@ -45,6 +45,14 @@ const DynamicUnitInputNumberWithSlider: React.FC<
   //     : undefined;
   // }, [warn, maxGiB?.number]);
   // console.log('##marks', marks);
+
+  // FIXME: this is a workaround to fix the issue that the value is not updated when the value is controlled
+  useEffect(() => {
+    setTimeout(() => {
+      setValue(value);
+    }, 0);
+  }, []);
+
   return (
     <Flex direction="row" gap={'md'}>
       <Flex

--- a/react/src/components/InputNumberWithSlider.tsx
+++ b/react/src/components/InputNumberWithSlider.tsx
@@ -2,7 +2,7 @@ import Flex from './Flex';
 import { useControllableValue } from 'ahooks';
 import { InputNumber, Slider, InputNumberProps, SliderSingleProps } from 'antd';
 import { SliderRangeProps } from 'antd/es/slider';
-import _ from 'lodash';
+import _, { set } from 'lodash';
 import React, { useEffect } from 'react';
 
 type OmitControlledProps<T> = Omit<T, 'value' | 'onChange'>;
@@ -37,6 +37,15 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step]);
+
+  // FIXME: this is a workaround to fix the issue that the value is not updated when the value is controlled
+  useEffect(() => {
+    setTimeout(() => {
+      setValue(value);
+    }, 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <Flex direction="row" gap={'md'}>
       <Flex

--- a/react/src/components/InputNumberWithSlider.tsx
+++ b/react/src/components/InputNumberWithSlider.tsx
@@ -1,8 +1,9 @@
+import { useUpdatableState } from '../hooks';
 import Flex from './Flex';
 import { useControllableValue } from 'ahooks';
 import { InputNumber, Slider, InputNumberProps, SliderSingleProps } from 'antd';
 import { SliderRangeProps } from 'antd/es/slider';
-import _, { set } from 'lodash';
+import _ from 'lodash';
 import React, { useEffect } from 'react';
 
 type OmitControlledProps<T> = Omit<T, 'value' | 'onChange'>;
@@ -39,9 +40,10 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
   }, [step]);
 
   // FIXME: this is a workaround to fix the issue that the value is not updated when the value is controlled
+  const [key, updateKey] = useUpdatableState('first');
   useEffect(() => {
     setTimeout(() => {
-      setValue(value);
+      updateKey(value);
     }, 0);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -54,6 +56,7 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
         direction="column"
       >
         <InputNumber
+          key={key}
           ref={inputRef}
           max={max}
           min={min}


### PR DESCRIPTION
### What changed?

This PR fixes the bug related to first update of `InputNumber` in Form.Item. 
- InputNumberWithSlider
- DynamicUnitInputNumberWithSlider
- DynamicInputNumber

### How to test?

- Change the CPU number in the Neo session launcher.
- Refresh the browser.
- If the CPU number is preserved after the refresh, it works fine.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
