### PR TITLE
style: set `popupMatchSelectWidth` to false of `ProjectSelect`

### DIFF
--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -129,6 +129,7 @@ const ProjectSelect: React.FC<ProjectSelectProps> = ({
         onSelectProject?.(option as ProjectInfo);
       }}
       placeholder={t('storageHost.quotaSettings.SelectProject')}
+      popupMatchSelectWidth={false}
       {...selectProps}
       value={value}
       optionFilterProp="projectName"

--- a/react/src/components/StorageHostSettingsPanel.tsx
+++ b/react/src/components/StorageHostSettingsPanel.tsx
@@ -125,7 +125,6 @@ const StorageHostSettingsPanel: React.FC<StorageHostSettingsPanelProps> = ({
                 </Form.Item>
                 <Form.Item label={t('webui.menu.Project')}>
                   <ProjectSelectForAdminPage
-                    style={{ width: '20vw' }}
                     value={selectedProjectId}
                     disabled={!selectedDomainName}
                     domain={selectedDomainName || ''}


### PR DESCRIPTION
closes https://github.com/lablup/backend.ai-webui/issues/2891

Adds `popupMatchSelectWidth={false}` to ProjectSelect component to allow the dropdown width to adjust based on content rather than matching the width of the select input.

**Checklist:**
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after