### PR TITLE
feat: move to detail page after modifying model service

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -547,7 +547,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                       name: updatedEndpoint?.name,
                     }),
                   );
-                  webuiNavigate('/serving');
+                  webuiNavigate(`/serving/${endpoint?.endpoint_id}`);
                 }
               },
               onError: (error) => {
@@ -566,7 +566,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                     name: endpoint.name, // FIXME: temporally get name from endpoint, not input value
                   }),
                 );
-                webuiNavigate('/serving');
+                webuiNavigate(`/serving/${endpoint?.endpoint_id}`);
               },
               onError: (error) => {
                 console.log(error);


### PR DESCRIPTION
**Changes:**

This PR modifies the navigation behavior after updating an endpoint in the Service Launcher page. Instead of redirecting to the general '/serving' page, it now navigates to the specific endpoint details page using the endpoint's ID.

**Rationale:**

This change improves the user experience by directly taking users to the relevant endpoint details after updating, rather than to a general serving page. This allows for immediate access to the newly updated endpoint's information.

**Effects:**

Users will now be automatically redirected to the specific endpoint details page after updating an endpoint, providing a more seamless and intuitive workflow.

**How to test:**
1. Create a new model service
2. Update
3. See detail page.

**Test list:**
- [ ] Go to the detail page after modifying a model service.
- [ ] Go to the list page after creating a new model service.

**Checklist:**

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after