### PR TITLE
test: refactor test code due to changes in the folder creation modal

### DIFF
--- a/e2e/test-util.ts
+++ b/e2e/test-util.ts
@@ -124,16 +124,29 @@ export async function fillOutVaadinGridCellFilter(
   await nameInput.fill(inputValue);
 }
 
-export async function createVFolderAndVerify(page: Page, folderName: string) {
+export async function createVFolderAndVerify(
+  page: Page,
+  folderName: string,
+  usageMode: 'general' | 'model' = 'general',
+  type: 'user' | 'project' = 'user',
+  permission: 'rw' | 'ro' | 'wd' = 'rw',
+) {
+  const permissionMap = {
+    rw: 'Read & Write',
+    ro: 'Read only',
+    wd: 'Delete',
+  };
   await navigateTo(page, 'data');
 
   await page.getByRole('button', { name: 'plus Add' }).click();
-  // TODO: wait for initial rendering without timeout
-  await page.waitForTimeout(1000);
-  await page.getByRole('textbox', { name: 'Folder name*' }).click();
-  await page.getByRole('textbox', { name: 'Folder name*' }).fill(folderName);
-  await page.getByRole('button', { name: 'Create', exact: true }).click();
+  await page.getByRole('textbox', { name: 'Folder name' }).fill(folderName);
+  // select parsed parameters in create modal form
+  await page.getByRole('radio', { name: usageMode }).click();
+  await page.getByRole('radio', { name: type }).click();
+  await page.getByRole('radio', { name: permissionMap[permission] }).click();
 
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
+  await page.reload();
   const nameInput = page
     .locator('#general-folder-storage vaadin-grid-cell-content')
     .filter({ hasText: 'Name' })
@@ -142,7 +155,9 @@ export async function createVFolderAndVerify(page: Page, folderName: string) {
     .locator('input');
   await nameInput.click();
   await nameInput.fill(folderName);
-  await page.waitForSelector(`text=folder_open ${folderName}`);
+  await expect(
+    page.locator('vaadin-grid-cell-content').filter({ hasText: folderName }),
+  ).toBeVisible();
   await nameInput.fill('');
 }
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR is about refactoring the test code via the [folder creation modal change](https://github.com/lablup/backend.ai-webui/pull/2745).

**Changes:**
- Fixed folder creation modal to pass selectable arguments as props. 
- Minimized exceptions by specifying types for selectable arguments. 
- Used `.toBeVisible()` function for vfolder test scenarios to improve accuracy. 
- When logging out of the page, there was a situation where logging out occurred once more after login, so we minimized the logout by using a new page.

**How to test:**
- Run the `vfolder.test.ts` test using the vscode playwright extension to verify that there are no errors. 
- Verify that running the same test multiple times produces the same results.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
