### PR TITLE
fix: `defaultValue` of `BAIPropertyFilter`

### DIFF
--- a/react/src/components/BAIPropertyFilter.stories.tsx
+++ b/react/src/components/BAIPropertyFilter.stories.tsx
@@ -36,3 +36,27 @@ export const Default: Story = {
     onChange: fn(),
   },
 };
+
+export const DefaultValue: Story = {
+  name: 'with default value',
+  args: {
+    filterProperties: [
+      {
+        key: 'property1',
+        defaultOperator: '==',
+        propertyLabel: 'Property 1',
+      },
+      {
+        key: 'property2',
+        defaultOperator: '!=',
+        propertyLabel: 'Property 2',
+      },
+      {
+        key: 'property3',
+        propertyLabel: 'Property 3',
+      },
+    ],
+    defaultValue: 'property1 == "value"',
+    onChange: fn(),
+  },
+};

--- a/react/src/components/BAIPropertyFilter.tsx
+++ b/react/src/components/BAIPropertyFilter.tsx
@@ -64,11 +64,17 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
 }) => {
   const [search, setSearch] = useControllableValue({});
 
-  const [value, setValue] = useControllableValue<string | undefined>({
-    value: propValue,
-    defaultValue: defaultValue,
-    onChange: propOnChange,
-  });
+  const [value, setValue] = useControllableValue<string | undefined>(
+    _.omitBy(
+      {
+        value: propValue,
+        defaultValue: defaultValue,
+        onChange: propOnChange,
+      },
+      _.isUndefined,
+    ),
+  );
+
   const filtersFromValue = useMemo(() => {
     if (value === undefined) return [];
     const filters = value.split('&').map((filter) => filter.trim());


### PR DESCRIPTION
### TL;DR

Add support for default value in BAIPropertyFilter component and its story.

### What changed?

Modified `BAIPropertyFilter.tsx` to use `_.omitBy` for managing undefined or empty values in value prop, and added a new story `DefaultValue` in `BAIPropertyFilter.stories.tsx` showcasing the default value functionality.

### How to test?

Run the storybook and navigate to `BAIPropertyFilter` component. Check the `DefaultValue` story to see if the default value is applied correctly.

### Why make this change?

This change was made to allow the `BAIPropertyFilter` component to handle default values more gracefully and to provide a corresponding story for developers to reference.
