### PR TITLE
feat: vFolder explorer permarlink

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -42,6 +42,9 @@ const ResourcePolicyPage = React.lazy(
   () => import('./pages/ResourcePolicyPage'),
 );
 const ResourcesPage = React.lazy(() => import('./pages/ResourcesPage'));
+const FolderExplorerOpener = React.lazy(
+  () => import('./components/FolderExplorerOpener'),
+);
 
 const router = createBrowserRouter([
   {
@@ -131,6 +134,11 @@ const router = createBrowserRouter([
       {
         path: '/data',
         handle: { labelKey: 'webui.menu.Data&Storage' },
+        element: (
+          <BAIErrorBoundary>
+            <FolderExplorerOpener />
+          </BAIErrorBoundary>
+        ),
       },
       {
         path: '/my-environment',

--- a/react/src/components/FolderExplorerOpener.tsx
+++ b/react/src/components/FolderExplorerOpener.tsx
@@ -1,0 +1,57 @@
+import { useBaiSignedRequestWithPromise } from '../helper';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { jotaiStore } from './DefaultProviders';
+import { VFolder } from './VFolderSelect';
+import { atom, useAtomValue } from 'jotai';
+import { useEffect } from 'react';
+import { StringParam, useQueryParam } from 'use-query-params';
+
+// TODO: Separate Folder Explorer from `backend-ai-data-view` and make it opened directly on all pages.
+
+const isDataViewReadyAtom = atom(false);
+document.addEventListener('backend-ai-data-view:connected', () => {
+  jotaiStore.set(isDataViewReadyAtom, true);
+});
+document.addEventListener('backend-ai-data-view:disconnected', () => {
+  jotaiStore.set(isDataViewReadyAtom, false);
+});
+
+const FolderExplorerOpener = () => {
+  const [folderId] = useQueryParam('folder', StringParam) || '';
+  const normalizedFolderId = folderId?.replaceAll('-', '');
+  const currentProject = useCurrentProjectValue();
+  const baiRequestWithPromise = useBaiSignedRequestWithPromise();
+
+  const isDataViewReady = useAtomValue(isDataViewReadyAtom);
+  useEffect(() => {
+    if (isDataViewReady && folderId) {
+      (
+        baiRequestWithPromise({
+          method: 'GET',
+          url: `/folders?group_id=${currentProject.id}`,
+        }) as Promise<VFolder[]>
+      )
+        .then((vFolders) => {
+          const vFolder = vFolders?.find(
+            // `id` of `/folders` API is not UUID, but UUID without `-`
+            (vFolder) => vFolder.id === normalizedFolderId,
+          );
+          document.dispatchEvent(
+            new CustomEvent('folderExplorer:open', {
+              detail: {
+                vFolder,
+              },
+            }),
+          );
+        })
+        .catch(() => {
+          // do nothing
+        });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDataViewReady]); // don't need to watch `folderId` because this used only once right after the backend-ai-data-view is ready
+
+  return null;
+};
+
+export default FolderExplorerOpener;

--- a/react/src/components/VFolderLazyView.tsx
+++ b/react/src/components/VFolderLazyView.tsx
@@ -43,7 +43,7 @@ const VFolderLazyView: React.FC<VFolderLazyViewProps> = ({
         onClick={() => {
           webuiNavigate({
             pathname: '/data',
-            search: `?folder=${vFolder.name}`,
+            search: `?folder=${vFolder.id}`,
           });
         }}
       >

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -10,7 +10,11 @@ import ServiceLauncherModal from '../components/ServiceLauncherModal';
 import VFolderLazyView from '../components/VFolderLazyView';
 import { InferenceSessionErrorModalFragment$key } from '../components/__generated__/InferenceSessionErrorModalFragment.graphql';
 import { baiSignedRequestWithPromise, filterNonNullItems } from '../helper';
-import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
+import {
+  useSuspendedBackendaiClient,
+  useUpdatableState,
+  useWebUINavigate,
+} from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import {
@@ -109,6 +113,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
     pageSize: 100,
   });
   const { message } = App.useApp();
+  const webuiNavigate = useWebUINavigate();
   const { endpoint, endpoint_token_list } =
     useLazyLoadQuery<EndpointDetailPageQuery>(
       graphql`
@@ -333,7 +338,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           <Flex direction="column" align="start">
             <VFolderLazyView
               uuid={endpoint?.model as string}
-              clickable={false}
+              clickable={true}
             />
             {baiClient.supports('endpoint-extra-mounts') &&
               endpoint?.model_mount_destination && (
@@ -357,8 +362,17 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
         <Flex direction="column" align="start">
           {_.map(endpoint?.extra_mounts, (vfolder) => {
             return (
-              <Flex direction="row" gap={'xxs'}>
-                <FolderOutlined /> {vfolder?.name}
+              <Flex direction="row" gap={'xxs'} key={vfolder?.row_id}>
+                <Typography.Link
+                  onClick={() => {
+                    webuiNavigate({
+                      pathname: '/data',
+                      search: `?folder=${vfolder?.row_id}`,
+                    });
+                  }}
+                >
+                  <FolderOutlined /> {vfolder?.name}
+                </Typography.Link>
               </Flex>
             );
           })}

--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -32,6 +32,8 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
  * This type definition is a workaround for resolving both Type error and Importing error.
  */
 type BackendAIDialog = HTMLElementTagNameMap['backend-ai-dialog'];
+type BackendAIStorageList = HTMLElementTagNameMap['backend-ai-storage-list'];
+type MwcTabBar = HTMLElementTagNameMap['mwc-tab-bar'];
 interface GroupData {
   id: string;
   name: string;
@@ -102,6 +104,9 @@ export default class BackendAIData extends BackendAIPage {
   @query('#add-folder-group') addFolderGroupSelect!: Select;
   @query('#add-folder-type') addFolderTypeSelect!: Select;
   @query('#cloneable-container') cloneableContainer!: HTMLDivElement;
+  @query('#general-folder-storage')
+  generalFolderStorageListElement!: BackendAIStorageList;
+  @query('#data-tab-bar') dataTabBar!: MwcTabBar;
 
   static get styles(): CSSResultGroup {
     return [
@@ -285,7 +290,7 @@ export default class BackendAIData extends BackendAIPage {
         <lablup-activity-panel elevation="1" noheader narrow autowidth>
           <div slot="message">
             <h3 class="horizontal center flex layout tab">
-              <mwc-tab-bar>
+              <mwc-tab-bar id="data-tab-bar">
                 <mwc-tab
                   title="general"
                   label="${_t('data.Folders')}"
@@ -898,6 +903,32 @@ export default class BackendAIData extends BackendAIPage {
     });
   }
 
+  openFolderExplorer = (e) => {
+    if (e?.detail?.vFolder) {
+      this.dataTabBar.activeIndex = 0;
+      this._showTab({ title: 'general' });
+      this.generalFolderStorageListElement._folderExplorer({
+        item: e?.detail?.vFolder,
+      });
+    }
+  };
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    document.addEventListener('folderExplorer:open', this.openFolderExplorer);
+    document.dispatchEvent(new CustomEvent('backend-ai-data-view:connected'));
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.removeEventListener(
+      'folderExplorer:open',
+      this.openFolderExplorer,
+    );
+    document.dispatchEvent(
+      new CustomEvent('backend-ai-data-view:disconnected'),
+    );
+  }
   /**
    * Initialize the admin.
    *

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1108,6 +1108,15 @@ export default class BackendAiStorageList extends BackendAIPage {
         class="folder-explorer"
         narrowLayout
         scrimClickAction
+        @dialog-closed=${() => {
+          const queryParams = new URLSearchParams(window.location.search);
+          queryParams.delete('folder');
+          window.history.replaceState(
+            {},
+            '',
+            `${location.pathname}${queryParams.toString().length == 0 ? '' : '?' + queryParams}`,
+          );
+        }}
       >
         <span slot="title" style="margin-right:1rem;">${this.explorer.id}</span>
         <div
@@ -1647,12 +1656,6 @@ export default class BackendAiStorageList extends BackendAIPage {
       this._refreshFolderUI(e),
     );
     this._refreshFolderUI({ detail: { 'mini-ui': globalThis.mini_ui } });
-    // @ts-ignore
-    const params = new URL(document.location).searchParams;
-    const folderName = params.get('folder');
-    if (folderName) {
-      // alert(folderName);
-    }
   }
 
   _modifySharedFolderPermissions() {
@@ -3398,7 +3401,7 @@ export default class BackendAiStorageList extends BackendAIPage {
     };
 
     const queryParams = new URLSearchParams();
-    queryParams.set('folder', folderName);
+    queryParams.set('folder', rowData.item.id);
     window.history.replaceState({}, '', `${location.pathname}?${queryParams}`);
 
     /**


### PR DESCRIPTION
### TL;DR
The PR enhances folder navigation by integrating `FolderExplorerOpener` component and fixing several bugs.

You can open the FolderExplorer directly for the folder using the folder id, as shown in the following address: `http://127.0.0.1:9081/data?folder=47b6463ba3de4480b968e3e0df9b6fb6`. By linking this URL to the folder name, users can directly access the contents of the folder.

### What changed?
1. Introduced `FolderExplorerOpener` component for opening folders using a UUID.
2. Modified `EndpointDetailPage` to make folder names clickable and navigate to the folder view.
3. Added new query parameters handling in `FolderExplorerOpener`.
4. Updated `VFolderLazyView` to navigate based on `vFolder.id` instead of `vFolder.name`.
5. Added event listeners to `BackendAIData` for opening Folder Explorer.
6. Enhanced `BackendAIStorageList` to update query parameters and handle folder explorer dialog closing.

### How to test?
1. Navigate to the `/data` page with a `folder` query parameter.
2. Ensure the Folder Explorer opens automatically for the specified folder.
3. Validate folder navigation from the `EndpointDetailPage`.
4. Verify query parameters update correctly when Folder Explorer is closed.

### Why make this change?
Improves usability by allowing direct navigation to folders via URLs and enhances folder interaction from various parts of the application.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
