### PR TITLE
fix: separate CUDA FGPU slots from ROCM GPU slots

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -3707,8 +3707,41 @@ ${rowData.item[this.sessionNameField]}</pre
                   </div>
                 `
               : html``}
+            ${rowData.item.cuda_fgpu_slot
+              ? html`
+                  <div class="vertical start-justified layout">
+                    <div class="usage-items">
+                      GPU(mem)
+                      ${rowData.item.live_stat
+                        ? `${BackendAISessionList._prefixFormatWithoutTrailingZeros(
+                            BackendAISessionList.bytesToGiB(
+                              rowData.item.live_stat?.cuda_mem?.current,
+                              2,
+                            ),
+                            2,
+                          )} /
+                            ${BackendAISessionList._prefixFormatWithoutTrailingZeros(
+                              BackendAISessionList.bytesToGiB(
+                                rowData.item.live_stat?.cuda_mem?.capacity,
+                                2,
+                              ),
+                              2,
+                            )}`
+                        : `-`}
+                      GiB
+                    </div>
+                    <div class="horizontal start-justified center layout">
+                      <lablup-progress-bar
+                        class="usage"
+                        progress="${rowData.item.live_stat?.cuda_mem?.ratio}"
+                        description=""
+                      ></lablup-progress-bar>
+                    </div>
+                  </div>
+                `
+              : html``}
             ${rowData.item.rocm_gpu_slot &&
-            parseFloat(rowData.item.cuda_rocm_gpu_slot) > 0
+            parseFloat(rowData.item.rocm_gpu_slot) > 0
               ? html`
                   <div class="vertical start-justified layout">
                     <div class="usage-items">
@@ -3731,7 +3764,7 @@ ${rowData.item[this.sessionNameField]}</pre
                   </div>
                 `
               : html``}
-            ${rowData.item.cuda_fgpu_slot || rowData.item.rocm_gpu_slot
+            ${rowData.item.rocm_gpu_slot
               ? html`
                   <div class="vertical start-justified layout">
                     <div class="usage-items">
@@ -3739,14 +3772,14 @@ ${rowData.item[this.sessionNameField]}</pre
                       ${rowData.item.live_stat
                         ? `${BackendAISessionList._prefixFormatWithoutTrailingZeros(
                             BackendAISessionList.bytesToGiB(
-                              rowData.item.live_stat?.cuda_mem?.current,
+                              rowData.item.live_stat?.rocm_mem?.current,
                               2,
                             ),
                             2,
                           )} /
                           ${BackendAISessionList._prefixFormatWithoutTrailingZeros(
                             BackendAISessionList.bytesToGiB(
-                              rowData.item.live_stat?.cuda_mem?.capacity,
+                              rowData.item.live_stat?.rocm_mem?.capacity,
                               2,
                             ),
                             2,
@@ -3757,7 +3790,7 @@ ${rowData.item[this.sessionNameField]}</pre
                     <div class="horizontal start-justified center layout">
                       <lablup-progress-bar
                         class="usage"
-                        progress="${rowData.item.live_stat?.cuda_mem?.ratio}"
+                        progress="${rowData.item.live_stat?.rocm_mem?.ratio}"
                         description=""
                       ></lablup-progress-bar>
                     </div>


### PR DESCRIPTION
###  This PR resolves an issue that does not show GPU resources.

[teams](https://teams.microsoft.com/l/message/19:86f7b329bde541d28d51542b4089bf95@thread.skype/1726712184037?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=483daa8a-29ee-4085-9f71-e93d7f112730&parentMessageId=1726102778706&teamName=project&channelName=KTCloud%20AI%20Serving%20(Public%2C%20South%20Cheongju)&createdTime=1726712184037)

This PR improves the display of GPU usage information in the session list component. It separates the display logic for CUDA and ROCm GPUs, providing more accurate and specific information for each GPU type.

**Changes:**

1. Added a new conditional block to display CUDA GPU memory usage.
2. Updated the existing ROCm GPU memory usage display.
3. Fixed a condition check for ROCm GPU slot parsing.

These changes allow for more precise reporting of GPU memory usage, distinguishing between CUDA and ROCm GPUs. This enhancement provides users with clearer insights into their GPU resource utilization.

**Checklist:**

- [ ] Documentation
- [ ] Test case(s) to demonstrate the difference of before/after