### PR TITLE
fix: apply decimal place rounding to session usage

### DIFF
--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -196,9 +196,8 @@ export function toFixedFloorWithoutTrailingZeros(
   num: number | string,
   fixed: number,
 ) {
-  return typeof num === 'number'
-    ? parseFloat(num.toFixed(fixed)).toString()
-    : parseFloat(parseFloat(num).toFixed(fixed)).toString();
+  const number = typeof num === 'string' ? parseFloat(num) : num;
+  return parseFloat(number.toFixed(fixed)).toString();
 }
 
 export function toFixedWithTypeValidation(num: number | string, fixed: number) {

--- a/src/components/backend-ai-resource-monitor.ts
+++ b/src/components/backend-ai-resource-monitor.ts
@@ -595,7 +595,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
       return parseInt(str) + postfix;
     }
   }
-  _prefixFormatWithTrailingZeros(num: string | number = '0', fixed: number) {
+  _prefixFormatWithoutTrailingZeros(num: string | number = '0', fixed: number) {
     const number = typeof num === 'string' ? parseFloat(num) : num;
     return parseFloat(number.toFixed(fixed)).toString();
   }
@@ -643,10 +643,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                   class="start"
                   progress="${this.used_resource_group_slot_percent.cpu /
                   100.0}"
-                  description="${this._prefixFormatWithTrailingZeros(
+                  description="${this._prefixFormatWithoutTrailingZeros(
                     this.used_resource_group_slot.cpu,
                     0,
-                  )} / ${this._prefixFormatWithTrailingZeros(
+                  )} / ${this._prefixFormatWithoutTrailingZeros(
                     this.total_resource_group_slot.cpu,
                     0,
                   )} Cores"
@@ -655,10 +655,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                   id="cpu-usage-bar-2"
                   class="end"
                   progress="${this.used_slot_percent.cpu / 100.0}"
-                  description="${this._prefixFormatWithTrailingZeros(
+                  description="${this._prefixFormatWithoutTrailingZeros(
                     this.used_slot.cpu,
                     0,
-                  )} / ${this._prefixFormatWithTrailingZeros(
+                  )} / ${this._prefixFormatWithoutTrailingZeros(
                     this.total_slot.cpu,
                     0,
                   )} Cores"
@@ -667,7 +667,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
               <div class="layout vertical center center-justified">
                 <span class="percentage start-bar">
                   ${this._numberWithPostfix(
-                    this._prefixFormatWithTrailingZeros(
+                    this._prefixFormatWithoutTrailingZeros(
                       this.used_resource_group_slot_percent.cpu,
                       1,
                     ),
@@ -676,7 +676,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                 </span>
                 <span class="percentage end-bar">
                   ${this._numberWithPostfix(
-                    this._prefixFormatWithTrailingZeros(
+                    this._prefixFormatWithoutTrailingZeros(
                       this.used_slot_percent.cpu,
                       1,
                     ),
@@ -697,10 +697,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                   class="start"
                   progress="${this.used_resource_group_slot_percent.mem /
                   100.0}"
-                  description="${this._prefixFormatWithTrailingZeros(
+                  description="${this._prefixFormatWithoutTrailingZeros(
                     this.used_resource_group_slot.mem,
                     2,
-                  )} / ${this._prefixFormatWithTrailingZeros(
+                  )} / ${this._prefixFormatWithoutTrailingZeros(
                     this.total_resource_group_slot.mem,
                     2,
                   )} GiB"
@@ -709,10 +709,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                   id="mem-usage-bar-2"
                   class="end"
                   progress="${this.used_slot_percent.mem / 100.0}"
-                  description="${this._prefixFormatWithTrailingZeros(
+                  description="${this._prefixFormatWithoutTrailingZeros(
                     this.used_slot.mem,
                     2,
-                  )} / ${this._prefixFormatWithTrailingZeros(
+                  )} / ${this._prefixFormatWithoutTrailingZeros(
                     this.total_slot.mem,
                     2,
                   )} GiB"
@@ -721,7 +721,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
               <div class="layout vertical center center-justified">
                 <span class="percentage start-bar">
                   ${this._numberWithPostfix(
-                    this._prefixFormatWithTrailingZeros(
+                    this._prefixFormatWithoutTrailingZeros(
                       this.used_resource_group_slot_percent.mem,
                       1,
                     ),
@@ -730,7 +730,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                 </span>
                 <span class="percentage end-bar">
                   ${this._numberWithPostfix(
-                    this._prefixFormatWithTrailingZeros(
+                    this._prefixFormatWithoutTrailingZeros(
                       this.used_slot_percent.mem,
                       1,
                     ),
@@ -778,7 +778,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_resource_group_slot_percent.cuda_device,
                             1,
                           ),
@@ -787,7 +787,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_slot_percent.cuda_device,
                             1,
                           ),
@@ -839,7 +839,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_resource_group_slot_percent.cuda_shares,
                             1,
                           ),
@@ -848,7 +848,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_slot_percent.cuda_shares,
                             1,
                           ),
@@ -902,7 +902,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_resource_group_slot_percent.rocm_device,
                             1,
                           ),
@@ -911,7 +911,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_slot_percent.rocm_device,
                             1,
                           ),
@@ -936,10 +936,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .tpu_device / 100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_resource_group_slot.tpu_device,
                           2,
-                        )} / ${this._prefixFormatWithTrailingZeros(
+                        )} / ${this._prefixFormatWithoutTrailingZeros(
                           this.total_resource_group_slot.tpu_device,
                           2,
                         )} TPUs"
