### PR TITLE
add: convert showing all environment images including uninstalled ones by config

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -67,6 +67,7 @@ allowNonAuthTCP = false             # Expose TCP apps to be executable in web br
 #allowlist = "" # Comma-separated image name. Image name should contain the repository (registry path and image name) part of the full image URL, excluding the protocol and tag
 # e.g. cr.backend.ai/stable/python
 # You should pick default_environment in general section too.
+showNonInstalledImages = false    # Show all environment images regardless of installation
 
 [server]
 webServerURL = "[Web server website URL. App will use the site instead of local app.]"

--- a/e2e/config-test.toml
+++ b/e2e/config-test.toml
@@ -1,0 +1,79 @@
+[general]
+# apiEndpoint = "http://127.0.0.1:8090"
+apiEndpointText = "Backend.AI Admin Training"
+
+defaultSessionEnvironment = "cr.backend.ai/stable/python-tensorflow"
+
+maxCountForPreOpenedPort = 1
+# siteDescription = ""
+connectionMode = "SESSION" #connectionMode = API
+allowChangeSigninMode = true
+signupSupport = true
+allowSignout = true
+allowAnonymousChangePassword = true
+allowProjectResourceMonitor = true
+allowManualImageNameForSession = true
+allowSignupWithoutConfirmation = true
+allowCustomResourceAllocation = false
+autoLogout = false
+# loginAttemptLimit = 1
+# loginBlockTime = 30
+debug = false
+maskUserInfo = true
+enableContainerCommit = true
+enablePipeline = true
+hideAgents = true
+alwaysEnqueueComputeSession = true
+# If false, show the `Agent Summary` menu in the sidebar.
+showCustomResourceAllocation = true
+enable2FA = true
+force2FA = false
+systemSSHImage = "cr.backend.ai/stable/python-tensorflow"
+isDirectorySizeVisible = false
+allowCustomResourceAllocation = true
+forceTerminateTimeThreshold = 259200
+enableModelStore = true
+enableExtendLoginSession = false
+
+[wsproxy]
+proxyURL = "http://127.0.0.1:5050/"
+autoPortSelection = true
+disableCertCheck = true
+
+[resources]
+openPortToPublic = true
+# Show option to open app proxy port to anyone.
+maxCPUCoresPerContainer = 256 # Maximum CPU per container.
+maxMemoryPerContainer = 64 # Maximum memory per container.
+maxCUDADevicesPerContainer = 16  # Maximum CUDA devices per container.
+maxCUDASharesPerContainer = 16  # Maximum CUDA shares per container.
+maxROCMDevicesPerContainer = 10     # Maximum ROCm devices per container.
+maxTPUDevicesPerContainer = 8       # Maximum TPU devices per container.
+maxIPUDevicesPerContainer = 8       # Maximum IPU devices per container.
+maxATOMDevicesPerContainer = 8      # Maximum ATOM devices per container.
+maxWarboyDevicesPerContainer = 8    # Maximum Warboy devices per container.
+maxShmPerContainer = 16 # Maximum shared memory per container.
+maxFileUploadSize = 4294967296 # Maximum size of single file upload. Set to -1 for unlimited upload.
+allowPreferredPort = true
+allowNonAuthTCP = true
+
+[menu]
+# blocklist = "pipeline,summary"
+#blocklist = "pipeline,serving" # "statistics"
+#blocklist = "" # Hide menus on the list which are separated by comma. please note that summary menu cannot be added to blocklist
+#inactivelist = "statistics,pipeline,serving" # Disable menus on the list which are separated by comma.
+
+[server]
+# webServerURL =
+
+[environments]
+#allowlist = ""
+showNonInstalledImages = true
+
+[plugin]
+# Reserved to load plugins
+
+[pipeline]
+#endpoint = "http://mlops.com:9500"   # FastTrack endpoint.
+frontendEndpoint = "http://127.0.0.1:9500"
+hideSideMenuButton = false

