### PR TITLE
fix: missed prefix function usage in resource panel

### DIFF
--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -599,7 +599,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
     const number = typeof num === 'string' ? parseFloat(num) : num;
     return parseFloat(number.toFixed(fixed)).toString();
   }
-  _prefixFormat(num: string | number = '0;', fixed: number) {
+  _prefixFormat(num: string | number = '0', fixed: number) {
     return typeof num === 'string'
       ? parseFloat(num)?.toFixed(fixed)
       : num?.toFixed(fixed);
@@ -753,9 +753,11 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot.cuda_device /
                         this.total_resource_group_slot.cuda_device}"
-                        description="${this.used_resource_group_slot.cuda_device.toFixed(
+                        description="${this._prefixFormat(
+                          this.used_resource_group_slot.cuda_device,
                           2,
-                        )} / ${this.total_resource_group_slot.cuda_device.toFixed(
+                        )} / ${this._prefixFormat(
+                          this.total_resource_group_slot.cuda_device,
                           2,
                         )} CUDA GPUs"
                       ></lablup-progress-bar>


### PR DESCRIPTION
### TL;DR

Fixes an issue with the `_prefixFormat` method default parameter and optimizes CUDA GPU description formatting.

### What changed?

- Fixed default parameter value in `_prefixFormat` method from `'0;'` to `'0'`.
- Optimized the CUDA GPU description formatting using the `_prefixFormat` helper method.

### How to test?

- Verify that the `_prefixFormat` method functions correctly with default and custom parameters.
- Ensure that CUDA GPU descriptions are formatted as expected in the resource monitor component.

### Why make this change?

The change corrects the default parameter value in the `_prefixFormat` method and streamlines the GPU description formatting for consistency and clarity.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
