### PR TITLE
bug: set dark theme color for error panel in session detail modal

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -531,6 +531,13 @@ export default class BackendAISessionList extends BackendAIPage {
         div.usage-items {
           font-size: 10px;
         }
+
+        div.error-detail-panel {
+          border-radius: var(--token-borderRadiusSM, 4px);
+          background-color: var(--token-colorBgContainerDisabled);
+          padding: var(--token-paddingSM, 10px);
+          margin: var(--token-marginSM, 10px);
+        }
       `,
     ];
   }
@@ -2341,9 +2348,7 @@ export default class BackendAISessionList extends BackendAIPage {
             </h3>
             ${errorList.map((item) => {
               return html`
-                <div
-                  style="border-radius: 4px;background-color:var(--paper-grey-300);padding:10px;margin:10px;"
-                >
+                <div class="error-detail-panel">
                   <div class="vertical layout start">
                     <span class="subheading">Error</span>
                     <lablup-shields
@@ -2373,7 +2378,8 @@ export default class BackendAISessionList extends BackendAIPage {
                           <pre
                             style="display: block; overflow: auto; width: 100%; height: 400px;"
                           >
-${item.traceback}</pre
+                            ${item.traceback}
+                          </pre
                           >
                         </div>
                       `


### PR DESCRIPTION
### This PR Resolves [#2408](https://github.com/lablup/backend.ai-webui/issues/2408)

|light|dark|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/c3c5a5a3-e109-45c7-a79a-62eb517372e4.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/64df73fd-c491-4da1-987b-6b056d2fc5b4.png)|
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
