### PR TITLE
fix: missed i18n

### DIFF
--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -629,7 +629,7 @@ const SessionLauncherPage = () => {
             upsertNotification({
               key: 'session-launcher:' + sessionName,
               to: backupTo,
-              toText: '수정',
+              toText: t('button.Edit'),
             });
             // this.metadata_updating = false;
             // console.log(err);


### PR DESCRIPTION
Internationalize notification edit button text in session launcher

Changes the hardcoded Korean text "수정" to use the internationalized string key `t('button.Edit')` for the edit button text in session notifications.

**Checklist:**

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after