### PR TITLE
[FR-22] feature: provide token-related information

### DIFF
--- a/react/src/components/lablupTalkativotUI/ChatMessage.tsx
+++ b/react/src/components/lablupTalkativotUI/ChatMessage.tsx
@@ -112,6 +112,7 @@ const ChatMessage: React.FC<{
               message.role !== 'user'
                 ? token.colorBgContainer
                 : token.colorBgContainerDisabled,
+            maxWidth: '100%',
           }}
         >
           <ChatMessageContent>


### PR DESCRIPTION
# Add token metrics to LLM Chat UI

> [!NOTE]  
> Many LLM models send token info as a NaN; So calculate usages on a front part.

Adds real-time performance metrics to the chat interface including:
- Token generation speed (tokens/second)
- Total tokens generated

The metrics are displayed in a tag at the bottom of the chat window, providing users visibility into the chat performance.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/bbfdb740-c30f-4889-9414-520dab1847e8.png)

**Checklist:**
- [ ] Documentation
- [ ] Test case: Verify metrics update correctly when:
  - Messages are generated
  - Files are uploaded
  - Chat session continues over time