### PR TITLE
fix: Image environment select form item's wrap style

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -323,6 +323,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
     <>
       <style>{cssRaw}</style>
       <Form.Item
+        className="image-environment-select-form-item"
         name={['environments', 'environment']}
         label={`${t('session.launcher.Environments')} / ${t(
           'session.launcher.Version',
@@ -515,6 +516,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
           });
           return (
             <Form.Item
+              className="image-environment-select-form-item"
               name={['environments', 'version']}
               rules={[{ required: _.isEmpty(environments?.manual) }]}
             >


### PR DESCRIPTION
#### TL;DR

Added CSS class `image-environment-select-form-item` to `Form.Item` components in `ImageEnvironmentSelectFormItems.tsx`.

| Before | After |
| -- | -- |
|  ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/8972879d-b3b5-4b3b-8509-34b52e2cbf7f.png) | ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/4330f7de-68d9-49ea-9085-19d43727b807.png)   ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/bfac69fe-60df-4d18-8f30-a76d090bcfd3.png) |

#### What changed?

- Added the CSS class `image-environment-select-form-item` to `Form.Item` components in the file `react/src/components/ImageEnvironmentSelectFormItems.tsx`.

#### How to test?

1. Run the application in small size of browser window.
2. Navigate to the component that uses `ImageEnvironmentSelectFormItems` (session launcher & service launcher)
3. Check the tags's gradations 

#### Why make this change?

To ensure consistent styling by adding a specific class to `Form.Item` components in the `ImageEnvironmentSelectFormItems` component.

