### PR TITLE
fix: hide "compare with other models" in LLM Playground

### DIFF
--- a/react/src/components/lablupTalkativotUI/ChatUIModal.tsx
+++ b/react/src/components/lablupTalkativotUI/ChatUIModal.tsx
@@ -117,6 +117,7 @@ const EndpointChatContent: React.FC<ChatUIBasicProps> = ({
         )
       }
       modelId={modelsResult?.data?.[0].id ?? 'custom'}
+      showCompareMenuItem
     />
   );
 };

--- a/react/src/components/lablupTalkativotUI/LLMChatCard.tsx
+++ b/react/src/components/lablupTalkativotUI/LLMChatCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { filterEmptyItem } from '../../helper';
 import { useWebUINavigate } from '../../hooks';
 import Flex from '../Flex';
 import ChatInput from './ChatInput';
@@ -56,6 +57,7 @@ export interface LLMChatCardProps extends CardProps {
   onModelChange?: (modelId: string) => void;
   onInputChange?: (input: string) => void;
   onSubmitChange?: () => void;
+  showCompareMenuItem?: boolean;
 }
 
 const LLMChatCard: React.FC<LLMChatCardProps> = ({
@@ -73,6 +75,7 @@ const LLMChatCard: React.FC<LLMChatCardProps> = ({
   submitKey,
   onInputChange,
   onSubmitChange,
+  showCompareMenuItem,
   ...cardProps
 }) => {
   const webuiNavigate = useWebUINavigate();
@@ -162,8 +165,8 @@ const LLMChatCard: React.FC<LLMChatCardProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [submitKey]);
 
-  const items: MenuProps['items'] = [
-    {
+  const items: MenuProps['items'] = filterEmptyItem([
+    showCompareMenuItem && {
       key: 'compare',
       label: t('chatui.CompareWithOtherModels'),
       icon: <Scale />,
@@ -185,7 +188,7 @@ const LLMChatCard: React.FC<LLMChatCardProps> = ({
         setMessages([]);
       },
     },
-  ];
+  ]);
 
   return (
     <Card


### PR DESCRIPTION
**Changes:**
Hide "Compare with Other Models" menu item" in LLM playground:

- Added `showCompareMenuItem` prop to `LLMChatCard` component
- Implemented conditional rendering of "Compare with Other Models" menu item based on `showCompareMenuItem` prop
- Utilized `filterEmptyItem` helper function to remove empty items from the menu

**Rationale:**

This change allows for more flexible control over the visibility of the "Compare with Other Models" menu item in the LLM Chat interface. By making it conditional, we can show or hide this option based on the context or user permissions.

**Effects:**

- Developers can now control the visibility of the comparison feature by passing the `showCompareMenuItem` prop
- Users may or may not see the "Compare with Other Models" option depending on how the component is configured
