### PR TITLE
feat: BAIProperty filter supports `boolean` type

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -802,15 +802,33 @@ const AgentList: React.FC<AgentListProps> = ({
               });
             }}
           />
+
           <BAIPropertyFilter
             filterProperties={[
               {
                 key: 'id',
                 propertyLabel: 'ID',
+                type: 'string',
               },
               {
                 key: 'addr',
                 propertyLabel: t('agent.Endpoint'),
+                type: 'string',
+              },
+              {
+                key: 'schedulable',
+                propertyLabel: t('agent.Schedulable'),
+                type: 'boolean',
+                options: [
+                  {
+                    label: t('general.Enabled'),
+                    value: 'true',
+                  },
+                  {
+                    label: t('general.Disabled'),
+                    value: 'false',
+                  },
+                ],
               },
             ]}
             value={filterString}

--- a/react/src/components/BAIPropertyFilter.stories.tsx
+++ b/react/src/components/BAIPropertyFilter.stories.tsx
@@ -21,18 +21,22 @@ export const Default: Story = {
       {
         key: 'property1',
         defaultOperator: '==',
-        propertyLabel: 'Property 1',
+        propertyLabel: 'Property String',
+        type: 'string',
       },
       {
         key: 'property2',
-        defaultOperator: '!=',
-        propertyLabel: 'Property 2',
+        propertyLabel: 'Property String',
+        type: 'string',
       },
       {
-        key: 'property3',
-        propertyLabel: 'Property 3',
+        key: 'booleanProperty',
+        propertyLabel: 'Property Boolean',
+        type: 'boolean',
       },
     ],
+
     onChange: fn(),
+    value: 'property2 ilike %ㅁㄴㅇㄹㅁㄴㅇㄹ% & booleanProperty == true',
   },
 };

--- a/react/src/components/BAIPropertyFilter.tsx
+++ b/react/src/components/BAIPropertyFilter.tsx
@@ -2,57 +2,102 @@ import useControllableState from '../hooks/useControllableState';
 import Flex from './Flex';
 import { CloseCircleOutlined } from '@ant-design/icons';
 import { useDynamicList } from 'ahooks';
-import { Button, Input, Select, Tag, Tooltip, theme } from 'antd';
+import {
+  AutoComplete,
+  AutoCompleteProps,
+  Button,
+  GetRef,
+  Input,
+  Select,
+  Space,
+  Tag,
+  Tooltip,
+  theme,
+} from 'antd';
 import _ from 'lodash';
