### PR TITLE
feat: move credential delete forever button to inactive tab

### DIFF
--- a/src/components/backend-ai-credential-list.ts
+++ b/src/components/backend-ai-credential-list.ts
@@ -765,17 +765,6 @@ export default class BackendAICredentialList extends BackendAIPage {
                   inverted
                   @click="${(e) => this._revokeKey(e)}"
                 ></mwc-icon-button>
-                <mwc-icon-button
-                  class="fg red"
-                  icon="delete_forever"
-                  fab
-                  ?disabled=${this._mainAccessKeyList.includes(
-                    rowData.item?.access_key,
-                  )}
-                  flat
-                  inverted
-                  @click="${(e) => this._deleteKeyPairDialog(e)}"
-                ></mwc-icon-button>
               `
             : html``}
           ${this._isActive() === false
@@ -787,6 +776,21 @@ export default class BackendAICredentialList extends BackendAIPage {
                   flat
                   inverted
                   @click="${(e) => this._reuseKey(e)}"
+                ></mwc-icon-button>
+              `
+            : html``}
+          ${this.isAdmin && !this._isActive()
+            ? html`
+                <mwc-icon-button
+                  class="fg red"
+                  icon="delete_forever"
+                  fab
+                  ?disabled=${this._mainAccessKeyList.includes(
+                    rowData.item?.access_key,
+                  )}
+                  flat
+                  inverted
+                  @click="${(e) => this._deleteKeyPairDialog(e)}"
                 ></mwc-icon-button>
               `
             : html``}


### PR DESCRIPTION

### TL;DR
The delete button that was visible in the active tab of credentials has been moved to the inactive tab. This change is to align with the vfolder list and improve usability.

### Screenshots
| Before | After |
|--------|--------|
| <img width="1657" alt="image" src="https://github.com/user-attachments/assets/294d8c40-d66a-4c04-ae10-5878eb456fab"> | <img width="1649" alt="image" src="https://github.com/user-attachments/assets/780fde81-ed01-4db9-b5de-978126f58e13"> | 
| <img width="1656" alt="image" src="https://github.com/user-attachments/assets/77d19eb2-ce60-44b7-9428-96c34f3f4549"> | <img width="1650" alt="image" src="https://github.com/user-attachments/assets/4b798ff8-9649-41d6-a5ce-1ef5f9a0664c"> |


### How to test
1. Log in with the superadmin user.
2. Navigate to the user's credentials tab.
3. Check the control column on both the active and inactive tabs.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup) 
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
