### PR TITLE
fix: switch to managing hiddenColumnKeys in TableColumnsSettingModal

### DIFF
--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -2,6 +2,7 @@ import { filterNonNullItems, transformSorterToOrderString } from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useSetBAINotification } from '../hooks/useBAINotification';
+import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
 import { usePainKiller } from '../hooks/usePainKiller';
 import BAIModal from './BAIModal';
 import BAIPropertyFilter from './BAIPropertyFilter';
@@ -23,7 +24,7 @@ import {
   SettingOutlined,
   SyncOutlined,
 } from '@ant-design/icons';
-import { useLocalStorageState, useToggle } from 'ahooks';
+import { useToggle } from 'ahooks';
 import {
   Button,
   Form,
@@ -441,11 +442,8 @@ const ContainerRegistryList: React.FC<{
     },
   ];
 
-  const [displayedColumnKeys, setDisplayedColumnKeys] = useLocalStorageState(
-    'backendaiwebui.ContainerRegistryList.displayedColumnKeys',
-    {
-      defaultValue: _.map(columns, (column) => _.toString(column.key)),
-    },
+  const [hiddenColumnKeys, setHiddenColumnKeys] = useHiddenColumnKeysSetting(
+    'ContainerRegistryList',
   );
 
   return (
@@ -541,8 +539,9 @@ const ContainerRegistryList: React.FC<{
         }}
         dataSource={filterNonNullItems(containerRegistries)}
         columns={
-          _.filter(columns, (column) =>
-            _.includes(displayedColumnKeys, _.toString(column.key)),
+          _.filter(
+            columns,
+            (column) => !_.includes(hiddenColumnKeys, _.toString(column?.key)),
           ) as ColumnType<AnyObject>[]
         }
       />
@@ -688,11 +687,16 @@ const ContainerRegistryList: React.FC<{
         open={visibleColumnSettingModal}
         onRequestClose={(values) => {
           values?.selectedColumnKeys &&
-            setDisplayedColumnKeys(values?.selectedColumnKeys);
+            setHiddenColumnKeys(
+              _.difference(
+                columns.map((column) => _.toString(column.key)),
+                values?.selectedColumnKeys,
+              ),
+            );
           toggleColumnSettingModal();
         }}
         columns={columns}
-        displayedColumnKeys={displayedColumnKeys ? displayedColumnKeys : []}
+        hiddenColumnKeys={hiddenColumnKeys}
       />
     </Flex>
   );

--- a/react/src/components/TableColumnsSettingModal.tsx
+++ b/react/src/components/TableColumnsSettingModal.tsx
@@ -9,21 +9,21 @@ import { useTranslation } from 'react-i18next';
 
 interface FormValues {
   searchInput?: string;
-  selectedColumnKeys?: string[];
+  selectedColumnKeys?: Array<string>;
 }
 
 interface TableColumnsSettingProps extends BAIModalProps {
   open: boolean;
   onRequestClose: (formValues?: FormValues) => void;
   columns: ColumnsType<any>;
-  displayedColumnKeys?: string[];
+  hiddenColumnKeys?: Array<string>;
 }
 
 const TableColumnsSettingModal: React.FC<TableColumnsSettingProps> = ({
   open,
   onRequestClose,
   columns,
-  displayedColumnKeys,
+  hiddenColumnKeys,
   ...modalProps
 }) => {
   const formRef = useRef<FormInstance>(null);
@@ -39,7 +39,7 @@ const TableColumnsSettingModal: React.FC<TableColumnsSettingProps> = ({
     return text;
   };
 
-  const columnOptions = columns.map((column) => {
+  const columnOptions = _.map(columns, (column) => {
     if (typeof column.title === 'string') {
       return {
         label: column.title,
@@ -81,9 +81,9 @@ const TableColumnsSettingModal: React.FC<TableColumnsSettingProps> = ({
         ref={formRef}
         preserve={false}
         initialValues={{
-          selectedColumnKeys:
-            displayedColumnKeys ||
-            columnOptions.map((columnOption) => columnOption.value),
+          selectedColumnKeys: _.map(columnOptions, 'value')?.filter(
+            (columnKey) => !_.includes(hiddenColumnKeys, columnKey),
+          ),
         }}
         layout="vertical"
       >
@@ -107,7 +107,7 @@ const TableColumnsSettingModal: React.FC<TableColumnsSettingProps> = ({
               ? _.toLower(getFieldValue('searchInput'))
               : undefined;
 
-            const filteredColumns = columnOptions.map((columnOption) =>
+            const filteredColumns = _.map(columnOptions, (columnOption) =>
               _.toLower(_.toString(columnOption.label)).includes(
                 searchKeyword || '',
               )

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -12,12 +12,13 @@ interface UserSettings {
   custom_ssh_port?: string;
   beta_feature?: boolean;
   last_window_close_time?: number;
-  endpoints?: string[];
+  endpoints?: Array<string>;
   auto_logout?: boolean;
   summary_items?: Array<Omit<SummaryItem, 'data'>>;
   selected_language?: string;
   classic_session_launcher?: boolean;
   recentSessionHistory?: Array<SessionHistory>;
+  [key: `hiddenColumnKeys.${string}`]: Array<string>;
 }
 
 export type SessionHistory = {

--- a/react/src/hooks/useHiddenColumnKeysSetting.tsx
+++ b/react/src/hooks/useHiddenColumnKeysSetting.tsx
@@ -1,0 +1,21 @@
+import { useBAISettingUserState } from './useBAISetting';
+
+type KnownSettingName =
+  | 'AgentList'
+  | 'AgentSummaryList'
+  | 'ContainerRegistryList'
+  | 'CustomizedImageList'
+  | 'ErrorLogList'
+  | 'ImageList'
+  | 'KeypairResourcePolicyList'
+  | 'ProjectResourcePolicyList'
+  | 'UserResourcePolicyList'
+  | 'EndpointListPage';
+
+export const useHiddenColumnKeysSetting = (listName: KnownSettingName) => {
+  const [hiddenColumnKeys, setHiddenColumnKeys] = useBAISettingUserState(
+    `hiddenColumnKeys.${listName}`,
+  );
+
+  return [hiddenColumnKeys, setHiddenColumnKeys] as const;
+};


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai-webui/issues/2809

**Changes:**
Refactored table column visibility management across multiple list components to use centralized user settings storage instead of individual localStorage entries. This change:

- Replaces `useLocalStorageState` with `useBAISettingUserState` for storing hidden column preferences
- Updates column visibility logic to use a hidden columns approach rather than displayed columns
- Standardizes column setting modal behavior across components using `useToggle`
- Implements consistent column visibility state management pattern across:
  - AgentList
  - AgentSummaryList
  - ContainerRegistryList
  - CustomizedImageList
  - ErrorLogList
  - ImageList
  - KeypairResourcePolicyList
  - ProjectResourcePolicyList
  - UserResourcePolicyList
  - EndpointListPage

**Rationale:**
This change provides a more maintainable and consistent approach to managing table column visibility preferences across the application, while ensuring user preferences persist across sessions through centralized storage.

**Checklist:**
- [ ] Documentation
- [ ] Test case(s) to demonstrate the difference of before/after

**Review Requirements:**
- Verify column visibility settings persist correctly across page refreshes
- Check column visibility toggles work as expected in all affected list components
- Confirm existing user column preferences are preserved during migration