### PR TITLE
feat: provide sorted resource presets to NeoSessionLauncher when presets are modifed

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -219,7 +219,7 @@ const ResourceAllocationFormItems: React.FC<
       ) {
         // if the current preset is available in the current resource group, do nothing.
       } else if (enableResourcePresets && allocatablePresetNames[0]) {
-        const autoSelectedPreset = _.sortBy(allocatablePresetNames, 'name')[0];
+        const autoSelectedPreset = _.sortBy(allocatablePresetNames)[0];
         form.setFieldsValue({
           allocationPreset: autoSelectedPreset,
         });

--- a/react/src/components/ResourcePresetSelect.tsx
+++ b/react/src/components/ResourcePresetSelect.tsx
@@ -1,3 +1,4 @@
+import { localeCompare } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { useResourceSlots } from '../hooks/backendai';
 import Flex from './Flex';
@@ -12,7 +13,7 @@ import { Select, Tooltip, theme } from 'antd';
 import { SelectProps } from 'antd/lib';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
-import React, { useMemo, useTransition } from 'react';
+import React, { useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyLoadQuery } from 'react-relay';
 
@@ -76,12 +77,6 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
     },
   );
 
-  const sortedResourcePresets = useMemo(() => {
-    return _.sortBy(resource_presets, (preset) =>
-      (preset?.name || '').toLowerCase(),
-    );
-  }, [resource_presets]);
-
   return (
     <Select
       loading={isPendingUpdate}
@@ -125,7 +120,7 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
           // value: 'preset1',
           label: 'Preset',
           // @ts-ignore
-          options: _.map(sortedResourcePresets, (preset, index) => {
+          options: _.map(resource_presets, (preset, index) => {
             const slotsInfo: {
               [key in string]: string;
             } = JSON.parse(preset?.resource_slots);
@@ -170,10 +165,14 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
               preset,
               disabled: disabled,
             };
-            // sort by disabled
-          }).sort((a, b) =>
-            a.disabled === b.disabled ? 0 : a.disabled ? 1 : -1,
-          ),
+          })
+            .sort(
+              (
+                a,
+                b, // by disabled
+              ) => (a.disabled === b.disabled ? 0 : a.disabled ? 1 : -1),
+            )
+            .sort((a, b) => localeCompare(a.value, b.value)), // by name
         },
       ]}
       showSearch

--- a/react/src/components/ResourcePresetSelect.tsx
+++ b/react/src/components/ResourcePresetSelect.tsx
@@ -12,7 +12,7 @@ import { Select, Tooltip, theme } from 'antd';
 import { SelectProps } from 'antd/lib';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
-import React, { useTransition } from 'react';
+import React, { useMemo, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyLoadQuery } from 'react-relay';
 
@@ -76,6 +76,12 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
     },
   );
 
+  const sortedResourcePresets = useMemo(() => {
+    return _.sortBy(resource_presets, (preset) =>
+      (preset?.name || '').toLowerCase(),
+    );
+  }, [resource_presets]);
+
   return (
     <Select
       loading={isPendingUpdate}
@@ -119,7 +125,7 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
           // value: 'preset1',
           label: 'Preset',
           // @ts-ignore
-          options: _.map(resource_presets, (preset, index) => {
+          options: _.map(sortedResourcePresets, (preset, index) => {
             const slotsInfo: {
               [key in string]: string;
             } = JSON.parse(preset?.resource_slots);


### PR DESCRIPTION
### Feature 
When the Resource Preset is modified, the item is moved to the end of the list. This makes it difficult for users to find the resource preset, so we provide sorting functionality by name for resource presets to improve the user experience.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
