### PR TITLE
fix: vfolder share button has disappeared

### DIFF
--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -825,38 +825,13 @@ export default class BackendAIData extends BackendAIPage {
     });
   }
 
-  openFolderExplorer = (e) => {
-    if (e?.detail?.vFolder) {
-      const activeStorageList =
-        this._activeTab === 'general'
-          ? this.generalFolderStorageListElement
-          : this._activeTab === 'model'
-            ? this.modelFolderStorageListElement
-            : this._activeTab === 'automount'
-              ? this.automountFolderStorageListElement
-              : this._activeTab === 'data'
-                ? this.dataFolderStorageListElement
-                : this._activeTab === 'trash-bin'
-                  ? this.trashBinFolderStorageListElement
-                  : null;
-      activeStorageList?._folderExplorer({
-        item: e?.detail?.vFolder,
-      });
-    }
-  };
-
   connectedCallback(): void {
     super.connectedCallback();
-    document.addEventListener('folderExplorer:open', this.openFolderExplorer);
     document.dispatchEvent(new CustomEvent('backend-ai-data-view:connected'));
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
-    document.removeEventListener(
-      'folderExplorer:open',
-      this.openFolderExplorer,
-    );
     document.dispatchEvent(
       new CustomEvent('backend-ai-data-view:disconnected'),
     );


### PR DESCRIPTION
### TL;DR

After https://github.com/lablup/backend.ai-webui/pull/2529, vFodler share button has disappeared.
- restore functionality to retrieve and process allowed vFolder hosts for the current user.
- Removed folder explorer event listener which event are not used.

### What changed?

- Removed `openFolderExplorer` method and its associated event listeners from `BackendAIData` class.
- Restore methods in `BackendAiStorageList` class:
  - `_getCurrentKeypairResourcePolicy`: Fetches the current keypair's resource policy.
  - `_getAllowedVFolderHostsByCurrentUserInfo`: Retrieves and processes allowed vFolder hosts for the current user, considering domain, group, and resource policy permissions.
- Restore `_viewStateChanged` and `connectedCallback` methods to call `_getAllowedVFolderHostsByCurrentUserInfo`.

### How to test?

1. Navigate to the data view in the Backend.AI interface.
2. Verify that folder explorer functionality still works as expected, despite the removal of the explicit event listener.
3. Create a vfolder
4. Verify that the share button in control column is displayed and works as expected.

### Why make this change?

This change improves the efficiency of handling folder explorer actions and provides a more comprehensive way to determine allowed vFolder hosts for the current user. By considering domain, group, and resource policy permissions, the system can now present a more accurate and personalized view of available storage options to each user.
