### PR TITLE
feat: Lucide icon with custom svgs

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -31,6 +31,7 @@
         "jotai": "^2.8.3",
         "jotai-effect": "^1.0.0",
         "lodash": "^4.17.21",
+        "lucide-react": "^0.383.0",
         "markdown-to-jsx": "^7.4.7",
         "prettier": "^3.3.1",
         "prism-react-renderer": "^2.3.1",
@@ -15883,6 +15884,14 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.383.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.383.0.tgz",
+      "integrity": "sha512-13xlG0CQCJtzjSQYwwJ3WRqMHtRj3EXmLlorrARt7y+IHnxUCp3XyFNL1DfaGySWxHObDvnu1u1dV+0VMKHUSg==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/react/package.json
+++ b/react/package.json
@@ -25,6 +25,7 @@
     "jotai": "^2.8.3",
     "jotai-effect": "^1.0.0",
     "lodash": "^4.17.21",
+    "lucide-react": "^0.383.0",
     "markdown-to-jsx": "^7.4.7",
     "prettier": "^3.3.1",
     "prism-react-renderer": "^2.3.1",

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -4,6 +4,8 @@ import rawFixAntCss from '../fix_antd.css?raw';
 import { useCustomThemeConfig } from '../helper/customThemeConfig';
 import { ReactWebComponentProps } from '../helper/react-to-webcomponent';
 import { ThemeModeProvider, useThemeMode } from '../hooks/useThemeMode';
+// @ts-ignore
+import indexCss from '../index.css?raw';
 import { StyleProvider, createCache } from '@ant-design/cssinjs';
 import { useUpdateEffect } from 'ahooks';
 import { App, AppProps, ConfigProvider, theme } from 'antd';
@@ -175,6 +177,7 @@ const DefaultProvidersForWebComponent: React.FC<DefaultProvidersProps> = ({
             <style>
               {styles}
               {rawFixAntCss}
+              {indexCss}
             </style>
             <QueryClientProvider client={queryClient}>
               <ShadowRootContext.Provider value={shadowRoot}>

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -12,7 +12,6 @@ import {
   ApiOutlined,
   BarChartOutlined,
   BarsOutlined,
-  CaretRightOutlined,
   CloudUploadOutlined,
   ControlOutlined,
   DashboardOutlined,
@@ -29,6 +28,7 @@ import { useToggle } from 'ahooks';
 import { theme, MenuProps, Typography } from 'antd';
 import { ItemType } from 'antd/lib/menu/interface';
 import _ from 'lodash';
+import { PlayIcon } from 'lucide-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
@@ -87,7 +87,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
     },
     {
       label: t('webui.menu.Import&Run'),
-      icon: <CaretRightOutlined />,
+      icon: <PlayIcon />,
       key: 'import',
     },
     {

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -1,13 +1,6 @@
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+/* fix: match the icon size between Lucide and Ant.d icons */
+.lucide {
+  width: 1em !important;
+  height: 1em !important;
+  vertical-align: -0.125em !important;
 }

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -11,6 +11,7 @@ import reactToWebComponent, {
 import { useSuspendedBackendaiClient } from './hooks';
 import { useCurrentResourceGroupValue } from './hooks/useCurrentProject';
 import { ThemeModeProvider } from './hooks/useThemeMode';
+import './index.css';
 import { Provider as JotaiProvider } from 'jotai';
 import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom/client';


### PR DESCRIPTION
### TL;DR

Add `lucide-react` dependency to the project.

This PR change a  only one icon for testing and improving UI.
| Before | After |
| -- | -- |
|  ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/92a511a7-b276-430f-93f6-9a010ffc47ae.png) |  ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/d8c0ed05-b34e-4ba7-9b42-05bb71dc92a3.png) |

FYI, only the icons that are imported into your project are included in the final bundle.

### What changed?

This PR adds the `lucide-react` library (version ^0.383.0) as a dependency in both `package.json` and `package-lock.json` files. The `lucide-react` library provides a set of SVG icons for React.

### How to test?

1. Run `npm install` to update your local dependencies.
2. Ensure there are no installation errors.
3. Verify that the `lucide-react` library is correctly listed in your `node_modules` directory.
4. Import and use any icon from `lucide-react` in your React components to ensure it's working as expected.

### Why make this change?

The `lucide-react` library adds a collection of essential React icons, enhancing our project's UI consistency and reducing the need to import individual icons from different sources.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
