### PR TITLE
feat: copyable i18n key for debug mode

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -167,7 +167,7 @@ const AgentList: React.FC<AgentListProps> = ({
       rowScope: 'row',
     },
     {
-      title: `ID / ${t('agent.Endpoint')}`,
+      title: <>ID / {t('agent.Endpoint')}</>,
       key: 'id',
       dataIndex: 'id',
       fixed: 'left',


### PR DESCRIPTION
### TL;DR

Introduce a debug mode in development environment and add functionality to make i18n keys copyable. This feature woks in React parts only.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/19c46a94-546d-4954-920a-55e83ee6d9d8.png)

### What changed?

1. Added `Typography` from `antd` and `GlobeIcon` from `lucide-react`.
2. Introduced a debug mode which can be toggled via URL parameter `debug`. You can add `?debug=true` in any page. It works only in development environment.
3. Added a post-processor to `i18n` configuration to make i18n keys copyable in debug mode.

### How to test?

1. Run the application in development mode.
2. Add `?debug=true` to the URL parameters. (or add `debug=true` in genera section of `config.toml`
3. Check if i18n keys(Glob Icon) are copyable.

### Why make this change?

To enhance debugging capabilities and allow developers to easily copy i18n keys for translation or reference.

### Ref
- [Teams thread](https://teams.microsoft.com/l/message/19:3c0acc0825024daeb2211f55c4e7f4aa@thread.skype/1722403051072?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=74ae2c4d-ec4d-4fdf-b2c2-f5041d1e8631&parentMessageId=1722403051072&teamName=devops&channelName=Backend.AI%20Talks&createdTime=1722403051072)
- https://www.i18next.com/misc/creating-own-plugins