### PR TITLE
fix: the conditions of allocatablePresetNames

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/ResourceAllocationFormItems.test.ts
@@ -1,0 +1,116 @@
+import {
+  MergedResourceLimits,
+  ResourcePreset,
+} from '../hooks/useResourceLimitAndRemaining';
+import { Image } from './ImageEnvironmentSelectFormItems';
+import { getAllocatablePresetNames } from './ResourceAllocationFormItems';
+import _ from 'lodash';
+
+describe('getAllocatablePresetNames', () => {
+  const presets: Array<ResourcePreset> = [
+    {
+      name: 'cuda_shares_prest_10',
+      resource_slots: { cpu: '2', mem: '4GB', 'cuda.shares': '10' },
+      shared_memory: '1GB',
+      allocatable: true,
+    },
+    {
+      name: 'cuda_shares_prest_1',
+      resource_slots: { cpu: '4', mem: '8GB', 'cuda.shares': '1' },
+      shared_memory: '1GB',
+      allocatable: false,
+    },
+    {
+      name: 'preset3',
+      resource_slots: { cpu: '1', mem: '2GB' },
+      shared_memory: '1GB',
+      allocatable: true,
+    },
+  ];
+
+  const resourceLimits_cpu4_mem8g_cudashares1: MergedResourceLimits = {
+    cpu: { max: 4 },
+    mem: { max: '8GB' },
+    accelerators: { 'cuda.shares': { max: 1 } },
+  };
+
+  const image_has_cuda_shares_min1_max1: Image = {
+    name: 'image1',
+    digest: 'digest1',
+    architecture: 'arm64',
+    humanized_name: 'Image 1',
+    installed: true,
+    labels: [],
+    registry: 'registry1',
+    tag: 'tag1',
+    resource_limits: [{ key: 'cuda.shares', min: '1', max: '1' }],
+  };
+
+  it('should return presets when currentImage has accelerator limits(with allocatable property)', () => {
+    const result = getAllocatablePresetNames(
+      presets,
+      resourceLimits_cpu4_mem8g_cudashares1,
+      image_has_cuda_shares_min1_max1,
+    );
+    //  Without comparing the preset's resource slots with the resource limits.
+    expect(result).toEqual(['cuda_shares_prest_10']);
+  });
+
+  it('should return presets when currentImage has accelerator limits(without allocatable property)', () => {
+    const result = getAllocatablePresetNames(
+      _.map(presets, (p) => _.omit(p, 'allocatable')),
+      resourceLimits_cpu4_mem8g_cudashares1,
+      image_has_cuda_shares_min1_max1,
+    );
+    // Must compare the preset's resource slots with the resource limits.
+    expect(result).toEqual(['cuda_shares_prest_1']);
+  });
+
+  it('should return empty array when no presets match', () => {
+    const noMatchPresets: Array<ResourcePreset> = [
+      {
+        name: 'preset4',
+        allocatable: false,
+        shared_memory: '1GB',
+        resource_slots: { cpu: '10', mem: '16GB', 'not_existed.device': '5' },
+      },
+    ];
+    const result = getAllocatablePresetNames(
+      noMatchPresets,
+      resourceLimits_cpu4_mem8g_cudashares1,
+      image_has_cuda_shares_min1_max1,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('should handle empty presets array', () => {
+    const result = getAllocatablePresetNames(
+      [],
+      resourceLimits_cpu4_mem8g_cudashares1,
+      image_has_cuda_shares_min1_max1,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('should handle empty resourceLimits', () => {
+    const result = getAllocatablePresetNames(
+      presets,
+      {
+        accelerators: {},
+      },
+      image_has_cuda_shares_min1_max1,
+    );
+    // Only presets that have cuda.shares minimum 1 should be returned.
+    expect(result).toEqual(['cuda_shares_prest_10']);
+  });
+
+  it('should handle empty image', () => {
+    const result = getAllocatablePresetNames(
+      presets,
+      resourceLimits_cpu4_mem8g_cudashares1,
+      undefined,
+    );
+    // all `preset.allocatable === true` presets should be returned
+    expect(result).toEqual(['cuda_shares_prest_10', 'preset3']);
+  });
+});

--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -11,10 +11,17 @@ import {
   useCurrentResourceGroupValue,
 } from '../hooks/useCurrentProject';
 import { useEventNotStable } from '../hooks/useEventNotStable';
-import { useResourceLimitAndRemaining } from '../hooks/useResourceLimitAndRemaining';
+import {
+  MergedResourceLimits,
+  ResourcePreset,
+  useResourceLimitAndRemaining,
+} from '../hooks/useResourceLimitAndRemaining';
 import DynamicUnitInputNumberWithSlider from './DynamicUnitInputNumberWithSlider';
 import Flex from './Flex';
-import { ImageEnvironmentFormInput } from './ImageEnvironmentSelectFormItems';
+import {
+  Image,
+  ImageEnvironmentFormInput,
+} from './ImageEnvironmentSelectFormItems';
 import InputNumberWithSlider from './InputNumberWithSlider';
 import ResourceGroupSelectForCurrentProject from './ResourceGroupSelectForCurrentProject';
 import { ACCELERATOR_UNIT_MAP } from './ResourceNumber';
@@ -122,10 +129,12 @@ const ResourceAllocationFormItems: React.FC<
     return false;
   });
 
-  const currentImageAcceleratorLimits = _.filter(
-    currentImage?.resource_limits,
-    (limit) =>
-      limit ? !_.includes(['cpu', 'mem', 'shmem'], limit.key) : false,
+  const currentImageAcceleratorLimits = useMemo(
+    () =>
+      _.filter(currentImage?.resource_limits, (limit) =>
+        limit ? !_.includes(['cpu', 'mem', 'shmem'], limit.key) : false,
+      ),
+    [currentImage?.resource_limits],
   );
 
   const sessionSliderLimitAndRemaining = {
@@ -135,80 +144,12 @@ const ResourceAllocationFormItems: React.FC<
   };
 
   const allocatablePresetNames = useMemo(() => {
-    const bySliderLimit = _.filter(checkPresetInfo?.presets, (preset) => {
-      if (
-        typeof preset.resource_slots.mem === 'string' &&
-        typeof resourceLimits.mem?.max === 'string' &&
-        compareNumberWithUnits(
-          preset.resource_slots.mem,
-          resourceLimits.mem?.max,
-        ) > 0
-      ) {
-        return false;
-      }
-      if (
-        typeof preset.resource_slots.cpu === 'number' &&
-        typeof resourceLimits.cpu?.max === 'number' &&
-        preset.resource_slots.cpu > resourceLimits.cpu?.max
-      ) {
-        return false;
-      }
-      const acceleratorKeys = _.keys(
-        _.omit(preset.resource_slots, ['mem', 'cpu', 'shmem']),
-      );
-      const isAvailable = _.every(acceleratorKeys, (key) => {
-        if (
-          key &&
-          typeof preset.resource_slots[key] === 'string' &&
-          typeof resourceLimits.accelerators[key]?.max === 'number' &&
-          _.toNumber(preset.resource_slots[key]) >
-            _.toNumber(resourceLimits.accelerators[key]?.max)
-        ) {
-          return false;
-        }
-        return true;
-      });
-      return isAvailable;
-    }).map((preset) => preset.name);
-
-    const byImageAcceleratorLimits = _.filter(
+    return getAllocatablePresetNames(
       checkPresetInfo?.presets,
-      (preset) => {
-        const acceleratorResourceOfPreset = _.omitBy(
-          preset.resource_slots,
-          (value, key) => {
-            if (['mem', 'cpu', 'shmem'].includes(key) || value === '0')
-              return true;
-          },
-        );
-        if (currentImageAcceleratorLimits.length === 0) {
-          if (_.isEmpty(acceleratorResourceOfPreset)) {
-            return true;
-          } else {
-            return false;
-          }
-        }
-
-        return _.some(currentImageAcceleratorLimits, (limit) => {
-          return _.some(acceleratorResourceOfPreset, (value, key) => {
-            return (
-              limit?.key === key && _.toNumber(value) >= _.toNumber(limit?.min)
-            );
-          });
-        });
-      },
-    ).map((preset) => preset.name);
-
-    return currentImageAcceleratorLimits.length > 0
-      ? bySliderLimit
-      : _.intersection(bySliderLimit, byImageAcceleratorLimits);
-  }, [
-    checkPresetInfo?.presets,
-    resourceLimits.accelerators,
-    resourceLimits.cpu?.max,
-    resourceLimits.mem?.max,
-    currentImageAcceleratorLimits,
-  ]);
+      resourceLimits,
+      currentImage,
+    );
+  }, [checkPresetInfo?.presets, resourceLimits, currentImage]);
 
   const ensureValidAcceleratorType = useEventNotStable(() => {
     const currentAcceleratorType = form.getFieldValue(
@@ -1309,3 +1250,85 @@ const MemoizedResourceAllocationFormItems = React.memo(
 );
 
 export default MemoizedResourceAllocationFormItems;
+
+export const getAllocatablePresetNames = (
+  presets: Array<ResourcePreset> | undefined,
+  resourceLimits: MergedResourceLimits,
+  currentImage: Image,
+) => {
+  const currentImageAcceleratorLimits = _.filter(
+    currentImage?.resource_limits,
+    (limit) =>
+      limit ? !_.includes(['cpu', 'mem', 'shmem'], limit.key) : false,
+  );
+
+  const bySliderLimit = _.filter(presets, (preset) => {
+    // Check if the preset has `allocatable` field, use it.
+    if (_.has(preset, 'allocatable')) {
+      return !!preset.allocatable;
+    }
+
+    // Check if all resource slots in the preset are less than or equal to resourceLimits
+    // Be careful with the type of values in resourceLimits, they are string or number
+    return _.every(preset.resource_slots, (value, key) => {
+      if (key === 'mem') {
+        // mem is special case
+        return (
+          typeof preset.resource_slots[key] === 'string' &&
+          typeof resourceLimits[key]?.max === 'string' &&
+          compareNumberWithUnits(
+            preset.resource_slots[key],
+            resourceLimits[key]?.max,
+          ) <= 0
+        );
+      } else if (key === 'shmem') {
+        // no need to check shmem
+        return true;
+      } else if (key === 'cpu') {
+        // if cpu resource limit is not defined, it is UNLIMITED
+        return (
+          (_.toNumber(preset.resource_slots[key]) || 0) <=
+          (_.toNumber(resourceLimits[key]?.max) || Number.MAX_SAFE_INTEGER)
+        );
+      } else {
+        // if accelerator resource limit is not defined, it is NOT SUPPORTED
+        return (
+          (_.toNumber(preset.resource_slots[key]) || 0) <=
+          (_.toNumber(resourceLimits.accelerators[key]?.max) || 0)
+        );
+      }
+    });
+  }).map((preset) => preset.name);
+
+  const byImageAcceleratorLimits = _.filter(presets, (preset) => {
+    const acceleratorResourceOfPreset = _.omitBy(
+      preset.resource_slots,
+      (value, key) => {
+        if (['mem', 'cpu', 'shmem'].includes(key)) return true;
+      },
+    );
+    if (currentImageAcceleratorLimits.length === 0) {
+      // When current image doesn't require any accelerator,
+      // It's available if the preset doesn't have any accelerator
+      if (_.isEmpty(acceleratorResourceOfPreset)) {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      // When current image requires some accelerator,
+      // It's available if the preset has a required accelerator value that is larger than the current image's minimum value
+      return _.some(currentImageAcceleratorLimits, (limit) => {
+        return (
+          limit?.key &&
+          acceleratorResourceOfPreset[limit?.key] &&
+          _.toNumber(acceleratorResourceOfPreset[limit?.key]) >=
+            _.toNumber(limit?.min)
+        );
+      });
+    }
+  }).map((preset) => preset.name);
+  return currentImageAcceleratorLimits.length === 0
+    ? bySliderLimit
+    : _.intersection(bySliderLimit, byImageAcceleratorLimits);
+};

--- a/react/src/hooks/useResourceLimitAndRemaining.tsx
+++ b/react/src/hooks/useResourceLimitAndRemaining.tsx
@@ -59,7 +59,7 @@ export type ResourcePreset = {
   name: string;
   resource_slots: ResourceSlots;
   shared_memory: string | null;
-  allocatable?: boolean;
+  allocatable: boolean;
 };
 
 type ResourceAllocation = {

--- a/react/src/hooks/useResourceLimitAndRemaining.tsx
+++ b/react/src/hooks/useResourceLimitAndRemaining.tsx
@@ -6,7 +6,7 @@ import { useResourceSlots } from '../hooks/backendai';
 import { useSuspenseTanQuery } from './reactQueryAlias';
 import _ from 'lodash';
 
-interface MergedResourceLimits {
+export interface MergedResourceLimits {
   accelerators: {
     [key: string]:
       | {
@@ -44,7 +44,6 @@ type ScalingGroup = {
 type ResourceSlots = {
   cpu: string;
   mem: string;
-  'cuda.device': string;
   [key: string]: string;
 };
 
@@ -60,7 +59,7 @@ export type ResourcePreset = {
   name: string;
   resource_slots: ResourceSlots;
   shared_memory: string | null;
-  allocatable: boolean;
+  allocatable?: boolean;
 };
 
 type ResourceAllocation = {


### PR DESCRIPTION
### TL;DR

fix the bug on resource allocation logic for presets and accelerators in the ResourceAllocationFormItems component.

### What changed?

- Optimized the calculation of `currentImageAcceleratorLimits` using useMemo for better performance.
- Refactored the `allocatablePresetNames` logic to:
  - Use the `allocatable` field if present in the preset.
  - Improve checks for resource slots against resource limits.
  - Handle special cases for mem, shmem, cpu, and accelerators.
- Updated the filtering logic for presets based on image accelerator limits.
- Simplified the intersection of preset filters for better readability.
- Separate a comparing logic into a `getAllocatablePresetNames`
- Add test codes for `getAllocatablePresetNames` function

### How to test?

1. Open the resource allocation form.
2. Verify that presets are correctly filtered based on resource limits and image accelerator requirements.
3. Test with various combinations of resource limits and image accelerator requirements to ensure proper preset allocation.
4. Check that performance is improved, especially when dealing with a large number of presets.

### Why make this change?

This change aims to improve the accuracy and efficiency of resource allocation in the application. By refining the logic for determining allocatable presets and handling accelerator requirements, we ensure that users are presented with the most appropriate options based on their resource limits and image requirements. The optimizations also contribute to better performance, especially when dealing with complex resource configurations.