### PR TITLE
fix: "Cannot update an unmounted root" error of `react-to-webcomponent`

### DIFF
--- a/react/src/helper/react-to-webcomponent.tsx
+++ b/react/src/helper/react-to-webcomponent.tsx
@@ -71,15 +71,20 @@ export default function reactToWebComponent(
     }
 
     attributeChangedCallback(name: any, oldValue: any, newValue: any) {
-      //re-render react component when attribute changes
-      if (name === 'value') {
-        this.reactRoot.render(
-          this.createReactElement(newValue, this.getAttribute('styles') || ''),
-        );
-      } else if (name === 'styles') {
-        this.reactRoot.render(
-          this.createReactElement(this.getAttribute('value') || '', newValue),
-        );
+      if (this.isConnected) {
+        //re-render react component when attribute changes
+        if (name === 'value') {
+          this.reactRoot.render(
+            this.createReactElement(
+              newValue,
+              this.getAttribute('styles') || '',
+            ),
+          );
+        } else if (name === 'styles') {
+          this.reactRoot.render(
+            this.createReactElement(this.getAttribute('value') || '', newValue),
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
### TL;DR

The "Cannot update an unmounted root." in development environment. 

How to reproduce?
- Visit the "Import & Run" page.
- Before the resource static panel is loaded, navigate to the "Serving" page.
- Please wait few seconds.
- You will see the following error:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/dee31b76-b3b6-402f-b538-b7fb7198ff63.png)

Added a check for element connection before re-rendering in attributeChangedCallback.

### What changed?

The `attributeChangedCallback` method in the web component class now checks if the element is connected to the DOM (`this.isConnected`) before re-rendering the React component. This prevents unnecessary re-renders when the element is not actually in the document.

### How to test?

- Follow "How to reproduce" again,
- Please make sure there is no dev error.

### Why make this change?

This change improves performance by avoiding unnecessary re-renders when the web component is not actually in the DOM. It ensures that React updates are only triggered when the component is visible and active in the document, potentially reducing resource usage and improving overall application efficiency.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