@@ -949,10 +949,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="end"
                         progress="${this.used_slot_percent.tpu_device / 100.0}"
                         buffer="${this.used_slot_percent.tpu_device / 100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_slot.tpu_device,
                           2,
-                        )}/${this._prefixFormatWithTrailingZeros(
+                        )}/${this._prefixFormatWithoutTrailingZeros(
                           this.total_slot.tpu_device,
                           2,
                         )} TPUs"
@@ -961,7 +961,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_resource_group_slot_percent.tpu_device,
                             1,
                           ),
@@ -970,7 +970,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_slot_percent.tpu_device,
                             1,
                           ),
@@ -995,10 +995,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .ipu_device / 100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_resource_group_slot.ipu_device,
                           2,
-                        )} / ${this._prefixFormatWithTrailingZeros(
+                        )} / ${this._prefixFormatWithoutTrailingZeros(
                           this.total_resource_group_slot.ipu_device,
                           2,
                         )} IPUs"
@@ -1008,10 +1008,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="end"
                         progress="${this.used_slot_percent.ipu_device / 100.0}"
                         buffer="${this.used_slot_percent.ipu_device / 100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_slot.ipu_device,
                           2,
-                        )} / ${this._prefixFormatWithTrailingZeros(
+                        )} / ${this._prefixFormatWithoutTrailingZeros(
                           this.total_slot.ipu_device,
                           2,
                         )} "
@@ -1020,7 +1020,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_resource_group_slot_percent.ipu_device,
                             1,
                           ),
@@ -1029,7 +1029,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_slot_percent.ipu_device,
                             1,
                           ),
@@ -1054,10 +1054,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .atom_device / 100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_resource_group_slot.atom_device,
                           2,
-                        )} / ${this._prefixFormatWithTrailingZeros(
+                        )} / ${this._prefixFormatWithoutTrailingZeros(
                           this.total_resource_group_slot.atom_device,
                           2,
                         )} ATOMs"
@@ -1067,10 +1067,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="end"
                         progress="${this.used_slot_percent.atom_device / 100.0}"
                         buffer="${this.used_slot_percent.atom_device / 100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_slot.atom_device,
                           2,
-                        )} / ${this._prefixFormatWithTrailingZeros(
+                        )} / ${this._prefixFormatWithoutTrailingZeros(
                           this.total_slot.atom_device,
                           2,
                         )} ATOMs"
