### PR TITLE
fix: invalid environment name parsing

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -507,7 +507,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
                               }}
                             />
                             <TextHighlighter keyword={environmentSearch}>
-                              {tagAlias(environmentGroup.displayName)}
+                              {environmentGroup.displayName}
                             </TextHighlighter>
                           </Flex>
                           <Flex


### PR DESCRIPTION
follows #2860 

Use the `name` value only of `image_metadata.json`. It resolves unexpected parsing problems.

### How to test
> endpoint: https://cloud.backend.ai/
1. Create a new session.
2. Click 'Environments & Resource allocation'.
3. Select Environments.
4. See error.

Before

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/edf376c1-4633-4633-9841-b56edcf87649.png)

After

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/6bd39a04-b7d1-43ac-abe6-6fdd7b90d5b1.png)

**Checklist:** (if applicable)

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
