### PR TITLE
fix: Remove unused device `gaudi.device`

### DIFF
--- a/src/components/backend-ai-session-launcher.ts
+++ b/src/components/backend-ai-session-launcher.ts
@@ -2742,7 +2742,7 @@ export default class BackendAiSessionLauncher extends BackendAIPage {
           this._NPUDeviceNameOnSlider = 'ATOM+';
           this.npu_device_metric = atom_plus_device_metric;
         }
-        if (item.key === 'gaudi2.device' || item.key === 'gaudi.device') {
+        if (item.key === 'gaudi2.device') {
           const gaudi2_device_metric = { ...item };
           gaudi2_device_metric.min = parseInt(gaudi2_device_metric.min);
           if ('gaudi2.device' in this.userResourceLimit) {


### PR DESCRIPTION
### TL;DR

Updated NPU device handling for Gaudi2 in session launcher

### What changed?

Modified the condition for handling Gaudi2 devices in the session launcher. The check for 'gaudi.device' has been removed, leaving only the check for 'gaudi2.device'.

### How to test?

1. Navigate to the session launcher
2. Verify that Gaudi2 devices are correctly recognized and handled
3. Ensure that 'gaudi.device' is no longer treated the same as 'gaudi2.device'

### Why make this change?

This change likely aims to differentiate between Gaudi and Gaudi2 devices, ensuring that only Gaudi2 devices are processed with the specific logic in this section. This may be necessary for accurate resource allocation or performance optimization specific to Gaudi2 hardware.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
