### PR TITLE
bug: language settings are intermittently not being applied

### DIFF
--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -27,6 +27,7 @@ const UserPreferencesPage = () => {
   const [compactSidebar, setCompactSidebar] =
     useBAISettingUserState('compact_sidebar');
   const [language, setLanguage] = useBAISettingUserState('language');
+  const [, setCurrentLanguage] = useBAISettingUserState('current_language');
   const [autoAutomaticUpdateCheck, setAutoAutomaticUpdateCheck] =
     useBAISettingUserState('automatic_update_check');
   const [autoLogout, setAutoLogout] = useBAISettingUserState('auto_logout');
@@ -113,6 +114,7 @@ const UserPreferencesPage = () => {
           setValue: setLanguage,
           onChange: (value) => {
             setLanguage(value);
+            setCurrentLanguage(value);
             const event = new CustomEvent('language-changed', {
               detail: { language: value },
             });


### PR DESCRIPTION
### TL;DR
This PR introduces a fix to sync the current language setting with the newly selected language in the user preferences page.

Prior to this PR, the language setting was sometimes not applied due to the absence of the current_language setting. 
(such as when moving tabs after changing the language setting).

### What changed?
- Added `currentLanguage` state and synced it with `language` state in `UserSettingsPage.tsx`.
- Updated the `onChange` event of the language dropdown to update `currentLanguage`.

### How to test?
1. Navigate to the user preferences page.
2. Change the language from the dropdown.
3. Ensure that the `currentLanguage` state is updated accordingly and the `language-changed` event is triggered.

### Why make this change?
This change ensures that the current language setting is consistently updated and in sync with the user's selection, providing a more reliable user experience.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
