### PR TITLE
feat: disable LLM Chat button based on endpoint status

### DIFF
--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -309,6 +309,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               onClick={() => {
                 setOpenChatModal(true);
               }}
+              disabled={endpoint?.status !== 'HEALTHY'}
             />
           </Tooltip>
         </>


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR disables/enables the LLM chat button based on the endpoint status.[teams](https://teams.microsoft.com/l/message/19:3c0acc0825024daeb2211f55c4e7f4aa@thread.skype/1728633372660?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=74ae2c4d-ec4d-4fdf-b2c2-f5041d1e8631&parentMessageId=1728631979059&teamName=devops&channelName=Backend.AI%20Talks&createdTime=1728633372660) issue. 

**Changes:**
- Enable the LLM chat button only if the endpoint status is `HEALTHY`.

**How to test:**
- On the endpoint detail page, check whether the LLM chat button is enabled or disabled based on the status.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
