### PR TITLE
ci: Bump codeql-action/init from v2 to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.


### PR DESCRIPTION
CodeQL Action v2 has been deprecated.
Upgrade to the new version.

<img width="1087" alt="CleanShot 2024-06-14 at 11 48 01@2x" src="https://github.com/lablup/backend.ai-webui/assets/31057849/3aefe435-86b5-4fb4-ad77-705721765628">
