### PR TITLE
feat: persist current Tab on the Environment page using search param

### DIFF
--- a/react/src/pages/EnvironmentPage.tsx
+++ b/react/src/pages/EnvironmentPage.tsx
@@ -3,35 +3,38 @@ import Flex from '../components/Flex';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { theme } from 'antd';
 import Card from 'antd/es/card/Card';
-import { useState, Suspense } from 'react';
+import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
+import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
-type TabKey = 'imageList' | 'presetList' | 'registryList';
+const tabParam = withDefault(StringParam, 'image');
+
 const EnvironmentPage = () => {
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useState<TabKey>('imageList');
+  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
   const baiClient = useSuspendedBackendaiClient();
   const isSupportContainerRegistryGraphQL = baiClient.supports(
     'container-registry-gql',
   );
   const { token } = theme.useToken();
+
   return (
     <Card
       activeTabKey={curTabKey}
-      onTabChange={(key) => setCurTabKey(key as TabKey)}
+      onTabChange={setCurTabKey}
       tabList={[
         {
-          key: 'imageList',
+          key: 'image',
           label: t('environment.Images'),
         },
         {
-          key: 'presetList',
+          key: 'preset',
           label: t('environment.ResourcePresets'),
         },
         ...(baiClient.is_superadmin
           ? [
               {
-                key: 'registryList',
+                key: 'registry',
                 label: t('environment.Registries'),
               },
             ]
@@ -47,39 +50,39 @@ const EnvironmentPage = () => {
     >
       <Flex
         style={{
-          display: curTabKey === 'imageList' ? 'block' : 'none',
+          display: curTabKey === 'image' ? 'block' : 'none',
           paddingTop: token.paddingContentVerticalSM,
         }}
       >
         {/* @ts-ignore */}
-        <backend-ai-environment-list active={curTabKey === 'imageList'} />
+        <backend-ai-environment-list active={curTabKey === 'image'} />
       </Flex>
       <Flex
         style={{
-          display: curTabKey === 'presetList' ? 'block' : 'none',
+          display: curTabKey === 'preset' ? 'block' : 'none',
           paddingTop: token.paddingContentVerticalSM,
         }}
       >
         {/* @ts-ignore */}
-        <backend-ai-resource-preset-list active={curTabKey === 'presetList'} />
+        <backend-ai-resource-preset-list active={curTabKey === 'preset'} />
       </Flex>
 
       <Flex
         style={{
-          display: curTabKey === 'registryList' ? 'block' : 'none',
+          display: curTabKey === 'registry' ? 'block' : 'none',
           height: 'calc(100vh - 145px)',
           // height: 'calc(100vh - 175px)',
         }}
       >
         {isSupportContainerRegistryGraphQL ? (
-          curTabKey === 'registryList' ? (
+          curTabKey === 'registry' ? (
             <Suspense>
               <ContainerRegistryList />
             </Suspense>
           ) : null
         ) : (
           // @ts-ignore
-          <backend-ai-registry-list active={curTabKey === 'registryList'} />
+          <backend-ai-registry-list active={curTabKey === 'registry'} />
         )}
       </Flex>
     </Card>


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR resolves [#2586 ](https://github.com/lablup/backend.ai-webui/issues/2586) issue
### TL;DR

manage tab as URL 

###  Why make this change?

since we didn't manage the tab as a URL, it doesn't persist on refresh. 

### What changed?

modify to use useQueryParam to manage tabs

` curTabKey === 'registryList'`  This is unnecessary code, so I deleted it
 because if curTabKey is not registryList, the parent component's display is none
```
 curTabKey === 'registryList' ? (
            <Suspense>
              <ContainerRegistryList />
            </Suspense>
          ) : null
```
### How to test?

1. enter the environment page
2. click preset or registry and check it's working well
3. refresh and check the tab is preserved 