### PR TITLE
fix: remove duplicated `form.getFieldValue` in `ensureValidAcceleratorType`

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -155,9 +155,10 @@ const ResourceAllocationFormItems: React.FC<
   }, [checkPresetInfo?.presets, resourceLimits, currentImage]);
 
   const ensureValidAcceleratorType = useEventNotStable(() => {
-    const currentAcceleratorType = form.getFieldValue(
-      form.getFieldValue(['resource', 'acceleratorType']),
-    );
+    const currentAcceleratorType = form.getFieldValue([
+      'resource',
+      'acceleratorType',
+    ]);
     // If the current accelerator type is not available,
     // change accelerator type to the first supported accelerator
     const nextAcceleratorType: string = acceleratorSlots[currentAcceleratorType]


### PR DESCRIPTION
### TL;DR

Fixed form field value retrieval for accelerator type in ResourceAllocationFormItems component.

### What changed?

Updated the `ensureValidAcceleratorType` function(#2628) to correctly retrieve the accelerator type from the form. The previous implementation was incorrectly nested, potentially leading to undefined values. The new implementation directly accesses the 'resource.acceleratorType' field.

### How to test?

Please ref to the #2628 's "How to test" section

### Why make this change?

This change ensures that the correct accelerator type is always retrieved from the form, preventing potential bugs or unexpected behavior when validating or updating the accelerator type. It improves the reliability of the resource allocation process and enhances the overall user experience when configuring resources.
