### PR TITLE
feat: allow duplicate hostname for container registries

### DIFF
--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -234,16 +234,6 @@ const ContainerRegistryEditorModal: React.FC<
               message: t('registry.DescHostnameIsEmpty'),
               pattern: new RegExp('^.+$'),
             },
-            {
-              validator: (_, value) => {
-                if (!containerRegistry && existingHostnames?.includes(value)) {
-                  return Promise.reject(
-                    t('registry.RegistryHostnameAlreadyExists'),
-                  );
-                }
-                return Promise.resolve();
-              },
-            },
           ]}
         >
           <Input

--- a/react/src/components/lablupTalkativotUI/LLMChatCard.tsx
+++ b/react/src/components/lablupTalkativotUI/LLMChatCard.tsx
@@ -277,9 +277,7 @@ const LLMChatCard: React.FC<LLMChatCardProps> = ({
               setTimeout(() => {
                 setInput('');
               }, 0);
-              if (onSubmitChange) {
-                onSubmitChange();
-              }
+              onSubmitChange?.();
             }
           }}
         />,

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "Geben Sie den zu löschenden Registrierungs-Hostnamen ein",
     "RegistryTurnedOn": "Registrierung aktiviert",
     "RegistryTurnedOff": "Registrierung deaktiviert",
-    "RegistryHostnameAlreadyExists": "Hostname ist bereits vorhanden. Bitte ändern Sie den hinzuzufügenden Hostnamen",
     "RegistrySuccessfullyAdded": "Registrierung erfolgreich hinzugefügt.",
     "RegistrySuccessfullyDeleted": "Registrierung erfolgreich gelöscht.",
     "HostnameDoesNotMatch": "Hostname stimmt nicht überein!",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "Πληκτρολογήστε το όνομα κεντρικού υπολογιστή μητρώου για διαγραφή",
     "RegistryTurnedOn": "Το μητρώο ενεργοποιήθηκε",
     "RegistryTurnedOff": "Το μητρώο απενεργοποιήθηκε",
-    "RegistryHostnameAlreadyExists": "Το όνομα κεντρικού υπολογιστή υπάρχει ήδη. Αλλάξτε το όνομα κεντρικού υπολογιστή για προσθήκη",
     "RegistrySuccessfullyAdded": "Το μητρώο προστέθηκε με επιτυχία.",
     "RegistrySuccessfullyDeleted": "Το μητρώο διαγράφηκε με επιτυχία.",
     "HostnameDoesNotMatch": "Το όνομα κεντρικού υπολογιστή δεν ταιριάζει!",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1198,7 +1198,6 @@
     "TypeRegistryNameToDelete": "Type registry hostname to delete",
     "RegistryTurnedOn": "Registry enabled",
     "RegistryTurnedOff": "Registry disabled",
-    "RegistryHostnameAlreadyExists": "Hostname Already Exists. Please change the hostname to add",
     "RegistrySuccessfullyAdded": "Registry successfully added.",
     "RegistrySuccessfullyDeleted": "Registry successfully deleted.",
     "HostnameDoesNotMatch": "Hostname does not match!",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -899,7 +899,6 @@
     "ProjectNameIsRequired": "El nombre del proyecto es obligatorio",
     "Registries": "Registros",
     "RegistryHostname": "Nombre de host de registro",
-    "RegistryHostnameAlreadyExists": "El nombre de host ya existe. Por favor, cambie el nombre de host para añadir",
     "RegistrySuccessfullyAdded": "Registro añadido correctamente.",
     "RegistrySuccessfullyDeleted": "Registro eliminado correctamente.",
     "RegistrySuccessfullyModified": "Registro modificado con éxito.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -896,7 +896,6 @@
     "ProjectNameIsRequired": "Hankkeen nimi vaaditaan",
     "Registries": "Rekisterit",
     "RegistryHostname": "Rekisterin isäntänimi",
-    "RegistryHostnameAlreadyExists": "Isäntänimi on jo olemassa. Vaihda isäntänimi lisäämällä",
     "RegistrySuccessfullyAdded": "Rekisteri lisätty onnistuneesti.",
     "RegistrySuccessfullyDeleted": "Rekisteri onnistuneesti poistettu.",
     "RegistrySuccessfullyModified": "Rekisteriä muutettu onnistuneesti.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "Tapez le nom d'hôte du registre à supprimer",
     "RegistryTurnedOn": "Registre activé",
     "RegistryTurnedOff": "Registre désactivé",
-    "RegistryHostnameAlreadyExists": "Le nom d'hôte existe déjà. Veuillez changer le nom d'hôte à ajouter",
     "RegistrySuccessfullyAdded": "Registre ajouté avec succès.",
     "RegistrySuccessfullyDeleted": "Registre supprimé avec succès.",
     "HostnameDoesNotMatch": "Le nom d'hôte ne correspond pas !",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1071,7 +1071,6 @@
     "TypeRegistryNameToDelete": "Ketik nama host registri untuk dihapus",
     "RegistryTurnedOn": "Registri diaktifkan",
     "RegistryTurnedOff": "Registri dinonaktifkan",
