### PR TITLE
feat: add a link to open a cloned folder in a notification

### DIFF
--- a/react/src/components/BAINotificationItem.tsx
+++ b/react/src/components/BAINotificationItem.tsx
@@ -79,9 +79,9 @@ const BAINotificationItem: React.FC<{
                   onClickAction && onClickAction(e, notification);
                 }}
               >
-                {notification.toTextKey
-                  ? t(notification.toTextKey)
-                  : t('notification.SeeDetail')}
+                {notification.toText ??
+                  notification.toTextKey ??
+                  t('notification.SeeDetail')}
               </Typography.Link>
             </Flex>
           ) : null}

--- a/react/src/components/FolderExplorerOpener.tsx
+++ b/react/src/components/FolderExplorerOpener.tsx
@@ -49,7 +49,7 @@ const FolderExplorerOpener = () => {
         });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDataViewReady]); // don't need to watch `folderId` because this used only once right after the backend-ai-data-view is ready
+  }, [isDataViewReady, folderId]); // don't need to watch `folderId` because this used only once right after the backend-ai-data-view is ready
 
   return null;
 };

--- a/react/src/components/ModelCardModal.tsx
+++ b/react/src/components/ModelCardModal.tsx
@@ -66,8 +66,13 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
         vfolder {
           cloneable
         }
