### PR TITLE
misc(FR-473): missing i18n update and remove table token value

### DIFF
--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -640,7 +640,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               },
             },
             {
-              title: 'Metric Name',
+              title: t('autoScalingRule.MetricName'),
               dataIndex: 'metric_name',
               fixed: 'left',
               render: (text, row) => (
@@ -768,7 +768,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               ),
             },
             {
-              title: 'Metric Source',
+              title: t('autoScalingRule.MetricSource'),
               dataIndex: 'metric_source',
               render: (text, row) => <Tag>{row?.metric_source}</Tag>,
             },
@@ -789,7 +789,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               dataIndex: 'step_size',
             },
             {
-              title: 'Min/Max Replicas',
+              title: t('autoScalingRule.MIN/MAXReplicas'),
               render: (text, row) => (
                 <span>
                   Min: {row?.min_replicas} / Max: {row?.max_replicas}
@@ -802,7 +802,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               // render: (text, row) => <span>{row?.cooldown_seconds}</span>,
             },
             {
-              title: 'Last Triggered',
+              title: t('autoScalingRule.LastTriggered'),
               render: (text, row) => {
                 return (
                   <span>
@@ -815,7 +815,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               sorter: dayDiff,
             },
             {
-              title: 'Created at',
+              title: t('autoScalingRule.CreatedAt'),
               dataIndex: 'created_at',
               render: (text, row) => (
                 <span>{dayjs(row?.created_at).format('ll LT')}</span>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "Min Repliken",
     "MaxReplicas": "Max Repliken",
     "MetricName": "Metrischer Name",
-    "MetricSource": "Metrische Quelle"
+    "MetricSource": "Metrische Quelle",
+    "MIN/MAXReplicas": "Min / Max Replikas",
+    "LastTriggered": "Zuletzt ausgelöst",
+    "CreatedAt": "Zeit erstellt"
   },
   "kernel": {
     "KernelId": "Kernel ID",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "Λεπτά αντίγραφα",
     "MaxReplicas": "Μέγιστα αντίγραφα",
     "MetricName": "Μετρικό όνομα",
-    "MetricSource": "Μετρική πηγή"
+    "MetricSource": "Μετρική πηγή",
+    "MIN/MAXReplicas": "Min / Max Replicas",
+    "LastTriggered": "Τελευταία ενεργοποιημένη",
+    "CreatedAt": "Δημιουργήθηκε ώρα"
   },
   "kernel": {
     "KernelId": "Αναγνωριστικό πυρήνα",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1782,7 +1782,10 @@
     "SuccessfullyDeleted": "Auto scaling rule has been successfuly deleted.",
     "ConfirmDeleteAutoScalingRule": "Are you sure to delete auto scaling rule {{ autoScalingRule }} ?",
     "EditAutoScalingRule": "Edit Auto Scaling Rule",
-    "StepSize": "Step Size"
+    "StepSize": "Step Size",
+    "MIN/MAXReplicas": "Min / MAX Replicas",
+    "LastTriggered": "Last Triggered",
+    "CreatedAt": "Created At"
   },
   "kernel": {
     "KernelId": "Kernel ID",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "Réplicas min",
     "MaxReplicas": "Réplicas máximas",
     "MetricName": "Nombre métrico",
-    "MetricSource": "Fuente métrica"
+    "MetricSource": "Fuente métrica",
+    "MIN/MAXReplicas": "Réplicas min / max",
+    "LastTriggered": "Última activación",
+    "CreatedAt": "Tiempo creado"
   },
   "kernel": {
     "KernelId": "ID de núcleo",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1775,7 +1775,10 @@
     "MinReplicas": "Min Replicas",
     "MaxReplicas": "Max replicas",
     "MetricName": "Metrinen nimi",
-    "MetricSource": "Metrilähde"
+    "MetricSource": "Metrilähde",
+    "MIN/MAXReplicas": "Min / max -kopiot",
+    "LastTriggered": "Viimeksi laukaistu",
+    "CreatedAt": "Luotu aika"
   },
   "kernel": {
     "KernelId": "Ytimen tunnus",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "Répliques min",
     "MaxReplicas": "Répliques maximales",
     "MetricName": "Nom métrique",
-    "MetricSource": "Source métrique"
+    "MetricSource": "Source métrique",
+    "MIN/MAXReplicas": "Répliques min / max",
+    "LastTriggered": "Dernière déclenché",
+    "CreatedAt": "Temps créé"
   },
   "kernel": {
     "KernelId": "ID du noyau",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "Replika min",
     "MaxReplicas": "Replika maks",
     "MetricName": "Nama metrik",
-    "MetricSource": "Sumber metrik"
+    "MetricSource": "Sumber metrik",
+    "MIN/MAXReplicas": "Replika min / maks",
+    "LastTriggered": "Terakhir dipicu",
+    "CreatedAt": "Waktu yang dibuat"
   },
   "kernel": {
     "KernelId": "ID kernel",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1774,7 +1774,10 @@
     "MinReplicas": "Repliche min",
     "MaxReplicas": "Repliche massime",
     "MetricName": "Nome metrico",
-    "MetricSource": "Fonte metrica"
+    "MetricSource": "Fonte metrica",
+    "MIN/MAXReplicas": "Repliche min / max",
+    "LastTriggered": "Ultimo attivato",
+    "CreatedAt": "Tempo creato"
   },
   "kernel": {
     "KernelId": "Kernel ID",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "最小レプリカ",
     "MaxReplicas": "マックスレプリカ",
     "MetricName": "メトリック名",
-    "MetricSource": "メトリックソース"
+    "MetricSource": "メトリックソース",
+    "MIN/MAXReplicas": "min / maxレプリカ",
+    "LastTriggered": "最後にトリガーされました",
+    "CreatedAt": "作成された時間"
   },
   "kernel": {
     "KernelId": "カーネルID",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1780,7 +1780,10 @@
     "SuccessfullyCreated": "오토스케일링 규칙이 성공적으로 작성되었습니다.",
     "Comparator": "연산자",
     "MetricName": "메트릭",
-    "MetricSource": "메트릭 소스"
+    "MetricSource": "메트릭 소스",
+    "MIN/MAXReplicas": "최소 / 최대 복제본 수",
+    "LastTriggered": "최근 실행 시점",
+    "CreatedAt": "생성 시간"
   },
   "kernel": {
     "KernelId": "커널 ID",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1775,7 +1775,10 @@
     "MinReplicas": "Min хуулбар",
     "MaxReplicas": "Макс хуулбарууд",
     "MetricName": "Хнхийн нэр",
-    "MetricSource": "Метрийн эх сургай"
+    "MetricSource": "Метрийн эх сургай",
+    "MIN/MAXReplicas": "Мин / Макс хуулбарууд",
+    "LastTriggered": "Хамгийн сүүлд өдөөсөн",
+    "CreatedAt": "Үед"
   },
   "kernel": {
     "KernelId": "Kernel ID",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "Min Replicas",
     "MaxReplicas": "Max Replicas",
     "MetricName": "Nama metrik",
-    "MetricSource": "Sumber metrik"
+    "MetricSource": "Sumber metrik",
+    "MIN/MAXReplicas": "Replika min / max",
+    "LastTriggered": "Yang terakhir dicetuskan",
+    "CreatedAt": "Masa yang dicipta"
   },
   "kernel": {
     "KernelId": "ID Kernel",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "Repliki min",
     "MaxReplicas": "Max Replicas",
     "MetricName": "Nazwa metryczna",
-    "MetricSource": "Źródło metryczne"
+    "MetricSource": "Źródło metryczne",
+    "MIN/MAXReplicas": "Repliki min / max",
+    "LastTriggered": "Ostatni wyzwolenie",
+    "CreatedAt": "Utworzony czas"
   },
   "kernel": {
     "KernelId": "ID jądra",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "Min Replicas",
     "MaxReplicas": "Réplicas máximas",
     "MetricName": "Nome métrico",
-    "MetricSource": "Fonte métrica"
+    "MetricSource": "Fonte métrica",
+    "MIN/MAXReplicas": "Min / Max Replicas",
+    "LastTriggered": "Último desencadeado",
+    "CreatedAt": "Tempo criado"
   },
   "kernel": {
     "KernelId": "ID do kernel",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "Min Replicas",
     "MaxReplicas": "Réplicas máximas",
     "MetricName": "Nome métrico",
-    "MetricSource": "Fonte métrica"
+    "MetricSource": "Fonte métrica",
+    "MIN/MAXReplicas": "Min / Max Replicas",
+    "LastTriggered": "Último desencadeado",
+    "CreatedAt": "Tempo criado"
   },
   "kernel": {
     "KernelId": "ID do kernel",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "Мин реплики",
     "MaxReplicas": "Макс Реплики",
     "MetricName": "Метрическое название",
-    "MetricSource": "Метрический источник"
+    "MetricSource": "Метрический источник",
+    "MIN/MAXReplicas": "Мин / максимальные реплики",
+    "LastTriggered": "Последний вызван",
+    "CreatedAt": "Создано время"
   },
   "kernel": {
     "KernelId": "Ядро идентификатор",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1756,7 +1756,10 @@
     "MinReplicas": "แบบจำลองขั้นต่ำ",
     "MaxReplicas": "แบบจำลองสูงสุด",
     "MetricName": "ชื่อเมตริก",
-    "MetricSource": "แหล่งวัด"
+    "MetricSource": "แหล่งวัด",
+    "MIN/MAXReplicas": "แบบจำลองขั้นต่ำ / สูงสุด",
+    "LastTriggered": "ทริกเกอร์ครั้งสุดท้าย",
+    "CreatedAt": "สร้างเวลา"
   },
   "kernel": {
     "KernelId": "ID เคอร์เนล",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1775,7 +1775,10 @@
     "MinReplicas": "Min kopyalar",
     "MaxReplicas": "Maksimum kopya",
     "MetricName": "Metrik adı",
-    "MetricSource": "Metrik kaynağı"
+    "MetricSource": "Metrik kaynağı",
+    "MIN/MAXReplicas": "Min / Max Replicas",
+    "LastTriggered": "Son tetiklendi",
+    "CreatedAt": "Yaratılan Zaman"
   },
   "kernel": {
     "KernelId": "Çekirdek kimliği",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "Tối thiểu bản sao",
     "MaxReplicas": "Tối đa bản sao",
     "MetricName": "Tên số liệu",
-    "MetricSource": "Nguồn số liệu"
+    "MetricSource": "Nguồn số liệu",
+    "MIN/MAXReplicas": "Bản sao tối thiểu / Max",
+    "LastTriggered": "Lần cuối cùng được kích hoạt",
+    "CreatedAt": "Đã tạo thời gian"
   },
   "kernel": {
     "KernelId": "Kernel Id",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1776,7 +1776,10 @@
     "MinReplicas": "最小复制品",
     "MaxReplicas": "最大复制品",
     "MetricName": "公制名称",
-    "MetricSource": "公制源"
+    "MetricSource": "公制源",
+    "MIN/MAXReplicas": "最小复制品",
+    "LastTriggered": "最后触发",
+    "CreatedAt": "创建的时间"
   },
   "kernel": {
     "KernelId": "内核ID",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1775,7 +1775,10 @@
     "MinReplicas": "最小複製品",
     "MaxReplicas": "最大復製品",
     "MetricName": "公制名稱",
-    "MetricSource": "公制源"
+    "MetricSource": "公制源",
+    "MIN/MAXReplicas": "最小複製品",
+    "LastTriggered": "最後觸發",
+    "CreatedAt": "創建的時間"
   },
   "kernel": {
     "KernelId": "內核ID",

--- a/resources/theme.json
+++ b/resources/theme.json
@@ -13,9 +13,6 @@
       "Tag": {
         "borderRadiusSM": 1
       },
-      "Table": {
-        "headerBg": "#E3E3E3"
-      },
       "Layout": {
         "lightSiderBg": "#FFF",
         "siderBg": "#141414",
@@ -38,8 +35,6 @@
     "components": {
       "Tag": {
         "borderRadiusSM": 1
-      },
-      "Table": {
       },
       "Layout": {
         "lightSiderBg": "#FFF",


### PR DESCRIPTION
resolves #2974 (FR-473)

Added internationalization support for auto-scaling rule table headers in the endpoint detail page. The following columns are now translated across all supported languages:
- Metric Name
- Metric Source
- Min/Max Replicas
- Last Triggered
- Created At

**Checklist:**
- [ ] Documentation
- [ ] Test case(s) to demonstrate the difference of before/after