### PR TITLE
fix: rename `enableModelStore` configuration

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -30,7 +30,7 @@ isDirectorySizeVisible = true           # If false, directory size in folder exp
 maxCountForPreopenPorts = 10            # The maximum allowed number of preopen ports. If you set this option to 0, the feature of preopen ports is disabled.
 allowCustomResourceAllocation = true    # If true, display the custom allocation on the session launcher.
 eduAppNamePrefix = ""                   # The prefix of edu applauncher's app name. If the app name starts with this prefix, split it by '-' and use the tail as the name of image.
-supportModelStore = false		        # Enable model store feature. (From Backend.AI 24.03)
+enableModelStore = false		        # Enable model store feature. (From Backend.AI 24.03)
 
 [wsproxy]
 proxyURL = "[Proxy URL]"

--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -75,7 +75,7 @@ const ProjectSelector: React.FC<Props> = ({
         email: currentUser.email,
         type:
           (userRole === 'admin' || userRole === 'superadmin') &&
-          baiClient._config.supportModelStore
+          baiClient._config.enableModelStore
             ? ['GENERAL', 'MODEL_STORE']
             : ['GENERAL'],
       },

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -312,7 +312,7 @@ type BackendAIConfig = {
   maskUserInfo: boolean;
   singleSignOnVendors: string[];
   ssoRealmName: string;
-  supportModelStore: boolean;
+  enableModelStore: boolean;
   enableContainerCommit: boolean;
   appDownloadUrl: string;
   systemSSHImage: string;

--- a/react/src/pages/VFolderListPage.tsx
+++ b/react/src/pages/VFolderListPage.tsx
@@ -74,7 +74,7 @@ const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
       tab: t('data.Models'),
     },
     baiClient.supports('model-store') &&
-      baiClient._config.supportModelStore && {
+      baiClient._config.enableModelStore && {
         key: 'model-store',
         tab: t('data.ModelStore'),
       },

--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -63,7 +63,7 @@ export default class BackendAIData extends BackendAIPage {
   @property({ type: Boolean }) is_admin = false;
   @property({ type: Boolean }) enableStorageProxy = false;
   @property({ type: Boolean }) enableInferenceWorkload = false;
-  @property({ type: Boolean }) supportModelStore = false;
+  @property({ type: Boolean }) enableModelStore = false;
   @property({ type: Boolean }) supportVFolderTrashBin = false;
   @property({ type: Boolean }) authenticated = false;
   @property({ type: String }) vhost = '';
@@ -325,7 +325,7 @@ export default class BackendAIData extends BackendAIPage {
                   </div>
                 `
               : html``}
-            ${this.supportModelStore
+            ${this.enableModelStore
               ? html`
                   <backend-ai-react-model-store-list
                     id="model-store-folder-lists"
@@ -880,9 +880,9 @@ export default class BackendAIData extends BackendAIPage {
         globalThis.backendaiclient.supports('storage-proxy');
       this.enableInferenceWorkload =
         globalThis.backendaiclient.supports('inference-workload');
-      this.supportModelStore =
+      this.enableModelStore =
         globalThis.backendaiclient.supports('model-store') &&
-        globalThis.backendaiclient._config.supportModelStore;
+        globalThis.backendaiclient._config.enableModelStore;
       this.supportVFolderTrashBin =
         globalThis.backendaiclient.supports('vfolder-trash-bin');
       if (this.enableInferenceWorkload && !this.usageModes.includes('Model')) {

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -138,7 +138,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: Number }) maxCountForPreopenPorts = 10;
   @property({ type: Boolean }) allowCustomResourceAllocation = true;
   @property({ type: Boolean }) isDirectorySizeVisible = true;
-  @property({ type: Boolean }) supportModelStore = false;
+  @property({ type: Boolean }) enableModelStore = false;
   @property({ type: String }) eduAppNamePrefix;
   @property({ type: String }) pluginPages;
   @property({ type: Array }) blockList = [] as string[];
@@ -842,10 +842,10 @@ export default class BackendAILogin extends BackendAIPage {
     } as ConfigValueObject) as string;
 
     // Enable model store support
-    this.supportModelStore = this._getConfigValueByExists(generalConfig, {
+    this.enableModelStore = this._getConfigValueByExists(generalConfig, {
       valueType: 'boolean',
       defaultValue: false,
-      value: generalConfig?.supportModelStore,
+      value: generalConfig?.enableModelStore,
     } as ConfigValueObject) as boolean;
   }
 
@@ -1837,8 +1837,8 @@ export default class BackendAILogin extends BackendAIPage {
           this.allowCustomResourceAllocation;
         globalThis.backendaiclient._config.isDirectorySizeVisible =
           this.isDirectorySizeVisible;
-        globalThis.backendaiclient._config.supportModelStore =
-          this.supportModelStore;
+        globalThis.backendaiclient._config.enableModelStore =
+          this.enableModelStore;
         globalThis.backendaiclient._config.pluginPages = this.pluginPages;
         globalThis.backendaiclient._config.blockList = this.blockList;
         globalThis.backendaiclient._config.inactiveList = this.inactiveList;


### PR DESCRIPTION
This pull request updates the configuration and codebase to replace the `supportModelStore` flag with `enableModelStore`([ref](https://github.com/lablup/backend.ai/blob/24491df67eded42cebf4c109fe9aabf254ec4592/src/ai/backend/web/config.py#L67-L68)). This affects multiple files including configuration samples, React components, and various TypeScript and JavaScript files.