### PR TITLE
fix: use antd color token for invalid mwc-textfield theme

### DIFF
--- a/src/components/backend-ai-folder-explorer.ts
+++ b/src/components/backend-ai-folder-explorer.ts
@@ -215,6 +215,7 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
 
         mwc-textfield {
           width: 100%;
+          --mdc-theme-error: var(--token-colorError);
         }
       `,
     ];


### PR DESCRIPTION
### TL;DR

Updated the error color for mwc-textfield in the folder explorer component.

|before|after|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/02c9ccb9-38d7-4fa7-91b4-a2c80f9417dd.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/32f67160-3461-4ce0-b41c-b67da9954a80.png)|

### How to test?

1. Navigate to the folder explorer component in the UI.
2. Trigger an error state in any textfield within the component.
3. Verify that the error color matches the `--token-colorError` defined in the theme.

### Why make this change?

This change ensures consistency in error color representation across the application by using the predefined `--token-colorError` variable. It improves the visual coherence of the UI and maintains a uniform look for error states in textfields within the folder explorer component.

---

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
