### PR TITLE
fix: modification of "model service's resource"

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -106,6 +106,10 @@ const ResourceAllocationFormItems: React.FC<
     form,
     preserve: true,
   });
+  const currentAllocationPreset = Form.useWatch(['allocationPreset'], {
+    form,
+    preserve: true,
+  });
   const [{ currentImageMinM, remaining, resourceLimits, checkPresetInfo }] =
     useResourceLimitAndRemaining({
       currentProjectName: currentProject.name,
@@ -202,6 +206,15 @@ const ResourceAllocationFormItems: React.FC<
       .catch(() => {});
   });
 
+  useEffect(() => {
+    if (currentAllocationPreset === 'auto-select') {
+      currentResourceGroup && updateAllocationPresetBasedOnResourceGroup();
+    }
+  }, [
+    currentResourceGroup,
+    updateAllocationPresetBasedOnResourceGroup,
+    currentAllocationPreset,
+  ]);
   // update allocation preset based on resource group and current image
   useEffect(() => {
     currentResourceGroup && updateAllocationPresetBasedOnResourceGroup();

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -23,6 +23,7 @@ import ResourceAllocationFormItems, {
   RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
   ResourceAllocationFormValue,
 } from './ResourceAllocationFormItems';
+import ResourceNumber from './ResourceNumber';
 import VFolderLazyView from './VFolderLazyView';
 import VFolderSelect from './VFolderSelect';
 import VFolderTableFormItem from './VFolderTableFormItem';
@@ -39,6 +40,8 @@ import {
   Select,
   Switch,
   theme,
+  Tooltip,
+  Tag,
 } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
@@ -139,6 +142,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
     useState(false);
 
   const [form] = Form.useForm<ServiceLauncherFormValue>();
+  const [wantToChangeResource, setWantToChangeResource] = useState(false);
 
   const endpoint = useFragment(
     graphql`
@@ -562,16 +566,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         }
       })
       .catch((err: any) => {
-        // error on input
-        if (err.errorFields?.length > 0) {
-          err.errorFields.forEach((error: any) => {
-            message.error(error.errors);
-          });
-        } else if (err.message) {
-          message.error(err.message);
-        } else {
-          message.error(t('modelService.FormValidationFailed'));
-        }
+        // this catch function only for form validation error and unhandled error in `form.validateFields()..then()`.
+        // It's not for error handling in mutation.
       });
   };
 
@@ -598,6 +594,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
     ? {
         serviceName: endpoint?.name,
         resourceGroup: endpoint?.resource_group,
+        allocationPreset: 'custom',
         desiredRoutingCount: endpoint?.desired_session_count || 0,
         // FIXME: memory doesn't applied to resource allocation
         resource: {
@@ -868,7 +865,60 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                       //   });
                       // }}
                       />
-                      <ResourceAllocationFormItems enableResourcePresets />
+                      {endpoint &&
+                        !wantToChangeResource &&
+                        !baiClient._config.allowCustomResourceAllocation && (
+                          <Form.Item
+                            label={
+                              <>
+                                {t('modelService.resources')}
+                                <Button
+                                  type="link"
+                                  onClick={() => {
+                                    form.setFieldsValue({
+                                      allocationPreset: 'auto-select',
+                                    });
+                                    setWantToChangeResource(true);
+                                  }}
+                                >
+                                  {t('general.Change')}
+                                </Button>
+                              </>
+                            }
+                            required
+                          >
+                            <Flex gap={'xs'}>
+                              <Tooltip title={t('session.ResourceGroup')}>
+                                <Tag>{endpoint?.resource_group}</Tag>
+                              </Tooltip>
+                              {_.map(
+                                JSON.parse(endpoint?.resource_slots || '{}'),
+                                (value: string, type) => {
+                                  return (
+                                    <ResourceNumber
+                                      key={type}
+                                      type={type}
+                                      value={value}
+                                      opts={endpoint?.resource_opts}
+                                    />
+                                  );
+                                },
+                              )}
+                            </Flex>
+                          </Form.Item>
+                        )}
+                      <div
+                        style={{
+                          display:
+                            endpoint &&
+                            !wantToChangeResource &&
+                            !baiClient._config.allowCustomResourceAllocation
+                              ? 'none'
+                              : 'block',
+                        }}
+                      >
+                        <ResourceAllocationFormItems enableResourcePresets />
+                      </div>
                       <Form.Item
                         label={t('session.launcher.EnvironmentVariable')}
                       >

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -510,7 +510,8 @@
     "Disabled": "Behinderte",
     "NSelected": "Ausgewählte(r) {{count}} Artikel",
     "Extend": "Verlängern",
-    "RemainingLoginSessionTime": "Zeit bis zur automatischen Abmeldung"
+    "RemainingLoginSessionTime": "Zeit bis zur automatischen Abmeldung",
+    "Change": "Ändern Sie"
   },
   "credential": {
     "Permission": "Genehmigung",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -510,7 +510,8 @@
     "Disabled": "Άτομα με ειδικές ανάγκες",
     "NSelected": "Επιλεγμένο {{count}} στοιχείο(α)",
     "Extend": "Επεκτείνω",
-    "RemainingLoginSessionTime": "Χρόνος μέχρι την αυτόματη αποσύνδεση"
+    "RemainingLoginSessionTime": "Χρόνος μέχρι την αυτόματη αποσύνδεση",
+    "Change": "Αλλαγή"
   },
   "credential": {
     "Permission": "Αδεια",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -635,7 +635,8 @@
     "Disabled": "Disabled",
     "NSelected": "Selected {{count}} item(s)",
     "Extend": "Extend",
-    "RemainingLoginSessionTime": "Time until auto logout"
+    "RemainingLoginSessionTime": "Time until auto logout",
+    "Change": "Change"
   },
   "credential": {
     "Permission": "Permission",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -532,7 +532,8 @@
     "Disabled": "Discapacitados",
     "NSelected": "Elemento(s) {{cuenta}} seleccionado(s)",
     "Extend": "Extender",
-    "RemainingLoginSessionTime": "Tiempo hasta el cierre de sesión automático"
+    "RemainingLoginSessionTime": "Tiempo hasta el cierre de sesión automático",
+    "Change": "Cambia"
   },
   "import": {
     "CleanUpImportTask": "Tarea de importación de limpieza...",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -532,7 +532,8 @@
     "Disabled": "Vammaiset",
     "NSelected": "Valittu {{count}} kohde(t)",
     "Extend": "Laajenna",
-    "RemainingLoginSessionTime": "Aika automaattiseen uloskirjautumiseen asti"
+    "RemainingLoginSessionTime": "Aika automaattiseen uloskirjautumiseen asti",
+    "Change": "Muuta"
   },
   "import": {
     "CleanUpImportTask": "Tuontitehtävän siivous...",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -510,7 +510,8 @@
     "Disabled": "Handicapés",
     "NSelected": "Élément(s) sélectionné(s) {{count}}",
     "Extend": "Étendre",
-    "RemainingLoginSessionTime": "Délai avant déconnexion automatique"
+    "RemainingLoginSessionTime": "Délai avant déconnexion automatique",
+    "Change": "Changer"
   },
   "credential": {
     "Permission": "Autorisation",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -511,7 +511,8 @@
     "Disabled": "Dinonaktifkan",
     "NSelected": "Item {{hitung}} yang dipilih",
     "Extend": "Memperpanjang",
-    "RemainingLoginSessionTime": "Waktu Hingga Keluar Otomatis"
+    "RemainingLoginSessionTime": "Waktu Hingga Keluar Otomatis",
+    "Change": "Perubahan"
   },
   "credential": {
     "Permission": "Izin",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -511,7 +511,8 @@
     "Disabled": "Disabili",
     "NSelected": "Articolo/i selezionato/i {{count}}",
     "Extend": "Estendere",
-    "RemainingLoginSessionTime": "Tempo fino alla disconnessione automatica"
+    "RemainingLoginSessionTime": "Tempo fino alla disconnessione automatica",
+    "Change": "Cambiamento"
   },
   "credential": {
     "Permission": "Autorizzazione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -510,7 +510,8 @@
     "Disabled": "無効",
     "NSelected": "選択された{{count}}項目（複数可）",
     "Extend": "伸ばす",
-    "RemainingLoginSessionTime": "自動ログアウトまでの時間"
+    "RemainingLoginSessionTime": "自動ログアウトまでの時間",
+    "Change": "変更"
   },
   "credential": {
     "Permission": "許可",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -622,7 +622,8 @@
     "Disabled": "비활성화",
     "NSelected": "{{count}}개 선택됨",
     "Extend": "연장",
-    "RemainingLoginSessionTime": "자동 로그아웃까지 남은 시간"
+    "RemainingLoginSessionTime": "자동 로그아웃까지 남은 시간",
+    "Change": "변경"
   },
   "credential": {
     "Permission": "권한",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -512,7 +512,8 @@
     "Disabled": "Идэвхгүй",
     "NSelected": "Сонгосон {{count}} зүйл(үүд)",
     "Extend": "Сунгах",
-    "RemainingLoginSessionTime": "Автоматаар гарах хүртэл хугацаа"
+    "RemainingLoginSessionTime": "Автоматаар гарах хүртэл хугацаа",
+    "Change": "Өөрчлөх"
   },
   "credential": {
     "Permission": "Зөвшөөрөл",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -509,7 +509,8 @@
     "General": "Umum",
     "Disabled": "Dilumpuhkan",
     "NSelected": "{{count}} item yang dipilih",
-    "Extend": "Panjangkan"
+    "Extend": "Panjangkan",
+    "Change": "Berubah"
   },
   "credential": {
     "Permission": "Kebenaran",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -510,7 +510,8 @@
     "Disabled": "Wyłączony",
     "NSelected": "Wybrane elementy {{count}}",
     "Extend": "Rozszerzyć",
-    "RemainingLoginSessionTime": "Czas do automatycznego wylogowania"
+    "RemainingLoginSessionTime": "Czas do automatycznego wylogowania",
+    "Change": "Zmiana"
   },
   "credential": {
     "Permission": "Pozwolenie",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -510,7 +510,8 @@
     "Disabled": "Desativado",
     "NSelected": "Item(ns) {{contagem}} selecionado(s)",
     "Extend": "Ampliar",
-    "RemainingLoginSessionTime": "Tempo até ao encerramento automático da sessão"
+    "RemainingLoginSessionTime": "Tempo até ao encerramento automático da sessão",
+    "Change": "Alterar"
   },
   "credential": {
     "Permission": "Permissão",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -510,7 +510,8 @@
     "Disabled": "Desativado",
     "NSelected": "Item(ns) {{contagem}} selecionado(s)",
     "Extend": "Ampliar",
-    "RemainingLoginSessionTime": "Tempo até ao encerramento automático da sessão"
+    "RemainingLoginSessionTime": "Tempo até ao encerramento automático da sessão",
+    "Change": "Alterar"
   },
   "credential": {
     "Permission": "Permissão",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -510,7 +510,8 @@
     "Disabled": "Инвалид",
     "NSelected": "Выбранный {{count}} элемент(ы)",
     "Extend": "Продлевать",
-    "RemainingLoginSessionTime": "Время до автоматического выхода из системы"
+    "RemainingLoginSessionTime": "Время до автоматического выхода из системы",
+    "Change": "Изменить"
   },
   "credential": {
     "Permission": "Разрешение",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -633,7 +633,8 @@
     "General": "ทั่วไป",
     "Disabled": "ปิดใช้งาน",
     "Extend": "ขยาย",
-    "RemainingLoginSessionTime": "เวลาจนกระทั่งออกจากระบบอัตโนมัติ"
+    "RemainingLoginSessionTime": "เวลาจนกระทั่งออกจากระบบอัตโนมัติ",
+    "Change": "เปลี่ยน"
   },
   "credential": {
     "Permission": "สิทธิ์",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -510,7 +510,8 @@
     "Disabled": "Engelli",
     "NSelected": "Seçilen {{count}} öğe(ler)",
     "Extend": "Uzatmak",
-    "RemainingLoginSessionTime": "Otomatik Çıkışa Kadar Geçen Süre"
+    "RemainingLoginSessionTime": "Otomatik Çıkışa Kadar Geçen Süre",
+    "Change": "Değişim"
   },
   "credential": {
     "Permission": "izin",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -510,7 +510,8 @@
     "Disabled": "Tàn tật",
     "NSelected": "Đã chọn {{count}} mục",
     "Extend": "Mở rộng",
-    "RemainingLoginSessionTime": "Thời gian cho đến khi tự động đăng xuất"
+    "RemainingLoginSessionTime": "Thời gian cho đến khi tự động đăng xuất",
+    "Change": "Thay đổi"
   },
   "credential": {
     "Permission": "Sự cho phép",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -510,7 +510,8 @@
     "Disabled": "残疾",
     "NSelected": "已选择的 {{count}} 项目",
     "Extend": "延长",
-    "RemainingLoginSessionTime": "自动注销前的时间"
+    "RemainingLoginSessionTime": "自动注销前的时间",
+    "Change": "改变"
   },
   "credential": {
     "Permission": "允许",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -510,7 +510,8 @@
     "Disabled": "残疾",
     "NSelected": "已选择的 {{count}} 项目",
     "Extend": "延長",
-    "RemainingLoginSessionTime": "自动注销前的时间"
+    "RemainingLoginSessionTime": "自动注销前的时间",
+    "Change": "改变"
   },
   "credential": {
     "Permission": "允許",


### PR DESCRIPTION
### TL;DR

This PR resolves the issue where the endpoint's resource allocation values are not displayed when modifying the model service, and the first allocatable preset is automatically selected.

### What changed?
The logic was changed as follows:
- case 1: `allowCustomResourceAllocation = false`
  - Hide resource group select and preset select. and display current value like below: 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/316ea45d-c563-41ce-98a3-8b640159e81d.png)

  - If the user click the "Change" button, the preset select component is shown with automatic selection of preset
- case 2: `allowCustomResourceAllocation = true`
  - When modifying, the `allocationPreset` field is set to custom.