### PR TITLE
feat: compatibility check function supports multiple conditions

### DIFF
--- a/react/data/client-directives.graphql
+++ b/react/data/client-directives.graphql
@@ -1,5 +1,7 @@
 # The client-only directives: These directives are handled by manipulateGraphQLQueryWithClientDirectives.
 
 directive @since(version: String!) on FIELD
+directive @sinceMultiple(versions: [String!]!) on FIELD
 directive @deprecatedSince(version: String!) on FIELD
+directive @deprecatedSinceMultiple(versions: [String!]!) on FIELD
 directive @skipOnClient(if: Boolean!) on FIELD

--- a/react/src/helper/graphql-transformer.test.ts
+++ b/react/src/helper/graphql-transformer.test.ts
@@ -1,7 +1,7 @@
 import { manipulateGraphQLQueryWithClientDirectives } from './graphql-transformer';
 
 describe('graphql-transformer', () => {
-  it('should be able to import graphql-ws', () => {
+  it('should transform the GraphQL query correctly', () => {
     const result = manipulateGraphQLQueryWithClientDirectives(
       `
     query MyQuery ($yesSkip:Boolean!, $noSkip:Boolean!, $otherNotUsed:String, $oldVersion:String) {
@@ -48,7 +48,11 @@ describe('graphql-transformer', () => {
         oldVersion: '99',
       },
       (version) => {
-        return 100 <= parseInt(version);
+        if (Array.isArray(version)) {
+          return false;
+        } else {
+          return 100 <= parseInt(version);
+        }
       },
     );
     expect(result).toBe(`query MyQuery {
@@ -62,6 +66,83 @@ describe('graphql-transformer', () => {
         oldField
       }
     }
+  }
+}
+`);
+  });
+
+  it('@sinceMultiple(@versions:) should transform the GraphQL query correctly', () => {
+    const result = manipulateGraphQLQueryWithClientDirectives(
+      `
+    query MyQuery ($versions1:[String!]!, $versions2:[String!]!) {
+      testQuery  (
+        props: {
+          name: "asdf",
+          age: 32 
+        }
+      ){
+        field20 @sinceMultiple(versions: $versions1) @required(ACTION:NONE)
+        filed21 @sinceMultiple(versions: $versions2)
+        filed30 @sinceMultiple(versions: ["23.09.123", "24.03.124"])
+        field31 @since(version: "101")
+      }
+      oldQuery (name:"test") @sinceMultiple(versions: $versions2) {
+        myValue
+      }
+    }
+  `,
+      {
+        versions1: ['23.09.9'],
+        versions2: ['23.09.9', '24.03.1'],
+      },
+      (version) => {
+        if (Array.isArray(version)) {
+          return true;
+        } else {
+          return false;
+        }
+      },
+    );
+    expect(result).toBe(`query MyQuery {
+  testQuery(props: {name: "asdf", age: 32}) {
+    field31
+  }
+}
+`);
+  });
+
+  it.only('@deprecatedSinceMultiple(@versions:) should transform the GraphQL query correctly', () => {
+    const result = manipulateGraphQLQueryWithClientDirectives(
+      `
+    query MyQuery ($versions1:[String!]!, $versions2:[String!]!) {
+      testQuery  (
+        props: {
+          name: "asdf",
+          age: 32 
+        }
+      ){
+        deprecatedField1 @deprecatedSince(version: "99")
+        deprecatedField2 @deprecatedSinceMultiple(versions: $versions1)
+        deprecatedField3 @deprecatedSinceMultiple(versions: $versions2)
+      }
+      
+    }
+  `,
+      {
+        versions1: ['23.09.9'],
+        versions2: ['23.09.9', '24.03.1'],
+      },
+      (version) => {
+        if (Array.isArray(version)) {
+          return version.length === 2;
+        } else {
+          return false;
+        }
+      },
+    );
+    expect(result).toBe(`query MyQuery {
+  testQuery(props: {name: "asdf", age: 32}) {
+    deprecatedField3
   }
 }
 `);

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -8,7 +8,7 @@ Licensed under MIT
 /*jshint esnext: true */
 import CryptoES from 'crypto-es';
 //var CryptoES = require("crypto-js"); /* Exclude for ES6 */
-import { comparePEP440Versions } from './pep440';
+import { comparePEP440Versions, isCompatibleMultipleConditions} from './pep440';
 type requestInfo = {
   method: string;
   headers: Headers;
@@ -705,9 +705,13 @@ class Client {
   /**
    * Return if manager is compatible with given version.
    */
-  isManagerVersionCompatibleWith(version) {
+  isManagerVersionCompatibleWith(version: string | Array<string>) {
     let managerVersion = this._managerVersion;
-    return comparePEP440Versions(managerVersion, version) >= 0;
+    if(Array.isArray(version)){
+      return isCompatibleMultipleConditions(managerVersion, version);
+    } else {
+      return comparePEP440Versions(managerVersion, version) >= 0;
+    }
   }
 
   /**

--- a/src/lib/pep440.test.ts
+++ b/src/lib/pep440.test.ts
@@ -1,4 +1,4 @@
-import { comparePEP440Versions, normalizePEP440Version } from './pep440';
+import { comparePEP440Versions, isCompatibleMultipleConditions, normalizePEP440Version } from './pep440';
 
 describe('normalizePEP440Version', () => {
   test('should normalize versions correctly', () => {
@@ -64,3 +64,12 @@ describe('comparePEP440Versions', () => {
     }
   });
 });
+
+describe('isCompatibleMultipleConditions', ()=>{
+  it('should compare versions correctly', ()=>{
+    expect(isCompatibleMultipleConditions('23.03.3', ['24.3.1', '23.03.2'])).toBe(true)
+    expect(isCompatibleMultipleConditions('23.03.3', ['24.3.1', '23.03.4'])).toBe(false)
+    expect(isCompatibleMultipleConditions('25.03.3', ['24.3.1', '23.03.4'])).toBe(true)
+    expect(isCompatibleMultipleConditions('22.03.3', ['24.3.1', '23.03.4'])).toBe(false)
+  });
+})

--- a/src/lib/pep440.ts
+++ b/src/lib/pep440.ts
@@ -97,3 +97,31 @@ export function comparePEP440Versions(version1: string, version2: string) {
   // If public versions are equal, compare local versions
   return comparePEP440LocalVersions(localVersion1, localVersion2);
 }
+
+
+/**
+ * Removes patch version components from a PEP 440 version string.
+ * 
+ * @param version - The PEP 440 version string.
+ * @returns The version string with only the major and minor version components.
+ */
+export const removeAfterMinorVersion = (version: string) => {
+  return normalizePEP440Version(version).split('.').slice(0, 2).join('.');
+}
+
+/**
+ * Checks if a source version is compatible with multiple conditions versions.
+ * @param source - The source version to check compatibility.
+ * @param conditionsVersions - An array of condition versions to compare against.
+ * @returns A boolean indicating if the source version is compatible with the conditions versions.
+ */
+export function isCompatibleMultipleConditions(source: string, conditionsVersions: string[]) {
+  const sorted = conditionsVersions.sort((a, b) => comparePEP440Versions(a, b));
+  const sourceMinor= removeAfterMinorVersion(source);
+  const minorMatchedVersion = sorted.find((version) => {
+    return sourceMinor === removeAfterMinorVersion(version);
+  });
+  const chooseCondition = minorMatchedVersion || sorted[sorted.length - 1];
+  return comparePEP440Versions(source, chooseCondition) >= 0;
+}
+


### PR DESCRIPTION
This PR implemented the compatibility check function that supports multiple conditions.

After this PR:
- the `version` argument of `isManagerVersionCompatibleWith(version)` can be `Array<string>`
- New GraphQL directives
    ```
    directive @sinceMultiple(versions: [String!]!) on FIELD
    directive @deprecatedSinceMultiple(versions: [String!]!) on FIELD
    ```

## Examples of Usages
```
this.isManagerVersionCompatibleWith(['24.03.4', '23.09.11'])
```

```
my_list {
  edges {
    node {
      newField @sinceMultiple(versions:['24.03.4', '23.09.11'])
    }
  }
}
```

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
