### PR TITLE
feat(FR-55): Support `ai.backend.accelerators` image label's `*` value

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -140,6 +140,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
             value
           }
           version @since(version: "24.12.0")
+          supported_accelerators
         }
       }
     `,

--- a/react/src/components/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/ResourceAllocationFormItems.test.ts
@@ -50,6 +50,7 @@ describe('getAllocatablePresetNames', () => {
     base_image_name: undefined,
     tags: undefined,
     version: undefined,
+    supported_accelerators: [],
   };
 
   it('should return presets when currentImage has accelerator limits', () => {

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -177,6 +177,7 @@ describe('getImageFullName', () => {
           },
         ],
         version: '01',
+        supported_accelerators: [],
       }) || '';
     expect(result).toBe(
       '192.168.0.1:7080/abc/def/training:01-py3-abc-v1-def@x86_64',
@@ -234,6 +235,7 @@ describe('getImageFullName', () => {
           },
         ],
         version: '01',
+        supported_accelerators: [],
       }) || '';
     expect(result).toBe(
       '192.168.0.1:7080/abc/def/training:01-py3-abc-v1-def@x86_64',
@@ -292,6 +294,7 @@ describe('getImageFullName', () => {
           },
         ],
         version: '01',
+        supported_accelerators: [],
       }) || '';
     expect(result).toBe(
       '192.168.0.1:7080/abc/def/training:01-py3-abc-v1-def@x86_64',

--- a/react/src/hooks/useBackendAIImageMetaData.test.tsx
+++ b/react/src/hooks/useBackendAIImageMetaData.test.tsx
@@ -148,6 +148,7 @@ describe('useBackendAIImageMetaData', () => {
         base_image_name: undefined,
         tags: undefined,
         version: undefined,
+        supported_accelerators: [],
       }) || '',
     );
     expect(key).toBe('training');


### PR DESCRIPTION
resolves #2781 (FR-55)

Uses `supported_accelerators` information from the image instead of `currentImageAcceleratorLimits` to determine available accelerator types in the session launcher. This provides more accurate accelerator compatibility information based on the image's declared support.

Key changes:
- Filters available accelerator types based on image's `supported_accelerators` field
- Renames `resourceLimits` to `mergedResourceLimit` for clarity
- Updates preset allocation logic to consider supported accelerators
- Adds wildcard support (`*`) for images that support all accelerator types

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version: 24.12.0
- [ ] Test case: Verify accelerator options are filtered correctly based on image's supported_accelerators field