### PR TITLE
feat(FR-448): Type counts in NEO session list tabs

### DIFF
--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -90,7 +90,6 @@ const ComputeSessionListPage = () => {
       first: baiPaginationOption.first,
       filter: mergeFilterValues([statusFilter, queryParams.filter, typeFilter]),
       order: queryParams.order,
-      runningTypeFilter: 'status != "TERMINATED" & status != "CANCELLED"',
     }),
     [
       currentProject.id,
@@ -106,7 +105,7 @@ const ComputeSessionListPage = () => {
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const deferredFetchKey = useDeferredValue(fetchKey);
 
-  const { compute_session_nodes, allRunningSessionForCount } =
+  const { compute_session_nodes, ...sessionCounts } =
     useLazyLoadQuery<ComputeSessionListPageQuery>(
       graphql`
         query ComputeSessionListPageQuery(
@@ -115,7 +114,6 @@ const ComputeSessionListPage = () => {
           $offset: Int = 0
           $filter: String
           $order: String
-          $runningTypeFilter: String!
         ) {
           compute_session_nodes(
             project_id: $projectId
@@ -133,11 +131,43 @@ const ComputeSessionListPage = () => {
             }
             count
           }
-          allRunningSessionForCount: compute_session_nodes(
+          all: compute_session_nodes(
             project_id: $projectId
             first: 0
             offset: 0
-            filter: $runningTypeFilter
+            filter: "status != \"TERMINATED\" & status != \"CANCELLED\""
+          ) {
+            count
+          }
+          interactive: compute_session_nodes(
+            project_id: $projectId
+            first: 0
+            offset: 0
+            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"interactive\""
+          ) {
+            count
+          }
+          inference: compute_session_nodes(
+            project_id: $projectId
+            first: 0
+            offset: 0
+            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"inference\""
+          ) {
+            count
+          }
+          batch: compute_session_nodes(
+            project_id: $projectId
+            first: 0
+            offset: 0
+            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"batch\""
+          ) {
+            count
+          }
+          system: compute_session_nodes(
+            project_id: $projectId
+            first: 0
+            offset: 0
+            filter: "status != \"TERMINATED\" & status != \"CANCELLED\" & type == \"system\""
           ) {
             count
           }
@@ -213,23 +243,28 @@ const ComputeSessionListPage = () => {
               label: (
                 <Flex justify="center" gap={10}>
                   {label}
-                  {key === 'all' && (
-                    <Badge
-                      count={allRunningSessionForCount?.count}
-                      color={
-                        queryParams.type === key
-                          ? token.colorPrimary
-                          : token.colorTextDisabled
-                      }
-                      size="small"
-                      showZero
-                      style={{
-                        paddingRight: token.paddingXS,
-                        paddingLeft: token.paddingXS,
-                        fontSize: 10,
-                      }}
-                    />
-                  )}
+                  {
+                    // display badge only if count is greater than 0
+                    // @ts-ignore
+                    (sessionCounts[key]?.count || 0) > 0 && (
+                      <Badge
+                        // @ts-ignore
+                        count={sessionCounts[key].count}
+                        color={
+                          queryParams.type === key
+                            ? token.colorPrimary
+                            : token.colorTextDisabled
+                        }
+                        size="small"
+                        showZero
+                        style={{
+                          paddingRight: token.paddingXS,
+                          paddingLeft: token.paddingXS,
+                          fontSize: 10,
+                        }}
+                      />
+                    )
+                  }
                   {/*  */}
                 </Flex>
               ),


### PR DESCRIPTION
resolves #3080 (FR-448)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/9896edd8-70ea-489a-9144-e55b213f252c.png)

Adds individual session count badges for each session type (interactive, inference, batch, system) in the compute session list page. Previously, only the total count of running sessions was displayed. Now, each tab shows the count of active sessions for its specific type.