### PR TITLE
[FR-344] feat: auto screenshot with Playwrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Logs
 logs
 *.log
@@ -62,6 +61,10 @@ typings/
 
 # dotenv environment variables file
 .env
+
+# dotenv environment variables file for playwright test
+/e2e/envs/*
+!/e2e/envs/.env.playwright.sample
 
 # next.js build output
 .next
@@ -139,3 +142,5 @@ yarn.lock
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+/e2e/screenshots/*

--- a/e2e/envs/.env.playwright.sample
+++ b/e2e/envs/.env.playwright.sample
@@ -1,0 +1,1 @@
+SCREENSHOT_PATH=./screenshots

--- a/e2e/screenshot.test.ts
+++ b/e2e/screenshot.test.ts
@@ -1,0 +1,106 @@
+import { loginAsAdmin, webuiEndpoint } from './test-util';
+import { test } from '@playwright/test';
+import * as path from 'path';
+
+const routes = [
+  '/summary',
+  '/session',
+  '/session/start',
+  '/serving',
+  '/service',
+  '/service/start',
+  '/import',
+  '/data',
+  '/my-environment',
+  '/agent-summary',
+  '/statistics',
+  '/environment',
+  '/agent',
+  '/settings',
+  '/maintenance',
+  '/information',
+  '/usersettings',
+  '/credential',
+  '/logs',
+  '/error',
+  '/unauthorized',
+];
+
+test.describe.configure({ mode: 'parallel' });
+test.describe.skip('Screenshot all routes', () => {
+  let screenshotPath: string;
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+    screenshotPath = process.env.SCREENSHOT_PATH
+      ? path.resolve(process.env.SCREENSHOT_PATH)
+      : path.resolve(__dirname + '/screenshots');
+  });
+
+  routes.forEach((route) => {
+    test(`screenshot ${route}`, async ({ page }) => {
+      await page.goto(`${webuiEndpoint}${route}`, {
+        waitUntil: 'networkidle',
+      });
+      await page.screenshot({
+        path: path.resolve(
+          `${screenshotPath}/${route.replace(/\//g, '_')}.png`,
+        ),
+        fullPage: true,
+      });
+    });
+
+    test(`screenshot ${route} (dark mode)`, async ({ page }) => {
+      await page.goto(`${webuiEndpoint}${route}`, {
+        waitUntil: 'networkidle',
+      });
+      await page.getByRole('button', { name: 'moon' }).click();
+      // Wait for the dark mode to be applied
+      await page.waitForTimeout(500);
+      await page.screenshot({
+        path: path.resolve(
+          `${screenshotPath}/${route.replace(/\//g, '_')}_dark.png`,
+        ),
+        fullPage: true,
+      });
+    });
+
+    test(`screenshot ${route} without sidebar`, async ({ page }) => {
+      await page.goto(`${webuiEndpoint}${route}`, {
+        waitUntil: 'networkidle',
+      });
+      await page.screenshot({
+        path: path.resolve(
+          `${screenshotPath}/${route.replace(/\//g, '_')}_no_sidebar.png`,
+        ),
+        clip: {
+          x: 240,
+          y: 0,
+          width: (page.viewportSize()?.width || 0) - 240,
+          height: page.viewportSize()?.height || 0,
+        },
+      });
+    });
+
+    test(`screenshot ${route} without sidebar (dark mode)`, async ({
+      page,
+    }) => {
+      await page.goto(`${webuiEndpoint}${route}`, {
+        waitUntil: 'networkidle',
+      });
+      await page.getByRole('button', { name: 'moon' }).click();
+      // Wait for the dark mode to be applied
+      await page.waitForTimeout(500);
+      await page.screenshot({
+        path: path.resolve(
+          `${screenshotPath}/${route.replace(/\//g, '_')}_no_sidebar_dark.png`,
+        ),
+        clip: {
+          x: 240,
+          y: 0,
+          width: (page.viewportSize()?.width || 0) - 240,
+          height: page.viewportSize()?.height || 0,
+        },
+      });
+    });
+  });
+});

--- a/e2e/test-util.ts
+++ b/e2e/test-util.ts
@@ -7,8 +7,6 @@ import {
   expect,
   request,
 } from '@playwright/test';
-import fs from 'fs/promises';
-import path from 'path';
 
 export const webuiEndpoint = 'http://127.0.0.1:9081';
 export const webServerEndpoint = 'http://127.0.0.1:8090';

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@babel/preset-typescript": "^7.24.7",
     "@babel/types": "^7.25.2",
     "@electron/packager": "^18.3.3",
-    "@playwright/test": "^1.46.1",
+    "@playwright/test": "^1.49.1",
     "@rollup/plugin-commonjs": "^25.0.8",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
+import * as dotenv from 'dotenv';
+dotenv.config({ path: './e2e/envs/.env.playwright' });
 
 /**
  * Read environment variables from file.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,8 +236,8 @@ importers:
         specifier: ^18.3.3
         version: 18.3.3
       '@playwright/test':
-        specifier: ^1.46.1
-        version: 1.46.1
+        specifier: ^1.49.1
+        version: 1.49.1
       '@rollup/plugin-commonjs':
         specifier: ^25.0.8
         version: 25.0.8(rollup@4.20.0)
@@ -3285,6 +3285,11 @@ packages:
 
   '@playwright/test@1.46.1':
     resolution: {integrity: sha512-Fq6SwLujA/DOIvNC2EL/SojJnkKf/rAwJ//APpJJHRyMi1PdKrY3Az+4XNQ51N4RTbItbIByQ0jgd1tayq1aeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@playwright/test@1.49.1':
+    resolution: {integrity: sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9820,8 +9825,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.49.1:
+    resolution: {integrity: sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.46.1:
     resolution: {integrity: sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.49.1:
+    resolution: {integrity: sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16444,6 +16459,10 @@ snapshots:
     dependencies:
       playwright: 1.46.1
 
+  '@playwright/test@1.49.1':
+    dependencies:
+      playwright: 1.49.1
+
   '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.11.0)(type-fest@2.19.0)(webpack-dev-server@4.15.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0))))(webpack-hot-middleware@2.26.1)(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0)))':
     dependencies:
       ansi-html: 0.0.9
@@ -18554,17 +18573,17 @@ snapshots:
 
   '@webcomponents/webcomponentsjs@2.8.0': {}
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.93.0)':
     dependencies:
       webpack: 5.93.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.93.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.93.0)':
     dependencies:
       webpack: 5.93.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.93.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.93.0)':
     dependencies:
       webpack: 5.93.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.93.0)
@@ -25096,9 +25115,17 @@ snapshots:
 
   playwright-core@1.46.1: {}
 
+  playwright-core@1.49.1: {}
+
   playwright@1.46.1:
     dependencies:
       playwright-core: 1.46.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.49.1:
+    dependencies:
+      playwright-core: 1.49.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -27641,7 +27668,7 @@ snapshots:
     optionalDependencies:
       esbuild: 0.19.12
 
-  terser-webpack-plugin@5.3.10(webpack@5.93.0(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.3.10(webpack@5.93.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -28412,9 +28439,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.93.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.93.0)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.93.0)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.93.0)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -28541,7 +28568,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.93.0(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.10(webpack@5.93.0)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     optionalDependencies:


### PR DESCRIPTION
resolves https://lablup.atlassian.net/browse/FR-344

Added screenshot testing functionality to capture UI states across all routes. The tests take screenshots in four variations for each route:
- Normal view
- Dark mode
- Without sidebar
- Dark mode without sidebar

Added configuration option `test.screenshotPath` to specify custom screenshot save location, defaulting to `e2e/screenshots` directory.

Upgraded Playwright test framework from v1.46.1 to v1.49.1 for improved testing capabilities.