### PR TITLE
misc: replace title of desktop app download to be more comprehensive

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -114,7 +114,7 @@
     "IPUEnabled": "IPU NPU Aktiviert",
     "ATOMEnabled": "ATOM NPU Aktiviert",
     "WarboyEnabled": "Warboy NPU Aktiviert",
-    "DownloadWebUIApp": "Backend.AI Web UI App herunterladen",
+    "DownloadWebUIApp": "Laden Sie die Desktop-App herunter",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel-LPU aktiviert",
     "ATOMPlusEnabled": "ATOM+ NPU aktiviert",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -114,7 +114,7 @@
     "IPUEnabled": "IPU NPU Ενεργοποιημένη",
     "ATOMEnabled": "ATOM NPU Ενεργοποιημένη",
     "WarboyEnabled": "Ενεργοποιημένη NPU Warboy",
-    "DownloadWebUIApp": "Κατεβάστε την εφαρμογή Backend.AI Web UI App",
+    "DownloadWebUIApp": "Κατεβάστε την εφαρμογή Desktop",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU Enabled",
     "ATOMPlusEnabled": "Ενεργοποιημένο ATOM+ NPU",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -123,7 +123,7 @@
     "AcceptSharedVFolder": "You can now access folder: ",
     "DeclineSharedVFolder": "Folder invitation is deleted: ",
     "connectingToCluster": "Connecting to Backend.AI Cluster...",
-    "DownloadWebUIApp": "Download Backend.AI Web UI App",
+    "DownloadWebUIApp": "Download Desktop App",
     "IPUEnabled": "IPU NPU Enabled",
     "ATOMEnabled": "ATOM NPU Enabled",
     "WarboyEnabled": "Warboy NPU Enabled",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -14,7 +14,7 @@
     "CurrentVersion": "Versión actual",
     "Decline": "Disminución",
     "DeclineSharedVFolder": "Se elimina la invitación a la carpeta:",
-    "DownloadWebUIApp": "Descargar Backend.AI Web UI App",
+    "DownloadWebUIApp": "Descargar la aplicación de escritorio",
     "FolderName": "Nombre de la carpeta",
     "FractionalGPUScalingEnabled": "Escalado fraccional de GPU activado",
     "IPUEnabled": "IPU NPU Activado",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -14,7 +14,7 @@
     "CurrentVersion": "Nykyinen versio",
     "Decline": "Lasku",
     "DeclineSharedVFolder": "Kansiokutsu on poistettu:",
-    "DownloadWebUIApp": "Lataa Backend.AI Web UI App",
+    "DownloadWebUIApp": "Lataa työpöytäsovellus",
     "FolderName": "Kansion nimi",
     "FractionalGPUScalingEnabled": "Murto-osittainen GPU-skaalaus käytössä",
     "IPUEnabled": "IPU NPU käytössä",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -111,7 +111,7 @@
     "AcceptSharedVFolder": "Vous pouvez maintenant accéder au dossier :",
     "DeclineSharedVFolder": "L'invitation au dossier est supprimée :",
     "connectingToCluster": "Connexion au cluster Backend.AI...",
-    "DownloadWebUIApp": "Télécharger l'application Backend.AI Web UI",
+    "DownloadWebUIApp": "Télécharger l'application de bureau",
     "IPUEnabled": "IPU NPU Activé",
     "ATOMEnabled": "ATOM NPU Activé",
     "WarboyEnabled": "Warboy NPU activé",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -111,7 +111,7 @@
     "AcceptSharedVFolder": "Anda sekarang dapat mengakses folder: ",
     "DeclineSharedVFolder": "Undangan folder dihapus: ",
     "connectingToCluster": "Menghubungkan ke Cluster Backend.AI...",
-    "DownloadWebUIApp": "Unduh Aplikasi UI Web Backend.AI",
+    "DownloadWebUIApp": "Unduh Aplikasi Desktop",
     "IPUEnabled": "IPU NPU Diaktifkan",
     "ATOMEnabled": "ATOM NPU Diaktifkan",
     "WarboyEnabled": "Warboy NPU Diaktifkan",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -114,7 +114,7 @@
     "IPUEnabled": "IPU NPU abilitata",
     "ATOMEnabled": "NPU ATOM abilitata",
     "WarboyEnabled": "NPU Warboy abilitata",
