### PR TITLE
fix: allow cmd/ctrl click to open link in new tab

### DIFF
--- a/react/src/components/WebUILink.tsx
+++ b/react/src/components/WebUILink.tsx
@@ -17,14 +17,16 @@ const WebUILink: React.FC<WebUILinkProps> = ({ options, ...props }) => {
         const pathName = _.isString(props.to)
           ? props.to
           : props.to.pathname || '';
-        document.dispatchEvent(
-          new CustomEvent('move-to-from-react', {
-            detail: {
-              path: pathName,
-              params: options?.params,
-            },
-          }),
-        );
+        if (!e.metaKey && !e.ctrlKey) {
+          document.dispatchEvent(
+            new CustomEvent('move-to-from-react', {
+              detail: {
+                path: pathName,
+                params: options?.params,
+              },
+            }),
+          );
+        }
       }}
     />
   );


### PR DESCRIPTION
Resolves #2905

**Changes:**
Adds meta/ctrl key detection to WebUILink component to prevent triggering navigation event for `backend-ai-app` web component navigation. 

**Impact:**
Users can now use standard keyboard shortcuts (cmd/ctrl + click) to open links in new tabs, matching expected browser behavior.

