### PR TITLE
feature: prevent stacking of duplicate notifications

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1271,7 +1271,6 @@ export default class BackendAISessionList extends BackendAIPage {
           }, refreshTime);
         }
         this._listStatus?.hide();
-        console.log(err);
         if (err && err.message) {
           this.notification.text = PainKiller.relieve(err.title);
           this.notification.detail = err.message;


### PR DESCRIPTION
### TL;DR

Removed unnecessary console log statements and improved notification handling by adding a unique key parameter to avoid duplicate notifications.

### What changed?

- Removed `console.log` statements in `backend-ai-session-list.ts` and `lablup-notification.ts` files.
- Enhanced the `show` method in `LablupNotification` component to include a `key` parameter for uniquely identifying notifications.
- Added logic to prevent dispatching duplicate notifications and handled the 'Network disconnected' message specifically.

### How to test?

1. Trigger an error in the application and verify that console log statements no longer appear.
2. Check that notifications are correctly displayed without duplication.
3. Ensure the 'Network disconnected' message is handled by the `NetworkStatusBanner` component.

### Why make this change?

To clean up the console output and improve the notification system by preventing duplicate messages and enhancing user experience.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
