### PR TITLE
fix: Wrong device name for Rebellions ATOM+

### DIFF
--- a/react/src/components/ResourceNumber.tsx
+++ b/react/src/components/ResourceNumber.tsx
@@ -129,7 +129,7 @@ export const ResourceTypeIcon: React.FC<AccTypeIconProps> = ({
     'tpu.device': [<MWCIconWrap size={size}>view_module</MWCIconWrap>, 'TPU'],
     'ipu.device': [<MWCIconWrap size={size}>view_module</MWCIconWrap>, 'IPU'],
     'atom.device': ['/resources/icons/rebel.svg', 'ATOM'],
-    'atom-plus.device': ['/resources/icons/rebel.svg', 'ATOM'],
+    'atom-plus.device': ['/resources/icons/rebel.svg', 'ATOM+'],
     'warboy.device': ['/resources/icons/furiosa.svg', 'Warboy'],
     'hyperaccel-lpu.device': [
       '/resources/icons/npu_generic.svg',


### PR DESCRIPTION
This pull request is a follow-up of #2504.

## Changes
- Update device name for Rebellions ATOM PLUS device from `ATOM` to `ATOM+`.

**Checklist:** (if applicable)

- [x] Mention to the original issue
