### PR TITLE
feat: NEO sider's toggle button and refactoring

### DIFF
--- a/react/src/components/BAISider.tsx
+++ b/react/src/components/BAISider.tsx
@@ -1,36 +1,39 @@
 import Flex from './Flex';
-import { ConfigProvider, Grid, SiderProps, Typography, theme } from 'antd';
+import { ConfigProvider, Grid, SiderProps, theme } from 'antd';
 import Sider from 'antd/es/layout/Sider';
+import classNames from 'classnames';
 import _ from 'lodash';
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 export interface BAISiderProps extends SiderProps {
   logoCollapsed?: React.ReactNode;
   logo?: React.ReactNode;
   logoTitleCollapsed?: React.ReactNode;
   logoTitle?: React.ReactNode;
-  bottomText?: React.ReactNode;
 }
 
-export const DEFAULT_COLLAPSED_WIDTH = 74;
-const BAISider: React.FC<BAISiderProps> = ({
-  children,
-  logo,
-  logoCollapsed,
-  logoTitle,
-  logoTitleCollapsed,
-  bottomText,
-  theme: siderTheme,
-  ...otherProps
-}) => {
-  const { token } = theme.useToken();
-  const { Text } = Typography;
-  const { xs } = Grid.useBreakpoint();
+export const COLLAPSED_SIDER_WIDTH = 74;
+export const SIDER_WIDTH = 240;
+const BAISider = forwardRef<HTMLDivElement, BAISiderProps>(
+  (
+    {
+      children,
+      logo,
+      logoCollapsed,
+      logoTitle,
+      logoTitleCollapsed,
+      theme: siderTheme,
+      ...otherProps
+    },
+    ref,
+  ) => {
+    const { token } = theme.useToken();
+    const { xs } = Grid.useBreakpoint();
 
-  return (
-    <>
-      <style>
-        {`
+    return (
+      <>
+        <style>
+          {`
           .bai-sider .ant-layout-sider-children {
             display: flex;
             flex-direction: column;
@@ -54,100 +57,70 @@ const BAISider: React.FC<BAISiderProps> = ({
             -webkit-app-region: no-drag;
           }
         `}
-      </style>
-      <Sider
-        width={240}
-        breakpoint="md"
-        style={{
-          overflowX: 'hidden',
-          overflowY: 'auto',
-          height: '100vh',
-          position: 'sticky',
-          top: 0,
-          left: 0,
-          scrollbarColor: 'auto',
-        }}
-        {...otherProps}
-        collapsedWidth={
-          xs
-            ? 0
-            : _.isNumber(otherProps.collapsedWidth)
-              ? otherProps.collapsedWidth
-              : DEFAULT_COLLAPSED_WIDTH
-        }
-        theme={siderTheme}
-        className="bai-sider"
-      >
-        <ConfigProvider
-          theme={{
-            algorithm: siderTheme === 'dark' ? theme.darkAlgorithm : undefined,
+        </style>
+        <Sider
+          ref={ref}
+          width={SIDER_WIDTH}
+          breakpoint="md"
+          style={{
+            boxShadow: '0px 0px 10px 0px rgba(0, 0, 0, 0.10)',
+            height: '100vh',
+            scrollbarColor: 'auto',
           }}
+          {...otherProps}
+          collapsedWidth={
+            xs
+              ? 0
+              : _.isNumber(otherProps.collapsedWidth)
+                ? otherProps.collapsedWidth
+                : COLLAPSED_SIDER_WIDTH
+          }
+          theme={siderTheme}
+          className={classNames('bai-sider', otherProps.className)}
+          trigger={null}
         >
-          <Flex
-            direction="column"
-            justify="center"
-            align={otherProps.collapsed ? 'center' : 'start'}
-            style={{
-              transition: 'all 0.2s ease-in-out',
-              backgroundColor: token.colorPrimary,
-              padding: otherProps.collapsed ? undefined : '0 30px',
-              height: token.Layout?.headerHeight || 60,
-              marginBottom: token.marginXL,
-              position: 'sticky',
-              top: 0,
+          <ConfigProvider
+            theme={{
+              algorithm:
+                siderTheme === 'dark' ? theme.darkAlgorithm : undefined,
             }}
-            className={'logo-and-text-container draggable'}
           >
-            <div className="logo-img-wrap non-draggable">
-              <div style={{ display: otherProps.collapsed ? 'none' : 'block' }}>
-                {logo}
-              </div>
-              <div style={{ display: otherProps.collapsed ? 'block' : 'none' }}>
-                {logoCollapsed}
-              </div>
-            </div>
-            {/* <div className="logo-title-wrap non-draggable">
-              <Typography.Text
-                style={{
-                  fontSize: 16,
-                  lineHeight: '16px',
-                  fontWeight: 200,
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {otherProps.collapsed ? logoTitleCollapsed : logoTitle}
-              </Typography.Text>
-            </div> */}
-          </Flex>
-          {children}
-          {bottomText && (
-            <>
-              <Flex style={{ flex: 1 }} />
+            <Flex direction="column" align="stretch" style={{ height: '100%' }}>
               <Flex
-                justify="center"
                 direction="column"
+                justify="center"
+                align={otherProps.collapsed ? 'center' : 'start'}
                 style={{
-                  width: '100%',
-                  padding: 30,
-                  textAlign: 'center',
+                  transition: 'all 0.2s ease-in-out',
+                  backgroundColor: token.colorPrimary,
+                  padding: otherProps.collapsed ? undefined : '0 30px',
+                  height: token.Layout?.headerHeight || 60,
+                  position: 'sticky',
+                  top: 0,
+                  zIndex: 1,
                 }}
+                className={'logo-and-text-container draggable'}
               >
-                <Text
-                  type="secondary"
-                  style={{
-                    fontSize: '12px',
-                    wordBreak: 'normal',
-                  }}
-                >
-                  {bottomText}
-                </Text>
+                <div className="logo-img-wrap non-draggable">
+                  <div
+                    style={{ display: otherProps.collapsed ? 'none' : 'block' }}
+                  >
+                    {logo}
+                  </div>
+                  <div
+                    style={{ display: otherProps.collapsed ? 'block' : 'none' }}
+                  >
+                    {logoCollapsed}
+                  </div>
+                </div>
               </Flex>
-            </>
-          )}
-        </ConfigProvider>
-      </Sider>
-    </>
-  );
-};
+              {children}
+            </Flex>
+          </ConfigProvider>
+        </Sider>
+      </>
+    );
+  },
+);
 
 export default BAISider;

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -1,5 +1,6 @@
 import { useCustomThemeConfig } from '../../helper/customThemeConfig';
 import { useBAISettingUserState } from '../../hooks/useBAISetting';
+import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';
 import { useThemeMode } from '../../hooks/useThemeMode';
 import BAIContentWithDrawerArea from '../BAIContentWithDrawerArea';
 import BAIErrorBoundary from '../BAIErrorBoundary';
@@ -50,6 +51,18 @@ function MainLayout() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [compactSidebarActive]);
+
+  useKeyboardShortcut(
+    (event) => {
+      if (event.key === '[') {
+        event.preventDefault();
+        setSideCollapsed((v) => !v);
+      }
+    },
+    {
+      skipShortcutOnMetaKey: true,
+    },
+  );
 
   // const currentDomainName = useCurrentDomainValue();
   const { token } = theme.useToken();
@@ -131,6 +144,9 @@ function MainLayout() {
             } else {
               !compactSidebarActive && setSideCollapsed(false);
             }
+          }}
+          onCollapse={(collapsed) => {
+            setSideCollapsed(collapsed);
           }}
           webuiplugins={webUIPlugins}
         />

--- a/react/src/components/SiderToggleButton.tsx
+++ b/react/src/components/SiderToggleButton.tsx
@@ -1,0 +1,88 @@
+import Flex from './Flex';
+import { Button, ConfigProvider, theme, Tooltip, Typography } from 'antd';
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface SiderToggleButtonProps {
+  collapsed?: boolean;
+  buttonTop?: number;
+  onClick?: (collapsed: boolean) => void;
+  hidden?: boolean;
+  // style?: React.CSSProperties;
+}
+const SiderToggleButton: React.FC<SiderToggleButtonProps> = ({
+  collapsed = false,
+  buttonTop,
+  onClick,
+  hidden,
+}) => {
+  const { t } = useTranslation();
+
+  const { token } = theme.useToken();
+  return (
+    <Flex
+      style={{
+        position: 'absolute',
+        right: 0,
+        transform: 'translateX(12px)',
+        paddingTop: buttonTop,
+        zIndex: 1,
+      }}
+      direction="column"
+      justify={buttonTop ? 'start' : 'center'}
+    >
+      <ConfigProvider
+        theme={{
+          components: {
+            Button: {
+              defaultBorderColor: token.colorBorderSecondary,
+            },
+          },
+        }}
+      >
+        <Tooltip
+          title={
+            <>
+              {collapsed ? t('button.Expand') : t('button.Collapse')}
+              <Typography.Text
+                code
+                style={{
+                  color: 'inherit',
+                }}
+              >
+                {'['}
+              </Typography.Text>
+            </>
+          }
+          placement="right"
+        >
+          <Button
+            shape="circle"
+            // className={classNames(styles.toggleBtn, 'toggle-btn')}
+            size="small"
+            icon={
+              collapsed ? (
+                <ChevronRightIcon color={token.colorTextTertiary} />
+              ) : (
+                <ChevronLeftIcon color={token.colorTextTertiary} />
+              )
+            }
+            onClick={() => {
+              onClick && onClick(!collapsed);
+            }}
+            style={{
+              boxShadow: 'none',
+              visibility: 'hidden',
+              opacity: 0,
+              transition: 'opacity 0.2s ease, visibility 0.2s ease',
+              ...(!hidden ? { visibility: 'visible', opacity: 1 } : {}),
+            }}
+          />
+        </Tooltip>
+      </ConfigProvider>
+    </Flex>
+  );
+};
+
+export default SiderToggleButton;

--- a/react/src/hooks/useKeyboardShortcut.ts
+++ b/react/src/hooks/useKeyboardShortcut.ts
@@ -1,0 +1,77 @@
+import { useEventListener } from 'ahooks';
+
+/**
+ * useKeyboardShortcut
+ * A custom hook to handle keyboard shortcuts when no input or textarea is focused,
+ * including within Shadow DOM.
+ *
+ * @param handler - The callback to invoke when the shortcut is triggered.
+ */
+const useKeyboardShortcut = (
+  handler: (event: KeyboardEvent) => void,
+  options?: {
+    skipShortcutOnMetaKey?: boolean;
+  },
+) => {
+  /**
+   * Checks if an element is a focusable input field (input, textarea, or select).
+   * @param element - The element to check.
+   */
+  const isInputElement = (element: Element | null): boolean => {
+    if (!element) return false;
+    const tagName = element.tagName.toLowerCase();
+    return (
+      tagName === 'input' || tagName === 'textarea' || tagName === 'select'
+    );
+  };
+
+  /**
+   * Recursively checks if the active element or its Shadow DOM ancestors are input fields.
+   * @param element - The starting element.
+   */
+  const isShadowInput = (element: Element | null): boolean => {
+    let currentElement: Element | null = element;
+    while (currentElement) {
+      if (isInputElement(currentElement)) return true;
+      if (currentElement instanceof HTMLElement && currentElement.shadowRoot) {
+        currentElement = currentElement.shadowRoot.activeElement;
+      } else {
+        break;
+      }
+    }
+    return false;
+  };
+
+  const isModalOpen = () => document.querySelector('.ant-modal');
+
+  /**
+   * Handles the keydown event, invoking the handler if conditions are met.
+   * @param event - The keyboard event.
+   */
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    const activeElement = document.activeElement;
+
+    if (
+      options?.skipShortcutOnMetaKey &&
+      (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey)
+    ) {
+      return;
+    }
+    if (
+      activeElement &&
+      (isInputElement(activeElement) ||
+        isShadowInput(activeElement) ||
+        isModalOpen())
+    ) {
+      // If the active element is a focusable input, do not trigger the shortcut
+      return;
+    }
+
+    handler(event);
+  };
+
+  // Use ahooks' useEventListener for global keyboard event management
+  useEventListener('keydown', handleKeyDown);
+};
+
+export default useKeyboardShortcut;

--- a/react/src/hooks/usePrimaryColors.ts
+++ b/react/src/hooks/usePrimaryColors.ts
@@ -1,0 +1,16 @@
+import { theme } from 'antd';
+import { useMemo } from 'react';
+
+const usePrimaryColors = () => {
+  const { token } = theme.useToken();
+  const customColors = useMemo(() => {
+    return {
+      primary: token.colorPrimary,
+      secondary: token.colorSuccess,
+      admin: token.colorInfo,
+    };
+  }, [token]);
+  return customColors;
+};
+
+export default usePrimaryColors;

--- a/src/components/backend-ai-webui-styles.ts
+++ b/src/components/backend-ai-webui-styles.ts
@@ -479,10 +479,6 @@ export const BackendAIWebUIStyles = [
       height: 0;
     }
 
-    .terms-of-use {
-      margin-bottom: 10px;
-    }
-
     footer#short-height {
       display: none;
     }

--- a/src/components/lablup-activity-panel.ts
+++ b/src/components/lablup-activity-panel.ts
@@ -63,11 +63,11 @@ export default class LablupActivityPanel extends LitElement {
           box-sizing: border-box;
           margin: 0 !important;
           padding: 0;
-          border-radius: 5px;
+          border-radius: var(--token-borderRadiusLG);
           width: 280px;
           line-height: 1.1;
           color: var(--token-colorText);
-          border: 1px solid var(--token-colorBorder, #424242);
+          border: 1px solid var(--token-colorBorderSecondary, #424242);
         }
 
         div.card > h4 {
@@ -79,7 +79,7 @@ export default class LablupActivityPanel extends LitElement {
           padding: 5px 15px 5px 20px;
           margin: 0 0 10px 0;
           border-radius: 5px 5px 0 0;
-          border-bottom: 1px solid var(--token-colorBorder, #ddd);
+          border-bottom: 1px solid var(--token-colorBorderSecondary, #ddd);
           display: flex;
           white-space: nowrap;
           text-overflow: ellipsis;


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/c3c9b8e7-7063-4fb9-b717-c805530a5a43.png)

**Changes:**
- Added keyboard shortcut '[' to toggle sidebar collapse state
- Introduced a collapsible button on the sidebar that appears on hover
- Moved sidebar footer content into a more structured layout
- Added `useKeyboardShortcut` hook to handle keyboard shortcuts when no input is focused
- Refactored BAISider component to use forwardRef and improve layout structure
- Standardized sidebar width constants (COLLAPSED_SIDER_WIDTH = 74, SIDER_WIDTH = 240)
- Removed bottomText prop from BAISider in favor of direct content rendering
- Added hover detection for showing/hiding the collapse toggle button

**Testing Requirements:**
1. Verify the '[' keyboard shortcut toggles sidebar when no input is focused
2. Check that the collapse button appears on sidebar hover
3. Confirm sidebar footer content displays correctly in both expanded/collapsed states
4. Test that keyboard shortcuts don't trigger when inputs or modals are focused