### PR TITLE
feat: Add `CREATING` session status

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -35,6 +35,7 @@ const isActive = (session: SessionActionButtonsFragment$data) => {
 //     'TERMINATING',
 //     'PENDING',
 //     'PREPARING',
+//     'CREATING',
 //     'PULLING',
 //   ].includes(session?.status || '');
 // };

--- a/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
@@ -16,8 +16,9 @@ interface SessionStatusTagProps {
 const statusTagColor = {
   //prepare
   RESTARTING: 'blue',
-  PREPARED: 'blue',
   PREPARING: 'blue',
+  PREPARED: 'blue',
+  CREATING: 'blue',
   PULLING: 'blue',
   //running
   RUNNING: 'green',
@@ -33,7 +34,8 @@ const isTransitional = (session: SessionStatusTagFragment$data) => {
     'RESTARTING',
     'TERMINATING',
     'PENDING',
-    'PREPARING',
+    `PREPARING`,
+    'CREATING',
     'PULLING',
   ].includes(session?.status || '');
 };

--- a/react/src/components/SessionList.tsx
+++ b/react/src/components/SessionList.tsx
@@ -115,8 +115,9 @@ const SessionList: React.FC<SessionListProps> = ({
   const statusTagColor = {
     //prepare
     RESTARTING: 'blue',
-    PREPARED: 'blue',
     PREPARING: 'blue',
+    PREPARED: 'blue',
+    CREATING: 'blue',
     PULLING: 'blue',
     //running
     RUNNING: 'green',

--- a/react/src/components/SessionListColums/SessionInfoCell.tsx
+++ b/react/src/components/SessionListColums/SessionInfoCell.tsx
@@ -20,14 +20,21 @@ const isRunningStatus = (status: string = '') => {
     'TERMINATING',
     'PENDING',
     'SCHEDULED',
-    'PREPARED',
     'PREPARING',
+    'PREPARED',
+    'CREATING',
     'PULLING',
   ].includes(status);
 };
 
 const isPreparing = (status: string = '') => {
-  return ['RESTARTING', 'PREPARED', 'PREPARING', 'PULLING'].includes(status);
+  return [
+    'RESTARTING',
+    'PREPARING',
+    'PREPARED',
+    'CREATING',
+    'PULLING',
+  ].includes(status);
 };
 
 const SessionInfoCell: React.FC<{

--- a/react/src/pages/SessionListPage.tsx
+++ b/react/src/pages/SessionListPage.tsx
@@ -15,8 +15,9 @@ const RUNNINGS = [
   'TERMINATING',
   'PENDING',
   'SCHEDULED',
-  'PREPARED',
   'PREPARING',
+  'PREPARED',
+  'CREATING',
   'PULLING',
 ];
 const TAB_STATUS_MAP = {

--- a/src/components/backend-ai-edu-applauncher.ts
+++ b/src/components/backend-ai-edu-applauncher.ts
@@ -261,6 +261,9 @@ export default class BackendAiEduApplauncher extends BackendAIPage {
         globalThis.backendaiclient.supports('prepared-session-status')
           ? 'PREPARED'
           : undefined,
+        globalThis.backendaiclient.supports('creating-session-status')
+          ? 'CREATING'
+          : undefined,
         'PREPARING',
         'PULLING',
       ]
@@ -274,6 +277,9 @@ export default class BackendAiEduApplauncher extends BackendAIPage {
         'PENDING',
         globalThis.backendaiclient.supports('prepared-session-status')
           ? 'PREPARED'
+          : undefined,
+        globalThis.backendaiclient.supports('creating-session-status')
+          ? 'CREATING'
           : undefined,
         'PREPARING',
         'PULLING',

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -580,8 +580,9 @@ export default class BackendAISessionList extends BackendAIPage {
   _isPreparing(status) {
     const preparingStatuses = [
       'RESTARTING',
-      'PREPARED',
       'PREPARING',
+      'PREPARED',
+      'CREATING',
       'PULLING',
     ];
     if (preparingStatuses.indexOf(status) === -1) {
@@ -772,6 +773,9 @@ export default class BackendAISessionList extends BackendAIPage {
         if (globalThis.backendaiclient.supports('prepared-session-status')) {
           status.push('PREPARED');
         }
+        if (globalThis.backendaiclient.supports('creating-session-status')) {
+          status.push('CREATING');
+        }
         break;
       case 'finished':
         status = ['TERMINATED', 'CANCELLED']; // TERMINATED, CANCELLED
@@ -788,6 +792,9 @@ export default class BackendAISessionList extends BackendAIPage {
         ];
         if (globalThis.backendaiclient.supports('prepared-session-status')) {
           status.push('PREPARED');
+        }
+        if (globalThis.backendaiclient.supports('creating-session-status')) {
+          status.push('CREATING');
         }
     }
     if (

--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -356,6 +356,9 @@ export default class BackendAISessionView extends BackendAIPage {
     if (globalThis.backendaiclient.supports('prepared-session-status')) {
       status.push('PREPARED');
     }
+    if (globalThis.backendaiclient.supports('creating-session-status')) {
+      status.push('CREATING');
+    }
     if (globalThis.backendaiclient.supports('detailed-session-states')) {
       status = status.join(',');
     }

--- a/src/lib/backend.ai-client-es6.js
+++ b/src/lib/backend.ai-client-es6.js
@@ -32471,7 +32471,7 @@
               'occupied_slots',
               'containers {live_stat last_stat}',
             ],
-            e = 'RUNNING,RESTARTING,TERMINATING,PENDING,SCHEDULED,PREPARING,PULLING,TERMINATED,CANCELLED,ERROR',
+            e = 'RUNNING,RESTARTING,TERMINATING,PENDING,SCHEDULED,CREATING,PULLING,TERMINATED,CANCELLED,ERROR',
             i = '',
             r = 100,
             n = 0,

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -725,6 +725,7 @@ class Client {
       this._features['extended-image-info'] = true;
       this._features['batch-timeout'] = true;
       this._features['prepared-session-status'] = true;
+      this._features['creating-session-status'] = true;
     }
   }
 
@@ -3612,7 +3613,7 @@ class ComputeSession {
    * Get the number of compute sessions with specific conditions.
    *
    * @param {string or array} status - status to query. Default is 'RUNNING'.
-   *        Available statuses are: `PREPARING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
+   *        Available statuses are: `PREPARING`, `CREATING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
    * @param {string} accessKey - access key that is used to start compute sessions.
    * @param {number} limit - limit number of query items.
    * @param {number} offset - offset for item query. Useful for pagination.
@@ -3650,7 +3651,7 @@ class ComputeSession {
    *
    * @param {array} fields - fields to query. Default fields are: ["id", "name", "image", "created_at", "terminated_at", "status", "status_info", "occupied_slots", "cpu_used", "io_read_bytes", "io_write_bytes"].
    * @param {string or array} status - status to query. Default is 'RUNNING'.
-   *        Available statuses are: `PREPARING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
+   *        Available statuses are:`PREPARING`, `PREPARED`, `CREATING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
    * @param {string} accessKey - access key that is used to start compute sessions.
    * @param {number} limit - limit number of query items.
    * @param {number} offset - offset for item query. Useful for pagination.
@@ -3722,7 +3723,7 @@ class ComputeSession {
       'occupied_slots',
       'containers {live_stat last_stat}',
     ],
-    status = 'RUNNING,RESTARTING,TERMINATING,PENDING,SCHEDULED,PREPARING,PULLING,TERMINATED,CANCELLED,ERROR',
+    status = 'RUNNING,RESTARTING,TERMINATING,PENDING,SCHEDULED,PREPARING,PREPARED,CREATING,PULLING,TERMINATED,CANCELLED,ERROR',
     accessKey = '',
     limit = 100,
     offset = 0,

--- a/src/lib/backend.ai-client-node.js
+++ b/src/lib/backend.ai-client-node.js
@@ -2824,7 +2824,7 @@ class ComputeSession {
    * Get the number of compute sessions with specific conditions.
    *
    * @param {string or array} status - status to query. Default is 'RUNNING'.
-   *        Available statuses are: `PREPARING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
+   *        Available statuses are: `PREPARING`, `PREPARED`, `CREATING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
    * @param {string} accessKey - access key that is used to start compute sessions.
    * @param {number} limit - limit number of query items.
    * @param {number} offset - offset for item query. Useful for pagination.
@@ -2861,7 +2861,7 @@ class ComputeSession {
    *
    * @param {array} fields - fields to query. Default fields are: ["id", "name", "image", "created_at", "terminated_at", "status", "status_info", "occupied_slots", "cpu_used", "io_read_bytes", "io_write_bytes"].
    * @param {string or array} status - status to query. Default is 'RUNNING'.
-   *        Available statuses are: `PREPARING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
+   *        Available statuses are: `PREPARING`, `PREPARED`, `CREATING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
    * @param {string} accessKey - access key that is used to start compute sessions.
    * @param {number} limit - limit number of query items.
    * @param {number} offset - offset for item query. Useful for pagination.
@@ -2932,7 +2932,7 @@ class ComputeSession {
       'occupied_slots',
       'containers {live_stat last_stat}',
     ],
-    status = 'RUNNING,RESTARTING,TERMINATING,PENDING,SCHEDULED,PREPARING,PULLING,TERMINATED,CANCELLED,ERROR',
+    status = 'RUNNING,RESTARTING,TERMINATING,PENDING,SCHEDULED,PREPARING,PREPARED,CREATING,PULLING,TERMINATED,CANCELLED,ERROR',
     accessKey = '',
     limit = 100,
     offset = 0,

--- a/src/lib/backend.ai-client-node.ts
+++ b/src/lib/backend.ai-client-node.ts
@@ -2363,7 +2363,7 @@ class Agent {
   /**
    * List computation agents.
    *
-   * @param {string} status - Status to query. Should be one of 'ALIVE', 'PREPARING', 'TERMINATING' and 'TERMINATED'.
+   * @param {string} status - Status to query. Should be one of 'ALIVE', 'CREATING', 'TERMINATING' and 'TERMINATED'.
    * @param {array} fields - Fields to query. Queryable fields are:  'id', 'status', 'region', 'first_contact', 'cpu_cur_pct', 'mem_cur_bytes', 'available_slots', 'occupied_slots'.
    * @param {number} timeout - timeout for the request. Default uses SDK default. (5 sec.)
    */
@@ -3074,7 +3074,7 @@ class ComputeSession {
    * Get the number of compute sessions with specific conditions.
    *
    * @param {string or array} status - status to query. Default is 'RUNNING'.
-   *        Available statuses are: `PREPARING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
+   *        Available statuses are: `CREATING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
    * @param {string} accessKey - access key that is used to start compute sessions.
    * @param {number} limit - limit number of query items.
    * @param {number} offset - offset for item query. Useful for pagination.
@@ -3112,7 +3112,7 @@ class ComputeSession {
    *
    * @param {array} fields - fields to query. Default fields are: ["id", "name", "image", "created_at", "terminated_at", "status", "status_info", "occupied_slots", "cpu_used", "io_read_bytes", "io_write_bytes"].
    * @param {string or array} status - status to query. Default is 'RUNNING'.
-   *        Available statuses are: `PREPARING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
+   *        Available statuses are: `CREATING`, `BUILDING`, `PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
    * @param {string} accessKey - access key that is used to start compute sessions.
    * @param {number} limit - limit number of query items.
    * @param {number} offset - offset for item query. Useful for pagination.
@@ -3184,7 +3184,7 @@ class ComputeSession {
       'occupied_slots',
       'containers {live_stat last_stat}',
     ],
-    status = 'RUNNING,RESTARTING,TERMINATING,PENDING,SCHEDULED,PREPARING,PULLING,TERMINATED,CANCELLED,ERROR',
+    status = 'RUNNING,RESTARTING,TERMINATING,PENDING,SCHEDULED,CREATING,PULLING,TERMINATED,CANCELLED,ERROR',
     accessKey = '',
     limit = 100,
     offset = 0,
@@ -3300,7 +3300,7 @@ class SessionTemplate {
    *
    * @param {array} fields - fields to query. Default fields are: ["id", "name", "image", "created_at", "terminated_at", "status", "status_info", "occupied_slots", "cpu_used", "io_read_bytes", "io_write_bytes"].
    * @param {string or array} status - status to query. Default is 'RUNNING'.
-   *        Available statuses are: `PREPARING`, `BUILDING`,`PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
+   *        Available statuses are: `CREATING`, `BUILDING`,`PENDING`, `SCHEDULED`, `RUNNING`, `RESTARTING`, `RESIZING`, `SUSPENDED`, `TERMINATING`, `TERMINATED`, `ERROR`.
    * @param {string} accessKey - access key that is used to start compute sessions.
    * @param {number} limit - limit number of query items.
    * @param {number} offset - offset for item query. Useful for pagination.


### PR DESCRIPTION
After https://github.com/lablup/backend.ai/pull/3114, Added `CREATING` session status to represent container creation phase, and redefined `PREPARING` status to specifically indicate pre-container preparation phases.

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [x] Minium required manager version: 24.12.0
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
