### PR TITLE
feat: Import notebook using Neo Session Launcher

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -5,13 +5,15 @@ import {
   RoutingEventHandler,
 } from './components/DefaultProviders';
 import Flex from './components/Flex';
+import LocationStateBreadCrumb from './components/LocationStateBreadCrumb';
 import MainLayout from './components/MainLayout/MainLayout';
 import { useSuspendedBackendaiClient, useWebUINavigate } from './hooks';
+import { useBAISettingUserState } from './hooks/useBAISetting';
 import Page401 from './pages/Page401';
 import Page404 from './pages/Page404';
 import VFolderListPage from './pages/VFolderListPage';
-import { theme } from 'antd';
-import React from 'react';
+import { Skeleton, theme } from 'antd';
+import React, { Suspense } from 'react';
 import { FC } from 'react';
 import {
   Navigate,
@@ -56,6 +58,7 @@ const ServiceLauncherUpdatePage = React.lazy(
 const InteractiveLoginPage = React.lazy(
   () => import('./pages/InteractiveLoginPage'),
 );
+const ImportAndRunPage = React.lazy(() => import('./pages/ImportAndRunPage'));
 
 const router = createBrowserRouter([
   {
@@ -181,6 +184,27 @@ const router = createBrowserRouter([
       {
         path: '/import',
         handle: { labelKey: 'webui.menu.Import&Run' },
+        Component: () => {
+          const { token } = theme.useToken();
+          const [is2409Launcher] = useBAISettingUserState(
+            'use_2409_session_launcher',
+          );
+          return (
+            <BAIErrorBoundary>
+              <NeoSessionLauncherSwitchAlert
+                style={{ marginBottom: token.paddingContentVerticalLG }}
+              />
+              {is2409Launcher ? null : <ImportAndRunPage />}
+              {/* @ts-ignore */}
+              <backend-ai-import-view
+                active
+                class="page"
+                name="import"
+                sessionLauncherType={is2409Launcher ? 'classic' : 'neo'}
+              />
+            </BAIErrorBoundary>
+          );
+        },
       },
       {
         path: '/data',
@@ -289,7 +313,16 @@ const router = createBrowserRouter([
                   }
                 }}
               />
-              <SessionLauncherPage />
+              <LocationStateBreadCrumb />
+              <Suspense
+                fallback={
+                  <Flex direction="column" style={{ maxWidth: 700 }}>
+                    <Skeleton active />
+                  </Flex>
+                }
+              >
+                <SessionLauncherPage />
+              </Suspense>
             </Flex>
           );
         },

--- a/react/src/components/ImportNotebook.tsx
+++ b/react/src/components/ImportNotebook.tsx
@@ -1,0 +1,92 @@
+import { generateRandomString } from '../helper';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import {
+  AppOption,
+  SessionLauncherFormValue,
+} from '../pages/SessionLauncherPage';
+import { SessionLauncherPageLocationState } from './LocationStateBreadCrumb';
+import { CloudDownloadOutlined } from '@ant-design/icons';
+import { Button, Form, FormInstance, FormProps, Input } from 'antd';
+import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const regularizeGithubURL = (url: string) => {
+  url = url.replace('/blob/', '/');
+  url = url.replace('github.com', 'raw.githubusercontent.com');
+  return url;
+};
+const ImportNotebook: React.FC<FormProps> = (props) => {
+  const formRef = useRef<FormInstance<{
+    url: string;
+  }> | null>(null);
+  const { t } = useTranslation();
+  const webuiNavigate = useWebUINavigate();
+  useSuspendedBackendaiClient();
+  return (
+    <Form ref={formRef} layout="inline" requiredMark="optional" {...props}>
+      <Form.Item
+        name="url"
+        label={t('import.NotebookURL')}
+        rules={[
+          {
+            required: true,
+          },
+          {
+            pattern: new RegExp('^(https?)://([\\w./-]{1,}).ipynb$'),
+            message: t('import.InvalidNotebookURL'),
+          },
+          {
+            type: 'string',
+            max: 2048,
+          },
+        ]}
+        style={{
+          flex: 1,
+        }}
+      >
+        <Input placeholder={t('import.NotebookURL')} />
+      </Form.Item>
+      <Button
+        icon={<CloudDownloadOutlined />}
+        type="primary"
+        onClick={() => {
+          formRef.current
+            ?.validateFields()
+            .then((values) => {
+              const notebookURL = regularizeGithubURL(values.url);
+              const launcherValue: DeepPartial<SessionLauncherFormValue> = {
+                sessionName: 'imported-notebook-' + generateRandomString(5),
+                environments: {
+                  environment: 'cr.backend.ai/stable/python',
+                },
+                bootstrap_script: '#!/bin/sh\ncurl -O ' + notebookURL,
+              };
+              const params = new URLSearchParams();
+              params.set('step', '4');
+              params.set('formValues', JSON.stringify(launcherValue));
+              params.set(
+                'appOption',
+                JSON.stringify({
+                  runtime: 'jupyter',
+                  filename: notebookURL.split('/').pop(),
+                } as AppOption),
+              );
+              webuiNavigate(`/session/start?${params.toString()}`, {
+                state: {
+                  from: {
+                    pathname: '/import',
+                    label: t('webui.menu.Import&Run'),
+                  },
+                } as SessionLauncherPageLocationState,
+              });
+            })
+            .catch(() => {});
+        }}
+      >
+        {t('import.GetAndRunNotebook')}
+      </Button>
+    </Form>
+  );
+};
+
+export default ImportNotebook;

--- a/react/src/components/LocationStateBreadCrumb.tsx
+++ b/react/src/components/LocationStateBreadCrumb.tsx
@@ -1,0 +1,49 @@
+import { useWebUINavigate } from '../hooks';
+import { Breadcrumb } from 'antd';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
+
+export type SessionLauncherPageLocationState = {
+  alert?: {
+    type: 'success' | 'info' | 'warning' | 'error';
+    message: string;
+    description?: string;
+  };
+  from?: {
+    pathname: string;
+    label?: any;
+  };
+};
+
+const LocationStateBreadCrumb = () => {
+  const {
+    state: locationState,
+  }: {
+    state: SessionLauncherPageLocationState | undefined;
+  } = useLocation();
+  const webuiNavigate = useWebUINavigate();
+  const { t } = useTranslation();
+  return (
+    locationState?.from && (
+      <Breadcrumb
+        items={[
+          {
+            title: locationState.from.label || locationState.from.pathname,
+            onClick: (e) => {
+              e.preventDefault();
+              locationState.from?.pathname &&
+                webuiNavigate(locationState.from?.pathname);
+            },
+            href: locationState.from.pathname,
+          },
+          {
+            title: t('session.launcher.StartNewSession'),
+          },
+        ]}
+      />
+    )
+  );
+};
+
+export default LocationStateBreadCrumb;

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -355,3 +355,21 @@ export const numberSorterWithInfinityValue = (
 export const filterEmptyItem = <T,>(
   arr: Array<T | undefined | null | '' | false | any[] | object>,
 ): Array<T> => _.filter(arr, (item) => !_.isEmpty(item)) as Array<T>;
+
+export const generateRandomString = (n = 3) => {
+  let randNum = Math.floor(Math.random() * 52 * 52 * 52);
+
+  const parseNum = (num: number) => {
+    if (num < 26) return String.fromCharCode(65 + num);
+    else return String.fromCharCode(97 + num - 26);
+  };
+
+  let randStr = '';
+
+  for (let i = 0; i < n; i++) {
+    randStr += parseNum(randNum % 52);
+    randNum = Math.floor(randNum / 52);
+  }
+
+  return randStr;
+};

--- a/react/src/pages/ImportAndRunPage.tsx
+++ b/react/src/pages/ImportAndRunPage.tsx
@@ -1,0 +1,23 @@
+import BAICard from '../BAICard';
+import ImportNotebook from '../components/ImportNotebook';
+import { theme } from 'antd';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const ImportAndRunPage = () => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  return (
+    <BAICard
+      title={t('import.ImportNotebook')}
+      style={{
+        maxWidth: 728,
+        marginBottom: token.paddingMD,
+      }}
+    >
+      <ImportNotebook />
+    </BAICard>
+  );
+};
+
+export default ImportAndRunPage;

--- a/react/src/react-app-env.d.ts
+++ b/react/src/react-app-env.d.ts
@@ -15,3 +15,13 @@ type ArgumentTypes<F extends Function> = F extends (...args: infer A) => any
 declare global {
   var isDarkMode: boolean;
 }
+
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T[P] extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T[P] extends object
+        ? DeepPartial<T[P]>
+        : T[P];
+};

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "GitLab-Repository importieren",
     "GitlabRepoWillBeFolder": "Importierte GitLab-Repositories werden in Ordner umgewandelt und können beim Start der Sitzung gemountet werden.",
     "GitlabURL": "GitLab-URL",
-    "GitlabDefaultBranch": "GitLab-Zweigname"
+    "GitlabDefaultBranch": "GitLab-Zweigname",
+    "InvalidNotebookURL": "Ungültige Notbook-URL."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Statistik für diesen Monat",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "Εισαγωγή αποθετηρίου GitLab",
     "GitlabRepoWillBeFolder": "Τα εισαγόμενα αποθετήρια GitLab μετατρέπονται σε φακέλους και μπορούν να προσαρτηθούν κατά την έναρξη της συνεδρίας.",
     "GitlabURL": "URL του GitLab",
-    "GitlabDefaultBranch": "Όνομα υποκαταστήματος GitLab"
+    "GitlabDefaultBranch": "Όνομα υποκαταστήματος GitLab",
+    "InvalidNotebookURL": "Μη έγκυρη διεύθυνση URL του Notbook."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Στατιστικά για αυτόν τον μήνα",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1513,7 +1513,8 @@
     "ImportGitlabRepo": "Import GitLab Repository",
     "GitlabRepoWillBeFolder": "Imported GitLab repositories are converted to folders and can be mounted when session starts.",
     "GitlabURL": "GitLab URL",
-    "GitlabDefaultBranch": "GitLab Branch Name"
+    "GitlabDefaultBranch": "GitLab Branch Name",
+    "InvalidNotebookURL": "Invalid Notbook URL."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Statistics for This Month",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -552,7 +552,8 @@
     "ReadyToImport": "Listo para importar",
     "RepoWillBeFolder": "Los repositorios de GitHub importados se convierten en carpetas y se pueden montar al iniciar la sesión.",
     "WrongURLType": "Tipo de URL incorrecto",
-    "YouCanCreateNotebookCode": "Introduce la URL del cuaderno para crear un código de insignia como el siguiente que puedes ejecutar directamente en Backend.AI."
+    "YouCanCreateNotebookCode": "Introduce la URL del cuaderno para crear un código de insignia como el siguiente que puedes ejecutar directamente en Backend.AI.",
+    "InvalidNotebookURL": "URL de Notbook no válida."
   },
   "information": {
     "APIVersion": "Versión API",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -552,7 +552,8 @@
     "ReadyToImport": "Valmis tuomaan",
     "RepoWillBeFolder": "Tuodut GitHub-arkistot muunnetaan kansioiksi ja ne voidaan asentaa istunnon alkaessa.",
     "WrongURLType": "Väärä URL-tyyppi",
-    "YouCanCreateNotebookCode": "Kirjoita muistikirjan URL-osoite luodaksesi alla olevan kaltaisen merkkikoodin, jonka voit suorittaa suoraan Backend.AI:ssa."
+    "YouCanCreateNotebookCode": "Kirjoita muistikirjan URL-osoite luodaksesi alla olevan kaltaisen merkkikoodin, jonka voit suorittaa suoraan Backend.AI:ssa.",
+    "InvalidNotebookURL": "Virheellinen Notbookin URL-osoite."
   },
   "information": {
     "APIVersion": "API-versio",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "Importer le dépôt GitLab",
     "GitlabRepoWillBeFolder": "Les dépôts GitLab importés sont convertis en dossiers et peuvent être montés au démarrage de la session.",
     "GitlabURL": "URL GitLab",
-    "GitlabDefaultBranch": "Nom de la branche GitLab"
+    "GitlabDefaultBranch": "Nom de la branche GitLab",
+    "InvalidNotebookURL": "L'URL de Notbook n'est pas valide."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Statistiques pour ce mois",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1390,7 +1390,8 @@
     "ImportGitlabRepo": "Impor Repositori GitLab",
     "GitlabRepoWillBeFolder": "Repositori GitLab yang diimpor akan dikonversi menjadi folder dan dapat dipasang saat sesi dimulai.",
     "GitlabURL": "URL GitLab",
-    "GitlabDefaultBranch": "Nama Cabang GitLab"
+    "GitlabDefaultBranch": "Nama Cabang GitLab",
+    "InvalidNotebookURL": "URL Notbook tidak valid."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Statistik Bulan Ini",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "Importare il repository GitLab",
     "GitlabRepoWillBeFolder": "I repository GitLab importati vengono convertiti in cartelle e possono essere montati all'avvio della sessione.",
     "GitlabURL": "URL di GitLab",
-    "GitlabDefaultBranch": "Nome della filiale GitLab"
+    "GitlabDefaultBranch": "Nome della filiale GitLab",
+    "InvalidNotebookURL": "URL del Notbook non valido."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Statistiche per questo mese",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "GitLabリポジトリのインポート",
     "GitlabRepoWillBeFolder": "インポートしたGitLabリポジトリはフォルダに変換され、セッション開始時にマウントすることができます。",
     "GitlabURL": "GitLabアドレス",
-    "GitlabDefaultBranch": "GitLab ブランチ名"
+    "GitlabDefaultBranch": "GitLab ブランチ名",
+    "InvalidNotebookURL": "無効なNotbook URLです。"
   },
   "usagepanel": {
     "StatisticsForThisMonth": "今月の統計",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1500,7 +1500,8 @@
     "ImportGitlabRepo": "GitLab 저장소 가져오기",
     "GitlabRepoWillBeFolder": "가져온 GitLab 저장소는 폴더로 변환되며, 세션을 시작할 때 마운트할 수 있습니다.",
     "GitlabURL": "GitLab 주소",
-    "GitlabDefaultBranch": "GitLab 브랜치 이름"
+    "GitlabDefaultBranch": "GitLab 브랜치 이름",
+    "InvalidNotebookURL": "유효하지 않은 노트북 URL입니다."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "이번달 통계",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1390,7 +1390,8 @@
     "ImportGitlabRepo": "GitLab репозиторыг импортлох",
     "GitlabRepoWillBeFolder": "Импортын GitLab репозиторуудыг хавтас болгон хөрвүүлдэг бөгөөд сесс эхлэхэд холбож болно.",
     "GitlabURL": "GitLab URL",
-    "GitlabDefaultBranch": "GitLab салбарын нэр"
+    "GitlabDefaultBranch": "GitLab салбарын нэр",
+    "InvalidNotebookURL": "Зөөврийн компьютерын URL буруу байна."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Энэ сарын статистик",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "Import Repositori GitLab",
     "GitlabRepoWillBeFolder": "Repositori GitLab yang diimport ditukar kepada folder dan boleh dipasang apabila sesi bermula.",
     "GitlabURL": "URL GitLab",
-    "GitlabDefaultBranch": "Nama Cawangan GitLab"
+    "GitlabDefaultBranch": "Nama Cawangan GitLab",
+    "InvalidNotebookURL": "URL Notbook tidak sah."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Statistik untuk Bulan Ini",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "Importowanie repozytorium GitLab",
     "GitlabRepoWillBeFolder": "Zaimportowane repozytoria GitLab są konwertowane do folderów i mogą być montowane podczas uruchamiania sesji.",
     "GitlabURL": "Adres URL GitLab",
-    "GitlabDefaultBranch": "Nazwa oddziału GitLab"
+    "GitlabDefaultBranch": "Nazwa oddziału GitLab",
+    "InvalidNotebookURL": "Nieprawidłowy adres URL Notbook."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Statystyki za ten miesiąc",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "Importar o repositório GitLab",
     "GitlabRepoWillBeFolder": "Os repositórios GitLab importados são convertidos em pastas e podem ser montados quando a sessão é iniciada.",
     "GitlabURL": "URL do GitLab",
-    "GitlabDefaultBranch": "Nome do ramo do GitLab"
+    "GitlabDefaultBranch": "Nome do ramo do GitLab",
+    "InvalidNotebookURL": "URL inválido do Notbook."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Estatísticas para este mês",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "Importar o repositório GitLab",
     "GitlabRepoWillBeFolder": "Os repositórios GitLab importados são convertidos em pastas e podem ser montados quando a sessão é iniciada.",
     "GitlabURL": "URL do GitLab",
-    "GitlabDefaultBranch": "Nome do ramo do GitLab"
+    "GitlabDefaultBranch": "Nome do ramo do GitLab",
+    "InvalidNotebookURL": "URL inválido do Notbook."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Estatísticas para este mês",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "Импорт репозитория GitLab",
     "GitlabRepoWillBeFolder": "Импортированные репозитории GitLab преобразуются в папки и могут быть смонтированы при запуске сессии.",
     "GitlabURL": "URL-адрес GitLab",
-    "GitlabDefaultBranch": "Имя филиала GitLab"
+    "GitlabDefaultBranch": "Имя филиала GitLab",
+    "InvalidNotebookURL": "Неверный URL-адрес Notbook."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Статистика за этот месяц",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "Gitlab Deposunu İçe Aktarma",
     "GitlabRepoWillBeFolder": "İçe aktarılan Gitlab depoları klasörlere dönüştürülür ve oturum başladığında bağlanabilir.",
     "GitlabURL": "Gitlab URL'si",
-    "GitlabDefaultBranch": "Gitlab Şube Adı"
+    "GitlabDefaultBranch": "Gitlab Şube Adı",
+    "InvalidNotebookURL": "Geçersiz Not Defteri URL'si."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Bu Ay İçin İstatistikler",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "Nhập kho lưu trữ GitLab",
     "GitlabRepoWillBeFolder": "Các kho lưu trữ GitLab đã nhập được chuyển đổi thành các thư mục và có thể được gắn kết khi phiên bắt đầu.",
     "GitlabURL": "URL GitLab",
-    "GitlabDefaultBranch": "Tên chi nhánh GitLab"
+    "GitlabDefaultBranch": "Tên chi nhánh GitLab",
+    "InvalidNotebookURL": "URL sổ tay không hợp lệ."
   },
   "usagepanel": {
     "StatisticsForThisMonth": "Số liệu thống kê cho tháng này",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "导入 GitLab 仓库",
     "GitlabRepoWillBeFolder": "导入的 GitLab 资源库会转换为文件夹，并可在会话启动时挂载。",
     "GitlabURL": "GitLab URL",
-    "GitlabDefaultBranch": "GitLab 分支名称"
+    "GitlabDefaultBranch": "GitLab 分支名称",
+    "InvalidNotebookURL": "Notbook URL 无效。"
   },
   "usagepanel": {
     "StatisticsForThisMonth": "本月统计",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1389,7 +1389,8 @@
     "ImportGitlabRepo": "导入 GitLab 仓库",
     "GitlabRepoWillBeFolder": "导入的 GitLab 资源库会转换为文件夹，并可在会话启动时挂载。",
     "GitlabURL": "GitLab URL",
-    "GitlabDefaultBranch": "GitLab 分支名称"
+    "GitlabDefaultBranch": "GitLab 分支名称",
+    "InvalidNotebookURL": "Notbook URL 无效。"
   },
   "usagepanel": {
     "StatisticsForThisMonth": "本月統計",

--- a/src/components/backend-ai-import-view.ts
+++ b/src/components/backend-ai-import-view.ts
@@ -70,6 +70,7 @@ export default class BackendAIImport extends BackendAIPage {
   @property({ type: String }) _helpDescription = '';
   @property({ type: String }) _helpDescriptionTitle = '';
   @property({ type: String }) _helpDescriptionIcon = '';
+  @property({ type: String }) sessionLauncherType = 'neo';
   @query('#loading-spinner') spinner!: LablupLoadingSpinner;
   @query('#resource-monitor') resourceMonitor!: BackendAiResourceMonitor;
   @query('#session-launcher') sessionLauncher!: BackendAiSessionLauncher;
@@ -228,10 +229,12 @@ export default class BackendAIImport extends BackendAIPage {
       this.requestUpdate();
     }
     // Given URL via URL path parameter.
-    this.requestURL = globalThis.currentPageParams.requestURL;
-    let queryString = globalThis.currentPageParams.queryString;
-    queryString = queryString.substring(queryString.indexOf('?') + 1);
-    this.queryString = queryString;
+    const currentUrl = window.location.href;
+    const url = new URL(currentUrl);
+    this.queryString = url.search;
+    const queryString = this.queryString.substring(
+      this.queryString.indexOf('?') + 1,
+    );
     this.importNotebookMessage = this.queryString;
     this.environment = this.guessEnvironment(this.queryString);
     if (queryString !== '') {
@@ -687,42 +690,46 @@ export default class BackendAIImport extends BackendAIPage {
     // language=HTML
     return html`
       <link rel="stylesheet" href="resources/custom.css" />
-      <div class="horizontal wrap layout" style="margin-bottom:24px;">
-        <lablup-activity-panel
-          title="${_t('import.ImportNotebook')}"
-          elevation="1"
-          horizontalsize="2x"
-        >
-          <div slot="message">
-            <div class="horizontal wrap layout center">
-              <mwc-textfield
-                id="notebook-url"
-                label="${_t('import.NotebookURL')}"
-                autoValidate
-                validationMessage="${_text('import.WrongURLType')}"
-                pattern="^(https?)://([\\w./-]{1,}).ipynb$"
-                maxLength="2048"
-                placeholder="${_t('maxLength.2048chars')}"
-                @change="${(e) =>
-                  this.urlTextfieldChanged(
-                    e,
-                    'import-notebook-button',
-                    'importNotebookMessage',
-                  )}"
-              ></mwc-textfield>
-              <mwc-button
-                id="import-notebook-button"
-                disabled
-                icon="cloud_download"
-                @click="${() => this.getNotebookFromURL()}"
+      ${this.sessionLauncherType !== 'neo'
+        ? html`
+            <div class="horizontal wrap layout" style="margin-bottom:24px;">
+              <lablup-activity-panel
+                title="${_t('import.ImportNotebook')}"
+                elevation="1"
+                horizontalsize="2x"
               >
-                <span>${_t('import.GetAndRunNotebook')}</span>
-              </mwc-button>
+                <div slot="message">
+                  <div class="horizontal wrap layout center">
+                    <mwc-textfield
+                      id="notebook-url"
+                      label="${_t('import.NotebookURL')}"
+                      autoValidate
+                      validationMessage="${_text('import.WrongURLType')}"
+                      pattern="^(https?)://([\\w./-]{1,}).ipynb$"
+                      maxLength="2048"
+                      placeholder="${_t('maxLength.2048chars')}"
+                      @change="${(e) =>
+                        this.urlTextfieldChanged(
+                          e,
+                          'import-notebook-button',
+                          'importNotebookMessage',
+                        )}"
+                    ></mwc-textfield>
+                    <mwc-button
+                      id="import-notebook-button"
+                      disabled
+                      icon="cloud_download"
+                      @click="${() => this.getNotebookFromURL()}"
+                    >
+                      <span>${_t('import.GetAndRunNotebook')}</span>
+                    </mwc-button>
+                  </div>
+                  ${this.importNotebookMessage}
+                </div>
+              </lablup-activity-panel>
             </div>
-            ${this.importNotebookMessage}
-          </div>
-        </lablup-activity-panel>
-      </div>
+          `
+        : html``}
       <backend-ai-session-launcher
         mode="import"
         location="import"

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -904,7 +904,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
         <backend-ai-import-view
           class="page"
           name="import"
-          ?active="${this._page === 'github' || this._page === 'import'}"
+          ?active="${this._page === 'github'}"
         >
           <mwc-circular-progress indeterminate></mwc-circular-progress>
         </backend-ai-import-view>


### PR DESCRIPTION
### TL;DR

This PR adds new components and lazy loading to the Neo session launcher. It also introduces a new `ImportAndRunPage` for importing and running notebooks directly from a URL, along with a breadcrumb component for navigation.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/a0518228-51de-4ea7-aa18-467fac48b22e.png)

### What changed?
- Added `ImportAndRunPage` component for notebook imports.
- Added `LocationStateBreadCrumb` component for breadcrumb navigation.
- Introduced lazy loading for `ImportAndRunPage` and other components to optimize performance.
- Updated `SessionLauncherPage` to integrate breadcrumbs and lazy loading.
- Refactored session launcher form to include a hidden bootstrap script input.
- Added various utility functions such as `generateRandomString`.

### How to test?
1. Navigate to the `/import` route in the application.
2. Test the notebook import functionality by providing a valid notebook URL.
For testing, you can use the following notebook URL:
```
https://github.com/hephaex/deeplearning-note/blob/3748249614eab59e6a801996e4fa53cdd7495c71/08_dimensionality_reduction.ipynb
```
3. Verify that the breadcrumb navigation appears correctly when navigating.
4. Ensure the lazy-loaded components are rendered correctly without impacting performance.

### Why make this change?
The addition of lazy loading and new components aims to optimize the performance and user experience. The new `ImportAndRunPage` feature is designed to simplify the process of importing and running notebooks.

---

