### PR TITLE
fix: eunsure valid acceleartorType in Session Launcher

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -210,6 +210,23 @@ const ResourceAllocationFormItems: React.FC<
     currentImageAcceleratorLimits,
   ]);
 
+  const ensureValidAcceleratorType = useEventNotStable(() => {
+    const currentAcceleratorType = form.getFieldValue(
+      form.getFieldValue(['resource', 'acceleratorType']),
+    );
+    // If the current accelerator type is not available,
+    // change accelerator type to the first supported accelerator
+    const nextAcceleratorType: string = acceleratorSlots[currentAcceleratorType]
+      ? currentAcceleratorType
+      : _.keys(acceleratorSlots)[0];
+
+    form.setFieldsValue({
+      resource: {
+        acceleratorType: nextAcceleratorType || currentAcceleratorType,
+      },
+    });
+  });
+
   const updateAllocationPresetBasedOnResourceGroup = useEventNotStable(() => {
     if (
       _.includes(
@@ -217,6 +234,7 @@ const ResourceAllocationFormItems: React.FC<
         form.getFieldValue('allocationPreset'),
       )
     ) {
+      ensureValidAcceleratorType();
     } else {
       if (
         allocatablePresetNames.includes(form.getFieldValue('allocationPreset'))
@@ -229,6 +247,8 @@ const ResourceAllocationFormItems: React.FC<
         });
         updateResourceFieldsBasedOnPreset(autoSelectedPreset);
       } else {
+        // if the current preset is not available in the current resource group, set to custom
+        ensureValidAcceleratorType();
         form.setFieldsValue({
           allocationPreset: 'custom',
         });


### PR DESCRIPTION
### TL;DR
Add a validation step for the accelerator type in the ResourceAllocationFormItems to ensure the type is set to a supported value.

reported from [Teams](https://teams.microsoft.com/l/message/19:3c0acc0825024daeb2211f55c4e7f4aa@thread.skype/1723432646506?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=74ae2c4d-ec4d-4fdf-b2c2-f5041d1e8631&parentMessageId=1723432646506&teamName=devops&channelName=Backend.AI%20Talks&createdTime=1723432646506)

### What changed?
Introduced the `ensureValidAcceleratorType` function to validate and set a supported accelerator type in the form values if the current type is unsupported. Updated `updateAllocationPresetBasedOnResourceGroup` to call this validation function when necessary.

### How to test?
1. Open the Resource Allocation Form.
2. Select `Custom allocation` on Resource Presets
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/0b3dd223-7f11-4b94-b3bc-0f87622b35e1.png)
3. Change the resource group which has a different accelerator type.
4. Check if the form automatically updates to the first supported accelerator type.

### Why make this change?
This change ensures that the form always has a valid and supported accelerator type, enhancing form reliability and user experience.
