### PR TITLE
fix: set autoSelectType to `usage` in FolderCreateModal

### DIFF
--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -189,7 +189,8 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
               formRef.current?.setFieldValue('host', value);
             }}
             showUsageStatus
-            autoSelectType="default"
+            autoSelectType="usage"
+            showSearch
           />
         </Form.Item>
         <Divider />

--- a/react/src/components/StorageSelect.tsx
+++ b/react/src/components/StorageSelect.tsx
@@ -106,7 +106,7 @@ const StorageSelect: React.FC<Props> = ({
       }}
       searchValue={controllableSearchValue}
       onSearch={setControllableSearchValue}
-      optionLabelProp="value"
+      optionLabelProp={showUsageStatus ? 'label' : 'value'}
       options={_.map(vhostInfo?.allowed, (host) => ({
         label: showUsageStatus ? (
           <Flex align="center" gap={'xs'}>


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/0b0c7b7f-8cfa-4eb6-9c17-5e38cc84aa0a.png)

**Changes:**

- Modified `FolderCreateModal.tsx`:
  - Changed `autoSelectType` from "default" to "usage" in the `StorageSelect` component
  - Added `showSearch` prop to the `StorageSelect` component
- Updated `StorageSelect.tsx`:
  - Changed `optionLabelProp` to conditionally use 'label' when `showUsageStatus` is true, otherwise use 'value'

**Rationale:**

These changes improve the user experience when selecting storage options. The "usage" auto-select type prioritizes storage based on usage, while the added search functionality allows users to quickly find specific storage options. The conditional `optionLabelProp` ensures that the correct label is displayed when usage status is shown.

**Impact:**

Users will now have a more intuitive and efficient storage selection process, with the ability to search and see usage status more clearly. Developers working with these components should be aware of the new props and their implications on component behavior.
