### PR TITLE
fix: change from `24.09.1.` to `24.09.1`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -5,6 +5,7 @@
     "Backendai",
     "backendaiclient",
     "backendaioptions",
+    "baseversion",
     "cssinjs",
     "cuda",
     "FGPU",
@@ -19,17 +20,14 @@
     "RNGD",
     "shmem",
     "superadmin",
+    "textbox",
+    "vaadin",
     "vfolder",
     "vfolders",
     "Warboy",
     "webcomponent",
     "webui",
-    "wsproxy",
-    "vfolders",
-    "vfolder",
-    "filebrowser",
-    "vaadin",
-    "textbox"
+    "wsproxy"
   ],
   "flagWords": [
     "데이터레이크",

--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -14,6 +14,28 @@ type Queries {
   agents(scaling_group: String, status: String): [Agent]
   agent_summary(agent_id: String!): AgentSummary
   agent_summary_list(limit: Int!, offset: Int!, filter: String, order: String, scaling_group: String, status: String): AgentSummaryList
+
+  """Added in 24.12.0."""
+  domain_node(id: GlobalIDField!, permission: DomainPermissionValueField = "read_attribute"): DomainNode
+
+  """Added in 24.12.0."""
+  domain_nodes(filter: String, order: String, permission: DomainPermissionValueField = "read_attribute", offset: Int, before: String, after: String, first: Int, last: Int): DomainConnection
+
+  """Added in 24.12.0."""
+  agent_nodes(
+    """Added in 24.12.0. Default is `system`."""
+    scope: ScopeField
+
+    """Added in 24.12.0. Default is create_compute_session."""
+    permission: AgentPermissionField = "create_compute_session"
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): AgentConnection
   domain(name: String): Domain
   domains(is_active: Boolean): [Domain]
 
@@ -21,7 +43,18 @@ type Queries {
   group_node(id: String!): GroupNode
 
   """Added in 24.03.0."""
-  group_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): GroupConnection
+  group_nodes(
+    """Added in 24.09.0."""
+    filter: String
+
+    """Added in 24.09.0."""
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): GroupConnection
   group(
     id: UUID!
     domain_name: String
@@ -287,12 +320,24 @@ type ImageNode implements Node {
 
   """Added in 24.03.4. The undecoded id value stored in DB."""
   row_id: UUID
-  name: String
+  name: String @deprecated(reason: "Deprecated since 24.09.1. use `namespace` instead")
+
+  """Added in 24.09.1."""
+  namespace: String
+
+  """Added in 24.09.1."""
+  base_image_name: String
 
   """Added in 24.03.10."""
   project: String
   humanized_name: String
   tag: String
+
+  """Added in 24.09.1."""
+  tags: [KVPair]
+
+  """Added in 24.09.1."""
+  version: String
   registry: String
   architecture: String
   is_local: Boolean
@@ -349,6 +394,231 @@ type AgentSummaryList implements PaginatedList {
   total_count: Int!
 }
 
+"""Added in 24.12.0."""
+type DomainNode implements Node {
+  """The ID of the object"""
+  id: ID!
+  name: String
+  description: String
+  is_active: Boolean
+  created_at: DateTime
+  modified_at: DateTime
+  total_resource_slots: JSONString
+  allowed_vfolder_hosts: JSONString
+  allowed_docker_registries: [String]
+  dotfiles: Bytes
+  integration_id: String
+  scaling_groups(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ScalinGroupConnection
+}
+
+"""Added in 24.09.1."""
+scalar Bytes
+
+"""Added in 24.12.0."""
+type ScalinGroupConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [ScalinGroupEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""
+The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+"""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+}
+
+"""
+Added in 24.12.0. A Relay edge containing a `ScalinGroup` and its cursor.
+"""
+type ScalinGroupEdge {
+  """The item at the end of the edge"""
+  node: ScalingGroupNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Added in 24.12.0."""
+type ScalingGroupNode implements Node {
+  """The ID of the object"""
+  id: ID!
+  name: String
+  description: String
+  is_active: Boolean
+  is_public: Boolean
+  created_at: DateTime
+  wsproxy_addr: String
+  wsproxy_api_token: String
+  driver: String
+  driver_opts: JSONString
+  scheduler: String
+  scheduler_opts: JSONString
+  use_host_network: Boolean
+}
+
+"""
+Added in 24.09.0. Global ID of GQL relay spec. Base64 encoded version of "<node type name>:<node id>". UUID or string type values are also allowed.
+"""
+scalar GlobalIDField
+
+"""
+Added in 24.12.0. One of ['read_attribute', 'read_sensitive_attribute', 'update_attribute', 'create_user', 'create_project'].
+"""
+scalar DomainPermissionValueField
+
+"""Added in 24.12.0"""
+type DomainConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [DomainEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""Added in 24.12.0 A Relay edge containing a `Domain` and its cursor."""
+type DomainEdge {
+  """The item at the end of the edge"""
+  node: DomainNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Added in 24.12.0."""
+type AgentConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [AgentEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""Added in 24.12.0. A Relay edge containing a `Agent` and its cursor."""
+type AgentEdge {
+  """The item at the end of the edge"""
+  node: AgentNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Added in 24.12.0."""
+type AgentNode implements Node {
+  """The ID of the object"""
+  id: ID!
+  row_id: String
+  status: String
+  status_changed: DateTime
+  region: String
+  scaling_group: String
+  schedulable: Boolean
+  available_slots: JSONString
+  occupied_slots: JSONString
+
+  """Agent's address with port. (bind/advertised host:port)"""
+  addr: String
+  architecture: String
+  first_contact: DateTime
+  lost_at: DateTime
+  live_stat: JSONString
+  version: String
+  compute_plugins: JSONString
+  hardware_metadata: JSONString
+  auto_terminate_abusing_kernel: Boolean
+  local_config: JSONString
+  container_count: Int
+  kernel_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): KernelConnection
+
+  """
+  Added in 24.12.0. One of ['read_attribute', 'update_attribute', 'create_compute_session', 'create_service'].
+  """
+  permissions: [AgentPermissionField]
+}
+
+"""Added in 24.09.0."""
+type KernelConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [KernelEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""Added in 24.09.0. A Relay edge containing a `Kernel` and its cursor."""
+type KernelEdge {
+  """The item at the end of the edge"""
+  node: KernelNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Added in 24.09.0."""
+type KernelNode implements Node {
+  """The ID of the object"""
+  id: ID!
+
+  """ID of kernel."""
+  row_id: UUID
+  cluster_idx: Int
+  local_rank: Int
+  cluster_role: String
+  cluster_hostname: String
+  session_id: UUID
+  image: ImageNode
+  status: String
+  status_changed: DateTime
+  status_info: String
+  status_data: JSONString
+  created_at: DateTime
+  terminated_at: DateTime
+  starts_at: DateTime
+  scheduled_at: DateTime
+  agent_id: String
+  agent_addr: String
+  container_id: String
+  resource_opts: JSONString
+  occupied_slots: JSONString
+  live_stat: JSONString
+  abusing_report: JSONString
+  preopen_ports: [Int]
+}
+
+"""
+Added in 24.12.0. One of ['read_attribute', 'update_attribute', 'create_compute_session', 'create_service'].
+"""
+scalar AgentPermissionField
+
+"""
+Added in 24.12.0. A string value in the format '<SCOPE_TYPE>:<SCOPE_ID>'. <SCOPE_TYPE> should be one of [system, domain, project, user]. <SCOPE_ID> should be the ID value of the scope. e.g. `domain:default`, `user:123e4567-e89b-12d3-a456-426614174000`.
+"""
+scalar ScopeField
+
 type Domain {
   name: String
   description: String
@@ -398,23 +668,6 @@ type UserConnection {
 
   """Total count of the GQL nodes of the query."""
   count: Int
-}
-
-"""
-The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
-"""
-type PageInfo {
-  """When paginating forwards, are there more items?"""
-  hasNextPage: Boolean!
-
-  """When paginating backwards, are there more items?"""
-  hasPreviousPage: Boolean!
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: String
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: String
 }
 
 """Added in 24.03.0 A Relay edge containing a `User` and its cursor."""
@@ -504,12 +757,24 @@ type Group {
 
 type Image {
   id: UUID
-  name: String
+  name: String @deprecated(reason: "Deprecated since 24.09.1. use `namespace` instead")
+
+  """Added in 24.09.1."""
+  namespace: String
+
+  """Added in 24.09.1."""
+  base_image_name: String
 
   """Added in 24.03.10."""
   project: String
   humanized_name: String
   tag: String
+
+  """Added in 24.09.1."""
+  tags: [KVPair]
+
+  """Added in 24.09.1."""
+  version: String
   registry: String
   architecture: String
   is_local: Boolean
@@ -956,58 +1221,6 @@ Added in 24.09.0. One of ['read_attribute', 'update_attribute', 'delete_session'
 scalar SessionPermissionValueField
 
 """Added in 24.09.0."""
-type KernelConnection {
-  """Pagination data for this connection."""
-  pageInfo: PageInfo!
-
-  """Contains the nodes in this connection."""
-  edges: [KernelEdge]!
-
-  """Total count of the GQL nodes of the query."""
-  count: Int
-}
-
-"""Added in 24.09.0. A Relay edge containing a `Kernel` and its cursor."""
-type KernelEdge {
-  """The item at the end of the edge"""
-  node: KernelNode
-
-  """A cursor for use in pagination"""
-  cursor: String!
-}
-
-"""Added in 24.09.0."""
-type KernelNode implements Node {
-  """The ID of the object"""
-  id: ID!
-
-  """ID of kernel."""
-  row_id: UUID
-  cluster_idx: Int
-  local_rank: Int
-  cluster_role: String
-  cluster_hostname: String
-  session_id: UUID
-  image: ImageNode
-  status: String
-  status_changed: DateTime
-  status_info: String
-  status_data: JSONString
-  created_at: DateTime
-  terminated_at: DateTime
-  starts_at: DateTime
-  scheduled_at: DateTime
-  agent_id: String
-  agent_addr: String
-  container_id: String
-  resource_opts: JSONString
-  occupied_slots: JSONString
-  live_stat: JSONString
-  abusing_report: JSONString
-  preopen_ports: [Int]
-}
-
-"""Added in 24.09.0."""
 type ComputeSessionConnection {
   """Pagination data for this connection."""
   pageInfo: PageInfo!
@@ -1029,11 +1242,6 @@ type ComputeSessionEdge {
   """A cursor for use in pagination"""
   cursor: String!
 }
-
-"""
-Added in 24.09.0. Global ID of GQL relay spec. Base64 encoded version of "<node type name>:<node id>". UUID or string type values are also allowed.
-"""
-scalar GlobalIDField
 
 type ComputeSessionList implements PaginatedList {
   items: [ComputeSession]!
@@ -1258,9 +1466,7 @@ type ContainerRegistryNode implements Node {
   """The ID of the object"""
   id: ID!
 
-  """
-  Added in 24.09.0. The undecoded UUID type id of DB container_registries row.
-  """
+  """Added in 24.09.0. The UUID type id of DB container_registries row."""
   row_id: UUID
   name: String
 
@@ -1393,6 +1599,12 @@ type Mutations {
   To purge domain, there should be no users and groups in the target domain.
   """
   purge_domain(name: String!): PurgeDomain
+
+  """Added in 24.12.0."""
+  create_domain_node(input: CreateDomainNodeInput!): CreateDomainNode
+
+  """Added in 24.12.0."""
+  modify_domain_node(input: ModifyDomainNodeInput!): ModifyDomainNode
   create_group(name: String!, props: GroupInput!): CreateGroup
   modify_group(gid: UUID!, props: ModifyGroupInput!): ModifyGroup
 
@@ -1566,6 +1778,9 @@ type Mutations {
   modify_container_registry(hostname: String!, props: ModifyContainerRegistryInput!): ModifyContainerRegistry
   delete_container_registry(hostname: String!): DeleteContainerRegistry
   modify_endpoint(endpoint_id: UUID!, props: ModifyEndpointInput!): ModifyEndpoint
+
+  """Added in 24.09.0."""
+  check_and_transit_session_status(input: CheckAndTransitStatusInput!): CheckAndTransitStatus
 }
 
 type ModifyAgent {
@@ -1624,6 +1839,47 @@ To purge domain, there should be no users and groups in the target domain.
 type PurgeDomain {
   ok: Boolean
   msg: String
+}
+
+"""Added in 24.12.0."""
+type CreateDomainNode {
+  ok: Boolean
+  msg: String
+  item: DomainNode
+}
+
+"""Added in 24.12.0."""
+input CreateDomainNodeInput {
+  name: String!
+  description: String
+  is_active: Boolean = true
+  total_resource_slots: JSONString = "{}"
+  allowed_vfolder_hosts: JSONString = "{}"
+  allowed_docker_registries: [String] = []
+  integration_id: String = null
+  dotfiles: Bytes = "90"
+  scaling_groups: [String]
+}
+
+"""Added in 24.12.0."""
+type ModifyDomainNode {
+  item: DomainNode
+  client_mutation_id: String
+}
+
+"""Added in 24.12.0."""
+input ModifyDomainNodeInput {
+  id: GlobalIDField!
+  description: String
+  is_active: Boolean
+  total_resource_slots: JSONString
+  allowed_vfolder_hosts: JSONString
+  allowed_docker_registries: [String]
+  integration_id: String
+  dotfiles: Bytes
+  sgroups_to_add: [String]
+  sgroups_to_remove: [String]
+  client_mutation_id: String
 }
 
 type CreateGroup {
@@ -2324,4 +2580,16 @@ input ExtraMountInput {
   Added in 24.03.4. Set permission of this mount. Should be one of (ro,rw,wd). Default is null
   """
   permission: String
+}
+
+"""Added in 24.12.0"""
+type CheckAndTransitStatus {
+  item: [ComputeSessionNode]
+  client_mutation_id: String
+}
+
+"""Added in 24.12.0."""
+input CheckAndTransitStatusInput {
+  ids: [GlobalIDField]!
+  client_mutation_id: String
 }

--- a/react/src/components/AliasedImageDoubleTags.tsx
+++ b/react/src/components/AliasedImageDoubleTags.tsx
@@ -1,0 +1,77 @@
+import { useBackendAIImageMetaData } from '../hooks';
+import DoubleTag, { DoubleTagObjectValue } from './DoubleTag';
+import Flex from './Flex';
+import TextHighlighter from './TextHighlighter';
+import { AliasedImageDoubleTagsFragment$key } from './__generated__/AliasedImageDoubleTagsFragment.graphql';
+import graphql from 'babel-plugin-relay/macro';
+import _ from 'lodash';
+import React from 'react';
+import { useFragment } from 'react-relay';
+
+interface AliasedImageDoubleTagsProps extends DoubleTagObjectValue {
+  imageFrgmt?: AliasedImageDoubleTagsFragment$key | null;
+  highlightKeyword?: string;
+}
+
+const AliasedImageDoubleTags: React.FC<AliasedImageDoubleTagsProps> = ({
+  imageFrgmt,
+  highlightKeyword,
+  ...doubleTagProps
+}) => {
+  const images = useFragment(
+    graphql`
+      fragment AliasedImageDoubleTagsFragment on ImageNode {
+        labels {
+          key
+          value
+        }
+        tags @since(version: "24.09.1.") {
+          key
+          value
+        }
+      }
+    `,
+    imageFrgmt,
+  );
+  const [, { tagAlias }] = useBackendAIImageMetaData();
+
+  return (
+    <Flex direction="row" align="start" gap={'xxs'}>
+      {_.map(images?.tags, (tag: { key: string; value: string }) => {
+        const isCustomized = _.includes(tag.key, 'customized_');
+        // If the tag is customized, we need to find the corresponding label instead of using the tag value (hash).
+        const tagValue = isCustomized
+          ? _.find(images?.labels, {
+              key: 'ai.backend.customized-image.name',
+            })?.value
+          : tag.value;
+        return (
+          <DoubleTag
+            key={tag.key}
+            values={[
+              {
+                label: (
+                  <TextHighlighter keyword={highlightKeyword} key={tag.key}>
+                    {tagAlias(tag.key)}
+                  </TextHighlighter>
+                ),
+                color: isCustomized ? 'cyan' : doubleTagProps.color,
+              },
+              {
+                label: (
+                  <TextHighlighter keyword={highlightKeyword} key={tagValue}>
+                    {tagValue}
+                  </TextHighlighter>
+                ),
+                color: isCustomized ? 'cyan' : doubleTagProps.color,
+              },
+            ]}
+            {...doubleTagProps}
+          />
+        );
+      })}
+    </Flex>
+  );
+};
+
+export default AliasedImageDoubleTags;

--- a/react/src/components/AliasedImageDoubleTags.tsx
+++ b/react/src/components/AliasedImageDoubleTags.tsx
@@ -25,7 +25,7 @@ const AliasedImageDoubleTags: React.FC<AliasedImageDoubleTagsProps> = ({
           key
           value
         }
-        tags @since(version: "24.09.1.") {
+        tags @since(version: "24.09.1") {
           key
           value
         }

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -1,30 +1,42 @@
 import Flex from '../components/Flex';
 import {
   BaseImageTags,
-  BaseVersionTags,
   ConstraintTags,
   LangTags,
 } from '../components/ImageTags';
 import TableColumnsSettingModal from '../components/TableColumnsSettingModal';
-import { getImageFullName, localeCompare } from '../helper';
+import { filterNonNullItems, getImageFullName, localeCompare } from '../helper';
 import {
   useBackendAIImageMetaData,
   useSuspendedBackendaiClient,
   useUpdatableState,
 } from '../hooks';
+import AliasedImageDoubleTags from './AliasedImageDoubleTags';
+import TextHighlighter from './TextHighlighter';
 import { CustomizedImageListForgetAndUntagMutation } from './__generated__/CustomizedImageListForgetAndUntagMutation.graphql';
 import {
   CustomizedImageListQuery,
   CustomizedImageListQuery$data,
 } from './__generated__/CustomizedImageListQuery.graphql';
-import { DeleteOutlined, SettingOutlined } from '@ant-design/icons';
+import CopyButton from './lablupTalkativotUI/CopyButton';
+import {
+  DeleteOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+  SettingOutlined,
+} from '@ant-design/icons';
 import { useLocalStorageState } from 'ahooks';
 import { App, Button, Popconfirm, Table, theme, Typography } from 'antd';
 import { AnyObject } from 'antd/es/_util/type';
 import { ColumnsType, ColumnType } from 'antd/es/table';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
-import React, { PropsWithChildren, useState, useTransition } from 'react';
+import React, {
+  PropsWithChildren,
+  useMemo,
+  useState,
+  useTransition,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyLoadQuery, useMutation } from 'react-relay';
 
@@ -45,6 +57,8 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
   const [customizedImageListFetchKey, updateCustomizedImageListFetchKey] =
     useUpdatableState('initial-fetch');
   const [inFlightImageId, setInFlightImageId] = useState<string>();
+  const [imageSearch, setImageSearch] = useState('');
+  const [isPendingSearchTransition, startSearchTransition] = useTransition();
   const [
     ,
     {
@@ -53,6 +67,9 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
       getBaseVersion,
       getBaseImage,
       getConstraints,
+      tagAlias,
+      getLang,
+      getBaseImages,
     },
   ] = useBackendAIImageMetaData();
 
@@ -73,6 +90,13 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
           }
           supported_accelerators
           namespace @since(version: "24.09.1.")
+          base_image_name @since(version: "24.09.1.")
+          tags @since(version: "24.09.1.") {
+            key
+            value
+          }
+          version @since(version: "24.09.1.")
+          ...AliasedImageDoubleTagsFragment
         }
       }
     `,
@@ -100,18 +124,128 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
       }
     `);
 
+  // Sort images by humanized_name to prevent the image list from jumping around when the images are updated
+  // TODO: after `images` query  supports sort order, we should remove this line
+  const defaultSortedImages = useMemo(
+    () => _.sortBy(customized_images, (image) => image?.humanized_name),
+    [customized_images],
+  );
+
+  const imageFilterValues = useMemo(() => {
+    return defaultSortedImages?.map((image) => {
+      return {
+        namespace: supportExtendedImageInfo ? image?.namespace : image?.name,
+        fullName: getImageFullName(image) || '',
+        digest: image?.digest || '',
+        // ------------ need only before 24.09.1 ------------
+        lang: image?.name ? getLang(image.name) : '',
+        baseversion: getBaseVersion(getImageFullName(image) || ''),
+        baseimage:
+          image?.tag && image?.name ? getBaseImages(image.tag, image.name) : [],
+        constraints:
+          image?.tag && image?.labels
+            ? getConstraints(
+                image.tag,
+                image.labels as { key: string; value: string }[],
+              )
+            : [],
+        isCustomized: image?.tag
+          ? image.tag.indexOf('customized') !== -1
+          : false,
+        // -------------------------------------------------
+        // ------------ need only after 24.09.1 ------------
+        baseImageName: supportExtendedImageInfo ? image?.base_image_name : '',
+        tags: supportExtendedImageInfo ? image?.tags : [],
+        version: supportExtendedImageInfo ? image?.version : '',
+        // -------------------------------------------------
+      };
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultSortedImages]);
+
+  const filteredImageData = useMemo(() => {
+    if (_.isEmpty(imageSearch)) return defaultSortedImages;
+    const regExp = new RegExp(`${_.escapeRegExp(imageSearch)}`, 'i');
+    return _.filter(defaultSortedImages, (image, idx) => {
+      return _.some(image, (value, key) => {
+        if (key === 'id') return false;
+        if (['digest', 'architecture', 'registry'].includes(key))
+          return regExp.test(_.toString(value));
+        const curFilterValues = imageFilterValues[idx] || {};
+        const baseVersionMatch = regExp.test(curFilterValues.baseversion);
+        const baseImagesMatch = _.some(curFilterValues.baseimage, (value) =>
+          regExp.test(value),
+        );
+        const constraintsMatch = _.some(
+          curFilterValues.constraints,
+          (constraint) => regExp.test(constraint),
+        );
+        const customizedMatch = curFilterValues.isCustomized
+          ? regExp.test('customized')
+          : false;
+        const langMatch = regExp.test(curFilterValues.lang);
+        const namespaceMatch = regExp.test(curFilterValues.namespace || '');
+        const fullNameMatch = regExp.test(curFilterValues.fullName);
+        const tagsMatch = _.some(
+          curFilterValues.tags,
+          (tag: { key: string; value: string }) =>
+            regExp.test(tag.key) || regExp.test(tag.value),
+        );
+        const versionMatch = regExp.test(curFilterValues.version || '');
+        const digestMatch = regExp.test(curFilterValues.digest);
+        return (
+          baseVersionMatch ||
+          baseImagesMatch ||
+          constraintsMatch ||
+          langMatch ||
+          namespaceMatch ||
+          customizedMatch ||
+          fullNameMatch ||
+          tagsMatch ||
+          versionMatch ||
+          digestMatch
+        );
+      });
+    });
+  }, [imageSearch, imageFilterValues, defaultSortedImages]);
+
   const columns: ColumnsType<CommittedImage> = [
+    {
+      title: t('environment.FullImagePath'),
+      key: 'fullImagePath',
+      render: (row) => (
+        <Flex gap={'xxs'}>
+          <TextHighlighter keyword={imageSearch}>
+            {getImageFullName(row) || ''}
+          </TextHighlighter>
+          <CopyButton
+            type="text"
+            style={{ color: token.colorPrimary }}
+            copyable={{
+              text: getImageFullName(row) || '',
+            }}
+          />
+        </Flex>
+      ),
+      sorter: (a, b) => localeCompare(getImageFullName(a), getImageFullName(b)),
+    },
     {
       title: t('environment.Registry'),
       dataIndex: 'registry',
       key: 'registry',
       sorter: (a, b) => localeCompare(a?.registry, b?.registry),
+      render: (text) => (
+        <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
+      ),
     },
     {
       title: t('environment.Architecture'),
       dataIndex: 'architecture',
       key: 'architecture',
       sorter: (a, b) => localeCompare(a?.architecture, b?.architecture),
+      render: (text) => (
+        <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
+      ),
     },
     ...(supportExtendedImageInfo
       ? [
@@ -121,6 +255,46 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
             dataIndex: 'namespace',
             sorter: (a: CommittedImage, b: CommittedImage) =>
               localeCompare(a?.namespace, b?.namespace),
+            render: (text: string) => (
+              <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
+            ),
+          },
+          {
+            title: t('environment.BaseImageName'),
+            key: 'base_image_name',
+            dataIndex: 'base_image_name',
+            sorter: (a: CommittedImage, b: CommittedImage) =>
+              localeCompare(a?.base_image_name, b?.base_image_name),
+            render: (text: string) => (
+              <TextHighlighter keyword={imageSearch}>
+                {tagAlias(text)}
+              </TextHighlighter>
+            ),
+          },
+          {
+            title: t('environment.Version'),
+            key: 'version',
+            dataIndex: 'version',
+            sorter: (a: CommittedImage, b: CommittedImage) =>
+              localeCompare(a?.version, b?.version),
+            render: (text: string) => (
+              <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
+            ),
+          },
+          {
+            title: t('environment.Tags'),
+            key: 'tags',
+            dataIndex: 'tags',
+            render: (
+              text: Array<{ key: string; value: string }>,
+              row: CommittedImage,
+            ) => (
+              <AliasedImageDoubleTags
+                imageFrgmt={row}
+                label={undefined}
+                highlightKeyword={imageSearch}
+              />
+            ),
           },
         ]
       : [
@@ -139,84 +313,87 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
               <span>{getNamespace(getImageFullName(row) || '')}</span>
             ),
           },
+          {
+            title: t('environment.Language'),
+            key: 'lang',
+            sorter: (a: CommittedImage, b: CommittedImage) =>
+              localeCompare(
+                getImageLang(getImageFullName(a) || ''),
+                getImageLang(getImageFullName(b) || ''),
+              ),
+            render: (text: string, row: CommittedImage) => (
+              <LangTags image={getImageFullName(row) || ''} color="green" />
+            ),
+          },
+          {
+            title: t('environment.Version'),
+            key: 'baseversion',
+            dataIndex: 'baseversion',
+            sorter: (a: CommittedImage, b: CommittedImage) =>
+              localeCompare(
+                getBaseVersion(getImageFullName(a) || ''),
+                getBaseVersion(getImageFullName(b) || ''),
+              ),
+            render: (text: string, row: CommittedImage) => (
+              <TextHighlighter keyword={imageSearch}>
+                {getBaseVersion(getImageFullName(row) || '')}
+              </TextHighlighter>
+            ),
+          },
+          {
+            title: t('environment.Base'),
+            key: 'baseimage',
+            dataIndex: 'baseimage',
+            sorter: (a: CommittedImage, b: CommittedImage) =>
+              localeCompare(
+                getBaseImage(getBaseImage(getImageFullName(a) || '')),
+                getBaseImage(getBaseImage(getImageFullName(b) || '')),
+              ),
+            render: (text: string, row: CommittedImage) => (
+              <BaseImageTags image={getImageFullName(row) || ''} />
+            ),
+          },
+          {
+            title: t('environment.Constraint'),
+            key: 'constraint',
+            dataIndex: 'constraint',
+            sorter: (a: CommittedImage, b: CommittedImage) => {
+              const requirementA =
+                a?.tag && b?.labels
+                  ? getConstraints(
+                      a?.tag,
+                      a?.labels as { key: string; value: string }[],
+                    )[0] || ''
+                  : '';
+              const requirementB =
+                b?.tag && b?.labels
+                  ? getConstraints(
+                      b?.tag,
+                      b?.labels as { key: string; value: string }[],
+                    )[0] || ''
+                  : '';
+              return localeCompare(requirementA, requirementB);
+            },
+            render: (text: string, row: CommittedImage) =>
+              row?.tag ? (
+                <ConstraintTags
+                  tag={row?.tag}
+                  labels={row?.labels as Array<{ key: string; value: string }>}
+                  highlightKeyword={imageSearch}
+                />
+              ) : null,
+          },
         ]),
-    {
-      title: t('environment.Language'),
-      key: 'lang',
-      sorter: (a, b) => {
-        const langA = getImageLang(getImageFullName(a) || '');
-        const langB = getImageLang(getImageFullName(b) || '');
-        return langA && langB ? langA.localeCompare(langB) : 0;
-      },
-      render: (text, row) => (
-        <LangTags image={getImageFullName(row) || ''} color="green" />
-      ),
-    },
-    {
-      title: t('environment.Version'),
-      key: 'baseversion',
-      sorter: (a, b) => {
-        const baseversionA = getBaseVersion(getImageFullName(a) || '');
-        const baseversionB = getBaseVersion(getImageFullName(b) || '');
-        return baseversionA && baseversionB
-          ? baseversionA.localeCompare(baseversionB)
-          : 0;
-      },
-      render: (text, row) => (
-        <BaseVersionTags image={getImageFullName(row) || ''} color="green" />
-      ),
-    },
-    {
-      title: t('environment.Base'),
-      key: 'baseimage',
-      sorter: (a, b) => {
-        const baseimageA = getBaseImage(getImageFullName(a) || '');
-        const baseimageB = getBaseImage(getImageFullName(b) || '');
-        return baseimageA && baseimageB
-          ? baseimageA.localeCompare(baseimageB)
-          : 0;
-      },
-      render: (text, row) => (
-        <BaseImageTags image={getImageFullName(row) || ''} />
-      ),
-    },
-    {
-      title: t('environment.Constraint'),
-      key: 'constraint',
-      sorter: (a, b) => {
-        const requirementA =
-          a?.tag && b?.labels
-            ? getConstraints(
-                a?.tag,
-                a?.labels as { key: string; value: string }[],
-              )[0] || ''
-            : '';
-        const requirementB =
-          b?.tag && b?.labels
-            ? getConstraints(
-                b?.tag,
-                b?.labels as { key: string; value: string }[],
-              )[0] || ''
-            : '';
-        if (requirementA === '' && requirementB === '') return 0;
-        if (requirementA === '') return -1;
-        if (requirementB === '') return 1;
-        return requirementA.localeCompare(requirementB);
-      },
-      render: (text, row) =>
-        row?.tag ? (
-          <ConstraintTags
-            tag={row.tag}
-            labels={row?.labels as { key: string; value: string }[]}
-          />
-        ) : null,
-    },
     {
       title: t('environment.Digest'),
       dataIndex: 'digest',
       key: 'digest',
-      sorter: (a, b) =>
-        a?.digest && b?.digest ? a.digest.localeCompare(b.digest) : 0,
+      sorter: (a, b) => localeCompare(a?.digest, b?.digest),
+      render: (text) => (
+        <Typography.Text ellipsis={{ tooltip: true }} style={{ maxWidth: 200 }}>
+          <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
+        </Typography.Text>
+      ),
     },
     {
       title: t('general.Control'),
@@ -224,15 +401,6 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
       fixed: 'right',
       render: (text, row) => (
         <Flex direction="row" align="stretch" justify="center" gap="xxs">
-          <Typography.Text
-            copyable={{
-              text: getImageFullName(row) || '',
-            }}
-            style={{
-              paddingTop: token.paddingXXS,
-              paddingBottom: token.paddingXXS,
-            }}
-          />
           <Popconfirm
             title={t('dialog.ask.DoYouWantToProceed')}
             description={t('dialog.warning.CannotBeUndone')}
@@ -293,14 +461,36 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
   return (
     <Flex direction="column" align="stretch" gap={'xs'}>
       <Flex direction="column" align="stretch">
+        <Flex justify="end" style={{ padding: token.paddingSM }} gap="xs">
+          <Input
+            allowClear
+            prefix={<SearchOutlined />}
+            placeholder={t('environment.SearchImages')}
+            onChange={(e) => {
+              startSearchTransition(() => setImageSearch(e.target.value));
+            }}
+            style={{
+              width: 200,
+            }}
+          />
+          <Button
+            icon={<ReloadOutlined />}
+            loading={isRefetchPending}
+            onClick={() => {
+              startRefetchTransition(() => updateCustomizedImageListFetchKey());
+            }}
+          >
+            {t('button.Refresh')}
+          </Button>
+        </Flex>
         <Table
-          loading={isRefetchPending}
+          loading={isPendingSearchTransition}
           columns={
             columns.filter((column) =>
               displayedColumnKeys?.includes(_.toString(column.key)),
             ) as ColumnType<AnyObject>[]
           }
-          dataSource={customized_images as readonly AnyObject[] | undefined}
+          dataSource={filterNonNullItems(filteredImageData)}
           rowKey="id"
           scroll={{ x: 'max-content' }}
           pagination={false}

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -26,7 +26,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import { useLocalStorageState } from 'ahooks';
-import { App, Button, Popconfirm, Table, theme, Typography } from 'antd';
+import { App, Button, Input, Popconfirm, Table, theme, Typography } from 'antd';
 import { AnyObject } from 'antd/es/_util/type';
 import { ColumnsType, ColumnType } from 'antd/es/table';
 import graphql from 'babel-plugin-relay/macro';

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -78,7 +78,7 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
       query CustomizedImageListQuery {
         customized_images {
           id
-          name @deprecatedSince(version: "24.09.1.")
+          name @deprecatedSince(version: "24.09.1")
           humanized_name
           tag
           registry
@@ -89,13 +89,13 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
             value
           }
           supported_accelerators
-          namespace @since(version: "24.09.1.")
-          base_image_name @since(version: "24.09.1.")
-          tags @since(version: "24.09.1.") {
+          namespace @since(version: "24.09.1")
+          base_image_name @since(version: "24.09.1")
+          tags @since(version: "24.09.1") {
             key
             value
           }
-          version @since(version: "24.09.1.")
+          version @since(version: "24.09.1")
           ...AliasedImageDoubleTagsFragment
         }
       }

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -1,0 +1,337 @@
+import Flex from '../components/Flex';
+import {
+  BaseImageTags,
+  BaseVersionTags,
+  ConstraintTags,
+  LangTags,
+} from '../components/ImageTags';
+import TableColumnsSettingModal from '../components/TableColumnsSettingModal';
+import { getImageFullName, localeCompare } from '../helper';
+import {
+  useBackendAIImageMetaData,
+  useSuspendedBackendaiClient,
+  useUpdatableState,
+} from '../hooks';
+import { CustomizedImageListForgetAndUntagMutation } from './__generated__/CustomizedImageListForgetAndUntagMutation.graphql';
+import {
+  CustomizedImageListQuery,
+  CustomizedImageListQuery$data,
+} from './__generated__/CustomizedImageListQuery.graphql';
+import { DeleteOutlined, SettingOutlined } from '@ant-design/icons';
+import { useLocalStorageState } from 'ahooks';
+import { App, Button, Popconfirm, Table, theme, Typography } from 'antd';
+import { AnyObject } from 'antd/es/_util/type';
+import { ColumnsType, ColumnType } from 'antd/es/table';
+import graphql from 'babel-plugin-relay/macro';
+import _ from 'lodash';
+import React, { PropsWithChildren, useState, useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLazyLoadQuery, useMutation } from 'react-relay';
+
+export type CommittedImage = NonNullable<
+  CustomizedImageListQuery$data['customized_images']
+>[number];
+
+const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { message } = App.useApp();
+  const baiClient = useSuspendedBackendaiClient();
+  const supportExtendedImageInfo =
+    baiClient?.supports('extended-image-info') ?? false;
+
+  const [isOpenColumnsSetting, setIsOpenColumnsSetting] = useState(false);
+  const [isRefetchPending, startRefetchTransition] = useTransition();
+  const [customizedImageListFetchKey, updateCustomizedImageListFetchKey] =
+    useUpdatableState('initial-fetch');
+  const [inFlightImageId, setInFlightImageId] = useState<string>();
+  const [
+    ,
+    {
+      getNamespace,
+      getImageLang,
+      getBaseVersion,
+      getBaseImage,
+      getConstraints,
+    },
+  ] = useBackendAIImageMetaData();
+
+  const { customized_images } = useLazyLoadQuery<CustomizedImageListQuery>(
+    graphql`
+      query CustomizedImageListQuery {
+        customized_images {
+          id
+          name @deprecatedSince(version: "24.09.1.")
+          humanized_name
+          tag
+          registry
+          architecture
+          digest
+          labels {
+            key
+            value
+          }
+          supported_accelerators
+          namespace @since(version: "24.09.1.")
+        }
+      }
+    `,
+    {},
+    {
+      fetchPolicy:
+        customizedImageListFetchKey === 'initial-fetch'
+          ? 'store-and-network'
+          : 'network-only',
+      fetchKey: customizedImageListFetchKey,
+    },
+  );
+
+  const [commitForgetAndUntag, isInflightForgetAndUntag] =
+    useMutation<CustomizedImageListForgetAndUntagMutation>(graphql`
+      mutation CustomizedImageListForgetAndUntagMutation($id: String!) {
+        untag_image_from_registry(image_id: $id) {
+          ok
+          msg
+        }
+        forget_image_by_id(image_id: $id) {
+          ok
+          msg
+        }
+      }
+    `);
+
+  const columns: ColumnsType<CommittedImage> = [
+    {
+      title: t('environment.Registry'),
+      dataIndex: 'registry',
+      key: 'registry',
+      sorter: (a, b) => localeCompare(a?.registry, b?.registry),
+    },
+    {
+      title: t('environment.Architecture'),
+      dataIndex: 'architecture',
+      key: 'architecture',
+      sorter: (a, b) => localeCompare(a?.architecture, b?.architecture),
+    },
+    ...(supportExtendedImageInfo
+      ? [
+          {
+            title: t('environment.Namespace'),
+            key: 'namespace',
+            dataIndex: 'namespace',
+            sorter: (a: CommittedImage, b: CommittedImage) =>
+              localeCompare(a?.namespace, b?.namespace),
+          },
+        ]
+      : [
+          {
+            title: t('environment.Namespace'),
+            key: 'name',
+            dataIndex: 'name',
+            sorter: (a: CommittedImage, b: CommittedImage) => {
+              const namespaceA = getNamespace(getImageFullName(a) || '');
+              const namespaceB = getNamespace(getImageFullName(b) || '');
+              return namespaceA && namespaceB
+                ? namespaceA.localeCompare(namespaceB)
+                : 0;
+            },
+            render: (text: string, row: CommittedImage) => (
+              <span>{getNamespace(getImageFullName(row) || '')}</span>
+            ),
+          },
+        ]),
+    {
+      title: t('environment.Language'),
+      key: 'lang',
+      sorter: (a, b) => {
+        const langA = getImageLang(getImageFullName(a) || '');
+        const langB = getImageLang(getImageFullName(b) || '');
+        return langA && langB ? langA.localeCompare(langB) : 0;
+      },
+      render: (text, row) => (
+        <LangTags image={getImageFullName(row) || ''} color="green" />
+      ),
+    },
+    {
+      title: t('environment.Version'),
+      key: 'baseversion',
+      sorter: (a, b) => {
+        const baseversionA = getBaseVersion(getImageFullName(a) || '');
+        const baseversionB = getBaseVersion(getImageFullName(b) || '');
+        return baseversionA && baseversionB
+          ? baseversionA.localeCompare(baseversionB)
+          : 0;
+      },
+      render: (text, row) => (
+        <BaseVersionTags image={getImageFullName(row) || ''} color="green" />
+      ),
+    },
+    {
+      title: t('environment.Base'),
+      key: 'baseimage',
+      sorter: (a, b) => {
+        const baseimageA = getBaseImage(getImageFullName(a) || '');
+        const baseimageB = getBaseImage(getImageFullName(b) || '');
+        return baseimageA && baseimageB
+          ? baseimageA.localeCompare(baseimageB)
+          : 0;
+      },
+      render: (text, row) => (
+        <BaseImageTags image={getImageFullName(row) || ''} />
+      ),
+    },
+    {
+      title: t('environment.Constraint'),
+      key: 'constraint',
+      sorter: (a, b) => {
+        const requirementA =
+          a?.tag && b?.labels
+            ? getConstraints(
+                a?.tag,
+                a?.labels as { key: string; value: string }[],
+              )[0] || ''
+            : '';
+        const requirementB =
+          b?.tag && b?.labels
+            ? getConstraints(
+                b?.tag,
+                b?.labels as { key: string; value: string }[],
+              )[0] || ''
+            : '';
+        if (requirementA === '' && requirementB === '') return 0;
+        if (requirementA === '') return -1;
+        if (requirementB === '') return 1;
+        return requirementA.localeCompare(requirementB);
+      },
+      render: (text, row) =>
+        row?.tag ? (
+          <ConstraintTags
+            tag={row.tag}
+            labels={row?.labels as { key: string; value: string }[]}
+          />
+        ) : null,
+    },
+    {
+      title: t('environment.Digest'),
+      dataIndex: 'digest',
+      key: 'digest',
+      sorter: (a, b) =>
+        a?.digest && b?.digest ? a.digest.localeCompare(b.digest) : 0,
+    },
+    {
+      title: t('general.Control'),
+      key: 'control',
+      fixed: 'right',
+      render: (text, row) => (
+        <Flex direction="row" align="stretch" justify="center" gap="xxs">
+          <Typography.Text
+            copyable={{
+              text: getImageFullName(row) || '',
+            }}
+            style={{
+              paddingTop: token.paddingXXS,
+              paddingBottom: token.paddingXXS,
+            }}
+          />
+          <Popconfirm
+            title={t('dialog.ask.DoYouWantToProceed')}
+            description={t('dialog.warning.CannotBeUndone')}
+            okType="danger"
+            okText={t('button.Delete')}
+            onConfirm={() => {
+              if (row?.id) {
+                setInFlightImageId(row.id + customizedImageListFetchKey);
+                commitForgetAndUntag({
+                  variables: {
+                    id: row.id,
+                  },
+                  onCompleted(data, errors) {
+                    if (errors) {
+                      message.error(errors[0]?.message);
+                      return;
+                    }
+                    startRefetchTransition(() => {
+                      updateCustomizedImageListFetchKey();
+                    });
+                    message.success(
+                      t('environment.CustomizedImageSuccessfullyDeleted'),
+                    );
+                  },
+                  onError(err) {
+                    message.error(err?.message);
+                  },
+                });
+              }
+            }}
+          >
+            <Button
+              type="text"
+              icon={<DeleteOutlined />}
+              danger
+              loading={
+                isInflightForgetAndUntag &&
+                inFlightImageId === row?.id + customizedImageListFetchKey
+              }
+              disabled={
+                isInflightForgetAndUntag &&
+                inFlightImageId !== row?.id + customizedImageListFetchKey
+              }
+            />
+          </Popconfirm>
+        </Flex>
+      ),
+    },
+  ];
+
+  const [displayedColumnKeys, setDisplayedColumnKeys] = useLocalStorageState(
+    'backendaiwebui.CustomizedImageList.displayedColumnKeys',
+    {
+      defaultValue: columns.map((column) => _.toString(column.key)),
+    },
+  );
+
+  return (
+    <Flex direction="column" align="stretch" gap={'xs'}>
+      <Flex direction="column" align="stretch">
+        <Table
+          loading={isRefetchPending}
+          columns={
+            columns.filter((column) =>
+              displayedColumnKeys?.includes(_.toString(column.key)),
+            ) as ColumnType<AnyObject>[]
+          }
+          dataSource={customized_images as readonly AnyObject[] | undefined}
+          rowKey="id"
+          scroll={{ x: 'max-content' }}
+          pagination={false}
+        />
+        <Flex
+          justify="end"
+          style={{
+            padding: token.paddingXXS,
+          }}
+        >
+          <Button
+            type="text"
+            icon={<SettingOutlined />}
+            onClick={() => {
+              setIsOpenColumnsSetting(true);
+            }}
+          />
+        </Flex>
+      </Flex>
+      <TableColumnsSettingModal
+        open={isOpenColumnsSetting}
+        onRequestClose={(values) => {
+          values?.selectedColumnKeys &&
+            setDisplayedColumnKeys(values?.selectedColumnKeys);
+          setIsOpenColumnsSetting(!isOpenColumnsSetting);
+        }}
+        columns={columns}
+        displayedColumnKeys={displayedColumnKeys ? displayedColumnKeys : []}
+      />
+    </Flex>
+  );
+};
+
+export default CustomizedImageList;

--- a/react/src/components/DoubleTag.tsx
+++ b/react/src/components/DoubleTag.tsx
@@ -32,7 +32,7 @@ const DoubleTag: React.FC<{
   return (
     <Flex direction="row">
       {_.map(objectValues, (objValue, idx) => {
-        return (
+        return !_.isEmpty(objValue.label) ? (
           <Tag
             key={idx}
             style={
@@ -44,7 +44,7 @@ const DoubleTag: React.FC<{
           >
             {objValue.label}
           </Tag>
-        );
+        ) : null;
       })}
     </Flex>
   );

--- a/react/src/components/EnvVarFormList.tsx
+++ b/react/src/components/EnvVarFormList.tsx
@@ -165,7 +165,7 @@ export function isSensitiveEnv(key: string) {
 }
 
 export function sanitizeSensitiveEnv(envs: EnvVarFormListValue[]) {
-  return envs.map((env) => {
+  return _.map(envs, (env) => {
     if (env && isSensitiveEnv(env.variable)) {
       return { ...env, value: '' };
     }

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -112,7 +112,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
       query ImageEnvironmentSelectFormItemsQuery($installed: Boolean) {
         images(is_installed: $installed) {
           id
-          name @deprecatedSince(version: "24.09.1.")
+          name @deprecatedSince(version: "24.09.1")
           humanized_name
           tag
           registry
@@ -128,13 +128,13 @@ const ImageEnvironmentSelectFormItems: React.FC<
             key
             value
           }
-          namespace @since(version: "24.09.1.")
-          base_image_name @since(version: "24.09.1.")
-          tags @since(version: "24.09.1.") {
+          namespace @since(version: "24.09.1")
+          base_image_name @since(version: "24.09.1")
+          tags @since(version: "24.09.1") {
             key
             value
           }
-          version @since(version: "24.09.1.")
+          version @since(version: "24.09.1")
         }
       }
     `,

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -97,7 +97,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
   const [environmentSearch, setEnvironmentSearch] = useState('');
   const [versionSearch, setVersionSearch] = useState('');
   const { t } = useTranslation();
-  const [metadata, { getImageMeta }] = useBackendAIImageMetaData();
+  const [metadata, { getImageMeta, tagAlias }] = useBackendAIImageMetaData();
   const { token } = theme.useToken();
   const { isDarkMode } = useThemeMode();
 
@@ -129,6 +129,12 @@ const ImageEnvironmentSelectFormItems: React.FC<
             value
           }
           namespace @since(version: "24.09.1.")
+          base_image_name @since(version: "24.09.1.")
+          tags @since(version: "24.09.1.") {
+            key
+            value
+          }
+          version @since(version: "24.09.1.")
         }
       }
     `,
@@ -498,7 +504,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
                               }}
                             />
                             <TextHighlighter keyword={environmentSearch}>
-                              {environmentGroup.displayName}
+                              {tagAlias(environmentGroup.displayName)}
                             </TextHighlighter>
                           </Flex>
                           <Flex
@@ -577,13 +583,25 @@ const ImageEnvironmentSelectFormItems: React.FC<
                         paddingLeft: token.paddingSM,
                       }}
                     >
-                      {t('session.launcher.Version')}
-                      <Divider type="vertical" />
-                      {t('session.launcher.Base')}
-                      <Divider type="vertical" />
-                      {t('session.launcher.Architecture')}
-                      <Divider type="vertical" />
-                      {t('session.launcher.Requirements')}
+                      {supportExtendedImageInfo ? (
+                        <>
+                          {t('session.launcher.Version')}
+                          <Divider type="vertical" />
+                          {t('session.launcher.Architecture')}
+                          <Divider type="vertical" />
+                          {t('session.launcher.Tags')}
+                        </>
+                      ) : (
+                        <>
+                          {t('session.launcher.Version')}
+                          <Divider type="vertical" />
+                          {t('session.launcher.Base')}
+                          <Divider type="vertical" />
+                          {t('session.launcher.Architecture')}
+                          <Divider type="vertical" />
+                          {t('session.launcher.Requirements')}
+                        </>
+                      )}
                     </Flex>
                     <Divider style={{ margin: '8px 0' }} />
                     {menu}
@@ -602,18 +620,21 @@ const ImageEnvironmentSelectFormItems: React.FC<
                       '-',
                     ) || ['', '', ''];
 
-                    let tagAlias = metadata?.tagAlias[tag];
-                    if (!tagAlias) {
+                    let metadataTagAlias = metadata?.tagAlias[tag];
+                    if (!metadataTagAlias) {
                       for (const [key, replaceString] of Object.entries(
                         metadata?.tagReplace || {},
                       )) {
                         const pattern = new RegExp(key);
                         if (pattern.test(tag)) {
-                          tagAlias = tag?.replace(pattern, replaceString);
+                          metadataTagAlias = tag?.replace(
+                            pattern,
+                            replaceString,
+                          );
                         }
                       }
-                      if (!tagAlias) {
-                        tagAlias = tag;
+                      if (!metadataTagAlias) {
+                        metadataTagAlias = tag;
                       }
                     }
 
@@ -695,39 +716,98 @@ const ImageEnvironmentSelectFormItems: React.FC<
                         value={getImageFullName(image)}
                         filterValue={[
                           version,
-                          tagAlias,
+                          metadataTagAlias,
                           image?.architecture,
                           ...extraFilterValues,
                         ].join('\t')}
                       >
-                        <Flex direction="row" justify="between">
+                        {supportExtendedImageInfo ? (
                           <Flex direction="row">
                             <TextHighlighter keyword={versionSearch}>
-                              {version}
-                            </TextHighlighter>
-                            <Divider type="vertical" />
-                            <TextHighlighter keyword={versionSearch}>
-                              {tagAlias}
+                              {image?.version}
                             </TextHighlighter>
                             <Divider type="vertical" />
                             <TextHighlighter keyword={versionSearch}>
                               {image?.architecture}
                             </TextHighlighter>
+                            <Divider type="vertical" />
+                            <Flex direction="row" align="start">
+                              {/* TODO: replace this with AliasedImageDoubleTags after image list query with ImageNode is implemented. */}
+                              {_.map(
+                                image?.tags,
+                                (tag: { key: string; value: string }) => {
+                                  const isCustomized = _.includes(
+                                    tag.key,
+                                    'customized_',
+                                  );
+                                  const tagValue = isCustomized
+                                    ? _.find(image?.labels, {
+                                        key: 'ai.backend.customized-image.name',
+                                      })?.value
+                                    : tag.value;
+                                  return (
+                                    <DoubleTag
+                                      key={tag.key}
+                                      values={[
+                                        {
+                                          label: (
+                                            <TextHighlighter
+                                              keyword={versionSearch}
+                                              key={tag.key}
+                                            >
+                                              {tagAlias(tag.key)}
+                                            </TextHighlighter>
+                                          ),
+                                          color: isCustomized ? 'cyan' : 'blue',
+                                        },
+                                        {
+                                          label: (
+                                            <TextHighlighter
+                                              keyword={versionSearch}
+                                              key={tagValue}
+                                            >
+                                              {tagValue}
+                                            </TextHighlighter>
+                                          ),
+                                          color: isCustomized ? 'cyan' : 'blue',
+                                        },
+                                      ]}
+                                    />
+                                  );
+                                },
+                              )}
+                            </Flex>
                           </Flex>
-                          <Flex
-                            direction="row"
-                            // set specific class name to handle flex wrap using css
-                            className={
-                              isDarkMode ? 'tag-wrap-dark' : 'tag-wrap-light'
-                            }
-                            style={{
-                              marginLeft: token.marginXS,
-                              flexShrink: 1,
-                            }}
-                          >
-                            {requirementTags || '-'}
+                        ) : (
+                          <Flex direction="row" justify="between">
+                            <Flex direction="row">
+                              <TextHighlighter keyword={versionSearch}>
+                                {version}
+                              </TextHighlighter>
+                              <Divider type="vertical" />
+                              <TextHighlighter keyword={versionSearch}>
+                                {metadataTagAlias}
+                              </TextHighlighter>
+                              <Divider type="vertical" />
+                              <TextHighlighter keyword={versionSearch}>
+                                {image?.architecture}
+                              </TextHighlighter>
+                            </Flex>
+                            <Flex
+                              direction="row"
+                              // set specific class name to handle flex wrap using css
+                              className={
+                                isDarkMode ? 'tag-wrap-dark' : 'tag-wrap-light'
+                              }
+                              style={{
+                                marginLeft: token.marginXS,
+                                flexShrink: 1,
+                              }}
+                            >
+                              {requirementTags || '-'}
+                            </Flex>
                           </Flex>
-                        </Flex>
+                        )}
                       </Select.Option>
                     );
                   },

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -92,6 +92,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
   const form = Form.useFormInstance<ImageEnvironmentFormInput>();
   const environments = Form.useWatch('environments', { form, preserve: true });
   const baiClient = useSuspendedBackendaiClient();
+  const supportExtendedImageInfo = baiClient?.supports('extended-image-info');
 
   const [environmentSearch, setEnvironmentSearch] = useState('');
   const [versionSearch, setVersionSearch] = useState('');
@@ -111,7 +112,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
       query ImageEnvironmentSelectFormItemsQuery($installed: Boolean) {
         images(is_installed: $installed) {
           id
-          name
+          name @deprecatedSince(version: "24.09.1.")
           humanized_name
           tag
           registry
@@ -127,6 +128,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
             key
             value
           }
+          namespace @since(version: "24.09.1.")
         }
       }
     `,
@@ -266,7 +268,9 @@ const ImageEnvironmentSelectFormItems: React.FC<
                   // metadata?.imageInfo[
                   //   getImageMeta(getImageFullName(image) || "").key
                   // ]?.name || image?.name
-                  image?.registry + '/' + image?.name
+                  `${image?.registry}/${
+                    supportExtendedImageInfo ? image?.namespace : image?.name
+                  }`
                 );
               })
               .map((images, environmentName) => {
@@ -365,7 +369,10 @@ const ImageEnvironmentSelectFormItems: React.FC<
             if (fullNameMatchedImage) {
               form.setFieldsValue({
                 environments: {
-                  environment: fullNameMatchedImage?.name || '',
+                  environment:
+                    (supportExtendedImageInfo
+                      ? fullNameMatchedImage?.namespace
+                      : fullNameMatchedImage?.name) || '',
                   version: getImageFullName(fullNameMatchedImage),
                   image: fullNameMatchedImage,
                 },
@@ -379,7 +386,10 @@ const ImageEnvironmentSelectFormItems: React.FC<
                 .images[0];
               form.setFieldsValue({
                 environments: {
-                  environment: firstInListImage?.name || '',
+                  environment:
+                    (supportExtendedImageInfo
+                      ? firstInListImage?.namespace
+                      : firstInListImage?.name) || '',
                   version: getImageFullName(firstInListImage),
                   image: firstInListImage,
                 },
@@ -393,7 +403,11 @@ const ImageEnvironmentSelectFormItems: React.FC<
         >
           {fullNameMatchedImage ? (
             <Select.Option
-              value={fullNameMatchedImage?.name}
+              value={
+                supportExtendedImageInfo
+                  ? fullNameMatchedImage?.namespace
+                  : fullNameMatchedImage?.name
+              }
               filterValue={getImageFullName(fullNameMatchedImage)}
             >
               <Flex

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -64,8 +64,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
   const [isPendingRefreshTransition, startRefreshTransition] = useTransition();
   const [isPendingSearchTransition, startSearchTransition] = useTransition();
   const baiClient = useSuspendedBackendaiClient();
-  const supportExtendedImageInfo =
-    baiClient?.supports('extended-image-info') ?? false;
+  const supportExtendedImageInfo = baiClient?.supports('extended-image-info');
 
   const { images } = useLazyLoadQuery<ImageListQuery>(
     graphql`

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -434,8 +434,10 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
   const imageFilterValues = useMemo(() => {
     return defaultSortedImages?.map((image) => {
       return {
-        installed: image?.installed ? t('environment.Installed') : '',
-        namespace: getNamespace(getImageFullName(image) || ''),
+        namespace: supportExtendedImageInfo ? image?.namespace : image?.name,
+        fullName: getImageFullName(image) || '',
+        digest: image?.digest || '',
+        // ------------ need only before 24.09.1 ------------
         lang: image?.name ? getLang(image.name) : '',
         baseversion: getBaseVersion(getImageFullName(image) || ''),
         baseimage:
@@ -450,7 +452,12 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
         isCustomized: image?.tag
           ? image.tag.indexOf('customized') !== -1
           : false,
-        fullName: getImageFullName(image) || '',
+        // -------------------------------------------------
+        // ------------ need only after 24.09.1 ------------
+        baseImageName: supportExtendedImageInfo ? image?.base_image_name : '',
+        tags: supportExtendedImageInfo ? image?.tags : [],
+        version: supportExtendedImageInfo ? image?.version : '',
+        // -------------------------------------------------
       };
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -465,7 +472,6 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
         if (['digest', 'architecture', 'registry'].includes(key))
           return regExp.test(_.toString(value));
         const curFilterValues = imageFilterValues[idx] || {};
-        if (key === 'installed') return regExp.test(curFilterValues.installed);
         const baseVersionMatch = regExp.test(curFilterValues.baseversion);
         const baseImagesMatch = _.some(curFilterValues.baseimage, (value) =>
           regExp.test(value),
@@ -478,8 +484,15 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
           ? regExp.test('customized')
           : false;
         const langMatch = regExp.test(curFilterValues.lang);
-        const namespaceMatch = regExp.test(curFilterValues.namespace);
+        const namespaceMatch = regExp.test(curFilterValues.namespace || '');
         const fullNameMatch = regExp.test(curFilterValues.fullName);
+        const tagsMatch = _.some(
+          curFilterValues.tags,
+          (tag: { key: string; value: string }) =>
+            regExp.test(tag.key) || regExp.test(tag.value),
+        );
+        const versionMatch = regExp.test(curFilterValues.version || '');
+        const digestMatch = regExp.test(curFilterValues.digest);
         return (
           baseVersionMatch ||
           baseImagesMatch ||
@@ -487,7 +500,10 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
           langMatch ||
           namespaceMatch ||
           customizedMatch ||
-          fullNameMatch
+          fullNameMatch ||
+          tagsMatch ||
+          versionMatch ||
+          digestMatch
         );
       });
     });

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -75,7 +75,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
       query ImageListQuery {
         images {
           id
-          name @deprecatedSince(version: "24.09.1.")
+          name @deprecatedSince(version: "24.09.1")
           tag
           registry
           architecture
@@ -91,13 +91,13 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             min
             max
           }
-          namespace @since(version: "24.09.1.")
-          base_image_name @since(version: "24.09.1.")
-          tags @since(version: "24.09.1.") {
+          namespace @since(version: "24.09.1")
+          base_image_name @since(version: "24.09.1")
+          tags @since(version: "24.09.1") {
             key
             value
           }
-          version @since(version: "24.09.1.")
+          version @since(version: "24.09.1")
         }
       }
     `,

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -345,8 +345,9 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             render: (text: string, row: EnvironmentImage) =>
               row?.tag ? (
                 <ConstraintTags
-                  tag={row.tag}
-                  labels={row?.labels as { key: string; value: string }[]}
+                  tag={row?.tag}
+                  labels={row?.labels as Array<{ key: string; value: string }>}
+                  highlightKeyword={imageSearch}
                 />
               ) : null,
           },

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -228,6 +228,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
                 //   highlightKeyword={imageSearch}
                 // />
                 <Flex direction="row" align="start">
+                  {/* TODO: replace this with AliasedImageDoubleTags after image list query with ImageNode is implemented. */}
                   {_.map(text, (tag: { key: string; value: string }) => {
                     const isCustomized = _.includes(tag.key, 'customized_');
                     const tagValue = isCustomized

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -198,7 +198,9 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             sorter: (a: EnvironmentImage, b: EnvironmentImage) =>
               localeCompare(a?.base_image_name, b?.base_image_name),
             render: (text: string, row: EnvironmentImage) => (
-              <TextHighlighter keyword={imageSearch}>{text}</TextHighlighter>
+              <TextHighlighter keyword={imageSearch}>
+                {tagAlias(text)}
+              </TextHighlighter>
             ),
           },
           {

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -214,12 +214,54 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             title: t('environment.Tags'),
             key: 'tags',
             dataIndex: 'tags',
-            render: (text: Array<{ key: string; value: string }>) => {
+            render: (
+              text: Array<{ key: string; value: string }>,
+              row: EnvironmentImage,
+            ) => {
               return (
+                // <AliasedImageDoubleTags
+                //   imageFrgmt={row}
+                //   label={undefined}
+                //   highlightKeyword={imageSearch}
+                // />
                 <Flex direction="row" align="start">
-                  {_.map(text, (tag) => (
-                    <DoubleTag values={[tag.key, tag.value]} />
-                  ))}
+                  {_.map(text, (tag: { key: string; value: string }) => {
+                    const isCustomized = _.includes(tag.key, 'customized_');
+                    const tagValue = isCustomized
+                      ? _.find(row?.labels, {
+                          key: 'ai.backend.customized-image.name',
+                        })?.value
+                      : tag.value;
+                    return (
+                      <DoubleTag
+                        key={tag.key}
+                        values={[
+                          {
+                            label: (
+                              <TextHighlighter
+                                keyword={imageSearch}
+                                key={tag.key}
+                              >
+                                {tagAlias(tag.key)}
+                              </TextHighlighter>
+                            ),
+                            color: isCustomized ? 'cyan' : 'blue',
+                          },
+                          {
+                            label: (
+                              <TextHighlighter
+                                keyword={imageSearch}
+                                key={tagValue}
+                              >
+                                {tagValue}
+                              </TextHighlighter>
+                            ),
+                            color: isCustomized ? 'cyan' : 'blue',
+                          },
+                        ]}
+                      />
+                    );
+                  })}
                 </Flex>
               );
             },

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -50,6 +50,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
       getBaseImages,
       getConstraints,
       getBaseImage,
+      tagAlias,
     },
   ] = useBackendAIImageMetaData();
   const { token } = theme.useToken();

--- a/react/src/components/ImageTags.tsx
+++ b/react/src/components/ImageTags.tsx
@@ -3,6 +3,7 @@ import DoubleTag, { DoubleTagObjectValue } from './DoubleTag';
 import Flex from './Flex';
 import TextHighlighter from './TextHighlighter';
 import { Tag, TagProps } from 'antd';
+import _ from 'lodash';
 import React from 'react';
 
 interface ImageAliasNameAndBaseVersionTagsProps
@@ -41,7 +42,7 @@ export const BaseVersionTags: React.FC<BaseVersionTagsProps> = ({
 }) => {
   image = image || '';
   const [, { getBaseVersion, tagAlias }] = useBackendAIImageMetaData();
-  return (
+  return _.isEmpty(tagAlias(getBaseVersion(image))) ? null : (
     <Tag color="green" {...props}>
       {tagAlias(getBaseVersion(image))}
     </Tag>
@@ -57,7 +58,7 @@ export const BaseImageTags: React.FC<BaseImageTagsProps> = ({
 }) => {
   image = image || '';
   const [, { getBaseImage, tagAlias }] = useBackendAIImageMetaData();
-  return (
+  return _.isEmpty(tagAlias(getBaseImage(image))) ? null : (
     <Tag color="green" {...props}>
       {tagAlias(getBaseImage(image))}
     </Tag>
@@ -73,7 +74,7 @@ export const ArchitectureTags: React.FC<ArchitectureTagsProps> = ({
 }) => {
   image = image || '';
   const [, { getArchitecture, tagAlias }] = useBackendAIImageMetaData();
-  return (
+  return _.isEmpty(tagAlias(getArchitecture(image))) ? null : (
     <Tag color="green" {...props}>
       {tagAlias(getArchitecture(image))}
     </Tag>
@@ -86,7 +87,7 @@ interface LangTagsProps extends TagProps {
 export const LangTags: React.FC<LangTagsProps> = ({ image, ...props }) => {
   image = image || '';
   const [, { getImageLang, tagAlias }] = useBackendAIImageMetaData();
-  return (
+  return _.isEmpty(tagAlias(getImageLang(image))) ? null : (
     <Tag color="green" {...props}>
       {tagAlias(getImageLang(image))}
     </Tag>
@@ -109,14 +110,14 @@ export const ConstraintTags: React.FC<ConstraintTagsProps> = ({
   const constraints = getConstraints(tag, labels);
   return (
     <Flex direction="row" align="start">
-      {constraints[0] ? (
+      {!_.isEmpty(constraints?.[0]) ? (
         <Tag color="blue" {...props}>
           <TextHighlighter keyword={highlightKeyword}>
             {constraints[0]}
           </TextHighlighter>
         </Tag>
       ) : null}
-      {constraints[1] ? (
+      {!_.isEmpty(constraints?.[1]) ? (
         <DoubleTag
           color="cyan"
           values={[

--- a/react/src/components/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/ResourceAllocationFormItems.test.ts
@@ -46,6 +46,9 @@ describe('getAllocatablePresetNames', () => {
     registry: 'registry1',
     tag: 'tag1',
     resource_limits: [{ key: 'cuda.shares', min: '1', max: '1' }],
+    base_image_name: undefined,
+    tags: undefined,
+    version: undefined,
   };
 
   it('should return presets when currentImage has accelerator limits', () => {

--- a/react/src/components/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/ResourceAllocationFormItems.test.ts
@@ -36,7 +36,8 @@ describe('getAllocatablePresetNames', () => {
 
   const image_has_cuda_shares_min1_max1: Image = {
     id: 'id1',
-    name: 'image1',
+    namespace: 'image1',
+    name: undefined,
     digest: 'digest1',
     architecture: 'arm64',
     humanized_name: 'Image 1',

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -314,7 +314,7 @@ export const getImageFullName = (
   image: Image | CommittedImage | EnvironmentImage,
 ) => {
   return image
-    ? `${image.registry}/${image.name}:${image.tag}@${image.architecture}`
+    ? `${image.registry}/${image.namespace ?? image.name}:${image.tag}@${image.architecture}`
     : undefined;
 };
 

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -1,7 +1,7 @@
+import { CommittedImage } from '../components/CustomizedImageList';
 import { Image } from '../components/ImageEnvironmentSelectFormItems';
 import { EnvironmentImage } from '../components/ImageList';
 import { useSuspendedBackendaiClient } from '../hooks';
-import { CommittedImage } from '../pages/MyEnvironmentPage';
 import { SorterResult } from 'antd/es/table/interface';
 import _ from 'lodash';
 

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -310,18 +310,17 @@ export const useBackendAIImageMetaData = () => {
       },
       tagAlias: (tag: string) => {
         let metadataTagAlias = metadata?.tagAlias[tag];
-        if (!metadataTagAlias && metadata?.tagReplace) {
-          for (const [key, replaceString] of Object.entries(
-            metadata.tagReplace,
-          )) {
+        metadataTagAlias = _.reduce(
+          _.entries(metadata.tagReplace),
+          (acc, [key, replaceString]) => {
             const pattern = new RegExp(key);
-            if (pattern.test(tag)) {
-              metadataTagAlias = tag.replace(pattern, replaceString);
-              break;
-            }
-          }
-        }
-        return metadataTagAlias || tag;
+            return pattern.test(tag)
+              ? _.startCase(_.replace(tag, pattern, replaceString))
+              : acc;
+          },
+          _.startCase(tag),
+        );
+        return metadataTagAlias;
       },
     },
   ] as const;

--- a/react/src/hooks/useBackendAIImageMetaData.test.tsx
+++ b/react/src/hooks/useBackendAIImageMetaData.test.tsx
@@ -145,6 +145,9 @@ describe('useBackendAIImageMetaData', () => {
             value: 'NVIDIA CORPORATION <cudatools@nvidia.com>',
           },
         ],
+        base_image_name: undefined,
+        tags: undefined,
+        version: undefined,
       }) || '',
     );
     expect(key).toBe('training');

--- a/react/src/hooks/useBackendAIImageMetaData.test.tsx
+++ b/react/src/hooks/useBackendAIImageMetaData.test.tsx
@@ -108,7 +108,8 @@ describe('useBackendAIImageMetaData', () => {
 
     const { key, tags } = getImageMeta(
       getImageFullName({
-        name: 'abc/def/training',
+        namespace: 'abc/def/training',
+        name: undefined,
         humanized_name: 'abc/def/training',
         tag: '01-py3-abc-v1',
         registry: '192.168.0.1:7080',

--- a/react/src/pages/MyEnvironmentPage.tsx
+++ b/react/src/pages/MyEnvironmentPage.tsx
@@ -1,348 +1,45 @@
-import Flex from '../components/Flex';
+import CustomizedImageList from '../components/CustomizedImageList';
 import FlexActivityIndicator from '../components/FlexActivityIndicator';
-import {
-  BaseImageTags,
-  BaseVersionTags,
-  ConstraintTags,
-  LangTags,
-} from '../components/ImageTags';
-import TableColumnsSettingModal from '../components/TableColumnsSettingModal';
-import { getImageFullName, localeCompare } from '../helper';
-import {
-  useBackendAIImageMetaData,
-  useSuspendedBackendaiClient,
-  useUpdatableState,
-} from '../hooks';
-import { MyEnvironmentPageForgetAndUntagMutation } from './__generated__/MyEnvironmentPageForgetAndUntagMutation.graphql';
-import {
-  MyEnvironmentPageQuery,
-  MyEnvironmentPageQuery$data,
-} from './__generated__/MyEnvironmentPageQuery.graphql';
-import { DeleteOutlined, SettingOutlined } from '@ant-design/icons';
-import { useLocalStorageState } from 'ahooks';
-import { App, Button, Card, Popconfirm, Table, theme, Typography } from 'antd';
-import { AnyObject } from 'antd/es/_util/type';
-import { ColumnsType, ColumnType } from 'antd/es/table';
-import graphql from 'babel-plugin-relay/macro';
-import _ from 'lodash';
-import React, {
-  PropsWithChildren,
-  Suspense,
-  useState,
-  useTransition,
-} from 'react';
+import Card from 'antd/es/card/Card';
+import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLazyLoadQuery, useMutation } from 'react-relay';
+import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
-type TabKey = 'images';
+const tabParam = withDefault(StringParam, 'image');
 
-export type CommittedImage = NonNullable<
-  MyEnvironmentPageQuery$data['customized_images']
->[number];
-
-const MyEnvironmentPage: React.FC<PropsWithChildren> = ({ children }) => {
+const MyEnvironmentPage = () => {
   const { t } = useTranslation();
-  const { token } = theme.useToken();
-  const { message } = App.useApp();
-  const baiClient = useSuspendedBackendaiClient();
-  const supportExtendedImageInfo = baiClient?.supports('extended-image-info');
-
-  const [isOpenColumnsSetting, setIsOpenColumnsSetting] = useState(false);
-  const [selectedTab] = useState<TabKey>('images');
-  const [isRefetchPending, startRefetchTransition] = useTransition();
-  const [myEnvironmentFetchKey, updateMyEnvironmentFetchKey] =
-    useUpdatableState('initial-fetch');
-  const [inFlightImageId, setInFlightImageId] = useState<string>();
-  const [
-    ,
-    {
-      getNamespace,
-      getImageLang,
-      getBaseVersion,
-      getBaseImage,
-      getConstraints,
-    },
-  ] = useBackendAIImageMetaData();
-
-  const { customized_images } = useLazyLoadQuery<MyEnvironmentPageQuery>(
-    graphql`
-      query MyEnvironmentPageQuery {
-        customized_images {
-          id
-          name @deprecatedSince(version: "24.09.1.")
-          humanized_name
-          tag
-          registry
-          architecture
-          digest
-          labels {
-            key
-            value
-          }
-          supported_accelerators
-          namespace @since(version: "24.09.1.")
-        }
-      }
-    `,
-    {},
-    {
-      fetchPolicy:
-        myEnvironmentFetchKey === 'initial-fetch'
-          ? 'store-and-network'
-          : 'network-only',
-      fetchKey: myEnvironmentFetchKey,
-    },
-  );
-
-  const [commitForgetAndUntag, isInflightForgetAndUntag] =
-    useMutation<MyEnvironmentPageForgetAndUntagMutation>(graphql`
-      mutation MyEnvironmentPageForgetAndUntagMutation($id: String!) {
-        untag_image_from_registry(image_id: $id) {
-          ok
-          msg
-        }
-        forget_image_by_id(image_id: $id) {
-          ok
-          msg
-        }
-      }
-    `);
-
-  const columns: ColumnsType<CommittedImage> = [
-    {
-      title: t('environment.Registry'),
-      dataIndex: 'registry',
-      key: 'registry',
-      sorter: (a, b) => localeCompare(a?.registry, b?.registry),
-    },
-    {
-      title: t('environment.Architecture'),
-      dataIndex: 'architecture',
-      key: 'architecture',
-      sorter: (a, b) => localeCompare(a?.architecture, b?.architecture),
-    },
-    ...(supportExtendedImageInfo
-      ? [
-          {
-            title: t('environment.Namespace'),
-            key: 'namespace',
-            dataIndex: 'namespace',
-            sorter: (a: CommittedImage, b: CommittedImage) =>
-              localeCompare(a?.namespace, b?.namespace),
-          },
-        ]
-      : [
-          {
-            title: t('environment.Namespace'),
-            key: 'name',
-            dataIndex: 'name',
-            sorter: (a: CommittedImage, b: CommittedImage) =>
-              localeCompare(
-                getNamespace(getImageFullName(a) || ''),
-                getNamespace(getImageFullName(b) || ''),
-              ),
-            render: (text: string, row: CommittedImage) => (
-              <span>{getNamespace(getImageFullName(row) || '')}</span>
-            ),
-          },
-        ]),
-    {
-      title: t('environment.Language'),
-      key: 'lang',
-      sorter: (a, b) =>
-        localeCompare(
-          getImageLang(getImageFullName(a) || ''),
-          getImageLang(getImageFullName(b) || ''),
-        ),
-
-      render: (text, row) => (
-        <LangTags image={getImageFullName(row) || ''} color="green" />
-      ),
-    },
-    {
-      title: t('environment.Version'),
-      key: 'baseversion',
-      sorter: (a, b) =>
-        localeCompare(
-          getBaseVersion(getImageFullName(a) || ''),
-          getBaseVersion(getImageFullName(b) || ''),
-        ),
-      render: (text, row) => (
-        <BaseVersionTags image={getImageFullName(row) || ''} color="green" />
-      ),
-    },
-    {
-      title: t('environment.Base'),
-      key: 'baseimage',
-      sorter: (a, b) =>
-        localeCompare(
-          getBaseImage(getImageFullName(a) || ''),
-          getBaseImage(getImageFullName(b) || ''),
-        ),
-      render: (text, row) => (
-        <BaseImageTags image={getImageFullName(row) || ''} />
-      ),
-    },
-    {
-      title: t('environment.Constraint'),
-      key: 'constraint',
-      sorter: (a, b) => {
-        const requirementA =
-          a?.tag && b?.labels
-            ? getConstraints(
-                a?.tag,
-                a?.labels as { key: string; value: string }[],
-              )[0] || ''
-            : '';
-        const requirementB =
-          b?.tag && b?.labels
-            ? getConstraints(
-                b?.tag,
-                b?.labels as { key: string; value: string }[],
-              )[0] || ''
-            : '';
-        return localeCompare(requirementA, requirementB);
-      },
-      render: (text, row) =>
-        row?.tag ? (
-          <ConstraintTags
-            tag={row.tag}
-            labels={row?.labels as { key: string; value: string }[]}
-          />
-        ) : null,
-    },
-    {
-      title: t('environment.Digest'),
-      dataIndex: 'digest',
-      key: 'digest',
-      sorter: (a, b) => localeCompare(a?.digest || '', b?.digest || ''),
-    },
-    {
-      title: t('general.Control'),
-      key: 'control',
-      fixed: 'right',
-      render: (text, row) => (
-        <Flex direction="row" align="stretch" justify="center" gap="xxs">
-          <Typography.Text
-            copyable={{
-              text: getImageFullName(row) || '',
-            }}
-            style={{
-              paddingTop: token.paddingXXS,
-              paddingBottom: token.paddingXXS,
-            }}
-          />
-          <Popconfirm
-            title={t('dialog.ask.DoYouWantToProceed')}
-            description={t('dialog.warning.CannotBeUndone')}
-            okType="danger"
-            okText={t('button.Delete')}
-            onConfirm={() => {
-              if (row?.id) {
-                setInFlightImageId(row.id + myEnvironmentFetchKey);
-                commitForgetAndUntag({
-                  variables: {
-                    id: row.id,
-                  },
-                  onCompleted(data, errors) {
-                    if (errors) {
-                      message.error(errors[0]?.message);
-                      return;
-                    }
-                    startRefetchTransition(() => {
-                      updateMyEnvironmentFetchKey();
-                    });
-                    message.success(
-                      t('environment.CustomizedImageSuccessfullyDeleted'),
-                    );
-                  },
-                  onError(err) {
-                    message.error(err?.message);
-                  },
-                });
-              }
-            }}
-          >
-            <Button
-              type="text"
-              icon={<DeleteOutlined />}
-              danger
-              loading={
-                isInflightForgetAndUntag &&
-                inFlightImageId === row?.id + myEnvironmentFetchKey
-              }
-              disabled={
-                isInflightForgetAndUntag &&
-                inFlightImageId !== row?.id + myEnvironmentFetchKey
-              }
-            />
-          </Popconfirm>
-        </Flex>
-      ),
-    },
-  ];
-
-  const [displayedColumnKeys, setDisplayedColumnKeys] = useLocalStorageState(
-    'backendaiwebui.MyEnvironmentPage.displayedColumnKeys',
-    {
-      defaultValue: columns.map((column) => _.toString(column.key)),
-    },
-  );
+  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
 
   return (
-    <Flex direction="column" align="stretch" gap={'xs'}>
-      <Flex direction="column" align="stretch">
-        <Card
-          tabList={[{ key: 'images', label: t('environment.Images') }]}
-          activeTabKey={selectedTab}
-          styles={{
-            body: {
-              padding: 0,
-              paddingTop: 1,
-            },
-          }}
-        >
-          <Suspense fallback={<FlexActivityIndicator />}>
-            <Table
-              loading={isRefetchPending}
-              columns={
-                columns.filter((column) =>
-                  displayedColumnKeys?.includes(_.toString(column.key)),
-                ) as ColumnType<AnyObject>[]
-              }
-              dataSource={customized_images as readonly AnyObject[] | undefined}
-              rowKey="id"
-              scroll={{ x: 'max-content' }}
-              pagination={false}
-            />
-            <Flex
-              justify="end"
-              style={{
-                padding: token.paddingXXS,
-              }}
-            >
-              <Button
-                type="text"
-                icon={<SettingOutlined />}
-                onClick={() => {
-                  setIsOpenColumnsSetting(true);
-                }}
-              />
-            </Flex>
-          </Suspense>
-        </Card>
-      </Flex>
-      <TableColumnsSettingModal
-        open={isOpenColumnsSetting}
-        onRequestClose={(values) => {
-          values?.selectedColumnKeys &&
-            setDisplayedColumnKeys(values?.selectedColumnKeys);
-          setIsOpenColumnsSetting(!isOpenColumnsSetting);
-        }}
-        columns={columns}
-        displayedColumnKeys={displayedColumnKeys ? displayedColumnKeys : []}
-      />
-    </Flex>
+    <Card
+      activeTabKey={curTabKey}
+      onTabChange={setCurTabKey}
+      tabList={[
+        {
+          key: 'image',
+          label: t('environment.Images'),
+        },
+      ]}
+      styles={{
+        body: {
+          padding: 0,
+          paddingTop: 1,
+          overflow: 'hidden',
+        },
+      }}
+    >
+      <Suspense
+        fallback={
+          <FlexActivityIndicator
+            style={{ height: 'calc(100vh - 145px)' }}
+            spinSize="large"
+          />
+        }
+      >
+        {curTabKey === 'image' && <CustomizedImageList />}
+      </Suspense>
+    </Card>
   );
 };
 

--- a/react/src/pages/MyEnvironmentPage.tsx
+++ b/react/src/pages/MyEnvironmentPage.tsx
@@ -7,8 +7,12 @@ import {
   LangTags,
 } from '../components/ImageTags';
 import TableColumnsSettingModal from '../components/TableColumnsSettingModal';
-import { getImageFullName } from '../helper';
-import { useBackendAIImageMetaData, useUpdatableState } from '../hooks';
+import { getImageFullName, localeCompare } from '../helper';
+import {
+  useBackendAIImageMetaData,
+  useSuspendedBackendaiClient,
+  useUpdatableState,
+} from '../hooks';
 import { MyEnvironmentPageForgetAndUntagMutation } from './__generated__/MyEnvironmentPageForgetAndUntagMutation.graphql';
 import {
   MyEnvironmentPageQuery,
@@ -40,6 +44,8 @@ const MyEnvironmentPage: React.FC<PropsWithChildren> = ({ children }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
+  const baiClient = useSuspendedBackendaiClient();
+  const supportExtendedImageInfo = baiClient?.supports('extended-image-info');
 
   const [isOpenColumnsSetting, setIsOpenColumnsSetting] = useState(false);
   const [selectedTab] = useState<TabKey>('images');
@@ -63,7 +69,7 @@ const MyEnvironmentPage: React.FC<PropsWithChildren> = ({ children }) => {
       query MyEnvironmentPageQuery {
         customized_images {
           id
-          name
+          name @deprecatedSince(version: "24.09.1.")
           humanized_name
           tag
           registry
@@ -74,6 +80,7 @@ const MyEnvironmentPage: React.FC<PropsWithChildren> = ({ children }) => {
             value
           }
           supported_accelerators
+          namespace @since(version: "24.09.1.")
         }
       }
     `,
@@ -106,40 +113,48 @@ const MyEnvironmentPage: React.FC<PropsWithChildren> = ({ children }) => {
       title: t('environment.Registry'),
       dataIndex: 'registry',
       key: 'registry',
-      sorter: (a, b) =>
-        a?.registry && b?.registry ? a.registry.localeCompare(b.registry) : 0,
+      sorter: (a, b) => localeCompare(a?.registry, b?.registry),
     },
     {
       title: t('environment.Architecture'),
       dataIndex: 'architecture',
       key: 'architecture',
-      sorter: (a, b) =>
-        a?.architecture && b?.architecture
-          ? a.architecture.localeCompare(b.architecture)
-          : 0,
+      sorter: (a, b) => localeCompare(a?.architecture, b?.architecture),
     },
-    {
-      title: t('environment.Namespace'),
-      key: 'namespace',
-      sorter: (a, b) => {
-        const namespaceA = getNamespace(getImageFullName(a) || '');
-        const namespaceB = getNamespace(getImageFullName(b) || '');
-        return namespaceA && namespaceB
-          ? namespaceA.localeCompare(namespaceB)
-          : 0;
-      },
-      render: (text, row) => (
-        <span>{getNamespace(getImageFullName(row) || '')}</span>
-      ),
-    },
+    ...(supportExtendedImageInfo
+      ? [
+          {
+            title: t('environment.Namespace'),
+            key: 'namespace',
+            dataIndex: 'namespace',
+            sorter: (a: CommittedImage, b: CommittedImage) =>
+              localeCompare(a?.namespace, b?.namespace),
+          },
+        ]
+      : [
+          {
+            title: t('environment.Namespace'),
+            key: 'name',
+            dataIndex: 'name',
+            sorter: (a: CommittedImage, b: CommittedImage) =>
+              localeCompare(
+                getNamespace(getImageFullName(a) || ''),
+                getNamespace(getImageFullName(b) || ''),
+              ),
+            render: (text: string, row: CommittedImage) => (
+              <span>{getNamespace(getImageFullName(row) || '')}</span>
+            ),
+          },
+        ]),
     {
       title: t('environment.Language'),
       key: 'lang',
-      sorter: (a, b) => {
-        const langA = getImageLang(getImageFullName(a) || '');
-        const langB = getImageLang(getImageFullName(b) || '');
-        return langA && langB ? langA.localeCompare(langB) : 0;
-      },
+      sorter: (a, b) =>
+        localeCompare(
+          getImageLang(getImageFullName(a) || ''),
+          getImageLang(getImageFullName(b) || ''),
+        ),
+
       render: (text, row) => (
         <LangTags image={getImageFullName(row) || ''} color="green" />
       ),
@@ -147,13 +162,11 @@ const MyEnvironmentPage: React.FC<PropsWithChildren> = ({ children }) => {
     {
       title: t('environment.Version'),
       key: 'baseversion',
-      sorter: (a, b) => {
-        const baseversionA = getBaseVersion(getImageFullName(a) || '');
-        const baseversionB = getBaseVersion(getImageFullName(b) || '');
-        return baseversionA && baseversionB
-          ? baseversionA.localeCompare(baseversionB)
-          : 0;
-      },
+      sorter: (a, b) =>
+        localeCompare(
+          getBaseVersion(getImageFullName(a) || ''),
+          getBaseVersion(getImageFullName(b) || ''),
+        ),
       render: (text, row) => (
         <BaseVersionTags image={getImageFullName(row) || ''} color="green" />
       ),
@@ -161,13 +174,11 @@ const MyEnvironmentPage: React.FC<PropsWithChildren> = ({ children }) => {
     {
       title: t('environment.Base'),
       key: 'baseimage',
-      sorter: (a, b) => {
-        const baseimageA = getBaseImage(getImageFullName(a) || '');
-        const baseimageB = getBaseImage(getImageFullName(b) || '');
-        return baseimageA && baseimageB
-          ? baseimageA.localeCompare(baseimageB)
-          : 0;
-      },
+      sorter: (a, b) =>
+        localeCompare(
+          getBaseImage(getImageFullName(a) || ''),
+          getBaseImage(getImageFullName(b) || ''),
+        ),
       render: (text, row) => (
         <BaseImageTags image={getImageFullName(row) || ''} />
       ),
@@ -190,10 +201,7 @@ const MyEnvironmentPage: React.FC<PropsWithChildren> = ({ children }) => {
                 b?.labels as { key: string; value: string }[],
               )[0] || ''
             : '';
-        if (requirementA === '' && requirementB === '') return 0;
-        if (requirementA === '') return -1;
-        if (requirementB === '') return 1;
-        return requirementA.localeCompare(requirementB);
+        return localeCompare(requirementA, requirementB);
       },
       render: (text, row) =>
         row?.tag ? (
@@ -207,8 +215,7 @@ const MyEnvironmentPage: React.FC<PropsWithChildren> = ({ children }) => {
       title: t('environment.Digest'),
       dataIndex: 'digest',
       key: 'digest',
-      sorter: (a, b) =>
-        a?.digest && b?.digest ? a.digest.localeCompare(b.digest) : 0,
+      sorter: (a, b) => localeCompare(a?.digest || '', b?.digest || ''),
     },
     {
       title: t('general.Control'),

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -39,9 +39,11 @@ import VFolderTableFormItem, {
 import {
   compareNumberWithUnits,
   generateRandomString,
+  getImageFullName,
   iSizeToSize,
 } from '../helper';
 import {
+  useBackendAIImageMetaData,
   useSuspendedBackendaiClient,
   useUpdatableState,
   useWebUINavigate,
@@ -73,6 +75,7 @@ import {
   Checkbox,
   Col,
   Descriptions,
+  Divider,
   Form,
   Grid,
   Input,
@@ -184,6 +187,10 @@ const SessionLauncherPage = () => {
   const currentUserRole = useCurrentUserRole();
   const [currentGlobalResourceGroup, setCurrentGlobalResourceGroup] =
     useCurrentResourceGroupState();
+  const [, { tagAlias }] = useBackendAIImageMetaData();
+
+  const supportExtendedImageInfo =
+    baiClient?.supports('extended-image-info') ?? false;
 
   const [isStartingSession, setIsStartingSession] = useState(false);
   const INITIAL_FORM_VALUES: DeepPartial<SessionLauncherFormValue> = useMemo(
@@ -1295,67 +1302,186 @@ const SessionLauncherPage = () => {
                           {currentProject.name}
                         </Descriptions.Item>
                         <Descriptions.Item label={t('general.Image')}>
-                          <Row
-                            style={{ flexFlow: 'nowrap', gap: token.sizeXS }}
-                          >
-                            <Col>
-                              <ImageMetaIcon
-                                image={
-                                  form.getFieldValue('environments')?.version ||
-                                  form.getFieldValue('environments')?.manual
-                                }
-                              />
-                            </Col>
-                            <Col>
-                              {/* {form.getFieldValue('environments').image} */}
-                              <Flex direction="row">
-                                {form.getFieldValue('environments')?.manual ? (
-                                  <Typography.Text
-                                    code
-                                    style={{ wordBreak: 'break-all' }}
-                                    copyable={{
-                                      text: form.getFieldValue('environments')
-                                        ?.manual,
-                                    }}
-                                  >
-                                    {form.getFieldValue('environments')?.manual}
-                                  </Typography.Text>
-                                ) : (
-                                  <>
-                                    <SessionKernelTags
-                                      image={
-                                        form.getFieldValue('environments')
-                                          ?.version
-                                      }
-                                    />
-                                    {form.getFieldValue('environments')
-                                      ?.customizedTag ? (
-                                      <DoubleTag
-                                        values={[
-                                          {
-                                            label: 'Customized',
-                                            color: 'cyan',
-                                          },
-                                          {
-                                            label:
-                                              form.getFieldValue('environments')
-                                                ?.customizedTag,
-                                            color: 'cyan',
-                                          },
-                                        ]}
-                                      />
-                                    ) : null}
+                          {supportExtendedImageInfo ? (
+                            <Row style={{ flexFlow: 'nowrap' }}>
+                              <Col>
+                                <ImageMetaIcon
+                                  image={
+                                    form.getFieldValue('environments')
+                                      ?.version ||
+                                    form.getFieldValue('environments')?.manual
+                                  }
+                                  style={{ marginRight: token.marginXS }}
+                                />
+                              </Col>
+                              <Col>
+                                <Flex direction="row">
+                                  {form.getFieldValue('environments')
+                                    ?.manual ? (
                                     <Typography.Text
+                                      code
+                                      style={{ wordBreak: 'break-all' }}
                                       copyable={{
                                         text: form.getFieldValue('environments')
-                                          ?.version,
+                                          ?.manual,
                                       }}
-                                    />
-                                  </>
-                                )}
-                              </Flex>
-                            </Col>
-                          </Row>
+                                    >
+                                      {
+                                        form.getFieldValue('environments')
+                                          ?.manual
+                                      }
+                                    </Typography.Text>
+                                  ) : (
+                                    <>
+                                      <Typography.Text>
+                                        {tagAlias(
+                                          form.getFieldValue('environments')
+                                            ?.image?.base_image_name,
+                                        )}
+                                      </Typography.Text>
+                                      <Divider type="vertical" />
+                                      <Typography.Text>
+                                        {
+                                          form.getFieldValue('environments')
+                                            ?.image?.version
+                                        }
+                                      </Typography.Text>
+                                      <Divider type="vertical" />
+                                      <Typography.Text>
+                                        {
+                                          form.getFieldValue('environments')
+                                            ?.image?.architecture
+                                        }
+                                      </Typography.Text>
+                                      <Divider type="vertical" />
+                                      {/* TODO: replace this with AliasedImageDoubleTags after image list query with ImageNode is implemented. */}
+                                      {_.map(
+                                        form.getFieldValue('environments')
+                                          ?.image?.tags,
+                                        (tag: {
+                                          key: string;
+                                          value: string;
+                                        }) => {
+                                          const isCustomized = _.includes(
+                                            tag.key,
+                                            'customized_',
+                                          );
+                                          const tagValue = isCustomized
+                                            ? _.find(
+                                                form.getFieldValue(
+                                                  'environments',
+                                                )?.image?.labels,
+                                                {
+                                                  key: 'ai.backend.customized-image.name',
+                                                },
+                                              )?.value
+                                            : tag.value;
+                                          return (
+                                            <DoubleTag
+                                              key={tag.key}
+                                              values={[
+                                                {
+                                                  label: tagAlias(tag.key),
+                                                  color: isCustomized
+                                                    ? 'cyan'
+                                                    : 'blue',
+                                                },
+                                                {
+                                                  label: tagValue,
+                                                  color: isCustomized
+                                                    ? 'cyan'
+                                                    : 'blue',
+                                                },
+                                              ]}
+                                            />
+                                          );
+                                        },
+                                      )}
+                                      <Typography.Text
+                                        style={{ color: token.colorPrimary }}
+                                        copyable={{
+                                          text:
+                                            getImageFullName(
+                                              form.getFieldValue('environments')
+                                                ?.image,
+                                            ) ||
+                                            form.getFieldValue('environments')
+                                              ?.version,
+                                        }}
+                                      />
+                                    </>
+                                  )}
+                                </Flex>
+                              </Col>
+                            </Row>
+                          ) : (
+                            <Row style={{ flexFlow: 'nowrap' }}>
+                              <Col>
+                                <ImageMetaIcon
+                                  image={
+                                    form.getFieldValue('environments')
+                                      ?.version ||
+                                    form.getFieldValue('environments')?.manual
+                                  }
+                                />
+                              </Col>
+                              <Col>
+                                {/* {form.getFieldValue('environments').image} */}
+                                <Flex direction="row">
+                                  {form.getFieldValue('environments')
+                                    ?.manual ? (
+                                    <Typography.Text
+                                      code
+                                      style={{ wordBreak: 'break-all' }}
+                                      copyable={{
+                                        text: form.getFieldValue('environments')
+                                          ?.manual,
+                                      }}
+                                    >
+                                      {
+                                        form.getFieldValue('environments')
+                                          ?.manual
+                                      }
+                                    </Typography.Text>
+                                  ) : (
+                                    <>
+                                      <SessionKernelTags
+                                        image={
+                                          form.getFieldValue('environments')
+                                            ?.version
+                                        }
+                                      />
+                                      {form.getFieldValue('environments')
+                                        ?.customizedTag ? (
+                                        <DoubleTag
+                                          values={[
+                                            {
+                                              label: 'Customized',
+                                              color: 'cyan',
+                                            },
+                                            {
+                                              label:
+                                                form.getFieldValue(
+                                                  'environments',
+                                                )?.customizedTag,
+                                              color: 'cyan',
+                                            },
+                                          ]}
+                                        />
+                                      ) : null}
+                                      <Typography.Text
+                                        copyable={{
+                                          text: form.getFieldValue(
+                                            'environments',
+                                          )?.version,
+                                        }}
+                                      />
+                                    </>
+                                  )}
+                                </Flex>
+                              </Col>
+                            </Row>
+                          )}
                         </Descriptions.Item>
                         {form.getFieldValue('envvars')?.length > 0 && (
                           <Descriptions.Item

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "Es existiert ein Auto-Mount-Ordner mit demselben Namen.",
       "InsufficientAllocationOfResourcesWarning": "Die zuweisbaren Ressourcen liegen unter der im ausgewählten Bild erforderlichen Mindestressource.",
       "RecentHistory": "Jüngere Geschichte",
-      "CreatedAt": "Erstellt am"
+      "CreatedAt": "Erstellt am",
+      "Tags": "Schlagworte"
     },
     "Preparing": "Vorbereitung...",
     "PreparingSession": "Sitzung vorbereiten...",

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "Installieren Sie ein Image?",
     "InstalledImagesAreExcluded": "Installierte Bilder sind davon ausgenommen.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Basisbildname",
+    "Tags": "Schlagworte",
+    "FullImagePath": "Vollständiger Bildpfad"
   },
   "resourcePreset": {
     "ResourcePresets": "Ressourcenvoreinstellungen",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "Υπάρχει ένας φάκελος αυτόματης προσάρτησης με το ίδιο όνομα.",
       "InsufficientAllocationOfResourcesWarning": "Οι κατανεμητέοι πόροι πέφτουν κάτω από τον ελάχιστο απαιτούμενο πόρο στην επιλεγμένη εικόνα.",
       "RecentHistory": "Πρόσφατη ιστορία",
-      "CreatedAt": "Δημιουργήθηκε στο"
+      "CreatedAt": "Δημιουργήθηκε στο",
+      "Tags": "Ετικέτες"
     },
     "Preparing": "Προετοιμασία ...",
     "PreparingSession": "Προετοιμασία συνεδρίας ...",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "Εγκαθιστώντας μια εικόνα;",
     "InstalledImagesAreExcluded": "Οι εγκατεστημένες εικόνες εξαιρούνται.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Όνομα εικόνας βάσης",
+    "Tags": "Ετικέτες",
+    "FullImagePath": "Πλήρης διαδρομή εικόνας"
   },
   "resourcePreset": {
     "ResourcePresets": "Προεπιλογές πόρων",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -989,7 +989,7 @@
     "Action": "Action",
     "Base": "Base",
     "Constraint": "Constraint",
-    "ResourceLimit": "Resource Limit",
+    "ResourceLimit": "Resource limit",
     "DescDeleteAppInfo": "You are about to delete the app info: ",
     "DescDeleteImage": "You are about to delete the image(s): ",
     "DescSignificantInstallTime": "This process requires significant install time.",
@@ -1027,7 +1027,10 @@
     "CheckImageInstallation": "Installing an image?",
     "SearchImages": "Search images",
     "DescDownloadImage": "DescDownloadImage",
-    "DescSignificantDownloadTime": "DescSignificantDownloadTime"
+    "DescSignificantDownloadTime": "DescSignificantDownloadTime",
+    "BaseImageName": "Base image name",
+    "Tags": "Tags",
+    "FullImagePath": "Full image path"
   },
   "resourcePreset": {
     "ResourcePresets": "Resource Presets",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -297,7 +297,8 @@
       "FolderAliasOverlappingToAutoMount": "An auto-mount folder with the same name exists.",
       "InsufficientAllocationOfResourcesWarning": "Allocatable resources falls below the minimum resource required in the selected image.",
       "RecentHistory": "Recent History",
-      "CreatedAt": "CreatedAt"
+      "CreatedAt": "CreatedAt",
+      "Tags": "Tags"
     },
     "Preparing": "Preparing...",
     "PreparingSession": "Preparing session...",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -536,7 +536,10 @@
     "CheckImageInstallation": "¿Instalar una imagen?",
     "InstalledImagesAreExcluded": "Se excluyen las imágenes instaladas.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nombre de la imagen base",
+    "Tags": "Etiquetas",
+    "FullImagePath": "Ruta de imagen completa"
   },
   "explorer": {
     "InputTooShort": "InputTooShort",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1318,7 +1318,8 @@
       "FolderAliasOverlappingToAutoMount": "Existe una carpeta de montaje automático con el mismo nombre.",
       "InsufficientAllocationOfResourcesWarning": "Los recursos asignables están por debajo del recurso mínimo requerido en la imagen seleccionada.",
       "RecentHistory": "Historia reciente",
-      "CreatedAt": "Creado en"
+      "CreatedAt": "Creado en",
+      "Tags": "Etiquetas"
     },
     "ExpiresAfter": "Tiempo restante",
     "CPU": "CPU",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1315,7 +1315,8 @@
       "FolderAliasOverlappingToAutoMount": "Samanniminen automaattinen kiinnityskansio on olemassa.",
       "InsufficientAllocationOfResourcesWarning": "Allokoitavat resurssit jäävät alle valitussa kuvassa vaaditun vähimmäisresurssin.",
       "RecentHistory": "Lähihistoria",
-      "CreatedAt": "LuotuAt"
+      "CreatedAt": "LuotuAt",
+      "Tags": "Tunnisteet"
     },
     "ExpiresAfter": "Jäljellä oleva aika",
     "CPU": "CPU",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -518,7 +518,7 @@
     "ProtocolMustBeOneOfSupported": "Protokollan on oltava jokin seuraavista: 'http', 'tcp', 'preopen' ja 'pty'.",
     "Registries": "Rekisterit",
     "Registry": "Rekisteri",
-    "ResourceLimit": "Resurssiraja",
+    "ResourceLimit": "Resurssirajoitus",
     "ResourcePresets": "Resurssien esiasetukset",
     "SelectedImagesAlreadyInstalled": "Valittu kuva (valitut kuvat) on jo asennettu tai Ei mitään. Tarkista uudelleen.",
     "SelectedImagesNotInstalled": "Valittuja kuvia ei ole asennettu. Tarkista uudelleen.",
@@ -536,7 +536,10 @@
     "CheckImageInstallation": "Kuvan asentaminen?",
     "InstalledImagesAreExcluded": "Asennettuja kuvia ei oteta huomioon.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Peruskuvan nimi",
+    "Tags": "Tunnisteet",
+    "FullImagePath": "Koko kuvan polku"
   },
   "explorer": {
     "InputTooShort": "InputTooShort",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "Installation d'une image ?",
     "InstalledImagesAreExcluded": "Les images installées sont exclues.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nom de l'image de base",
+    "Tags": "Balises",
+    "FullImagePath": "Chemin d'accès complet à l'image"
   },
   "resourcePreset": {
     "ResourcePresets": "Préréglages de ressources",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "Il existe un dossier de montage automatique portant le même nom.",
       "InsufficientAllocationOfResourcesWarning": "Les ressources allouables sont inférieures à la ressource minimale requise dans l'image sélectionnée.",
       "RecentHistory": "Histoire récente",
-      "CreatedAt": "Créé à"
+      "CreatedAt": "Créé à",
+      "Tags": "Balises"
     },
     "Preparing": "En train de préparer...",
     "PreparingSession": "Séance de préparation...",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -284,7 +284,8 @@
       "FolderAliasOverlappingToAutoMount": "Folder pemasangan otomatis dengan nama yang sama tersedia.",
       "InsufficientAllocationOfResourcesWarning": "Sumber daya yang dapat dialokasikan berada di bawah sumber daya minimum yang diperlukan pada gambar yang dipilih.",
       "RecentHistory": "Riwayat Terbaru",
-      "CreatedAt": "DibuatPada"
+      "CreatedAt": "DibuatPada",
+      "Tags": "Tag"
     },
     "Preparing": "Mempersiapkan...",
     "PreparingSession": "Mempersiapkan sesi...",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -859,7 +859,7 @@
     "Action": "Tindakan",
     "Base": "Basis",
     "Constraint": "Batasan",
-    "ResourceLimit": "Batas Sumber Daya",
+    "ResourceLimit": "Batasan sumber daya",
     "DescDeleteAppInfo": "Anda akan menghapus info aplikasi: ",
     "DescDeleteImage": "Anda akan menghapus image: ",
     "DescSignificantInstallTime": "Proses ini membutuhkan waktu pengunduhan yang signifikan.",
@@ -898,7 +898,10 @@
     "CheckImageInstallation": "Memasang gambar?",
     "InstalledImagesAreExcluded": "Gambar yang diinstal tidak termasuk.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nama gambar dasar",
+    "Tags": "Tag",
+    "FullImagePath": "Jalur gambar penuh"
   },
   "resourcePreset": {
     "ResourcePresets": "Preset Sumber Daya",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -859,7 +859,7 @@
     "Action": "Azione",
     "Base": "Base",
     "Constraint": "vincolo",
-    "ResourceLimit": "Limite di risorse",
+    "ResourceLimit": "Limite delle risorse",
     "DescDeleteAppInfo": "Stai per eliminare le informazioni sull'app:",
     "DescDeleteImage": "Stai per eliminare le immagini:",
     "DescSignificantInstallTime": "Questo processo richiede un tempo di download significativo.",
@@ -898,7 +898,10 @@
     "CheckImageInstallation": "Installare un'immagine?",
     "InstalledImagesAreExcluded": "Le immagini installate sono escluse.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nome dell'immagine di base",
+    "Tags": "Tag",
+    "FullImagePath": "Percorso completo dell'immagine"
   },
   "resourcePreset": {
     "ResourcePresets": "Preimpostazioni delle risorse",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "Esiste una cartella di montaggio automatico con lo stesso nome.",
       "InsufficientAllocationOfResourcesWarning": "Le risorse assegnabili sono inferiori alla risorsa minima richiesta nell'immagine selezionata.",
       "RecentHistory": "Storia recente",
-      "CreatedAt": "CreatoAt"
+      "CreatedAt": "CreatoAt",
+      "Tags": "Tag"
     },
     "Preparing": "Preparazione...",
     "PreparingSession": "Preparazione della sessione...",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "同名の自動マウントフォルダが存在する。",
       "InsufficientAllocationOfResourcesWarning": "割り当て可能なリソースが、選択したイメージに必要な最小リソースを下回ります。",
       "RecentHistory": "最近の歴史",
-      "CreatedAt": "作成日"
+      "CreatedAt": "作成日",
+      "Tags": "タグ"
     },
     "Preparing": "準備...",
     "PreparingSession": "セッションの準備...",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "イメージのインストール？",
     "InstalledImagesAreExcluded": "インストールされたイメージは除く。",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "ベースイメージ名",
+    "Tags": "タグ",
+    "FullImagePath": "完全な画像パス"
   },
   "resourcePreset": {
     "ResourcePresets": "リソースプリセット",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1013,7 +1013,10 @@
     "CheckImageInstallation": "다음 이미지를 설치하시겠습니까?",
     "SearchImages": "이미지 검색",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "기본 이미지 이름",
+    "Tags": "태그",
+    "FullImagePath": "전체 이미지 경로"
   },
   "resourcePreset": {
     "ResourcePresets": "자원 프리셋",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -284,7 +284,8 @@
       "FolderAliasOverlappingToAutoMount": "동일한 이름의 자동 마운트 폴더가 존재합니다.",
       "InsufficientAllocationOfResourcesWarning": "할당 가능한 자원이 선택된 이미지에서 요구되는 최소 자원보다 부족합니다.",
       "RecentHistory": "최근 기록",
-      "CreatedAt": "생성 시간"
+      "CreatedAt": "생성 시간",
+      "Tags": "태그"
     },
     "Preparing": "준비중...",
     "PreparingSession": "세션 준비중...",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -859,7 +859,7 @@
     "Action": "Үйлдэл",
     "Base": "Суурь",
     "Constraint": "Хязгаарлалт",
-    "ResourceLimit": "Нөөцийн хязгаарлалт",
+    "ResourceLimit": "Нөөцийн хязгаар",
     "DescDeleteAppInfo": "Та аппын мэдээллийг устгах гэж байна:",
     "DescDeleteImage": "Та зураг (ууд) ыг устгах гэж байна:",
     "DescSignificantInstallTime": "Энэ процесс нь татаж авахад ихээхэн хугацаа шаарддаг.",
@@ -898,7 +898,10 @@
     "CheckImageInstallation": "Зураг суулгаж байна уу?",
     "InstalledImagesAreExcluded": "Суулгасан зургуудыг оруулаагүй болно.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Зургийн үндсэн нэр",
+    "Tags": "Шошго",
+    "FullImagePath": "Зургийн бүрэн зам"
   },
   "resourcePreset": {
     "ResourcePresets": "Нөөцийн урьдчилсан тохируулга",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -284,7 +284,8 @@
       "FolderAliasOverlappingToAutoMount": "Ижил нэртэй автоматаар холбох хавтас байна.",
       "InsufficientAllocationOfResourcesWarning": "Хуваарилах нөөц нь сонгосон зурагт шаардагдах хамгийн бага нөөцөөс доогуур байна.",
       "RecentHistory": "Сүүлийн үеийн түүх",
-      "CreatedAt": "Үүсгэсэн"
+      "CreatedAt": "Үүсгэсэн",
+      "Tags": "Шошго"
     },
     "Preparing": "Бэлтгэж байна ...",
     "PreparingSession": "Session бэлтгэж байна ...",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -858,7 +858,7 @@
     "Action": "Tindakan",
     "Base": "Pangkalan",
     "Constraint": "Kekangan",
-    "ResourceLimit": "Had Sumber",
+    "ResourceLimit": "Had sumber",
     "DescDeleteAppInfo": "Anda akan memadamkan maklumat aplikasi:",
     "DescDeleteImage": "Anda akan memadamkan gambar:",
     "DescSignificantInstallTime": "Proses ini memerlukan masa muat turun yang ketara.",
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "Memasang imej?",
     "InstalledImagesAreExcluded": "Imej yang dipasang dikecualikan.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nama imej asas",
+    "Tags": "Tag",
+    "FullImagePath": "Laluan imej penuh"
   },
   "resourcePreset": {
     "ResourcePresets": "Pratetap Sumber",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "Folder auto-lekap dengan nama yang sama wujud.",
       "InsufficientAllocationOfResourcesWarning": "Sumber yang boleh diperuntukkan berada di bawah sumber minimum yang diperlukan dalam imej yang dipilih.",
       "RecentHistory": "Sejarah Terkini",
-      "CreatedAt": "Dicipta Pada"
+      "CreatedAt": "Dicipta Pada",
+      "Tags": "Tag"
     },
     "Preparing": "Menyiapkan ...",
     "PreparingSession": "Menyiapkan sesi ...",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "Istnieje folder automatycznego montażu o tej samej nazwie.",
       "InsufficientAllocationOfResourcesWarning": "Zasoby, które można przydzielić, są mniejsze niż minimalne zasoby wymagane w wybranym obrazie.",
       "RecentHistory": "Najnowsza historia",
-      "CreatedAt": "Utworzono o godz"
+      "CreatedAt": "Utworzono o godz",
+      "Tags": "Tagi"
     },
     "Preparing": "Przygotowuję...",
     "PreparingSession": "Przygotowuję sesję...",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "Instalowanie obrazu?",
     "InstalledImagesAreExcluded": "Zainstalowane obrazy są wykluczone.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Podstawowa nazwa obrazu",
+    "Tags": "Tagi",
+    "FullImagePath": "Pełna ścieżka obrazu"
   },
   "resourcePreset": {
     "ResourcePresets": "Predefiniowane ustawienia zasobów",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "Existe uma pasta de montagem automática com o mesmo nome.",
       "InsufficientAllocationOfResourcesWarning": "Os recursos alocáveis ​​ficam abaixo do recurso mínimo exigido na imagem selecionada.",
       "RecentHistory": "História recente",
-      "CreatedAt": "Criado em"
+      "CreatedAt": "Criado em",
+      "Tags": "Etiquetas"
     },
     "Preparing": "Preparando...",
     "PreparingSession": "Preparando sessão ...",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "Instalar uma imagem?",
     "InstalledImagesAreExcluded": "As imagens instaladas são excluídas.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nome da imagem base",
+    "Tags": "Etiquetas",
+    "FullImagePath": "Caminho completo da imagem"
   },
   "resourcePreset": {
     "ResourcePresets": "Predefinições de recursos",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "Existe uma pasta de montagem automática com o mesmo nome.",
       "InsufficientAllocationOfResourcesWarning": "Os recursos alocáveis ​​ficam abaixo do recurso mínimo exigido na imagem selecionada.",
       "RecentHistory": "História recente",
-      "CreatedAt": "Criado em"
+      "CreatedAt": "Criado em",
+      "Tags": "Etiquetas"
     },
     "Preparing": "Preparando...",
     "PreparingSession": "Preparando sessão ...",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "Instalar uma imagem?",
     "InstalledImagesAreExcluded": "As imagens instaladas são excluídas.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Nome da imagem base",
+    "Tags": "Etiquetas",
+    "FullImagePath": "Caminho completo da imagem"
   },
   "resourcePreset": {
     "ResourcePresets": "Predefinições de recursos",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "Установка образа?",
     "InstalledImagesAreExcluded": "Установленные образы исключены.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Имя базового изображения",
+    "Tags": "Теги",
+    "FullImagePath": "Полный путь к изображению"
   },
   "resourcePreset": {
     "ResourcePresets": "Предустановки ресурсов",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "Существует папка автомонтирования с таким же именем.",
       "InsufficientAllocationOfResourcesWarning": "Выделяемые ресурсы ниже минимального ресурса, необходимого для выбранного изображения.",
       "RecentHistory": "Новейшая история",
-      "CreatedAt": "Создано в"
+      "CreatedAt": "Создано в",
+      "Tags": "Теги"
     },
     "Preparing": "Подготовка ...",
     "PreparingSession": "Подготовка сеанса ...",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -297,7 +297,8 @@
       "FolderAliasOverlappingToAutoMount": "มีโฟลเดอร์ที่เมาท์อัตโนมัติที่มีชื่อเดียวกันอยู่แล้ว",
       "InsufficientAllocationOfResourcesWarning": "ทรัพยากรที่จัดสรรได้อยู่ต่ำกว่าทรัพยากรขั้นต่ำที่จำเป็นในรูปภาพที่เลือก",
       "RecentHistory": "ประวัติศาสตร์ล่าสุด",
-      "CreatedAt": "สร้างเมื่อ"
+      "CreatedAt": "สร้างเมื่อ",
+      "Tags": "แท็ก"
     },
     "Preparing": "กำลังเตรียมการ...",
     "PreparingSession": "กำลังเตรียมเซสชัน...",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1011,7 +1011,10 @@
     "CustomizedImageSuccessfullyDeleted": "ลบอิมเมจที่กำหนดเองสำเร็จแล้ว",
     "DescImageResourceModified": "แก้ไขขีดจำกัดทรัพยากรสำเร็จแล้ว",
     "DescImagePortsModified": "แก้ไขพอร์ตอิมเมจสำเร็จแล้ว",
-    "ModifyImageResourceLimitReinstallRequired": "<p>หากคุณแก้ไขอิมเมจที่ได้รับการติดตั้งแล้ว คุณจะต้องติดตั้งอิมเมจใหม่</p><p>การแก้ไขจะไม่มีผลจนกว่าจะมีการติดตั้งอิมเมจใหม่\n</p>"
+    "ModifyImageResourceLimitReinstallRequired": "<p>หากคุณแก้ไขอิมเมจที่ได้รับการติดตั้งแล้ว คุณจะต้องติดตั้งอิมเมจใหม่</p><p>การแก้ไขจะไม่มีผลจนกว่าจะมีการติดตั้งอิมเมจใหม่\n</p>",
+    "BaseImageName": "ชื่อภาพฐาน",
+    "Tags": "แท็ก",
+    "FullImagePath": "เส้นทางภาพเต็ม"
   },
   "resourcePreset": {
     "ResourcePresets": "ค่าที่กำหนดไว้ล่วงหน้าของทรัพยากร",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "Aynı ada sahip bir otomatik montaj klasörü mevcut.",
       "InsufficientAllocationOfResourcesWarning": "Tahsis edilebilir kaynaklar, seçilen görüntüde gereken minimum kaynağın altına düşüyor.",
       "RecentHistory": "Yakın Tarih",
-      "CreatedAt": "Oluşturulma Tarihi"
+      "CreatedAt": "Oluşturulma Tarihi",
+      "Tags": "Etiketler"
     },
     "Preparing": "hazırlanıyor...",
     "PreparingSession": "Oturum hazırlanıyor...",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -858,7 +858,7 @@
     "Action": "Aksiyon",
     "Base": "baz",
     "Constraint": "Kısıtlama",
-    "ResourceLimit": "Kaynak Sınırı",
+    "ResourceLimit": "Kaynak sınırı",
     "DescDeleteAppInfo": "Uygulama bilgilerini silmek üzeresiniz:",
     "DescDeleteImage": "Resim(ler)i silmek üzeresiniz:",
     "DescSignificantInstallTime": "Bu işlem önemli indirme süresi gerektirir.",
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "Bir görüntü mü yüklüyorsunuz?",
     "InstalledImagesAreExcluded": "Yüklü görüntüler hariçtir.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Temel resim adı",
+    "Tags": "Etiketler",
+    "FullImagePath": "Tam görüntü yolu"
   },
   "resourcePreset": {
     "ResourcePresets": "Kaynak Ön Ayarları",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "Đã tồn tại một thư mục tự động gắn kết có cùng tên.",
       "InsufficientAllocationOfResourcesWarning": "Tài nguyên có thể phân bổ giảm xuống dưới mức tài nguyên tối thiểu được yêu cầu trong hình ảnh đã chọn.",
       "RecentHistory": "Lịch sử gần đây",
-      "CreatedAt": "Đã tạoTại"
+      "CreatedAt": "Đã tạoTại",
+      "Tags": "Thẻ"
     },
     "Preparing": "Đang chuẩn bị ...",
     "PreparingSession": "Đang chuẩn bị phiên ...",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "Cài đặt một hình ảnh?",
     "InstalledImagesAreExcluded": "Hình ảnh được cài đặt được loại trừ.",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "Tên hình ảnh cơ sở",
+    "Tags": "Thẻ",
+    "FullImagePath": "Đường dẫn hình ảnh đầy đủ"
   },
   "resourcePreset": {
     "ResourcePresets": "Cài đặt trước tài nguyên",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "存在同名的自动挂载文件夹。",
       "InsufficientAllocationOfResourcesWarning": "可分配资源低于所选映像所需的最低资源。",
       "RecentHistory": "近代历史",
-      "CreatedAt": "创建时间"
+      "CreatedAt": "创建时间",
+      "Tags": "标签"
     },
     "Preparing": "正在准备...",
     "PreparingSession": "正在准备会议...",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -897,7 +897,10 @@
     "CheckImageInstallation": "安装图像？",
     "InstalledImagesAreExcluded": "不包括已安装的图像。",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "基础镜像名称",
+    "Tags": "标签",
+    "FullImagePath": "完整图像路径"
   },
   "resourcePreset": {
     "ResourcePresets": "资源预设",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -898,7 +898,10 @@
     "CheckImageInstallation": "安装图像？",
     "InstalledImagesAreExcluded": "不包括已安装的图像。",
     "DescDownloadImage": "__NOT_TRANSLATED__",
-    "DescSignificantDownloadTime": "__NOT_TRANSLATED__"
+    "DescSignificantDownloadTime": "__NOT_TRANSLATED__",
+    "BaseImageName": "基礎鏡像名稱",
+    "Tags": "標籤",
+    "FullImagePath": "完整影像路徑"
   },
   "resourcePreset": {
     "ResourcePresets": "資源預設",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -283,7 +283,8 @@
       "FolderAliasOverlappingToAutoMount": "存在同名的自动挂载文件夹。",
       "InsufficientAllocationOfResourcesWarning": "可分配資源低於所選映像所需的最低資源。",
       "RecentHistory": "近代历史",
-      "CreatedAt": "創建時間"
+      "CreatedAt": "創建時間",
+      "Tags": "標籤"
     },
     "Preparing": "正在準備...",
     "PreparingSession": "正在準備會議...",

--- a/resources/image_metadata.json
+++ b/resources/image_metadata.json
@@ -891,6 +891,8 @@
   "tagReplace": {
     "^(tf)([0-9.]*)$": "TensorFlow $2",
     "^(pytorch)([0-9.]*)$": "PyTorch $2",
-    "^(cuda)([0-9.]*)$": "GPU:CUDA$2"
+    "^(cuda)([0-9.]*)$": "GPU:CUDA$2",
+    "^(customized)_.*$": "Customized",
+    "^(-_)$": " "
   }
 }

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -717,6 +717,9 @@ class Client {
     if (this.isManagerVersionCompatibleWith('24.09')) {
       this._features['extend-login-session'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('24.09.1')) {
+      this._features['extended-image-info'] = true;
+    }
   }
 
   /**


### PR DESCRIPTION
**Changes:**
Removes trailing periods from GraphQL version annotations across image-related queries. This affects:
- `@since(version: "24.09.1.")` → `@since(version: "24.09.1")`
- `@deprecatedSince(version: "24.09.1.")` → `@deprecatedSince(version: "24.09.1")`

**Rationale:**
Standardizes version string format in GraphQL directives by removing unnecessary trailing periods, making version annotations more consistent.

**Checklist:**
- [ ] Minimum required manager version: 24.09.1
- [ ] Test cases: Verify GraphQL queries continue to work with updated version annotations