### PR TITLE
feat: resource preset in Service Launcher

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -879,7 +879,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                         //   });
                         // }}
                         />
-                        <ResourceAllocationFormItems />
+                        <ResourceAllocationFormItems enableResourcePresets />
                         <Form.Item
                           label={t('session.launcher.EnvironmentVariable')}
                         >


### PR DESCRIPTION
### TL;DR

Added support for resource presets in the Resource Allocation Form.

### What changed?

- Modified the `ServiceLauncherPageContent` component to enable resource presets by default in the `ResourceAllocationFormItems` component.

### How to test?

1. Navigate to the Service Launcher page in the application.
2. Verify that the Resource Allocation Form now supports and displays resource presets.
3. Set `allowCustomResourceAllocation=false` in `config.toml` 4. Check
  - if the resource slot form items have disappeared.
  - if the `custom` option of the preset select has disappeared.

### Why make this change?

This change improves the user experience by allowing users to quickly select predefined resource settings in the Resource Allocation Form.