### PR TITLE
feat(FR-17): update `desired_session_count` field name to `replicas`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -36,7 +36,8 @@
     "Keypairs",
     "Hyperaccel",
     "Tensorboard",
-    "Automount"
+    "Automount",
+    "Talkativot"
   ],
   "flagWords": [
     "데이터레이크",

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -88,7 +88,8 @@ interface ServiceCreateConfigType {
 }
 export interface ServiceCreateType {
   name: string;
-  desired_session_count: number;
+  desired_session_count?: number;
+  replicas?: number;
   image: string;
   runtime_variant: string;
   architecture: string;
@@ -106,7 +107,7 @@ export interface ServiceCreateType {
 interface ServiceLauncherInput extends ImageEnvironmentFormInput {
   serviceName: string;
   vFolderID: string;
-  desiredRoutingCount: number;
+  replicas: number;
   openToPublic: boolean;
   modelMountDestination: string;
   modelDefinitionPath: string;
@@ -153,7 +154,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
     graphql`
       fragment ServiceLauncherPageContentFragment on Endpoint {
         endpoint_id
-        desired_session_count
+        desired_session_count @deprecatedSince(version: "24.12.0")
+        replicas @since(version: "24.12.0")
         resource_group
         resource_slots
         resource_opts
@@ -264,7 +266,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
   const legacyMutationToUpdateService = useTanMutation({
     mutationFn: (values: ServiceLauncherFormValue) => {
       const body = {
-        to: values.desiredRoutingCount,
+        to: values.replicas,
       };
       return baiSignedRequestWithPromise({
         method: 'POST',
@@ -289,7 +291,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
       }
       const body: ServiceCreateType = {
         name: values.serviceName,
-        desired_session_count: values.desiredRoutingCount,
+        // REST API does not support `replicas` field. To use `replicas` field, we need `create_endpoint` mutation.
+        desired_session_count: values.replicas,
         ...getImageInfoFromInputInCreating(
           checkManualImageAllowed(
             baiClient._config.allow_manual_image_name_for_session,
@@ -407,7 +410,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         msg
         endpoint {
           endpoint_id
-          desired_session_count
+          desired_session_count @deprecatedSince(version: "24.12.0")
+          replicas @since(version: "24.12.0")
           resource_group
           resource_slots
           resource_opts
@@ -500,7 +504,11 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                       ? 'SINGLE_NODE'
                       : 'MULTI_NODE',
                   cluster_size: values.cluster_size,
-                  desired_session_count: values.desiredRoutingCount,
+                  ...(baiClient.supports('replicas')
+                    ? { replicas: values.replicas }
+                    : {
+                        desired_session_count: values.replicas,
+                      }),
                   ...getImageInfoFromInputInEditing(
                     checkManualImageAllowed(
                       baiClient._config.allow_manual_image_name_for_session,
@@ -643,7 +651,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         serviceName: endpoint?.name,
         resourceGroup: endpoint?.resource_group,
         allocationPreset: 'custom',
-        desiredRoutingCount: endpoint?.desired_session_count ?? 1,
+        replicas: endpoint?.replicas ?? endpoint?.desired_session_count ?? 1,
         // FIXME: memory doesn't applied to resource allocation
         resource: {
           cpu: parseInt(JSON.parse(endpoint?.resource_slots || '{}')?.cpu),
@@ -692,7 +700,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         // TODO: set mounts alias map according to extra_mounts if possible
       }
     : {
-        desiredRoutingCount: 1,
+        replicas: 1,
         runtimeVariant: 'custom',
         ...RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
         ...(baiClient._config?.default_session_environment && {
@@ -899,8 +907,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                     </>
                   )}
                   <Form.Item
-                    label={t('modelService.DesiredRoutingCount')}
-                    name="desiredRoutingCount"
+                    label={t('modelService.NumberOfReplicas')}
+                    name={'replicas'}
                     rules={[
                       {
                         required: true,

--- a/react/src/components/ServiceValidationView.tsx
+++ b/react/src/components/ServiceValidationView.tsx
@@ -53,7 +53,11 @@ const ServiceValidationView: React.FC<ServiceValidationModalProps> = ({
       const image: string = `${values.environments.image?.registry}/${values.environments.image?.name}:${values.environments.image?.tag}`;
       const body: ServiceCreateType = {
         name: values.serviceName,
-        desired_session_count: values.desiredRoutingCount,
+        ...(baiClient.supports('replicas')
+          ? { replicas: values.replicas }
+          : {
+              desired_session_count: values.replicas,
+            }),
         image: image,
         runtime_variant: values.runtimeVariant,
         architecture: values.environments.image?.architecture as string,

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1540,7 +1540,6 @@
     "ServiceName": "Dienst Name",
     "ServiceNameRule": "Erlauben Sie nur alphanumerische Zeichen, Unterstriche (_) und Bindestriche (-) und müssen mit einem alphanumerischen Zeichen enden.",
     "OpenToPublic": "Offen für die Öffentlichkeit",
-    "DesiredRoutingCount": "Gewünschte Routinganzahl",
     "ServingRouteErrorModalTitle": "Serving Route Fehler",
     "SessionId": "Sitzungs-ID",
     "Services": "Dienstleistungen",
@@ -1598,7 +1597,8 @@
     "ServiceNameMinLength": "Bitte geben Sie mindestens 4 Zeichen ein.",
     "ServiceNameMaxLength": "Bitte geben Sie maximal 24 Zeichen ein.",
     "ServiceNameCannotStartWithHyphen": "Bindestriche (-) dürfen an beiden Enden nicht verwendet werden.",
-    "Resources": "Ressourcen"
+    "Resources": "Ressourcen",
+    "NumberOfReplicas": "Anzahl der Replikate"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1540,7 +1540,6 @@
     "ServiceName": "Όνομα υπηρεσίας",
     "ServiceNameRule": "Επιτρέπονται μόνο αλφαριθμητικά, κάτω παύλα(_) και παύλα(-) και πρέπει να τελειώνει με αλφαριθμητικό χαρακτήρα.",
     "OpenToPublic": "Ανοιχτό για το κοινό",
-    "DesiredRoutingCount": "Επιθυμητός αριθμός δρομολόγησης",
     "ServingRouteErrorModalTitle": "Σφάλμα διαδρομής εξυπηρέτησης",
     "SessionId": "Αναγνωριστικό συνεδρίας",
     "Services": "Υπηρεσίες",
@@ -1598,7 +1597,8 @@
     "ServiceNameMinLength": "Εισαγάγετε τουλάχιστον 4 χαρακτήρες.",
     "ServiceNameMaxLength": "Εισαγάγετε 24 χαρακτήρες ή λιγότερους.",
     "ServiceNameCannotStartWithHyphen": "Οι παύλες (-) δεν μπορούν να χρησιμοποιηθούν σε κανένα άκρο.",
-    "Resources": "Πόροι"
+    "Resources": "Πόροι",
+    "NumberOfReplicas": "Αριθμός αντιγράφων"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -453,7 +453,6 @@
     "StartNewServing": "Start new serving",
     "ServiceName": "Service Name",
     "OpenToPublic": "Open To Public",
-    "DesiredRoutingCount": "Desired Routing Count",
     "DesiredSessionCount": "Desired Session Count",
     "EndpointName": "Endpoint Name",
     "EndpointId": "Endpoint ID",
@@ -525,7 +524,8 @@
     "ServiceNameMinLength": "Please enter at least 4 characters.",
     "ServiceNameMaxLength": "Please enter 24 characters or less.",
     "ServiceNameCannotStartWithHyphen": "Hyphens (-) cannot be used at either end.",
-    "Resources": "Resources"
+    "Resources": "Resources",
+    "NumberOfReplicas": "Number of replicas"
   },
   "button": {
     "Cancel": "Cancel",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -781,7 +781,6 @@
     "Controls": "Controla",
     "CreatedAt": "Creado en",
     "CurrentTime": "Hora actual",
-    "DesiredRoutingCount": "Recuento de rutas deseado",
     "DesiredSessionCount": "Recuento de sesiones deseado",
     "EditModelService": "Editar modelo de servicio",
     "EndpointId": "ID de punto final",
@@ -852,7 +851,8 @@
     "ServiceNameMinLength": "Por favor ingrese al menos 4 caracteres.",
     "ServiceNameMaxLength": "Por favor ingrese 24 caracteres o menos.",
     "ServiceNameCannotStartWithHyphen": "No se pueden utilizar guiones (-) en ninguno de los extremos.",
-    "Resources": "Recursos"
+    "Resources": "Recursos",
+    "NumberOfReplicas": "Número de réplicas"
   },
   "notification": {
     "Initializing": "Inicializando...",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -781,7 +781,6 @@
     "Controls": "Ohjaimet",
     "CreatedAt": "Created at",
     "CurrentTime": "Nykyinen aika",
-    "DesiredRoutingCount": "Haluttu reititysmäärä",
     "DesiredSessionCount": "Haluttu istunnon määrä",
     "EditModelService": "Muokkaa mallipalvelua",
     "EndpointId": "Päätepisteen tunnus",
@@ -851,7 +850,8 @@
     "ServiceNameMinLength": "Kirjoita vähintään 4 merkkiä.",
     "ServiceNameMaxLength": "Anna enintään 24 merkkiä.",
     "ServiceNameCannotStartWithHyphen": "Tavuviivoja (-) ei voi käyttää kummassakaan päässä.",
-    "Resources": "Resurssit"
+    "Resources": "Resurssit",
+    "NumberOfReplicas": "Kopioiden määrä"
   },
   "notification": {
     "Initializing": "Aloitetaan...",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1580,7 +1580,6 @@
     "StartNewServing": "Commencer une nouvelle distribution",
     "ServiceName": "Nom du service",
     "OpenToPublic": "Ouvert au public",
-    "DesiredRoutingCount": "Nombre d'acheminements souhaités",
     "Services": "Services",
     "RoutingInfo": "Informations sur le routage",
     "ServiceInfo": "Informations sur le service",
@@ -1650,7 +1649,8 @@
     "ServiceNameMinLength": "Veuillez saisir au moins 4 caractères.",
     "ServiceNameMaxLength": "Veuillez saisir 24 caractères ou moins.",
     "ServiceNameCannotStartWithHyphen": "Les tirets (-) ne peuvent pas être utilisés à chaque extrémité.",
-    "Resources": "Ressources"
+    "Resources": "Ressources",
+    "NumberOfReplicas": "Nombre de répliques"
   },
   "modelStore": {
     "Description": "Description",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1581,7 +1581,6 @@
     "StartNewServing": "Memulai sajian baru",
     "ServiceName": "Nama Layanan",
     "OpenToPublic": "Terbuka Untuk Umum",
-    "DesiredRoutingCount": "Jumlah Perutean yang Diinginkan",
     "Services": "Layanan",
     "RoutingInfo": "Info Perutean",
     "ServiceInfo": "Info Layanan",
@@ -1650,7 +1649,8 @@
     "ServiceNameMinLength": "Silakan masukkan setidaknya 4 karakter.",
     "ServiceNameMaxLength": "Silakan masukkan 24 karakter atau kurang.",
     "ServiceNameCannotStartWithHyphen": "Tanda hubung (-) tidak dapat digunakan pada kedua ujungnya.",
-    "Resources": "Sumber daya"
+    "Resources": "Sumber daya",
+    "NumberOfReplicas": "Jumlah replika"
   },
   "modelStore": {
     "Description": "Keterangan",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1539,7 +1539,6 @@
     "ServiceName": "Nome del servizio",
     "ServiceNameRule": "Consenti solo caratteri alfanumerici, trattino basso (_) e trattino (-) e deve terminare con un carattere alfanumerico.",
     "OpenToPublic": "Aperto al pubblico",
-    "DesiredRoutingCount": "Conteggio dell'instradamento desiderato",
     "ServingRouteErrorModalTitle": "Errore del percorso di servizio",
     "SessionId": "ID sessione",
     "Services": "Servizi",
@@ -1596,7 +1595,8 @@
     "ServiceNameMinLength": "Inserisci almeno 4 caratteri.",
     "ServiceNameMaxLength": "Inserisci 24 caratteri o meno.",
     "ServiceNameCannotStartWithHyphen": "I trattini (-) non possono essere utilizzati alle due estremità.",
-    "Resources": "Risorse"
+    "Resources": "Risorse",
+    "NumberOfReplicas": "Numero di repliche"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1540,7 +1540,6 @@
     "ServiceName": "サービス名",
     "ServiceNameRule": "英数字、アンダースコア (_)、およびハイフン (-) のみを使用でき、英数字で終わる必要があります。",
     "OpenToPublic": "アプリを外部に公開",
-    "DesiredRoutingCount": "希望のルーティング数",
     "ServingRouteErrorModalTitle": "サービングルートエラー",
     "SessionId": "セッションID",
     "Services": "モデルサービス",
@@ -1598,7 +1597,8 @@
     "ServiceNameMinLength": "少なくとも 4 文字を入力してください。",
     "ServiceNameMaxLength": "24文字以内で入力してください。",
     "ServiceNameCannotStartWithHyphen": "両端にハイフン（-）を使用することはできません。",
-    "Resources": "リソース"
+    "Resources": "リソース",
+    "NumberOfReplicas": "レプリカの数"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -441,7 +441,6 @@
     "StartNewServing": "새 서비스 시작",
     "ServiceName": "서비스 이름",
     "OpenToPublic": "앱을 외부에 공개",
-    "DesiredRoutingCount": "원하는 라우팅 수",
     "DesiredSessionCount": "원하는 세션 수",
     "EndpointName": "엔드포인트 이름",
     "EndpointId": "엔드포인트 ID",
@@ -513,7 +512,8 @@
     "ServiceNameMinLength": "4자 이상 입력해주세요.",
     "ServiceNameMaxLength": "24자 이하로 입력해주세요.",
     "ServiceNameCannotStartWithHyphen": "하이픈(-)은 양쪽 끝에 사용할 수 없습니다.",
-    "Resources": "자원"
+    "Resources": "자원",
+    "NumberOfReplicas": "복제본 수"
   },
   "button": {
     "Cancel": "취소",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1579,7 +1579,6 @@
     "StartNewServing": "Шинээр үйлчилж эхлэх",
     "ServiceName": "Үйлчилгээний нэр",
     "OpenToPublic": "Олон нийтэд нээлттэй",
-    "DesiredRoutingCount": "Хүссэн чиглүүлэлтийн тоо",
     "Services": "Үйлчилгээ",
     "RoutingInfo": "Чиглүүлэлтийн мэдээлэл",
     "ServiceInfo": "Үйлчилгээний мэдээлэл",
@@ -1649,7 +1648,8 @@
     "ServiceNameMinLength": "Дор хаяж 4 тэмдэгт оруулна уу.",
     "ServiceNameMaxLength": "24 ба түүнээс бага тэмдэгт оруулна уу.",
     "ServiceNameCannotStartWithHyphen": "Хоёр төгсгөлд зураас (-) ашиглах боломжгүй.",
-    "Resources": "Нөөц"
+    "Resources": "Нөөц",
+    "NumberOfReplicas": "Хуулбаруудын тоо"
   },
   "modelStore": {
     "Description": "Тодорхойлолт",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1575,7 +1575,6 @@
     "ServiceName": "Nama Perkhidmatan",
     "ServiceNameRule": "Hanya benarkan abjad angka, garis bawah(_), dan sempang(-) dan ia mesti berakhir dengan aksara abjad angka.",
     "OpenToPublic": "Terbuka Kepada Umum",
-    "DesiredRoutingCount": "Kiraan Laluan yang Diingini",
     "ServingRouteErrorModalTitle": "Ralat Laluan Pelayanan",
     "SessionId": "ID Sesi",
     "Services": "Perkhidmatan",
@@ -1633,7 +1632,8 @@
     "ServiceNameMinLength": "Sila masukkan sekurang-kurangnya 4 aksara.",
     "ServiceNameMaxLength": "Sila masukkan 24 aksara atau kurang.",
     "ServiceNameCannotStartWithHyphen": "Tanda sempang (-) tidak boleh digunakan pada kedua-dua hujung.",
-    "Resources": "Sumber"
+    "Resources": "Sumber",
+    "NumberOfReplicas": "Bilangan replika"
   },
   "totp": {
     "TotpSetupCompleted": "Didayakan 2FA",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1540,7 +1540,6 @@
     "ServiceName": "Nazwa usługi",
     "ServiceNameRule": "Zezwalaj tylko na znaki alfanumeryczne, podkreślenie (_) i łącznik (-) i muszą one kończyć się znakiem alfanumerycznym.",
     "OpenToPublic": "Otwarte dla publiczności",
-    "DesiredRoutingCount": "Pożądana liczba tras",
     "ServingRouteErrorModalTitle": "Błąd trasy serwowania",
     "SessionId": "Identyfikator sesji",
     "Services": "Usługi",
@@ -1598,7 +1597,8 @@
     "ServiceNameMinLength": "Proszę wpisać co najmniej 4 znaki.",
     "ServiceNameMaxLength": "Wprowadź maksymalnie 24 znaki.",
     "ServiceNameCannotStartWithHyphen": "Łączników (-) nie można używać na żadnym końcu.",
-    "Resources": "Zasoby"
+    "Resources": "Zasoby",
+    "NumberOfReplicas": "Liczba replik"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1575,7 +1575,6 @@
     "ServiceName": "Nome do serviço",
     "ServiceNameRule": "Permitir apenas alfanumérico, sublinhado (_) e hífen (-) e deve terminar com um caractere alfanumérico.",
     "OpenToPublic": "Aberto ao público",
-    "DesiredRoutingCount": "Contagem de roteiros desejada",
     "ServingRouteErrorModalTitle": "Erro de rota de serviço",
     "SessionId": "ID da sessão",
     "Services": "Serviços",
@@ -1633,7 +1632,8 @@
     "ServiceNameMinLength": "Por favor insira pelo menos 4 caracteres.",
     "ServiceNameMaxLength": "Insira 24 caracteres ou menos.",
     "ServiceNameCannotStartWithHyphen": "Hífens (-) não podem ser usados ​​em nenhuma das extremidades.",
-    "Resources": "Recursos"
+    "Resources": "Recursos",
+    "NumberOfReplicas": "Número de réplicas"
   },
   "totp": {
     "TotpSetupCompleted": "Ativado 2FA",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1575,7 +1575,6 @@
     "ServiceName": "Nome do serviço",
     "ServiceNameRule": "Permitir apenas alfanumérico, sublinhado (_) e hífen (-) e deve terminar com um caractere alfanumérico.",
     "OpenToPublic": "Aberto ao público",
-    "DesiredRoutingCount": "Contagem de roteiros desejada",
     "ServingRouteErrorModalTitle": "Erro de rota de serviço",
     "SessionId": "ID da sessão",
     "Services": "Serviços",
@@ -1633,7 +1632,8 @@
     "ServiceNameMinLength": "Por favor insira pelo menos 4 caracteres.",
     "ServiceNameMaxLength": "Insira 24 caracteres ou menos.",
     "ServiceNameCannotStartWithHyphen": "Hífens (-) não podem ser usados ​​em nenhuma das extremidades.",
-    "Resources": "Recursos"
+    "Resources": "Recursos",
+    "NumberOfReplicas": "Número de réplicas"
   },
   "totp": {
     "TotpSetupCompleted": "Ativado 2FA",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1580,7 +1580,6 @@
     "StartNewServing": "Запуск новой порции",
     "ServiceName": "Название услуги",
     "OpenToPublic": "Открыт для посещения",
-    "DesiredRoutingCount": "Желаемое количество маршрутов",
     "Services": "Услуги",
     "RoutingInfo": "Маршрутная информация",
     "ServiceInfo": "Служебная информация",
@@ -1650,7 +1649,8 @@
     "ServiceNameMinLength": "Пожалуйста, введите не менее 4 символов.",
     "ServiceNameMaxLength": "Введите не более 24 символов.",
     "ServiceNameCannotStartWithHyphen": "Дефисы (-) нельзя использовать ни на одном конце.",
-    "Resources": "Ресурсы"
+    "Resources": "Ресурсы",
+    "NumberOfReplicas": "Количество реплик"
   },
   "modelStore": {
     "Description": "Описание",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -451,7 +451,6 @@
     "StartNewServing": "เริ่มการให้บริการใหม่",
     "ServiceName": "ชื่อบริการ",
     "OpenToPublic": "เปิดให้สาธารณะ",
-    "DesiredRoutingCount": "จำนวนการกำหนดเส้นทางที่ต้องการ",
     "DesiredSessionCount": "จำนวนเซสชันที่ต้องการ",
     "EndpointName": "ชื่อจุดสิ้นสุด",
     "EndpointId": "รหัสจุดสิ้นสุด",
@@ -523,7 +522,8 @@
     "ServiceNameMinLength": "กรุณากรอกอย่างน้อย 4 ตัวอักษร",
     "ServiceNameMaxLength": "โปรดป้อนอักขระ 24 ตัวหรือน้อยกว่า",
     "ServiceNameCannotStartWithHyphen": "เครื่องหมายยัติภังค์ (-) ไม่สามารถใช้ที่ปลายทั้งสองข้างได้",
-    "Resources": "ทรัพยากร"
+    "Resources": "ทรัพยากร",
+    "NumberOfReplicas": "จำนวนแบบจำลอง"
   },
   "button": {
     "Cancel": "ยกเลิก",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1539,7 +1539,6 @@
     "ServiceName": "Hizmet Adı",
     "ServiceNameRule": "Yalnızca alfasayısal, alt çizgi(_) ve kısa çizgiye(-) izin verilir ve alfasayısal bir karakterle bitmelidir.",
     "OpenToPublic": "Halka Açık",
-    "DesiredRoutingCount": "İstenen Yönlendirme Sayısı",
     "ServingRouteErrorModalTitle": "Hizmet Veren Rota Hatası",
     "SessionId": "Oturum Kimliği",
     "Services": "Hizmetler",
@@ -1597,7 +1596,8 @@
     "ServiceNameMinLength": "Lütfen en az 4 karakter giriniz.",
     "ServiceNameMaxLength": "Lütfen 24 veya daha az karakter girin.",
     "ServiceNameCannotStartWithHyphen": "Kısa çizgi (-) her iki uçta da kullanılamaz.",
-    "Resources": "Kaynaklar"
+    "Resources": "Kaynaklar",
+    "NumberOfReplicas": "Kopya sayısı"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1575,7 +1575,6 @@
     "ServiceName": "Tên dịch vụ",
     "ServiceNameRule": "Chỉ cho phép chữ và số, dấu gạch dưới (_), dấu gạch nối (-) và phải kết thúc bằng ký tự chữ và số.",
     "OpenToPublic": "Mở cửa cho công chúng",
-    "DesiredRoutingCount": "Số lượng định tuyến mong muốn",
     "ServingRouteErrorModalTitle": "Lỗi tuyến đường phục vụ",
     "SessionId": "ID phiên",
     "Services": "Dịch vụ",
@@ -1633,7 +1632,8 @@
     "ServiceNameMinLength": "Vui lòng nhập ít nhất 4 ký tự.",
     "ServiceNameMaxLength": "Vui lòng nhập 24 ký tự trở xuống.",
     "ServiceNameCannotStartWithHyphen": "Dấu gạch nối (-) không thể được sử dụng ở cả hai đầu.",
-    "Resources": "Tài nguyên"
+    "Resources": "Tài nguyên",
+    "NumberOfReplicas": "Số lượng bản sao"
   },
   "totp": {
     "TotpSetupCompleted": "Đã bật 2FA",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1575,7 +1575,6 @@
     "ServiceName": "服务名称",
     "ServiceNameRule": "仅允许使用字母数字、下划线 (_) 和连字符 (-)，并且必须以字母数字字符结尾。",
     "OpenToPublic": "向公众开放",
-    "DesiredRoutingCount": "所需的路由计数",
     "ServingRouteErrorModalTitle": "服务路由错误",
     "SessionId": "会话 ID",
     "Services": "服务",
@@ -1633,7 +1632,8 @@
     "ServiceNameMinLength": "请输入至少 4 个字符。",
     "ServiceNameMaxLength": "请输入 24 个或更少的字符。",
     "ServiceNameCannotStartWithHyphen": "两端不能使用连字符 (-)。",
-    "Resources": "资源"
+    "Resources": "资源",
+    "NumberOfReplicas": "副本数量"
   },
   "totp": {
     "TotpSetupCompleted": "已启用 2FA",

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -727,6 +727,7 @@ class Client {
       this._features['prepared-session-status'] = true;
       this._features['creating-session-status'] = true;
       this._features['max_network_count'] = true;
+      this._features['replicas'] = true;
     }
   }
 


### PR DESCRIPTION
### This PR resolves [#2957](https://github.com/lablup/backend.ai-webui/issues/2957) issue

Since Backend.AI Core version 24.12.0, the desired_session_count field has been replaced with `replicas`. 

**Changes:**
- Added `replicas` field to service creation and update interfaces
- Deprecated `desired_session_count` field for manager version >= 24.12.0
- Updated GraphQL queries to handle both `desired_session_count` and `replicas` fields
- Added version-based field selection using `@deprecatedSince` and `@since` directives
- Added `replicas` feature flag check in client capabilities

**How to test:**
- Check whether `desired_session_count` or `replicas` is used when creating or modifying a service, depending on the manager version. (From 24.12.0 onwards, replicas is used.) 
- Check whether desired_session_count is displayed correctly on the Service page and Detail page.