### PR TITLE
feat: memorize board's items by using local storage in SummaryPage

### DIFF
--- a/react/src/components/BAIBoard.tsx
+++ b/react/src/components/BAIBoard.tsx
@@ -1,9 +1,9 @@
 import Flex from './Flex';
 import Board, { BoardProps } from '@cloudscape-design/board-components/board';
 import BoardItem from '@cloudscape-design/board-components/board-item';
-import { DataFallbackType } from '@cloudscape-design/board-components/internal/interfaces';
-import { Typography } from 'antd';
+import { Skeleton, Typography } from 'antd';
 import { createStyles } from 'antd-style';
+import { Suspense } from 'react';
 
 const useStyles = createStyles(({ css }) => ({
   board: css`
@@ -35,14 +35,14 @@ const useStyles = createStyles(({ css }) => ({
 }));
 
 interface BAICustomizableGridProps {
-  parsedItems: BoardProps.Item<DataFallbackType>[];
+  items: Array<BoardProps.Item>;
   onItemsChange: (
     event: CustomEvent<BoardProps.ItemsChangeDetail<unknown>>,
   ) => void;
 }
 
-const BAICustomizableGrid: React.FC<BAICustomizableGridProps> = ({
-  parsedItems,
+const BAIBoard: React.FC<BAICustomizableGridProps> = ({
+  items: parsedItems,
   ...BoardProps
 }) => {
   const { styles } = useStyles();
@@ -69,7 +69,9 @@ const BAICustomizableGrid: React.FC<BAICustomizableGridProps> = ({
               </Flex>
             }
           >
-            {item.data.content}
+            <Suspense fallback={<Skeleton active />}>
+              {item.data.content}
+            </Suspense>
           </BoardItem>
         );
       }}
@@ -158,4 +160,4 @@ const BAICustomizableGrid: React.FC<BAICustomizableGridProps> = ({
   );
 };
 
-export default BAICustomizableGrid;
+export default BAIBoard;

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -1,4 +1,5 @@
 import { jotaiStore } from '../components/DefaultProviders';
+import { SummaryItem } from '../pages/SummaryPage';
 import { atom, useAtom } from 'jotai';
 import { atomFamily } from 'jotai/utils';
 
@@ -16,6 +17,7 @@ interface UserSettings {
   last_window_close_time?: number;
   endpoints?: string[];
   auto_logout?: boolean;
+  summary_items?: Array<Omit<SummaryItem, 'data'>>;
 }
 
 interface GeneralSettings {

--- a/react/src/pages/SummaryPage.tsx
+++ b/react/src/pages/SummaryPage.tsx
@@ -1,54 +1,85 @@
-import BAICustomizableGrid from '../components/BAIBoard';
+import BAIBoard from '../components/BAIBoard';
 import SummaryItemDownloadApp from '../components/SummaryPageItems/SummaryItemDownloadApp';
 import SummaryItemInvitation from '../components/SummaryPageItems/SummaryItemInvitation';
 import SummaryItemStartMenu from '../components/SummaryPageItems/SummaryItemStartMenu';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { BoardProps } from '@cloudscape-design/board-components/board';
-import { DataFallbackType } from '@cloudscape-design/board-components/internal/interfaces';
+import _ from 'lodash';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+export interface SummaryItem
+  extends BoardProps.Item<{
+    title: string;
+    content: JSX.Element;
+  }> {
+  id: 'startMenu' | 'invitation' | 'downloadApp';
+}
+
 const SummaryPage: React.FC = () => {
   const { t } = useTranslation();
-  const [boardItems, setBoardItems] = useState<
-    BoardProps.Item<DataFallbackType>[]
-  >([
-    {
-      id: '1',
-      rowSpan: 5,
-      columnSpan: 1,
-      data: {
-        title: t('summary.StartMenu'),
-        content: <SummaryItemStartMenu allowNeoSessionLauncher />,
-      },
+  const defaultSummaryElements: {
+    [key in SummaryItem['id']]: SummaryItem['data'];
+  } = {
+    startMenu: {
+      title: t('summary.StartMenu'),
+      content: <SummaryItemStartMenu allowNeoSessionLauncher />,
     },
-    {
-      id: '2',
-      rowSpan: 1,
-      columnSpan: 1,
-      data: {
-        title: t('summary.Invitation'),
-        content: <SummaryItemInvitation />,
-      },
+
+    invitation: {
+      title: t('summary.Invitation'),
+      content: <SummaryItemInvitation />,
     },
-    {
-      id: '3',
-      rowSpan: 1,
-      columnSpan: 1,
-      data: {
-        title: t('summary.DownloadWebUIApp'),
-        content: <SummaryItemDownloadApp />,
-      },
+
+    downloadApp: {
+      title: t('summary.DownloadWebUIApp'),
+      content: <SummaryItemDownloadApp />,
     },
-  ]);
+  };
+  const [summaryItemsSetting, setSummaryItemsSetting] =
+    useBAISettingUserState('summary_items');
+
+  const [items, setItems] = useState<Array<SummaryItem>>(
+    !_.isEmpty(summaryItemsSetting)
+      ? _.map(summaryItemsSetting, (item) => ({
+          ...item,
+          data: {
+            ...defaultSummaryElements[item.id],
+          },
+        }))
+      : [
+          {
+            id: 'startMenu',
+            rowSpan: 5,
+            columnSpan: 1,
+            data: defaultSummaryElements.startMenu,
+          },
+          {
+            id: 'invitation',
+            rowSpan: 1,
+            columnSpan: 1,
+            data: defaultSummaryElements.invitation,
+          },
+          {
+            id: 'downloadApp',
+            rowSpan: 1,
+            columnSpan: 1,
+            data: defaultSummaryElements.downloadApp,
+          },
+        ],
+  );
 
   return (
-    <BAICustomizableGrid
-      parsedItems={boardItems}
-      onItemsChange={(event) =>
-        setBoardItems(event.detail.items as BoardProps.Item<DataFallbackType>[])
-      }
+    <BAIBoard
+      items={items}
+      onItemsChange={(event) => {
+        const changedItems = event.detail.items as typeof items;
+        setItems(changedItems);
+        setSummaryItemsSetting(
+          _.map(changedItems, (item) => _.omit(item, 'data')),
+        );
+      }}
     />
   );
 };
-
 export default SummaryPage;


### PR DESCRIPTION
### This PR is one of several steps to resolve issue #2170.
> [!CAUTION]
> **The PR associated with #2170 was not created with graphite from the beginning! There is some code that was committed from the PR on an earlier stack. Please read the Description carefully to see all the code that is included in the PRs on that stack!**
### Feature
The scope of this PR stack is to allow changes to Summary page items to be saved via using local-storage and to display item loading indicators via using Suspense.
- Enable local storage so that changes to items on the Summary page can be saved. 
- Use Suspense to show an indicator for slow rendering of Board Item Components.
### How to test?
>You don't need to review the components that go into the children of a board item; that's covered in other stacks.
- Restore the Commented out SummaryPage component in App.tsx.
- Remove <backend-ai-summary-view> components in backend-ai-webui.ts
- If you can't see Summary Page Items, delete localStorage.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
