### PR TITLE
fix: handle Undefined onResize in BAITable component

### DIFF
--- a/react/src/components/BAITable.tsx
+++ b/react/src/components/BAITable.tsx
@@ -41,7 +41,7 @@ const ResizableTitle = (
   // This is a workaround for the initial width of resizable columns if the width is not specified
   useEffect(() => {
     if (wrapRef.current && _.isUndefined(width)) {
-      onResize(undefined, {
+      onResize?.(undefined, {
         size: {
           width: wrapRef.current.offsetWidth,
           height: wrapRef.current.offsetHeight,


### PR DESCRIPTION
Fixed a potential null reference error in BAITable's ResizableTitle component by adding an optional chaining operator to the `onResize` callback. This prevents runtime errors when the callback is undefined.

[Teams](https://teams.microsoft.com/l/message/19:14c484402d874dafb15806d093b95a82@thread.skype/1730194784997?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=74ae2c4d-ec4d-4fdf-b2c2-f5041d1e8631&parentMessageId=1730194784997&teamName=devops&channelName=Frontend&createdTime=1730194784997)

**Checklist:**

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after