### PR TITLE
fix: set `Max Network Count` field to project resource policy

### DIFF
--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -214,6 +214,12 @@ type Queries {
 
   """Added in 24.03.0."""
   model_cards(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ModelCardConnection
+
+  """Added in 24.12.0."""
+  network(id: String!): NetworkNode
+
+  """Added in 24.12.0."""
+  networks(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): NetworkConnection
 }
 
 """
@@ -1023,6 +1029,11 @@ type ProjectResourcePolicy {
   """
   max_quota_scope_size: BigInt
   max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.2.")
+
+  """
+  Added in 24.12.0. Limitation of the number of networks created on behalf of project.
+  """
+  max_network_count: Int
 }
 
 type ResourcePreset {
@@ -1368,7 +1379,10 @@ type Endpoint implements Item {
   environ: JSONString
   name: String
   resource_opts: JSONString
-  desired_session_count: Int
+
+  """Added in 24.12.0. Replaces `desired_session_count`."""
+  replicas: Int
+  desired_session_count: Int @deprecated(reason: "Deprecated since 24.12.0. Use `replicas` instead.")
   cluster_mode: String
   cluster_size: Int
   open_to_public: Boolean
@@ -1382,6 +1396,9 @@ type Endpoint implements Item {
   status: String
   lifecycle_stage: String
   errors: [InferenceSessionError!]!
+
+  """Added in 24.12.0."""
+  live_stat: JSONString
 }
 
 """Added in 24.03.5."""
@@ -1399,6 +1416,9 @@ type Routing implements Item {
   traffic_ratio: Float
   created_at: DateTime
   error_data: JSONString
+
+  """Added in 24.12.0."""
+  live_stat: JSONString
 }
 
 type InferenceSessionError {
@@ -1590,6 +1610,42 @@ type ModelCardConnection {
 type ModelCardEdge {
   """The item at the end of the edge"""
   node: ModelCard
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Added in 24.12.0."""
+type NetworkNode implements Node {
+  """The ID of the object"""
+  id: ID!
+  row_id: UUID
+  name: String
+  ref_name: String
+  driver: String
+  project: UUID
+  domain_name: String
+  options: JSONString
+  created_at: DateTime
+  updated_at: DateTime
+}
+
+"""Added in 24.12.0."""
+type NetworkConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [NetworkEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""Added in 24.12.0. A Relay edge containing a `Network` and its cursor."""
+type NetworkEdge {
+  """The item at the end of the edge"""
+  node: NetworkNode
 
   """A cursor for use in pagination"""
   cursor: String!
@@ -1799,6 +1855,15 @@ type Mutations {
 
   """Added in 24.09.0."""
   check_and_transit_session_status(input: CheckAndTransitStatusInput!): CheckAndTransitStatus
+
+  """Added in 24.12.0."""
+  create_network(driver: String, name: String!, project_id: UUID!): CreateNetwork
+
+  """Added in 24.12.0."""
+  modify_network(network: String!, props: ModifyNetworkInput!): ModifyNetwork
+
+  """Added in 24.12.0."""
+  delete_network(network: String!): DeleteNetwork
 }
 
 type ModifyAgent {
@@ -2310,6 +2375,11 @@ input CreateProjectResourcePolicyInput {
   """
   max_quota_scope_size: BigInt
   max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.2.")
+
+  """
+  Added in 24.12.0. Limitation of the number of networks created on behalf of project. Set as -1 to allow creating unlimited networks.
+  """
+  max_network_count: Int
 }
 
 type ModifyProjectResourcePolicy {
@@ -2328,6 +2398,11 @@ input ModifyProjectResourcePolicyInput {
   """
   max_quota_scope_size: BigInt
   max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.2.")
+
+  """
+  Added in 24.12.0. Limitation of the number of networks created on behalf of project. Set as -1 to allow creating unlimited networks.
+  """
+  max_network_count: Int
 }
 
 type DeleteProjectResourcePolicy {
@@ -2555,7 +2630,10 @@ input ModifyEndpointInput {
   resource_opts: JSONString
   cluster_mode: String
   cluster_size: Int
-  desired_session_count: Int
+
+  """Added in 24.12.0. Replaces `desired_session_count`."""
+  replicas: Int
+  desired_session_count: Int @deprecated(reason: "Deprecated since 24.12.0. Use `replicas` instead.")
   image: ImageRefType
   name: String
   resource_group: String
@@ -2610,4 +2688,29 @@ type CheckAndTransitStatus {
 input CheckAndTransitStatusInput {
   ids: [GlobalIDField]!
   client_mutation_id: String
+}
+
+"""Added in 24.12.0."""
+type CreateNetwork {
+  ok: Boolean
+  msg: String
+  network: NetworkNode
+}
+
+"""Added in 24.12.0."""
+type ModifyNetwork {
+  ok: Boolean
+  msg: String
+  network: NetworkNode
+}
+
+"""Added in 24.12.0."""
+input ModifyNetworkInput {
+  name: String!
+}
+
+"""Added in 24.12.0."""
+type DeleteNetwork {
+  ok: Boolean
+  msg: String
 }

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -69,6 +69,7 @@ const ProjectResourcePolicyList: React.FC<
     'max-vfolder-count-in-user-and-project-resource-policy',
   );
   const supportMaxQuotaScopeSize = baiClient?.supports('max-quota-scope-size');
+  const supportMaxNetworkCount = baiClient?.supports('max_network_count');
 
   const { project_resource_policies } =
     useLazyLoadQuery<ProjectResourcePolicyListQuery>(
@@ -83,6 +84,7 @@ const ProjectResourcePolicyList: React.FC<
             max_vfolder_count @since(version: "23.09.6")
             max_quota_scope_size @since(version: "23.09.2")
             # ---------------- END ---------------------
+            max_network_count @since(version: "24.12.0")
             ...ProjectResourcePolicySettingModalFragment
           }
         }
@@ -115,31 +117,44 @@ const ProjectResourcePolicyList: React.FC<
       fixed: 'left',
       sorter: (a, b) => localeCompare(a?.name, b?.name),
     },
-    supportMaxVfolderCount && {
-      title: t('resourcePolicy.MaxVFolderCount'),
-      dataIndex: 'max_vfolder_count',
-      key: 'max_vfolder_count',
-      render: (text: ProjectResourcePolicies) =>
-        _.toNumber(text) === 0 ? '∞' : text,
-      sorter: (a, b) =>
-        numberSorterWithInfinityValue(
-          a?.max_vfolder_count,
-          b?.max_vfolder_count,
-          0,
-        ),
-    },
-    supportMaxQuotaScopeSize && {
-      title: t('resourcePolicy.MaxQuotaScopeSize'),
-      dataIndex: 'max_quota_scope_size',
-      key: 'max_quota_scope_size',
-      render: (text) => (text === -1 ? '∞' : bytesToGB(text)),
-      sorter: (a, b) =>
-        numberSorterWithInfinityValue(
-          a?.max_quota_scope_size,
-          b?.max_quota_scope_size,
-          -1,
-        ),
-    },
+    supportMaxVfolderCount
+      ? {
+          title: t('resourcePolicy.MaxVFolderCount'),
+          dataIndex: 'max_vfolder_count',
+          key: 'max_vfolder_count',
+          render: (text: ProjectResourcePolicies) =>
+            _.toNumber(text) === 0 ? '∞' : text,
+          sorter: (a, b) =>
+            numberSorterWithInfinityValue(
+              a?.max_vfolder_count,
+              b?.max_vfolder_count,
+              0,
+            ),
+        }
+      : {},
+    supportMaxQuotaScopeSize
+      ? {
+          title: t('resourcePolicy.MaxQuotaScopeSize'),
+          dataIndex: 'max_quota_scope_size',
+          key: 'max_quota_scope_size',
+          render: (text) => (text === -1 ? '∞' : bytesToGB(text)),
+          sorter: (a, b) =>
+            numberSorterWithInfinityValue(
+              a?.max_quota_scope_size,
+              b?.max_quota_scope_size,
+              -1,
+            ),
+        }
+      : {},
+    supportMaxNetworkCount
+      ? {
+          title: t('resourcePolicy.MaxNetworkCount'),
+          dataIndex: 'max_network_count',
+          key: 'max_network_count',
+          render: (text) => (text === -1 ? '∞' : text),
+          sorter: (a, b) => true,
+        }
+      : {},
     {
       title: 'ID',
       dataIndex: 'id',

--- a/react/src/components/ProjectResourcePolicySettingModal.tsx
+++ b/react/src/components/ProjectResourcePolicySettingModal.tsx
@@ -49,6 +49,7 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
     'max-vfolder-count-in-user-and-project-resource-policy',
   );
   const supportMaxQuotaScopeSize = baiClient?.supports('max-quota-scope-size');
+  const supportMaxNetworkCount = baiClient?.supports('max_network_count');
 
   const projectResourcePolicy = useFragment(
     graphql`
@@ -61,6 +62,7 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
         max_vfolder_count @since(version: "23.09.6")
         max_quota_scope_size @since(version: "23.09.2")
         # ---------------- END ---------------------
+        max_network_count @since(version: "24.12.0")
       }
     `,
     projectResourcePolicyFrgmt,
@@ -103,6 +105,7 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
         // Initialize unlimited values as a default when creating a new policy.\
         max_vfolder_count: 0,
         max_quota_scope_size: -1,
+        max_network_count: -1,
       };
     }
     let maxQuotaScopeSize = projectResourcePolicy?.max_quota_scope_size;
@@ -134,12 +137,16 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
             values?.max_quota_scope_size === -1
               ? -1
               : GBToBytes(values?.max_quota_scope_size),
+          max_network_count: values?.max_network_count || -1,
         };
         if (!supportMaxVfolderCount) {
           delete props.max_vfolder_count;
         }
         if (!supportMaxQuotaScopeSize) {
           delete props.max_quota_scope_size;
+        }
+        if (!supportMaxNetworkCount) {
+          delete props.max_network_count;
         }
         if (projectResourcePolicy === null) {
           commitCreateProjectResourcePolicy({
@@ -270,6 +277,16 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
               style={{ width: '100%', margin: 0 }}
             >
               <InputNumber min={0} addonAfter="GB" style={{ width: '100%' }} />
+            </FormItemWithUnlimited>
+          ) : null}
+          {supportMaxNetworkCount ? (
+            <FormItemWithUnlimited
+              name={'max_network_count'}
+              unlimitedValue={-1}
+              label={t('resourcePolicy.MaxNetworkCount')}
+              style={{ width: '100%', margin: 0 }}
+            >
+              <InputNumber min={0} style={{ width: '100%' }} />
             </FormItemWithUnlimited>
           ) : null}
         </Flex>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "Die Daten für den CSV-Extrakt sind nicht vorhanden.",
     "ExportCSV": "CSV exportieren",
     "Tools": "Werkzeuge",
-    "MemorySizeExceedsLimit": "Die Speichergröße sollte weniger als 300 PiB betragen"
+    "MemorySizeExceedsLimit": "Die Speichergröße sollte weniger als 300 PiB betragen",
+    "MaxNetworkCount": "Maximale Netzwerkanzahl"
   },
   "registry": {
     "Hostname": "Hostname",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "Τα δεδομένα για το απόσπασμα CSV δεν υπάρχουν.",
     "ExportCSV": "εξαγωγή CSV",
     "Tools": "Εργαλεία",
-    "MemorySizeExceedsLimit": "Το μέγεθος της μνήμης πρέπει να είναι μικρότερο από 300 PiB"
+    "MemorySizeExceedsLimit": "Το μέγεθος της μνήμης πρέπει να είναι μικρότερο από 300 PiB",
+    "MaxNetworkCount": "Μέγιστος αριθμός δικτύου"
   },
   "registry": {
     "Hostname": "Όνομα κεντρικού υπολογιστή",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1212,7 +1212,8 @@
     "NoDataToExport": "The data for the CSV extract does not exist.",
     "ExportCSV": "export CSV",
     "Tools": "Tools",
-    "MemorySizeExceedsLimit": "Memory size should be less than 300 PiB"
+    "MemorySizeExceedsLimit": "Memory size should be less than 300 PiB",
+    "MaxNetworkCount": "Max Network Count"
   },
   "registry": {
     "Hostname": "Hostname",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -996,7 +996,8 @@
     "NoDataToExport": "Los datos para el extracto CSV no existen.",
     "ExportCSV": "exportar CSV",
     "Tools": "Herramientas",
-    "MemorySizeExceedsLimit": "El tamaño de la memoria debe ser inferior a 300 PiB"
+    "MemorySizeExceedsLimit": "El tamaño de la memoria debe ser inferior a 300 PiB",
+    "MaxNetworkCount": "Recuento máximo de red"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Está a punto de borrar este preajuste:",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -993,7 +993,8 @@
     "NoDataToExport": "CSV-otteen tietoja ei ole olemassa.",
     "ExportCSV": "vie CSV",
     "Tools": "Työkalut",
-    "MemorySizeExceedsLimit": "Muistin koon tulee olla alle 300 PiB"
+    "MemorySizeExceedsLimit": "Muistin koon tulee olla alle 300 PiB",
+    "MaxNetworkCount": "Verkkojen enimmäismäärä"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Olet poistamassa tätä esiasetusta:",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "Les données pour l'extrait CSV n'existent pas.",
     "ExportCSV": "exporter au format CSV",
     "Tools": "Outils",
-    "MemorySizeExceedsLimit": "La taille de la mémoire doit être inférieure à 300 PiB"
+    "MemorySizeExceedsLimit": "La taille de la mémoire doit être inférieure à 300 PiB",
+    "MaxNetworkCount": "Nombre maximum de réseaux"
   },
   "registry": {
     "Hostname": "Nom d'hôte",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1084,7 +1084,8 @@
     "NoDataToExport": "Data untuk ekstrak CSV tidak ada.",
     "ExportCSV": "ekspor CSV",
     "Tools": "Peralatan",
-    "MemorySizeExceedsLimit": "Ukuran memori harus kurang dari 300 PiB"
+    "MemorySizeExceedsLimit": "Ukuran memori harus kurang dari 300 PiB",
+    "MaxNetworkCount": "Jumlah Jaringan Maks"
   },
   "registry": {
     "Hostname": "Nama host",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "I dati per l'estrazione CSV non esistono.",
     "ExportCSV": "esportare CSV",
     "Tools": "Utensili",
-    "MemorySizeExceedsLimit": "La dimensione della memoria deve essere inferiore a 300 PiB"
+    "MemorySizeExceedsLimit": "La dimensione della memoria deve essere inferiore a 300 PiB",
+    "MaxNetworkCount": "Conteggio massimo della rete"
   },
   "registry": {
     "Hostname": "Nome host",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "CSV抽出用のデータが存在しません。",
     "ExportCSV": "CSVエクスポート",
     "Tools": "ツール",
-    "MemorySizeExceedsLimit": "メモリ サイズは 300 PiB 未満である必要があります"
+    "MemorySizeExceedsLimit": "メモリ サイズは 300 PiB 未満である必要があります",
+    "MaxNetworkCount": "最大ネットワーク数"
   },
   "registry": {
     "Hostname": "ホスト名",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1199,7 +1199,8 @@
     "NoDataToExport": "CSV 추출을 위한 데이터가 존재하지 않습니다. ",
     "ExportCSV": "CSV로 내보내기",
     "Tools": "도구",
-    "MemorySizeExceedsLimit": "메모리 크기는 300PiB 미만이어야 합니다."
+    "MemorySizeExceedsLimit": "메모리 크기는 300PiB 미만이어야 합니다.",
+    "MaxNetworkCount": "최대 네트워크 수"
   },
   "registry": {
     "Hostname": "호스트명",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "CSV хандалтын өгөгдөл байхгүй байна.",
     "ExportCSV": "CSV экспортлох",
     "Tools": "Багаж хэрэгсэл",
-    "MemorySizeExceedsLimit": "Санах ойн хэмжээ 300 PiB-ээс бага байх ёстой"
+    "MemorySizeExceedsLimit": "Санах ойн хэмжээ 300 PiB-ээс бага байх ёстой",
+    "MaxNetworkCount": "Хамгийн их сүлжээний тоо"
   },
   "registry": {
     "Hostname": "Хостын нэр",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "Data untuk ekstrak CSV tidak wujud.",
     "ExportCSV": "eksport CSV",
     "Tools": "Alatan",
-    "MemorySizeExceedsLimit": "Saiz memori hendaklah kurang daripada 300 PiB"
+    "MemorySizeExceedsLimit": "Saiz memori hendaklah kurang daripada 300 PiB",
+    "MaxNetworkCount": "Kiraan Rangkaian Maks"
   },
   "registry": {
     "Hostname": "Nama Hos",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "Dane do ekstraktu CSV nie istnieją.",
     "ExportCSV": "eksportuj plik CSV",
     "Tools": "Narzędzia",
-    "MemorySizeExceedsLimit": "Rozmiar pamięci powinien być mniejszy niż 300 PiB"
+    "MemorySizeExceedsLimit": "Rozmiar pamięci powinien być mniejszy niż 300 PiB",
+    "MaxNetworkCount": "Maksymalna liczba sieci"
   },
   "registry": {
     "Hostname": "Nazwa hosta",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "Os dados para a extração CSV não existem.",
     "ExportCSV": "exportar CSV",
     "Tools": "Ferramentas",
-    "MemorySizeExceedsLimit": "O tamanho da memória deve ser inferior a 300 PiB"
+    "MemorySizeExceedsLimit": "O tamanho da memória deve ser inferior a 300 PiB",
+    "MaxNetworkCount": "Contagem máxima de rede"
   },
   "registry": {
     "Hostname": "nome de anfitrião",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "Os dados para a extração CSV não existem.",
     "ExportCSV": "exportar CSV",
     "Tools": "Ferramentas",
-    "MemorySizeExceedsLimit": "O tamanho da memória deve ser inferior a 300 PiB"
+    "MemorySizeExceedsLimit": "O tamanho da memória deve ser inferior a 300 PiB",
+    "MaxNetworkCount": "Contagem máxima de rede"
   },
   "registry": {
     "Hostname": "nome de anfitrião",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "Данные для извлечения CSV не существуют.",
     "ExportCSV": "экспортировать CSV",
     "Tools": "Инструменты",
-    "MemorySizeExceedsLimit": "Размер памяти должен быть менее 300 ПиБ."
+    "MemorySizeExceedsLimit": "Размер памяти должен быть менее 300 ПиБ.",
+    "MaxNetworkCount": "Максимальное количество сетей"
   },
   "registry": {
     "Hostname": "Имя хоста",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1194,7 +1194,8 @@
     "NoDataToExport": "ไม่มีข้อมูลสำหรับการส่งออก CSV",
     "ExportCSV": "ส่งออก CSV",
     "Tools": "เครื่องมือ",
-    "MemorySizeExceedsLimit": "ขนาดหน่วยความจำควรน้อยกว่า 300 PiB"
+    "MemorySizeExceedsLimit": "ขนาดหน่วยความจำควรน้อยกว่า 300 PiB",
+    "MaxNetworkCount": "จำนวนเครือข่ายสูงสุด"
   },
   "registry": {
     "Hostname": "ชื่อโฮสต์",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1082,7 +1082,8 @@
     "NoDataToExport": "CSV ekstresine ilişkin veriler mevcut değil.",
     "ExportCSV": "CSV'yi dışa aktar",
     "Tools": "Aletler",
-    "MemorySizeExceedsLimit": "Bellek boyutu 300 PiB'den az olmalıdır"
+    "MemorySizeExceedsLimit": "Bellek boyutu 300 PiB'den az olmalıdır",
+    "MaxNetworkCount": "Maksimum Ağ Sayısı"
   },
   "registry": {
     "Hostname": "ana bilgisayar adı",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "Dữ liệu cho bản trích xuất CSV không tồn tại.",
     "ExportCSV": "xuất CSV",
     "Tools": "Công cụ",
-    "MemorySizeExceedsLimit": "Kích thước bộ nhớ phải nhỏ hơn 300 PiB"
+    "MemorySizeExceedsLimit": "Kích thước bộ nhớ phải nhỏ hơn 300 PiB",
+    "MaxNetworkCount": "Số lượng mạng tối đa"
   },
   "registry": {
     "Hostname": "Tên máy chủ",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1083,7 +1083,8 @@
     "NoDataToExport": "CSV 提取的数据不存在。",
     "ExportCSV": "导出 CSV",
     "Tools": "工具",
-    "MemorySizeExceedsLimit": "内存大小应小于 300 PiB"
+    "MemorySizeExceedsLimit": "内存大小应小于 300 PiB",
+    "MaxNetworkCount": "最大网络数"
   },
   "registry": {
     "Hostname": "主机名",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1084,7 +1084,8 @@
     "NoDataToExport": "CSV 擷取的資料不存在。",
     "ExportCSV": "匯出 CSV",
     "Tools": "工具",
-    "MemorySizeExceedsLimit": "記憶體大小應小於 300 PiB"
+    "MemorySizeExceedsLimit": "記憶體大小應小於 300 PiB",
+    "MaxNetworkCount": "最大網路數"
   },
   "registry": {
     "Hostname": "主機名",

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -726,6 +726,7 @@ class Client {
       this._features['batch-timeout'] = true;
       this._features['prepared-session-status'] = true;
       this._features['creating-session-status'] = true;
+      this._features['max_network_count'] = true;
     }
   }
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR resolves [#2988](https://github.com/lablup/backend.ai-webui/issues/2988) issue. 

Related PR: [Core #2857](https://github.com/lablup/backend.ai/pull/2857)

Fixes an issue where the addition of the `max_network_count` field to the Project resource policy prevented the creation of a new project resource policy due to the undefinedType input of that field.

**Changes:**
- Since core version "24.12.0", `max_network_count` field was added to the proeject resource policy.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
