### PR TITLE
fix: display Gaudi 2 util in session list

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -3893,6 +3893,31 @@ ${rowData.item[this.sessionNameField]}</pre
                   </div>
                 `
               : html``}
+            ${rowData.item.gaudi2_slot &&
+            parseFloat(rowData.item.gaudi2_slot) > 0
+              ? html`
+                  <div class="vertical start-justified layout">
+                    <div class="usage-items">
+                      Gaudi 2(util)
+                      ${rowData.item.live_stat?.gaudi2_util
+                        ? (
+                            rowData.item.live_stat?.gaudi2_util?.ratio * 100
+                          ).toFixed(1)
+                        : `-`}
+                      %
+                    </div>
+                    <div class="horizontal start-justified center layout">
+                      <lablup-progress-bar
+                        class="usage"
+                        progress="${rowData.item?.live_stat?.gaudi2_util
+                          ?.current /
+                          rowData.item?.live_stat?.gaudi2_util?.capacity || 0}"
+                        description=""
+                      ></lablup-progress-bar>
+                    </div>
+                  </div>
+                `
+              : html``}
             <div class="horizontal start-justified center layout">
               <div class="usage-items">I/O</div>
               <div


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/7fd86dab-ce1f-46ac-8e9a-2976ac3b5e1f.png)

**Changes:**

This PR adds support for displaying Gaudi 2 utilization in the session list. It introduces a new section that shows the Gaudi 2 utilization percentage and a progress bar, similar to existing resource utilization displays.

**Details:**

- Adds a conditional rendering block for Gaudi 2 slot information
- Displays Gaudi 2 utilization percentage
- Includes a progress bar to visually represent Gaudi 2 utilization

**Rationale:**

This addition allows users to monitor Gaudi 2 resource usage directly in the session list, providing better visibility and management of Gaudi 2 accelerators.