### PR TITLE
Fix: all elements are NOT clickable after a page transition with openped modal

### DIFF
--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -5,6 +5,7 @@ import { useCustomThemeConfig } from '../helper/customThemeConfig';
 import { ReactWebComponentProps } from '../helper/react-to-webcomponent';
 import { ThemeModeProvider, useThemeMode } from '../hooks/useThemeMode';
 import { StyleProvider, createCache } from '@ant-design/cssinjs';
+import { useUpdateEffect } from 'ahooks';
 import { App, AppProps, ConfigProvider, theme } from 'antd';
 import en_US from 'antd/locale/en_US';
 import ko_KR from 'antd/locale/ko_KR';
@@ -29,7 +30,7 @@ import React, {
 import { useTranslation, initReactI18next } from 'react-i18next';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { RelayEnvironmentProvider } from 'react-relay';
-import { BrowserRouter, useNavigate } from 'react-router-dom';
+import { BrowserRouter, useLocation, useNavigate } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
@@ -227,6 +228,7 @@ const DefaultProvidersForWebComponent: React.FC<DefaultProvidersProps> = ({
 
 export const RoutingEventHandler = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   useLayoutEffect(() => {
     const handleNavigate = (e: any) => {
       const { detail } = e;
@@ -242,6 +244,10 @@ export const RoutingEventHandler = () => {
       document.removeEventListener('react-navigate', handleNavigate);
     };
   }, [navigate]);
+
+  useUpdateEffect(() => {
+    document.dispatchEvent(new CustomEvent('locationPath:changed'));
+  }, [location.pathname]);
 
   return null;
 };

--- a/src/components/backend-ai-dialog.ts
+++ b/src/components/backend-ai-dialog.ts
@@ -205,6 +205,12 @@ export default class BackendAIDialog extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    document.addEventListener('locationPath:changed', this.hide);
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.removeEventListener('locationPath:changed', this.hide);
   }
 
   /**
@@ -224,7 +230,7 @@ export default class BackendAIDialog extends LitElement {
   /**
    * Hide a dialog.
    */
-  hide() {
+  hide = () => {
     if (this.closeWithConfirmation) {
       const closeEvent = new CustomEvent('dialog-closing-confirm', {
         detail: '',
@@ -234,7 +240,7 @@ export default class BackendAIDialog extends LitElement {
       this.dialog.close();
       this._resetScroll();
     }
-  }
+  };
 
   /**
    * Move to top of the dialog.


### PR DESCRIPTION
### TL;DR

Implemented automatic dialog closure on route changes to ensure dialogs do not persist incorrectly.
Resolve https://github.com/lablup/backend.ai-webui/issues/2176

### What changed?

- Added `useLocation` from `react-router-dom` to the `RoutingEventHandler` component.
- Implemented `useUpdateEffect` from `ahooks` to dispatch `locationPath:changed` custom event on route change.
- Subscribed `BackendAIDialog` to `locationPath:changed` event to trigger `hide` method.

### How to test?

1. Navigate to a route that opens a dialog.
2. Change routes and verify that the dialog closes automatically and clickable elements work properly.

### Why make this change?

This change was made to prevent dialogs from persisting incorrectly when navigating between routes.

---

Reslove https://github.com/lablup/backend.ai-webui/issues/2176

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
