### PR TITLE
feat: migrate create user modal into react component

### DIFF
--- a/react/src/components/UserInfoModal.tsx
+++ b/react/src/components/UserInfoModal.tsx
@@ -58,6 +58,7 @@ const UserInfoModal: React.FC<Props> = ({ ...baiModalProps }) => {
             id
             name
           }
+          resource_policy
           # TODO: reflect https://github.com/lablup/backend.ai-webui/pull/1999
           # support from 23.09.0b1
           # https://github.com/lablup/backend.ai/pull/1530
@@ -115,6 +116,9 @@ const UserInfoModal: React.FC<Props> = ({ ...baiModalProps }) => {
         <Descriptions.Item label={t('credential.UserID')}>
           {user?.email}
         </Descriptions.Item>
+        <Descriptions.Item label={t('credential.Description')}>
+          {user?.description}
+        </Descriptions.Item>
         <Descriptions.Item label={t('credential.UserName')}>
           {user?.username}
         </Descriptions.Item>
@@ -150,11 +154,14 @@ const UserInfoModal: React.FC<Props> = ({ ...baiModalProps }) => {
         title={t('credential.Association')}
         labelStyle={{ width: '50%' }}
       >
+        <Descriptions.Item label={t('credential.Role')}>
+          {user?.role}
+        </Descriptions.Item>
         <Descriptions.Item label={t('credential.Domain')}>
           {user?.domain_name}
         </Descriptions.Item>
-        <Descriptions.Item label={t('credential.Role')}>
-          {user?.role}
+        <Descriptions.Item label={t('credential.ResourcePolicy')}>
+          {user?.resource_policy}
         </Descriptions.Item>
       </Descriptions>
       <br />

--- a/src/components/backend-ai-credential-view.ts
+++ b/src/components/backend-ai-credential-view.ts
@@ -70,6 +70,7 @@ export default class BackendAICredentialView extends BackendAIPage {
   @property({ type: Boolean }) enableSessionLifetime = false;
   @property({ type: String }) activeUserInnerTab = 'active';
   @property({ type: String }) activeCredentialInnerTab = 'active';
+  @property({ type: Boolean }) openUserSettingModal = false;
   @query('#active-credential-list')
   activeCredentialList!: BackendAICredentialList;
   @query('#inactive-credential-list')
@@ -306,6 +307,14 @@ export default class BackendAICredentialView extends BackendAIPage {
    */
   _launchUserAddDialog() {
     this.newUserDialog.show();
+  }
+
+  /**
+   * Open react user create modal.
+   * UserSettingModal.tsx
+   */
+  _openUserCreateModal() {
+    this.openUserSettingModal = true;
   }
 
   /**
@@ -782,7 +791,7 @@ export default class BackendAICredentialView extends BackendAIPage {
                 id="add-user"
                 icon="add"
                 label="${_t('credential.CreateUser')}"
-                @click="${this._launchUserAddDialog}"
+                @click="${() => this._openUserCreateModal()}"
               ></mwc-button>
             </h4>
             <div>
@@ -1018,6 +1027,20 @@ export default class BackendAICredentialView extends BackendAIPage {
           ></mwc-button>
         </div>
       </backend-ai-dialog>
+      ${this.openUserSettingModal
+        ? html`
+            <backend-ai-react-user-setting-dialog
+              value="${JSON.stringify({
+                open: this.openUserSettingModal,
+              })}"
+              @ok="${() => {
+                this.openUserSettingModal = false;
+                this.activeUserList.refresh();
+              }}"
+              @cancel="${() => (this.openUserSettingModal = false)}"
+            ></backend-ai-react-user-setting-dialog>
+          `
+        : html``}
     `;
   }
 }


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR is about migrating user generate modal to React components.

> This PR is the bottom of the stack so that it can be merged into main first.This is why this PR also including the part that will be fixed in #2757 PR.

**Changes:**
- I modified the `UserSettingModal.tsx` component because the input for the `modify_user` query and the `create_user` query are not very different.
- If you don't pass a userEmail value in the web component, the response data for the user query will be null. I took advantage of this and branched the modify and create logic.
- (minor) Modified UserInfoModal to show resource policy and description.

**How to test:**
1. move to `User Credential & Polices` page
2. Verify that the modal looks correctly different on create/modify.
3. Verify that user creation is successful.
4. Verify that the non-required value is mapped and applied correctly.
5. Verify that the User is properly part of the `default`, `model-store` group.
6. Verify that user information is modified correctly. 

|before|after|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/68176aef-2729-41f2-9084-541fc9f45576.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/98fe7179-c7cc-4720-83ac-4fc13478e7f8.png)|

|Info Modal||
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/21382d4d-1b60-4017-b59f-c042f25e969e.png)||

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
