### PR TITLE
feat: introduce exporting CSV module

### DIFF
--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -1,4 +1,8 @@
-import { localeCompare, numberSorterWithInfinityValue } from '../helper';
+import {
+  exportCSVWithFormattingRules,
+  localeCompare,
+  numberSorterWithInfinityValue,
+} from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import Flex from './Flex';
 import KeypairResourcePolicySettingModal, {
@@ -15,12 +19,22 @@ import {
 import { KeypairResourcePolicySettingModalFragment$key } from './__generated__/KeypairResourcePolicySettingModalFragment.graphql';
 import {
   DeleteOutlined,
+  DownOutlined,
   PlusOutlined,
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
 import { useLocalStorageState } from 'ahooks';
-import { App, Button, Popconfirm, Table, Tag, theme, Typography } from 'antd';
+import {
+  App,
+  Button,
+  Dropdown,
+  Popconfirm,
+  Space,
+  Table,
+  Tag,
+  theme,
+} from 'antd';
 import { AnyObject } from 'antd/es/_util/type';
 import { ColumnsType, ColumnType } from 'antd/es/table';
 import graphql from 'babel-plugin-relay/macro';
@@ -272,6 +286,38 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
     },
   );
 
+  const handleExportCSV = () => {
+    if (!keypair_resource_policies) {
+      message.error(t('resourcePolicy.NoDataToExport'));
+      return;
+    }
+
+    const columnkeys = _.without(displayedColumnKeys, 'control');
+    const responseData = _.map(keypair_resource_policies, (policy) => {
+      return _.pick(
+        policy,
+        columnkeys.map((key) => key as keyof KeypairResourcePolicies),
+      );
+    });
+
+    exportCSVWithFormattingRules(
+      responseData as KeypairResourcePolicies[],
+      {
+        total_resource_slots: (text) =>
+          _.isEmpty(text) ? '-' : JSON.stringify(text),
+        max_concurrent_sessions: (text) =>
+          text === UNLIMITED_MAX_CONCURRENT_SESSIONS ? '-' : text,
+        max_containers_per_session: (text) =>
+          text === UNLIMITED_MAX_CONTAINERS_PER_SESSIONS ? '-' : text,
+        idle_timeout: (text) => (text ? text : '-'),
+        max_session_lifetime: (text) => (text ? text : '-'),
+        allowed_vfolder_hosts: (text) =>
+          _.isEmpty(text) ? '-' : _.keys(JSON.parse(text)).join(', '),
+      },
+      'keypair_resource_policies',
+    );
+  };
+
   return (
     <Flex direction="column" align="stretch">
       <Flex
@@ -286,9 +332,30 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         }}
       >
         <Flex direction="column" align="start">
-          <Typography.Text style={{ margin: 0, padding: 0 }}>
-            {t('resourcePolicy.KeypairResourcePolicy')}
-          </Typography.Text>
+          <Dropdown
+            menu={{
+              items: [
+                {
+                  key: 'exportCSV',
+                  label: t('resourcePolicy.ExportCSV'),
+                  onClick: () => {
+                    handleExportCSV();
+                  },
+                },
+              ],
+            }}
+          >
+            <Button
+              type="link"
+              style={{ padding: 0 }}
+              onClick={(e) => e.preventDefault()}
+            >
+              <Space style={{ color: token.colorLinkHover }}>
+                {t('resourcePolicy.Tools')}
+                <DownOutlined />
+              </Space>
+            </Button>
+          </Dropdown>
         </Flex>
         <Flex direction="row" gap={'xs'} wrap="wrap" style={{ flexShrink: 1 }}>
           <Flex gap={'xs'}>

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -383,3 +383,74 @@ export const generateRandomString = (n = 3) => {
 
   return randStr;
 };
