### PR TITLE
fix: apply decimal place rounding

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -1,6 +1,7 @@
 import {
   bytesToGB,
   iSizeToSize,
+  toFixedFloorWithoutTrailingZeros,
   transformSorterToOrderString,
 } from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
@@ -279,8 +280,15 @@ const AgentList: React.FC<AgentListProps> = ({
                     <Flex gap="xxs">
                       <ResourceTypeIcon key={key} type={key} />
                       <Typography.Text>
-                        {parsedOccupiedSlots[key] ?? 0}/
-                        {parsedAvailableSlots[key] ?? 0}
+                        {toFixedFloorWithoutTrailingZeros(
+                          parsedOccupiedSlots[key],
+                          0,
+                        )}
+                        /
+                        {toFixedFloorWithoutTrailingZeros(
+                          parsedAvailableSlots[key],
+                          0,
+                        )}
                       </Typography.Text>
                       <Typography.Text
                         type="secondary"
@@ -303,11 +311,14 @@ const AgentList: React.FC<AgentListProps> = ({
                       }
                       width={120}
                       valueLabel={
-                        _.toFinite(
-                          (parsedOccupiedSlots[key] /
-                            parsedAvailableSlots[key]) *
-                            100,
-                        ).toFixed(2) + ' %'
+                        toFixedFloorWithoutTrailingZeros(
+                          _.toFinite(
+                            (parsedOccupiedSlots[key] /
+                              parsedAvailableSlots[key]) *
+                              100,
+                          ),
+                          1,
+                        ) + ' %'
                       }
                     />
                   </Flex>
@@ -319,10 +330,10 @@ const AgentList: React.FC<AgentListProps> = ({
                       <ResourceTypeIcon key={key} type={key} />
                       <Typography.Text>
                         {iSizeToSize(parsedOccupiedSlots[key], 'g', 0)
-                          ?.numberFixed ?? 0}
+                          ?.numberFixed ?? 2}
                         /
                         {iSizeToSize(parsedAvailableSlots[key], 'g', 0)
-                          ?.numberFixed ?? 0}
+                          ?.numberFixed ?? 2}
                       </Typography.Text>
                       <Typography.Text
                         type="secondary"
@@ -345,11 +356,14 @@ const AgentList: React.FC<AgentListProps> = ({
                       }
                       width={120}
                       valueLabel={
-                        _.toFinite(
-                          (parsedOccupiedSlots[key] /
-                            parsedAvailableSlots[key]) *
-                            100,
-                        ).toFixed(2) + ' %'
+                        toFixedFloorWithoutTrailingZeros(
+                          _.toFinite(
+                            (parsedOccupiedSlots[key] /
+                              parsedAvailableSlots[key]) *
+                              100,
+                          ),
+                          1,
+                        ) + ' %'
                       }
                     />
                   </Flex>
@@ -368,8 +382,15 @@ const AgentList: React.FC<AgentListProps> = ({
                     <Flex gap="xxs">
                       <ResourceTypeIcon key={key} type={key} />
                       <Typography.Text>
-                        {parsedOccupiedSlots[key] ?? 0}/
-                        {parsedAvailableSlots[key] ?? 0}
+                        {toFixedFloorWithoutTrailingZeros(
+                          parsedOccupiedSlots[key],
+                          2,
+                        )}
+                        /
+                        {toFixedFloorWithoutTrailingZeros(
+                          parsedAvailableSlots[key],
+                          2,
+                        )}
                       </Typography.Text>
                       <Typography.Text
                         type="secondary"
@@ -392,11 +413,14 @@ const AgentList: React.FC<AgentListProps> = ({
                       }
                       width={120}
                       valueLabel={
-                        _.toFinite(
-                          (parsedOccupiedSlots[key] /
-                            parsedAvailableSlots[key]) *
-                            100,
-                        ).toFixed(2) + ' %'
+                        toFixedFloorWithoutTrailingZeros(
+                          _.toFinite(
+                            (parsedOccupiedSlots[key] /
+                              parsedAvailableSlots[key]) *
+                              100,
+                          ),
+                          1,
+                        ) + ' %'
                       }
                     />
                   </Flex>
@@ -476,7 +500,10 @@ const AgentList: React.FC<AgentListProps> = ({
                   percent={liveStat.cpu_util.ratio}
                   width={120}
                   valueLabel={
-                    _.toFinite(liveStat.cpu_util.ratio.toFixed(1)) + ' %'
+                    toFixedFloorWithoutTrailingZeros(
+                      _.toFinite(liveStat.cpu_util.ratio),
+                      1,
+                    ) + ' %'
                   }
                 />
               </Flex>
@@ -523,9 +550,10 @@ const AgentList: React.FC<AgentListProps> = ({
                         }
                         valueLabel={
                           _.toFinite(
-                            liveStat[
-                              statKey as keyof typeof liveStat
-                            ].ratio.toFixed(1),
+                            toFixedFloorWithoutTrailingZeros(
+                              liveStat[statKey as keyof typeof liveStat].ratio,
+                              1,
+                            ),
                           ) + ' %'
                         }
                       />
@@ -589,12 +617,12 @@ const AgentList: React.FC<AgentListProps> = ({
         const parsedDisk =
           JSON.parse(record?.live_stat || '{}')?.node?.disk ?? {};
         const pctValue = parseFloat(parsedDisk.pct) || 0;
-        const pct = parseFloat(pctValue.toFixed(1));
+        const pct = parseFloat(toFixedFloorWithoutTrailingZeros(pctValue, 2));
         const color = pct > 80 ? token.colorError : token.colorSuccess;
         return (
           <Flex direction="column">
             <BAIProgressWithLabel
-              valueLabel={pct + ' %'}
+              valueLabel={toFixedFloorWithoutTrailingZeros(pct, 1) + ' %'}
               percent={pct}
               strokeColor={color}
               width={120}

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -7,6 +7,7 @@ import {
   isOutsideRangeWithUnits,
   localeCompare,
   numberSorterWithInfinityValue,
+  toFixedFloorWithoutTrailingZeros,
   transformSorterToOrderString,
 } from './index';
 
@@ -291,5 +292,31 @@ describe('filterEmptyItem', () => {
     const input = ['item1', 'item2', 'item3'];
     const output = filterEmptyItem(input);
     expect(output).toEqual(['item1', 'item2', 'item3']);
+  });
+});
+
+describe('toFixedFloorWithoutTrailingZeros', () => {
+  it('should return the number with trailing zeros', () => {
+    expect(toFixedFloorWithoutTrailingZeros(1.1, 2)).toEqual('1.1');
+    expect(toFixedFloorWithoutTrailingZeros(1.01, 2)).toEqual('1.01');
+    expect(toFixedFloorWithoutTrailingZeros(1.001, 2)).toEqual('1');
+    expect(toFixedFloorWithoutTrailingZeros(1.0001, 2)).toEqual('1');
+    expect(toFixedFloorWithoutTrailingZeros(1.0010001, 2)).toEqual('1');
+    expect(toFixedFloorWithoutTrailingZeros(1.0010001, 3)).toEqual('1.001');
+    expect(toFixedFloorWithoutTrailingZeros(1.0010001, 4)).toEqual('1.001');
+    expect(toFixedFloorWithoutTrailingZeros(1.006, 2)).toEqual('1.01');
+    expect(toFixedFloorWithoutTrailingZeros(1.097, 2)).toEqual('1.1');
+  });
+
+  it('should work incase of string type input', () => {
+    expect(toFixedFloorWithoutTrailingZeros('1.1', 2)).toEqual('1.1');
+    expect(toFixedFloorWithoutTrailingZeros('1.01', 2)).toEqual('1.01');
+    expect(toFixedFloorWithoutTrailingZeros('1.001', 2)).toEqual('1');
+    expect(toFixedFloorWithoutTrailingZeros('1.0001', 2)).toEqual('1');
+    expect(toFixedFloorWithoutTrailingZeros('1.0010001', 2)).toEqual('1');
+    expect(toFixedFloorWithoutTrailingZeros('1.0010001', 3)).toEqual('1.001');
+    expect(toFixedFloorWithoutTrailingZeros('1.0010001', 4)).toEqual('1.001');
+    expect(toFixedFloorWithoutTrailingZeros('1.006', 2)).toEqual('1.01');
+    expect(toFixedFloorWithoutTrailingZeros('1.097', 2)).toEqual('1.1');
   });
 });

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -191,9 +191,19 @@ export function iSizeToSize(
 }
 
 //
-function toFixedFloorWithoutTrailingZeros(num: number, fixed: number) {
-  var re = new RegExp('^-?\\d+(?:.\\d{0,' + (fixed || -1) + '})?');
-  return num.toString().match(re)?.[0] || '0';
+export function toFixedFloorWithoutTrailingZeros(
+  num: number | string,
+  fixed: number,
+) {
+  return typeof num === 'number'
+    ? parseFloat(num.toFixed(fixed)).toString()
+    : parseFloat(parseFloat(num).toFixed(fixed)).toString();
+}
+
+export function toFixedWithTypeValidation(num: number | string, fixed: number) {
+  return typeof num === 'number'
+    ? num.toFixed(fixed)
+    : parseFloat(num).toFixed(fixed);
 }
 
 export function compareNumberWithUnits(size1: string, size2: string) {

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -88,12 +88,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
           height: 5px;
           --mdc-theme-primary: #98be5a;
         }
-
-        .horizontal-panel lablup-progress-bar {
-          --progress-bar-width: 90px;
-        }
-
-        .vertical-panel lablup-progress-bar {
+        .lablup-progress-bar {
           --progress-bar-width: 186px;
         }
 
@@ -312,10 +307,6 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
         }
 
         @media screen and (max-width: 1015px) {
-          .horizontal-panel lablup-progress-bar {
-            --progress-bar-width: 8rem;
-          }
-
           div#resource-gauges {
             justify-content: center;
           }
@@ -604,6 +595,15 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
       return parseInt(str) + postfix;
     }
   }
+  _prefixFormatWithTrailingZeros(num: string | number = '0', fixed: number) {
+    const number = typeof num === 'string' ? parseFloat(num) : num;
+    return parseFloat(number.toFixed(fixed)).toString();
+  }
+  _prefixFormat(num: string | number = '0;', fixed: number) {
+    return typeof num === 'string'
+      ? parseFloat(num)?.toFixed(fixed)
+      : num?.toFixed(fixed);
+  }
 
   render() {
     // language=HTML
@@ -643,25 +643,45 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                   class="start"
                   progress="${this.used_resource_group_slot_percent.cpu /
                   100.0}"
-                  description="${this.used_resource_group_slot.cpu}/${this
-                    .total_resource_group_slot.cpu}"
+                  description="${this._prefixFormatWithTrailingZeros(
+                    this.used_resource_group_slot.cpu,
+                    0,
+                  )} / ${this._prefixFormatWithTrailingZeros(
+                    this.total_resource_group_slot.cpu,
+                    0,
+                  )} Cores"
                 ></lablup-progress-bar>
                 <lablup-progress-bar
                   id="cpu-usage-bar-2"
                   class="end"
                   progress="${this.used_slot_percent.cpu / 100.0}"
-                  description="${this.used_slot.cpu}/${this.total_slot.cpu}"
+                  description="${this._prefixFormatWithTrailingZeros(
+                    this.used_slot.cpu,
+                    0,
+                  )} / ${this._prefixFormatWithTrailingZeros(
+                    this.total_slot.cpu,
+                    0,
+                  )} Cores"
                 ></lablup-progress-bar>
               </div>
               <div class="layout vertical center center-justified">
                 <span class="percentage start-bar">
                   ${this._numberWithPostfix(
-                    this.used_resource_group_slot_percent.cpu,
+                    this._prefixFormatWithTrailingZeros(
+                      this.used_resource_group_slot_percent.cpu,
+                      1,
+                    ),
                     '%',
                   )}
                 </span>
                 <span class="percentage end-bar">
-                  ${this._numberWithPostfix(this.used_slot_percent.cpu, '%')}
+                  ${this._numberWithPostfix(
+                    this._prefixFormatWithTrailingZeros(
+                      this.used_slot_percent.cpu,
+                      1,
+                    ),
+                    '%',
+                  )}
                 </span>
               </div>
             </div>
@@ -677,25 +697,45 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                   class="start"
                   progress="${this.used_resource_group_slot_percent.mem /
                   100.0}"
-                  description="${this.used_resource_group_slot.mem}/${this
-                    .total_resource_group_slot.mem}GiB"
+                  description="${this._prefixFormatWithTrailingZeros(
+                    this.used_resource_group_slot.mem,
+                    2,
+                  )} / ${this._prefixFormatWithTrailingZeros(
+                    this.total_resource_group_slot.mem,
+                    2,
+                  )} GiB"
                 ></lablup-progress-bar>
                 <lablup-progress-bar
                   id="mem-usage-bar-2"
                   class="end"
                   progress="${this.used_slot_percent.mem / 100.0}"
-                  description="${this.used_slot.mem}/${this.total_slot.mem}GiB"
+                  description="${this._prefixFormatWithTrailingZeros(
+                    this.used_slot.mem,
+                    2,
+                  )} / ${this._prefixFormatWithTrailingZeros(
+                    this.total_slot.mem,
+                    2,
+                  )} GiB"
                 ></lablup-progress-bar>
               </div>
               <div class="layout vertical center center-justified">
                 <span class="percentage start-bar">
                   ${this._numberWithPostfix(
-                    this.used_resource_group_slot_percent.mem,
+                    this._prefixFormatWithTrailingZeros(
+                      this.used_resource_group_slot_percent.mem,
+                      1,
+                    ),
                     '%',
                   )}
                 </span>
                 <span class="percentage end-bar">
