### PR TITLE
fix: align button consistency on Resource Group pages

### DIFF
--- a/src/components/backend-ai-resource-group-list.ts
+++ b/src/components/backend-ai-resource-group-list.ts
@@ -519,7 +519,6 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
     const name = this.resourceGroupInfo.name;
     if (this.deleteResourceGroupInput.value !== name) {
       this.notification.text = _text('resourceGroup.ResourceGroupNameNotMatch');
-      this._hideDialogById('#delete-resource-group-dialog');
       this.notification.show();
       return;
     }
@@ -674,6 +673,7 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
    */
   _launchDeleteDialog(resourceGroup: object) {
     this.resourceGroupInfo = resourceGroup;
+    this.deleteResourceGroupInput.value = '';
     this._launchDialogById('#delete-resource-group-dialog');
   }
 

--- a/src/components/backend-ai-resource-group-list.ts
+++ b/src/components/backend-ai-resource-group-list.ts
@@ -119,11 +119,8 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
           --mdc-theme-primary: var(--general-textfield-selected-color);
         }
 
-        mwc-button[outlined] {
-          width: 100%;
-          margin: 10px auto;
-          background-image: none;
-          --mdc-button-outline-width: 2px;
+        mwc-button[raised] {
+          margin-left: var(--token-marginXXS);
         }
 
         mwc-textarea {
@@ -983,9 +980,13 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
         <div slot="footer" class="horizontal end-justified flex layout">
           <mwc-button
             outlined
-            icon="delete"
+            label="${_t('button.Cancel')}"
+            @click="${(e) => this._hideDialog(e)}"
+          ></mwc-button>
+          <mwc-button
+            raised
+            class="warning fg red"
             label="${_t('button.Delete')}"
-            style="box-sizing: border-box;"
             @click="${this._deleteResourceGroup}"
           ></mwc-button>
         </div>


### PR DESCRIPTION
### Fixed
Resolves an issue where buttons on the Resource Group page are inconsistent with other pages. 


|before|after|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/73ba5c7a-e4c3-41d8-8ddf-c12e970a481b.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/c766de21-0af0-4ecc-b865-79e73c378feb.png)|

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
