### PR TITLE
fix: hide auto mounted vfolder in the service launcher

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -829,7 +829,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                     filter={(vf) =>
                                       vf.name !== getFieldValue('vFolderID') &&
                                       vf.status === 'ready' &&
-                                      vf.usage_mode !== 'model'
+                                      vf.usage_mode !== 'model' &&
+                                      !vf.name?.startsWith('.')
                                     }
                                     tableProps={{
                                       size: 'small',


### PR DESCRIPTION
### TL;DR

Filtered out vfolders with usage mode 'model' and names starting with a period(auto mounted folder) in ServiceLauncherPageContent to ensure they are not selectable.

### What changed?

- Added an additional condition in the 'filter' function to check for vfolder names starting with a period (.)

### How to test?

- Navigate to the Service Launcher Page.
- Check the available vfolders in the selection list.
- Verify that vfolders with usage mode 'model' and names starting with a period (.) are not displayed.

### Why make this change?

This change is made to prevent users from selecting hidden or model-specific vfolders which could lead to potential issues.