### PR TITLE
[FR-356] fix: remove `enableLinks` to prevent logs from disappearing in the container log

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
@@ -264,7 +264,6 @@ const ContainerLogModal: React.FC<ContainerLogModalProps> = ({
             startFollowing={true}
             render={({ follow, onScroll }) => (
               <LazyLog
-                enableLinks
                 caseInsensitive
                 enableSearch
                 enableSearchNavigation


### PR DESCRIPTION
resolves https://lablup.atlassian.net/browse/FR-356

**Changes:**
Disabled clickable links (`enableLinks`) in container log viewer to prevent logs from disappearing.

**How to check:**
1. login with demo-admin@lablup.com in dogbowl
2. search `test2-4fadc1ba-d370-4f9b-a682-ca15b5963c2a` logs in terminated session.
3. compare 161 line.
4. check all contents appear.

**Checklist:**
- [x] Mention to the original issue
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after