### PR TITLE
e2e: set-timout-to-session-e2e

### DIFF
--- a/e2e/config.test.ts
+++ b/e2e/config.test.ts
@@ -134,12 +134,6 @@ test.describe.parallel('config.toml', () => {
       await page
         .getByRole('button', { name: '2 Environments & Resource' })
         .click();
-      await page
-        .locator(
-          '.ant-form-item-control-input-content > .ant-select > .ant-select-selector',
-        )
-        .first()
-        .click();
       await page.getByLabel('Environments / Version').fill('AF');
       await page
         .locator('.rc-virtual-list-holder-inner > div:nth-child(2)')

--- a/e2e/session-launcher.test.ts
+++ b/e2e/session-launcher.test.ts
@@ -8,7 +8,9 @@ import {
 import { test, expect } from '@playwright/test';
 
 test.describe('NEO Sessions Launcher', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    // session test code needs more time to run
+    testInfo.setTimeout(60_000);
     await loginAsUser(page);
   });
 

--- a/e2e/test-util.ts
+++ b/e2e/test-util.ts
@@ -226,7 +226,7 @@ export async function createSession(page: Page, sessionName: string) {
   await page
     .getByRole('heading', { name: 'App close' })
     .getByLabel('close')
-    .click();
+    .click({ timeout: 15000 });
 
   // Verify that a cell exists to display the session name
   const session = page
@@ -256,7 +256,9 @@ export async function deleteSession(page: Page, sessionName: string) {
 
   // Verify session is cleared
   await searchSessionInfo.fill('');
-  await expect(page.getByText(sessionName)).toBeHidden();
+  await expect(
+    page.locator('vaadin-grid-cell-content').filter({ hasText: sessionName }),
+  ).toBeHidden({ timeout: 30_000 });
 }
 
 /**


### PR DESCRIPTION
**Changes:**

This PR updates several end-to-end tests to improve reliability and reduce flakiness:

1. In `config.test.ts`, removed an unnecessary click action on the environment selector.
2. In `session-launcher.test.ts`, increased the timeout for session tests to 60 seconds.
3. In `test-util.ts`:
   - Added a 15-second timeout to the "App close" button click.
   - Updated the session deletion verification to use a more specific locator with a 15-second timeout.

**Rationale:**

These changes address potential timing issues in the tests, allowing for slower operations or network delays. The removal of the unnecessary click in the config test simplifies the test flow.