-    "RegistryHostnameAlreadyExists": "Nama Host Sudah Ada. Silakan ubah nama host untuk menambahkan",
     "RegistrySuccessfullyAdded": "Registri berhasil ditambahkan.",
     "RegistrySuccessfullyDeleted": "Registri berhasil dihapus.",
     "HostnameDoesNotMatch": "Nama host tidak cocok!",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "Digita il nome host del registro da eliminare",
     "RegistryTurnedOn": "Registro abilitato",
     "RegistryTurnedOff": "Registro disabilitato",
-    "RegistryHostnameAlreadyExists": "Il nome host esiste già. Per favore cambia il nome host da aggiungere",
     "RegistrySuccessfullyAdded": "Registro aggiunto con successo.",
     "RegistrySuccessfullyDeleted": "Registro eliminato con successo.",
     "HostnameDoesNotMatch": "Il nome host non corrisponde!",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "削除するレジストリホスト名を入力します",
     "RegistryTurnedOn": "レジストリが有効",
     "RegistryTurnedOff": "レジストリが無効になっています",
-    "RegistryHostnameAlreadyExists": "ホスト名はすでに存在します。追加するホスト名を変更してください",
     "RegistrySuccessfullyAdded": "レジストリが正常に追加されました。",
     "RegistrySuccessfullyDeleted": "レジストリが正常に削除されました。",
     "HostnameDoesNotMatch": "ホスト名が一致しません！",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1184,7 +1184,6 @@
     "TypeRegistryNameToDelete": "삭제 확인을 위해 레지스트리 이름을 입력하세요.",
     "RegistryTurnedOn": "레지스트리가 활성화 되었습니다",
     "RegistryTurnedOff": "레지스트리가 비활성화 되었습니다",
-    "RegistryHostnameAlreadyExists": "호스트이름이 이미 존재합니다. 다른 이름으로 변경 후 등록해주세요.",
     "RegistrySuccessfullyAdded": "레지스트리가 성공적으로 등록되었습니다.",
     "RegistrySuccessfullyDeleted": "레지스트리가 성공적으로 삭제되었습니다.",
     "HostnameDoesNotMatch": "호스트명이 일치하지 않습니다.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "Устгахын тулд бүртгэлийн хостын нэрийг бичнэ үү",
     "RegistryTurnedOn": "Бүртгэлийг идэвхжүүлсэн",
     "RegistryTurnedOff": "Бүртгэлийг идэвхгүйжүүлсэн",
-    "RegistryHostnameAlreadyExists": "Хостын нэр аль хэдийн байна. Нэмэхийн тулд хостын нэрийг солино уу",
     "RegistrySuccessfullyAdded": "Бүртгэл амжилттай нэмэгдэв.",
     "RegistrySuccessfullyDeleted": "Бүртгэлийг амжилттай устгалаа.",
     "HostnameDoesNotMatch": "Хостын нэр таарахгүй байна!",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1069,7 +1069,6 @@
     "TypeRegistryNameToDelete": "Taip nama hos pendaftaran untuk dipadamkan",
     "RegistryTurnedOn": "Pendaftaran didayakan",
     "RegistryTurnedOff": "Pendaftaran dilumpuhkan",
-    "RegistryHostnameAlreadyExists": "Nama Hos Sudah Ada. Tukar nama host untuk ditambahkan",
     "RegistrySuccessfullyAdded": "Pendaftaran berjaya ditambahkan.",
     "RegistrySuccessfullyDeleted": "Pendaftaran berjaya dipadamkan.",
     "HostnameDoesNotMatch": "Nama hos tidak sepadan!",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "Wpisz nazwę hosta rejestru do usunięcia",
     "RegistryTurnedOn": "Rejestr włączony",
     "RegistryTurnedOff": "Rejestr wyłączony",
-    "RegistryHostnameAlreadyExists": "Nazwa hosta już istnieje. Zmień nazwę hosta do dodania",
     "RegistrySuccessfullyAdded": "Pomyślnie dodano rejestr.",
     "RegistrySuccessfullyDeleted": "Rejestr został pomyślnie usunięty.",
     "HostnameDoesNotMatch": "Nazwa hosta nie pasuje!",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "Digite o nome do host do registro para excluir",
     "RegistryTurnedOn": "Registro habilitado",
     "RegistryTurnedOff": "Registro desativado",
-    "RegistryHostnameAlreadyExists": "O nome do host já existe. Por favor, altere o nome do host para adicionar",
     "RegistrySuccessfullyAdded": "Registro adicionado com sucesso.",
     "RegistrySuccessfullyDeleted": "Registro excluído com sucesso.",
     "HostnameDoesNotMatch": "O nome do host não corresponde!",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "Digite o nome do host do registro para excluir",
     "RegistryTurnedOn": "Registro habilitado",
     "RegistryTurnedOff": "Registro desativado",
