### PR TITLE
feat: add `enableImportFromHuggingFace` option

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -33,6 +33,7 @@ eduAppNamePrefix = ""                   # The prefix of edu applauncher's app na
 enableModelStore = false                # Enable model store feature. (From Backend.AI 24.03)
 enableLLMPlayground = false             # Enable LLM Playground feature. (From Backend.AI 24.03)
 enableExtendLoginSession = false        # If true, enables login session extension UI. (From Backend.AI 24.09)
+enableImportFromHuggingFace = false     # Enable import from Hugging Face feature. (From Backend.AI 24.09)
 
 [wsproxy]
 proxyURL = "[Proxy URL]"

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -368,6 +368,7 @@ type BackendAIConfig = {
   ssoRealmName: string;
   enableModelStore: boolean;
   enableLLMPlayground: boolean;
+  enableImportFromHuggingFace: boolean;
   enableContainerCommit: boolean;
   appDownloadUrl: string;
   systemSSHImage: string;

--- a/react/src/pages/VFolderListPage.tsx
+++ b/react/src/pages/VFolderListPage.tsx
@@ -52,6 +52,8 @@ const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
   ] = useToggle(false);
 
   const { token } = theme.useToken();
+  const enableImportFromHuggingFace =
+    baiClient._config.enableImportFromHuggingFace;
 
   useEffect(() => {
     const handler = () => {
@@ -129,12 +131,11 @@ const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
         }}
         tabBarExtraContent={
           <Flex gap="xs">
-            {_.includes(['model', 'model-store'], curTabKey) ? (
+            {_.includes(['model', 'model-store'], curTabKey) &&
+            enableImportFromHuggingFace ? (
               <Button
                 icon={<ImportOutlined />}
                 onClick={toggleImportFromHuggingFaceModal}
-                // Remove this line to test
-                style={{ display: 'none' }}
               >
                 {t('data.modelStore.ImportFromHuggingFace')}
               </Button>

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -141,6 +141,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: Boolean }) isDirectorySizeVisible = true;
   @property({ type: Boolean }) enableModelStore = false;
   @property({ type: Boolean }) enableLLMPlayground = false;
+  @property({ type: Boolean }) enableImportFromHuggingFace = false;
   @property({ type: Boolean }) enableExtendLoginSession = false;
   @property({ type: Boolean }) showNonInstalledImages = false;
   @property({ type: String }) eduAppNamePrefix;
@@ -858,6 +859,16 @@ export default class BackendAILogin extends BackendAIPage {
       defaultValue: false,
       value: generalConfig?.enableLLMPlayground,
     } as ConfigValueObject) as boolean;
+
+    // Enable importing from Hugging Face support
+    this.enableImportFromHuggingFace = this._getConfigValueByExists(
+      generalConfig,
+      {
+        valueType: 'boolean',
+        defaultValue: false,
+        value: generalConfig?.enableImportFromHuggingFace,
+      } as ConfigValueObject,
+    ) as boolean;
 
     // Enable extend login session
     this.enableExtendLoginSession = this._getConfigValueByExists(
@@ -1886,6 +1897,8 @@ export default class BackendAILogin extends BackendAIPage {
           this.enableModelStore;
         globalThis.backendaiclient._config.enableLLMPlayground =
           this.enableLLMPlayground;
+        globalThis.backendaiclient._config.enableImportFromHuggingFace =
+          this.enableImportFromHuggingFace;
         globalThis.backendaiclient._config.enableExtendLoginSession =
           this.enableExtendLoginSession;
         globalThis.backendaiclient._config.pluginPages = this.pluginPages;


### PR DESCRIPTION
# Add support for importing models from Hugging Face

This PR introduces a new feature that allows users to import models from Hugging Face. The changes include:

- Added a new configuration option `enableImportFromHuggingFace` in `config.toml.sample`
- Updated the `BackendAIConfig` type to include the new configuration option
- Modified the `VFolderListPage` component to conditionally render the "Import from Hugging Face" button based on the new configuration
- Updated the `BackendAILogin` component to handle the new configuration option and pass it to the global client configuration

**Checklist:**

- [ ] Documentation: Update user documentation to explain the new feature and how to enable it
- [x] Minimum required manager version: Backend.AI 24.09
- [x] Test case: Verify that the "Import from Hugging Face" button appears when `enableImportFromHuggingFace` is set to true and is hidden when set to false