### PR TITLE
[FR-52] feat: Session usage monitor in react

### DIFF
--- a/react/src/components/BAIProgressWithLabel.tsx
+++ b/react/src/components/BAIProgressWithLabel.tsx
@@ -1,15 +1,17 @@
 import Flex from './Flex';
-import { Typography, theme } from 'antd';
+import { ProgressProps, Typography, theme } from 'antd';
 import _ from 'lodash';
 import React from 'react';
 
-export interface BAIProgressWithLabelProps {
+export interface BAIProgressWithLabelProps
+  extends Omit<ProgressProps, 'width' | 'size'> {
   title?: React.ReactNode;
   valueLabel?: React.ReactNode;
   percent?: number;
   width?: React.CSSProperties['width'];
   strokeColor?: string;
   labelStyle?: React.CSSProperties;
+  progressStyle?: React.CSSProperties;
   size?: 'small' | 'middle' | 'large';
 }
 const BAIProgressWithLabel: React.FC<BAIProgressWithLabelProps> = ({
@@ -19,6 +21,7 @@ const BAIProgressWithLabel: React.FC<BAIProgressWithLabelProps> = ({
   width,
   strokeColor,
   labelStyle,
+  progressStyle,
   size = 'small',
 }) => {
   const { token } = theme.useToken();
@@ -39,6 +42,7 @@ const BAIProgressWithLabel: React.FC<BAIProgressWithLabelProps> = ({
         ...(_.isNumber(width) || _.isString(width)
           ? { width: width }
           : { flex: 1 }),
+        ...progressStyle,
       }}
       direction="column"
       align="stretch"

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -10,6 +10,7 @@ import SessionStatusTag from './ComputeSessionNodeItems/SessionStatusTag';
 import SessionTypeTag from './ComputeSessionNodeItems/SessionTypeTag';
 import Flex from './Flex';
 import ImageMetaIcon from './ImageMetaIcon';
+import SessionUsageMonitor from './SessionUsageMonitor';
 import { SessionDetailContentLegacyQuery } from './__generated__/SessionDetailContentLegacyQuery.graphql';
 import { SessionDetailContentQuery } from './__generated__/SessionDetailContentQuery.graphql';
 import {
@@ -100,6 +101,7 @@ const SessionDetailContent: React.FC<{
             # fix: This fragment is not used in this component, but it is required by the SessionActionButtonsFragment.
             # It might be a bug in relay
             ...ContainerLogModalFragment
+            ...SessionUsageMonitorFragment
           }
           legacy_session: compute_session(id: $uuid) {
             image
@@ -201,10 +203,13 @@ const SessionDetailContent: React.FC<{
         <Descriptions.Item label={t('session.Agent')}>
           {session.agent_ids || '-'}
         </Descriptions.Item>
-        <Descriptions.Item label={t('session.Reservation')}>
+        <Descriptions.Item label={t('session.Reservation')} span={md ? 2 : 1}>
           <Flex gap={'xs'} wrap={'wrap'}>
             <SessionReservation sessionFrgmt={session} />
           </Flex>
+        </Descriptions.Item>
+        <Descriptions.Item label={'Resource Usage'} span={md ? 2 : 1}>
+          <SessionUsageMonitor sessionFrgmt={session} />
         </Descriptions.Item>
       </Descriptions>
     </Flex>

--- a/react/src/components/SessionUsageMonitor.tsx
+++ b/react/src/components/SessionUsageMonitor.tsx
@@ -1,0 +1,311 @@
+import {
+  convertBinarySizeUnit,
+  convertDecimalSizeUnit,
+  toFixedFloorWithoutTrailingZeros,
+} from '../helper';
+import { useResourceSlotsDetails } from '../hooks/backendai';
+import BAIProgressWithLabel from './BAIProgressWithLabel';
+import Flex from './Flex';
+import { SessionUsageMonitorFragment$key } from './__generated__/SessionUsageMonitorFragment.graphql';
+import {
+  Progress,
+  ProgressProps,
+  Tooltip,
+  Typography,
+  theme,
+  Row,
+  Col,
+} from 'antd';
+import graphql from 'babel-plugin-relay/macro';
+import _ from 'lodash';
+import { useMemo } from 'react';
+import { useFragment } from 'react-relay';
+
+interface SessionUsageMonitorProps extends ProgressProps {
+  sessionFrgmt: SessionUsageMonitorFragment$key | null;
+  size?: 'small' | 'default';
+}
+
+const SessionUsageMonitor: React.FC<SessionUsageMonitorProps> = ({
+  sessionFrgmt,
+  size = 'default',
+}) => {
+  const { token } = theme.useToken();
+  const { mergedResourceSlots } = useResourceSlotsDetails();
+
+  const sessionNode = useFragment(
+    graphql`
+      fragment SessionUsageMonitorFragment on ComputeSessionNode {
+        kernel_nodes {
+          edges {
+            node {
+              live_stat
+              occupied_slots
+            }
+          }
+        }
+      }
+    `,
+    sessionFrgmt,
+  );
+
+  const firstKernelNode = _.get(sessionNode, 'kernel_nodes.edges[0].node');
+  const occupiedSlots = useMemo(
+    () => JSON.parse(firstKernelNode?.occupied_slots ?? '{}'),
+    [firstKernelNode?.occupied_slots],
+  );
+  const resourceSlotNames = _.keysIn(occupiedSlots);
+  const liveStat = JSON.parse(
+    _.get(sessionNode, 'kernel_nodes.edges[0].node.live_stat') ?? '{}',
+  );
+
+  // to display util first, mem second
+  const sortedLiveStat = useMemo(
+    () =>
+      Object.keys(liveStat)
+        .sort((a, b) => {
+          const aUtil = a.includes('_util');
+          const bUtil = b.includes('_util');
+          const aMem = a.includes('_mem');
+          const bMem = b.includes('_mem');
+
+          if (aUtil && !bUtil) return -1;
+          if (!aUtil && bUtil) return 1;
+          if (aMem && !bMem) return -1;
+          if (!aMem && bMem) return 1;
+
+          return 0;
+        })
+        .reduce((acc: { [key: string]: any }, key) => {
+          acc[key] = liveStat[key];
+          return acc;
+        }, {}),
+    [liveStat],
+  );
+
+  const displayMemoryUsage = (
+    current: string,
+    capacity: string,
+    decimalSize: number = 2,
+  ) => {
+    return `${convertBinarySizeUnit(current, 'g', decimalSize)?.numberFixed ?? '-'} / ${
+      convertBinarySizeUnit(capacity, 'g', decimalSize)?.numberFixed ?? '-'
+    } GiB`;
+  };
+
+  return (
+    <Row gutter={[16, 16]}>
+      {sortedLiveStat?.cpu_util ? (
+        <Col xs={24} sm={12}>
+          <Flex direction="column" align="stretch">
+            {size === 'default' ? (
+              <>
+                <Typography.Text>
+                  {mergedResourceSlots?.['cpu']?.human_readable_name}
+                </Typography.Text>
+                <BAIProgressWithLabel
+                  percent={sortedLiveStat?.cpu_util?.pct || 0}
+                  valueLabel={
+                    toFixedFloorWithoutTrailingZeros(
+                      liveStat?.cpu_util?.pct || 0,
+                      1,
+                    ) + '%'
+                  }
+                  strokeColor="#BFBFBF"
+                  progressStyle={{ border: 'none' }}
+                />
+              </>
+            ) : (
+              <Tooltip
+                title={mergedResourceSlots?.['cpu']?.human_readable_name}
+              >
+                <Progress
+                  format={(percent) => (
+                    <Typography.Text style={{ fontSize: token.fontSizeSM }}>
+                      {percent + '%'}
+                    </Typography.Text>
+                  )}
+                  percent={
+                    _.toNumber(
+                      toFixedFloorWithoutTrailingZeros(
+                        sortedLiveStat?.cpu_util?.pct,
+                        1,
+                      ),
+                    ) || 0
+                  }
+                  strokeColor="#BFBFBF"
+                  strokeLinecap="butt"
+                />
+              </Tooltip>
+            )}
+          </Flex>
+        </Col>
+      ) : null}
+
+      {sortedLiveStat?.mem ? (
+        <Col xs={24} sm={12}>
+          <Flex direction="column" align="stretch">
+            {size === 'default' ? (
+              <>
+                <Flex justify="between">
+                  <Typography.Text>
+                    {mergedResourceSlots?.['mem']?.human_readable_name}
+                  </Typography.Text>
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: token.fontSizeSM }}
+                  >
+                    {displayMemoryUsage(
+                      sortedLiveStat?.mem?.current,
+                      // mem.capacity does not report total amount of memory allocated to
+                      // the container, so, we just replace with the value of occupied slot.
+                      // NOTE: this assumes every containers in a session have the same
+                      // amount of memory.
+                      occupiedSlots?.mem,
+                    )}
+                  </Typography.Text>
+                </Flex>
+                <BAIProgressWithLabel
+                  percent={sortedLiveStat?.mem?.pct || 0}
+                  valueLabel={
+                    toFixedFloorWithoutTrailingZeros(
+                      liveStat?.mem?.pct || 0,
+                      1,
+                    ) + '%'
+                  }
+                  strokeColor="#BFBFBF"
+                  progressStyle={{ border: 'none' }}
+                />
+              </>
+            ) : (
+              <Tooltip
+                title={
+                  <Flex direction="column" align="stretch">
+                    {mergedResourceSlots?.['mem']?.human_readable_name}
+                    <br />
+                    {displayMemoryUsage(
+                      sortedLiveStat?.mem?.current,
+                      // mem.capacity does not report total amount of memory allocated to
+                      // the container, so, we just replace with the value of occupied slot.
+                      // NOTE: this assumes every containers in a session have the same
+                      // amount of memory.
+                      occupiedSlots?.mem,
+                    )}
+                  </Flex>
+                }
+              >
+                <Progress
+                  format={(percent) => (
+                    <Typography.Text style={{ fontSize: token.fontSizeSM }}>
+                      {percent + '%'}
+                    </Typography.Text>
+                  )}
+                  percent={
+                    _.toNumber(
+                      toFixedFloorWithoutTrailingZeros(
+                        sortedLiveStat?.mem?.pct,
+                        1,
+                      ),
+                    ) || 0
+                  }
+                  strokeColor="#BFBFBF"
+                  strokeLinecap="butt"
+                />
+              </Tooltip>
+            )}
+          </Flex>
+        </Col>
+      ) : null}
+
+      {_.map(
+        _.omit(sortedLiveStat, 'cpu_util', 'cpu_used', 'mem'),
+        (value, key) => {
+          const deviceName = _.split(key, '_')[0];
+          const deviceKey = _.find(resourceSlotNames, (name) =>
+            _.includes(name, deviceName),
+          );
+
+          return deviceKey ? (
+            <Col xs={24} sm={12} key={key}>
+              <Flex direction="column" align="stretch">
+                {size === 'default' ? (
+                  <>
+                    <Flex justify="between">
+                      <Typography.Text>
+                        {mergedResourceSlots?.[deviceKey]?.human_readable_name}
+                        <Typography.Text type="secondary">
+                          {_.includes(key, 'util') && ' (util)'}
+                          {_.includes(key, 'mem') && ' (mem)'}
+                        </Typography.Text>
+                      </Typography.Text>
+                      {_.includes(key, 'mem') ? (
+                        <Typography.Text
+                          type="secondary"
+                          style={{ fontSize: token.fontSizeSM }}
+                        >
+                          {displayMemoryUsage(value?.current, value?.capacity)}
+                        </Typography.Text>
+                      ) : null}
+                    </Flex>
+
+                    <BAIProgressWithLabel
+                      percent={value.pct || 0}
+                      valueLabel={
+                        toFixedFloorWithoutTrailingZeros(value.pct || 0, 1) +
+                        '%'
+                      }
+                      strokeColor="#BFBFBF"
+                      progressStyle={{ border: 'none' }}
+                    />
+                  </>
+                ) : (
+                  <Tooltip
+                    title={
+                      <Flex direction="column" align="stretch">
+                        {mergedResourceSlots?.[deviceKey]?.human_readable_name}
+                        {_.includes(key, 'mem') && (
+                          <>
+                            (mem)
+                            <br />
+                            {displayMemoryUsage(
+                              value?.current,
+                              value?.capacity,
+                            )}
+                          </>
+                        )}
+                      </Flex>
+                    }
+                  >
+                    <Progress
+                      format={(percent) => (
+                        <Typography.Text style={{ fontSize: token.fontSizeSM }}>
+                          {percent + '%'}
+                        </Typography.Text>
+                      )}
+                      percent={
+                        _.toNumber(
+                          toFixedFloorWithoutTrailingZeros(value?.pct, 1),
+                        ) || 0
+                      }
+                      strokeColor="#BFBFBF"
+                      strokeLinecap="butt"
+                    />
+                  </Tooltip>
+                )}
+              </Flex>
+            </Col>
+          ) : null;
+        },
+      )}
+      <Col span={24}>
+        <Flex justify="end">
+          <Typography.Text>
+            {`I/O Read: ${convertDecimalSizeUnit(sortedLiveStat?.io_read?.current, 'm')?.numberUnit ?? '-'}B / Write: ${convertDecimalSizeUnit(sortedLiveStat?.io_write?.current, 'm')?.numberUnit ?? '-'}B`}
+          </Typography.Text>
+        </Flex>
+      </Col>
+    </Row>
+  );
+};
+
+export default SessionUsageMonitor;


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR resolves [#2803](https://github.com/lablup/backend.ai-webui/issues/2803) issue.

**Changes:**
- Displays the resources allocated to the session. Currently, the compute session node does not include a live stat field, which shows the live stat information of the main kernel associated with the session.
- Since each device has different usage, I've shown the usage below the progress bar to bring consistency to the design.

**How to test:**
- Access the Detail page of the endpoint that is currently in service. 
- Verify that resource usage looks normal.

|normal|small screen|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/b491c912-330f-4467-b995-b0d05aded2ea.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/c1bb67ea-d3c5-4b79-8ee1-18fb9e052906.png)|

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
