### PR TITLE
fix: Correct CPU util ratio for cluster sessions

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1040,7 +1040,8 @@ export default class BackendAISessionList extends BackendAIPage {
                   //   - {capacity: 1000, current: 6952.082, slots: 16}
                   //     -> ratio: 6.95 | pct: 695% | progressbar: 0.43 (== ratio / 16)
                   liveStat.cpu_util.ratio =
-                    liveStat.cpu_util.current / liveStat.cpu_util.capacity || 0;
+                    (liveStat.cpu_util.current / liveStat.cpu_util.capacity) *
+                      sessions[objectKey].containers.length || 0;
                   liveStat.cpu_util.slots = occupiedSlots.cpu;
                   // Memory is simple. It's just a ratio of current memory utilization.
                   liveStat.mem.ratio =


### PR DESCRIPTION
related https://app.graphite.dev/github/pr/lablup/backend.ai-control-panel/804/fix-Correct-CPU-util-ratio-for-cluster-sessions
resolves https://github.com/lablup/giftbox/issues/697

### TL;DR
Adjusts the calculation for the cpu utilization ratio in backend-ai-session-list component.

### What changed?
Modified the cpu utilization calculation by multiplying the current utilization ratio with the length of the containers array for each session, fixing potential miscalculations.

### How to test?
Verify the cpu utilization ratio is accurately reflecting the multiplied value of current utilization and container length in session statistics.

### Why make this change?
Ensures accurate representation of CPU utilization by accounting for the number of containers in sessions.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
