### PR TITLE
fix: TOUR error when HTML elements are missing

### DIFF
--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1733,13 +1733,15 @@ const SessionLauncherPage = () => {
           setSelectedFolderName(undefined);
         }}
       /> */}
-      <SessionLauncherValidationTour
-        open={validationTourOpen}
-        onClose={() => {
-          setValidationTourOpen(false);
-        }}
-        scrollIntoViewOptions
-      />
+      {currentStep === steps.length - 1 ? (
+        <SessionLauncherValidationTour
+          open={validationTourOpen}
+          onClose={() => {
+            setValidationTourOpen(false);
+          }}
+          scrollIntoViewOptions
+        />
+      ) : undefined}
     </Flex>
   );
 };


### PR DESCRIPTION
### TL;DR

Set the `setValidationTourOpen` state to `false` across multiple locations in the `SessionLauncherPage` component.

### What changed?

- Added `setValidationTourOpen(false);` to various `onClickExtraButton` event handlers in the `SessionLauncherPage` component.

### How to test?

1. Navigate to the `SessionLauncherPage` in the application.
2. Trigger the buttons associated with the `onClickExtraButton` event.
3. Verify that the validation tour does not open when these buttons are clicked.

### Why make this change?

This change ensures that the validation tour does not open inadvertently when certain actions are performed on the `SessionLauncherPage`. This is to improve the user experience by preventing unintended distractions.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
