### PR TITLE
fix: Change resource display basis from Ratio to current amount

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -3634,17 +3634,20 @@ ${rowData.item[this.sessionNameField]}</pre
               <div class="usage-items">
                 RAM
                 ${rowData.item.live_stat
-                  ? BackendAISessionList._prefixFormatWithoutTrailingZeros(
+                  ? `${BackendAISessionList._prefixFormatWithoutTrailingZeros(
                       BackendAISessionList.bytesToGiB(
                         rowData.item.live_stat?.mem?.current,
-                        1,
-                      ) /
-                        BackendAISessionList.bytesToGiB(
-                          rowData.item.live_stat?.mem?.capacity,
-                          1,
-                        ),
+                        2,
+                      ),
                       2,
-                    )
+                    )} /
+                    ${BackendAISessionList._prefixFormatWithoutTrailingZeros(
+                      BackendAISessionList.bytesToGiB(
+                        rowData.item.live_stat?.mem?.capacity,
+                        2,
+                      ),
+                      2,
+                    )}`
                   : `-`}
                 GiB
               </div>
@@ -3734,17 +3737,20 @@ ${rowData.item[this.sessionNameField]}</pre
                     <div class="usage-items">
                       GPU(mem)
                       ${rowData.item.live_stat
-                        ? BackendAISessionList._prefixFormatWithoutTrailingZeros(
+                        ? `${BackendAISessionList._prefixFormatWithoutTrailingZeros(
                             BackendAISessionList.bytesToGiB(
                               rowData.item.live_stat?.cuda_mem?.current,
-                              1,
-                            ) /
-                              BackendAISessionList.bytesToGiB(
-                                rowData.item.live_stat?.cuda_mem?.capacity,
-                                1,
-                              ),
+                              2,
+                            ),
                             2,
-                          )
+                          )} /
+                          ${BackendAISessionList._prefixFormatWithoutTrailingZeros(
+                            BackendAISessionList.bytesToGiB(
+                              rowData.item.live_stat?.cuda_mem?.capacity,
+                              2,
+                            ),
+                            2,
+                          )}`
                         : `-`}
                       GiB
                     </div>


### PR DESCRIPTION
### TL;DR

> After https://github.com/lablup/backend.ai-webui/pull/2640/files PR, With the use of ternary operators, the traditional string '/' has been marked as an arithmetic operation to represent Ratio.

Updated session list display to show absolute memory usage instead of percentage.

### What changed?

- Modified the memory usage display in the session list to show absolute values in GiB instead of percentages.
- Removed the calculation that divided current memory usage by total capacity.
- Adjusted the decimal precision for memory display from 2 to 1 for system memory and kept it at 2 for CUDA memory.
- Added a console log statement to output row data for debugging purposes.

### How to test?

1. Navigate to the session list view.
2. Create or observe existing sessions in 'batch', 'interactive', 'inference', or 'running' states.
3. Verify that the memory usage is displayed as absolute values in GiB rather than percentages.
4. Check that system memory is displayed with one decimal place and CUDA memory with two decimal places.

### Why make this change?

This change provides users with a clearer understanding of actual memory consumption in sessions. Displaying absolute values instead of percentages allows for more accurate resource monitoring and helps users make informed decisions about their session management.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
