### PR TITLE
feat: import from HuggingFace and show result with modal

### DIFF
--- a/react/src/components/ImportFromHuggingFaceModal.tsx
+++ b/react/src/components/ImportFromHuggingFaceModal.tsx
@@ -1,22 +1,34 @@
 import { baiSignedRequestWithPromise } from '../helper';
-import { useSuspendedBackendaiClient } from '../hooks';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
+import { useTanMutation } from '../hooks/reactQueryAlias';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
-import { FilterOutlined } from '@ant-design/icons';
+import { ImportFromHuggingFaceModalQuery } from './__generated__/ImportFromHuggingFaceModalQuery.graphql';
+import {
+  CloudUploadOutlined,
+  FilterOutlined,
+  RocketOutlined,
+} from '@ant-design/icons';
 import { useToggle } from 'ahooks';
 import {
+  App,
   Button,
   Card,
   Empty,
   Form,
   FormInstance,
   Input,
+  Modal,
+  Result,
   Space,
   Switch,
   theme,
+  Tooltip,
   Typography,
 } from 'antd';
+import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import { CheckIcon } from 'lucide-react';
 import Markdown from 'markdown-to-jsx';
@@ -28,11 +40,23 @@ import React, {
   useTransition,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLazyLoadQuery } from 'react-relay';
 
 type Service = {
   url: string;
   service_name?: string;
   folder_name?: string;
+};
+
+type ImportFromHuggingFaceResult = {
+  folder: {
+    id: string;
+    name: string;
+  };
+  service?: {
+    endpoint_id: string;
+    name: string;
+  };
 };
 
 const ReadmeFallbackCard = () => {
@@ -69,13 +93,30 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
+  const { message } = App.useApp();
+  const baiClient = useSuspendedBackendaiClient();
   const formRef = useRef<FormInstance<Service>>(null);
+  const currentProject = useCurrentProjectValue();
+  const webuiNavigate = useWebUINavigate();
   const [isImportOnly, { toggle: toggleIsImportOnly }] = useToggle(false);
   const [huggingFaceURL, setHuggingFaceURL] = useState<string | undefined>();
-  const [typedURL, setTypedURL] = useState('');
-  const baiClient = useSuspendedBackendaiClient();
-
+  const [typedURL, setTypedURL] = useState<string>('');
   const [isPendingCheck, startCheckTransition] = useTransition();
+  const [importResult, setImportResult] = useState<
+    ImportFromHuggingFaceResult | undefined
+  >();
+
+  const { group } = useLazyLoadQuery<ImportFromHuggingFaceModalQuery>(
+    graphql`
+      query ImportFromHuggingFaceModalQuery($id: UUID!) {
+        group(id: $id) {
+          type @since(version: "24.03.0")
+        }
+      }
+    `,
+    { id: currentProject?.id },
+  );
+
   const huggingFaceModelInfo = useSuspenseTanQuery<{
     author?: string;
     model_name?: string;
@@ -121,6 +162,27 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
     }
   }, [baiModalProps.open]);
 