-                  ${this._numberWithPostfix(this.used_slot_percent.mem, '%')}
+                  ${this._numberWithPostfix(
+                    this._prefixFormatWithTrailingZeros(
+                      this.used_slot_percent.mem,
+                      1,
+                    ),
+                    '%',
+                  )}
                 </span>
               </div>
             </div>
@@ -713,29 +753,42 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot.cuda_device /
                         this.total_resource_group_slot.cuda_device}"
-                        description="${this.used_resource_group_slot
-                          .cuda_device}/${this.total_resource_group_slot
-                          .cuda_device}"
+                        description="${this.used_resource_group_slot.cuda_device.toFixed(
+                          2,
+                        )} / ${this.total_resource_group_slot.cuda_device.toFixed(
+                          2,
+                        )} CUDA GPUs"
                       ></lablup-progress-bar>
                       <lablup-progress-bar
                         id="gpu-usage-bar-2"
                         class="end"
                         progress="${this.used_slot.cuda_device}/${this
                           .total_slot.cuda_device}"
-                        description="${this.used_slot.cuda_device}/${this
-                          .total_slot.cuda_device}"
+                        description="${this._prefixFormat(
+                          this.used_slot.cuda_device,
+                          2,
+                        )} / ${this._prefixFormat(
+                          this.total_slot.cuda_device,
+                          2,
+                        )} CUDA GPUs"
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this.used_resource_group_slot_percent.cuda_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_resource_group_slot_percent.cuda_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this.used_slot_percent.cuda_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_slot_percent.cuda_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -758,29 +811,45 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot.cuda_shares /
                         this.total_resource_group_slot.cuda_shares}"
