### PR TITLE
feat: export users and credential to csv

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -624,7 +624,9 @@
     "DeactivateCredential": "Anmeldeinformationen deaktivieren",
     "YouAreAboutToDeleteCredential": "Sie sind dabei, die Anmeldeinformationen dieses Benutzers zu löschen:",
     "DeleteCredential": "Anmeldedaten löschen",
-    "ActivateCredential": "Anmeldeinformationen aktivieren"
+    "ActivateCredential": "Anmeldeinformationen aktivieren",
+    "NoDataToExport": "Die Daten für den CSV-Extrakt sind nicht vorhanden.",
+    "ExportCSV": "CSV exportieren"
   },
   "data": {
     "Folders": "Ordner",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -624,7 +624,9 @@
     "DeactivateCredential": "Απενεργοποίηση διαπιστευτηρίων",
     "YouAreAboutToDeleteCredential": "Πρόκειται να διαγράψετε τα διαπιστευτήρια αυτού του χρήστη:",
     "DeleteCredential": "Διαγραφή διαπιστευτηρίων",
-    "ActivateCredential": "Ενεργοποίηση διαπιστευτηρίων"
+    "ActivateCredential": "Ενεργοποίηση διαπιστευτηρίων",
+    "NoDataToExport": "Τα δεδομένα για το απόσπασμα CSV δεν υπάρχουν.",
+    "ExportCSV": "εξαγωγή CSV"
   },
   "data": {
     "Folders": "Φάκελοι",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -751,7 +751,9 @@
     "DeactivateCredential": "Deactivate credential",
     "YouAreAboutToDeleteCredential": "You are about to delete this user's credential:",
     "DeleteCredential": "Delete credential",
-    "ActivateCredential": "Activate credential"
+    "ActivateCredential": "Activate credential",
+    "NoDataToExport": "The data for the CSV extract does not exist.",
+    "ExportCSV": "export CSV"
   },
   "data": {
     "Folders": "Folders",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -243,7 +243,9 @@
     "DeactivateCredential": "Desactivar credencial",
     "YouAreAboutToDeleteCredential": "Estás a punto de eliminar la credencial de este usuario:",
     "DeleteCredential": "Eliminar credencial",
-    "ActivateCredential": "Activar credencial"
+    "ActivateCredential": "Activar credencial",
+    "NoDataToExport": "Los datos para el extracto CSV no existen.",
+    "ExportCSV": "exportar CSV"
   },
   "data": {
     "Allowslettersnumbersand-_": "Permite letras, números y -_",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -234,6 +234,8 @@
     "ReqPer15Min": "Req per 15 min",
     "Sessions": "Istunnot",
     "LastUsed": "Viimeksi käytetty",
+    "NoDataToExport": "CSV-otteen tietoja ei ole olemassa.",
+    "ExportCSV": "vie CSV",
     "KeypairStatusUpdatedSuccessfully": "Näppäinparin tila on muuttunut.",
     "KeypairSuccessfullyDeleted": "Avainparin poistaminen onnistui.",
     "ActivateUser": "Aktivoi käyttäjä",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -624,7 +624,9 @@
     "DeactivateCredential": "Désactiver l'identifiant",
     "YouAreAboutToDeleteCredential": "Vous êtes sur le point de supprimer les identifiants de cet utilisateur :",
     "DeleteCredential": "Supprimer l'identifiant",
-    "ActivateCredential": "Activer l'identifiant"
+    "ActivateCredential": "Activer l'identifiant",
+    "NoDataToExport": "Les données pour l'extrait CSV n'existent pas.",
+    "ExportCSV": "exporter au format CSV"
   },
   "data": {
     "Folders": "Dossiers",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -616,6 +616,8 @@
     "ReqPer15Min": "Persyaratan per 15 menit",
     "Sessions": "Sesi",
     "LastUsed": "Terakhir digunakan",
+    "NoDataToExport": "Data untuk ekstrak CSV tidak ada.",
+    "ExportCSV": "ekspor CSV",
     "KeypairStatusUpdatedSuccessfully": "Status pasangan kunci telah berubah.",
     "KeypairSuccessfullyDeleted": "KeyPair berhasil dihapus.",
     "ActivateUser": "Aktifkan pengguna",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -625,7 +625,9 @@
     "DeactivateCredential": "Disattiva credenziale",
     "YouAreAboutToDeleteCredential": "Stai per eliminare le credenziali di questo utente:",
     "DeleteCredential": "Elimina credenziale",
-    "ActivateCredential": "Attiva credenziale"
+    "ActivateCredential": "Attiva credenziale",
+    "NoDataToExport": "I dati per l'estrazione CSV non esistono.",
+    "ExportCSV": "esportare CSV"
   },
   "data": {
     "Folders": "cartelle",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -615,6 +615,8 @@
     "ReqPer15Min": "15分あたりの要求",
     "Sessions": "セッション",
     "LastUsed": "最後に使用した",
+    "NoDataToExport": "CSV抽出用のデータが存在しません。",
+    "ExportCSV": "CSVエクスポート",
     "KeypairStatusUpdatedSuccessfully": "キーペアのステータスが変更されました。",
     "KeypairSuccessfullyDeleted": "キーペアは正常に削除されました。",
     "ActivateUser": "ユーザーをアクティブ化する",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -730,6 +730,8 @@
     "ReqPer15Min": "15분당 요청 수",
     "Sessions": "세션",
     "LastUsed": "최종 사용일",
+    "NoDataToExport": "CSV 추출을 위한 데이터가 존재하지 않습니다.",
+    "ExportCSV": "CSV로 내보내기",
     "KeypairStatusUpdatedSuccessfully": "키페어 상태가 변경되었습니다.",
     "KeypairSuccessfullyDeleted": "키페어가 정상적으로 삭제되었습니다.",
     "ActivateUser": "사용자 활성화",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -617,6 +617,8 @@
     "ReqPer15Min": "15 минут тутамд хэрэгцээ",
     "Sessions": "Хурал",
     "LastUsed": "Сүүлд ашигласан",
+    "NoDataToExport": "CSV хандалтын өгөгдөл байхгүй байна.",
+    "ExportCSV": "CSV экспортлох",
     "KeypairStatusUpdatedSuccessfully": "Товчлуурын хослол өөрчлөгдсөн.",
     "KeypairSuccessfullyDeleted": "KeyPair амжилттай устгагдлаа.",
     "ActivateUser": "Хэрэглэгчийг идэвхжүүлэх",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -615,6 +615,8 @@
     "ReqPer15Min": "Req setiap 15 min",
     "Sessions": "Sesi",
     "LastUsed": "Kali terakhir digunakan",
+    "NoDataToExport": "Data untuk ekstrak CSV tidak wujud.",
+    "ExportCSV": "eksport CSV",
     "KeypairStatusUpdatedSuccessfully": "Status pasangan kekunci telah berubah.",
     "KeypairSuccessfullyDeleted": "KeyPair berjaya dipadamkan.",
     "ActivateUser": "Aktifkan pengguna",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -615,6 +615,8 @@
     "Queries": "Zapytania",
     "ReqPer15Min": "Zapotrzebowanie na 15 min",
     "Sessions": "Sesje",
+    "NoDataToExport": "Dane do ekstraktu CSV nie istnieją.",
+    "ExportCSV": "eksportuj plik CSV",
     "KeypairStatusUpdatedSuccessfully": "Stan pary kluczy uległ zmianie.",
     "KeypairSuccessfullyDeleted": "KeyPair został pomyślnie usunięty.",
     "ActivateUser": "Aktywuj użytkownika",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -615,6 +615,8 @@
     "ReqPer15Min": "Solicitação por 15 min",
     "Sessions": "Sessões",
     "LastUsed": "Usado por último",
+    "NoDataToExport": "Os dados para a extração CSV não existem.",
+    "ExportCSV": "exportar CSV",
     "KeypairStatusUpdatedSuccessfully": "O status do par de chaves mudou.",
     "KeypairSuccessfullyDeleted": "KeyPair foi excluído com sucesso.",
     "ActivateUser": "Ativar usuário",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -615,6 +615,8 @@
     "ReqPer15Min": "Solicitação por 15 min",
     "Sessions": "Sessões",
     "LastUsed": "Usado por último",
+    "NoDataToExport": "Os dados para a extração CSV não existem.",
+    "ExportCSV": "exportar CSV",
     "KeypairStatusUpdatedSuccessfully": "O status do par de chaves mudou.",
     "KeypairSuccessfullyDeleted": "KeyPair foi excluído com sucesso.",
     "ActivateUser": "Ativar usuário",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -624,7 +624,9 @@
     "DeactivateCredential": "Деактивировать учетные данные",
     "YouAreAboutToDeleteCredential": "Вы собираетесь удалить учетные данные этого пользователя:",
     "DeleteCredential": "Удалить учетные данные",
-    "ActivateCredential": "Активировать учетные данные"
+    "ActivateCredential": "Активировать учетные данные",
+    "NoDataToExport": "Данные для извлечения CSV не существуют.",
+    "ExportCSV": "экспортировать CSV"
   },
   "data": {
     "Folders": "Папки",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -738,6 +738,8 @@
     "ReqPer15Min": "ต้องการต่อ 15 นาที",
     "Sessions": "เซสชัน",
     "LastUsed": "ใช้ครั้งล่าสุด",
+    "NoDataToExport": "ไม่มีข้อมูลสำหรับการแยก CSV",
+    "ExportCSV": "ส่งออก CSV",
     "KeypairStatusUpdatedSuccessfully": "สถานะคู่กุญแจเปลี่ยนไป",
     "KeypairSuccessfullyDeleted": "ลบ KeyPair สำเร็จแล้ว",
     "ActivateUser": "เปิดใช้งานผู้ใช้",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -623,7 +623,9 @@
     "DeactivateCredential": "Kimlik bilgilerini devre dışı bırak",
     "YouAreAboutToDeleteCredential": "Bu kullanıcının kimlik bilgilerini silmek üzeresiniz:",
     "DeleteCredential": "Kimlik bilgisini sil",
-    "ActivateCredential": "Kimlik bilgisini etkinleştir"
+    "ActivateCredential": "Kimlik bilgisini etkinleştir",
+    "NoDataToExport": "CSV ekstresine ilişkin veriler mevcut değil.",
+    "ExportCSV": "CSV'yi dışa aktar"
   },
   "data": {
     "Folders": "klasörler",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -615,6 +615,8 @@
     "ReqPer15Min": "Yêu cầu mỗi 15 phút",
     "Sessions": "Phiên",
     "LastUsed": "Lần sử dụng cuối cùng",
+    "NoDataToExport": "Dữ liệu cho bản trích xuất CSV không tồn tại.",
+    "ExportCSV": "xuất CSV",
     "KeypairStatusUpdatedSuccessfully": "Trạng thái cặp khóa đã thay đổi.",
     "KeypairSuccessfullyDeleted": "KeyPair đã được xóa thành công.",
     "ActivateUser": "Kích hoạt người dùng",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -617,6 +617,8 @@
     "KeypairStatusUpdatedSuccessfully": "密钥对状态已更改。",
     "KeypairSuccessfullyDeleted": "密钥对已成功删除。",
     "LastUsed": "最后使用",
+    "NoDataToExport": "CSV 提取的数据不存在。",
+    "ExportCSV": "导出 CSV",
     "ActivateUser": "激活用户",
     "DeactivateUser": "停用用户",
     "Deactivate": "停用",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -617,6 +617,8 @@
     "KeypairStatusUpdatedSuccessfully": "密鑰對狀態已變更。",
     "KeypairSuccessfullyDeleted": "密鑰對已成功刪除。",
     "LastUsed": "最後使用",
+    "NoDataToExport": "CSV 擷取的資料不存在。",
+    "ExportCSV": "匯出 CSV",
     "ActivateUser": "啟用用戶",
     "DeactivateUser": "停用用戶",
     "Deactivate": "停用",


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR resolves [#2956](https://github.com/lablup/backend.ai-webui/issues/2956)

**Changes:**
- Added the ability to extract User List and Credential List to CSV.
- Since many interaction buttons already exist in the Card Content, I use the Card Tab Extra field and provide them via Event Listen.

**How to test:**
- In the User List or Credential List, run the CSV extract via the buttons in the Card Tab Extra section
- Verify that each column is displayed correctly.

**Discussions:**
Currently, CSV exports are executed based on the data fetched via the request, not the information shown in the table. So, if the key is not the same as the Key of the response data type, or is shown separately in the render function without using response data, you cannot extract that data.

The CSV export function will be changed in the future. We plan to define CSV columns in the same way as Antd's table column definitions to support column ordering and customization of CSV data. This will be a separate issue and stack.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
