### PR TITLE
fix: 0 desired routing count in endpoint edit page

### DIFF
--- a/react/src/components/BAILink.tsx
+++ b/react/src/components/BAILink.tsx
@@ -1,5 +1,4 @@
 import { createStyles } from 'antd-style';
-import { X } from 'lucide-react';
 import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
 

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -638,7 +638,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         serviceName: endpoint?.name,
         resourceGroup: endpoint?.resource_group,
         allocationPreset: 'custom',
-        desiredRoutingCount: endpoint?.desired_session_count || 1,
+        desiredRoutingCount: endpoint?.desired_session_count ?? 1,
         // FIXME: memory doesn't applied to resource allocation
         resource: {
           cpu: parseInt(JSON.parse(endpoint?.resource_slots)?.cpu),


### PR DESCRIPTION
**Changes:**

This PR modifies the `ServiceLauncherPageContent` component to use the nullish coalescing operator (`??`) instead of the logical OR operator (`||`) when setting the `desiredRoutingCount` value. This ensures that a value of `0` for `endpoint?.desired_session_count` is respected rather than defaulting to `1`.

**Rationale:**

The previous implementation using `||` would treat `0` as a falsy value, causing it to default to `1`. By using `??`, we now correctly handle cases where `desired_session_count` is explicitly set to `0`, while still defaulting to `1` when the value is `null` or `undefined`.

**Impact:**

This change allows users to set a `desired_session_count` of `0` for endpoints, which may be necessary for certain service configurations or management scenarios.