### PR TITLE
feat: disable customize board items in BAIBoard component

### DIFF
--- a/react/patches/@cloudscape-design+board-components+3.0.60.patch
+++ b/react/patches/@cloudscape-design+board-components+3.0.60.patch
@@ -31,31 +31,55 @@ index 9ce96ef..cd0a89e 100644
  //# sourceMappingURL=internal.js.map
 \ No newline at end of file
 diff --git a/node_modules/@cloudscape-design/board-components/board-item/styles.css.js b/node_modules/@cloudscape-design/board-components/board-item/styles.css.js
-index 1dcaf7c..f794aaa 100644
+index 1dcaf7c..f1d982c 100644
 --- a/node_modules/@cloudscape-design/board-components/board-item/styles.css.js
 +++ b/node_modules/@cloudscape-design/board-components/board-item/styles.css.js
-@@ -2,7 +2,7 @@
+@@ -2,15 +2,15 @@
      import './styles.scoped.css';
      export default {
    "root": "awsui_root_9ckv7_1974t_1",
 -  "container-override": "awsui_container-override_9ckv7_1974t_6",
 +  "container-override": "awsui_container-override_9ckv7_1974t_6 bai_board_container-override",
    "active": "awsui_active_9ckv7_1974t_6",
-   "header": "awsui_header_9ckv7_1974t_28",
+-  "header": "awsui_header_9ckv7_1974t_28",
++  "header": "awsui_header_9ckv7_1974t_28 bai_board_header",
    "flexible": "awsui_flexible_9ckv7_1974t_34",
+-  "handle": "awsui_handle_9ckv7_1974t_38",
++  "handle": "awsui_handle_9ckv7_1974t_38 bai_board_handle",
+   "refresh": "awsui_refresh_9ckv7_1974t_41",
+   "header-content": "awsui_header-content_9ckv7_1974t_45",
+   "settings": "awsui_settings_9ckv7_1974t_49",
+   "fixed": "awsui_fixed_9ckv7_1974t_57",
+-  "resizer": "awsui_resizer_9ckv7_1974t_61"
++  "resizer": "awsui_resizer_9ckv7_1974t_61 bai_board_resizer",
+ };
+   
+\ No newline at end of file
 diff --git a/node_modules/@cloudscape-design/board-components/board-item/styles.selectors.js b/node_modules/@cloudscape-design/board-components/board-item/styles.selectors.js
-index 2acfd3b..4a35479 100644
+index 2acfd3b..beebd8d 100644
 --- a/node_modules/@cloudscape-design/board-components/board-item/styles.selectors.js
 +++ b/node_modules/@cloudscape-design/board-components/board-item/styles.selectors.js
-@@ -3,7 +3,7 @@
+@@ -3,15 +3,15 @@
      Object.defineProperty(exports, "__esModule", { value: true });
      module.exports.default = {
    "root": "awsui_root_9ckv7_1974t_1",
 -  "container-override": "awsui_container-override_9ckv7_1974t_6",
 +  "container-override": "awsui_container-override_9ckv7_1974t_6 bai_board_container-override",
    "active": "awsui_active_9ckv7_1974t_6",
-   "header": "awsui_header_9ckv7_1974t_28",
+-  "header": "awsui_header_9ckv7_1974t_28",
++  "header": "awsui_header_9ckv7_1974t_28 bai_board_header",
    "flexible": "awsui_flexible_9ckv7_1974t_34",
+-  "handle": "awsui_handle_9ckv7_1974t_38",
++  "handle": "awsui_handle_9ckv7_1974t_38 bai_board_handle",
+   "refresh": "awsui_refresh_9ckv7_1974t_41",
+   "header-content": "awsui_header-content_9ckv7_1974t_45",
+   "settings": "awsui_settings_9ckv7_1974t_49",
+   "fixed": "awsui_fixed_9ckv7_1974t_57",
+-  "resizer": "awsui_resizer_9ckv7_1974t_61"
++  "resizer": "awsui_resizer_9ckv7_1974t_61 bai_board_resizer"
+ };
+   
+\ No newline at end of file
 diff --git a/node_modules/@cloudscape-design/board-components/board/interfaces.d.ts b/node_modules/@cloudscape-design/board-components/board/interfaces.d.ts
 index 8833051..4c47c4d 100644
 --- a/node_modules/@cloudscape-design/board-components/board/interfaces.d.ts

