### PR TITLE
test: add more edge cases of `iSizeToSize` and `parseUnit`

### DIFF
--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -7,6 +7,7 @@ import {
   isOutsideRangeWithUnits,
   localeCompare,
   numberSorterWithInfinityValue,
+  parseUnit,
   toFixedFloorWithoutTrailingZeros,
   transformSorterToOrderString,
 } from './index';
@@ -81,6 +82,36 @@ describe('iSizeToSize', () => {
     const sizeWithUnit = undefined;
     const result = iSizeToSize(sizeWithUnit);
     expect(result).toBeUndefined();
+  });
+
+  it('should return 0 when input is zero', () => {
+    const result = iSizeToSize('0g', 'b');
+    expect(result?.number).toBe(0);
+    expect(result?.unit).toBe('B');
+  });
+});
+
+describe('parseUnit', () => {
+  test('parses a number with a unit', () => {
+    expect(parseUnit('123px')).toEqual([123, 'px']);
+    expect(parseUnit('45.67em')).toEqual([45.67, 'em']);
+    expect(parseUnit('100%')).toEqual([100, '%']);
+  });
+
+  test('parses a number without a unit', () => {
+    expect(parseUnit('123')).toEqual([123, 'b']);
+    expect(parseUnit('45.67')).toEqual([45.67, 'b']);
+  });
+
+  test('handles invalid input gracefully', () => {
+    expect(parseUnit('abc')).toEqual([NaN, 'b']);
+    expect(parseUnit('')).toEqual([NaN, 'b']);
+  });
+
+  test('handles edge cases', () => {
+    expect(parseUnit('0')).toEqual([0, 'b']);
+    expect(parseUnit('0px')).toEqual([0, 'px']);
+    expect(parseUnit('.5em')).toEqual([0.5, 'em']);
   });
 });
 

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -278,7 +278,7 @@ export function filterNonNullItems<T extends { [key: string]: any }>(
 }
 
 export function parseUnit(str: string): [number, string] {
-  const match = str?.match(/^(\d+(?:\.\d+)?)([a-zA-Z]*)$/);
+  const match = str?.match(/^(\d*\.?\d+)([a-zA-Z%]*)$/);
   if (!match) {
     // If the input doesn't match the pattern, assume it's in bytes
     return [parseFloat(str), 'b'];


### PR DESCRIPTION
### TL;DR

Enhanced unit parsing functionality and added comprehensive tests for the `parseUnit` function.

### What changed?

- Updated the regular expression in `parseUnit` function to handle more edge cases, including numbers with leading decimal points.
- Added extensive unit tests for the `parseUnit` function to cover various scenarios.
- Included an additional test case for `iSizeToSize` function to handle zero input.

### How to test?

1. Run the updated test suite for the `parseUnit` function.
2. Verify that all new test cases pass, including:
   - Parsing numbers with different units (px, em, %)
   - Parsing numbers without units
   - Handling invalid inputs
   - Edge cases like '0', '0px', and '.5em'
3. Check that the `iSizeToSize` function correctly handles zero input.

### Why make this change?

This change improves the robustness of the `parseUnit` function, ensuring it can handle a wider range of inputs correctly. The additional tests provide better coverage and confidence in the function's behavior, making the codebase more reliable and easier to maintain.
