### PR TITLE
ci: update `add-to-project` github action to add PRs to project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,25 +4,28 @@ on:
   issues:
     types:
       - opened
+  pull_request:
+    types:
+      - opened
 
 jobs:
   add-to-project:
-    name: Add issue to project
+    name: Add issue or pull request to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v1.0.2
         with:
           # You can target a repository in a different organization
           # to the issue
           project-url: https://github.com/orgs/lablup/projects/13
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v1.0.2
         with:
           # You can target a repository in a different organization
           # to the issue
           project-url: https://github.com/orgs/lablup/projects/20
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v1.0.2
         with:
           # You can target a repository in a different organization
           # to the issue


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to automatically add new issues and pull requests to specific project boards. It updates the 'add-to-project' action version from 'v0.5.0' to 'v1.0.2' and adjusts the workflow to handle both issue and pull request events.

ref: https://github.com/actions/add-to-project

follows #2585 

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