-    "DownloadWebUIApp": "Scarica l'applicazione Backend.AI Web UI",
+    "DownloadWebUIApp": "Scarica l'applicazione desktop",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel abilitato",
     "ATOMPlusEnabled": "NPU ATOM+ abilitata",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -114,7 +114,7 @@
     "IPUEnabled": "IPU NPU使用中",
     "ATOMEnabled": "ATOM NPU使用中",
     "WarboyEnabled": "Warboy NPU使用中",
-    "DownloadWebUIApp": "Backend.AI Web UIアプリのダウンロード",
+    "DownloadWebUIApp": "デスクトップアプリをダウンロード",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "ハイパーアクセル LPU が有効になりました",
     "ATOMPlusEnabled": "ATOM+ NPU 有効",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -111,7 +111,7 @@
     "AcceptSharedVFolder": "다음 폴더에 대한 공유를 받습니다. 공유 받은 폴더 명: ",
     "DeclineSharedVFolder": "다음 폴더에 대한 초대를 거부하였습니다. 거부한 폴더 명: ",
     "connectingToCluster": "Backend.AI 클러스터에 연결중...",
-    "DownloadWebUIApp": "Backend.AI Web UI 앱 다운로드",
+    "DownloadWebUIApp": "데스크톱 앱 다운로드",
     "IPUEnabled": "IPU NPU 사용중",
     "ATOMEnabled": "ATOM NPU 사용중",
     "WarboyEnabled": "Warboy NPU 사용중",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -111,7 +111,7 @@
     "AcceptSharedVFolder": "Та энэ фолдер рүү нэвтрэх боломжтой боллоо:",
     "DeclineSharedVFolder": "Энэхүү фолдерын уралгыг устгалаа:",
     "connectingToCluster": "Backend.AI кластерт холбогдож байна ...",
-    "DownloadWebUIApp": "Backend.AI Web UI програмыг татаж аваарай",
+    "DownloadWebUIApp": "Ширээний програмыг татаж авах",
     "IPUEnabled": "IPU NPU идэвхжүүлсэн",
     "ATOMEnabled": "ATOM NPU-г идэвхжүүлсэн",
     "WarboyEnabled": "Warboy NPU идэвхжүүлсэн",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -114,7 +114,7 @@
     "IPUEnabled": "IPU NPU Didayakan",
     "ATOMEnabled": "ATOM NPU Didayakan",
     "WarboyEnabled": "Warboy NPU Didayakan",
-    "DownloadWebUIApp": "Muat turun Apl UI Web Backend.AI",
+    "DownloadWebUIApp": "Muat turun Apl Desktop",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel Didayakan",
     "ATOMPlusEnabled": "ATOM+ NPU Didayakan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -114,7 +114,7 @@
     "IPUEnabled": "IPU NPU Enabled",
     "ATOMEnabled": "ATOM NPU Enabled",
     "WarboyEnabled": "Warboy NPU Enabled",
-    "DownloadWebUIApp": "Pobierz aplikację Backend.AI Web UI",
+    "DownloadWebUIApp": "Pobierz aplikację komputerową",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Włączono funkcję Hyperaccel LPU",
     "ATOMPlusEnabled": "Włączono NPU ATOM+",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -114,7 +114,7 @@
     "IPUEnabled": "IPU NPU Activada",
     "ATOMEnabled": "ATOM NPU Ativado",
     "WarboyEnabled": "NPU do Warboy activada",
-    "DownloadWebUIApp": "Descarregar a aplicação Backend.AI Web UI",
+    "DownloadWebUIApp": "Baixe o aplicativo para desktop",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel habilitada",
     "ATOMPlusEnabled": "ATOM+ NPU habilitado",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -114,7 +114,7 @@
     "IPUEnabled": "IPU NPU Activada",
     "ATOMEnabled": "ATOM NPU Ativado",
     "WarboyEnabled": "NPU do Warboy activada",
