### PR TITLE
refactor: EndpointSelect

### DIFF
--- a/react/src/components/EndpointSelect.tsx
+++ b/react/src/components/EndpointSelect.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { useLazyLoadQuery } from 'react-relay';
 
 interface EndpointSelectProps extends Omit<SelectProps, 'options'> {
-  autoSelectDefault?: boolean;
+  fetchKey?: string;
 }
 
 export type Endpoint = NonNullableItem<
@@ -19,7 +19,7 @@ export type Endpoint = NonNullableItem<
 >;
 
 const EndpointSelect: React.FC<EndpointSelectProps> = ({
-  autoSelectDefault,
+  fetchKey,
   ...selectProps
 }) => {
   const { baiPaginationOption } = useBAIPaginationOptionState({
@@ -40,6 +40,7 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
             name
             endpoint_id
             url
+            ...EndpointLLMChatCard_endpoint
           }
         }
       }
@@ -48,19 +49,26 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
       limit: baiPaginationOption.limit,
       offset: baiPaginationOption.offset,
     },
+    {
+      fetchKey: fetchKey,
+    },
   );
-  const [controllableValue, setControllableValue] = useControllableValue(
-    selectProps,
-    autoSelectDefault
-      ? {
-          defaultValue: endpoint_list?.items?.[0]?.endpoint_id,
-        }
-      : undefined,
-  );
+  const [controllableValue, setControllableValue] =
+    useControllableValue(selectProps);
+
+  // useEffect(() => {
+  //   if (autoSelectDefault && _.isEmpty(controllableValue)) {
+  //     setControllableValue(
+  //       endpoint_list?.items[0]?.endpoint_id,
+  //       endpoint_list?.items[0],
+  //     );
+  //   }
+  // }, []);
 
   return (
     <Select
       showSearch
+      optionFilterProp="label"
       {...selectProps}
       options={_.map(endpoint_list?.items, (item) => {
         return {

--- a/react/src/components/lablupTalkativotUI/ChatMessageContent.tsx
+++ b/react/src/components/lablupTalkativotUI/ChatMessageContent.tsx
@@ -74,4 +74,4 @@ const X: React.FC<SyntaxHighlighterProps> = ({ children, ...props }) => {
 };
 const CodeBlock = React.memo(X);
 
-export default ChatMessageContent;
+export default React.memo(ChatMessageContent);

--- a/react/src/components/lablupTalkativotUI/EndpointLLMChatCard.tsx
+++ b/react/src/components/lablupTalkativotUI/EndpointLLMChatCard.tsx
@@ -1,16 +1,21 @@
 import { useTanQuery } from '../../hooks/reactQueryAlias';
-import EndpointSelect, { Endpoint } from '../EndpointSelect';
+import EndpointSelect from '../EndpointSelect';
 import { Model } from './ChatUIModal';
 import LLMChatCard, { BAIModel } from './LLMChatCard';
+import { EndpointLLMChatCard_endpoint$key } from './__generated__/EndpointLLMChatCard_endpoint.graphql';
 import { CloseOutlined } from '@ant-design/icons';
-import { Alert, Button, CardProps, Popconfirm, Skeleton, theme } from 'antd';
+import { Alert, Button, CardProps, Popconfirm, theme } from 'antd';
+import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
-import React, { useState } from 'react';
+import React, { startTransition, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useFragment } from 'react-relay';
 
 interface EndpointLLMChatCardProps extends CardProps {
   basePath?: string;
   closable?: boolean;
+  defaultEndpoint?: EndpointLLMChatCard_endpoint$key;
+  fetchKey?: string;
   onRequestClose?: () => void;
   onModelChange?: (modelId: string) => void;
 }
@@ -18,37 +23,52 @@ interface EndpointLLMChatCardProps extends CardProps {
 const EndpointLLMChatCard: React.FC<EndpointLLMChatCardProps> = ({
   basePath = 'v1',
   closable,
+  defaultEndpoint,
   onRequestClose,
   onModelChange,
+  fetchKey,
   ...cardProps
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [endpoint, setEndpoint] = useState<Endpoint>();
+  const [endpointFrgmt, setEndpointFrgmt] =
+    useState<EndpointLLMChatCard_endpoint$key | null>(defaultEndpoint || null);
+  const endpoint = useFragment(
+    graphql`
+      fragment EndpointLLMChatCard_endpoint on Endpoint {
+        endpoint_id
+        url
+      }
+    `,
+    endpointFrgmt,
+  );
+  const [promisingEndpoint, setPromisingEndpoint] = useState(endpoint);
 
-  const {
-    data: modelsResult,
-    // error,
-    isFetching,
-  } = useTanQuery<{
+  const { data: modelsResult } = useTanQuery<{
     data: Array<Model>;
   }>({
-    queryKey: ['models', endpoint],
+    queryKey: ['models', fetchKey, endpoint?.endpoint_id],
     queryFn: () => {
-      return fetch(
-        new URL(basePath + '/models', endpoint?.url ?? undefined).toString(),
-      ).then((res) => res.json());
+      return endpoint?.url
+        ? fetch(
+            new URL(
+              basePath + '/models',
+              endpoint?.url ?? undefined,
+            ).toString(),
+          )
+            .then((res) => res.json())
+            .catch((e) => ({ data: [] }))
+        : Promise.resolve({ data: [] });
     },
-    suspense: false,
+    suspense: true,
   });
+
   const models = _.map(modelsResult?.data, (m) => ({
     id: m.id,
     name: m.id,
   })) as BAIModel[];
 
-  return isFetching ? (
-    <Skeleton active />
-  ) : (
+  return (
     <LLMChatCard
       {...cardProps}
       baseURL={
@@ -64,14 +84,23 @@ const EndpointLLMChatCard: React.FC<EndpointLLMChatCardProps> = ({
           style={{
             fontWeight: 'normal',
           }}
+          fetchKey={fetchKey}
           showSearch
+          loading={promisingEndpoint?.endpoint_id !== endpoint?.endpoint_id}
           onChange={(v, endpoint) => {
-            setEndpoint(endpoint as Endpoint);
+            // TODO: fix type definitions
+            // @ts-ignore'
+            setPromisingEndpoint(endpoint);
+            startTransition(() => {
+              // @ts-ignore'
+              setEndpointFrgmt(endpoint);
+            });
           }}
           value={endpoint?.endpoint_id}
+          popupMatchSelectWidth={false}
         />
       }
-      modelId={modelsResult?.data?.[0].id ?? 'custom'}
+      modelId={modelsResult?.data?.[0]?.id ?? 'custom'}
       extra={
         closable ? (
           <Popconfirm

--- a/react/src/components/lablupTalkativotUI/LLMChatCard.tsx
+++ b/react/src/components/lablupTalkativotUI/LLMChatCard.tsx
@@ -15,11 +15,12 @@ import {
   CardProps,
   Dropdown,
   Form,
+  FormInstance,
   Input,
   MenuProps,
   theme,
 } from 'antd';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export type BAIModel = {
@@ -66,7 +67,7 @@ const LLMChatCard: React.FC<LLMChatCardProps> = ({
     defaultValue: models[0]?.id,
   });
 
-  const [customModelForm] = Form.useForm();
+  const customModelFormRef = useRef<FormInstance>(null);
 
   // const [userInput, setUserInput] = useControllableValue(cardProps,{
   //   valuePropName: "userInput",
@@ -101,17 +102,17 @@ const LLMChatCard: React.FC<LLMChatCardProps> = ({
         const body = JSON.parse(init?.body as string);
         const provider = createOpenAI({
           baseURL: allowCustomModel
-            ? customModelForm.getFieldValue('baseURL')
+            ? customModelFormRef.current?.getFieldValue('baseURL')
             : baseURL,
           apiKey:
             (allowCustomModel
-              ? customModelForm.getFieldValue('token')
+              ? customModelFormRef.current?.getFieldValue('token')
               : apiKey) || 'dummy',
         });
         return streamText({
           model: provider(
             allowCustomModel
-              ? customModelForm.getFieldValue('modelId')
+              ? customModelFormRef.current?.getFieldValue('modelId')
               : modelId,
           ),
           messages: body?.messages,
@@ -235,11 +236,12 @@ const LLMChatCard: React.FC<LLMChatCardProps> = ({
         }}
       >
         <Form
-          form={customModelForm}
+          ref={customModelFormRef}
           layout="horizontal"
           size="small"
           requiredMark="optional"
           style={{ flex: 1 }}
+          key={baseURL}
           initialValues={{
             baseURL: baseURL,
           }}


### PR DESCRIPTION
### TL;DR

This pull request introduces the `fetchKey` prop to `EndpointSelect` and `EndpointLLMChatCard` components to support more dynamic querying and better state management.

### What changed?

1. **EndpointSelect Component**: Added `fetchKey` prop to refresh queries dynamically.
2. **EndpointLLMChatCard Component**: Implemented `fetchKey` and adjusted state management with `useTransition` and `useFragment`.
3. **ChatMessageList Component**: Wrapped the component with `Suspense` for better loading handling. 
4. **LLMPlaygroundPage Component**: Added relay query for initial endpoint data and wrapped `EndpointLLMChatCard` with `Suspense`.
5. **LLMChatCard Component**: Removed unused initial form values for `baseURL`.

### How to test?

1. Check dropdown options in `EndpointSelect` component.
2. Ensure `EndpointLLMChatCard` dynamically updates based on `fetchKey`.
3. Verify chat messages load properly with suspense fallback.
4. Load `LLMPlaygroundPage` and validate multiple chat cards function as expected.

### Why make this change?

To enhance flexibility in API querying and improve the user experience through better state and loading management.

