### PR TITLE
Add copyable button to My Environment page

### DIFF
--- a/react/src/pages/MyEnvironmentPage.tsx
+++ b/react/src/pages/MyEnvironmentPage.tsx
@@ -16,7 +16,7 @@ import {
 } from './__generated__/MyEnvironmentPageQuery.graphql';
 import { DeleteOutlined, SettingOutlined } from '@ant-design/icons';
 import { useLocalStorageState } from 'ahooks';
-import { App, Button, Card, Popconfirm, Table, theme } from 'antd';
+import { App, Button, Card, Popconfirm, Table, theme, Typography } from 'antd';
 import { AnyObject } from 'antd/es/_util/type';
 import { ColumnsType, ColumnType } from 'antd/es/table';
 import graphql from 'babel-plugin-relay/macro';
@@ -211,7 +211,16 @@ const MyEnvironmentPage: React.FC<PropsWithChildren> = ({ children }) => {
       key: 'control',
       fixed: 'right',
       render: (text, row) => (
-        <Flex direction="row" align="stretch">
+        <Flex direction="row" align="stretch" justify="center" gap="xxs">
+          <Typography.Text
+            copyable={{
+              text: getImageFullName(row) || '',
+            }}
+            style={{
+              paddingTop: token.paddingXXS,
+              paddingBottom: token.paddingXXS,
+            }}
+          />
           <Popconfirm
             title={t('dialog.ask.DoYouWantToProceed')}
             description={t('dialog.warning.CannotBeUndone')}


### PR DESCRIPTION
### TL;DR

Adds a copyable text component to the control column in the My Environment Page table.

### What changed?

- Added `Typography` import from `antd`
- Modified the table's control column to include a `Typography.Text` component that allows copying of the image full name
- Applied styling to ensure proper padding

### How to test?

- Navigate to the `My Environment Page`
- Verify that the control column now includes a copyable text element for the image full name
- Ensure that the copying functionality works as expected

### Why make this change?

This change enhances the user experience by providing a convenient way to copy the full name of the image directly from the table.

### Scrennshots
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/bc914193-3fb2-4cc8-94eb-292a8c8a69e2.png)


---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
