### PR TITLE
feat: Add error view for expired login session

### DIFF
--- a/react/src/RelayEnvironment.ts
+++ b/react/src/RelayEnvironment.ts
@@ -62,7 +62,11 @@ const fetchFn: FetchFunction = async (
     (await globalThis.backendaiclient
       ?._wrapWithPromise(reqInfo, false, null, 10000, 0)
       .catch((err: any) => {
-        // console.log(err);
+        if (err.isError && err.statusCode === 401) {
+          const error = new Error('GraphQL Authorization Error');
+          error.name = 'AuthorizationError';
+          throw error;
+        }
       })) || {};
 
   return result;

--- a/react/src/components/BAIErrorBoundary.tsx
+++ b/react/src/components/BAIErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import Flex from './Flex';
+import { isLoginSessionExpiredState } from './LoginSessionExtendButton';
 import { ReloadOutlined } from '@ant-design/icons';
 import { Alert, Button, Result, Typography } from 'antd';
+import { useAtomValue } from 'jotai';
 import React from 'react';
 import {
   ErrorBoundary,
@@ -9,67 +11,90 @@ import {
 import { useTranslation } from 'react-i18next';
 
 interface BAIErrorBoundaryProps
-  extends Omit<ErrorBoundaryPropsWithRender, 'fallbackRender'> {}
-const BAIErrorBoundary: React.FC<BAIErrorBoundaryProps> = ({ ...props }) => {
+  extends Omit<ErrorBoundaryPropsWithRender, 'fallbackRender'> {
+  style?: React.CSSProperties;
+}
+
+const BAIErrorBoundary: React.FC<BAIErrorBoundaryProps> = ({
+  style,
+  ...props
+}) => {
   const { t } = useTranslation();
+  const isExpiredLoginSession = useAtomValue(isLoginSessionExpiredState);
   return (
     <ErrorBoundary
       {...props}
       fallbackRender={({ error, resetErrorBoundary }) => {
-        console.error('BAIErrorBoundary', error);
+        const isLoginSessionExpiredError =
+          isExpiredLoginSession ||
+          error?.name === 'AuthorizationError' ||
+          error?.statusCode === 401;
         return (
-          <Result
-            status="warning"
-            title={t('ErrorBoundary.title')}
-            extra={
-              <Flex direction="column" gap="md">
-                <Button
-                  type="primary"
-                  key="console"
-                  onClick={() => {
-                    // @ts-ignore
-                    if (globalThis.isElectron) {
+          <Flex
+            style={{ margin: 'auto', ...style }}
+            justify="center"
+            align="center"
+          >
+            <Result
+              status="warning"
+              title={
+                isLoginSessionExpiredError
+                  ? t('ErrorBoundary.expiredLoginSessionTitle')
+                  : t('ErrorBoundary.title')
+              }
+              extra={
+                <Flex direction="column" gap="md">
+                  <Button
+                    type="primary"
+                    key="console"
+                    onClick={() => {
                       // @ts-ignore
-                      globalThis.location.href = globalThis.electronInitialHref;
-                    } else {
-                      globalThis.location.reload();
-                    }
-                  }}
-                  icon={<ReloadOutlined />}
-                >
-                  {t('ErrorBoundary.reloadPage')}
-                </Button>
-                {process.env.NODE_ENV === 'development' && (
-                  <Flex
-                    direction="column"
-                    gap="sm"
-                    align="center"
-                    style={{ width: '100%' }}
-                  >
-                    <Alert
-                      type="info"
-                      showIcon
-                      description={
-                        <Flex direction="column" align="start" gap={'md'}>
-                          <Button
-                            type="default"
-                            icon={<ReloadOutlined />}
-                            onClick={() => {
-                              resetErrorBoundary();
-                            }}
-                          >
-                            {t('ErrorBoundary.resetErrorBoundary')}
-                          </Button>
-                          <Typography.Text>{error.message}</Typography.Text>
-                        </Flex>
+                      if (globalThis.isElectron) {
+                        globalThis.location.href =
+                          // @ts-ignore
+                          globalThis.electronInitialHref;
+                      } else {
+                        globalThis.location.reload();
                       }
-                      message={t('ErrorBoundary.displayOnlyDevEnv')}
-                    />
-                  </Flex>
-                )}
-              </Flex>
-            }
-          ></Result>
+                    }}
+                    icon={<ReloadOutlined />}
+                  >
+                    {isLoginSessionExpiredError
+                      ? t('ErrorBoundary.expiredLoginSessionReLogin')
+                      : t('ErrorBoundary.reloadPage')}
+                  </Button>
+                  {process.env.NODE_ENV === 'development' && (
+                    <Flex
+                      direction="column"
+                      gap="sm"
+                      align="center"
+                      style={{ width: '100%' }}
+                    >
+                      <Alert
+                        type="info"
+                        showIcon
+                        description={
+                          <Flex direction="column" align="start" gap={'md'}>
+                            <Button
+                              type="default"
+                              icon={<ReloadOutlined />}
+                              onClick={() => {
+                                resetErrorBoundary();
+                              }}
+                            >
+                              {t('ErrorBoundary.resetErrorBoundary')}
+                            </Button>
+                            <Typography.Text>{error.message}</Typography.Text>
+                          </Flex>
+                        }
+                        message={t('ErrorBoundary.displayOnlyDevEnv')}
+                      />
+                    </Flex>
+                  )}
+                </Flex>
+              }
+            ></Result>
+          </Flex>
         );
       }}
     />

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1602,7 +1602,9 @@
     "title": "Es ist ein Fehler aufgetreten.",
     "reloadPage": "Laden Sie die Seite neu",
     "resetErrorBoundary": "ErrorBoundary zurücksetzen",
-    "displayOnlyDevEnv": "Dieser Fehlerblock wird nur in der WebUI-Entwicklungsumgebung angezeigt."
+    "displayOnlyDevEnv": "Dieser Fehlerblock wird nur in der WebUI-Entwicklungsumgebung angezeigt.",
+    "expiredLoginSessionTitle": "Ihre Anmeldesitzung ist abgelaufen.",
+    "expiredLoginSessionReLogin": "Anmeldung"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1602,7 +1602,9 @@
     "title": "Εμφανίστηκε σφάλμα.",
     "reloadPage": "Επαναφόρτωση της σελίδας",
     "resetErrorBoundary": "Επαναφορά ErrorBoundary",
-    "displayOnlyDevEnv": "Αυτό το μπλοκ σφάλματος εμφανίζεται μόνο στο περιβάλλον ανάπτυξης WebUI."
+    "displayOnlyDevEnv": "Αυτό το μπλοκ σφάλματος εμφανίζεται μόνο στο περιβάλλον ανάπτυξης WebUI.",
+    "expiredLoginSessionTitle": "Η περίοδος σύνδεσής σας έχει λήξει.",
+    "expiredLoginSessionReLogin": "Σύνδεση"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1663,7 +1663,9 @@
     "title": "An error has occurred.",
     "reloadPage": "Reload the page",
     "resetErrorBoundary": "Reset ErrorBoundary",
-    "displayOnlyDevEnv": "This error block is displayed only in WebUI development environment."
+    "displayOnlyDevEnv": "This error block is displayed only in WebUI development environment.",
+    "expiredLoginSessionTitle": "Your login session has expired.",
+    "expiredLoginSessionReLogin": "Login"
   },
   "modelStore": {
     "FilterByName": "Filter By Name",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -76,7 +76,9 @@
     "displayOnlyDevEnv": "Este bloque de error sólo se muestra en el entorno de desarrollo WebUI.",
     "reloadPage": "Recargar la página",
     "resetErrorBoundary": "Restablecer ErrorBoundary",
-    "title": "Se ha producido un error."
+    "title": "Se ha producido un error.",
+    "expiredLoginSessionTitle": "Su sesión ha expirado.",
+    "expiredLoginSessionReLogin": "Inicio de sesión"
   },
   "OpenVSCodeRemote": "Abrir código local de Visual Studio",
   "agent": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -76,7 +76,9 @@
     "displayOnlyDevEnv": "Tämä virhelohko näytetään vain WebUI-kehitysympäristössä.",
     "reloadPage": "Lataa sivu uudelleen",
     "resetErrorBoundary": "Nollaa ErrorBoundary",
-    "title": "On tapahtunut virhe."
+    "title": "On tapahtunut virhe.",
+    "expiredLoginSessionTitle": "Kirjautumisistuntosi on päättynyt.",
+    "expiredLoginSessionReLogin": "Kirjaudu sisään"
   },
   "OpenVSCodeRemote": "Avaa paikallinen Visual Studio Code",
   "agent": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1655,7 +1655,9 @@
     "title": "Une erreur s'est produite.",
     "reloadPage": "Recharger la page",
     "resetErrorBoundary": "Réinitialisation de la limite d'erreur",
-    "displayOnlyDevEnv": "Ce bloc d'erreur n'est affiché que dans l'environnement de développement WebUI."
+    "displayOnlyDevEnv": "Ce bloc d'erreur n'est affiché que dans l'environnement de développement WebUI.",
+    "expiredLoginSessionTitle": "Votre session de connexion a expiré.",
+    "expiredLoginSessionReLogin": "Connexion"
   },
   "modelStore": {
     "Description": "Description",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1655,7 +1655,9 @@
     "title": "Telah terjadi kesalahan.",
     "reloadPage": "Muat ulang halaman",
     "resetErrorBoundary": "Setel Ulang Batas Kesalahan",
-    "displayOnlyDevEnv": "Blok kesalahan ini hanya ditampilkan di lingkungan pengembangan WebUI."
+    "displayOnlyDevEnv": "Blok kesalahan ini hanya ditampilkan di lingkungan pengembangan WebUI.",
+    "expiredLoginSessionTitle": "Sesi login Anda telah kedaluwarsa.",
+    "expiredLoginSessionReLogin": "Masuk"
   },
   "modelStore": {
     "Description": "Keterangan",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1602,7 +1602,9 @@
     "title": "Si è verificato un errore.",
     "reloadPage": "Ricarica la pagina",
     "resetErrorBoundary": "Azzeramento di ErrorBoundary",
-    "displayOnlyDevEnv": "Questo blocco di errore viene visualizzato solo nell'ambiente di sviluppo WebUI."
+    "displayOnlyDevEnv": "Questo blocco di errore viene visualizzato solo nell'ambiente di sviluppo WebUI.",
+    "expiredLoginSessionTitle": "La sessione di accesso è scaduta.",
+    "expiredLoginSessionReLogin": "Accesso"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1602,7 +1602,9 @@
     "title": "エラーが発生しました。",
     "reloadPage": "ページの更新",
     "resetErrorBoundary": "ErrorBoundaryの初期化",
-    "displayOnlyDevEnv": "このエラーブロックはWebUI開発環境でのみ表示されます。"
+    "displayOnlyDevEnv": "このエラーブロックはWebUI開発環境でのみ表示されます。",
+    "expiredLoginSessionTitle": "ログインセッションの有効期限が切れました。",
+    "expiredLoginSessionReLogin": "ログイン"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1657,7 +1657,9 @@
     "title": "에러가 발생했습니다.",
     "reloadPage": "페이지 새로고침",
     "resetErrorBoundary": "ErrorBoundary 초기화",
-    "displayOnlyDevEnv": "이 에러 블록은 WebUI 개발 환경에서만 표시됩니다."
+    "displayOnlyDevEnv": "이 에러 블록은 WebUI 개발 환경에서만 표시됩니다.",
+    "expiredLoginSessionTitle": "로그인 세션이 만료되었습니다.",
+    "expiredLoginSessionReLogin": "로그인"
   },
   "modelStore": {
     "Description": "설명",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1655,7 +1655,9 @@
     "title": "Алдаа гарсан байна.",
     "reloadPage": "Хуудсыг дахин ачаална уу",
     "resetErrorBoundary": "Алдааны хил хязгаарыг дахин тохируулах",
-    "displayOnlyDevEnv": "Энэ алдааны блок нь зөвхөн WebUI хөгжүүлэлтийн орчинд харагдана."
+    "displayOnlyDevEnv": "Энэ алдааны блок нь зөвхөн WebUI хөгжүүлэлтийн орчинд харагдана.",
+    "expiredLoginSessionTitle": "Таны нэвтрэх хугацаа дууссан.",
+    "expiredLoginSessionReLogin": "Нэвтрэх"
   },
   "modelStore": {
     "Description": "Тодорхойлолт",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1523,7 +1523,9 @@
     "title": "Ralat telah berlaku.",
     "reloadPage": "Muat semula halaman",
     "resetErrorBoundary": "Tetapkan Semula ErrorBoundary",
-    "displayOnlyDevEnv": "Blok ralat ini hanya dipaparkan dalam persekitaran pembangunan WebUI."
+    "displayOnlyDevEnv": "Blok ralat ini hanya dipaparkan dalam persekitaran pembangunan WebUI.",
+    "expiredLoginSessionTitle": "Sesi log masuk anda telah tamat tempoh.",
+    "expiredLoginSessionReLogin": "Log masuk"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1602,7 +1602,9 @@
     "title": "Wystąpił błąd.",
     "reloadPage": "Przeładuj stronę",
     "resetErrorBoundary": "Reset ErrorBoundary",
-    "displayOnlyDevEnv": "Ten blok błędu jest wyświetlany tylko w środowisku programistycznym WebUI."
+    "displayOnlyDevEnv": "Ten blok błędu jest wyświetlany tylko w środowisku programistycznym WebUI.",
+    "expiredLoginSessionTitle": "Sesja logowania wygasła.",
+    "expiredLoginSessionReLogin": "Logowanie"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1523,7 +1523,9 @@
     "title": "Ocorreu um erro.",
     "reloadPage": "Recarregar a página",
     "resetErrorBoundary": "Repor ErrorBoundary",
-    "displayOnlyDevEnv": "Este bloco de erro é apresentado apenas no ambiente de desenvolvimento da WebUI."
+    "displayOnlyDevEnv": "Este bloco de erro é apresentado apenas no ambiente de desenvolvimento da WebUI.",
+    "expiredLoginSessionTitle": "A sua sessão de início de sessão expirou.",
+    "expiredLoginSessionReLogin": "Iniciar sessão"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1523,7 +1523,9 @@
     "title": "Ocorreu um erro.",
     "reloadPage": "Recarregar a página",
     "resetErrorBoundary": "Repor ErrorBoundary",
-    "displayOnlyDevEnv": "Este bloco de erro é apresentado apenas no ambiente de desenvolvimento da WebUI."
+    "displayOnlyDevEnv": "Este bloco de erro é apresentado apenas no ambiente de desenvolvimento da WebUI.",
+    "expiredLoginSessionTitle": "A sua sessão de início de sessão expirou.",
+    "expiredLoginSessionReLogin": "Iniciar sessão"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1655,7 +1655,9 @@
     "title": "Произошла ошибка.",
     "reloadPage": "Перезагрузить страницу",
     "resetErrorBoundary": "Сброс границы ошибки",
-    "displayOnlyDevEnv": "Данный блок ошибок отображается только в среде разработки WebUI."
+    "displayOnlyDevEnv": "Данный блок ошибок отображается только в среде разработки WebUI.",
+    "expiredLoginSessionTitle": "Срок действия вашей сессии входа в систему истек.",
+    "expiredLoginSessionReLogin": "Вход в систему"
   },
   "modelStore": {
     "Description": "Описание",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1639,7 +1639,9 @@
     "title": "เกิดข้อผิดพลาด",
     "reloadPage": "โหลดหน้าใหม่",
     "resetErrorBoundary": "รีเซ็ต ErrorBoundary",
-    "displayOnlyDevEnv": "บล็อกข้อผิดพลาดนี้จะแสดงเฉพาะในสภาพแวดล้อมการพัฒนา WebUI เท่านั้น"
+    "displayOnlyDevEnv": "บล็อกข้อผิดพลาดนี้จะแสดงเฉพาะในสภาพแวดล้อมการพัฒนา WebUI เท่านั้น",
+    "expiredLoginSessionTitle": "เซสชั่นการเข้าสู่ระบบของคุณหมดอายุแล้ว",
+    "expiredLoginSessionReLogin": "เข้าสู่ระบบ"
   },
   "modelStore": {
     "FilterByName": "กรองตามชื่อ",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1601,7 +1601,9 @@
     "title": "Bir hata oluştu.",
     "reloadPage": "Sayfayı yeniden yükle",
     "resetErrorBoundary": "ErrorBoundary'yi Sıfırla",
-    "displayOnlyDevEnv": "Bu hata bloğu yalnızca WebUI geliştirme ortamında görüntülenir."
+    "displayOnlyDevEnv": "Bu hata bloğu yalnızca WebUI geliştirme ortamında görüntülenir.",
+    "expiredLoginSessionTitle": "Giriş oturumunuzun süresi doldu.",
+    "expiredLoginSessionReLogin": "Giriş"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1523,7 +1523,9 @@
     "title": "Một lỗi đã xảy ra.",
     "reloadPage": "Tải lại trang",
     "resetErrorBoundary": "Đặt lại ranh giới lỗi",
-    "displayOnlyDevEnv": "Khối lỗi này chỉ được hiển thị trong môi trường phát triển WebUI."
+    "displayOnlyDevEnv": "Khối lỗi này chỉ được hiển thị trong môi trường phát triển WebUI.",
+    "expiredLoginSessionTitle": "Phiên đăng nhập của bạn đã hết hạn.",
+    "expiredLoginSessionReLogin": "Đăng nhập"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1523,7 +1523,9 @@
     "title": "发生错误。",
     "reloadPage": "重新载入页面",
     "resetErrorBoundary": "重置错误边界",
-    "displayOnlyDevEnv": "此错误块仅在 WebUI 开发环境中显示。"
+    "displayOnlyDevEnv": "此错误块仅在 WebUI 开发环境中显示。",
+    "expiredLoginSessionTitle": "您的登录会话已过期。",
+    "expiredLoginSessionReLogin": "登录"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1524,7 +1524,9 @@
     "title": "发生错误。",
     "reloadPage": "重新载入页面",
     "resetErrorBoundary": "重置错误边界",
-    "displayOnlyDevEnv": "此错误块仅在 WebUI 开发环境中显示。"
+    "displayOnlyDevEnv": "此错误块仅在 WebUI 开发环境中显示。",
+    "expiredLoginSessionTitle": "您的登录会话已过期。",
+    "expiredLoginSessionReLogin": "登录"
   },
   "storageHost": {
     "quotaSettings": {


### PR DESCRIPTION
Resolves #2918

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/74c5eea1-ed45-41f7-bbe4-9c39197af2d3.png)

**Changes:**
Improves login session expiration handling by:
- Adding dedicated error messages and UI for expired login sessions
- Implementing proper error propagation for 401/authorization errors
- Centralizing login session state management using Jotai
- Adding translations for session expiration messages across all supported languages

**Impact:**
- Users now see a clear "Session Expired" message instead of a generic error
- Provides a direct "Login" button when sessions expire
- More graceful handling of authorization failures
- Consistent experience across all languages


**Testing Requirements:**
1. Verify session expiration message appears when token expires
2. Confirm authorization errors show proper UI
3. Check translations display correctly in different languages
4. Test login button functionality after session expiration