### PR TITLE
fix: handle search params using `URLSearchParams`

### DIFF
--- a/react/src/components/FolderExplorerOpener.tsx
+++ b/react/src/components/FolderExplorerOpener.tsx
@@ -25,10 +25,12 @@ const FolderExplorerOpener = () => {
   const isDataViewReady = useAtomValue(isDataViewReadyAtom);
   useEffect(() => {
     if (isDataViewReady && folderId) {
+      const search = new URLSearchParams();
+      search.set('group_id', currentProject.id);
       (
         baiRequestWithPromise({
           method: 'GET',
-          url: `/folders?group_id=${currentProject.id}`,
+          url: `/folders?${search.toString()}`,
         }) as Promise<VFolder[]>
       )
         .then((vFolders) => {

--- a/react/src/components/ResourceGroupSelect.tsx
+++ b/react/src/components/ResourceGroupSelect.tsx
@@ -66,10 +66,12 @@ const ResourceGroupSelect: React.FC<ResourceGroupSelectProps> = ({
   >({
     queryKey: ['ResourceGroupSelectQuery', key, currentProject.name],
     queryFn: () => {
+      const search = new URLSearchParams();
+      search.set('group', currentProject.name);
       return Promise.all([
         baiRequestWithPromise({
           method: 'GET',
-          url: `/scaling-groups?group=${currentProject.name}`,
+          url: `/scaling-groups?${search.toString()}`,
         }),
         baiRequestWithPromise({
           method: 'GET',

--- a/react/src/components/VFolderLazyView.tsx
+++ b/react/src/components/VFolderLazyView.tsx
@@ -22,9 +22,11 @@ const VFolderLazyView: React.FC<VFolderLazyViewProps> = ({
   const { data: vFolders } = useTanQuery({
     queryKey: ['VFolderSelectQuery'],
     queryFn: () => {
+      const search = new URLSearchParams();
+      search.set('group_id', currentProject.id);
       return baiRequestWithPromise({
         method: 'GET',
-        url: `/folders?group_id=${currentProject.id}`,
+        url: `/folders?${search.toString()}`,
       }) as Promise<VFolder[]>;
     },
     staleTime: 1000,

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -75,9 +75,11 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
   const { data } = useTanQuery({
     queryKey: ['VFolderSelectQuery', key],
     queryFn: () => {
+      const search = new URLSearchParams();
+      search.set('group_id', currentProject.id);
       return baiRequestWithPromise({
         method: 'GET',
-        url: `/folders?group_id=${currentProject.id}`,
+        url: `/folders?${search.toString()}`,
       }) as Promise<VFolder[]>;
     },
     staleTime: 0,

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -140,9 +140,11 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   const { data: allFolderList } = useTanQuery({
     queryKey: ['VFolderSelectQuery', fetchKey, currentProject.id],
     queryFn: () => {
+      const search = new URLSearchParams();
+      search.set('group_id', currentProject.id);
       return baiRequestWithPromise({
         method: 'GET',
-        url: `/folders?group_id=${currentProject.id}`,
+        url: `/folders?${search.toString()}`,
       }) as Promise<VFolder[]>;
     },
     staleTime: 1000,

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -73,16 +73,18 @@ export const useResourceSlotsDetails = (resourceGroupName?: string) => {
     queryFn: () => {
       // return baiClient.get_resource_slots();
       if (
-        _.isEmpty(resourceGroupName) ||
+        !resourceGroupName ||
         !baiClient.isManagerVersionCompatibleWith('23.09.0')
       ) {
         return undefined;
       } else {
         // `/resource-slots/details` is available since 23.09
         // https://github.com/lablup/backend.ai/issues/1589
+        const search = new URLSearchParams();
+        search.set('sgroup', resourceGroupName);
         return baiRequestWithPromise({
           method: 'GET',
-          url: `/config/resource-slots/details?sgroup=${resourceGroupName}`,
+          url: `/config/resource-slots/details?${search.toString()}`,
         });
       }
     },


### PR DESCRIPTION
### TL;DR

Replaced string concatenation with `URLSearchParams` for constructing query parameters in several GET requests.

### What changed?

- Refactored various components such as `FolderExplorerOpener`, `ResourceGroupSelect`, `VFolderLazyView`, `VFolderSelect`, `VFolderTable`, and `backendai` hook to use `URLSearchParams` instead of manual string concatenation for query parameters.

### How to test?

1. Verify that the `FolderExplorerOpener` component correctly fetches folders using the updated URL search parameters.
2. Check that the `ResourceGroupSelect` component functions as expected with the new query parameter construction.
3. Ensure the `VFolderLazyView`, `VFolderSelect`, and `VFolderTable` components properly retrieve folder data with the updated URL structure.
4. Test the `backendai` hook's functionality, particularly the `/config/resource-slots/details` endpoint, to confirm the `URLSearchParams` integration.

### Why make this change?

To improve the readability, maintainability, and reliability of URL query parameter construction across the codebase by utilizing `URLSearchParams` instead of manual string concatenation.

---

The pull request refactors multiple components to use URLSearchParams for setting query parameters in backend API requests. This approach improves code consistency and readability. The affected components include FolderExplorerOpener, ResourceGroupSelect, VFolderLazyView, VFolderSelect, VFolderTable, and a hook in backendai for resource slot details.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
