### PR TITLE
feature(FR-352): update-useBAINotification

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
@@ -58,7 +58,7 @@ const ContainerCommitModal: React.FC<ContainerCommitModalProps> = ({
               backgroundTask: {
                 taskId: res.task_id,
                 status: 'pending',
-                statusDescriptions: {
+                onChange: {
                   pending: t('session.CommitOnGoing'),
                   resolved: t('session.CommitFinished'),
                   rejected: t('session.CommitFailed'),

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -221,7 +221,7 @@ const ContainerRegistryList: React.FC<{
               status: 'pending',
               percent: 0,
               taskId: rescan_images.task_id,
-              statusDescriptions: {
+              onChange: {
                 pending: t('registry.RescanImages'),
                 resolved: t('registry.RegistryUpdateFinished'),
                 rejected: t('registry.RegistryUpdateFailed'),

--- a/react/src/components/ContainerRegistryListBefore2409.tsx
+++ b/react/src/components/ContainerRegistryListBefore2409.tsx
@@ -176,7 +176,7 @@ const ContainerRegistryListBefore2409: React.FC<{
               status: 'pending',
               percent: 0,
               taskId: rescan_images.task_id,
-              statusDescriptions: {
+              onChange: {
                 pending: t('registry.RescanImages'),
                 resolved: t('registry.RegistryUpdateFinished'),
                 rejected: t('registry.RegistryUpdateFailed'),

--- a/react/src/components/ModelCloneModal.tsx
+++ b/react/src/components/ModelCloneModal.tsx
@@ -109,7 +109,7 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
                         status: 'pending',
                         percent: 0,
                         taskId: data.bgtask_id,
-                        statusDescriptions: {
+                        onChange: {
                           pending: t('data.folders.FolderClonePending'),
                           resolved: t('data.folders.FolderCloned'),
                           rejected: t('data.folders.FolderCloneFailed'),

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -570,7 +570,7 @@ const SessionLauncherPage = () => {
           backgroundTask: {
             promise: Promise.all(sessionPromises),
             status: 'pending',
-            statusDescriptions: {
+            onChange: {
               pending: t('session.PreparingSession'),
               resolved: t('eduapi.ComputeSessionPrepared'),
             },


### PR DESCRIPTION
resolves #3060, [(FR-352)](https://lablup.atlassian.net/browse/FR-352)

I added functionality to handle `task's status` based on the notification in `useNotification`. Since the existing approach was not changed, no additional modifications are needed.

**changes**
* update `useBAINotification` to handle task's status
* refactor `MaintenanceSetttingList` component (I have confirmed that it is working properly.)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
