### PR TITLE
refactor(FR-587): Start page components

### DIFF
--- a/react/src/components/ActionItemContent.tsx
+++ b/react/src/components/ActionItemContent.tsx
@@ -1,7 +1,7 @@
 import Flex from './Flex';
-import useResizeObserver from '@react-hook/resize-observer';
+// import useResizeObserver from '@react-hook/resize-observer';
 import { Button, Divider, Typography, theme } from 'antd';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 
 interface StartItemContentProps {
   title: string;
@@ -10,7 +10,6 @@ interface StartItemContentProps {
   buttonText: string;
   onClick?: () => void;
   themeColor?: string;
-  iconBgColor?: string;
   itemRole?: 'user' | 'admin';
 }
 
@@ -21,23 +20,11 @@ const ActionItemContent: React.FC<StartItemContentProps> = ({
   buttonText,
   onClick,
   themeColor,
-  iconBgColor,
   itemRole = 'user',
 }) => {
   const { token } = theme.useToken();
-  const [needScroll, setNeedScroll] = useState<boolean>(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const colorPrimaryWithAlpha = `rgba(${parseInt(token.colorPrimary.slice(1, 3), 16)}, ${parseInt(token.colorPrimary.slice(3, 5), 16)}, ${parseInt(token.colorPrimary.slice(5, 7), 16)}, 0.15)`;
-  const colorInfoWithAlpha = `rgba(${parseInt(token.colorInfo.slice(1, 3), 16)}, ${parseInt(token.colorInfo.slice(3, 5), 16)}, ${parseInt(token.colorInfo.slice(5, 7), 16)}, 0.15)`;
-
-  useResizeObserver(
-    containerRef,
-    (entry: { contentRect: { width: number } }) => {
-      entry.contentRect.width <= 220
-        ? setNeedScroll(true)
-        : setNeedScroll(false);
-    },
-  );
 
   return (
     <Flex
@@ -48,8 +35,9 @@ const ActionItemContent: React.FC<StartItemContentProps> = ({
       style={{
         height: '100%',
         textAlign: 'center',
-        overflowY: 'auto',
         padding: token.marginMD,
+        paddingBottom: 0,
+        overflow: 'auto',
       }}
     >
       <Flex direction="column" gap={token.marginSM}>
@@ -60,11 +48,9 @@ const ActionItemContent: React.FC<StartItemContentProps> = ({
             borderRadius: 25,
             width: 50,
             height: 50,
-            backgroundColor: iconBgColor
-              ? iconBgColor
-              : itemRole === 'user'
-                ? colorPrimaryWithAlpha
-                : colorInfoWithAlpha,
+            fontSize: token.fontSizeHeading3,
+            color: token.colorPrimary,
+            backgroundColor: colorPrimaryWithAlpha,
           }}
         >
           {icon}
@@ -88,12 +74,24 @@ const ActionItemContent: React.FC<StartItemContentProps> = ({
           type="secondary"
           style={{ fontSize: token.fontSizeSM }}
         >
-          {!needScroll && description}
+          {description}
         </Typography.Text>
       </Flex>
-      <Flex direction="column" style={{ width: '100%' }}>
+      <Flex
+        direction="column"
+        style={{
+          width: '100%',
+          position: 'sticky',
+          bottom: 0,
+          backgroundColor: token.colorBgContainer,
+          marginTop: token.marginSM,
+          paddingBottom: token.marginMD,
+        }}
+      >
         {description && (
-          <Divider style={{ margin: token.marginSM, borderWidth: 2 }} />
+          <Divider
+            style={{ margin: token.marginSM, marginTop: 0, borderWidth: 2 }}
+          />
         )}
         <Flex style={{ width: '100%', padding: `0 ${token.paddingMD}px` }}>
           <Button

--- a/react/src/components/BAIBoard.tsx
+++ b/react/src/components/BAIBoard.tsx
@@ -2,25 +2,27 @@ import Board, { BoardProps } from '@cloudscape-design/board-components/board';
 import BoardItem from '@cloudscape-design/board-components/board-item';
 import { Skeleton } from 'antd';
 import { createStyles } from 'antd-style';
+import classNames from 'classnames';
 import { Suspense } from 'react';
 
-const useStyles = createStyles(({ css }) => {
-  const defaultBoard = css`
-    .bai_board_placeholder {
-      border-radius: var(--token-borderRadius) !important;
-    }
-    .bai_board_placeholder--active {
-      background-color: var(--token-colorSplit) !important ;
-    }
-    .bai_board_placeholder--hover {
-      background-color: var(--token-colorPrimaryHover) !important ;
-      // FIXME: global token doesn't exist, so opacity fits color
-      opacity: 0.3;
-    }
-  `;
+const useStyles = createStyles(({ css, token }) => {
   return {
     board: css`
-      ${defaultBoard}
+      .bai_board_placeholder {
+        border-radius: var(--token-borderRadius) !important;
+      }
+      .bai_board_placeholder--active {
+        background-color: var(--token-colorSplit) !important ;
+      }
+      .bai_board_placeholder--hover {
+        background-color: var(--token-colorPrimaryHover) !important ;
+        // FIXME: global token doesn't exist, so opacity fits color
+        opacity: 0.3;
+      }
+
+      .bai_board_handle button span {
+        color: ${token.colorTextTertiary} !important;
+      }
     `,
     disableResize: css`
       .bai_board_resizer {
@@ -52,37 +54,36 @@ const useStyles = createStyles(({ css }) => {
   };
 });
 
-interface BAICustomizableGridProps {
-  items: Array<BoardProps.Item>;
-  onItemsChange: (
-    event: CustomEvent<BoardProps.ItemsChangeDetail<unknown>>,
-  ) => void;
+export interface BAIBoardDataType {
+  content?: React.ReactNode;
+}
+
+export type BAIBoardItem = BoardProps.Item<BAIBoardDataType>;
+export interface BAIBoardProps<T extends BAIBoardDataType = BAIBoardDataType> {
+  items: Array<BoardProps.Item<T>>;
+  onItemsChange: (event: CustomEvent<BoardProps.ItemsChangeDetail<T>>) => void;
   resizable?: boolean;
   movable?: boolean;
 }
 
-const BAIBoard: React.FC<BAICustomizableGridProps> = ({
-  items: parsedItems,
+const BAIBoard = <T extends BAIBoardDataType>({
+  items,
   resizable = false,
   movable = false,
   ...BoardProps
-}) => {
+}: BAIBoardProps<T>) => {
   const { styles } = useStyles();
-
-  const boardStyles = [
-    styles.board,
-    !movable && styles.disableMove,
-    !resizable && styles.disableResize,
-  ].join(' ');
-
   return (
-    <Board
-      className={boardStyles}
+    <Board<T>
+      className={classNames(
+        styles.board,
+        !movable && styles.disableMove,
+        !resizable && styles.disableResize,
+      )}
       empty
-      renderItem={(item: any) => {
+      renderItem={(item: BoardProps.Item<T>) => {
         return (
           <BoardItem
-            //@ts-ignore
             className={styles.boardItems}
             key={item.id}
             i18nStrings={{
@@ -98,7 +99,7 @@ const BAIBoard: React.FC<BAICustomizableGridProps> = ({
           </BoardItem>
         );
       }}
-      items={parsedItems}
+      items={items}
       i18nStrings={(() => {
         const createAnnouncement = (
           operationAnnouncement: any,

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -10,7 +10,7 @@ import SessionsIcon from '../BAIIcons/SessionsIcon';
 import BAIMenu from '../BAIMenu';
 import BAISider, { BAISiderProps } from '../BAISider';
 import Flex from '../Flex';
-import ReverseThemeProvider from '../ReverseThemeProvider';
+import ThemeReverseProvider from '../ReverseThemeProvider';
 import SiderToggleButton from '../SiderToggleButton';
 import SignoutModal from '../SignoutModal';
 import WebUILink from '../WebUILink';
@@ -327,7 +327,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
         <BAIMenu
           collapsed={props.collapsed}
           selectedKeys={[
-            location.pathname.split('/')[1] || 'summary',
+            location.pathname.split('/')[1] || 'start',
             // TODO: After matching first path of 'storage-settings' and 'agent', remove this code
             location.pathname.split('/')[1] === 'storage-settings'
               ? 'agent'
@@ -349,7 +349,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
             <BAIMenu
               collapsed={props.collapsed}
               selectedKeys={[
-                location.pathname.split('/')[1] || 'summary',
+                location.pathname.split('/')[1] || 'start',
                 // TODO: After matching first path of 'storage-settings' and 'agent', remove this code
                 location.pathname.split('/')[1] === 'storage-settings'
                   ? 'agent'
@@ -514,9 +514,9 @@ const WebUISiderWithCustomTheme: React.FC<WebUISiderProps> = (props) => {
     (!isParentDark && themeConfig?.sider?.theme === 'dark');
 
   return shouldReverse ? (
-    <ReverseThemeProvider>
+    <ThemeReverseProvider>
       <WebUISider {...props} />
-    </ReverseThemeProvider>
+    </ThemeReverseProvider>
   ) : (
     <WebUISider {...props} />
   );

--- a/react/src/components/ThemeAdminProvider.tsx
+++ b/react/src/components/ThemeAdminProvider.tsx
@@ -1,0 +1,34 @@
+import { useCustomThemeConfig } from '../helper/customThemeConfig';
+import usePrimaryColors from '../hooks/usePrimaryColors';
+import { theme, ConfigProvider, ConfigProviderProps, ThemeConfig } from 'antd';
+import _ from 'lodash';
+import React, { useContext } from 'react';
+
+const ThemeAdminProvider: React.FC<ConfigProviderProps> = ({ ...props }) => {
+  const themeConfig = useCustomThemeConfig();
+  const config = useContext(ConfigProvider.ConfigContext);
+  const isParentDark = config.theme?.algorithm === theme.darkAlgorithm;
+  const primaryColors = usePrimaryColors();
+
+  const additionalThemeConfig = {
+    token: { colorPrimary: primaryColors.admin },
+  } as ThemeConfig;
+  return (
+    <ConfigProvider
+      {...props}
+      theme={{
+        ...(isParentDark
+          ? _.merge({}, themeConfig?.dark, additionalThemeConfig, props.theme)
+          : _.merge(
+              {},
+              themeConfig?.light,
+              additionalThemeConfig,
+              props.theme,
+            )),
+        algorithm: isParentDark ? theme.darkAlgorithm : theme.defaultAlgorithm,
+      }}
+    />
+  );
+};
+
+export default ThemeAdminProvider;

--- a/react/src/components/ThemeSecondaryProvider.tsx
+++ b/react/src/components/ThemeSecondaryProvider.tsx
@@ -1,0 +1,36 @@
+import { useCustomThemeConfig } from '../helper/customThemeConfig';
+import usePrimaryColors from '../hooks/usePrimaryColors';
+import { theme, ConfigProvider, ConfigProviderProps, ThemeConfig } from 'antd';
+import _ from 'lodash';
+import React, { useContext } from 'react';
+
+const ThemeSecondaryProvider: React.FC<ConfigProviderProps> = ({
+  ...props
+}) => {
+  const themeConfig = useCustomThemeConfig();
+  const config = useContext(ConfigProvider.ConfigContext);
+  const isParentDark = config.theme?.algorithm === theme.darkAlgorithm;
+  const primaryColors = usePrimaryColors();
+
+  const additionalThemeConfig = {
+    token: { colorPrimary: primaryColors.secondary },
+  } as ThemeConfig;
+  return (
+    <ConfigProvider
+      {...props}
+      theme={{
+        ...(isParentDark
+          ? _.merge({}, themeConfig?.dark, additionalThemeConfig, props.theme)
+          : _.merge(
+              {},
+              themeConfig?.light,
+              additionalThemeConfig,
+              props.theme,
+            )),
+        algorithm: isParentDark ? theme.darkAlgorithm : theme.defaultAlgorithm,
+      }}
+    />
+  );
+};
+
+export default ThemeSecondaryProvider;

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -1,5 +1,5 @@
+import { BAIBoardItem } from '../components/BAIBoard';
 import { jotaiStore } from '../components/DefaultProviders';
-import { StartItem } from '../pages/StartPage';
 import { atom, useAtom } from 'jotai';
 import { atomFamily } from 'jotai/utils';
 
@@ -14,11 +14,11 @@ interface UserSettings {
   last_window_close_time?: number;
   endpoints?: Array<string>;
   auto_logout?: boolean;
-  summary_items?: Array<Omit<StartItem, 'data'>>;
   selected_language?: string;
   classic_session_launcher?: boolean;
   recentSessionHistory?: Array<SessionHistory>;
   experimental_neo_session_list?: boolean;
+  start_board_items?: Array<Omit<BAIBoardItem, 'data'>>;
   [key: `hiddenColumnKeys.${string}`]: Array<string>;
 }
 

--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -1,237 +1,185 @@
 import ActionItemContent from '../components/ActionItemContent';
-import BAIBoard from '../components/BAIBoard';
-import { SessionLauncherPageLocationState } from '../components/LocationStateBreadCrumb';
-import { useWebUINavigate } from '../hooks';
+import BAIBoard, { BAIBoardItem } from '../components/BAIBoard';
+import FolderCreateModal from '../components/FolderCreateModal';
+import ThemeSecondaryProvider from '../components/ThemeSecondaryProvider';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { SessionLauncherFormValue } from './SessionLauncherPage';
 import {
   AppstoreAddOutlined,
   FolderAddOutlined,
   LinkOutlined,
-  PlaySquareOutlined,
 } from '@ant-design/icons';
-import { BoardProps } from '@cloudscape-design/board-components/board';
-import { theme } from 'antd';
 import _ from 'lodash';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export interface StartItem
-  extends BoardProps.Item<{
-    content: JSX.Element;
-  }> {
-  id:
-    | 'createFolder'
-    | 'startSession'
-    | 'startBatchSession'
-    | 'modelService'
-    | 'startFromExample'
-    | 'startFromURL';
-}
-
 const StartPage: React.FC = () => {
   const { t } = useTranslation();
-  const { token } = theme.useToken();
+
+  // to avoid flickering
+  useSuspendedBackendaiClient();
+
   const webuiNavigate = useWebUINavigate();
 
-  const defaultSummaryElements: {
-    [key in StartItem['id']]: StartItem['data'];
-  } = {
-    createFolder: {
-      content: (
-        <ActionItemContent
-          title={t('start.CreateFolder')}
-          description={t('start.CreateFolderDesc')}
-          buttonText={t('start.button.CreateFolder')}
-          icon={
-            <FolderAddOutlined
-              style={{
-                fontSize: token.fontSizeHeading3,
-                color: token.colorPrimary,
-              }}
-            />
-          }
-          onClick={() => webuiNavigate('/data')}
-        />
-      ),
-    },
-    startSession: {
-      content: (
-        <ActionItemContent
-          title={t('start.StartSession')}
-          description={t('start.StartSessionDesc')}
-          buttonText={t('start.button.StartSession')}
-          icon={
-            <AppstoreAddOutlined
-              style={{
-                fontSize: token.fontSizeHeading3,
-                color: token.colorPrimary,
-              }}
-            />
-          }
-          onClick={() => webuiNavigate('/session/start')}
-        />
-      ),
-    },
-    startBatchSession: {
-      content: (
-        <ActionItemContent
-          title={t('start.StartBatchSession')}
-          description={t('start.StartBatchSessionDesc')}
-          buttonText={t('start.button.StartSession')}
-          icon={
-            <AppstoreAddOutlined
-              style={{
-                fontSize: token.fontSizeHeading3,
-                color: token.colorPrimary,
-              }}
-            />
-          }
-          onClick={() => {
-            const launcherValue: DeepPartial<SessionLauncherFormValue> = {
-              sessionType: 'batch',
-            };
-            const params = new URLSearchParams();
-            params.set('step', '0');
-            params.set('formValues', JSON.stringify(launcherValue));
-            webuiNavigate(`/session/start?${params.toString()}`, {
-              state: {
-                from: {
-                  pathname: '/start',
-                  label: t('start.StartSession'),
-                },
-              } as SessionLauncherPageLocationState,
-            });
-          }}
-        />
-      ),
-    },
-    modelService: {
-      content: (
-        <ActionItemContent
-          itemRole="admin"
-          title={t('start.ModelService')}
-          description={t('start.ModelServiceDesc')}
-          buttonText={t('start.button.ModelService')}
-          icon={
-            <AppstoreAddOutlined
-              style={{
-                fontSize: token.fontSizeHeading3,
-                color: token.colorInfo,
-              }}
-            />
-          }
-          onClick={() => webuiNavigate('/service/start')}
-        />
-      ),
-    },
-    startFromExample: {
-      content: (
-        <ActionItemContent
-          itemRole="admin"
-          title={t('start.StartFromExample')}
-          description={t('start.StartFromExampleDesc')}
-          buttonText={t('start.button.StartNow')}
-          icon={
-            <PlaySquareOutlined
-              style={{
-                fontSize: token.fontSizeHeading3,
-                color: token.colorInfo,
-              }}
-            />
-          }
-          onClick={() => webuiNavigate('/import')}
-        />
-      ),
-    },
-    startFromURL: {
-      content: (
-        <ActionItemContent
-          itemRole="admin"
-          title={t('start.StartFromURL')}
-          description={t('start.StartFromURLDesc')}
-          buttonText={t('start.button.StartNow')}
-          icon={
-            <LinkOutlined
-              style={{
-                fontSize: token.fontSizeHeading3,
-                color: token.colorInfo,
-              }}
-            />
-          }
-          onClick={() => webuiNavigate('/import')}
-        />
-      ),
-    },
-  };
-  const [summaryItemsSetting, setSummaryItemsSetting] =
-    useBAISettingUserState('summary_items');
+  const [isOpenCreateModal, setIsOpenCreateModal] = useState<boolean>(false);
 
-  const [items, setItems] = useState<Array<StartItem>>(
-    !_.isEmpty(summaryItemsSetting)
-      ? _.map(summaryItemsSetting, (item) => ({
-          ...item,
-          data: {
-            ...defaultSummaryElements[item?.id],
-          },
-        }))
-      : [
-          {
-            id: 'createFolder',
-            rowSpan: 3,
-            columnSpan: 1,
-            columnOffset: { 4: 0 },
-            data: defaultSummaryElements.createFolder,
-          },
-          {
-            id: 'startSession',
-            rowSpan: 3,
-            columnSpan: 1,
-            columnOffset: { 4: 1 },
-            data: defaultSummaryElements.startSession,
-          },
-          {
-            id: 'startBatchSession',
-            rowSpan: 3,
-            columnSpan: 1,
-            columnOffset: { 4: 2 },
-            data: defaultSummaryElements.startBatchSession,
-          },
-          {
-            id: 'modelService',
-            rowSpan: 3,
-            columnSpan: 1,
-            columnOffset: { 4: 0 },
-            data: defaultSummaryElements.modelService,
-          },
-          {
-            id: 'startFromExample',
-            rowSpan: 3,
-            columnSpan: 1,
-            columnOffset: { 4: 1 },
-            data: defaultSummaryElements.startFromExample,
-          },
-          {
-            id: 'startFromURL',
-            rowSpan: 3,
-            columnSpan: 1,
-            columnOffset: { 4: 2 },
-            data: defaultSummaryElements.startFromURL,
-          },
-        ],
-  );
+  const [itemSettings, setItemSettings] =
+    useBAISettingUserState('start_board_items');
+
+  const [items, setItems] = useState<Array<BAIBoardItem>>(() => {
+    const defaultItems: Array<BAIBoardItem> = [
+      {
+        id: 'createFolder',
+        rowSpan: 3,
+        columnSpan: 1,
+        columnOffset: { 6: 0, 4: 0 },
+        data: {
+          content: (
+            <ActionItemContent
+              title={t('start.CreateFolder')}
+              description={t('start.CreateFolderDesc')}
+              buttonText={t('start.button.CreateFolder')}
+              icon={<FolderAddOutlined />}
+              onClick={() => setIsOpenCreateModal(true)}
+            />
+          ),
+        },
+      },
+      {
+        id: 'startSession',
+        rowSpan: 3,
+        columnSpan: 1,
+        columnOffset: { 6: 1, 4: 1 },
+        data: {
+          content: (
+            <ActionItemContent
+              title={t('start.StartSession')}
+              description={t('start.StartSessionDesc')}
+              buttonText={t('start.button.StartSession')}
+              icon={<AppstoreAddOutlined />}
+              onClick={() => webuiNavigate('/session/start')}
+            />
+          ),
+        },
+      },
+      {
+        id: 'startBatchSession',
+        rowSpan: 3,
+        columnSpan: 1,
+        columnOffset: { 6: 2, 4: 2 },
+        data: {
+          content: (
+            <ActionItemContent
+              title={t('start.StartBatchSession')}
+              description={t('start.StartBatchSessionDesc')}
+              buttonText={t('start.button.StartSession')}
+              icon={<AppstoreAddOutlined />}
+              onClick={() => {
+                const launcherValue: DeepPartial<SessionLauncherFormValue> = {
+                  sessionType: 'batch',
+                };
+                const params = new URLSearchParams();
+                params.set('step', '0');
+                params.set('formValues', JSON.stringify(launcherValue));
+                webuiNavigate(`/session/start?${params.toString()}`);
+              }}
+            />
+          ),
+        },
+      },
+      {
+        id: 'modelService',
+        rowSpan: 3,
+        columnSpan: 1,
+        columnOffset: { 6: 0, 4: 0 },
+        data: {
+          content: (
+            <ThemeSecondaryProvider>
+              <ActionItemContent
+                title={t('start.ModelService')}
+                description={t('start.ModelServiceDesc')}
+                buttonText={t('start.button.ModelService')}
+                icon={<AppstoreAddOutlined />}
+                onClick={() => webuiNavigate('/service/start')}
+              />
+            </ThemeSecondaryProvider>
+          ),
+        },
+      },
+      {
+        id: 'startFromURL',
+        rowSpan: 3,
+        columnSpan: 1,
+        columnOffset: { 6: 1, 4: 1 },
+        data: {
+          content: (
+            <ThemeSecondaryProvider>
+              <ActionItemContent
+                title={t('start.StartFromURL')}
+                description={t('start.StartFromURLDesc')}
+                buttonText={t('start.button.StartNow')}
+                icon={<LinkOutlined />}
+                onClick={() => webuiNavigate('/import')}
+              />
+            </ThemeSecondaryProvider>
+          ),
+        },
+      },
+      // {
+      //   id: 'startFromExample',
+      //   rowSpan: 3,
+      //   columnSpan: 1,
+      //   columnOffset: { 6:2, 4: 2 },
+      //   data: {
+      //     content: (
+      //       <ThemeSecondaryProvider>
+      //         <ActionItemContent
+      //           title={t('start.StartFromExample')}
+      //           description={t('start.StartFromExampleDesc')}
+      //           buttonText={t('start.button.StartNow')}
+      //           icon={<PlaySquareOutlined />}
+      //           onClick={() => webuiNavigate('/import')}
+      //         />
+      //       </ThemeSecondaryProvider>
+      //     ),
+      //   },
+      // },
+    ];
+
+    if (itemSettings) {
+      return defaultItems.map((item) => {
+        const savedSetting = itemSettings.find(
+          (setting) => setting.id === item.id,
+        );
+        return savedSetting ? { ...item, ...savedSetting } : item;
+      });
+    }
+
+    return defaultItems;
+  });
 
   return (
-    <BAIBoard
-      items={items}
-      onItemsChange={(event) => {
-        const changedItems = event.detail.items as typeof items;
-        setItems(changedItems);
-        setSummaryItemsSetting(
-          _.map(changedItems, (item) => _.omit(item, 'data')),
-        );
-      }}
-    />
+    <>
+      <BAIBoard
+        items={items}
+        onItemsChange={(event) => {
+          // use spread operator to ignore readonly type error
+          const changedItems = [...event.detail.items];
+          setItems(changedItems);
+          setItemSettings(_.map(changedItems, (item) => _.omit(item, 'data')));
+        }}
+      />
+      <FolderCreateModal
+        open={isOpenCreateModal}
+        onRequestClose={(response) => {
+          setIsOpenCreateModal(false);
+          if (response) {
+            webuiNavigate('/data');
+          }
+        }}
+      />
+    </>
   );
 };
 export default StartPage;

--- a/resources/theme.json
+++ b/resources/theme.json
@@ -7,7 +7,8 @@
       "colorLink": "#FF7A00",
       "colorText": "#141414",
       "colorInfo": "#028DF2",
-      "colorError": "#FF4D4F"
+      "colorError": "#FF4D4F",
+      "colorSuccess": "#00BD9B"
     },
     "components": {
       "Tag": {
@@ -30,7 +31,8 @@
       "colorLink": "#DC6B03",
       "colorText": "#FFF",
       "colorInfo": "#009BDD",
-      "colorError": "#DC4446"
+      "colorError": "#DC4446",
+      "colorSuccess": "#03A487"
     },
     "components": {
       "Tag": {

--- a/src/backend-ai-app.ts
+++ b/src/backend-ai-app.ts
@@ -50,7 +50,7 @@ export const navigate =
     }
     let page;
     if (['/', 'build', '/build', 'app', '/app'].includes(path)) {
-      page = 'summary';
+      page = 'start';
     } else if (path[0] === '/') {
       page = path.slice(1);
     } else {

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -647,6 +647,10 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
       },
     ];
 
+    if (this._page === 'start') {
+      this._moveTo('/start');
+    }
+
     // redirect to error page when blocked by config option or the page is not available page.
     if (
       this.optionalPages


### PR DESCRIPTION
**Changes:**
- Refactored the Start Page layout and components to improve maintainability and user experience
- Added theme providers (ThemeAdminProvider and ThemeSecondaryProvider) for consistent styling
- Updated BAIBoard component with proper TypeScript types and improved class handling
- Simplified ActionItemContent by removing unnecessary scroll detection
- Renamed settings key from `summary_items` to `start_board_items` for better clarity
- Added colorSuccess token to theme configuration
- Removed unused startFromExample component

**Rationale:**
The changes improve code organization and type safety while providing better theming support for different UI components. The Start Page layout has been simplified to focus on core functionality and maintain consistent styling across different themes.

**Effects:**
- Users will see a more consistent UI with proper theming across components
- Developers benefit from improved TypeScript support and cleaner component structure
- Settings migration may be needed for users with existing `summary_items` configurations
