### PR TITLE
ci: remove job to add to Frontend daily board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -25,9 +25,3 @@ jobs:
           # to the issue
           project-url: https://github.com/orgs/lablup/projects/20
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-      - uses: actions/add-to-project@v1.0.2
-        with:
-          # You can target a repository in a different organization
-          # to the issue
-          project-url: https://github.com/orgs/lablup/projects/24
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Remove the automation workflow that adds issues/PRs to the Frontend daily board because it is now handled by the workflow feature of GitHub Projects.