### PR TITLE
fix: blank `/change-password` page

### DIFF
--- a/src/components/backend-ai-change-forgot-password-view.ts
+++ b/src/components/backend-ai-change-forgot-password-view.ts
@@ -73,7 +73,6 @@ export default class BackendAIChangeForgotPasswordView extends BackendAIPage {
    */
   _initClient(apiEndpoint: string) {
     this.webUIShell = document.querySelector('#webui-shell');
-    this.webUIShell.appBody.style.visibility = 'visible';
     this.notification = globalThis.lablupNotification;
     this.passwordChangeDialog = this.shadowRoot?.querySelector(
       '#update-password-dialog',

--- a/src/components/backend-ai-edu-applauncher.ts
+++ b/src/components/backend-ai-edu-applauncher.ts
@@ -157,7 +157,6 @@ export default class BackendAiEduApplauncher extends BackendAIPage {
   async _initClient(apiEndpoint: string) {
     this.notification = globalThis.lablupNotification;
     const webUIShell: any = document.querySelector('#webui-shell');
-    // webUIShell.appBody.style.visibility = 'visible';
     if (apiEndpoint === '') {
       const api_endpoint: any = localStorage.getItem(
         'backendaiwebui.api_endpoint',

--- a/src/components/backend-ai-email-verification-view.ts
+++ b/src/components/backend-ai-email-verification-view.ts
@@ -66,7 +66,6 @@ export default class BackendAIEmailVerificationView extends BackendAIPage {
    */
   _initClient(apiEndpoint: string) {
     this.webUIShell = document.querySelector('#webui-shell');
-    this.webUIShell.appBody.style.visibility = 'visible';
     this.notification = globalThis.lablupNotification;
     this.successDialog = this.shadowRoot?.querySelector(
       '#verification-success-dialog',

--- a/src/types/backend-ai-console.d.ts
+++ b/src/types/backend-ai-console.d.ts
@@ -70,7 +70,6 @@ export default class BackendAIWebUI extends BackendAIWebUI_base {
   _offlineIndicatorOpened: boolean;
   _offline: boolean;
   config: any;
-  appBody: any;
   appPage: any;
   contentBody: any;
   mainToolbar: any;


### PR DESCRIPTION
### TL;DR

This PR fixed blank `/chage-password` page
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/69f6a035-0d9a-4a9d-90b1-4edf82257576.png)

Removed lines of code related to setting the visibility of `appBody` in various components. `appBody` has been deleted in https://github.com/lablup/backend.ai-webui/pull/2350

### What changed?

- In `backend-ai-change-forgot-password-view.ts`, removed code setting `this.webUIShell.appBody.style.visibility`.
- In `backend-ai-edu-applauncher.ts`, removed the commented-out code for setting `webUIShell.appBody.style.visibility`.
- In `backend-ai-email-verification-view.ts`, removed code setting `this.webUIShell.appBody.style.visibility`.
- In `backend-ai-console.d.ts`, removed the declaration of `appBody`.

### How to test?

1. Access `/change-password?token=sometoken` page.
2. If you want to get the link, you can use `cloud.backend.ai`

### Why make this change?

The visibility setting of `appBody` was redundant and possibly causing issues with page rendering.
