### PR TITLE
feat: Improve form item and switch to README preview on validation check

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -791,7 +791,10 @@
       "CheckHuggingFaceUrl": "Siehe",
       "ModelName": "Name des Modells",
       "Author": "Autor",
-      "InvalidHuggingFaceUrl": "Ungültige Hugging Face URL."
+      "InvalidHuggingFaceUrl": "Ungültige Hugging Face URL.",
+      "ServiceName": "Dienstname",
+      "ModelStoreFolderName": "Name des Modellspeicherordners",
+      "NotSupportedModel": "Das Modell wird nicht unterstützt. \nBitte nutzen Sie das LLM-Modell."
     }
   },
   "dialog": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -791,7 +791,10 @@
       "CheckHuggingFaceUrl": "Ελέγξτε το",
       "ModelName": "Όνομα μοντέλου",
       "Author": "Συγγραφέας",
-      "InvalidHuggingFaceUrl": "Μη έγκυρη διεύθυνση URL Hugging Face."
+      "InvalidHuggingFaceUrl": "Μη έγκυρη διεύθυνση URL Hugging Face.",
+      "ServiceName": "Όνομα υπηρεσίας",
+      "ModelStoreFolderName": "Όνομα φακέλου καταστήματος μοντέλου",
+      "NotSupportedModel": "Το μοντέλο δεν υποστηρίζεται. \nΧρησιμοποιήστε το μοντέλο LLM."
     }
   },
   "dialog": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -916,7 +916,10 @@
       "CheckHuggingFaceUrl": "Check",
       "ModelName": "Model name",
       "Author": "Author",
-      "InvalidHuggingFaceUrl": "Invalid Hugging Face URL."
+      "InvalidHuggingFaceUrl": "Invalid Hugging Face URL.",
+      "ModelStoreFolderName": "Model store folder name",
+      "ServiceName": "Service name",
+      "NotSupportedModel": "The model is not supported. Please use the LLM model."
     }
   },
   "dialog": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -422,7 +422,10 @@
       "CheckHuggingFaceUrl": "Consulte",
       "ModelName": "Nombre del modelo",
       "Author": "Autor",
-      "InvalidHuggingFaceUrl": "URL Hugging Face no válida."
+      "InvalidHuggingFaceUrl": "URL Hugging Face no válida.",
+      "ServiceName": "Nombre del servicio",
+      "ModelStoreFolderName": "Nombre de la carpeta de la tienda de modelos",
+      "NotSupportedModel": "El modelo no es compatible. \nUtilice el modelo LLM."
     }
   },
   "dialog": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -422,7 +422,10 @@
       "CheckHuggingFaceUrl": "Tarkista",
       "ModelName": "Mallin nimi",
       "Author": "Kirjoittaja",
-      "InvalidHuggingFaceUrl": "Virheellinen Hugging Face URL-osoite."
+      "InvalidHuggingFaceUrl": "Virheellinen Hugging Face URL-osoite.",
+      "ServiceName": "Palvelun nimi",
+      "ModelStoreFolderName": "Mallin tallennuskansion nimi",
+      "NotSupportedModel": "Mallia ei tueta. \nKäytä LLM-mallia."
     }
   },
   "dialog": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -791,7 +791,10 @@
       "CheckHuggingFaceUrl": "Vérifier",
       "ModelName": "Nom du modèle",
       "Author": "Auteur",
-      "InvalidHuggingFaceUrl": "URL Hugging Face non valide."
+      "InvalidHuggingFaceUrl": "URL Hugging Face non valide.",
+      "ServiceName": "Nom du service",
+      "ModelStoreFolderName": "Nom du dossier du magasin de modèles",
+      "NotSupportedModel": "Le modèle n'est pas pris en charge. \nVeuillez utiliser le modèle LLM."
     }
   },
   "dialog": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -792,7 +792,10 @@
       "CheckHuggingFaceUrl": "Periksa",
       "ModelName": "Nama model",
       "Author": "Penulis",
-      "InvalidHuggingFaceUrl": "URL Hugging Face tidak valid."
+      "InvalidHuggingFaceUrl": "URL Hugging Face tidak valid.",
+      "ServiceName": "Nama layanan",
+      "ModelStoreFolderName": "Nama folder penyimpanan model",
+      "NotSupportedModel": "Model ini tidak didukung. \nSilakan gunakan model LLM."
     }
   },
   "dialog": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -792,7 +792,10 @@
       "CheckHuggingFaceUrl": "Controllo",
       "ModelName": "Nome del modello",
       "Author": "Autore",
