### PR TITLE
refactor(FR-535): Endpoint destroying category

### DIFF
--- a/react/src/components/EndpointList.tsx
+++ b/react/src/components/EndpointList.tsx
@@ -56,13 +56,18 @@ export type Endpoint = NonNullable<
     NonNullable<NonNullable<EndpointListQuery$data>['endpoint_list']>['items']
   >[0]
 >;
-export const isDestroyingStatus = (
-  desiredSessionCount: number | null | undefined,
-  status: string | null | undefined,
+
+export const isEndpointInDestroyingCategory = (
+  endpoint?: {
+    desired_session_count: number | null | undefined;
+    replicas: number | null | undefined;
+    status: string | null | undefined;
+  } | null,
 ) => {
+  const count = endpoint?.replicas ?? endpoint?.desired_session_count;
+  const status = endpoint?.status;
   return (
-    (desiredSessionCount ?? 0) < 0 ||
-    _.includes(['DESTROYED', 'DESTROYING'], status ?? '')
+    (count ?? 0) < 0 || _.includes(['DESTROYED', 'DESTROYING'], status ?? '')
   );
 };
 
@@ -153,10 +158,7 @@ const EndpointList: React.FC<EndpointListProps> = ({ style, children }) => {
             type="text"
             icon={<SettingOutlined />}
             style={
-              isDestroyingStatus(
-                row.replicas ?? row.desired_session_count,
-                row.status,
-              ) ||
+              isEndpointInDestroyingCategory(row) ||
               (!!row.created_user_email &&
                 row.created_user_email !== currentUser.email)
                 ? {
@@ -167,10 +169,7 @@ const EndpointList: React.FC<EndpointListProps> = ({ style, children }) => {
                   }
             }
             disabled={
-              isDestroyingStatus(
-                row.replicas ?? row.desired_session_count,
-                row.status,
-              ) ||
+              isEndpointInDestroyingCategory(row) ||
               (!!row.created_user_email &&
                 row.created_user_email !== currentUser.email)
             }
@@ -183,10 +182,7 @@ const EndpointList: React.FC<EndpointListProps> = ({ style, children }) => {
             icon={
               <DeleteOutlined
                 style={
-                  isDestroyingStatus(
-                    row.replicas ?? row.desired_session_count,
-                    row.status,
-                  )
+                  isEndpointInDestroyingCategory(row)
                     ? undefined
                     : {
                         color: token.colorError,
@@ -198,10 +194,7 @@ const EndpointList: React.FC<EndpointListProps> = ({ style, children }) => {
               terminateModelServiceMutation.isPending &&
               optimisticDeletingId === row.endpoint_id
             }
-            disabled={isDestroyingStatus(
-              row.replicas ?? row.desired_session_count,
-              row.status,
-            )}
+            disabled={isEndpointInDestroyingCategory(row)}
             onClick={() => {
               modal.confirm({
                 title: t('dialog.ask.DoYouWantToDeleteSomething', {

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -3,7 +3,7 @@ import AutoScalingRuleEditorModal, {
 } from '../components/AutoScalingRuleEditorModal';
 import BAIJSONViewerModal from '../components/BAIJSONViewerModal';
 import CopyableCodeText from '../components/CopyableCodeText';
-import { isDestroyingStatus } from '../components/EndpointList';
+import { isEndpointInDestroyingCategory } from '../components/EndpointList';
 import EndpointOwnerInfo from '../components/EndpointOwnerInfo';
 import EndpointStatusTag from '../components/EndpointStatusTag';
 import EndpointTokenGenerationModal from '../components/EndpointTokenGenerationModal';
@@ -566,10 +566,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           <Button
             loading={isPendingRefetch}
             icon={<ReloadOutlined />}
-            disabled={isDestroyingStatus(
-              endpoint?.replicas ?? endpoint?.desired_session_count,
-              endpoint?.status,
-            )}
+            disabled={isEndpointInDestroyingCategory(endpoint)}
             onClick={() => {
               startRefetchTransition(() => {
                 updateFetchKey();
@@ -587,10 +584,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
             type="primary"
             icon={<SettingOutlined />}
             disabled={
-              isDestroyingStatus(
-                endpoint?.replicas ?? endpoint?.desired_session_count,
-                endpoint?.status,
-              ) ||
+              isEndpointInDestroyingCategory(endpoint) ||
               (!!endpoint?.created_user_email &&
                 endpoint?.created_user_email !== currentUser.email)
             }
@@ -618,10 +612,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
             <Button
               type="primary"
               icon={<PlusOutlined />}
-              disabled={isDestroyingStatus(
-                endpoint?.replicas ?? endpoint?.desired_session_count,
-                endpoint?.status,
-              )}
+              disabled={isEndpointInDestroyingCategory(endpoint)}
               onClick={() => {
                 setIsOpenAutoScalingRuleModal(true);
               }}
@@ -675,10 +666,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
                       type="text"
                       icon={<SettingOutlined />}
                       style={
-                        isDestroyingStatus(
-                          endpoint?.replicas ?? endpoint?.desired_session_count,
-                          endpoint?.status,
-                        ) ||
+                        isEndpointInDestroyingCategory(endpoint) ||
                         (!!endpoint?.created_user_email &&
                           endpoint?.created_user_email !== currentUser.email)
                           ? {
@@ -689,10 +677,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
                             }
                       }
                       disabled={
-                        isDestroyingStatus(
-                          endpoint?.replicas ?? endpoint?.desired_session_count,
-                          endpoint?.status,
-                        ) ||
+                        isEndpointInDestroyingCategory(endpoint) ||
                         (!!endpoint?.created_user_email &&
                           endpoint?.created_user_email !== currentUser.email)
                       }
@@ -760,11 +745,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
                         icon={
                           <DeleteOutlined
                             style={
-                              isDestroyingStatus(
-                                endpoint?.replicas ??
-                                  endpoint?.desired_session_count,
-                                endpoint?.status,
-                              )
+                              isEndpointInDestroyingCategory(endpoint)
                                 ? undefined
                                 : {
                                     color: token.colorError,
@@ -863,10 +844,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           <Button
             type="primary"
             icon={<PlusOutlined />}
-            disabled={isDestroyingStatus(
-              endpoint?.replicas ?? endpoint?.desired_session_count,
-              endpoint?.status,
-            )}
+            disabled={isEndpointInDestroyingCategory(endpoint)}
             onClick={() => {
               setIsOpenTokenGenerationModal(true);
             }}
@@ -946,10 +924,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
             <Button
               icon={<SyncOutlined />}
               loading={mutationToSyncRoutes.isPending}
-              disabled={isDestroyingStatus(
-                endpoint?.replicas ?? endpoint?.desired_session_count,
-                endpoint?.status,
-              )}
+              disabled={isEndpointInDestroyingCategory(endpoint)}
               onClick={() => {
                 endpoint?.endpoint_id &&
                   mutationToSyncRoutes.mutateAsync(endpoint?.endpoint_id, {


### PR DESCRIPTION
resolves #3183 (FR-535)

Refactors endpoint status checking by introducing a new function `isEndpointInDestroyingCategory` that accepts an endpoint object instead of individual parameters. This improves code readability and reduces repetitive parameter passing throughout the codebase.

The function consolidates the logic for determining if an endpoint is in a destroying state by checking both the replica count and status in a single location.