### PR TITLE
fix: remove an unintended condition from `endpoint_list`

### DIFF
--- a/react/src/components/EndpointSelect.tsx
+++ b/react/src/components/EndpointSelect.tsx
@@ -29,12 +29,7 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
   const { endpoint_list } = useLazyLoadQuery<EndpointSelectQuery>(
     graphql`
       query EndpointSelectQuery($offset: Int!, $limit: Int!, $projectID: UUID) {
-        endpoint_list(
-          offset: $offset
-          limit: $limit
-          project: $projectID
-          filter: "name != 'koalpaca-test'"
-        ) {
+        endpoint_list(offset: $offset, limit: $limit, project: $projectID) {
           total_count
           items {
             name

--- a/react/src/components/lablupTalkativotUI/LLMPlaygroundPage.tsx
+++ b/react/src/components/lablupTalkativotUI/LLMPlaygroundPage.tsx
@@ -23,7 +23,7 @@ const LLMPlaygroundPage: React.FC<LLMPlaygroundPageProps> = ({ ...props }) => {
   const { endpoint_list } = useLazyLoadQuery<LLMPlaygroundPageQuery>(
     graphql`
       query LLMPlaygroundPageQuery {
-        endpoint_list(limit: 1, offset: 0, filter: "name != 'koalpaca-test'") {
+        endpoint_list(limit: 1, offset: 0) {
           items {
             ...EndpointLLMChatCard_endpoint
           }

--- a/react/src/pages/EndpointListPage.tsx
+++ b/react/src/pages/EndpointListPage.tsx
@@ -300,12 +300,7 @@ const EndpointListPage: React.FC<PropsWithChildren> = ({ children }) => {
           $limit: Int!
           $projectID: UUID
         ) {
-          endpoint_list(
-            offset: $offset
-            limit: $limit
-            project: $projectID
-            filter: "name != 'koalpaca-test'"
-          ) {
+          endpoint_list(offset: $offset, limit: $limit, project: $projectID) {
             total_count
             items {
               name


### PR DESCRIPTION
The purpose of this pull request is to refactor the `EndpointSelect` component and related files by removing the filter `name != 'koalpaca-test'` from the `endpoint_list` queries. This filter was deemed unnecessary and has been removed to clean up the code. The changes span across `EndpointSelect.tsx`, `LLMPlaygroundPage.tsx`, and `EndpointListPage.tsx`.