-      "InvalidHuggingFaceUrl": "URL Hugging Face non valido."
+      "InvalidHuggingFaceUrl": "URL Hugging Face non valido.",
+      "ServiceName": "Nome del servizio",
+      "ModelStoreFolderName": "Nome della cartella dell'archivio modelli",
+      "NotSupportedModel": "Il modello non è supportato. \nSi prega di utilizzare il modello LLM."
     }
   },
   "dialog": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -791,7 +791,10 @@
       "CheckHuggingFaceUrl": "チェック",
       "ModelName": "モデル名",
       "Author": "著者",
-      "InvalidHuggingFaceUrl": "無効なHugging Face URLです。"
+      "InvalidHuggingFaceUrl": "無効なHugging Face URLです。",
+      "ServiceName": "サービス名",
+      "ModelStoreFolderName": "モデルストアフォルダー名",
+      "NotSupportedModel": "このモデルはサポートされていません。 \nLLMモデルを使用してください。"
     }
   },
   "dialog": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -904,7 +904,10 @@
       "ModelName": "모델 이름",
       "Author": "작성자",
       "InvalidHuggingFaceUrl": "유효한 Hugging Face URL을 입력해주세요",
-      "PleaseClickCheckButton": "확인 버튼을 클릭해주세요"
+      "PleaseClickCheckButton": "확인 버튼을 클릭해주세요",
+      "ServiceName": "서비스 이름",
+      "ModelStoreFolderName": "모델 저장소 폴더 이름",
+      "NotSupportedModel": "해당 모델은 지원되지 않습니다. \nLLM 모델을 사용하세요."
     }
   },
   "dialog": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -792,7 +792,10 @@
       "StartWithHuggingFaceUrl": "Энэ нь https://huggingface.co-ээс эхлэх ёстой",
       "CheckHuggingFaceUrl": "Шалгах",
       "ModelName": "Загварын нэр",
-      "InvalidHuggingFaceUrl": "Хүчингүй Hugging Face URL."
+      "InvalidHuggingFaceUrl": "Хүчингүй Hugging Face URL.",
+      "ServiceName": "Үйлчилгээний нэр",
+      "ModelStoreFolderName": "Загварын дэлгүүрийн хавтасны нэр",
+      "NotSupportedModel": "Энэ загварыг дэмждэггүй. \nLLM загварыг ашиглана уу."
     }
   },
   "dialog": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -790,7 +790,10 @@
       "CheckHuggingFaceUrl": "Semak",
       "ModelName": "Nama model",
       "Author": "Pengarang",
-      "InvalidHuggingFaceUrl": "URL Hugging Face tidak sah."
+      "InvalidHuggingFaceUrl": "URL Hugging Face tidak sah.",
+      "ServiceName": "Nama perkhidmatan",
+      "ModelStoreFolderName": "Nama folder kedai model",
+      "NotSupportedModel": "Model tidak disokong. \nSila gunakan model LLM."
     }
   },
   "dialog": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -791,7 +791,10 @@
       "CheckHuggingFaceUrl": "Sprawdź",
       "ModelName": "Nazwa modelu",
       "Author": "Autor",
-      "InvalidHuggingFaceUrl": "Nieprawidłowy adres URL Hugging Face."
+      "InvalidHuggingFaceUrl": "Nieprawidłowy adres URL Hugging Face.",
+      "ServiceName": "Nazwa usługi",
+      "ModelStoreFolderName": "Nazwa folderu sklepu modelu",
+      "NotSupportedModel": "Model nie jest obsługiwany. \nProszę skorzystać z modelu LLM."
     }
   },
   "dialog": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -791,7 +791,10 @@
       "CheckHuggingFaceUrl": "Verificar",
       "ModelName": "Nome do modelo",
       "Author": "Autor",
-      "InvalidHuggingFaceUrl": "URL Hugging Face inválido."
+      "InvalidHuggingFaceUrl": "URL Hugging Face inválido.",
+      "ServiceName": "Nome do serviço",
+      "ModelStoreFolderName": "Nome da pasta de armazenamento de modelos",
+      "NotSupportedModel": "O modelo não é suportado. \nPor favor, use o modelo LLM."
     }
   },
   "dialog": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -791,7 +791,10 @@
       "CheckHuggingFaceUrl": "Verificar",
       "ModelName": "Nome do modelo",
       "Author": "Autor",
-      "InvalidHuggingFaceUrl": "URL Hugging Face inválido."
+      "InvalidHuggingFaceUrl": "URL Hugging Face inválido.",
+      "ServiceName": "Nome do serviço",
+      "ModelStoreFolderName": "Nome da pasta de armazenamento de modelos",
+      "NotSupportedModel": "O modelo não é suportado. \nPor favor, use o modelo LLM."
     }
   },
   "dialog": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -791,7 +791,10 @@
       "CheckHuggingFaceUrl": "Проверьте",
       "ModelName": "Название модели",
       "Author": "Автор",
