### PR TITLE
fix: `allowCustomResourceAllocation` options in Neo session launcher

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -445,8 +445,10 @@ const ResourceAllocationFormItems: React.FC<
           style={{ marginBottom: token.marginXS }}
         >
           <ResourcePresetSelect
-            showCustom
-            showMinimumRequired
+            showCustom={baiClient._config.allowCustomResourceAllocation}
+            showMinimumRequired={
+              baiClient._config.allowCustomResourceAllocation
+            }
             onChange={(value, options) => {
               switch (value) {
                 case 'custom':


### PR DESCRIPTION

### TL;DR

This pull request updates the `ResourceAllocationFormItems` component to dynamically configure the display of custom and minimum required resource options based on `allowCustomResourceAllocation`configuration.

### What changed?

- The `ResourcePresetSelect` component's `showCustom` and `showMinimumRequired` props are now set based on the `allowCustomResourceAllocation` field in `config.toml`.

### How to test?

1. Ensure that the application is running.
2. Navigate to the form where the resource allocation is done.
3. Verify that the custom resource option is not visible only if `allowCustomResourceAllocation` of `config.toml` is false.

### Why make this change?

This change ensures that the visibility of custom resource options is configurable through the client's settings, providing more flexibility and control in resource allocation.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
