### PR TITLE
[FR-341] fix: Page Error on Accessing Agent Summary with a Regular User Account

### DIFF
--- a/react/src/hooks/useCurrentProject.tsx
+++ b/react/src/hooks/useCurrentProject.tsx
@@ -100,6 +100,7 @@ const resourceGroupsForCurrentProjectAtom = atom(async (get) => {
       (rg) => !allSftpScalingGroups.includes(rg.name),
     ),
     vhostInfo,
+    allSftpScalingGroups,
   };
 });
 


### PR DESCRIPTION
Refactors SFTP scaling group data fetching in agent summary list because original code is for only superadmin. To allow all users access to the agent summary page, a different API should be used.

This PR moves the SFTP scaling group data fetching logic from the AgentSummaryList component to the useCurrentProject hook. Instead of making a direct API call within the component, it now uses the pre-fetched data from the project context, improving code organization and reducing redundant API calls.

The change simplifies the AgentSummaryList component by removing the direct backend client dependency and API call logic, while maintaining the same filtering functionality for SFTP upload agents.

**Checklist:**

- [ ] Documentation
- [ ] Test case(s) to demonstrate the difference of before/after
  - Verify that SFTP agents are still properly filtered from the agent summary list
  - Confirm that the SFTP scaling group data is correctly shared through the project context