### PR TITLE
fix: initialize detail text after the notification is shown

### DIFF
--- a/src/components/lablup-notification.ts
+++ b/src/components/lablup-notification.ts
@@ -217,6 +217,7 @@ export default class LablupNotification extends LitElement {
       document.dispatchEvent(event);
       this._spawnDesktopNotification('Backend.AI', this.text, '');
     }
+    this.detail = ''; // Reset the temporary detail scripts
   }
 
   // /**


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR is about initializing `detail text` in notification 

Since we've decided to show the details of the notification, we need to take care of handling the detail value of the notification in the web component. [ref](https://github.com/lablup/backend.ai-webui/pull/2503)

Since the web component shares a single variable for the detail text of the notification, an initialization process is required for the detail variable. In this PR, I change that detail text to be initialized after the notification's `show()` function is called.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
