### PR TITLE
style: dynamic model card ui

### DIFF
--- a/react/src/components/ModelCardModal.tsx
+++ b/react/src/components/ModelCardModal.tsx
@@ -10,7 +10,6 @@ import {
   Card,
   Col,
   Descriptions,
-  Grid,
   Row,
   Tag,
   Typography,
@@ -23,8 +22,6 @@ import Markdown from 'markdown-to-jsx';
 import React, { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFragment } from 'react-relay';
-
-const { Title, Paragraph } = Typography;
 
 interface ModelCardModalProps extends BAIModalProps {
   modelCardModalFrgmt?: ModelCardModalFragment$key | null;
@@ -40,7 +37,6 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
 
   const [visibleCloneModal, setVisibleCloneModal] = useState(false);
 
-  const screen = Grid.useBreakpoint();
   const [metadata] = useBackendAIImageMetaData();
   const model_card = useFragment(
     graphql`
@@ -85,7 +81,7 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
       centered
       onCancel={onRequestClose}
       destroyOnClose
-      width={screen.xxl ? '75%' : '90%'}
+      width={800}
       footer={[
         <Button
           onClick={() => {
@@ -175,26 +171,12 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
         </Flex>
       </Flex>
       <Row gutter={[token.marginLG, token.marginLG]}>
-        <Col xs={{ span: 24 }} lg={{ span: 12 }}>
+        <Col xs={{ span: 24 }}>
           <Flex direction="column" align="stretch" gap={'xs'}>
-            <Title level={5} style={{ marginTop: 0 }}>
-              {t('modelStore.Description')}
-            </Title>
-            <Card
-              size="small"
-              style={{
-                whiteSpace: 'pre-wrap',
-                minHeight: screen.lg ? 100 : undefined,
-                height: screen.lg ? 'calc(100vh - 590px)' : undefined,
-                maxHeight: 'calc(100vh - 590px)',
-                overflow: 'auto',
-              }}
-            >
-              <Paragraph>{model_card?.description}</Paragraph>
-            </Card>
+            {model_card?.description}
             <Descriptions
               style={{ marginTop: token.marginMD }}
-              title={t('modelStore.Metadata')}
+              // title={t('modelStore.Metadata')}
               column={1}
               size="small"
               bordered
@@ -286,25 +268,29 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
             />
           </Flex>
         </Col>
-        <Col xs={{ span: 24 }} lg={{ span: 12 }}>
-          <Card
-            size="small"
-            title={
-              <Flex direction="row" gap={'xs'}>
-                <FileOutlined />
-                README.md
-              </Flex>
-            }
-            bodyStyle={{
-              padding: token.paddingLG,
-              overflow: 'auto',
-              height: screen.lg ? 'calc(100vh - 243px)' : undefined,
-              minHeight: 200,
-            }}
-          >
-            <Markdown>{model_card?.readme || ''}</Markdown>
-          </Card>
-        </Col>
+        {!!model_card?.readme ? (
+          <Col xs={{ span: 24 }}>
+            <Card
+              size="small"
+              title={
+                <Flex direction="row" gap={'xs'}>
+                  <FileOutlined />
+                  README.md
+                </Flex>
+              }
+              styles={{
+                body: {
+                  padding: token.paddingLG,
+                  overflow: 'auto',
+                  // height: screen.lg ? 'calc(100vh - 243px)' : undefined,
+                  minHeight: 200,
+                },
+              }}
+            >
+              <Markdown>{model_card?.readme || ''}</Markdown>
+            </Card>
+          </Col>
+        ) : null}
       </Row>
       <Suspense>
         <ModelCloneModal

--- a/react/src/pages/ModelStoreListPage.tsx
+++ b/react/src/pages/ModelStoreListPage.tsx
@@ -6,11 +6,22 @@ import { useUpdatableState } from '../hooks';
 import { ModelStoreListPageQuery } from './__generated__/ModelStoreListPageQuery.graphql';
 import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
 import { Button, Card, Input, List, Select, Tag, theme } from 'antd';
+import { createStyles } from 'antd-style';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React, { useMemo, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyLoadQuery } from 'react-relay';
+
+const useStyles = createStyles(({ css, token }) => {
+  return {
+    cardList: css`
+      .ant-col {
+        height: calc(100% - ${token.marginMD}px);
+      }
+    `,
+  };
+});
 
 const ModelStoreListPage: React.FC = () => {
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
@@ -21,6 +32,8 @@ const ModelStoreListPage: React.FC = () => {
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [selectedTasks, setSelectedTasks] = useState<string[]>([]);
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
+
+  const { styles } = useStyles();
 
   const [currentModelInfo, setCurrentModelInfo] =
     useState<ModelCardModalFragment$key | null>();
@@ -176,6 +189,7 @@ const ModelStoreListPage: React.FC = () => {
         </Flex>
       </Flex>
       <List
+        className={styles.cardList}
         grid={{ gutter: 16, xs: 1, sm: 2, md: 2, lg: 3, xl: 4, xxl: 5 }}
         dataSource={model_cards?.edges
           ?.map((edge) => edge?.node)
@@ -208,6 +222,9 @@ const ModelStoreListPage: React.FC = () => {
             onClick={() => {
               setCurrentModelInfo(item);
             }}
+            style={{
+              height: '100%',
+            }}
           >
             <Card
               hoverable
@@ -216,6 +233,9 @@ const ModelStoreListPage: React.FC = () => {
                   {item?.title}
                 </TextHighlighter>
               }
+              style={{
+                height: '100%',
+              }}
               size="small"
             >
               <Flex direction="row" wrap="wrap" gap={'xs'}>


### PR DESCRIPTION
### TL;DR

Updated the layout of `ModelCardModal` and the styling in `ModelStoreListPage` to improve the user interface and experience.

### What changed?

- `ModelCardModal.tsx`
  - Changed the width setting from responsive percentages to a fixed pixel value for better consistency.
  - Simplified the layout by removing redundant `Card` components
  - Conditionally rendered the README section only if available.
- `ModelStoreListPage.tsx`
  - Introduced custom styles using `antd-style`.
  - Applied these styles to the card list for uniform height and improved spacing.

### How to test?

1. Open the ModelCardModal and verify the new layout.
2. Check the ModelStoreListPage for consistent card heights and proper styling.

### Why make this change?

To provide a more consistent user experience and address UI issues related to varying screen sizes and element styling.

---



### Screenshots

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/40b310fd-f49d-4924-811a-14180be78d04.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/687d277b-5e05-4ba0-8040-7ee96dd58d85.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/66088720-35a0-497d-861e-691d0be82568.png)


**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup) : dogbowl, enable `enableModelStore`
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
