### PR TITLE
feat(FR-249): open folder explorer from session detail panel using vfolder_nodes

### DIFF
--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -170,7 +170,9 @@ type Queries {
 
   """Added in 24.09.0."""
   compute_session_nodes(
-    """Added in 24.12.0."""
+    """
+    Added in 25.2.0. Default value `system` queries across the entire system.
+    """
     scope_id: ScopeField
 
     """Added in 24.09.0."""
@@ -612,6 +614,14 @@ type KernelNode implements Node {
   cluster_hostname: String
   session_id: UUID
   image: ImageNode
+
+  """Added in 25.2.0."""
+  image_reference: String
+
+  """
+  Added in 24.12.0. The architecture that the image of this kernel requires
+  """
+  architecture: String
   status: String
   status_changed: DateTime
   status_info: String
@@ -1227,6 +1237,12 @@ type ComputeSessionNode implements Node {
   vfolder_mounts: [String]
   occupied_slots: JSONString
   requested_slots: JSONString
+
+  """Added in 25.2.0."""
+  image_references: [String]
+
+  """Added in 25.2.0."""
+  vfolder_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): VirtualFolderConnection
   num_queries: BigInt
   inference_metrics: JSONString
   kernel_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): KernelConnection

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -195,7 +195,6 @@ const router = createBrowserRouter([
               const [experimentalNeoSessionList] = useBAISettingUserState(
                 'experimental_neo_session_list',
               );
-              const { t } = useTranslation();
 
               useSuspendedBackendaiClient();
 

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -756,7 +756,7 @@ class Client {
     if (this.isManagerVersionCompatibleWith(['25.1.0', '24.09.6', '24.03.12'])) {
       this._features['vfolder-id-based'] = true;
     }
-    if (this.isManagerVersionCompatibleWith(['25.1.1', '24.09.6'])) {
+    if (this.isManagerVersionCompatibleWith(['25.3.0', '24.09.8'])) {
       this._features['vfolder-mounts'] = true;
     }
   }


### PR DESCRIPTION
resolves #3051 (FR-249)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

>https://github.com/lablup/backend.ai/pull/2987 PR must be merged first.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR makes folder explorer available in the Session Detail Panel.

In versions after to Backend.AI Core 24.12.0, the vfolder_nodes field is provided.

**Feature:**
- allow to open folder explorer in session detail panel

**How to test:**
- checkout Core branch to https://github.com/lablup/backend.ai/pull/2987
- open session detail panel. you can open session detail panel via using query string (?sessionDetail=<sessionID>)
- click the folder icon in session detail panel
- Verify that folder opener works for the vfolder you clicked on (name, contents, etc. match)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
