### PR TITLE
feat: add `AliasedBaseImageName`

### DIFF
--- a/react/src/components/AliasedBaseImageName.tsx
+++ b/react/src/components/AliasedBaseImageName.tsx
@@ -1,0 +1,35 @@
+import { useBackendAIImageMetaData } from '../hooks';
+import TextHighlighter from './TextHighlighter';
+import { AliasedBaseImageNameFragment$key } from './__generated__/AliasedBaseImageNameFragment.graphql';
+import graphql from 'babel-plugin-relay/macro';
+import React from 'react';
+import { useFragment } from 'react-relay';
+
+interface AliasedBaseImageNameProps {
+  imageFrgmt?: AliasedBaseImageNameFragment$key | null;
+  highlightKeyword?: string;
+}
+
+const AliasedBaseImageName: React.FC<AliasedBaseImageNameProps> = ({
+  imageFrgmt,
+  highlightKeyword,
+}) => {
+  const images = useFragment(
+    graphql`
+      fragment AliasedBaseImageNameFragment on ImageNode {
+        base_image_name @since(version: "24.09.1.")
+      }
+    `,
+    imageFrgmt,
+  );
+
+  const [, { tagAlias }] = useBackendAIImageMetaData();
+
+  return (
+    <TextHighlighter keyword={highlightKeyword}>
+      {tagAlias(images?.base_image_name ?? '')}
+    </TextHighlighter>
+  );
+};
+
+export default AliasedBaseImageName;

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -66,6 +66,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
   const [isOpenColumnsSetting, setIsOpenColumnsSetting] = useState(false);
   const [isPendingRefreshTransition, startRefreshTransition] = useTransition();
   const [isPendingSearchTransition, startSearchTransition] = useTransition();
+  const [, { tagAlias }] = useBackendAIImageMetaData();
   const baiClient = useSuspendedBackendaiClient();
   const supportExtendedImageInfo = baiClient?.supports('extended-image-info');
 
@@ -197,7 +198,14 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             sorter: (a: EnvironmentImage, b: EnvironmentImage) =>
               localeCompare(a?.base_image_name, b?.base_image_name),
             render: (text: string, row: EnvironmentImage) => (
-              <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
+              // Replace with this code after using ImageNode instead of Image
+              // <AliasedBaseImageName
+              //   imageFrgmt={row}
+              //   highlightKeyword={imageSearch}
+              // />
+              <TextHighlighter keyword={imageSearch}>
+                {tagAlias(text)}
+              </TextHighlighter>
             ),
           },
           {
@@ -310,11 +318,10 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
       title: t('environment.Digest'),
       dataIndex: 'digest',
       key: 'digest',
-      sorter: (a, b) =>
-        a?.digest && b?.digest ? a.digest.localeCompare(b.digest) : 0,
-      render: (text, row) => (
+      sorter: (a, b) => localeCompare(a?.digest, b?.digest),
+      render: (text) => (
         <Typography.Text ellipsis={{ tooltip: true }} style={{ maxWidth: 200 }}>
-          <TextHighlighter keyword={imageSearch}>{row.digest}</TextHighlighter>
+          <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
         </Typography.Text>
       ),
     },


### PR DESCRIPTION
# Add AliasedBaseImageName component for image base name display

This PR introduces a new `AliasedBaseImageName` component to enhance the display of base image names in the ImageList. The component utilizes the `useBackendAIImageMetaData` hook to apply tag aliases to the base image names.

## Changes:

- Created a new `AliasedBaseImageName.tsx` component
- Updated `ImageList.tsx` to use the new component for rendering base image names
- Added a GraphQL fragment for the base image name in the ImageList query

## How to test:
> endpoint: 10.100.64.15
1. Checkout core branch to `topic/10-22-feature_add_info_field_to_gql_image_schema`
2. Visit Environments - Images pages.
3. Check the 'Base image name' column. (The Environments page uses same code with `AliasedImageDoubleTags` and it will be replaced after the image list query using `ImageNode` is implemented).
4. Check it can be highlighted by searching.

## Rationale:

The new component allows for more flexible and consistent display of base image names across the application, potentially improving user experience by showing more recognizable or user-friendly names.

## Effects:

- Users will see aliased base image names in the ImageList, which may be more intuitive or familiar
- Developers can now easily reuse the `AliasedBaseImageName` component in other parts of the application where base image names are displayed


## Screenshots:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/e9341db9-adc3-4fe4-9070-50560a64c8da.png)

**Checklist:**

- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version: 24.09.1 (as indicated by the `@since` directive)
- [ ] Specific setting for review
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after