+
+/**
+ * make a CSV file from the given data and download it.
+ * @param {Array<string>} columns
+ * A single array of strings that represents the columns of the CSV file.
+ * It will be used to devide the content into rows.
+ * @param {Array<Array<string>>} content
+ * A single array of strings that represents the content of the CSV file.
+ * It will be devided into rows by the number of columns.
+ * @param {string} filename - The name of the CSV file.
+ */
+export const exportAsCSV = (
+  columnsTitle: Array<string>,
+  content: Array<Array<string>>,
+  filename: string,
+) => {
+  const escapeCSV = (value: string) => {
+    if (typeof value === 'string') {
+      return `"${value.replace(/"/g, '""')}"`;
+    }
+    return value;
+  };
+
+  const csvContent = content
+    .map((row) => row.map(escapeCSV).join(','))
+    .join('\n');
+  const csvData = [columnsTitle.map(escapeCSV).join(','), csvContent].join(
+    '\n',
+  );
+  const blob = new Blob([csvData], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+
+  a.href = url;
+  a.download = `${filename}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+/**
+ * For the GQL data, displayedColumnKeys, and format rules, return a CSV string.
+ *
+ * @param {readonly T[]} data
+ * @param {object} format_rules
+ * - Each key should be the key of the data object.
+ * @param {string[]} displayedColumnKeys
+ * - The keys of the data object to be displayed.
+ * - If not provided, all keys will be displayed and order by the data object.
+ */
+export const exportCSVWithFormattingRules = <T,>(
+  data: T[],
+  format_rules: Record<keyof T, (value: any) => any>,
+  filename: string,
+) => {
+  const displayedData = _.map(data, (row) => {
+    return _.omit(row as object, '__fragments', '__fragmentOwner', '__id');
+  });
+
+  const CSVTitle = _.keys(displayedData[0]);
+  const CSVData = _.map(displayedData, (row) => {
+    return _.map(row, (value, key) => {
+      if (format_rules[key as keyof T]) {
+        const v = format_rules[key as keyof T](value);
+        return typeof v === 'string' ? v : JSON.stringify(v);
+      }
+      return typeof value === 'string' ? value : JSON.stringify(value);
+    });
+  });
+
+  exportAsCSV(CSVTitle, CSVData, filename);
+};

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "Maximale Anzahl benutzerdefinierter Bilder",
     "CreatedAt": "Hergestellt in",
     "MaxFolderCount": "Maximale Ordneranzahl",
-    "ProjectResourcePolicy": "Projektressourcenrichtlinie"
+    "ProjectResourcePolicy": "Projektressourcenrichtlinie",
+    "NoDataToExport": "Die Daten für den CSV-Extrakt sind nicht vorhanden.",
+    "ExportCSV": "CSV exportieren",
+    "Tools": "Werkzeuge"
   },
   "registry": {
     "Hostname": "Hostname",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "Μέγιστος προσαρμοσμένος αριθμός εικόνων",
     "CreatedAt": "Δημιουργήθηκε στο",
     "MaxFolderCount": "Μέγιστος αριθμός φακέλων",
-    "ProjectResourcePolicy": "Πολιτική πόρων έργου"
+    "ProjectResourcePolicy": "Πολιτική πόρων έργου",
+    "NoDataToExport": "Τα δεδομένα για το απόσπασμα CSV δεν υπάρχουν.",
+    "ExportCSV": "εξαγωγή CSV",
+    "Tools": "Εργαλεία"
   },
   "registry": {
     "Hostname": "Όνομα κεντρικού υπολογιστή",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1118,7 +1118,10 @@
     "MaxCustomizedImageCount": "Max Customized Image Count",
     "CreatedAt": "Created At",
     "MaxFolderCount": "Max Folder Count",
-    "ProjectResourcePolicy": "Project Resource Policy"
+    "ProjectResourcePolicy": "Project Resource Policy",
+    "NoDataToExport": "The data for the CSV extract does not exist.",
+    "ExportCSV": "export CSV",
+    "Tools": "Tools"
   },
   "registry": {
     "Hostname": "Hostname",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -946,7 +946,10 @@
     "MaxCustomizedImageCount": "Número máximo de imágenes personalizadas",
     "CreatedAt": "Creado en",
     "MaxFolderCount": "Número máximo de carpetas",
-    "ProjectResourcePolicy": "Política de recursos del proyecto"
+    "ProjectResourcePolicy": "Política de recursos del proyecto",
+    "NoDataToExport": "Los datos para el extracto CSV no existen.",
+    "ExportCSV": "exportar CSV",
+    "Tools": "Herramientas"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Está a punto de borrar este preajuste:",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -943,7 +943,10 @@
     "MaxCustomizedImageCount": "Suurin mukautettu kuvien määrä",
     "CreatedAt": "Luotu klo",
     "MaxFolderCount": "Kansioiden enimmäismäärä",
-    "ProjectResourcePolicy": "Projektin resurssipolitiikka"
+    "ProjectResourcePolicy": "Projektin resurssipolitiikka",
+    "NoDataToExport": "CSV-otteen tietoja ei ole olemassa.",
+    "ExportCSV": "vie CSV",
+    "Tools": "Työkalut"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Olet poistamassa tätä esiasetusta:",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "Nombre maximal d'images personnalisées",
     "CreatedAt": "Créé à",
     "MaxFolderCount": "Nombre maximum de dossiers",
-    "ProjectResourcePolicy": "Politique des ressources du projet"
+    "ProjectResourcePolicy": "Politique des ressources du projet",
+    "NoDataToExport": "Les données pour l'extrait CSV n'existent pas.",
+    "ExportCSV": "exporter au format CSV",
+    "Tools": "Outils"
   },
   "registry": {
     "Hostname": "Nom d'hôte",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -994,7 +994,10 @@
     "MaxCustomizedImageCount": "Jumlah Gambar Khusus Maksimum",
     "CreatedAt": "Dibuat di",
     "MaxFolderCount": "Jumlah Folder Maks",
-    "ProjectResourcePolicy": "Kebijakan Sumber Daya Proyek"
+    "ProjectResourcePolicy": "Kebijakan Sumber Daya Proyek",
+    "NoDataToExport": "Data untuk ekstrak CSV tidak ada.",
+    "ExportCSV": "ekspor CSV",
+    "Tools": "Peralatan"
   },
   "registry": {
     "Hostname": "Nama host",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -993,7 +993,10 @@
     "MaxQuotaScopeSize": "Dimensione massima ambito quota (GB)",
     "MaxCustomizedImageCount": "Conteggio massimo di immagini personalizzate",
     "CreatedAt": "Creato a",
-    "MaxFolderCount": "Conteggio massimo cartelle"
+    "MaxFolderCount": "Conteggio massimo cartelle",
+    "NoDataToExport": "I dati per l'estrazione CSV non esistono.",
+    "ExportCSV": "esportare CSV",
+    "Tools": "Utensili"
   },
   "registry": {
     "Hostname": "Nome host",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "カスタマイズされた画像の最大数",
     "CreatedAt": "作成日",
     "MaxFolderCount": "最大フォルダ数",
-    "ProjectResourcePolicy": "プロジェクトリソースポリシー"
+    "ProjectResourcePolicy": "プロジェクトリソースポリシー",
+    "NoDataToExport": "CSV抽出用のデータが存在しません。",
+    "ExportCSV": "CSVエクスポート",
+    "Tools": "ツール"
   },
   "registry": {
     "Hostname": "ホスト名",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1105,7 +1105,10 @@
     "MaxCustomizedImageCount": "최대 사용자 정의 이미지 수",
     "CreatedAt": "생성 날짜",
     "MaxFolderCount": "최대 폴더 수",
-    "ProjectResourcePolicy": "프로젝트 자원 정책"
+    "ProjectResourcePolicy": "프로젝트 자원 정책",
+    "NoDataToExport": "CSV 추출을 위한 데이터가 존재하지 않습니다. ",
+    "ExportCSV": "CSV로 내보내기",
+    "Tools": "도구"
   },
   "registry": {
     "Hostname": "호스트명",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -994,7 +994,10 @@
     "MaxQuotaScopeSize": "Хамгийн их квот хамрах хүрээний хэмжээ (ГБ)",
     "MaxCustomizedImageCount": "Хамгийн их тохируулсан зургийн тоо",
     "CreatedAt": "Үүсгэсэн",
-    "MaxFolderCount": "Хамгийн их хавтасны тоо"
+    "MaxFolderCount": "Хамгийн их хавтасны тоо",
+    "NoDataToExport": "CSV хандалтын өгөгдөл байхгүй байна.",
+    "ExportCSV": "CSV экспортлох",
+    "Tools": "Багаж хэрэгсэл"
   },
   "registry": {
     "Hostname": "Хостын нэр",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "Kiraan Imej Tersuai Maks",
     "CreatedAt": "Dicipta Pada",
     "MaxFolderCount": "Kiraan Folder Maks",
-    "ProjectResourcePolicy": "Dasar Sumber Projek"
+    "ProjectResourcePolicy": "Dasar Sumber Projek",
+    "NoDataToExport": "Data untuk ekstrak CSV tidak wujud.",
+    "ExportCSV": "eksport CSV",
+    "Tools": "Alatan"
   },
   "registry": {
     "Hostname": "Nama Hos",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "Maksymalna dostosowana liczba obrazów",
     "CreatedAt": "Utworzono o godz",
     "MaxFolderCount": "Maksymalna liczba folderów",
-    "ProjectResourcePolicy": "Polityka zasobów projektu"
+    "ProjectResourcePolicy": "Polityka zasobów projektu",
+    "NoDataToExport": "Dane do ekstraktu CSV nie istnieją.",
+    "ExportCSV": "eksportuj plik CSV",
+    "Tools": "Narzędzia"
   },
   "registry": {
     "Hostname": "Nazwa hosta",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "Contagem máxima de imagens personalizadas",
     "CreatedAt": "Criado em",
     "MaxFolderCount": "Contagem máxima de pastas",
-    "ProjectResourcePolicy": "Política de Recursos do Projeto"
+    "ProjectResourcePolicy": "Política de Recursos do Projeto",
+    "NoDataToExport": "Os dados para a extração CSV não existem.",
+    "ExportCSV": "exportar CSV",
+    "Tools": "Ferramentas"
   },
   "registry": {
     "Hostname": "nome de anfitrião",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "Contagem máxima de imagens personalizadas",
     "CreatedAt": "Criado em",
     "MaxFolderCount": "Contagem máxima de pastas",
-    "ProjectResourcePolicy": "Política de Recursos do Projeto"
+    "ProjectResourcePolicy": "Política de Recursos do Projeto",
+    "NoDataToExport": "Os dados para a extração CSV não existem.",
+    "ExportCSV": "exportar CSV",
+    "Tools": "Ferramentas"
   },
   "registry": {
     "Hostname": "nome de anfitrião",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "Максимальное количество индивидуальных изображений",
     "CreatedAt": "Создан в",
     "MaxFolderCount": "Максимальное количество папок",
-    "ProjectResourcePolicy": "Ресурсная политика проекта"
+    "ProjectResourcePolicy": "Ресурсная политика проекта",
+    "NoDataToExport": "Данные для извлечения CSV не существуют.",
+    "ExportCSV": "экспортировать CSV",
+    "Tools": "Инструменты"
   },
   "registry": {
     "Hostname": "Имя хоста",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "Maksimum Özelleştirilmiş Görüntü Sayısı",
     "CreatedAt": "Oluşturulma Tarihi",
     "MaxFolderCount": "Maksimum Klasör Sayısı",
-    "ProjectResourcePolicy": "Proje Kaynak Politikası"
+    "ProjectResourcePolicy": "Proje Kaynak Politikası",
+    "NoDataToExport": "CSV ekstresine ilişkin veriler mevcut değil.",
+    "ExportCSV": "CSV'yi dışa aktar",
+    "Tools": "Aletler"
   },
   "registry": {
     "Hostname": "ana bilgisayar adı",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "Số lượng hình ảnh tùy chỉnh tối đa",
     "CreatedAt": "Được tạo tại",
     "MaxFolderCount": "Số lượng thư mục tối đa",
-    "ProjectResourcePolicy": "Chính sách tài nguyên dự án"
+    "ProjectResourcePolicy": "Chính sách tài nguyên dự án",
+    "NoDataToExport": "Dữ liệu cho bản trích xuất CSV không tồn tại.",
+    "ExportCSV": "xuất CSV",
+    "Tools": "Công cụ"
   },
   "registry": {
     "Hostname": "Tên máy chủ",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "最大自定义图像数量",
     "CreatedAt": "创建于",
     "MaxFolderCount": "最大文件夹数",
-    "ProjectResourcePolicy": "项目资源政策"
+    "ProjectResourcePolicy": "项目资源政策",
+    "NoDataToExport": "CSV 提取的数据不存在。",
+    "ExportCSV": "导出 CSV",
+    "Tools": "工具"
   },
   "registry": {
     "Hostname": "主机名",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -993,7 +993,10 @@
     "MaxCustomizedImageCount": "最大自訂圖像數量",
     "CreatedAt": "創建於",
     "MaxFolderCount": "最大資料夾數",
-    "ProjectResourcePolicy": "專案資源政策"
+    "ProjectResourcePolicy": "專案資源政策",
+    "NoDataToExport": "CSV 擷取的資料不存在。",
+    "ExportCSV": "匯出 CSV",
+    "Tools": "工具"
   },
   "registry": {
     "Hostname": "主機名",


### PR DESCRIPTION
### TL;DR

This PR adds CSV export functionality to the Keypair, Project, and User Resource Policy Lists, along with associated UI updates.

### What changed?
- Added `exportAsCSV` and `exportCSVWithFormattingRules` functions to helper.
- Integrated CSV export options into the UI of Keypair Resource Policy list, Project Resource Policy list, and User Resource Policy List.
- Updated translations to support new CSV export functionalities.

### How to test?
1. Navigate to each Resource Policy List in the UI.
2. Use the new 'Tools' dropdown and select 'Export CSV'.
3. Verify the CSV file content and format.

### Why make this change?
To provide users with an easy way to export and share resource policy data.


**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
