### PR TITLE
fix: do not apply preset when disabled presets

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -218,7 +218,7 @@ const ResourceAllocationFormItems: React.FC<
         allocatablePresetNames.includes(form.getFieldValue('allocationPreset'))
       ) {
         // if the current preset is available in the current resource group, do nothing.
-      } else if (allocatablePresetNames[0]) {
+      } else if (enableResourcePresets && allocatablePresetNames[0]) {
         const autoSelectedPreset = _.sortBy(allocatablePresetNames, 'name')[0];
         form.setFieldsValue({
           allocationPreset: autoSelectedPreset,


### PR DESCRIPTION
### What changed?

After this PR, the resource allocation form items do not apply when the preset is disabled.
(bug report from [Teams](https://teams.microsoft.com/l/message/19:14c484402d874dafb15806d093b95a82@thread.skype/1716362564395?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=74ae2c4d-ec4d-4fdf-b2c2-f5041d1e8631&parentMessageId=1716359409725&teamName=devops&channelName=Frontend&createdTime=1716362564395))

### How to test?

- Create two model services with different CPU numbers.
- Click the modify button and check if the CPU number is preserved or not.

### Why make this change?

This change was made to improve the user experience and meet the requirements of the project.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