+  const importAndStartService = useTanMutation({
+    mutationFn: (values: {
+      huggingFaceUrl: string;
+      importOnly?: boolean;
+      serviceName?: string;
+      folderName?: string;
+    }) => {
+      return baiSignedRequestWithPromise({
+        method: 'POST',
+        url: '/services/_/huggingface/models',
+        body: {
+          huggingface_url: values.huggingFaceUrl,
+          import_only: values?.importOnly,
+          service_name: values?.serviceName,
+          folder_name: values?.folderName,
+        },
+        client: baiClient,
+      });
+    },
+  });
+
   // validate when huggingFaceModelInfo is updated
   useEffect(() => {
     if (huggingFaceModelInfo.data.url) {
@@ -132,8 +194,23 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
     formRef.current
       ?.validateFields()
       .then((values) => {
-        // TODO: Implement import from Hugging Face
-        onRequestClose();
+        importAndStartService.mutate(
+          {
+            huggingFaceUrl: values.url,
+            importOnly: isImportOnly,
+            serviceName: values.service_name || undefined,
+            folderName: values.folder_name || undefined,
+          },
+          {
+            onSuccess(data: any) {
+              setImportResult(data);
+              onRequestClose();
+            },
+            onError(e) {
+              message.error(e.message || t('dialog.ErrorOccurred'));
+            },
+          },
+        );
       })
       .catch(() => {});
   };
@@ -150,155 +227,259 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
   };
 
   return (
-    <BAIModal
-      title={t('data.modelStore.ImportFromHuggingFace')}
-      centered
-      footer={
-        <Button
-          type="primary"
-          htmlType="submit"
-          onClick={handleOnClick}
-          disabled={
+    <>
+      <BAIModal
+        title={t('data.modelStore.ImportFromHuggingFace')}
+        centered
+        confirmLoading={importAndStartService.isPending}
+        okText={
+          isImportOnly
+            ? t('data.modelStore.Import')
+            : t('data.modelStore.ImportAndStartService')
+        }
+        onOk={handleOnClick}
+        okButtonProps={{
+          disabled:
             !shouldSkipURLCheck ||
             (!_.isEmpty(huggingFaceModelInfo.data?.pipeline_tag) &&
-              huggingFaceModelInfo.data?.pipeline_tag !== 'text-generation')
-          }
-        >
-          {isImportOnly
-            ? t('data.modelStore.Import')
-            : t('data.modelStore.ImportAndStartService')}
-        </Button>
-      }
-      onCancel={onRequestClose}
-      destroyOnClose
-      {...baiModalProps}
-    >
-      <Form
-        ref={formRef}
-        preserve={false}
-        layout="vertical"
-        requiredMark="optional"
+              huggingFaceModelInfo.data?.pipeline_tag !== 'text-generation'),
+        }}
+        onCancel={onRequestClose}
+        destroyOnClose
+        {...baiModalProps}
       >
-        <Form.Item label="Hugging Face URL" required>
-          <Space.Compact style={{ width: '100%' }}>
-            <Form.Item
-              noStyle
-              name="url"
-              rules={[
-                { required: true },
-                {
-                  pattern: /^https:\/\/huggingface.co\/.*/,
-                  message: t('data.modelStore.StartWithHuggingFaceUrl'),
-                },
-              ]}
-            >
-              <Input
-                onPressEnter={() => {
+        <Form
+          ref={formRef}
+          preserve={false}
+          layout="vertical"
+          requiredMark="optional"
+        >
+          <Form.Item label="Hugging Face URL" required>
+            <Space.Compact style={{ width: '100%' }}>
+              <Form.Item
+                noStyle
+                name="url"
+                rules={[
+                  { required: true },
+                  {
+                    pattern: /^https:\/\/huggingface.co\/.*/,
+                    message: t('data.modelStore.StartWithHuggingFaceUrl'),
+                  },
+                ]}
+              >
+                <Input
+                  onPressEnter={() => {
+                    handleOnCheck();
+                  }}
+                  onChange={(e) => {
+                    setTypedURL(e.target.value);
+                  }}
+                />
+              </Form.Item>
+              <Button
+                type={!shouldSkipURLCheck ? 'primary' : 'default'}
+                disabled={shouldSkipURLCheck}
+                onClick={() => {
                   handleOnCheck();
                 }}
-                onChange={(e) => {
-                  setTypedURL(e.target.value);
-                }}
-              />
-            </Form.Item>
-            <Button
-              type={!shouldSkipURLCheck ? 'primary' : 'default'}
-              disabled={shouldSkipURLCheck}
-              onClick={() => {
-                handleOnCheck();
-              }}
-              loading={isPendingCheck}
-            >
-              {shouldSkipURLCheck ? (
-                <CheckIcon />
-              ) : (
-                t('data.modelStore.CheckHuggingFaceUrl')
-              )}
-            </Button>
-          </Space.Compact>
-          <Form.Item
-            noStyle
-            name=""
-            rules={[
-              {
-                validator: async () => {
-                  if (
-                    !isHuggingfaceURLExisted &&
-                    huggingFaceModelInfo.data?.isError &&
-                    huggingFaceModelInfo.data.url === typedURL
-                  ) {
-                    return Promise.reject(
-                      t('data.modelStore.InvalidHuggingFaceUrl'),
-                    );
-                  } else {
-                    if (!shouldSkipURLCheck) {
+                loading={isPendingCheck}
+              >
+                {shouldSkipURLCheck ? (
+                  <CheckIcon />
+                ) : (
+                  t('data.modelStore.CheckHuggingFaceUrl')
+                )}
+              </Button>
+            </Space.Compact>
+            <Form.Item
+              noStyle
+              name=""
+              rules={[
+                {
+                  validator: async () => {
+                    if (
+                      !isHuggingfaceURLExisted &&
+                      huggingFaceModelInfo.data?.isError &&
+                      huggingFaceModelInfo.data.url === typedURL
+                    ) {
                       return Promise.reject(
                         t('data.modelStore.InvalidHuggingFaceUrl'),
                       );
-                    } else if (
-                      !_.isEmpty(huggingFaceModelInfo.data?.pipeline_tag) &&
-                      huggingFaceModelInfo.data?.pipeline_tag !==
-                        'text-generation'
-                    ) {
-                      return Promise.reject(
-                        t('data.modelStore.NotSupportedModel'),
-                      );
                     } else {
-                      return Promise.resolve();
+                      if (!shouldSkipURLCheck) {
+                        return Promise.reject(
+                          t('data.modelStore.InvalidHuggingFaceUrl'),
+                        );
+                      } else if (
+                        !_.isEmpty(huggingFaceModelInfo.data?.pipeline_tag) &&
+                        huggingFaceModelInfo.data?.pipeline_tag !==
+                          'text-generation'
+                      ) {
+                        return Promise.reject(
+                          t('data.modelStore.NotSupportedModel'),
+                        );
+                      } else {
+                        return Promise.resolve();
+                      }
                     }
-                  }
+                  },
                 },
-              },
-            ]}
-          ></Form.Item>
-        </Form.Item>
-        <Form.Item
-          label={t('data.modelStore.ModelStoreFolderName')}
-          name="folder_name"
-        >
-          <Input />
-        </Form.Item>
-        <Form.Item label={t('data.modelStore.ServiceName')} name="service_name">
-          <Input />
-        </Form.Item>
-        {huggingFaceURL && huggingFaceModelInfo.data?.markdown ? (
-          <Suspense fallback={<ReadmeFallbackCard />}>
-            <Card
-              size="small"
-              title={
-                <Flex direction="row" gap="xs">
-                  <FilterOutlined />
-                  README.md
-                </Flex>
-              }
-              styles={{
-                body: {
-                  padding: token.paddingLG,
-                  overflow: 'auto',
-                  height: 200,
-                },
+              ]}
+            ></Form.Item>
+          </Form.Item>
+          <Form.Item
+            label={t('data.modelStore.ModelStoreFolderName')}
+            name="folder_name"
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item
+            label={t('data.modelStore.ServiceName')}
+            name="service_name"
+          >
+            <Input />
+          </Form.Item>
+          {huggingFaceURL && huggingFaceModelInfo.data?.markdown ? (
+            <Suspense fallback={<ReadmeFallbackCard />}>
+              <Card
+                size="small"
+                title={
+                  <Flex direction="row" gap="xs">
+                    <FilterOutlined />
+                    README.md
+                  </Flex>
+                }
+                styles={{
+                  body: {
+                    padding: token.paddingLG,
+                    overflow: 'auto',
+                    height: 200,
+                  },
+                }}
+              >
+                <Markdown>{huggingFaceModelInfo.data?.markdown}</Markdown>
+              </Card>
+            </Suspense>
+          ) : (
+            <ReadmeFallbackCard />
+          )}
+          <Flex
+            gap={'xs'}
+            style={{ marginTop: token.marginLG, marginBottom: token.marginLG }}
+          >
+            <Switch
+              checked={isImportOnly}
+              onChange={(e) => {
+                toggleIsImportOnly();
               }}
-            >
-              <Markdown>{huggingFaceModelInfo.data?.markdown}</Markdown>
-            </Card>
-          </Suspense>
-        ) : (
-          <ReadmeFallbackCard />
-        )}
-        <Flex
-          gap={'xs'}
-          style={{ marginTop: token.marginLG, marginBottom: token.marginLG }}
+            />
+            <Typography.Text>{t('data.modelStore.ImportOnly')}</Typography.Text>
+          </Flex>
+        </Form>
+      </BAIModal>
+      <Modal
+        open={!_.isEmpty(importResult)}
+        onCancel={() => setImportResult(undefined)}
+        footer={null}
+      >
+        <Result
+          status={importAndStartService?.isSuccess ? 'success' : 'error'}
+          title={
+            importAndStartService?.isSuccess
+              ? t('data.modelStore.ImportSucceeded')
+              : t('dialog.ErrorOccurred')
+          }
+          subTitle={
+            importAndStartService?.isSuccess
+              ? isImportOnly
+                ? t('data.modelStore.ImportOnlySuccessDesc', {
+                    folderName: importResult?.folder?.name,
+                  })
+                : t('data.modelStore.ImportAndStartServiceSuccessDesc', {
+                    folderName: importResult?.folder?.name,
+                    serviceName: importResult?.service?.name,
+                  })
+              : importAndStartService?.error?.message
+          }
+          extra={
+            importAndStartService?.isSuccess && (
+              <Flex gap={'xs'} justify="center" align="center">
+                {importResult?.folder?.id && (
+                  <Tooltip
+                    title={
+                      baiClient?.is_admin && group?.type !== 'MODEL_STORE'
+                        ? t(
+                            'data.modelStore.ChangeTheCurrentProjectToModelStore',
+                          )
+                        : ''
+                    }
+                  >
+                    <Button
+                      disabled={
+                        baiClient?.is_admin && group?.type !== 'MODEL_STORE'
+                      }
+                      onClick={() => {
+                        webuiNavigate(
+                          `/data?tab=model&folder=${importResult.folder.id}`,
+                        );
+                      }}
+                    >
+                      {t('data.modelStore.OpenModelFolder')}
+                    </Button>
+                  </Tooltip>
+                )}
+                {importResult?.service?.endpoint_id && (
+                  <Button
+                    type="primary"
+                    onClick={() => {
+                      webuiNavigate(
+                        `/serving/${importResult.service?.endpoint_id}`,
+                      );
+                    }}
+                  >
+                    {t('data.modelStore.ViewServiceInfo')}
+                  </Button>
+                )}
+              </Flex>
+            )
+          }
         >
-          <Switch
-            checked={isImportOnly}
-            onChange={(e) => {
-              toggleIsImportOnly();
-            }}
-          />
-          <Typography.Text>{t('data.modelStore.ImportOnly')}</Typography.Text>
-        </Flex>
-      </Form>
-    </BAIModal>
+          {importAndStartService?.isSuccess && (
+            <div className="desc">
+              <Typography.Paragraph>
+                <Typography.Text strong>
+                  {t('data.modelStore.AddedItems')}
+                </Typography.Text>
+              </Typography.Paragraph>
+              {importResult?.folder?.name && (
+                <Typography.Paragraph>
+                  <Typography.Text>
+                    <CloudUploadOutlined
+                      style={{ marginRight: token.marginXXS }}
+                    />
+                    {t('data.modelStore.ModelFolderName')}:{' '}
+                    <Typography.Text copyable>
+                      {importResult?.folder?.name}
+                    </Typography.Text>
+                  </Typography.Text>
+                </Typography.Paragraph>
+              )}
+              {importResult?.service?.name && (
+                <Typography.Paragraph>
+                  <Typography.Text>
+                    <RocketOutlined style={{ marginRight: token.marginXXS }} />
+                    {t('data.modelStore.ServiceName')}:{' '}
+                    <Typography.Text copyable>
+                      {importResult?.service?.name}
+                    </Typography.Text>
+                  </Typography.Text>
+                </Typography.Paragraph>
+              )}
+            </div>
+          )}
+        </Result>
+      </Modal>
+    </>
   );
 };
 

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -794,7 +794,19 @@
       "InvalidHuggingFaceUrl": "Ungültige Hugging Face URL.",
       "ServiceName": "Dienstname",
       "ModelStoreFolderName": "Name des Modellspeicherordners",
-      "NotSupportedModel": "Das Modell wird nicht unterstützt. \nBitte nutzen Sie das LLM-Modell."
+      "NotSupportedModel": "Das Modell wird nicht unterstützt. \nBitte nutzen Sie das LLM-Modell.",
+      "NewModelStoreFolderHasBeenCreated": "Ein neuer Modellspeicherordner wurde erstellt",
+      "NewServiceHasBeenCreated": "Ein neuer Dienst wurde erstellt",
+      "OpenModelFolder": "Modellordner öffnen",
+      "ViewServiceInfo": "Serviceinformationen anzeigen",
+      "NewModelFolderHasBeenCreated": "Ein neuer Modellordner wurde erstellt",
+      "ChangeTheCurrentProjectToModelStore": "Ändern Sie das aktuelle Projekt in „model-store“.",
+      "ImportSucceeded": "Das Modell wurde erfolgreich importiert",
+      "ImportAndStartServiceSucceeded": "Das Modell wurde erfolgreich importiert und der Dienst wurde ausgeführt",
+      "ImportOnlySuccessDesc": "Der neue Modellordner ist fertig. \nStarten Sie den Dienst jetzt und probieren Sie den gewünschten Vorgang aus.",
+      "ImportAndStartServiceSuccessDesc": "Die neue Modellmappe und der Service sind fertig. \nKlicken Sie auf die Schaltfläche „Serviceinformationen anzeigen“, um die Modelldetails zu überprüfen und den gewünschten Vorgang zu starten.",
+      "AddedItems": "Artikel hinzugefügt",
+      "ModelFolderName": "Name des Modellordners"
     }
   },
   "dialog": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -792,9 +792,21 @@
       "ModelName": "Όνομα μοντέλου",
       "Author": "Συγγραφέας",
       "InvalidHuggingFaceUrl": "Μη έγκυρη διεύθυνση URL Hugging Face.",
-      "ServiceName": "Όνομα υπηρεσίας",
       "ModelStoreFolderName": "Όνομα φακέλου καταστήματος μοντέλου",
-      "NotSupportedModel": "Το μοντέλο δεν υποστηρίζεται. \nΧρησιμοποιήστε το μοντέλο LLM."
+      "ServiceName": "Όνομα υπηρεσίας",
+      "NewModelStoreFolderHasBeenCreated": "Δημιουργήθηκε ένας νέος φάκελος καταστήματος μοντέλων",
+      "NewServiceHasBeenCreated": "Μια νέα υπηρεσία δημιουργήθηκε",
+      "OpenModelFolder": "Άνοιγμα φακέλου μοντέλου",
+      "ViewServiceInfo": "Προβολή πληροφοριών υπηρεσίας",
+      "NotSupportedModel": "Το μοντέλο δεν υποστηρίζεται. \nΧρησιμοποιήστε το μοντέλο LLM.",
+      "NewModelFolderHasBeenCreated": "Ένας νέος φάκελος μοντέλου δημιουργήθηκε",
+      "ChangeTheCurrentProjectToModelStore": "Αλλάξτε το τρέχον έργο σε «μοντέλο-κατάστημα».",
+      "ImportSucceeded": "Το μοντέλο έχει εισαχθεί με επιτυχία",
+      "ImportAndStartServiceSucceeded": "Το μοντέλο έχει εισαχθεί με επιτυχία και η υπηρεσία εκτελέστηκε",
+      "ImportOnlySuccessDesc": "Ο νέος φάκελος μοντέλου είναι έτοιμος. \nΞεκινήστε την υπηρεσία τώρα και δοκιμάστε τη λειτουργία που θέλετε.",
+      "ImportAndStartServiceSuccessDesc": "Ο νέος φάκελος μοντέλου και η υπηρεσία είναι έτοιμα. \nΚάντε κλικ στο κουμπί «Προβολή πληροφοριών υπηρεσίας» για να ελέγξετε τις λεπτομέρειες του μοντέλου και να ξεκινήσετε την επιθυμητή λειτουργία.",
+      "AddedItems": "Προστέθηκαν στοιχεία",
+      "ModelFolderName": "Όνομα φακέλου μοντέλου"
     }
   },
   "dialog": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -919,7 +919,21 @@
       "InvalidHuggingFaceUrl": "Invalid Hugging Face URL.",
       "ModelStoreFolderName": "Model store folder name",
       "ServiceName": "Service name",
-      "NotSupportedModel": "The model is not supported. Please use the LLM model."
+      "HuggingFaceURL": "Higging Face",
+      "NewModelStoreFolderHasBeenCreated": "A new model store folder has been created",
+      "NewServiceHasBeenCreated": "A new service has been created",
+      "OpenModelFolder": "Open model folder",
+      "ViewServiceInfo": "View service info",
+      "NotSupportedModel": "The model is not supported. Please use the LLM model.",
+      "NewModelFolderHasBeenCreated": "A new model folder has been created",
+      "UpdateCurrentProject": "",
+      "ChangeTheCurrentProjectToModelStore": "Change the current project to 'model-store'.",
+      "ImportSucceeded": "The model has been successfully imported",
+      "ImportAndStartServiceSucceeded": "The model has been successfully imported and the service was executed",
+      "ImportOnlySuccessDesc": "The new model folder is ready. Start the service now and try the operation you want.",
+      "ImportAndStartServiceSuccessDesc": "The new model folder and service are ready. Click the 'View service info' button to check the model details and start the desired operation.",
+      "AddedItems": "Added items",
+      "ModelFolderName": "Model folder name"
     }
   },
   "dialog": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -423,9 +423,21 @@
       "ModelName": "Nombre del modelo",
       "Author": "Autor",
       "InvalidHuggingFaceUrl": "URL Hugging Face no válida.",
