### PR TITLE
fix: change `extended-image-info` version to 24.12.0

### DIFF
--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -320,12 +320,12 @@ type ImageNode implements Node {
 
   """Added in 24.03.4. The undecoded id value stored in DB."""
   row_id: UUID
-  name: String @deprecated(reason: "Deprecated since 24.09.1. use `namespace` instead")
+  name: String @deprecated(reason: "Deprecated since 24.12.0. use `namespace` instead")
 
-  """Added in 24.09.1."""
+  """Added in 24.12.0."""
   namespace: String
 
-  """Added in 24.09.1."""
+  """Added in 24.12.0."""
   base_image_name: String
 
   """Added in 24.03.10."""
@@ -333,10 +333,10 @@ type ImageNode implements Node {
   humanized_name: String
   tag: String
 
-  """Added in 24.09.1."""
+  """Added in 24.12.0."""
   tags: [KVPair]
 
-  """Added in 24.09.1."""
+  """Added in 24.12.0."""
   version: String
   registry: String
   architecture: String
@@ -411,7 +411,7 @@ type DomainNode implements Node {
   scaling_groups(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ScalinGroupConnection
 }
 
-"""Added in 24.09.1."""
+"""Added in 24.12.0."""
 scalar Bytes
 
 """Added in 24.12.0."""
@@ -757,12 +757,12 @@ type Group {
 
 type Image {
   id: UUID
-  name: String @deprecated(reason: "Deprecated since 24.09.1. use `namespace` instead")
+  name: String @deprecated(reason: "Deprecated since 24.12.0. use `namespace` instead")
 
-  """Added in 24.09.1."""
+  """Added in 24.12.0."""
   namespace: String
 
-  """Added in 24.09.1."""
+  """Added in 24.12.0."""
   base_image_name: String
 
   """Added in 24.03.10."""
@@ -770,10 +770,10 @@ type Image {
   humanized_name: String
   tag: String
 
-  """Added in 24.09.1."""
+  """Added in 24.12.0."""
   tags: [KVPair]
 
-  """Added in 24.09.1."""
+  """Added in 24.12.0."""
   version: String
   registry: String
   architecture: String

--- a/react/src/components/AliasedImageDoubleTags.tsx
+++ b/react/src/components/AliasedImageDoubleTags.tsx
@@ -25,7 +25,7 @@ const AliasedImageDoubleTags: React.FC<AliasedImageDoubleTagsProps> = ({
           key
           value
         }
-        tags @since(version: "24.09.1") {
+        tags @since(version: "24.12.0") {
           key
           value
         }

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -77,7 +77,7 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
       query CustomizedImageListQuery {
         customized_images {
           id
-          name @deprecatedSince(version: "24.09.1")
+          name @deprecatedSince(version: "24.12.0")
           humanized_name
           tag
           registry
@@ -88,13 +88,13 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
             value
           }
           supported_accelerators
-          namespace @since(version: "24.09.1")
-          base_image_name @since(version: "24.09.1")
-          tags @since(version: "24.09.1") {
+          namespace @since(version: "24.12.0")
+          base_image_name @since(version: "24.12.0")
+          tags @since(version: "24.12.0") {
             key
             value
           }
-          version @since(version: "24.09.1")
+          version @since(version: "24.12.0")
           ...AliasedImageDoubleTagsFragment
         }
       }
@@ -136,7 +136,7 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
         namespace: supportExtendedImageInfo ? image?.namespace : image?.name,
         fullName: getImageFullName(image) || '',
         digest: image?.digest || '',
-        // ------------ need only before 24.09.1 ------------
+        // ------------ need only before 24.12.0 ------------
         lang: image?.name ? getLang(image.name) : '',
         baseversion: getBaseVersion(getImageFullName(image) || ''),
         baseimage:
@@ -152,7 +152,7 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
           ? image.tag.indexOf('customized') !== -1
           : false,
         // -------------------------------------------------
-        // ------------ need only after 24.09.1 ------------
+        // ------------ need only after 24.12.0 ------------
         baseImageName: supportExtendedImageInfo ? image?.base_image_name : '',
         tags: supportExtendedImageInfo ? image?.tags : [],
         version: supportExtendedImageInfo ? image?.version : '',

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -112,7 +112,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
       query ImageEnvironmentSelectFormItemsQuery($installed: Boolean) {
         images(is_installed: $installed) {
           id
-          name @deprecatedSince(version: "24.09.1")
+          name @deprecatedSince(version: "24.12.0")
           humanized_name
           tag
           registry
@@ -128,13 +128,13 @@ const ImageEnvironmentSelectFormItems: React.FC<
             key
             value
           }
-          namespace @since(version: "24.09.1")
-          base_image_name @since(version: "24.09.1")
-          tags @since(version: "24.09.1") {
+          namespace @since(version: "24.12.0")
+          base_image_name @since(version: "24.12.0")
+          tags @since(version: "24.12.0") {
             key
             value
           }
-          version @since(version: "24.09.1")
+          version @since(version: "24.12.0")
         }
       }
     `,

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -74,7 +74,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
       query ImageListQuery {
         images {
           id
-          name @deprecatedSince(version: "24.09.1")
+          name @deprecatedSince(version: "24.12.0")
           tag
           registry
           architecture
@@ -90,13 +90,13 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             min
             max
           }
-          namespace @since(version: "24.09.1")
-          base_image_name @since(version: "24.09.1")
-          tags @since(version: "24.09.1") {
+          namespace @since(version: "24.12.0")
+          base_image_name @since(version: "24.12.0")
+          tags @since(version: "24.12.0") {
             key
             value
           }
-          version @since(version: "24.09.1")
+          version @since(version: "24.12.0")
         }
       }
     `,
@@ -429,7 +429,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
         namespace: supportExtendedImageInfo ? image?.namespace : image?.name,
         fullName: getImageFullName(image) || '',
         digest: image?.digest || '',
-        // ------------ need only before 24.09.1 ------------
+        // ------------ need only before 24.12.0 ------------
         lang: image?.name ? getLang(image.name) : '',
         baseversion: getBaseVersion(getImageFullName(image) || ''),
         baseimage:
@@ -445,7 +445,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
           ? image.tag.indexOf('customized') !== -1
           : false,
         // -------------------------------------------------
-        // ------------ need only after 24.09.1 ------------
+        // ------------ need only after 24.12.0 ------------
         baseImageName: supportExtendedImageInfo ? image?.base_image_name : '',
         tags: supportExtendedImageInfo ? image?.tags : [],
         version: supportExtendedImageInfo ? image?.version : '',

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -718,7 +718,7 @@ class Client {
       this._features['extend-login-session'] = true;
       this._features['session-node'] = true;
     }
-    if (this.isManagerVersionCompatibleWith('24.09.1')) {
+    if (this.isManagerVersionCompatibleWith('24.12.0')) {
       this._features['extended-image-info'] = true;
     }
   }


### PR DESCRIPTION
Updates version references from 24.09.1 to 24.12.0 for extended image information features

This PR updates version references for extended image information features (namespace, base_image_name, tags, version) from 24.09.1 to 24.12.0 across GraphQL schema and React components. This change ensures proper version compatibility checks and deprecation notices.

**Checklist:**

- [ ] Minimum required manager version: 24.12.0
- [ ] Minimum requirements to check:
  - Verify extended image information features work correctly with manager version 24.12.0
  - Confirm deprecation notices display properly for the `name` field
  - Validate version compatibility checks in backend client

The changes affect:
- GraphQL schema deprecation notices and version tags
- React component queries and version checks
- Backend client version compatibility detection