### PR TITLE
fix: add `undefined` type to `useResourceSlotsDetails`

### DIFF
--- a/react/src/components/ImageResourceFormItem.tsx
+++ b/react/src/components/ImageResourceFormItem.tsx
@@ -27,17 +27,17 @@ const ImageResourceFormItem: React.FC<ImageResourceFormItemProps> = ({
     return (
       {
         cpu: {
-          label: resourceSlotsDetails?.cpu.description,
+          label: resourceSlotsDetails?.cpu?.description,
           steps: _.map(
             ['0', '1', '2', '3', '4', '5', '6', '7', '8'],
             (value) => ({
               value,
-              label: `${value} ${resourceSlotsDetails?.cpu.display_unit}`,
+              label: `${value} ${resourceSlotsDetails?.cpu?.display_unit}`,
             }),
           ),
         },
         mem: {
-          label: resourceSlotsDetails?.mem.description,
+          label: resourceSlotsDetails?.mem?.description,
           steps: _.map(
             [
               '64m',
@@ -62,24 +62,24 @@ const ImageResourceFormItem: React.FC<ImageResourceFormItemProps> = ({
           ),
         },
         'cuda.device': {
-          label: resourceSlotsDetails?.['cuda.device'].description,
+          label: resourceSlotsDetails?.['cuda.device']?.description,
           steps: _.map(['0', '1', '2', '3', '4', '5', '6', '7', '8'], (v) => ({
             value: v,
-            label: `${v} ${resourceSlotsDetails?.['cuda.device'].display_unit}`,
+            label: `${v} ${resourceSlotsDetails?.['cuda.device']?.display_unit}`,
           })),
         },
         'cuda.shares': {
-          label: resourceSlotsDetails?.['cuda.shares'].description,
+          label: resourceSlotsDetails?.['cuda.shares']?.description,
           steps: _.map(
             ['0', '0.1', '0.2', '0.5', '1.0', '2.0', '4.0', '8.0'],
             (v) => ({
               value: v,
-              label: `${v} ${resourceSlotsDetails?.['cuda.shares'].display_unit}`,
+              label: `${v} ${resourceSlotsDetails?.['cuda.shares']?.display_unit}`,
             }),
           ),
         },
         'rocm.device': {
-          label: resourceSlotsDetails?.['rocm.device'].description,
+          label: resourceSlotsDetails?.['rocm.device']?.description,
           steps: ['0', '1', '2', '3', '4', '5', '6', '7', '8'],
         },
       }[type] || {

--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -299,12 +299,12 @@ const KeypairResourcePolicySettingModal: React.FC<
                 <FormItemWithUnlimited
                   name={['parsedTotalResourceSlots', 'cpu']}
                   unlimitedValue={undefined}
-                  label={resourceSlotsDetails?.cpu.description}
+                  label={resourceSlotsDetails?.cpu?.description}
                 >
                   <InputNumber
                     min={0}
                     max={512}
-                    addonAfter={resourceSlotsDetails?.cpu.display_unit}
+                    addonAfter={resourceSlotsDetails?.cpu?.display_unit}
                   />
                 </FormItemWithUnlimited>
               </Col>
@@ -312,7 +312,7 @@ const KeypairResourcePolicySettingModal: React.FC<
                 <FormItemWithUnlimited
                   name={['parsedTotalResourceSlots', 'mem']}
                   unlimitedValue={undefined}
-                  label={resourceSlotsDetails?.mem.description}
+                  label={resourceSlotsDetails?.mem?.description}
                 >
                   <DynamicUnitInputNumber />
                 </FormItemWithUnlimited>
@@ -323,13 +323,13 @@ const KeypairResourcePolicySettingModal: React.FC<
                 <FormItemWithUnlimited
                   name={['parsedTotalResourceSlots', 'cuda.device']}
                   unlimitedValue={undefined}
-                  label={resourceSlotsDetails?.['cuda.device'].description}
+                  label={resourceSlotsDetails?.['cuda.device']?.description}
                 >
                   <InputNumber
                     min={0}
                     max={64}
                     addonAfter={
-                      resourceSlotsDetails?.['cuda.device'].display_unit
+                      resourceSlotsDetails?.['cuda.device']?.display_unit
                     }
                   />
                 </FormItemWithUnlimited>
@@ -338,14 +338,14 @@ const KeypairResourcePolicySettingModal: React.FC<
                 <FormItemWithUnlimited
                   name={['parsedTotalResourceSlots', 'cuda.shares']}
                   unlimitedValue={undefined}
-                  label={resourceSlotsDetails?.['cuda.shares'].description}
+                  label={resourceSlotsDetails?.['cuda.shares']?.description}
                 >
                   <InputNumber
                     min={0}
                     max={256}
                     step={0.1}
                     addonAfter={
-                      resourceSlotsDetails?.['cuda.shares'].display_unit
+                      resourceSlotsDetails?.['cuda.shares']?.display_unit
                     }
                   />
                 </FormItemWithUnlimited>

--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -487,7 +487,7 @@ const ResourceAllocationFormItems: React.FC<
                     name={['resource', 'cpu']}
                     // initialValue={0}
                     label={
-                      resourceSlotsDetails?.cpu.human_readable_name || 'CPU'
+                      resourceSlotsDetails?.cpu?.human_readable_name || 'CPU'
                     }
                     tooltip={{
                       placement: 'right',
@@ -526,7 +526,7 @@ const ResourceAllocationFormItems: React.FC<
                     <InputNumberWithSlider
                       inputNumberProps={{
                         addonAfter:
-                          resourceSlotsDetails?.cpu.display_unit ||
+                          resourceSlotsDetails?.cpu?.display_unit ||
                           t('session.launcher.Core'),
                       }}
                       sliderProps={{

--- a/react/src/components/ResourceNumber.tsx
+++ b/react/src/components/ResourceNumber.tsx
@@ -56,14 +56,14 @@ const ResourceNumber: React.FC<ResourceNumberProps> = ({
       )}
 
       <Typography.Text>
-        {resourceSlotsDetails?.[type].number_format.binary
+        {resourceSlotsDetails?.[type]?.number_format.binary
           ? Number(iSizeToSize(amount, 'g', 3, true)?.numberFixed).toString()
-          : (resourceSlotsDetails?.[type].number_format.round_length || 0) > 0
+          : (resourceSlotsDetails?.[type]?.number_format.round_length || 0) > 0
             ? parseFloat(amount).toFixed(2)
             : amount}
       </Typography.Text>
       <Typography.Text type="secondary">
-        {resourceSlotsDetails?.[type].display_unit || ''}
+        {resourceSlotsDetails?.[type]?.display_unit || ''}
       </Typography.Text>
       {type === 'mem' && opts?.shmem && opts?.shmem > 0 ? (
         <Typography.Text

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -67,7 +67,7 @@ export const useResourceSlotsDetails = (resourceGroupName?: string) => {
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
   const baiClient = useSuspendedBackendaiClient();
   let { data: resourceSlots } = useTanQuery<{
-    [key: string]: ResourceSlotDetail;
+    [key: string]: ResourceSlotDetail | undefined;
   }>({
     queryKey: ['useResourceSlots', resourceGroupName, key],
     queryFn: () => {
@@ -91,7 +91,7 @@ export const useResourceSlotsDetails = (resourceGroupName?: string) => {
 
   // TODO: improve waterfall loading
   const { data: deviceMetadata } = useTanQuery<{
-    [key: string]: ResourceSlotDetail;
+    [key: string]: ResourceSlotDetail | undefined;
   }>({
     queryKey: ['backendai-metadata-device', key],
     queryFn: () => {


### PR DESCRIPTION
### TL;DR
This PR introduces optional chaining for `resourceSlotsDetails` across various components to ensure that property access does not cause runtime errors when `resourceSlotsDetails` is undefined.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/0648389e-3a38-455b-a759-df37af8da44b.png)

### What changed?
- Added optional chaining for `resourceSlotsDetails` in `ImageResourceFormItem.tsx`, `KeypairResourcePolicySettingModal.tsx`, `ResourceAllocationFormItems.tsx`, `ResourceNumber.tsx`, and `backendai.tsx`.

### How to test?
- Ensure that components render correctly even when `resourceSlotsDetails` is undefined.
- Check if the appropriate display labels and input components are rendered.
- Validate that no runtime errors occur due to property access on potentially undefined `resourceSlotsDetails`.

### Why make this change?
This change is necessary to prevent runtime errors that can disrupt the user experience. By using optional chaining, we ensure that the components are more robust and can handle scenarios where `resourceSlotsDetails` might not be available.
