### PR TITLE
fix: Add the missing session `type` argument to the SFTP session creation API

### DIFF
--- a/src/components/backend-ai-folder-explorer.ts
+++ b/src/components/backend-ai-folder-explorer.ts
@@ -1599,6 +1599,7 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
     imageResource['mounts'] = [this.vfolderName];
     imageResource['cpu'] = 1;
     imageResource['mem'] = '256m';
+    imageResource['type'] = 'system';
     imageResource['domain'] = globalThis.backendaiclient._config.domainName;
     imageResource['scaling_group'] =
       this.volumeInfo[this.vhost]?.sftp_scaling_groups[0];


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR resolves an issue where the SFTP session is created as an interactive session rather than an upload session due to the missing session `type` argument.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Test case(s) to demonstrate the difference of before/after
