### PR TITLE
feat: refetch endpoint's models

### DIFF
--- a/react/src/components/lablupTalkativotUI/ChatUIModal.tsx
+++ b/react/src/components/lablupTalkativotUI/ChatUIModal.tsx
@@ -2,7 +2,8 @@ import { useTanQuery } from '../../hooks/reactQueryAlias';
 import Flex from '../Flex';
 import LLMChatCard from './LLMChatCard';
 import { ChatUIModalFragment$key } from './__generated__/ChatUIModalFragment.graphql';
-import { Alert, Modal, ModalProps, Skeleton, theme } from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
+import { Alert, Button, Modal, ModalProps, Skeleton, theme } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React from 'react';
@@ -40,6 +41,7 @@ const ChatUIModal: React.FC<ChatUIModalProps> = ({
       centered
       width={'80%'}
       style={{ maxWidth: token.screenLGMax }}
+      destroyOnClose
     >
       <Flex direction="column" align="stretch" style={{ flex: 1 }}>
         <EndpointChatContent
@@ -61,6 +63,7 @@ const EndpointChatContent: React.FC<ChatUIBasicProps> = ({
       fragment ChatUIModalFragment on Endpoint {
         endpoint_id
         url
+        status
       }
     `,
     endpointFrgmt,
@@ -69,6 +72,7 @@ const EndpointChatContent: React.FC<ChatUIBasicProps> = ({
     data: modelsResult,
     // error,
     isFetching,
+    refetch,
   } = useTanQuery<{
     data: Array<Model>;
   }>({
@@ -99,6 +103,16 @@ const EndpointChatContent: React.FC<ChatUIBasicProps> = ({
             type="warning"
             showIcon
             message={t('chatui.CannotFindModel')}
+            action={
+              <Button
+                icon={<ReloadOutlined />}
+                onClick={() => {
+                  refetch();
+                }}
+              >
+                {t('button.Refresh')}
+              </Button>
+            }
           />
         )
       }

--- a/react/src/components/lablupTalkativotUI/EndpointLLMChatCard.tsx
+++ b/react/src/components/lablupTalkativotUI/EndpointLLMChatCard.tsx
@@ -1,9 +1,10 @@
+import { useUpdatableState } from '../../hooks';
 import { useSuspenseTanQuery } from '../../hooks/reactQueryAlias';
 import EndpointSelect from '../EndpointSelect';
 import { Model } from './ChatUIModal';
 import LLMChatCard, { BAIModel } from './LLMChatCard';
 import { EndpointLLMChatCard_endpoint$key } from './__generated__/EndpointLLMChatCard_endpoint.graphql';
-import { CloseOutlined } from '@ant-design/icons';
+import { CloseOutlined, ReloadOutlined } from '@ant-design/icons';
 import { Alert, Button, CardProps, Popconfirm, theme } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import { atom, useAtom } from 'jotai';
@@ -22,7 +23,6 @@ interface EndpointLLMChatCardProps extends CardProps {
   closable?: boolean;
   defaultModelId?: string;
   defaultEndpoint?: EndpointLLMChatCard_endpoint$key;
-  fetchKey?: string;
   isSynchronous?: boolean;
   onRequestClose?: () => void;
   onModelChange?: (modelId: string) => void;
@@ -33,7 +33,6 @@ const EndpointLLMChatCard: React.FC<EndpointLLMChatCardProps> = ({
   closable,
   defaultModelId,
   defaultEndpoint,
-  fetchKey,
   isSynchronous,
   onRequestClose,
   onModelChange,
@@ -42,6 +41,7 @@ const EndpointLLMChatCard: React.FC<EndpointLLMChatCardProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
 
+  const [fetchKey, updateFetchKey] = useUpdatableState('first');
   const [endpointFrgmt, setEndpointFrgmt] =
     useState<EndpointLLMChatCard_endpoint$key | null>(defaultEndpoint || null);
   const endpoint = useFragment(
@@ -152,6 +152,16 @@ const EndpointLLMChatCard: React.FC<EndpointLLMChatCardProps> = ({
             type="warning"
             showIcon
             message={t('chatui.CannotFindModel')}
+            action={
+              <Button
+                icon={<ReloadOutlined />}
+                onClick={() => {
+                  updateFetchKey();
+                }}
+              >
+                {t('button.Refresh')}
+              </Button>
+            }
           />
         )
       }

--- a/react/src/components/lablupTalkativotUI/LLMPlaygroundPage.tsx
+++ b/react/src/components/lablupTalkativotUI/LLMPlaygroundPage.tsx
@@ -93,6 +93,7 @@ const LLMPlaygroundPage: React.FC<LLMPlaygroundPageProps> = ({ ...props }) => {
         </Flex>
         <Flex
           gap={'xs'}
+          direction="row"
           style={{
             margin: token.margin,
             marginTop: 0,
@@ -104,7 +105,14 @@ const LLMPlaygroundPage: React.FC<LLMPlaygroundPageProps> = ({ ...props }) => {
           {_.map(list, (__, index) => (
             <Suspense
               fallback={
-                <Card style={{ flex: 1 }}>
+                <Card
+                  bordered
+                  style={{
+                    width: '100%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                  }}
+                >
                   <Skeleton active />
                 </Card>
               }


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/f2a0490e-249e-46d8-98cd-2cb853a4bc6a.png)

**Changes:**

This PR enhances the ChatUIModal, EndpointLLMChatCard, and LLMPlaygroundPage components:

1. Added a refresh button to the "Cannot Find Model" alert in ChatUIModal and EndpointLLMChatCard.
2. Implemented the `destroyOnClose` prop for the Modal component in ChatUIModal. After this change, it refetches models when the modal is opened.
3. `useUpdatableState hook` in EndpointLLMChatCard for managing fetch key.
4. Improved layout and styling of LLMPlaygroundPage, particularly for the card skeleton.

**Rationale:**

These changes improve user experience by providing a way to refresh model data and enhance the overall UI responsiveness and appearance.

**Effects:**

- Users can now easily refresh model data when it's not found.
- The chat modal will reset its state when closed, ensuring a fresh start on reopening.
- The playground page layout is more consistent and visually appealing.