-    "RegistryHostnameAlreadyExists": "O nome do host já existe. Por favor, altere o nome do host para adicionar",
     "RegistrySuccessfullyAdded": "Registro adicionado com sucesso.",
     "RegistrySuccessfullyDeleted": "Registro excluído com sucesso.",
     "HostnameDoesNotMatch": "O nome do host não corresponde!",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1068,7 +1068,6 @@
     "TypeRegistryNameToDelete": "Введите имя хоста реестра для удаления",
     "RegistryTurnedOn": "Реестр включен",
     "RegistryTurnedOff": "Реестр отключен",
-    "RegistryHostnameAlreadyExists": "Имя хоста уже существует. Пожалуйста, измените имя хоста, чтобы добавить",
     "RegistrySuccessfullyAdded": "Реестр успешно добавлен.",
     "RegistrySuccessfullyDeleted": "Реестр успешно удален.",
     "HostnameDoesNotMatch": "Имя хоста не совпадает!",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1184,7 +1184,6 @@
     "TypeRegistryNameToDelete": "พิมพ์ชื่อโฮสต์ทะเบียนเพื่อลบ",
     "RegistryTurnedOn": "เปิดใช้งานทะเบียนแล้ว",
     "RegistryTurnedOff": "ปิดใช้งานทะเบียนแล้ว",
-    "RegistryHostnameAlreadyExists": "มีชื่อโฮสต์นี้อยู่แล้ว กรุณาเปลี่ยนชื่อโฮสต์เพื่อเพิ่ม",
     "RegistrySuccessfullyAdded": "เพิ่มทะเบียนสำเร็จแล้ว",
     "RegistrySuccessfullyDeleted": "ลบทะเบียนสำเร็จแล้ว",
     "HostnameDoesNotMatch": "ชื่อโฮสต์ไม่ตรงกัน!",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "Silmek için kayıt defteri ana bilgisayar adını yazın",
     "RegistryTurnedOn": "Kayıt etkinleştirildi",
     "RegistryTurnedOff": "Kayıt devre dışı",
-    "RegistryHostnameAlreadyExists": "Ana Bilgisayar Adı Zaten Var. Lütfen eklemek için ana bilgisayar adını değiştirin",
     "RegistrySuccessfullyAdded": "Kayıt başarıyla eklendi.",
     "RegistrySuccessfullyDeleted": "Kayıt defteri başarıyla silindi.",
     "HostnameDoesNotMatch": "Ana bilgisayar adı eşleşmiyor!",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "Nhập tên máy chủ đăng ký để xóa",
     "RegistryTurnedOn": "Đã bật đăng ký",
     "RegistryTurnedOff": "Đăng ký bị vô hiệu hóa",
-    "RegistryHostnameAlreadyExists": "Tên máy chủ đã tồn tại. Vui lòng thay đổi tên máy chủ để thêm",
     "RegistrySuccessfullyAdded": "Đã thêm đăng ký thành công.",
     "RegistrySuccessfullyDeleted": "Đã xóa sổ đăng ký thành công.",
     "HostnameDoesNotMatch": "Tên máy chủ không khớp!",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1070,7 +1070,6 @@
     "TypeRegistryNameToDelete": "键入要删除的注册表主机名",
     "RegistryTurnedOn": "启用注册表",
     "RegistryTurnedOff": "注册表已禁用",
-    "RegistryHostnameAlreadyExists": "主机名已存在。请更改主机名以添加",
     "RegistrySuccessfullyAdded": "注册表添加成功。",
     "RegistrySuccessfullyDeleted": "注册表删除成功。",
     "HostnameDoesNotMatch": "主机名不匹配！",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1069,7 +1069,6 @@
     "TypeRegistryNameToDelete": "鍵入要刪除的註冊表主機名",
     "RegistryTurnedOn": "啟用註冊表",
     "RegistryTurnedOff": "註冊表已禁用",
-    "RegistryHostnameAlreadyExists": "主機名已存在。請更改主機名以添加",
     "RegistrySuccessfullyAdded": "註冊表添加成功。",
     "RegistrySuccessfullyDeleted": "註冊表刪除成功。",
     "HostnameDoesNotMatch": "主機名不匹配！",

--- a/src/components/backend-ai-registry-list.ts
+++ b/src/components/backend-ai-registry-list.ts
@@ -266,13 +266,6 @@ class BackendAIRegistryList extends BackendAIPage {
       input['project'] = '';
     }
 
-    // if hostname already exists
-    if (!this._editMode && this._hostnames.includes(hostname)) {
-      this.notification.text = _text('registry.RegistryHostnameAlreadyExists');
-      this.notification.show();
-      return;
-    }
-
     globalThis.backendaiclient.registry
       .set(hostname, input)
       .then(({ result }) => {


### PR DESCRIPTION
Follow-up of lablup/backend.ai#1917.

This pull request updates to embrace duplicated `hostname` when creating a new container registry, as the `ContainerRegistry.registry_name` field is not **unique**.

![image](https://github.com/user-attachments/assets/635b8878-612c-4009-bbdf-80d2cfe19ece)

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