-                        description="${this.used_resource_group_slot
-                          .cuda_shares}/${this.total_resource_group_slot
-                          .cuda_shares}"
+                        description="${this._prefixFormat(
+                          this.used_resource_group_slot.cuda_shares,
+                          2,
+                        )} / ${this._prefixFormat(
+                          this.total_resource_group_slot.cuda_shares,
+                          2,
+                        )} CUDA FGPUs"
                       ></lablup-progress-bar>
                       <lablup-progress-bar
                         id="fgpu-usage-bar-2"
                         class="end"
                         progress="${this.used_slot.cuda_shares /
                         this.total_slot.cuda_shares}"
-                        description="${this.used_slot.cuda_shares}/${this
-                          .total_slot.cuda_shares}"
+                        description="${this._prefixFormat(
+                          this.used_slot.cuda_shares,
+                          2,
+                        )} /
+                        ${this._prefixFormat(
+                          this.total_slot.cuda_shares,
+                          2,
+                        )} CUDA FGPUs"
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this.used_resource_group_slot_percent.cuda_shares,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_resource_group_slot_percent.cuda_shares,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this.used_slot_percent.cuda_shares,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_slot_percent.cuda_shares,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -806,29 +875,44 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .rocm_device / 100.0}"
-                        description="${this.used_resource_group_slot
-                          .rocm_device}/${this.total_resource_group_slot
-                          .rocm_device}"
+                        description="${this._prefixFormat(
+                          this.used_resource_group_slot.rocm_device,
+                          2,
+                        )} / ${this._prefixFormat(
+                          this.total_resource_group_slot.rocm_device,
+                          2,
+                        )} ROCm GPUs"
                       ></lablup-progress-bar>
                       <lablup-progress-bar
                         id="rocm-gpu-usage-bar-2"
                         class="end"
                         progress="${this.used_slot_percent.rocm_device / 100.0}"
                         buffer="${this.used_slot_percent.rocm_device / 100.0}"
-                        description="${this.used_slot.rocm_device}/${this
-                          .total_slot.rocm_device}"
+                        description="${this._prefixFormat(
+                          this.used_slot.rocm_device,
+                          2,
+                        )} / ${this._prefixFormat(
+                          this.total_slot.rocm_device,
+                          2,
+                        )} ROCm GPUs"
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this.used_resource_group_slot_percent.rocm_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_resource_group_slot_percent.rocm_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this.used_slot_percent.rocm_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_slot_percent.rocm_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -850,29 +934,44 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .tpu_device / 100.0}"
-                        description="${this.used_resource_group_slot
-                          .tpu_device}/${this.total_resource_group_slot
-                          .tpu_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_resource_group_slot.tpu_device,
+                          2,
+                        )} / ${this._prefixFormatWithTrailingZeros(
+                          this.total_resource_group_slot.tpu_device,
+                          2,
+                        )} TPUs"
                       ></lablup-progress-bar>
                       <lablup-progress-bar
                         id="tpu-usage-bar-2"
                         class="end"
                         progress="${this.used_slot_percent.tpu_device / 100.0}"
                         buffer="${this.used_slot_percent.tpu_device / 100.0}"
