### PR TITLE
ci: add permissions to Jest report github action

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -10,9 +10,12 @@ on:
 defaults:
   run:
     working-directory: ./react
-
 jobs:
   coverage:
+    permissions: 
+      checks: write
+      pull-requests: write
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
After changing to GitHub Enterprise, the default permission setting has been changed. Therefore, it's necessary to set the permissions in the GitHub Actions YAML file.