### PR TITLE
fix: Setting initial values for antd form instances

### DIFF
--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -15,10 +15,19 @@ import {
   ModifyKeyPairResourcePolicyInput,
 } from './__generated__/KeypairResourcePolicySettingModalModifyMutation.graphql';
 // import { KeypairResourcePolicySettingModalQuery } from './__generated__/KeypairResourcePolicySettingModalQuery.graphql';
-import { App, Card, Col, Form, Input, InputNumber, Row } from 'antd';
+import {
+  App,
+  Card,
+  Col,
+  Form,
+  FormInstance,
+  Input,
+  InputNumber,
+  Row,
+} from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   useFragment, // useLazyLoadQuery,
@@ -44,7 +53,7 @@ const KeypairResourcePolicySettingModal: React.FC<
 }) => {
   const { t } = useTranslation();
   const { message } = App.useApp();
-  const [form] = Form.useForm();
+  const formRef = useRef<FormInstance>(null);
   const [resourceSlotsDetails] = useResourceSlotsDetails();
   const baiClient = useSuspendedBackendaiClient();
   const isDeprecatedMaxVfolderCountInKeypairResourcePolicy =
@@ -147,8 +156,8 @@ const KeypairResourcePolicySettingModal: React.FC<
   ]);
 
   const handleOk = () => {
-    return form
-      .validateFields()
+    return formRef?.current
+      ?.validateFields()
       .then((values) => {
         let totalResourceSlots = _.mapValues(
           values?.parsedTotalResourceSlots,
@@ -257,7 +266,7 @@ const KeypairResourcePolicySettingModal: React.FC<
       {...props}
     >
       <Form
-        form={form}
+        ref={formRef}
         layout="vertical"
         requiredMark="optional"
         initialValues={initialValues}


### PR DESCRIPTION
### TL;DR

Refactor KeypairResourcePolicySettingModal component to use React's useRef hook for managing form instance instead of useForm hook.

### What changed?

- Replaced useForm with useRef for managing the form instance.
- Reorganized import statements to include FormInstance from antd.

### How to test?

1. Open the KeypairResourcePolicySettingModal component.
2. Ensure the form behaves as expected when setting resource policies.
3. Validate that there are no errors related to form management.

### Why make this change?

The change aims to optimize the way the form instance is managed within the KeypairResourcePolicySettingModal component by utilizing the useRef hook. This can offer better performance and cleaner code structure.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
