### PR TITLE
feat: add session name copy button

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -3064,7 +3064,8 @@ export default class BackendAISessionList extends BackendAIPage {
                 --general-monospace-font-family
               );
             }
-            #session-rename-icon {
+            #session-rename-icon,
+            #session-name-copy-icon {
               --mdc-icon-size: 20px;
             }
           </style>
@@ -3099,6 +3100,15 @@ ${rowData.item[this.sessionNameField]}</pre
                     ></mwc-icon-button-toggle>
                   `
                 : html``}
+              <mwc-icon-button
+                id="session-name-copy-icon"
+                class="fg controls-running"
+                icon="content_copy"
+                @click="${async () =>
+                  await navigator.clipboard.writeText(
+                    rowData.item[this.sessionNameField],
+                  )}"
+              ></mwc-icon-button>
             </div>
             <div class="horizontal center center-justified layout">
               ${rowData.item.icon


### PR DESCRIPTION
**Changes:**

- Added a new "Copy" button next to the session name in the session list
- The new button allows users to easily copy the session name to the clipboard
- Updated CSS to apply the same icon size styling to both rename and copy icons

**Rationale:**

This change enhances user experience by providing a quick and convenient way to copy session names, which can be useful for referencing or sharing session information.

**Effects:**

- Users can now copy session names with a single click, improving efficiency
- The UI remains consistent with the existing design, maintaining visual harmony

**Screenshots:**

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/5650c335-6b0b-4695-b1bb-9ea8677812bc.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/53a0d135-b9b5-4106-8cce-b51c38ac4e04.png)

**Checklist:**

- [ ] Documentation
- [ ] Test case(s) to demonstrate the difference of before/after