### PR TITLE
feat: name-based query search feature on `EndpointSelect`

### DIFF
--- a/react/src/components/EndpointSelect.tsx
+++ b/react/src/components/EndpointSelect.tsx
@@ -1,5 +1,4 @@
 import { useSuspendedBackendaiClient } from '../hooks';
-import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import {
   EndpointSelectQuery,
   EndpointSelectQuery$data,
@@ -8,33 +7,46 @@ import { useControllableValue } from 'ahooks';
 import { Select, SelectProps } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
-import React from 'react';
+import React, { useState, useTransition } from 'react';
 import { useLazyLoadQuery } from 'react-relay';
 
 interface EndpointSelectProps extends Omit<SelectProps, 'options'> {
   fetchKey?: string;
+  lifecycleStageFilter?: LifecycleStage[];
 }
 
 export type Endpoint = NonNullableItem<
   EndpointSelectQuery$data['endpoint_list']
 >;
 
+type LifecycleStage = 'created' | 'destroying' | 'destroyed';
+
 const EndpointSelect: React.FC<EndpointSelectProps> = ({
   fetchKey,
-  ...selectProps
+  lifecycleStageFilter = ['created'],
+  loading,
+  ...selectPropsWithoutLoading
 }) => {
   const baiClient = useSuspendedBackendaiClient();
-  const { baiPaginationOption } = useBAIPaginationOptionState({
-    current: 1,
-    pageSize: 100,
-  });
-  const { endpoint_list } = useLazyLoadQuery<EndpointSelectQuery>(
+  const [controllableValue, setControllableValue] = useControllableValue(
+    selectPropsWithoutLoading,
+  );
+  const [searchStr, setSearchStr] = useState<string>();
+  const [isSearchPending, startSearchTransition] = useTransition();
+
+  const lifecycleStageFilterStr = lifecycleStageFilter
+    .map((v) => `lifecycle_stage == "${v}"`)
+    .join(' | ');
+
+  const { endpoint_list, endpoint } = useLazyLoadQuery<EndpointSelectQuery>(
     graphql`
       query EndpointSelectQuery(
         $offset: Int!
         $limit: Int!
         $projectID: UUID
         $filter: String
+        $endpoint_id: UUID!
+        $skipEndpoint: Boolean!
       ) {
         endpoint_list(
           offset: $offset
@@ -50,21 +62,29 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
             ...EndpointLLMChatCard_endpoint
           }
         }
+        endpoint(endpoint_id: $endpoint_id) @skip(if: $skipEndpoint) {
+          name
+          endpoint_id
+          ...EndpointLLMChatCard_endpoint
+        }
       }
     `,
     {
-      limit: baiPaginationOption.limit,
-      offset: baiPaginationOption.offset,
+      limit: 10,
+      offset: 0,
       filter: baiClient.supports('endpoint-lifecycle-stage-filter')
-        ? `lifecycle_stage == "created"`
+        ? [lifecycleStageFilterStr, searchStr]
+            .filter(Boolean)
+            .map((v) => `(${v})`)
+            .join(' & ')
         : undefined,
+      endpoint_id: controllableValue,
+      skipEndpoint: !controllableValue,
     },
     {
       fetchKey: fetchKey,
     },
   );
-  const [controllableValue, setControllableValue] =
-    useControllableValue(selectProps);
 
   // useEffect(() => {
   //   if (autoSelectDefault && _.isEmpty(controllableValue)) {
@@ -75,18 +95,38 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
   //   }
   // }, []);
 
-  return (
-    <Select
-      showSearch
-      optionFilterProp="label"
-      {...selectProps}
-      options={_.map(endpoint_list?.items, (item) => {
+  const selectOptions = endpoint
+    ? _.map(
+        _.uniqBy(_.concat(endpoint_list?.items, endpoint), 'endpoint_id'),
+        (item) => {
+          return {
+            label: item?.name,
+            value: item?.endpoint_id,
+            endpoint: item,
+          };
+        },
+      )
+    : _.map(endpoint_list?.items, (item) => {
         return {
           label: item?.name,
           value: item?.endpoint_id,
           endpoint: item,
         };
-      })}
+      });
+
+  return (
+    <Select
+      showSearch
+      onSearch={(v) => {
+        startSearchTransition(() => {
+          setSearchStr(v && `name ilike "%${v}%"`);
+        });
+      }}
+      filterOption={false}
+      loading={isSearchPending || loading}
+      options={selectOptions}
+      {...selectPropsWithoutLoading}
+      // override value and onChange
       value={controllableValue}
       onChange={(v, option) => {
         setControllableValue(v, _.castArray(option)?.[0].endpoint);


### PR DESCRIPTION
**Changes:**

The current EndpointList only fetches up to 100 endpoints via gql, and if you have more than 100 endpoints, it is not possible to search the entire data.

This PR enhances the `EndpointSelect` component to allow searching over the entire data using gql filters:

1. Introduced `useState` and `useTransition` hooks for managing search state and transitions.
2. Added a search filter to the GraphQL query when the backend supports 'endpoint-lifecycle-stage-filter'.
3. Implemented `onSearch` handler for the Select component to update the search string.
4. Added loading indicator during search transitions.

**How to test**
  1. move to LLM Playground page.
  2. Verify that endpoint select requests a new gql based on search string

**Rationale:**

These changes improve the user experience by allowing users to search for specific endpoints within the select component, especially useful when dealing with a large number of endpoints.

**Effects:**

- Users can now search for endpoints by name in the select dropdown.
- The component will show a loading state while searching, providing visual feedback.
- The search is performed on the backend, potentially improving performance for large datasets.

**Checklist:**

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after