### PR TITLE
fix: batch session schedule date picker in the Classic session launcher

### DIFF
--- a/react/src/components/BatchSessionScheduledTimeSetting.tsx
+++ b/react/src/components/BatchSessionScheduledTimeSetting.tsx
@@ -4,8 +4,9 @@ import { useWebComponentInfo } from './DefaultProviders';
 import Flex from './Flex';
 import { useToggle } from 'ahooks';
 import { Typography, Checkbox, theme } from 'antd';
+import { GetRef } from 'antd/lib';
 import dayjs from 'dayjs';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface Props extends DatePickerISOProps {}
@@ -24,6 +25,8 @@ const BatchSessionScheduledTimeSetting: React.FC<Props> = ({
     dispatchEvent('change', value);
   };
 
+  const datePickerRef = useRef<GetRef<typeof DatePickerISO>>(null);
+
   return (
     <>
       <Typography.Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
@@ -32,7 +35,7 @@ const BatchSessionScheduledTimeSetting: React.FC<Props> = ({
       <Flex align="start" gap="sm">
         <Checkbox
           checked={isChecked}
-          onClick={(v) => {
+          onChange={(v) => {
             toggleChecked();
             const newScheduleTime = v
               ? dayjs().add(2, 'minutes').toISOString()
@@ -44,10 +47,11 @@ const BatchSessionScheduledTimeSetting: React.FC<Props> = ({
         </Checkbox>
         <Flex direction="column" align="end">
           <DatePickerISO
+            ref={datePickerRef}
             {...datePickerISOProps}
             popupStyle={{ position: 'fixed' }}
             disabledDate={(date) => {
-              return date.isBefore(dayjs().startOf('minute'));
+              return date.isBefore(dayjs().startOf('day'));
             }}
             disabled={!isChecked}
             showTime={{
@@ -57,8 +61,11 @@ const BatchSessionScheduledTimeSetting: React.FC<Props> = ({
             onChange={(value) => {
               dispatchAndSetScheduleTime(value);
             }}
-            onBlur={() => {
-              dispatchAndSetScheduleTime(scheduleTime);
+            onCalendarChange={() => {
+              datePickerRef.current?.focus();
+            }}
+            onPanelChange={() => {
+              datePickerRef.current?.focus();
             }}
             status={
               isChecked && !scheduleTime
@@ -67,6 +74,8 @@ const BatchSessionScheduledTimeSetting: React.FC<Props> = ({
                   ? 'error'
                   : undefined
             }
+            needConfirm={false}
+            showNow={false}
           />
           {isChecked && scheduleTime && (
             <Typography.Text

--- a/react/src/components/DatePickerISO.tsx
+++ b/react/src/components/DatePickerISO.tsx
@@ -1,6 +1,7 @@
 import { useControllableValue } from 'ahooks';
 import { DatePicker } from 'antd';
 import { PickerProps } from 'antd/es/date-picker/generatePicker';
+import { GetRef } from 'antd/lib';
 import dayjs, { Dayjs } from 'dayjs';
 import _ from 'lodash';
 import React from 'react';
@@ -11,12 +12,10 @@ export interface DatePickerISOProps
   onChange?: (value: string | undefined) => void;
   localFormat?: boolean;
 }
-const DatePickerISO: React.FC<DatePickerISOProps> = ({
-  value,
-  onChange,
-  localFormat,
-  ...pickerProps
-}) => {
+const DatePickerISO = React.forwardRef<
+  GetRef<typeof DatePicker>,
+  DatePickerISOProps
+>(({ value, onChange, localFormat, ...pickerProps }, ref) => {
   const [, setControllableValue] = useControllableValue({
     value,
     onChange,
@@ -24,6 +23,7 @@ const DatePickerISO: React.FC<DatePickerISOProps> = ({
 
   return (
     <DatePicker
+      ref={ref}
       value={value ? dayjs(value) : undefined}
       onChange={(value) => {
         if (_.isArray(value)) {
@@ -38,6 +38,6 @@ const DatePickerISO: React.FC<DatePickerISOProps> = ({
       {...pickerProps}
     />
   );
-};
+});
 
 export default DatePickerISO;


### PR DESCRIPTION
This PR resolves two bugs related to `BatchSessionScheduledTimeSetting` in the Classic Session Launcher.

1. Unexpected closing: When a user clicks the calendar twice, the picker popup is closed unexpectedly.
  - Solution: A new `useRef` hook was introduced to handle the focus on the `DatePickerISO` component. The `DatePickerISO` component itself was modified to accept a forwarded ref, allowing the `datePickerRef` to focus on the date picker when the calendar changes. This should resolve issues related to automatic focus handling and date selection.

2. This pull request addresses an issue in the `BatchSessionScheduledTimeSetting` component where the checkbox change was handled incorrectly. The `onClick` event was replaced with `onChange` for the `Checkbox` component, ensuring the state changes properly.

Additionally, this PR removes the Now and confirm buttons of the DatePicker.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/8993ec7d-1e56-4844-ba46-044e61840ce5.png)

