### PR TITLE
feat: support for extra field in registry type

### DIFF
--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -131,8 +131,11 @@ type Queries {
 
   """Added in 24.03.4."""
   vfolder_nodes(
+    """Added in 24.12.0."""
+    scope_id: ScopeField
+
     """Added in 24.09.0."""
-    project_id: UUID!
+    project_id: UUID @deprecated(reason: "Deprecated since 24.12.0. use `scope_id` instead.")
 
     """Added in 24.09.0."""
     permission: VFolderPermissionValueField
@@ -155,8 +158,11 @@ type Queries {
   compute_session_node(
     id: GlobalIDField!
 
+    """Added in 24.12.0."""
+    scope_id: ScopeField
+
     """Added in 24.09.0."""
-    project_id: UUID!
+    project_id: UUID @deprecated(reason: "Deprecated since 24.12.0. use `scope_id` instead.")
 
     """Added in 24.09.0. Default is read_attribute."""
     permission: SessionPermissionValueField = "read_attribute"
@@ -164,8 +170,11 @@ type Queries {
 
   """Added in 24.09.0."""
   compute_session_nodes(
+    """Added in 24.12.0."""
+    scope_id: ScopeField
+
     """Added in 24.09.0."""
-    project_id: UUID!
+    project_id: UUID @deprecated(reason: "Deprecated since 24.12.0. use `scope_id` instead.")
 
     """Added in 24.09.0. Default is read_attribute."""
     permission: SessionPermissionValueField = "read_attribute"
@@ -411,7 +420,7 @@ type DomainNode implements Node {
   scaling_groups(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ScalinGroupConnection
 }
 
-"""Added in 24.12.0."""
+"""Added in 24.09.1."""
 scalar Bytes
 
 """Added in 24.12.0."""
@@ -1493,6 +1502,9 @@ type ContainerRegistryNode implements Node {
 
   """Added in 24.09.0."""
   ssl_verify: Boolean
+
+  """Added in 24.09.3."""
+  extra: JSONString
 }
 
 """Added in 24.09.0."""
@@ -1710,6 +1722,9 @@ type Mutations {
 
   """Added in 24.09.0."""
   create_container_registry_node(
+    """Added in 24.09.3."""
+    extra: JSONString
+
     """Added in 24.09.0."""
     is_global: Boolean
 
@@ -1739,6 +1754,9 @@ type Mutations {
 
   """Added in 24.09.0."""
   modify_container_registry_node(
+    """Added in 24.09.3."""
+    extra: JSONString
+
     """Object id. Can be either global id or object id. Added in 24.09.0."""
     id: String!
 

--- a/react/src/components/BAICodeEditor.tsx
+++ b/react/src/components/BAICodeEditor.tsx
@@ -4,8 +4,8 @@ import CodeMirror, { ReactCodeMirrorProps } from '@uiw/react-codemirror';
 import { EditorView } from '@uiw/react-codemirror';
 
 interface BAICodeEditorProps extends Omit<ReactCodeMirrorProps, 'language'> {
-  value: string;
-  onChange: (value: string) => void;
+  value?: string;
+  onChange?: (value: string) => void;
   language: LanguageName;
   editable?: boolean;
   showLineNumbers?: boolean;
@@ -39,9 +39,9 @@ const BAICodeEditor: React.FC<BAICodeEditorProps> = ({
       basicSetup={{
         lineNumbers: showLineNumbers,
       }}
-      {...CodeMirrorProps}
       value={script}
       onChange={(value, viewUpdate) => setScript(value)}
+      {...CodeMirrorProps}
     />
   );
 };

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "Registrierungsname",
     "DescRegistryNameIsEmpty": "Der Registrierungsname ist leer",
     "RegistryNameAlreadyExists": "Der Registrierungsname ist bereits vorhanden. \nBitte ändern Sie den hinzuzufügenden Registrierungsnamen.",
-    "Project": "Projekt"
+    "Project": "Projekt",
+    "DescExtraJsonFormat": "Bitte geben Sie gültig formatiertes JSON ein",
+    "ExtraInformation": "Zusätzliche Informationen"
   },
   "resourceGroup": {
     "ResourceGroups": "Ressourcengruppen",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "Όνομα Μητρώου",
     "DescRegistryNameIsEmpty": "Το όνομα μητρώου είναι κενό",
     "RegistryNameAlreadyExists": "Το όνομα μητρώου υπάρχει ήδη. \nΑλλάξτε το όνομα μητρώου για προσθήκη.",
-    "Project": "Σχέδιο"
+    "Project": "Σχέδιο",
+    "DescExtraJsonFormat": "Εισαγάγετε JSON με έγκυρη μορφή",
+    "ExtraInformation": "Επιπλέον Πληροφορίες"
   },
   "resourceGroup": {
     "ResourceGroups": "Ομάδες πόρων",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1243,7 +1243,9 @@
     "RegistryName": "Registry Name",
     "DescRegistryNameIsEmpty": "Registry name is empty",
     "RegistryNameAlreadyExists": "Registry name already exists. Please change the registry name to add.",
-    "Project": "Project"
+    "Project": "Project",
+    "DescExtraJsonFormat": "Please enter validly formatted JSON",
+    "ExtraInformation": "Extra Information"
   },
   "resourceGroup": {
     "ResourceGroups": "Resource Groups",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -905,7 +905,9 @@
     "RegistryName": "Nombre de registro",
     "DescRegistryNameIsEmpty": "El nombre del registro está vacío",
     "RegistryNameAlreadyExists": "El nombre del registro ya existe. \nCambie el nombre del registro para agregar.",
-    "Project": "Proyecto"
+    "Project": "Proyecto",
+    "DescExtraJsonFormat": "Por favor ingrese JSON con formato válido",
+    "ExtraInformation": "Información adicional"
   },
   "resourceGroup": {
     "Active": "Activo",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -902,7 +902,9 @@
     "RegistryName": "Rekisterin nimi",
     "DescRegistryNameIsEmpty": "Rekisterin nimi on tyhjä",
     "RegistryNameAlreadyExists": "Rekisterin nimi on jo olemassa. \nMuuta lisättävä rekisterinimi.",
-    "Project": "Projekti"
+    "Project": "Projekti",
+    "DescExtraJsonFormat": "Anna kelvollisesti muotoiltu JSON",
+    "ExtraInformation": "Lisätiedot"
   },
   "resourceGroup": {
     "Active": "Aktiivinen",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "Nom du registre",
     "DescRegistryNameIsEmpty": "Le nom du registre est vide",
     "RegistryNameAlreadyExists": "Le nom du registre existe déjà. \nVeuillez modifier le nom du registre à ajouter.",
-    "Project": "Projet"
+    "Project": "Projet",
+    "DescExtraJsonFormat": "Veuillez saisir un JSON au format valide",
+    "ExtraInformation": "Informations supplémentaires"
   },
   "resourceGroup": {
     "ResourceGroups": "Groupes de ressources",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1115,7 +1115,9 @@
     "RegistryName": "Nama Registri",
     "DescRegistryNameIsEmpty": "Nama registri kosong",
     "RegistryNameAlreadyExists": "Nama registri sudah ada. \nSilakan ubah nama registri untuk ditambahkan.",
-    "Project": "Proyek"
+    "Project": "Proyek",
+    "DescExtraJsonFormat": "Silakan masukkan JSON yang diformat secara valid",
+    "ExtraInformation": "Informasi Tambahan"
   },
   "resourceGroup": {
     "ResourceGroups": "Grup Sumber Daya",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "Nome del registro",
     "DescRegistryNameIsEmpty": "Il nome del registro è vuoto",
     "RegistryNameAlreadyExists": "Il nome del registro esiste già. \nModificare il nome del registro da aggiungere.",
-    "Project": "Progetto"
+    "Project": "Progetto",
+    "DescExtraJsonFormat": "Inserisci JSON formattato in modo valido",
+    "ExtraInformation": "Informazioni aggiuntive"
   },
   "resourceGroup": {
     "ResourceGroups": "Gruppi di risorse",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "レジストリ名",
     "DescRegistryNameIsEmpty": "レジストリ名が空です",
     "RegistryNameAlreadyExists": "レジストリ名はすでに存在します。\n追加するレジストリ名を変更してください。",
-    "Project": "プロジェクト"
+    "Project": "プロジェクト",
+    "DescExtraJsonFormat": "有効な形式の JSON を入力してください",
+    "ExtraInformation": "追加情報"
   },
   "resourceGroup": {
     "ResourceGroups": "リソースグループ",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1230,7 +1230,9 @@
     "RegistryName": "레지스트리 이름",
     "DescRegistryNameIsEmpty": "레지스트리 이름이 비어 있습니다.",
     "RegistryNameAlreadyExists": "레지스트리 이름이 이미 존재합니다. \n레지스트리 이름을 변경해주세요.",
-    "Project": "프로젝트"
+    "Project": "프로젝트",
+    "DescExtraJsonFormat": "유효한 형식의 JSON을 입력해 주세요",
+    "ExtraInformation": "추가 정보"
   },
   "resourceGroup": {
     "ResourceGroups": "자원 그룹",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "Бүртгэлийн нэр",
     "DescRegistryNameIsEmpty": "Бүртгэлийн нэр хоосон байна",
     "RegistryNameAlreadyExists": "Бүртгэлийн нэр аль хэдийн байна. \nНэмэх бүртгэлийн нэрийг өөрчилнө үү.",
-    "Project": "Төсөл"
+    "Project": "Төсөл",
+    "DescExtraJsonFormat": "Зөв форматтай JSON оруулна уу",
+    "ExtraInformation": "Нэмэлт мэдээлэл"
   },
   "resourceGroup": {
     "ResourceGroups": "Нөөцийн бүлгүүд",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "Nama Pendaftaran",
     "DescRegistryNameIsEmpty": "Nama pendaftaran kosong",
     "RegistryNameAlreadyExists": "Nama pendaftaran sudah wujud. \nSila tukar nama pendaftaran untuk ditambahkan.",
-    "Project": "Projek"
+    "Project": "Projek",
+    "DescExtraJsonFormat": "Sila masukkan JSON yang diformatkan dengan sah",
+    "ExtraInformation": "Maklumat Tambahan"
   },
   "resourceGroup": {
     "ResourceGroups": "Kumpulan Sumber",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "Nazwa rejestru",
     "DescRegistryNameIsEmpty": "Nazwa rejestru jest pusta",
     "RegistryNameAlreadyExists": "Nazwa rejestru już istnieje. \nZmień nazwę rejestru, aby go dodać.",
-    "Project": "Projekt"
+    "Project": "Projekt",
+    "DescExtraJsonFormat": "Proszę wprowadzić prawidłowo sformatowany JSON",
+    "ExtraInformation": "Dodatkowe informacje"
   },
   "resourceGroup": {
     "ResourceGroups": "Grupy zasobów",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "Nome do registro",
     "DescRegistryNameIsEmpty": "O nome do registro está vazio",
     "RegistryNameAlreadyExists": "O nome do registro já existe. \nAltere o nome do registro para adicionar.",
-    "Project": "Projeto"
+    "Project": "Projeto",
+    "DescExtraJsonFormat": "Insira JSON formatado de forma válida",
+    "ExtraInformation": "Informações extras"
   },
   "resourceGroup": {
     "ResourceGroups": "Grupos de Recursos",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "Nome do Registro",
     "DescRegistryNameIsEmpty": "O nome do registro está vazio",
     "RegistryNameAlreadyExists": "O nome do registro já existe. \nAltere o nome do registro para adicionar.",
-    "Project": "Projeto"
+    "Project": "Projeto",
+    "DescExtraJsonFormat": "Insira JSON formatado de forma válida",
+    "ExtraInformation": "Informações extras"
   },
   "resourceGroup": {
     "ResourceGroups": "Grupos de Recursos",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "Имя реестра",
     "DescRegistryNameIsEmpty": "Имя реестра пусто",
     "RegistryNameAlreadyExists": "Имя реестра уже существует. \nПожалуйста, измените имя реестра для добавления.",
-    "Project": "Проект"
+    "Project": "Проект",
+    "DescExtraJsonFormat": "Пожалуйста, введите JSON в правильном формате.",
+    "ExtraInformation": "Дополнительная информация"
   },
   "resourceGroup": {
     "ResourceGroups": "Группы ресурсов",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1225,7 +1225,9 @@
     "RegistryName": "ชื่อรีจิสทรี",
     "DescRegistryNameIsEmpty": "ชื่อรีจิสทรีว่างเปล่า",
     "RegistryNameAlreadyExists": "มีชื่อรีจิสทรีอยู่แล้ว \nกรุณาเปลี่ยนชื่อรีจิสทรีที่จะเพิ่ม",
-    "Project": "โครงการ"
+    "Project": "โครงการ",
+    "DescExtraJsonFormat": "โปรดป้อน JSON ที่มีรูปแบบถูกต้อง",
+    "ExtraInformation": "ข้อมูลเพิ่มเติม"
   },
   "resourceGroup": {
     "ResourceGroups": "กลุ่มทรัพยากร",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1113,7 +1113,9 @@
     "RegistryName": "Kayıt Defteri Adı",
     "DescRegistryNameIsEmpty": "Kayıt defteri adı boş",
     "RegistryNameAlreadyExists": "Kayıt defteri adı zaten mevcut. \nLütfen eklemek için kayıt defteri adını değiştirin.",
-    "Project": "Proje"
+    "Project": "Proje",
+    "DescExtraJsonFormat": "Lütfen geçerli olarak biçimlendirilmiş JSON girin",
+    "ExtraInformation": "Ekstra Bilgi"
   },
   "resourceGroup": {
     "ResourceGroups": "Kaynak Grupları",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "Tên đăng ký",
     "DescRegistryNameIsEmpty": "Tên đăng ký trống",
     "RegistryNameAlreadyExists": "Tên đăng ký đã tồn tại. \nVui lòng thay đổi tên đăng ký để thêm.",
-    "Project": "Dự án"
+    "Project": "Dự án",
+    "DescExtraJsonFormat": "Vui lòng nhập JSON được định dạng hợp lệ",
+    "ExtraInformation": "Thông tin bổ sung"
   },
   "resourceGroup": {
     "ResourceGroups": "Nhóm tài nguyên",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1114,7 +1114,9 @@
     "RegistryName": "注册表名称",
     "DescRegistryNameIsEmpty": "注册表名称为空",
     "RegistryNameAlreadyExists": "注册表名称已存在。\n请更改注册表名称来添加。",
-    "Project": "项目"
+    "Project": "项目",
+    "DescExtraJsonFormat": "请输入格式有效的 JSON",
+    "ExtraInformation": "额外信息"
   },
   "resourceGroup": {
     "ResourceGroups": "资源组",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1115,7 +1115,9 @@
     "RegistryName": "註冊表名稱",
     "DescRegistryNameIsEmpty": "註冊表名稱為空",
     "RegistryNameAlreadyExists": "註冊表名稱已存在。\n請更改註冊表名稱來新增。",
-    "Project": "專案"
+    "Project": "專案",
+    "DescExtraJsonFormat": "請輸入格式有效的 JSON",
+    "ExtraInformation": "額外資訊"
   },
   "resourceGroup": {
     "ResourceGroups": "資源組",


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR resolves [#2914](https://github.com/lablup/backend.ai-webui/issues/2914) issue

related Core PR: [#3208](https://github.com/lablup/backend.ai/pull/3208)

24.09~24.09.2 : Using `container_registry_nodes` but does not support extra fields.
24.09.3 ~ : support extra field

**Changes:**
Extra field and argument are supported from version 24.09.3 onwards. 
Because the arguments for each mutation are not provided as input types, you must create a separate mutation if you want to exclude a specific argument.

- Added `extra` field to container registry nodes to support additional JSON metadata
- Added JSON editor UI component for managing extra information in container registry editor
- Added validation for proper JSON formatting with error messages
- Made `value` and `onChange` props optional in BAICodeEditor component
- Added translations for JSON format validation messages across all languages

**How to test:**
1. move to registry page
2. enter Extra Information to verify that the request succeeds only for valid JSON types.

|dark|light|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/2d12bdad-402f-4fdf-a3ca-f3a33c7839a2.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/1b44f9a6-384d-4f6d-9d3b-a51ed8b79e51.png)|

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
