### PR TITLE
fix: enable a session log button when `PREPARING`

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -3313,8 +3313,7 @@ ${rowData.item[this.sessionNameField]}</pre
             : html``}
           ${((this._isRunning && !this._isPreparing(rowData.item.status)) ||
             this._APIMajorVersion > 4) &&
-          !this._isPending(rowData.item.status) &&
-          !this._isPreparing(rowData.item.status)
+          !['RESTARTING', 'PENDING', 'PULLING'].includes(rowData.item.status)
             ? html`
                 <mwc-icon-button
                   class="fg blue controls-running"


### PR DESCRIPTION
### TL;DR

Disable the session log button only when the status is 'RESTARTING', 'PENDING', or 'PULLING'. The difference from the previous version of this PR is the disabling condition for the 'PREPARING' status. After this PR, the button is enabled.

### What changed?

Updated the condition for displaying the control button in the session list. Replaced multiple status checks with a single array inclusion check for 'RESTARTING', 'PENDING', and 'PULLING' statuses.

### How to test?

1. Navigate to the session list view.
2. Create sessions with various statuses.
3. Verify that the control button appears correctly for running sessions.
4. Ensure the button doesn't appear for sessions with 'RESTARTING', 'PENDING', or 'PULLING' status.