### PR TITLE
refactor: Change the items on the summary page to match BAIBoard

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -28,7 +28,7 @@ const EndpointListPage = React.lazy(() => import('./pages/EndpointListPage'));
 const EndpointDetailPage = React.lazy(
   () => import('./pages/EndpointDetailPage'),
 );
-// const SummaryPage = React.lazy(() => import('./pages/SummaryPage'));
+const SummaryPage = React.lazy(() => import('./pages/SummaryPage'));
 const EnvironmentPage = React.lazy(() => import('./pages/EnvironmentPage'));
 const MyEnvironmentPage = React.lazy(() => import('./pages/MyEnvironmentPage'));
 const StorageHostSettingPage = React.lazy(
@@ -116,7 +116,7 @@ const router = createBrowserRouter([
                 style={{ marginBottom: token.paddingContentVerticalLG }}
                 closable
               />
-              {/* <SummaryPage /> */}
+              <SummaryPage />
             </>
           );
         },

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -9,6 +9,7 @@ import indexCss from '../index.css?raw';
 import { StyleProvider, createCache } from '@ant-design/cssinjs';
 import { useUpdateEffect } from 'ahooks';
 import { App, AppProps, ConfigProvider, theme } from 'antd';
+import { CustomToken, ThemeProvider } from 'antd-style';
 import en_US from 'antd/locale/en_US';
 import ko_KR from 'antd/locale/ko_KR';
 import dayjs from 'dayjs';
@@ -267,6 +268,17 @@ const DefaultProviders: React.FC<DefaultProvidersProps> = (props) => {
 
 export default DefaultProviders;
 
+declare module 'antd-style' {
+  export interface CustomToken {
+    containerHeightSM: number;
+    containerHeightMD: number;
+    containerHeightLG: number;
+    containerWidthSM: number;
+    containerWidthMD: number;
+    containerWidthLG: number;
+  }
+}
+
 export const DefaultProvidersForReactRoot: React.FC<
   Partial<DefaultProvidersProps>
 > = ({ children, value, styles }) => {
@@ -296,16 +308,27 @@ export const DefaultProvidersForReactRoot: React.FC<
                   : theme.defaultAlgorithm,
               }}
             >
-              <App {...commonAppProps}>
-                {/* <StyleProvider container={shadowRoot} cache={cache}> */}
-                <Suspense>
-                  {/* <BrowserRouter> */}
-                  {/* <RoutingEventHandler /> */}
-                  {children}
-                  {/* </BrowserRouter> */}
-                </Suspense>
-                {/* </StyleProvider> */}
-              </App>
+              <ThemeProvider<CustomToken>
+                customToken={{
+                  containerHeightSM: 180,
+                  containerHeightMD: 300,
+                  containerHeightLG: 420,
+                  containerWidthSM: 272,
+                  containerWidthMD: 410,
+                  containerWidthLG: 820,
+                }}
+              >
+                <App {...commonAppProps}>
+                  {/* <StyleProvider container={shadowRoot} cache={cache}> */}
+                  <Suspense>
+                    {/* <BrowserRouter> */}
+                    {/* <RoutingEventHandler /> */}
+                    {children}
+                    {/* </BrowserRouter> */}
+                  </Suspense>
+                  {/* </StyleProvider> */}
+                </App>
+              </ThemeProvider>
             </ConfigProvider>
           </QueryClientProvider>
         </RelayEnvironmentProvider>

--- a/react/src/components/SummaryPageItems/SummaryItemDownloadApp.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemDownloadApp.tsx
@@ -35,7 +35,7 @@ const SummaryItemDownloadApp: React.FC = () => {
     },
   };
   const downloadApp = (architecture: string) => {
-    //@ts-ignore
+    // @ts-ignore
     const pkgVersion = globalThis.packageVersion;
     const os = appDownloadMap[OS].os;
     const extension = appDownloadMap[OS].extension;
@@ -44,12 +44,7 @@ const SummaryItemDownloadApp: React.FC = () => {
   };
 
   return (
-    <Flex
-      direction="column"
-      justify="between"
-      align="start"
-      style={{ width: '100%', gap: token.paddingMD }}
-    >
+    <Flex direction="column" gap={token.paddingMD}>
       <Select
         defaultValue={OS}
         options={[
@@ -59,7 +54,7 @@ const SummaryItemDownloadApp: React.FC = () => {
         ]}
         style={{
           width: '100%',
-          height: '50px',
+          height: token.sizeXXL,
         }}
         onChange={(value) => setOS(value)}
         dropdownRender={(menu) => (
@@ -68,12 +63,13 @@ const SummaryItemDownloadApp: React.FC = () => {
           </Typography.Text>
         )}
       />
-      <Flex style={{ width: '100%', gap: token.paddingXS }}>
-        {appDownloadMap[OS].architecture.map((arch: any) => (
+      <Flex gap={token.paddingXS} style={{ width: '100%' }}>
+        {appDownloadMap[OS].architecture.map((arch: string) => (
           <Button
             key={arch}
             size="large"
             style={{ flex: 1, color: token.colorPrimary }}
+            //FIXME : change any type to specific type
             onClick={(e: any) => {
               downloadApp(e.target.innerText.toLowerCase());
             }}

--- a/react/src/components/SummaryPageItems/SummaryItemDownloadApp.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemDownloadApp.tsx
@@ -35,7 +35,7 @@ const SummaryItemDownloadApp: React.FC = () => {
     },
   };
   const downloadApp = (architecture: string) => {
-    // @ts-ignore
+    //@ts-ignore
     const pkgVersion = globalThis.packageVersion;
     const os = appDownloadMap[OS].os;
     const extension = appDownloadMap[OS].extension;
@@ -44,7 +44,12 @@ const SummaryItemDownloadApp: React.FC = () => {
   };
 
   return (
-    <Flex direction="column" gap={token.paddingMD}>
+    <Flex
+      direction="column"
+      justify="between"
+      align="start"
+      style={{ gap: token.paddingMD }}
+    >
       <Select
         defaultValue={OS}
         options={[
@@ -54,7 +59,7 @@ const SummaryItemDownloadApp: React.FC = () => {
         ]}
         style={{
           width: '100%',
-          height: token.sizeXXL,
+          height: '50px',
         }}
         onChange={(value) => setOS(value)}
         dropdownRender={(menu) => (
@@ -63,13 +68,12 @@ const SummaryItemDownloadApp: React.FC = () => {
           </Typography.Text>
         )}
       />
-      <Flex gap={token.paddingXS} style={{ width: '100%' }}>
-        {appDownloadMap[OS].architecture.map((arch: string) => (
+      <Flex style={{ width: '100%', gap: token.paddingXS }}>
+        {appDownloadMap[OS].architecture.map((arch: any) => (
           <Button
             key={arch}
             size="large"
             style={{ flex: 1, color: token.colorPrimary }}
-            //FIXME : change any type to specific type
             onClick={(e: any) => {
               downloadApp(e.target.innerText.toLowerCase());
             }}

--- a/react/src/components/SummaryPageItems/SummaryItemInvitation.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemInvitation.tsx
@@ -111,12 +111,10 @@ const SummaryItemInvitation: React.FC = () => {
   };
 
   return (
-    <Flex direction="column" gap={token.marginSM} style={{ height: '100%' }}>
+    <Flex direction="column" gap={token.marginSM}>
       {invitations.length > 0 ? (
         <>
-          {/* FIXME: change any type to specific type */}
           {invitations.map((invitation: Invitation) => {
-            console.log(invitation);
             return (
               <BAICard className={styles.card}>
                 <Descriptions

--- a/react/src/components/SummaryPageItems/SummaryItemShortCut.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemShortCut.tsx
@@ -1,0 +1,187 @@
+import { useWebUINavigate } from '../../hooks';
+import Flex from '../Flex';
+import {
+  FileOutlined,
+  InboxOutlined,
+  SettingOutlined,
+  ToolOutlined,
+} from '@ant-design/icons';
+import { Typography, theme } from 'antd';
+import { useTheme } from 'antd-style';
+import _ from 'lodash';
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface itemProps {
+  id: string;
+  title: string;
+  content: string;
+  icon?: JSX.Element;
+  onClick?: () => void;
+}
+
+const SummaryItemShortCut: React.FC = () => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const customTheme = useTheme();
+  const webuiNavigate = useWebUINavigate();
+  const [items] = useState<itemProps[]>([
+    {
+      id: 'systemSetting',
+      title: t('summary.ChangeSystemSetting'),
+      content: t('summary.ChangeSystemSettingDescription'),
+      icon: (
+        <SettingOutlined
+          style={{
+            fontSize: token.fontSizeHeading3,
+            color: token.colorTextDescription,
+          }}
+        />
+      ),
+      onClick: () => {
+        webuiNavigate('/settings');
+      },
+    },
+    {
+      id: 'userSetting',
+      title: t('summary.ChangeUserSetting'),
+      content: t('summary.ChangeUserSettingDescription'),
+      icon: (
+        <SettingOutlined
+          style={{
+            fontSize: token.fontSizeHeading3,
+            color: token.colorTextDescription,
+          }}
+        />
+      ),
+      onClick: () => {
+        webuiNavigate('/usersettings');
+      },
+    },
+    {
+      id: 'checkResources',
+      title: t('summary.CheckResources'),
+      content: t('summary.CheckResourcesDescription'),
+      icon: (
+        <InboxOutlined
+          style={{
+            fontSize: token.fontSizeHeading3,
+            color: token.colorTextDescription,
+          }}
+        />
+      ),
+      onClick: () => {
+        webuiNavigate('/agent');
+      },
+    },
+    {
+      id: 'manageEnvironment',
+      title: t('summary.ManageEnvironment'),
+      content: t('summary.ManageEnvironmentDescription'),
+      icon: (
+        <FileOutlined
+          style={{
+            fontSize: token.fontSizeHeading3,
+            color: token.colorTextDescription,
+          }}
+        />
+      ),
+      onClick: () => {
+        webuiNavigate('/environment');
+      },
+    },
+    {
+      id: 'maintenance',
+      title: t('summary.Maintenance'),
+      content: t('summary.MaintenanceDescription'),
+      icon: (
+        <ToolOutlined
+          style={{
+            fontSize: token.fontSizeHeading3,
+            color: token.colorTextDescription,
+          }}
+        />
+      ),
+      onClick: () => {
+        webuiNavigate('/maintenance');
+      },
+    },
+  ]);
+  const [chunkSize, setChunkSize] = useState<number>(2);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const updateImageSize = () => {
+      const containerWidth = container.clientWidth;
+
+      if (containerWidth <= customTheme.containerWidthMD) {
+        setChunkSize(1);
+      } else if (containerWidth <= customTheme.containerWidthLG) {
+        setChunkSize(2);
+      } else {
+        setChunkSize(3);
+      }
+    };
+    const resizeObserver = new ResizeObserver(() => {
+      updateImageSize();
+    });
+    resizeObserver.observe(container);
+    updateImageSize();
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Flex ref={containerRef} direction="column" gap={'xl'}>
+      {_.chunk(items, chunkSize).map((row, index) => (
+        <Flex
+          key={index}
+          gap={'sm'}
+          justify="between"
+          style={{ width: '100%' }}
+        >
+          {_.map(row, (item, index) => (
+            <Flex
+              key={index}
+              gap={'sm'}
+              style={{
+                flex: 1,
+                cursor: 'pointer',
+              }}
+              onClick={item.onClick}
+            >
+              {item.icon}
+              <Flex direction="column" align="start" style={{ flex: 1 }}>
+                <Typography.Text style={{ fontSize: token.fontSize }}>
+                  {item.title}
+                </Typography.Text>
+                <Typography.Text
+                  style={{
+                    fontSize: token.fontSizeSM,
+                    color: token.colorTextSecondary,
+                  }}
+                >
+                  {item.content}
+                </Typography.Text>
+              </Flex>
+            </Flex>
+          ))}
+          {_.times(chunkSize - row.length, (emptyIndex) => (
+            <Flex key={emptyIndex} style={{ flex: 1 }}>
+              {/* Empty box for maintaining layout consistency */}
+            </Flex>
+          ))}
+        </Flex>
+      ))}
+    </Flex>
+  );
+};
+
+export default SummaryItemShortCut;

--- a/react/src/components/SummaryPageItems/SummaryItemStartMenu.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemStartMenu.tsx
@@ -9,6 +9,7 @@ interface StartMenuProps {
   deactivate?: boolean;
   allowNeoSessionLauncher?: boolean;
 }
+type ImageSize = 'NONE' | 'SM' | 'LG';
 
 export const SummaryItemStartMenu: React.FC<StartMenuProps> = ({
   deactivate,
@@ -18,24 +19,54 @@ export const SummaryItemStartMenu: React.FC<StartMenuProps> = ({
   const { token } = theme.useToken();
   const webuiNavigate = useWebUINavigate();
   const containerRef = useRef<HTMLDivElement>(null);
-  const [imgSize, setImgSize] = useState<number>(400);
+  const [imgSize, setImgSize] = useState<ImageSize>('LG');
 
-  // useEffect(() => {
-  //   const updateImageSize = () => {
-  //     if (!containerRef.current) {
-  //       return;
-  //     }
-  //     const containerHeight = containerRef.current.clientHeight;
-  //     console.log(containerHeight);
-  //   };
-  // }, []);
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const updateImageSize = () => {
+      const containerHeight = container.clientHeight;
+      const containerWidth = container.clientWidth;
+      if (containerHeight <= 300) {
+        setImgSize('NONE');
+      } else if (containerHeight <= 420) {
+        setImgSize('SM');
+      } else {
+        if (containerWidth <= 272) {
+          setImgSize('SM');
+          return;
+        }
+        setImgSize('LG');
+      }
+    };
+    const resizeObserver = new ResizeObserver(() => {
+      updateImageSize();
+    });
+    resizeObserver.observe(container);
+    updateImageSize();
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, []);
 
   return (
-    <Flex direction="column" justify="around" style={{ height: '100%' }}>
+    <Flex
+      ref={containerRef}
+      direction="column"
+      justify="around"
+      style={{ height: '100%' }}
+    >
       <img
         src="/resources/images/launcher-background.png"
         alt="launcher background"
-        style={{ width: 400, marginBottom: token.marginMD }}
+        style={{
+          width: imgSize === 'LG' ? 400 : imgSize === 'SM' ? 250 : 0,
+          marginBottom: token.marginMD,
+          display: imgSize === 'NONE' ? 'none' : 'block',
+        }}
       />
       <Flex direction="column" style={{ width: '100%' }}>
         <Button
@@ -59,7 +90,7 @@ export const SummaryItemStartMenu: React.FC<StartMenuProps> = ({
         <Flex
           style={{
             width: 'inherit',
-            marginTop: token.marginMD,
+            marginTop: imgSize === 'NONE' ? 0 : token.marginMD,
             alignItems: 'start',
             cursor: 'pointer',
           }}

--- a/react/src/components/SummaryPageItems/SummaryItemStartMenu.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemStartMenu.tsx
@@ -9,7 +9,7 @@ interface StartMenuProps {
   deactivate?: boolean;
   allowNeoSessionLauncher?: boolean;
 }
-type ImageSize = 'NONE' | 'SM' | 'LG';
+type ImageSize = 'NONE' | 'SM' | 'MD' | 'LG';
 
 export const SummaryItemStartMenu: React.FC<StartMenuProps> = ({
   deactivate,
@@ -29,13 +29,15 @@ export const SummaryItemStartMenu: React.FC<StartMenuProps> = ({
     const updateImageSize = () => {
       const containerHeight = container.clientHeight;
       const containerWidth = container.clientWidth;
-      if (containerHeight <= 300) {
+      if (containerHeight <= 180) {
         setImgSize('NONE');
-      } else if (containerHeight <= 420) {
+      } else if (containerHeight <= 300) {
         setImgSize('SM');
+      } else if (containerHeight <= 420) {
+        setImgSize('MD');
       } else {
         if (containerWidth <= 272) {
-          setImgSize('SM');
+          setImgSize('MD');
           return;
         }
         setImgSize('LG');
@@ -63,7 +65,7 @@ export const SummaryItemStartMenu: React.FC<StartMenuProps> = ({
         src="/resources/images/launcher-background.png"
         alt="launcher background"
         style={{
-          width: imgSize === 'LG' ? 400 : imgSize === 'SM' ? 250 : 0,
+          width: imgSize === 'LG' ? 400 : imgSize === 'MD' ? 250 : 0,
           marginBottom: token.marginMD,
           display: imgSize === 'NONE' ? 'none' : 'block',
         }}

--- a/react/src/components/SummaryPageItems/SummaryItemStartMenu.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemStartMenu.tsx
@@ -2,6 +2,7 @@ import { useWebUINavigate } from '../../hooks';
 import Flex from '../Flex';
 import { PoweroffOutlined } from '@ant-design/icons';
 import { Button, Typography, theme } from 'antd';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface StartMenuProps {
@@ -13,130 +14,144 @@ export const SummaryItemStartMenu: React.FC<StartMenuProps> = ({
   deactivate,
   allowNeoSessionLauncher,
 }) => {
+  const { t } = useTranslation();
   const { token } = theme.useToken();
   const webuiNavigate = useWebUINavigate();
-  const { t } = useTranslation();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [imgSize, setImgSize] = useState<number>(400);
+
+  // useEffect(() => {
+  //   const updateImageSize = () => {
+  //     if (!containerRef.current) {
+  //       return;
+  //     }
+  //     const containerHeight = containerRef.current.clientHeight;
+  //     console.log(containerHeight);
+  //   };
+  // }, []);
 
   return (
-    <Flex direction="column" justify="between" align="center">
+    <Flex direction="column" justify="around" style={{ height: '100%' }}>
       <img
         src="/resources/images/launcher-background.png"
         alt="launcher background"
-        style={{ width: 300, marginBottom: token.marginMD }}
+        style={{ width: 400, marginBottom: token.marginMD }}
       />
-      <Button
-        type="primary"
-        disabled={deactivate}
-        onClick={() =>
-          allowNeoSessionLauncher
-            ? webuiNavigate('/session/start')
-            : webuiNavigate('/job')
-        }
-        size="large"
-        style={{
-          width: '100%',
-          textTransform: 'uppercase',
-          fontSize: token.fontSizeSM,
-        }}
-        icon={<PoweroffOutlined />}
-      >
-        {t('session.launcher.Start')}
-      </Button>
-      <Flex
-        style={{
-          width: '100%',
-          marginTop: token.marginMD,
-          alignItems: 'start',
-          cursor: 'pointer',
-        }}
-      >
-        <Flex
-          direction="column"
+      <Flex direction="column" style={{ width: '100%' }}>
+        <Button
+          type="primary"
+          disabled={deactivate}
+          onClick={() =>
+            allowNeoSessionLauncher
+              ? webuiNavigate('/session/start')
+              : webuiNavigate('/job')
+          }
+          size="large"
           style={{
-            flex: 1,
+            width: 'inherit',
+            textTransform: 'uppercase',
+            fontSize: token.fontSizeSM,
           }}
-          onClick={() => webuiNavigate('/data')}
+          icon={<PoweroffOutlined />}
         >
-          <img
-            alt="upload_files"
-            src="/resources/menu_icons/icon_upload_files.svg"
-            style={{
-              width: token.controlHeightSM,
-              height: token.controlHeightSM,
-              margin: token.marginSM,
-              filter: 'invert(0.5)',
-            }}
-          />
-          <Typography.Text
-            type="secondary"
-            style={{ fontSize: token.fontSizeSM }}
-          >
-            {t('summary.UploadFiles')}
-          </Typography.Text>
-        </Flex>
+          {t('session.launcher.Start')}
+        </Button>
         <Flex
-          direction="column"
           style={{
-            flex: 1,
-            borderRight: `1px solid ${token.colorBorder}`,
-            borderLeft: `1px solid ${token.colorBorder}`,
-          }}
-          onClick={() => {
-            webuiNavigate({
-              pathname: '/credential',
-              search: '?action=add',
-            });
+            width: 'inherit',
+            marginTop: token.marginMD,
+            alignItems: 'start',
+            cursor: 'pointer',
           }}
         >
-          <img
-            alt="upload_files"
-            src="/resources/menu_icons/icon_create_a_key_pair.svg"
+          <Flex
+            direction="column"
             style={{
-              width: token.controlHeightSM,
-              height: token.controlHeightSM,
-              margin: token.marginSM,
-              filter: 'invert(0.5)',
+              flex: 1,
             }}
-          />
-          <Typography.Text
-            type="secondary"
+            onClick={() => webuiNavigate('/data')}
+          >
+            <img
+              alt="upload_files"
+              src="/resources/menu_icons/icon_upload_files.svg"
+              style={{
+                width: token.controlHeightSM,
+                height: token.controlHeightSM,
+                margin: token.marginSM,
+                filter: 'invert(0.5)',
+              }}
+            />
+            <Typography.Text
+              type="secondary"
+              style={{ fontSize: token.fontSizeSM }}
+            >
+              {t('summary.UploadFiles')}
+            </Typography.Text>
+          </Flex>
+          <Flex
+            direction="column"
             style={{
-              fontSize: token.fontSizeSM,
-              textAlign: 'center',
+              flex: 1,
+              borderRight: `1px solid ${token.colorBorder}`,
+              borderLeft: `1px solid ${token.colorBorder}`,
+            }}
+            onClick={() => {
+              webuiNavigate({
+                pathname: '/credential',
+                search: '?action=add',
+              });
             }}
           >
-            {t('summary.CreateANewKeypair')}
-          </Typography.Text>
-        </Flex>
-        <Flex
-          direction="column"
-          style={{ flex: 1 }}
-          onClick={() => {
-            webuiNavigate({
-              pathname: '/credential',
-              search: '?action=manage',
-            });
-          }}
-        >
-          <img
-            alt="upload_files"
-            src="/resources/menu_icons/icon_keypair_management.svg"
-            style={{
-              width: token.controlHeightSM,
-              height: token.controlHeightSM,
-              margin: token.marginSM,
-              filter: 'invert(0.5)',
-            }}
-          />
-          <Typography.Text
-            type="secondary"
-            style={{
-              fontSize: token.fontSizeSM,
-              textAlign: 'center',
+            <img
+              alt="upload_files"
+              src="/resources/menu_icons/icon_create_a_key_pair.svg"
+              style={{
+                width: token.controlHeightSM,
+                height: token.controlHeightSM,
+                margin: token.marginSM,
+                filter: 'invert(0.5)',
+              }}
+            />
+            <Typography.Text
+              type="secondary"
+              style={{
+                fontSize: token.fontSizeSM,
+                textAlign: 'center',
+              }}
+            >
+              {t('summary.CreateANewKeypair')}
+            </Typography.Text>
+          </Flex>
+          <Flex
+            direction="column"
+            style={{ flex: 1 }}
+            onClick={() => {
+              webuiNavigate({
+                pathname: '/credential',
+                search: '?action=manage',
+              });
             }}
           >
-            {t('summary.MaintainKeypairs')}
-          </Typography.Text>
+            <img
+              alt="upload_files"
+              src="/resources/menu_icons/icon_keypair_management.svg"
+              style={{
+                width: token.controlHeightSM,
+                height: token.controlHeightSM,
+                margin: token.marginSM,
+                filter: 'invert(0.5)',
+              }}
+            />
+            <Typography.Text
+              type="secondary"
+              style={{
+                fontSize: token.fontSizeSM,
+                textAlign: 'center',
+              }}
+            >
+              {t('summary.MaintainKeypairs')}
+            </Typography.Text>
+          </Flex>
         </Flex>
       </Flex>
     </Flex>

--- a/react/src/components/SummaryPageItems/SummaryItemStartMenu.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemStartMenu.tsx
@@ -2,6 +2,7 @@ import { useWebUINavigate } from '../../hooks';
 import Flex from '../Flex';
 import { PoweroffOutlined } from '@ant-design/icons';
 import { Button, Typography, theme } from 'antd';
+import { useTheme } from 'antd-style';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -17,6 +18,7 @@ export const SummaryItemStartMenu: React.FC<StartMenuProps> = ({
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
+  const customTheme = useTheme();
   const webuiNavigate = useWebUINavigate();
   const containerRef = useRef<HTMLDivElement>(null);
   const [imgSize, setImgSize] = useState<ImageSize>('LG');
@@ -29,14 +31,14 @@ export const SummaryItemStartMenu: React.FC<StartMenuProps> = ({
     const updateImageSize = () => {
       const containerHeight = container.clientHeight;
       const containerWidth = container.clientWidth;
-      if (containerHeight <= 180) {
+      if (containerHeight <= customTheme.containerHeightSM) {
         setImgSize('NONE');
-      } else if (containerHeight <= 300) {
+      } else if (containerHeight <= customTheme.containerHeightMD) {
         setImgSize('SM');
-      } else if (containerHeight <= 420) {
+      } else if (containerHeight <= customTheme.containerHeightLG) {
         setImgSize('MD');
       } else {
-        if (containerWidth <= 272) {
+        if (containerWidth <= customTheme.containerWidthSM) {
           setImgSize('MD');
           return;
         }
@@ -52,6 +54,7 @@ export const SummaryItemStartMenu: React.FC<StartMenuProps> = ({
     return () => {
       resizeObserver.disconnect();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -65,7 +68,7 @@ export const SummaryItemStartMenu: React.FC<StartMenuProps> = ({
         src="/resources/images/launcher-background.png"
         alt="launcher background"
         style={{
-          width: imgSize === 'LG' ? 400 : imgSize === 'MD' ? 250 : 0,
+          width: imgSize === 'LG' ? 300 : imgSize === 'MD' ? 250 : 0,
           marginBottom: token.marginMD,
           display: imgSize === 'NONE' ? 'none' : 'block',
         }}

--- a/react/src/pages/SummaryPage.tsx
+++ b/react/src/pages/SummaryPage.tsx
@@ -1,6 +1,7 @@
 import BAIBoard from '../components/BAIBoard';
 import SummaryItemDownloadApp from '../components/SummaryPageItems/SummaryItemDownloadApp';
 import SummaryItemInvitation from '../components/SummaryPageItems/SummaryItemInvitation';
+import SummaryItemShortCut from '../components/SummaryPageItems/SummaryItemShortCut';
 import SummaryItemStartMenu from '../components/SummaryPageItems/SummaryItemStartMenu';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { BoardProps } from '@cloudscape-design/board-components/board';
@@ -13,7 +14,7 @@ export interface SummaryItem
     title: string;
     content: JSX.Element;
   }> {
-  id: 'startMenu' | 'invitation' | 'downloadApp';
+  id: 'startMenu' | 'invitation' | 'downloadApp' | 'shortCut';
 }
 
 const SummaryPage: React.FC = () => {
@@ -34,6 +35,11 @@ const SummaryPage: React.FC = () => {
     downloadApp: {
       title: t('summary.DownloadWebUIApp'),
       content: <SummaryItemDownloadApp />,
+    },
+
+    shortCut: {
+      title: t('summary.shortCut'),
+      content: <SummaryItemShortCut />,
     },
   };
   const [summaryItemsSetting, setSummaryItemsSetting] =
@@ -65,6 +71,12 @@ const SummaryPage: React.FC = () => {
             rowSpan: 1,
             columnSpan: 1,
             data: defaultSummaryElements.downloadApp,
+          },
+          {
+            id: 'shortCut',
+            rowSpan: 1,
+            columnSpan: 1,
+            data: defaultSummaryElements.shortCut,
           },
         ],
   );

--- a/react/src/react-app-env.d.ts
+++ b/react/src/react-app-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="react-scripts" />
-
 declare module 'babel-plugin-relay/macro' {
   export { graphql as default } from 'react-relay';
 }

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "Backend.AI Web UI App herunterladen",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel-LPU aktiviert",
-    "ATOMPlusEnabled": "ATOM+ NPU aktiviert"
+    "ATOMPlusEnabled": "ATOM+ NPU aktiviert",
+    "InvitatedFrom": "Aus:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel-LPU aktiviert",
     "ATOMPlusEnabled": "ATOM+ NPU aktiviert",
-    "InvitatedFrom": "Aus:"
+    "InvitatedFrom": "Aus:",
+    "ChangeSystemSettingDescription": "Ändern Sie Bilder der Rechenumgebung, Grafikumgebung, Skalierung und Plugins.",
+    "ChangeUserSetting": "Benutzereinstellungen ändern",
+    "ChangeUserSettingDescription": "Sie können Ihre persönlichen Einstellungen ändern, um Ihr Erlebnis individuell zu gestalten.",
+    "CheckResourcesDescription": "Sie können die aktuell verwendeten Ressourcen überprüfen und verwalten.",
+    "ManageEnvironment": "Verwalten laufender Umgebungsbilder",
+    "ManageEnvironmentDescription": "Installieren Sie ein laufendes Umgebungs-Image oder ändern Sie die Image-Einstellungen.",
+    "Maintenance": "Systemwartung",
+    "MaintenanceDescription": "Bietet Funktionalität für die Systemwartung.",
+    "shortCut": "Verknüpfungen"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU Enabled",
     "ATOMPlusEnabled": "Ενεργοποιημένο ATOM+ NPU",
-    "InvitatedFrom": "Από:"
+    "InvitatedFrom": "Από:",
+    "ChangeSystemSettingDescription": "Αλλαγή εικόνων υπολογιστικού περιβάλλοντος, περιβάλλοντος γραφικών, κλιμάκωσης και προσθηκών.",
+    "ChangeUserSetting": "Αλλάξτε τις ρυθμίσεις χρήστη",
+    "ChangeUserSettingDescription": "Μπορείτε να αλλάξετε τις προσωπικές σας ρυθμίσεις για να προσαρμόσετε την εμπειρία σας.",
+    "CheckResourcesDescription": "Μπορείτε να ελέγξετε και να διαχειριστείτε τους πόρους που χρησιμοποιούνται αυτήν τη στιγμή.",
+    "ManageEnvironment": "Διαχείριση εικόνων περιβάλλοντος λειτουργίας",
+    "ManageEnvironmentDescription": "Εγκαταστήστε μια εικόνα περιβάλλοντος που εκτελείται ή αλλάξτε τις ρυθμίσεις εικόνας.",
+    "Maintenance": "ΣΥΝΤΗΡΗΣΗ ΣΥΣΤΗΜΑΤΟΣ",
+    "MaintenanceDescription": "Παρέχει λειτουργικότητα για τη συντήρηση του συστήματος.",
+    "shortCut": "Συντομεύσεις"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "Κατεβάστε την εφαρμογή Backend.AI Web UI App",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU Enabled",
-    "ATOMPlusEnabled": "Ενεργοποιημένο ATOM+ NPU"
+    "ATOMPlusEnabled": "Ενεργοποιημένο ATOM+ NPU",
+    "InvitatedFrom": "Από:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -131,7 +131,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU Enabled",
     "ATOMPlusEnabled": "ATOM+ NPU Enabled",
-    "InvitatedFrom": "From: "
+    "InvitatedFrom": "From: ",
+    "ChangeSystemSettingDescription": "Change compute environment images, graphics environment, scaling, and plugins.",
+    "ChangeUserSetting": "Change user settings",
+    "ChangeUserSettingDescription": "You can change your personal settings to customize your experience.",
+    "CheckResourcesDescription": "You can check and manage the resources currently in use.",
+    "ManageEnvironment": "Managing Running Environment Images",
+    "ManageEnvironmentDescription": "Install a running environment image or change image settings.",
+    "Maintenance": "System maintenance",
+    "MaintenanceDescription": "Provides functionality for system maintenance.",
+    "shortCut": "Short Cut"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -130,7 +130,8 @@
     "WarboyEnabled": "Warboy NPU Enabled",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU Enabled",
-    "ATOMPlusEnabled": "ATOM+ NPU Enabled"
+    "ATOMPlusEnabled": "ATOM+ NPU Enabled",
+    "InvitatedFrom": "From: "
   },
   "session": {
     "launcher": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -39,7 +39,8 @@
     "connectingToCluster": "Conectando al Cluster Backend.AI...",
     "reserved": "reservado",
     "HyperaccelLPUEnabled": "LPU de hiperaccel habilitada",
-    "ATOMPlusEnabled": "NPU ATOM+ habilitada"
+    "ATOMPlusEnabled": "NPU ATOM+ habilitada",
+    "InvitatedFrom": "De:"
   },
   "error": {
     "WrongAPIServerAddress": "Dirección del servidor API incorrecta.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -40,7 +40,16 @@
     "reserved": "reservado",
     "HyperaccelLPUEnabled": "LPU de hiperaccel habilitada",
     "ATOMPlusEnabled": "NPU ATOM+ habilitada",
-    "InvitatedFrom": "De:"
+    "InvitatedFrom": "De:",
+    "ChangeSystemSettingDescription": "Cambie las imágenes del entorno informático, el entorno gráfico, el escalado y los complementos.",
+    "ChangeUserSetting": "Cambiar la configuración del usuario",
+    "ChangeUserSettingDescription": "Puede cambiar su configuración personal para personalizar su experiencia.",
+    "CheckResourcesDescription": "Puede comprobar y gestionar los recursos actualmente en uso.",
+    "ManageEnvironment": "Gestión de imágenes del entorno de ejecución",
+    "ManageEnvironmentDescription": "Instale una imagen del entorno en ejecución o cambie la configuración de la imagen.",
+    "Maintenance": "Mantenimiento del sistema",
+    "MaintenanceDescription": "Proporciona funcionalidad para el mantenimiento del sistema.",
+    "shortCut": "Atajos"
   },
   "error": {
     "WrongAPIServerAddress": "Dirección del servidor API incorrecta.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -40,7 +40,16 @@
     "reserved": "varattu",
     "HyperaccelLPUEnabled": "Hyperaccel LPU käytössä",
     "ATOMPlusEnabled": "ATOM+ NPU käytössä",
-    "InvitatedFrom": "Lähettäjä:"
+    "InvitatedFrom": "Lähettäjä:",
+    "ChangeSystemSettingDescription": "Muuta laskentaympäristön kuvia, grafiikkaympäristöä, skaalausta ja laajennuksia.",
+    "ChangeUserSetting": "Muuta käyttäjäasetuksia",
+    "ChangeUserSettingDescription": "Voit mukauttaa käyttökokemustasi muuttamalla henkilökohtaisia ​​asetuksiasi.",
+    "CheckResourcesDescription": "Voit tarkistaa ja hallita tällä hetkellä käytössä olevia resursseja.",
+    "ManageEnvironment": "Käyttöympäristön kuvien hallinta",
+    "ManageEnvironmentDescription": "Asenna käyttöympäristön kuva tai muuta kuvan asetuksia.",
+    "Maintenance": "Järjestelmän ylläpito",
+    "MaintenanceDescription": "Tarjoaa toimintoja järjestelmän ylläpitoon.",
+    "shortCut": "Pikanäppäimet"
   },
   "error": {
     "WrongAPIServerAddress": "Väärä API-palvelimen osoite.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -39,7 +39,8 @@
     "connectingToCluster": "Yhteyden muodostaminen Backend.AI-klusteriin...",
     "reserved": "varattu",
     "HyperaccelLPUEnabled": "Hyperaccel LPU käytössä",
-    "ATOMPlusEnabled": "ATOM+ NPU käytössä"
+    "ATOMPlusEnabled": "ATOM+ NPU käytössä",
+    "InvitatedFrom": "Lähettäjä:"
   },
   "error": {
     "WrongAPIServerAddress": "Väärä API-palvelimen osoite.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU activé",
     "ATOMPlusEnabled": "ATOM+ NPU activé",
-    "InvitatedFrom": "Depuis:"
+    "InvitatedFrom": "Depuis:",
+    "ChangeSystemSettingDescription": "Modifiez les images de l'environnement de calcul, l'environnement graphique, la mise à l'échelle et les plugins.",
+    "ChangeUserSetting": "Modifier les paramètres utilisateur",
+    "ChangeUserSettingDescription": "Vous pouvez modifier vos paramètres personnels pour personnaliser votre expérience.",
+    "CheckResourcesDescription": "Vous pouvez vérifier et gérer les ressources actuellement utilisées.",
+    "ManageEnvironment": "Gestion des images de l'environnement d'exécution",
+    "ManageEnvironmentDescription": "Installez une image d'environnement en cours d'exécution ou modifiez les paramètres de l'image.",
+    "Maintenance": "Entretien du système",
+    "MaintenanceDescription": "Fournit des fonctionnalités pour la maintenance du système.",
+    "shortCut": "Raccourcis"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -117,7 +117,8 @@
     "WarboyEnabled": "Warboy NPU activé",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU activé",
-    "ATOMPlusEnabled": "ATOM+ NPU activé"
+    "ATOMPlusEnabled": "ATOM+ NPU activé",
+    "InvitatedFrom": "Depuis:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -117,7 +117,8 @@
     "WarboyEnabled": "Warboy NPU Diaktifkan",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel Diaktifkan",
-    "ATOMPlusEnabled": "ATOM+ NPU Diaktifkan"
+    "ATOMPlusEnabled": "ATOM+ NPU Diaktifkan",
+    "InvitatedFrom": "Dari:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel Diaktifkan",
     "ATOMPlusEnabled": "ATOM+ NPU Diaktifkan",
-    "InvitatedFrom": "Dari:"
+    "InvitatedFrom": "Dari:",
+    "ChangeSystemSettingDescription": "Ubah gambar lingkungan komputasi, lingkungan grafis, penskalaan, dan plugin.",
+    "ChangeUserSetting": "Ubah pengaturan pengguna",
+    "ChangeUserSettingDescription": "Anda dapat mengubah pengaturan pribadi untuk menyesuaikan pengalaman Anda.",
+    "CheckResourcesDescription": "Anda dapat memeriksa dan mengelola sumber daya yang sedang digunakan.",
+    "ManageEnvironment": "Mengelola Gambar Lingkungan Berjalan",
+    "ManageEnvironmentDescription": "Instal gambar lingkungan yang sedang berjalan atau ubah pengaturan gambar.",
+    "Maintenance": "Perbaikan sistem",
+    "MaintenanceDescription": "Menyediakan fungsionalitas untuk pemeliharaan sistem.",
+    "shortCut": "Jalan pintas"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel abilitato",
     "ATOMPlusEnabled": "NPU ATOM+ abilitata",
-    "InvitatedFrom": "Da:"
+    "InvitatedFrom": "Da:",
+    "ChangeSystemSettingDescription": "Modifica le immagini dell'ambiente di elaborazione, l'ambiente grafico, il ridimensionamento e i plug-in.",
+    "ChangeUserSetting": "Modificare le impostazioni dell'utente",
+    "ChangeUserSettingDescription": "Puoi modificare le tue impostazioni personali per personalizzare la tua esperienza.",
+    "CheckResourcesDescription": "Puoi controllare e gestire le risorse attualmente in uso.",
+    "ManageEnvironment": "Gestione delle immagini dell'ambiente di esecuzione",
+    "ManageEnvironmentDescription": "Installa un'immagine dell'ambiente in esecuzione o modifica le impostazioni dell'immagine.",
+    "Maintenance": "Sistema in manutenzione",
+    "MaintenanceDescription": "Fornisce funzionalità per la manutenzione del sistema.",
+    "shortCut": "Scorciatoie"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "Scarica l'applicazione Backend.AI Web UI",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel abilitato",
-    "ATOMPlusEnabled": "NPU ATOM+ abilitata"
+    "ATOMPlusEnabled": "NPU ATOM+ abilitata",
+    "InvitatedFrom": "Da:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "Backend.AI Web UIアプリのダウンロード",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "ハイパーアクセル LPU が有効になりました",
-    "ATOMPlusEnabled": "ATOM+ NPU 有効"
+    "ATOMPlusEnabled": "ATOM+ NPU 有効",
+    "InvitatedFrom": "から："
   },
   "session": {
     "launcher": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "ハイパーアクセル LPU が有効になりました",
     "ATOMPlusEnabled": "ATOM+ NPU 有効",
-    "InvitatedFrom": "から："
+    "InvitatedFrom": "から：",
+    "ChangeSystemSettingDescription": "計算環境画像、グラフィック環境、スケーリング、プラグインを変更します。",
+    "ChangeUserSetting": "ユーザー設定を変更する",
+    "ChangeUserSettingDescription": "個人設定を変更して、ユーザーの経験をカスタマイズできます。",
+    "CheckResourcesDescription": "現在使用しているリソースを確認して管理できます。",
+    "ManageEnvironment": "実行環境イメージの管理",
+    "ManageEnvironmentDescription": "実行環境イメージをインストールするか、イメージ設定を変更します。",
+    "Maintenance": "システム・メンテナンス",
+    "MaintenanceDescription": "システムメンテナンスのための機能を提供します。",
+    "shortCut": "ショートカット"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU 사용중",
     "ATOMPlusEnabled": "ATOM+ NPU 사용중",
-    "InvitatedFrom": "수신: "
+    "InvitatedFrom": "수신: ",
+    "ChangeSystemSettingDescription": "계산환경 이미지, 그래픽 환경, 스케일링 및 플러그인을 변경합니다.",
+    "ChangeUserSetting": "사용자 설정 변경",
+    "ChangeUserSettingDescription": "개인 설정을 변경하여 사용자의 경험을 맞춤화할 수 있습니다.",
+    "CheckResourcesDescription": "현재 사용중인 자원을 확인하고 관리할 수 있습니다.",
+    "ManageEnvironment": "실행 환경 이미지 관리",
+    "ManageEnvironmentDescription": "실행 환경 이미지를 설치하거나 이미지 설정을 변경합니다.",
+    "Maintenance": "시스템 유지보수",
+    "MaintenanceDescription": "시스템 유지보수를 위한 기능을 제공합니다.",
+    "shortCut": "바로가기"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -117,7 +117,8 @@
     "WarboyEnabled": "Warboy NPU 사용중",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU 사용중",
-    "ATOMPlusEnabled": "ATOM+ NPU 사용중"
+    "ATOMPlusEnabled": "ATOM+ NPU 사용중",
+    "InvitatedFrom": "수신: "
   },
   "session": {
     "launcher": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -117,7 +117,8 @@
     "WarboyEnabled": "Warboy NPU идэвхжүүлсэн",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU идэвхжүүлсэн",
-    "ATOMPlusEnabled": "ATOM+ NPU-г идэвхжүүлсэн"
+    "ATOMPlusEnabled": "ATOM+ NPU-г идэвхжүүлсэн",
+    "InvitatedFrom": "Хэнээс:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU идэвхжүүлсэн",
     "ATOMPlusEnabled": "ATOM+ NPU-г идэвхжүүлсэн",
-    "InvitatedFrom": "Хэнээс:"
+    "InvitatedFrom": "Хэнээс:",
+    "ChangeSystemSettingDescription": "Тооцоолох орчны зураг, график орчин, масштаб болон залгаасуудыг өөрчлөх.",
+    "ChangeUserSetting": "Хэрэглэгчийн тохиргоог өөрчлөх",
+    "ChangeUserSettingDescription": "Та туршлагаа өөрчлөхийн тулд хувийн тохиргоогоо өөрчилж болно.",
+    "CheckResourcesDescription": "Та одоо ашиглаж байгаа нөөцүүдийг шалгаж, удирдах боломжтой.",
+    "ManageEnvironment": "Ажиллаж буй орчны зургийг удирдах",
+    "ManageEnvironmentDescription": "Ажиллаж буй орчны дүрсийг суулгах эсвэл зургийн тохиргоог өөрчлөх.",
+    "Maintenance": "Системийн засвар үйлчилгээ",
+    "MaintenanceDescription": "Системийн засвар үйлчилгээ хийх функцээр хангадаг.",
+    "shortCut": "Товчлолууд"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "Muat turun Apl UI Web Backend.AI",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel Didayakan",
-    "ATOMPlusEnabled": "ATOM+ NPU Didayakan"
+    "ATOMPlusEnabled": "ATOM+ NPU Didayakan",
+    "InvitatedFrom": "Daripada:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel Didayakan",
     "ATOMPlusEnabled": "ATOM+ NPU Didayakan",
-    "InvitatedFrom": "Daripada:"
+    "InvitatedFrom": "Daripada:",
+    "ChangeSystemSettingDescription": "Tukar imej persekitaran pengiraan, persekitaran grafik, penskalaan dan pemalam.",
+    "ChangeUserSetting": "Tukar tetapan pengguna",
+    "ChangeUserSettingDescription": "Anda boleh menukar tetapan peribadi anda untuk menyesuaikan pengalaman anda.",
+    "CheckResourcesDescription": "Anda boleh menyemak dan mengurus sumber yang sedang digunakan.",
+    "ManageEnvironment": "Mengurus Imej Persekitaran Berjalan",
+    "ManageEnvironmentDescription": "Pasang imej persekitaran yang sedang berjalan atau tukar tetapan imej.",
+    "Maintenance": "Penyelenggaraan sistem",
+    "MaintenanceDescription": "Menyediakan fungsi untuk penyelenggaraan sistem.",
+    "shortCut": "Jalan pintas"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Włączono funkcję Hyperaccel LPU",
     "ATOMPlusEnabled": "Włączono NPU ATOM+",
-    "InvitatedFrom": "Z:"
+    "InvitatedFrom": "Z:",
+    "ChangeSystemSettingDescription": "Zmień obrazy środowiska obliczeniowego, środowisko graficzne, skalowanie i wtyczki.",
+    "ChangeUserSetting": "Zmień ustawienia użytkownika",
+    "ChangeUserSettingDescription": "Możesz zmienić swoje ustawienia osobiste, aby dostosować swoje doświadczenie.",
+    "CheckResourcesDescription": "Możesz sprawdzić i zarządzać aktualnie używanymi zasobami.",
+    "ManageEnvironment": "Zarządzanie obrazami środowiska biegania",
+    "ManageEnvironmentDescription": "Zainstaluj działający obraz środowiska lub zmień ustawienia obrazu.",
+    "Maintenance": "Konserwacja systemu",
+    "MaintenanceDescription": "Zapewnia funkcjonalność do konserwacji systemu.",
+    "shortCut": "Skróty"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "Pobierz aplikację Backend.AI Web UI",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Włączono funkcję Hyperaccel LPU",
-    "ATOMPlusEnabled": "Włączono NPU ATOM+"
+    "ATOMPlusEnabled": "Włączono NPU ATOM+",
+    "InvitatedFrom": "Z:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "Descarregar a aplicação Backend.AI Web UI",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel habilitada",
-    "ATOMPlusEnabled": "ATOM+ NPU habilitado"
+    "ATOMPlusEnabled": "ATOM+ NPU habilitado",
+    "InvitatedFrom": "De:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel habilitada",
     "ATOMPlusEnabled": "ATOM+ NPU habilitado",
-    "InvitatedFrom": "De:"
+    "InvitatedFrom": "De:",
+    "ChangeSystemSettingDescription": "Altere imagens do ambiente de computação, ambiente gráfico, dimensionamento e plug-ins.",
+    "ChangeUserSetting": "Alterar configurações do usuário",
+    "ChangeUserSettingDescription": "Você pode alterar suas configurações pessoais para personalizar sua experiência.",
+    "CheckResourcesDescription": "Você pode verificar e gerenciar os recursos atualmente em uso.",
+    "ManageEnvironment": "Gerenciando imagens do ambiente em execução",
+    "ManageEnvironmentDescription": "Instale uma imagem de ambiente em execução ou altere as configurações da imagem.",
+    "Maintenance": "Manutenção de sistema",
+    "MaintenanceDescription": "Fornece funcionalidade para manutenção do sistema.",
+    "shortCut": "Atalhos"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "Descarregar a aplicação Backend.AI Web UI",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel habilitada",
-    "ATOMPlusEnabled": "ATOM+ NPU habilitado"
+    "ATOMPlusEnabled": "ATOM+ NPU habilitado",
+    "InvitatedFrom": "De:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel habilitada",
     "ATOMPlusEnabled": "ATOM+ NPU habilitado",
-    "InvitatedFrom": "De:"
+    "InvitatedFrom": "De:",
+    "ChangeSystemSettingDescription": "Altere imagens do ambiente de computação, ambiente gráfico, dimensionamento e plug-ins.",
+    "ChangeUserSetting": "Alterar configurações do usuário",
+    "ChangeUserSettingDescription": "Você pode alterar suas configurações pessoais para personalizar sua experiência.",
+    "CheckResourcesDescription": "Você pode verificar e gerenciar os recursos atualmente em uso.",
+    "ManageEnvironment": "Gerenciando imagens do ambiente em execução",
+    "ManageEnvironmentDescription": "Instale uma imagem de ambiente em execução ou altere as configurações da imagem.",
+    "Maintenance": "Manutenção de sistema",
+    "MaintenanceDescription": "Fornece funcionalidade para manutenção do sistema.",
+    "shortCut": "Atalhos"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -117,7 +117,8 @@
     "WarboyEnabled": "Warboy NPU Enabled",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU включен",
-    "ATOMPlusEnabled": "NPU ATOM+ включен"
+    "ATOMPlusEnabled": "NPU ATOM+ включен",
+    "InvitatedFrom": "От:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU включен",
     "ATOMPlusEnabled": "NPU ATOM+ включен",
-    "InvitatedFrom": "От:"
+    "InvitatedFrom": "От:",
+    "ChangeSystemSettingDescription": "Меняйте изображения вычислительной среды, графическую среду, масштабирование и плагины.",
+    "ChangeUserSetting": "Изменение настроек пользователя",
+    "ChangeUserSettingDescription": "Вы можете изменить свои личные настройки, чтобы персонализировать свой опыт.",
+    "CheckResourcesDescription": "Вы можете проверять и управлять ресурсами, которые используются в данный момент.",
+    "ManageEnvironment": "Управление изображениями рабочей среды",
+    "ManageEnvironmentDescription": "Установите образ работающей среды или измените настройки образа.",
+    "Maintenance": "Обслуживание системы",
+    "MaintenanceDescription": "Обеспечивает функциональные возможности для обслуживания системы.",
+    "shortCut": "Ярлыки"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU Etkin",
     "ATOMPlusEnabled": "ATOM+ NPU Etkin",
-    "InvitatedFrom": "İtibaren:"
+    "InvitatedFrom": "İtibaren:",
+    "ChangeSystemSettingDescription": "Bilgi işlem ortamı görüntülerini, grafik ortamını, ölçeklendirmeyi ve eklentileri değiştirin.",
+    "ChangeUserSetting": "Kullanıcı ayarlarını değiştir",
+    "ChangeUserSettingDescription": "Deneyiminizi kişiselleştirmek için kişisel ayarlarınızı değiştirebilirsiniz.",
+    "CheckResourcesDescription": "Şu anda kullanımda olan kaynakları kontrol edebilir ve yönetebilirsiniz.",
+    "ManageEnvironment": "Koşu Ortamı Görüntülerini Yönetme",
+    "ManageEnvironmentDescription": "Çalışan bir ortam görüntüsü yükleyin veya görüntü ayarlarını değiştirin.",
+    "Maintenance": "Sistem bakımı",
+    "MaintenanceDescription": "Sistem bakımı için işlevsellik sağlar.",
+    "shortCut": "Kısayollar"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "Backend.AI Web UI Uygulamasını İndirin",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU Etkin",
-    "ATOMPlusEnabled": "ATOM+ NPU Etkin"
+    "ATOMPlusEnabled": "ATOM+ NPU Etkin",
+    "InvitatedFrom": "İtibaren:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "Tải xuống ứng dụng giao diện người dùng web Backend.AI",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Đã bật LPU Hyperaccel",
-    "ATOMPlusEnabled": "Đã bật NPU ATOM+"
+    "ATOMPlusEnabled": "Đã bật NPU ATOM+",
+    "InvitatedFrom": "Từ:"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Đã bật LPU Hyperaccel",
     "ATOMPlusEnabled": "Đã bật NPU ATOM+",
-    "InvitatedFrom": "Từ:"
+    "InvitatedFrom": "Từ:",
+    "ChangeSystemSettingDescription": "Thay đổi hình ảnh môi trường điện toán, môi trường đồ họa, chia tỷ lệ và plugin.",
+    "ChangeUserSetting": "Thay đổi cài đặt người dùng",
+    "ChangeUserSettingDescription": "Bạn có thể thay đổi cài đặt cá nhân để tùy chỉnh trải nghiệm của mình.",
+    "CheckResourcesDescription": "Bạn có thể kiểm tra và quản lý các tài nguyên hiện đang được sử dụng.",
+    "ManageEnvironment": "Quản lý hình ảnh môi trường đang chạy",
+    "ManageEnvironmentDescription": "Cài đặt hình ảnh môi trường đang chạy hoặc thay đổi cài đặt hình ảnh.",
+    "Maintenance": "Bảo trì hệ thống",
+    "MaintenanceDescription": "Cung cấp chức năng bảo trì hệ thống.",
+    "shortCut": "Phím tắt"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "下载 Backend.AI Web UI 应用程序",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU 已启用",
-    "ATOMPlusEnabled": "ATOM+ NPU 启用"
+    "ATOMPlusEnabled": "ATOM+ NPU 启用",
+    "InvitatedFrom": "从："
   },
   "session": {
     "launcher": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU 已启用",
     "ATOMPlusEnabled": "ATOM+ NPU 启用",
-    "InvitatedFrom": "从："
+    "InvitatedFrom": "从：",
+    "ChangeSystemSettingDescription": "更改计算环境图像、图形环境、缩放和插件。",
+    "ChangeUserSetting": "更改用户设置",
+    "ChangeUserSettingDescription": "您可以更改您的个人设置来定制您的体验。",
+    "CheckResourcesDescription": "您可以查看和管理当前正在使用的资源。",
+    "ManageEnvironment": "管理运行环境镜像",
+    "ManageEnvironmentDescription": "安装运行环境映像或更改映像设置。",
+    "Maintenance": "系统维护",
+    "MaintenanceDescription": "提供系统维护功能。",
+    "shortCut": "快捷方式"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -118,7 +118,16 @@
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU 已啟用。",
     "ATOMPlusEnabled": "ATOM+ NPU 啟用",
-    "InvitatedFrom": "從："
+    "InvitatedFrom": "從：",
+    "ChangeSystemSettingDescription": "更改計算環境圖像、圖形環境、縮放和插件。",
+    "ChangeUserSetting": "更改用戶設定",
+    "ChangeUserSettingDescription": "您可以更改您的個人設定來自訂您的體驗。",
+    "CheckResourcesDescription": "您可以查看和管理目前正在使用的資源。",
+    "ManageEnvironment": "管理運行環境鏡像",
+    "ManageEnvironmentDescription": "安裝運行環境映像或變更映像設定。",
+    "Maintenance": "系統維​​護",
+    "MaintenanceDescription": "提供系統維護功能。",
+    "shortCut": "快速方式"
   },
   "session": {
     "launcher": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -117,7 +117,8 @@
     "DownloadWebUIApp": "下载 Backend.AI Web UI 应用程序",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU 已啟用。",
-    "ATOMPlusEnabled": "ATOM+ NPU 啟用"
+    "ATOMPlusEnabled": "ATOM+ NPU 啟用",
+    "InvitatedFrom": "從："
   },
   "session": {
     "launcher": {

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -1129,7 +1129,6 @@ export default class BackendAILogin extends BackendAIPage {
    * @return {Promise<any> | void}
    * */
   private _loadConfigFromWebServer() {
-    console.log('!');
     if (!window.location.href.startsWith(this.api_endpoint)) {
       // Override configs with Webserver's config.
       const webuiEl = document.querySelector('backend-ai-webui');

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -1129,6 +1129,7 @@ export default class BackendAILogin extends BackendAIPage {
    * @return {Promise<any> | void}
    * */
   private _loadConfigFromWebServer() {
+    console.log('!');
     if (!window.location.href.startsWith(this.api_endpoint)) {
       // Override configs with Webserver's config.
       const webuiEl = document.querySelector('backend-ai-webui');

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -418,7 +418,6 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   }
 
   loadConfig(config): void {
-    console.log('!');
     if (
       typeof config.general !== 'undefined' &&
       'siteDescription' in config.general

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -418,6 +418,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   }
 
   loadConfig(config): void {
+    console.log('!');
     if (
       typeof config.general !== 'undefined' &&
       'siteDescription' in config.general
@@ -894,13 +895,6 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
         <div id="loading-drag-area" class="loading-background-drag-area"></div>
       </div>
       <div id="app-page">
-        <backend-ai-summary-view
-          class="page"
-          name="summary"
-          ?active="${this._page === 'summary'}"
-        >
-          <mwc-circular-progress indeterminate></mwc-circular-progress>
-        </backend-ai-summary-view>
         <backend-ai-import-view
           class="page"
           name="import"


### PR DESCRIPTION
### This PR is one of several steps to resolve issue #2170.
> [!CAUTION]
> **The PR associated with #2170 was not created with graphite from the beginning! There is some code that was committed from the PR on an earlier stack. Please read the Description carefully to see all the code that is included in the PRs on that stack!**
### Feature
The scope of this PR is to reflect on each item in the BAIBoard. Each item name starts with SummaryItem. All items will behave responsively in preparation for resize. 

We need a new component design for the BAIBoard. 
- StartMenu
  - The size of the logo changes depending on the container size. 
- Invitation 
  - The default UI has changed. 
- App Download 
  - Same as before. 
- ShortCut 
  - The default UI has changed. 
  - The number of items in a single ROW depends on the component size. 
  - Description added.

### How to test?
>You don't need to review the components that go into the children of a board item; that's covered in other stacks.
- Restore the Commented out SummaryPage component in App.tsx.
- Remove `<backend-ai-summary-view>` components in backend-ai-webui.ts
- If you can't see Summary Page Items, delete localStorage.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