--- a/e2e/config.test.ts
+++ b/e2e/config.test.ts
@@ -1,0 +1,87 @@
+import { loginAsAdmin, mockConfigToml, webuiEndpoint } from './test-util';
+import { test, expect } from '@playwright/test';
+
+test.describe('config read and test', () => {
+  test('showNonInstalledImages', async ({ page, context }) => {
+    // manipulate config file from mocked one
+    await mockConfigToml(page, './config-test.toml');
+
+    await loginAsAdmin(page);
+
+    await page.getByRole('group').getByText('Environments').click();
+    await page
+      .getByRole('columnheader', { name: 'Status' })
+      .locator('div')
+      .click();
+    await page
+      .getByRole('columnheader', { name: 'Status' })
+      .locator('div')
+      .click();
+
+    const registryCell = await page
+      .locator('.ant-table-row > td:nth-child(3)')
+      .first();
+    const registry = await registryCell.textContent();
+
+    const architectureCell = await page
+      .locator('.ant-table-row > td:nth-child(4)')
+      .first();
+    const architecture = await architectureCell.textContent();
+
+    const namespaceCell = await page
+      .getByRole('cell', { name: 'community' })
+      .first();
+    const namespace = await namespaceCell.textContent();
+
+    const languageCell = await page.getByRole('cell', { name: 'afni' }).first();
+    const language = await languageCell.textContent();
+
+    const versionCell = await page
+      .getByRole('cell', { name: 'ubuntu18.04' })
+      .first();
+    const version = await versionCell.textContent();
+
+    const uninstalledImageString = `${registry}/${namespace}/${language}:${version}@${architecture}`;
+
+    await page.goto(webuiEndpoint);
+    await page.getByLabel('power_settings_new').click();
+    await page
+      .getByRole('button', { name: '2 Environments & Resource' })
+      .click();
+    await page
+      .locator(
+        '.ant-form-item-control-input-content > .ant-select > .ant-select-selector',
+      )
+      .first()
+      .click();
+    await page.getByLabel('Environments / Version').fill('AF');
+    await page
+      .locator('.rc-virtual-list-holder-inner > div:nth-child(2)')
+      .click();
+
+    await page
+      .locator('span')
+      .filter({ hasText: 'ubuntu18.04x86_64' })
+      .locator('div')
+      .first()
+      .click();
+    await page
+      .locator(
+        'div:nth-child(4) > .rc-virtual-list-holder > div > .rc-virtual-list-holder-inner > .ant-select-item > .ant-select-item-option-content > div',
+      )
+      .click();
+    await page
+      .getByRole('button', { name: 'Skip to review double-right' })
+      .click();
+    await page.getByRole('button', { name: 'Copy' }).click();
+
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    const handle = await page.evaluateHandle(() =>
+      navigator.clipboard.readText(),
+    );
+    const clipboardContent = await handle.jsonValue();
+
+    expect(clipboardContent).toEqual(uninstalledImageString);
+  });
+});

--- a/e2e/test-util.ts
+++ b/e2e/test-util.ts
@@ -1,4 +1,6 @@
-import { Locator, Page, expect } from "@playwright/test";
+import { Locator, Page, expect } from '@playwright/test';
+import fs from 'fs/promises';
+import path from 'path';
 
 export const webuiEndpoint = 'http://127.0.0.1:9081';
 export const webServerEndpoint = 'http://127.0.0.1:8090';
@@ -9,34 +11,34 @@ export async function login(
   endpoint: string,
 ) {
   await page.goto(webuiEndpoint);
-  await page.getByLabel("E-mail or Username").fill(username);
-  await page.getByRole("textbox", { name: "Password" }).fill(password);
-  await page.getByRole("textbox", { name: "Endpoint" }).fill(endpoint);
-  await page.getByLabel("Login", { exact: true }).click();
+  await page.getByLabel('E-mail or Username').fill(username);
+  await page.getByRole('textbox', { name: 'Password' }).fill(password);
+  await page.getByRole('textbox', { name: 'Endpoint' }).fill(endpoint);
+  await page.getByLabel('Login', { exact: true }).click();
   await page.waitForSelector('[data-testid="user-dropdown-button"]');
 }
 
 export const userInfo = {
   admin: {
-    email: "admin@lablup.com",
-    password: "wJalrXUt",
+    email: 'admin@lablup.com',
+    password: 'wJalrXUt',
   },
   user: {
-    email: "user@lablup.com",
-    password: "C8qnIo29",
+    email: 'user@lablup.com',
+    password: 'C8qnIo29',
   },
   user2: {
-    email: "user2@lablup.com",
-    password: "P7oxTDdz",
+    email: 'user2@lablup.com',
+    password: 'P7oxTDdz',
   },
   monitor: {
-    email: "monitor@lablup.com",
-    password: "7tuEwF1J",
+    email: 'monitor@lablup.com',
+    password: '7tuEwF1J',
   },
   domainAdmin: {
-    email: "domain-admin@lablup.com",
-    password: "cWbsM_vB",
-  }
+    email: 'domain-admin@lablup.com',
+    password: 'cWbsM_vB',
+  },
 };
 
 export async function loginAsAdmin(page: Page) {
@@ -52,7 +54,7 @@ export async function loginAsDomainAdmin(page: Page) {
     page,
     userInfo.domainAdmin.email,
     userInfo.domainAdmin.password,
-    "http://127.0.0.1:8090",
+    'http://127.0.0.1:8090',
   );
 }
 export async function loginAsUser(page: Page) {
@@ -72,12 +74,17 @@ export async function loginAsUser2(page: Page) {
   );
 }
 export async function loginAsMonitor(page: Page) {
-  await login(page, userInfo.monitor.email, userInfo.monitor.password, webServerEndpoint);
+  await login(
+    page,
+    userInfo.monitor.email,
+    userInfo.monitor.password,
+    webServerEndpoint,
+  );
 }
 
 export async function logout(page: Page) {
-  await page.getByTestId("user-dropdown-button").click();
-  await page.getByText("Log Out").click();
+  await page.getByTestId('user-dropdown-button').click();
+  await page.getByText('Log Out').click();
   await page.waitForTimeout(1000);
 }
 
