### PR TITLE
fix: run form validation after changing preset

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -338,7 +338,11 @@ const ResourceAllocationFormItems: React.FC<
     if (form.getFieldValue('enabledAutomaticShmem')) {
       runShmemAutomationRule(form.getFieldValue(['resource', 'mem']) || '0g');
     }
-    form.validateFields(['resource']).catch(() => {});
+    form
+      .validateFields(['resource'], {
+        recursive: true,
+      })
+      .catch(() => {});
   };
 
   useEffect(() => {
@@ -387,6 +391,12 @@ const ResourceAllocationFormItems: React.FC<
       },
     });
     runShmemAutomationRule(mem || '0g');
+
+    form
+      .validateFields(['resource'], {
+        recursive: true,
+      })
+      .catch(() => {});
   };
 
   const runShmemAutomationRule = (M_plus_S: string) => {


### PR DESCRIPTION
This pull request ensures that when the 'resource' field is validated when preset is changed, the validation is conducted recursively. It addresses an issue where non-recursive validation could have missed nested fields under 'resource'. The change involves modifying the validateFields method to include the 'recursive: true' option. This update impacts the ResourceAllocationFormItems component in the React codebase.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
