### PR TITLE
feat(FR-459): User setting for experimental NEO session list

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -144,12 +144,19 @@ const router = createBrowserRouter([
       {
         path: '/job',
         handle: { labelKey: 'webui.menu.Sessions' },
-        element: (
-          <BAIErrorBoundary>
-            <SessionDetailAndContainerLogOpenerLegacy />
-            <ComputeSessionListPage />
-          </BAIErrorBoundary>
-        ),
+        Component: () => {
+          const location = useLocation();
+          const [experimentalNeoSessionList] = useBAISettingUserState(
+            'experimental_neo_session_list',
+          );
+          return experimentalNeoSessionList ? (
+            <WebUINavigate to={'/session' + location.search} replace />
+          ) : (
+            <BAIErrorBoundary>
+              <SessionDetailAndContainerLogOpenerLegacy />
+            </BAIErrorBoundary>
+          );
+        },
       },
       {
         path: '/session',
@@ -159,7 +166,25 @@ const router = createBrowserRouter([
             path: '',
             Component: () => {
               const location = useLocation();
-              return <WebUINavigate to={'/job' + location.search} replace />;
+              const [experimentalNeoSessionList] = useBAISettingUserState(
+                'experimental_neo_session_list',
+              );
+
+              return experimentalNeoSessionList ? (
+                <BAIErrorBoundary>
+                  <Suspense
+                    fallback={
+                      <Flex direction="column" style={{ maxWidth: 700 }}>
+                        <Skeleton active />
+                      </Flex>
+                    }
+                  >
+                    <ComputeSessionListPage />
+                  </Suspense>
+                </BAIErrorBoundary>
+              ) : (
+                <WebUINavigate to={'/job' + location.search} replace />
+              );
             },
           },
           {

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -2,6 +2,7 @@ import { filterEmptyItem } from '../../helper';
 import { useCustomThemeConfig } from '../../helper/customThemeConfig';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../../hooks';
 import { useCurrentUserRole } from '../../hooks/backendai';
+import { useBAISettingUserState } from '../../hooks/useBAISetting';
 import usePrimaryColors from '../../hooks/usePrimaryColors';
 import EndpointsIcon from '../BAIIcons/EndpointsIcon';
 import MyEnvironmentsIcon from '../BAIIcons/MyEnvironmentsIcon';
@@ -84,6 +85,9 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
   const gridBreakpoint = Grid.useBreakpoint();
   const primaryColors = usePrimaryColors();
 
+  const [experimentalNeoSessionList] = useBAISettingUserState(
+    'experimental_neo_session_list',
+  );
   const generalMenu = filterEmptyItem<ItemType>([
     {
       label: <WebUILink to="/summary">{t('webui.menu.Summary')}</WebUILink>,
@@ -91,7 +95,11 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
       key: 'summary',
     },
     {
-      label: <WebUILink to="/job">{t('webui.menu.Sessions')}</WebUILink>,
+      label: (
+        <WebUILink to={experimentalNeoSessionList ? '/session' : '/job'}>
+          {t('webui.menu.Sessions')}
+        </WebUILink>
+      ),
       icon: <SessionsIcon style={{ color: token.colorPrimary }} />,
       key: 'job',
     },

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -18,6 +18,7 @@ interface UserSettings {
   selected_language?: string;
   classic_session_launcher?: boolean;
   recentSessionHistory?: Array<SessionHistory>;
+  experimental_neo_session_list?: boolean;
   [key: `hiddenColumnKeys.${string}`]: Array<string>;
 }
 

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -46,6 +46,8 @@ const UserPreferencesPage = () => {
   ] = useToggle(false);
   const [preserveLogin, setPreserveLogin] =
     useBAISettingUserState('preserve_login');
+  const [experimentalNeoSessionList, setExperimentalNeoSessionList] =
+    useBAISettingUserState('experimental_neo_session_list');
   const [shellInfo, setShellInfo] = useState<ShellScriptType>('bootstrap');
   const [isOpenShellScriptEditModal, { toggle: toggleShellScriptEditModal }] =
     useToggle(false);
@@ -236,6 +238,22 @@ const UserPreferencesPage = () => {
               {t('button.Config')}
             </Button>
           ),
+        },
+      ],
+    },
+    {
+      title: t('userSettings.ExperimentalFeatures'),
+      settingItems: [
+        {
+          type: 'checkbox',
+          title: t('userSettings.NEOSessionList'),
+          description: t('general.Enabled'),
+          defaultValue: false,
+          value: experimentalNeoSessionList,
+          setValue: setExperimentalNeoSessionList,
+          onChange: (e) => {
+            setExperimentalNeoSessionList(e.target.checked);
+          },
         },
       ],
     },

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "Das Skript ist leer. \nBitte geben Sie das Skript ein.",
     "BootstrapScriptDeleted": "Bootstrap-Skript gelöscht",
     "ClassicSessionLauncher": "Classic Sitzungsstarter",
-    "DescClassicSessionLauncher": "Verwenden Sie den Classic-Sitzungsstarter anstelle des NEO-Sitzungsstarters. \nDer Classic Sitzungsstarter verfügt möglicherweise nicht über die neuesten Funktionen."
+    "DescClassicSessionLauncher": "Verwenden Sie den Classic-Sitzungsstarter anstelle des NEO-Sitzungsstarters. \nDer Classic Sitzungsstarter verfügt möglicherweise nicht über die neuesten Funktionen.",
+    "NEOSessionList": "NEO Sitzungsliste",
+    "ExperimentalFeatures": "Experimentelle Merkmale"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Erweiterte Web-Terminal-Nutzung: Terminal-Inhalte kopieren",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "Το σενάριο είναι κενό. \nΕισαγάγετε το σενάριο.",
     "BootstrapScriptDeleted": "Το σενάριο Bootstrap διαγράφηκε",
     "ClassicSessionLauncher": "Classic Session Launcher",
-    "DescClassicSessionLauncher": "Χρησιμοποιήστε το πρόγραμμα εκκίνησης συνεδρίας Classic αντί για το πρόγραμμα εκκίνησης συνεδρίας NEO. \nΤο πρόγραμμα εκκίνησης περιόδου λειτουργίας Classic ενδέχεται να μην έχει τις πιο πρόσφατες δυνατότητες."
+    "DescClassicSessionLauncher": "Χρησιμοποιήστε το πρόγραμμα εκκίνησης συνεδρίας Classic αντί για το πρόγραμμα εκκίνησης συνεδρίας NEO. \nΤο πρόγραμμα εκκίνησης περιόδου λειτουργίας Classic ενδέχεται να μην έχει τις πιο πρόσφατες δυνατότητες.",
+    "NEOSessionList": "NEO Κατάλογος συνόδων",
+    "ExperimentalFeatures": "Πειραματικά χαρακτηριστικά"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Σύνθετη χρήση τερματικού Web: Αντιγραφή περιεχομένου τερματικού",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1143,7 +1143,9 @@
     "BootstrapScriptEmpty": "The script is empty. \nPlease enter the script.",
     "BootstrapScriptDeleted": "Bootstrap script deleted",
     "ClassicSessionLauncher": "Classic Session Launcher",
-    "DescClassicSessionLauncher": "Use the Classic session launcher instead of the NEO session launcher. Classic session launcher may not have the latest features."
+    "DescClassicSessionLauncher": "Use the Classic session launcher instead of the NEO session launcher. Classic session launcher may not have the latest features.",
+    "NEOSessionList": "NEO Session list",
+    "ExperimentalFeatures": "Experimental features"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Advanced Web Terminal Usage: Copy terminal contents",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1564,7 +1564,9 @@
     "BootstrapScriptEmpty": "El guión está vacío. \nPor favor ingrese el guión.",
     "BootstrapScriptDeleted": "Se eliminó el script de arranque",
     "ClassicSessionLauncher": "Lanzador de sesiones Classic",
-    "DescClassicSessionLauncher": "Utilice el iniciador de sesiones Classic en lugar del iniciador de sesiones NEO. \nEs posible que el iniciador de sesiones Classic no tenga las funciones más recientes."
+    "DescClassicSessionLauncher": "Utilice el iniciador de sesiones Classic en lugar del iniciador de sesiones NEO. \nEs posible que el iniciador de sesiones Classic no tenga las funciones más recientes.",
+    "NEOSessionList": "Lista de sesiones NEO",
+    "ExperimentalFeatures": "Características experimentales"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Uso avanzado del terminal web: Copiar el contenido del terminal",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1563,7 +1563,9 @@
     "BootstrapScriptEmpty": "Käsikirjoitus on tyhjä. \nAnna käsikirjoitus.",
     "BootstrapScriptDeleted": "Bootstrap-skripti poistettu",
     "ClassicSessionLauncher": "Classic istunnon käynnistysohjelma",
-    "DescClassicSessionLauncher": "Käytä Classic-istunnonkäynnistysohjelmaa NEO-istunnonkäynnistimen sijaan. \nClassic istunnonkäynnistysohjelmassa ei välttämättä ole uusimpia ominaisuuksia."
+    "DescClassicSessionLauncher": "Käytä Classic-istunnonkäynnistysohjelmaa NEO-istunnonkäynnistimen sijaan. \nClassic istunnonkäynnistysohjelmassa ei välttämättä ole uusimpia ominaisuuksia.",
+    "NEOSessionList": "NEO-istuntoluettelo",
+    "ExperimentalFeatures": "Kokeelliset ominaisuudet"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Edistynyt verkkopäätteen käyttö: Kopioi terminaalin sisältö",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "Le script est vide. \nVeuillez entrer le script.",
     "BootstrapScriptDeleted": "Script d'amorçage supprimé",
     "ClassicSessionLauncher": "Lanceur de session Classic",
-    "DescClassicSessionLauncher": "Utilisez le lanceur de session Classic au lieu du lanceur de session NEO. \nLe lanceur de session Classic peut ne pas disposer des dernières fonctionnalités."
+    "DescClassicSessionLauncher": "Utilisez le lanceur de session Classic au lieu du lanceur de session NEO. \nLe lanceur de session Classic peut ne pas disposer des dernières fonctionnalités.",
+    "NEOSessionList": "Liste des sessions NEO",
+    "ExperimentalFeatures": "Caractéristiques expérimentales"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Utilisation avancée du terminal Web : copier le contenu du terminal",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1017,7 +1017,9 @@
     "BootstrapScriptEmpty": "Skripnya kosong. \nSilakan masukkan skripnya.",
     "BootstrapScriptDeleted": "Skrip bootstrap dihapus",
     "ClassicSessionLauncher": "Peluncur Sesi Classic",
-    "DescClassicSessionLauncher": "Gunakan peluncur sesi Classic alih-alih peluncur sesi NEO. \nPeluncur sesi Classic mungkin tidak memiliki fitur terbaru."
+    "DescClassicSessionLauncher": "Gunakan peluncur sesi Classic alih-alih peluncur sesi NEO. \nPeluncur sesi Classic mungkin tidak memiliki fitur terbaru.",
+    "NEOSessionList": "Daftar Sesi NEO",
+    "ExperimentalFeatures": "Fitur eksperimental"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Penggunaan Terminal Web Tingkat Lanjut: Salin konten terminal",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "La sceneggiatura è vuota. \nInserisci la sceneggiatura.",
     "BootstrapScriptDeleted": "Script di bootstrap eliminato",
     "ClassicSessionLauncher": "Avvio sessioni Classic",
-    "DescClassicSessionLauncher": "Utilizza l'avvio della sessione Classic anziché l'avvio della sessione NEO. \nIl launcher della sessione Classic potrebbe non avere le funzionalità più recenti."
+    "DescClassicSessionLauncher": "Utilizza l'avvio della sessione Classic anziché l'avvio della sessione NEO. \nIl launcher della sessione Classic potrebbe non avere le funzionalità più recenti.",
+    "NEOSessionList": "Elenco delle sessioni NEO",
+    "ExperimentalFeatures": "Caratteristiche sperimentali"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Utilizzo avanzato del terminale Web: copia il contenuto del terminale",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "スクリプトが空です。\nスクリプトを入力してください。",
     "BootstrapScriptDeleted": "ブートストラップ スクリプトが削除されました",
     "ClassicSessionLauncher": "Classic セッションランチャー",
-    "DescClassicSessionLauncher": "NEO セッション ランチャーの代わりに Classic セッション ランチャーを使用します。\nClassic セッション ランチャーには最新の機能が含まれていない可能性があります。"
+    "DescClassicSessionLauncher": "NEO セッション ランチャーの代わりに Classic セッション ランチャーを使用します。\nClassic セッション ランチャーには最新の機能が含まれていない可能性があります。",
+    "NEOSessionList": "NEOセッションリスト",
+    "ExperimentalFeatures": "実験的特徴"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "高度なWeb端末の使用法：端末の内容をコピーする",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -648,7 +648,8 @@
     "MaxValueNotification": "{{ name }} 최대 값은 {{ max }}입니다",
     "TotalItems": "총 {{ total }}개",
     "ExtendLoginSession": "로그인 세션 연장",
-    "Cores": "코어"
+    "Cores": "코어",
+    "Enable": "활성화"
   },
   "credential": {
     "Permission": "권한",
@@ -1131,7 +1132,10 @@
     "BootstrapScriptEmpty": "스크립트가 비어있습니다. 스크립트를 입력해 주세요.",
     "BootstrapScriptDeleted": "부트스트랩 스크립트가 삭제되었습니다.",
     "ClassicSessionLauncher": "Classic 세션 런처",
-    "DescClassicSessionLauncher": "최신의 NEO 세션 런처 대신 Classic 세션 런처를 사용합니다. Classic 세션 런처에는 최신 기능이 지원되지 않을 수 있습니다."
+    "DescClassicSessionLauncher": "최신의 NEO 세션 런처 대신 Classic 세션 런처를 사용합니다. Classic 세션 런처에는 최신 기능이 지원되지 않을 수 있습니다.",
+    "ExperimentalFeatures": "실험적 기능",
+    "NEOSessionList": "NEO 세션 목록"
+
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "웹 터미널 고급 사용법: 터미널 내용 복사하기",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "Скрипт хоосон байна. \nСкриптийг оруулна уу.",
     "BootstrapScriptDeleted": "Bootstrap скриптийг устгасан",
     "ClassicSessionLauncher": "Classic сесс эхлүүлэгч",
-    "DescClassicSessionLauncher": "NEO сесс эхлүүлэгчийн оронд Classic сесс эхлүүлэгчийг ашиглана уу. \nClassic сесс эхлүүлэгч нь хамгийн сүүлийн үеийн функцгүй байж магадгүй."
+    "DescClassicSessionLauncher": "NEO сесс эхлүүлэгчийн оронд Classic сесс эхлүүлэгчийг ашиглана уу. \nClassic сесс эхлүүлэгч нь хамгийн сүүлийн үеийн функцгүй байж магадгүй.",
+    "NEOSessionList": "Neo-ийн хуралдааны жагсаалт",
+    "ExperimentalFeatures": "Туршилтын шинж чанарууд"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Дэвшилтэт вэб терминалын хэрэглээ: Терминалын агуулгыг хуулах",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "Skripnya kosong. \nSila masukkan skrip.",
     "BootstrapScriptDeleted": "Skrip Bootstrap dipadamkan",
     "ClassicSessionLauncher": "Pelancar Sesi Classic",
-    "DescClassicSessionLauncher": "Gunakan pelancar sesi Classic dan bukannya pelancar sesi NEO. \nPelancar sesi Classic mungkin tidak mempunyai ciri terkini."
+    "DescClassicSessionLauncher": "Gunakan pelancar sesi Classic dan bukannya pelancar sesi NEO. \nPelancar sesi Classic mungkin tidak mempunyai ciri terkini.",
+    "NEOSessionList": "Senarai Sesi NEO",
+    "ExperimentalFeatures": "Ciri -ciri eksperimen"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Penggunaan Terminal Web Lanjutan: Salin kandungan terminal",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "Skrypt jest pusty. \nProszę wprowadzić skrypt.",
     "BootstrapScriptDeleted": "Usunięto skrypt Bootstrap",
     "ClassicSessionLauncher": "Classic program uruchamiający sesję",
-    "DescClassicSessionLauncher": "Użyj Classic programu uruchamiającego sesję zamiast programu uruchamiającego sesję NEO. \nClassic program uruchamiający sesję może nie mieć najnowszych funkcji."
+    "DescClassicSessionLauncher": "Użyj Classic programu uruchamiającego sesję zamiast programu uruchamiającego sesję NEO. \nClassic program uruchamiający sesję może nie mieć najnowszych funkcji.",
+    "NEOSessionList": "Lista sesji NEO",
+    "ExperimentalFeatures": "Cechy eksperymentalne"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Zaawansowane korzystanie z terminala internetowego: Skopiuj zawartość terminala",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "O script está vazio. \nPor favor insira o roteiro.",
     "BootstrapScriptDeleted": "Script de inicialização excluído",
     "ClassicSessionLauncher": "Lançador de sessão Classic",
-    "DescClassicSessionLauncher": "Use o iniciador de sessão Classic em vez do iniciador de sessão NEO. \nO iniciador de sessão Classic pode não ter os recursos mais recentes."
+    "DescClassicSessionLauncher": "Use o iniciador de sessão Classic em vez do iniciador de sessão NEO. \nO iniciador de sessão Classic pode não ter os recursos mais recentes.",
+    "NEOSessionList": "Lista de sessões NEO",
+    "ExperimentalFeatures": "Caraterísticas experimentais"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Uso avançado do terminal da Web: Copiar o conteúdo do terminal",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "O script está vazio. \nPor favor insira o roteiro.",
     "BootstrapScriptDeleted": "Script de inicialização excluído",
     "ClassicSessionLauncher": "Lançador de sessão Classic",
-    "DescClassicSessionLauncher": "Use o iniciador de sessão Classic em vez do iniciador de sessão NEO. \nO iniciador de sessão Classic pode não ter os recursos mais recentes."
+    "DescClassicSessionLauncher": "Use o iniciador de sessão Classic em vez do iniciador de sessão NEO. \nO iniciador de sessão Classic pode não ter os recursos mais recentes.",
+    "NEOSessionList": "Lista de sessões NEO",
+    "ExperimentalFeatures": "Características experimentais"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Uso avançado do terminal da Web: Copiar o conteúdo do terminal",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "Скрипт пуст. \nПожалуйста, введите сценарий.",
     "BootstrapScriptDeleted": "Скрипт начальной загрузки удален.",
     "ClassicSessionLauncher": "__NOT_TRANSLATED__",
-    "DescClassicSessionLauncher": "__NOT_TRANSLATED__"
+    "DescClassicSessionLauncher": "__NOT_TRANSLATED__",
+    "NEOSessionList": "Список сессий NEO",
+    "ExperimentalFeatures": "Экспериментальные особенности"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Расширенное использование веб-терминала: копирование содержимого терминала",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1128,7 +1128,9 @@
     "BootstrapScriptEmpty": "สคริปต์ว่างเปล่า \nกรุณาป้อนสคริปต์",
     "BootstrapScriptDeleted": "ลบสคริปต์บูตสแตรปแล้ว",
     "ClassicSessionLauncher": "ตัวเปิดเซสชัน Classic",
-    "DescClassicSessionLauncher": "ใช้ตัวเรียกใช้เซสชัน Classic แทนตัวเรียกใช้เซสชัน NEO \nตัวเรียกใช้เซสชัน Classic อาจไม่มีคุณสมบัติล่าสุด"
+    "DescClassicSessionLauncher": "ใช้ตัวเรียกใช้เซสชัน Classic แทนตัวเรียกใช้เซสชัน NEO \nตัวเรียกใช้เซสชัน Classic อาจไม่มีคุณสมบัติล่าสุด",
+    "NEOSessionList": "รายการเซสชัน NEO",
+    "ExperimentalFeatures": "คุณสมบัติการทดลอง"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "คำแนะนำการใช้งานเทอร์มินัลเว็บขั้นสูง: คัดลอกเนื้อหาเทอร์มินัล",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1015,7 +1015,9 @@
     "BootstrapScriptEmpty": "Senaryo boş. \nLütfen betiği girin.",
     "BootstrapScriptDeleted": "Bootstrap komut dosyası silindi",
     "ClassicSessionLauncher": "Classic Oturum Başlatıcı",
-    "DescClassicSessionLauncher": "NEO oturum başlatıcısı yerine Classic oturum başlatıcıyı kullanın. \nClassic oturum başlatıcı en son özelliklere sahip olmayabilir."
+    "DescClassicSessionLauncher": "NEO oturum başlatıcısı yerine Classic oturum başlatıcıyı kullanın. \nClassic oturum başlatıcı en son özelliklere sahip olmayabilir.",
+    "NEOSessionList": "NEO Oturum listesi",
+    "ExperimentalFeatures": "Deneysel özellikler"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Gelişmiş Web Terminali Kullanımı: Terminal içeriğini kopyalayın",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "Kịch bản trống rỗng. \nVui lòng nhập kịch bản.",
     "BootstrapScriptDeleted": "Tập lệnh Bootstrap đã bị xóa",
     "ClassicSessionLauncher": "Trình khởi chạy phiên Classic",
-    "DescClassicSessionLauncher": "Sử dụng trình khởi chạy phiên Classic thay vì trình khởi chạy phiên NEO. \nTrình khởi chạy phiên Classic có thể không có các tính năng mới nhất."
+    "DescClassicSessionLauncher": "Sử dụng trình khởi chạy phiên Classic thay vì trình khởi chạy phiên NEO. \nTrình khởi chạy phiên Classic có thể không có các tính năng mới nhất.",
+    "NEOSessionList": "Danh sách phiên Neo",
+    "ExperimentalFeatures": "Các tính năng thử nghiệm"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "Sử dụng đầu cuối web nâng cao: Sao chép nội dung đầu cuối",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1016,7 +1016,9 @@
     "BootstrapScriptEmpty": "脚本是空的。\n请输入脚本。",
     "BootstrapScriptDeleted": "引导脚本已删除",
     "ClassicSessionLauncher": "Classic会话启动器",
-    "DescClassicSessionLauncher": "使用 Classic 会话启动器而不是 NEO 会话启动器。 \nClassic 会话启动器可能不具有最新功能。"
+    "DescClassicSessionLauncher": "使用 Classic 会话启动器而不是 NEO 会话启动器。 \nClassic 会话启动器可能不具有最新功能。",
+    "NEOSessionList": "近地天体会议列表",
+    "ExperimentalFeatures": "实验特点"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "高级 Web 终端使用：复制终端内容",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1015,7 +1015,9 @@
     "BootstrapScriptEmpty": "腳本是空的。\n請輸入腳本。",
     "BootstrapScriptDeleted": "引導腳本已刪除",
     "ClassicSessionLauncher": "Classic會話啟動器",
-    "DescClassicSessionLauncher": "使用 Classic 會話啟動器而不是 NEO 會話啟動器。 \nClassic 會話啟動器可能不具有最新功能。"
+    "DescClassicSessionLauncher": "使用 Classic 會話啟動器而不是 NEO 會話啟動器。 \nClassic 會話啟動器可能不具有最新功能。",
+    "NEOSessionList": "近地天体会议列表",
+    "ExperimentalFeatures": "实验特点"
   },
   "webTerminalUsageGuide": {
     "CopyGuide": "高級 Web 終端使用：複製終端內容",


### PR DESCRIPTION
Resolves #3094 (FR-459)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/0e714569-eebf-4c33-99c2-bb23ef81335c.png)

Adds an experimental NEO session list feature that can be toggled in user settings. When enabled, users are redirected to a new `/session` path instead of the legacy `/job` path for viewing compute sessions. The new view includes a loading skeleton while the session list loads.

To test:
1. Enable the "NEO Session List" option under User Settings > Experimental Features
2. Navigate to Sessions from the sidebar
3. Verify redirection to new `/session` path with loading skeleton
4. Verify legacy `/job` path still works when feature is disabled