### PR TITLE
feat(FR-527): introduce BAIFetchKeyButton

### DIFF
--- a/react/src/components/BAIFetchKeyButton.tsx
+++ b/react/src/components/BAIFetchKeyButton.tsx
@@ -1,0 +1,100 @@
+import useControllableState from '../hooks/useControllableState';
+import { useInterval, useIntervalValue } from '../hooks/useIntervalValue';
+import { ReloadOutlined } from '@ant-design/icons';
+import { Button, ButtonProps, Tooltip } from 'antd';
+import dayjs from 'dayjs';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface BAIAutoRefetchButtonProps {
+  value: string;
+  loading?: boolean;
+  lastLoadTime?: Date;
+  showLastLoadTime?: boolean;
+  autoUpdateDelay?: number | null;
+  size?: ButtonProps['size'];
+  onChange: (fetchKey: string) => void;
+  hidden?: boolean;
+}
+const BAIFetchKeyButton: React.FC<BAIAutoRefetchButtonProps> = ({
+  value,
+  loading,
+  onChange,
+  showLastLoadTime,
+  autoUpdateDelay = null,
+  size,
+  hidden,
+  ...props
+}) => {
+  const { t } = useTranslation();
+  const [lastLoadTime, setLastLoadTime] = useControllableState(
+    {
+      value: props.lastLoadTime,
+    },
+    {
+      defaultValue: new Date(),
+    },
+  );
+
+  // display loading icon for at least "some ms" to avoid flickering
+  const [displayLoading, setDisplayLoading] = useState(false);
+  useEffect(() => {
+    if (loading) {
+      const startTime = Date.now();
+      setDisplayLoading(true);
+
+      return () => {
+        const elapsedTime = Date.now() - startTime;
+        const remainingTime = Math.max(700 - elapsedTime, 0);
+
+        setTimeout(() => {
+          setDisplayLoading(false);
+        }, remainingTime);
+      };
+    }
+  }, [loading]);
+
+  const loadTimeMessage = useIntervalValue(
+    () => {
+      if (lastLoadTime) {
+        return `${t('general.LastUpdated')}: ${dayjs(lastLoadTime).fromNow()}`;
+      }
+      return '';
+    },
+    showLastLoadTime ? 5_000 : null,
+    lastLoadTime.toISOString(),
+  );
+
+  // remember when loading is done to display when the last fetch was done
+  useLayoutEffect(() => {
+    if (!loading) {
+      setLastLoadTime(new Date());
+    }
+  }, [loading, setLastLoadTime]);
+
+  useInterval(
+    () => {
+      onChange(new Date().toISOString());
+    },
+    // only start auto-updating after the previous loading is false(done).
+    loading ? null : autoUpdateDelay,
+  );
+
+  return hidden ? null : (
+    <Tooltip
+      title={showLastLoadTime ? loadTimeMessage : undefined}
+      placement="topLeft"
+    >
+      <Button
+        loading={displayLoading}
+        size={size}
+        icon={<ReloadOutlined />}
+        onClick={() => {
+          onChange(new Date().toISOString());
+        }}
+      />
+    </Tooltip>
+  );
+};
+
+export default BAIFetchKeyButton;

