### PR TITLE
feat: remove password validation for superadmin

### DIFF
--- a/react/src/components/UserProfileSettingModal.tsx
+++ b/react/src/components/UserProfileSettingModal.tsx
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2024 Lablup Inc. All rights reserved.
  */
 import { useSuspendedBackendaiClient } from '../hooks';
-import { useCurrentUserInfo } from '../hooks/backendai';
+import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import BAIModal from './BAIModal';
 import { passwordPattern } from './ResetPasswordRequired';
@@ -58,6 +58,7 @@ const UserProfileSettingModal: React.FC<Props> = ({
   const [isOpenTOTPActivateModal, { toggle: toggleTOTPActivateModal }] =
     useToggle(false);
   const baiClient = useSuspendedBackendaiClient();
+  const userRole = useCurrentUserRole();
   const [userInfo, userMutations] = useCurrentUserInfo();
   // const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
 
@@ -196,7 +197,8 @@ const UserProfileSettingModal: React.FC<Props> = ({
               label={t('webui.menu.NewPassword')}
               rules={[
                 {
-                  pattern: passwordPattern,
+                  pattern:
+                    userRole === 'superadmin' ? undefined : passwordPattern,
                   message: t('webui.menu.InvalidPasswordMessage'),
                 },
               ]}


### PR DESCRIPTION
### TL;DR

Allow superadmins to bypass password patterns in password reset and profile settings.
Related PR: https://github.com/lablup/backend.ai-webui/pull/1716

### What changed?

- Imported and used `useCurrentUserRole` hook.
- Modified password validation rules in `ResetPasswordRequired` and `UserProfileSettingModal` components to bypass pattern checks for superadmins.

### How to test?

1. Log in as a superadmin.
2. Try to reset the password and update the profile.
3. Verify that the password pattern validation is bypassed.

### Why make this change?

To allow superadmins more flexibility when resetting passwords or updating profiles.