### PR TITLE
feat: user can open a session detail panel in notifications

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -19,6 +19,7 @@ import {
   IndexRouteObject,
   RouterProvider,
   createBrowserRouter,
+  useLocation,
 } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
@@ -147,7 +148,10 @@ const router = createBrowserRouter([
         children: [
           {
             path: '',
-            element: <WebUINavigate to="/job" replace />,
+            Component: () => {
+              const location = useLocation();
+              return <WebUINavigate to={'/job' + location.search} replace />;
+            },
           },
           {
             path: '/session/start',

--- a/react/src/components/WebUINavigate.tsx
+++ b/react/src/components/WebUINavigate.tsx
@@ -3,20 +3,20 @@ import _ from 'lodash';
 import React, { useEffect } from 'react';
 import { Navigate, NavigateProps } from 'react-router-dom';
 
-interface WebUINavigateProps extends NavigateProps {
-  options?: {
-    params?: any;
-  };
-}
-const WebUINavigate: React.FC<WebUINavigateProps> = ({ options, ...props }) => {
+interface WebUINavigateProps extends NavigateProps {}
+const WebUINavigate: React.FC<WebUINavigateProps> = ({ ...props }) => {
   useSuspendedBackendaiClient();
   const pathName = _.isString(props.to) ? props.to : props.to.pathname || '';
+  const [path, query] = pathName.split('?');
+  const params = {
+    params: Object.fromEntries(new URLSearchParams(query)),
+  };
   useEffect(() => {
     document.dispatchEvent(
       new CustomEvent('move-to-from-react', {
         detail: {
-          path: pathName,
-          params: options?.params,
+          path: path,
+          params,
         },
       }),
     );

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -606,6 +606,11 @@ const SessionLauncherPage = () => {
               sessionName: string;
               servicePorts: Array<{ name: string }>;
             }>) => {
+              // After the session is created, add a "See Details" button to navigate to the session page.
+              upsertNotification({
+                key: 'session-launcher:' + sessionName,
+                to: `/session?sessionDetail=${firstSession.sessionId}`,
+              });
               pushSessionHistory({
                 id: firstSession.sessionId,
                 params: usedSearchParams,


### PR DESCRIPTION
Resovles #2857

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/cd44d032-74db-4ecc-8c24-1907f7f30d8e.png)

**Changes:**
- Preserves query parameters when redirecting from root to `/job` path
- Simplifies WebUINavigate component by extracting query parameters directly from the URL
- Adds "See Detail" notification with navigation link after session creation

**Impact:**
- Users will maintain their URL parameters when being redirected from the root path
- Session creation now provides a direct link to view session details via notification
- Improves navigation flow between different sections of the application

**Testing Steps:**
1. Create a new session
2. Confirm "See Details" notification appears with correct session link
3. Click "See Details" in session creation notification.
4. Confirm a session detail panel is opened