### PR TITLE
fix: modify the locale of reservation time to the language of Backend.AI

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1366,7 +1366,9 @@ export default class BackendAISessionList extends BackendAIPage {
    */
   _humanReadableTime(d: any) {
     d = new Date(d);
-    return d.toLocaleString();
+    return d.toLocaleString(
+      globalThis.backendaioptions.get('language', null, 'general'),
+    );
   }
 
   /**


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### TL;DR

modify the locale of reservation time to the language of Backend.AI

###  Why make this change?

The locale of the reservation time in the session list is the OS default language, not the Backend.AI set language. 
So when the OS default is Korean, no matter how I set the language, the reservation time displays Korean. 
![image](https://github.com/user-attachments/assets/82f5c7c7-8757-4154-a6b6-6b5fc3946952)


### What changed?

Set the toLocaleString function's parameter Locales to the general.language of Backend.AI

### How to test?
1. change language to ko  in settings
2. Verify reservation time looks like this `2024. 8. 21. 오전 2:45:26`
3. change language to en in settings
4. Verify reservation time looks like this `8/21/2024, 2:45:26 AM`

