### PR TITLE
fix(FR-441): unexpected disabled download button

### DIFF
--- a/src/components/backend-ai-folder-explorer.ts
+++ b/src/components/backend-ai-folder-explorer.ts
@@ -97,7 +97,7 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
   @property({ type: Object }) _boundCreatedTimeRenderer = Object();
   @property({ type: Object }) _boundSizeRenderer = Object();
   @property({ type: Object }) _boundControlFileListRenderer = Object();
-  @state() private _unionedAllowedPermissionByVolume = Object();
+  @state() _unionedAllowedPermissionByVolume = Object();
 
   @query('#rename-file-dialog') renameDialog!: BackendAIDialog;
   @query('#new-file-name') newNameInput!: TextField;
@@ -760,6 +760,7 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
         };
       }),
     );
+    this.fileListGrid.clearCache();
   }
 
   private async _getCurrentKeypairResourcePolicy() {


### PR DESCRIPTION
Resolves #3069 (FR-441)

Fixes file list grid cache refresh issue in folder explorer

**Changes:**
- Makes `_unionedAllowedPermissionByVolume` property accessible to child components
- Adds cache clearing after file list grid updates to ensure UI reflects latest changes

** How to reproduce
If you want to simulate race condition to reproduce bug, add a test promise to [here](https://github.com/lablup/backend.ai-webui/blob/5bcd327ab581264e1fc0a372253b786462e21b25/src/components/backend-ai-folder-explorer.ts#L727-L730) like below:

```
const [vhostInfo, currentKeypairResourcePolicy] = await Promise.all([
      globalThis.backendaiclient.vfolder.list_hosts(),
      this._getCurrentKeypairResourcePolicy(),
      new Promise((resolve)=>{
        setTimeout(()=>{
          resolve(undefined);
        },5000);
      })
    ]);
```



**Test Steps:**
1. Navigate to folder explorer
3. Ensure Download button enabled when user had download permission


