### PR TITLE
chore: update NVIDIA references in image metadata

### DIFF
--- a/react/src/hooks/useBackendAIImageMetaData.test.tsx
+++ b/react/src/hooks/useBackendAIImageMetaData.test.tsx
@@ -32,7 +32,7 @@ describe('useBackendAIImageMetaData', () => {
               r: 'R',
               'r-base': 'R',
               py3: 'Python3',
-              ngc: 'Nvidia GPU Cloud',
+              ngc: 'NVIDIA GPU Cloud',
               py310: 'Python3',
             },
             tagReplace: {},
@@ -71,7 +71,7 @@ describe('useBackendAIImageMetaData', () => {
     const [, { getBaseImages }] = result.current;
     const baseImages = getBaseImages('21.11-py3', 'testing/ngc-pytorc');
     expect(baseImages[0]).toBe('Python3');
-    expect(baseImages[1]).toBe('Nvidia GPU Cloud');
+    expect(baseImages[1]).toBe('NVIDIA GPU Cloud');
   });
   it('get constraint data', async () => {
     const { result } = renderHook(() => useBackendAIImageMetaData(), {

--- a/resources/image_metadata.json
+++ b/resources/image_metadata.json
@@ -45,7 +45,7 @@
           "color": "blue"
         },
         {
-          "tag": "Nvidia GPU Cloud",
+          "tag": "NVIDIA GPU Cloud",
           "color": "green"
         }
       ]
@@ -209,7 +209,7 @@
     },
     "ngc-digits": {
       "name": "DIGITS (NGC)",
-      "description": "This environment is integrated with Nvidia GPU Cloud. ",
+      "description": "This environment is integrated with NVIDIA GPU Cloud. ",
       "group": "Machine Learning / Deep Learning",
       "tags": [],
       "label": [
@@ -219,14 +219,14 @@
           "color": "blue"
         },
         {
-          "tag": "Nvidia GPU Cloud",
+          "tag": "NVIDIA GPU Cloud",
           "color": "green"
         }
       ]
     },
     "ngc-tensorflow": {
       "name": "TensorFlow (NGC)",
-      "description": "TensorFlow is an end-to-end open source platform for machine learning. It has a comprehensive, flexible ecosystem of tools, libraries and community resources that lets researchers push the state-of-the-art in ML and developers easily build and deploy ML powered applications. This environment is integrated with Nvidia GPU Cloud.",
+      "description": "TensorFlow is an end-to-end open source platform for machine learning. It has a comprehensive, flexible ecosystem of tools, libraries and community resources that lets researchers push the state-of-the-art in ML and developers easily build and deploy ML powered applications. This environment is integrated with NVIDIA GPU Cloud.",
       "group": "Machine Learning / Deep Learning",
       "tags": [],
       "icon": "tensorflow.png",
@@ -237,14 +237,14 @@
           "color": "blue"
         },
         {
-          "tag": "Nvidia GPU Cloud",
+          "tag": "NVIDIA GPU Cloud",
           "color": "green"
         }
       ]
     },
     "ngc-pytorch": {
       "name": "PyTorch (NGC)",
-      "description": "PyTorch is an open source machine learning framework that accelerates the path from research prototyping to production deployment. This environment is integrated with Nvidia GPU Cloud.",
+      "description": "PyTorch is an open source machine learning framework that accelerates the path from research prototyping to production deployment. This environment is integrated with NVIDIA GPU Cloud.",
       "group": "Machine Learning / Deep Learning",
       "tags": [],
       "icon": "pytorch.svg",
@@ -255,14 +255,14 @@
           "color": "blue"
         },
         {
-          "tag": "Nvidia GPU Cloud",
+          "tag": "NVIDIA GPU Cloud",
           "color": "green"
         }
       ]
     },
     "ngc-caffe2": {
       "name": "Caffe 2 (NGC)",
-      "description": "Caffe2 is a deep learning framework that provides an easy and straightforward way for you to experiment with deep learning and leverage community contributions of new models and algorithms. This environment is integrated with Nvidia GPU Cloud.",
+      "description": "Caffe2 is a deep learning framework that provides an easy and straightforward way for you to experiment with deep learning and leverage community contributions of new models and algorithms. This environment is integrated with NVIDIA GPU Cloud.",
       "group": "Machine Learning / Deep Learning",
       "tags": [],
       "icon": "caffe2.svg",
@@ -273,14 +273,14 @@
           "color": "blue"
         },
         {
-          "tag": "Nvidia GPU Cloud",
+          "tag": "NVIDIA GPU Cloud",
           "color": "green"
         }
       ]
     },
     "ngc-caffe3": {
       "name": "Caffe (NGC, Python 3)",
-      "description": "Caffe is a deep learning framework made with expression, speed, and modularity in mind. This environment is integrated with Nvidia GPU Cloud.",
+      "description": "Caffe is a deep learning framework made with expression, speed, and modularity in mind. This environment is integrated with NVIDIA GPU Cloud.",
       "group": "Machine Learning / Deep Learning",
       "tags": [],
       "icon": "caffe.png",
@@ -291,14 +291,14 @@
           "color": "blue"
         },
         {
-          "tag": "Nvidia GPU Cloud",
+          "tag": "NVIDIA GPU Cloud",
           "color": "green"
         }
       ]
     },
     "ngc-nvcaffe": {
       "name": "NVCaffe (NGC)",
-      "description": "Caffe is a deep-learning framework made with flexibility, speed, and modularity in mind. NVCaffe is an NVIDIA-maintained fork of BVLC Caffe tuned for NVIDIA GPUs, particularly in multi-GPU configurations. This environment is integrated with Nvidia GPU Cloud.",
+      "description": "Caffe is a deep-learning framework made with flexibility, speed, and modularity in mind. NVCaffe is an NVIDIA-maintained fork of BVLC Caffe tuned for NVIDIA GPUs, particularly in multi-GPU configurations. This environment is integrated with NVIDIA GPU Cloud.",
       "group": "Machine Learning / Deep Learning",
       "tags": [],
       "icon": "caffe2.svg",
@@ -309,14 +309,14 @@
           "color": "blue"
         },
         {
-          "tag": "Nvidia GPU Cloud",
+          "tag": "NVIDIA GPU Cloud",
           "color": "green"
         }
       ]
     },
     "ngc-mxnet": {
       "name": "MXNet (NGC)",
-      "description": "MXNet is an open source deep learning framework suited for flexible research prototyping and production. This environment is integrated with Nvidia GPU Cloud.",
+      "description": "MXNet is an open source deep learning framework suited for flexible research prototyping and production. This environment is integrated with NVIDIA GPU Cloud.",
       "group": "Machine Learning / Deep Learning",
       "tags": [],
       "icon": "mxnet.svg",
@@ -327,14 +327,14 @@
           "color": "blue"
         },
         {
-          "tag": "Nvidia GPU Cloud",
+          "tag": "NVIDIA GPU Cloud",
           "color": "green"
         }
       ]
     },
     "ngc-triton": {
       "name": "Triton Server (NGC)",
-      "description": "NVIDIA Triton Inference Server is an open-source, high-performance server that simplifies the deployment of AI models for inference in production environments..This environment is integrated with Nvidia GPU Cloud.",
+      "description": "NVIDIA Triton Inference Server is an open-source, high-performance server that simplifies the deployment of AI models for inference in production environments..This environment is integrated with NVIDIA GPU Cloud.",
       "group": "Machine Learning / Deep Learning",
       "tags": [],
       "icon": "nvidia.svg",
@@ -345,14 +345,14 @@
           "color": "blue"
         },
         {
-          "tag": "Nvidia GPU Cloud",
+          "tag": "NVIDIA GPU Cloud",
           "color": "green"
         }
       ]
     },
     "ngc-matlab": {
       "name": "MATLAB (NGC)",
-      "description": "MATLAB® combines a desktop environment tuned for iterative analysis and design processes with a programming language that expresses matrix and array mathematics directly. This environment is integrated with Nvidia GPU Cloud.",
+      "description": "MATLAB® combines a desktop environment tuned for iterative analysis and design processes with a programming language that expresses matrix and array mathematics directly. This environment is integrated with NVIDIA GPU Cloud.",
       "group": "Scientific Language",
       "tags": [],
       "icon": "matlab.png",
@@ -367,7 +367,7 @@
           "color": "blue"
         },
         {
-          "tag": "Nvidia GPU Cloud",
+          "tag": "NVIDIA GPU Cloud",
           "color": "green"
         }
       ]
@@ -902,7 +902,7 @@
     "anaconda2022.12": "Anaconda 2022.12",
     "alpine3.8": "Alpine Linux 3.8",
     "alpine3.12": "Alpine Linux 3.12",
-    "ngc": "Nvidia GPU Cloud",
+    "ngc": "NVIDIA GPU Cloud",
     "ff": "Research Env.",
     "atom-orbit": "Orbit"
   },


### PR DESCRIPTION
**Changes:**
Updated all instances of "Nvidia" to "NVIDIA" in GPU Cloud references across image metadata and test files to maintain consistent branding with NVIDIA's official capitalization.

> The correct way of writing NVIDIA is in all uppercase letters.

**Rationale:**
Ensures proper brand name representation and consistency with NVIDIA's corporate identity guidelines.

Ref
- https://http.download.nvidia.com/image_kit/LG_NVCorpBadge.pdf

**Checklist:**
- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after