### PR TITLE
fix: overlapping vscode desktop passwords.

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -2004,7 +2004,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
             <span>${_t('session.VSCodeRemotePasswordTitle')}:</span>
             <backend-ai-react-copyable-code-text
               value="${this.vscodeDesktopPassword}"
-              style="width:max-content;margin-bottom:10px;"
+              style="max-width:420px;margin-bottom:10px;"
             ></backend-ai-react-copyable-code-text>
             <div class="horizontal wrap layout vscode-connection-example">
               <span>${_t('session.VSCodeRemoteNoticeSSHConfig')}</span>


### PR DESCRIPTION
Resolves [Teams threads](https://teams.microsoft.com/l/message/19:56185f8ff32e4393bff26c11ce37a5d1@thread.tacv2/1723192390168?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=b1f3bcf4-facf-40d3-94ab-169abb4f0f52&parentMessageId=1723182202872&teamName=customers%20%26%20clients&channelName=NHNCloud-AICA&createdTime=1723192390168).

The maximum width is the same as the `vscode-connection-example` div container (just below the SSH password).

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/52220012-e460-431a-a2cb-ceeb9ef3c17a.png)

After:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/4bb37580-bc03-4927-a1ec-e1ead1029490.png)

### How to test
1. Run backend.ai application
2. Create a new session
3. Launch the vscode desktop app.

### Checklist
Check if the SSH password does not overlap.

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