-                        description="${this.used_slot.tpu_device}/${this
-                          .total_slot.tpu_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_slot.tpu_device,
+                          2,
+                        )}/${this._prefixFormatWithTrailingZeros(
+                          this.total_slot.tpu_device,
+                          2,
+                        )} TPUs"
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this.used_resource_group_slot_percent.tpu_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_resource_group_slot_percent.tpu_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this.used_slot_percent.tpu_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_slot_percent.tpu_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -894,29 +993,44 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .ipu_device / 100.0}"
-                        description="${this.used_resource_group_slot
-                          .ipu_device}/${this.total_resource_group_slot
-                          .ipu_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_resource_group_slot.ipu_device,
+                          2,
+                        )} / ${this._prefixFormatWithTrailingZeros(
+                          this.total_resource_group_slot.ipu_device,
+                          2,
+                        )} IPUs"
                       ></lablup-progress-bar>
                       <lablup-progress-bar
                         id="ipu-usage-bar-2"
                         class="end"
                         progress="${this.used_slot_percent.ipu_device / 100.0}"
                         buffer="${this.used_slot_percent.ipu_device / 100.0}"
-                        description="${this.used_slot.ipu_device}/${this
-                          .total_slot.ipu_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_slot.ipu_device,
+                          2,
+                        )} / ${this._prefixFormatWithTrailingZeros(
+                          this.total_slot.ipu_device,
+                          2,
+                        )} "
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this.used_resource_group_slot_percent.ipu_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_resource_group_slot_percent.ipu_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this.used_slot_percent.ipu_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_slot_percent.ipu_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -938,29 +1052,44 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .atom_device / 100.0}"
-                        description="${this.used_resource_group_slot
-                          .atom_device}/${this.total_resource_group_slot
-                          .atom_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_resource_group_slot.atom_device,
+                          2,
+                        )} / ${this._prefixFormatWithTrailingZeros(
+                          this.total_resource_group_slot.atom_device,
+                          2,
+                        )} ATOMs"
                       ></lablup-progress-bar>
                       <lablup-progress-bar
                         id="atom-usage-bar-2"
                         class="end"
                         progress="${this.used_slot_percent.atom_device / 100.0}"
                         buffer="${this.used_slot_percent.atom_device / 100.0}"
-                        description="${this.used_slot.atom_device}/${this
-                          .total_slot.atom_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_slot.atom_device,
+                          2,
+                        )} / ${this._prefixFormatWithTrailingZeros(
+                          this.total_slot.atom_device,
+                          2,
+                        )} ATOMs"
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this.used_resource_group_slot_percent.atom_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_resource_group_slot_percent.atom_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this.used_slot_percent.atom_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_slot_percent.atom_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -982,9 +1111,13 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .atom_plus_device / 100.0}"
-                        description="${this.used_resource_group_slot
-                          .atom_plus_device}/${this.total_resource_group_slot
-                          .atom_plus_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_resource_group_slot.atom_plus_device,
+                          2,
+                        )} / ${this._prefixFormatWithTrailingZeros(
+                          this.total_resource_group_slot.atom_plus_device,
+                          2,
+                        )} ATOM+"
                       ></lablup-progress-bar>
                       <lablup-progress-bar
                         id="atom-plus-usage-bar-2"
@@ -993,8 +1126,13 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         100.0}"
                         buffer="${this.used_slot_percent.atom_plus_device /
                         100.0}"
-                        description="${this.used_slot.atom_plus_device}/${this
-                          .total_slot.atom_plus_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_slot.atom_plus_device,
+                          2,
+                        )} / ${this._prefixFormatWithTrailingZeros(
+                          this.total_slot.atom_plus_device,
+                          2,
+                        )} ATOM+"
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
@@ -1004,8 +1142,11 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       "
                       >
                         ${this._numberWithPostfix(
-                          this.used_resource_group_slot_percent
-                            .atom_plus_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_resource_group_slot_percent
+                              .atom_plus_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -1015,7 +1156,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       "
                       >
                         ${this._numberWithPostfix(
-                          this.used_slot_percent.atom_plus_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_slot_percent.atom_plus_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -1037,9 +1181,13 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .warboy_device / 100.0}"
-                        description="${this.used_resource_group_slot
-                          .warboy_device}/${this.total_resource_group_slot
-                          .warboy_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_resource_group_slot.warboy_device,
+                          2,
+                        )} / ${this._prefixFormatWithTrailingZeros(
+                          this.total_resource_group_slot.warboy_device,
+                          2,
+                        )} Warboys"
                       ></lablup-progress-bar>
                       <lablup-progress-bar
                         id="warboy-usage-bar-2"
@@ -1047,20 +1195,31 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         progress="${this.used_slot_percent.warboy_device /
                         100.0}"
                         buffer="${this.used_slot_percent.warboy_device / 100.0}"
-                        description="${this.used_slot.warboy_device}/${this
-                          .total_slot.warboy_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_slot.warboy_device,
+                          2,
+                        )} / ${this._prefixFormatWithTrailingZeros(
+                          this.total_slot.warboy_device,
+                          2,
+                        )} Warboys"
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this.used_resource_group_slot_percent.warboy_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_resource_group_slot_percent.warboy_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this.used_slot_percent.warboy_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_slot_percent.warboy_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -1082,9 +1241,13 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .hyperaccel_lpu_device / 100.0}"
-                        description="${this.used_resource_group_slot
-                          .hyperaccel_lpu_device}/${this
-                          .total_resource_group_slot.hyperaccel_lpu_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_resource_group_slot.hyperaccel_lpu_device,
+                          2,
+                        )} / ${this._prefixFormatWithTrailingZeros(
+                          this.total_resource_group_slot.hyperaccel_lpu_device,
+                          2,
+                        )} Hyperaccel LPUs"
                       ></lablup-progress-bar>
                       <lablup-progress-bar
                         id="hyperaccel-lpu-usage-bar-2"
@@ -1093,22 +1256,32 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                           .hyperaccel_lpu_device / 100.0}"
                         buffer="${this.used_slot_percent.hyperaccel_lpu_device /
                         100.0}"
