### PR TITLE
refactor: `KeypairResourcePolicySettingModal` update to support policy settings for all available accelerators.

### DIFF
--- a/react/src/components/FormItemWithUnlimited.tsx
+++ b/react/src/components/FormItemWithUnlimited.tsx
@@ -1,7 +1,12 @@
 import Flex from './Flex';
 import { Form, Checkbox, FormItemProps } from 'antd';
 import { CheckboxChangeEvent } from 'antd/es/checkbox';
-import React, { cloneElement, useEffect, useState } from 'react';
+import React, {
+  cloneElement,
+  isValidElement,
+  useEffect,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface FormItemWithUnlimitedProps extends FormItemProps {
@@ -25,19 +30,19 @@ const FormItemWithUnlimited: React.FC<FormItemWithUnlimitedProps> = ({
   }, [form, name, unlimitedValue]);
 
   // Disable children when isUnlimited is true.
-  const childrenWithProps = React.isValidElement(children)
+  const childrenWithProps = isValidElement(children)
     ? cloneElement(children, {
         disabled: isUnlimited,
       } as React.Attributes & { disabled?: boolean })
     : children;
 
-  const childrenWithUndefinedValue =
-    isUnlimited && React.isValidElement(children)
+  const childrenWithNullValue =
+    isUnlimited && isValidElement(children)
       ? cloneElement(children, {
-          value: undefined,
+          value: null,
           disabled: isUnlimited,
         } as React.Attributes & { value?: any })
-      : undefined;
+      : null;
 
   return (
     <Flex direction="column" align="start">
@@ -54,7 +59,7 @@ const FormItemWithUnlimited: React.FC<FormItemWithUnlimitedProps> = ({
           style={{ margin: 0 }}
           {...formItemPropsWithoutNameAndChildren}
         >
-          {childrenWithUndefinedValue}
+          {childrenWithNullValue}
         </Form.Item>
       ) : null}
       <Checkbox

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -37,7 +37,7 @@ import { AnyObject } from 'antd/es/_util/type';
 import { ColumnsType, ColumnType } from 'antd/es/table';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
-import React, { useState, useTransition } from 'react';
+import React, { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyLoadQuery, useMutation } from 'react-relay';
 
@@ -416,23 +416,25 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         columns={columns}
         displayedColumnKeys={displayedColumnKeys ? displayedColumnKeys : []}
       />
-      <KeypairResourcePolicySettingModal
-        existingPolicyNames={_.map(
-          keypair_resource_policies,
-          (policy) => policy?.name || '',
-        )}
-        open={!!editingKeypairResourcePolicy || isCreatingPolicySetting}
-        keypairResourcePolicyFrgmt={editingKeypairResourcePolicy || null}
-        onRequestClose={(success) => {
-          setEditingKeypairResourcePolicy(null);
-          setIsCreatingPolicySetting(false);
-          if (success) {
-            startRefetchTransition(() => {
-              updateKeypairResourcePolicyFetchKey();
-            });
-          }
-        }}
-      />
+      <Suspense>
+        <KeypairResourcePolicySettingModal
+          existingPolicyNames={_.map(
+            keypair_resource_policies,
+            (policy) => policy?.name || '',
+          )}
+          open={!!editingKeypairResourcePolicy || isCreatingPolicySetting}
+          keypairResourcePolicyFrgmt={editingKeypairResourcePolicy || null}
+          onRequestClose={(success) => {
+            setEditingKeypairResourcePolicy(null);
+            setIsCreatingPolicySetting(false);
+            if (success) {
+              startRefetchTransition(() => {
+                updateKeypairResourcePolicyFetchKey();
+              });
+            }
+          }}
+        />
+      </Suspense>
     </Flex>
   );
 };

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1042,7 +1042,8 @@
     "ProjectResourcePolicy": "Projektressourcenrichtlinie",
     "NoDataToExport": "Die Daten für den CSV-Extrakt sind nicht vorhanden.",
     "ExportCSV": "CSV exportieren",
-    "Tools": "Werkzeuge"
+    "Tools": "Werkzeuge",
+    "MemorySizeExceedsLimit": "Die Speichergröße sollte weniger als 300 PiB betragen"
   },
   "registry": {
     "Hostname": "Hostname",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1042,7 +1042,8 @@
     "ProjectResourcePolicy": "Πολιτική πόρων έργου",
     "NoDataToExport": "Τα δεδομένα για το απόσπασμα CSV δεν υπάρχουν.",
     "ExportCSV": "εξαγωγή CSV",
-    "Tools": "Εργαλεία"
+    "Tools": "Εργαλεία",
+    "MemorySizeExceedsLimit": "Το μέγεθος της μνήμης πρέπει να είναι μικρότερο από 300 PiB"
   },
   "registry": {
     "Hostname": "Όνομα κεντρικού υπολογιστή",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1169,7 +1169,8 @@
     "ProjectResourcePolicy": "Project Resource Policy",
     "NoDataToExport": "The data for the CSV extract does not exist.",
     "ExportCSV": "export CSV",
-    "Tools": "Tools"
+    "Tools": "Tools",
+    "MemorySizeExceedsLimit": "Memory size should be less than 300 PiB"
   },
   "registry": {
     "Hostname": "Hostname",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -995,7 +995,8 @@
     "ProjectResourcePolicy": "Política de recursos del proyecto",
     "NoDataToExport": "Los datos para el extracto CSV no existen.",
     "ExportCSV": "exportar CSV",
-    "Tools": "Herramientas"
+    "Tools": "Herramientas",
+    "MemorySizeExceedsLimit": "El tamaño de la memoria debe ser inferior a 300 PiB"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Está a punto de borrar este preajuste:",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -992,7 +992,8 @@
     "ProjectResourcePolicy": "Projektin resurssipolitiikka",
     "NoDataToExport": "CSV-otteen tietoja ei ole olemassa.",
     "ExportCSV": "vie CSV",
-    "Tools": "Työkalut"
+    "Tools": "Työkalut",
+    "MemorySizeExceedsLimit": "Muistin koon tulee olla alle 300 PiB"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Olet poistamassa tätä esiasetusta:",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1042,7 +1042,8 @@
     "ProjectResourcePolicy": "Politique des ressources du projet",
     "NoDataToExport": "Les données pour l'extrait CSV n'existent pas.",
     "ExportCSV": "exporter au format CSV",
-    "Tools": "Outils"
+    "Tools": "Outils",
+    "MemorySizeExceedsLimit": "La taille de la mémoire doit être inférieure à 300 PiB"
   },
   "registry": {
     "Hostname": "Nom d'hôte",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1043,7 +1043,8 @@
     "ProjectResourcePolicy": "Kebijakan Sumber Daya Proyek",
     "NoDataToExport": "Data untuk ekstrak CSV tidak ada.",
     "ExportCSV": "ekspor CSV",
-    "Tools": "Peralatan"
+    "Tools": "Peralatan",
+    "MemorySizeExceedsLimit": "Ukuran memori harus kurang dari 300 PiB"
   },
   "registry": {
     "Hostname": "Nama host",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1042,7 +1042,8 @@
     "MaxFolderCount": "Conteggio massimo cartelle",
     "NoDataToExport": "I dati per l'estrazione CSV non esistono.",
     "ExportCSV": "esportare CSV",
-    "Tools": "Utensili"
+    "Tools": "Utensili",
+    "MemorySizeExceedsLimit": "La dimensione della memoria deve essere inferiore a 300 PiB"
   },
   "registry": {
     "Hostname": "Nome host",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1042,7 +1042,8 @@
     "ProjectResourcePolicy": "プロジェクトリソースポリシー",
     "NoDataToExport": "CSV抽出用のデータが存在しません。",
     "ExportCSV": "CSVエクスポート",
-    "Tools": "ツール"
+    "Tools": "ツール",
+    "MemorySizeExceedsLimit": "メモリ サイズは 300 PiB 未満である必要があります"
   },
   "registry": {
     "Hostname": "ホスト名",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1155,7 +1155,8 @@
     "ProjectResourcePolicy": "프로젝트 자원 정책",
     "NoDataToExport": "CSV 추출을 위한 데이터가 존재하지 않습니다. ",
     "ExportCSV": "CSV로 내보내기",
-    "Tools": "도구"
+    "Tools": "도구",
+    "MemorySizeExceedsLimit": "메모리 크기는 300PiB 미만이어야 합니다."
   },
   "registry": {
     "Hostname": "호스트명",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1042,7 +1042,8 @@
     "MaxFolderCount": "Хамгийн их хавтасны тоо",
     "NoDataToExport": "CSV хандалтын өгөгдөл байхгүй байна.",
     "ExportCSV": "CSV экспортлох",
-    "Tools": "Багаж хэрэгсэл"
+    "Tools": "Багаж хэрэгсэл",
+    "MemorySizeExceedsLimit": "Санах ойн хэмжээ 300 PiB-ээс бага байх ёстой"
   },
   "registry": {
     "Hostname": "Хостын нэр",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1041,7 +1041,8 @@
     "ProjectResourcePolicy": "Dasar Sumber Projek",
     "NoDataToExport": "Data untuk ekstrak CSV tidak wujud.",
     "ExportCSV": "eksport CSV",
-    "Tools": "Alatan"
+    "Tools": "Alatan",
+    "MemorySizeExceedsLimit": "Saiz memori hendaklah kurang daripada 300 PiB"
   },
   "registry": {
     "Hostname": "Nama Hos",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1042,7 +1042,8 @@
     "ProjectResourcePolicy": "Polityka zasobów projektu",
     "NoDataToExport": "Dane do ekstraktu CSV nie istnieją.",
     "ExportCSV": "eksportuj plik CSV",
-    "Tools": "Narzędzia"
+    "Tools": "Narzędzia",
+    "MemorySizeExceedsLimit": "Rozmiar pamięci powinien być mniejszy niż 300 PiB"
   },
   "registry": {
     "Hostname": "Nazwa hosta",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1042,7 +1042,8 @@
     "ProjectResourcePolicy": "Política de Recursos do Projeto",
     "NoDataToExport": "Os dados para a extração CSV não existem.",
     "ExportCSV": "exportar CSV",
-    "Tools": "Ferramentas"
+    "Tools": "Ferramentas",
+    "MemorySizeExceedsLimit": "O tamanho da memória deve ser inferior a 300 PiB"
   },
   "registry": {
     "Hostname": "nome de anfitrião",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1042,7 +1042,8 @@
     "ProjectResourcePolicy": "Política de Recursos do Projeto",
     "NoDataToExport": "Os dados para a extração CSV não existem.",
     "ExportCSV": "exportar CSV",
-    "Tools": "Ferramentas"
+    "Tools": "Ferramentas",
+    "MemorySizeExceedsLimit": "O tamanho da memória deve ser inferior a 300 PiB"
   },
   "registry": {
     "Hostname": "nome de anfitrião",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1042,7 +1042,8 @@
     "ProjectResourcePolicy": "Ресурсная политика проекта",
     "NoDataToExport": "Данные для извлечения CSV не существуют.",
     "ExportCSV": "экспортировать CSV",
-    "Tools": "Инструменты"
+    "Tools": "Инструменты",
+    "MemorySizeExceedsLimit": "Размер памяти должен быть менее 300 ПиБ."
   },
   "registry": {
     "Hostname": "Имя хоста",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1155,7 +1155,8 @@
     "ProjectResourcePolicy": "นโยบายทรัพยากรโครงการ",
     "NoDataToExport": "ไม่มีข้อมูลสำหรับการส่งออก CSV",
     "ExportCSV": "ส่งออก CSV",
-    "Tools": "เครื่องมือ"
+    "Tools": "เครื่องมือ",
+    "MemorySizeExceedsLimit": "ขนาดหน่วยความจำควรน้อยกว่า 300 PiB"
   },
   "registry": {
     "Hostname": "ชื่อโฮสต์",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1042,7 +1042,8 @@
     "ProjectResourcePolicy": "Proje Kaynak Politikası",
     "NoDataToExport": "CSV ekstresine ilişkin veriler mevcut değil.",
     "ExportCSV": "CSV'yi dışa aktar",
-    "Tools": "Aletler"
+    "Tools": "Aletler",
+    "MemorySizeExceedsLimit": "Bellek boyutu 300 PiB'den az olmalıdır"
   },
   "registry": {
     "Hostname": "ana bilgisayar adı",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1042,7 +1042,8 @@
     "ProjectResourcePolicy": "Chính sách tài nguyên dự án",
     "NoDataToExport": "Dữ liệu cho bản trích xuất CSV không tồn tại.",
     "ExportCSV": "xuất CSV",
-    "Tools": "Công cụ"
+    "Tools": "Công cụ",
+    "MemorySizeExceedsLimit": "Kích thước bộ nhớ phải nhỏ hơn 300 PiB"
   },
   "registry": {
     "Hostname": "Tên máy chủ",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1042,7 +1042,8 @@
     "ProjectResourcePolicy": "项目资源政策",
     "NoDataToExport": "CSV 提取的数据不存在。",
     "ExportCSV": "导出 CSV",
-    "Tools": "工具"
+    "Tools": "工具",
+    "MemorySizeExceedsLimit": "内存大小应小于 300 PiB"
   },
   "registry": {
     "Hostname": "主机名",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1041,7 +1041,8 @@
     "ProjectResourcePolicy": "專案資源政策",
     "NoDataToExport": "CSV 擷取的資料不存在。",
     "ExportCSV": "匯出 CSV",
-    "Tools": "工具"
+    "Tools": "工具",
+    "MemorySizeExceedsLimit": "記憶體大小應小於 300 PiB"
   },
   "registry": {
     "Hostname": "主機名",


### PR DESCRIPTION
follows #2357 

### TL;DR

Enhanced the KeypairResourcePolicySettingModal component with dynamic resource slot rendering and improved form validation.

### What changed?

- Added dynamic rendering of resource slots based on available slots
- Implemented memory size validation (limit to 300 PiB)
- Improved layout consistency for form items
- Added step size of 0.1 for resource slots with '.shares' in their name
- Updated the totalResourceSlots calculation to handle all memory-related slots
- Remove the max value of `InputNumber` because the core doesn't set the max value.

### How to test?

1. Open the KeypairResourcePolicySettingModal
2. Verify that all available resource slots are displayed dynamically
3. Try entering a memory size larger than 300 PiB and check for validation error
4. Test the step size of 0.1 for resource slots with '.shares' in their name
5. Ensure the layout is consistent across all form items

### Why make this change?

This change improves the flexibility and user experience of the KeypairResourcePolicySettingModal by dynamically adapting to available resource slots and providing better input validation. It also enhances the consistency of the form layout and improves the handling of memory-related slots.

### Test server
: 10.100.64.15

### Screenshots

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/94ee7d05-99ba-4996-b487-85ec1e7b7063.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/4bf53fde-1660-4f93-a005-965daab4d781.png)

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version: 23.09
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
