### PR TITLE
feat: add confirm dialog before moving to trash bin tab

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -670,10 +670,11 @@
       "DeleteForever": "Unwiederuflich löschen",
       "FolderRestored": "Der Ordner {{ folderName }} wurde wiederhergestellt.",
       "FolderDeletedForever": "Der Ordner {{ folderName }} wurde endgültig gelöscht.",
-      "MoveToTrashBin": "In den Papierkorb verschieben",
+      "MoveToTrash": "Ab in den Müll",
       "MovedToTrashBin": "Der Ordner {{ folderName }} wurde in den Papierkorb verschoben.",
       "FolderCloneFailed": "Der Ordner konnte nicht geklont werden.",
-      "FolderClonePending": "Das Klonen des Ordners ist im Gange."
+      "FolderClonePending": "Das Klonen des Ordners ist im Gange.",
+      "MoveToTrashDescription": "Sind Sie sicher, dass Sie \"{{ folderName }}\" in den Papierkorb verschieben möchten?"
     },
     "explorer": {
       "Delete": "Löschen...",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -671,9 +671,10 @@
       "FolderRestored": "Ο φάκελος {{ folderName }} έχει αποκατασταθεί.",
       "FolderDeletedForever": "Ο φάκελος {{ folderName }} έχει διαγραφεί οριστικά.",
       "MovedToTrashBin": "Ο φάκελος {{ folderName }} έχει μετακινηθεί στον κάδο απορριμμάτων.",
-      "MoveToTrashBin": "Μετακίνηση στον κάδο απορριμμάτων",
+      "MoveToTrash": "Μετακίνηση στον κάδο απορριμμάτων",
       "FolderCloneFailed": "Απέτυχε η κλωνοποίηση του φακέλου.",
-      "FolderClonePending": "Η κλωνοποίηση του φακέλου βρίσκεται σε εξέλιξη."
+      "FolderClonePending": "Η κλωνοποίηση του φακέλου βρίσκεται σε εξέλιξη.",
+      "MoveToTrashDescription": "Είστε βέβαιοι ότι θέλετε να μετακινήσετε το \"{{ folderName }}\" στον κάδο απορριμμάτων;"
     },
     "explorer": {
       "Delete": "Διαγράφω...",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -804,9 +804,10 @@
       "FolderRestored": "The {{ folderName }} folder has been restored.",
       "FolderDeletedForever": "The {{ folderName }} folder has been deleted forever.",
       "MovedToTrashBin": "The {{ folderName }} folder has been moved to the trash bin.",
-      "MoveToTrashBin": "Move to trash bin",
+      "MoveToTrash": "Move to trash",
       "FolderCloneFailed": "Failed to clone the folder.",
-      "FolderClonePending": "Cloning the folder is in progress."
+      "FolderClonePending": "Cloning the folder is in progress.",
+      "MoveToTrashDescription": "Are you sure you want to move \"{{ folderName }}\" to trash?"
     },
     "explorer": {
       "Delete": "Delete",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -366,14 +366,15 @@
       "TypeFolderNameToLeave": "Escriba el nombre de la carpeta que desea abandonar",
       "TypeNewFolderName": "Escriba el nombre de la nueva carpeta",
       "View": "Ver",
-      "MoveToTrashBin": "Mover a la papelera",
+      "MoveToTrash": "Mover a la papelera",
       "MovedToTrashBin": "La carpeta {{ folderName }} se ha movido a la papelera.",
       "DeleteForever": "Borrar para siempre",
       "Restore": "Restaurar",
       "FolderRestored": "La carpeta {{ folderName }} ha sido restaurada.",
       "FolderDeletedForever": "La carpeta {{ folderName }} se ha eliminado para siempre.",
       "FolderCloneFailed": "Error al clonar la carpeta.",
-      "FolderClonePending": "La clonación de la carpeta está en curso."
+      "FolderClonePending": "La clonación de la carpeta está en curso.",
+      "MoveToTrashDescription": "¿Estás seguro de que quieres mover \"{{ folderName }}\" a la papelera?"
     },
     "invitation": {
       "FolderSharingNotAvailableToUser": "El uso compartido de carpetas no está disponible para los usuarios solicitados:",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -366,14 +366,15 @@
       "TypeFolderNameToLeave": "Kirjoita poistuvan kansion nimi",
       "TypeNewFolderName": "Kirjoita uuden kansion nimi",
       "View": "Näytä",
-      "MoveToTrashBin": "Siirrä roskakoriin",
+      "MoveToTrash": "Siirtää roskakoriin",
       "MovedToTrashBin": "Kansio {{ folderName }} on siirretty roskakoriin.",
       "DeleteForever": "Poista ikuisesti",
       "Restore": "Palauttaa",
       "FolderRestored": "Kansio {{ folderName }} on palautettu.",
       "FolderDeletedForever": "Kansio {{ folderName }} on poistettu pysyvästi.",
       "FolderCloneFailed": "Kansiota ei onnistuttu kloonaamaan.",
-      "FolderClonePending": "Kansion kloonaus on käynnissä."
+      "FolderClonePending": "Kansion kloonaus on käynnissä.",
+      "MoveToTrashDescription": "Haluatko varmasti siirtää \"{{ folderName }}\" roskakoriin?"
     },
     "invitation": {
       "FolderSharingNotAvailableToUser": "Kansioiden jakaminen ei ole käytettävissä pyydetyille käyttäjille:",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -670,10 +670,11 @@
       "DeleteForever": "Supprimer pour toujours",
       "FolderRestored": "Le dossier {{ folderName }} a été restauré.",
       "FolderDeletedForever": "Le dossier {{ folderName }} a été supprimé définitivement.",
-      "MoveToTrashBin": "Déplacer vers la poubelle",
+      "MoveToTrash": "Mettre à la corbeille",
       "MovedToTrashBin": "Le dossier {{ folderName }} a été déplacé vers la corbeille.",
       "FolderCloneFailed": "Échec du clonage du dossier.",
-      "FolderClonePending": "Le clonage du dossier est en cours."
+      "FolderClonePending": "Le clonage du dossier est en cours.",
+      "MoveToTrashDescription": "Êtes-vous sûr de vouloir déplacer \"{{ folderName }}\" vers la corbeille ?"
     },
     "explorer": {
       "Delete": "Effacer...",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -672,9 +672,10 @@
       "FolderRestored": "Folder {{ folderName }} telah dipulihkan.",
       "FolderDeletedForever": "Folder {{ folderName }} telah dihapus selamanya.",
       "MovedToTrashBin": "Folder {{ folderName }} telah dipindahkan ke tempat sampah.",
-      "MoveToTrashBin": "Pindah ke tempat sampah",
+      "MoveToTrash": "Pindah ke sampah",
       "FolderCloneFailed": "Gagal mengkloning folder.",
-      "FolderClonePending": "Kloning folder sedang berlangsung."
+      "FolderClonePending": "Kloning folder sedang berlangsung.",
+      "MoveToTrashDescription": "Yakin ingin memindahkan \"{{ folderName }}\" ke sampah?"
     },
     "explorer": {
       "Delete": "Menghapus...",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -671,10 +671,11 @@
       "DeleteForever": "Elimina per sempre",
       "FolderRestored": "La cartella {{ folderName }} è stata ripristinata.",
       "FolderDeletedForever": "La cartella {{ folderName }} è stata eliminata per sempre.",
-      "MoveToTrashBin": "Sposta nel cestino",
+      "MoveToTrash": "Sposta nel cestino",
       "MovedToTrashBin": "La cartella {{ folderName }} è stata spostata nel cestino.",
       "FolderCloneFailed": "Non è stato possibile clonare la cartella.",
-      "FolderClonePending": "La clonazione della cartella è in corso."
+      "FolderClonePending": "La clonazione della cartella è in corso.",
+      "MoveToTrashDescription": "Sei sicuro di voler spostare \"{{ folderName }}\" nel cestino?"
     },
     "explorer": {
       "Delete": "Elimina...",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -670,10 +670,11 @@
       "DeleteForever": "永久に削除",
       "FolderRestored": "{{ folderName }} フォルダが復元されました。",
       "FolderDeletedForever": "{{ folderName }} フォルダは完全に削除されました。",
-      "MoveToTrashBin": "ゴミ箱に移動",
+      "MoveToTrash": "ゴミ箱に移動",
       "MovedToTrashBin": "{{ folderName }} フォルダーはゴミ箱に移動されました。",
       "FolderCloneFailed": "フォルダのクローンに失敗しました。",
-      "FolderClonePending": "フォルダのクローンを作成中です。"
+      "FolderClonePending": "フォルダのクローンを作成中です。",
+      "MoveToTrashDescription": "\"{{ folderName }}\" をゴミ箱に移動してもよろしいですか?"
     },
     "explorer": {
       "Delete": "削除...",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -791,10 +791,11 @@
       "DeleteForever": "영구 삭제",
       "FolderRestored": "{{ folderName }} 폴더가 복원되었습니다.",
       "FolderDeletedForever": "{{ folderName }} 폴더가 완전히 삭제되었습니다.",
-      "MoveToTrashBin": "휴지통으로 이동",
+      "MoveToTrash": "휴지통으로 이동",
       "MovedToTrashBin": "{{ folderName }} 폴더가 휴지통으로 이동되었습니다.",
       "FolderCloneFailed": "폴더 복제에 실패하였습니다.",
-      "FolderClonePending": "폴더 복제가 진행중입니다."
+      "FolderClonePending": "폴더 복제가 진행중입니다.",
+      "MoveToTrashDescription": "\"{{ folderName }}\"을(를) 휴지통으로 이동하시겠습니까?"
     },
     "explorer": {
       "Delete": "삭제",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -673,9 +673,10 @@
       "FolderRestored": "{{ folderName }} хавтас сэргээгдсэн.",
       "FolderDeletedForever": "{{ folderName }} хавтас бүрмөсөн устгагдсан.",
       "MovedToTrashBin": "{{ folderName }} фолдерыг хогийн сав руу зөөв.",
-      "MoveToTrashBin": "Хогийн сав руу шилжүүлнэ үү",
+      "MoveToTrash": "Хогийн сав руу шилжүүлэх",
       "FolderCloneFailed": "Фолдерыг хуулбарлаж чадсангүй.",
-      "FolderClonePending": "Фолдерыг хуулбарлаж байна."
+      "FolderClonePending": "Фолдерыг хуулбарлаж байна.",
+      "MoveToTrashDescription": "Та \"{{ folderName }}\"-г хогийн сав руу зөөхдөө итгэлтэй байна уу?"
     },
     "explorer": {
       "Delete": "Устгах ...",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -666,14 +666,15 @@
       "ShareFolder": "Kongsi folder",
       "ModifyPermissions": "Ubah suai kebenaran",
       "LeaveFolder": "Tinggalkan folder",
-      "MoveToTrashBin": "Pindah ke tong sampah",
+      "MoveToTrash": "Pindah ke tong sampah",
       "MovedToTrashBin": "Folder {{ folderName }} telah dialihkan ke tong sampah.",
       "DeleteForever": "Padam selama-lamanya",
       "Restore": "Pulihkan",
       "FolderRestored": "Folder {{ folderName }} telah dipulihkan.",
       "FolderDeletedForever": "Folder {{ folderName }} telah dipadamkan selama-lamanya.",
       "FolderCloneFailed": "Gagal mengklon folder.",
-      "FolderClonePending": "Pengklonan folder sedang dijalankan."
+      "FolderClonePending": "Pengklonan folder sedang dijalankan.",
+      "MoveToTrashDescription": "Adakah anda pasti mahu mengalihkan \"{{ folderName }}\" ke sampah?"
     },
     "explorer": {
       "Delete": "Padamkan ...",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -670,10 +670,11 @@
       "DeleteForever": "Usuń na zawsze",
       "FolderRestored": "Folder {{ folderName }} został przywrócony.",
       "FolderDeletedForever": "Folder {{ folderName }} został usunięty na zawsze.",
-      "MoveToTrashBin": "Przenieś do kosza",
+      "MoveToTrash": "Przenieść do kosza",
       "MovedToTrashBin": "Folder {{ folderName }} został przeniesiony do kosza.",
       "FolderCloneFailed": "Nie udało się sklonować folderu.",
-      "FolderClonePending": "Klonowanie folderu jest w toku."
+      "FolderClonePending": "Klonowanie folderu jest w toku.",
+      "MoveToTrashDescription": "Czy na pewno chcesz przenieść folder \"{{ folderName }}\" do kosza?"
     },
     "explorer": {
       "Delete": "Kasować...",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -670,10 +670,11 @@
       "Restore": "Restaurar",
       "FolderRestored": "A pasta {{ folderName }} foi restaurada.",
       "FolderDeletedForever": "A pasta {{ folderName }} foi excluída definitivamente.",
-      "MoveToTrashBin": "Mover para a lixeira",
+      "MoveToTrash": "Mover para lixeira",
       "MovedToTrashBin": "A pasta {{ folderName }} foi movida para a lixeira.",
       "FolderCloneFailed": "Falha ao clonar a pasta.",
-      "FolderClonePending": "A clonagem da pasta está a decorrer."
+      "FolderClonePending": "A clonagem da pasta está a decorrer.",
+      "MoveToTrashDescription": "Tem certeza de que deseja mover \"{{ folderName }}\" para a lixeira?"
     },
     "explorer": {
       "Delete": "Excluir...",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -670,10 +670,11 @@
       "DeleteForever": "Apagar para sempre",
       "FolderRestored": "A pasta {{ folderName }} foi restaurada.",
       "FolderDeletedForever": "A pasta {{ folderName }} foi excluída definitivamente.",
-      "MoveToTrashBin": "Mover para a lixeira",
+      "MoveToTrash": "Mover para lixeira",
       "MovedToTrashBin": "A pasta {{ folderName }} foi movida para a lixeira.",
       "FolderCloneFailed": "Falha ao clonar a pasta.",
-      "FolderClonePending": "A clonagem da pasta está a decorrer."
+      "FolderClonePending": "A clonagem da pasta está a decorrer.",
+      "MoveToTrashDescription": "Tem certeza de que deseja mover \"{{ folderName }}\" para a lixeira?"
     },
     "explorer": {
       "Delete": "Excluir...",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -670,10 +670,11 @@
       "DeleteForever": "Удалить навсегда",
       "FolderRestored": "Папка {{ folderName }} восстановлена.",
       "FolderDeletedForever": "Папка {{ folderName}} удалена навсегда.",
-      "MoveToTrashBin": "Переместить в мусорное ведро",
+      "MoveToTrash": "Переместить в корзину",
       "MovedToTrashBin": "Папка {{ folderName }} была перемещена в корзину.",
       "FolderCloneFailed": "Не удалось клонировать папку.",
-      "FolderClonePending": "Выполняется клонирование папки."
+      "FolderClonePending": "Выполняется клонирование папки.",
+      "MoveToTrashDescription": "Вы уверены, что хотите переместить папку \"{{ folderName }}\" в корзину?"
     },
     "explorer": {
       "Delete": "Удалить...",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -670,10 +670,11 @@
       "DeleteForever": "Tamamen sil",
       "FolderRestored": "{{ klasörAdı }} klasörü geri yüklendi.",
       "FolderDeletedForever": "{{ folderName }} klasörü kalıcı olarak silindi.",
-      "MoveToTrashBin": "Çöp kutusuna taşı",
+      "MoveToTrash": "Çöp kutusuna taşıyın",
       "MovedToTrashBin": "{{ folderName }} klasörü çöp kutusuna taşındı.",
       "FolderCloneFailed": "Klasör klonlanamadı.",
-      "FolderClonePending": "Klasörün klonlanması devam ediyor."
+      "FolderClonePending": "Klasörün klonlanması devam ediyor.",
+      "MoveToTrashDescription": "\"{{ folderName }}\" dosyasını çöp kutusuna taşımak istediğinizden emin misiniz?"
     },
     "explorer": {
       "Delete": "Sil...",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -670,10 +670,11 @@
       "DeleteForever": "Xóa vĩnh viễn",
       "FolderRestored": "Thư mục {{ folderName }} đã được khôi phục.",
       "FolderDeletedForever": "Thư mục {{ folderName }} đã bị xóa vĩnh viễn.",
-      "MoveToTrashBin": "Di chuyển vào thùng rác",
+      "MoveToTrash": "Di chuyển vào thùng rác",
       "MovedToTrashBin": "Thư mục {{ folderName }} đã được chuyển vào thùng rác.",
       "FolderCloneFailed": "Không sao chép được thư mục.",
-      "FolderClonePending": "Đang nhân bản thư mục."
+      "FolderClonePending": "Đang nhân bản thư mục.",
+      "MoveToTrashDescription": "Bạn có chắc chắn muốn chuyển \"{{ folderName }}\" vào thùng rác không?"
     },
     "explorer": {
       "Delete": "Xóa bỏ...",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -670,10 +670,11 @@
       "DeleteForever": "永久删除",
       "FolderRestored": "{{ folderName }} 文件夹已恢复。",
       "FolderDeletedForever": "{{ folderName }} 文件夹已被永久删除。",
-      "MoveToTrashBin": "移至垃圾箱",
+      "MoveToTrash": "移到废纸篓",
       "MovedToTrashBin": "{{ folderName }} 文件夹已移至垃圾箱。",
       "FolderCloneFailed": "克隆文件夹失败。",
-      "FolderClonePending": "正在克隆文件夹。"
+      "FolderClonePending": "正在克隆文件夹。",
+      "MoveToTrashDescription": "您确定要将 \"{{ folderName }}\" 移至回收站吗？"
     },
     "explorer": {
       "Delete": "删除...",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -670,10 +670,11 @@
       "DeleteForever": "永久刪除",
       "FolderRestored": "{{ folderName }} 資料夾已恢復。",
       "FolderDeletedForever": "{{ folderName }} 資料夾已永久刪除。",
-      "MoveToTrashBin": "移至垃圾箱",
+      "MoveToTrash": "移到廢紙簍",
       "MovedToTrashBin": "{{ folderName }} 資料夾已移至垃圾箱。",
       "FolderCloneFailed": "克隆文件夹失败。",
-      "FolderClonePending": "正在克隆文件夹。"
+      "FolderClonePending": "正在克隆文件夹。",
+      "MoveToTrashDescription": "您確定要將 \"{{ folderName }}\" 移至回收站嗎？"
     },
     "explorer": {
       "Delete": "刪除...",

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -884,6 +884,32 @@ export default class BackendAiStorageList extends BackendAIPage {
           </mwc-button>
         </div>
       </backend-ai-dialog>
+      <backend-ai-dialog id="delete-folder-without-confirm-dialog">
+        <span slot="title">${_t('data.folders.MoveToTrash')}</span>
+        <div slot="content">
+          <div>
+            ${_t('data.folders.MoveToTrashDescription', {
+              folderName: this.deleteFolderName || '',
+            })}
+          </div>
+        </div>
+        <div slot="footer" class="horizontal center-justified flex layout">
+          <mwc-button
+            raised
+            fullwidth
+            class="warning fg red"
+            type="submit"
+            icon="delete"
+            id="delete-without-confirm-button"
+            @click="${() => {
+              this._deleteFolder(this.deleteFolderID);
+              this.closeDialog('delete-folder-without-confirm-dialog');
+            }}"
+          >
+            ${_t('data.folders.MoveToTrash')}
+          </mwc-button>
+        </div>
+      </backend-ai-dialog>
 
       <backend-ai-dialog id="delete-folder-dialog" fixed backdrop>
         <span slot="title">${_t('data.folders.DeleteAFolder')}</span>
