### PR TITLE
fix: PEP440 suffix normalization for `alpha` and `beta`

### DIFF
--- a/src/lib/pep440.test.ts
+++ b/src/lib/pep440.test.ts
@@ -33,6 +33,15 @@ describe('comparePEP440Versions', () => {
     expect(comparePEP440Versions('24.03.0dev3', '24.03.0dev5')).toBe(-1);
     expect(comparePEP440Versions('24.03.0dev3', '24.03.0dev3')).toBe(0);
     expect(comparePEP440Versions('24.03.0a1', '24.03.0b1')).toBe(-1);
+    expect(comparePEP440Versions('24.03.4', '24.03.4-post.1')).toBe(-1);
+    expect(comparePEP440Versions('24.03.4-post.2', '24.03.4-post.1')).toBe(1);
+    expect(comparePEP440Versions('24.03.4-post.2', '24.03.4.post2')).toBe(0);
+    expect(comparePEP440Versions('24.03.4-post.2', '24.03.4-post.2')).toBe(0);
+    expect(comparePEP440Versions('24.03.4-beta.2', '24.03.4-post.2')).toBe(-1);
+    expect(comparePEP440Versions('24.03.4-b.2', '24.03.4-beta.2')).toBe(0);
+    expect(comparePEP440Versions('24.03.4-alpha.2', '24.03.4-a.2')).toBe(0);
+    expect(comparePEP440Versions('24.03.4-b.2', '24.03.4-alpha.2')).toBe(1);
+
   });
 
   test('comparePEP440Versions', () => {

--- a/src/lib/pep440.ts
+++ b/src/lib/pep440.ts
@@ -55,7 +55,14 @@ function comparePEP440LocalVersions(
   // If all parts are equal, the local versions are the same
   return 0;
 }
+const getNormalizedSuffixesIndex = (suffix) => {
+  const normalized = {
+    'beta': 'b',
+    'alpha': 'a'
+  }[suffix] || suffix;
 
+  return ['dev', 'a', 'b', 'c', 'rc', undefined, 'post'].indexOf(normalized);
+}
 export function comparePEP440Versions(version1: string, version2: string) {
   // Normalize versions
   const normalizedVersion1 = normalizePEP440Version(version1);
@@ -69,7 +76,6 @@ export function comparePEP440Versions(version1: string, version2: string) {
   const parts1 = publicVersion1.split('.');
   const parts2 = publicVersion2.split('.');
 
-  const suffixes = ['dev', 'a', 'b', 'c', 'rc', undefined, 'post'];
   // Compare each part of the version
   for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
     const part1 = parts1[i];
@@ -87,8 +93,8 @@ export function comparePEP440Versions(version1: string, version2: string) {
     } else if (/^\d+$/.test(part1) && !/^\d+$/.test(part2)) {
       return 1;
     } else {
-      const suffix1 = suffixes.indexOf(part1);
-      const suffix2 = suffixes.indexOf(part2);
+      const suffix1 = getNormalizedSuffixesIndex(part1);
+      const suffix2 = getNormalizedSuffixesIndex(part2);
       if (suffix1 !== suffix2) {
         return suffix1 < suffix2 ? -1 : 1;
       }


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
