### PR TITLE
feat: user resource policy allocation in user setting modal

### DIFF
--- a/react/src/components/UserResourcePolicySelector.tsx
+++ b/react/src/components/UserResourcePolicySelector.tsx
@@ -1,0 +1,55 @@
+import { localeCompare } from '../helper';
+import { UserResourcePolicySelectorQuery } from './__generated__/UserResourcePolicySelectorQuery.graphql';
+import { Select, SelectProps } from 'antd';
+import graphql from 'babel-plugin-relay/macro';
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { useLazyLoadQuery } from 'react-relay';
+
+interface Props extends SelectProps {
+  defaultValue?: string;
+}
+
+const UserResourcePolicySelector: React.FC<Props> = ({ ...selectProps }) => {
+  const { t } = useTranslation();
+  const { user_resource_policies } =
+    useLazyLoadQuery<UserResourcePolicySelectorQuery>(
+      graphql`
+        query UserResourcePolicySelectorQuery {
+          user_resource_policies {
+            id
+            name
+            created_at
+            # follows version of https://github.com/lablup/backend.ai/pull/1993
+            # --------------- START --------------------
+            max_vfolder_count @since(version: "23.09.6")
+            max_session_count_per_model_session @since(version: "23.09.10")
+            max_quota_scope_size @since(version: "23.09.2")
+            # ---------------- END ---------------------
+            max_customized_image_count @since(version: "24.03.0")
+            ...UserResourcePolicySettingModalFragment
+          }
+        }
+      `,
+      {},
+      {
+        fetchPolicy: 'store-and-network',
+      },
+    );
+
+  return (
+    <Select
+      showSearch // user_resource_policy does not have filtering options
+      placeholder={t('credential.SelectPolicy')}
+      options={_.map(user_resource_policies, (policy) => {
+        return {
+          value: policy?.name,
+          label: policy?.name,
+        };
+      }).sort((a, b) => localeCompare(a?.label, b?.label))}
+      {...selectProps}
+    />
+  );
+};
+
+export default UserResourcePolicySelector;

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -4,6 +4,7 @@ import { useTanMutation } from '../hooks/reactQueryAlias';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { useWebComponentInfo } from './DefaultProviders';
 import TOTPActivateModal from './TOTPActivateModal';
+import UserResourcePolicySelector from './UserResourcePolicySelector';
 import { UserSettingModalMutation } from './__generated__/UserSettingModalMutation.graphql';
 import {
   UserSettingModalQuery,
@@ -108,6 +109,7 @@ const UserSettingModal: React.FC<Props> = ({
             id
             name
           }
+          resource_policy
           # TODO: reflect https://github.com/lablup/backend.ai-webui/pull/1999
           # support from 23.09.0b1
           # https://github.com/lablup/backend.ai/pull/1530
@@ -158,6 +160,7 @@ const UserSettingModal: React.FC<Props> = ({
               id
               name
             }
+            resource_policy
             # TODO: reflect https://github.com/lablup/backend.ai-webui/pull/1999
             # support from 23.09.0b1
             # https://github.com/lablup/backend.ai/pull/1530
@@ -169,7 +172,6 @@ const UserSettingModal: React.FC<Props> = ({
         }
       }
     `);
-
   const mutationToRemoveTotp = useTanMutation({
     mutationFn: (email: string) => {
       return baiClient.remove_totp(email);
@@ -386,6 +388,12 @@ const UserSettingModal: React.FC<Props> = ({
             />
           </Form.Item>
         )}
+        <Form.Item
+          name="resource_policy"
+          label={t('resourcePolicy.ResourcePolicy')}
+        >
+          <UserResourcePolicySelector />
+        </Form.Item>
       </Form>
       {!!isTOTPSupported && (
         <TOTPActivateModal


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR resolves #2727 issue.

**Changes:**
- The user creation modal is written as a Lit Element, so I applied it to the edit modal first. 
- When migrating the user creation modal to react component, I thought that we need a user resource policy selector, so I wrote it as a separate component. 
- The `user_resource_policy` query doesn't provide filtering options yet, so I didn't add any filtering logic, but used antd's built-in search.

**How to test:**
- Verify that the existing user's resource policy is properly applied as the default value. 
- In the user information edit modal, verify that the user's resoure policy is modified correctly.

|before|after|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/e0c21f2d-a56b-4fd8-ab23-36048c46904d.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/b520b92e-be57-40dc-bd99-4ce9b04dc451.png)|

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
