### PR TITLE
fix: Mishandling of undefined value in the ModifyImage mutation

### DIFF
--- a/react/src/components/ManageAppsModal.tsx
+++ b/react/src/components/ManageAppsModal.tsx
@@ -1,3 +1,4 @@
+import { useSuspendedBackendaiClient } from '../hooks';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { useWebComponentInfo } from './DefaultProviders';
 import Flex from './Flex';
@@ -22,6 +23,7 @@ import { useMutation } from 'react-relay';
 
 const ManageAppsModal: React.FC<BAIModalProps> = ({ ...baiModalProps }) => {
   const { t } = useTranslation();
+  const baiClient = useSuspendedBackendaiClient();
   const formRef = React.useRef<FormInstance>(null);
   const app = App.useApp();
 
@@ -83,7 +85,11 @@ const ManageAppsModal: React.FC<BAIModalProps> = ({ ...baiModalProps }) => {
               architecture: image.architecture,
               props: {
                 labels: labels,
-                resource_limits: null,
+                resource_limits: baiClient.isManagerVersionCompatibleWith(
+                  '24.03.4.*',
+                )
+                  ? undefined
+                  : null,
               },
             },
             onCompleted: (res, err) => {

--- a/react/src/components/ManageImageResourceLimitModal.tsx
+++ b/react/src/components/ManageImageResourceLimitModal.tsx
@@ -72,7 +72,7 @@ const ManageImageResourceLimitModal: React.FC<BAIModalProps> = ({
       min: value.toString() ?? '0',
       max:
         image.resource_limits?.find((item) => item?.key === key)?.max ??
-        baiClient.isManagerVersionCompatibleWith('23.09.11.*')
+        baiClient.isManagerVersionCompatibleWith('24.03.4.*')
           ? undefined
           : null,
     }));


### PR DESCRIPTION
### Feature 
Depending on your version of Manager, the type of values that do not pass through to properties must be differentiated between undefined and null. [ref](https://github.com/lablup/backend.ai/pull/2028)

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
