### PR TITLE
fix: `supports` type of `useSuspendedBackendaiClient`

### DIFF
--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -1,3 +1,4 @@
+import { filterEmptyItem } from '../../helper';
 import { useCustomThemeConfig } from '../../helper/customThemeConfig';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../../hooks';
 import { useCurrentUserRole } from '../../hooks/backendai';
@@ -26,6 +27,7 @@ import {
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
 import { theme, MenuProps, Typography } from 'antd';
+import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -67,7 +69,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
 
   const [isOpenSignoutModal, { toggle: toggleSignoutModal }] = useToggle(false);
 
-  const generalMenu: MenuProps['items'] = [
+  const generalMenu = filterEmptyItem<ItemType>([
     {
       label: t('webui.menu.Summary'),
       icon: <DashboardOutlined />,
@@ -116,7 +118,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
         window.open(fasttrackEndpoint, '_blank', 'noopener noreferrer');
       },
     },
-  ];
+  ]);
 
   const adminMenu: MenuProps['items'] = [
     {

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -1,5 +1,6 @@
 import {
   bytesToGB,
+  filterEmptyItem,
   localeCompare,
   numberSorterWithInfinityValue,
 } from '../helper';
@@ -94,7 +95,7 @@ const ProjectResourcePolicyList: React.FC<
       }
     `);
 
-  const columns = _.filter<ColumnType<ProjectResourcePolicies>>([
+  const columns = filterEmptyItem<ColumnType<ProjectResourcePolicies>>([
     {
       title: t('resourcePolicy.Name'),
       dataIndex: 'name',

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -1,5 +1,6 @@
 import {
   bytesToGB,
+  filterEmptyItem,
   localeCompare,
   numberSorterWithInfinityValue,
 } from '../helper';
@@ -102,7 +103,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
       }
     `);
 
-  const columns = _.filter<ColumnType<UserResourcePolicies>>([
+  const columns = filterEmptyItem<ColumnType<UserResourcePolicies>>([
     {
       title: t('resourcePolicy.Name'),
       dataIndex: 'name',

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -1,6 +1,7 @@
 import {
   addNumberWithUnits,
   compareNumberWithUnits,
+  filterEmptyItem,
   iSizeToSize,
   isOutsideRange,
   isOutsideRangeWithUnits,
@@ -270,5 +271,25 @@ describe('numberSorterWithInfinityValue', () => {
     expect(numberSorterWithInfinityValue(1, undefined, -1, 0)).toBeGreaterThan(
       0,
     );
+  });
+});
+
+describe('filterEmptyItem', () => {
+  it('should filter out undefined, null, empty string, false, empty array, and empty object', () => {
+    const input = [undefined, null, '', false, [], {}, 'item1', 'item2'];
+    const output = filterEmptyItem(input);
+    expect(output).toEqual(['item1', 'item2']);
+  });
+
+  it('should return an empty array when all items are empty', () => {
+    const input = [undefined, null, '', false, [], {}];
+    const output = filterEmptyItem(input);
+    expect(output).toEqual([]);
+  });
+
+  it('should return the same array when no items are empty', () => {
+    const input = ['item1', 'item2', 'item3'];
+    const output = filterEmptyItem(input);
+    expect(output).toEqual(['item1', 'item2', 'item3']);
   });
 });

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -344,3 +344,14 @@ export const numberSorterWithInfinityValue = (
   };
   return transform(a) - transform(b);
 };
+
+/**
+ * Filters out empty items from an array.
+ *
+ * @template T - The type of items in the array.
+ * @param arr - The array to filter.
+ * @returns An array containing only non-empty items.
+ */
+export const filterEmptyItem = <T,>(
+  arr: Array<T | undefined | null | '' | false | any[] | object>,
+): Array<T> => _.filter(arr, (item) => !_.isEmpty(item)) as Array<T>;

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -122,6 +122,7 @@ export const useSuspendedBackendaiClient = () => {
       list_allowed_types: () => Promise<string[]>;
       clone: (input: any, name: string) => Promise<any>;
     };
+    supports: (feature: string) => boolean;
     [key: string]: any;
     _config: BackendAIConfig;
     isManagerVersionCompatibleWith: (version: string) => boolean;

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -2,6 +2,7 @@ import FlexActivityIndicator from '../components/FlexActivityIndicator';
 import KeypairResourcePolicyList from '../components/KeypairResourcePolicyList';
 import ProjectResourcePolicyList from '../components/ProjectResourcePolicyList';
 import UserResourcePolicyList from '../components/UserResourcePolicyList';
+import { filterEmptyItem } from '../helper';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { Card } from 'antd';
 import React, { Suspense } from 'react';
@@ -36,7 +37,7 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
           },
         );
       }}
-      tabList={[
+      tabList={filterEmptyItem([
         {
           key: 'keypair',
           label: t('resourcePolicy.Keypair'),
@@ -49,7 +50,7 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
           key: 'project',
           label: t('resourcePolicy.Project'),
         },
-      ]}
+      ])}
       styles={{
         body: {
           padding: 0,


### PR DESCRIPTION
This PR has two changes:

- The `supports` function of Backend.AI client returns a boolean type. Before this PR, there was no return type definition for `supports`, so TypeScript handled it as an `any` type. However, this is not ideal for checking type errors.
- The item type of `Menu` and `Column` cannot handle boolean values, so we need a function to filter and preserve TS types. This PR introduces `filterEmptyItem` for that.


<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
