### PR TITLE
fix: show/update supported AI accelerator based on selected environment in session launcher

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -125,16 +125,7 @@ const ResourceAllocationFormItems: React.FC<
     currentResourceGroup || undefined,
   );
 
-  const acceleratorSlots = _.omitBy(resourceSlots, (value, key) => {
-    if (['cpu', 'mem', 'shmem'].includes(key)) return true;
-
-    if (
-      !resourceLimits.accelerators[key]?.max ||
-      resourceLimits.accelerators[key]?.max === 0
-    )
-      return true;
-    return false;
-  });
+  const acceleratorSlots = remaining.accelerators;
 
   const currentImageAcceleratorLimits = useMemo(
     () =>
@@ -348,7 +339,6 @@ const ResourceAllocationFormItems: React.FC<
       _.keys(acceleratorSlots),
       (value) => acceleratorObj[value] !== undefined,
     );
-
     let acceleratorSetting: {
       acceleratorType?: string;
       accelerator: number;


### PR DESCRIPTION
**Changes:**

This PR refactors the resource allocation logic in the React components and hooks:

1. In `ResourceAllocationFormItems.tsx`:
   - Simplified the `acceleratorSlots` calculation by using `remaining.accelerators`.
   - Updated the accelerator setting logic in the form submission.

2. In `useResourceLimitAndRemaining.tsx`:
   - Introduced `currentImageSupportedAIAccelerator` to filter AI accelerators supported by the current image.
   - Created `filteredAcceleratorSlots` to include only the supported accelerators.
   - Updated resource limit and remaining calculations to use `filteredAcceleratorSlots`.

**Rationale:**

These changes improve the accuracy of resource allocation by considering only the AI accelerators supported by the current image. This prevents potential issues with allocating unsupported resources and provides a more tailored user experience.

**Impact:**

- Users will see only relevant AI accelerator options for the selected image.
- Resource limit and remaining calculations will be more accurate, reflecting only the supported accelerators.
- Developers working on resource allocation features will need to be aware of the new filtering logic.

**Checklist:**

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after