### PR TITLE
fix: use `recursive` validation  option for `ResourceAllocationFormItems`

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -230,10 +230,12 @@ const ResourceAllocationFormItems: React.FC<
         });
       }
     }
-    // monkey patch for the issue that the validation result is not updated when the resource group is changed.
-    setTimeout(() => {
-      form.validateFields().catch(() => {});
-    }, 200);
+
+    form
+      .validateFields(['resource'], {
+        recursive: true,
+      })
+      .catch(() => {});
   });
 
   // update allocation preset based on resource group and current image


### PR DESCRIPTION
### TL;DR

This PR aims to enhance the validation trigger.

### What changed?

Use the `recursive` option for validation to limit the subpath.

### How to test?

- Open the Service launcher.
  - Before the PR: You can see the validation error in the name field.
  - After the PR: No validation error results right after opening the modal.
- In the Neo session launcher:
  - Change the resource group. You can see the changed validation result in the resource allocation fields.

### Why make this change?

Without the `recursive` option, it's hard to limit the validation to the subpath. After introducing the `recursive` option, we can do it easily.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
