### PR TITLE
fix(FR-242): show vfolder list based on delegated user

### DIFF
--- a/react/src/components/SessionOwnerSetterCard.tsx
+++ b/react/src/components/SessionOwnerSetterCard.tsx
@@ -89,6 +89,7 @@ const SessionOwnerSetterCard: React.FC<CardProps> = (props) => {
   const owner = form.getFieldValue(['owner', 'email']) ? data?.user : undefined;
 
   const nonExistentOwner = !isFetching && fetchingEmail && !owner;
+
   return (
     <Card
       title={t('session.launcher.SetSessionOwner')}
@@ -143,7 +144,6 @@ const SessionOwnerSetterCard: React.FC<CardProps> = (props) => {
                   <Input.Search
                     onSearch={(v) => {
                       // startTransition(()=>{
-
                       form
                         .validateFields([['owner', 'email']])
                         .then(() => {

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -76,6 +76,7 @@ export interface VFolderTableProps extends Omit<TableProps<VFolder>, 'rowKey'> {
   rowKey: string | number;
   onChangeAutoMountedFolders?: (names: Array<string>) => void;
   showAutoMountedFoldersSection?: boolean;
+  ownerEmail?: string;
 }
 
 export const vFolderAliasNameRegExp = /^[a-zA-Z0-9_/.-]*$/;
@@ -91,6 +92,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   rowKey = 'name',
   onChangeAutoMountedFolders,
   showAutoMountedFoldersSection,
+  ownerEmail,
   ...tableProps
 }) => {
   const { generateFolderPath } = useFolderExplorerOpener();
@@ -150,10 +152,11 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
   const [isPendingRefetch, startRefetchTransition] = useTransition();
   const { data: allFolderList } = useSuspenseTanQuery({
-    queryKey: ['VFolderSelectQuery', fetchKey, currentProject.id],
+    queryKey: ['VFolderSelectQuery', fetchKey, currentProject.id, ownerEmail],
     queryFn: () => {
       const search = new URLSearchParams();
       search.set('group_id', currentProject.id);
+      ownerEmail && search.set('owner_user_email', ownerEmail);
       return baiRequestWithPromise({
         method: 'GET',
         url: `/folders?${search.toString()}`,

--- a/react/src/components/VFolderTableFormItem.tsx
+++ b/react/src/components/VFolderTableFormItem.tsx
@@ -7,7 +7,7 @@ import VFolderTable, {
 } from './VFolderTable';
 import { Form, FormItemProps, Input } from 'antd';
 import _ from 'lodash';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface VFolderTableFormItemProps extends Omit<FormItemProps, 'name'> {
@@ -30,6 +30,15 @@ const VFolderTableFormItem: React.FC<VFolderTableFormItemProps> = ({
 }) => {
   const form = Form.useFormInstance();
   const { t } = useTranslation();
+
+  useEffect(() => {
+    form.setFieldsValue({
+      mounts: [],
+      vfoldersAliasMap: {},
+      autoMountedFolderNames: [],
+    });
+  }, [tableProps?.ownerEmail, form]);
+
   return (
     <>
       <Form.Item

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1362,14 +1362,32 @@ const SessionLauncherPage = () => {
                     display: currentStepKey === 'storage' ? 'block' : 'none',
                   }}
                 >
-                  <VFolderTableFormItem
-                    filter={(vfolder) => {
+                  <Form.Item noStyle dependencies={['owner']}>
+                    {({ getFieldValue }) => {
+                      const ownerInfo = getFieldValue('owner');
+                      const isValidOwner =
+                        ownerInfo?.enabled &&
+                        _.every(_.omit(ownerInfo, 'enabled'), (key, value) => {
+                          return key !== undefined;
+                        });
+
                       return (
-                        vfolder.status === 'ready' &&
-                        !vfolder.name?.startsWith('.')
+                        <VFolderTableFormItem
+                          filter={(vfolder) => {
+                            return (
+                              vfolder.status === 'ready' &&
+                              !vfolder.name?.startsWith('.')
+                            );
+                          }}
+                          tableProps={{
+                            ownerEmail: isValidOwner
+                              ? ownerInfo?.email
+                              : undefined,
+                          }}
+                        />
                       );
                     }}
-                  />
+                  </Form.Item>
                   {/* <VFolderTable /> */}
                 </Card>
 


### PR DESCRIPTION
resolves #3017 (FR-242)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

> The ability to create a session by setting a Session Owner is not currently available. https://lablup.atlassian.net/browse/BA-414
> In this PR, I'm aiming to show the right vfolder list for the set session owner.

In the `VFolderTable` used by the session launcher, we are fetching the vfolder list via the REST API. Since the API provides the ability to filter the data based on owner email, use it to show the vfolder list based on the delegated owner email assigned by the session launcher.

**feature:**
- If owner is set in the session launcher, it will show a list of vfolders for that user.
- If a previously selected vfolder exists, all selections will be reset when the owner related settings are changed.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
