### PR TITLE
fix: migrate husky command to v9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "update": "npx tsc",
     "postinstall": "npx concurrently -c \"auto\" --names \"react-dependencies,patch-package\" \"cd react && npm install\" \"patch-package\"",
     "patch:lit-translate": "unzip -o ./scripts/lit-translate.zip -d ./node_modules/lit-translate && cp -f ./scripts/lit-translate-index.js ./node_modules/lit-translate/index.js",
-    "prepare": "husky install",
+    "prepare": "husky",
     "theme-schema:update": "npx typescript-json-schema \"./react/node_modules/antd/es/config-provider/context.d.ts\" ThemeConfig -o ./resources/antdThemeConfig.schema.json --esModuleInterop"
   },
   "dependencies": {


### PR DESCRIPTION
### This PR is a command change due to a husky update. [ref](https://github.com/OpenDevin/OpenDevin/issues/2190)

.husky/pre-commit and package.json have been updated to fix the husky prepare script. The prepare script has been simplified from 'husky install' to 'husky' to ensure compatibility with newer husky versions. Additionally, some redundant lines in .husky/pre-commit have been removed for cleanup.

### How to Test
1. remove Husky from the project.
2. reinstall husky via `npm i`, and commit any changes to make sure it works.
---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
