### PR TITLE
fix: session launcher validation logic when max_concurrent_sessions is set to 0 (unlimited)

### DIFF
--- a/react/src/hooks/hooksUsingRelay.tsx
+++ b/react/src/hooks/hooksUsingRelay.tsx
@@ -51,6 +51,7 @@ export const useCurrentKeyPairResourcePolicyLazyLoadQuery = (
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
   const baiClient = useSuspendedBackendaiClient();
   const [keypair] = useKeyPairLazyLoadQuery(baiClient?._config.accessKey);
+  const UNLIMITED_MAX_CONCURRENT_SESSIONS = 1000000;
 
   const { keypair_resource_policy } =
     useLazyLoadQuery<hooksUsingRelay_KeyPairResourcePolicyQuery>(
@@ -83,7 +84,8 @@ export const useCurrentKeyPairResourcePolicyLazyLoadQuery = (
       keypair: (keypair || {}) as NonNullable<typeof keypair>,
       sessionLimitAndRemaining: {
         max: _.min([
-          (keypair_resource_policy || {}).max_concurrent_sessions,
+          (keypair_resource_policy || {}).max_concurrent_sessions ||
+            UNLIMITED_MAX_CONCURRENT_SESSIONS,
           3, //BackendAiResourceBroker.DEFAULT_CONCURRENT_SESSION_COUNT
         ]) as number,
         remaining:


### PR DESCRIPTION
### This PR Resolves [giftbox#727](https://github.com/lablup/giftbox/issues/727) Issue

[Teams](https://teams.microsoft.com/l/message/19:b8327ceb372045beb1d0c6e28ca281da@thread.skype/1727081884563?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=483daa8a-29ee-4085-9f71-e93d7f112730&parentMessageId=1726212159210&teamName=project&channelName=KTCloud%20NPU&createdTime=1727081884563)

### What's changed
In Backend.AI core, when the value of max_concurrent_session is 0, it is treated as unlimited. I also changed the webui to treat a value of 0 as infinite. 

If the value of max_concurrent_session is 0, the webui passes a value of 100,000 to the session form item in the neo session launcher. (Maximum you can set in the control panel)

The `sessionSliderLimitAndRemaining` used by neo session laucner takes the minimum of the value of max_concurrent_session and 3, so if max_concurrent_session is 0, the maximum number of concurrent sessions that can be created is set to 3.

### How to Test
1. set max_concurrent_session in the keyfair resource policy to 0 (can be set in the control panel). This value is treated as an unlimited value in backend.ai core.
2. Create a new session. At this point, the webui policy sets max_concurrent_session to 3, which allows you to create up to three sessions at the same time.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
