### PR TITLE
fix: Apply one decimal place rounding to per session I/O stat

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -3584,8 +3584,8 @@ ${rowData.item[this.sessionNameField]}</pre
                 style="font-size:10px;margin-left:5px;"
                 class="horizontal start-justified center layout"
               >
-                R: ${rowData.item?.live_stat?.io_read?.current} MB / W:
-                ${rowData.item?.live_stat?.io_write?.current} MB
+                R: ${rowData.item?.live_stat?.io_read?.current.toFixed(1)} MB /
+                W: ${rowData.item?.live_stat?.io_write?.current.toFixed(1)} MB
               </div>
             </div>
           </div>
@@ -3664,14 +3664,14 @@ ${rowData.item[this.sessionNameField]}</pre
             </mwc-icon>
             <div class="vertical start layout">
               <span style="font-size:9px">
-                ${rowData.item.live_stat?.io_read?.current}
+                ${rowData.item.live_stat?.io_read?.current.toFixed(1)}
                 <span class="indicator">MB</span>
               </span>
               <span class="indicator">READ</span>
             </div>
             <div class="vertical start layout">
               <span style="font-size:8px">
-                ${rowData.item.live_stat?.io_write?.current}
+                ${rowData.item.live_stat?.io_write?.current.toFixed(1)}
                 <span class="indicator">MB</span>
               </span>
               <span class="indicator">WRITE</span>


### PR DESCRIPTION
### This PR Resolves [giftbox #690](https://github.com/lablup/giftbox/issues/690) issue

### TL;DR
Updates the display of `io_read` and `io_write` values to show up to one decimal place in the `backend-ai-session-list` component.

### What changed?
 - Modified the template literals in `backend-ai-session-list.ts` to format `io_read.current` and `io_write.current` values with `toFixed(1)`.
 
### How to test?
1. Start the backend AI session and navigate to the session list.
2. Observe the `io_read` and `io_write` values in the session list.
3. Ensure the values are displayed with one decimal precision.

### Why make this change?
Ensures consistency and readability in the display of data, particularly for values with variable precision.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
