### PR TITLE
fix: cannot search agents in session list

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1118,11 +1118,13 @@ export default class BackendAISessionList extends BackendAIPage {
               if (this.is_superadmin) {
                 sessions[objectKey].agents_ids_with_container_ids = sessions[
                   objectKey
-                ].containers?.map((c) => {
-                  const agentID = c.agent;
-                  const containerID = c.container_id?.slice(0, 4);
-                  return `${agentID}(${containerID})`;
-                });
+                ].containers
+                  ?.map((c) => {
+                    const agentID = c.agent;
+                    const containerID = c.container_id?.slice(0, 4);
+                    return `${agentID}(${containerID})`;
+                  })
+                  ?.join('\n');
               }
             }
 
@@ -4055,7 +4057,7 @@ ${rowData.item[this.sessionNameField]}</pre
     render(
       // language=HTML
       html`
-        <pre>${rowData.item.agents_ids_with_container_ids?.join('\n')}</pre>
+        <pre>${rowData.item.agents_ids_with_container_ids}</pre>
       `,
       root,
     );
@@ -4457,6 +4459,7 @@ ${rowData.item[this.sessionNameField]}</pre
                   !globalThis.backendaiclient._config.hideAgents
                     ? html`
                         <lablup-grid-sort-filter-column
+                          path="agents_ids_with_container_ids"
                           width="140px"
                           flex-grow="0"
                           resizable


### PR DESCRIPTION
resolves [Teams threads](https://teams.microsoft.com/l/message/19:56185f8ff32e4393bff26c11ce37a5d1@thread.tacv2/1723792481934?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=b1f3bcf4-facf-40d3-94ab-169abb4f0f52&parentMessageId=1723784330896&teamName=customers%20%26%20clients&channelName=NHNCloud-AICA&createdTime=1723792481934)

### TL;DR

Make it possible to search agent and container id in session list page.

### What changed?

- Modified the `agents_ids_with_container_ids` property to join the array elements with newline characters.
- Updated the rendering of `agents_ids_with_container_ids` in the grid to display the pre-formatted string.
- Added a `path` attribute to the `lablup-grid-sort-filter-column` for agent and container IDs.

### How to test?

1. Log in as a superadmin user.
2. Navigate to the session list.
3. Verify that the agent and container IDs are displayed correctly, with each entry on a new line.
4. Check if sorting and filtering work properly for the agent and container ID column.

### Why make this change?

This change improves the readability and usability of the session list for superadmin users. By displaying agent and container IDs on separate lines and enabling sorting and filtering for this column, it becomes easier for administrators to manage and analyze session information.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
