### PR TITLE
ci: add Frontend Daily Board project automatically

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -22,3 +22,9 @@ jobs:
           # to the issue
           project-url: https://github.com/orgs/lablup/projects/20
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          # You can target a repository in a different organization
+          # to the issue
+          project-url: https://github.com/orgs/lablup/projects/24
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Update `add-to-project.yml` github workflow to add [Frontend Daily Board]([url](https://github.com/orgs/lablup/projects/24)) project.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
