### PR TITLE
fix: hide resource slots form items when `allowCustomResourceAllocation` is false

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -470,6 +470,9 @@ const ResourceAllocationFormItems: React.FC<
       <Card
         style={{
           marginBottom: token.margin,
+          display: baiClient._config.allowCustomResourceAllocation
+            ? 'block'
+            : 'none',
         }}
       >
         <Form.Item


### PR DESCRIPTION
### TL;DR
Follow up : https://github.com/lablup/backend.ai-webui/pull/2522
Conditional rendering of a Card component in ResourceAllocationFormItems.tsx based on the allowCustomResourceAllocation configuration setting.

### What changed?

- Added a condition to the style of the Card component to render it only if baiClient._config.allowCustomResourceAllocation is set to true.

### How to test?

1. Set baiClient._config.allowCustomResourceAllocation to true and verify that the Resource slot form items displayed.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/3870c12a-c3b6-4a11-9759-f711ef407008.png)
2. Set baiClient._config.allowCustomResourceAllocation to false and verify that the Resource slot form items are hidden.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/0424e56c-1909-4ce4-a6ac-26bca7a1c5d4.png)


### Why make this change?

To ensure that the Card component in the ResourceAllocationFormItems is only rendered when custom resource allocation is permitted, improving the flexibility and configuration of the application.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
