### PR TITLE
feat: create folder in the vfolder form item

### DIFF
--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -48,7 +48,22 @@ interface FolderCreateFormItemsType {
 }
 
 interface FolderCreateModalProps extends BAIModalProps {
-  onRequestClose: () => void;
+  onRequestClose: (response?: FolderCreationResponse) => void;
+}
+export interface FolderCreationResponse {
+  id: string;
+  name: string;
+  quota_scope_id: string;
+  host: string;
+  usage_mode: 'general' | 'model';
+  permission: 'rw' | 'ro' | 'wd';
+  max_size: number;
+  creator: string;
+  ownership_type: 'user' | 'project';
+  user: string;
+  group: string | null;
+  cloneable: boolean;
+  status: string;
 }
 
 const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
@@ -67,7 +82,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
 
   const mutationToCreateFolder = useTanMutation<
-    unknown,
+    FolderCreationResponse,
     { message?: string },
     FolderCreateFormItemsType
   >({
@@ -103,12 +118,12 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
       ?.validateFields()
       .then((values) => {
         mutationToCreateFolder.mutate(values, {
-          onSuccess: () => {
+          onSuccess: (result) => {
             message.success(t('data.folders.FolderCreated'));
             document.dispatchEvent(
               new CustomEvent('backend-ai-folder-list-changed'),
             );
-            onRequestClose();
+            onRequestClose(result);
           },
           onError: (error) => {
             message.error(error.message);


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/b7260560-a79b-4fb3-9c20-f8f48866d892.png)

## Changes

This PR enhances the folder creation functionality and improves the VFolderTable component:

1. Updated `FolderCreateModal`:
   - Modified `onRequestClose` to accept an optional `FolderCreationResponse` parameter
   - Added `FolderCreationResponse` interface to define the structure of the created folder data
   - Updated `mutationToCreateFolder` to use the `FolderCreationResponse` type
   - Modified the `onSuccess` callback to pass the created folder data to `onRequestClose`

2. Enhanced `VFolderTable`:
   - Added a "Create Folder" button with a plus icon
   - Implemented a modal for creating new folders
   - Updated the table to refresh and select the newly created folder after creation
   - Added tooltips for the refresh and create folder buttons
   - Set the default sort order for the "Created" column to descending

3. Improved table functionality:
   - Added `sortDirections` prop to allow both ascending and descending sorting


## How to test
- Create vFolder in Session Launcher and Service Launcher by clicking the "+" button on the top right of the vFolder Table form item.
- You can see the created vFolder in the list with a selected status.