### PR TITLE
hotfix: replace ellipsis in Notification with `_.turuncate`

### DIFF
--- a/react/src/components/BAINotificationItem.tsx
+++ b/react/src/components/BAINotificationItem.tsx
@@ -56,14 +56,21 @@ const BAINotificationItem: React.FC<{
             style={{
               fontWeight: 500,
             }}
-            ellipsis={{ rows: 3 }}
           >
-            {notification.message}
+            {_.isString(notification.message)
+              ? _.truncate(notification.message, {
+                  length: 200,
+                })
+              : notification.message}
           </Typography.Paragraph>
         </Flex>
         <Flex direction="row" align="end" gap={'xxs'} justify="between">
-          <Typography.Paragraph ellipsis={{ rows: 3, expandable: true }}>
-            {notification.description}
+          <Typography.Paragraph>
+            {_.isString(notification.description)
+              ? _.truncate(notification.description, {
+                  length: 300,
+                })
+              : notification.description}
           </Typography.Paragraph>
           {notification.to ? (
             <Flex>


### PR DESCRIPTION
To prevent flickering issues in notifications when using ellipsis in Typography, we temporarily replace it with "truncated".

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
