### PR TITLE
fix: Cannot read properties of null (reading 'slice') error

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1099,7 +1099,7 @@ export default class BackendAISessionList extends BackendAIPage {
                   objectKey
                 ].containers?.map((c) => {
                   const agentID = c.agent;
-                  const containerID = c.container_id.slice(0, 4);
+                  const containerID = c.container_id?.slice(0, 4);
                   return `${agentID}(${containerID})`;
                 });
               }
@@ -1366,7 +1366,7 @@ export default class BackendAISessionList extends BackendAIPage {
         namespace = imageParts[1];
         langName = imageParts[2];
       } else if (imageParts.length > 3) {
-        namespace = imageParts.slice(2, imageParts.length - 1).join('/');
+        namespace = imageParts?.slice(2, imageParts.length - 1).join('/');
         langName = imageParts[imageParts.length - 1];
       } else {
         namespace = '';


### PR DESCRIPTION
### TL;DR

Corrected potential runtime errors caused by null values in container_id and namespace slicing operations.

### What changed?

- Added null checks before slicing `container_id` in `backend-ai-session-list.ts`
- Implemented safe slicing for `namespace` by adding null checks.

### How to test?

1. Run the application and monitor the session list component to ensure no errors occur.
2. Verify that the session list displays correctly without any slicing errors.

### Why make this change?

To prevent runtime errors caused by null values, improving the stability and robustness of the session list feature.

### Error image
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/16078cb6-dc6b-4fdd-9b9e-0bfcb602b2a7.png)


**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