-import React, { ComponentProps, useEffect, useMemo, useState } from 'react';
+import React, {
+  ComponentProps,
+  ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 
-// const OPERATION_LABELS = {
-//   '==': 'is',
-//   '!=': 'is not',
-//   '<': 'less than',
-//   '<=': 'less than or equal to',
-//   '>': 'greater than',
-//   '>=': 'greater than or equal to',
-//   '%': 'like',
-//   in: 'in',
-//   contains: 'contains',
-// };
-// operators: ['==', '!=', '<', '<=', '>', '>=', '%'],
-
+//github.com/lablup/backend.ai/blob/main/src/ai/backend/manager/models/minilang/queryfilter.py
 type FilterProperty = {
   key: string;
   // operators: Array<string>;
   defaultOperator?: string;
   propertyLabel: string;
+  // TODO: support array, number
+  type: 'string' | 'boolean';
+  options?: AutoCompleteProps['options'];
 };
 export interface BAIPropertyFilterProps
-  extends Omit<ComponentProps<typeof Input.Search>, 'value' | 'onChange'> {
+  extends Omit<ComponentProps<typeof Flex>, 'value' | 'onChange'> {
   value?: string;
   onChange?: (value: string) => void;
   defaultValue?: string;
   filterProperties: Array<FilterProperty>;
+  loading?: boolean;
 }
 
 interface FilterInput {
   property: string;
   operator: string;
   value: string;
+  label?: ReactNode;
+  type: FilterProperty['type'];
   propertyLabel: string;
 }
 
-const DEFAULT_OPERATOR = 'ilike';
+const DEFAULT_OPERATOR_OF_TYPES = {
+  string: 'ilike',
+  boolean: '==',
+};
+
+const DEFAULT_OPTIONS_OF_TYPES: {
+  [key: string]: AutoCompleteProps['options'] | undefined;
+} = {
+  boolean: [
+    {
+      label: 'True',
+      value: 'true',
+    },
+    {
+      label: 'False',
+      value: 'false',
+    },
+  ],
+  string: undefined,
+};
 
 function trimFilterValue(filterValue: string): string {
   return filterValue.replace(/^%|%$/g, '');
 }
 
+/**
+ * Parses the filter value and returns an object containing the property, operator, and value.
+ * @param filter - The filter string to parse.
+ * @returns An object containing the parsed property, operator, and value.
+ */
 export function parseFilterValue(filter: string) {
+  // Split the filter string into an array of strings using a regular expression.
+  // The regular expression splits the string at whitespace characters, but ignores whitespace within double quotes.
   const [property, ...rest] = filter.split(/\s+(?=(?:(?:[^"]*"){2})*[^"]*$)/);
+
+  // Join the remaining strings in the array and split them again using the same regular expression.
+  // This extracts the operator and the value from the filter string.
   const [operator, ...valueParts] = rest
     .join(' ')
     .split(/\s+(?=(?:(?:[^"]*"){2})*[^"]*$)/);
+
+  // Join the value parts into a single string and remove any leading or trailing double quotes.
   const value = valueParts.join(' ').replace(/^"|"$/g, '');
+
+  // Return an object containing the parsed property, operator, and value.
   return { property, operator, value };
 }
 
@@ -61,9 +106,12 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
   value: propValue,
   onChange: propOnChange,
   defaultValue,
-  ...otherProps
+  loading,
+  ...containerProps
 }) => {
   const [search, setSearch] = useControllableState({});
+  const autoCompleteRef = useRef<GetRef<typeof AutoComplete>>(null);
+  const [isOpenAutoComplete, setIsOpenAutoComplete] = useState(false);
 
   const [value, setValue] = useControllableState<string | undefined>({
     value: propValue,
@@ -82,6 +130,8 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
         propertyLabel:
           _.find(filterProperties, (f) => f.key === property)?.propertyLabel ||
           property,
+        type:
+          _.find(filterProperties, (f) => f.key === property)?.type || 'string',
       };
     });
   }, [value, filterProperties]);
@@ -106,50 +156,78 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
     } else {
       setValue(
         _.map(list, (item) => {
-          return `${item.property} ${item.operator} "${item.value}"`;
+          const valueStringInResult =
+            item.type === 'string' ? `"${item.value}"` : item.value;
+          return `${item.property} ${item.operator} ${valueStringInResult}`;
         }).join(' & '),
       );
     }
   }, [list, setValue]);
 
+  const onSearch = (value: string) => {
+    if (_.isEmpty(value)) return;
+    setSearch('');
+    const operator =
+      selectedProperty.defaultOperator ||
+      DEFAULT_OPERATOR_OF_TYPES[selectedProperty.type];
+    const filterValue =
+      operator === 'ilike' || operator === 'like' ? `%${value}%` : `${value}`;
+    push({
+      property: selectedProperty.key,
+      propertyLabel: selectedProperty.propertyLabel,
+      operator,
+      value: filterValue,
+      label: selectedProperty.options?.find((o) => o.value === value)?.label,
+      type: selectedProperty.type,
+    });
+  };
   return (
     <Flex direction="column" gap={'xs'} style={{ flex: 1 }} align="start">
-      <Flex>
-        <Input.Search
-          addonBefore={
-            <Select
-              popupMatchSelectWidth={false}
-              options={options}
-              value={selectedProperty.key}
-              onChange={(value, options) => {
-                setSelectedProperty(_.castArray(options)[0].filter);
-              }}
-            />
-          }
-          style={{ minWidth: 250 }}
-          onSearch={(value) => {
-            if (_.isEmpty(value)) return;
-            setSearch('');
-            const operator =
-              selectedProperty.defaultOperator || DEFAULT_OPERATOR;
-            const filterValue =
-              operator === 'ilike' || operator === 'like'
-                ? `%${value}%`
-                : `${value}`;
-            push({
-              property: selectedProperty.key,
-              propertyLabel: selectedProperty.propertyLabel,
-              operator,
-              value: filterValue,
-            });
+      <Space.Compact>
+        <Select
+          popupMatchSelectWidth={false}
+          options={options}
+          value={selectedProperty.key}
+          onChange={(value, options) => {
+            setSelectedProperty(_.castArray(options)[0].filter);
           }}
-          allowClear
-          placeholder={t('propertyFilter.placeHolder')}
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          {...otherProps}
+          onSelect={() => {
+            autoCompleteRef.current?.focus();
+            setIsOpenAutoComplete(true);
+          }}
+          showSearch
+          optionFilterProp="label"
         />
-      </Flex>
+        <AutoComplete
+          ref={autoCompleteRef}
+          value={search}
+          open={isOpenAutoComplete}
+          onDropdownVisibleChange={setIsOpenAutoComplete}
+          // https://ant.design/components/auto-complete#why-doesnt-the-text-composition-system-work-well-with-onsearch-in-controlled-mode
+          // onSearch={(value) => {}}
+          onSelect={onSearch}
+          onChange={(value) => {
+            setSearch(value);
+          }}
+          style={{
+            minWidth: 200,
+          }}
+          // @ts-ignore
+          options={_.filter(
+            selectedProperty.options ||
+              DEFAULT_OPTIONS_OF_TYPES[selectedProperty.type],
+            (option) => {
+              return _.isEmpty(search)
+                ? true
+                : option.label?.toString().includes(search);
+            },
+          )}
+          placeholder={t('propertyFilter.placeHolder')}
+          allowClear
+        >
+          <Input.Search onSearch={onSearch} />
+        </AutoComplete>
+      </Space.Compact>
       {list.length > 0 && (
         <Flex
           direction="row"
@@ -167,7 +245,8 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
                 }}
                 style={{ margin: 0 }}
               >
-                {item.propertyLabel}: {trimFilterValue(item.value)}
+                {item.propertyLabel}:{' '}
+                {item.label || trimFilterValue(item.value)}
               </Tag>
             );
           })}

--- a/react/src/components/EndpointSelect.tsx
+++ b/react/src/components/EndpointSelect.tsx
@@ -29,12 +29,7 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
   const { endpoint_list } = useLazyLoadQuery<EndpointSelectQuery>(
     graphql`
       query EndpointSelectQuery($offset: Int!, $limit: Int!, $projectID: UUID) {
-        endpoint_list(
-          offset: $offset
-          limit: $limit
-          project: $projectID
-          filter: "name != 'koalpaca-test'"
-        ) {
+        endpoint_list(offset: $offset, limit: $limit, project: $projectID) {
           total_count
           items {
             name

--- a/react/src/components/lablupTalkativotUI/LLMPlaygroundPage.tsx
+++ b/react/src/components/lablupTalkativotUI/LLMPlaygroundPage.tsx
@@ -23,7 +23,7 @@ const LLMPlaygroundPage: React.FC<LLMPlaygroundPageProps> = ({ ...props }) => {
   const { endpoint_list } = useLazyLoadQuery<LLMPlaygroundPageQuery>(
     graphql`
       query LLMPlaygroundPageQuery {
-        endpoint_list(limit: 1, offset: 0, filter: "name != 'koalpaca-test'") {
+        endpoint_list(limit: 1, offset: 0) {
           items {
             ...EndpointLLMChatCard_endpoint
           }

--- a/react/src/pages/EndpointListPage.tsx
+++ b/react/src/pages/EndpointListPage.tsx
@@ -300,12 +300,7 @@ const EndpointListPage: React.FC<PropsWithChildren> = ({ children }) => {
           $limit: Int!
           $projectID: UUID
         ) {
-          endpoint_list(
-            offset: $offset
-            limit: $limit
-            project: $projectID
-            filter: "name != 'koalpaca-test'"
-          ) {
+          endpoint_list(offset: $offset, limit: $limit, project: $projectID) {
             total_count
             items {
               name

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -505,7 +505,8 @@
     "All": "Alle",
     "InProgress": "In Arbeit",
     "Session": "Sitzung",
-    "General": "Allgemein"
+    "General": "Allgemein",
+    "Disabled": "Behinderte"
   },
   "credential": {
     "Permission": "Genehmigung",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -505,7 +505,8 @@
     "All": "Όλα",
     "InProgress": "Σε εξέλιξη",
     "Session": "Σύνοδος",
-    "General": "Γενικά"
+    "General": "Γενικά",
+    "Disabled": "Άτομα με ειδικές ανάγκες"
   },
   "credential": {
     "Permission": "Αδεια",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -630,7 +630,8 @@
     "All": "All",
     "InProgress": "In progress",
     "Session": "Session",
-    "General": "General"
+    "General": "General",
+    "Disabled": "Disabled"
   },
   "credential": {
     "Permission": "Permission",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -521,7 +521,8 @@
     "All": "Todos",
     "InProgress": "En curso",
     "Session": "Sesión",
-    "General": "General"
+    "General": "General",
+    "Disabled": "Discapacitados"
   },
   "import": {
     "CleanUpImportTask": "Tarea de importación de limpieza...",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -521,7 +521,8 @@
     "All": "Kaikki",
     "InProgress": "Käynnissä",
     "Session": "Istunto",
-    "General": "Yleistä"
+    "General": "Yleistä",
+    "Disabled": "Vammaiset"
   },
   "import": {
     "CleanUpImportTask": "Tuontitehtävän siivous...",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -505,7 +505,8 @@
     "All": "Tous",
     "InProgress": "En cours",
     "Session": "Session",
-    "General": "Général"
+    "General": "Général",
+    "Disabled": "Handicapés"
   },
   "credential": {
     "Permission": "Autorisation",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -506,7 +506,8 @@
     "All": "Semua",
     "InProgress": "Sedang Berlangsung",
     "Session": "Sesi",
-    "General": "Umum"
+    "General": "Umum",
+    "Disabled": "Dinonaktifkan"
   },
   "credential": {
     "Permission": "Izin",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -506,7 +506,8 @@
     "All": "Tutti",
     "InProgress": "In corso",
     "Session": "Sessione",
-    "General": "Generale"
+    "General": "Generale",
+    "Disabled": "Disabili"
   },
   "credential": {
     "Permission": "Autorizzazione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -505,7 +505,8 @@
     "All": "全体",
     "InProgress": "進行中",
     "Session": "セッション",
-    "General": "一般"
+    "General": "一般",
+    "Disabled": "無効"
   },
   "credential": {
     "Permission": "許可",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -543,7 +543,7 @@
     "Terminated": "종료됨",
     "Maintaining": "보수중",
     "Status": "상태",
-    "Schedulable": "스케쥴링 가능 여부",
+    "Schedulable": "스케쥴링 가능",
     "AgentSetting": "에이전트 설정",
     "AgentSettingUpdated": "에이전트 설정이 변경되었습니다.",
     "NoChanges": "변경 사항이 없습니다.",
@@ -610,14 +610,15 @@
     "ConfirmPassword": "비밀번호 (확인)",
     "Control": "제어",
     "NewPassword": "새 비밀번호",
-    "Enabled": "활성화됨",
+    "Enabled": "활성화",
     "StorageProxies": "스토리지",
     "None": "없음",
     "Image": "이미지",
     "All": "전체",
     "InProgress": "진행중",
     "Session": "세션",
-    "General": "일반"
+    "General": "일반",
+    "Disabled": "비활성화"
   },
   "credential": {
     "Permission": "권한",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -507,7 +507,8 @@
     "All": "бүхэлд нь",
     "InProgress": "Ажиллаж байна",
     "Session": "Сессия",
-    "General": "Генерал"
+    "General": "Генерал",
+    "Disabled": "Идэвхгүй"
   },
   "credential": {
     "Permission": "Зөвшөөрөл",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -505,7 +505,8 @@
     "All": "keseluruhan",
     "InProgress": "Prosiding",
     "Session": "Sesi",
-    "General": "Umum"
+    "General": "Umum",
+    "Disabled": "Dilumpuhkan"
   },
   "credential": {
     "Permission": "Kebenaran",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -505,7 +505,8 @@
     "All": "Wszystkie",
     "InProgress": "W toku",
     "Session": "Sesja",
-    "General": "Ogólne"
+    "General": "Ogólne",
+    "Disabled": "Wyłączony"
   },
   "credential": {
     "Permission": "Pozwolenie",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -505,7 +505,8 @@
     "All": "Todos",
     "InProgress": "Em curso",
     "Session": "Sessão",
-    "General": "Geral"
+    "General": "Geral",
+    "Disabled": "Desativado"
   },
   "credential": {
     "Permission": "Permissão",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -505,7 +505,8 @@
     "All": "Todos",
     "InProgress": "Em curso",
     "Session": "Sessão",
-    "General": "Geral"
+    "General": "Geral",
+    "Disabled": "Desativado"
   },
   "credential": {
     "Permission": "Permissão",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -505,7 +505,8 @@
     "All": "Все",
     "InProgress": "В процессе",
     "Session": "Сессия",
-    "General": "Общие сведения"
+    "General": "Общие сведения",
+    "Disabled": "Инвалид"
   },
   "credential": {
     "Permission": "Разрешение",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -505,7 +505,8 @@
     "All": "Tümü",
     "InProgress": "Devam Ediyor",
     "Session": "Oturum",
-    "General": "Genel"
+    "General": "Genel",
+    "Disabled": "Engelli"
   },
   "credential": {
     "Permission": "izin",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -505,7 +505,8 @@
     "All": "toàn bộ",
     "InProgress": "Đang tiến hành",
     "Session": "Phiên họp",
-    "General": "Tổng quan"
+    "General": "Tổng quan",
+    "Disabled": "Tàn tật"
   },
   "credential": {
     "Permission": "Sự cho phép",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -505,7 +505,8 @@
     "All": "全部",
     "InProgress": "进行中",
     "Session": "会话",
-    "General": "一般情况"
+    "General": "一般情况",
+    "Disabled": "残疾"
   },
   "credential": {
     "Permission": "允许",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -505,7 +505,8 @@
     "All": "全部",
     "InProgress": "进行中",
     "Session": "會話",
-    "General": "一般情况"
+    "General": "一般情况",
+    "Disabled": "残疾"
   },
   "credential": {
     "Permission": "允許",


### PR DESCRIPTION
### TL;DR

Added support for boolean options in BAIPropertyFilter component.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/70f8c94e-fffe-4e20-bddf-b1e5f530ab1b.png)

Related core PR: https://github.com/lablup/backend.ai/pull/2605

### What changed?

1. `AgentList.tsx`: Added `type` and `options` properties to filter properties.
2. `BAIPropertyFilter.stories.tsx`: Updated story to include boolean type property.
3. `BAIPropertyFilter.tsx`: Major updates to support boolean options including default boolean filter options and enhanced value handling.
4. Updated i18n files for new labels.

### How to test?

1. Go to the AgentList component and verify the filter functionality with boolean options.
2. Check the storybook for BAIPropertyFilter and ensure the new boolean property works as expected.
3. Verify i18n changes reflect correctly in the UI.

### Why make this change?

To enhance the filtering capabilities by allowing boolean options, providing more flexibility and utility in data filtering.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
