### PR TITLE
fxi(FR-423): Unkown image error in Image list's control modal

### DIFF
--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -96,6 +96,8 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             value
           }
           version @since(version: "24.12.0")
+          ...ManageImageResourceLimitModal_image
+          ...ManageAppsModal_image
         }
       }
     `,
@@ -573,7 +575,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
               updateEnvironmentFetchKey();
             });
         }}
-        image={managingResourceLimit}
+        imageFrgmt={managingResourceLimit}
       />
       <ManageAppsModal
         open={!!managingApp}
@@ -584,7 +586,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
               updateEnvironmentFetchKey();
             });
         }}
-        image={managingApp}
+        imageFrgmt={managingApp}
       />
       <ImageInstallModal
         open={isOpenInstallModal}


### PR DESCRIPTION
resolves #3063 (FR-423)

Updates image fragment handling in ManageAppsModal and ManageImageResourceLimitModal to support the new namespace field introduced in version 24.12.0, while maintaining backwards compatibility with the deprecated name field.

**Checklist:**
- [x] Minimum required manager version: 24.12.0
- [x] Minimum requirements to check during review:
  - Verify image management works with both old and new image naming formats
  - Confirm resource limits and app management functions correctly with namespaced images