### PR TITLE
fix: auto-update login inconsistency in ResourceAllocationFormItems

### DIFF
--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -206,7 +206,7 @@ const SessionLauncherPage = () => {
     () => ({
       sessionType: 'interactive',
       // If you set `allocationPreset` to 'custom', `allocationPreset` is not changed automatically any more.
-      allocationPreset: 'auto-preset',
+      allocationPreset: 'auto-select',
       hpcOptimization: {
         autoEnabled: true,
         OMP_NUM_THREADS: '1',


### PR DESCRIPTION
Resolves #2958

**Changes:**
To fix the inconsistency bug, refactored resource allocation preset handling in session launcher to improve reliability and maintainability:

1. Typo: renamed initial allocation preset from 'auto-preset' to 'auto-select'
2. Wrapped resource field update functions with useEventNotStable to prevent invoke useEffect unnecessary.
3. Consolidated preset selection logic into a single useEffect hook that handles:
   - Initial form setup when resourceSlots are loaded
   - Automatic preset selection based on available resources
   - Validation of accelerator type
4. Added separate useEffect for handling minimum-required preset updates when image changes

These changes make the resource allocation behavior more predictable and easier to maintain while fixing potential race conditions in the preset selection logic.

### Steps to Reproduce
I can reproduce with the dogbowl backend.
1. Navigate to the session list in the Backend.AI WebUI.
2. Refresh the browser.
3. Click the "Start Session" button.
4. Proceed to the second step of the session creation process.
5. Check the automatically selected preset.
6. Verify if the resources allocated match the selected preset.