-                        description="${this.used_slot
-                          .hyperaccel_lpu_device}/${this.total_slot
-                          .hyperaccel_lpu_device}"
+                        description="${this._prefixFormatWithTrailingZeros(
+                          this.used_slot.hyperaccel_lpu_device,
+                          2,
+                        )} / ${this._prefixFormatWithTrailingZeros(
+                          this.total_slot.hyperaccel_lpu_device,
+                          2,
+                        )} Hyperaccel LPUs"
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this.used_resource_group_slot_percent
-                            .hyperaccel_lpu_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_resource_group_slot_percent
+                              .hyperaccel_lpu_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this.used_slot_percent.hyperaccel_lpu_device,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_slot_percent.hyperaccel_lpu_device,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -1129,16 +1302,24 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                   id="concurrency-usage-bar"
                   class="start"
                   progress="${this.used_slot_percent.concurrency / 100.0}"
-                  description="${this.concurrency_used}/${this
-                    .concurrency_max === 1000000
+                  description="${this._prefixFormatWithTrailingZeros(
+                    this.concurrency_used,
+                    0,
+                  )} / ${this.concurrency_max === 1000000
                     ? '∞'
-                    : parseInt(this.concurrency_max)}"
+                    : this._prefixFormatWithTrailingZeros(
+                        this.concurrency_max,
+                        2,
+                      )}"
                 ></lablup-progress-bar>
               </div>
               <div class="layout vertical center center-justified">
                 <span class="percentage end-bar" style="margin-top:0px;">
                   ${this._numberWithPostfix(
-                    this.used_slot_percent.concurrency,
+                    this._prefixFormatWithTrailingZeros(
+                      this.used_slot_percent.concurrency,
+                      1,
+                    ),
                     '%',
                   )}
                 </span>
@@ -1222,21 +1403,32 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       id="cpu-project-usage-bar"
                       class="start"
                       progress="${this.used_project_slot_percent.cpu / 100.0}"
-                      description="${this.used_project_slot.cpu}/${this
-                        .total_project_slot.cpu === Infinity
+                      description="${this._prefixFormatWithTrailingZeros(
+                        this.used_project_slot.cpu,
+                        0,
+                      )} / ${this.total_project_slot.cpu === Infinity
                         ? '∞'
-                        : this.total_project_slot.cpu}"
+                        : this._prefixFormatWithTrailingZeros(
+                            this.total_project_slot.cpu,
+                            0,
+                          )} Cores"
                     ></lablup-progress-bar>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this.used_project_slot_percent.cpu,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_project_slot_percent.cpu,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this.total_project_slot.cpu,
+                          this._prefixFormatWithTrailingZeros(
+                            this.total_project_slot.cpu,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -1250,21 +1442,30 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       id="mem-project-usage-bar"
                       class="end"
                       progress="${this.used_project_slot_percent.mem / 100.0}"
-                      description=">${this.used_project_slot.mem}/${this
+                      description=">${this.used_project_slot.mem} / ${this
                         .total_project_slot.mem === Infinity
                         ? '∞'
-                        : this.total_project_slot.mem}"
+                        : this._prefixFormatWithTrailingZeros(
+                            this.total_project_slot.mem,
+                            2,
+                          )} GiB"
                     ></lablup-progress-bar>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this.used_project_slot_percent.mem,
+                          this._prefixFormatWithTrailingZeros(
+                            this.used_project_slot_percent.mem,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this.total_project_slot.mem,
+                          this._prefixFormatWithTrailingZeros(
+                            this.total_project_slot.mem,
+                            1,
+                          ),
                           '%',
                         )}
                       </span>
@@ -1283,22 +1484,33 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                             class="end"
                             progress="${this.used_project_slot_percent
                               .cuda_device / 100.0}"
-                            description="${this.used_project_slot
-                              .cuda_device}/${this.total_project_slot
-                              .cuda_device === 'Infinity'
+                            description="${this._prefixFormatWithTrailingZeros(
+                              this.used_project_slot.cuda_device,
+                              2,
+                            )} / ${this.total_project_slot.cuda_device ===
+                            'Infinity'
                               ? '∞'
-                              : this.total_project_slot.cuda_device}"
+                              : this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.cuda_device,
+                                  2,
+                                )} CUDA GPUs"
                           ></lablup-progress-bar>
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this.used_project_slot_percent.cuda_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.used_project_slot_percent.cuda_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this.total_project_slot.cuda_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.cuda_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
@@ -1323,18 +1535,27 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .cuda_shares}/${this.total_project_slot
                               .cuda_shares === 'Infinity'
                               ? '∞'
-                              : this.total_project_slot.cuda_shares}"
+                              : this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.cuda_shares,
+                                  2,
+                                )} CUDA FGPUs"
                           ></lablup-progress-bar>
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this.used_project_slot_percent.cuda_shares,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.used_project_slot_percent.cuda_shares,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this.total_project_slot.cuda_shares,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.cuda_shares,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
@@ -1359,18 +1580,27 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .rocm_device}/${this.total_project_slot
                               .rocm_device === 'Infinity'
                               ? '∞'
-                              : this.total_project_slot.rocm_device}"
+                              : this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.rocm_device,
+                                  2,
+                                )} ROCm GPUs"
                           ></lablup-progress-bar>
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this.used_project_slot_percent.rocm_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.used_project_slot_percent.rocm_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this.total_project_slot.rocm_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.rocm_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
@@ -1395,18 +1625,27 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .tpu_device}/${this.total_project_slot
                               .tpu_device === 'Infinity'
                               ? '∞'
-                              : this.total_project_slot.tpu_device}"
+                              : this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.tpu_device,
+                                  2,
+                                )} TPUs"
                           ></lablup-progress-bar>
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this.used_project_slot_percent.tpu_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.used_project_slot_percent.tpu_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this.total_project_slot.tpu_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.tpu_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
@@ -1431,18 +1670,27 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .ipu_device}/${this.total_project_slot
                               .ipu_device === 'Infinity'
                               ? '∞'
-                              : this.total_project_slot.ipu_device}"
+                              : this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.ipu_device,
+                                  2,
+                                )} IPUs"
                           ></lablup-progress-bar>
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this.used_project_slot_percent.ipu_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.used_project_slot_percent.ipu_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this.total_project_slot.ipu_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.ipu_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
@@ -1467,18 +1715,27 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .atom_device}/${this.total_project_slot
                               .atom_device === 'Infinity'
                               ? '∞'
-                              : this.total_project_slot.atom_device}"
+                              : this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.atom_device,
+                                  2,
+                                )} ATOMs"
                           ></lablup-progress-bar>
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this.used_project_slot_percent.atom_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.used_project_slot_percent.atom_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this.total_project_slot.atom_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.atom_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
@@ -1503,18 +1760,27 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .warboy_device}/${this.total_project_slot
                               .warboy_device === 'Infinity'
                               ? '∞'
-                              : this.total_project_slot.warboy_device}"
+                              : this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.warboy_device,
+                                  2,
+                                )} Warboys"
                           ></lablup-progress-bar>
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this.used_project_slot_percent.warboy_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.used_project_slot_percent.warboy_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this.total_project_slot.warboy_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.warboy_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
@@ -1539,19 +1805,28 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .hyperaccel_lpu_device}/${this.total_project_slot
                               .hyperaccel_lpu_device === 'Infinity'
                               ? '∞'
-                              : this.total_project_slot.hyperaccel_lpu_device}"
+                              : this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.hyperaccel_lpu_device,
+                                  2,
+                                )} Hyperaccel LPUs"
                           ></lablup-progress-bar>
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this.used_project_slot_percent
-                                  .hyperaccel_lpu_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.used_project_slot_percent
+                                    .hyperaccel_lpu_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this.total_project_slot.hyperaccel_lpu_device,
+                                this._prefixFormatWithTrailingZeros(
+                                  this.total_project_slot.hyperaccel_lpu_device,
+                                  1,
+                                ),
                                 '%',
                               )}
                             </span>

