### PR TITLE
fix: improve clipboard handling with optional chaining

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -1588,9 +1588,9 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         );
         this.notification.show();
       } else {
-        if (navigator.clipboard !== undefined) {
+        if (navigator?.clipboard !== undefined) {
           // for Chrome, Safari
-          navigator.clipboard.writeText(textToCopy).then(
+          navigator.clipboard.writeText?.(textToCopy).then(
             () => {
               this.notification.text = _text(
                 'session.applauncher.SSHConnectionExampleClipboardCopy',

--- a/src/components/backend-ai-import-view.ts
+++ b/src/components/backend-ai-import-view.ts
@@ -630,9 +630,9 @@ export default class BackendAIImport extends BackendAIPage {
         this.notification.text = _text('import.NoNotebookCode');
         this.notification.show();
       } else {
-        if (navigator.clipboard !== undefined) {
+        if (navigator?.clipboard !== undefined) {
           // for Chrome, Safari
-          navigator.clipboard.writeText(copyText).then(
+          navigator.clipboard.writeText?.(copyText).then(
             () => {
               this.notification.text = _text('import.NotebookBadgeCodeCopied');
               this.notification.show();

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -3035,6 +3035,25 @@ export default class BackendAISessionList extends BackendAIPage {
     );
   }
 
+  copyText(text: string) {
+    if (navigator.clipboard !== undefined) {
+      // for Chrome, Safari
+      navigator?.clipboard?.writeText(text)?.then((err) => {
+        console.error('Could not copy text: ', err);
+      });
+    } else {
+      // other browsers
+      const tmpInputElement = document.createElement('input');
+      tmpInputElement.type = 'text';
+      tmpInputElement.value = text;
+
+      document.body.appendChild(tmpInputElement);
+      tmpInputElement.select();
+      document.execCommand('copy');
+      document.body.removeChild(tmpInputElement);
+    }
+  }
+
   /**
    * Render session information - category, color, description, etc.
    *
@@ -3131,10 +3150,8 @@ ${rowData.item[this.sessionNameField]}</pre
                 id="session-name-copy-icon"
                 class="fg controls-running"
                 icon="content_copy"
-                @click="${async () =>
-                  await navigator.clipboard.writeText(
-                    rowData.item[this.sessionNameField],
-                  )}"
+                @click="${() =>
+                  this.copyText(rowData.item[this.sessionNameField])}"
               ></mwc-icon-button>
             </div>
             <div class="horizontal center center-justified layout">


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai-webui/issues/2843

**Changes:**
Improves clipboard functionality across browsers by:
- Adding optional chaining operators to clipboard API calls for better error handling
- Introducing a new `copyText()` method in session list for cross-browser text copying
- Implementing fallback copy mechanism for browsers without clipboard API support

**Rationale:**
The clipboard operations needed to be more robust across different browsers and handle cases where the clipboard API might be unavailable or restricted.

**Effects:**
- More reliable text copying functionality in session management
- Better error handling for clipboard operations
- Support for browsers without native clipboard API

**Checklist:**
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

**Testing Requirements:**
- Verify clipboard operations in Chrome/Safari
- Test copying functionality in browsers without clipboard API
- Confirm error handling when clipboard access is denied