### PR TITLE
fix(FR-366): remove unnecessary panel disabling via querySelector at vfolder invitation panel in summary view page

### DIFF
--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -389,7 +389,36 @@ export default class BackendAISummary extends BackendAIPage {
   }
 
   /**
-   * Accept invitation and make you can access vfloder.
+   * Returns tab according to vfolder information
+   *
+   * @param vfolderInfo
+   * @returns {string} - tab name of vfolder (model, general, data, automount)
+   */
+  static getVFolderTabByVFolderInfo(vfolderInfo) {
+    if (
+      !vfolderInfo.name.startsWith('.') &&
+      vfolderInfo.usage_mode == 'model'
+    ) {
+      return 'model';
+    } else if (
+      !vfolderInfo.name.startsWith('.') &&
+      vfolderInfo.usage_mode == 'general'
+    ) {
+      return 'general';
+    } else if (
+      !vfolderInfo.name.startsWith('.') &&
+      vfolderInfo.usage_mode == 'data'
+    ) {
+      return 'data';
+    } else if (vfolderInfo.name.startsWith('.')) {
+      return 'automount';
+    } else {
+      return 'general';
+    }
+  }
+
+  /**
+   * Accept invitation and make you can access vfolder.
    *
    * @param {Event} e - Click the accept button
    * @param {any} invitation
@@ -398,16 +427,16 @@ export default class BackendAISummary extends BackendAIPage {
     if (!this.activeConnected) {
       return;
     }
-    const panel = e.target.closest('lablup-activity-panel');
     try {
-      panel.setAttribute('disabled', 'true');
-      panel.querySelectorAll('mwc-button').forEach((btn) => {
-        btn.setAttribute('disabled', 'true');
-      });
       await globalThis.backendaiclient.vfolder.accept_invitation(invitation.id);
+      const vfolderInfo = await globalThis.backendaiclient.vfolder.info(
+        invitation.vfolder_name,
+      );
+      const tabName = BackendAISummary.getVFolderTabByVFolderInfo(vfolderInfo);
+      this.notification.url = `/data?tab=${tabName}&folder=${invitation.vfolder_id.replace('-', '')}`;
       this.notification.text =
         _text('summary.AcceptSharedVFolder') + `${invitation.vfolder_name}`;
-      this.notification.show();
+      this.notification.show(true);
     } catch (err) {
       this.notification.text = PainKiller.relieve(err.title);
       this.notification.detail = err.message;
@@ -426,13 +455,8 @@ export default class BackendAISummary extends BackendAIPage {
     if (!this.activeConnected) {
       return;
     }
-    const panel = e.target.closest('lablup-activity-panel');
 
     try {
-      panel.setAttribute('disabled', 'true');
-      panel.querySelectorAll('mwc-button').forEach((btn) => {
-        btn.setAttribute('disabled', 'true');
-      });
       await globalThis.backendaiclient.vfolder.delete_invitation(invitation.id);
       this.notification.text =
         _text('summary.DeclineSharedVFolder') + `${invitation.vfolder_name}`;


### PR DESCRIPTION
resolves #3023 (FR-366)

Removes unnecessary UI element disabling when accepting or declining vfolder invitations. Previously, the code would disable the entire panel and all buttons when processing these actions, which was redundant since the operations are quick and the panel gets removed upon completion anyway.

Also fixes a typo in the method documentation ("vfloder" -> "vfolder").

### How to test
> Prerequisites: You need two user account to test this.

1. Login with user A.
2. Create at least two vfolders if there's no vfolder created.
3. Invite user B with vfolders created in step 2 or that alreay exists.
4. Logout user A and Login with user B.
5. Go to `Summary` page.
6. See the Invitation panel.
7. Click Accept/Decline inside the panel.
8. Click another one in the panel.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after