### PR TITLE
Add an 'Import from hugging face' modal

### DIFF
--- a/react/src/components/ImportFromHuggingFaceModal.tsx
+++ b/react/src/components/ImportFromHuggingFaceModal.tsx
@@ -1,0 +1,107 @@
+import BAIModal, { BAIModalProps } from './BAIModal';
+import Flex from './Flex';
+import { FilterOutlined } from '@ant-design/icons';
+import { useToggle } from 'ahooks';
+import {
+  Button,
+  Card,
+  Form,
+  FormInstance,
+  Input,
+  Switch,
+  theme,
+  Typography,
+} from 'antd';
+import Markdown from 'markdown-to-jsx';
+import React, { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+type Service = {
+  url: string;
+  inference_engine_version?: string;
+  replica_number?: number;
+};
+
+interface ImportFromHuggingFaceModalProps extends BAIModalProps {
+  onRequestClose: () => void;
+}
+
+const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
+  onRequestClose,
+  ...baiModalProps
+}) => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const formRef = useRef<FormInstance<Service>>(null);
+  const [isImportOnly, { toggle: toggleIsImportOnly }] = useToggle(false);
+
+  const handleOnClick = () => {
+    formRef.current
+      ?.validateFields()
+      .then((values) => {
+        // TODO: Implement import from Hugging Face
+        onRequestClose();
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <BAIModal
+      title={t('data.modelStore.ImportFromHuggingFace')}
+      centered
+      footer={
+        <Button type="primary" htmlType="submit" onClick={handleOnClick}>
+          {isImportOnly
+            ? t('data.modelStore.Import')
+            : t('data.modelStore.ImportAndStartService')}
+        </Button>
+      }
+      onCancel={onRequestClose}
+      {...baiModalProps}
+    >
+      <Form
+        ref={formRef}
+        preserve={false}
+        layout="vertical"
+        requiredMark="optional"
+      >
+        <Form.Item name="url" rules={[{ required: true }]}>
+          <Input placeholder={t('data.modelStore.huggingFaceUrlPlaceholder')} />
+        </Form.Item>
+        <Card
+          size="small"
+          title={
+            <Flex direction="row" gap="xs">
+              <FilterOutlined />
+              README.md
+            </Flex>
+          }
+          styles={{
+            body: {
+              padding: token.paddingLG,
+              overflow: 'auto',
+              minHeight: 200,
+              maxHeight: token.screenXS,
+            },
+          }}
+        >
+          <Markdown>{''}</Markdown>
+        </Card>
+        <Flex
+          gap={'xs'}
+          style={{ marginTop: token.marginLG, marginBottom: token.marginLG }}
+        >
+          <Switch
+            checked={isImportOnly}
+            onChange={(e) => {
+              toggleIsImportOnly();
+            }}
+          />
+          <Typography.Text>{t('data.modelStore.ImportOnly')}</Typography.Text>
+        </Flex>
+      </Form>
+    </BAIModal>
+  );
+};
+
+export default ImportFromHuggingFaceModal;

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -95,6 +95,7 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
         value: _.first(filteredVFolders)?.[valuePropName],
       }
     : undefined;