-      "ServiceName": "Nombre del servicio",
       "ModelStoreFolderName": "Nombre de la carpeta de la tienda de modelos",
-      "NotSupportedModel": "El modelo no es compatible. \nUtilice el modelo LLM."
+      "ServiceName": "Nombre del servicio",
+      "NewModelStoreFolderHasBeenCreated": "Se ha creado una nueva carpeta de tienda de modelos.",
+      "NewServiceHasBeenCreated": "Se ha creado un nuevo servicio.",
+      "OpenModelFolder": "Abrir carpeta de modelo",
+      "ViewServiceInfo": "Ver información del servicio",
+      "NotSupportedModel": "El modelo no es compatible. \nUtilice el modelo LLM.",
+      "NewModelFolderHasBeenCreated": "Se ha creado una nueva carpeta de modelo.",
+      "ChangeTheCurrentProjectToModelStore": "Cambie el proyecto actual a 'model-store'.",
+      "ImportSucceeded": "El modelo ha sido importado exitosamente.",
+      "ImportAndStartServiceSucceeded": "El modelo se importó exitosamente y se ejecutó el servicio.",
+      "ImportOnlySuccessDesc": "La carpeta del nuevo modelo está lista. \nInicie el servicio ahora y pruebe la operación que desee.",
+      "ImportAndStartServiceSuccessDesc": "La carpeta del nuevo modelo y el servicio están listos. \nHaga clic en el botón 'Ver información de servicio' para verificar los detalles del modelo e iniciar la operación deseada.",
+      "AddedItems": "Artículos agregados",
+      "ModelFolderName": "Nombre de la carpeta del modelo"
     }
   },
   "dialog": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -423,9 +423,21 @@
       "ModelName": "Mallin nimi",
       "Author": "Kirjoittaja",
       "InvalidHuggingFaceUrl": "Virheellinen Hugging Face URL-osoite.",
