### PR TITLE
feat: new image parsing on Environment page

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -5,6 +5,7 @@
     "Backendai",
     "backendaiclient",
     "backendaioptions",
+    "baseversion",
     "cssinjs",
     "cuda",
     "FGPU",

--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -14,6 +14,28 @@ type Queries {
   agents(scaling_group: String, status: String): [Agent]
   agent_summary(agent_id: String!): AgentSummary
   agent_summary_list(limit: Int!, offset: Int!, filter: String, order: String, scaling_group: String, status: String): AgentSummaryList
+
+  """Added in 24.12.0."""
+  domain_node(id: GlobalIDField!, permission: DomainPermissionValueField = "read_attribute"): DomainNode
+
+  """Added in 24.12.0."""
+  domain_nodes(filter: String, order: String, permission: DomainPermissionValueField = "read_attribute", offset: Int, before: String, after: String, first: Int, last: Int): DomainConnection
+
+  """Added in 24.12.0."""
+  agent_nodes(
+    """Added in 24.12.0. Default is `system`."""
+    scope: ScopeField
+
+    """Added in 24.12.0. Default is create_compute_session."""
+    permission: AgentPermissionField = "create_compute_session"
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): AgentConnection
   domain(name: String): Domain
   domains(is_active: Boolean): [Domain]
 
@@ -298,12 +320,24 @@ type ImageNode implements Node {
 
   """Added in 24.03.4. The undecoded id value stored in DB."""
   row_id: UUID
-  name: String
+  name: String @deprecated(reason: "Deprecated since 24.09.1. use `namespace` instead")
+
+  """Added in 24.09.1."""
+  namespace: String
+
+  """Added in 24.09.1."""
+  base_image_name: String
 
   """Added in 24.03.10."""
   project: String
   humanized_name: String
   tag: String
+
+  """Added in 24.09.1."""
+  tags: [KVPair]
+
+  """Added in 24.09.1."""
+  version: String
   registry: String
   architecture: String
   is_local: Boolean
@@ -360,6 +394,231 @@ type AgentSummaryList implements PaginatedList {
   total_count: Int!
 }
 
+"""Added in 24.12.0."""
+type DomainNode implements Node {
+  """The ID of the object"""
+  id: ID!
+  name: String
+  description: String
+  is_active: Boolean
+  created_at: DateTime
+  modified_at: DateTime
+  total_resource_slots: JSONString
+  allowed_vfolder_hosts: JSONString
+  allowed_docker_registries: [String]
+  dotfiles: Bytes
+  integration_id: String
+  scaling_groups(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ScalinGroupConnection
+}
+
+"""Added in 24.09.1."""
+scalar Bytes
+
+"""Added in 24.12.0."""
+type ScalinGroupConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [ScalinGroupEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""
+The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+"""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+}
+
+"""
+Added in 24.12.0. A Relay edge containing a `ScalinGroup` and its cursor.
+"""
+type ScalinGroupEdge {
+  """The item at the end of the edge"""
+  node: ScalingGroupNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Added in 24.12.0."""
+type ScalingGroupNode implements Node {
+  """The ID of the object"""
+  id: ID!
+  name: String
+  description: String
+  is_active: Boolean
+  is_public: Boolean
+  created_at: DateTime
+  wsproxy_addr: String
+  wsproxy_api_token: String
+  driver: String
+  driver_opts: JSONString
+  scheduler: String
+  scheduler_opts: JSONString
+  use_host_network: Boolean
+}
+
+"""
+Added in 24.09.0. Global ID of GQL relay spec. Base64 encoded version of "<node type name>:<node id>". UUID or string type values are also allowed.
+"""
+scalar GlobalIDField
+
+"""
+Added in 24.12.0. One of ['read_attribute', 'read_sensitive_attribute', 'update_attribute', 'create_user', 'create_project'].
+"""
+scalar DomainPermissionValueField
+
+"""Added in 24.12.0"""
+type DomainConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [DomainEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""Added in 24.12.0 A Relay edge containing a `Domain` and its cursor."""
+type DomainEdge {
+  """The item at the end of the edge"""
+  node: DomainNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Added in 24.12.0."""
+type AgentConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [AgentEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""Added in 24.12.0. A Relay edge containing a `Agent` and its cursor."""
+type AgentEdge {
+  """The item at the end of the edge"""
+  node: AgentNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Added in 24.12.0."""
+type AgentNode implements Node {
+  """The ID of the object"""
+  id: ID!
+  row_id: String
+  status: String
+  status_changed: DateTime
+  region: String
+  scaling_group: String
+  schedulable: Boolean
+  available_slots: JSONString
+  occupied_slots: JSONString
+
+  """Agent's address with port. (bind/advertised host:port)"""
+  addr: String
+  architecture: String
+  first_contact: DateTime
+  lost_at: DateTime
+  live_stat: JSONString
+  version: String
+  compute_plugins: JSONString
+  hardware_metadata: JSONString
+  auto_terminate_abusing_kernel: Boolean
+  local_config: JSONString
+  container_count: Int
+  kernel_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): KernelConnection
+
+  """
+  Added in 24.12.0. One of ['read_attribute', 'update_attribute', 'create_compute_session', 'create_service'].
+  """
+  permissions: [AgentPermissionField]
+}
+
+"""Added in 24.09.0."""
+type KernelConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [KernelEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""Added in 24.09.0. A Relay edge containing a `Kernel` and its cursor."""
+type KernelEdge {
+  """The item at the end of the edge"""
+  node: KernelNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Added in 24.09.0."""
+type KernelNode implements Node {
+  """The ID of the object"""
+  id: ID!
+
+  """ID of kernel."""
+  row_id: UUID
+  cluster_idx: Int
+  local_rank: Int
+  cluster_role: String
+  cluster_hostname: String
+  session_id: UUID
+  image: ImageNode
+  status: String
+  status_changed: DateTime
+  status_info: String
+  status_data: JSONString
+  created_at: DateTime
+  terminated_at: DateTime
+  starts_at: DateTime
+  scheduled_at: DateTime
+  agent_id: String
+  agent_addr: String
+  container_id: String
+  resource_opts: JSONString
+  occupied_slots: JSONString
+  live_stat: JSONString
+  abusing_report: JSONString
+  preopen_ports: [Int]
+}
+
+"""
+Added in 24.12.0. One of ['read_attribute', 'update_attribute', 'create_compute_session', 'create_service'].
+"""
+scalar AgentPermissionField
+
+"""
+Added in 24.12.0. A string value in the format '<SCOPE_TYPE>:<SCOPE_ID>'. <SCOPE_TYPE> should be one of [system, domain, project, user]. <SCOPE_ID> should be the ID value of the scope. e.g. `domain:default`, `user:123e4567-e89b-12d3-a456-426614174000`.
+"""
+scalar ScopeField
+
 type Domain {
   name: String
   description: String
@@ -409,23 +668,6 @@ type UserConnection {
 
   """Total count of the GQL nodes of the query."""
   count: Int
-}
-
-"""
-The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
-"""
-type PageInfo {
-  """When paginating forwards, are there more items?"""
-  hasNextPage: Boolean!
-
-  """When paginating backwards, are there more items?"""
-  hasPreviousPage: Boolean!
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: String
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: String
 }
 
 """Added in 24.03.0 A Relay edge containing a `User` and its cursor."""
@@ -515,12 +757,24 @@ type Group {
 
 type Image {
   id: UUID
-  name: String
+  name: String @deprecated(reason: "Deprecated since 24.09.1. use `namespace` instead")
+
+  """Added in 24.09.1."""
+  namespace: String
+
+  """Added in 24.09.1."""
+  base_image_name: String
 
   """Added in 24.03.10."""
   project: String
   humanized_name: String
   tag: String
+
+  """Added in 24.09.1."""
+  tags: [KVPair]
+
+  """Added in 24.09.1."""
+  version: String
   registry: String
   architecture: String
   is_local: Boolean
@@ -967,58 +1221,6 @@ Added in 24.09.0. One of ['read_attribute', 'update_attribute', 'delete_session'
 scalar SessionPermissionValueField
 
 """Added in 24.09.0."""
-type KernelConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [KernelEdge]!
-
-  """Total count of the GQL nodes of the query."""
-  count: Int
-}
-
-"""Added in 24.09.0. A Relay edge containing a `Kernel` and its cursor."""
-type KernelEdge {
-  """The item at the end of the edge"""
-  node: KernelNode
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-"""Added in 24.09.0."""
-type KernelNode implements Node {
-  """The ID of the object"""
-  id: ID!
-
-  """ID of kernel."""
-  row_id: UUID
-  cluster_idx: Int
-  local_rank: Int
-  cluster_role: String
-  cluster_hostname: String
-  session_id: UUID
-  image: ImageNode
-  status: String
-  status_changed: DateTime
-  status_info: String
-  status_data: JSONString
-  created_at: DateTime
-  terminated_at: DateTime
-  starts_at: DateTime
-  scheduled_at: DateTime
-  agent_id: String
-  agent_addr: String
-  container_id: String
-  resource_opts: JSONString
-  occupied_slots: JSONString
-  live_stat: JSONString
-  abusing_report: JSONString
-  preopen_ports: [Int]
-}
-
-"""Added in 24.09.0."""
 type ComputeSessionConnection {
   """Pagination data for this connection."""
   pageInfo: PageInfo!
@@ -1040,11 +1242,6 @@ type ComputeSessionEdge {
   """A cursor for use in pagination"""
   cursor: String!
 }
-
-"""
-Added in 24.09.0. Global ID of GQL relay spec. Base64 encoded version of "<node type name>:<node id>". UUID or string type values are also allowed.
-"""
-scalar GlobalIDField
 
 type ComputeSessionList implements PaginatedList {
   items: [ComputeSession]!
@@ -1402,6 +1599,12 @@ type Mutations {
   To purge domain, there should be no users and groups in the target domain.
   """
   purge_domain(name: String!): PurgeDomain
+
+  """Added in 24.12.0."""
+  create_domain_node(input: CreateDomainNodeInput!): CreateDomainNode
+
+  """Added in 24.12.0."""
+  modify_domain_node(input: ModifyDomainNodeInput!): ModifyDomainNode
   create_group(name: String!, props: GroupInput!): CreateGroup
   modify_group(gid: UUID!, props: ModifyGroupInput!): ModifyGroup
 
@@ -1575,6 +1778,9 @@ type Mutations {
   modify_container_registry(hostname: String!, props: ModifyContainerRegistryInput!): ModifyContainerRegistry
   delete_container_registry(hostname: String!): DeleteContainerRegistry
   modify_endpoint(endpoint_id: UUID!, props: ModifyEndpointInput!): ModifyEndpoint
+
+  """Added in 24.09.0."""
+  check_and_transit_session_status(input: CheckAndTransitStatusInput!): CheckAndTransitStatus
 }
 
 type ModifyAgent {
@@ -1633,6 +1839,47 @@ To purge domain, there should be no users and groups in the target domain.
 type PurgeDomain {
   ok: Boolean
   msg: String
+}
+
+"""Added in 24.12.0."""
+type CreateDomainNode {
+  ok: Boolean
+  msg: String
+  item: DomainNode
+}
+
+"""Added in 24.12.0."""
+input CreateDomainNodeInput {
+  name: String!
+  description: String
+  is_active: Boolean = true
+  total_resource_slots: JSONString = "{}"
+  allowed_vfolder_hosts: JSONString = "{}"
+  allowed_docker_registries: [String] = []
+  integration_id: String = null
+  dotfiles: Bytes = "90"
+  scaling_groups: [String]
+}
+
+"""Added in 24.12.0."""
+type ModifyDomainNode {
+  item: DomainNode
+  client_mutation_id: String
+}
+
+"""Added in 24.12.0."""
+input ModifyDomainNodeInput {
+  id: GlobalIDField!
+  description: String
+  is_active: Boolean
+  total_resource_slots: JSONString
+  allowed_vfolder_hosts: JSONString
+  allowed_docker_registries: [String]
+  integration_id: String
+  dotfiles: Bytes
+  sgroups_to_add: [String]
+  sgroups_to_remove: [String]
+  client_mutation_id: String
 }
 
 type CreateGroup {
@@ -2333,4 +2580,16 @@ input ExtraMountInput {
   Added in 24.03.4. Set permission of this mount. Should be one of (ro,rw,wd). Default is null
   """
   permission: String
+}
+
+"""Added in 24.12.0"""
+type CheckAndTransitStatus {
+  item: [ComputeSessionNode]
+  client_mutation_id: String
+}
+
+"""Added in 24.12.0."""
+input CheckAndTransitStatusInput {
+  ids: [GlobalIDField]!
+  client_mutation_id: String
 }

--- a/react/src/components/DoubleTag.tsx
+++ b/react/src/components/DoubleTag.tsx
@@ -32,7 +32,7 @@ const DoubleTag: React.FC<{
   return (
     <Flex direction="row">
       {_.map(objectValues, (objValue, idx) => {
-        return (
+        return !_.isEmpty(objValue.label) ? (
           <Tag
             key={idx}
             style={
@@ -44,7 +44,7 @@ const DoubleTag: React.FC<{
           >
             {objValue.label}
           </Tag>
-        );
+        ) : null;
       })}
     </Flex>
   );

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -1,8 +1,13 @@
 import Flex from '../components/Flex';
-import { filterNonNullItems, getImageFullName } from '../helper';
-import { useBackendAIImageMetaData, useUpdatableState } from '../hooks';
+import { filterNonNullItems, getImageFullName, localeCompare } from '../helper';
+import {
+  useBackendAIImageMetaData,
+  useSuspendedBackendaiClient,
+  useUpdatableState,
+} from '../hooks';
+import DoubleTag from './DoubleTag';
 import ImageInstallModal from './ImageInstallModal';
-import { ConstraintTags } from './ImageTags';
+import { BaseImageTags, ConstraintTags, LangTags } from './ImageTags';
 import ManageAppsModal from './ManageAppsModal';
 import ManageImageResourceLimitModal from './ManageImageResourceLimitModal';
 import ResourceNumber from './ResourceNumber';
@@ -11,10 +16,8 @@ import {
   ImageListQuery,
   ImageListQuery$data,
 } from './__generated__/ImageListQuery.graphql';
-import CopyButton from './lablupTalkativotUI/CopyButton';
 import {
   AppstoreOutlined,
-  CopyOutlined,
   ReloadOutlined,
   SearchOutlined,
   SettingOutlined,
@@ -37,7 +40,15 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
   const [selectedRows, setSelectedRows] = useState<EnvironmentImage[]>([]);
   const [
     ,
-    { getNamespace, getBaseVersion, getLang, getBaseImages, getConstraints },
+    {
+      getNamespace,
+      getBaseVersion,
+      getLang,
+      getBaseImages,
+      getConstraints,
+      getBaseImage,
+      tagAlias,
+    },
   ] = useBackendAIImageMetaData();
   const { token } = theme.useToken();
   const [managingApp, setManagingApp] = useState<EnvironmentImage | null>(null);
@@ -52,13 +63,15 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
   const [imageSearch, setImageSearch] = useState('');
   const [isPendingRefreshTransition, startRefreshTransition] = useTransition();
   const [isPendingSearchTransition, startSearchTransition] = useTransition();
+  const baiClient = useSuspendedBackendaiClient();
+  const supportExtendedImageInfo = baiClient?.supports('extended-image-info');
 
   const { images } = useLazyLoadQuery<ImageListQuery>(
     graphql`
       query ImageListQuery {
         images {
           id
-          name
+          name @deprecatedSince(version: "24.09.1")
           tag
           registry
           architecture
@@ -74,6 +87,13 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             min
             max
           }
+          namespace @since(version: "24.09.1")
+          base_image_name @since(version: "24.09.1")
+          tags @since(version: "24.09.1") {
+            key
+            value
+          }
+          version @since(version: "24.09.1")
         }
       }
     `,
@@ -119,145 +139,212 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
         ) : null,
     },
     {
+      title: t('environment.FullImagePath'),
+      key: 'fullImagePath',
+      render: (row) => (
+        <Typography.Text
+          copyable={{
+            text: getImageFullName(row) || '',
+          }}
+        >
+          <TextHighlighter keyword={imageSearch}>
+            {getImageFullName(row) || ''}
+          </TextHighlighter>
+        </Typography.Text>
+      ),
+      sorter: (a, b) => localeCompare(getImageFullName(a), getImageFullName(b)),
+    },
+    {
       title: t('environment.Registry'),
       dataIndex: 'registry',
       key: 'registry',
-      sorter: (a, b) =>
-        a?.registry && b?.registry ? a.registry.localeCompare(b.registry) : 0,
-      render: (text, row) => (
-        <TextHighlighter keyword={imageSearch}>{row.registry}</TextHighlighter>
+      sorter: (a, b) => localeCompare(a?.registry, b?.registry),
+      render: (text) => (
+        <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
       ),
     },
     {
       title: t('environment.Architecture'),
       dataIndex: 'architecture',
       key: 'architecture',
-      sorter: (a, b) =>
-        a?.architecture && b?.architecture
-          ? a.architecture.localeCompare(b.architecture)
-          : 0,
-      render: (text, row) => (
-        <TextHighlighter keyword={imageSearch}>
-          {row.architecture}
-        </TextHighlighter>
+      sorter: (a, b) => localeCompare(a?.architecture, b?.architecture),
+      render: (text) => (
+        <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
       ),
     },
-    {
-      title: t('environment.Namespace'),
-      key: 'namespace',
-      dataIndex: 'namespace',
-      sorter: (a, b) => {
-        const namespaceA = getNamespace(getImageFullName(a) || '');
-        const namespaceB = getNamespace(getImageFullName(b) || '');
-        return namespaceA && namespaceB
-          ? namespaceA.localeCompare(namespaceB)
-          : 0;
-      },
-      render: (text, row) => (
-        <TextHighlighter keyword={imageSearch}>
-          {getNamespace(getImageFullName(row) || '')}
-        </TextHighlighter>
-      ),
-    },
-    {
-      title: t('environment.Language'),
-      key: 'lang',
-      dataIndex: 'lang',
-      sorter: (a, b) => {
-        const langA = a?.name ? getLang(a?.name) : '';
-        const langB = b?.name ? getLang(b?.name) : '';
-        return langA && langB ? langA.localeCompare(langB) : 0;
-      },
-      render: (text, row) => (
-        <TextHighlighter keyword={imageSearch}>
-          {row.name ? getLang(row.name) : null}
-        </TextHighlighter>
-      ),
-    },
-    {
-      title: t('environment.Version'),
-      key: 'baseversion',
-      dataIndex: 'baseversion',
-      sorter: (a, b) => {
-        const baseversionA = getBaseVersion(getImageFullName(a) || '');
-        const baseversionB = getBaseVersion(getImageFullName(b) || '');
-        return baseversionA && baseversionB
-          ? baseversionA.localeCompare(baseversionB)
-          : 0;
-      },
-      render: (text, row) => (
-        <TextHighlighter keyword={imageSearch}>
-          {getBaseVersion(getImageFullName(row) || '')}
-        </TextHighlighter>
-      ),
-    },
-    {
-      title: t('environment.Base'),
-      key: 'baseimage',
-      dataIndex: 'baseimage',
-      sorter: (a, b) => {
-        const baseimageA =
-          !a?.tag || !a?.name ? '' : getBaseImages(a?.tag, a?.name)[0] || '';
-        const baseimageB =
-          !b?.tag || !b?.name ? '' : getBaseImages(b?.tag, b?.name)[0] || '';
-        if (baseimageA === '' && baseimageB === '') return 0;
-        if (baseimageA === '') return -1;
-        if (baseimageB === '') return 1;
-        return baseimageA.localeCompare(baseimageB);
-      },
-      render: (text, row) => (
-        <Flex direction="row" align="start">
-          {row?.tag && row?.name
-            ? getBaseImages(row.tag, row.name).map((baseImage) => (
-                <Tag color="green">
-                  <TextHighlighter keyword={imageSearch}>
-                    {baseImage}
-                  </TextHighlighter>
-                </Tag>
-              ))
-            : null}
-        </Flex>
-      ),
-    },
-    {
-      title: t('environment.Constraint'),
-      key: 'constraint',
-      dataIndex: 'constraint',
-      sorter: (a, b) => {
-        const requirementA =
-          a?.tag && b?.labels
-            ? getConstraints(
-                a?.tag,
-                a?.labels as { key: string; value: string }[],
-              )[0] || ''
-            : '';
-        const requirementB =
-          b?.tag && b?.labels
-            ? getConstraints(
-                b?.tag,
-                b?.labels as { key: string; value: string }[],
-              )[0] || ''
-            : '';
-        if (requirementA === '' && requirementB === '') return 0;
-        if (requirementA === '') return -1;
-        if (requirementB === '') return 1;
-        return requirementA.localeCompare(requirementB);
-      },
-      render: (text, row) =>
-        row?.tag ? (
-          <ConstraintTags
-            tag={row?.tag}
-            labels={row?.labels as { key: string; value: string }[]}
-            highlightKeyword={imageSearch}
-          />
-        ) : null,
-    },
+    ...(supportExtendedImageInfo
+      ? [
+          {
+            title: t('environment.Namespace'),
+            key: 'namespace',
+            dataIndex: 'namespace',
+            sorter: (a: EnvironmentImage, b: EnvironmentImage) =>
+              localeCompare(a?.namespace, b?.namespace),
+            render: (text: string) => (
+              <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
+            ),
+          },
+          {
+            title: t('environment.BaseImageName'),
+            key: 'base_image_name',
+            dataIndex: 'base_image_name',
+            sorter: (a: EnvironmentImage, b: EnvironmentImage) =>
+              localeCompare(a?.base_image_name, b?.base_image_name),
+            render: (text: string, row: EnvironmentImage) => (
+              <TextHighlighter keyword={imageSearch}>
+                {tagAlias(text)}
+              </TextHighlighter>
+            ),
+          },
+          {
+            title: t('environment.Version'),
+            key: 'version',
+            dataIndex: 'version',
+            sorter: (a: EnvironmentImage, b: EnvironmentImage) =>
+              localeCompare(a?.version, b?.version),
+            render: (text: string) => (
+              <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
+            ),
+          },
+          {
+            title: t('environment.Tags'),
+            key: 'tags',
+            dataIndex: 'tags',
+            render: (
+              text: Array<{ key: string; value: string }>,
+              row: EnvironmentImage,
+            ) => {
+              return (
+                <Flex direction="row" align="start">
+                  {/* TODO: replace this with AliasedImageDoubleTags after image list query with ImageNode is implemented. */}
+                  {_.map(text, (tag: { key: string; value: string }) => {
+                    const isCustomized = _.includes(tag.key, 'customized_');
+                    const tagValue = isCustomized
+                      ? _.find(row?.labels, {
+                          key: 'ai.backend.customized-image.name',
+                        })?.value
+                      : tag.value;
+                    return (
+                      <DoubleTag
+                        key={tag.key}
+                        values={[
+                          {
+                            label: (
+                              <TextHighlighter
+                                keyword={imageSearch}
+                                key={tag.key}
+                              >
+                                {tagAlias(tag.key)}
+                              </TextHighlighter>
+                            ),
+                            color: isCustomized ? 'cyan' : 'blue',
+                          },
+                          {
+                            label: (
+                              <TextHighlighter
+                                keyword={imageSearch}
+                                key={tagValue}
+                              >
+                                {tagValue}
+                              </TextHighlighter>
+                            ),
+                            color: isCustomized ? 'cyan' : 'blue',
+                          },
+                        ]}
+                      />
+                    );
+                  })}
+                </Flex>
+              );
+            },
+          },
+        ]
+      : [
+          {
+            title: t('environment.Namespace'),
+            key: 'name',
+            dataIndex: 'name',
+            sorter: (a: EnvironmentImage, b: EnvironmentImage) =>
+              localeCompare(getImageFullName(a), getImageFullName(b)),
+            render: (text: string, row: EnvironmentImage) => (
+              <TextHighlighter keyword={imageSearch}>
+                {getNamespace(getImageFullName(row) || '')}
+              </TextHighlighter>
+            ),
+          },
+          {
+            title: t('environment.Language'),
+            key: 'lang',
+            dataIndex: 'lang',
+            sorter: (a: EnvironmentImage, b: EnvironmentImage) =>
+              localeCompare(getLang(a.name ?? ''), getLang(b.name ?? '')),
+            render: (text: string, row: EnvironmentImage) => (
+              <LangTags image={getImageFullName(row) || ''} color="green" />
+            ),
+          },
+          {
+            title: t('environment.Version'),
+            key: 'baseversion',
+            dataIndex: 'baseversion',
+            sorter: (a: EnvironmentImage, b: EnvironmentImage) =>
+              localeCompare(
+                getBaseVersion(getImageFullName(a) || ''),
+                getBaseVersion(getImageFullName(b) || ''),
+              ),
+            render: (text: string, row: EnvironmentImage) => (
+              <TextHighlighter keyword={imageSearch}>
+                {getBaseVersion(getImageFullName(row) || '')}
+              </TextHighlighter>
+            ),
+          },
+          {
+            title: t('environment.Base'),
+            key: 'baseimage',
+            dataIndex: 'baseimage',
+            sorter: (a: EnvironmentImage, b: EnvironmentImage) =>
+              localeCompare(
+                getBaseImage(getImageFullName(a) || ''),
+                getBaseImage(getImageFullName(b) || ''),
+              ),
+            render: (text: string, row: EnvironmentImage) => (
+              <BaseImageTags image={getImageFullName(row) || ''} />
+            ),
+          },
+          {
+            title: t('environment.Constraint'),
+            key: 'constraint',
+            dataIndex: 'constraint',
+            sorter: (a: EnvironmentImage, b: EnvironmentImage) => {
+              const requirementA =
+                a?.tag && b?.labels
+                  ? getConstraints(
+                      a?.tag,
+                      a?.labels as { key: string; value: string }[],
+                    )[0] || ''
+                  : '';
+              const requirementB =
+                b?.tag && b?.labels
+                  ? getConstraints(
+                      b?.tag,
+                      b?.labels as { key: string; value: string }[],
+                    )[0] || ''
+                  : '';
+              return localeCompare(requirementA, requirementB);
+            },
+            render: (text: string, row: EnvironmentImage) =>
+              row?.tag ? (
+                <ConstraintTags
+                  tag={row?.tag}
+                  labels={row?.labels as Array<{ key: string; value: string }>}
+                />
+              ) : null,
+          },
+        ]),
     {
       title: t('environment.Digest'),
       dataIndex: 'digest',
       key: 'digest',
-      sorter: (a, b) =>
-        a?.digest && b?.digest ? a.digest.localeCompare(b.digest) : 0,
+      sorter: (a, b) => localeCompare(a?.digest || '', b?.digest || ''),
       render: (text, row) => (
         <TextHighlighter keyword={imageSearch}>{row.digest}</TextHighlighter>
       ),
@@ -294,14 +381,6 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             e.stopPropagation();
           }}
         >
-          <CopyButton
-            type="text"
-            defaultIcon={<CopyOutlined />}
-            style={{ color: token.colorPrimary }}
-            copyable={{
-              text: getImageFullName(row) || '',
-            }}
-          ></CopyButton>
           <Button
             type="text"
             icon={

--- a/react/src/components/ImageTags.tsx
+++ b/react/src/components/ImageTags.tsx
@@ -3,6 +3,7 @@ import DoubleTag, { DoubleTagObjectValue } from './DoubleTag';
 import Flex from './Flex';
 import TextHighlighter from './TextHighlighter';
 import { Tag, TagProps } from 'antd';
+import _ from 'lodash';
 import React from 'react';
 
 interface ImageAliasNameAndBaseVersionTagsProps
@@ -41,7 +42,7 @@ export const BaseVersionTags: React.FC<BaseVersionTagsProps> = ({
 }) => {
   image = image || '';
   const [, { getBaseVersion, tagAlias }] = useBackendAIImageMetaData();
-  return (
+  return _.isEmpty(tagAlias(getBaseVersion(image))) ? null : (
     <Tag color="green" {...props}>
       {tagAlias(getBaseVersion(image))}
     </Tag>
@@ -57,7 +58,7 @@ export const BaseImageTags: React.FC<BaseImageTagsProps> = ({
 }) => {
   image = image || '';
   const [, { getBaseImage, tagAlias }] = useBackendAIImageMetaData();
-  return (
+  return _.isEmpty(tagAlias(getBaseImage(image))) ? null : (
     <Tag color="green" {...props}>
       {tagAlias(getBaseImage(image))}
     </Tag>
@@ -73,7 +74,7 @@ export const ArchitectureTags: React.FC<ArchitectureTagsProps> = ({
 }) => {
   image = image || '';
   const [, { getArchitecture, tagAlias }] = useBackendAIImageMetaData();
-  return (
+  return _.isEmpty(tagAlias(getArchitecture(image))) ? null : (
     <Tag color="green" {...props}>
       {tagAlias(getArchitecture(image))}
     </Tag>
@@ -86,7 +87,7 @@ interface LangTagsProps extends TagProps {
 export const LangTags: React.FC<LangTagsProps> = ({ image, ...props }) => {
   image = image || '';
   const [, { getImageLang, tagAlias }] = useBackendAIImageMetaData();
-  return (
+  return _.isEmpty(tagAlias(getImageLang(image))) ? null : (
     <Tag color="green" {...props}>
       {tagAlias(getImageLang(image))}
     </Tag>
@@ -109,14 +110,14 @@ export const ConstraintTags: React.FC<ConstraintTagsProps> = ({
   const constraints = getConstraints(tag, labels);
   return (
     <Flex direction="row" align="start">
-      {constraints[0] ? (
+      {!_.isEmpty(constraints?.[0]) ? (
         <Tag color="blue" {...props}>
           <TextHighlighter keyword={highlightKeyword}>
             {constraints[0]}
           </TextHighlighter>
         </Tag>
       ) : null}
-      {constraints[1] ? (
+      {!_.isEmpty(constraints?.[1]) ? (
         <DoubleTag
           color="cyan"
           values={[

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -316,19 +316,20 @@ export const useBackendAIImageMetaData = () => {
         return architecture;
       },
       tagAlias: (tag: string) => {
-        let metadataTagAlias = metadata?.tagAlias[tag];
-        if (!metadataTagAlias && metadata?.tagReplace) {
-          for (const [key, replaceString] of Object.entries(
-            metadata.tagReplace,
-          )) {
-            const pattern = new RegExp(key);
-            if (pattern.test(tag)) {
-              metadataTagAlias = tag.replace(pattern, replaceString);
-              break;
-            }
-          }
-        }
-        return metadataTagAlias || tag;
+        return (
+          metadata?.tagAlias[tag] ??
+          _.chain(metadata.tagReplace)
+            .toPairs()
+            .find(([regExpStr]) => new RegExp(regExpStr).test(tag))
+            .thru((pair) => {
+              if (pair) {
+                const [regExpStr, replaceStr] = pair;
+                return _.replace(tag, new RegExp(regExpStr), replaceStr);
+              }
+            })
+            .value() ??
+          _.startCase(tag)
+        );
       },
     },
   ] as const;

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "Installieren Sie ein Image?",
     "InstalledImagesAreExcluded": "Installierte Bilder sind davon ausgenommen.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Basisbildname",
+    "Tags": "Schlagworte",
+    "FullImagePath": "Vollständiger Bildpfad"
   },
   "resourcePreset": {
     "ResourcePresets": "Ressourcenvoreinstellungen",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "Εγκαθιστώντας μια εικόνα;",
     "InstalledImagesAreExcluded": "Οι εγκατεστημένες εικόνες εξαιρούνται.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Όνομα εικόνας βάσης",
+    "Tags": "Ετικέτες",
+    "FullImagePath": "Πλήρης διαδρομή εικόνας"
   },
   "resourcePreset": {
     "ResourcePresets": "Προεπιλογές πόρων",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -991,7 +991,7 @@
     "Action": "Action",
     "Base": "Base",
     "Constraint": "Constraint",
-    "ResourceLimit": "Resource Limit",
+    "ResourceLimit": "Resource limit",
     "DescDeleteAppInfo": "You are about to delete the app info: ",
     "DescDeleteImage": "You are about to delete the image(s): ",
     "DescSignificantInstallTime": "This process requires significant install time.",
@@ -1029,7 +1029,10 @@
     "CheckImageInstallation": "Installing an image?",
     "SearchImages": "Search images",
     "DescDownloadImage": "DescDownloadImage",
-    "DescSignificantDownloadTime": "DescSignificantDownloadTime"
+    "DescSignificantDownloadTime": "DescSignificantDownloadTime",
+    "BaseImageName": "Base image name",
+    "Tags": "Tags",
+    "FullImagePath": "Full image path"
   },
   "resourcePreset": {
     "ResourcePresets": "Resource Presets",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -537,7 +537,10 @@
     "CheckImageInstallation": "¿Instalar una imagen?",
     "InstalledImagesAreExcluded": "Se excluyen las imágenes instaladas.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nombre de la imagen base",
+    "Tags": "Etiquetas",
+    "FullImagePath": "Ruta de imagen completa"
   },
   "explorer": {
     "InputTooShort": "InputTooShort",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -519,7 +519,7 @@
     "ProtocolMustBeOneOfSupported": "Protokollan on oltava jokin seuraavista: 'http', 'tcp', 'preopen' ja 'pty'.",
     "Registries": "Rekisterit",
     "Registry": "Rekisteri",
-    "ResourceLimit": "Resurssiraja",
+    "ResourceLimit": "Resurssirajoitus",
     "ResourcePresets": "Resurssien esiasetukset",
     "SelectedImagesAlreadyInstalled": "Valittu kuva (valitut kuvat) on jo asennettu tai Ei mitään. Tarkista uudelleen.",
     "SelectedImagesNotInstalled": "Valittuja kuvia ei ole asennettu. Tarkista uudelleen.",
@@ -537,7 +537,10 @@
     "CheckImageInstallation": "Kuvan asentaminen?",
     "InstalledImagesAreExcluded": "Asennettuja kuvia ei oteta huomioon.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Peruskuvan nimi",
+    "Tags": "Tunnisteet",
+    "FullImagePath": "Koko kuvan polku"
   },
   "explorer": {
     "InputTooShort": "InputTooShort",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "Installation d'une image ?",
     "InstalledImagesAreExcluded": "Les images installées sont exclues.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nom de l'image de base",
+    "Tags": "Balises",
+    "FullImagePath": "Chemin d'accès complet à l'image"
   },
   "resourcePreset": {
     "ResourcePresets": "Préréglages de ressources",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -861,7 +861,7 @@
     "Action": "Tindakan",
     "Base": "Basis",
     "Constraint": "Batasan",
-    "ResourceLimit": "Batas Sumber Daya",
+    "ResourceLimit": "Batasan sumber daya",
     "DescDeleteAppInfo": "Anda akan menghapus info aplikasi: ",
     "DescDeleteImage": "Anda akan menghapus image: ",
     "DescSignificantInstallTime": "Proses ini membutuhkan waktu pengunduhan yang signifikan.",
@@ -900,7 +900,10 @@
     "CheckImageInstallation": "Memasang gambar?",
     "InstalledImagesAreExcluded": "Gambar yang diinstal tidak termasuk.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nama gambar dasar",
+    "Tags": "Tag",
+    "FullImagePath": "Jalur gambar penuh"
   },
   "resourcePreset": {
     "ResourcePresets": "Preset Sumber Daya",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -861,7 +861,7 @@
     "Action": "Azione",
     "Base": "Base",
     "Constraint": "vincolo",
-    "ResourceLimit": "Limite di risorse",
+    "ResourceLimit": "Limite delle risorse",
     "DescDeleteAppInfo": "Stai per eliminare le informazioni sull'app:",
     "DescDeleteImage": "Stai per eliminare le immagini:",
     "DescSignificantInstallTime": "Questo processo richiede un tempo di download significativo.",
@@ -900,7 +900,10 @@
     "CheckImageInstallation": "Installare un'immagine?",
     "InstalledImagesAreExcluded": "Le immagini installate sono escluse.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nome dell'immagine di base",
+    "Tags": "Tag",
+    "FullImagePath": "Percorso completo dell'immagine"
   },
   "resourcePreset": {
     "ResourcePresets": "Preimpostazioni delle risorse",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "イメージのインストール？",
     "InstalledImagesAreExcluded": "インストールされたイメージは除く。",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "ベースイメージ名",
+    "Tags": "タグ",
+    "FullImagePath": "完全な画像パス"
   },
   "resourcePreset": {
     "ResourcePresets": "リソースプリセット",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1015,7 +1015,10 @@
     "CheckImageInstallation": "다음 이미지를 설치하시겠습니까?",
     "SearchImages": "이미지 검색",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "기본 이미지 이름",
+    "Tags": "태그",
+    "FullImagePath": "전체 이미지 경로"
   },
   "resourcePreset": {
     "ResourcePresets": "자원 프리셋",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -861,7 +861,7 @@
     "Action": "Үйлдэл",
     "Base": "Суурь",
     "Constraint": "Хязгаарлалт",
-    "ResourceLimit": "Нөөцийн хязгаарлалт",
+    "ResourceLimit": "Нөөцийн хязгаар",
     "DescDeleteAppInfo": "Та аппын мэдээллийг устгах гэж байна:",
     "DescDeleteImage": "Та зураг (ууд) ыг устгах гэж байна:",
     "DescSignificantInstallTime": "Энэ процесс нь татаж авахад ихээхэн хугацаа шаарддаг.",
@@ -900,7 +900,10 @@
     "CheckImageInstallation": "Зураг суулгаж байна уу?",
     "InstalledImagesAreExcluded": "Суулгасан зургуудыг оруулаагүй болно.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Зургийн үндсэн нэр",
+    "Tags": "Шошго",
+    "FullImagePath": "Зургийн бүрэн зам"
   },
   "resourcePreset": {
     "ResourcePresets": "Нөөцийн урьдчилсан тохируулга",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -860,7 +860,7 @@
     "Action": "Tindakan",
     "Base": "Pangkalan",
     "Constraint": "Kekangan",
-    "ResourceLimit": "Had Sumber",
+    "ResourceLimit": "Had sumber",
     "DescDeleteAppInfo": "Anda akan memadamkan maklumat aplikasi:",
     "DescDeleteImage": "Anda akan memadamkan gambar:",
     "DescSignificantInstallTime": "Proses ini memerlukan masa muat turun yang ketara.",
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "Memasang imej?",
     "InstalledImagesAreExcluded": "Imej yang dipasang dikecualikan.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nama imej asas",
+    "Tags": "Tag",
+    "FullImagePath": "Laluan imej penuh"
   },
   "resourcePreset": {
     "ResourcePresets": "Pratetap Sumber",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "Instalowanie obrazu?",
     "InstalledImagesAreExcluded": "Zainstalowane obrazy są wykluczone.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Podstawowa nazwa obrazu",
+    "Tags": "Tagi",
+    "FullImagePath": "Pełna ścieżka obrazu"
   },
   "resourcePreset": {
     "ResourcePresets": "Predefiniowane ustawienia zasobów",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "Instalar uma imagem?",
     "InstalledImagesAreExcluded": "As imagens instaladas são excluídas.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nome da imagem base",
+    "Tags": "Etiquetas",
+    "FullImagePath": "Caminho completo da imagem"
   },
   "resourcePreset": {
     "ResourcePresets": "Predefinições de recursos",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "Instalar uma imagem?",
     "InstalledImagesAreExcluded": "As imagens instaladas são excluídas.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nome da imagem base",
+    "Tags": "Etiquetas",
+    "FullImagePath": "Caminho completo da imagem"
   },
   "resourcePreset": {
     "ResourcePresets": "Predefinições de recursos",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "Установка образа?",
     "InstalledImagesAreExcluded": "Установленные образы исключены.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Имя базового изображения",
+    "Tags": "Теги",
+    "FullImagePath": "Полный путь к изображению"
   },
   "resourcePreset": {
     "ResourcePresets": "Предустановки ресурсов",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1013,7 +1013,10 @@
     "CustomizedImageSuccessfullyDeleted": "ลบอิมเมจที่กำหนดเองสำเร็จแล้ว",
     "DescImageResourceModified": "แก้ไขขีดจำกัดทรัพยากรสำเร็จแล้ว",
     "DescImagePortsModified": "แก้ไขพอร์ตอิมเมจสำเร็จแล้ว",
-    "ModifyImageResourceLimitReinstallRequired": "<p>หากคุณแก้ไขอิมเมจที่ได้รับการติดตั้งแล้ว คุณจะต้องติดตั้งอิมเมจใหม่</p><p>การแก้ไขจะไม่มีผลจนกว่าจะมีการติดตั้งอิมเมจใหม่\n</p>"
+    "ModifyImageResourceLimitReinstallRequired": "<p>หากคุณแก้ไขอิมเมจที่ได้รับการติดตั้งแล้ว คุณจะต้องติดตั้งอิมเมจใหม่</p><p>การแก้ไขจะไม่มีผลจนกว่าจะมีการติดตั้งอิมเมจใหม่\n</p>",
+    "BaseImageName": "ชื่อภาพฐาน",
+    "Tags": "แท็ก",
+    "FullImagePath": "เส้นทางภาพเต็ม"
   },
   "resourcePreset": {
     "ResourcePresets": "ค่าที่กำหนดไว้ล่วงหน้าของทรัพยากร",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -860,7 +860,7 @@
     "Action": "Aksiyon",
     "Base": "baz",
     "Constraint": "Kısıtlama",
-    "ResourceLimit": "Kaynak Sınırı",
+    "ResourceLimit": "Kaynak sınırı",
     "DescDeleteAppInfo": "Uygulama bilgilerini silmek üzeresiniz:",
     "DescDeleteImage": "Resim(ler)i silmek üzeresiniz:",
     "DescSignificantInstallTime": "Bu işlem önemli indirme süresi gerektirir.",
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "Bir görüntü mü yüklüyorsunuz?",
     "InstalledImagesAreExcluded": "Yüklü görüntüler hariçtir.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Temel resim adı",
+    "Tags": "Etiketler",
+    "FullImagePath": "Tam görüntü yolu"
   },
   "resourcePreset": {
     "ResourcePresets": "Kaynak Ön Ayarları",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "Cài đặt một hình ảnh?",
     "InstalledImagesAreExcluded": "Hình ảnh được cài đặt được loại trừ.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Tên hình ảnh cơ sở",
+    "Tags": "Thẻ",
+    "FullImagePath": "Đường dẫn hình ảnh đầy đủ"
   },
   "resourcePreset": {
     "ResourcePresets": "Cài đặt trước tài nguyên",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -899,7 +899,10 @@
     "CheckImageInstallation": "安装图像？",
     "InstalledImagesAreExcluded": "不包括已安装的图像。",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "基础镜像名称",
+    "Tags": "标签",
+    "FullImagePath": "完整图像路径"
   },
   "resourcePreset": {
     "ResourcePresets": "资源预设",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -900,7 +900,10 @@
     "CheckImageInstallation": "安装图像？",
     "InstalledImagesAreExcluded": "不包括已安装的图像。",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "基礎鏡像名稱",
+    "Tags": "標籤",
+    "FullImagePath": "完整影像路徑"
   },
   "resourcePreset": {
     "ResourcePresets": "資源預設",

--- a/resources/image_metadata.json
+++ b/resources/image_metadata.json
@@ -891,6 +891,8 @@
   "tagReplace": {
     "^(tf)([0-9.]*)$": "TensorFlow $2",
     "^(pytorch)([0-9.]*)$": "PyTorch $2",
-    "^(cuda)([0-9.]*)$": "GPU:CUDA$2"
+    "^(cuda)([0-9.]*)$": "GPU:CUDA$2",
+    "^(customized)_.*$": "Customized",
+    "^(-_)$": " "
   }
 }

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -718,6 +718,9 @@ class Client {
       this._features['extend-login-session'] = true;
       this._features['session-node'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('24.09.1')) {
+      this._features['extended-image-info'] = true;
+    }
   }
 
   /**


### PR DESCRIPTION
related PR: https://github.com/lablup/backend.ai/pull/2939

# Extended Image Information Support

This PR adds support for extended image information in the ImageList component and related translations. It introduces new fields and modifies the display of image details when the backend supports the 'extended-image-info' feature.

**Checklist:**
- [ ] Minimum required manager version: 24.09.1

## Changes

1. Updated `ImageListQuery` to include new fields: `namespace`, `base_image_name`, `tags`, and `version`.
2. Modified the ImageList component to conditionally render columns based on the `supportExtendedImageInfo` flag.
3. Added new translations for "Base image name" and "Tags" in multiple languages.
4. Updated the backend client to support the 'extended-image-info' feature for manager version 24.09.1 and above.

## Impact

- Users will see more detailed image information when using a compatible backend version.
- The image list will display new columns for base image name and tags when supported.
- Existing functionality is preserved for older backend versions.

## Review Notes

- Verify that the image list displays correctly with both old and new backend versions.
- Check that new translations are applied correctly in different languages.
- Ensure that sorting and filtering work properly with the new fields.

## How to test
1. Checkout core branch to `topic/10-22-feature_add_info_field_to_gql_image_schema` https://github.com/lablup/backend.ai/pull/2993
2. Go to Environment page. 

## What to check:
- [ ] Check the data is valid.
  - [ ]  Since 24.09.1: Full image path, Registry, Architecture, Namespace, Base image name, Version, Tags, Digest, Resource limit, Control.
  - [ ] Before 24.09.1: Full image path, Registry, Architecture, Name, Language, Version, Base, Constraints, Digest, Resource limit, Control.
- [ ] All data is highlightable by searching images.
- [ ] Sortable data works fine.

## Screenshots

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/88e5ad80-559a-4b41-a93a-5a08f3a4c062.png)