--- a/react/src/components/BAIBoard.tsx
+++ b/react/src/components/BAIBoard.tsx
@@ -5,8 +5,8 @@ import { Skeleton, Typography } from 'antd';
 import { createStyles } from 'antd-style';
 import { Suspense } from 'react';
 
-const useStyles = createStyles(({ css }) => ({
-  board: css`
+const useStyles = createStyles(({ css }) => {
+  const defaultBoard = css`
     .bai_board_placeholder {
       border-radius: var(--token-borderRadius) !important;
     }
@@ -18,44 +18,63 @@ const useStyles = createStyles(({ css }) => ({
       // FIXME: global token doesn't exist, so opacity fits color
       opacity: 0.3;
     }
-  `,
-  boardItem: css`
-    & > div:first-child {
-      border: 1px solid var(--token-colorBorder) !important ;
-      border-radius: var(--token-borderRadius) !important ;
-      background-color: var(--token-colorBgContainer) !important ;
-    }
+  `;
+  return {
+    board: css`
+      ${defaultBoard}
+    `,
+    disableCustomize: css`
+      ${defaultBoard}
+      .bai_board_handle {
+        display: none !important;
+      }
+      .bai_board_resizer {
+        display: none !important;
+      }
+      .bai_board_header {
+        height: var(--token-boardHeaderHeight, 55px) !important;
+      }
+    `,
+    boardItems: css`
+      & > div:first-child {
+        border: 1px solid var(--token-colorBorder) !important ;
+        border-radius: var(--token-borderRadius) !important ;
+        background-color: var(--token-colorBgContainer) !important ;
+      }
 
-    & > div:first-child > div:first-child > div:first-child {
-      border-bottom: 1px solid var(--token-colorBorder) !important;
-      margin-bottom: var(--token-margin);
-      background-color: var(--token-colorBgContainer) !important ;
-    }
-  `,
-}));
+      & > div:first-child > div:first-child > div:first-child {
+        border-bottom: 1px solid var(--token-colorBorder) !important;
+        margin-bottom: var(--token-margin);
+        background-color: var(--token-colorBgContainer) !important ;
+      }
+    `,
+  };
+});
 
 interface BAICustomizableGridProps {
   items: Array<BoardProps.Item>;
   onItemsChange: (
     event: CustomEvent<BoardProps.ItemsChangeDetail<unknown>>,
   ) => void;
+  customizable?: boolean;
 }
 
 const BAIBoard: React.FC<BAICustomizableGridProps> = ({
   items: parsedItems,
+  customizable = false,
   ...BoardProps
 }) => {
   const { styles } = useStyles();
   return (
     <Board
       //@ts-ignore
-      className={styles.board}
+      className={customizable ? styles.board : styles.disableCustomize}
       empty
       renderItem={(item: any) => {
         return (
           <BoardItem
             //@ts-ignore
-            className={styles.boardItem}
+            className={styles.boardItems}
             key={item.id}
             i18nStrings={{
               dragHandleAriaLabel: '',


### PR DESCRIPTION
### This PR is one of several steps to resolve issue #2170.
> [!CAUTION]
> **The PR associated with #2170 was not created with graphite from the beginning! There is some code that was committed from the PR on an earlier stack. Please read the Description carefully to see all the code that is included in the PRs on that stack!**

### Feature
The scope of this PR stack is to prevent the entire item from resizing and moving within the BAIBoard via the `customizable` property.
- Since the event triggers for resize and move are tied to the icon, I specified a className that is accessible via patch-package. 
- Used antd's `createStyles` to apply conditionally created styles.

### How to test?
> You don't need to review the components that go into the children of a board item; that's covered in other stacks.
- Since it uses patch package to change the modules, you should delete the node_modules under the react folder and reinstall it with npm i.
- Restore the Commented out SummaryPage component in App.tsx.
- Remove <backend-ai-summary-view> components in backend-ai-webui.ts
- The default value of `customizable` is `false`. If you want to customize board items, set the value to true. 

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
