### PR TITLE
fix: hide divider in LLMChatCard

### DIFF
--- a/react/src/components/lablupTalkativotUI/LLMChatCard.tsx
+++ b/react/src/components/lablupTalkativotUI/LLMChatCard.tsx
@@ -176,7 +176,7 @@ const LLMChatCard: React.FC<LLMChatCardProps> = ({
         );
       },
     },
-    {
+    showCompareMenuItem && {
       type: 'divider',
     },
     {


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR is for the conditional divider render that is missing from the https://github.com/lablup/backend.ai-webui/pull/2762 PR.

|before|after|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/e43dc73e-8a82-4809-88cc-ed40fa5189d5.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/cc530c3f-fd0b-4637-a569-5195b3d3645a.png)|

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
