### PR TITLE
feat: open folder explorer in vfolder table component and session launcher

### DIFF
--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -332,6 +332,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
           // TODO: After 'SessionListPage' is completed and used as the main page, remove this code
           //       and change 'job' key to 'session'
           location.pathname.split('/')[1] === 'session' ? 'job' : '',
+          location.pathname.split('/')[1] === 'service' ? 'serving' : '',
         ]}
         items={
           // TODO: add plugin menu

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -26,6 +26,7 @@ import ResourceAllocationFormItems, {
 import ResourceNumber from './ResourceNumber';
 import VFolderLazyView from './VFolderLazyView';
 import VFolderSelect from './VFolderSelect';
+import { AliasMap } from './VFolderTable';
 import VFolderTableFormItem from './VFolderTableFormItem';
 import { ServiceLauncherPageContentFragment$key } from './__generated__/ServiceLauncherPageContentFragment.graphql';
 import { ServiceLauncherPageContentModifyMutation } from './__generated__/ServiceLauncherPageContentModifyMutation.graphql';
@@ -109,7 +110,7 @@ interface ServiceLauncherInput extends ImageEnvironmentFormInput {
   openToPublic: boolean;
   modelMountDestination: string;
   modelDefinitionPath: string;
-  vfoldersAliasMap: Record<string, string>;
+  vfoldersAliasMap: AliasMap;
   mounts?: Array<string>;
   envvars: EnvVarFormListValue[];
   runtimeVariant: string;
@@ -309,7 +310,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
               (acc, key: string) => {
                 acc[key] = {
                   ...(values.vfoldersAliasMap[key] && {
-                    mount_destination: values.vfoldersAliasMap[key],
+                    mount_destination: values.vfoldersAliasMap[key]?.alias,
                   }),
                   type: 'bind', // FIXME: hardcoded. change it with option later
                 };
@@ -505,11 +506,13 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                     ),
                     values,
                   ),
+                  //FIXME: alias map 형식으로 변환 해야함.
                   extra_mounts: _.map(values.mounts, (vfolder) => {
                     return {
                       vfolder_id: vfolder,
                       ...(values.vfoldersAliasMap[vfolder] && {
-                        mount_destination: values.vfoldersAliasMap[vfolder],
+                        mount_destination:
+                          values.vfoldersAliasMap[vfolder]?.alias,
                       }),
                     };
                   }),

--- a/react/src/components/ServiceValidationView.tsx
+++ b/react/src/components/ServiceValidationView.tsx
@@ -71,7 +71,7 @@ const ServiceValidationView: React.FC<ServiceValidationModalProps> = ({
               (acc, key: string) => {
                 acc[key] = {
                   ...(values.vfoldersAliasMap[key] && {
-                    mount_destination: values.vfoldersAliasMap[key],
+                    mount_destination: values.vfoldersAliasMap[key]?.alias,
                   }),
                   type: 'bind', // FIXME: hardcoded. change it with option later
                 };

--- a/react/src/components/VFolderTableFormItem.tsx
+++ b/react/src/components/VFolderTableFormItem.tsx
@@ -31,6 +31,18 @@ const VFolderTableFormItem: React.FC<VFolderTableFormItemProps> = ({
   const form = Form.useFormInstance();
   const { t } = useTranslation();
   Form.useWatch('vfoldersAliasMap', form);
+
+  // const result = _.reduce(
+  //   form.getFieldValue('vfoldersAliasMap'),
+  //   (acc, v, k) => {
+  //     if (v) { // alias 값이 존재하는 경우에만 처리
+  //       acc.push({ id: null, name: k, alias: v });
+  //     }
+  //     return acc;
+  //   },
+  //   []
+  // );
+
   return (
     <>
       <Form.Item
@@ -39,14 +51,11 @@ const VFolderTableFormItem: React.FC<VFolderTableFormItemProps> = ({
         name="vfoldersAliasMap"
         rules={[
           {
-            validator(rule, map) {
-              const arr = _.chain(form.getFieldValue('mounts'))
-                .reduce((result, name) => {
-                  result[name] = map[name] || '/home/work/' + name;
-                  return result;
-                }, {} as AliasMap)
-                .values()
-                .value();
+            validator(rule, value) {
+              const arr = _.map(value, (v, k) =>
+                v.alias ? v.alias : DEFAULT_ALIAS_BASE_PATH + k,
+              );
+
               if (_.uniq(arr).length !== arr.length) {
                 return Promise.reject(
                   t('session.launcher.FolderAliasOverlapping'),

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -7,6 +7,7 @@ import EnvVarFormList, {
   EnvVarFormListValue,
 } from '../components/EnvVarFormList';
 import Flex from '../components/Flex';
+import { useFolderExplorerOpener } from '../components/FolderExplorerOpener';
 import ImageEnvironmentSelectFormItems, {
   ImageEnvironmentFormInput,
 } from '../components/ImageEnvironmentSelectFormItems';
@@ -172,6 +173,7 @@ export type AppOption = {
   // [key in string]: any;
 };
 const SessionLauncherPage = () => {
+  const { open } = useFolderExplorerOpener();
   const app = App.useApp();
   let sessionMode: SessionMode = 'normal';
 
@@ -469,7 +471,12 @@ const SessionLauncherPage = () => {
                 }
               : undefined),
             mounts: values.mounts,
-            mount_map: values.vfoldersAliasMap,
+            mount_map: _.fromPairs(
+              _.filter(
+                _.map(values.vfoldersAliasMap, (v, k) => [k, v.alias]),
+                ([, alias]) => alias !== null && alias !== undefined,
+              ),
+            ),
 
             env: {
               ..._.fromPairs(values.envvars.map((v) => [v.variable, v.value])),
@@ -520,8 +527,6 @@ const SessionLauncherPage = () => {
               });
           },
         );
-        // console.log('##', values.mounts);
-        // console.log(sessionInfo);
         const backupTo = window.location.pathname + window.location.search;
         webuiNavigate(redirectTo || '/job');
         upsertNotification({
@@ -1542,6 +1547,29 @@ const SessionLauncherPage = () => {
                               {
                                 dataIndex: 'name',
                                 title: t('data.folders.Name'),
+                                render: (value, record) => {
+                                  return (
+                                    <Flex
+                                      onClick={() => {
+                                        record?.id && open(record.id);
+                                      }}
+                                      style={{
+                                        width: 'fit-content',
+                                        cursor: 'pointer',
+                                      }}
+                                    >
+                                      <Typography.Text
+                                        style={{
+                                          whiteSpace: 'pre-line',
+                                          wordBreak: 'break-all',
+                                          textAlign: 'start',
+                                        }}
+                                      >
+                                        {value}
+                                      </Typography.Text>
+                                    </Flex>
+                                  );
+                                },
                               },
                               {
                                 dataIndex: 'alias',
@@ -1566,9 +1594,13 @@ const SessionLauncherPage = () => {
                               form.getFieldValue('mounts'),
                               (v) => {
                                 return {
+                                  id: form.getFieldValue('vfoldersAliasMap')?.[
+                                    v
+                                  ]?.id,
                                   name: v,
                                   alias:
-                                    form.getFieldValue('vfoldersAliasMap')?.[v],
+                                    form.getFieldValue('vfoldersAliasMap')?.[v]
+                                      ?.alias,
                                 };
                               },
                             )}


### PR DESCRIPTION
### This PR allows `folder explorer` to be opened in the `vfolder table`component and `session launcher review step`.

### Changes
- Added functionality to open folder explorer when clicking on folder names in the VFolder table
- Updated the VFolder table to display folder names as clickable links
- Modified the alias map structure to include folder ID and name alongside the alias
- Adjusted the session launcher page to handle the updated alias map structure
- Added a new column in the session launcher page to display folder names as clickable buttons
- Integrated the `useFolderExplorerOpener` hook to handle folder opening functionality
- Updated the sidebar menu to include a 'serving' key for the service path

### What to look for in testing
- The data structure for aliasMap has changed, so you need to make sure that the functionality of your existing session launcher and service launcher work correctly.
   1. Launching and deleting sessions
   2. Whether aliases for vfolders are applied correctly
   3. Whether folder explorer works properly in session launcher and vfolder table
   4. When creating and modifying services, you need to ensure that vfolder explorer works properly and that aliases are applied correctly.

**Checklist:**

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after