### PR TITLE
feature(FR-393): add e2e test for maintenance page

### DIFF
--- a/e2e/maintenance.test.ts
+++ b/e2e/maintenance.test.ts
@@ -1,0 +1,48 @@
+import { loginAsAdmin } from './test-util';
+import {
+  getNotificationDescriptionBox,
+  getNotificationMessageBox,
+} from './test-util-antd';
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.getByRole('menuitem', { name: 'Maintenance' }).click();
+});
+
+test.describe('test maintenance page', () => {
+  test.describe('Recalculate Usage', () => {
+    test('click the Recalculate Usage button', async ({ page }) => {
+      await page.getByRole('button', { name: 'Recalculate Usage' }).click();
+
+      await expect(getNotificationMessageBox(page)).toContainText(
+        'Recalculate Usage',
+      );
+      // skip the Recalculating message because it's too fast
+      await expect(getNotificationDescriptionBox(page)).toContainText(
+        'Recalculation finished',
+      );
+    });
+  });
+
+  test.describe('Rescan Images', () => {
+    test.setTimeout(90 * 1000);
+    test('click the Rescan Images button', async ({ page }) => {
+      await page.getByRole('button', { name: 'Rescan Images' }).click();
+
+      await expect(getNotificationMessageBox(page)).toContainText(
+        'Rescan Images',
+      );
+
+      await expect(getNotificationDescriptionBox(page)).toContainText(
+        'Rescanning...',
+      );
+      await expect(getNotificationDescriptionBox(page)).toContainText(
+        'Rescanning image finished.',
+        {
+          timeout: 60 * 1000,
+        },
+      );
+    });
+  });
+});

--- a/e2e/test-util-antd.ts
+++ b/e2e/test-util-antd.ts
@@ -1,4 +1,4 @@
-import { Locator, expect } from '@playwright/test';
+import { Locator, Page, expect } from '@playwright/test';
 
 export async function checkActiveTab(
   tabsLocator: Locator,
@@ -9,7 +9,7 @@ export async function checkActiveTab(
 }
 
 export async function getTableHeaders(locator: Locator) {
-  return await locator.locator(".ant-table-thead th");
+  return await locator.locator('.ant-table-thead th');
 }
 
 export async function findColumnIndex(
@@ -22,4 +22,16 @@ export async function findColumnIndex(
   }, columnTitle);
 
   return columnIndex;
+}
+
+export function getNotificationTextContainer(page: Page) {
+  return page.locator('.ant-notification-notice-description');
+}
+
+export function getNotificationMessageBox(page: Page) {
+  return getNotificationTextContainer(page).locator('li > div > div >> nth=0');
+}
+
+export function getNotificationDescriptionBox(page: Page) {
+  return getNotificationTextContainer(page).locator('li > div > div >> nth=1');
 }

--- a/react/src/components/MaintenanceSettingList.tsx
+++ b/react/src/components/MaintenanceSettingList.tsx
@@ -63,6 +63,7 @@ const MaintenanceSettingList = () => {
                     },
                   },
                 },
+                duration: 0,
               };
             } else {
               throw new Error(t('maintenance.RescanFailed'));


### PR DESCRIPTION
resolves #3041, [(FR-393)](https://lablup.atlassian.net/browse/FR-393)

**changes**
* Added test cases for `Rescan Images` and `Recalculate Usage` on the `maintenance` page.
* Added functions in `test-util-antd.ts` to retrieve notification text.
* Added `1-minute` timeout to rescan image test (1min)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
