### PR TITLE
fix: display only active endpoints in EndpointSelect

### DIFF
--- a/react/src/components/EndpointSelect.tsx
+++ b/react/src/components/EndpointSelect.tsx
@@ -1,3 +1,4 @@
+import { useSuspendedBackendaiClient } from '../hooks';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import {
   EndpointSelectQuery,
@@ -22,14 +23,25 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
   fetchKey,
   ...selectProps
 }) => {
+  const baiClient = useSuspendedBackendaiClient();
   const { baiPaginationOption } = useBAIPaginationOptionState({
     current: 1,
     pageSize: 100,
   });
   const { endpoint_list } = useLazyLoadQuery<EndpointSelectQuery>(
     graphql`
-      query EndpointSelectQuery($offset: Int!, $limit: Int!, $projectID: UUID) {
-        endpoint_list(offset: $offset, limit: $limit, project: $projectID) {
+      query EndpointSelectQuery(
+        $offset: Int!
+        $limit: Int!
+        $projectID: UUID
+        $filter: String
+      ) {
+        endpoint_list(
+          offset: $offset
+          limit: $limit
+          project: $projectID
+          filter: $filter
+        ) {
           total_count
           items {
             name
@@ -43,6 +55,9 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
     {
       limit: baiPaginationOption.limit,
       offset: baiPaginationOption.offset,
+      filter: baiClient.supports('endpoint-lifecycle-stage-filter')
+        ? `lifecycle_stage == "created"`
+        : undefined,
     },
     {
       fetchKey: fetchKey,


### PR DESCRIPTION
**Changes:**

This PR enhances the `EndpointSelect` component by adding support for filtering endpoints based on their lifecycle stage. The main changes include:

1. Importing the `useSuspendedBackendaiClient` hook.
2. Adding a `filter` parameter to the `EndpointSelectQuery`.
3. Implementing a conditional filter based on the client's support for the 'endpoint-lifecycle-stage-filter' feature.

**Rationale:**

The addition of the lifecycle stage filter allows for more precise endpoint selection, showing only endpoints in the "created" stage when supported by the client. This improves the user experience by presenting a more relevant list of endpoints.

**Effects:**

- Users will see a filtered list of endpoints in the "created" stage when using a client that supports this feature.
- Developers can now leverage the new filter parameter in the `EndpointSelectQuery` for more flexible endpoint querying.