-      "ServiceName": "Palvelun nimi",
       "ModelStoreFolderName": "Mallin tallennuskansion nimi",
-      "NotSupportedModel": "Mallia ei tueta. \nKäytä LLM-mallia."
+      "ServiceName": "Palvelun nimi",
+      "NewModelStoreFolderHasBeenCreated": "Uusi mallikauppakansio on luotu",
+      "NewServiceHasBeenCreated": "Uusi palvelu on luotu",
+      "OpenModelFolder": "Avaa mallikansio",
+      "ViewServiceInfo": "Katso palvelutiedot",
+      "NotSupportedModel": "Mallia ei tueta. \nKäytä LLM-mallia.",
+      "NewModelFolderHasBeenCreated": "Uusi mallikansio on luotu",
+      "ChangeTheCurrentProjectToModelStore": "Muuta nykyinen projekti \"mallikauppaan\".",
+      "ImportSucceeded": "Mallin tuonti onnistui",
+      "ImportAndStartServiceSucceeded": "Malli on tuotu onnistuneesti ja palvelu suoritettu",
+      "ImportOnlySuccessDesc": "Uusi mallikansio on valmis. \nKäynnistä palvelu nyt ja kokeile haluamaasi toimintoa.",
+      "ImportAndStartServiceSuccessDesc": "Uusi mallikansio ja palvelu ovat valmiina. \nNapsauta \"Näytä palvelutiedot\" -painiketta tarkistaaksesi mallin tiedot ja aloittaaksesi haluamasi toiminnon.",
+      "AddedItems": "Lisätyt kohteet",
+      "ModelFolderName": "Mallin kansion nimi"
     }
   },
   "dialog": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -792,9 +792,21 @@
       "ModelName": "Nom du modèle",
       "Author": "Auteur",
       "InvalidHuggingFaceUrl": "URL Hugging Face non valide.",
-      "ServiceName": "Nom du service",
       "ModelStoreFolderName": "Nom du dossier du magasin de modèles",
-      "NotSupportedModel": "Le modèle n'est pas pris en charge. \nVeuillez utiliser le modèle LLM."
+      "ServiceName": "Nom du service",
+      "NewModelStoreFolderHasBeenCreated": "Un nouveau dossier de magasin de modèles a été créé",
+      "NewServiceHasBeenCreated": "Un nouveau service a été créé",
+      "OpenModelFolder": "Ouvrir le dossier modèle",
+      "ViewServiceInfo": "Afficher les informations sur les services",
+      "NotSupportedModel": "Le modèle n'est pas pris en charge. \nVeuillez utiliser le modèle LLM.",
+      "NewModelFolderHasBeenCreated": "Un nouveau dossier modèle a été créé",
+      "ChangeTheCurrentProjectToModelStore": "Changez le projet actuel en 'model-store'.",
+      "ImportSucceeded": "Le modèle a été importé avec succès",
+      "ImportAndStartServiceSucceeded": "Le modèle a été importé avec succès et le service a été exécuté",
+      "ImportOnlySuccessDesc": "Le nouveau dossier modèle est prêt. \nDémarrez le service maintenant et essayez l'opération souhaitée.",
+      "ImportAndStartServiceSuccessDesc": "Le nouveau dossier modèle et le nouveau service sont prêts. \nCliquez sur le bouton « Afficher les informations de service » pour vérifier les détails du modèle et démarrer l'opération souhaitée.",
+      "AddedItems": "Éléments ajoutés",
+      "ModelFolderName": "Nom du dossier modèle"
     }
   },
   "dialog": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -793,9 +793,21 @@
       "ModelName": "Nama model",
       "Author": "Penulis",
       "InvalidHuggingFaceUrl": "URL Hugging Face tidak valid.",
-      "ServiceName": "Nama layanan",
       "ModelStoreFolderName": "Nama folder penyimpanan model",
