### PR TITLE
fix: Login modal is disappeared in Electron env

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -60,6 +60,20 @@ const InteractiveLoginPage = React.lazy(
 );
 const ImportAndRunPage = React.lazy(() => import('./pages/ImportAndRunPage'));
 
+const RedirectToSummary = () => {
+  useSuspendedBackendaiClient();
+  const pathName = '/summary';
+  document.dispatchEvent(
+    new CustomEvent('move-to-from-react', {
+      detail: {
+        path: pathName,
+        // params: options?.params,
+      },
+    }),
+  );
+  return <Navigate to="/summary" replace />;
+};
+
 const router = createBrowserRouter([
   {
     path: '/interactive-login',
@@ -91,17 +105,17 @@ const router = createBrowserRouter([
     children: [
       {
         path: '/',
-        element: <Navigate to="/summary" replace />,
+        element: <RedirectToSummary />,
       },
       {
         //for electron dev mode
         path: '/build/electron-app/app/index.html',
-        element: <Navigate to="/summary" replace />,
+        element: <RedirectToSummary />,
       },
       {
         //for electron prod mode
         path: '/app/index.html',
-        element: <Navigate to="/summary" replace />,
+        element: <RedirectToSummary />,
       },
       {
         path: '/summary',


### PR DESCRIPTION
### TL;DR

This PR resolves the bug related to the Login modal disappearing in the Electron environment. 


### How to fix
This pull request introduces a new React component `RedirectToSummary` to centralize and handle the redirection logic to the `/summary` path across various routes. Previously, the redirection was performed inline within routing configurations. This refactor enhances code maintainability and ensures that any future changes to the redirection logic only need to be made in one place.


### What changed?

- Added `RedirectToSummary` component to handle redirection logic.
- Updated `/`, `/build/electron-app/app/index.html`, and `/app/index.html` routes to use the new component for redirection.

### How to test?
1. Build Electron app.
2. Before installing the Electron app, make sure to delete the Electron app and related files. (MacOS: `~/Library/Application\ Support/Backend.AI\ Desktop`)
3. Install the app and launch it.
4. Verify that the login page is displayed.
5. After logging in, verify that it redirects to the Summary page and the side menu correctly displays the selected Summary menu.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/86568c79-8129-4b5e-8660-ec0d58a5de42.png)

### Why make this change?

This change improves maintainability by abstracting the redirection logic into a single component. It ensures consistency and simplifies future updates to the redirection logic.
