### PR TITLE
feat(FR-534): introduce NEO style Tabs and RadioGroup

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -15,6 +15,7 @@ import AgentSettingModal from './AgentSettingModal';
 import BAIIntervalView from './BAIIntervalView';
 import BAIProgressWithLabel from './BAIProgressWithLabel';
 import BAIPropertyFilter from './BAIPropertyFilter';
+import BAIRadioGroup from './BAIRadioGroup';
 import DoubleTag from './DoubleTag';
 import Flex from './Flex';
 import { ResourceTypeIcon } from './ResourceNumber';
@@ -36,7 +37,6 @@ import {
 import { useToggle } from 'ahooks';
 import {
   Button,
-  Segmented,
   Table,
   TableProps,
   Tag,
@@ -778,7 +778,7 @@ const AgentList: React.FC<AgentListProps> = ({
           style={{ flex: 1 }}
           wrap="wrap"
         >
-          <Segmented
+          <BAIRadioGroup
             options={[
               {
                 label: t('agent.Connected'),
@@ -792,7 +792,8 @@ const AgentList: React.FC<AgentListProps> = ({
             value={
               isPendingStatusFetch ? optimisticSelectedStatus : selectedStatus
             }
-            onChange={(value) => {
+            onChange={(e) => {
+              const value = e.target.value;
               setOptimisticSelectedStatus(value);
               startStatusFetchTransition(() => {
                 setSelectedStatus(value);

--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -11,6 +11,7 @@ import { useResourceGroupsForCurrentProject } from '../hooks/useCurrentProject';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
 import BAIProgressWithLabel from './BAIProgressWithLabel';
 import BAIPropertyFilter from './BAIPropertyFilter';
+import BAIRadioGroup from './BAIRadioGroup';
 import Flex from './Flex';
 import { ResourceTypeIcon } from './ResourceNumber';
 import TableColumnsSettingModal from './TableColumnsSettingModal';
@@ -26,15 +27,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import {
-  Button,
-  Segmented,
-  Table,
-  TableProps,
-  theme,
-  Tooltip,
-  Typography,
-} from 'antd';
+import { Button, Table, TableProps, theme, Tooltip, Typography } from 'antd';
 import { AnyObject } from 'antd/es/_util/type';
 import { ColumnsType, ColumnType } from 'antd/es/table';
 import graphql from 'babel-plugin-relay/macro';
@@ -374,7 +367,7 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
           style={{ flex: 1 }}
           wrap="wrap"
         >
-          <Segmented
+          <BAIRadioGroup
             options={[
               {
                 label: t('agent.Connected'),
@@ -388,7 +381,8 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
             value={
               isPendingStatusFetch ? optimisticSelectedStatus : selectedStatus
             }
-            onChange={(value) => {
+            onChange={(e) => {
+              const value = e.target.value;
               setOptimisticSelectedStatus(value);
               startStatusFetchTransition(() => {
                 setSelectedStatus(value);

--- a/react/src/components/BAICard.tsx
+++ b/react/src/components/BAICard.tsx
@@ -6,6 +6,7 @@ import React, { ReactNode } from 'react';
 export interface BAICardProps extends CardProps {
   status?: 'success' | 'error' | 'warning' | 'default';
   extraButtonTitle?: string | ReactNode;
+  showDivider?: boolean;
   onClickExtraButton?: () => void;
   ref?: React.LegacyRef<HTMLDivElement> | undefined;
 }
@@ -16,6 +17,8 @@ const BAICard: React.FC<BAICardProps> = ({
   onClickExtraButton,
   extra,
   style,
+  styles,
+  showDivider,
   ...cardProps
 }) => {
   const { token } = theme.useToken();
@@ -50,6 +53,19 @@ const BAICard: React.FC<BAICardProps> = ({
                 ? token.colorSuccess
                 : style?.borderColor, // default
       })}
+      styles={_.merge(
+        showDivider
+          ? {}
+          : {
+              header: {
+                borderBottom: 'none',
+              },
+              body: {
+                paddingTop: token.marginXS,
+              },
+            },
+        styles,
+      )}
       extra={_extra}
       {...cardProps}
     />

--- a/react/src/components/BAIRadioGroup.tsx
+++ b/react/src/components/BAIRadioGroup.tsx
@@ -1,0 +1,65 @@
+import { ConfigProvider, Radio, theme } from 'antd';
+import type { RadioGroupProps } from 'antd';
+import { createStyles } from 'antd-style';
+import classNames from 'classnames';
+import React from 'react';
+
+interface BAIRadioGroupProps extends RadioGroupProps {}
+
+const useStyle = createStyles(({ css, token }) => ({
+  baiRadioGroup: css`
+    // border version
+    .ant-radio-button-wrapper:not(.ant-radio-button-wrapper-checked)::before,
+    .ant-radio-button-wrapper:hover::before {
+      background-color: transparent;
+    }
+    .ant-radio-button-wrapper-checked:hover::before,
+    .ant-radio-button-wrapper-checked::before {
+      background-color: transparent;
+      /* background-color: ${`rgba(${parseInt(token.colorPrimary.slice(1, 3), 16)}, ${parseInt(token.colorPrimary.slice(3, 5), 16)}, ${parseInt(token.colorPrimary.slice(5, 7), 16)}, 0.30)`}; */
+    }
+
+    // original design version
+    /* .ant-radio-button-wrapper-checked::before,
+    .ant-radio-button-wrapper::before {
+      background-color: ${token.colorBorder};
+    }
+    .ant-radio-button-wrapper-checked:hover::before,
+    .ant-radio-button-wrapper:hover::before {
+      background-color: ${token.colorBorder};
+    }
+
+    .ant-radio-button-wrapper-checked {
+      border-color: transparent !important;
+    } */
+  `,
+}));
+const BAIRadioGroup: React.FC<BAIRadioGroupProps> = ({ options, ...props }) => {
+  const { styles } = useStyle();
+  const { token } = theme.useToken();
+  const colorPrimaryWithAlpha = `rgba(${parseInt(token.colorPrimary.slice(1, 3), 16)}, ${parseInt(token.colorPrimary.slice(3, 5), 16)}, ${parseInt(token.colorPrimary.slice(5, 7), 16)}, 0.15)`;
+  const colorPrimaryWithLessAlpha = `rgba(${parseInt(token.colorPrimary.slice(1, 3), 16)}, ${parseInt(token.colorPrimary.slice(3, 5), 16)}, ${parseInt(token.colorPrimary.slice(5, 7), 16)}, 0.3)`;
+  return (
+    <ConfigProvider
+      theme={{
+        components: {
+          Radio: {
+            buttonSolidCheckedBg: colorPrimaryWithAlpha,
+            buttonSolidCheckedColor: token.colorPrimary,
+            buttonSolidCheckedHoverBg: colorPrimaryWithLessAlpha,
+          },
+        },
+      }}
+    >
+      <Radio.Group
+        className={classNames(styles.baiRadioGroup, props.className)}
+        options={options}
+        optionType="button"
+        buttonStyle="solid"
+        {...props}
+      />
+    </ConfigProvider>
+  );
+};
+
+export default BAIRadioGroup;

--- a/react/src/components/BAITable.tsx
+++ b/react/src/components/BAITable.tsx
@@ -1,6 +1,6 @@
 import { useThemeMode } from '../hooks/useThemeMode';
 import { useDebounce } from 'ahooks';
-import { ConfigProvider, GetProps, Table } from 'antd';
+import { ConfigProvider, GetProps, Table, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import { ColumnsType, ColumnType } from 'antd/es/table';
 import { TableProps } from 'antd/lib';
@@ -124,6 +124,7 @@ const BAITable = <RecordType extends object = any>({
   ...tableProps
 }: BAITableProps<RecordType>) => {
   const { styles } = useStyles();
+  const { token } = theme.useToken();
   const { isDarkMode } = useThemeMode();
   const [resizedColumnWidths, setResizedColumnWidths] = useState<
     Record<string, number>
@@ -163,6 +164,8 @@ const BAITable = <RecordType extends object = any>({
             !isDarkMode && neoStyle
               ? {
                   headerBg: '#E3E3E3',
+                  headerSplitColor: token.colorTextQuaternary,
+                  // headerSplitColor: token.colorTextQuaternary
                 }
               : undefined,
         },

--- a/react/src/components/BAITabs.tsx
+++ b/react/src/components/BAITabs.tsx
@@ -1,0 +1,32 @@
+import { Tabs, TabsProps } from 'antd';
+import { createStyles } from 'antd-style';
+import classNames from 'classnames';
+import React from 'react';
+
+const useStyles = createStyles(({ token, css }) => ({
+  baiTabs: css`
+    .ant-tabs-nav::before {
+      border-color: ${token.colorPrimary};
+    }
+    .ant-tabs-tab:not(.ant-tabs-tab-active) {
+      border-bottom-color: ${token.colorPrimary};
+    }
+    .ant-tabs-tab.ant-tabs-tab-active {
+      border-color: ${token.colorPrimary};
+    }
+  `,
+}));
+
+interface BAITabsProps extends TabsProps {}
+const BAITabs: React.FC<BAITabsProps> = ({ className, ...props }) => {
+  const { styles } = useStyles();
+  return (
+    <Tabs
+      className={classNames(styles.baiTabs, className)}
+      type="card"
+      {...props}
+    />
+  );
+};
+
+export default BAITabs;

--- a/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
@@ -4,7 +4,7 @@ import {
   SessionStatusTagFragment$key,
 } from './__generated__/SessionStatusTagFragment.graphql';
 import { LoadingOutlined } from '@ant-design/icons';
-import { Tag, theme } from 'antd';
+import { Tag, theme, Tooltip } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React from 'react';
@@ -69,24 +69,32 @@ const SessionStatusTag: React.FC<SessionStatusTagProps> = ({
 
   return session ? (
     _.isEmpty(session.status_info) || !showInfo ? (
-      <Tag
-        color={
-          session.status ? _.get(statusTagColor, session.status) : undefined
-        }
-        icon={isTransitional(session) ? <LoadingOutlined spin /> : undefined}
-        // Comment out to match the legacy tag style temporarily
-        // style={{
-        //   borderRadius: 11,
-        //   paddingLeft: token.paddingSM,
-        //   paddingRight: token.paddingSM,
-        // }}
-      >
-        {session.status || ' '}
-      </Tag>
+      <Tooltip title={session.status_info}>
+        <Tag
+          color={
+            session.status ? _.get(statusTagColor, session.status) : undefined
+          }
+          icon={isTransitional(session) ? <LoadingOutlined spin /> : undefined}
+          // Comment out to match the legacy tag style temporarily
+          style={{
+            borderRadius: 11,
+            paddingLeft: token.paddingSM,
+            paddingRight: token.paddingSM,
+          }}
+        >
+          {session.status || ' '}
+        </Tag>
+      </Tooltip>
     ) : (
       <Flex>
         <Tag
-          style={{ margin: 0, zIndex: 1 }}
+          style={{
+            margin: 0,
+            zIndex: 1,
+            paddingLeft: token.paddingSM,
+            borderTopLeftRadius: 11,
+            borderBottomLeftRadius: 11,
+          }}
           color={
             session.status ? _.get(statusTagColor, session.status) : undefined
           }
@@ -98,6 +106,9 @@ const SessionStatusTag: React.FC<SessionStatusTagProps> = ({
             margin: 0,
             marginLeft: -1,
             borderStyle: 'dashed',
+            paddingRight: token.paddingSM,
+            borderTopRightRadius: 11,
+            borderBottomRightRadius: 11,
             color:
               session.status_info &&
               _.get(statusInfoTagColor, session.status_info)

--- a/react/src/components/EndpointList.tsx
+++ b/react/src/components/EndpointList.tsx
@@ -1,8 +1,3 @@
-import BAIPropertyFilter from '../components/BAIPropertyFilter';
-import EndpointOwnerInfo from '../components/EndpointOwnerInfo';
-import EndpointStatusTag from '../components/EndpointStatusTag';
-import Flex from '../components/Flex';
-import TableColumnsSettingModal from '../components/TableColumnsSettingModal';
 import {
   baiSignedRequestWithPromise,
   filterEmptyItem,
@@ -20,24 +15,31 @@ import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOption
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
+import BAIPropertyFilter from './BAIPropertyFilter';
+import BAIRadioGroup from './BAIRadioGroup';
+import BAITable from './BAITable';
+import EndpointOwnerInfo from './EndpointOwnerInfo';
+import EndpointStatusTag from './EndpointStatusTag';
+import Flex from './Flex';
+import TableColumnsSettingModal from './TableColumnsSettingModal';
 import {
-  EndpointListPageQuery,
-  EndpointListPageQuery$data,
-} from './__generated__/EndpointListPageQuery.graphql';
+  EndpointListQuery,
+  EndpointListQuery$data,
+} from './__generated__/EndpointListQuery.graphql';
 import {
   CheckOutlined,
   CloseOutlined,
   DeleteOutlined,
-  LoadingOutlined,
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
 import { useRafInterval, useToggle } from 'ahooks';
-import { Button, Table, Typography, theme, Radio, App } from 'antd';
+import { Button, Typography, theme, App, Tooltip } from 'antd';
 import { ColumnType } from 'antd/lib/table';
 import graphql from 'babel-plugin-relay/macro';
 import { default as dayjs } from 'dayjs';
 import _ from 'lodash';
+import { InfoIcon } from 'lucide-react';
 import React, {
   PropsWithChildren,
   useState,
@@ -51,9 +53,7 @@ import { StringParam, useQueryParam } from 'use-query-params';
 
 export type Endpoint = NonNullable<
   NonNullable<
-    NonNullable<
-      NonNullable<EndpointListPageQuery$data>['endpoint_list']
-    >['items']
+    NonNullable<NonNullable<EndpointListQuery$data>['endpoint_list']>['items']
   >[0]
 >;
 export const isDestroyingStatus = (
@@ -68,7 +68,10 @@ export const isDestroyingStatus = (
 
 type LifecycleStage = 'created&destroying' | 'destroyed';
 
-const EndpointListPage: React.FC<PropsWithChildren> = ({ children }) => {
+interface EndpointListProps extends PropsWithChildren {
+  style?: React.CSSProperties;
+}
+const EndpointList: React.FC<EndpointListProps> = ({ style, children }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message, modal } = App.useApp();
@@ -286,12 +289,15 @@ const EndpointListPage: React.FC<PropsWithChildren> = ({ children }) => {
     },
     {
       title: (
-        <Flex direction="column" align="start">
+        <Flex direction="row" align="center" gap={'xs'}>
           {t('modelService.RoutingsCount')}
-          <br />
+          <Tooltip title={t('modelService.Active/Total')}>
+            <InfoIcon />
+          </Tooltip>
+          {/* <br />
           <Typography.Text type="secondary" style={{ fontWeight: 'normal' }}>
             ({t('modelService.Active/Total')})
-          </Typography.Text>
+          </Typography.Text> */}
         </Flex>
       ),
       // dataIndex: "active_route_count",
@@ -326,9 +332,9 @@ const EndpointListPage: React.FC<PropsWithChildren> = ({ children }) => {
   }, 7000);
 
   const { endpoint_list: modelServiceList } =
-    useLazyLoadQuery<EndpointListPageQuery>(
+    useLazyLoadQuery<EndpointListQuery>(
       graphql`
-        query EndpointListPageQuery(
+        query EndpointListQuery(
           $offset: Int!
           $limit: Int!
           $projectID: UUID
@@ -419,18 +425,13 @@ const EndpointListPage: React.FC<PropsWithChildren> = ({ children }) => {
   });
 
   return (
-    <Flex direction="column" align="stretch">
+    <Flex direction="column" align="stretch" style={style} gap={'sm'}>
       <Flex
         direction="row"
         justify="between"
         align="start"
         wrap="wrap"
         gap={'xs'}
-        style={{
-          padding: token.paddingContentVertical,
-          paddingLeft: token.paddingContentHorizontalSM,
-          paddingRight: token.paddingContentHorizontalSM,
-        }}
       >
         <Flex
           direction="row"
@@ -441,7 +442,7 @@ const EndpointListPage: React.FC<PropsWithChildren> = ({ children }) => {
         >
           {baiClient.supports('endpoint-lifecycle-stage-filter') && (
             <>
-              <Radio.Group
+              <BAIRadioGroup
                 value={selectedLifecycleStage}
                 onChange={(e) => {
                   startPageChangeTransition(() => {
@@ -532,70 +533,66 @@ const EndpointListPage: React.FC<PropsWithChildren> = ({ children }) => {
           </Flex>
         </Flex>
       </Flex>
-      <Table
-        loading={{
-          spinning: isFilterPending || isPendingPageChange,
-          indicator: <LoadingOutlined />,
-        }}
-        scroll={{ x: 'max-content' }}
-        rowKey={'endpoint_id'}
-        dataSource={filterNonNullItems(modelServiceList?.items)}
-        columns={_.filter(
-          columns,
-          (column) => !_.includes(hiddenColumnKeys, _.toString(column?.key)),
-        )}
-        sortDirections={['descend', 'ascend', 'descend']}
-        pagination={{
-          pageSize: tablePaginationOption.pageSize,
-          current: tablePaginationOption.current,
-          pageSizeOptions: ['10', '20', '50'],
-          total: modelServiceList?.total_count || 0,
-          showSizeChanger: true,
-          style: { marginRight: token.marginXS },
-        }}
-        onChange={({ pageSize, current }, filter, sorter) => {
-          startPageChangeTransition(() => {
-            if (_.isNumber(current) && _.isNumber(pageSize)) {
-              setTablePaginationOption({
-                current,
-                pageSize,
-              });
-            }
-            setOrder(transformSorterToOrderString(sorter));
-          });
-        }}
-      />
-      <Flex
-        justify="end"
-        style={{
-          padding: token.paddingXXS,
-        }}
-      >
-        <Button
-          type="text"
-          icon={<SettingOutlined />}
-          onClick={() => {
-            toggleColumnSettingModal();
+      <Flex direction="column" align="stretch">
+        <BAITable
+          neoStyle
+          size="small"
+          loading={isFilterPending || isPendingPageChange}
+          scroll={{ x: 'max-content' }}
+          rowKey={'endpoint_id'}
+          dataSource={filterNonNullItems(modelServiceList?.items)}
+          columns={_.filter(
+            columns,
+            (column) => !_.includes(hiddenColumnKeys, _.toString(column?.key)),
+          )}
+          sortDirections={['descend', 'ascend', 'descend']}
+          pagination={{
+            pageSize: tablePaginationOption.pageSize,
+            current: tablePaginationOption.current,
+            pageSizeOptions: ['10', '20', '50'],
+            total: modelServiceList?.total_count || 0,
+            showSizeChanger: true,
+            style: { marginRight: token.marginXS },
+          }}
+          onChange={({ pageSize, current }, filter, sorter) => {
+            startPageChangeTransition(() => {
+              if (_.isNumber(current) && _.isNumber(pageSize)) {
+                setTablePaginationOption({
+                  current,
+                  pageSize,
+                });
+              }
+              setOrder(transformSorterToOrderString(sorter));
+            });
           }}
         />
+        <Flex justify="end">
+          <Button
+            type="text"
+            icon={<SettingOutlined />}
+            onClick={() => {
+              toggleColumnSettingModal();
+            }}
+          />
+        </Flex>
+        <TableColumnsSettingModal
+          open={visibleColumnSettingModal}
+          onRequestClose={(values) => {
+            values?.selectedColumnKeys &&
+              setHiddenColumnKeys(
+                _.difference(
+                  columns.map((column) => _.toString(column.key)),
+                  values?.selectedColumnKeys,
+                ),
+              );
+            toggleColumnSettingModal();
+          }}
+          columns={columns}
+          hiddenColumnKeys={hiddenColumnKeys}
+        />
       </Flex>
-      <TableColumnsSettingModal
-        open={visibleColumnSettingModal}
-        onRequestClose={(values) => {
-          values?.selectedColumnKeys &&
-            setHiddenColumnKeys(
-              _.difference(
-                columns.map((column) => _.toString(column.key)),
-                values?.selectedColumnKeys,
-              ),
-            );
-          toggleColumnSettingModal();
-        }}
-        columns={columns}
-        hiddenColumnKeys={hiddenColumnKeys}
-      />
     </Flex>
   );
 };
 
-export default EndpointListPage;
+export default EndpointList;

--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -57,6 +57,7 @@ const SessionLauncherPreview: React.FC<{
     <>
       <BAICard
         title={t('session.launcher.SessionType')}
+        showDivider
         size="small"
         status={
           form.getFieldError('sessionName').length > 0 ||
@@ -136,6 +137,7 @@ const SessionLauncherPreview: React.FC<{
       />
       <BAICard
         title={t('session.launcher.Environments')}
+        showDivider
         size="small"
         status={
           _.some(
@@ -373,6 +375,7 @@ const SessionLauncherPreview: React.FC<{
       </BAICard>
       <BAICard
         title={t('session.launcher.ResourceAllocation')}
+        showDivider
         status={
           _.some(form.getFieldValue('resource'), (v, key) => {
             return (
@@ -516,6 +519,7 @@ const SessionLauncherPreview: React.FC<{
       </BAICard>
       <BAICard
         title={t('webui.menu.Data&Storage')}
+        showDivider
         size="small"
         status={
           form.getFieldError('vfoldersAliasMap').length > 0
@@ -586,6 +590,7 @@ const SessionLauncherPreview: React.FC<{
       </BAICard>
       <BAICard
         title="Network"
+        showDivider
         size="small"
         status={form.getFieldError('ports').length > 0 ? 'error' : undefined}
         extraButtonTitle={t('button.Edit')}

--- a/react/src/components/SessionOwnerSetterCard.tsx
+++ b/react/src/components/SessionOwnerSetterCard.tsx
@@ -283,6 +283,7 @@ export const SessionOwnerSetterPreviewCard: React.FC<BAICardProps> = (
     isActive && (
       <BAICard
         title={t('session.launcher.SetSessionOwner')}
+        showDivider
         size="small"
         status={
           form.getFieldError(['owner', 'email']).length > 0 ||

--- a/react/src/components/SummaryPageItems/SummaryItemInvitation.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemInvitation.tsx
@@ -88,7 +88,7 @@ const SummaryItemInvitation: React.FC = () => {
       {invitations.length > 0 ? (
         <>
           {invitations.map((invitation: any) => (
-            <BAICard style={{ width: '100%' }}>
+            <BAICard showDivider style={{ width: '100%' }}>
               <Descriptions title={`From: ${invitation.inviter}`} column={1}>
                 <Descriptions.Item
                   label={t('summary.FolderName')}

--- a/react/src/components/UserCredentialList.tsx
+++ b/react/src/components/UserCredentialList.tsx
@@ -6,6 +6,7 @@ import {
 import { useUpdatableState } from '../hooks';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import BAIPropertyFilter from './BAIPropertyFilter';
+import BAIRadioGroup from './BAIRadioGroup';
 import BAITable from './BAITable';
 import Flex from './Flex';
 import KeypairInfoModal from './KeypairInfoModal';
@@ -24,16 +25,7 @@ import {
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
-import {
-  App,
-  Button,
-  Popconfirm,
-  Radio,
-  Tag,
-  Tooltip,
-  Typography,
-  theme,
-} from 'antd';
+import { App, Button, Popconfirm, Tag, Tooltip, Typography, theme } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import dayjs from 'dayjs';
 import _ from 'lodash';
@@ -169,7 +161,7 @@ const UserCredentialList: React.FC = () => {
         wrap="wrap"
       >
         <Flex gap={'sm'} align="start">
-          <Radio.Group
+          <BAIRadioGroup
             value={activeType}
             onChange={(value) => {
               startActiveTypeTransition(() => {

--- a/react/src/components/UserNodeList.tsx
+++ b/react/src/components/UserNodeList.tsx
@@ -7,6 +7,7 @@ import {
 } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
+import BAIRadioGroup from './BAIRadioGroup';
 import UserInfoModal from './UserInfoModal';
 import UserSettingModal from './UserSettingModal';
 import { UserNodeListModifyMutation } from './__generated__/UserNodeListModifyMutation.graphql';
@@ -17,7 +18,7 @@ import {
   InfoCircleOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
-import { Tooltip, Button, Table, theme, Radio, Popconfirm, App } from 'antd';
+import { Tooltip, Button, Table, theme, Popconfirm, App } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import dayjs from 'dayjs';
 import _ from 'lodash';
@@ -134,7 +135,7 @@ const UserNodeList: React.FC<UserNodeListProps> = () => {
         wrap="wrap"
       >
         <Flex direction="row" gap={'sm'} align="start" wrap="wrap">
-          <Radio.Group
+          <BAIRadioGroup
             value={activeFilter}
             onChange={(e) => {
               startStatusFetchTransition(() => {

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -1,4 +1,5 @@
 import BAIFetchKeyButton from '../components/BAIFetchKeyButton';
+import BAICard from '../components/BAICard';
 import BAILink from '../components/BAILink';
 import BAIPropertyFilter, {
   mergeFilterValues,
@@ -20,7 +21,7 @@ import {
   ComputeSessionListPageQuery$data,
   ComputeSessionListPageQuery$variables,
 } from './__generated__/ComputeSessionListPageQuery.graphql';
-import { Badge, Button, Card, Radio, Tabs, theme, Tooltip, Typography } from 'antd';
+import { Badge, Button, theme, Tooltip, Typography } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import { PowerOffIcon } from 'lucide-react';
@@ -28,6 +29,8 @@ import { useDeferredValue, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyLoadQuery } from 'react-relay';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
+import BAITabs from '../components/BAITabs';
+import BAIRadioGroup from '../components/BAIRadioGroup';
 
 type TypeFilterType = 'all' | 'interactive' | 'batch' | 'inference' | 'system';
 type SessionNode = NonNullableNodeOnEdges<
@@ -184,7 +187,7 @@ const ComputeSessionListPage = () => {
     <>
       {/* TODO: add legacy opener */}
       {/* <SessionDetailAndContainerLogOpenerForLegacy /> */}
-      <Card
+      <BAICard
         bordered={false}
         title={t('webui.menu.Sessions')}
         extra={
@@ -216,8 +219,7 @@ const ComputeSessionListPage = () => {
         }}
       >
         {/* {mergeFilterValues([statusFilter, queryParams.filter, typeFilter])} */}
-        <Tabs
-          type="card"
+        <BAITabs
           activeKey={queryParams.type}
           onChange={(key) => {
             const storedQuery = queryMapRef.current[key] || {
@@ -281,7 +283,7 @@ const ComputeSessionListPage = () => {
               }}
               wrap="wrap"
             >
-              <Radio.Group
+              <BAIRadioGroup
                 optionType="button"
                 value={queryParams.statusCategory}
                 onChange={(e) => {
@@ -387,7 +389,7 @@ const ComputeSessionListPage = () => {
             }}
           />
         </Flex>
-      </Card>
+      </BAICard>
       <TerminateSessionModal
         open={isOpenTerminateModal}
         sessionFrgmts={selectedSessionList}

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -3,6 +3,7 @@ import AutoScalingRuleEditorModal, {
 } from '../components/AutoScalingRuleEditorModal';
 import BAIJSONViewerModal from '../components/BAIJSONViewerModal';
 import CopyableCodeText from '../components/CopyableCodeText';
+import { isDestroyingStatus } from '../components/EndpointList';
 import EndpointOwnerInfo from '../components/EndpointOwnerInfo';
 import EndpointStatusTag from '../components/EndpointStatusTag';
 import EndpointTokenGenerationModal from '../components/EndpointTokenGenerationModal';
@@ -25,7 +26,6 @@ import {
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useTanMutation } from '../hooks/reactQueryAlias';
-import { isDestroyingStatus } from './EndpointListPage';
 import { EndpointDetailPageAutoScalingRuleDeleteMutation } from './__generated__/EndpointDetailPageAutoScalingRuleDeleteMutation.graphql';
 import {
   EndpointDetailPageQuery,

--- a/react/src/pages/ImportAndRunPage.tsx
+++ b/react/src/pages/ImportAndRunPage.tsx
@@ -10,6 +10,7 @@ const ImportAndRunPage = () => {
   return (
     <BAICard
       title={t('import.ImportNotebook')}
+      showDivider
       style={{
         maxWidth: 728,
         marginBottom: token.paddingMD,

--- a/react/src/pages/ServingPage.tsx
+++ b/react/src/pages/ServingPage.tsx
@@ -8,7 +8,7 @@ import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 // FIXME: need to apply filtering type of service later
 type TabKey = 'services' | 'chatting'; //  "running" | "finished" | "others";
 
-const EndpointListPage = React.lazy(() => import('./EndpointListPage'));
+const EndpointListPage = React.lazy(() => import('../components/EndpointList'));
 
 interface ServingPageProps {}
 
@@ -57,7 +57,11 @@ const ServingPage: React.FC<ServingPageProps> = ({ ...props }) => {
           <Suspense
             fallback={<Skeleton active style={{ padding: token.paddingMD }} />}
           >
-            <EndpointListPage />
+            <EndpointListPage
+              style={{
+                padding: token.paddingMD,
+              }}
+            />
           </Suspense>
         ) : null}
       </Card>

--- a/react/src/pages/UserCredentialsPage.tsx
+++ b/react/src/pages/UserCredentialsPage.tsx
@@ -36,6 +36,7 @@ const UserCredentialsPage: React.FC = () => {
 
   return (
     <BAICard
+      showDivider
       className={styles.card}
       activeTabKey={curTabKey}
       onTabChange={setCurTabKey}


### PR DESCRIPTION
resolves #3182 (FR-534)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/8b9d95ff-9578-41d9-9ca5-9c1bc6ee0068.png)
resolves #3182 (FR-534)

Introduces new UI components and enhances existing ones to improve visual consistency and user experience:

- Added BAIRadioGroup component with custom styling for radio buttons
- Added BAITabs component with customized tab styling and borders
- Enhanced BAICard with divider control and styling options
- Updated SessionStatusTag with improved tooltip and border radius
- Refactored EndpointList from a page to a reusable component
- Enhanced table headers with tooltips instead of multi-line text
- Applied consistent spacing and styling across components
- Updated serving page layout and padding