### PR TITLE
e2e: test NEO session launcher and imageList 

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,6 @@
 src/lib/
 !/src
 !/react
+!/e2e
 **/__generated__/*.graphql.ts
 *.graphql

--- a/e2e/.prettierrc.json
+++ b/e2e/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "importOrderSeparation": true,
+  "importOrderParserPlugins": ["typescript", "jsx"],
+  "printWidth": 80,
+  "bracketSpacing": true,
+  "trailingComma": "all",
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
+  "singleAttributePerLine": false
+}

--- a/e2e/agent.test.ts
+++ b/e2e/agent.test.ts
@@ -1,47 +1,47 @@
-import { test, expect } from "@playwright/test";
-import { loginAsAdmin } from "./test-util";
-import { checkActiveTab, findColumnIndex } from "./test-util-antd";
+import { loginAsAdmin } from './test-util';
+import { checkActiveTab, findColumnIndex } from './test-util-antd';
+import { test, expect } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
   await loginAsAdmin(page);
-  await page.getByRole("menuitem", { name: "hdd Resources" }).click();
+  await page.getByRole('menuitem', { name: 'hdd Resources' }).click();
   await expect(
-    page.getByRole("heading", { name: "Computation Resources" }),
+    page.getByRole('heading', { name: 'Computation Resources' }),
   ).toBeVisible();
 });
 
-test.describe("Agent list", () => {
+test.describe('Agent list', () => {
   let resourcesPageTab;
   let agentListTable;
 
   test.beforeEach(async ({ page }) => {
     const firstCard = await page
-      .locator(".ant-layout-content .ant-card")
+      .locator('.ant-layout-content .ant-card')
       .first();
-    resourcesPageTab = await firstCard.locator(".ant-tabs");
-    agentListTable = await firstCard.locator(".ant-table");
+    resourcesPageTab = await firstCard.locator('.ant-tabs');
+    agentListTable = await firstCard.locator('.ant-table');
   });
 
-  test("should have at least one connected agent", async ({ page }) => {
+  test('should have at least one connected agent', async ({ page }) => {
     const firstCard = await page
-      .locator(".ant-layout-content .ant-card")
+      .locator('.ant-layout-content .ant-card')
       .first();
-    await checkActiveTab(firstCard.locator(".ant-tabs"), "Agent");
+    await checkActiveTab(firstCard.locator('.ant-tabs'), 'Agent');
 
-    const selectedSegment = await page.locator(".ant-segmented-item-selected");
-    await expect(selectedSegment).toContainText("Connected");
+    const selectedSegment = await page.locator('.ant-segmented-item-selected');
+    await expect(selectedSegment).toContainText('Connected');
 
-    const rows = await agentListTable.locator(".ant-table-row");
+    const rows = await agentListTable.locator('.ant-table-row');
     const rowCount = await rows.count();
     expect(rowCount).toBeGreaterThan(0);
     const firstRow = rows.first();
 
-    const columnIndex = await findColumnIndex(agentListTable, "ID / Endpoint");
+    const columnIndex = await findColumnIndex(agentListTable, 'ID / Endpoint');
     const specificColumn = await firstRow
-      .locator(".ant-table-cell")
+      .locator('.ant-table-cell')
       .nth(columnIndex);
     const columnText = await specificColumn.textContent();
-    const firstAgentId = columnText?.split("tcp://")[0];
+    const firstAgentId = columnText?.split('tcp://')[0];
     expect(firstAgentId).toBeTruthy();
   });
 });

--- a/e2e/environment.test.ts
+++ b/e2e/environment.test.ts
@@ -1,0 +1,190 @@
+import { loginAsAdmin, navigateTo } from './test-util';
+import { findColumnIndex } from './test-util-antd';
+import { expect, test } from '@playwright/test';
+
+test.describe('environment ', () => {
+  let imageListTable;
+  test.beforeEach(async ({ page }) => {
+    imageListTable = await page.locator('.ant-table');
+  });
+  test('Rendering Image List', async ({ page }) => {
+    await loginAsAdmin(page);
+    await navigateTo(page, 'environment');
+    const table = page.locator('.ant-table-content');
+    await expect(table).toBeVisible();
+  });
+
+  // skip this test because there is no way to uninstall the image in WebUI
+  test.skip('user can install image', async ({ page }) => {
+    await loginAsAdmin(page);
+    await navigateTo(page, 'environment');
+    await expect(imageListTable).toBeVisible();
+    // Sort installation status
+    await page.locator('.ant-table-cell.ant-table-column-sort').first().click();
+
+    // Find uninstalled item and select
+    const uninstalledImage = page
+      .locator('.ant-table-cell.ant-table-column-sort')
+      .filter({
+        hasNot: page.locator('.ant-tag-gold'),
+      })
+      .nth(1);
+    // If all images are installed, skip the test
+    const count = await uninstalledImage.count();
+    if (count === 0) {
+      test.skip();
+    }
+    await uninstalledImage.click();
+
+    // Install image
+    await page
+      .getByRole('button', { name: 'vertical-align-bottom Install' })
+      .click();
+    await page.getByRole('button', { name: 'Install', exact: true }).click();
+    await expect(
+      page.getByText('It takes time so have a cup of coffee!'),
+    ).toBeVisible();
+
+    // Verify installing status
+    const rows = await imageListTable.locator('.ant-table-row');
+    const statusColumnIndex = await findColumnIndex(imageListTable, 'Status');
+
+    const installingItem = await rows
+      .locator('.ant-table-cell')
+      .nth(statusColumnIndex)
+      .first();
+    await expect(installingItem.getByText('installing')).toBeVisible();
+  });
+
+  test('user can modify image resource limit', async ({ page }) => {
+    await loginAsAdmin(page);
+    await navigateTo(page, 'environment');
+    await expect(imageListTable).toBeVisible();
+
+    // Click resource limit button
+    const rows = await imageListTable.locator('.ant-table-row');
+    const firstRow = await rows.first();
+    const controlColumnIndex = await findColumnIndex(imageListTable, 'Control');
+    await firstRow
+      .locator('.ant-table-cell')
+      .nth(controlColumnIndex)
+      .getByRole('button', { name: 'setting' })
+      .click();
+
+    // Modify resource limit
+    const resourceValue = await page
+      .getByRole('slider')
+      .first()
+      .getAttribute('aria-valuenow');
+    let modifiedResourceValue;
+    if (resourceValue === '0') {
+      modifiedResourceValue = Number(resourceValue) + 1;
+      await page.locator('.ant-slider-dot').nth(modifiedResourceValue).click();
+    } else {
+      modifiedResourceValue = Number(resourceValue) - 1;
+      await page
+        .locator('.ant-slider-dot.ant-slider-dot-active')
+        .nth(modifiedResourceValue)
+        .click();
+    }
+
+    // Click OK Button
+    await page.getByRole('button', { name: 'OK' }).click();
+    const reinstallationText = await page
+      .getByText('Image reinstallation required')
+      .count();
+    if (reinstallationText > 0) {
+      await page.getByRole('button', { name: 'OK' }).nth(1).click();
+    }
+
+    // Verify image is modified
+    const resourceLimitControlIndex = await findColumnIndex(
+      imageListTable,
+      'Resource Limit',
+    );
+    const resource = await firstRow
+      .locator('.ant-table-cell')
+      .nth(resourceLimitControlIndex);
+    await expect(resource.getByText(`${modifiedResourceValue}`)).toBeVisible();
+
+    // Reset resource limit
+    await firstRow
+      .locator('.ant-table-cell')
+      .nth(controlColumnIndex)
+      .getByRole('button', { name: 'setting' })
+      .click();
+    await page.locator('.ant-slider-dot').nth(Number(resourceValue)).click();
+    await page.getByRole('button', { name: 'OK' }).click();
+    if (reinstallationText > 0) {
+      await page.getByRole('button', { name: 'OK' }).nth(1).click();
+    }
+  });
+
+  test('user can manage apps', async ({ page }) => {
+    await loginAsAdmin(page);
+    await navigateTo(page, 'environment');
+    await expect(imageListTable).toBeVisible();
+    // Click manage apps button
+
+    const rows = await imageListTable.locator('.ant-table-row');
+    const firstRow = await rows.first();
+    const controlColumnIndex = await findColumnIndex(imageListTable, 'Control');
+    await firstRow
+      .locator('.ant-table-cell')
+      .nth(controlColumnIndex)
+      .getByRole('button', { name: 'appstore' })
+      .click();
+
+    // Add app
+    const numberOfApps = await page
+      .locator('.ant-form-item-control-input-content > div')
+      .count();
+    await page.getByRole('button', { name: 'plus Add' }).click();
+    const addInfo = {
+      app: 'e2e-test-app',
+      protocol: 'tcp',
+      port: '6006',
+    };
+    await page.locator(`#apps_${numberOfApps}_app`).fill(addInfo.app);
+    await page.locator(`#apps_${numberOfApps}_protocol`).fill(addInfo.protocol);
+    await page.locator(`#apps_${numberOfApps}_port`).fill(addInfo.port);
+
+    // Click OK Button
+    await page.getByRole('button', { name: 'OK' }).click();
+    const reinstallationText = await page
+      .getByText('Image reinstallation required')
+      .count();
+    if (reinstallationText > 0) {
+      await page.getByRole('button', { name: 'OK' }).nth(1).click();
+    }
+
+    // Verify app is added
+    await firstRow
+      .locator('.ant-table-cell')
+      .nth(controlColumnIndex)
+      .getByRole('button', { name: 'appstore' })
+      .click();
+    const numberOfAppsAfterAdd = await page
+      .locator('.ant-form-item-control-input-content > div')
+      .count();
+    expect(numberOfAppsAfterAdd).toBe(numberOfApps + 1);
+    const lastRow = page
+      .locator('.ant-form-item-control-input-content > div')
+      .last();
+    await expect(lastRow.getByPlaceholder('App Name')).toHaveValue(addInfo.app);
+    await expect(lastRow.getByPlaceholder('Protocol')).toHaveValue(
+      addInfo.protocol,
+    );
+    await expect(lastRow.getByPlaceholder('Port')).toHaveValue(addInfo.port);
+
+    // Reset apps
+    await page
+      .getByRole('button', { name: 'delete' })
+      .nth(numberOfAppsAfterAdd - 1)
+      .click();
+    await page.getByRole('button', { name: 'OK' }).click();
+    if (reinstallationText > 0) {
+      await page.getByRole('button', { name: 'OK' }).nth(1).click();
+    }
+  });
+});

--- a/e2e/login.test.ts
+++ b/e2e/login.test.ts
@@ -1,9 +1,8 @@
-import { test, expect } from '@playwright/test';
 import { loginAsAdmin } from './test-util';
+import { test, expect } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('http://127.0.0.1:9081');
-  
 });
 
 test.describe('Before login', () => {
@@ -24,4 +23,3 @@ test.describe('Login using the admin account', () => {
     await expect(page.getByRole('heading', { name: 'Summary' })).toBeVisible();
   });
 });
-

--- a/e2e/session.test.ts
+++ b/e2e/session.test.ts
@@ -1,0 +1,11 @@
+import { createSession, deleteSession, loginAsUser } from './test-util';
+import { test, expect } from '@playwright/test';
+
+test.describe('Sessions ', () => {
+  const sessionName = 'e2e-test-session';
+  test('User can create session in NEO', async ({ page }) => {
+    await loginAsUser(page);
+    await createSession(page, sessionName);
+    await deleteSession(page, sessionName);
+  });
+});

--- a/e2e/test-util-antd.ts
+++ b/e2e/test-util-antd.ts
@@ -1,22 +1,22 @@
-import { Locator, expect } from "@playwright/test";
+import { Locator, expect } from '@playwright/test';
 
 export async function checkActiveTab(
   tabsLocator: Locator,
   expectedTabName: string,
 ) {
-  const activeTab = await tabsLocator.locator(".ant-tabs-tab-active");
+  const activeTab = await tabsLocator.locator('.ant-tabs-tab-active');
   await expect(activeTab).toContainText(expectedTabName);
 }
 
 export async function getTableHeaders(page: Locator) {
-  return await page.locator(".ant-table-thead th");
+  return await page.locator('.ant-table-thead th');
 }
 
 export async function findColumnIndex(
   tableLocator: Locator,
   columnTitle: string,
 ) {
-  const headers = await tableLocator.locator(".ant-table-thead th");
+  const headers = await tableLocator.locator('.ant-table-thead th');
   const columnIndex = await headers.evaluateAll((ths, title) => {
     return ths.findIndex((th) => th.textContent?.trim() === title);
   }, columnTitle);

--- a/e2e/test-util.ts
+++ b/e2e/test-util.ts
@@ -1,7 +1,7 @@
-import { Page, expect } from "@playwright/test";
+import { Page, expect } from '@playwright/test';
 
-const webuiEndpoint = "http://127.0.0.1:9081";
-const webServerEndpoint =  "http://127.0.0.1:8090";
+const webuiEndpoint = 'http://127.0.0.1:9081';
+const webServerEndpoint = 'http://127.0.0.1:8090';
 export async function login(
   page: Page,
   username: string,
@@ -9,43 +9,42 @@ export async function login(
   endpoint: string,
 ) {
   await page.goto(webuiEndpoint);
-  await page.locator("#id_password label").click();
-  await page.getByLabel("E-mail or Username").click();
-  await page.getByLabel("E-mail or Username").fill(username);
-  await page.getByRole("textbox", { name: "Password" }).click();
-  await page.getByRole("textbox", { name: "Password" }).fill(password);
-  await page.getByRole("textbox", { name: "Endpoint" }).click();
-  await page.getByRole("textbox", { name: "Endpoint" }).fill(endpoint);
-  await page.getByLabel("Login", { exact: true }).click();
+  await page.locator('#id_password label').click();
+  await page.getByLabel('E-mail or Username').click();
+  await page.getByLabel('E-mail or Username').fill(username);
+  await page.getByRole('textbox', { name: 'Password' }).click();
+  await page.getByRole('textbox', { name: 'Password' }).fill(password);
+  await page.getByRole('textbox', { name: 'Endpoint' }).click();
+  await page.getByRole('textbox', { name: 'Endpoint' }).fill(endpoint);
+  await page.getByLabel('Login', { exact: true }).click();
   await page.waitForSelector('[data-testid="user-dropdown-button"]');
-
 }
 
 export async function loginAsAdmin(page: Page) {
-  await login(page, "admin@lablup.com", "wJalrXUt", webServerEndpoint);
+  await login(page, 'admin@lablup.com', 'wJalrXUt', webServerEndpoint);
 }
 export async function loginAsDomainAdmin(page: Page) {
   await login(
     page,
-    "domain-admin@lablup.com",
-    "cWbsM_vB",
-    "http://127.0.0.1:8090",
+    'domain-admin@lablup.com',
+    'cWbsM_vB',
+    'http://127.0.0.1:8090',
   );
 }
 export async function loginAsUser(page: Page) {
-  await login(page, "user@lablup.com", "C8qnIo29", webServerEndpoint);
+  await login(page, 'user@lablup.com', 'C8qnIo29', webServerEndpoint);
 }
 export async function loginAsUser2(page: Page) {
-  await login(page, "user2@lablup.com", "P7oxTDdz", webServerEndpoint);
+  await login(page, 'user2@lablup.com', 'P7oxTDdz', webServerEndpoint);
 }
 export async function loginAsMonitor(page: Page) {
-  await login(page, "monitor@lablup.com", "7tuEwF1J", webServerEndpoint);
+  await login(page, 'monitor@lablup.com', '7tuEwF1J', webServerEndpoint);
 }
 
 export async function logout(page: Page) {
-  await page.locator("text=Logout").click();
-  await page.getByTestId("user-dropdown-button").click();
-  await page.getByText("Log Out").click();
+  await page.locator('text=Logout').click();
+  await page.getByTestId('user-dropdown-button').click();
+  await page.getByText('Log Out').click();
 }
 
 export async function navigateTo(page: Page, path: string) {
@@ -64,7 +63,12 @@ export async function createVFolderAndVerify(page: Page, folderName: string) {
   await page.getByRole('textbox', { name: 'Folder name*' }).fill(folderName);
   await page.getByRole('button', { name: 'Create', exact: true }).click();
 
-  const nameInput = page.locator('#general-folder-storage vaadin-grid-cell-content').filter({ hasText: 'Name' }).locator('vaadin-text-field').nth(1).locator('input');
+  const nameInput = page
+    .locator('#general-folder-storage vaadin-grid-cell-content')
+    .filter({ hasText: 'Name' })
+    .locator('vaadin-text-field')
+    .nth(1)
+    .locator('input');
   await nameInput.click();
   await nameInput.fill(folderName);
   await page.waitForSelector(`text=folder_open ${folderName}`);
@@ -72,25 +76,102 @@ export async function createVFolderAndVerify(page: Page, folderName: string) {
 
 export async function deleteVFolderAndVerify(page: Page, folderName: string) {
   await navigateTo(page, 'data');
-  const nameInput = page.locator('#general-folder-storage vaadin-grid-cell-content').filter({ hasText: 'Name' }).locator('vaadin-text-field').nth(1).locator('input');
+  const nameInput = page
+    .locator('#general-folder-storage vaadin-grid-cell-content')
+    .filter({ hasText: 'Name' })
+    .locator('vaadin-text-field')
+    .nth(1)
+    .locator('input');
   await nameInput.click();
   await nameInput.fill(folderName);
   await page.waitForTimeout(1000);
   await page.getByRole('button', { name: 'delete' }).first().click();
-  await page.locator('#delete-without-confirm-button').getByLabel('delete').click();
+  await page
+    .locator('#delete-without-confirm-button')
+    .getByLabel('delete')
+    .click();
   await page.getByRole('tab', { name: 'delete' }).click();
 
   await page.waitForTimeout(1000);
-  const nameInputInTrash = page.locator('#trash-bin-folder-storage vaadin-grid-cell-content').filter({ hasText: 'Name' }).locator('vaadin-text-field').nth(1).locator('input');
+  const nameInputInTrash = page
+    .locator('#trash-bin-folder-storage vaadin-grid-cell-content')
+    .filter({ hasText: 'Name' })
+    .locator('vaadin-text-field')
+    .nth(1)
+    .locator('input');
   await nameInputInTrash.click();
   await nameInputInTrash.fill(folderName);
   await page.getByLabel('delete_forever').click();
-  await page.getByRole('textbox', { name: 'Type folder name to delete' }).fill(folderName);
+  await page
+    .getByRole('textbox', { name: 'Type folder name to delete' })
+    .fill(folderName);
   await page.waitForTimeout(1000);
-  await page.getByRole('textbox', { name: 'Type folder name to delete' }).click();
-  
-  await expect(page.locator('#trash-bin-folder-storage').getByText('e2e-test-folder', { exact: true })).toBeVisible();
-  
+  await page
+    .getByRole('textbox', { name: 'Type folder name to delete' })
+    .click();
+
+  await expect(
+    page
+      .locator('#trash-bin-folder-storage')
+      .getByText('e2e-test-folder', { exact: true }),
+  ).toBeVisible();
+
   await page.getByRole('button', { name: 'Delete forever' }).click();
-  await expect(page.locator('#trash-bin-folder-storage').getByText('e2e-test-folder', { exact: true })).toBeHidden();
+  await expect(
+    page
+      .locator('#trash-bin-folder-storage')
+      .getByText('e2e-test-folder', { exact: true }),
+  ).toBeHidden();
+}
+
+export async function createSession(page: Page, sessionName: string) {
+  await navigateTo(page, 'job');
+  await page.locator('#launch-session').filter({ hasText: 'Start' }).click();
+
+  // Session launch
+  const sessionNameInput = page.locator('#sessionName');
+  await sessionNameInput.fill(sessionName);
+  await page.getByRole('button', { name: 'Skip to review' }).click();
+
+  await page.locator('button').filter({ hasText: 'Launch' }).click();
+  await expect(page.locator('.ant-modal-confirm-title')).toHaveText(
+    'No storage folder is mounted',
+  );
+  await page.getByRole('button', { name: 'Start' }).click();
+
+  // Wait for App dialog and close it
+  await page
+    .getByRole('heading', { name: 'App close' })
+    .getByLabel('close')
+    .click();
+
+  // Verify that a cell exists to display the session name
+  const session = page
+    .locator('vaadin-grid-cell-content')
+    .filter({ hasText: `${sessionName} edit done` });
+  // it takes time to show the created session
+  await expect(session).toBeVisible({ timeout: 10000 });
+}
+
+export async function deleteSession(page: Page, sessionName: string) {
+  // Search by session name
+  const sessionList = page.locator('#running-jobs').locator('#list-grid');
+  const searchSessionInfo = sessionList
+    .locator('vaadin-grid-cell-content')
+    .nth(2)
+    .locator('vaadin-text-field')
+    .nth(1)
+    .locator('input');
+  await searchSessionInfo.fill(sessionName);
+
+  // Click terminate button
+  await page
+    .locator('[id="\\30 -power"]')
+    .getByLabel('power_settings_new')
+    .click();
+  await page.getByRole('button', { name: 'Okay' }).click();
+
+  // Verify session is cleared
+  await searchSessionInfo.fill('');
+  await expect(page.getByText(sessionName)).toBeHidden();
 }

--- a/e2e/vfolder.test.ts
+++ b/e2e/vfolder.test.ts
@@ -1,6 +1,9 @@
+import {
+  createVFolderAndVerify,
+  deleteVFolderAndVerify,
+  loginAsUser,
+} from './test-util';
 import { test } from '@playwright/test';
-import { createVFolderAndVerify, deleteVFolderAndVerify, loginAsUser } from './test-util';
-
 
 test.describe('VFolder ', () => {
   test('User can create and delete vFolder', async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -188,6 +188,9 @@
     ],
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
       "prettier --write"
+    ], 
+    "e2e/**/*.{js,ts}": [
+      "prettier --write"
     ]
   },
   "husky": {


### PR DESCRIPTION
### This PR resolves [#2657 ](https://github.com/lablup/backend.ai-webui/issues/2657) issue
### TL;DR

e2e test for NEO session creation and `imageList`

### What changed?
Test:
 - create and terminate a session without setting anything except the session name.  
 - rendering image list
 - install image
 - modify image resource limit
 - manage apps

