### PR TITLE
misc: add a space between Environments and Version

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -345,7 +345,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
               ),
             }}
           >
-            {t('session.launcher.Environments')} /
+            {t('session.launcher.Environments')} /{' '}
             {t('session.launcher.Version')}
           </Typography.Text>
         }


### PR DESCRIPTION
**Changes:**

This PR adds a space between the "Environments" and "Version" labels in the ImageEnvironmentSelectFormItems component. The change ensures proper spacing in the UI, improving readability.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/bde817ea-7281-4abc-aabe-30d8a7faadce.png)

**Checklist:**

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after