### PR TITLE
refactor: parsing image data for versions before 24.12

### DIFF
--- a/react/src/components/AliasedImageDoubleTags.tsx
+++ b/react/src/components/AliasedImageDoubleTags.tsx
@@ -1,8 +1,10 @@
+import { preserveDotStartCase } from '../helper';
 import { useBackendAIImageMetaData } from '../hooks';
 import DoubleTag, { DoubleTagObjectValue } from './DoubleTag';
 import Flex from './Flex';
 import TextHighlighter from './TextHighlighter';
 import { AliasedImageDoubleTagsFragment$key } from './__generated__/AliasedImageDoubleTagsFragment.graphql';
+import { Tag } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React from 'react';
@@ -45,7 +47,11 @@ const AliasedImageDoubleTags: React.FC<AliasedImageDoubleTagsProps> = ({
               key: 'ai.backend.customized-image.name',
             })?.value
           : tag.value;
-        return (
+        const aliasedTag = tagAlias(tag.key + tagValue);
+        return _.isEqual(
+          aliasedTag,
+          preserveDotStartCase(tag.key + tagValue),
+        ) ? (
           <DoubleTag
             key={tag.key}
             values={[
@@ -68,6 +74,13 @@ const AliasedImageDoubleTags: React.FC<AliasedImageDoubleTagsProps> = ({
             ]}
             {...doubleTagProps}
           />
+        ) : (
+          <Tag
+            key={tag.key}
+            color={isCustomized ? 'cyan' : doubleTagProps.color}
+          >
+            {aliasedTag}
+          </Tag>
         );
       })}
     </Flex>

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -1,4 +1,5 @@
 import { getImageFullName, localeCompare } from '../helper';
+import { preserveDotStartCase } from '../helper';
 import {
   useBackendAIImageMetaData,
   useSuspendedBackendaiClient,
@@ -745,7 +746,13 @@ const ImageEnvironmentSelectFormItems: React.FC<
                                         key: 'ai.backend.customized-image.name',
                                       })?.value
                                     : tag.value;
-                                  return (
+                                  const aliasedTag = tagAlias(
+                                    tag.key + tagValue,
+                                  );
+                                  return _.isEqual(
+                                    aliasedTag,
+                                    preserveDotStartCase(tag.key + tagValue),
+                                  ) ? (
                                     <DoubleTag
                                       key={tag.key}
                                       values={[
@@ -773,6 +780,15 @@ const ImageEnvironmentSelectFormItems: React.FC<
                                         },
                                       ]}
                                     />
+                                  ) : (
+                                    <Tag
+                                      key={tag.key}
+                                      color={isCustomized ? 'cyan' : 'blue'}
+                                    >
+                                      <TextHighlighter keyword={versionSearch}>
+                                        {aliasedTag}
+                                      </TextHighlighter>
+                                    </Tag>
                                   );
                                 },
                               )}

--- a/react/src/components/ImageTags.tsx
+++ b/react/src/components/ImageTags.tsx
@@ -1,3 +1,4 @@
+import { preserveDotStartCase } from '../helper';
 import { useBackendAIImageMetaData } from '../hooks';
 import DoubleTag, { DoubleTagObjectValue } from './DoubleTag';
 import Flex from './Flex';
@@ -76,7 +77,7 @@ export const ArchitectureTags: React.FC<ArchitectureTagsProps> = ({
   const [, { getArchitecture, tagAlias }] = useBackendAIImageMetaData();
   return _.isEmpty(tagAlias(getArchitecture(image))) ? null : (
     <Tag color="green" {...props}>
-      {tagAlias(getArchitecture(image))}
+      {getArchitecture(image)}
     </Tag>
   );
 };
@@ -161,3 +162,59 @@ const SessionKernelTags: React.FC<{
 };
 
 export default React.memo(SessionKernelTags);
+
+interface ImageTagsProps extends TagProps {
+  tag: string;
+  labels: Array<{ key: string; value: string }>;
+  highlightKeyword?: string;
+}
+export const ImageTags: React.FC<ImageTagsProps> = ({
+  tag,
+  labels,
+  highlightKeyword,
+  ...props
+}) => {
+  labels = labels || [];
+  const [, { getTags, tagAlias }] = useBackendAIImageMetaData();
+  const tags = getTags(tag, labels);
+  return (
+    <Flex direction="row" align="start">
+      {_.map(tags, (tag: { key: string; value: string }, index) => {
+        const isCustomized = tag.key === 'Customized';
+        const aliasedTag = tagAlias(tag.key + tag.value);
+        return _.isEqual(
+          aliasedTag,
+          preserveDotStartCase(tag.key + tag.value),
+        ) ? (
+          <DoubleTag
+            key={tag.key}
+            values={[
+              {
+                label: (
+                  <TextHighlighter keyword={highlightKeyword}>
+                    {tagAlias(tag.key)}
+                  </TextHighlighter>
+                ),
+                color: isCustomized ? 'cyan' : 'blue',
+              },
+              {
+                label: (
+                  <TextHighlighter keyword={highlightKeyword} key={index}>
+                    {tag.value}
+                  </TextHighlighter>
+                ),
+                color: isCustomized ? 'cyan' : 'blue',
+              },
+            ]}
+          />
+        ) : (
+          <Tag key={tag.key} color={isCustomized ? 'cyan' : 'blue'}>
+            <TextHighlighter keyword={highlightKeyword} key={index}>
+              {aliasedTag}
+            </TextHighlighter>
+          </Tag>
+        );
+      })}
+    </Flex>
+  );
+};

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -396,3 +396,14 @@ export function formatToUUID(str: string) {
 export const toGlobalId = (type: string, id: string): string => {
   return btoa(`${type}:${id}`);
 };
+
+export function preserveDotStartCase(str: string) {
+  // Temporarily replace periods with a unique placeholder
+  const placeholder = '<<<DOT>>>';
+  const tempStr = str.replace(/\./g, placeholder);
+
+  const startCased = _.startCase(tempStr);
+
+  // Replace the placeholder back with periods
+  return startCased.replace(new RegExp(placeholder, 'g'), '.');
+}


### PR DESCRIPTION
**Changes:**
Refactored image handling similar to #2785 and #2795 for versions before 24.12. Before 24.12, most data parsing is handled on the frontend.

Key changes:
- Consolidated separate tag components (BaseImageTags, ConstraintTags, LangTags) into a single ImageTags component
- Simplified image metadata extraction by using string operations instead of complex parsing
- Removed redundant language column and consolidated information into Tags column
- Added new getTags utility function to consistently parse and format image tag information
- Updated image search functionality to search through tag keys and values

**Impact:**
- Cleaner, more consistent display of image metadata in the UI
- More maintainable code structure for handling image tags
- Improved search capabilities across image metadata

**Screenshots:**

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/483e263b-88bc-4d5e-8a22-d3e219695f76.png)

**What to check:**
Data parsing is the same as 24.12.

**Checklist:**
- [ ] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version: manager < 24.12
- [x] Specific setting for review: 10.100.64.15
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after: will be handled in another stack