### PR TITLE
fix: change login input validation logic to support both email and non-email types

### DIFF
--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -2070,7 +2070,7 @@ export default class BackendAILogin extends BackendAIPage {
                     disabled
                   ></mwc-icon-button>
                   <mwc-textfield
-                    type="email"
+                    required
                     id="id_user_id"
                     maxlength="64"
                     autocomplete="username"


### PR DESCRIPTION
### This PR resolves [giftbox #683](https://github.com/lablup/giftbox/issues/683) issue

### TL;DR

Added input validation for the login form to ensure that the user ID is either a valid email address or a username that matches specified patterns.

### What changed?

- Introduced `_validateInput` function in `backend-ai-login.ts`.
- Updated the `<mwc-textfield>` element to use the `_validateInput` function for validation.
- Modified the input field to adhere to the validation patterns specified for email and username.

### How to test?

1. Open the login form.
2. Try entering an invalid email or username. Ensure that the validation message is shown.
3. Enter a valid email or username. Ensure that no validation message is shown and the form can be submitted.

`email type` : Beginning with uppercase and lowercase letters of the alphabet, numbers, dots, underscores, and minus signs. The @ symbol followed by uppercase and lowercase letters of the alphabet, numbers, dots, and minus signs.
`username type` : Text between 3 and 20 characters, consisting of uppercase and lowercase letters of the alphabet, numbers, dots, underscores, and minuses.

### Why make this change?

To improve user experience by providing immediate feedback on input errors in the login form, thereby preventing users from submitting invalid data.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
