### PR TITLE
fix: object merging with mutation in VFolderTable, hooks, and SessionLauncherPage

### DIFF
--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -192,6 +192,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
     );
 
     const mergedVFolderPermissions = _.merge(
+      {}, // start with empty object
       allowedVFolderHostsByDomain,
       allowedVFolderHostsByGroup,
       allowedVFolderHostsByKeypairResourcePolicy,

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -119,7 +119,7 @@ export const useResourceSlotsDetails = (resourceGroupName?: string) => {
   });
 
   return [
-    _.merge(deviceMetadata, resourceSlots),
+    _.merge({}, deviceMetadata, resourceSlots),
     {
       refresh: () => checkUpdate(),
     },

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -274,7 +274,7 @@ const SessionLauncherPage = () => {
   }, []);
 
   const mergedInitialValues = useMemo(() => {
-    return _.merge(INITIAL_FORM_VALUES, formValuesFromQueryParams);
+    return _.merge({}, INITIAL_FORM_VALUES, formValuesFromQueryParams);
   }, [INITIAL_FORM_VALUES, formValuesFromQueryParams]);
 
   // ScrollTo top when step is changed


### PR DESCRIPTION
### TL;DR

Modified `_.merge()` calls to include an empty object as the first argument.

This PR fixed a bug where the user could not turn on the "Use automatic OpenMP optimization" option after turning it off in the Neo Session Launcher.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/935c7236-ab00-49a2-a83a-469048b0c31d.png)

### What changed?

Updated three instances of `_.merge()` function calls in different files:
1. In `VFolderTable.tsx`, added an empty object as the first argument to `mergedVFolderPermissions`.
2. In `backendai.tsx`, added an empty object as the first argument when merging `deviceMetadata` and `resourceSlots`.
3. In `SessionLauncherPage.tsx`, added an empty object as the first argument when merging `INITIAL_FORM_VALUES` and `formValuesFromQueryParams`.

### Why make this change?

The addition of an empty object as the first argument in `_.merge()` calls ensures that the original objects are not modified during the merge operation. This prevents potential side effects and maintains the immutability of the source objects, leading to more predictable and safer code behavior.