### PR TITLE
misc: realign session name of upload session list

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -2830,10 +2830,11 @@ ${item.traceback}</pre
               display: block;
               white-space: pre-wrap;
               word-break: break-all;
+              white-space-collapse: collapse;
             }
           </style>
           <div class="layout vertical start">
-            <div class="horizontal center center-justified layout">
+            <div class="horizontal center start-justified layout">
               <pre id="session-name-field">
                 ${rowData.item.mounts[0]} SFTP Session
               </pre
@@ -2851,6 +2852,7 @@ ${item.traceback}</pre
               display: block;
               margin-left: 16px;
               white-space: pre-wrap;
+              white-space-collapse: collapse;
               word-break: break-all;
             }
             #session-rename-field {


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR fixes miscellaneous cosmetic issue in upload session list about realigning name of session to start-justified.

| After | Before |
|------|--------|
| <img width="930" alt="Screenshot 2024-05-27 at 2 13 43 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/84edaa37-585c-4eff-8503-dee59bf4a2f5"> | <img width="930" alt="Screenshot 2024-05-27 at 2 14 50 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/31e555e3-ddba-4f64-82c9-b88d156c6a37"> |



**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
