### PR TITLE
fix: use `id` as a key of Image

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -101,6 +101,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
     graphql`
       query ImageEnvironmentSelectFormItemsQuery($installed: Boolean) {
         images(is_installed: $installed) {
+          id
           name
           humanized_name
           tag
@@ -562,7 +563,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
                 }
               >
                 {_.map(
-                  _.uniqBy(selectedEnvironmentGroup?.images, 'digest'),
+                  _.uniqBy(selectedEnvironmentGroup?.images, 'id'),
 
                   (image) => {
                     const [version, tag, ...requirements] = image?.tag?.split(
@@ -658,7 +659,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
                     }
                     return (
                       <Select.Option
-                        key={image?.digest}
+                        key={image?.id}
                         value={getImageFullName(image)}
                         filterValue={[
                           version,

--- a/react/src/components/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/ResourceAllocationFormItems.test.ts
@@ -35,6 +35,7 @@ describe('getAllocatablePresetNames', () => {
   };
 
   const image_has_cuda_shares_min1_max1: Image = {
+    id: 'id1',
     name: 'image1',
     digest: 'digest1',
     architecture: 'arm64',


### PR DESCRIPTION
### TL;DR

Updated image identification and selection logic in ImageEnvironmentSelectFormItems component.
Images can have the same `digest`, but it's a rare case.

### What changed?

- Added 'id' field to the GraphQL query for images
- Changed image uniqueness check from 'digest' to 'id'
- Updated Select.Option key from 'image?.digest' to 'image?.id'
- Added 'id' property to Image type in ResourceAllocationFormItems test