### PR TITLE
Fix: Resource Number displays an infinity symbol unexpectedly

### DIFF
--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -270,7 +270,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             <ResourceNumber
               type={resource_limit?.key || ''}
               value={resource_limit?.min || '0'}
-              max={resource_limit?.max || ''}
+              max={resource_limit?.max || 'Infinity'}
             />
           ))}
         </Flex>

--- a/react/src/components/ResourceNumber.tsx
+++ b/react/src/components/ResourceNumber.tsx
@@ -3,6 +3,7 @@ import { useResourceSlotsDetails } from '../hooks/backendai';
 import { useCurrentResourceGroupValue } from '../hooks/useCurrentProject';
 import Flex from './Flex';
 import { Tooltip, Typography, theme } from 'antd';
+import _ from 'lodash';
 import React, { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -29,8 +30,7 @@ interface ResourceNumberProps {
   opts?: ResourceOpts;
   value: string;
   hideTooltip?: boolean;
-  max?: string | null | undefined;
-  range?: boolean;
+  max?: string;
 }
 
 type ResourceTypeInfo<V> = {
@@ -43,7 +43,6 @@ const ResourceNumber: React.FC<ResourceNumberProps> = ({
   opts,
   hideTooltip = false,
   max,
-  range,
 }) => {
   const { token } = theme.useToken();
   const currentGroup = useCurrentResourceGroupValue();
@@ -69,7 +68,11 @@ const ResourceNumber: React.FC<ResourceNumberProps> = ({
 
       <Typography.Text>
         {formatAmount(amount)}
-        {range && max ? `~${formatAmount(max)}` : '~∞'}
+        {_.isUndefined(max)
+          ? null
+          : max === 'Infinity'
+            ? '~∞'
+            : `~${formatAmount(max)}`}
       </Typography.Text>
       <Typography.Text type="secondary">
         {resourceSlotsDetails?.[type]?.display_unit || ''}


### PR DESCRIPTION
### TL;DR

After #2615, the Resource Number displays an infinity symbol unexpectedly.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/ee78810c-da7e-4312-be4a-09aa269931b9.png)

This PR fixes that bug and refactors the code related to the `max` display.