### PR TITLE
refactor: folder creation modal

### DIFF
--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -1,0 +1,264 @@
+import { useBaiSignedRequestWithPromise } from '../helper';
+import { useCurrentDomainValue } from '../hooks';
+import { useTanMutation } from '../hooks/reactQueryAlias';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import BAIModal, { BAIModalProps } from './BAIModal';
+import Flex from './Flex';
+import ProjectSelector from './ProjectSelect';
+import StorageSelect from './StorageSelect';
+import { App, Button, Divider, Form, Input, Radio, Switch, theme } from 'antd';
+import { createStyles } from 'antd-style';
+import { FormInstance } from 'antd/lib';
+import { Suspense, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const useStyles = createStyles(({ css }) => ({
+  modal: css`
+    .ant-modal-body {
+      padding-top: 24px !important;
+      padding-bottom: 0 !important;
+    }
+  `,
+  form: css`
+    .ant-form-item-label {
+      display: flex;
+      align-items: start;
+      padding-left: var(--token-paddingSM);
+    }
+    .ant-form-item .ant-form-item-label > label {
+      flex-direction: row-reverse !important;
+      gap: var(--token-paddingXS);
+    }
+    .ant-form-item-control {
+      padding-right: var(--token-paddingSM);
+    }
+    .ant-form-item-label > label::after {
+      display: none !important;
+    }
+  `,
+}));
+interface FolderCreateFormItemsType {
+  name: string;
+  host: string | undefined;
+  group: string | undefined;
+  usage_mode: 'general' | 'model';
+  type: 'user' | 'project';
+  permission: 'rw' | 'ro' | 'wd';
+  cloneable: boolean;
+}
+
+interface FolderCreateModalProps extends BAIModalProps {
+  onRequestClose: () => void;
+}
+
+const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
+  onRequestClose,
+  ...modalProps
+}) => {
+  const { t } = useTranslation();
+  const { styles } = useStyles();
+  const { token } = theme.useToken();
+  const { message } = App.useApp();
+
+  const formRef = useRef<FormInstance>(null);
+  const currentDomain = useCurrentDomainValue();
+  const currentProject = useCurrentProjectValue();
+
+  const baiRequestWithPromise = useBaiSignedRequestWithPromise();
+
+  const mutationToCreateFolder = useTanMutation<
+    unknown,
+    { message?: string },
+    FolderCreateFormItemsType
+  >({
+    mutationFn: (values) => {
+      const body = {
+        name: values.name,
+        host: values.host,
+        group: values.group,
+        usage_mode: values.usage_mode,
+        permission: values.permission,
+        cloneable: values.cloneable ?? false,
+      };
+      return baiRequestWithPromise({
+        method: 'POST',
+        url: '/folders',
+        body: body,
+      });
+    },
+  });
+
+  const INITIAL_FORM_VALUES: FolderCreateFormItemsType = {
+    name: '',
+    host: undefined,
+    group: currentProject.name,
+    usage_mode: 'general',
+    type: 'user',
+    permission: 'rw',
+    cloneable: false,
+  };
+
+  const handleOk = () => {
+    formRef.current
+      ?.validateFields()
+      .then((values) => {
+        mutationToCreateFolder.mutate(values, {
+          onSuccess: () => {
+            message.success(t('data.folders.FolderCreated'));
+            document.dispatchEvent(
+              new CustomEvent('backend-ai-folder-list-changed'),
+            );
+            onRequestClose();
+          },
+          onError: (error) => {
+            message.error(error.message);
+          },
+        });
+      })
+      .catch((error) => console.log(error));
+  };
+
+  return (
+    <BAIModal
+      className={styles.modal}
+      title={t('data.CreateANewStorageFolder')}
+      footer={
+        <Flex justify="between">
+          <Button
+            danger
+            onClick={() => {
+              formRef.current?.setFieldsValue(INITIAL_FORM_VALUES);
+            }}
+          >
+            {t('button.Reset')}
+          </Button>
+          <Flex gap={token.marginSM}>
+            <Button
+              onClick={() => {
+                onRequestClose();
+              }}
+            >
+              {t('button.Cancel')}
+            </Button>
+            <Button
+              type="primary"
+              onClick={() => {
+                handleOk();
+              }}
+            >
+              {t('data.Create')}
+            </Button>
+          </Flex>
+        </Flex>
+      }
+      width={650}
+      onCancel={() => {
+        onRequestClose();
+      }}
+      destroyOnClose
+      {...modalProps}
+    >
+      <Form
+        className={styles.form}
+        ref={formRef}
+        initialValues={INITIAL_FORM_VALUES}
+        labelCol={{ span: 8 }}
+      >
+        <Form.Item
+          label={t('data.Foldername')}
+          name={'name'}
+          rules={[
+            { required: true },
+            {
+              pattern: /^[a-zA-Z0-9-_.]+$/,
+              message: t('data.Allowslettersnumbersand-_dot'),
+            },
+            {
+              max: 64,
+              message: t('data.FolderNameTooLong'),
+            },
+          ]}
+        >
+          <Input placeholder={t('maxLength.64chars')} />
+        </Form.Item>
+        <Divider />
+
+        <Form.Item label={t('data.Host')} name={'host'}>
+          <StorageSelect
+            onChange={(value) => {
+              formRef.current?.setFieldValue('host', value);
+            }}
+            showUsageStatus
+            autoSelectType="default"
+          />
+        </Form.Item>
+        <Divider />
+
+        <Form.Item label={t('data.UsageMode')} name={'usage_mode'}>
+          <Radio.Group>
+            <Radio value={'general'}>General</Radio>
+            <Radio value={'model'}>Model</Radio>
+          </Radio.Group>
+        </Form.Item>
+        <Divider />
+
+        <Form.Item
+          label={t('data.Type')}
+          name={'type'}
+          style={{ flex: 1, marginBottom: 0 }}
+        >
+          <Radio.Group>
+            <Radio value={'user'}>User</Radio>
+            <Radio value={'project'}>Project</Radio>
+          </Radio.Group>
+        </Form.Item>
+        <Divider />
+
+        <Suspense>
+          <Form.Item dependencies={['type']} noStyle>
+            {({ getFieldValue }) => {
+              return (
+                getFieldValue('type') === 'project' && (
+                  <>
+                    <Form.Item label={t('data.Project')} name={'group'}>
+                      <ProjectSelector domain={currentDomain} />
+                    </Form.Item>
+                    <Divider />
+                  </>
+                )
+              );
+            }}
+          </Form.Item>
+        </Suspense>
+
+        <Form.Item label={t('data.Permission')} name={'permission'}>
+          <Radio.Group>
+            <Radio value={'rw'}>Read & Write</Radio>
+            <Radio value={'ro'}>Read Only</Radio>
+            <Radio value={'wd'}>Delete</Radio>
+          </Radio.Group>
+        </Form.Item>
+
+        <Form.Item dependencies={['usage_mode']} noStyle>
+          {({ getFieldValue }) => {
+            return (
+              getFieldValue('usage_mode') === 'model' && (
+                <>
+                  <Divider />
+                  <Form.Item
+                    label={t('data.folders.Cloneable')}
+                    name={'cloneable'}
+                  >
+                    <Switch defaultChecked={false} />
+                  </Form.Item>
+                </>
+              )
+            );
+          }}
+        </Form.Item>
+      </Form>
+    </BAIModal>
+  );
+};
+
+export default FolderCreateModal;

