### PR TITLE
fix: add 5s delay when session expiration datetime is over

### DIFF
--- a/react/src/components/BAIIntervalView.tsx
+++ b/react/src/components/BAIIntervalView.tsx
@@ -11,7 +11,7 @@ const BAIIntervalView = <T,>({
 }: {
   callback: () => T;
   render?: RenderProp<T>;
-  delay: number;
+  delay: number | null;
   triggerKey?: string;
 }) => {
   const value = useIntervalValue(callback, delay, triggerKey);

--- a/react/src/hooks/useIntervalValue.tsx
+++ b/react/src/hooks/useIntervalValue.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState } from 'react';
  * @param callback The function to be executed at the specified interval.
  * @param delay The delay (in milliseconds) between each execution of the callback function. If `null`, the interval is cleared(pause).
  */
-export function useInterval(callback: () => void, delay: number) {
+export function useInterval(callback: () => void, delay: number | null) {
   const savedCallback = useRef<() => any>();
 
   useEffect(() => {
@@ -35,7 +35,7 @@ export function useInterval(callback: () => void, delay: number) {
  */
 export const useIntervalValue = (
   calculator: () => any,
-  delay: number,
+  delay: number | null,
   triggerKey?: string,
 ) => {
   const [result, setResult] = useState(calculator());


### PR DESCRIPTION
**Changes:**
This PR resolves [backend.ai#3180](https://github.com/lablup/backend.ai/issues/3180)
Added a 5-second timeout delay before reloading the page when the login session expires in the LoginSessionExtendButton component. This ensures the page reload is properly applied after session expiration. Also added a disabled state to prevent button interaction during expiration.

**Rationale:**
The immediate page reload was causing issues with proper application of the reload. The timeout ensures the system has enough time to process the session expiration before triggering the reload action. The disabled state prevents users from attempting to extend an already expired session.

**Impact:**
Users will experience a 5-second delay between their session expiring and the page reloading, providing a more reliable session expiration behavior in both Electron and browser environments. The extend session button will be disabled during this period.

**Checklist:**
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after