### PR TITLE
feat: Adjust fetch timeout to 15s for improved user experience (cllient-esm)

### DIFF
--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -266,7 +266,7 @@ class Client {
     this._features = {}; // feature support list
     this.abortController = new AbortController();
     this.abortSignal = this.abortController.signal;
-    this.requestTimeout = 5000;
+    this.requestTimeout = 15000;
     if (localStorage.getItem('backendaiwebui.sessionid')) {
       this._loginSessionId = localStorage.getItem('backendaiwebui.sessionid');
     } else {


### PR DESCRIPTION

### TL;DR

follow up #2490 
Increase the request timeout in `backend.ai-client-esm.ts` from 5 seconds to 15 seconds to improve network reliability.

### What changed?

The value of `this.requestTimeout` was changed from `5000` to `15000` milliseconds in the `Client` class.

### How to test?

Verify that network requests initiated by the `Client` class can now succeed within a 15-second window instead of 5 seconds.

### Why make this change?

This change was made to reduce the likelihood of network timeouts for operations requiring more than 5 seconds, thereby enhancing user experience and system robustness.