-      "NotSupportedModel": "Model ini tidak didukung. \nSilakan gunakan model LLM."
+      "ServiceName": "Nama layanan",
+      "NewModelStoreFolderHasBeenCreated": "Folder penyimpanan model baru telah dibuat",
+      "NewServiceHasBeenCreated": "Layanan baru telah dibuat",
+      "OpenModelFolder": "Buka folder model",
+      "ViewServiceInfo": "Lihat info layanan",
+      "NotSupportedModel": "Model ini tidak didukung. \nSilakan gunakan model LLM.",
+      "NewModelFolderHasBeenCreated": "Folder model baru telah dibuat",
+      "ChangeTheCurrentProjectToModelStore": "Ubah proyek saat ini menjadi 'model-store'.",
+      "ImportSucceeded": "Model telah berhasil diimpor",
+      "ImportAndStartServiceSucceeded": "Model telah berhasil diimpor dan layanan dijalankan",
+      "ImportOnlySuccessDesc": "Folder model baru sudah siap. \nMulai layanan sekarang dan coba operasi yang Anda inginkan.",
+      "ImportAndStartServiceSuccessDesc": "Folder model baru dan layanan sudah siap. \nKlik tombol 'Lihat info layanan' untuk memeriksa detail model dan memulai pengoperasian yang diinginkan.",
+      "AddedItems": "Item yang ditambahkan",
+      "ModelFolderName": "Nama folder model"
     }
   },
   "dialog": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -793,9 +793,21 @@
       "ModelName": "Nome del modello",
       "Author": "Autore",
       "InvalidHuggingFaceUrl": "URL Hugging Face non valido.",
-      "ServiceName": "Nome del servizio",
       "ModelStoreFolderName": "Nome della cartella dell'archivio modelli",
-      "NotSupportedModel": "Il modello non è supportato. \nSi prega di utilizzare il modello LLM."
+      "ServiceName": "Nome del servizio",
+      "NewModelStoreFolderHasBeenCreated": "È stata creata una nuova cartella dell'archivio modelli",
+      "NewServiceHasBeenCreated": "È stato creato un nuovo servizio",
+      "OpenModelFolder": "Apri la cartella del modello",
+      "ViewServiceInfo": "Visualizza le informazioni sul servizio",
+      "NotSupportedModel": "Il modello non è supportato. \nSi prega di utilizzare il modello LLM.",
+      "NewModelFolderHasBeenCreated": "È stata creata una nuova cartella del modello",
+      "ChangeTheCurrentProjectToModelStore": "Cambia il progetto corrente in 'model-store'.",
+      "ImportSucceeded": "Il modello è stato importato con successo",
+      "ImportAndStartServiceSucceeded": "Il modello è stato importato con successo e il servizio è stato eseguito",
+      "ImportOnlySuccessDesc": "La nuova cartella del modello è pronta. \nAvvia subito il servizio e prova l'operazione che desideri.",
+      "ImportAndStartServiceSuccessDesc": "La nuova cartella modello e il servizio sono pronti. \nFare clic sul pulsante \"Visualizza informazioni servizio\" per verificare i dettagli del modello e avviare l'operazione desiderata.",
+      "AddedItems": "Elementi aggiunti",
+      "ModelFolderName": "Nome della cartella del modello"
     }
   },
   "dialog": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -792,9 +792,21 @@
       "ModelName": "モデル名",
       "Author": "著者",
       "InvalidHuggingFaceUrl": "無効なHugging Face URLです。",
-      "ServiceName": "サービス名",
       "ModelStoreFolderName": "モデルストアフォルダー名",
-      "NotSupportedModel": "このモデルはサポートされていません。 \nLLMモデルを使用してください。"
+      "ServiceName": "サービス名",
+      "NewModelStoreFolderHasBeenCreated": "新しいモデル ストア フォルダーが作成されました",
+      "NewServiceHasBeenCreated": "新しいサービスが作成されました",
+      "OpenModelFolder": "モデルフォルダーを開く",
+      "ViewServiceInfo": "サービス情報を見る",
+      "NotSupportedModel": "このモデルはサポートされていません。 \nLLMモデルを使用してください。",
+      "NewModelFolderHasBeenCreated": "新しいモデルフォルダーが作成されました",
+      "ChangeTheCurrentProjectToModelStore": "現在のプロジェクトを「model-store」に変更します。",
+      "ImportSucceeded": "モデルは正常にインポートされました",
+      "ImportAndStartServiceSucceeded": "モデルは正常にインポートされ、サービスが実行されました。",
+      "ImportOnlySuccessDesc": "新しいモデルフォルダーの準備ができました。\n今すぐサービスを開始し、必要な操作を試してください。",
+      "ImportAndStartServiceSuccessDesc": "新しいモデルのフォルダーとサービスが準備できました。 \n「サービス情報を見る」ボタンをクリックすると機種の詳細を確認し、必要な操作を開始します。",
+      "AddedItems": "追加された項目",
+      "ModelFolderName": "モデルフォルダ名"
     }
   },
   "dialog": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -905,9 +905,21 @@
       "Author": "작성자",
       "InvalidHuggingFaceUrl": "유효한 Hugging Face URL을 입력해주세요",
       "PleaseClickCheckButton": "확인 버튼을 클릭해주세요",
-      "ServiceName": "서비스 이름",
       "ModelStoreFolderName": "모델 저장소 폴더 이름",
-      "NotSupportedModel": "해당 모델은 지원되지 않습니다. \nLLM 모델을 사용하세요."
+      "ServiceName": "서비스 이름",
+      "NewModelStoreFolderHasBeenCreated": "새 모델 저장소 폴더가 생성되었습니다.",
+      "NewServiceHasBeenCreated": "새로운 서비스가 생성되었습니다",
+      "OpenModelFolder": "모델 폴더 열기",
+      "ViewServiceInfo": "서비스 정보 보기",
+      "NotSupportedModel": "해당 모델은 지원되지 않습니다. \nLLM 모델을 사용하세요.",
+      "NewModelFolderHasBeenCreated": "새 모델 폴더가 생성되었습니다.",
+      "ChangeTheCurrentProjectToModelStore": "현재 프로젝트를 'model-store'로 변경하세요.",
+      "ImportSucceeded": "모델을 성공적으로 가져왔습니다.",
+      "ImportAndStartServiceSucceeded": "모델을 성공적으로 가져와 서비스를 실행했습니다.",
+      "ImportOnlySuccessDesc": "새 모델 폴더가 준비되었습니다. 지금 바로 서비스를 시작하여 원하는 작업을 해보세요.",
+      "ImportAndStartServiceSuccessDesc": "새로운 모델 폴더와 서비스가 준비되었습니다. \n'서비스 정보 보기' 버튼을 클릭하시면 모델 상세 정보를 확인하고 원하는 작업을 시작하실 수 있습니다.",
+      "AddedItems": "추가된 항목",
+      "ModelFolderName": "모델 폴더 이름"
     }
   },
   "dialog": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -793,9 +793,21 @@
       "CheckHuggingFaceUrl": "Шалгах",
       "ModelName": "Загварын нэр",
       "InvalidHuggingFaceUrl": "Хүчингүй Hugging Face URL.",
-      "ServiceName": "Үйлчилгээний нэр",
       "ModelStoreFolderName": "Загварын дэлгүүрийн хавтасны нэр",