--- a/react/src/pages/VFolderListPage.tsx
+++ b/react/src/pages/VFolderListPage.tsx
@@ -1,4 +1,5 @@
 import Flex from '../components/Flex';
+import FolderCreateModal from '../components/FolderCreateModal';
 import ImportFromHuggingFaceModal from '../components/ImportFromHuggingFaceModal';
 import InviteFolderPermissionSettingModal from '../components/InviteFolderPermissionSettingModal';
 import { filterEmptyItem } from '../helper';
@@ -45,6 +46,7 @@ const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
   const baiClient = useSuspendedBackendaiClient();
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
   const dataViewRef = useRef(null);
+  const [isOpenCreateModal, { toggle: openCreateModal }] = useToggle(false);
   const [inviteFolderId, setInviteFolderId] = useState<string | null>(null);
   const [
     isVisibleImportFromHuggingFaceModal,
@@ -144,8 +146,9 @@ const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
               type="primary"
               icon={<PlusOutlined />}
               onClick={() => {
+                openCreateModal();
                 // @ts-ignore
-                dataViewRef.current?.openAddFolderDialog();
+                // dataViewRef.current?.openAddFolderDialog();
               }}
             >
               {t('data.Add')}
@@ -178,6 +181,10 @@ const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
         onRequestClose={() => {
           toggleImportFromHuggingFaceModal();
         }}
+      />
+      <FolderCreateModal
+        open={isOpenCreateModal}
+        onRequestClose={() => openCreateModal()}
       />
     </Flex>
   );


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR introduces a new `FolderCreateModal` component and integrates it into the `VFolderListPage`.

|before|after|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/55ecbe42-f539-416a-8b63-7daf6132d564.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/9a71c8cc-fe1b-4be0-bcb5-bbae71317983.png)|

 The new modal provides a interface for creating storage folders with react component. 

**How to test:**
1. Move to `Data & Storage` page
2. Create a vfolder with new modal
3. Ensure that the new modal covers all of the functionality of the regacy modal. (e.g. validation logic, conditional options such as clonable, project select, etc..) 

**Key changes:**
- Created a new `FolderCreateModal` component with form fields for folder name, host, usage mode, type, permission, and cloneable option.
- Integrated the new modal into `VFolderListPage`, replacing the previous folder creation method.
- Added form validation and error handling for folder creation.
- Implemented responsive design and styling using Ant Design components and custom styles.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
