### PR TITLE
fix: change description validating logic in lablup-notification

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1878,7 +1878,7 @@ export default class BackendAISessionList extends BackendAIPage {
       this.terminateSessionDialog.accessKey,
       forced,
     )
-      .then((response) => {
+      .then(() => {
         this._selected_items = [];
         this._clearCheckboxes();
         this.terminateSessionDialog.hide();
@@ -1889,18 +1889,10 @@ export default class BackendAISessionList extends BackendAIPage {
         });
         document.dispatchEvent(event);
       })
-      .catch((err) => {
+      .catch(() => {
         this._selected_items = [];
         this._clearCheckboxes();
         this.terminateSessionDialog.hide();
-        this.notification.text = PainKiller.relieve(
-          'Problem occurred during termination.',
-        );
-        this.notification.show(true, err);
-        const event = new CustomEvent('backend-ai-resource-refreshed', {
-          detail: 'running',
-        });
-        document.dispatchEvent(event);
       });
   }
 
@@ -1931,20 +1923,16 @@ export default class BackendAISessionList extends BackendAIPage {
     });
     this._selected_items = [];
     return Promise.all(terminateSessionQueue)
-      .then((response) => {
+      .then(() => {
         this.terminateSelectedSessionsDialog.hide();
         this._clearCheckboxes();
         this.multipleActionButtons.style.display = 'none';
         this.notification.text = _text('session.SessionsTerminated');
         this.notification.show();
       })
-      .catch((err) => {
+      .catch(() => {
         this.terminateSelectedSessionsDialog.hide();
         this._clearCheckboxes();
-        this.notification.text = PainKiller.relieve(
-          'Problem occurred during termination.',
-        );
-        this.notification.show(true, err);
       });
   }
 
@@ -1960,25 +1948,17 @@ export default class BackendAISessionList extends BackendAIPage {
       return this._terminateKernel(item['session_id'], item.access_key);
     });
     return Promise.all(terminateSessionQueue)
-      .then((response) => {
+      .then(() => {
         this._selected_items = [];
         this._clearCheckboxes();
         this.multipleActionButtons.style.display = 'none';
         this.notification.text = _text('session.SessionsTerminated');
         this.notification.show();
       })
-      .catch((err) => {
+      .catch(() => {
         this._listStatus?.hide();
         this._selected_items = [];
         this._clearCheckboxes();
-        if ('description' in err) {
-          this.notification.text = PainKiller.relieve(err.description);
-        } else {
-          this.notification.text = PainKiller.relieve(
-            'Problem occurred during termination.',
-          );
-        }
-        this.notification.show(true, err);
       });
   }
 
@@ -2030,6 +2010,7 @@ export default class BackendAISessionList extends BackendAIPage {
             this.notification.show(true, err);
           }
         }
+        throw err;
       });
   }
 

--- a/src/components/lablup-notification.ts
+++ b/src/components/lablup-notification.ts
@@ -196,7 +196,7 @@ export default class LablupNotification extends LitElement {
       open: true,
       type: shouldSaveLog ? 'error' : null,
       message: this.text,
-      description: this.text ? undefined : this.detail,
+      description: this.text === this.detail ? undefined : this.detail,
       to: shouldSaveLog ? '/usersettings?tab=logs' : this.url,
       duration: persistent ? 0 : undefined,
       // closeIcon: persistent,


### PR DESCRIPTION
### Existing Problems
The existing web component notification does not output any accompanying description when a text field is provided for the title. [ref](https://github.com/lablup/backend.ai-webui/blob/119f64e320befec545680934722a05cce00ede65/src/components/lablup-notification.ts#L196)

However, most of the usage of notifications in web components is providing the notification title through the painkiller, so even if the title of the error is undefined, the painkiller will always provide a specific string (e.g. `problem occured`). Therefore, a description of the error is never provided.

### Changes
- Changed the logic for checking if description is visible to a comparison to see if it is the same as title.
- Fixed an issue where the same notification would appear twice when deleting a session.

### How to Test
1. After causing an error in the webui, make sure both title and description are displayed
2. Delete the session that is causing the deletion error, then verify that the same notification doesn't occur more than once

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
