### PR TITLE
fix: typo error

### DIFF
--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1527,7 +1527,7 @@
     "QueryingExisitingComputeSession": "기존 연산 세션 조회중 ...",
     "PleaseReload": "잠시 후에 다시 시도해 보십시오.",
     "FoundExistingComputeSession": "실행 중인 계산 세션이 발견되었습니다.",
-    "FindingSessionTemplate": "세션 템플릿 탐석 중 ...",
+    "FindingSessionTemplate": "세션 템플릿 탐색 중 ...",
     "NoSessionTemplate": "사용 가능한 세션 템플릿이 없습니다",
     "CreatingComputeSession": "연산 세션 생성 중 ...",
     "SessionStillPreparing": "연산 세션이 계속 준비중입니다. 잠시 후 리로드 하십시오.",


### PR DESCRIPTION
### TL;DR
Fixed a typo in the Korean localization file `ko.json`.

### What changed?
Corrected the word "탐석" to "탐색" in the key "FindingSessionTemplate".

### How to test?
No specific testing required, but you can verify the change by checking the affected key in `ko.json` file for correct spelling.

### Why make this change?
This fixes a minor typo to ensure accurate translations in the Korean localization.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
