### PR TITLE
fix(FR-470): Unable to access service update page

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -270,7 +270,15 @@ const router = createBrowserRouter([
             handle: { labelKey: 'modelService.UpdateService' },
             element: (
               <BAIErrorBoundary>
-                <ServiceLauncherUpdatePage />
+                <Suspense
+                  fallback={
+                    <Flex direction="column" style={{ maxWidth: 700 }}>
+                      <Skeleton active />
+                    </Flex>
+                  }
+                >
+                  <ServiceLauncherUpdatePage />
+                </Suspense>
               </BAIErrorBoundary>
             ),
           },

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -203,6 +203,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
             ...EndpointOwnerInfoFragment
             ...EndpointStatusTagFragment
             ...ChatUIModalFragment
+            ...ServiceLauncherPageContentFragment
           }
           endpoint_token_list(
             offset: $tokenListOffset

--- a/react/src/pages/ServiceLauncherPage.tsx
+++ b/react/src/pages/ServiceLauncherPage.tsx
@@ -18,7 +18,7 @@ const ServiceLauncherPage: React.FC = () => {
       endpointId: endpointId || '',
     },
     {
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'store-and-network',
     },
   );
 


### PR DESCRIPTION
resolves #3110 (FR-470)

To fix unexpected infinite rendering:

Updates the GraphQL fragment in EndpointDetailPage to include ServiceLauncherPageContentFragment and modifies the fetch policy in ServiceLauncherPage from 'network-only' to 'store-and-network' to improve data caching behavior.
