### PR TITLE
fix(FR-458): set session detail panel version compatibility

### DIFF
--- a/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
+++ b/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
@@ -1,3 +1,4 @@
+import { useSuspendedBackendaiClient } from '../hooks';
 import ContainerLogModalWithLazyQueryLoader from './ComputeSessionNodeItems/ContainerLogModalWithLazyQueryLoader';
 import SessionDetailDrawer from './SessionDetailDrawer';
 import { useState, useEffect, useTransition } from 'react';
@@ -8,6 +9,7 @@ const SessionDetailAndContainerLogOpenerLegacy = () => {
   const [containerLogModalSessionId, setContainerLogModalSessionId] =
     useState<string>();
   const [isPendingLogModalOpen, startLogModalOpenTransition] = useTransition();
+  const baiClient = useSuspendedBackendaiClient();
 
   useEffect(() => {
     const handler = (e: any) => {
@@ -21,15 +23,19 @@ const SessionDetailAndContainerLogOpenerLegacy = () => {
     };
   }, [startLogModalOpenTransition, setContainerLogModalSessionId]);
 
+  const supportSessionDetailPanel = baiClient?.supports('session-node');
+
   return (
     <>
-      <SessionDetailDrawer
-        open={!sessionId}
-        sessionId={sessionId || undefined}
-        onClose={() => {
-          setSessionId(null, 'replaceIn');
-        }}
-      />
+      {supportSessionDetailPanel ? (
+        <SessionDetailDrawer
+          open={!sessionId}
+          sessionId={sessionId || undefined}
+          onClose={() => {
+            setSessionId(null, 'replaceIn');
+          }}
+        />
+      ) : null}
       <ContainerLogModalWithLazyQueryLoader
         open={!!containerLogModalSessionId || isPendingLogModalOpen}
         loading={isPendingLogModalOpen}

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -220,25 +220,27 @@ const SessionDetailContent: React.FC<{
             )}
           </Descriptions.Item>
           <Descriptions.Item label={t('session.launcher.MountedFolders')}>
-            {_.map(
-              _.zip(legacy_session?.mounts, session?.vfolder_mounts),
-              (mountInfo) => {
-                const [name, id] = mountInfo;
-                return (
-                  <Button
-                    key={id}
-                    type="link"
-                    size="small"
-                    icon={<FolderOutlined />}
-                    onClick={() => {
-                      open(id ?? '');
-                    }}
-                  >
-                    {name}
-                  </Button>
-                );
-              },
-            )}
+            {baiClient.supports('vfolder-mounts')
+              ? _.map(
+                  _.zip(legacy_session?.mounts, session?.vfolder_mounts),
+                  (mountInfo) => {
+                    const [name, id] = mountInfo;
+                    return (
+                      <Button
+                        key={id}
+                        type="link"
+                        size="small"
+                        icon={<FolderOutlined />}
+                        onClick={() => {
+                          open(id ?? '');
+                        }}
+                      >
+                        {name}
+                      </Button>
+                    );
+                  },
+                )
+              : legacy_session?.mounts?.join(', ')}
           </Descriptions.Item>
           <Descriptions.Item label={t('session.launcher.ResourceAllocation')}>
             <Flex gap={'sm'} wrap="wrap">

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -654,7 +654,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               title: t('modelService.SessionId'),
               dataIndex: 'session',
               render: (sessionId) => {
-                return (
+                return baiClient.supports('session-node') ? (
                   <Typography.Link
                     onClick={() => {
                       setSelectedSessionId(sessionId);
@@ -662,6 +662,8 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
                   >
                     {sessionId}
                   </Typography.Link>
+                ) : (
+                  <Typography.Text>{sessionId}</Typography.Text>
                 );
               },
             },

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -3117,9 +3117,11 @@ export default class BackendAISessionList extends BackendAIPage {
               white-space: pre-wrap;
               white-space-collapse: collapse;
               word-break: break-all;
+            }
+            #session-name-field[data-allow-detail-panel='true'] {
               cursor: pointer;
             }
-            #session-name-field:hover {
+            #session-name-field[data-allow-detail-panel='true']:hover {
               text-decoration: underline;
               color: var(--token-colorLink);
             }
@@ -3147,6 +3149,9 @@ export default class BackendAISessionList extends BackendAIPage {
             <div class="horizontal center center-justified layout">
               <pre
                 id="session-name-field"
+                data-allow-detail-panel=${globalThis.backendaiclient.supports(
+                  'session-node',
+                )}
                 @click="${() => this.triggerOpenSessionDetailDrawer(rowData)}"
                 @keyup="${() => {}}"
               >

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -738,6 +738,9 @@ class Client {
     if (this.isManagerVersionCompatibleWith(['25.1.0', '24.09.6', '24.03.12'])) {
       this._features['vfolder-id-based'] = true;
     }
+    if (this.isManagerVersionCompatibleWith(['25.1.1', '24.09.6'])) {
+      this._features['vfolder-mounts'] = true;
+    }
   }
 
   /**


### PR DESCRIPTION
resolves #3091 (FR-458)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

Adds version compatibility to the session detail panel. 

**Feature:**
- session detail panel is available in version after 24.09 and later (after additional versions of session-node)
- folder explorer in session detail panel is available in version after 25.1.1, and after 24.09.6. Not available in version 24.12.xx

**How to test:**
- You can use the folder explorer opener by clicking the session list name or by clicking the session id on the endpoint detail page.
- Verify that the session detail panel is not available in versions prior to 24.09.
- Verify that the folder explorer in session detail panel is not available in versions prior to 25.1.1, and prior to 24.09.6.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
