### PR TITLE
fix: request update when commit session dialog is opened

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1821,6 +1821,7 @@ export default class BackendAISessionList extends BackendAIPage {
     (
       this.shadowRoot?.querySelector('#new-image-name-field') as TextField
     ).value = '';
+    this.requestUpdate();
     this.commitSessionDialog.show();
   }
 


### PR DESCRIPTION
### What I fixed
When the image commit dialog on the session page was opened, the information for that session was being reflected late, so I fixed it to request an update when the dialog is opened so that the information is reflected immediately. 

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
