### PR TITLE
fix: disabled accelerator select when no GPUs are allowed

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -1053,10 +1053,11 @@ const ResourceAllocationFormItems: React.FC<
                             },
                           }}
                           disabled={
-                            currentImageAcceleratorLimits.length === 0 &&
-                            _.isEmpty(
-                              form.getFieldValue(['environments', 'manual']),
-                            )
+                            _.isEmpty(acceleratorSlots) ||
+                            (currentImageAcceleratorLimits.length === 0 &&
+                              _.isEmpty(
+                                form.getFieldValue(['environments', 'manual']),
+                              ))
                           }
                           min={0}
                           max={
@@ -1081,26 +1082,11 @@ const ResourceAllocationFormItems: React.FC<
                               >
                                 <Select
                                   tabIndex={-1}
-                                  disabled={
-                                    currentImageAcceleratorLimits.length ===
-                                      0 &&
-                                    _.isEmpty(
-                                      form.getFieldValue([
-                                        'environments',
-                                        'manual',
-                                      ]),
-                                    )
-                                  }
                                   suffixIcon={
                                     _.size(acceleratorSlots) > 1
                                       ? undefined
                                       : null
                                   }
-                                  // open={
-                                  //   _.size(acceleratorSlots) > 1
-                                  //     ? undefined
-                                  //     : false
-                                  // }
                                   popupMatchSelectWidth={false}
                                   options={_.map(
                                     acceleratorSlots,


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR resolves [#2903](https://github.com/lablup/backend.ai-webui/issues/2903) issue.

[Teams](https://teams.microsoft.com/l/message/19:14c484402d874dafb15806d093b95a82@thread.skype/1733106308378?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=74ae2c4d-ec4d-4fdf-b2c2-f5041d1e8631&parentMessageId=1733106308378&teamName=devops&channelName=Frontend&createdTime=1733106308378)

Currently, the `Accelerator` form in `ResourceAllocationFormItems.tsx` sets disable based on the accelerator resource limit of the selected image.

However, there are cases where the selected resource group does not support accelerators, so we need to add whether the resource group has selectable accelerators to the disabled determination.

**Changes:**
- Added a condition to the disabled determination condition for AI Accelerator for if there are no selectable accelerators in the resource group (empty).
- Removed the disabled field on select for maintenance because if the parent is disabled, the child select will also be disabled.

**How to test:**
- On the session list page, select the resource group that does not allow accelerators, and then create a service or session. 
- In the Resource Allocation section, make sure AI Accelerator is disabled. 
- For resource groups with selectable accelerators, make sure that the corresponding field is enabled.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
