### PR TITLE
fix: use `||` operator instead of unreachable `??`

### DIFF
--- a/react/src/components/AgentDetailModal.tsx
+++ b/react/src/components/AgentDetailModal.tsx
@@ -93,13 +93,14 @@ const AgentDetailModal: React.FC<AgentDetailModalProps> = ({
                 </Typography.Title>
                 <BAIProgressWithLabel
                   percent={
-                    ((convertBinarySizeUnit(
-                      _.toString(agent?.mem_cur_bytes),
-                      'g',
-                    )?.number ?? 0) /
-                      (convertBinarySizeUnit(parsedAvailableSlots?.mem, 'g')
-                        ?.number ?? 0)) *
-                      100 ?? 0
+                    (_.toNumber(
+                      convertBinarySizeUnit(_.toString(agent?.mem_cur_bytes), 'g')
+                        ?.number,
+                    ) /
+                      _.toNumber(
+                        convertBinarySizeUnit(parsedAvailableSlots?.mem, 'g')?.number,
+                      )) *
+                      100 || 0
                   }
                   valueLabel={`${
                     convertBinarySizeUnit(_.toString(agent?.mem_cur_bytes), 'g')

--- a/react/src/components/BAIProgressWithLabel.tsx
+++ b/react/src/components/BAIProgressWithLabel.tsx
@@ -15,7 +15,7 @@ export interface BAIProgressWithLabelProps {
 const BAIProgressWithLabel: React.FC<BAIProgressWithLabelProps> = ({
   title,
   valueLabel,
-  percent = 0,
+  percent,
   width,
   strokeColor,
   labelStyle,
@@ -46,7 +46,7 @@ const BAIProgressWithLabel: React.FC<BAIProgressWithLabelProps> = ({
       <Flex
         style={{
           height: '100%',
-          width: `${percent > 100 ? 100 : percent}%`,
+          width: `${!percent || _.isNaN(percent) ? 0 : _.min([percent, 100])}%`,
           position: 'absolute',
           left: 0,
           top: 0,
@@ -60,7 +60,16 @@ const BAIProgressWithLabel: React.FC<BAIProgressWithLabelProps> = ({
         <Typography.Text style={{ fontSize, ...labelStyle }}>
           {title}
         </Typography.Text>
-        <Typography.Text style={{ fontSize, ...labelStyle }}>
+        <Typography.Text
+          style={{
+            fontSize,
+            color:
+              _.isNaN(percent) || _.isUndefined(percent)
+                ? token.colorTextDisabled
+                : undefined,
+            ...labelStyle,
+          }}
+        >
           {valueLabel}
         </Typography.Text>
       </Flex>


### PR DESCRIPTION
Fix `Right operand of ?? is unreachable because the left operand is never nullish.` error by using `||` operator.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
