### PR TITLE
fix: replace `skip` with `skipOnClient` to avoid runtime errors

### DIFF
--- a/react/src/components/EndpointSelect.tsx
+++ b/react/src/components/EndpointSelect.tsx
@@ -28,9 +28,8 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
   ...selectPropsWithoutLoading
 }) => {
   const baiClient = useSuspendedBackendaiClient();
-  const [controllableValue, setControllableValue] = useControllableValue(
-    selectPropsWithoutLoading,
-  );
+  const [controllableValue, setControllableValue] =
+    useControllableValue<string>(selectPropsWithoutLoading);
   const [searchStr, setSearchStr] = useState<string>();
   const [isSearchPending, startSearchTransition] = useTransition();
 
@@ -62,7 +61,7 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
             ...EndpointLLMChatCard_endpoint
           }
         }
-        endpoint(endpoint_id: $endpoint_id) @skip(if: $skipEndpoint) {
+        endpoint(endpoint_id: $endpoint_id) @skipOnClient(if: $skipEndpoint) {
           name
           endpoint_id
           ...EndpointLLMChatCard_endpoint


### PR DESCRIPTION
follows #2743 

**Changes:**

- Updated `useControllableValue` hook in `EndpointSelect` component to explicitly type it with `string`
- Changed `@skip` directive to `@skipOnClient` in GraphQL query for the `endpoint` field

**Rationale:**

- The explicit typing of `useControllableValue<string>` improves type safety and clarity in the codebase
- Switching from `@skip` to `@skipOnClient` directive likely aligns with updated GraphQL schema or client-side optimization strategies

**Effects:**

- These changes should not directly affect users
- Developers will benefit from improved type checking and potentially more efficient GraphQL query execution
- Avoid runtime errors when endpoint is empty.

**How to test:**
1. Remove all services
2. Enable `enableLLMPlayground` from config.toml
3. Visit LLM Playground page

**Checklist for reviewer:**
- [ ] Check if runtime error disappears.


**Checklist:**

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after