### PR TITLE
feat: replace name with namespace

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/ResourceAllocationFormItems.test.ts
@@ -36,7 +36,8 @@ describe('getAllocatablePresetNames', () => {
 
   const image_has_cuda_shares_min1_max1: Image = {
     id: 'id1',
-    name: 'image1',
+    namespace: 'image1',
+    name: undefined,
     digest: 'digest1',
     architecture: 'arm64',
     humanized_name: 'Image 1',

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -314,7 +314,7 @@ export const getImageFullName = (
   image: Image | CommittedImage | EnvironmentImage,
 ) => {
   return image
-    ? `${image.registry}/${image.name}:${image.tag}@${image.architecture}`
+    ? `${image.registry}/${image.namespace ?? image.name}:${image.tag}@${image.architecture}`
     : undefined;
 };
 

--- a/react/src/hooks/useBackendAIImageMetaData.test.tsx
+++ b/react/src/hooks/useBackendAIImageMetaData.test.tsx
@@ -108,7 +108,8 @@ describe('useBackendAIImageMetaData', () => {
 
     const { key, tags } = getImageMeta(
       getImageFullName({
-        name: 'abc/def/training',
+        namespace: 'abc/def/training',
+        name: undefined,
         humanized_name: 'abc/def/training',
         tag: '01-py3-abc-v1',
         registry: '192.168.0.1:7080',

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -721,6 +721,9 @@ class Client {
     if (this.isManagerVersionCompatibleWith('24.09.1')) {
       this._features['extended-image-info'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('24.09.1')) {
+      this._features['extended-image-info'] = true;
+    }
   }
 
   /**


### PR DESCRIPTION
# Support for Extended Image Info

This PR introduces support for the extended image info feature, which affects how image namespaces are handled and displayed throughout the application.

**Changes:**

- Added a `supportExtendedImageInfo` flag based on the backend client's capabilities
- Updated image queries to use `namespace` instead of `name` when extended image info is supported
- Modified image full name generation to prioritize `namespace` over `name`
- Adjusted environment selection logic to use `namespace` when available
- Updated table columns in MyEnvironmentPage to display and sort by `namespace` when supported

**Rationale:**

These changes allow the application to work with both the old and new image information structures, providing a smooth transition as the backend evolves.

**Effects:**

- Users will see more accurate namespace information when using a backend that supports extended image info
- Developers should be aware of the `supportExtendedImageInfo` flag when working with image-related components

**How to test:**
1. Checkout core branch to `topic/10-22-feature_add_info_field_to_gql_image_schema`
2. Check the environments, my environments, session page which are using `namespace` (before lablup/backend.ai#2939, it was `name`.) of `images` query. 

**Screenshots:**
In #2785, the part of the full image path field had `undefined`. But it has some value now.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/a2553afe-d555-40b3-bc4e-bb1b79fa4b87.png)

**Checklist:**

- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version: 24.09.1
- [x] Specific setting for review
- [x] Minimum requirements to check during review:
  - Verify that image namespaces are correctly displayed and used when extended image info is supported
  - Ensure backwards compatibility with older backend versions
- [ ] Test case(s) to demonstrate the difference of before/after