### PR TITLE
hotfix: `sudo_session_enable` setting doesn't work

### DIFF
--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -225,7 +225,7 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
         if (user) {
           const props: ModifyUserInput = _.omitBy(
             _.omit(values, ['email', 'password_confirm']),
-            _.isEmpty,
+            _.isNil,
           );
           commitModifyUserSetting({
             variables: {


### PR DESCRIPTION
closes https://github.com/lablup/backend.ai-webui/issues/2964

Updates the user settings modification logic to use `_.isNil` instead of `_.isEmpty` when filtering properties, ensuring that `sudo_session_enable` is changed properly.

**Checklist:**

- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after