### PR TITLE
style: change `EndpointLLMChatCard` close button color

### DIFF
--- a/react/src/components/lablupTalkativotUI/EndpointLLMChatCard.tsx
+++ b/react/src/components/lablupTalkativotUI/EndpointLLMChatCard.tsx
@@ -134,7 +134,7 @@ const EndpointLLMChatCard: React.FC<EndpointLLMChatCardProps> = ({
             <Button
               icon={<CloseOutlined />}
               type="text"
-              style={{ color: token.colorBgMask }}
+              style={{ color: token.colorIcon }}
             />
           </Popconfirm>
         ) : undefined


### PR DESCRIPTION
Updated the style of the Button component in EndpointLLMChatCard to use token.colorIcon instead of token.colorBgMask for the icon color, ensuring consistency with design tokens.

### Screenshot

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/7ae74ade-e891-4348-86df-2b073eb19fde.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/ab1799fa-d390-4a2b-95c5-c2d5757bf685.png)

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
