### PR TITLE
fix(FR-528): session list filter UI in small screen

### DIFF
--- a/react/src/components/BAIPropertyFilter.tsx
+++ b/react/src/components/BAIPropertyFilter.tsx
@@ -244,7 +244,7 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
   };
 
   return (
-    <Flex direction="column" gap={'xs'} style={{ flex: 1 }} align="start">
+    <Flex direction="column" gap={'xs'} align="start">
       <Space.Compact>
         <Select
           popupMatchSelectWidth={false}

--- a/react/src/components/SessionUsageMonitor.tsx
+++ b/react/src/components/SessionUsageMonitor.tsx
@@ -68,8 +68,11 @@ const SessionUtilItem: React.FC<SessionUtilItemProps> = ({
       <Flex direction="row" gap={'xxs'}>
         <Flex
           style={{
-            // Max width is 140px, min width is 3px
-            width: _.max([Math.round(_.toNumber(percent) * 1.4), 3]),
+            // Max width is 140px (even if over 100%), min width is 3px
+            width: _.min([
+              _.max([Math.round(_.toNumber(percent) * 1.4), 3]),
+              140,
+            ]),
             height: 12,
             backgroundColor: '#BFBFBF',
           }}

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -214,8 +214,15 @@ const ComputeSessionListPage = () => {
           )}
         />
         <Flex direction="column" align="stretch" gap={'sm'}>
-          <Flex justify="between">
-            <Flex gap={'sm'} align="start">
+          <Flex justify="between" wrap="wrap" gap={'sm'}>
+            <Flex
+              gap={'sm'}
+              align="start"
+              style={{
+                flexShrink: 1,
+              }}
+              wrap="wrap"
+            >
               <Radio.Group
                 optionType="button"
                 value={queryParams.statusCategory}


### PR DESCRIPTION
resolves #3175 (FR-528)

Improves UI layout and responsiveness:
- Removes unnecessary flex styling in BAIPropertyFilter
- Caps session utilization bar width to 140px in SessionUsageMonitor
- Makes compute session list filters wrap properly on smaller screens
