### PR TITLE
test: add `getImageFullName` tests

### DIFF
--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -2,6 +2,7 @@ import {
   addNumberWithUnits,
   compareNumberWithUnits,
   filterEmptyItem,
+  getImageFullName,
   iSizeToSize,
   isOutsideRange,
   isOutsideRangeWithUnits,
@@ -349,5 +350,180 @@ describe('toFixedFloorWithoutTrailingZeros', () => {
     expect(toFixedFloorWithoutTrailingZeros('1.0010001', 4)).toEqual('1.001');
     expect(toFixedFloorWithoutTrailingZeros('1.006', 2)).toEqual('1.01');
     expect(toFixedFloorWithoutTrailingZeros('1.097', 2)).toEqual('1.1');
+  });
+});
+
+describe('getImageFullName', () => {
+  it('should return the full image name using only the namespace if there is a namespace but no name.', () => {
+    const result =
+      getImageFullName({
+        namespace: 'abc/def/training',
+        name: undefined,
+        humanized_name: 'abc/def/training',
+        tag: '01-py3-abc-v1-def',
+        registry: '192.168.0.1:7080',
+        architecture: 'x86_64',
+        digest: 'sha256:123456',
+        id: 'sample id',
+        installed: true,
+        resource_limits: [
+          {
+            key: 'cpu',
+            min: '1',
+            max: null,
+          },
+          {
+            key: 'mem',
+            min: '1g',
+            max: null,
+          },
+          {
+            key: 'cuda.device',
+            min: '0',
+            max: null,
+          },
+          {
+            key: 'cuda.shares',
+            min: '0',
+            max: null,
+          },
+        ],
+        labels: [
+          {
+            key: 'maintainer',
+            value: 'NVIDIA CORPORATION <cudatools@nvidia.com>',
+          },
+        ],
+        base_image_name: 'def/training',
+        tags: [
+          {
+            key: 'py3',
+            value: 'abc',
+          },
+          {
+            key: 'v1',
+            value: 'def',
+          },
+        ],
+        version: '01',
+      }) || '';
+    expect(result).toBe(
+      '192.168.0.1:7080/abc/def/training:01-py3-abc-v1-def@x86_64',
+    );
+  });
+  it('should return the full image name using only the name if there is a name but no namespace.', () => {
+    const result =
+      getImageFullName({
+        namespace: undefined,
+        name: 'abc/def/training',
+        humanized_name: 'abc/def/training',
+        tag: '01-py3-abc-v1-def',
+        registry: '192.168.0.1:7080',
+        architecture: 'x86_64',
+        digest: 'sha256:123456',
+        id: 'sample id',
+        installed: true,
+        resource_limits: [
+          {
+            key: 'cpu',
+            min: '1',
+            max: null,
+          },
+          {
+            key: 'mem',
+            min: '1g',
+            max: null,
+          },
+          {
+            key: 'cuda.device',
+            min: '0',
+            max: null,
+          },
+          {
+            key: 'cuda.shares',
+            min: '0',
+            max: null,
+          },
+        ],
+        labels: [
+          {
+            key: 'maintainer',
+            value: 'NVIDIA CORPORATION <cudatools@nvidia.com>',
+          },
+        ],
+        base_image_name: 'def/training',
+        tags: [
+          {
+            key: 'py3',
+            value: 'abc',
+          },
+          {
+            key: 'v1',
+            value: 'def',
+          },
+        ],
+        version: '01',
+      }) || '';
+    expect(result).toBe(
+      '192.168.0.1:7080/abc/def/training:01-py3-abc-v1-def@x86_64',
+    );
+  });
+
+  it('should return the full image name using namespace if there are both name and namespace.', () => {
+    const result =
+      getImageFullName({
+        namespace: 'abc/def/training',
+        name: 'ghi/jkl/training',
+        humanized_name: 'abc/def/training',
+        tag: '01-py3-abc-v1-def',
+        registry: '192.168.0.1:7080',
+        architecture: 'x86_64',
+        digest: 'sha256:123456',
+        id: 'sample id',
+        installed: true,
+        resource_limits: [
+          {
+            key: 'cpu',
+            min: '1',
+            max: null,
+          },
+          {
+            key: 'mem',
+            min: '1g',
+            max: null,
+          },
+          {
+            key: 'cuda.device',
+            min: '0',
+            max: null,
+          },
+          {
+            key: 'cuda.shares',
+            min: '0',
+            max: null,
+          },
+        ],
+        labels: [
+          {
+            key: 'maintainer',
+            value: 'NVIDIA CORPORATION <cudatools@nvidia.com>',
+          },
+        ],
+        base_image_name: 'def/training',
+        tags: [
+          {
+            key: 'py3',
+            value: 'abc',
+          },
+          {
+            key: 'v1',
+            value: 'def',
+          },
+        ],
+        version: '01',
+      }) || '';
+    expect(result).toBe(
+      '192.168.0.1:7080/abc/def/training:01-py3-abc-v1-def@x86_64',
+    );
   });
 });


### PR DESCRIPTION
resolves https://app.graphite.dev/github/pr/lablup/backend.ai-webui/2787/feat-replace-name-with-namespace#comment-PRRC_kwDOCRTcws5s0Ev6 

**Changes:**
Added unit tests for the `getImageFullName` helper function to verify image name construction under different scenarios:
- When only namespace is provided
- When only name is provided
- When both namespace and name are provided

The tests ensure the function correctly formats the full image name using the registry, namespace/name, tag, and architecture in the format: `registry/<namespace or name>:tag@architecture`

**How to test:**
run `pnpm run test:react`

**Checklist:**
- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after