@@ -1079,7 +1079,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_resource_group_slot_percent.atom_device,
                             1,
                           ),
@@ -1088,7 +1088,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_slot_percent.atom_device,
                             1,
                           ),
@@ -1113,10 +1113,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .atom_plus_device / 100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_resource_group_slot.atom_plus_device,
                           2,
-                        )} / ${this._prefixFormatWithTrailingZeros(
+                        )} / ${this._prefixFormatWithoutTrailingZeros(
                           this.total_resource_group_slot.atom_plus_device,
                           2,
                         )} ATOM+"
@@ -1128,10 +1128,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         100.0}"
                         buffer="${this.used_slot_percent.atom_plus_device /
                         100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_slot.atom_plus_device,
                           2,
-                        )} / ${this._prefixFormatWithTrailingZeros(
+                        )} / ${this._prefixFormatWithoutTrailingZeros(
                           this.total_slot.atom_plus_device,
                           2,
                         )} ATOM+"
@@ -1144,7 +1144,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       "
                       >
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_resource_group_slot_percent
                               .atom_plus_device,
                             1,
@@ -1158,7 +1158,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       "
                       >
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_slot_percent.atom_plus_device,
                             1,
                           ),
@@ -1183,10 +1183,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .warboy_device / 100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_resource_group_slot.warboy_device,
                           2,
-                        )} / ${this._prefixFormatWithTrailingZeros(
+                        )} / ${this._prefixFormatWithoutTrailingZeros(
                           this.total_resource_group_slot.warboy_device,
                           2,
                         )} Warboys"
@@ -1197,10 +1197,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         progress="${this.used_slot_percent.warboy_device /
                         100.0}"
                         buffer="${this.used_slot_percent.warboy_device / 100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_slot.warboy_device,
                           2,
-                        )} / ${this._prefixFormatWithTrailingZeros(
+                        )} / ${this._prefixFormatWithoutTrailingZeros(
                           this.total_slot.warboy_device,
                           2,
                         )} Warboys"
@@ -1209,7 +1209,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_resource_group_slot_percent.warboy_device,
                             1,
                           ),
@@ -1218,7 +1218,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_slot_percent.warboy_device,
                             1,
                           ),
@@ -1243,10 +1243,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                         class="start"
                         progress="${this.used_resource_group_slot_percent
                           .hyperaccel_lpu_device / 100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_resource_group_slot.hyperaccel_lpu_device,
                           2,
-                        )} / ${this._prefixFormatWithTrailingZeros(
+                        )} / ${this._prefixFormatWithoutTrailingZeros(
                           this.total_resource_group_slot.hyperaccel_lpu_device,
                           2,
                         )} Hyperaccel LPUs"
@@ -1258,10 +1258,10 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                           .hyperaccel_lpu_device / 100.0}"
                         buffer="${this.used_slot_percent.hyperaccel_lpu_device /
                         100.0}"
-                        description="${this._prefixFormatWithTrailingZeros(
+                        description="${this._prefixFormatWithoutTrailingZeros(
                           this.used_slot.hyperaccel_lpu_device,
                           2,
-                        )} / ${this._prefixFormatWithTrailingZeros(
+                        )} / ${this._prefixFormatWithoutTrailingZeros(
                           this.total_slot.hyperaccel_lpu_device,
                           2,
                         )} Hyperaccel LPUs"
@@ -1270,7 +1270,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_resource_group_slot_percent
                               .hyperaccel_lpu_device,
                             1,
@@ -1280,7 +1280,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_slot_percent.hyperaccel_lpu_device,
                             1,
                           ),
@@ -1304,12 +1304,12 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                   id="concurrency-usage-bar"
                   class="start"
                   progress="${this.used_slot_percent.concurrency / 100.0}"