@@ -87,76 +94,88 @@ export async function navigateTo(page: Page, path: string) {
   await page.goto(url.toString());
 }
 
-export async function fillOutVaadinGridCellFilter(gridWrap:Locator, columnTitle:string, inputValue:string ) {
-  const nameInput = gridWrap.locator("vaadin-grid-cell-content")
+export async function fillOutVaadinGridCellFilter(
+  gridWrap: Locator,
+  columnTitle: string,
+  inputValue: string,
+) {
+  const nameInput = gridWrap
+    .locator('vaadin-grid-cell-content')
     .filter({ hasText: columnTitle })
-    .locator("vaadin-text-field")
+    .locator('vaadin-text-field')
     .nth(1)
-    .locator("input");
+    .locator('input');
   await nameInput.click();
   await nameInput.fill(inputValue);
 }
 
 export async function createVFolderAndVerify(page: Page, folderName: string) {
-  await navigateTo(page, "data");
+  await navigateTo(page, 'data');
 
-  await page.getByRole("button", { name: "plus Add" }).click();
+  await page.getByRole('button', { name: 'plus Add' }).click();
   // TODO: wait for initial rendering without timeout
   await page.waitForTimeout(1000);
-  await page.getByRole("textbox", { name: "Folder name*" }).click();
-  await page.getByRole("textbox", { name: "Folder name*" }).fill(folderName);
-  await page.getByRole("button", { name: "Create", exact: true }).click();
+  await page.getByRole('textbox', { name: 'Folder name*' }).click();
+  await page.getByRole('textbox', { name: 'Folder name*' }).fill(folderName);
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
 
   const nameInput = page
-    .locator("#general-folder-storage vaadin-grid-cell-content")
-    .filter({ hasText: "Name" })
-    .locator("vaadin-text-field")
+    .locator('#general-folder-storage vaadin-grid-cell-content')
+    .filter({ hasText: 'Name' })
+    .locator('vaadin-text-field')
     .nth(1)
-    .locator("input");
+    .locator('input');
   await nameInput.click();
   await nameInput.fill(folderName);
   await page.waitForSelector(`text=folder_open ${folderName}`);
-  await nameInput.fill("");
+  await nameInput.fill('');
 }
 
 export async function deleteVFolderAndVerify(page: Page, folderName: string) {
-  await navigateTo(page, "data");
+  await navigateTo(page, 'data');
   const nameInput = page
-    .locator("#general-folder-storage vaadin-grid-cell-content")
-    .filter({ hasText: "Name" })
-    .locator("vaadin-text-field")
+    .locator('#general-folder-storage vaadin-grid-cell-content')
+    .filter({ hasText: 'Name' })
+    .locator('vaadin-text-field')
     .nth(1)
-    .locator("input");
+    .locator('input');
   await nameInput.click();
   await nameInput.fill(folderName);
   await page.waitForTimeout(1000);
-  await page.getByRole("button", { name: "delete" }).first().click();
+  await page.getByRole('button', { name: 'delete' }).first().click();
   await page
-    .locator("#delete-without-confirm-button")
-    .getByLabel("delete")
+    .locator('#delete-without-confirm-button')
+    .getByLabel('delete')
     .click();
   await page.waitForLoadState('networkidle');
-  await page.getByRole("tab", { name: "delete" }).click();
+  await page.getByRole('tab', { name: 'delete' }).click();
   const nameInputInTrash = page
-    .locator("#trash-bin-folder-storage vaadin-grid-cell-content")
-    .filter({ hasText: "Name" })
-    .locator("vaadin-text-field")
+    .locator('#trash-bin-folder-storage vaadin-grid-cell-content')
+    .filter({ hasText: 'Name' })
+    .locator('vaadin-text-field')
     .nth(1)
-    .locator("input");
+    .locator('input');
   await nameInputInTrash.fill(folderName);
   // after filling the input, the vaadin-grid will be updated asynchronously. So we need to wait for the grid to be updated.
   await page.waitForTimeout(1000);
-  await page.locator("vaadin-grid-cell-content").filter({ hasText: folderName }).locator("//following-sibling::*[7]").getByRole('button', { name: 'delete_forever' }).click();
   await page
-    .getByRole("textbox", { name: "Type folder name to delete" })
+    .locator('vaadin-grid-cell-content')
+    .filter({ hasText: folderName })
+    .locator('//following-sibling::*[7]')
+    .getByRole('button', { name: 'delete_forever' })
+    .click();
+  await page
+    .getByRole('textbox', { name: 'Type folder name to delete' })
     .fill(folderName);
-  await page.getByRole("button", { name: "Delete forever" }).click();
+  await page.getByRole('button', { name: 'Delete forever' }).click();
   await expect(
-    page.locator("vaadin-grid-cell-content").filter({ hasText: folderName }).locator(':visible')
+    page
+      .locator('vaadin-grid-cell-content')
+      .filter({ hasText: folderName })
+      .locator(':visible'),
   ).toHaveCount(0);
-  await nameInputInTrash.fill("");
+  await nameInputInTrash.fill('');
 }
-
 
 export async function createSession(page: Page, sessionName: string) {
   await navigateTo(page, 'job');
@@ -208,4 +227,16 @@ export async function deleteSession(page: Page, sessionName: string) {
   // Verify session is cleared
   await searchSessionInfo.fill('');
   await expect(page.getByText(sessionName)).toBeHidden();
+}
+
+export async function mockConfigToml(page: Page, rawPath) {
+  const filePath = path.resolve(__dirname, rawPath);
+  const mockData = await fs.readFile(filePath, 'utf-8');
+  await page.route('http://127.0.0.1:9081/config.toml', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/plain',
+      body: mockData,
+    });
+  });
 }

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -93,7 +93,10 @@ const ImageEnvironmentSelectFormItems: React.FC<
 
   const envSelectRef = useRef<RefSelectProps>(null);
   const versionSelectRef = useRef<RefSelectProps>(null);
