### PR TITLE
feat(FR-368): Update folder list Immediately after creating a new folder.

### DIFF
--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -135,6 +135,9 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
             document.dispatchEvent(
               new CustomEvent('backend-ai-folder-list-changed'),
             );
+            document.dispatchEvent(
+              new CustomEvent('backend-ai-folder-created'),
+            );
             onRequestClose(result);
           },
           onError: (error) => {

--- a/src/components/backend-ai-data-view.ts
+++ b/src/components/backend-ai-data-view.ts
@@ -58,7 +58,6 @@ interface GroupData {
 @customElement('backend-ai-data-view')
 export default class BackendAIData extends BackendAIPage {
   @property({ type: String }) apiMajorVersion = '';
-  @property({ type: String }) folderListFetchKey = 'first';
   @property({ type: Boolean }) is_admin = false;
   @property({ type: Boolean }) enableStorageProxy = false;
   @property({ type: Boolean }) enableInferenceWorkload = false;
@@ -814,9 +813,6 @@ export default class BackendAIData extends BackendAIPage {
       // already connected
       this._getStorageProxyInformation();
     }
-    document.addEventListener('backend-ai-folder-list-changed', () => {
-      this.folderListFetchKey = new Date().toISOString();
-    });
     document.addEventListener('backend-ai-vfolder-cloning', (e: any) => {
       if (e.detail) {
         const selectedItems = e.detail;

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -1049,6 +1049,9 @@ export default class BackendAiStorageList extends BackendAIPage {
     document.addEventListener('backend-ai-group-changed', (e) =>
       this._refreshFolderList(true, 'group-changed'),
     );
+    document.addEventListener('backend-ai-folder-created', (e) =>
+      this._refreshFolderList(true, 'folder-updated'),
+    );
   }
 
   _isUncontrollableStatus(status: VFolderOperationStatus) {


### PR DESCRIPTION
resolves #3031 (FR-368)

Adds a new `backend-ai-folder-created` event to refresh the folder list immediately after folder creation in the React modal component. This ensures the storage list view stays synchronized when folders are created through the new React-based creation modal.

**Checklist:**
- [ ] Documentation
- [x] Minium required webui version: `v24.09.0+post.0`
- [x] Specific setting for review:
  1. Create a new folder
  2. Check the folder list is updated immediately.
- [x] Minimum requirements to check during review
    Check the folder list is updated immediately.
- [ ] Test case(s) to demonstrate the difference of before/after