### PR TITLE
fix: set max shared memory to 7.999PiB in ResourcePresetSettingModal

### DIFF
--- a/react/src/components/ResourcePresetSettingModal.tsx
+++ b/react/src/components/ResourcePresetSettingModal.tsx
@@ -301,7 +301,7 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
                   }),
                 ]}
               >
-                <DynamicUnitInputNumber />
+                <DynamicUnitInputNumber max="7.999p" />
               </Form.Item>
             </Col>
           </Row>


### PR DESCRIPTION
**Changes:**

This PR modifies the `ResourcePresetSettingModal` component by adding a `max` prop to the `DynamicUnitInputNumber` component. The `max` prop is set to "7.999p", which likely represents a maximum value of 7.999 petabytes. (BigInt)

**Rationale:**

Adding a maximum value to the input helps prevent users from entering unreasonably large resource allocations, improving the overall user experience and reducing the risk of configuration errors.

**Effects:**

- Users will be limited to entering resource values up to 7.999 petabytes in the affected input field.
- This change enhances input validation and provides clearer boundaries for resource allocation.

**Checklist:**

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after