### PR TITLE
fix:  Resource group change does not update related data in form

### DIFF
--- a/react/__test__/matchMedia.mock.js
+++ b/react/__test__/matchMedia.mock.js
@@ -1,0 +1,13 @@
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});

--- a/react/src/components/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/ResourceAllocationFormItems.test.ts
@@ -1,3 +1,4 @@
+import '../../__test__/matchMedia.mock.js';
 import {
   MergedResourceLimits,
   ResourcePreset,

--- a/react/src/hooks/useResourceLimitAndRemaining.test.ts
+++ b/react/src/hooks/useResourceLimitAndRemaining.test.ts
@@ -1,3 +1,4 @@
+import '../../__test__/matchMedia.mock.js';
 import { isMatchingMaxPerContainer } from './useResourceLimitAndRemaining';
 
 describe('getConfigName', () => {


### PR DESCRIPTION
Resolves #2911

### Description
When a user changes the resource group, the related data is not updated as expected. This issue occurs in the following scenario:

### Steps to Reproduce
1. The user navigates to the session launcher or service launcher.
2. The user changes the resource group
3. The expected behavior is that all related data and configurations should update to reflect the new resource group such as accelerator types.
4. However, the data remains unchanged, leading to inconsistencies.

**Changes:**
- Replaced global resource group state with form-level resource group state in ResourceAllocationFormItems
- Added transition handling for resource group selection changes to prevent UI jitters
- Added validation to ensure selected resource group exists before checking presets
- Improved auto-selection behavior for resource groups
- Added loading and disabled states during resource group transitions
- Use BAISelect with `autoSelectOption` for accelerator type

**Rationale:**
The changes improve form stability by using form-level state instead of global state for resource group selection. This prevents unwanted side effects when multiple forms are present. The addition of transitions makes the UI more stable during resource group changes.

**Effects:**
- More reliable resource group selection behavior in forms
- Smoother UI transitions during resource group changes
- Better handling of invalid resource group selections
- Improved auto-selection behavior for default resource groups

**Review Focus:**
- Verify resource group selection behavior in forms
- Check transition states during resource group changes
- Validate auto-selection of default resource groups
- Confirm proper handling of invalid resource group selections