### PR TITLE
fix: adjust the position of mwc selection menu items

### DIFF
--- a/src/components/backend-ai-credential-list.ts
+++ b/src/components/backend-ai-credential-list.ts
@@ -147,8 +147,8 @@ export default class BackendAICredentialList extends BackendAIPage {
           padding-right: 5px;
         }
 
-        #policy-list {
-          width: 100%;
+        mwc-list-item {
+          width: var(--token-mwc-select-item-width, 340px);
         }
 
         backend-ai-dialog {
@@ -1362,6 +1362,7 @@ export default class BackendAICredentialList extends BackendAIPage {
             <mwc-select
               id="policy-list"
               label="${_t('credential.SelectPolicy')}"
+              fixedMenuPosition
             >
               ${Object.keys(this.resourcePolicy).map(
                 (rp) => html`


### PR DESCRIPTION
### This PR Resolves #2455 Issue

### Changes
I've set the `fixedMenuPosition' property to true and specified width.

|before|after|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/58cf847f-f08b-4e0e-b666-271ced4f411b.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/6e1609cc-b7f5-4199-92e6-5b4daa6945a8.png)|

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
