### PR TITLE
chore: suppress Relay warning messages in development mode

### DIFF
--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -20,6 +20,24 @@ import ReactDOM from 'react-dom/client';
 import { useTranslation } from 'react-i18next';
 import { Route, Routes } from 'react-router-dom';
 
+// To maintain compatibility with various manager versions, the WebUI client uses directives to manipulate GraphQL queries.
+// This can cause Relay to show "Warning: RelayResponseNormalizer: Payload did not contain a value for field" in the browser console during development.
+// It's advisable to ignore these frequent logs in development mode.
+if (process.env.NODE_ENV === 'development') {
+  const originalConsoleError = console.error;
+  console.error = function (message, ...args) {
+    if (
+      typeof message === 'string' &&
+      message.includes(
+        'Warning: RelayResponseNormalizer: Payload did not contain a value for field',
+      )
+    ) {
+      return;
+    }
+    originalConsoleError.apply(console, [message, ...args]);
+  };
+}
+
 // Load custom theme config once in react/index.tsx
 loadCustomThemeConfig();
 


### PR DESCRIPTION
Suppress Relay GraphQL Field Warning Messages in Development

This change filters out frequent Relay warning messages in the browser console during development. These warnings occur due to GraphQL query directives used for manager version compatibility and do not indicate actual issues.

The warnings specifically relate to "RelayResponseNormalizer: Payload did not contain a value for field" messages, which are expected behavior but can clutter the development console.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/b66da35e-1379-4f81-a24b-5c8640df1416.png)

**Checklist:**
- [ ] Test case(s) to demonstrate the difference of before/after
  - Before: Console shows repeated Relay field warnings
  - After: These specific warnings are suppressed while preserving other console messages