-      "NotSupportedModel": "Энэ загварыг дэмждэггүй. \nLLM загварыг ашиглана уу."
+      "ServiceName": "Үйлчилгээний нэр",
+      "NewModelStoreFolderHasBeenCreated": "Шинэ загварын дэлгүүрийн хавтас үүсгэгдсэн",
+      "NewServiceHasBeenCreated": "Шинэ үйлчилгээ бий болсон",
+      "OpenModelFolder": "Загварын хавтсыг нээнэ үү",
+      "ViewServiceInfo": "Үйлчилгээний мэдээллийг харах",
+      "NotSupportedModel": "Энэ загварыг дэмждэггүй. \nLLM загварыг ашиглана уу.",
+      "NewModelFolderHasBeenCreated": "Шинэ загварын хавтас үүсгэсэн",
+      "ChangeTheCurrentProjectToModelStore": "Одоогийн төслийг \"загвар дэлгүүр\" болгон өөрчил.",
+      "ImportSucceeded": "Загварыг амжилттай оруулж ирлээ",
+      "ImportAndStartServiceSucceeded": "Загварыг амжилттай оруулж ирсэн бөгөөд үйлчилгээгээ гүйцэтгэсэн",
+      "ImportOnlySuccessDesc": "Шинэ загварын хавтас бэлэн боллоо. \nҮйлчилгээг яг одоо эхлүүлээд хүссэн үйлдлээ туршиж үзээрэй.",
+      "ImportAndStartServiceSuccessDesc": "Шинэ загварын хавтас, үйлчилгээ бэлэн боллоо. \nЗагварын дэлгэрэнгүй мэдээллийг шалгахын тулд \"Үйлчилгээний мэдээллийг харах\" товчийг дарж, хүссэн үйлдлийг эхлүүлнэ үү.",
+      "AddedItems": "Нэмэгдсэн зүйлс",
+      "ModelFolderName": "Загварын хавтасны нэр"
     }
   },
   "dialog": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -791,9 +791,21 @@
       "ModelName": "Nama model",
       "Author": "Pengarang",
       "InvalidHuggingFaceUrl": "URL Hugging Face tidak sah.",
-      "ServiceName": "Nama perkhidmatan",
       "ModelStoreFolderName": "Nama folder kedai model",
-      "NotSupportedModel": "Model tidak disokong. \nSila gunakan model LLM."
+      "ServiceName": "Nama perkhidmatan",
+      "NewModelStoreFolderHasBeenCreated": "Folder kedai model baharu telah dibuat",
+      "NewServiceHasBeenCreated": "Perkhidmatan baharu telah dibuat",
+      "OpenModelFolder": "Buka folder model",
+      "ViewServiceInfo": "Lihat maklumat perkhidmatan",
+      "NotSupportedModel": "Model tidak disokong. \nSila gunakan model LLM.",
+      "NewModelFolderHasBeenCreated": "Folder model baharu telah dibuat",
+      "ChangeTheCurrentProjectToModelStore": "Tukar projek semasa kepada 'model-store'.",
+      "ImportSucceeded": "Model telah berjaya diimport",
+      "ImportAndStartServiceSucceeded": "Model telah berjaya diimport dan perkhidmatan telah dilaksanakan",
+      "ImportOnlySuccessDesc": "Folder model baharu sudah sedia. \nMulakan perkhidmatan sekarang dan cuba operasi yang anda mahu.",
+      "ImportAndStartServiceSuccessDesc": "Folder dan perkhidmatan model baharu sudah sedia. \nKlik butang 'Lihat maklumat perkhidmatan' untuk menyemak butiran model dan memulakan operasi yang diingini.",
+      "AddedItems": "Item ditambah",
+      "ModelFolderName": "Nama folder model"
     }
   },
   "dialog": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -792,9 +792,21 @@
       "ModelName": "Nazwa modelu",
       "Author": "Autor",
       "InvalidHuggingFaceUrl": "Nieprawidłowy adres URL Hugging Face.",
-      "ServiceName": "Nazwa usługi",
       "ModelStoreFolderName": "Nazwa folderu sklepu modelu",
-      "NotSupportedModel": "Model nie jest obsługiwany. \nProszę skorzystać z modelu LLM."
+      "ServiceName": "Nazwa usługi",
+      "NewModelStoreFolderHasBeenCreated": "Utworzono nowy folder sklepu z modelami",
+      "NewServiceHasBeenCreated": "Powstał nowy serwis",
+      "OpenModelFolder": "Otwórz folder modelu",
+      "ViewServiceInfo": "Wyświetl informacje o usłudze",
+      "NotSupportedModel": "Model nie jest obsługiwany. \nProszę skorzystać z modelu LLM.",
+      "NewModelFolderHasBeenCreated": "Utworzono nowy folder modelu",
+      "ChangeTheCurrentProjectToModelStore": "Zmień bieżący projekt na „sklep modelowy”.",
+      "ImportSucceeded": "Model został pomyślnie zaimportowany",
+      "ImportAndStartServiceSucceeded": "Model został pomyślnie zaimportowany, a usługa wykonana",
+      "ImportOnlySuccessDesc": "Folder nowego modelu jest gotowy. \nUruchom usługę teraz i wypróbuj żądaną operację.",
+      "ImportAndStartServiceSuccessDesc": "Nowy folder modelu i usługa są gotowe. \nKliknij przycisk „Wyświetl informacje serwisowe”, aby sprawdzić szczegóły modelu i rozpocząć żądaną operację.",
+      "AddedItems": "Dodane elementy",
+      "ModelFolderName": "Nazwa folderu modelu"
     }
   },
   "dialog": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -792,9 +792,21 @@
       "ModelName": "Nome do modelo",
       "Author": "Autor",
       "InvalidHuggingFaceUrl": "URL Hugging Face inválido.",
-      "ServiceName": "Nome do serviço",
       "ModelStoreFolderName": "Nome da pasta de armazenamento de modelos",
-      "NotSupportedModel": "O modelo não é suportado. \nPor favor, use o modelo LLM."
+      "ServiceName": "Nome do serviço",
+      "NewModelStoreFolderHasBeenCreated": "Uma nova pasta de armazenamento de modelos foi criada",
+      "NewServiceHasBeenCreated": "Um novo serviço foi criado",
+      "OpenModelFolder": "Abra a pasta do modelo",
+      "ViewServiceInfo": "Ver informações de serviço",
+      "NotSupportedModel": "O modelo não é suportado. \nPor favor, use o modelo LLM.",
+      "NewModelFolderHasBeenCreated": "Uma nova pasta de modelo foi criada",
+      "ChangeTheCurrentProjectToModelStore": "Mude o projeto atual para 'model-store'.",
+      "ImportSucceeded": "O modelo foi importado com sucesso",
+      "ImportAndStartServiceSucceeded": "O modelo foi importado com sucesso e o serviço foi executado",
+      "ImportOnlySuccessDesc": "A nova pasta do modelo está pronta. \nInicie o serviço agora e experimente a operação desejada.",
+      "ImportAndStartServiceSuccessDesc": "A pasta e o serviço do novo modelo estão prontos. \nClique no botão 'Ver informações de serviço' para verificar os detalhes do modelo e iniciar a operação desejada.",
+      "AddedItems": "Itens adicionados",
+      "ModelFolderName": "Nome da pasta do modelo"
     }
   },
   "dialog": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -792,9 +792,21 @@
       "ModelName": "Nome do modelo",
       "Author": "Autor",
       "InvalidHuggingFaceUrl": "URL Hugging Face inválido.",