@@ -2124,7 +2150,7 @@ export default class BackendAiStorageList extends BackendAIPage {
                 ></mwc-icon-button>
                 <vaadin-tooltip
                   for="${rowData.item.id + '-delete'}"
-                  text="${_t('data.folders.MoveToTrashBin')}"
+                  text="${_t('data.folders.MoveToTrash')}"
                   position="top-start"
                 ></vaadin-tooltip>
               `
@@ -3015,7 +3041,8 @@ export default class BackendAiStorageList extends BackendAIPage {
     // let isDelible = await this._checkVfolderMounted(deleteFolderId);
     // if (isDelible) {
     if (this.enableVfolderTrashBin) {
-      this._deleteFolder(this.deleteFolderID);
+      // this._deleteFolder(this.deleteFolderID);
+      this.openDialog('delete-folder-without-confirm-dialog');
     } else {
       this.openDialog('delete-folder-dialog');
     }


### PR DESCRIPTION
### TL;DR

Changed the action label for moving a folder to trash in various languages and added a confirmation dialog for the delete(move to the trash bin) button.

### What changed?

- Updated the label "Move to trash bin" to "Move to trash" in translation files for multiple languages.
- Added a description asking for confirmation before moving a folder to the trash in the UI.

### How to test?

1. Attempt to move a folder to the trash.
2. Confirm the appearance of the confirmation dialog with the updated text.
3. Validate the folder is moved to the trash upon confirming the action.

### Why make this change?

To improve user experience by providing a clear and concise action description and ensuring users confirm their intent before moving a folder to the trash.

### Screenshot

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/5f8869ec-5471-495c-849c-b03004169100.png)

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
