### PR TITLE
hotfix: session list fetch failure due to missing version condition for `PREPARED`

### DIFF
--- a/src/components/backend-ai-edu-applauncher.ts
+++ b/src/components/backend-ai-edu-applauncher.ts
@@ -258,20 +258,28 @@ export default class BackendAiEduApplauncher extends BackendAIPage {
         'TERMINATING',
         'PENDING',
         'SCHEDULED',
-        'PREPARED',
+        globalThis.backendaiclient.supports('prepared-session-status')
+          ? 'PREPARED'
+          : undefined,
         'PREPARING',
         'PULLING',
-      ].join(',');
+      ]
+        .filter((v) => !!v)
+        .join(',');
     } else {
       statuses = [
         'RUNNING',
         'RESTARTING',
         'TERMINATING',
         'PENDING',
-        'PREPARED',
+        globalThis.backendaiclient.supports('prepared-session-status')
+          ? 'PREPARED'
+          : undefined,
         'PREPARING',
         'PULLING',
-      ].join(',');
+      ]
+        .filter((v) => !!v)
+        .join(',');
     }
 
     const accessKey = globalThis.backendaiclient._config.accessKey;

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -765,11 +765,13 @@ export default class BackendAISessionList extends BackendAIPage {
           'TERMINATING',
           'PENDING',
           'SCHEDULED',
-          'PREPARED',
           'PREPARING',
           'PULLING',
           'ERROR',
         ];
+        if (globalThis.backendaiclient.supports('prepared-session-status')) {
+          status.push('PREPARED');
+        }
         break;
       case 'finished':
         status = ['TERMINATED', 'CANCELLED']; // TERMINATED, CANCELLED
@@ -781,10 +783,12 @@ export default class BackendAISessionList extends BackendAIPage {
           'TERMINATING',
           'PENDING',
           'SCHEDULED',
-          'PREPARED',
           'PREPARING',
           'PULLING',
         ];
+        if (globalThis.backendaiclient.supports('prepared-session-status')) {
+          status.push('PREPARED');
+        }
     }
     if (
       !globalThis.backendaiclient.supports('avoid-hol-blocking') &&

--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -334,7 +334,6 @@ export default class BackendAISessionView extends BackendAIPage {
         'TERMINATING',
         'PENDING',
         'SCHEDULED',
-        'PREPARED',
         'PREPARING',
         'PULLING',
         'TERMINATED',
@@ -347,13 +346,15 @@ export default class BackendAISessionView extends BackendAIPage {
         'RESTARTING',
         'TERMINATING',
         'PENDING',
-        'PREPARED',
         'PREPARING',
         'PULLING',
         'TERMINATED',
         'CANCELLED',
         'ERROR',
       ];
+    }
+    if (globalThis.backendaiclient.supports('prepared-session-status')) {
+      status.push('PREPARED');
     }
     if (globalThis.backendaiclient.supports('detailed-session-states')) {
       status = status.join(',');

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -724,6 +724,7 @@ class Client {
     if (this.isManagerVersionCompatibleWith('24.12.0')) {
       this._features['extended-image-info'] = true;
       this._features['batch-timeout'] = true;
+      this._features['prepared-session-status'] = true;
     }
   }
 


### PR DESCRIPTION
**Changes:**
Adds conditional support for the 'PREPARED' session status based on manager version compatibility (24.12.0+). The status is now only included in session listings and filters when supported by the backend.

**Testing:**
Verify that the 'PREPARED' session status only appears in the UI when using Backend.AI manager version 24.12.0 or higher.