### PR TITLE
refactor: improve error handling of `CustomizedImageList`

### DIFF
--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -402,17 +402,29 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
                   variables: {
                     id: row.id,
                   },
-                  onCompleted(data, errors) {
-                    if (errors) {
-                      message.error(errors[0]?.message);
+                  onCompleted(res, errors) {
+                    if (!res?.forget_image_by_id?.ok) {
+                      message.error(res?.forget_image_by_id?.msg);
                       return;
+                    } else if (!res?.untag_image_from_registry?.ok) {
+                      message.error(res?.untag_image_from_registry?.msg);
+                      return;
+                    } else if (errors && errors?.length > 0) {
+                      const errorMsgList = _.map(
+                        errors,
+                        (error) => error.message,
+                      );
+                      for (const error of errorMsgList) {
+                        message.error(error, 2.5);
+                      }
+                    } else {
+                      startRefetchTransition(() => {
+                        updateCustomizedImageListFetchKey();
+                      });
+                      message.success(
+                        t('environment.CustomizedImageSuccessfullyDeleted'),
+                      );
                     }
-                    startRefetchTransition(() => {
-                      updateCustomizedImageListFetchKey();
-                    });
-                    message.success(
-                      t('environment.CustomizedImageSuccessfullyDeleted'),
-                    );
                   },
                   onError(err) {
                     message.error(err?.message);


### PR DESCRIPTION
**Changes:**
Improves error handling when deleting customized images by:
- Adding specific error checks for `forget_image_by_id` and `untag_image_from_registry` operations
- Displaying individual error messages from the error array with 2.5s duration
- Only showing success message and refreshing the environment when all operations complete successfully

**Checklist:**
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

**Test Cases:**
1. Delete an image with `forget_image_by_id` failure
2. Delete an image with `untag_image_from_registry` failure
3. Delete an image with multiple GraphQL errors
4. Delete an image successfully