-                  description="${this._prefixFormatWithTrailingZeros(
+                  description="${this._prefixFormatWithoutTrailingZeros(
                     this.concurrency_used,
                     0,
                   )} / ${this.concurrency_max === 1000000
                     ? '∞'
-                    : this._prefixFormatWithTrailingZeros(
+                    : this._prefixFormatWithoutTrailingZeros(
                         this.concurrency_max,
                         2,
                       )}"
@@ -1318,7 +1318,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
               <div class="layout vertical center center-justified">
                 <span class="percentage end-bar" style="margin-top:0px;">
                   ${this._numberWithPostfix(
-                    this._prefixFormatWithTrailingZeros(
+                    this._prefixFormatWithoutTrailingZeros(
                       this.used_slot_percent.concurrency,
                       1,
                     ),
@@ -1405,12 +1405,12 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       id="cpu-project-usage-bar"
                       class="start"
                       progress="${this.used_project_slot_percent.cpu / 100.0}"
-                      description="${this._prefixFormatWithTrailingZeros(
+                      description="${this._prefixFormatWithoutTrailingZeros(
                         this.used_project_slot.cpu,
                         0,
                       )} / ${this.total_project_slot.cpu === Infinity
                         ? '∞'
-                        : this._prefixFormatWithTrailingZeros(
+                        : this._prefixFormatWithoutTrailingZeros(
                             this.total_project_slot.cpu,
                             0,
                           )} Cores"
@@ -1418,7 +1418,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_project_slot_percent.cpu,
                             1,
                           ),
@@ -1427,7 +1427,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.total_project_slot.cpu,
                             1,
                           ),
@@ -1447,7 +1447,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       description=">${this.used_project_slot.mem} / ${this
                         .total_project_slot.mem === Infinity
                         ? '∞'
-                        : this._prefixFormatWithTrailingZeros(
+                        : this._prefixFormatWithoutTrailingZeros(
                             this.total_project_slot.mem,
                             2,
                           )} GiB"
@@ -1455,7 +1455,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.used_project_slot_percent.mem,
                             1,
                           ),
@@ -1464,7 +1464,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                       </span>
                       <span class="percentage end-bar">
                         ${this._numberWithPostfix(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.total_project_slot.mem,
                             1,
                           ),
@@ -1486,13 +1486,13 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                             class="end"
                             progress="${this.used_project_slot_percent
                               .cuda_device / 100.0}"
-                            description="${this._prefixFormatWithTrailingZeros(
+                            description="${this._prefixFormatWithoutTrailingZeros(
                               this.used_project_slot.cuda_device,
                               2,
                             )} / ${this.total_project_slot.cuda_device ===
                             'Infinity'
                               ? '∞'
-                              : this._prefixFormatWithTrailingZeros(
+                              : this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.cuda_device,
                                   2,
                                 )} CUDA GPUs"
@@ -1500,7 +1500,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.used_project_slot_percent.cuda_device,
                                   1,
                                 ),
@@ -1509,7 +1509,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.cuda_device,
                                   1,
                                 ),
@@ -1537,7 +1537,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .cuda_shares}/${this.total_project_slot
                               .cuda_shares === 'Infinity'
                               ? '∞'
-                              : this._prefixFormatWithTrailingZeros(
+                              : this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.cuda_shares,
                                   2,
                                 )} CUDA FGPUs"
@@ -1545,7 +1545,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.used_project_slot_percent.cuda_shares,
                                   1,
                                 ),
@@ -1554,7 +1554,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.cuda_shares,
                                   1,
                                 ),
@@ -1582,7 +1582,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .rocm_device}/${this.total_project_slot
                               .rocm_device === 'Infinity'
                               ? '∞'
-                              : this._prefixFormatWithTrailingZeros(
+                              : this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.rocm_device,
                                   2,
                                 )} ROCm GPUs"
@@ -1590,7 +1590,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.used_project_slot_percent.rocm_device,
                                   1,
                                 ),
@@ -1599,7 +1599,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.rocm_device,
                                   1,
                                 ),
