### PR TITLE
fix(FR-382, FR-384): Handle deprecated image name fields in service launcher and image download

### DIFF
--- a/react/src/components/ImageInstallModal.tsx
+++ b/react/src/components/ImageInstallModal.tsx
@@ -39,7 +39,12 @@ const ImageInstallModal: React.FC<ImageInstallModalInterface> = ({
   const handleClick = () => {
     onRequestClose();
     const installPromises = imagesToInstall.map(async (image) => {
-      const imageName = image?.registry + '/' + image?.name + ':' + image?.tag;
+      const imageName =
+        image?.registry +
+        '/' +
+        (image?.namespace ?? image?.name) +
+        ':' +
+        image?.tag;
       let isGPURequired = false;
       const imageResource = {} as { [key: string]: any };
       image?.resource_limits?.forEach((resourceLimit) => {
@@ -163,7 +168,8 @@ const ImageInstallModal: React.FC<ImageInstallModalInterface> = ({
           <List
             size="small"
             dataSource={imagesToInstall.map(
-              (image) => `${image?.registry}/${image?.name}/${image?.tag}`,
+              (image) =>
+                `${image?.registry}/${image?.namespace ?? image?.name}/${image?.tag}`,
             )}
             style={{
               width: '100%',

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -174,7 +174,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           row_id
         }
         image_object @since(version: "23.09.9") {
-          name
+          name @deprecatedSince(version: "24.12.0")
+          namespace @since(version: "24.12.0")
           humanized_name
           tag
           registry
@@ -256,7 +257,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
     return {
       image: (isManualImageEnabled
         ? formInput.environments.manual?.split('@')[0]
-        : `${formInput.environments.image?.registry}/${formInput.environments.image?.name}:${formInput.environments.image?.tag}`) as string,
+        : formInput.environments.version?.split('@')[0]) as string,
       architecture: (isManualImageEnabled
         ? formInput.environments.manual?.split('@')[1]
         : formInput.environments.image?.architecture) as string,
@@ -420,7 +421,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           open_to_public
           model
           image_object @since(version: "23.09.9") {
-            name
+            name @deprecatedSince(version: "24.12.0")
+            namespace @since(version: "24.12.0")
             humanized_name
             tag
             registry
@@ -682,8 +684,9 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         cluster_size: endpoint?.cluster_size,
         openToPublic: endpoint?.open_to_public,
         environments: {
-          environment: endpoint?.image_object?.name,
-          version: `${endpoint?.image_object?.registry}/${endpoint?.image_object?.name}:${endpoint?.image_object?.tag}@${endpoint?.image_object?.architecture}`,
+          environment:
+            endpoint?.image_object?.namespace ?? endpoint?.image_object?.name,
+          version: `${endpoint?.image_object?.registry}/${endpoint?.image_object?.namespace ?? endpoint?.image_object?.name}:${endpoint?.image_object?.tag}@${endpoint?.image_object?.architecture}`,
           image: endpoint?.image_object,
         },
         vFolderID: endpoint?.model,

--- a/react/src/components/ServiceValidationView.tsx
+++ b/react/src/components/ServiceValidationView.tsx
@@ -50,7 +50,7 @@ const ServiceValidationView: React.FC<ServiceValidationModalProps> = ({
     ServiceLauncherFormValue
   >({
     mutationFn: (values) => {
-      const image: string = `${values.environments.image?.registry}/${values.environments.image?.name}:${values.environments.image?.tag}`;
+      const image: string = `${values.environments.image?.registry}/${values.environments.image?.namespace ?? values.environments.image?.name}:${values.environments.image?.tag}`;
       const body: ServiceCreateType = {
         name: values.serviceName,
         ...(baiClient.supports('replicas')

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -130,6 +130,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
             image @deprecatedSince(version: "23.09.9")
             image_object @since(version: "23.09.9") {
               name
+              namespace @since(version: "24.12.0")
               humanized_name
               tag
               registry
@@ -268,11 +269,10 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
     return color;
   };
 
-  const fullImageString: string = (
-    baiClient.supports('modify-endpoint')
-      ? `${endpoint?.image_object?.registry}/${endpoint?.image_object?.name}:${endpoint?.image_object?.tag}@${endpoint?.image_object?.architecture}`
-      : endpoint?.image
-  ) as string;
+  const fullImageString =
+    baiClient.supports('modify-endpoint') && endpoint?.image_object
+      ? `${endpoint.image_object.registry}/${endpoint.image_object.namespace ?? endpoint.image_object.name}:${endpoint.image_object.tag}@${endpoint.image_object.architecture}`
+      : endpoint?.image;
 
   const resource_opts = JSON.parse(endpoint?.resource_opts || '{}');
 
@@ -420,7 +420,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
       ? endpoint?.image_object
       : endpoint?.image) && (
       <Flex direction="row" gap={'xs'}>
-        <ImageMetaIcon image={fullImageString} />
+        <ImageMetaIcon image={fullImageString || null} />
         <CopyableCodeText>{fullImageString}</CopyableCodeText>
         {endpoint?.runtime_variant?.human_readable_name ? (
           <Tag>{endpoint?.runtime_variant?.human_readable_name}</Tag>


### PR DESCRIPTION
resolves #3043 (FR-384) #3044 (FR-382)

Introduces a new `namespace` field for image objects while deprecating the existing `name` field. This change affects how image names are constructed throughout the application, particularly in the image installation modal, service launcher, and endpoint detail pages.

The image name construction now prioritizes the `namespace` field, falling back to `name` when namespace is not available: `registry/namespace:tag` or `registry/name:tag`.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after