### PR TITLE
refactor: Show as many agent IDs as the number of agents.

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1086,6 +1086,15 @@ export default class BackendAISessionList extends BackendAIPage {
                 sessions[objectKey].cpu_used_time =
                   this._automaticScaledTime(0);
               }
+              if (this.is_superadmin) {
+                sessions[objectKey].agents_ids_with_container_ids = sessions[
+                  objectKey
+                ].containers?.map((c) => {
+                  const agentID = c.agent;
+                  const containerID = c.container_id.slice(0, 4);
+                  return `${agentID}(${containerID})`;
+                });
+              }
             }
 
             const service_info = JSON.parse(sessions[objectKey].service_ports);
@@ -3942,15 +3951,8 @@ ${rowData.item[this.sessionNameField]}</pre
   agentListRenderer(root, column?, rowData?) {
     render(
       // language=HTML
-      // FIXME: temporally show allocated agent only, not in session-agent pair
       html`
-        <div class="layout vertical">
-          ${[...new Set(rowData.item.agents)]?.map(
-            (agent) => html`
-              <span>${agent}</span>
-            `,
-          )}
-        </div>
+        <pre>${rowData.item.agents_ids_with_container_ids?.join('\n')}</pre>
       `,
       root,
     );


### PR DESCRIPTION
### TL;DR
Added functionality to display agent IDs alongside their corresponding truncated container IDs for superadmin users in the session list.

### What changed?
- Modified `backend-ai-session-list.ts` to include a new field `agents_ids_with_container_ids` that concatenates agent IDs with truncated container IDs and displays them in a preformatted text block for superadmin users.

### How to test?
1. Log in as a superadmin user.
2. Navigate to the session list page.
3. Verify that the `agents_ids_with_container_ids` field is visible and displays the agent IDs with truncated container IDs.

### Why make this change?
This change enhances the visibility of agent-to-container mappings for superadmin users, providing more concise yet complete information in the session list.

### Screenshots
Before: Show unique agent ID even though user made multi-node session.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/15f3fc91-64d1-40d6-80ee-e7f6bbf4384d.png)


After: Show all agent IDs with ellipsized container ID.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/d7df024b-8423-4535-aba5-e67ccf722e40.png)


---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
