### PR TITLE
feature: Add `model` query param to start the service with folder mounting

### DIFF
--- a/react/src/components/ServiceValidationView.tsx
+++ b/react/src/components/ServiceValidationView.tsx
@@ -63,7 +63,7 @@ const ServiceValidationView: React.FC<ServiceValidationModalProps> = ({
         cluster_mode: values.cluster_mode,
         open_to_public: values.openToPublic,
         config: {
-          model: values.vFolderName,
+          model: values.vFolderID,
           model_version: 1, // FIXME: hardcoded. change it with option later
           ...(baiClient.supports('endpoint-extra-mounts') && {
             extra_mounts: _.reduce(

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -31,12 +31,14 @@ export type VFolder = {
 
 interface VFolderSelectProps extends SelectProps {
   autoSelectDefault?: boolean;
+  valuePropName?: 'id' | 'name';
   filter?: (vFolder: VFolder) => boolean;
 }
 
 const VFolderSelect: React.FC<VFolderSelectProps> = ({
   filter,
   autoSelectDefault,
+  valuePropName = 'name',
   ...selectProps
 }) => {
   const currentProject = useCurrentProjectValue();
@@ -86,9 +88,10 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
   const autoSelectedOption = _.first(filteredVFolders)
     ? {
         label: _.first(filteredVFolders)?.name,
-        value: _.first(filteredVFolders)?.name,
+        value: _.first(filteredVFolders)?.[valuePropName],
       }
     : undefined;
+  // TODO: use controllable value
   useEffect(() => {
     if (autoSelectDefault && autoSelectedOption) {
       selectProps.onChange?.(autoSelectedOption.value, autoSelectedOption);
@@ -106,15 +109,13 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
           });
         }
       }}
-    >
-      {_.map(filteredVFolders, (vfolder) => {
-        return (
-          <Select.Option key={vfolder?.id} value={vfolder?.name}>
-            {vfolder?.name}
-          </Select.Option>
-        );
+      options={_.map(filteredVFolders, (vfolder) => {
+        return {
+          label: vfolder?.name,
+          value: vfolder?.[valuePropName],
+        };
       })}
-    </Select>
+    />
   );
 };
 

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
+import { navigate } from '../backend-ai-app';
 import tus from '../lib/tus';
 import '../plastics/lablup-shields/lablup-shields';
 import {
@@ -9,6 +10,7 @@ import {
   IronFlexAlignment,
   IronPositioning,
 } from '../plastics/layout/iron-flex-layout-classes';
+import { store } from '../store';
 import './backend-ai-dialog';
 import BackendAIDialog from './backend-ai-dialog';
 import { BackendAiStyles } from './backend-ai-general-styles';
@@ -1715,6 +1717,22 @@ export default class BackendAiStorageList extends BackendAIPage {
   }
 
   /**
+   *
+   * @param {string} url - page to redirect from the current page.
+   */
+  _moveTo(url = '') {
+    const page = url !== '' ? url : 'summary';
+    // globalThis.history.pushState({}, '', page);
+    store.dispatch(navigate(decodeURIComponent(page), {}));
+
+    document.dispatchEvent(
+      new CustomEvent('react-navigate', {
+        detail: url,
+      }),
+    );
+  }
+
+  /**
    * Render permission options - View, Edit, EditDelete, KickOut.
    *
    * @param {Element} root - the row details content DOM element
@@ -1978,7 +1996,8 @@ export default class BackendAiStorageList extends BackendAIPage {
                 <mwc-icon-button
                   class="fg green controls-running"
                   icon="play_arrow"
-                  @click="${(e) => this._inferModel(e)}"
+                  @click="${(e) =>
+                    this._moveTo('/service/start?model=' + rowData.item.id)}"
                   ?disabled="${this._isUncontrollableStatus(
                     rowData.item.status,
                   )}"


### PR DESCRIPTION
### TL;DR
- Added the `model` parameter to start the service immediately with the folder mounted when pressing the play button in the Model tab.
- Replaced all occurrences of `vFolderName` with `vFolderID` in `ServiceLauncherPageContent.tsx` and related files to ensure consistency and correct usage of virtual folder identifiers.

### What changed?

- Updated `ServiceLauncherPageContent.tsx` to use `vFolderID` instead of `vFolderName`.
- Modified form items and fields to reflect the change from `vFolderName` to `vFolderID`.
- Adjusted the `VFolderSelect` component to support selecting by ID instead of name.
- Added a query parameter handler for `model` in `ServiceLauncherPageContent`.

### What's needed for testing
- endpoint: 10.100.64.15 
- enable `enableModelStore` of config.toml

### How to test?

1. Verify that the Service Launcher page loads correctly without errors.
2. Test form submissions to ensure that `vFolderID` is being correctly handled and passed to backend services.
3. Ensure that virtual folder selections reflect the updated ID-based system.

### Why make this change?
Started developing this feature to start a new service directly with a specific folder mounted in the model and Model Store tabs.
This change also ensures consistency in how virtual folder identifiers (IDs) are used throughout the `ServiceLauncherPageContent` component and related modules. It fixes potential mismatches and errors that could arise from using names instead of IDs.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
