### PR TITLE
fix: Fix for container registry form entry validation rules in version earlier 24.09.0

### DIFF
--- a/react/src/components/ContainerRegistryEditorModalBefore2409.tsx
+++ b/react/src/components/ContainerRegistryEditorModalBefore2409.tsx
@@ -396,9 +396,14 @@ const ContainerRegistryEditorModal: React.FC<
                       message: t('registry.ProjectNameIsRequired'),
                     },
                     {
-                      type: 'string',
-                      max: 255,
-                      message: t('maxLength.255chars'),
+                      validator(rule, value, callback) {
+                        _.map(value, (v) => {
+                          if (v.length > 255) {
+                            return Promise.reject(t('maxLength.255chars'));
+                          }
+                        });
+                        return Promise.resolve();
+                      },
                     },
                   ]}
                 >

--- a/react/src/components/ContainerRegistryListBefore2409.tsx
+++ b/react/src/components/ContainerRegistryListBefore2409.tsx
@@ -301,8 +301,8 @@ const ContainerRegistryListBefore2409: React.FC<{
           {
             title: t('registry.HarborProject'),
             dataIndex: ['config', 'project'],
-            render: (value, record) => {
-              return <Tag key={value || ''}>{value || ''}</Tag>;
+            render: (value: string[], record) => {
+              return _.map(value, (v) => <Tag key={v || ''}>{v || ''}</Tag>);
             },
           },
           {


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

## This PR resolves validation rule errors when the manager version is lower than version 24.09.0

**Changes:**
- Since we are using a switch with a string[] type input, I use a custom validator to validate it. 
- Modify tag in list to output correctly by specifying the data type used in from item.

**How to test:**
As of Core 24.09.0rc1, 
- Modify the query in `ContainerRegistryList.tsx` to @since(version: "24.09.0rc1"). 
- In `EnvironmentPage.tsx`, modify isManagerVersionCompatibleWith('24.09.0") to "24.09.0rc1". 
- Go to the registry tab and verify the behavior. 

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
