### PR TITLE
fix: eslint error of Chat UI components

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -62,7 +62,7 @@
     "eject": "react-scripts eject",
     "relay": "relay-compiler",
     "relay:watch": "nodemon --watch schema.graphql --watch client-directives.graphql --exec 'pnpm run relay --watch'",
-    "lint": "pnpm dlx eslint ./src --ignore-pattern '*.test.*' --max-warnings=0",
+    "lint": "eslint ./src --ignore-pattern '*.test.*' --max-warnings=0",
     "format": "pnpm dlx prettier --check 'src/**/*.{js,jsx,ts,tsx}'",
     "format-fix": "pnpm dlx prettier --write './src/**/*.{js,jsx,ts,tsx}'",
     "storybook": "storybook dev -p 6006",

--- a/react/src/components/BAIModal.tsx
+++ b/react/src/components/BAIModal.tsx
@@ -6,7 +6,6 @@ import { Modal, ModalProps, theme } from 'antd';
 import React, { useState, useRef } from 'react';
 import type { DraggableData, DraggableEvent } from 'react-draggable';
 import Draggable from 'react-draggable';
-import style from 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark';
 
 export const DEFAULT_BAI_MODAL_Z_INDEX = 1001;
 export interface BAIModalProps extends ModalProps {

--- a/react/src/components/lablupTalkativotUI/ChatMessageContent.tsx
+++ b/react/src/components/lablupTalkativotUI/ChatMessageContent.tsx
@@ -1,7 +1,6 @@
 import CopyButton from './CopyButton';
 import { Card, Typography } from 'antd';
 import React from 'react';
-import { PropsWithChildren } from 'react';
 import Markdown from 'react-markdown';
 import {
   Prism as SyntaxHighlighter,

--- a/react/src/components/lablupTalkativotUI/ChatMessageList.tsx
+++ b/react/src/components/lablupTalkativotUI/ChatMessageList.tsx
@@ -2,7 +2,6 @@ import Flex, { FlexProps } from '../Flex';
 import ChatMessage from './ChatMessage';
 import CopyButton from './CopyButton';
 import { Message } from 'ai';
-import { Button } from 'antd';
 import Compact from 'antd/es/space/Compact';
 import React from 'react';
 

--- a/react/src/components/lablupTalkativotUI/ScrollBottomHandlerButton.tsx
+++ b/react/src/components/lablupTalkativotUI/ScrollBottomHandlerButton.tsx
@@ -1,3 +1,4 @@
+import { useEventNotStable } from '../../hooks/useEventNotStable';
 import { Button } from 'antd';
 import { ArrowDownIcon } from 'lucide-react';
 import React, { useEffect } from 'react';
@@ -6,19 +7,21 @@ interface ScrollBottomHandlerButtonProps {
   autoScroll?: boolean;
   atBottom?: boolean;
   lastMessageContent?: string;
-  onScrollToBottom?: (type: 'click' | 'auto') => void;
+  onScrollToBottom: (type: 'click' | 'auto') => void;
 }
 const ScrollBottomHandlerButton: React.FC<ScrollBottomHandlerButtonProps> = ({
   autoScroll,
   atBottom,
   lastMessageContent,
-  onScrollToBottom,
+  ...props
 }) => {
+  const onScrollToBottom = useEventNotStable(props.onScrollToBottom);
+
   useEffect(() => {
     if (atBottom && autoScroll) {
       onScrollToBottom?.('auto');
     }
-  }, [atBottom, autoScroll, lastMessageContent]);
+  }, [atBottom, autoScroll, lastMessageContent, onScrollToBottom]);
 
   return (
     <Button


### PR DESCRIPTION
### TL;DR

This PR primarily focuses on cleaning up unused dependencies and improving the linting script of files related to https://github.com/lablup/backend.ai-webui/pull/2553

### What changed?
- Removed unused imports in several components (`BAIModal.tsx`, `ChatMessageContent.tsx`, `ChatMessageList.tsx`).
- Updated `lint` script in `package.json` to remove redundant `pnpm dlx` for eslint.

### How to test?
Ensure all components render and function as expected without any errors or warnings. Run the linting script to verify no linting issues.

### Why make this change?
Removing unused imports and redundant commands helps in keeping the codebase clean and improving the efficiency of the development process.