-      "ServiceName": "Nome do serviço",
       "ModelStoreFolderName": "Nome da pasta de armazenamento de modelos",
-      "NotSupportedModel": "O modelo não é suportado. \nPor favor, use o modelo LLM."
+      "ServiceName": "Nome do serviço",
+      "NewModelStoreFolderHasBeenCreated": "Uma nova pasta de armazenamento de modelos foi criada",
+      "NewServiceHasBeenCreated": "Um novo serviço foi criado",
+      "OpenModelFolder": "Abra a pasta do modelo",
+      "ViewServiceInfo": "Ver informações de serviço",
+      "NotSupportedModel": "O modelo não é suportado. \nPor favor, use o modelo LLM.",
+      "NewModelFolderHasBeenCreated": "Uma nova pasta de modelo foi criada",
+      "ChangeTheCurrentProjectToModelStore": "Mude o projeto atual para 'model-store'.",
+      "ImportSucceeded": "O modelo foi importado com sucesso",
+      "ImportAndStartServiceSucceeded": "O modelo foi importado com sucesso e o serviço foi executado",
+      "ImportOnlySuccessDesc": "A nova pasta do modelo está pronta. \nInicie o serviço agora e experimente a operação desejada.",
+      "ImportAndStartServiceSuccessDesc": "A pasta e o serviço do novo modelo estão prontos. \nClique no botão 'Ver informações de serviço' para verificar os detalhes do modelo e iniciar a operação desejada.",
+      "AddedItems": "Itens adicionados",
+      "ModelFolderName": "Nome da pasta do modelo"
     }
   },
   "dialog": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -792,9 +792,21 @@
       "ModelName": "Название модели",
       "Author": "Автор",
       "InvalidHuggingFaceUrl": "Неверный URL-адрес Hugging Face.",
-      "ServiceName": "Название службы",
       "ModelStoreFolderName": "Имя папки хранилища моделей",
-      "NotSupportedModel": "Модель не поддерживается. \nПожалуйста, используйте модель LLM."
+      "ServiceName": "Название службы",
+      "NewModelStoreFolderHasBeenCreated": "Создана новая папка хранилища моделей.",
+      "NewServiceHasBeenCreated": "Создан новый сервис",
+      "OpenModelFolder": "Открыть папку модели",
+      "ViewServiceInfo": "Посмотреть информацию об услуге",
+      "NotSupportedModel": "Модель не поддерживается. \nПожалуйста, используйте модель LLM.",
+      "NewModelFolderHasBeenCreated": "Создана новая папка модели.",
+      "ChangeTheCurrentProjectToModelStore": "Измените текущий проект на «магазин моделей».",
+      "ImportSucceeded": "Модель успешно импортирована.",
+      "ImportAndStartServiceSucceeded": "Модель успешно импортирована и услуга выполнена.",
+      "ImportOnlySuccessDesc": "Папка новой модели готова. \nЗапустите службу сейчас и попробуйте выполнить нужную операцию.",
+      "ImportAndStartServiceSuccessDesc": "Папка и сервис новой модели готовы. \nНажмите кнопку «Просмотреть информацию об услуге», чтобы проверить сведения о модели и начать нужную операцию.",
+      "AddedItems": "Добавлены предметы",
+      "ModelFolderName": "Имя папки модели"
     }
   },
   "dialog": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -909,9 +909,21 @@
       "ModelName": "ชื่อรุ่น",
       "Author": "ผู้เขียน",
       "InvalidHuggingFaceUrl": "URL Hugging Face ไม่ถูกต้อง",
-      "ServiceName": "ชื่อบริการ",
       "ModelStoreFolderName": "ชื่อโฟลเดอร์ร้านค้าโมเดล",
-      "NotSupportedModel": "ไม่รองรับโมเดลนี้ \nกรุณาใช้แบบจำลอง LLM"
+      "ServiceName": "ชื่อบริการ",
+      "NewModelStoreFolderHasBeenCreated": "สร้างโฟลเดอร์ร้านค้าโมเดลใหม่แล้ว",
+      "NewServiceHasBeenCreated": "มีการสร้างบริการใหม่แล้ว",
+      "OpenModelFolder": "เปิดโฟลเดอร์โมเดล",
+      "ViewServiceInfo": "ดูข้อมูลบริการ",
+      "NotSupportedModel": "ไม่รองรับโมเดลนี้ \nกรุณาใช้แบบจำลอง LLM",
+      "NewModelFolderHasBeenCreated": "มีการสร้างโฟลเดอร์โมเดลใหม่แล้ว",
+      "ChangeTheCurrentProjectToModelStore": "เปลี่ยนโครงการปัจจุบันเป็น 'model-store'",
+      "ImportSucceeded": "นำเข้าแบบจำลองสำเร็จแล้ว",
+      "ImportAndStartServiceSucceeded": "นำเข้าแบบจำลองสำเร็จแล้วและดำเนินการบริการแล้ว",
+      "ImportOnlySuccessDesc": "โฟลเดอร์โมเดลใหม่พร้อมแล้ว \nเริ่มบริการทันทีและลองดำเนินการตามที่คุณต้องการ",
+      "ImportAndStartServiceSuccessDesc": "โฟลเดอร์และบริการรุ่นใหม่พร้อมแล้ว \nคลิกปุ่ม 'ดูข้อมูลบริการ' เพื่อตรวจสอบรายละเอียดรุ่นและเริ่มการดำเนินการที่ต้องการ",
+      "AddedItems": "เพิ่มรายการแล้ว",
+      "ModelFolderName": "ชื่อโฟลเดอร์โมเดล"
     }
   },
   "dialog": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -792,9 +792,21 @@
       "ModelName": "Model adı",
       "Author": "Yazar",
       "InvalidHuggingFaceUrl": "Geçersiz Hugging Face URL'si.",
-      "ServiceName": "Hizmet adı",
       "ModelStoreFolderName": "Model deposu klasör adı",
-      "NotSupportedModel": "Model desteklenmiyor. \nLütfen LLM modelini kullanın."
+      "ServiceName": "Hizmet adı",
+      "NewModelStoreFolderHasBeenCreated": "Yeni bir model mağazası klasörü oluşturuldu",
+      "NewServiceHasBeenCreated": "Yeni bir hizmet oluşturuldu",
+      "OpenModelFolder": "Model klasörünü aç",
+      "ViewServiceInfo": "Hizmet bilgilerini görüntüle",
+      "NotSupportedModel": "Model desteklenmiyor. \nLütfen LLM modelini kullanın.",
+      "NewModelFolderHasBeenCreated": "Yeni bir model klasörü oluşturuldu",
+      "ChangeTheCurrentProjectToModelStore": "Mevcut projeyi 'model mağazası' olarak değiştirin.",
+      "ImportSucceeded": "Model başarıyla içe aktarıldı",
+      "ImportAndStartServiceSucceeded": "Model başarıyla içe aktarıldı ve hizmet yürütüldü",
+      "ImportOnlySuccessDesc": "Yeni model klasörü hazır. \nŞimdi hizmeti başlatın ve istediğiniz işlemi deneyin.",
+      "ImportAndStartServiceSuccessDesc": "Yeni model klasörü ve servisi hazır. \nModel ayrıntılarını kontrol etmek ve istediğiniz işlemi başlatmak için 'Servis bilgilerini görüntüle' düğmesine tıklayın.",
+      "AddedItems": "Eklenen öğeler",
+      "ModelFolderName": "Model klasörü adı"
     }
   },
   "dialog": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -792,9 +792,21 @@
       "ModelName": "Tên mẫu",
       "Author": "Tác giả",
       "InvalidHuggingFaceUrl": "URL Hugging Face không hợp lệ.",
