### PR TITLE
fix: correct mistaken 'rocm_device' in resource monitor

### DIFF
--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -813,25 +813,22 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       <lablup-progress-bar
                         id="rocm-gpu-usage-bar-2"
                         class="end"
-                        progress="${this.used_slot_percent.rocm_device_slot /
-                        100.0}"
-                        buffer="${this.used_slot_percent.rocm_device_slot /
-                        100.0}"
-                        description="${this.used_slot.rocm_device_slot}/${this
-                          .total_slot.rocm_device_slot}"
+                        progress="${this.used_slot_percent.rocm_device / 100.0}"
+                        buffer="${this.used_slot_percent.rocm_device / 100.0}"
+                        description="${this.used_slot.rocm_device}/${this
+                          .total_slot.rocm_device}"
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this.used_resource_group_slot_percent
-                            .rocm_device_slot,
+                          this.used_resource_group_slot_percent.rocm_device,
                           '%',
                         )}
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this.used_slot_percent.rocm_device_slot,
+                          this.used_slot_percent.rocm_device,
                           '%',
                         )}
                       </span>


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

> NOTE: This issue has been reported by @kyujin-cho. 
This PR fixes displaying ROCm device in resource monitor gauge, which was missing due to wrong value assigning.

| After | Before |
|------|--------|
| <img width="293" alt="Screenshot 2024-07-04 at 5 15 38 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/723f2c66-facc-44aa-b06e-baef3718b49d"> | <img width="293" alt="Screenshot 2024-07-04 at 5 16 28 PM" src="https://github.com/lablup/backend.ai-webui/assets/46954439/c34e6477-9916-473b-89f1-ab9ce29157da"> |


**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
