### PR TITLE
feat(FR-462): Add CSP nonce string that will be injected by webserver.

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <title>Backend.AI</title>
   <script src="./src/lib/webcomponents-loader.js"></script>
   <script src="./src/lib/web-animations-js/web-animations-next-lite.min.js"></script>
-  <script>
+  <script nonce="{{nonce}}">
     globalThis.isElectron = isElectron();
     if (isElectron) {
       globalThis.electronInitialHref = window.location.href;
@@ -34,14 +34,15 @@
     };
     globalThis.packageVersion = "25.3.0-alpha.0";
     globalThis.buildNumber = "6477";
-
+    globalThis.litNonce = "{{nonce}}";
+    globalThis.baiNonce = "{{nonce}}";
   </script>
   <!-- DO NOT CHANGE BELOW LINE -->
   <!-- REACT_BUNDLE_INJECTING FOR DEV-->
 </head>
 
 <body>
-  <script>
+  <script nonce="{{nonce}}">
     //To avoid flickering when first loading the page, we add a class to the body to indicate the theme.
     const userPrefersDark = localStorage.getItem('backendaiwebui.settings.isDarkMode');
     const systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -84,7 +85,7 @@
       <p>Could not render Backend.AI Web UI. Check that JavaScript is enabled.</p>
     </noscript>
     <script src="./dist/components/backend-ai-webui.js" type="module"></script>
-    <script>
+    <script nonce="{{nonce}}">
       document.getElementById('version-detail').innerText = globalThis.packageVersion;
       document.getElementById('build-detail').innerText = ' Build ' + globalThis.buildVersion;
       document.getElementById('license-detail').innerText = '';

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -327,6 +327,8 @@ export const DefaultProvidersForReactRoot: React.FC<
                   ? theme.darkAlgorithm
                   : theme.defaultAlgorithm,
               }}
+              // @ts-ignore
+              csp={{ nonce: globalThis.baiNonce }}
             >
               <App {...commonAppProps}>
                 {/* <StyleProvider container={shadowRoot} cache={cache}> */}


### PR DESCRIPTION
resolves #3098 (FR-462)
related with https://github.com/lablup/backend.ai/pull/3585
refer https://lit.dev/docs/api/ReactiveElement/#ReactiveElement.styles

Added CSP nonce support to the AntD ConfigProvider to enable Content Security Policy compatibility in the React application. This allows the application to properly handle style injection when CSP is enabled. The webserver will replace the `'{{nonce}}'` string with proper nonce value.

**Checklist:**
- [ ] Documentation
- [ ] Test case(s) to demonstrate the difference of before/after