+  // TODO: use controllable value
   useEffect(() => {
     if (autoSelectDefault && autoSelectedOption) {
       setValue(autoSelectedOption.value, autoSelectedOption);

--- a/react/src/pages/VFolderListPage.tsx
+++ b/react/src/pages/VFolderListPage.tsx
@@ -1,9 +1,16 @@
 import Flex from '../components/Flex';
+import ImportFromHuggingFaceModal from '../components/ImportFromHuggingFaceModal';
 import InviteFolderPermissionSettingModal from '../components/InviteFolderPermissionSettingModal';
 import { filterEmptyItem } from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
-import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
+import {
+  DeleteOutlined,
+  ImportOutlined,
+  PlusOutlined,
+} from '@ant-design/icons';
+import { useToggle } from 'ahooks';
 import { Alert, Button, Card, Skeleton, theme } from 'antd';
+import _ from 'lodash';
 import React, { Suspense, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
@@ -39,6 +46,10 @@ const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
   const dataViewRef = useRef(null);
   const [inviteFolderId, setInviteFolderId] = useState<string | null>(null);
+  const [
+    isVisibleImportFromHuggingFaceModal,
+    { toggle: toggleImportFromHuggingFaceModal },
+  ] = useToggle(false);
 
   const { token } = theme.useToken();
 
@@ -117,16 +128,28 @@ const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
           },
         }}
         tabBarExtraContent={
-          <Button
-            type="primary"
-            icon={<PlusOutlined />}
-            onClick={() => {
-              // @ts-ignore
-              dataViewRef.current?.openAddFolderDialog();
-            }}
-          >
-            {t('data.Add')}
-          </Button>
+          <Flex gap="xs">
+            {_.includes(['model', 'model-store'], curTabKey) ? (
+              <Button
+                icon={<ImportOutlined />}
+                onClick={toggleImportFromHuggingFaceModal}
+                // Remove this line to test
+                style={{ display: 'none' }}
+              >
+                {t('data.modelStore.ImportFromHuggingFace')}
+              </Button>
+            ) : null}
+            <Button
+              type="primary"
+              icon={<PlusOutlined />}
+              onClick={() => {
+                // @ts-ignore
+                dataViewRef.current?.openAddFolderDialog();
+              }}
+            >
+              {t('data.Add')}
+            </Button>
+          </Flex>
         }
       >
         {tabBannerText ? (
@@ -148,6 +171,12 @@ const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
         }}
         vfolderId={inviteFolderId}
         open={inviteFolderId !== null}
+      />
+      <ImportFromHuggingFaceModal
+        open={isVisibleImportFromHuggingFaceModal}
+        onRequestClose={() => {
+          toggleImportFromHuggingFaceModal();
+        }}
       />
     </Flex>
   );

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -777,7 +777,17 @@
     "Add": "hinzufügen",
     "CloningIsOnlyPossibleSameHost": "Derzeit ist das Klonen nur auf demselben Host möglich.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Neuer Ordnername"
