### PR TITLE
fix: add missing checkbox PR in session list page

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -733,6 +733,15 @@ export default class BackendAISessionList extends BackendAIPage {
    * @param {boolean} repeat - repeat the job data reading. Set refreshTime to 5000 for running list else 30000
    * */
   async _refreshJobData(refresh = false, repeat = true) {
+    this._grid?.addEventListener('selected-items-changed', () => {
+      this._selected_items = this._grid.selectedItems;
+      if (this._selected_items.length > 0) {
+        this.multipleActionButtons.style.display = 'flex';
+      } else {
+        this.multipleActionButtons.style.display = 'none';
+      }
+    });
+
     await this.updateComplete;
     if (this.active !== true) {
       return;
@@ -1321,6 +1330,7 @@ export default class BackendAISessionList extends BackendAIPage {
           this.notification.show(true, err);
         }
       });
+    this._clearCheckboxes();
   }
 
   /**
@@ -2059,6 +2069,7 @@ export default class BackendAISessionList extends BackendAIPage {
   _clearCheckboxes() {
     this._grid.selectedItems = [];
     this._selected_items = [];
+    this._grid.clearCache();
   }
 
   _handleSelectedItems() {
@@ -4292,13 +4303,10 @@ ${rowData.item[this.sessionNameField]}</pre
                 >
                   ${this._isRunning
                     ? html`
-                        <vaadin-grid-column
+                        <vaadin-grid-selection-column
                           frozen
-                          width="60px"
-                          flex-grow="0"
-                          text-align="center"
-                          .renderer="${this._boundCheckboxRenderer}"
-                        ></vaadin-grid-column>
+                          auto-select
+                        ></vaadin-grid-selection-column>
                       `
                     : html``}
                   <vaadin-grid-column


### PR DESCRIPTION
### TL;DR
https://github.com/lablup/backend.ai-webui/pull/2519 PR is missing when https://github.com/lablup/backend.ai-webui/pull/2581 is merged.

This PR is about adding missing parts of 2519 PR 

### What changed?

- Replaced `vaadin-grid-column` with `vaadin-grid-selection-column` for session list selection
- Added `_clearCheckboxes` method call to ensure checkboxes are cleared

### How to test?

1. Verify session list displays selection column correctly
2. Test checkbox auto-selection functionality
3. Perform operations that utilize checkboxes and ensure they are cleared appropriately

### Why make this change?

To improve the user experience by providing auto-selection in the session list and ensuring that checkboxes do not retain stale state after operations.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