@@ -1627,7 +1627,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .tpu_device}/${this.total_project_slot
                               .tpu_device === 'Infinity'
                               ? '∞'
-                              : this._prefixFormatWithTrailingZeros(
+                              : this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.tpu_device,
                                   2,
                                 )} TPUs"
@@ -1635,7 +1635,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.used_project_slot_percent.tpu_device,
                                   1,
                                 ),
@@ -1644,7 +1644,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.tpu_device,
                                   1,
                                 ),
@@ -1672,7 +1672,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .ipu_device}/${this.total_project_slot
                               .ipu_device === 'Infinity'
                               ? '∞'
-                              : this._prefixFormatWithTrailingZeros(
+                              : this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.ipu_device,
                                   2,
                                 )} IPUs"
@@ -1680,7 +1680,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.used_project_slot_percent.ipu_device,
                                   1,
                                 ),
@@ -1689,7 +1689,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.ipu_device,
                                   1,
                                 ),
@@ -1717,7 +1717,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .atom_device}/${this.total_project_slot
                               .atom_device === 'Infinity'
                               ? '∞'
-                              : this._prefixFormatWithTrailingZeros(
+                              : this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.atom_device,
                                   2,
                                 )} ATOMs"
@@ -1725,7 +1725,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.used_project_slot_percent.atom_device,
                                   1,
                                 ),
@@ -1734,7 +1734,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.atom_device,
                                   1,
                                 ),
@@ -1762,7 +1762,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .warboy_device}/${this.total_project_slot
                               .warboy_device === 'Infinity'
                               ? '∞'
-                              : this._prefixFormatWithTrailingZeros(
+                              : this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.warboy_device,
                                   2,
                                 )} Warboys"
@@ -1770,7 +1770,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.used_project_slot_percent.warboy_device,
                                   1,
                                 ),
@@ -1779,7 +1779,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.warboy_device,
                                   1,
                                 ),
@@ -1807,7 +1807,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                               .hyperaccel_lpu_device}/${this.total_project_slot
                               .hyperaccel_lpu_device === 'Infinity'
                               ? '∞'
-                              : this._prefixFormatWithTrailingZeros(
+                              : this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.hyperaccel_lpu_device,
                                   2,
                                 )} Hyperaccel LPUs"
@@ -1815,7 +1815,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                           <div class="layout vertical center center-justified">
                             <span class="percentage start-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.used_project_slot_percent
                                     .hyperaccel_lpu_device,
                                   1,