--- a/src/components/backend-ai-resource-panel.ts
+++ b/src/components/backend-ai-resource-panel.ts
@@ -524,6 +524,16 @@ export default class BackendAIResourcePanel extends BackendAIPage {
     return num.toString().replace(regexp, ',');
   }
 
+  _prefixFormatWithTrailingZeros(num: string | number = '0', fixed: number) {
+    const number = typeof num === 'string' ? parseFloat(num) : num;
+    return parseFloat(number.toFixed(fixed)).toString();
+  }
+  _prefixFormat(num: string | number = '0;', fixed: number) {
+    return typeof num === 'string'
+      ? parseFloat(num)?.toFixed(fixed)
+      : num?.toFixed(fixed);
+  }
+
   render() {
     // language=HTML
     return html`
@@ -565,25 +575,41 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                         class="start"
                         progress="${this.cpu_total_usage_ratio / 100.0}"
                         description="${this._addComma(
-                          this.cpu_used,
-                        )}/${this._addComma(this.cpu_total)} ${_t(
-                          'summary.CoresReserved',
-                        )}."
+                          this._prefixFormatWithTrailingZeros(this.cpu_used, 0),
+                        )}/${this._addComma(
+                          this._prefixFormatWithTrailingZeros(
+                            this.cpu_total,
+                            0,
+                          ),
+                        )} ${_t('summary.CoresReserved')}."
                       ></lablup-progress-bar>
                       <lablup-progress-bar
                         id="cpu-usage-bar-2"
                         class="end"
                         progress="${this.cpu_current_usage_ratio / 100.0}"
-                        description="${_t('summary.Using')} ${this
-                          .cpu_total_percent} % (util. ${this.cpu_percent} %)"
+                        description="${_t(
+                          'summary.Using',
+                        )} ${this._prefixFormatWithTrailingZeros(
+                          this.cpu_total_percent,
+                          1,
+                        )} % (util. ${this._prefixFormatWithTrailingZeros(
+                          this.cpu_percent,
+                          1,
+                        )} %)"
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
-                        ${parseInt(this.cpu_total_percent) + '%'}
+                        ${this._prefixFormatWithTrailingZeros(
+                          this.cpu_total_percent,
+                          1,
+                        ) + '%'}
                       </span>
                       <span class="percentage end-bar">
-                        ${parseInt(this.cpu_percent) + '%'}
+                        ${this._prefixFormatWithTrailingZeros(
+                          this.cpu_percent,
+                          1,
+                        ) + '%'}
                       </span>
                     </div>
                   </div>
@@ -600,38 +626,49 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                         class="start"
                         progress="${this.mem_total_usage_ratio / 100.0}"
                         description="${this._addComma(
-                          this.mem_allocated,
-                        )} / ${this._addComma(this.mem_total)} GiB ${_t(
-                          'summary.reserved',
-                        )}."
+                          this._prefixFormatWithTrailingZeros(
+                            this.mem_allocated,
+                            2,
+                          ),
+                        )} / ${this._addComma(
+                          this._prefixFormatWithTrailingZeros(
+                            this.mem_total,
+                            2,
+                          ),
+                        )} GiB ${_t('summary.reserved')}."
                       ></lablup-progress-bar>
                       <lablup-progress-bar
                         id="mem-usage-bar-2"
                         class="end"
                         progress="${this.mem_current_usage_ratio / 100.0}"
                         description="${_t('summary.Using')} ${this._addComma(
-                          this.mem_used,
+                          this._prefixFormatWithTrailingZeros(this.mem_used, 2),
                         )} GiB
                     (${parseInt(this.mem_used) !== 0
-                          ? (
+                          ? this._prefixFormatWithTrailingZeros(
                               (parseInt(this.mem_used) /
                                 parseInt(this.mem_total)) *
-                              100
-                            ).toFixed(0)
+                                100,
+                              1,
+                            )
                           : '0'} %)"
                       ></lablup-progress-bar>
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
-                        ${this.mem_total_usage_ratio.toFixed(1) + '%'}
+                        ${this._prefixFormatWithTrailingZeros(
+                          this.mem_total_usage_ratio,
+                          1,
+                        ) + '%'}
                       </span>
                       <span class="percentage end-bar">
                         ${(parseInt(this.mem_used) !== 0
-                          ? (
+                          ? this._prefixFormatWithTrailingZeros(
                               (parseInt(this.mem_used) /
                                 parseInt(this.mem_total)) *
-                              100
-                            ).toFixed(0)
+                                100,
+                              1,
+                            )
                           : '0') + '%'}
                       </span>
                     </div>
@@ -665,11 +702,13 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         class="start"
                                         progress="${this.cuda_gpu_used /
                                         this.cuda_gpu_total}"
-                                        description="${this
-                                          .cuda_gpu_used} / ${this
-                                          .cuda_gpu_total} CUDA GPUs ${_t(
-                                          'summary.reserved',
-                                        )}."
+                                        description="${this._prefixFormat(
+                                          this.cuda_gpu_used,
+                                          2,
+                                        )} / ${this._prefixFormat(
+                                          this.cuda_gpu_total,
+                                          2,
+                                        )} CUDA GPUs ${_t('summary.reserved')}."
                                       ></lablup-progress-bar>
                                       <lablup-progress-bar
                                         id="gpu-usage-bar-2"
@@ -685,11 +724,12 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                     >
                                       <span class="percentage start-bar">
                                         ${this.cuda_gpu_used !== 0
-                                          ? (
+                                          ? this._prefixFormatWithTrailingZeros(
                                               (this.cuda_gpu_used /
                                                 this.cuda_gpu_total) *
-                                              100
-                                            ).toFixed(1)
+                                                100,
+                                              1,
+                                            )
                                           : 0}%
                                       </span>
                                       <span class="percentage end-bar">
@@ -710,9 +750,13 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         class="start"
                                         progress="${this.cuda_fgpu_used /
                                         this.cuda_fgpu_total}"
-                                        description="${this
-                                          .cuda_fgpu_used} / ${this
-                                          .cuda_fgpu_total} CUDA FGPUs ${_t(
+                                        description="${this._prefixFormat(
+                                          this.cuda_fgpu_used,
+                                          2,
+                                        )} / ${this._prefixFormat(
+                                          this.cuda_fgpu_total,
+                                          2,
+                                        )} CUDA FGPUs ${_t(
                                           'summary.reserved',
                                         )}."
                                       ></lablup-progress-bar>
@@ -730,11 +774,12 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                     >
                                       <span class="percentage start-bar">
                                         ${this.cuda_fgpu_used !== 0
-                                          ? (
+                                          ? this._prefixFormatWithTrailingZeros(
                                               (this.cuda_fgpu_used /
                                                 this.cuda_fgpu_total) *
-                                              100
-                                            ).toFixed(1)
+                                                100,
+                                              1,
+                                            )
                                           : 0}%
                                       </span>
                                       <span class="percentage end-bar">
@@ -754,11 +799,13 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         id="rocm-gpu-usage-bar"
                                         class="start"
                                         progress="${this.rocm_gpu_used / 100.0}"
-                                        description="${this
-                                          .rocm_gpu_used} / ${this
-                                          .rocm_gpu_total} ROCm GPUs ${_t(
-                                          'summary.reserved',
-                                        )}."
+                                        description="${this._prefixFormat(
+                                          this.rocm_gpu_used,
+                                          2,
+                                        )} / ${this._prefixFormat(
+                                          this.rocm_gpu_total,
+                                          2,
+                                        )} ROCm GPUs ${_t('summary.reserved')}."
                                       ></lablup-progress-bar>
                                       <lablup-progress-bar
                                         id="rocm-gpu-usage-bar-2"
@@ -773,7 +820,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this.rocm_gpu_used.toFixed(1) + '%'}
+                                        ${this._prefixFormatWithTrailingZeros(
+                                          this.rocm_gpu_used,
+                                          1,
+                                        ) + '%'}
                                       </span>
                                       <span class="percentage end-bar">
                                         &nbsp;
@@ -792,10 +842,13 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         id="tpu-usage-bar"
                                         class="start"
                                         progress="${this.tpu_used / 100.0}"
-                                        description="${this.tpu_used} / ${this
-                                          .tpu_total} TPUs ${_t(
-                                          'summary.reserved',
-                                        )}."
+                                        description="${this._prefixFormatWithTrailingZeros(
+                                          this.tpu_used,
+                                          2,
+                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                          this.tpu_total,
+                                          2,
+                                        )} TPUs ${_t('summary.reserved')}."
                                       ></lablup-progress-bar>
                                       <lablup-progress-bar
                                         id="tpu-usage-bar-2"
@@ -810,7 +863,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this.tpu_used.toFixed(1) + '%'}
+                                        ${this._prefixFormatWithTrailingZeros(
+                                          this.tpu_used,
+                                          1,
+                                        ) + '%'}
                                       </span>
                                       <span class="percentage end-bar"></span>
                                     </div>
@@ -827,10 +883,13 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         id="ipu-usage-bar"
                                         class="start"
                                         progress="${this.ipu_used / 100.0}"
-                                        description="${this.ipu_used} / ${this
-                                          .ipu_total} IPUs ${_t(
-                                          'summary.reserved',
-                                        )}."
+                                        description="${this._prefixFormatWithTrailingZeros(
+                                          this.ipu_used,
+                                          2,
+                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                          this.ipu_total,
+                                          2,
+                                        )} IPUs ${_t('summary.reserved')}."
                                       ></lablup-progress-bar>
                                       <lablup-progress-bar
                                         id="ipu-usage-bar-2"
@@ -845,7 +904,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this.ipu_used.toFixed(1) + '%'}
+                                        ${this._prefixFormatWithTrailingZeros(
+                                          this.ipu_used,
+                                          1,
+                                        ) + '%'}
                                       </span>
                                       <span class="percentage end-bar"></span>
                                     </div>
@@ -862,10 +924,13 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         id="atom-usage-bar"
                                         class="start"
                                         progress="${this.atom_used / 100.0}"
-                                        description="${this.atom_used} / ${this
-                                          .atom_total} ATOMs ${_t(
-                                          'summary.reserved',
-                                        )}."
+                                        description="${this._prefixFormatWithTrailingZeros(
+                                          this.atom_used,
+                                          2,
+                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                          this.atom_total,
+                                          2,
+                                        )} ATOMs ${_t('summary.reserved')}."
                                       ></lablup-progress-bar>
                                       <lablup-progress-bar
                                         id="atom-usage-bar-2"
@@ -880,7 +945,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this.atom_used.toFixed(1) + '%'}
+                                        ${this._prefixFormatWithTrailingZeros(
+                                          this.atom_used,
+                                          1,
+                                        ) + '%'}
                                       </span>
                                       <span class="percentage end-bar"></span>
                                     </div>
@@ -898,11 +966,13 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         class="start"
                                         progress="${this.atom_plus_used /
                                         100.0}"
-                                        description="${this
-                                          .atom_plus_used} / ${this
-                                          .atom_plus_total} ATOM+ ${_t(
-                                          'summary.reserved',
-                                        )}."
+                                        description="${this._prefixFormatWithTrailingZeros(
+                                          this.atom_plus_used,
+                                          2,
+                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                          this.atom_plus_total,
+                                          2,
+                                        )} ATOM+ ${_t('summary.reserved')}."
                                       ></lablup-progress-bar>
                                       <lablup-progress-bar
                                         id="atom-plus-usage-bar-2"
@@ -917,7 +987,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this.atom_plus_used.toFixed(1) + '%'}
+                                        ${this._prefixFormatWithTrailingZeros(
+                                          this.atom_plus_used,
+                                          1,
+                                        ) + '%'}
                                       </span>
                                       <span class="percentage end-bar"></span>
                                     </div>
@@ -934,11 +1007,13 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         id="warboy-usage-bar"
                                         class="start"
                                         progress="${this.warboy_used / 100.0}"
-                                        description="${this
-                                          .warboy_used} / ${this
-                                          .warboy_total} Warboys ${_t(
-                                          'summary.reserved',
-                                        )}."
+                                        description="${this._prefixFormatWithTrailingZeros(
+                                          this.warboy_used,
+                                          2,
+                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                          this.warboy_total,
+                                          2,
+                                        )} Warboys ${_t('summary.reserved')}."
                                       ></lablup-progress-bar>
                                       <lablup-progress-bar
                                         id="warboy-usage-bar-2"
@@ -953,7 +1028,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this.warboy_used.toFixed(1) + '%'}
+                                        ${this._prefixFormatWithTrailingZeros(
+                                          this.warboy_used,
+                                          1,
+                                        ) + '%'}
                                       </span>
                                       <span class="percentage end-bar"></span>
                                     </div>
@@ -971,9 +1049,13 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         class="start"
                                         progress="${this.hyperaccel_lpu_used /
                                         100.0}"
-                                        description="${this
-                                          .hyperaccel_lpu_used} / ${this
-                                          .hyperaccel_lpu_total} Hyperaccel LPUs ${_t(
+                                        description="${this._prefixFormatWithTrailingZeros(
+                                          this.hyperaccel_lpu_used,
+                                          2,
+                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                          this.hyperaccel_lpu_total,
+                                          2,
+                                        )} Hyperaccel LPUs ${_t(
                                           'summary.reserved',
                                         )}."
                                       ></lablup-progress-bar>
@@ -990,8 +1072,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this.hyperaccel_lpu_used.toFixed(1) +
-                                        '%'}
+                                        ${this._prefixFormatWithTrailingZeros(
+                                          this.hyperaccel_lpu_used,
+                                          1,
+                                        ) + '%'}
                                       </span>
                                       <span class="percentage end-bar"></span>
                                     </div>


### PR DESCRIPTION
### TL;DR

Handle visible decimal points according to [backend.ai writing rules](https://loop.cloud.microsoft/p/eyJ3Ijp7InUiOiJodHRwczovL2xhYmx1cC5zaGFyZXBvaW50LmNvbS8%2FbmF2PWN6MGxNa1ltWkQxaUlXZG1ZbUpTWDA1eFMxVnhkblpoY0hrd2MyeDFaV05ZTnkxVmJ6TlRXVkpCZFdod1dFNUJiMGhxTFVOWVRqRjJSRVZrY3poVWNFeEpNR1JvVWt0bWRuTW1aajB3TVVkTlQwaEpVVk5WUjBOYVJGQllOa3hTTlVKWlYwNVVOMUJSVjA1S1F6ZFhKbU05Sm1ac2RXbGtQVEUlM0QiLCJyIjpmYWxzZX0sInAiOnsidSI6Imh0dHBzOi8vbGFibHVwLnNoYXJlcG9pbnQuY29tL2NvbnRlbnRzdG9yYWdlL0NTUF80N2RiZjY4MS02YWYzLTRhMjktYWZiZC1hYTcyZDJjOTZlNzk%2FbmF2PWN6MGxNa1pqYjI1MFpXNTBjM1J2Y21GblpTVXlSa05UVUY4ME4yUmlaalk0TVMwMllXWXpMVFJoTWprdFlXWmlaQzFoWVRjeVpESmpPVFpsTnprbVpEMWlJV2RtWW1KU1gwNXhTMVZ4ZG5aaGNIa3djMngxWldOWU55MVZiek5UV1ZKQmRXaHdXRTVCYjBocUxVTllUakYyUkVWa2N6aFVjRXhKTUdSb1VrdG1kbk1tWmowd01VZE5UMGhKVVZKU1RsRk1Va2hEVWxkWlJrSktNa3N5TkVkUFFWcFlWbG8wSm1NOUptWnNkV2xrUFRFJTNEIiwiciI6ZmFsc2V9LCJpIjp7ImkiOiI5NTM1ZjRmMy1iMTE4LTQwZDQtOWVhNS05OTliMDJlYjdiYjkifX0%3D)

### Changes 
- Allow string as input type for the `toFixedFloorWithoutTrailingZeros` function. Changed logic to handle exception cases.
- add new `toFixedWithTypeValidation` function to show zero-terminated decimals as they are (e.g. 1.00, 2.10 for GPU or fGPU)
- The same functionality has been applied to webcomponent.

### How to Test
- Verify that decimalization is properly applied to the `resource-panel` and `resource-monitor` parts of the summary page.
- Verify that the decimal points shown on the Agent tab of the Resource Page are handled correctly.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