-      "ServiceName": "Tên dịch vụ",
       "ModelStoreFolderName": "Tên thư mục lưu trữ mô hình",
-      "NotSupportedModel": "Mô hình không được hỗ trợ. \nVui lòng sử dụng mô hình LLM."
+      "ServiceName": "Tên dịch vụ",
+      "NewModelStoreFolderHasBeenCreated": "Một thư mục lưu trữ mô hình mới đã được tạo",
+      "NewServiceHasBeenCreated": "Một dịch vụ mới đã được tạo",
+      "OpenModelFolder": "Mở thư mục mô hình",
+      "ViewServiceInfo": "Xem thông tin dịch vụ",
+      "NotSupportedModel": "Mô hình không được hỗ trợ. \nVui lòng sử dụng mô hình LLM.",
+      "NewModelFolderHasBeenCreated": "Một thư mục mô hình mới đã được tạo",
+      "ChangeTheCurrentProjectToModelStore": "Thay đổi dự án hiện tại thành 'model-store'.",
+      "ImportSucceeded": "Mô hình đã được nhập thành công",
+      "ImportAndStartServiceSucceeded": "Mô hình đã được nhập thành công và dịch vụ đã được thực thi",
+      "ImportOnlySuccessDesc": "Thư mục mô hình mới đã sẵn sàng. \nHãy bắt đầu dịch vụ ngay bây giờ và thử thao tác bạn muốn.",
+      "ImportAndStartServiceSuccessDesc": "Thư mục mô hình và dịch vụ mới đã sẵn sàng. \nNhấp vào nút 'Xem thông tin dịch vụ' để kiểm tra chi tiết mẫu máy và bắt đầu thao tác mong muốn.",
+      "AddedItems": "Các mục đã thêm",
+      "ModelFolderName": "Tên thư mục mẫu"
     }
   },
   "dialog": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -794,7 +794,19 @@
       "InvalidHuggingFaceUrl": "Hugging Face URL 无效。",
       "ServiceName": "服务名称",
       "ModelStoreFolderName": "模型存储文件夹名称",
-      "NotSupportedModel": "不支持该型号。\n请使用LLM模型。"
+      "NotSupportedModel": "不支持该型号。\n请使用LLM模型。",
+      "NewModelStoreFolderHasBeenCreated": "已创建新的模型存储文件夹",
+      "NewServiceHasBeenCreated": "已创建新服务",
+      "OpenModelFolder": "打开模型文件夹",
+      "ViewServiceInfo": "查看服务信息",
+      "NewModelFolderHasBeenCreated": "已创建一个新的模型文件夹",
+      "ChangeTheCurrentProjectToModelStore": "将当前项目更改为“model-store”。",
+      "ImportSucceeded": "模型已成功导入",
+      "ImportAndStartServiceSucceeded": "模型已成功导入，服务已执行",
+      "ImportOnlySuccessDesc": "新的模型文件夹已准备就绪。\n现在启动服务并尝试您想要的操作。",
+      "ImportAndStartServiceSuccessDesc": "新的模型文件夹和服务已准备就绪。\n单击“查看服务信息”按钮以检查型号详细信息并开始所需的操作。",
+      "AddedItems": "添加的项目",
+      "ModelFolderName": "模型文件夹名称"
     }
   },
   "dialog": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -793,7 +793,19 @@
       "InvalidHuggingFaceUrl": "Hugging Face URL 无效。",
       "ServiceName": "服務名稱",
       "ModelStoreFolderName": "模型儲存資料夾名稱",
-      "NotSupportedModel": "不支援該型號。\n請使用LLM模型。"
+      "NotSupportedModel": "不支援該型號。\n請使用LLM模型。",
+      "NewModelStoreFolderHasBeenCreated": "已建立新的模型儲存資料夾",
+      "NewServiceHasBeenCreated": "已建立新服務",
+      "OpenModelFolder": "打開模型資料夾",
+      "ViewServiceInfo": "查看服務資訊",
+      "NewModelFolderHasBeenCreated": "已建立一個新的模型資料夾",
+      "ChangeTheCurrentProjectToModelStore": "將目前項目變更為“model-store”。",
+      "ImportSucceeded": "模型已成功導入",
+      "ImportAndStartServiceSucceeded": "模型已成功導入，服務已執行",
+      "ImportOnlySuccessDesc": "新的模型資料夾已準備就緒。\n現在啟動服務並嘗試您想要的操作。",
+      "ImportAndStartServiceSuccessDesc": "新的模型資料夾和服務已準備就緒。\n點擊“查看服務資訊”按鈕以檢查型號詳細資訊並開始所需的操作。",
+      "AddedItems": "新增的項目",
+      "ModelFolderName": "模型資料夾名稱"
     }
   },
   "dialog": {


### PR DESCRIPTION
### TR;DR
Import or import and start a new service from HuggingFace and show the result with Modal.

### How to test?
- [ ] import only works well.
- [ ] import & start service works well.
- [ ] folder name, service name setting
- [ ] result modal
    - import only
      - [ ] user can access a new model folder by clicking 'Open model folder' button.
      - [ ] admin can access a new model-store project folder by clicking 'Open model folder'.
      - [ ] but, admin cannot access a new model-store project folder when the current project is not 'model-store'.
    - import & start service
      - [ ] same as import only for folders
      - [ ] added redirect button that can visit new service (allow for both of user, admin)
    - common
      - [ ] folder name and service name are displayed below buttons.

### Screenshots
- Only for (super)admin, the current project is not 'model-store'.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/83a9fb35-deda-4565-b73b-e8b946a4ba02.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/e6218cae-853d-4335-8152-59c51608afd7.png)
- After clicking import & start service
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/ab43ecff-4570-4972-ad52-f4271713a7e8.png)
- After clicking import with 'import only' option
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/3db7daf8-99bc-4bed-bdad-36e96cf5ff67.png)

**Checklist:** (if applicable)

- [x] Mention to the original PR: https://app.graphite.dev/github/pr/lablup/backend.ai-webui/2514/Add-an-Import-from-hugging-face-modal
- [ ] Documentation
- [x] Minium required manager version: 24.03
- [x] Specific setting for review (eg., KB link, endpoint or how to setup): 
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