@@ -1825,7 +1825,7 @@ export default class BackendAiResourceMonitor extends BackendAIPage {
                             </span>
                             <span class="percentage end-bar">
                               ${this._numberWithPostfix(
-                                this._prefixFormatWithTrailingZeros(
+                                this._prefixFormatWithoutTrailingZeros(
                                   this.total_project_slot.hyperaccel_lpu_device,
                                   1,
                                 ),

--- a/src/components/backend-ai-resource-panel.ts
+++ b/src/components/backend-ai-resource-panel.ts
@@ -524,7 +524,7 @@ export default class BackendAIResourcePanel extends BackendAIPage {
     return num.toString().replace(regexp, ',');
   }
 
-  _prefixFormatWithTrailingZeros(num: string | number = '0', fixed: number) {
+  _prefixFormatWithoutTrailingZeros(num: string | number = '0', fixed: number) {
     const number = typeof num === 'string' ? parseFloat(num) : num;
     return parseFloat(number.toFixed(fixed)).toString();
   }
@@ -575,9 +575,12 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                         class="start"
                         progress="${this.cpu_total_usage_ratio / 100.0}"
                         description="${this._addComma(
-                          this._prefixFormatWithTrailingZeros(this.cpu_used, 0),
+                          this._prefixFormatWithoutTrailingZeros(
+                            this.cpu_used,
+                            0,
+                          ),
                         )}/${this._addComma(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.cpu_total,
                             0,
                           ),
@@ -589,10 +592,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                         progress="${this.cpu_current_usage_ratio / 100.0}"
                         description="${_t(
                           'summary.Using',
-                        )} ${this._prefixFormatWithTrailingZeros(
+                        )} ${this._prefixFormatWithoutTrailingZeros(
                           this.cpu_total_percent,
                           1,
-                        )} % (util. ${this._prefixFormatWithTrailingZeros(
+                        )} % (util. ${this._prefixFormatWithoutTrailingZeros(
                           this.cpu_percent,
                           1,
                         )} %)"
@@ -600,13 +603,13 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
-                        ${this._prefixFormatWithTrailingZeros(
+                        ${this._prefixFormatWithoutTrailingZeros(
                           this.cpu_total_percent,
                           1,
                         ) + '%'}
                       </span>
                       <span class="percentage end-bar">
-                        ${this._prefixFormatWithTrailingZeros(
+                        ${this._prefixFormatWithoutTrailingZeros(
                           this.cpu_percent,
                           1,
                         ) + '%'}
@@ -626,12 +629,12 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                         class="start"
                         progress="${this.mem_total_usage_ratio / 100.0}"
                         description="${this._addComma(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.mem_allocated,
                             2,
                           ),
                         )} / ${this._addComma(
-                          this._prefixFormatWithTrailingZeros(
+                          this._prefixFormatWithoutTrailingZeros(
                             this.mem_total,
                             2,
                           ),
@@ -642,10 +645,13 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                         class="end"
                         progress="${this.mem_current_usage_ratio / 100.0}"
                         description="${_t('summary.Using')} ${this._addComma(
-                          this._prefixFormatWithTrailingZeros(this.mem_used, 2),
+                          this._prefixFormatWithoutTrailingZeros(
+                            this.mem_used,
+                            2,
+                          ),
                         )} GiB
                     (${parseInt(this.mem_used) !== 0
-                          ? this._prefixFormatWithTrailingZeros(
+                          ? this._prefixFormatWithoutTrailingZeros(
                               (parseInt(this.mem_used) /
                                 parseInt(this.mem_total)) *
                                 100,
@@ -656,14 +662,14 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                     </div>
                     <div class="layout vertical center center-justified">
                       <span class="percentage start-bar">
-                        ${this._prefixFormatWithTrailingZeros(
+                        ${this._prefixFormatWithoutTrailingZeros(
                           this.mem_total_usage_ratio,
                           1,
                         ) + '%'}
                       </span>
                       <span class="percentage end-bar">
                         ${(parseInt(this.mem_used) !== 0
-                          ? this._prefixFormatWithTrailingZeros(
+                          ? this._prefixFormatWithoutTrailingZeros(
                               (parseInt(this.mem_used) /
                                 parseInt(this.mem_total)) *
                                 100,
@@ -724,7 +730,7 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                     >
                                       <span class="percentage start-bar">
                                         ${this.cuda_gpu_used !== 0
-                                          ? this._prefixFormatWithTrailingZeros(
+                                          ? this._prefixFormatWithoutTrailingZeros(
                                               (this.cuda_gpu_used /
                                                 this.cuda_gpu_total) *
                                                 100,
@@ -774,7 +780,7 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                     >
                                       <span class="percentage start-bar">
                                         ${this.cuda_fgpu_used !== 0
-                                          ? this._prefixFormatWithTrailingZeros(
+                                          ? this._prefixFormatWithoutTrailingZeros(
                                               (this.cuda_fgpu_used /
                                                 this.cuda_fgpu_total) *
                                                 100,
@@ -820,7 +826,7 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this._prefixFormatWithTrailingZeros(
+                                        ${this._prefixFormatWithoutTrailingZeros(
                                           this.rocm_gpu_used,
                                           1,
                                         ) + '%'}
@@ -842,10 +848,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         id="tpu-usage-bar"
                                         class="start"
                                         progress="${this.tpu_used / 100.0}"
-                                        description="${this._prefixFormatWithTrailingZeros(
+                                        description="${this._prefixFormatWithoutTrailingZeros(
                                           this.tpu_used,
                                           2,
-                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                        )} / ${this._prefixFormatWithoutTrailingZeros(
                                           this.tpu_total,
                                           2,
                                         )} TPUs ${_t('summary.reserved')}."
@@ -863,7 +869,7 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this._prefixFormatWithTrailingZeros(
+                                        ${this._prefixFormatWithoutTrailingZeros(
                                           this.tpu_used,
                                           1,
                                         ) + '%'}
@@ -883,10 +889,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         id="ipu-usage-bar"
                                         class="start"
                                         progress="${this.ipu_used / 100.0}"
-                                        description="${this._prefixFormatWithTrailingZeros(
+                                        description="${this._prefixFormatWithoutTrailingZeros(
                                           this.ipu_used,
                                           2,
-                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                        )} / ${this._prefixFormatWithoutTrailingZeros(
                                           this.ipu_total,
                                           2,
                                         )} IPUs ${_t('summary.reserved')}."
@@ -904,7 +910,7 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this._prefixFormatWithTrailingZeros(
+                                        ${this._prefixFormatWithoutTrailingZeros(
                                           this.ipu_used,
                                           1,
                                         ) + '%'}
@@ -924,10 +930,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         id="atom-usage-bar"
                                         class="start"
                                         progress="${this.atom_used / 100.0}"
-                                        description="${this._prefixFormatWithTrailingZeros(
+                                        description="${this._prefixFormatWithoutTrailingZeros(
                                           this.atom_used,
                                           2,
-                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                        )} / ${this._prefixFormatWithoutTrailingZeros(
                                           this.atom_total,
                                           2,
                                         )} ATOMs ${_t('summary.reserved')}."
@@ -945,7 +951,7 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this._prefixFormatWithTrailingZeros(
+                                        ${this._prefixFormatWithoutTrailingZeros(
                                           this.atom_used,
                                           1,
                                         ) + '%'}
@@ -966,10 +972,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         class="start"
                                         progress="${this.atom_plus_used /
                                         100.0}"
-                                        description="${this._prefixFormatWithTrailingZeros(
+                                        description="${this._prefixFormatWithoutTrailingZeros(
                                           this.atom_plus_used,
                                           2,
-                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                        )} / ${this._prefixFormatWithoutTrailingZeros(
                                           this.atom_plus_total,
                                           2,
                                         )} ATOM+ ${_t('summary.reserved')}."
@@ -987,7 +993,7 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this._prefixFormatWithTrailingZeros(
+                                        ${this._prefixFormatWithoutTrailingZeros(
                                           this.atom_plus_used,
                                           1,
                                         ) + '%'}
@@ -1007,10 +1013,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         id="warboy-usage-bar"
                                         class="start"
                                         progress="${this.warboy_used / 100.0}"
-                                        description="${this._prefixFormatWithTrailingZeros(
+                                        description="${this._prefixFormatWithoutTrailingZeros(
                                           this.warboy_used,
                                           2,
-                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                        )} / ${this._prefixFormatWithoutTrailingZeros(
                                           this.warboy_total,
                                           2,
                                         )} Warboys ${_t('summary.reserved')}."
@@ -1028,7 +1034,7 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this._prefixFormatWithTrailingZeros(
+                                        ${this._prefixFormatWithoutTrailingZeros(
                                           this.warboy_used,
                                           1,
                                         ) + '%'}
@@ -1049,10 +1055,10 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                         class="start"
                                         progress="${this.hyperaccel_lpu_used /
                                         100.0}"
-                                        description="${this._prefixFormatWithTrailingZeros(
+                                        description="${this._prefixFormatWithoutTrailingZeros(
                                           this.hyperaccel_lpu_used,
                                           2,
-                                        )} / ${this._prefixFormatWithTrailingZeros(
+                                        )} / ${this._prefixFormatWithoutTrailingZeros(
                                           this.hyperaccel_lpu_total,
                                           2,
                                         )} Hyperaccel LPUs ${_t(
@@ -1072,7 +1078,7 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                       class="layout vertical center center-justified"
                                     >
                                       <span class="percentage start-bar">
-                                        ${this._prefixFormatWithTrailingZeros(
+                                        ${this._prefixFormatWithoutTrailingZeros(
                                           this.hyperaccel_lpu_used,
                                           1,
                                         ) + '%'}

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1466,6 +1466,14 @@ export default class BackendAISessionList extends BackendAIPage {
     return (value / 2 ** 30).toFixed(decimalPoint);
   }
 
+  static _prefixFormatWithoutTrailingZeros(
+    num: string | number = '0',
+    fixed: number,
+  ) {
+    const number = typeof num === 'string' ? parseFloat(num) : num;
+    return parseFloat(number.toFixed(fixed)).toString();
+  }
+
   /**
    * Return elapsed time
    *
@@ -3607,13 +3615,16 @@ ${rowData.item[this.sessionNameField]}</pre
               <div class="usage-items">
                 RAM
                 ${rowData.item.live_stat
-                  ? BackendAISessionList.bytesToGiB(
-                      rowData.item.live_stat?.mem?.current,
-                      1,
-                    ) /
-                    BackendAISessionList.bytesToGiB(
-                      rowData.item.live_stat?.mem?.capacity,
-                      1,
+                  ? BackendAISessionList._prefixFormatWithoutTrailingZeros(
+                      BackendAISessionList.bytesToGiB(
+                        rowData.item.live_stat?.mem?.current,
+                        1,
+                      ) /
+                        BackendAISessionList.bytesToGiB(
+                          rowData.item.live_stat?.mem?.capacity,
+                          1,
+                        ),
+                      2,
                     )
                   : `-`}
                 GiB
@@ -3704,13 +3715,16 @@ ${rowData.item[this.sessionNameField]}</pre
                     <div class="usage-items">
                       GPU(mem)
                       ${rowData.item.live_stat
-                        ? BackendAISessionList.bytesToGiB(
-                            rowData.item.live_stat?.cuda_mem?.current,
-                            1,
-                          ) /
-                          BackendAISessionList.bytesToGiB(
-                            rowData.item.live_stat?.cuda_mem?.capacity,
-                            1,
+                        ? BackendAISessionList._prefixFormatWithoutTrailingZeros(
+                            BackendAISessionList.bytesToGiB(
+                              rowData.item.live_stat?.cuda_mem?.current,
+                              1,
+                            ) /
+                              BackendAISessionList.bytesToGiB(
+                                rowData.item.live_stat?.cuda_mem?.capacity,
+                                1,
+                              ),
+                            2,
                           )
                         : `-`}
                       GiB


### PR DESCRIPTION
follows #2518 
resolves [Teams threads](https://teams.microsoft.com/l/message/19:eedd90a03a4d44b181161b0241b68a64@thread.tacv2/1724737890117?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=b1f3bcf4-facf-40d3-94ab-169abb4f0f52&parentMessageId=1724640841809&teamName=customers%20%26%20clients&channelName=SEC%20GTR&createdTime=1724737890117)

### TL;DR

Improved formatting of RAM and GPU memory usage display in session list.

### What changed?

- Added a new static method `_prefixFormatWithTrailingZeros` to format numbers with a fixed number of decimal places.
- Updated the RAM and GPU memory usage display to use the new formatting method, ensuring consistent decimal places.

### How to test?

1. Open the session list view.
2. Create or connect to a session with active resource usage.
3. Verify that the RAM and GPU memory usage values are displayed with two decimal places consistently.
4. Check different sessions with varying resource usage to ensure the formatting is applied correctly in all cases.

### Why make this change?

This change improves the readability and consistency of resource usage information in the session list. By formatting the RAM and GPU memory usage values with a fixed number of decimal places, it becomes easier for users to compare resource utilization across different sessions at a glance.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version: 23.09
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
