### PR TITLE
style: update `BAIPropertyFilter` label and fix overlapped clear icon

### DIFF
--- a/react/src/components/BAIPropertyFilter.tsx
+++ b/react/src/components/BAIPropertyFilter.tsx
@@ -223,9 +223,8 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
             },
           )}
           placeholder={t('propertyFilter.placeHolder')}
-          allowClear
         >
-          <Input.Search onSearch={onSearch} />
+          <Input.Search onSearch={onSearch} allowClear />
         </AutoComplete>
       </Space.Compact>
       {list.length > 0 && (

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1653,7 +1653,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Αναζήτηση",
-    "ResetFilter": "Επαναφορά φίλτρου"
+    "ResetFilter": "Επαναφορά φίλτρων"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Συνδεθείτε με το λογαριασμό σας Backend.AI",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1655,7 +1655,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Search",
-    "ResetFilter": "ResetFilter"
+    "ResetFilter": "Reset filters"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Login with your Backend.AI account",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1655,7 +1655,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Buscar en",
-    "ResetFilter": "Restablecer filtro"
+    "ResetFilter": "Restablecer filtros"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Inicia sesión con tu cuenta de Backend.AI",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1652,7 +1652,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Etsi",
-    "ResetFilter": "ResetFilter"
+    "ResetFilter": "Nollaa suodattimet"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Kirjaudu sisään Backend.AI-tililläsi",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1653,7 +1653,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Recherche",
-    "ResetFilter": "Réinitialiser le filtre"
+    "ResetFilter": "Réinitialiser les filtres"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Connectez-vous avec votre compte Backend.AI",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1653,7 +1653,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Pencarian",
-    "ResetFilter": "Filter Ulang"
+    "ResetFilter": "Setel ulang filter"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Login dengan akun Backend.AI Anda",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1653,7 +1653,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Ricerca",
-    "ResetFilter": "Reimposta filtro"
+    "ResetFilter": "Reimposta i filtri"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Accedere con il proprio account Backend.AI",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1653,7 +1653,7 @@
   },
   "propertyFilter": {
     "placeHolder": "検索",
-    "ResetFilter": "リセットフィルター"
+    "ResetFilter": "フィルターをリセットする"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Backend.AIのアカウントでログイン",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1654,7 +1654,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Хайх",
-    "ResetFilter": "Reset Filter"
+    "ResetFilter": "Шүүлтүүрийг дахин тохируулах"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Backend.AI бүртгэлээрээ нэвтэрнэ үү",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1653,7 +1653,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Cari",
-    "ResetFilter": "ResetFilter"
+    "ResetFilter": "Tetapkan semula penapis"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Log masuk dengan akaun Backend.AI anda",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1653,7 +1653,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Wyszukiwanie",
-    "ResetFilter": "Zresetuj filtr"
+    "ResetFilter": "Zresetuj filtry"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Zaloguj się za pomocą konta Backend.AI",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1653,7 +1653,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Pesquisar",
-    "ResetFilter": "RedefinirFiltro"
+    "ResetFilter": "Redefinir filtros"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Inicie sessão com a sua conta Backend.AI",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1653,7 +1653,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Pesquisar",
-    "ResetFilter": "RedefinirFiltro"
+    "ResetFilter": "Redefinir filtros"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Inicie sessão com a sua conta Backend.AI",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1653,7 +1653,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Поиск",
-    "ResetFilter": "СброситьФильтр"
+    "ResetFilter": "Сбросить фильтры"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Войдите в систему под своей учетной записью Backend.AI",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1653,7 +1653,7 @@
   },
   "propertyFilter": {
     "placeHolder": "Arama",
-    "ResetFilter": "Filtreyi Sıfırla"
+    "ResetFilter": "Filtreleri sıfırla"
   },
   "interactiveLogin": {
     "InteractiveLoginWithBackendAI": "Backend.AI hesabınızla giriş yapın",


### PR DESCRIPTION
follows #2603 
- Fix overlapped clear icon.
- According to the writing rules, change Reset Filter -> Reset filters.

Before
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/7076710e-a405-4888-a487-c1d1857ad6df.png)

After
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/5dca04c6-b3a7-4613-8090-a9329d78f70b.png)
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/da070dcb-bd11-4af3-bdab-93b6ffc852f8.png)

### How to check
- Go to the searchable page such as Agent.

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
