### PR TITLE
fix: resource icon and unit are not displayed on KeypairResourcePolicyList

### DIFF
--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -66,7 +66,7 @@ export const useResourceSlotsDetails = (resourceGroupName?: string) => {
   const [key, checkUpdate] = useUpdatableState('first');
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
   const baiClient = useSuspendedBackendaiClient();
-  let { data: resourceSlots } = useTanQuery<{
+  const { data: resourceSlots } = useTanQuery<{
     [key: string]: ResourceSlotDetail | undefined;
   }>({
     queryKey: ['useResourceSlots', resourceGroupName, key],
@@ -103,10 +103,9 @@ export const useResourceSlotsDetails = (resourceGroupName?: string) => {
     },
     staleTime: 1000 * 60 * 60 * 24,
   });
-  resourceSlots = resourceSlots || deviceMetadata;
 
   return [
-    resourceSlots,
+    _.merge(deviceMetadata, resourceSlots),
     {
       refresh: () => checkUpdate(),
     },


### PR DESCRIPTION
### This PR resolves [#2558 ](https://github.com/lablup/backend.ai-webui/issues/2558) issue
### TL;DR

fix error that resource icon and unit are not displayed on KeyPairResourcePolicyList

### What changed?

Added `isImportingDeviceMetaData` in `ResourceNumber.tsx`. `isImportingDeviceMetaData` determines whether to import device meta data
Modified  `KeyPairResourcePolicyList` to pass true to `isImportingDeviceMetaData` prop 

Importing deviceMetaData directly into the `KeyPairResourcePolicyList `was not implemented in that way due to duplication and flow of data