### PR TITLE
chore: Update PR template to remind mentioning both GitHub/Jira issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+resolves #NNN (FR-MMM)
+<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->
+
 <!--
 Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
 and how it affects the users and other developers.
@@ -5,7 +8,6 @@ and how it affects the users and other developers.
 
 **Checklist:** (if applicable)
 
-- [ ] Mention to the original issue
 - [ ] Documentation
 - [ ] Minium required manager version
 - [ ] Specific setting for review (eg., KB link, endpoint or how to setup)


### PR DESCRIPTION
This PR adds a reminder to explicitly link the GitHub issue and the corresponding Jira issue.