--- a/react/src/components/BAITable.tsx
+++ b/react/src/components/BAITable.tsx
@@ -120,6 +120,7 @@ const BAITable = <RecordType extends object = any>({
   columns,
   components,
   neoStyle,
+  loading,
   ...tableProps
 }: BAITableProps<RecordType>) => {
   const { styles } = useStyles();
@@ -174,6 +175,10 @@ const BAITable = <RecordType extends object = any>({
           resizable && styles.resizableTable,
           neoStyle && styles.neoHeader,
         )}
+        style={{
+          opacity: loading ? 0.7 : 1,
+          transition: 'opacity 0.3s ease',
+        }}
         components={
           resizable
             ? _.merge(components || {}, {

--- a/react/src/hooks/useDeferredQueryParams.tsx
+++ b/react/src/hooks/useDeferredQueryParams.tsx
@@ -53,7 +53,7 @@ export function useDeferredQueryParams<QPCMap extends QueryParamConfigMap>(
 
       // Update Jotai state
       if (updateType === 'replaceIn' || updateType === 'pushIn') {
-        setLocalQuery((prev) => ({ ...prev, ...newQuery }));
+        setLocalQuery({ ...localQuery, ...newQuery });
       } else {
         setLocalQuery(newQuery as DecodedValueMap<QPCMap>);
       }

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -536,7 +536,8 @@
     "TotalItems": "Insgesamt {{Gesamt}} Artikel",
     "ExtendLoginSession": "Eine Anmeldesitzung verlängern",
     "Cores": "Kerne",
-    "InvalidJSONFormat": "Ungültiges JSON-Format."
+    "InvalidJSONFormat": "Ungültiges JSON-Format.",
+    "LastUpdated": "Zuletzt aktualisiert"
   },
   "credential": {
     "Permission": "Genehmigung",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -536,7 +536,8 @@
     "TotalItems": "Σύνολο {{total}} στοιχείων",
     "ExtendLoginSession": "Επέκταση μιας περιόδου σύνδεσης",
     "Cores": "πυρήνες",
-    "InvalidJSONFormat": "Μη έγκυρη μορφή JSON."
+    "InvalidJSONFormat": "Μη έγκυρη μορφή JSON.",
+    "LastUpdated": "Τελευταία ενημέρωση"
   },
   "credential": {
     "Permission": "Αδεια",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -666,7 +666,8 @@
     "TotalItems": "Total {{total}} items",
     "ExtendLoginSession": "Extend login session",
     "Cores": "cores",
-    "InvalidJSONFormat": "Invalid JSON format."
+    "InvalidJSONFormat": "Invalid JSON format.",
+    "LastUpdated": "Last Updated"
   },
   "credential": {
     "Permission": "Permission",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -585,7 +585,8 @@
     "TotalItems": "Total {{total}} artículos",
     "ExtendLoginSession": "Prolongar una sesión de inicio de sesión",
     "Cores": "núcleos",
-    "InvalidJSONFormat": "Formato JSON no válido."
+    "InvalidJSONFormat": "Formato JSON no válido.",
+    "LastUpdated": "Última actualización"
   },
   "import": {
     "CleanUpImportTask": "Tarea de importación de limpieza...",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -585,7 +585,8 @@
     "TotalItems": "Yhteensä {{total}} kohteita",
     "ExtendLoginSession": "Sisäänkirjautumisistunnon laajentaminen",
     "Cores": "ytimet",
-    "InvalidJSONFormat": "Väärä JSON-muoto."
+    "InvalidJSONFormat": "Väärä JSON-muoto.",
+    "LastUpdated": "Viimeksi päivitetty"
   },
   "import": {
     "CleanUpImportTask": "Tuontitehtävän siivous...",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -536,7 +536,8 @@
     "TotalItems": "Total des éléments {{total}}",
     "ExtendLoginSession": "Prolonger une session de connexion",
     "Cores": "cœurs",
-    "InvalidJSONFormat": "Format JSON non valide."
+    "InvalidJSONFormat": "Format JSON non valide.",
+    "LastUpdated": "Dernière mise à jour"
   },
   "credential": {
     "Permission": "Autorisation",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -537,7 +537,8 @@
     "TotalItems": "Total item {{total}}",
     "ExtendLoginSession": "Memperpanjang sesi masuk",
     "Cores": "core",
-    "InvalidJSONFormat": "Format JSON tidak valid."
+    "InvalidJSONFormat": "Format JSON tidak valid.",
+    "LastUpdated": "Terakhir diperbarui"
   },
   "credential": {
     "Permission": "Izin",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -536,7 +536,8 @@
     "TotalItems": "Totale articoli {{totale}}",
     "ExtendLoginSession": "Estendere una sessione di login",
     "Cores": "core",
-    "InvalidJSONFormat": "Formato JSON non valido."
+    "InvalidJSONFormat": "Formato JSON non valido.",
+    "LastUpdated": "Ultimo aggiornamento"
   },
   "credential": {
     "Permission": "Autorizzazione",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -536,7 +536,8 @@
     "TotalItems": "合計{{total}}項目",
     "ExtendLoginSession": "ログインセッションの延長",
     "Cores": "コア",
-    "InvalidJSONFormat": "JSON形式が間違っています。"
+    "InvalidJSONFormat": "JSON形式が間違っています。",
+    "LastUpdated": "最終更新日"
   },
   "credential": {
     "Permission": "許可",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -655,7 +655,8 @@
     "ExtendLoginSession": "로그인 세션 연장",
     "Cores": "코어",
     "Enable": "활성화",
-    "InvalidJSONFormat": "잘못된 JSON 형식입니다."
+    "InvalidJSONFormat": "잘못된 JSON 형식입니다.",
+    "LastUpdated": "최근 업데이트"
   },
   "credential": {
     "Permission": "권한",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -537,7 +537,8 @@
     "TotalItems": "Нийт {{total}} зүйл",
     "ExtendLoginSession": "Нэвтрэх сессийг сунгах",
     "Cores": "цөм",
-    "InvalidJSONFormat": "Буруу JSON формат."
+    "InvalidJSONFormat": "Буруу JSON формат.",
+    "LastUpdated": "Өнөөхээр нь онуулсан өдөр"
   },
   "credential": {
     "Permission": "Зөвшөөрөл",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -536,7 +536,8 @@
     "TotalItems": "Jumlah {{total}} item",
     "ExtendLoginSession": "Lanjutkan sesi log masuk",
     "Cores": "teras",
-    "InvalidJSONFormat": "Format JSON yang salah."
+    "InvalidJSONFormat": "Format JSON yang salah.",
+    "LastUpdated": "Dikemas kini terakhir"
   },
   "credential": {
     "Permission": "Kebenaran",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -536,7 +536,8 @@
     "TotalItems": "Łącznie {{total}} pozycji",
     "ExtendLoginSession": "Przedłużanie sesji logowania",
     "Cores": "rdzenie",
-    "InvalidJSONFormat": "Nieprawidłowy format JSON."
+    "InvalidJSONFormat": "Nieprawidłowy format JSON.",
+    "LastUpdated": "Ostatnia aktualizacja"
   },
   "credential": {
     "Permission": "Pozwolenie",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -536,7 +536,8 @@
     "TotalItems": "Total de itens {{total}}",
     "ExtendLoginSession": "Prolongar uma sessão de início de sessão",
     "Cores": "núcleos",
-    "InvalidJSONFormat": "Formato JSON inválido."
+    "InvalidJSONFormat": "Formato JSON inválido.",
+    "LastUpdated": "Última atualização"
   },
   "credential": {
     "Permission": "Permissão",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -536,7 +536,8 @@
     "TotalItems": "Total de itens {{total}}",
     "ExtendLoginSession": "Prolongar uma sessão de início de sessão",
     "Cores": "núcleos",
-    "InvalidJSONFormat": "Formato JSON inválido."
+    "InvalidJSONFormat": "Formato JSON inválido.",
+    "LastUpdated": "Última atualização"
   },
   "credential": {
     "Permission": "Permissão",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -536,7 +536,8 @@
     "TotalItems": "Всего {{total}} предметов",
     "ExtendLoginSession": "Продление сеанса входа в систему",
     "Cores": "ядра",
-    "InvalidJSONFormat": "Неверный формат JSON."
+    "InvalidJSONFormat": "Неверный формат JSON.",
+    "LastUpdated": "Последнее обновление"
   },
   "credential": {
     "Permission": "Разрешение",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -664,7 +664,9 @@
     "TotalItems": "รวม {{total}} รายการ",
     "ExtendLoginSession": "ขยายเซสชันการเข้าสู่ระบบ",
     "Cores": "คอร์",
-    "InvalidJSONFormat": "รูปแบบ JSON ไม่ถูกต้อง"
+    "InvalidJSONFormat": "รูปแบบ JSON ไม่ถูกต้อง",
+    "NSelected": "{{count}} เลือก",
+    "LastUpdated": "อัปเดตล่าสุด"
   },
   "credential": {
     "Permission": "สิทธิ์",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -535,7 +535,8 @@
     "TotalItems": "Toplam {{toplam}} öğe",
     "ExtendLoginSession": "Oturum açma oturumunu uzatma",
     "Cores": "çekirdek",
-    "InvalidJSONFormat": "Geçersiz JSON biçimi."
+    "InvalidJSONFormat": "Geçersiz JSON biçimi.",
+    "LastUpdated": "Son Güncelleme"
   },
   "credential": {
     "Permission": "izin",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -536,7 +536,8 @@
     "TotalItems": "Tổng số {{total}} mặt hàng",
     "ExtendLoginSession": "Gia hạn phiên đăng nhập",
     "Cores": "lõi",
-    "InvalidJSONFormat": "Định dạng JSON không chính xác."
+    "InvalidJSONFormat": "Định dạng JSON không chính xác.",
+    "LastUpdated": "Cập nhật lần cuối"
   },
   "credential": {
     "Permission": "Sự cho phép",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -536,7 +536,8 @@
     "TotalItems": "{{总计}}项目总数",
     "ExtendLoginSession": "延长登录会话",
     "Cores": "核心",
-    "InvalidJSONFormat": "JSON 格式无效。"
+    "InvalidJSONFormat": "JSON 格式无效。",
+    "LastUpdated": "最后更新"
   },
   "credential": {
     "Permission": "允许",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -535,7 +535,8 @@
     "TotalItems": "{{总计}}项目总数",
     "ExtendLoginSession": "延长登录会话",
     "Cores": "核心",
-    "InvalidJSONFormat": "JSON 格式无效。"
+    "InvalidJSONFormat": "JSON 格式无效。",
+    "LastUpdated": "最后更新"
   },
   "credential": {
     "Permission": "允許",


### PR DESCRIPTION
resolves #3174 (FR-567)

Adds auto-refresh functionality to the compute session list page with a dedicated refresh button that shows loading state and supports automatic updates every 15 seconds. The table now displays a loading state with reduced opacity during updates and shows the total number of items.

Key changes:
- New `BAIFetchKeyButton` component for manual/automatic data refresh
- Enhanced table loading states with smooth opacity transitions
- Added "Last Updated" translations across all languages
- Improved badge visibility for running sessions
- Fixed state updates in `useDeferredQueryParams` hook