### PR TITLE
fix: compare time is expired by using `asSeconds()` instead of `seconds()`

### DIFF
--- a/react/src/components/LoginSessionExtendButton.tsx
+++ b/react/src/components/LoginSessionExtendButton.tsx
@@ -41,8 +41,8 @@ const LoginSessionExtendButton: React.FC<
         callback={() => {
           const diff = dayjs(data?.expires).diff(dayjs(), 'seconds');
           const duration = dayjs.duration(Math.max(0, diff), 'seconds');
-          const days = duration.days();
-          if (duration.seconds() === 0) {
+          const days = Math.floor(duration.asDays());
+          if (duration.asSeconds() <= 0) {
             // @ts-ignore
             if (globalThis.isElectron) {
               // @ts-ignore


### PR DESCRIPTION


The PR resolves [backend.ai#3180](https://github.com/lablup/backend.ai/issues/3180) changes the condition for detecting an expired session from checking if seconds are exactly 0 to checking if the total duration in seconds is less than or equal to 0. This fixes an edge case where the session could appear valid even when expired.

**Checklist:**

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after

### How to test
> Prerequisites
> [Webserver related setup]
> 1. Set `enable_extend_login_session` to True in the `service` section of the `webserver.conf` file.
> 2. Set `login_session_extension_sec` to 3600 (one hour) in the `session` section of the `webserver.conf` file.
> 3. Restart the webserver process.
>
> [WebUI related setup]
> 1. Set `enableExtendLoginSession` to true in the `general` section of the `config.toml` file.

1. Login with any active user account.
2. Leave the browser window open without any user interaction for about a minute.
3. Observe that the browser refreshes automatically after one minute.