### PR TITLE
fix: error handling for ModifyEndpoint GQL fails

### DIFF
--- a/react/src/components/ServiceLauncherModal.tsx
+++ b/react/src/components/ServiceLauncherModal.tsx
@@ -361,6 +361,10 @@ const ServiceLauncherModal: React.FC<ServiceLauncherProps> = ({
             commitModifyEndpoint({
               variables: mutationVariables,
               onCompleted: (res, errors) => {
+                if (!res.modify_endpoint?.ok) {
+                  message.error(res.modify_endpoint?.msg);
+                  return;
+                }
                 if (errors && errors?.length > 0) {
                   const errorMsgList = errors.map((error) => error.message);
                   for (let error of errorMsgList) {


### PR DESCRIPTION
### Feature 
Added error handling logic for when ModifyEndpoint GQL gets an error with a 200 response. [teams](https://teams.microsoft.com/l/message/19:14c484402d874dafb15806d093b95a82@thread.skype/1716362888818?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=74ae2c4d-ec4d-4fdf-b2c2-f5041d1e8631&parentMessageId=1716359409725&teamName=devops&channelName=Frontend&createdTime=1716362888818)

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
