### PR TITLE
feat: open vFolder in vFolder form item

### DIFF
--- a/react/src/components/BAILink.tsx
+++ b/react/src/components/BAILink.tsx
@@ -1,0 +1,31 @@
+import { createStyles } from 'antd-style';
+import { X } from 'lucide-react';
+import React from 'react';
+import { Link, LinkProps } from 'react-router-dom';
+
+const useStyles = createStyles(({ css, token }) => ({
+  hover: css`
+    text-decoration: none;
+    color: inherit;
+
+    &:hover {
+      color: ${token.colorLinkHover};
+      text-decoration: underline;
+    }
+  `,
+}));
+
+interface BAILinkProps extends LinkProps {
+  type: 'hover';
+}
+const BAILink: React.FC<BAILinkProps> = ({ type, ...linkProps }) => {
+  const { styles } = useStyles();
+  return (
+    <Link
+      className={type === 'hover' ? styles.hover : undefined}
+      {...linkProps}
+    />
+  );
+};
+
+export default BAILink;

--- a/react/src/components/FolderExplorerOpener.tsx
+++ b/react/src/components/FolderExplorerOpener.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import { StringParam, useQueryParam } from 'use-query-params';
 
 const LegacyFolderExplorer = React.lazy(() => import('./LegacyFolderExplorer'));
@@ -23,9 +24,24 @@ export default FolderExplorerOpener;
 
 export const useFolderExplorerOpener = () => {
   const [, setFolderId] = useQueryParam('folder', StringParam);
+
+  const location = useLocation();
+  // a function to generate new path with folder id based on current path
+  const generateFolderPath = (id: string) => {
+    // get current path
+    const searchParams = new URLSearchParams(location.search);
+    // set folder id
+    searchParams.set('folder', id);
+    return {
+      pathname: location.pathname,
+      search: searchParams.toString(),
+    };
+  };
+
   return {
     open: (id: string) => {
       setFolderId(id);
     },
+    generateFolderPath,
   };
 };

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -5,9 +5,11 @@ import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
 import useControllableState from '../hooks/useControllableState';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useEventNotStable } from '../hooks/useEventNotStable';
+import BAILink from './BAILink';
 import { useShadowRoot } from './DefaultProviders';
 import Flex from './Flex';
 import FolderCreateModal from './FolderCreateModal';
+import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import TextHighlighter from './TextHighlighter';
 import VFolderPermissionTag from './VFolderPermissionTag';
 import { VFolder } from './VFolderSelect';
@@ -92,6 +94,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   showAutoMountedFoldersSection,
   ...tableProps
 }) => {
+  const { generateFolderPath } = useFolderExplorerOpener();
   const getRowKey = React.useMemo(() => {
     return (record: VFolder) => {
       const key = record && record[rowKey as DataIndex];
@@ -320,7 +323,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
         return (
           <Flex
             direction="column"
-            align="stretch"
+            align="start"
             gap={'xxs'}
             style={
               showAliasInput && isCurrentRowSelected
@@ -330,7 +333,9 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
                   }
             }
           >
-            <TextHighlighter keyword={searchKey}>{value}</TextHighlighter>
+            <BAILink type="hover" to={generateFolderPath(record.id)}>
+              <TextHighlighter keyword={searchKey}>{value}</TextHighlighter>
+            </BAILink>
             {showAliasInput && isCurrentRowSelected && (
               <Form.Item
                 noStyle


### PR DESCRIPTION
**Changes:**

- Added a new `BAILink` component for consistent link styling
- Enhanced `FolderExplorerOpener` with a `generateFolderPath` function
- Updated `VFolderTable` to use `BAILink` for folder names, making them clickable
- Improved folder name display in `VFolderTable` with better alignment and hover effects

**Rationale:**

These changes improve the user experience by making folder navigation more intuitive and consistent. The new `BAILink` component ensures uniform styling for links across the application, while the `generateFolderPath` function allows for dynamic link generation based on the current URL.

**Effects:**

- Users can now click on folder names in the `VFolderTable` to open them directly
- Folder links have a consistent hover effect, improving visual feedback
- The folder explorer can be opened with the correct folder pre-selected based on the current URL