### PR TITLE
fix: unnecessary POST request in SSH keypair generation modal

### DIFF
--- a/react/src/components/SSHKeypairGenerationModal.tsx
+++ b/react/src/components/SSHKeypairGenerationModal.tsx
@@ -1,5 +1,5 @@
 import { useSuspendedBackendaiClient } from '../hooks';
-import { useTanQuery, useTanMutation } from '../hooks/reactQueryAlias';
+import { useTanQuery } from '../hooks/reactQueryAlias';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
 import { LoadingOutlined } from '@ant-design/icons';
@@ -9,13 +9,11 @@ import { useTranslation } from 'react-i18next';
 
 interface SSHKeypairGenerationModalProps extends BAIModalProps {
   onRequestClose: () => void;
-  onRequestRefresh: () => void;
   isRefreshModalPending?: boolean;
 }
 
 const SSHKeypairGenerationModal: React.FC<SSHKeypairGenerationModalProps> = ({
   onRequestClose,
-  onRequestRefresh,
   isRefreshModalPending,
   ...baiModalProps
 }) => {
@@ -33,24 +31,6 @@ const SSHKeypairGenerationModal: React.FC<SSHKeypairGenerationModalProps> = ({
     },
   });
 
-  const mutationToPostSSHKeypair = useTanMutation({
-    mutationFn: () => {
-      return baiClient.postSSHKeypair({
-        pubkey: data?.ssh_public_key,
-        privkey: data?.ssh_private_key,
-      });
-    },
-  });
-
-  const _onConfirm = () => {
-    mutationToPostSSHKeypair.mutate(undefined, {
-      onSuccess: () => {
-        onRequestRefresh();
-      },
-    });
-    onRequestClose();
-  };
-
   return (
     <BAIModal
       title={t('usersettings.SSHKeypairGeneration')}
@@ -60,7 +40,7 @@ const SSHKeypairGenerationModal: React.FC<SSHKeypairGenerationModalProps> = ({
           key="close"
           title={t('button.Confirm')}
           description={t('usersettings.ClearSSHKeypairInput')}
-          onConfirm={_onConfirm}
+          onConfirm={onRequestClose}
         >
           <Button>{t('button.Close')}</Button>
         </Popconfirm>,

--- a/react/src/components/SSHKeypairManagementModal.tsx
+++ b/react/src/components/SSHKeypairManagementModal.tsx
@@ -94,8 +94,6 @@ const SSHKeypairManagementModal: React.FC<SSHKeypairManagementModalProps> = ({
         isRefreshModalPending={isPendingRefreshModal}
         onRequestClose={() => {
           toggleSSHKeypairGenerationModal();
-        }}
-        onRequestRefresh={() => {
           startRefreshModalTransition(() => {
             updateFetchKey();
           });


### PR DESCRIPTION
### This PR resolves [#2642](https://github.com/lablup/backend.ai-webui/issues/2642) issue
### TL;DR

Fix unnecessary POST request in SSH keypair generation modal

###  Why make this change?

SSH keypair generation modal has an unnecessary POST request
1. Open the SSH Keypair Generation dialog
2. Click the close button
3. Open the confirmation dialog
4. Click the OK button
5. Unnecessary POST API requests

### What changed?

Delete unnecessary POST request

### How to test?

1. Open the SSH Keypair Generation dialog
2. Click the close button
3. Open the confirmation dialog
4. Click the OK button
5. Check for unnecessary POST requests 