### PR TITLE
feat: re-render once when `backend-ai-page` is inactive

### DIFF
--- a/src/components/backend-ai-page.ts
+++ b/src/components/backend-ai-page.ts
@@ -29,6 +29,7 @@ registerTranslateConfig({
 export class BackendAIPage extends LitElement {
   public notification: any; // Global notification
   public tasker: any; // Global Background tasker
+  private requiresUpdateWhenInactive: boolean = false;
   @property({ type: Boolean, reflect: true }) active = false;
   @property({ type: Boolean }) hasLoadedStrings = false;
   @property({ type: String }) permission; // Reserved for plugin pages
@@ -83,7 +84,12 @@ export class BackendAIPage extends LitElement {
   }
 
   shouldUpdate(): boolean {
-    return this.active;
+    if (!this.active && this.requiresUpdateWhenInactive) {
+      this.requiresUpdateWhenInactive = false; // Only need to update once
+      return true;
+    } else {
+      return this.active;
+    }
   }
 
   attributeChangedCallback(
@@ -98,6 +104,7 @@ export class BackendAIPage extends LitElement {
         this.active = true;
         this._viewStateChanged(true);
       } else {
+        this.requiresUpdateWhenInactive = true;
         this.active = false;
         this._viewStateChanged(false);
       }

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -4280,121 +4280,141 @@ ${rowData.item[this.sessionNameField]}</pre
         </div>
       </div>
       <div class="list-wrapper">
-        <vaadin-grid id="list-grid" theme="row-stripes column-borders compact dark" aria-label="Session list"
-          .items="${this.compute_sessions}" height-by-rows>
-          ${
-            this._isRunning
-              ? html`
-                  <vaadin-grid-selection-column
+        ${
+          this.active
+            ? html`
+                <vaadin-grid
+                  id="list-grid"
+                  theme="row-stripes column-borders compact dark"
+                  aria-label="Session list"
+                  .items="${this.compute_sessions}"
+                  height-by-rows
+                >
+                  ${this._isRunning
+                    ? html`
+                        <vaadin-grid-column
+                          frozen
+                          width="60px"
+                          flex-grow="0"
+                          text-align="center"
+                          .renderer="${this._boundCheckboxRenderer}"
+                        ></vaadin-grid-column>
+                      `
+                    : html``}
+                  <vaadin-grid-column
                     frozen
-                    auto-select
-                  ></vaadin-grid-selection-column>
-                `
-              : html``
-          }
-          <vaadin-grid-column frozen width="40px" flex-grow="0" header="#" .renderer="${
-            this._indexRenderer
-          }"></vaadin-grid-column>
-          ${
-            this.is_admin
-              ? html`
+                    width="40px"
+                    flex-grow="0"
+                    header="#"
+                    .renderer="${this._indexRenderer}"
+                  ></vaadin-grid-column>
+                  ${this.is_admin
+                    ? html`
+                        <lablup-grid-sort-filter-column
+                          frozen
+                          path="${this._connectionMode === 'API'
+                            ? 'access_key'
+                            : 'user_email'}"
+                          header="${this._connectionMode === 'API'
+                            ? 'API Key'
+                            : 'User ID'}"
+                          resizable
+                          .renderer="${this._boundUserInfoRenderer}"
+                        ></lablup-grid-sort-filter-column>
+                      `
+                    : html``}
                   <lablup-grid-sort-filter-column
                     frozen
-                    path="${this._connectionMode === 'API'
-                      ? 'access_key'
-                      : 'user_email'}"
-                    header="${this._connectionMode === 'API'
-                      ? 'API Key'
-                      : 'User ID'}"
+                    path="${this.sessionNameField}"
+                    width="260px"
+                    header="${_t('session.SessionInfo')}"
                     resizable
-                    .renderer="${this._boundUserInfoRenderer}"
+                    .renderer="${this._boundSessionInfoRenderer}"
                   ></lablup-grid-sort-filter-column>
-                `
-              : html``
-          }
-          <lablup-grid-sort-filter-column frozen path="${this.sessionNameField}" 
-            width="260px"
-            header="${_t('session.SessionInfo')}" 
-            resizable
-            .renderer="${this._boundSessionInfoRenderer}"
-          >
-          </lablup-grid-sort-filter-column>
-          <lablup-grid-sort-filter-column width="120px" path="status" header="${_t('session.Status')}" 
-            resizable
-            .renderer="${this._boundStatusRenderer}">
-          </lablup-grid-sort-filter-column>
-          <vaadin-grid-column width=${
-            this._isContainerCommitEnabled ? '260px' : '210px'
-          } flex-grow="0" resizable header="${_t('general.Control')}"
-                              .renderer="${
-                                this._boundControlRenderer
-                              }"></vaadin-grid-column>
-          <vaadin-grid-column width="200px" flex-grow="0" resizable header="${_t(
-            'session.Configuration',
-          )}"
-                              .renderer="${
-                                this._boundConfigRenderer
-                              }"></vaadin-grid-column>
-          <vaadin-grid-column width="140px" flex-grow="0" resizable header="${_t(
-            'session.Usage',
-          )}"
-                              .renderer="${this._boundUsageRenderer}">
-          </vaadin-grid-column>
-          <vaadin-grid-sort-column resizable width="180px" flex-grow="0" header="${_t(
-            'session.Reservation',
-          )}"
-            path="created_at" 
-            .renderer="${this._boundReservationRenderer}">
-          </vaadin-grid-sort-column>
-          ${
-            globalThis.backendaiclient.supports('idle-checks') &&
-            this.activeIdleCheckList.size > 0
-              ? html`
+                  <lablup-grid-sort-filter-column
+                    width="120px"
+                    path="status"
+                    header="${_t('session.Status')}"
+                    resizable
+                    .renderer="${this._boundStatusRenderer}"
+                  ></lablup-grid-sort-filter-column>
                   <vaadin-grid-column
+                    width=${this._isContainerCommitEnabled ? '260px' : '210px'}
+                    flex-grow="0"
+                    resizable
+                    header="${_t('general.Control')}"
+                    .renderer="${this._boundControlRenderer}"
+                  ></vaadin-grid-column>
+                  <vaadin-grid-column
+                    width="200px"
+                    flex-grow="0"
+                    resizable
+                    header="${_t('session.Configuration')}"
+                    .renderer="${this._boundConfigRenderer}"
+                  ></vaadin-grid-column>
+                  <vaadin-grid-column
+                    width="140px"
+                    flex-grow="0"
+                    resizable
+                    header="${_t('session.Usage')}"
+                    .renderer="${this._boundUsageRenderer}"
+                  ></vaadin-grid-column>
+                  <vaadin-grid-sort-column
                     resizable
                     width="180px"
                     flex-grow="0"
-                    .headerRenderer="${this._boundIdleChecksHeaderderer}"
-                    .renderer="${this._boundIdleChecksRenderer}"
-                  ></vaadin-grid-column>
-                `
-              : html``
-          }
-          <lablup-grid-sort-filter-column width="110px" path="architecture" header="${_t(
-            'session.Architecture',
-          )}" resizable
-                                     .renderer="${
-                                       this._boundArchitectureRenderer
-                                     }">
-          </lablup-grid-sort-filter-column>
-          ${
-            this._isIntegratedCondition
-              ? html`
+                    header="${_t('session.Reservation')}"
+                    path="created_at"
+                    .renderer="${this._boundReservationRenderer}"
+                  ></vaadin-grid-sort-column>
+                  ${globalThis.backendaiclient.supports('idle-checks') &&
+                  this.activeIdleCheckList.size > 0
+                    ? html`
+                        <vaadin-grid-column
+                          resizable
+                          width="180px"
+                          flex-grow="0"
+                          .headerRenderer="${this._boundIdleChecksHeaderderer}"
+                          .renderer="${this._boundIdleChecksRenderer}"
+                        ></vaadin-grid-column>
+                      `
+                    : html``}
                   <lablup-grid-sort-filter-column
-                    path="type"
-                    width="140px"
-                    flex-grow="0"
-                    header="${_t('session.launcher.SessionType')}"
+                    width="110px"
+                    path="architecture"
+                    header="${_t('session.Architecture')}"
                     resizable
-                    .renderer="${this._boundSessionTypeRenderer}"
+                    .renderer="${this._boundArchitectureRenderer}"
                   ></lablup-grid-sort-filter-column>
-                `
-              : html``
-          }
-          ${
-            this.is_superadmin || !globalThis.backendaiclient._config.hideAgents
-              ? html`
-                  <lablup-grid-sort-filter-column
-                    width="140px"
-                    flex-grow="0"
-                    resizable
-                    header="${_t('session.Agents')}"
-                    .renderer="${this._boundAgentListRenderer}"
-                  ></lablup-grid-sort-filter-column>
-                `
-              : html``
-          }
-          </vaadin-grid>
+                  ${this._isIntegratedCondition
+                    ? html`
+                        <lablup-grid-sort-filter-column
+                          path="type"
+                          width="140px"
+                          flex-grow="0"
+                          header="${_t('session.launcher.SessionType')}"
+                          resizable
+                          .renderer="${this._boundSessionTypeRenderer}"
+                        ></lablup-grid-sort-filter-column>
+                      `
+                    : html``}
+                  ${this.is_superadmin ||
+                  !globalThis.backendaiclient._config.hideAgents
+                    ? html`
+                        <lablup-grid-sort-filter-column
+                          width="140px"
+                          flex-grow="0"
+                          resizable
+                          header="${_t('session.Agents')}"
+                          .renderer="${this._boundAgentListRenderer}"
+                        ></lablup-grid-sort-filter-column>
+                      `
+                    : html``}
+                </vaadin-grid>
+              `
+            : html``
+        }
+        
           <backend-ai-list-status id="list-status" statusCondition="${
             this.listCondition
           }" message="${_text(


### PR DESCRIPTION
### TL;DR

Added a 'requiresUpdateWhenInactive' flag to ensure the `backend-ai-page` component updates at least once when it becomes inactive.

### What changed?
The BackendAIPage component now includes a 'requiresUpdateWhenInactive' flag. This ensures that an update is triggered once when the component goes inactive. Additionally, updated the BackendAISessionList component to render the session list grid dynamically based on the 'active' state.

### How to test?
1. Navigate to the page using the BackendAIPage component.
2. Visit session list and move to other page to trigger active/inactive state and observe if the session list updates accordingly.
- When inactive, the `ReservationTimeCounter` React component in the session list should be unmounted. You can ensure it to check 
 whether the [`useIntervalValue` hook is cleared](https://github.com/lablup/backend.ai-webui/blob/15d929f4891b1d56c0e13ec819d979e8b638fb14/react/src/hooks/useIntervalValue.tsx#L23-L24
).

### Why make this change?
This change addresses an issue where the session list would not update properly when becoming inactive. Ensuring an update is triggered helps maintain the consistency and accuracy of the displayed information.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
