### PR TITLE
fix(FR-468): showNonInstalledImages test in config.toml test

### DIFF
--- a/e2e/config.test.ts
+++ b/e2e/config.test.ts
@@ -128,6 +128,20 @@ test.describe.parallel('config.toml', () => {
         )
         .click();
       await page
+        .locator('.ant-input-number-wrapper', {
+          hasText: 'Core',
+        })
+        .locator('input')
+        .fill('1');
+
+      await page
+        .locator('.ant-input-number-wrapper', {
+          hasText: 'Mem',
+        })
+        .locator('input.ant-input-number-input')
+        .fill('1');
+
+      await page
         .getByRole('button', { name: 'Skip to review double-right' })
         .click();
       await page.getByRole('button', { name: 'Copy' }).click();


### PR DESCRIPTION
resolves #3106 [(FR-468)](https://lablup.atlassian.net/browse/FR-468)

**changes**
* Added the ability to select `CPU` and `Memory` values in Resource Presets.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
