### PR TITLE
fix: resizing column action causes order change in BAITable

### DIFF
--- a/react/src/components/BAITable.tsx
+++ b/react/src/components/BAITable.tsx
@@ -1,3 +1,4 @@
+import { useDebounce } from 'ahooks';
 import { GetProps, Table } from 'antd';
 import { createStyles } from 'antd-style';
 import { ColumnsType } from 'antd/es/table';
@@ -34,9 +35,10 @@ const ResizableTitle = (
     width: number;
   },
 ) => {
-  const { onResize, width, ...restProps } = props;
-
+  const { onResize, width, onClick, ...restProps } = props;
   const wrapRef = useRef<HTMLTableCellElement>(null);
+  const [isResizing, setIsResizing] = useState(false);
+  const debouncedIsResizing = useDebounce(isResizing, { wait: 100 });
 
   // This is a workaround for the initial width of resizable columns if the width is not specified
   useEffect(() => {
@@ -67,9 +69,24 @@ const ResizableTitle = (
         />
       }
       onResize={onResize}
+      onResizeStart={() => {
+        setIsResizing(true);
+      }}
+      onResizeStop={() => {
+        setIsResizing(false);
+      }}
       draggableOpts={{ enableUserSelectHack: false }}
     >
-      <th {...restProps} />
+      <th
+        onClick={(e) => {
+          if (debouncedIsResizing) {
+            e.preventDefault();
+          } else {
+            onClick?.(e);
+          }
+        }}
+        {...restProps}
+      />
     </Resizable>
   );
 };


### PR DESCRIPTION
Resolves #2830

Prevents column sorting when resizing columns in BAITable

This PR fixes an issue where users could accidentally trigger column sorting while resizing table columns. It adds a debounced resize state check that temporarily disables click events during and shortly after column resizing operations.

**Implementation details:**
- Added `isResizing` state to track when a column is being resized
- Implemented a 100ms debounced version of the resize state
- Modified click handler to prevent column sorting when resize is in progress
- Preserved original click behavior when not resizing
