### PR TITLE
feat(FR-404): show or hide model folder related info

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -35,6 +35,7 @@ enableLLMPlayground = false             # Enable LLM Playground feature. (From B
 enableExtendLoginSession = false        # If true, enables login session extension UI. (From Backend.AI 24.09)
 enableImportFromHuggingFace = false     # Enable import from Hugging Face feature. (From Backend.AI 24.09)
 enableInteractiveLoginAccountSwitch = true  # If false, hide the "Sign in with a different account" button from the interactive login page.
+enableModelFolders = true               # Enable model folders feature. (From Backend.AI 23.03)
 
 [wsproxy]
 proxyURL = "[Proxy URL]"

--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -239,7 +239,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
         </Form.Item>
         <Divider />
 
-        <Form.Item label={t('data.Host')} name={'host'}>
+        <Form.Item label={t('data.folders.Location')} name={'host'}>
           <Suspense fallback={<Skeleton.Input active />}>
             <StorageSelect
               onChange={(value) => {
@@ -256,7 +256,9 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
         <Form.Item label={t('data.UsageMode')} name={'usage_mode'}>
           <Radio.Group>
             <Radio value={'general'}>General</Radio>
-            <Radio value={'model'}>Model</Radio>
+            {baiClient._config.enableModelFolders ? (
+              <Radio value={'model'}>Model</Radio>
+            ) : null}
           </Radio.Group>
         </Form.Item>
         <Divider />

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -484,6 +484,7 @@ type BackendAIConfig = {
   enableLLMPlayground: boolean;
   enableImportFromHuggingFace: boolean;
   enableContainerCommit: boolean;
+  enableModelFolders: boolean;
   appDownloadUrl: string;
   systemSSHImage: string;
   fasttrackEndpoint: string;

--- a/react/src/pages/VFolderListPage.tsx
+++ b/react/src/pages/VFolderListPage.tsx
@@ -99,7 +99,7 @@ const VFolderListPage: React.FC<VFolderListPageProps> = (props) => {
       key: 'automount',
       tab: t('data.AutomountFolders'),
     },
-    {
+    baiClient._config.enableModelFolders && {
       key: 'model',
       tab: t('data.Models'),
     },

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -18,11 +18,12 @@ import RestoreVFolderModal from '../components/RestoreVFolderModal';
 import StorageStatusPanelCard from '../components/StorageStatusPanelCard';
 import VFolderNodes, { VFolderNodeInList } from '../components/VFolderNodes';
 import {
+  filterEmptyItem,
   filterNonNullItems,
   handleRowSelectionChange,
   transformSorterToOrderString,
 } from '../helper';
-import { useUpdatableState } from '../hooks';
+import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useDeferredQueryParams } from '../hooks/useDeferredQueryParams';
@@ -92,6 +93,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   const { token } = theme.useToken();
   const { lg } = Grid.useBreakpoint();
   const currentProject = useCurrentProjectValue();
+  const baiClient = useSuspendedBackendaiClient();
 
   const [selectedFolderList, setSelectedFolderList] = useState<
     Array<VFolderNodesType>
@@ -401,7 +403,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                   setTablePaginationOption({ current: 1 });
                   setSelectedFolderList([]);
                 }}
-                options={[
+                options={filterEmptyItem([
                   {
                     label: t('data.All'),
                     value: 'all',
@@ -418,11 +420,11 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                     label: t('data.AutoMount'),
                     value: 'automount',
                   },
-                  {
+                  baiClient._config.enableModelFolders && {
                     label: t('data.Models'),
                     value: 'model',
                   },
-                ]}
+                ])}
               />
               <BAIPropertyFilter
                 filterProperties={[

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -144,6 +144,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: Boolean }) enableLLMPlayground = false;
   @property({ type: Boolean }) enableImportFromHuggingFace = false;
   @property({ type: Boolean }) enableExtendLoginSession = false;
+  @property({ type: Boolean }) enableModelFolders = true;
   @property({ type: Boolean }) showNonInstalledImages = false;
   @property({ type: Boolean }) enableInteractiveLoginAccountSwitch = true;
   @property({ type: String }) eduAppNamePrefix;
@@ -881,7 +882,7 @@ export default class BackendAILogin extends BackendAIPage {
         value: generalConfig?.enableExtendLoginSession,
       } as ConfigValueObject,
     ) as boolean;
-
+    // Enable "Sign in with a different account" button from the interactive login page
     this.enableInteractiveLoginAccountSwitch = this._getConfigValueByExists(
       generalConfig,
       {
@@ -890,6 +891,12 @@ export default class BackendAILogin extends BackendAIPage {
         value: generalConfig?.enableInteractiveLoginAccountSwitch,
       } as ConfigValueObject,
     ) as boolean;
+    // Enable model folders support
+    this.enableModelFolders = this._getConfigValueByExists(generalConfig, {
+      valueType: 'boolean',
+      defaultValue: true,
+      value: generalConfig?.enableModelFolders,
+    } as ConfigValueObject) as boolean;
   }
 
   /**
@@ -1928,6 +1935,8 @@ export default class BackendAILogin extends BackendAIPage {
           this.enableExtendLoginSession;
         globalThis.backendaiclient._config.enableInteractiveLoginAccountSwitch =
           this.enableInteractiveLoginAccountSwitch;
+        globalThis.backendaiclient._config.enableModelFolders =
+          this.enableModelFolders;
         globalThis.backendaiclient._config.pluginPages = this.pluginPages;
         globalThis.backendaiclient._config.blockList = this.blockList;
         globalThis.backendaiclient._config.inactiveList = this.inactiveList;


### PR DESCRIPTION
resolves (FR-404)
related PR: https://github.com/lablup/backend.ai/pull/3503

Adds a configuration flag `enableModelFolders` to control the visibility of model folder features in the UI. When disabled, this removes the "Model" option from folder creation and hides the Models tab in the folder list view.

**Checklist:**
- [ ] Documentation
- [x] Minium required manager version: Backend.AI 23.03
- [x] Specific setting for review: Set `enableModelFolders = false` in config.toml to verify feature is hidden
- [x] Minimum requirements to check during review:
  - Model radio option should be hidden in folder creation dialog when disabled
  - Models tab should not appear in folder list when disabled
  - Features should be visible when enabled (default true)