### PR TITLE
add: kernel_id param on fetching container log by kernel id in session

### DIFF
--- a/react/src/pages/SummaryPage.tsx
+++ b/react/src/pages/SummaryPage.tsx
@@ -44,7 +44,7 @@ const SummaryPage: React.FC = () => {
       ? _.map(summaryItemsSetting, (item) => ({
           ...item,
           data: {
-            ...defaultSummaryElements[item.id],
+            ...defaultSummaryElements[item?.id],
           },
         }))
       : [

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -832,7 +832,7 @@ export default class BackendAISessionList extends BackendAIPage {
     }
     if (globalThis.backendaiclient.supports('per-user-image')) {
       containerFields.push(
-        'kernel_id role image_object { labels { key value } }',
+        'kernel_id role local_rank image_object { labels { key value } }',
       );
     }
 
@@ -1553,15 +1553,13 @@ export default class BackendAISessionList extends BackendAIPage {
     this.workDialog.sessionUuid = sessionUuid;
     this.workDialog.sessionName = sessionName;
     this.workDialog.accessKey = accessKey;
-    let subContainerLength = 0;
     this.selectedKernels = this.compute_sessions
       .find((session) => session.session_id === sessionUuid)
       ?.containers.map((container) => {
         if (container.role === 'main') {
           container.role = 'main1';
         } else {
-          subContainerLength++;
-          container.role = `sub${subContainerLength}`;
+          container.role = `sub${container.local_rank}`;
         }
         return container;
       })

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -1282,10 +1282,17 @@ class Client {
    * @param {string | null} ownerKey - owner key to access
    * @param {number} timeout - timeout to wait log query. Set to 0 to use default value.
    */
-  async get_logs(sessionId, ownerKey = null, timeout = 0): Promise<any> {
-    let queryString = `${this.kernelPrefix}/${sessionId}/logs`;
+  async get_logs(sessionId, ownerKey = null, kernelId = null, timeout = 0): Promise<any> {
+    let queryParams: Array<string> = [];
     if (ownerKey != null) {
-      queryString = `${queryString}?owner_access_key=${ownerKey}`;
+      queryParams.push(`owner_access_key=${ownerKey}`);
+    }
+    if (kernelId != null) {
+      queryParams.push(`kernel_id=${kernelId}`);
+    }
+    let queryString = `${this.kernelPrefix}/${sessionId}/logs`;
+    if (queryParams.length > 0) {
+      queryString += `?${queryParams.join('&')}`;
     }
     let rqst = this.newSignedRequest('GET', queryString, null, null);
     return this._wrapWithPromise(rqst, false, null, timeout);


### PR DESCRIPTION
related: [backend.ai#2364](https://github.com/lablup/backend.ai/pull/2364)

This diff contains changes across several TypeScript files within a React project. Key updates include:

1. **SummaryPage.tsx:**
   - Modified a mapping function to access a potentially undefined `id` property with optional chaining.

2. **backend-ai-session-list.ts:**
   - Added `mwc-select` import.
   - Removed unused imports (`translateUnsafeHTML`).
   - Introduced several new properties (`selectedKernels`, `selectedKernelId`).
   - Updated constructor to initialize new properties.
   - Adjusted `_showLogs` function to support kernel-specific logs fetching using `selectedKernelId`.
   - Added `_setSelectedSession` and `_updateLogsByKernelId` methods to manage selected session state.
   - Updated UI components and event handling to support the new features.

3. **backend.ai-client-esm.ts:**
   - Enhanced the `get_logs` method to include `kernelId` as an optional query parameter.

### Screenshot(s)
| After | Before |
|------|--------|
| ![Screenshot 2024-07-02 at 5.32.14 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/acc8daff-263e-426c-872f-66ecc9fd8852.png) | ![Screenshot 2024-07-02 at 5.34.31 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/0d14b9e9-e743-4911-8131-71476b0f8bbc.png) |

---


<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
