### PR TITLE
fix: `VFolderSelect` component search feature

### DIFF
--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -103,6 +103,7 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
   return (
     <Select
       showSearch
+      optionFilterProp={'label'}
       {...selectProps}
       onDropdownVisibleChange={(open) => {
         if (open) {


### PR DESCRIPTION
After https://github.com/lablup/backend.ai-webui/pull/2520 , the search feature of `VFolderSelect` component doesn't work in Service Launcher.