### PR TITLE
fix: incorrect agent utilization stats

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -281,7 +281,7 @@ const AgentList: React.FC<AgentListProps> = ({
                       <ResourceTypeIcon key={key} type={key} />
                       <Typography.Text>
                         {toFixedFloorWithoutTrailingZeros(
-                          parsedOccupiedSlots[key],
+                          parsedOccupiedSlots[key] || 0,
                           0,
                         )}
                         /
@@ -299,11 +299,13 @@ const AgentList: React.FC<AgentListProps> = ({
                     </Flex>
                     <BAIProgressWithLabel
                       percent={
-                        (parsedOccupiedSlots[key] / parsedAvailableSlots[key]) *
+                        ((parsedOccupiedSlots[key] || 0) /
+                          parsedAvailableSlots[key]) *
                         100
                       }
                       strokeColor={
-                        (parsedOccupiedSlots[key] / parsedAvailableSlots[key]) *
+                        ((parsedOccupiedSlots[key] || 0) /
+                          parsedAvailableSlots[key]) *
                           100 >
                         80
                           ? token.colorError
@@ -313,7 +315,7 @@ const AgentList: React.FC<AgentListProps> = ({
                       valueLabel={
                         toFixedFloorWithoutTrailingZeros(
                           _.toFinite(
-                            (parsedOccupiedSlots[key] /
+                            ((parsedOccupiedSlots[key] || 0) /
                               parsedAvailableSlots[key]) *
                               100,
                           ),
@@ -330,10 +332,10 @@ const AgentList: React.FC<AgentListProps> = ({
                       <ResourceTypeIcon key={key} type={key} />
                       <Typography.Text>
                         {iSizeToSize(parsedOccupiedSlots[key], 'g', 0)
-                          ?.numberFixed ?? 2}
+                          ?.numberFixed ?? 0}
                         /
                         {iSizeToSize(parsedAvailableSlots[key], 'g', 0)
-                          ?.numberFixed ?? 2}
+                          ?.numberFixed ?? 0}
                       </Typography.Text>
                       <Typography.Text
                         type="secondary"
@@ -344,11 +346,13 @@ const AgentList: React.FC<AgentListProps> = ({
                     </Flex>
                     <BAIProgressWithLabel
                       percent={
-                        (parsedOccupiedSlots[key] / parsedAvailableSlots[key]) *
+                        ((parsedOccupiedSlots[key] || 0) /
+                          parsedAvailableSlots[key]) *
                         100
                       }
                       strokeColor={
-                        (parsedOccupiedSlots[key] / parsedAvailableSlots[key]) *
+                        ((parsedOccupiedSlots[key] || 0) /
+                          parsedAvailableSlots[key]) *
                           100 >
                         80
                           ? token.colorError
@@ -358,7 +362,7 @@ const AgentList: React.FC<AgentListProps> = ({
                       valueLabel={
                         toFixedFloorWithoutTrailingZeros(
                           _.toFinite(
-                            (parsedOccupiedSlots[key] /
+                            ((parsedOccupiedSlots[key] || 0) /
                               parsedAvailableSlots[key]) *
                               100,
                           ),
@@ -452,10 +456,9 @@ const AgentList: React.FC<AgentListProps> = ({
               parsedValue.node.cpu_util.current,
             );
             liveStat.cpu_util.ratio =
-              (liveStat.cpu_util.current /
+              liveStat.cpu_util.current /
                 liveStat.cpu_util.capacity /
-                numCores) *
-                100 || 0;
+                numCores || 0;
             liveStat.mem_util.capacity = _.toInteger(
               available_slots.mem || parsedValue.node.mem.capacity,
             );
@@ -463,8 +466,7 @@ const AgentList: React.FC<AgentListProps> = ({
               parsedValue.node.mem.current,
             );
             liveStat.mem_util.ratio =
-              (liveStat.mem_util.current / liveStat.mem_util.capacity) * 100 ||
-              0;
+              liveStat.mem_util.current / liveStat.mem_util.capacity || 0;
           }
           _.forEach(_.keys(parsedValue?.node), (statKey) => {
             if (
@@ -497,11 +499,11 @@ const AgentList: React.FC<AgentListProps> = ({
                   {resourceSlotsDetails?.cpu?.human_readable_name}
                 </Typography.Text>
                 <BAIProgressWithLabel
-                  percent={liveStat.cpu_util.ratio}
+                  percent={liveStat.cpu_util.ratio * 100}
                   width={120}
                   valueLabel={
                     toFixedFloorWithoutTrailingZeros(
-                      _.toFinite(liveStat.cpu_util.ratio),
+                      _.toFinite(liveStat.cpu_util.ratio * 100),
                       1,
                     ) + ' %'
                   }
@@ -546,12 +548,16 @@ const AgentList: React.FC<AgentListProps> = ({
                       <BAIProgressWithLabel
                         width={120}
                         percent={
-                          liveStat[statKey as keyof typeof liveStat].ratio
+                          (liveStat[statKey as keyof typeof liveStat].current /
+                            liveStat[statKey as keyof typeof liveStat]
+                              .capacity) *
+                            100 || 0
                         }
                         valueLabel={
                           _.toFinite(
                             toFixedFloorWithoutTrailingZeros(
-                              liveStat[statKey as keyof typeof liveStat].ratio,
+                              liveStat[statKey as keyof typeof liveStat].ratio *
+                                100,
                               1,
                             ),
                           ) + ' %'
@@ -578,7 +584,10 @@ const AgentList: React.FC<AgentListProps> = ({
                       <BAIProgressWithLabel
                         width={120}
                         percent={
-                          liveStat[statKey as keyof typeof liveStat].ratio
+                          (liveStat[statKey as keyof typeof liveStat].current /
+                            liveStat[statKey as keyof typeof liveStat]
+                              .capacity) *
+                            100 || 0
                         }
                         valueLabel={
                           iSizeToSize(
@@ -616,8 +625,8 @@ const AgentList: React.FC<AgentListProps> = ({
       render: (value, record) => {
         const parsedDisk =
           JSON.parse(record?.live_stat || '{}')?.node?.disk ?? {};
-        const pctValue = parseFloat(parsedDisk.pct) || 0;
-        const pct = parseFloat(toFixedFloorWithoutTrailingZeros(pctValue, 2));
+        const pctValue = _.toFinite(parsedDisk.pct) || 0;
+        const pct = _.toFinite(toFixedFloorWithoutTrailingZeros(pctValue, 2));
         const color = pct > 80 ? token.colorError : token.colorSuccess;
         return (
           <Flex direction="column">

--- a/react/src/components/BAIProgressWithLabel.tsx
+++ b/react/src/components/BAIProgressWithLabel.tsx
@@ -46,7 +46,7 @@ const BAIProgressWithLabel: React.FC<BAIProgressWithLabelProps> = ({
       <Flex
         style={{
           height: '100%',
-          width: `${percent}%`,
+          width: `${percent > 100 ? 100 : percent}%`,
           position: 'absolute',
           left: 0,
           top: 0,


### PR DESCRIPTION
resolves [Teams threads](https://teams.microsoft.com/l/message/19:56185f8ff32e4393bff26c11ce37a5d1@thread.tacv2/1723792019070?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=b1f3bcf4-facf-40d3-94ab-169abb4f0f52&parentMessageId=1723784330896&teamName=customers%20%26%20clients&channelName=NHNCloud-AICA&createdTime=1723792019070)

reference
- https://github.com/lablup/backend.ai-control-panel/blob/main/frontend/src/pages/hub-resource-agents.js#L1038
- https://github.com/lablup/backend.ai-control-panel/blob/main/frontend/src/hub-utils.js#L541

### TL;DR

Fix incorrect resource utilization calculation in AgentList component.

### What changed?

- Modified CPU and memory utilization ratio calculations to remove unnecessary multiplication by 100.
- Updated BAIProgressWithLabel component to handle percentages exceeding 100%.
- Adjusted resource utilization display logic for custom resource types.
- Refined disk usage percentage parsing and formatting.

### How to test?

1. Navigate to the AgentList view.
2. Verify that CPU and memory utilization percentages are displayed correctly.
3. Check that custom resource utilization is accurately represented.
4. Ensure disk usage percentages are properly formatted and color-coded.
5. Test with various resource utilization scenarios, including cases where utilization exceeds 100%.

### Why make this change?

This change improves the accuracy and consistency of resource utilization calculations and display. It ensures that percentages are correctly calculated and presented, preventing potential misrepresentation of resource usage. The updates also enhance the handling of edge cases, such as utilization exceeding 100%, providing a more robust and reliable user interface for monitoring agent resources.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