+    "NewFolderName": "Neuer Ordnername",
+    "modelStore": {
+      "ImportFromHuggingFace": "Import aus Hugging Face",
+      "Import": "Importieren",
+      "StartService": "Dienst starten",
+      "InferenceEngineVersion": "Version der Inferenz-Engine",
+      "ReplicaNumber": "Replikatnummer",
+      "ImportAndStartService": "Dienst importieren und starten",
+      "huggingFaceUrlPlaceholder": "Geben Sie die URL Hugging Face ein",
+      "ImportOnly": "Nur importieren"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -777,7 +777,17 @@
     "Add": "Προσθέστε",
     "CloningIsOnlyPossibleSameHost": "Προς το παρόν, η κλωνοποίηση είναι δυνατή μόνο στον ίδιο κεντρικό υπολογιστή.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Νέο όνομα φακέλου"
+    "NewFolderName": "Νέο όνομα φακέλου",
+    "modelStore": {
+      "ImportFromHuggingFace": "Εισαγωγή από το Hugging Face",
+      "Import": "Εισαγωγή",
+      "StartService": "Ξεκινήστε την υπηρεσία",
+      "InferenceEngineVersion": "Έκδοση Inference Engine",
+      "ReplicaNumber": "Αριθμός αντιγράφου",
+      "ImportAndStartService": "Εισαγωγή και έναρξη υπηρεσίας",
+      "huggingFaceUrlPlaceholder": "Εισαγάγετε τη διεύθυνση URL Hugging Face.",
+      "ImportOnly": "Μόνο εισαγωγή"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -902,7 +902,17 @@
     "Add": "Add",
     "CloningIsOnlyPossibleSameHost": "Currently, cloning is only possible on the same host.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "New folder name"
+    "NewFolderName": "New folder name",
+    "modelStore": {
+      "ImportFromHuggingFace": "Import from Hugging Face",
+      "Import": "Import",
+      "StartService": "Start Service",
+      "InferenceEngineVersion": "Inference Engine Version",
+      "ReplicaNumber": "Replica Number",
+      "ImportAndStartService": "Import & Start Service",
+      "huggingFaceUrlPlaceholder": "Input Hugging Face URL",
+      "ImportOnly": "Import only"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -407,7 +407,17 @@
     "Add": "Añadir",
     "CloningIsOnlyPossibleSameHost": "Actualmente, la clonación sólo es posible en el mismo host.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Nuevo nombre de carpeta"
+    "NewFolderName": "Nuevo nombre de carpeta",
+    "modelStore": {
+      "ImportFromHuggingFace": "Importar desde Hugging Face",
+      "Import": "Importar",
+      "StartService": "Comienza el servicio",
+      "InferenceEngineVersion": "Versión del motor de inferencia",
+      "ReplicaNumber": "Número de réplica",
+      "ImportAndStartService": "Servicio de importación e inicio",
+      "huggingFaceUrlPlaceholder": "Introduzca la URL Hugging Face",
+      "ImportOnly": "Sólo importar"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -407,7 +407,17 @@
     "CloningIsOnlyPossibleSameHost": "Tällä hetkellä kloonaus on mahdollista vain samassa isännässä.",
     "New": "Uusi",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Uusi kansion nimi"
+    "NewFolderName": "Uusi kansion nimi",
+    "modelStore": {
+      "ImportFromHuggingFace": "Tuo Hugging Facesta",
+      "Import": "Tuonti",
+      "StartService": "Aloita palvelu",
+      "InferenceEngineVersion": "Päättele moottorin versio",
+      "ReplicaNumber": "Replikan numero",
+      "ImportAndStartService": "Tuo ja käynnistä palvelu",
+      "huggingFaceUrlPlaceholder": "Syötä Hugging Face-URL-osoite",
+      "ImportOnly": "Vain tuonti"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -777,7 +777,17 @@
     "Add": "Ajouter",
     "CloningIsOnlyPossibleSameHost": "Actuellement, le clonage n'est possible que sur le même hôte.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Nouveau nom de dossier"
+    "NewFolderName": "Nouveau nom de dossier",
+    "modelStore": {
+      "ImportFromHuggingFace": "Importer depuis Hugging Face",
+      "Import": "Importer",
+      "StartService": "Démarrer le service",
+      "InferenceEngineVersion": "Version du moteur d'inférence",
+      "ReplicaNumber": "Numéro de réplique",
+      "ImportAndStartService": "Service d'importation et de démarrage",
+      "huggingFaceUrlPlaceholder": "Saisissez l'URL Hugging Face",
+      "ImportOnly": "Importer uniquement"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -778,7 +778,17 @@
     "Add": "Menambahkan",
     "CloningIsOnlyPossibleSameHost": "Saat ini, kloning hanya dapat dilakukan pada host yang sama.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Nama folder baru"
+    "NewFolderName": "Nama folder baru",
+    "modelStore": {
+      "ImportFromHuggingFace": "Impor dari Hugging Face",
+      "Import": "Impor",
+      "StartService": "Memulai layanan",
+      "InferenceEngineVersion": "Versi Mesin Inferensi",
+      "ReplicaNumber": "Nomor Replika",
+      "ImportAndStartService": "Impor dan Mulai Layanan",
+      "huggingFaceUrlPlaceholder": "Masukkan URL Hugging Face",
+      "ImportOnly": "Impor saja"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -778,7 +778,17 @@
     "Add": "Aggiungi",
     "CloningIsOnlyPossibleSameHost": "Attualmente la clonazione è possibile solo sullo stesso host.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Nuovo nome della cartella"
+    "NewFolderName": "Nuovo nome della cartella",
+    "modelStore": {
+      "ImportFromHuggingFace": "Importa da Hugging Face",
+      "Import": "Importare",
+      "StartService": "Avvia servizio",
+      "InferenceEngineVersion": "Versione del motore di inferenza",
+      "ReplicaNumber": "Numero di replica",
+      "ImportAndStartService": "Importa e avvia il servizio",
+      "huggingFaceUrlPlaceholder": "Inserisci l'URL Hugging Face.",
+      "ImportOnly": "Solo importazione"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -777,7 +777,17 @@
     "Add": "追加",
     "CloningIsOnlyPossibleSameHost": "現在、クローン作成は同じホスト上でのみ可能です。",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "新しいフォルダ名"
+    "NewFolderName": "新しいフォルダ名",
+    "modelStore": {
+      "ImportFromHuggingFace": "Hugging Face からインポート",
+      "Import": "輸入",
+      "StartService": "サービスを開始する",
+      "InferenceEngineVersion": "推論エンジンのバージョン",
+      "ReplicaNumber": "レプリカ番号",
+      "ImportAndStartService": "サービスのインポートと開始",
+      "huggingFaceUrlPlaceholder": "Hugging Faceの URL を入力してください",
+      "ImportOnly": "輸入のみ"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -889,7 +889,17 @@
     "Add": "추가",
     "CloningIsOnlyPossibleSameHost": "현재 폴더 복사는 동일한 호스트간에만 가능합니다.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "새 폴더 이름"
+    "NewFolderName": "새 폴더 이름",
+    "modelStore": {
+      "ImportFromHuggingFace": "Hugging Face에서 가져오기",
+      "Import": "가져오기",
+      "StartService": "서비스 시작",
+      "InferenceEngineVersion": "추론 엔진 버전",
+      "ReplicaNumber": "복제 번호",
+      "ImportAndStartService": "가져오기 및 서비스 시작",
+      "huggingFaceUrlPlaceholder": "Hugging Face URL을 입력하세요.",
+      "ImportOnly": "가져오기만 허용"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -779,7 +779,17 @@
     "Add": "Нэмэх",
     "CloningIsOnlyPossibleSameHost": "Одоогоор зөвхөн нэг хост дээр клон хийх боломжтой.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Шинэ фолдерын нэр"
+    "NewFolderName": "Шинэ фолдерын нэр",
+    "modelStore": {
+      "ImportFromHuggingFace": "Hugging Face-ээс импортлох",
+      "Import": "Импорт",
+      "StartService": "Үйлчилгээг эхлүүлэх",
+      "InferenceEngineVersion": "Дүгнэлт хөдөлгүүрийн хувилбар",
+      "ReplicaNumber": "Хуулбарын дугаар",
+      "ImportAndStartService": "Импорт хийх ба эхлүүлэх үйлчилгээ",
+      "huggingFaceUrlPlaceholder": "Hugging Face URL-г оруулна уу",
+      "ImportOnly": "Зөвхөн импортлох"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -776,7 +776,17 @@
     "Add": "Tambah",
     "CloningIsOnlyPossibleSameHost": "Pada masa ini, pengklonan hanya boleh dilakukan pada hos yang sama.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Nama folder baharu"
+    "NewFolderName": "Nama folder baharu",
+    "modelStore": {
+      "ImportFromHuggingFace": "Import daripada Hugging Face",
+      "Import": "Import",
+      "StartService": "Mulakan Perkhidmatan",
+      "InferenceEngineVersion": "Versi Enjin Inferens",
+      "ReplicaNumber": "Nombor Replika",
+      "ImportAndStartService": "Import dan Mulakan Perkhidmatan",
+      "huggingFaceUrlPlaceholder": "Masukkan URL Hugging Face",
+      "ImportOnly": "Import sahaja"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -777,7 +777,17 @@
     "Add": "Dodaj",
     "CloningIsOnlyPossibleSameHost": "Obecnie klonowanie jest możliwe tylko na tym samym hoście.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Nowa nazwa folderu"
+    "NewFolderName": "Nowa nazwa folderu",
+    "modelStore": {
+      "ImportFromHuggingFace": "Importuj z Hugging Face",
+      "Import": "Import",
+      "StartService": "Uruchomić usługę",
+      "InferenceEngineVersion": "Wersja silnika wnioskowania",
+      "ReplicaNumber": "Numer repliki",
+      "ImportAndStartService": "Importuj i uruchamiaj usługę",
+      "huggingFaceUrlPlaceholder": "Wpisz adres URL Hugging Face",
+      "ImportOnly": "Tylko importuj"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -777,7 +777,17 @@
     "Add": "Adicionar",
     "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Novo nome da pasta"
+    "NewFolderName": "Novo nome da pasta",
+    "modelStore": {
+      "ImportFromHuggingFace": "Importar do Hugging Face",
+      "Import": "Importar",
+      "StartService": "Começar serviço",
+      "InferenceEngineVersion": "Versão do mecanismo de inferência",
+      "ReplicaNumber": "Número da réplica",
+      "ImportAndStartService": "Importar e iniciar serviço",
+      "huggingFaceUrlPlaceholder": "Insira o URL Hugging Face",
+      "ImportOnly": "Somente importação"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -777,7 +777,17 @@
     "Add": "Adicionar",
     "CloningIsOnlyPossibleSameHost": "Atualmente, a clonagem só é possível no mesmo host.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Novo nome da pasta"
+    "NewFolderName": "Novo nome da pasta",
+    "modelStore": {
+      "ImportFromHuggingFace": "Importar do Hugging Face",
+      "Import": "Importar",
+      "StartService": "Começar serviço",
+      "InferenceEngineVersion": "Versão do mecanismo de inferência",
+      "ReplicaNumber": "Número da réplica",
+      "ImportAndStartService": "Importar e iniciar serviço",
+      "huggingFaceUrlPlaceholder": "Insira o URL Hugging Face",
+      "ImportOnly": "Somente importação"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -777,7 +777,17 @@
     "Add": "Добавить",
     "CloningIsOnlyPossibleSameHost": "В настоящее время клонирование возможно только на том же хосте.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Новое имя папки"
+    "NewFolderName": "Новое имя папки",
+    "modelStore": {
+      "ImportFromHuggingFace": "Импорт из Hugging Face",
+      "Import": "Импортировать",
+      "StartService": "Запустить службу",
+      "InferenceEngineVersion": "Версия механизма вывода",
+      "ReplicaNumber": "Номер реплики",
+      "ImportAndStartService": "Импортировать и запустить службу",
+      "huggingFaceUrlPlaceholder": "Введите URL-адрес Hugging Face",
+      "ImportOnly": "Только импорт"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -900,7 +900,11 @@
     "Add": "เพิ่ม",
     "CloningIsOnlyPossibleSameHost": "ปัจจุบันการโคลนสามารถทำได้เฉพาะบนโฮสต์เดียวกัน",
     "userQuotaScopeId": "รหัสขอบเขตโควตาผู้ใช้",
-    "NewFolderName": "ชื่อโฟลเดอร์ใหม่"
+    "NewFolderName": "ชื่อโฟลเดอร์ใหม่",
+    "modelStore": {
+      "ImportFromHuggingFace": "นำเข้าจาก Hugging Face",
+      "ImportOnly": "นำเข้าเท่านั้น"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -777,7 +777,17 @@
     "Add": "Ekle",
     "CloningIsOnlyPossibleSameHost": "Şu anda klonlama yalnızca aynı ana bilgisayarda mümkündür.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Yeni klasör adı"
+    "NewFolderName": "Yeni klasör adı",
+    "modelStore": {
+      "ImportFromHuggingFace": "Hugging Face'ten içe aktar",
+      "Import": "İçe aktarmak",
+      "StartService": "Hizmeti Başlat",
+      "InferenceEngineVersion": "Çıkarım Motoru Sürümü",
+      "ReplicaNumber": "Çoğaltma Numarası",
+      "ImportAndStartService": "Hizmeti İçe Aktarma ve Başlatma",
+      "huggingFaceUrlPlaceholder": "Hugging Face URL'sini girin",
+      "ImportOnly": "Yalnızca içe aktar"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -777,7 +777,17 @@
     "Add": "Thêm vào",
     "CloningIsOnlyPossibleSameHost": "Hiện tại, việc nhân bản chỉ có thể thực hiện được trên cùng một máy chủ.",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "Tên thư mục mới"
+    "NewFolderName": "Tên thư mục mới",
+    "modelStore": {
+      "ImportFromHuggingFace": "Nhập từ Hugging Face",
+      "Import": "Nhập khẩu",
+      "StartService": "Bắt đầu dịch vụ",
+      "InferenceEngineVersion": "Phiên bản công cụ suy luận",
+      "ReplicaNumber": "Số bản sao",
+      "ImportAndStartService": "Dịch vụ nhập và bắt đầu",
+      "huggingFaceUrlPlaceholder": "Nhập URL Hugging Face",
+      "ImportOnly": "Chỉ nhập khẩu"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -777,7 +777,17 @@
     "Add": "添加",
     "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主机上进行。",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "新文件夹名称"
+    "NewFolderName": "新文件夹名称",
+    "modelStore": {
+      "ImportFromHuggingFace": "从 Hugging Face 导入",
+      "Import": "进口",
+      "StartService": "启动服务",
+      "InferenceEngineVersion": "推理引擎版本",
+      "ReplicaNumber": "副本号",
+      "ImportAndStartService": "导入并启动服务",
+      "huggingFaceUrlPlaceholder": "输入Hugging Face网址",
+      "ImportOnly": "仅导入"
+    }
   },
   "dialog": {
     "warning": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -776,7 +776,17 @@
     "Add": "添加",
     "CloningIsOnlyPossibleSameHost": "目前，克隆只能在同一主機上進行。",
     "userQuotaScopeId": "Quota Scope ID",
-    "NewFolderName": "新文件夹名称"
+    "NewFolderName": "新文件夹名称",
+    "modelStore": {
+      "ImportFromHuggingFace": "從 Hugging Face 匯入",
+      "Import": "進口",
+      "StartService": "啟動服務",
+      "InferenceEngineVersion": "推理引擎版本",
+      "ReplicaNumber": "副本號",
+      "ImportAndStartService": "導入並啟動服務",
+      "huggingFaceUrlPlaceholder": "輸入Hugging Face網址",
+      "ImportOnly": "僅導入"
+    }
   },
   "dialog": {
     "warning": {


### PR DESCRIPTION
### TL;DR

Add a new feature to import from Hugging Face in the VFolderListPage.

### What changed?

1. Modified `config.toml.sample` for indentation fix.
2. Added `ImportFromHuggingFaceModal` component to `react/src/components`.
3. Integrated `ImportFromHuggingFaceModal` in `VFolderListPage`.
4. Added new buttons and toggle functionality to `VFolderListPage.tsx`.
5. Updated language JSON files to include new translations for the Hugging Face import feature.

### How to test?

1. [Remove this line ](https://github.com/lablup/backend.ai-webui/pull/2514/files#diff-65e44191bce624d5e51a52298306cdece45d544cfb5ac1cc5fa4a202ddde6693R122)
2. Navigate to the data page. And click the model or model-store tab.
3. You can check the added modal by clicking an 'Import From Hugging Face' button.

### Screenshots

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/fe73fa7c-5b00-44a0-af85-4a292067614f.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/55a18038-4783-4c65-b012-c270a5da9e26.png)


---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
