### PR TITLE
fix: Convert network live stats to decimal size units.

### DIFF
--- a/react/src/components/AgentDetailModal.tsx
+++ b/react/src/components/AgentDetailModal.tsx
@@ -1,4 +1,4 @@
-import { convertBinarySizeUnit } from '../helper';
+import { convertBinarySizeUnit, convertDecimalSizeUnit } from '../helper';
 import { useResourceSlotsDetails } from '../hooks/backendai';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import BAIProgressWithLabel from './BAIProgressWithLabel';
@@ -94,11 +94,14 @@ const AgentDetailModal: React.FC<AgentDetailModalProps> = ({
                 <BAIProgressWithLabel
                   percent={
                     (_.toNumber(
-                      convertBinarySizeUnit(_.toString(agent?.mem_cur_bytes), 'g')
-                        ?.number,
+                      convertBinarySizeUnit(
+                        _.toString(agent?.mem_cur_bytes),
+                        'g',
+                      )?.number,
                     ) /
                       _.toNumber(
-                        convertBinarySizeUnit(parsedAvailableSlots?.mem, 'g')?.number,
+                        convertBinarySizeUnit(parsedAvailableSlots?.mem, 'g')
+                          ?.number,
                       )) *
                       100 || 0
                   }
@@ -118,26 +121,26 @@ const AgentDetailModal: React.FC<AgentDetailModalProps> = ({
                   <Typography.Text>TX:</Typography.Text>
                   <Typography.Text>
                     {
-                      convertBinarySizeUnit(
+                      convertDecimalSizeUnit(
                         parsedLiveStat?.node?.net_tx?.current,
                         'm',
                         1,
                       )?.numberUnit
                     }
-                    iB
+                    B
                   </Typography.Text>
                 </Flex>
                 <Flex gap="xl">
                   <Typography.Text>RX:</Typography.Text>
                   <Typography.Text>
                     {
-                      convertBinarySizeUnit(
+                      convertDecimalSizeUnit(
                         parsedLiveStat?.node?.net_rx?.current,
                         'm',
                         1,
                       )?.numberUnit
                     }
-                    iB
+                    B
                   </Typography.Text>
                 </Flex>
               </Flex>


### PR DESCRIPTION
closes https://github.com/lablup/backend.ai-webui/issues/2890

**Changes:**
Updates network statistics display in the Agent Detail Modal to use decimal units (B) instead of binary units (iB) for TX/RX values, making the display more consistent with common network traffic representations.

**Checklist:**
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

**Testing:**
Verify that network traffic values (TX/RX) in the Agent Detail Modal are now displayed with 'B' (bytes) instead of 'iB' (binary bytes) suffix.