### PR TITLE
[FR-316] feat: introduce `useTokenCount` using `gpt-tokenizer`

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -29,6 +29,7 @@
     "antd-style": "^3.7.1",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.13",
+    "gpt-tokenizer": "^2.8.1",
     "graphql": "^16.9.0",
     "i18next": "^23.16.8",
     "i18next-http-backend": "^2.7.0",

--- a/react/pnpm-lock.yaml
+++ b/react/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
+      gpt-tokenizer:
+        specifier: ^2.8.1
+        version: 2.8.1
       graphql:
         specifier: ^16.9.0
         version: 16.9.0
@@ -4457,6 +4460,9 @@ packages:
 
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+
+  gpt-tokenizer@2.8.1:
+    resolution: {integrity: sha512-8+a9ojzqfgiF3TK4oivGYjlycD8g5igLt8NQw3ndOIgLVKSGJDhUDNAfYSbtyyuTkha3R/R9F8XrwC7/B5TKfQ==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -13684,6 +13690,8 @@ snapshots:
   gopd@1.0.1:
     dependencies:
       get-intrinsic: 1.2.4
+
+  gpt-tokenizer@2.8.1: {}
 
   graceful-fs@4.2.11: {}
 

--- a/react/src/hooks/useTokenizer.ts
+++ b/react/src/hooks/useTokenizer.ts
@@ -1,0 +1,23 @@
+import { startTransition, useEffect, useState } from 'react';
+
+export const encodeAsync = async (str: string) => {
+  const { encode } = await import('gpt-tokenizer');
+
+  return encode(str).length;
+};
+
+export const useTokenCount = (input: string = '') => {
+  const [value, setNum] = useState(0);
+
+  useEffect(() => {
+    startTransition(() => {
+      encodeAsync(input)
+        .then(setNum)
+        .catch(() => {
+          setNum(input.length);
+        });
+    });
+  }, [input]);
+
+  return value;
+};


### PR DESCRIPTION
**Changes:**
Implements accurate token counting for LLM chat using the `gpt-tokenizer` library instead of character length calculations. This provides more precise token measurements for GPT model interactions.

**Details:**
- Added `gpt-tokenizer` package dependency
- Created new `useTokenizer` hook for async token counting
- Updated token calculations in LLMChatCard to use proper tokenization
- Separated token counting for input, chat messages, and assistant responses
- Improved tokens per second calculation accuracy

**Impact:**
Users will see more accurate token counts and token/second metrics in the chat interface, which better reflects actual GPT model token usage.