### PR TITLE
refactor: replace Recoil with Jotai

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -36,7 +36,6 @@
     "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
     "react-syntax-highlighter": "^15.5.0",
-    "recoil": "^0.7.7",
     "typescript": "^5.4.5",
     "use-query-params": "^2.2.1",
     "uuid": "^9.0.1",

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -17,7 +17,6 @@ import {
   RouterProvider,
   createBrowserRouter,
 } from 'react-router-dom';
-import { RecoilRoot } from 'recoil';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
@@ -246,11 +245,9 @@ const router = createBrowserRouter([
 
 const App: FC = () => {
   return (
-    <RecoilRoot>
-      <DefaultProvidersForReactRoot>
-        <RouterProvider router={router} />
-      </DefaultProvidersForReactRoot>
-    </RecoilRoot>
+    <DefaultProvidersForReactRoot>
+      <RouterProvider router={router} />
+    </DefaultProvidersForReactRoot>
   );
 };
 

--- a/react/src/components/BAIContentWithDrawerArea.tsx
+++ b/react/src/components/BAIContentWithDrawerArea.tsx
@@ -1,8 +1,8 @@
 import { isOpenDrawerState } from './BAINotificationButton';
 import { Grid, Layout, theme } from 'antd';
 import { BasicProps } from 'antd/lib/layout/layout';
+import { useAtomValue } from 'jotai';
 import React from 'react';
-import { useRecoilValue } from 'recoil';
 
 interface Props extends BasicProps {
   drawerWidth?: number;
@@ -11,7 +11,7 @@ const BAIContentWithDrawerArea: React.FC<Props> = ({
   drawerWidth = 256,
   ...contextProps
 }) => {
-  const isOpenDrawer = useRecoilValue(isOpenDrawerState);
+  const isOpenDrawer = useAtomValue(isOpenDrawerState);
   const { xl } = Grid.useBreakpoint();
   const { token } = theme.useToken();
   const drawerStyle = xl && isOpenDrawer ? 'margin-style' : 'overlay-style';

--- a/react/src/components/BAINotificationButton.tsx
+++ b/react/src/components/BAINotificationButton.tsx
@@ -6,21 +6,18 @@ import WEBUINotificationDrawer from './WEBUINotificationDrawer';
 import { BellOutlined } from '@ant-design/icons';
 import { Badge, Button } from 'antd';
 import type { ButtonProps } from 'antd';
+import { atom, useAtom } from 'jotai';
 import _ from 'lodash';
 import React, { useEffect } from 'react';
-import { atom, useRecoilState } from 'recoil';
 
 interface Props extends ButtonProps {}
-export const isOpenDrawerState = atom({
-  key: 'is-open-bai-drawer',
-  default: false,
-});
+export const isOpenDrawerState = atom(false);
 
 const BAINotificationButton: React.FC<Props> = ({ ...props }) => {
   const [notifications, { upsertNotification }] = useBAINotificationState();
   useBAINotificationEffect();
 
-  const [isOpenDrawer, setIsOpenDrawer] = useRecoilState(isOpenDrawerState);
+  const [isOpenDrawer, setIsOpenDrawer] = useAtom(isOpenDrawerState);
   useEffect(() => {
     const handler = (e: any) => {
       upsertNotification(e.detail);

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -11,9 +11,9 @@ import { DRAWER_WIDTH } from '../WEBUINotificationDrawer';
 import WebUIHeader from './WebUIHeader';
 import WebUISider from './WebUISider';
 import { App, Layout, theme } from 'antd';
+import { atom, useSetAtom } from 'jotai';
 import { Suspense, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useNavigate, Outlet } from 'react-router-dom';
-import { atom, useSetRecoilState } from 'recoil';
 
 export const HEADER_Z_INDEX_IN_MAIN_LAYOUT = 5;
 export type PluginPage = {
@@ -30,13 +30,14 @@ export type WebUIPluginType = {
   'menuitem-superadmin': string[];
 };
 
-export const mainContentDivRefState = atom<React.RefObject<HTMLElement>>({
-  key: 'MainLayout.mainContentDivRefState',
-});
+export const mainContentDivRefState = atom<React.RefObject<HTMLElement | null>>(
+  {
+    current: null,
+  },
+);
 
 function MainLayout() {
   const navigate = useNavigate();
-
   const [compactSidebarActive] = useBAISettingUserState('compact_sidebar');
   const [sideCollapsed, setSideCollapsed] =
     useState<boolean>(!!compactSidebarActive);
@@ -52,7 +53,7 @@ function MainLayout() {
   const { token } = theme.useToken();
   const webUIRef = useRef<HTMLElement>(null);
   const contentScrollFlexRef = useRef<HTMLDivElement>(null);
-  const setMainContentDivRefState = useSetRecoilState(mainContentDivRefState);
+  const setMainContentDivRefState = useSetAtom(mainContentDivRefState);
   useEffect(() => {
     setMainContentDivRefState(contentScrollFlexRef);
   }, [contentScrollFlexRef, setMainContentDivRefState]);

--- a/react/src/components/NeoSessionLauncherSwitchAlert.tsx
+++ b/react/src/components/NeoSessionLauncherSwitchAlert.tsx
@@ -2,17 +2,14 @@ import { useBAISettingUserState } from '../hooks/useBAISetting';
 import Flex from './Flex';
 import { ThunderboltTwoTone } from '@ant-design/icons';
 import { Alert, AlertProps, Segmented, Typography, theme } from 'antd';
+import { atom, useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { atom, useRecoilState } from 'recoil';
 
 interface NeoSessionLauncherSwitchAlertProps extends AlertProps {
   onChange?: (value: 'current' | 'neo') => void;
 }
 
-const isClosedState = atom<boolean>({
-  key: 'NeoSessionLauncherSwitchAlert:isCloseState',
-  default: false,
-});
+const isClosedState = atom<boolean>(false);
 
 const NeoSessionLauncherSwitchAlert: React.FC<
   NeoSessionLauncherSwitchAlertProps
@@ -23,7 +20,7 @@ const NeoSessionLauncherSwitchAlert: React.FC<
   const { token } = theme.useToken();
   const { t } = useTranslation();
 
-  const [isClosed, setIsClosed] = useRecoilState(isClosedState);
+  const [isClosed, setIsClosed] = useAtom(isClosedState);
   return (
     isClosed || (
       <Alert

--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -2,10 +2,10 @@ import { useSuspendedBackendaiClient, useWebUINavigate } from '.';
 import BAINotificationItem from '../components/BAINotificationItem';
 import { App } from 'antd';
 import { ArgsProps } from 'antd/lib/notification';
+import { atom, useAtomValue, useSetAtom } from 'jotai';
 import _ from 'lodash';
 import { Key, useCallback, useEffect, useRef } from 'react';
 import { To } from 'react-router-dom';
-import { atom, useRecoilValue, useSetRecoilState } from 'recoil';
 import { v4 as uuidv4 } from 'uuid';
 
 const _activeNotificationKeys: Key[] = [];
@@ -32,10 +32,7 @@ export interface NotificationState
   extraDescription?: string;
 }
 
-export const notificationListState = atom<NotificationState[]>({
-  key: 'webui-notification',
-  default: [],
-});
+export const notificationListState = atom<NotificationState[]>([]);
 
 export const CLOSING_DURATION = 1; //second
 
@@ -44,7 +41,7 @@ export const CLOSING_DURATION = 1; //second
  * @returns A tuple containing the notifications and a function to set the BAI notification.
  */
 export const useBAINotificationState = () => {
-  const _notifications = useRecoilValue(notificationListState);
+  const _notifications = useAtomValue(notificationListState);
 
   return [_notifications, useSetBAINotification()] as const;
 };
@@ -53,7 +50,7 @@ export const useBAINotificationState = () => {
  * Custom hook that listens to background tasks and updates notifications accordingly.
  */
 export const useBAINotificationEffect = () => {
-  const _notifications = useRecoilValue(notificationListState);
+  const _notifications = useAtomValue(notificationListState);
 
   const listeningTaskIdsRef = useRef<(string | undefined)[]>([]);
   // const closedNotificationKeysRef = useRef<(React.Key | undefined)[]>([]);
@@ -237,7 +234,7 @@ export const useBAINotificationEffect = () => {
  */
 export const useSetBAINotification = () => {
   // Don't use _notifications carefully when you need to mutate it.
-  const setNotifications = useSetRecoilState(notificationListState);
+  const setNotifications = useSetAtom(notificationListState);
 
   const app = App.useApp();
 

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -76,6 +76,7 @@ import {
   theme,
 } from 'antd';
 import dayjs from 'dayjs';
+import { useAtomValue } from 'jotai';
 import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -83,7 +84,6 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { dark } from 'react-syntax-highlighter/dist/esm/styles/hljs';
-import { useRecoilValue } from 'recoil';
 import {
   JsonParam,
   NumberParam,
@@ -150,7 +150,7 @@ const SessionLauncherPage = () => {
   const app = App.useApp();
   let sessionMode: SessionMode = 'normal';
 
-  const mainContentDivRef = useRecoilValue(mainContentDivRefState);
+  const mainContentDivRef = useAtomValue(mainContentDivRefState);
   const baiClient = useSuspendedBackendaiClient();
 
   const [isStartingSession, setIsStartingSession] = useState(false);

--- a/src/components/backend-ai-settings-store.ts
+++ b/src/components/backend-ai-settings-store.ts
@@ -63,27 +63,31 @@ export default class BackendAiSettingsStore extends BackendAIPage {
     }
   }
 
-  set(name, value, namespace = 'user') {
-    const event = new CustomEvent('backendaiwebui.settings:set', {
-      detail: {
-        name: name,
-        value: value,
-        namespace: namespace,
-      },
-    });
-    document.dispatchEvent(event);
-    return this._writeUserSetting(name, value, namespace);
+  set(name, value, namespace = 'user', skipDispatch = false) {
+    if (!skipDispatch) {
+      const event = new CustomEvent('backendaiwebui.settings:set', {
+        detail: {
+          name: name,
+          value: value,
+          namespace: namespace,
+        },
+      });
+      document.dispatchEvent(event);
+    }
+    this.options[namespace + '.' + name] = value;
   }
 
-  delete(name, namespace = 'user') {
-    const event = new CustomEvent('backendaiwebui.settings:delete', {
-      detail: {
-        name: name,
-        namespace: namespace,
-      },
-    });
-    document.dispatchEvent(event);
-    return this._deleteUserSetting(name, namespace);
+  delete(name, namespace = 'user', skipDispatch = false) {
+    if (!skipDispatch) {
+      const event = new CustomEvent('backendaiwebui.settings:delete', {
+        detail: {
+          name: name,
+          namespace: namespace,
+        },
+      });
+      document.dispatchEvent(event);
+    }
+    delete this.options[namespace + '.' + name];
   }
 
   _readSetting(name, default_value = true, namespace = 'user') {
@@ -103,39 +107,6 @@ export default class BackendAiSettingsStore extends BackendAIPage {
     } else {
       this.options[name] = default_value;
     }
-  }
-
-  _writeUserSetting(name, value, namespace) {
-    if (value === false) {
-      localStorage.setItem(
-        'backendaiwebui.settings.' + namespace + '.' + name,
-        'false',
-      );
-    } else if (value === true) {
-      localStorage.setItem(
-        'backendaiwebui.settings.' + namespace + '.' + name,
-        'true',
-      );
-    } else if (typeof value === 'object') {
-      localStorage.setItem(
-        'backendaiwebui.settings.' + namespace + '.' + name,
-        JSON.stringify(value),
-      );
-    } else {
-      localStorage.setItem(
-        'backendaiwebui.settings.' + namespace + '.' + name,
-        value,
-      );
-    }
-    this.options[namespace + '.' + name] = value;
-  }
-
-  _deleteUserSetting(name, namespace) {
-    localStorage.removeItem(
-      'backendaiwebui.settings.' + namespace + '.' + name,
-    );
-    delete this.options[namespace + '.' + name];
-    return true;
   }
 
   isJson(str) {


### PR DESCRIPTION
This PR replaces Recoil with Jotai because Recoil is unmaintained and has a bug in React 19.