### PR TITLE
feat: add `enableLLMPlayground` config

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -30,7 +30,8 @@ isDirectorySizeVisible = true           # If false, directory size in folder exp
 maxCountForPreopenPorts = 10            # The maximum allowed number of preopen ports. If you set this option to 0, the feature of preopen ports is disabled.
 allowCustomResourceAllocation = true    # If true, display the custom allocation on the session launcher.
 eduAppNamePrefix = ""                   # The prefix of edu applauncher's app name. If the app name starts with this prefix, split it by '-' and use the tail as the name of image.
-enableModelStore = false		        # Enable model store feature. (From Backend.AI 24.03)
+enableModelStore = false    		        # Enable model store feature. (From Backend.AI 24.03)
+enableLLMPlayground = false             # Enable LLM Playground feature. (From Backend.AI 24.03)
 
 [wsproxy]
 proxyURL = "[Proxy URL]"

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -220,7 +220,7 @@ export const useBackendAIImageMetaData = () => {
       getImageLang: (imageName: string) => {
         const names = imageName.split('/');
         const langs =
-          names.length < 3 ? '' : names[2].split(':')[0]?.split('-') ?? '';
+          names.length < 3 ? '' : (names[2].split(':')[0]?.split('-') ?? '');
         return langs[langs.length - 1];
       },
       getImageTags: (imageName: string) => {
@@ -311,6 +311,7 @@ type BackendAIConfig = {
   singleSignOnVendors: string[];
   ssoRealmName: string;
   enableModelStore: boolean;
+  enableLLMPlayground: boolean;
   enableContainerCommit: boolean;
   appDownloadUrl: string;
   systemSSHImage: string;

--- a/react/src/pages/ServingPage.tsx
+++ b/react/src/pages/ServingPage.tsx
@@ -1,5 +1,6 @@
 import Flex from '../components/Flex';
 import { filterEmptyItem } from '../helper';
+import { useSuspendedBackendaiClient } from '../hooks';
 import { Card, Skeleton, theme } from 'antd';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -23,6 +24,7 @@ const ServingPage: React.FC<ServingPageProps> = ({ ...props }) => {
   const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam, {
     updateType: 'replace',
   });
+  const baiClient = useSuspendedBackendaiClient();
 
   const tabList = filterEmptyItem([
     { key: 'services', label: t('modelService.Services') },
@@ -39,7 +41,10 @@ const ServingPage: React.FC<ServingPageProps> = ({ ...props }) => {
     //   key: "others",
     //   label: t("session.Others"),
     // },
-    { key: 'chatting', label: 'LLM Playground' },
+    baiClient._config.enableLLMPlayground && {
+      key: 'chatting',
+      label: 'LLM Playground',
+    },
   ]);
   return (
     <Flex direction="column" align="stretch" gap={'md'}>
@@ -64,7 +69,7 @@ const ServingPage: React.FC<ServingPageProps> = ({ ...props }) => {
             <EndpointListPage />
           </Suspense>
         ) : null}
-        {curTabKey === 'chatting' ? (
+        {curTabKey === 'chatting' && baiClient._config.enableLLMPlayground ? (
           <Suspense
             fallback={<Skeleton active style={{ padding: token.paddingMD }} />}
           >

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -139,6 +139,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: Boolean }) allowCustomResourceAllocation = true;
   @property({ type: Boolean }) isDirectorySizeVisible = true;
   @property({ type: Boolean }) enableModelStore = false;
+  @property({ type: Boolean }) enableLLMPlayground = false;
   @property({ type: String }) eduAppNamePrefix;
   @property({ type: String }) pluginPages;
   @property({ type: Array }) blockList = [] as string[];
@@ -846,6 +847,13 @@ export default class BackendAILogin extends BackendAIPage {
       valueType: 'boolean',
       defaultValue: false,
       value: generalConfig?.enableModelStore,
+    } as ConfigValueObject) as boolean;
+
+    // Enable LLM Playground support
+    this.enableLLMPlayground = this._getConfigValueByExists(generalConfig, {
+      valueType: 'boolean',
+      defaultValue: false,
+      value: generalConfig?.enableLLMPlayground,
     } as ConfigValueObject) as boolean;
   }
 
@@ -1839,6 +1847,8 @@ export default class BackendAILogin extends BackendAIPage {
           this.isDirectorySizeVisible;
         globalThis.backendaiclient._config.enableModelStore =
           this.enableModelStore;
+        globalThis.backendaiclient._config.enableLLMPlayground =
+          this.enableLLMPlayground;
         globalThis.backendaiclient._config.pluginPages = this.pluginPages;
         globalThis.backendaiclient._config.blockList = this.blockList;
         globalThis.backendaiclient._config.inactiveList = this.inactiveList;


### PR DESCRIPTION
Add `enableLLMPlayground` config to show/hide LLM Playground tab in the model serving page.

### How to test
1. Go to model serving page
2. Toggle `enableLLMPlayground` option from `config.toml`.
3. If `enableLLMPlayground` is true, LLM playground tab will appear. 

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version: 24.03
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
