### PR TITLE
fix: useBackendAIImageMetaData test code related to `waitFor`

### DIFF
--- a/e2e/test-util.ts
+++ b/e2e/test-util.ts
@@ -1,7 +1,7 @@
 import { Locator, Page, expect } from "@playwright/test";
 
-const webuiEndpoint = "http://127.0.0.1:9081";
-const webServerEndpoint = "http://127.0.0.1:8090";
+export const webuiEndpoint = 'http://127.0.0.1:9081';
+export const webServerEndpoint = 'http://127.0.0.1:8090';
 export async function login(
   page: Page,
   username: string,

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -142,26 +142,22 @@ interface ImageMetadata {
 }
 
 export const useBackendAIImageMetaData = () => {
-  const { data: metadata } = useSuspenseTanQuery({
+  const { data: metadata } = useSuspenseTanQuery<{
+    imageInfo: {
+      [key: string]: ImageMetadata | undefined;
+    };
+    tagAlias: {
+      [key: string]: string;
+    };
+    tagReplace: {
+      [key: string]: string;
+    };
+  }>({
     queryKey: ['backendai-metadata-for-suspense'],
     queryFn: () => {
-      return fetch('resources/image_metadata.json')
-        .then((response) => response.json())
-        .then(
-          (json: {
-            imageInfo: {
-              [key: string]: ImageMetadata | undefined;
-            };
-            tagAlias: {
-              [key: string]: string;
-            };
-            tagReplace: {
-              [key: string]: string;
-            };
-          }) => {
-            return json;
-          },
-        );
+      return fetch('resources/image_metadata.json').then((response) =>
+        response.json(),
+      );
     },
     retry: false,
   });

--- a/react/src/hooks/useBackendAIImageMetaData.test.tsx
+++ b/react/src/hooks/useBackendAIImageMetaData.test.tsx
@@ -6,46 +6,56 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { ReactNode } from 'react';
 
 describe('useBackendAIImageMetaData', () => {
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 
-  (global as any).fetch = jest.fn(async () =>
-    Promise.resolve({
-      ok: true,
-      status: 200,
-      json: () =>
-        Promise.resolve({
-          imageInfo: {},
-          tagAlias: {
-            pytorch: 'PyTorch',
-            r: 'R',
-            'r-base': 'R',
-            py3: 'Python3',
-            ngc: 'Nvidia GPU Cloud',
-            py310: 'Python3',
-          },
-          tagReplace: {},
-        }),
-    }),
-  );
+  beforeEach(() => {
+    (global as any).fetch = jest.fn(async () =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            imageInfo: {},
+            tagAlias: {
+              pytorch: 'PyTorch',
+              r: 'R',
+              'r-base': 'R',
+              py3: 'Python3',
+              ngc: 'Nvidia GPU Cloud',
+              py310: 'Python3',
+            },
+            tagReplace: {},
+          }),
+      }),
+    );
+  });
 
-  const { result } = renderHook(() => useBackendAIImageMetaData(), { wrapper });
   it('get image lang data', async () => {
-    await waitFor(() => {
-      expect(result.current).toBeDefined();
+    const { result } = renderHook(() => useBackendAIImageMetaData(), {
+      wrapper,
     });
-
+    await waitFor(() => expect(result.current).toBeTruthy());
     const [, { getLang }] = result.current;
     const lang = getLang('testing/ngc-pytorch');
     expect(lang).toBe('PyTorch');
   });
 
   it('get image r lang data', async () => {
-    await waitFor(() => {
-      expect(result.current).toBeDefined();
+    const { result } = renderHook(() => useBackendAIImageMetaData(), {
+      wrapper,
     });
+    await waitFor(() => expect(result.current).toBeTruthy());
 
     const [, { getLang }] = result.current;
     const lang = getLang('stable/r-base');
@@ -53,9 +63,10 @@ describe('useBackendAIImageMetaData', () => {
   });
 
   it('get baseImage data', async () => {
-    await waitFor(() => {
-      expect(result.current).toBeDefined();
+    const { result } = renderHook(() => useBackendAIImageMetaData(), {
+      wrapper,
     });
+    await waitFor(() => expect(result.current).toBeTruthy());
 
     const [, { getBaseImages }] = result.current;
     const baseImages = getBaseImages('21.11-py3', 'testing/ngc-pytorc');
@@ -63,9 +74,10 @@ describe('useBackendAIImageMetaData', () => {
     expect(baseImages[1]).toBe('Nvidia GPU Cloud');
   });
   it('get constraint data', async () => {
-    await waitFor(() => {
-      expect(result.current).toBeDefined();
+    const { result } = renderHook(() => useBackendAIImageMetaData(), {
+      wrapper,
     });
+    await waitFor(() => expect(result.current).toBeTruthy());
 
     const [, { getConstraints }] = result.current;
     const baseImages = getConstraints('23.08-tf2.13-py310-cuda12.2', []);
@@ -74,9 +86,10 @@ describe('useBackendAIImageMetaData', () => {
   });
 
   it('get constraint customized data', async () => {
-    await waitFor(() => {
-      expect(result.current).toBeDefined();
+    const { result } = renderHook(() => useBackendAIImageMetaData(), {
+      wrapper,
     });
+    await waitFor(() => expect(result.current).toBeTruthy());
 
     const [, { getConstraints }] = result.current;
     const baseImages = getConstraints(
@@ -88,6 +101,9 @@ describe('useBackendAIImageMetaData', () => {
   });
 
   it('`getImageMeta` function can handle images with more than two `/` in name.', async () => {
+    const { result } = renderHook(() => useBackendAIImageMetaData(), {
+      wrapper,
+    });
     const [, { getImageMeta }] = result.current;
 
     const { key, tags } = getImageMeta(


### PR DESCRIPTION
### TL;DR

Refactored useBackendAIImageMetaData hook and improved its test suite.

This will solve [the GitHub Action failure.](https://github.com/lablup/backend.ai-webui/runs/29470763524)

### What changed?

- Simplified the useSuspenseTanQuery in useBackendAIImageMetaData hook by removing unnecessary type casting and promise chaining.
- Updated the test suite for useBackendAIImageMetaData:
  - The handler of the `waitFor` function in `@testing-library/react` should return a promise if it's an async action. [ref](https://testing-library.com/docs/dom-testing-library/api-async/#waitfor)
  - For the `waitFor`, use `toBeTruthy` instead of `toBeDefined` because `expect(null).toBeDefined();` pass the test. 

### How to test?

1. Run the existing test suite for useBackendAIImageMetaData.
2. Verify that all tests pass and cover the expected functionality.
3. Manually test the useBackendAIImageMetaData hook in the application to ensure it still functions correctly with the refactored code.

