### PR TITLE
Fix overflow issue in manual image tag

### DIFF
--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1198,54 +1198,67 @@ const SessionLauncherPage = () => {
                           {currentProject.name}
                         </Descriptions.Item>
                         <Descriptions.Item label={t('general.Image')}>
-                          <Flex direction="row" gap="xs" style={{ flex: 1 }}>
-                            <ImageMetaIcon
-                              image={
-                                form.getFieldValue('environments')?.version ||
-                                form.getFieldValue('environments')?.manual
-                              }
-                            />
-                            {/* {form.getFieldValue('environments').image} */}
-                            <Flex direction="row">
-                              {form.getFieldValue('environments')?.manual ? (
-                                <Typography.Text copyable code>
-                                  {form.getFieldValue('environments')?.manual}
-                                </Typography.Text>
-                              ) : (
-                                <>
-                                  <SessionKernelTags
-                                    image={
-                                      form.getFieldValue('environments')
-                                        ?.version
-                                    }
-                                  />
-                                  {form.getFieldValue('environments')
-                                    ?.customizedTag ? (
-                                    <DoubleTag
-                                      values={[
-                                        {
-                                          label: 'Customized',
-                                          color: 'cyan',
-                                        },
-                                        {
-                                          label:
-                                            form.getFieldValue('environments')
-                                              ?.customizedTag,
-                                          color: 'cyan',
-                                        },
-                                      ]}
-                                    />
-                                  ) : null}
+                          <Row
+                            style={{ flexFlow: 'nowrap', gap: token.sizeXS }}
+                          >
+                            <Col>
+                              <ImageMetaIcon
+                                image={
+                                  form.getFieldValue('environments')?.version ||
+                                  form.getFieldValue('environments')?.manual
+                                }
+                              />
+                            </Col>
+                            <Col>
+                              {/* {form.getFieldValue('environments').image} */}
+                              <Flex direction="row">
+                                {form.getFieldValue('environments')?.manual ? (
                                   <Typography.Text
+                                    code
+                                    style={{ wordBreak: 'break-all' }}
                                     copyable={{
                                       text: form.getFieldValue('environments')
-                                        ?.version,
+                                        ?.manual,
                                     }}
-                                  />
-                                </>
-                              )}
-                            </Flex>
-                          </Flex>
+                                  >
+                                    {form.getFieldValue('environments')?.manual}
+                                  </Typography.Text>
+                                ) : (
+                                  <>
+                                    <SessionKernelTags
+                                      image={
+                                        form.getFieldValue('environments')
+                                          ?.version
+                                      }
+                                    />
+                                    {form.getFieldValue('environments')
+                                      ?.customizedTag ? (
+                                      <DoubleTag
+                                        values={[
+                                          {
+                                            label: 'Customized',
+                                            color: 'cyan',
+                                          },
+                                          {
+                                            label:
+                                              form.getFieldValue('environments')
+                                                ?.customizedTag,
+                                            color: 'cyan',
+                                          },
+                                        ]}
+                                      />
+                                    ) : null}
+                                    <Typography.Text
+                                      copyable={{
+                                        text: form.getFieldValue('environments')
+                                          ?.version,
+                                      }}
+                                    />
+                                  </>
+                                )}
+                              </Flex>
+                            </Col>
+                          </Row>
                         </Descriptions.Item>
                         {form.getFieldValue('envvars')?.length > 0 && (
                           <Descriptions.Item


### PR DESCRIPTION
Fix text overflowing outside the card when inserting manual image

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/b392a35b-9981-4781-ba30-d6d13196b186.png)


**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
