### PR TITLE
add: login session extension feature with UI button

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -30,8 +30,9 @@ isDirectorySizeVisible = true           # If false, directory size in folder exp
 maxCountForPreopenPorts = 10            # The maximum allowed number of preopen ports. If you set this option to 0, the feature of preopen ports is disabled.
 allowCustomResourceAllocation = true    # If true, display the custom allocation on the session launcher.
 eduAppNamePrefix = ""                   # The prefix of edu applauncher's app name. If the app name starts with this prefix, split it by '-' and use the tail as the name of image.
-enableModelStore = false    		        # Enable model store feature. (From Backend.AI 24.03)
+enableModelStore = false                # Enable model store feature. (From Backend.AI 24.03)
 enableLLMPlayground = false             # Enable LLM Playground feature. (From Backend.AI 24.03)
+enableExtendLoginSession = false        # If true, enables login session extension UI. (From Backend.AI 24.09)
 
 [wsproxy]
 proxyURL = "[Proxy URL]"

--- a/react/src/components/MainLayout/WebUIHeader.tsx
+++ b/react/src/components/MainLayout/WebUIHeader.tsx
@@ -1,4 +1,5 @@
 import { useCurrentDomainValue } from '../../hooks';
+import { useSuspendedBackendaiClient } from '../../hooks';
 import {
   useCurrentProjectValue,
   useSetCurrentProject,
@@ -7,6 +8,7 @@ import { useScrollBreakPoint } from '../../hooks/useScrollBreackPoint';
 import BAINotificationButton from '../BAINotificationButton';
 import Flex, { FlexProps } from '../Flex';
 import ProjectSelect from '../ProjectSelect';
+import TimeContainer from '../TimeContainer';
 import UserDropdownMenu from '../UserDropdownMenu';
 import WEBUIHelpButton from '../WEBUIHelpButton';
 import WebUIThemeToggleButton from '../WebUIThemeToggleButton';
@@ -34,6 +36,7 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({
   const currentDomainName = useCurrentDomainValue();
   const currentProject = useCurrentProjectValue();
   const setCurrentProject = useSetCurrentProject();
+  const baiClient = useSuspendedBackendaiClient();
   const matches = useMatches();
   const { y: scrolled } = useScrollBreakPoint(
     {
@@ -112,6 +115,10 @@ const WebUIHeader: React.FC<WebUIHeaderProps> = ({
           <BAINotificationButton />
           <WebUIThemeToggleButton />
           <WEBUIHelpButton />
+          {baiClient.supports('extend-login-session') &&
+            baiClient._config.enableExtendLoginSession && (
+              <TimeContainer format="HH:mm:ss" />
+            )}
           <UserDropdownMenu />
         </Flex>
       </Flex>

--- a/react/src/components/TimeContainer.tsx
+++ b/react/src/components/TimeContainer.tsx
@@ -1,22 +1,59 @@
+import { useBaiSignedRequestWithPromise } from '../helper';
+import { useUpdatableState } from '../hooks';
+import { useTanQuery } from '../hooks/reactQueryAlias';
+import BAIIntervalText from './BAIIntervalText';
+import Flex from './Flex';
+import { ClockCircleOutlined } from '@ant-design/icons';
+import { Button } from 'antd';
 import { default as dayjs } from 'dayjs';
-import React, { useState, useEffect } from 'react';
+import React, { useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
 
-interface TimeContainerProps {}
+interface TimeContainerProps {
+  format?: string;
+}
 
-const TimeContainer: React.FC<TimeContainerProps> = () => {
-  const [date, setDate] = useState(new Date());
+const TimeContainer: React.FC<TimeContainerProps> = ({
+  format = 'YYYY/MM/DD dddd HH:mm:ss',
+}) => {
+  const { t } = useTranslation();
+  const baiRequestWithPromise = useBaiSignedRequestWithPromise();
+  const [isPending, startTransition] = useTransition();
+  const [fetchKey, updateFetchKey] = useUpdatableState('first');
 
-  useEffect(() => {
-    const timer = setInterval(() => setDate(new Date()), 1000);
-    return () => {
-      clearInterval(timer);
-    };
+  const { data } = useTanQuery<{
+    expires: string;
+  }>({
+    queryKey: ['TimeContainerExpires', fetchKey],
+    queryFn: () => {
+      return baiRequestWithPromise({
+        method: 'POST',
+        url: `/server/extend-login-session`,
+      });
+    },
+    staleTime: 0,
+    cacheTime: 0,
+    suspense: true,
   });
 
   return (
-    <>
-      <p>{dayjs(date).format('YYYY/MM/DD dddd HH:mm:ss')}</p>
-    </>
+    <Flex direction="row" gap="xxs">
+      <ClockCircleOutlined />
+      <BAIIntervalText
+        callback={() => {
+          const diff = dayjs(data?.expires).diff(dayjs(), 'seconds');
+          const duration = dayjs.duration(Math.max(0, diff), 'seconds');
+          return duration.format(format);
+        }}
+        delay={1000}
+      ></BAIIntervalText>
+      <Button
+        loading={isPending}
+        onClick={() => startTransition(() => updateFetchKey())}
+      >
+        {t('general.Extend')}
+      </Button>
+    </Flex>
   );
 };
 

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -380,5 +380,6 @@ type BackendAIConfig = {
   inactiveList: string[];
   allowSignout: boolean;
   allowNonAuthTCP: boolean;
+  enableExtendLoginSession: boolean;
   [key: string]: any;
 };

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -507,7 +507,8 @@
     "Session": "Sitzung",
     "General": "Allgemein",
     "Disabled": "Behinderte",
-    "NSelected": "Ausgewählte(r) {{count}} Artikel"
+    "NSelected": "Ausgewählte(r) {{count}} Artikel",
+    "Extend": "Verlängern"
   },
   "credential": {
     "Permission": "Genehmigung",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -507,7 +507,8 @@
     "Session": "Σύνοδος",
     "General": "Γενικά",
     "Disabled": "Άτομα με ειδικές ανάγκες",
-    "NSelected": "Επιλεγμένο {{count}} στοιχείο(α)"
+    "NSelected": "Επιλεγμένο {{count}} στοιχείο(α)",
+    "Extend": "Επεκτείνω"
   },
   "credential": {
     "Permission": "Αδεια",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -632,7 +632,8 @@
     "Session": "Session",
     "General": "General",
     "Disabled": "Disabled",
-    "NSelected": "Selected {{count}} item(s)"
+    "NSelected": "Selected {{count}} item(s)",
+    "Extend": "Extend"
   },
   "credential": {
     "Permission": "Permission",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -530,7 +530,8 @@
     "Session": "Sesión",
     "General": "General",
     "Disabled": "Discapacitados",
-    "NSelected": "Elemento(s) {{cuenta}} seleccionado(s)"
+    "NSelected": "Elemento(s) {{cuenta}} seleccionado(s)",
+    "Extend": "Extender"
   },
   "import": {
     "CleanUpImportTask": "Tarea de importación de limpieza...",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -530,7 +530,8 @@
     "Session": "Istunto",
     "General": "Yleistä",
     "Disabled": "Vammaiset",
-    "NSelected": "Valittu {{count}} kohde(t)"
+    "NSelected": "Valittu {{count}} kohde(t)",
+    "Extend": "Laajenna"
   },
   "import": {
     "CleanUpImportTask": "Tuontitehtävän siivous...",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -507,7 +507,8 @@
     "Session": "Session",
     "General": "Général",
     "Disabled": "Handicapés",
-    "NSelected": "Élément(s) sélectionné(s) {{count}}"
+    "NSelected": "Élément(s) sélectionné(s) {{count}}",
+    "Extend": "Étendre"
   },
   "credential": {
     "Permission": "Autorisation",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -508,7 +508,8 @@
     "Session": "Sesi",
     "General": "Umum",
     "Disabled": "Dinonaktifkan",
-    "NSelected": "Item {{hitung}} yang dipilih"
+    "NSelected": "Item {{hitung}} yang dipilih",
+    "Extend": "Memperpanjang"
   },
   "credential": {
     "Permission": "Izin",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -508,7 +508,8 @@
     "Session": "Sessione",
     "General": "Generale",
     "Disabled": "Disabili",
-    "NSelected": "Articolo/i selezionato/i {{count}}"
+    "NSelected": "Articolo/i selezionato/i {{count}}",
+    "Extend": "Estendere"
   },
   "credential": {
     "Permission": "Autorizzazione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -507,7 +507,8 @@
     "Session": "セッション",
     "General": "一般",
     "Disabled": "無効",
-    "NSelected": "選択された{{count}}項目（複数可）"
+    "NSelected": "選択された{{count}}項目（複数可）",
+    "Extend": "伸ばす"
   },
   "credential": {
     "Permission": "許可",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -619,7 +619,8 @@
     "Session": "세션",
     "General": "일반",
     "Disabled": "비활성화",
-    "NSelected": "{{count}}개 선택됨"
+    "NSelected": "{{count}}개 선택됨",
+    "Extend": "연장"
   },
   "credential": {
     "Permission": "권한",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -509,7 +509,8 @@
     "Session": "Сессия",
     "General": "Генерал",
     "Disabled": "Идэвхгүй",
-    "NSelected": "Сонгосон {{count}} зүйл(үүд)"
+    "NSelected": "Сонгосон {{count}} зүйл(үүд)",
+    "Extend": "Сунгах"
   },
   "credential": {
     "Permission": "Зөвшөөрөл",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -507,7 +507,8 @@
     "Session": "Sesi",
     "General": "Umum",
     "Disabled": "Dilumpuhkan",
-    "NSelected": "{{count}} item yang dipilih"
+    "NSelected": "{{count}} item yang dipilih",
+    "Extend": "Panjangkan"
   },
   "credential": {
     "Permission": "Kebenaran",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -507,7 +507,8 @@
     "Session": "Sesja",
     "General": "Ogólne",
     "Disabled": "Wyłączony",
-    "NSelected": "Wybrane elementy {{count}}"
+    "NSelected": "Wybrane elementy {{count}}",
+    "Extend": "Rozszerzyć"
   },
   "credential": {
     "Permission": "Pozwolenie",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -507,7 +507,8 @@
     "Session": "Sessão",
     "General": "Geral",
     "Disabled": "Desativado",
-    "NSelected": "Item(ns) {{contagem}} selecionado(s)"
+    "NSelected": "Item(ns) {{contagem}} selecionado(s)",
+    "Extend": "Ampliar"
   },
   "credential": {
     "Permission": "Permissão",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -507,7 +507,8 @@
     "Session": "Sessão",
     "General": "Geral",
     "Disabled": "Desativado",
-    "NSelected": "Item(ns) {{contagem}} selecionado(s)"
+    "NSelected": "Item(ns) {{contagem}} selecionado(s)",
+    "Extend": "Ampliar"
   },
   "credential": {
     "Permission": "Permissão",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -507,7 +507,8 @@
     "Session": "Сессия",
     "General": "Общие сведения",
     "Disabled": "Инвалид",
-    "NSelected": "Выбранный {{count}} элемент(ы)"
+    "NSelected": "Выбранный {{count}} элемент(ы)",
+    "Extend": "Продлевать"
   },
   "credential": {
     "Permission": "Разрешение",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -507,7 +507,8 @@
     "Session": "Oturum",
     "General": "Genel",
     "Disabled": "Engelli",
-    "NSelected": "Seçilen {{count}} öğe(ler)"
+    "NSelected": "Seçilen {{count}} öğe(ler)",
+    "Extend": "Uzatmak"
   },
   "credential": {
     "Permission": "izin",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -507,7 +507,8 @@
     "Session": "Phiên họp",
     "General": "Tổng quan",
     "Disabled": "Tàn tật",
-    "NSelected": "Đã chọn {{count}} mục"
+    "NSelected": "Đã chọn {{count}} mục",
+    "Extend": "Mở rộng"
   },
   "credential": {
     "Permission": "Sự cho phép",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -507,7 +507,8 @@
     "Session": "会话",
     "General": "一般情况",
     "Disabled": "残疾",
-    "NSelected": "已选择的 {{count}} 项目"
+    "NSelected": "已选择的 {{count}} 项目",
+    "Extend": "延长"
   },
   "credential": {
     "Permission": "允许",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -507,7 +507,8 @@
     "Session": "會話",
     "General": "一般情况",
     "Disabled": "残疾",
-    "NSelected": "已选择的 {{count}} 项目"
+    "NSelected": "已选择的 {{count}} 项目",
+    "Extend": "延長"
   },
   "credential": {
     "Permission": "允許",

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -140,6 +140,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: Boolean }) isDirectorySizeVisible = true;
   @property({ type: Boolean }) enableModelStore = false;
   @property({ type: Boolean }) enableLLMPlayground = false;
+  @property({ type: Boolean }) enableExtendLoginSession = false;
   @property({ type: String }) eduAppNamePrefix;
   @property({ type: String }) pluginPages;
   @property({ type: Array }) blockList = [] as string[];
@@ -855,6 +856,16 @@ export default class BackendAILogin extends BackendAIPage {
       defaultValue: false,
       value: generalConfig?.enableLLMPlayground,
     } as ConfigValueObject) as boolean;
+
+    // Enable extend login session
+    this.enableExtendLoginSession = this._getConfigValueByExists(
+      generalConfig,
+      {
+        valueType: 'boolean',
+        defaultValue: false,
+        value: generalConfig?.enableExtendLoginSession,
+      } as ConfigValueObject,
+    ) as boolean;
   }
 
   /**
@@ -1849,6 +1860,8 @@ export default class BackendAILogin extends BackendAIPage {
           this.enableModelStore;
         globalThis.backendaiclient._config.enableLLMPlayground =
           this.enableLLMPlayground;
+        globalThis.backendaiclient._config.enableExtendLoginSession =
+          this.enableExtendLoginSession;
         globalThis.backendaiclient._config.pluginPages = this.pluginPages;
         globalThis.backendaiclient._config.blockList = this.blockList;
         globalThis.backendaiclient._config.inactiveList = this.inactiveList;

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -710,6 +710,9 @@ class Client {
     if (this.isManagerVersionCompatibleWith('24.03.7')) {
       this._features['per-kernel-logs'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('24.09')) {
+      this._features['extend-login-session'] = true;
+    }
   }
 
   /**


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Related: [backend.ai#2456](https://github.com/lablup/backend.ai/pull/2456)
This PR refactors TimeContainer component to be used as counting down valid login session time received from server.

### How to test:
> Prerequisites: 
> 1. Apply your Core version to [backend.ai#2456](https://github.com/lablup/backend.ai/pull/2456)
> 2. add `login_session_extension_sec` in  "[session]" section of webserver configuration file. (for test, please input short amount of time such as 30sec or 15sec.)
> 3. restart Backend.AI Webserver process.

1. See until the time passes on right side of header.
2. Click `Extend` button on the right top of header.
3. Wait until 5 or 3 seconds left and Click the `Extend` button again.
4. See session login time extension works.

### Screenshot(s):
<img width="910" alt="Screenshot 2024-07-26 at 8 13 50 PM" src="https://github.com/user-attachments/assets/42e0d320-4017-4b64-b901-20fbd747f8fa">

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [x] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after
