### PR TITLE
[FR-7] fix: neo session launcher reset function behavior

### DIFF
--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -429,7 +429,7 @@ export const toGlobalId = (type: string, id: string): string => {
   return btoa(`${type}:${id}`);
 };
 
-export function preserveDotStartCase(str: string) {
+export function preserveDotStartCase(str: string = '') {
   // Temporarily replace periods with a unique placeholder
   const placeholder = '<<<DOT>>>';
   const tempStr = str.replace(/\./g, placeholder);

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -84,7 +84,7 @@ import {
 import dayjs from 'dayjs';
 import { useAtomValue } from 'jotai';
 import _ from 'lodash';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
@@ -689,6 +689,14 @@ const SessionLauncherPage = () => {
   };
 
   const [validationTourOpen, setValidationTourOpen] = useState(false);
+
+  const [isQueryReset, setIsQueryReset] = useState(false);
+  useLayoutEffect(() => {
+    if (isQueryReset) {
+      form.resetFields();
+      setIsQueryReset(false);
+    }
+  }, [isQueryReset, form]);
 
   return (
     <Flex
@@ -1381,8 +1389,8 @@ const SessionLauncherPage = () => {
                       title={t('button.Reset')}
                       description={t('session.launcher.ResetFormConfirm')}
                       onConfirm={() => {
-                        webuiNavigate('/session/start');
-                        form.resetFields();
+                        setQuery({}, 'replace');
+                        setIsQueryReset(true);
                       }}
                       icon={
                         <QuestionCircleOutlined


### PR DESCRIPTION
### This PR resolves [#2976](https://github.com/lablup/backend.ai-webui/issues/2976) issue

**Changes:**
- Adds default empty string parameter to `preserveDotStartCase` function to prevent undefined errors
- Initialize the query string via setQuery on reset. currentTabKey will change, so it will be moved to the first step.
- use form.resetFields() method to initialize the form value to the Initial value. If the form value changes, `syncFormToURLWithDebounce` is executed by the provider and the initialization value is saved as a query string.

**Checklist:**
- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after