-      "InvalidHuggingFaceUrl": "Неверный URL-адрес Hugging Face."
+      "InvalidHuggingFaceUrl": "Неверный URL-адрес Hugging Face.",
+      "ServiceName": "Название службы",
+      "ModelStoreFolderName": "Имя папки хранилища моделей",
+      "NotSupportedModel": "Модель не поддерживается. \nПожалуйста, используйте модель LLM."
     }
   },
   "dialog": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -908,7 +908,10 @@
       "CheckHuggingFaceUrl": "ตรวจสอบ",
       "ModelName": "ชื่อรุ่น",
       "Author": "ผู้เขียน",
-      "InvalidHuggingFaceUrl": "URL Hugging Face ไม่ถูกต้อง"
+      "InvalidHuggingFaceUrl": "URL Hugging Face ไม่ถูกต้อง",
+      "ServiceName": "ชื่อบริการ",
+      "ModelStoreFolderName": "ชื่อโฟลเดอร์ร้านค้าโมเดล",
+      "NotSupportedModel": "ไม่รองรับโมเดลนี้ \nกรุณาใช้แบบจำลอง LLM"
     }
   },
   "dialog": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -791,7 +791,10 @@
       "CheckHuggingFaceUrl": "Kontrol et",
       "ModelName": "Model adı",
       "Author": "Yazar",
-      "InvalidHuggingFaceUrl": "Geçersiz Hugging Face URL'si."
+      "InvalidHuggingFaceUrl": "Geçersiz Hugging Face URL'si.",
+      "ServiceName": "Hizmet adı",
+      "ModelStoreFolderName": "Model deposu klasör adı",
+      "NotSupportedModel": "Model desteklenmiyor. \nLütfen LLM modelini kullanın."
     }
   },
   "dialog": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -791,7 +791,10 @@
       "CheckHuggingFaceUrl": "Kiểm tra",
       "ModelName": "Tên mẫu",
       "Author": "Tác giả",
-      "InvalidHuggingFaceUrl": "URL Hugging Face không hợp lệ."
+      "InvalidHuggingFaceUrl": "URL Hugging Face không hợp lệ.",
+      "ServiceName": "Tên dịch vụ",
+      "ModelStoreFolderName": "Tên thư mục lưu trữ mô hình",
+      "NotSupportedModel": "Mô hình không được hỗ trợ. \nVui lòng sử dụng mô hình LLM."
     }
   },
   "dialog": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -791,7 +791,10 @@
       "CheckHuggingFaceUrl": "检查",
       "ModelName": "型号名称",
       "Author": "作者",
-      "InvalidHuggingFaceUrl": "Hugging Face URL 无效。"
+      "InvalidHuggingFaceUrl": "Hugging Face URL 无效。",
+      "ServiceName": "服务名称",
+      "ModelStoreFolderName": "模型存储文件夹名称",
+      "NotSupportedModel": "不支持该型号。\n请使用LLM模型。"
     }
   },
   "dialog": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -790,7 +790,10 @@
       "CheckHuggingFaceUrl": "检查",
       "ModelName": "型号名称",
       "Author": "作者",
-      "InvalidHuggingFaceUrl": "Hugging Face URL 无效。"
+      "InvalidHuggingFaceUrl": "Hugging Face URL 无效。",
+      "ServiceName": "服務名稱",
+      "ModelStoreFolderName": "模型儲存資料夾名稱",
+      "NotSupportedModel": "不支援該型號。\n請使用LLM模型。"
     }
   },
   "dialog": {


### PR DESCRIPTION
**Changes:**

This PR updates the ImportFromHuggingFaceModal component and related translations to enhance the user experience when importing models from Hugging Face. Key changes include:

1. Added new form fields for "Model store folder name" and "Service name".
2. Implemented a README.md preview card with Markdown support.
3. Added validation to ensure only LLM models (text-generation pipeline) are supported.
4. Updated translations for new strings across multiple languages.

**Rationale:**

These changes provide users with more control over the import process and better information about the model being imported. The README preview allows users to review model details before importing, while the additional form fields enable customization of the import location and service name.

**Effects:**

- Users can now specify custom folder names and service names for imported models.
- The UI now displays a preview of the model's README, improving user understanding of the model before import.
- The system now restricts imports to LLM models only, preventing potential issues with unsupported model types.
- Improved localization support for the new features across multiple languages.

**Screenshots:**
- Default
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/22e37a3e-2eb1-48dd-b36d-36999677273c.png)
- Valid
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/cc02186d-b148-4576-b2d1-686e25958bb5.png)
- Invalid URL
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/2e4e0e40-1295-41e1-86b4-7e00a1049943.png)
- Not LLM model
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/71bfc317-6295-438f-aeee-3cc4057885bb.png)

**Checklist:**

- [ ] Documentation
- [ ] Test case(s) to demonstrate the difference of before/after