### PR TITLE
fix: vaadin table in `backend-ai-folder-explorer` does not output some content when there is scrolling

### DIFF
--- a/react/src/components/LegacyFolderExplorer.tsx
+++ b/react/src/components/LegacyFolderExplorer.tsx
@@ -187,7 +187,6 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
         ref={folderExplorerRef}
         active
         vfolderID={vfolderID}
-        style={{ width: '100%' }}
       />
     </BAIModal>
   );

--- a/src/components/backend-ai-folder-explorer.ts
+++ b/src/components/backend-ai-folder-explorer.ts
@@ -1792,8 +1792,7 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
             .renderer="${this._boundSizeRenderer}"
           ></vaadin-grid-sort-column>
           <vaadin-grid-column
-            resizable
-            auto-width
+            width="130px"
             header="${_t('data.explorer.Actions')}"
             .renderer="${this._boundControlFileListRenderer}"
           ></vaadin-grid-column>


### PR DESCRIPTION
### TL;DR

Remove the inline style for the LegacyFolderExplorer component and introduce `vaadin-grid` elements to the BackendAIFolderExplorer component with fixed width for the action columns.

### What changed?

Fixed the width of the last column of the vaadin table used in `backend-ai-folder-explorer` to output the full width of the content even when scrolling occurs.

### How to test?
1. Move to `Data & Storage` Page
2. Open folder explorer by clicking folder icon 
3. Resize the screen so that `folder explorer` scrolls.
4. Verify that all the contents of `folder explorer` are printed correctly.

### Why make this change?

There is currently an issue where scrolling in a vaadin table inside the `backend-ai-folder-explorer` used as a modal on the `Data & Storage` page, or any other page that uses storage, does not output the full width of the content.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