-        vfolder_node {
+        vfolder_node @since(version: "24.09.*") {
           ...ModelCloneModalVFolderFragment
+        }
+        vfolder {
+          id
+          name
+          host
         }
       }
     `,
@@ -304,6 +309,11 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
       <Suspense>
         <ModelCloneModal
           vfolderNode={model_card?.vfolder_node || null}
+          deprecatedVFolderInfo={{
+            id: model_card?.vfolder?.id || '',
+            host: model_card?.vfolder?.host || '',
+            name: model_card?.vfolder?.name || '',
+          }}
           title={t('modelStore.CloneAsFolder')}
           open={visibleCloneModal}
           onOk={() => {

--- a/react/src/helper/graphql-transformer.ts
+++ b/react/src/helper/graphql-transformer.ts
@@ -8,6 +8,7 @@ export function manipulateGraphQLQueryWithClientDirectives(
   isNotCompatibleWith: (version: string | Array<string>) => boolean,
 ) {
   const ast = parse(query);
+  const fragmentSpreadNames = new Set<string>();
   let newAst = visit(ast, {
     Field: {
       enter(node) {
@@ -111,6 +112,19 @@ export function manipulateGraphQLQueryWithClientDirectives(
             'skipOnClient',
           ].includes(directiveName)
         ) {
+          return null;
+        }
+      },
+    },
+    FragmentSpread: {
+      enter(node) {
+        fragmentSpreadNames.add(node.name.value);
+      },
+    },
+    // delete unused fragment definitions to prevent "Fragment 'OOOOFragment' is never used." error.
+    FragmentDefinition: {
+      leave(node) {
+        if (!fragmentSpreadNames.has(node.name.value)) {
           return null;
         }
       },

--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -15,6 +15,7 @@ export interface NotificationState
   key: React.Key;
   created?: string;
   toTextKey?: string;
+  toText?: string;
   to?: string | To;
   open?: boolean;
   backgroundTask?: {
@@ -34,7 +35,7 @@ export interface NotificationState
 
 export const notificationListState = atom<NotificationState[]>([]);
 
-export const CLOSING_DURATION = 1; //second
+export const CLOSING_DURATION = 4; //second
 
 /**
  * Custom hook that returns the BAI notification state.

--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -105,6 +105,14 @@ export default class BackendAIData extends BackendAIPage {
   @query('#cloneable-container') cloneableContainer!: HTMLDivElement;
   @query('#general-folder-storage')
   generalFolderStorageListElement!: BackendAIStorageList;
+  @query('#data-folder-storage')
+  dataFolderStorageListElement!: BackendAIStorageList;
+  @query('#automount-folder-storage')
+  automountFolderStorageListElement!: BackendAIStorageList;
+  @query('#model-folder-storage')
+  modelFolderStorageListElement!: BackendAIStorageList;
+  @query('#trash-bin-folder-storage')
+  trashBinFolderStorageListElement!: BackendAIStorageList;
 
   static get styles(): CSSResultGroup {
     return [
@@ -820,7 +828,19 @@ export default class BackendAIData extends BackendAIPage {
 
   openFolderExplorer = (e) => {
     if (e?.detail?.vFolder) {
-      this.generalFolderStorageListElement._folderExplorer({
+      const activeStorageList =
+        this._activeTab === 'general'
+          ? this.generalFolderStorageListElement
+          : this._activeTab === 'model'
+            ? this.modelFolderStorageListElement
+            : this._activeTab === 'automount'
+              ? this.automountFolderStorageListElement
+              : this._activeTab === 'data'
+                ? this.dataFolderStorageListElement
+                : this._activeTab === 'trash-bin'
+                  ? this.trashBinFolderStorageListElement
+                  : null;
+      activeStorageList?._folderExplorer({
         item: e?.detail?.vFolder,
       });
     }

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1109,13 +1109,7 @@ export default class BackendAiStorageList extends BackendAIPage {
         narrowLayout
         scrimClickAction
         @dialog-closed=${() => {
-          const queryParams = new URLSearchParams(window.location.search);
-          queryParams.delete('folder');
-          window.history.replaceState(
-            {},
-            '',
-            `${location.pathname}${queryParams.toString().length == 0 ? '' : '?' + queryParams}`,
-          );
+          this.triggerCloseFilebrowserToReact();
         }}
       >
         <span slot="title" style="margin-right:1rem;">${this.explorer.id}</span>
@@ -1769,7 +1763,9 @@ export default class BackendAiStorageList extends BackendAIPage {
                   class="fg blue controls-running"
                   icon="folder_open"
                   title=${_t('data.folders.OpenAFolder')}
-                  @click="${(e) => this._folderExplorer(rowData)}"
+                  @click="${() => {
+                    this.triggerOpenFilebrowserToReact(rowData);
+                  }}"
                   ?disabled="${this._isUncontrollableStatus(
                     rowData.item.status,
                   )}"
@@ -1780,7 +1776,7 @@ export default class BackendAiStorageList extends BackendAIPage {
           <div
             @click="${(e) =>
               !this._isUncontrollableStatus(rowData.item.status) &&
-              this._folderExplorer(rowData)}"
+              this.triggerOpenFilebrowserToReact(rowData)}"
             .folder-id="${rowData.item.name}"
             style="cursor:${this._isUncontrollableStatus(rowData.item.status)
               ? 'default'
@@ -3381,6 +3377,32 @@ export default class BackendAiStorageList extends BackendAIPage {
     }
   }
 
+  triggerOpenFilebrowserToReact(rowData) {
+    const queryParams = new URLSearchParams(window.location.search);
+    queryParams.set('folder', rowData.item.id);
+    document.dispatchEvent(
+      new CustomEvent('react-navigate', {
+        detail: {
+          pathname: '/data',
+          search: queryParams.toString(),
+        },
+      }),
+    );
+  }
+
+  triggerCloseFilebrowserToReact() {
+    const queryParams = new URLSearchParams(window.location.search);
+    queryParams.delete('folder');
+    document.dispatchEvent(
+      new CustomEvent('react-navigate', {
+        detail: {
+          pathname: window.location.pathname,
+          search: queryParams.toString(),
+        },
+      }),
+    );
+  }
+
   /**
    * Set up the explorer of the folder and call the _clearExplorer() function.
    *
@@ -3399,10 +3421,6 @@ export default class BackendAiStorageList extends BackendAIPage {
       uuid: rowData.item.id,
       breadcrumb: ['.'],
     };
-
-    const queryParams = new URLSearchParams();
-    queryParams.set('folder', rowData.item.id);
-    window.history.replaceState({}, '', `${location.pathname}?${queryParams}`);
 
     /**
      * NOTICE: If it's admin user and the folder type is group, It will have write permission.


### PR DESCRIPTION
### TL;DR
Adds a feature that utilizes a link to open the folder explorer directly from a notification.

### What changed?
- Updated `BAINotificationItem` component to use `notification.toText` property before falling back to other properties.
- Adjusted `FolderExplorerOpener` to watch both `isDataViewReady` and `folderId` states.
- Modified `ModelCloneModal` component to include new properties in mutation response and make use of them.
- Extended `NotificationState` interface to include `toText` property.
- Enhanced `BackendAIData` to handle folder explorers for different tabs.
- Refactored folder explorer opening logic in `BackendAiStorageList` and introduced two new methods: `triggerOpenFilebrowserToReact` and `triggerCloseFilebrowserToReact`.

### How to test?
1. Clone folder in the Model store page.
2. Check if the clone result notification includes a link to open the folder explorer.
3. Ensure the link accurately directs to the correct folder based on different tabs.
4. Verify state updates and component behavior in `FolderExplorerOpener` and `ModelCloneModal`.

### Why make this change?
To enhance user experience by providing direct access to folder explorers from notifications, streamlining the workflow and reducing the number of clicks needed to navigate to a folder.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
