### PR TITLE
fix: Windows architecture mismatch issue when downloading the app.

### DIFF
--- a/react/src/components/SummaryPageItems/SummaryItemDownloadApp.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemDownloadApp.tsx
@@ -16,6 +16,9 @@ const SummaryItemDownloadApp: React.FC = () => {
 
   const baiClient = useSuspendedBackendaiClient();
   const url = baiClient._config.appDownloadUrl;
+  const windowOS = baiClient.supports('use-win-instead-of-win32')
+    ? 'win'
+    : 'win32';
 
   const appDownloadMap: Record<string, any> = {
     Linux: {
@@ -29,7 +32,7 @@ const SummaryItemDownloadApp: React.FC = () => {
       extension: 'dmg',
     },
     Windows: {
-      os: 'win',
+      os: windowOS,
       architecture: ['arm64', 'x64'],
       extension: 'zip',
     },

--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -108,7 +108,7 @@ export default class BackendAISummary extends BackendAIPage {
         extension: 'dmg',
       },
       Windows: {
-        os: 'win',
+        os: 'win32',
         architecture: ['arm64', 'x64'],
         extension: 'zip',
       },
@@ -321,6 +321,9 @@ export default class BackendAISummary extends BackendAIPage {
             globalThis.backendaiclient._config.appDownloadUrl;
           this.allowAppDownloadPanel =
             globalThis.backendaiclient._config.allowAppDownloadPanel;
+          if (globalThis.backendaiclient.supports('use-win-instead-of-win32')) {
+            this.appDownloadMap['Windows']['os'] = 'win';
+          }
 
           if (this.activeConnected) {
             this._refreshConsoleUpdateInformation();
@@ -338,6 +341,9 @@ export default class BackendAISummary extends BackendAIPage {
       this.appDownloadUrl = globalThis.backendaiclient._config.appDownloadUrl;
       this.allowAppDownloadPanel =
         globalThis.backendaiclient._config.allowAppDownloadPanel;
+      if (globalThis.backendaiclient.supports('use-win-instead-of-win32')) {
+        this.appDownloadMap['Windows']['os'] = 'win';
+      }
       this._refreshConsoleUpdateInformation();
       this._refreshInvitations();
       // let event = new CustomEvent("backend-ai-resource-refreshed", {"detail": {}});

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -672,6 +672,7 @@ class Client {
     if (this.isManagerVersionCompatibleWith('23.09.4')) {
       this._features['deprecated-max-vfolder-count-in-keypair-resource-policy'] = true;
       this._features['deprecated-max-vfolder-size-in-keypair-resource-policy'] = true;
+      this._features['use-win-instead-of-win32'] = true;
     }
     if (this.isManagerVersionCompatibleWith('23.09.6')) {
       this._features['max-vfolder-count-in-user-and-project-resource-policy'] = true;


### PR DESCRIPTION
resolves [Teams Threads](https://teams.microsoft.com/l/message/19:18bc1a6cadc74b0c9e7807209ecdf76f@thread.tacv2/1724229202285?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=b1f3bcf4-facf-40d3-94ab-169abb4f0f52&parentMessageId=1724226512054&teamName=customers%20%26%20clients&channelName=KT%20AI&createdTime=1724229202285).
### TL;DR

Fixing Windows architecture mismatch issue when downloading the app.

### What changed?

- Updated the 'os' identifier for Windows in the appDownloadMap from 'win' to 'win32'.
- Introduced a new feature flag 'use-win-instead-of-win32' for manager versions 23.09.5 and above.
- After 23.09.5, use 'win'. Before that, use 'win32'.

### How to test?

1. Upgrade the backend.ai manager to version 23.09.5 or later.
2. Check if the app download functionality works correctly for Windows systems.
3. Verify that older manager versions still use 'win32' as the OS identifier.
4. Ensure that the app download panel and URL are correctly displayed based on the configuration.

### Why make this change?

This change aims to improve compatibility and consistency in identifying Windows operating systems across different versions of the backend.ai manager. The 'win32' identifier is more standard and accurate, while the feature flag ensures backward compatibility with older systems that may still rely on the 'win' identifier.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version: before/after 23.09.5
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
