### PR TITLE
chore: add test code for `getImageMeta`

### DIFF
--- a/react/src/hooks/useBackendAIImageMetaData.test.tsx
+++ b/react/src/hooks/useBackendAIImageMetaData.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable testing-library/render-result-naming-convention */
 import { useBackendAIImageMetaData } from '.';
+import { getImageFullName } from '../helper';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { ReactNode } from 'react';
@@ -84,5 +85,52 @@ describe('useBackendAIImageMetaData', () => {
     );
     expect(baseImages[0]).toBe('');
     expect(baseImages[1]).toBe('test12');
+  });
+
+  it('`getImageMeta` function can handle images with more than two `/` in name.', async () => {
+    const [, { getImageMeta }] = result.current;
+
+    const { key, tags } = getImageMeta(
+      getImageFullName({
+        name: 'abc/def/training',
+        humanized_name: 'abc/def/training',
+        tag: '01-py3-abc-v1',
+        registry: '192.168.0.1:7080',
+        architecture: 'x86_64',
+        digest: 'sha256:123456',
+        id: 'sample id',
+        installed: true,
+        resource_limits: [
+          {
+            key: 'cpu',
+            min: '1',
+            max: null,
+          },
+          {
+            key: 'mem',
+            min: '1g',
+            max: null,
+          },
+          {
+            key: 'cuda.device',
+            min: '0',
+            max: null,
+          },
+          {
+            key: 'cuda.shares',
+            min: '0',
+            max: null,
+          },
+        ],
+        labels: [
+          {
+            key: 'maintainer',
+            value: 'NVIDIA CORPORATION <cudatools@nvidia.com>',
+          },
+        ],
+      }) || '',
+    );
+    expect(key).toBe('training');
+    expect(tags).toStrictEqual(['01', 'py3', 'abc', 'v1']);
   });
 });


### PR DESCRIPTION
### TL;DR

Added a new test case for handling exceptions in the `getImageMeta` function.
This is test code for https://github.com/lablup/backend.ai-webui/pull/2109

### What changed?

- Imported the `getImageFullName` function from the helper module.
- Added a new test case `getImageMeta handle exception` to the `useBackendAIImageMetaData` test suite.
- The new test case verifies that `getImageMeta` correctly handles and processes complex image metadata.

### How to test?

1. Run the test suite for `useBackendAIImageMetaData`.
2. Verify that the new test case passes successfully.
3. Ensure that the `getImageMeta` function correctly extracts the `key` and `tags` from the provided image metadata.

### Why make this change?

This change improves the test coverage for the `getImageMeta` function, specifically for handling complex image metadata scenarios. It ensures that the function can correctly process and extract relevant information from various image configurations, including those with multiple resource limits and labels.