### PR TITLE
fix: backward compatibility for extra mounts of a service

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -111,7 +111,7 @@ interface ServiceLauncherInput extends ImageEnvironmentFormInput {
   modelMountDestination: string;
   modelDefinitionPath: string;
   vfoldersAliasMap: Record<string, string>;
-  mounts: Array<string>;
+  mounts?: Array<string>;
   envvars: EnvVarFormListValue[];
   runtimeVariant: string;
 }
@@ -399,8 +399,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
             supported_accelerators
           }
           name
-          model_definition_path
-          model_mount_destination
+          model_definition_path @since(version: "24.03.4")
+          model_mount_destination @since(version: "24.03.4")
           extra_mounts @since(version: "24.03.4") {
             id
             host
@@ -471,7 +471,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                     ),
                     values,
                   ),
-                  extra_mounts: (values.mounts || []).map((vfolder) => {
+                  extra_mounts: _.map(values.mounts, (vfolder) => {
                     return {
                       vfolder_id: vfolder,
                       ...(values.vfoldersAliasMap[vfolder] && {


### PR DESCRIPTION
### TL;DR

Make the 'mounts' attribute optional in the ServiceLauncherInput interface and add GraphQL directives to specific model attributes in the ServiceLauncherPageContent component.

reported from [Teams](https://teams.microsoft.com/l/message/19:fceea950220e430ca12c3040d152efe9@thread.tacv2/1721282677260?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=b1f3bcf4-facf-40d3-94ab-169abb4f0f52&parentMessageId=1721282297006&teamName=customers%20%26%20clients&channelName=KT%20Cloud&createdTime=1721282677260)

### What changed?

- Updated the 'ServiceLauncherInput' interface, making the 'mounts' attribute optional.
- Added GraphQL directives `@since(version: "24.03.4")` to 'model_definition_path', 'model_mount_destination', and 'extra_mounts'.

### How to test?

1. Ensure that updating service modal  without errors in before 24.03.4 version.

### Why make this change?

This change ensures better flexibility for the 'mounts' attribute and properly annotates new fields introduced in version 24.03.4, enhancing the maintainability and readability of the codebase.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
