### PR TITLE
bug: Neo session launcher summary page UI is broken for long execution commands in batch sessions

### DIFF
--- a/react/src/components/SourceCodeViewer.tsx
+++ b/react/src/components/SourceCodeViewer.tsx
@@ -35,39 +35,32 @@ const SourceCodeViewer: React.FC<SourceCodeViewerProps> = ({
       {({ className, style, tokens, getLineProps, getTokenProps }) => (
         <pre
           style={{
-            ...style,
-            width: '100%',
             margin: 0,
             padding: token.padding,
             borderRadius: token.borderRadius,
             overflow: wordWrap ? undefined : 'overlay',
+            ...style,
           }}
         >
           <code
             style={{
-              whiteSpace: wordWrap ? 'pre-wrap' : undefined,
+              display: 'block',
+              whiteSpace: wordWrap ? 'pre-wrap' : 'scroll',
               overflowWrap: wordWrap ? 'anywhere' : undefined,
             }}
           >
             {_.map(tokens, (line, i) => {
               return (
-                <span key={i} {...getLineProps({ line })}>
+                <div key={i} {...getLineProps({ line })}>
                   {_.map(line, (token, key) => {
-                    /** The codes below fix some line wrapping errors during the conversion process. **/
-                    if (!token.content && key === line.length - 1) {
-                      return '\n';
-                    }
-                    if (line.length === 1 && token.content === ' ') {
-                      return '\n';
-                    }
-                    /** **/
                     return (
                       <span key={key} {...getTokenProps({ token })}>
                         {token.content}
                       </span>
                     );
                   })}
-                </span>
+                  {'\n'}
+                </div>
               );
             })}
           </code>
@@ -80,6 +73,7 @@ const SourceCodeViewer: React.FC<SourceCodeViewerProps> = ({
     <Flex
       onMouseEnter={() => setIsMouseEntered(true)}
       onMouseLeave={() => setIsMouseEntered(false)}
+      style={{ width: '100%' }}
     >
       <CopyToClipboard
         text={children}
@@ -91,26 +85,26 @@ const SourceCodeViewer: React.FC<SourceCodeViewerProps> = ({
           }, 2000);
         }}
       >
-        <Tooltip
-          title={
-            isCopied ? t('sourceCodeViewer.Copied') : t('sourceCodeViewer.Copy')
-          }
-        >
-          <Button
-            style={{
-              top: token.sizeSM,
-              right: token.sizeSM,
-              zIndex: token.zIndexBase + 1,
-              opacity: isMouseEntered ? 1 : 0,
-              backgroundColor: token.colorFillSecondary,
-              cursor: 'pointer',
-              position: 'absolute',
-              transition: 'opacity 0.2s ease-in-out',
-            }}
-            size="small"
-            icon={isCopied ? <CheckOutlined /> : <CopyOutlined />}
-          />
-        </Tooltip>
+        <Flex style={{ position: 'absolute', top: '10px', right: '10px' }}>
+          <Tooltip
+            title={
+              isCopied
+                ? t('sourceCodeViewer.Copied')
+                : t('sourceCodeViewer.Copy')
+            }
+          >
+            <Button
+              size="small"
+              icon={isCopied ? <CheckOutlined /> : <CopyOutlined />}
+              style={{
+                opacity: isMouseEntered ? 1 : 0,
+                cursor: 'pointer',
+                transition: 'opacity 0.2s ease-in-out',
+                position: 'sticky',
+              }}
+            />
+          </Tooltip>
+        </Flex>
       </CopyToClipboard>
       {HighLightedCode}
     </Flex>

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -25,6 +25,7 @@ import SessionLauncherValidationTour from '../components/SessionLauncherErrorTou
 import SessionNameFormItem, {
   SessionNameFormItemValue,
 } from '../components/SessionNameFormItem';
+import SourceCodeViewer from '../components/SourceCodeViewer';
 import VFolderTableFormItem, {
   VFolderTableFormValues,
 } from '../components/VFolderTableFormItem';
@@ -1133,18 +1134,15 @@ const SessionLauncherPage = () => {
                           <>
                             <Descriptions.Item
                               label={t('session.launcher.StartUpCommand')}
+                              labelStyle={{ whiteSpace: 'nowrap' }}
+                              contentStyle={{
+                                overflow: 'auto',
+                              }}
                             >
                               {form.getFieldValue(['batch', 'command']) ? (
-                                <SyntaxHighlighter
-                                  style={isDarkMode ? dark : undefined}
-                                  language="shell"
-                                  customStyle={{
-                                    margin: 0,
-                                    width: '100%',
-                                  }}
-                                >
+                                <SourceCodeViewer language="shell">
                                   {form.getFieldValue(['batch', 'command'])}
-                                </SyntaxHighlighter>
+                                </SourceCodeViewer>
                               ) : (
                                 <Typography.Text type="secondary">
                                   {t('general.None')}


### PR DESCRIPTION
### This PR Resolves [#2487](https://github.com/orgs/lablup/projects/24/views/22?pane=issue&itemId=68239092)

Replaced the Command component with the SourceCodeViewer component

|before|after|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/80a09b84-e282-446f-9519-7a17cfbe68f9.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/19c0f13e-35d0-450e-b7b7-9fcdb0104c89.png)|

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
