### PR TITLE
fix: workaround of considering version-compatibility for fetching per container(kernel) logs

### DIFF
--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -706,6 +706,9 @@ class Client {
       this._features['modify-endpoint-environ'] = true;
       this._features['endpoint-runtime-variant'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('24.03.7')) {
+      this._features['per-kernel-logs'] = true;
+    }
   }
 
   /**
@@ -1291,7 +1294,7 @@ class Client {
     if (ownerKey != null) {
       queryParams.push(`owner_access_key=${ownerKey}`);
     }
-    if (kernelId != null) {
+    if (this.supports('per-kernel-logs') && kernelId !== null) {
       queryParams.push(`kernel_id=${kernelId}`);
     }
     let queryString = `${this.kernelPrefix}/${sessionId}/logs`;


### PR DESCRIPTION
### TL;DR

This pull request fixes the bug occurred when opening container log dialog which originated by #2510 by adding support for fetching logs on a per-kernel basis if the backend supports it. It introduces a new property `_isPerKernelLogSupported` to determine the backend capability and modifies the `_showLogs` method to utilize this feature if available.

### What changed?

- Added `_isPerKernelLogSupported` property.
- Modified `_showLogs` method to fetch per-kernel logs if supported.
- Updated `Client` class to check for backend support for per-kernel logs.
- Made UI changes to support the selection and display of per-kernel logs.

### How to test?

1. Ensure that your backend supports the 'per-kernel-logs' feature.
2. Initiate sessions and try fetching logs to see if the logs are fetched on a per-kernel basis.
3. Validate the UI elements for kernel selection and log display.

### Why make this change?

This change provides users the ability to view logs specific to individual kernels, thus making debugging and monitoring more precise and effective.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