-    "DownloadWebUIApp": "Descarregar a aplicação Backend.AI Web UI",
+    "DownloadWebUIApp": "Baixe o aplicativo para desktop",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "LPU Hyperaccel habilitada",
     "ATOMPlusEnabled": "ATOM+ NPU habilitado",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -111,7 +111,7 @@
     "AcceptSharedVFolder": "Теперь вы можете получить доступ к папке:",
     "DeclineSharedVFolder": "Папка приглашения удалена:",
     "connectingToCluster": "Подключение к Backend.AI кластеру ...",
-    "DownloadWebUIApp": "Скачать приложение Backend.AI Web UI",
+    "DownloadWebUIApp": "Загрузите настольное приложение",
     "IPUEnabled": "IPU NPU Включено",
     "ATOMEnabled": "ATOM NPU Включено",
     "WarboyEnabled": "Warboy NPU Enabled",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -124,7 +124,7 @@
     "AcceptSharedVFolder": "ตอนนี้คุณสามารถเข้าถึงโฟลเดอร์ได้แล้ว: ",
     "DeclineSharedVFolder": "ลบคำเชิญโฟลเดอร์แล้ว: ",
     "connectingToCluster": "กำลังเชื่อมต่อกับคลัสเตอร์ Backend.AI...",
-    "DownloadWebUIApp": "ดาวน์โหลดแอป Backend.AI Web UI",
+    "DownloadWebUIApp": "ดาวน์โหลดแอพเดสก์ท็อป",
     "IPUEnabled": "เปิดใช้งาน IPU NPU",
     "ATOMEnabled": "เปิดใช้งาน ATOM NPU",
     "WarboyEnabled": "เปิดใช้งาน Warboy NPU",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -114,7 +114,7 @@
     "IPUEnabled": "Đã bật NPU IPU",
     "ATOMEnabled": "Đã bật NPU ATOM",
     "WarboyEnabled": "NPU Warboy đã được kích hoạt",
-    "DownloadWebUIApp": "Tải xuống ứng dụng giao diện người dùng web Backend.AI",
+    "DownloadWebUIApp": "Tải xuống ứng dụng dành cho máy tính để bàn",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Đã bật LPU Hyperaccel",
     "ATOMPlusEnabled": "Đã bật NPU ATOM+",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -114,7 +114,7 @@
     "IPUEnabled": "启用 IPU NPU",
     "ATOMEnabled": "已启用 ATOM NPU",
     "WarboyEnabled": "启用 Warboy NPU",
-    "DownloadWebUIApp": "下载 Backend.AI Web UI 应用程序",
+    "DownloadWebUIApp": "下载桌面应用程序",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU 已启用",
     "ATOMPlusEnabled": "ATOM+ NPU 启用",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -114,7 +114,7 @@
     "IPUEnabled": "启用 IPU NPU",
     "ATOMEnabled": "已启用 ATOM NPU",
     "WarboyEnabled": "启用 Warboy NPU",
-    "DownloadWebUIApp": "下载 Backend.AI Web UI 应用程序",
+    "DownloadWebUIApp": "下載桌面應用程式",
     "FastTrack": "FastTrack",
     "HyperaccelLPUEnabled": "Hyperaccel LPU 已啟用。",
     "ATOMPlusEnabled": "ATOM+ NPU 啟用",


### PR DESCRIPTION
This PR resolves #2921 by updating the "Download Backend.AI Web UI App" text across all language files to reference "Desktop App" instead, making the terminology more generic and user-friendly.

**Changes:**
- Replaces "Backend.AI Web UI App" with "Desktop App" (or equivalent translation) in:
  - German: "Laden Sie die Desktop-App herunter"
  - Greek: "Κατεβάστε την εφαρμογή Desktop"
  - English: "Download Desktop App"
  - Spanish: "Descargar la aplicación de escritorio"
  - Finnish: "Lataa työpöytäsovellus"
  - French: "Télécharger l'application de bureau"
  - And 13 other language files

**Checklist:**
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after