### PR TITLE
feat: Set the initial value of the chat modal to the recently created token

### DIFF
--- a/react/src/components/lablupTalkativotUI/LLMChatCard.tsx
+++ b/react/src/components/lablupTalkativotUI/LLMChatCard.tsx
@@ -58,6 +58,7 @@ export interface LLMChatCardProps extends CardProps {
   onInputChange?: (input: string) => void;
   onSubmitChange?: () => void;
   showCompareMenuItem?: boolean;
+  modelToken?: string;
 }
 
 const LLMChatCard: React.FC<LLMChatCardProps> = ({
@@ -76,6 +77,7 @@ const LLMChatCard: React.FC<LLMChatCardProps> = ({
   onInputChange,
   onSubmitChange,
   showCompareMenuItem,
+  modelToken,
   ...cardProps
 }) => {
   const webuiNavigate = useWebUINavigate();
@@ -306,6 +308,7 @@ const LLMChatCard: React.FC<LLMChatCardProps> = ({
           key={baseURL}
           initialValues={{
             baseURL: baseURL,
+            token: modelToken,
           }}
         >
           {alert ? (

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -202,6 +202,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               created_at
               valid_until
             }
+            ...ChatUIModalEndpointTokenListFragment
           }
         }
       `,
@@ -723,6 +724,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
       ></EndpointTokenGenerationModal>
       <ChatUIModal
         endpointFrgmt={endpoint}
+        endpointTokenFrgmt={endpoint_token_list}
         open={openChatModal}
         onCancel={() => {
           setOpenChatModal(false);


### PR DESCRIPTION
resolves #2865 

**Changes:**
Adds automatic token population in the chat UI modal by passing the most recently created endpoint token to the chat interface.

**Details:**
- Extends `ChatUIModal` to accept endpoint token fragment data
- Adds logic to find the newest token from the endpoint token list
- Automatically populates the token field in the chat interface with the most recent token
- Enhances user experience by removing manual token entry requirement

**How to test:**
1. Click the LLM Chat Test from the serving page.
2. If it is not a public vllm model, you can get the custom modal.
3. If there are tokens, the most recently created and valid token will be set as the placeholder.
4. If there is no valid token, the placeholder is empty.

**Checklist:**
- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

**Review Requirements:**
1. Verify that the newest token is correctly identified from the endpoint token list
2. Confirm the token field is pre-populated in the chat interface
3. Test that the chat functionality works with the auto-populated token