### PR TITLE
fix: handle current resource group using initial values in launchers

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -23,7 +23,7 @@ import {
   ImageEnvironmentFormInput,
 } from './ImageEnvironmentSelectFormItems';
 import InputNumberWithSlider from './InputNumberWithSlider';
-import ResourceGroupSelectForCurrentProject from './ResourceGroupSelectForCurrentProject';
+import ResourceGroupSelect from './ResourceGroupSelect';
 import ResourcePresetSelect from './ResourcePresetSelect';
 import { CaretDownOutlined } from '@ant-design/icons';
 import {
@@ -42,18 +42,19 @@ import React, { useEffect, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 export const AUTOMATIC_DEFAULT_SHMEM = '64m';
-export const RESOURCE_ALLOCATION_INITIAL_FORM_VALUES = {
-  resource: {
-    cpu: 0,
-    mem: '0g',
-    shmem: '0g',
-    accelerator: 0,
-  },
-  num_of_sessions: 1,
-  cluster_mode: 'single-node',
-  cluster_size: 1,
-  enabledAutomaticShmem: true,
-};
+export const RESOURCE_ALLOCATION_INITIAL_FORM_VALUES: DeepPartial<ResourceAllocationFormValue> =
+  {
+    resource: {
+      cpu: 0,
+      mem: '0g',
+      shmem: '0g',
+      accelerator: 0,
+    },
+    num_of_sessions: 1,
+    cluster_mode: 'single-node',
+    cluster_size: 1,
+    enabledAutomaticShmem: true,
+  };
 
 export const isMinOversMaxValue = (min: number, max: number) => {
   return min >= max;
@@ -408,8 +409,8 @@ const ResourceAllocationFormItems: React.FC<
           },
         ]}
       >
-        {/* WARN: ResourceGroupSelectForCurrentProject component can not be controlled (no `value` props).  It uses global state */}
-        <ResourceGroupSelectForCurrentProject showSearch />
+        <ResourceGroupSelect projectName={currentProject.name} showSearch />
+        {/* <ResourceGroupSelectForCurrentProject showSearch /> */}
       </Form.Item>
 
       {enableResourcePresets ? (

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -11,6 +11,7 @@ import {
 } from '../hooks';
 import { KnownAcceleratorResourceSlotName } from '../hooks/backendai';
 import { useSuspenseTanQuery, useTanMutation } from '../hooks/reactQueryAlias';
+import { useCurrentResourceGroupState } from '../hooks/useCurrentProject';
 import BAIModal, { DEFAULT_BAI_MODAL_Z_INDEX } from './BAIModal';
 import EnvVarFormList, { EnvVarFormListValue } from './EnvVarFormList';
 import Flex from './Flex';
@@ -145,6 +146,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
 
   const [form] = Form.useForm<ServiceLauncherFormValue>();
   const [wantToChangeResource, setWantToChangeResource] = useState(false);
+  const [currentGlobalResourceGroup, setCurrentGlobalResourceGroup] =
+    useCurrentResourceGroupState();
 
   const endpoint = useFragment(
     graphql`
@@ -578,6 +581,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           // create service
           mutationToCreateService.mutate(values, {
             onSuccess: () => {
+              // After creating service, navigate to serving page and set current resource group
+              setCurrentGlobalResourceGroup(values.resourceGroup);
               // FIXME: temporally refer to mutate input to message
               message.success(
                 t('modelService.ServiceCreated', { name: values.serviceName }),
@@ -693,6 +698,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           },
         }),
         vFolderID: model ? model : undefined,
+        resourceGroup: currentGlobalResourceGroup,
       };
 
   return (


### PR DESCRIPTION
This PR control the resource group value of the launcher using initial values, and update the global current resource group through the launcher when creating, so that the resource group of the resource monitor becomes the resource group just used.

resolve https://github.com/lablup/backend.ai-webui/issues/2770

- Replacing ResourceGroupSelectForCurrentProject with ResourceGroupSelect component
- Adding resource group state management to maintain selection consistency
- Setting initial form values with the current global resource group
- Updating the global resource group state when creating new sessions or services. 
