### PR TITLE
feat: introduce `useControllableState`

### DIFF
--- a/react/src/components/BAICodeEditor.tsx
+++ b/react/src/components/BAICodeEditor.tsx
@@ -30,9 +30,6 @@ const BAICodeEditor: React.FC<BAICodeEditorProps> = ({
 
   return (
     <CodeMirror
-      {...CodeMirrorProps}
-      value={script}
-      onChange={(value, viewUpdate) => setScript(value)}
       theme={'dark'}
       extensions={
         lineWrapping ? [EditorView.lineWrapping, ...extensions] : extensions
@@ -42,6 +39,9 @@ const BAICodeEditor: React.FC<BAICodeEditorProps> = ({
       basicSetup={{
         lineNumbers: showLineNumbers,
       }}
+      {...CodeMirrorProps}
+      value={script}
+      onChange={(value, viewUpdate) => setScript(value)}
     />
   );
 };

--- a/react/src/components/BAICodeEditor.tsx
+++ b/react/src/components/BAICodeEditor.tsx
@@ -1,10 +1,10 @@
+import useControllableState from '../hooks/useControllableState';
 import { loadLanguage, LanguageName } from '@uiw/codemirror-extensions-langs';
 import CodeMirror, { ReactCodeMirrorProps } from '@uiw/react-codemirror';
 import { EditorView } from '@uiw/react-codemirror';
-import { useControllableValue } from 'ahooks';
 
 interface BAICodeEditorProps extends Omit<ReactCodeMirrorProps, 'language'> {
-  children: string;
+  value: string;
   onChange: (value: string) => void;
   language: LanguageName;
   editable?: boolean;
@@ -13,7 +13,7 @@ interface BAICodeEditorProps extends Omit<ReactCodeMirrorProps, 'language'> {
 }
 
 const BAICodeEditor: React.FC<BAICodeEditorProps> = ({
-  children,
+  value,
   onChange,
   language = 'shell',
   editable = false,
@@ -21,15 +21,16 @@ const BAICodeEditor: React.FC<BAICodeEditorProps> = ({
   lineWrapping = false,
   ...CodeMirrorProps
 }) => {
-  const [script, setScript] = useControllableValue<string>({
+  const [script, setScript] = useControllableState<string>({
     defaultValue: '',
-    value: children,
+    value,
     onChange,
   });
   const extensions = [loadLanguage(language)!];
 
   return (
     <CodeMirror
+      {...CodeMirrorProps}
       value={script}
       onChange={(value, viewUpdate) => setScript(value)}
       theme={'dark'}
@@ -41,7 +42,6 @@ const BAICodeEditor: React.FC<BAICodeEditorProps> = ({
       basicSetup={{
         lineNumbers: showLineNumbers,
       }}
-      {...CodeMirrorProps}
     />
   );
 };

--- a/react/src/components/BAIPropertyFilter.tsx
+++ b/react/src/components/BAIPropertyFilter.tsx
@@ -1,6 +1,7 @@
+import useControllableState from '../hooks/useControllableState';
 import Flex from './Flex';
 import { CloseCircleOutlined } from '@ant-design/icons';
-import { useControllableValue, useDynamicList } from 'ahooks';
+import { useDynamicList } from 'ahooks';
 import { Button, Input, Select, Tag, Tooltip, theme } from 'antd';
 import _ from 'lodash';
 import React, { ComponentProps, useEffect, useMemo, useState } from 'react';
@@ -62,9 +63,9 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
   defaultValue,
   ...otherProps
 }) => {
-  const [search, setSearch] = useControllableValue({});
+  const [search, setSearch] = useControllableState({});
 
-  const [value, setValue] = useControllableValue<string | undefined>({
+  const [value, setValue] = useControllableState<string | undefined>({
     value: propValue,
     defaultValue: defaultValue,
     onChange: propOnChange,

--- a/react/src/components/DynamicStepInputNumber.tsx
+++ b/react/src/components/DynamicStepInputNumber.tsx
@@ -1,5 +1,5 @@
 import { useUpdatableState } from '../hooks';
-import { useControllableValue } from 'ahooks';
+import useControllableState from '../hooks/useControllableState';
 import { InputNumber, InputNumberProps } from 'antd';
 import _ from 'lodash';
 import React, { useEffect } from 'react';
@@ -21,7 +21,7 @@ const DynamicInputNumber: React.FC<DynamicInputNumberProps> = ({
   // onChange,
   ...inputNumberProps
 }) => {
-  const [value, setValue] = useControllableValue<number>(inputNumberProps, {
+  const [value, setValue] = useControllableState<number>(inputNumberProps, {
     defaultValue: dynamicSteps[0],
   });
 

--- a/react/src/components/DynamicUnitInputNumber.tsx
+++ b/react/src/components/DynamicUnitInputNumber.tsx
@@ -1,5 +1,6 @@
 import { iSizeToSize, parseUnit } from '../helper';
-import { useControllableValue, usePrevious } from 'ahooks';
+import useControllableState from '../hooks/useControllableState';
+import { usePrevious } from 'ahooks';
 import { InputNumber, InputNumberProps, Select, Typography } from 'antd';
 import _ from 'lodash';
 import React, { useEffect, useRef } from 'react';
@@ -28,7 +29,7 @@ const DynamicUnitInputNumber: React.FC<DynamicUnitInputNumberProps> = ({
   roundStep,
   ...inputNumberProps
 }) => {
-  const [value, setValue] = useControllableValue<string | null | undefined>(
+  const [value, setValue] = useControllableState<string | null | undefined>(
     inputNumberProps,
     {
       defaultValue: '0g',

--- a/react/src/components/DynamicUnitInputNumberWithSlider.tsx
+++ b/react/src/components/DynamicUnitInputNumberWithSlider.tsx
@@ -1,10 +1,10 @@
 import { compareNumberWithUnits, iSizeToSize } from '../helper';
 import { useUpdatableState } from '../hooks';
+import useControllableState from '../hooks/useControllableState';
 import DynamicUnitInputNumber, {
   DynamicUnitInputNumberProps,
 } from './DynamicUnitInputNumber';
 import Flex from './Flex';
-import { useControllableValue } from 'ahooks';
 import { Slider, theme } from 'antd';
 import { SliderMarks } from 'antd/es/slider';
 import _ from 'lodash';
@@ -29,7 +29,7 @@ const DynamicUnitInputNumberWithSlider: React.FC<
   step = 0.05,
   ...otherProps
 }) => {
-  const [value, setValue] = useControllableValue<string | undefined | null>(
+  const [value, setValue] = useControllableState<string | undefined | null>(
     otherProps,
     {
       defaultValue: '0g',

--- a/react/src/components/InputNumberWithSlider.tsx
+++ b/react/src/components/InputNumberWithSlider.tsx
@@ -1,6 +1,6 @@
 import { useUpdatableState } from '../hooks';
+import useControllableState from '../hooks/useControllableState';
 import Flex from './Flex';
-import { useControllableValue } from 'ahooks';
 import { InputNumber, Slider, InputNumberProps, SliderSingleProps } from 'antd';
 import { SliderRangeProps } from 'antd/es/slider';
 import _ from 'lodash';
@@ -29,7 +29,7 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
   sliderProps,
   ...otherProps
 }) => {
-  const [value, setValue] = useControllableValue(otherProps);
+  const [value, setValue] = useControllableState(otherProps);
   const inputRef = React.useRef<HTMLInputElement>(null);
   useEffect(() => {
     // when step is 1, make sure the value is integer

--- a/react/src/components/NonLinearSlider.tsx
+++ b/react/src/components/NonLinearSlider.tsx
@@ -1,4 +1,4 @@
-import { useControllableValue } from 'ahooks';
+import useControllableState from '../hooks/useControllableState';
 import { Slider, SliderSingleProps } from 'antd';
 import _, { isNumber } from 'lodash';
 import React from 'react';
@@ -36,16 +36,11 @@ const NonLinearSlider: React.FC<NonLinearSliderProps> = ({
     return step;
   });
 
-  const [controlledValue, setControlledValue] = useControllableValue(
-    {
-      value,
-      defaultValue,
-      onChange,
-    },
-    {
-      defaultValue: defaultValue ?? normalizedSteps[0]?.value,
-    },
-  );
+  const [controlledValue, setControlledValue] = useControllableState({
+    value,
+    defaultValue: defaultValue ?? normalizedSteps[0]?.value,
+    onChange,
+  });
 
   const isFirstAndLast = (index: number) =>
     index === 0 || index === normalizedSteps.length - 1;

--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -1,7 +1,7 @@
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
+import useControllableState from '../hooks/useControllableState';
 import { ProjectSelectorQuery } from './__generated__/ProjectSelectorQuery.graphql';
-import { useControllableValue } from 'ahooks';
 import { Select, SelectProps } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
@@ -32,7 +32,7 @@ const ProjectSelector: React.FC<Props> = ({
   const [currentUser] = useCurrentUserInfo();
   const baiClient = useSuspendedBackendaiClient();
 
-  const [value, setValue] = useControllableValue(selectProps);
+  const [value, setValue] = useControllableState(selectProps);
   const userRole = useCurrentUserRole();
   const { projectsSince2403, projectsBefore2403, user } =
     useLazyLoadQuery<ProjectSelectorQuery>(

--- a/react/src/components/ResourceGroupSelect.tsx
+++ b/react/src/components/ResourceGroupSelect.tsx
@@ -1,9 +1,9 @@
 import { useBaiSignedRequestWithPromise } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { useTanQuery } from '../hooks/reactQueryAlias';
+import useControllableState from '../hooks/useControllableState';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import TextHighlighter from './TextHighlighter';
-import { useControllableValue } from 'ahooks';
 import { Select, SelectProps } from 'antd';
 import _ from 'lodash';
 import React, { useEffect, useTransition } from 'react';
@@ -27,18 +27,13 @@ const ResourceGroupSelect: React.FC<ResourceGroupSelectProps> = ({
   const currentProject = useCurrentProjectValue();
   const [key, checkUpdate] = useUpdatableState('first');
   const [controllableSearchValue, setControllableSearchValue] =
-    useControllableValue<string>(
-      _.omitBy(
-        {
-          value: searchValue,
-          onChange: onSearch,
-        },
-        _.isUndefined,
-      ),
-    );
+    useControllableState<string>({
+      value: searchValue,
+      onChange: onSearch,
+    });
 
   const [controllableValue, setControllableValue] =
-    useControllableValue(selectProps);
+    useControllableState(selectProps);
 
   const [isPendingLoading, startLoadingTransition] = useTransition();
   const { data: resourceGroupSelectQueryResult } = useTanQuery<

--- a/react/src/components/ResourceGroupSelectForCurrentProject.tsx
+++ b/react/src/components/ResourceGroupSelectForCurrentProject.tsx
@@ -1,10 +1,10 @@
 import { useSuspendedBackendaiClient } from '../hooks';
+import useControllableState from '../hooks/useControllableState';
 import {
   useCurrentResourceGroupState,
   useResourceGroupsForCurrentProject,
 } from '../hooks/useCurrentProject';
 import TextHighlighter from './TextHighlighter';
-import { useControllableValue } from 'ahooks';
 import { Select, SelectProps } from 'antd';
 import _ from 'lodash';
 import React, { useEffect, useState, useTransition } from 'react';
@@ -27,15 +27,10 @@ const ResourceGroupSelectForCurrentProject: React.FC<
 }) => {
   useSuspendedBackendaiClient(); // To make sure the client is ready
   const [controllableSearchValue, setControllableSearchValue] =
-    useControllableValue<string>(
-      _.omitBy(
-        {
-          value: searchValue,
-          onChange: onSearch,
-        },
-        _.isUndefined,
-      ),
-    );
+    useControllableState<string>({
+      value: searchValue,
+      onChange: onSearch,
+    });
   const [currentResourceGroup, setCurrentResourceGroup] =
     useCurrentResourceGroupState();
 

--- a/react/src/components/ResourcePresetSelect.tsx
+++ b/react/src/components/ResourcePresetSelect.tsx
@@ -1,6 +1,7 @@
 import { localeCompare } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { useResourceSlots } from '../hooks/backendai';
+import useControllableState from '../hooks/useControllableState';
 import Flex from './Flex';
 import ResourceNumber from './ResourceNumber';
 import {
@@ -8,7 +9,7 @@ import {
   ResourcePresetSelectQuery$data,
 } from './__generated__/ResourcePresetSelectQuery.graphql';
 import { EditOutlined, InfoCircleOutlined } from '@ant-design/icons';
-import { useControllableValue, useThrottleFn } from 'ahooks';
+import { useThrottleFn } from 'ahooks';
 import { Select, Tooltip, theme } from 'antd';
 import { SelectProps } from 'antd/lib';
 import graphql from 'babel-plugin-relay/macro';
@@ -54,7 +55,7 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
   const { token } = theme.useToken();
   const [isPendingUpdate, _startTransition] = useTransition();
   const [controllableValue, setControllableValue] =
-    useControllableValue(selectProps);
+    useControllableState(selectProps);
   const updateFetchKeyUnderTransition = () => {
     _startTransition(() => {
       updateFetchKeyThrottled();

--- a/react/src/components/ShellScriptEditModal.tsx
+++ b/react/src/components/ShellScriptEditModal.tsx
@@ -309,9 +309,8 @@ const ShellScriptEditModal: React.FC<BootstrapScriptEditModalProps> = ({
           onChange={(value) => setScript(value)}
           language="shell"
           editable
-        >
-          {script}
-        </BAICodeEditor>
+          value={script}
+        />
       </Flex>
     </BAIModal>
   );

--- a/react/src/components/StorageSelect.tsx
+++ b/react/src/components/StorageSelect.tsx
@@ -1,9 +1,9 @@
 import { usageIndicatorColor } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
+import useControllableState from '../hooks/useControllableState';
 import { useShadowRoot } from './DefaultProviders';
 import Flex from './Flex';
 import TextHighlighter from './TextHighlighter';
-import { useControllableValue } from 'ahooks';
 import { Select, SelectProps, Badge, Tooltip } from 'antd';
 import _ from 'lodash';
 import React, { useEffect } from 'react';
@@ -58,13 +58,13 @@ const StorageSelect: React.FC<Props> = ({
     return baiClient.vfolder.list_hosts();
   });
 
-  const [controllableState, setControllableState] = useControllableValue(
-    _.omitBy({ value, onChange, defaultValue }, _.isUndefined),
-  );
+  const [controllableState, setControllableState] = useControllableState({
+    value,
+    onChange,
+    defaultValue,
+  });
   const [controllableSearchValue, setControllableSearchValue] =
-    useControllableValue(
-      _.omitBy({ value: searchValue, onChange: onSearch }, _.isUndefined),
-    );
+    useControllableState({ value: searchValue, onChange: onSearch });
   useEffect(() => {
     if (!autoSelectType) return;
     let nextHost = vhostInfo?.default ?? vhostInfo?.allowed[0] ?? '';

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -1,6 +1,7 @@
 import { useBaiSignedRequestWithPromise } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { useTanQuery } from '../hooks/reactQueryAlias';
+import useControllableState from '../hooks/useControllableState';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { Select, SelectProps } from 'antd';
 import _ from 'lodash';
@@ -43,6 +44,7 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
 }) => {
   const currentProject = useCurrentProjectValue();
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
+  const [value, setValue] = useControllableState(selectProps);
   // const { vfolder_list } = useLazyLoadQuery<VFolderSelectQuery>(
   //   graphql`
   //     # query VFolderSelectQuery($group_id: UUID) {
@@ -93,10 +95,9 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
         value: _.first(filteredVFolders)?.[valuePropName],
       }
     : undefined;
-  // TODO: use controllable value
   useEffect(() => {
     if (autoSelectDefault && autoSelectedOption) {
-      selectProps.onChange?.(autoSelectedOption.value, autoSelectedOption);
+      setValue(autoSelectedOption.value, autoSelectedOption);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoSelectDefault]);
@@ -104,6 +105,8 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
     <Select
       showSearch
       {...selectProps}
+      value={value}
+      onChange={setValue}
       onDropdownVisibleChange={(open) => {
         if (open) {
           startTransition(() => {

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -2,6 +2,7 @@ import { useBaiSignedRequestWithPromise } from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import { useKeyPairLazyLoadQuery } from '../hooks/hooksUsingRelay';
 import { useTanQuery } from '../hooks/reactQueryAlias';
+import useControllableState from '../hooks/useControllableState';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useEventNotStable } from '../hooks/useEventNotStable';
 import { useShadowRoot } from './DefaultProviders';
@@ -15,7 +16,6 @@ import {
   ReloadOutlined,
   UserOutlined,
 } from '@ant-design/icons';
-import { useControllableValue } from 'ahooks';
 import {
   Button,
   Descriptions,
@@ -91,7 +91,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
     };
   }, [rowKey]);
 
-  const [selectedRowKeys, setSelectedRowKeys] = useControllableValue<
+  const [selectedRowKeys, setSelectedRowKeys] = useControllableState<
     VFolderKey[]
   >(
     {
@@ -103,7 +103,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
     },
   );
 
-  const [aliasMap, setAliasMap] = useControllableValue<AliasMap>(
+  const [aliasMap, setAliasMap] = useControllableState<AliasMap>(
     {
       value: controlledAliasMap,
       onChange: onChangeAliasMap,

--- a/react/src/hooks/useControllableState.test.ts
+++ b/react/src/hooks/useControllableState.test.ts
@@ -1,0 +1,173 @@
+/* eslint-disable testing-library/render-result-naming-convention */
+import useControllableState, { Options, Props } from './useControllableState';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+
+describe('useControllableState', () => {
+  const setUp = (props?: Props, options?: Options): any =>
+    renderHook(() => useControllableState(props, options));
+
+  it('defaultValue should work', () => {
+    const hook = setUp({ defaultValue: 1 });
+    expect(hook.result.current[0]).toBe(1);
+  });
+
+  it('value should work', () => {
+    const hook = setUp({ defaultValue: 1, value: 2 });
+    expect(hook.result.current[0]).toBe(2);
+  });
+
+  it('state should be undefined', () => {
+    const hook = setUp();
+    expect(hook.result.current[0]).toBeUndefined();
+  });
+
+  it('onChange should work', () => {
+    let extraParam: string = '';
+    const props = {
+      value: 2,
+      onChange(v: any, extra: any) {
+        this.value = v;
+        extraParam = extra;
+      },
+    };
+    const hook = setUp(props);
+    expect(hook.result.current[0]).toBe(2);
+    act(() => {
+      hook.result.current[1](3, 'extraParam');
+    });
+    expect(props.value).toBe(3);
+    expect(extraParam).toBe('extraParam');
+  });
+
+  it('test on state update', () => {
+    const props: any = {
+      value: 1,
+    };
+    const { result, rerender } = setUp(props);
+    props.value = 2;
+    rerender(props);
+    expect(result.current[0]).toBe(2);
+    props.value = 3;
+    rerender(props);
+    expect(result.current[0]).toBe(3);
+  });
+
+  it('test set state', async () => {
+    const { result } = setUp({
+      newValue: 1,
+    });
+    const [, setValue] = result.current;
+    act(() => setValue(undefined));
+    expect(result.current[0]).toBeUndefined();
+
+    act(() => setValue(null));
+    expect(result.current[0]).toBeNull();
+
+    act(() => setValue(55));
+    expect(result.current[0]).toBe(55);
+
+    act(() => setValue((prevState: number) => prevState + 1));
+    expect(result.current[0]).toBe(56);
+  });
+
+  it('type inference should work', async () => {
+    type Value = {
+      foo: number;
+    };
+    const props: {
+      value: Value;
+      defaultValue: Value;
+      onChange: (val: Value) => void;
+    } = {
+      value: {
+        foo: 123,
+      },
+      defaultValue: {
+        foo: 123,
+      },
+      onChange: () => {},
+    };
+    const hook = renderHook(() => useControllableState(props));
+    const [v] = hook.result.current;
+    expect(v.foo).toBe(123);
+  });
+
+  it('test valuePropName of options', () => {
+    const props: any = {
+      value: 1,
+    };
+    const options = {
+      valuePropName: 'testValue',
+    };
+    const { result, rerender } = setUp(props, options);
+    expect(result.current[0]).toBe(undefined);
+
+    props.testValue = 2;
+    rerender(props);
+    expect(result.current[0]).toBe(2);
+  });
+
+  it('test defaultValuePropName of options', () => {
+    const props: any = {
+      defaultValue: 1,
+    };
+    const options = {
+      defaultValuePropName: 'defaultValueProp',
+    };
+    const { result: undefinedResult } = setUp(props, options);
+    expect(undefinedResult.current[0]).toBe(undefined);
+
+    props.defaultValueProp = 2;
+    const { result: defaultValueResult } = setUp(props, options);
+    expect(defaultValueResult.current[0]).toBe(2);
+  });
+
+  it('test trigger of options', () => {
+    const trigger = jest.fn();
+    const props: any = {
+      value: 3,
+      onChange: trigger,
+    };
+    const options: any = {
+      trigger: 'trigger',
+    };
+    const { result, rerender } = setUp(props, options);
+    const [value, setValue] = result.current;
+    expect(value).toBe(3);
+    act(() => setValue());
+    expect(trigger).not.toHaveBeenCalled();
+
+    props.trigger = trigger;
+    rerender(props);
+    act(() => setValue('c'));
+    expect(trigger).toHaveBeenCalled();
+  });
+
+  it('warning is logged when changed from uncontrolled to controlled', () => {
+    const consoleWarnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const props: any = {
+      value: undefined,
+      onChange: () => {
+        props.value = 3;
+      },
+    };
+
+    const { result, rerender } = setUp(props);
+    const [, setValue] = result.current;
+    act(() => setValue());
+    rerender(props);
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'WARN: A component changed from uncontrolled to controlled.',
+    );
+  });
+
+  it('defaultValue should be applied when value is undefined', () => {
+    const { result } = setUp({ value: undefined, defaultValue: 1 });
+    expect(result.current[0]).toBe(1);
+  });
+});

--- a/react/src/hooks/useControllableState.test.ts
+++ b/react/src/hooks/useControllableState.test.ts
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react';
 import { act } from 'react';
 
 describe('useControllableState', () => {
-  const setUp = (props?: Props, options?: Options): any =>
+  const setUp = (props?: Props, options?: Options<any>): any =>
     renderHook(() => useControllableState(props, options));
 
   it('defaultValue should work', () => {

--- a/react/src/hooks/useControllableState.test.ts
+++ b/react/src/hooks/useControllableState.test.ts
@@ -144,28 +144,6 @@ describe('useControllableState', () => {
     expect(trigger).toHaveBeenCalled();
   });
 
-  it('warning is logged when changed from uncontrolled to controlled', () => {
-    const consoleWarnSpy = jest
-      .spyOn(console, 'warn')
-      .mockImplementation(() => {});
-
-    const props: any = {
-      value: undefined,
-      onChange: () => {
-        props.value = 3;
-      },
-    };
-
-    const { result, rerender } = setUp(props);
-    const [, setValue] = result.current;
-    act(() => setValue());
-    rerender(props);
-
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      'WARN: A component changed from uncontrolled to controlled.',
-    );
-  });
-
   it('defaultValue should be applied when value is undefined', () => {
     const { result } = setUp({ value: undefined, defaultValue: 1 });
     expect(result.current[0]).toBe(1);

--- a/react/src/hooks/useControllableState.ts
+++ b/react/src/hooks/useControllableState.ts
@@ -42,18 +42,10 @@ function useControllableState<T = any>(
 
   const value = props[valuePropName] as T;
 
-  let isControlledRef = useRef(value !== undefined);
-  let isControlled = value !== undefined;
+  const isControlledRef = useRef(value !== undefined);
+  const isControlled = value !== undefined;
 
   useEffect(() => {
-    let wasControlled = isControlledRef.current;
-    if (wasControlled !== isControlled) {
-      console.warn(
-        `WARN: A component changed from ${wasControlled ? 'controlled' : 'uncontrolled'} to ${
-          isControlled ? 'controlled' : 'uncontrolled'
-        }.`,
-      );
-    }
     isControlledRef.current = isControlled;
   }, [isControlled]);
 

--- a/react/src/hooks/useControllableState.ts
+++ b/react/src/hooks/useControllableState.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SetStateAction } from 'react';
 
-export interface Options {
+export interface Options<T> {
+  defaultValue?: T;
   defaultValuePropName?: string;
   valuePropName?: string;
   trigger?: string;
@@ -19,19 +20,21 @@ export interface StandardProps<T> {
  * useControllableState is based on useControllableValue.
  * However if the value is undefined, the component is treated as an uncontrolled component
  */
+// params 설명 더 작성하기
 
 function useControllableState<T = any>(
   props: StandardProps<T>,
 ): [T, (v: SetStateAction<T>) => void];
 function useControllableState<T = any>(
   props?: Props,
-  options?: Options,
+  options?: Options<T>,
 ): [T, (v: SetStateAction<T>, ...args: any[]) => void];
 function useControllableState<T = any>(
   props: Props = {},
-  options: Options = {},
+  options: Options<T> = {},
 ) {
   const {
+    defaultValue,
     defaultValuePropName = 'defaultValue',
     valuePropName = 'value',
     trigger = 'onChange',
@@ -61,7 +64,7 @@ function useControllableState<T = any>(
     if (Object.prototype.hasOwnProperty.call(props, defaultValuePropName)) {
       return props[defaultValuePropName];
     }
-    return undefined;
+    return defaultValue;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/react/src/hooks/useControllableState.ts
+++ b/react/src/hooks/useControllableState.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { SetStateAction } from 'react';
+
+export interface Options {
+  defaultValuePropName?: string;
+  valuePropName?: string;
+  trigger?: string;
+}
+
+export type Props = Record<string, any>;
+
+export interface StandardProps<T> {
+  value: T;
+  defaultValue?: T;
+  onChange: (val: T) => void;
+}
+/**
+ * Custom hook to  manage this kind of state. managed by itself or controlled by it's parent
+ * useControllableState is based on useControllableValue.
+ * However if the value is undefined, the component is treated as an uncontrolled component
+ */
+
+function useControllableState<T = any>(
+  props: StandardProps<T>,
+): [T, (v: SetStateAction<T>) => void];
+function useControllableState<T = any>(
+  props?: Props,
+  options?: Options,
+): [T, (v: SetStateAction<T>, ...args: any[]) => void];
+function useControllableState<T = any>(
+  props: Props = {},
+  options: Options = {},
+) {
+  const {
+    defaultValuePropName = 'defaultValue',
+    valuePropName = 'value',
+    trigger = 'onChange',
+  } = options;
+
+  const value = props[valuePropName] as T;
+
+  let isControlledRef = useRef(value !== undefined);
+  let isControlled = value !== undefined;
+
+  useEffect(() => {
+    let wasControlled = isControlledRef.current;
+    if (wasControlled !== isControlled) {
+      console.warn(
+        `WARN: A component changed from ${wasControlled ? 'controlled' : 'uncontrolled'} to ${
+          isControlled ? 'controlled' : 'uncontrolled'
+        }.`,
+      );
+    }
+    isControlledRef.current = isControlled;
+  }, [isControlled]);
+
+  const initialValue = useMemo(() => {
+    if (isControlled) {
+      return value;
+    }
+    if (Object.prototype.hasOwnProperty.call(props, defaultValuePropName)) {
+      return props[defaultValuePropName];
+    }
+    return undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const stateRef = useRef(initialValue);
+  if (isControlled) {
+    stateRef.current = value;
+  }
+
+  const update = useUpdate();
+
+  function setState(v: SetStateAction<T>, ...args: any[]) {
+    const r = isFunction(v) ? v(stateRef.current) : v;
+
+    if (!isControlled) {
+      stateRef.current = r;
+      update();
+    }
+    if (props[trigger]) {
+      props[trigger](r, ...args);
+    }
+  }
+
+  return [stateRef.current, useMemoizedFn(setState)] as const;
+}
+
+export default useControllableState;
+
+function isFunction(value: unknown): value is (...args: any) => any {
+  return typeof value === 'function';
+}
+
+type noop = (this: any, ...args: any[]) => any;
+
+type PickFunction<T extends noop> = (
+  this: ThisParameterType<T>,
+  ...args: Parameters<T>
+) => ReturnType<T>;
+
+function useMemoizedFn<T extends noop>(fn: T) {
+  const isDev =
+    process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
+  if (isDev) {
+    if (!isFunction(fn)) {
+      console.error(
+        `useMemoizedFn expected parameter is a function, got ${typeof fn}`,
+      );
+    }
+  }
+
+  const fnRef = useRef<T>(fn);
+
+  fnRef.current = useMemo<T>(() => fn, [fn]);
+
+  const memoizedFn = useRef<PickFunction<T>>();
+  if (!memoizedFn.current) {
+    memoizedFn.current = function (this, ...args) {
+      return fnRef.current.apply(this, args);
+    };
+  }
+
+  return memoizedFn.current as T;
+}
+
+function useUpdate() {
+  const [, setState] = useState({});
+
+  return useCallback(() => setState({}), []);
+}

--- a/react/src/hooks/useControllableState.ts
+++ b/react/src/hooks/useControllableState.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SetStateAction } from 'react';
 
@@ -20,7 +21,6 @@ export interface StandardProps<T> {
  * useControllableState is based on useControllableValue.
  * However if the value is undefined, the component is treated as an uncontrolled component
  */
-// params 설명 더 작성하기
 
 function useControllableState<T = any>(
   props: StandardProps<T>,
@@ -76,7 +76,7 @@ function useControllableState<T = any>(
   const update = useUpdate();
 
   function setState(v: SetStateAction<T>, ...args: any[]) {
-    const r = isFunction(v) ? v(stateRef.current) : v;
+    const r = _.isFunction(v) ? v(stateRef.current) : v;
 
     if (!isControlled) {
       stateRef.current = r;
@@ -92,10 +92,6 @@ function useControllableState<T = any>(
 
 export default useControllableState;
 
-function isFunction(value: unknown): value is (...args: any) => any {
-  return typeof value === 'function';
-}
-
 type noop = (this: any, ...args: any[]) => any;
 
 type PickFunction<T extends noop> = (
@@ -107,7 +103,7 @@ function useMemoizedFn<T extends noop>(fn: T) {
   const isDev =
     process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
   if (isDev) {
-    if (!isFunction(fn)) {
+    if (!_.isFunction(fn)) {
       console.error(
         `useMemoizedFn expected parameter is a function, got ${typeof fn}`,
       );


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR resolves [#2570 ](https://github.com/lablup/backend.ai-webui/issues/2570) issue
### TL;DR

implement useControllableState hook 


### What changed?

### useControllableState
The overall implementation is based on [useControllableValue](https://github.com/alibaba/hooks/blob/master/packages/hooks/src/useControllableValue/index.ts), and the code to determine whether it is controlled is based on [useControlledState](https://github.com/adobe/react-spectrum/blob/main/packages/%40react-stately/utils/src/useControlledState.ts)

1.  isControlled :  `useControllableValue` of ahooks treats a component as a controlled component if the value exists for props object . But `useControllableState` treats a component as a uncontrolled component  If value is undefined, even if value exists like `useControlledState` of react-spectrum hook 
so I changed the code to determine whether component is controlled 

2. display a warning if the value of isControlled changes. ( console.warn ~ )


### change from useControllableValue to useControllableState

1. BAICodeEditor : I changed the value from being passed to children to being passed to value prop and
The below code was modified because {...CodeMirrorProps} could potentially overwrite value and defaultValue 
```
 <CodeMirror
      value={script}
      onChange={(value, viewUpdate) => setScript(value)}
       {...CodeMirrorProps}/>

```


2. NonLinearSlider : Removed defaultValue in the second argument because the presence of defaultValue in the first argument makes the defaultValue in the second argument meaningless 
```
  const [controlledValue, setControlledValue] = useControllableState(
    {
      value,
      defaultValue,
      onChange,
    },
    {
      defaultValue: defaultValue ?? normalizedSteps[0]?.value,
    },
  );

```

3. ResourceGroupSelect , ResourceGroupSelectForCurrentProject , StorageSelect : I removed _.omitBy because component can be uncontrolled component even if the value exists on prop
```
 useControllableValue<string>(
      _.omitBy(
        {
          value: searchValue,
          onChange: onSearch,
        },
        _.isUndefined,
      ),
```


and DatePickerISO also used useControllableValue, but I didn't change it due to a bug issue. 

### How to test?

I used the test code from useControllableValue and added a few more tests  
The test I added  : `test valuePropName of options`, `test defaultValuePropName of options`,`test trigger of options`,`warning is logged when changed from uncontrolled to controlled`,`defaultValue should be applied when value is undefined`

### Why make this change?

Even if the value is explicitly set to undefined, it will be treated as uncontrolled, just like React's built-in components.
so I implement useControllableState hook to replace useControllableValue 