### PR TITLE
[FR-240] fix: show vfolder types in folder create modal based on user permission

### DIFF
--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -1,6 +1,7 @@
 import { useBaiSignedRequestWithPromise } from '../helper';
-import { useCurrentDomainValue } from '../hooks';
-import { useTanMutation } from '../hooks/reactQueryAlias';
+import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
+import { useCurrentUserRole } from '../hooks/backendai';
+import { useTanMutation, useTanQuery } from '../hooks/reactQueryAlias';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
@@ -9,6 +10,7 @@ import StorageSelect from './StorageSelect';
 import { App, Button, Divider, Form, Input, Radio, Switch, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import { FormInstance } from 'antd/lib';
+import _ from 'lodash';
 import { Suspense, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -76,10 +78,20 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
   const { message } = App.useApp();
 
   const formRef = useRef<FormInstance>(null);
+  const baiClient = useSuspendedBackendaiClient();
+  const userRole = useCurrentUserRole();
   const currentDomain = useCurrentDomainValue();
   const currentProject = useCurrentProjectValue();
 
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
+
+  const { data: allowedTypes, isFetching: isFetchingAllowedTypes } =
+    useTanQuery({
+      queryKey: ['allowedTypes', modalProps.open],
+      enabled: modalProps.open,
+      queryFn: () =>
+        modalProps.open ? baiClient.vfolder.list_allowed_types() : undefined,
+    });
 
   const mutationToCreateFolder = useTanMutation<
     FolderCreationResponse,
@@ -135,6 +147,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
 
   return (
     <BAIModal
+      loading={isFetchingAllowedTypes}
       className={styles.modal}
       title={t('data.CreateANewStorageFolder')}
       footer={
@@ -167,6 +180,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
         </Flex>
       }
       width={650}
+      okButtonProps={{ loading: mutationToCreateFolder.isPending }}
       onCancel={() => {
         onRequestClose();
       }}
@@ -224,8 +238,19 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
           style={{ flex: 1, marginBottom: 0 }}
         >
           <Radio.Group>
-            <Radio value={'user'}>User</Radio>
-            <Radio value={'project'}>Project</Radio>
+            {/* Both checks are required:
+             * - role check (admin/superadmin): Controls permission to create project folders
+             * - allowedTypes check: Ensures the 'group' type is registered in ETCD
+             * allowedTypes comes from ETCD and contains all registered types regardless of permissions,
+             * so we need both checks for proper access control
+             */}
+            {_.includes(allowedTypes, 'user') ? (
+              <Radio value={'user'}>User</Radio>
+            ) : null}
+            {(userRole === 'admin' || userRole === 'superadmin') &&
+            _.includes(allowedTypes, 'group') ? (
+              <Radio value={'project'}>Project</Radio>
+            ) : null}
           </Radio.Group>
         </Form.Item>
         <Divider />

--- a/react/src/pages/VFolderListPage.tsx
+++ b/react/src/pages/VFolderListPage.tsx
@@ -40,12 +40,11 @@ const tabParam = withDefault(StringParam, 'general');
 
 const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
   const { t } = useTranslation();
+  const { token } = theme.useToken();
   const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam, {
     updateType: 'replace',
   });
-  const baiClient = useSuspendedBackendaiClient();
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
-  const dataViewRef = useRef(null);
   const [isOpenCreateModal, { toggle: openCreateModal }] = useToggle(false);
   const [inviteFolderId, setInviteFolderId] = useState<string | null>(null);
   const [
@@ -53,7 +52,8 @@ const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
     { toggle: toggleImportFromHuggingFaceModal },
   ] = useToggle(false);
 
-  const { token } = theme.useToken();
+  const dataViewRef = useRef(null);
+  const baiClient = useSuspendedBackendaiClient();
   const enableImportFromHuggingFace =
     baiClient._config.enableImportFromHuggingFace;
 


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

### This PR resolves [#FR-240](https://lablup.atlassian.net/browse/FR-240?atlOrigin=eyJpIjoiYTA1Mjk0NjJiNjFiNGI0MjhjYzJiNjEwZWI2MDlmZDYiLCJwIjoiaiJ9) issue

Apply rules based on the `current user role` and `list_allowed_types` to the vfolder type selector in `FolderCreateModal`. 

**Changes:**
- Only `super admin` or `admin` can create project type vfolder. 
- vfolder type in folder create modal is based on `list_allowed_types` comes from server
- Show `max_vfolder_count` in `Project Resource Policy` if user role is only `Super Admin` or `Admin`.

**Checklist:** (if applicable)

- [ ] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
