### PR TITLE
refactor: add more tagReplace patterns

### DIFF
--- a/resources/image_metadata.json
+++ b/resources/image_metadata.json
@@ -909,7 +909,16 @@
   "tagReplace": {
     "^(tf)([0-9.]*)$": "TensorFlow $2",
     "^(pytorch)([0-9.]*)$": "PyTorch $2",
+    "^py(\\d)(\\d+)$": "Python $1.$2",
+    "^py(\\d)\\.(\\d+)$": "Python $1.$2",
     "^(cuda)([0-9.]*)$": "GPU:CUDA$2",
+    "^rocm(\\d*)$": "GPU:ROCm$1",
+    "^ubuntu(\\d+\\.\\d+)$": "Ubuntu $1",
+    "^anaconda(\\d+\\.\\d+)$": "Anaconda $1",
+    "^ji(\\d)(\\d+)$": "Julia $1.$2",
+    "^ji(\\d)\\.(\\d+)$": "Julia $1.$2",
+    "^tpuv(\\d+)$": "TPU:TPUv$1",
+    "^alpine(\\d+)$": "Alpine Linux $1",
     "^(customized)_.*$": "Customized",
     "^(-_)$": " "
   }


### PR DESCRIPTION
Adds additional tag pattern replacements for image metadata

This PR extends the tag replacement patterns in `image_metadata.json` to support more standardized formatting of:

- Python versions (py35 → Python 3.5)
- ROCm GPU versions (rocm5 → GPU:ROCm5) 
- Ubuntu versions (ubuntu20.04 → Ubuntu 20.04)
- Anaconda versions (anaconda3.7 → Anaconda 3.7)
- Julia versions (ji1.6 → Julia 1.6)
- TPU versions (tpuv3 → TPU:TPUv3)
- Alpine Linux versions (alpine3 → Alpine Linux 3)

**Checklist:**

- [ ] Documentation
- [ ] Test case(s) to demonstrate the difference of before/after

Example transformations:
```
py37 → Python 3.7
rocm5 → GPU:ROCm5
ubuntu20.04 → Ubuntu 20.04
ji1.6 → Julia 1.6
tpuv3 → TPU:TPUv3
alpine3 → Alpine Linux 3
```