### PR TITLE
fix(FR-472): empty resource preset in service launcher

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -713,6 +713,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         }),
         vFolderID: model ? model : undefined,
         resourceGroup: currentGlobalResourceGroup,
+        allocationPreset: 'auto-select',
       };
 
   return (


### PR DESCRIPTION
resolves #3114 (FR-472)

Adds `allocationPreset` parameter with default value of 'auto-select' to the service launcher configuration, enabling automatic resource allocation for new service instances.