### PR TITLE
feat: introduce `useSuspenseQuery` with support for `fetchKey`.

### DIFF
--- a/react/src/hooks/reactQueryAlias.tsx
+++ b/react/src/hooks/reactQueryAlias.tsx
@@ -1,4 +1,80 @@
-import { useQuery, useMutation } from 'react-query';
+import { useRef } from 'react';
+import {
+  type QueryKey,
+  useQuery,
+  useMutation,
+  UseQueryOptions,
+  useQueryClient,
+  QueryObserver,
+} from 'react-query';
 
 export const useTanQuery = useQuery;
 export const useTanMutation = useMutation;
+
+/**
+ * Custom hook that wraps the `useQuery` hook from `react-query` and enables suspense mode refetch using `fetchKey`.
+ *
+ * @template TQueryFnData The type of the data returned by the query function.
+ * @template TError The type of the error thrown by the query function.
+ * @template TData The type of the data returned by the query.
+ * @template TQueryKey The type of the query key.
+ *
+ * @param {Omit<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & { fetchKey?: string; }, 'suspense'>} options The options for the query.
+ *
+ * @returns {QueryResult<TQueryFnData, TError, TData>} The query result.
+ */
+export const useSuspenseQuery = <
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>({
+  fetchKey,
+  ...options
+}: Omit<
+  UseQueryOptions<TQueryFnData, TError, TData, TQueryKey> & {
+    fetchKey?: string;
+  },
+  'suspense'
+>) => {
+  const queryClient = useQueryClient();
+
+  const queryResult = useQuery<TQueryFnData, TError, TData, TQueryKey>({
+    ...options,
+    suspense: true,
+  });
+
+  const promiseInfoRef = useRef<{
+    fetchKey?: string;
+    promise?: Promise<any>;
+    resolved?: boolean;
+  }>({
+    fetchKey,
+  });
+
+  if (fetchKey !== promiseInfoRef.current.fetchKey) {
+    const observer = new QueryObserver(queryClient, {
+      queryKey: options.queryKey,
+    });
+    queryClient.invalidateQueries({
+      queryKey: options.queryKey,
+    });
+    promiseInfoRef.current.fetchKey = fetchKey;
+    promiseInfoRef.current.resolved = false;
+    promiseInfoRef.current.promise = new Promise((resolve) => {
+      const unsubscribe = observer.subscribe((result) => {
+        unsubscribe();
+        resolve(result);
+        if (promiseInfoRef.current?.fetchKey === fetchKey) {
+          promiseInfoRef.current.resolved = true;
+        }
+      });
+    });
+  }
+
+  if (promiseInfoRef.current?.promise && !promiseInfoRef.current.resolved) {
+    throw promiseInfoRef.current.promise;
+  }
+
+  return queryResult;
+};


### PR DESCRIPTION
### TL;DR

This pull request introduces the `useSuspenseQuery` custom hook that wraps the `useQuery` hook from `react-query`, enabling suspense mode refetch using a `fetchKey`.

### What changed?

- Added a new custom hook `useSuspenseQuery` to the `reactQueryAlias.tsx` file.
- This hook adds support for suspense mode refetching using a `fetchKey`.

### How to test?

1. Import and use the `useSuspenseQuery` hook in a component.
2. Pass the necessary options including an optional `fetchKey` to the hook.
3. Observe that the query refetches correctly in suspense mode when the `fetchKey` is updated.

> You can test this in #2591 . There is [a use case ](https://github.com/lablup/backend.ai-webui/pull/2591/files#r1698071491)for `fetchKey` 
### Why make this change?

This change enables more advanced data fetching patterns, allowing for smoother user experiences with suspense mode in React applications that use `react-query`. It ensures that queries can refetch as needed without blocking the UI unnecessarily.