-
+  const imageEnvironmentSelectFormItemsVariables = baiClient?._config
+    ?.showNonInstalledImages
+    ? {}
+    : { installed: true };
   const { images } = useLazyLoadQuery<ImageEnvironmentSelectFormItemsQuery>(
     graphql`
       query ImageEnvironmentSelectFormItemsQuery($installed: Boolean) {
@@ -117,9 +120,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
         }
       }
     `,
-    {
-      installed: true,
-    },
+    imageEnvironmentSelectFormItemsVariables,
     {
       fetchPolicy: 'store-and-network',
     },

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -383,5 +383,6 @@ type BackendAIConfig = {
   allowSignout: boolean;
   allowNonAuthTCP: boolean;
   enableExtendLoginSession: boolean;
+  showNonInstalledImages: boolean;
   [key: string]: any;
 };

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -142,6 +142,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: Boolean }) enableModelStore = false;
   @property({ type: Boolean }) enableLLMPlayground = false;
   @property({ type: Boolean }) enableExtendLoginSession = false;
+  @property({ type: Boolean }) showNonInstalledImages = false;
   @property({ type: String }) eduAppNamePrefix;
   @property({ type: String }) pluginPages;
   @property({ type: Array }) blockList = [] as string[];
@@ -1038,6 +1039,16 @@ export default class BackendAILogin extends BackendAIPage {
         ? environmentsConfig?.allowlist.split(',').map((el) => el.trim())
         : [],
     } as ConfigValueObject) as string[];
+
+    // Enable show all images when creating session/service
+    this.showNonInstalledImages = this._getConfigValueByExists(
+      environmentsConfig,
+      {
+        valueType: 'boolean',
+        defaultValue: false,
+        value: environmentsConfig?.showNonInstalledImages,
+      } as ConfigValueObject,
+    ) as boolean;
   }
 
   /**
@@ -1846,6 +1857,8 @@ export default class BackendAILogin extends BackendAIPage {
           this.maxFileUploadSize;
         globalThis.backendaiclient._config.allow_image_list =
           this.allow_image_list;
+        globalThis.backendaiclient._config.showNonInstalledImages =
+          this.showNonInstalledImages;
         globalThis.backendaiclient._config.maskUserInfo = this.maskUserInfo;
         globalThis.backendaiclient._config.singleSignOnVendors =
           this.singleSignOnVendors;


### PR DESCRIPTION
### TL;DR

Added option to show all environment images, regardless of installation status.

### What changed?

- Introduced a new configuration option `showNonInstalledImages` in `config.toml.sample`
- Updated `ImageEnvironmentSelectFormItems` component to use the new configuration
- Added `showNonInstalledImages` to the `BackendAIConfig` type
- Implemented the new configuration in the `BackendAILogin` component