### PR TITLE
feat(FR-502): introduce UnmountModalAfterClose

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -4,6 +4,7 @@ import { useCurrentProjectValue } from '../../hooks/useCurrentProject';
 import BAITable from '../BAITable';
 import DoubleTag from '../DoubleTag';
 import Flex from '../Flex';
+import UnmountModalAfterClose from '../UnmountModalAfterClose';
 import ContainerLogModal from './ContainerLogModal';
 import { ConnectedKernelListLegacyQuery } from './__generated__/ConnectedKernelListLegacyQuery.graphql';
 import {
@@ -225,7 +226,8 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
         // TODO: implement pagination when compute_session_node query supports pagination
         pagination={false}
       />
-      {kernelIdForLogModal && (
+
+      <UnmountModalAfterClose>
         <ContainerLogModal
           open={!!kernelIdForLogModal}
           sessionFrgmt={session || null}
@@ -234,7 +236,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
             setKernelIdForLogModal(undefined);
           }}
         />
-      )}
+      </UnmountModalAfterClose>
     </Flex>
   );
 };

--- a/react/src/components/UnmountModalAfterClose.tsx
+++ b/react/src/components/UnmountModalAfterClose.tsx
@@ -1,0 +1,51 @@
+import { BAIModalProps } from './BAIModal';
+import { ModalProps } from 'antd';
+import React, { useState, useLayoutEffect } from 'react';
+
+interface UnmountModalAfterCloseProps {
+  children: React.ReactElement<BAIModalProps> | React.ReactElement<ModalProps>;
+}
+
+const UnmountModalAfterClose: React.FC<UnmountModalAfterCloseProps> = ({
+  children,
+}) => {
+  // Ensure there is only one child element
+  const modalElement = React.Children.only(children);
+  const isModalOpen = modalElement.props.open;
+
+  // Manage internal rendering state
+  const [isMount, setIsMount] = useState(isModalOpen);
+
+  // Update internal state when the child's open prop becomes true
+  useLayoutEffect(() => {
+    if (isModalOpen) {
+      setIsMount(true);
+    }
+  }, [isModalOpen]);
+
+  // Return null if the modal should not be rendered
+  if (!isMount) {
+    return null;
+  }
+
+  // Preserve the original afterClose callback if it exists
+  const originalAfterClose = modalElement.props.afterClose;
+
+  // New handler to intercept afterClose
+  const handleModalAfterClose: ModalProps['afterClose'] = (...args) => {
+    if (originalAfterClose) {
+      originalAfterClose(...args);
+    }
+    // Set internal state to false after the exit animation completes
+    setIsMount(false);
+  };
+
+  // Clone the child element, keeping the open prop and replacing afterClose with the new handler
+  const clonedChild = React.cloneElement(modalElement, {
+    afterClose: handleModalAfterClose,
+  });
+
+  return clonedChild;
+};
+
+export default UnmountModalAfterClose;


### PR DESCRIPTION
resolves #3137 (FR-502)

Introduces a new `UnmountModalAfterClose` component that properly unmounts modal components after they close, preventing unnecessary re-renders and memory leaks. The component is implemented in the `ConnectedKernelList` to manage the `ContainerLogModal`.

The new component:
- Tracks modal open/close state internally
- Preserves original `afterClose` callbacks
- Only renders the modal when needed
- Handles cleanup after modal animations complete