### PR TITLE
fix: modify runtime variant

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -482,6 +482,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                   name: values.serviceName,
                   resource_group: values.resourceGroup,
                   model_definition_path: values.modelDefinitionPath,
+                  runtime_variant: values.runtimeVariant,
                 },
               };
             if (baiClient.supports('modify-endpoint-environ')) {


### PR DESCRIPTION
### TL;DR

Include the `runtime_variant` property in the payload when launching the service to ensure the correct variant is used.

### What changed?

- Added `runtime_variant` field to the service payload in `ServiceLauncherPageContent.tsx`

### How to test?

1. Open the existing service launcher.
2. Change the desired `runtime_variant`.
3. Save the service and observe that the correct `runtime_variant` is included in the payload.

### Why make this change?

This change ensures that the correct runtime variant is passed to the backend, allowing for more precise service configuration.
