### PR TITLE
hotfix: container registry password caanot be set when creating

### DIFF
--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -110,11 +110,12 @@ const ContainerRegistryEditorModal: React.FC<
           type: values.type,
           project: values.type === 'docker' ? 'library' : values.project,
           username: _.isEmpty(values.username) ? null : values.username,
-          password: values.isChangedPassword
-            ? _.isEmpty(values.password)
-              ? null // unset
-              : values.password
-            : undefined, // no change
+          password:
+            values.isChangedPassword || !containerRegistry
+              ? _.isEmpty(values.password)
+                ? null // unset
+                : values.password
+              : undefined, // no change
         };
         if (containerRegistry) {
           if (!values.isChangedPassword) {


### PR DESCRIPTION
related PR: https://github.com/lablup/backend.ai-control-panel/pull/892

**Changes:**

This PR modifies the password handling logic in the `ContainerRegistryEditorModal` component. The condition for setting the password has been updated to include cases where a new container registry is being created (`!containerRegistry`). This ensures that the password is properly set for both new and existing registries.

**Rationale:**

The previous implementation only considered the `isChangedPassword` flag, which could lead to issues when creating a new container registry. By including the `!containerRegistry` condition, we ensure that the password is always set correctly for new registries, even if the `isChangedPassword` flag is not explicitly set.

**Impact:**

This change improves the reliability of password handling when creating or updating container registries. Users should now experience more consistent behavior when managing registry credentials.

**Checklist:**

- [ ] Test case(s) to demonstrate the difference of before/after
  - Create a new container registry and verify that the password is set correctly
  - Update an existing container registry with and without changing the password