### PR TITLE
fix: set notification's description field to empty string

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1277,7 +1277,7 @@ export default class BackendAISessionList extends BackendAIPage {
         }
 
         this.compute_sessions = sessions;
-        this._grid.recalculateColumnWidths();
+        this._grid?.recalculateColumnWidths();
         // this._grid.clearCache();
         this.requestUpdate();
         let refreshTime;
@@ -1652,6 +1652,7 @@ export default class BackendAISessionList extends BackendAIPage {
           this.notification.show(true, err);
         } else if (err && err.title) {
           this.notification.text = PainKiller.relieve(err.title);
+          this.notification.detail = '';
           this.notification.show(true, err);
         }
       });
@@ -1685,6 +1686,7 @@ export default class BackendAISessionList extends BackendAIPage {
           this.notification.show(true, err);
         } else if (err && err.title) {
           this.notification.text = PainKiller.relieve(err.title);
+          this.notification.detail = '';
           this.notification.show(true, err);
         }
       });
@@ -1720,6 +1722,7 @@ export default class BackendAISessionList extends BackendAIPage {
           this.notification.show(true, err);
         } else if (err && err.title) {
           this.notification.text = PainKiller.relieve(err.title);
+          this.notification.detail = '';
           this.notification.show(true, err);
         }
       });
@@ -1960,6 +1963,7 @@ export default class BackendAISessionList extends BackendAIPage {
 
     if (this.terminationQueue.includes(sessionId)) {
       this.notification.text = _text('session.AlreadyTerminatingSession');
+      this.notification.detail = '';
       this.notification.show();
       return false;
     }
@@ -1970,6 +1974,7 @@ export default class BackendAISessionList extends BackendAIPage {
     // TODO define extended type for custom properties
     if (this.terminationQueue.includes(this.terminateSessionDialog.sessionId)) {
       this.notification.text = _text('session.AlreadyTerminatingSession');
+      this.notification.detail = '';
       this.notification.show();
       return false;
     }
@@ -1985,6 +1990,7 @@ export default class BackendAISessionList extends BackendAIPage {
         this._clearCheckboxes();
         this.terminateSessionDialog.hide();
         this.notification.text = _text('session.SessionTerminated');
+        this.notification.detail = '';
         this.notification.show();
         const event = new CustomEvent('backend-ai-resource-refreshed', {
           detail: 'running',
@@ -2095,6 +2101,7 @@ export default class BackendAISessionList extends BackendAIPage {
         this._clearCheckboxes();
         this.multipleActionButtons.style.display = 'none';
         this.notification.text = _text('session.SessionsTerminated');
+        this.notification.detail = '';
         this.notification.show();
       })
       .catch(() => {
@@ -2120,6 +2127,7 @@ export default class BackendAISessionList extends BackendAIPage {
         this._clearCheckboxes();
         this.multipleActionButtons.style.display = 'none';
         this.notification.text = _text('session.SessionsTerminated');
+        this.notification.detail = '';
         this.notification.show();
       })
       .catch(() => {
@@ -2155,6 +2163,7 @@ export default class BackendAISessionList extends BackendAIPage {
             'Problem occurred during termination.',
           );
         }
+        this.notification.detail = '';
         this.notification.show(true, err);
       });
   }
@@ -2648,6 +2657,7 @@ export default class BackendAISessionList extends BackendAIPage {
           .then((req) => {
             this.refreshList();
             this.notification.text = _text('session.SessionRenamed');
+            this.notification.detail = '';
             this.notification.show();
           })
           .catch((err) => {


### PR DESCRIPTION
### Why did I make the change?
Because the `backend-ai-session-list` shares a single description stored variable with the notification, it is displaying the description as it is if it was stored by another action.

So, in the part that shows the notifications, if you don't want a description, you have to explicitly put in an empty string value.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
