### PR TITLE
feat(FR-532): display error_data of model service's route

### DIFF
--- a/react/src/components/BAIJSONViewerModal.tsx
+++ b/react/src/components/BAIJSONViewerModal.tsx
@@ -1,0 +1,64 @@
+import { useThemeMode } from '../hooks/useThemeMode';
+import BAICodeEditor from './BAICodeEditor';
+import BAIModal, { BAIModalProps } from './BAIModal';
+import Flex from './Flex';
+import { Alert } from 'antd';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface BAIJSONViewerModalProps extends Omit<BAIModalProps, 'children'> {
+  json?: object | string;
+  description?: React.ReactNode;
+}
+
+const BAIJSONViewerModal: React.FC<BAIJSONViewerModalProps> = ({
+  json,
+  description,
+  ...modalProps
+}) => {
+  const { t } = useTranslation();
+  const { isDarkMode } = useThemeMode();
+
+  const { formattedJson, hasError } = useMemo(() => {
+    if (typeof json === 'string') {
+      try {
+        return {
+          formattedJson: JSON.stringify(JSON.parse(json), null, 2),
+          hasError: false,
+        };
+      } catch (e) {
+        return {
+          formattedJson: json,
+          hasError: true,
+        };
+      }
+    }
+    return {
+      formattedJson: JSON.stringify(json, null, 2),
+      hasError: false,
+    };
+  }, [json]);
+
+  return (
+    <BAIModal footer={null} width={800} {...modalProps}>
+      <Flex direction="column" align="stretch" gap={'sm'}>
+        {hasError && (
+          <Alert
+            type="warning"
+            message={t('general.InvalidJSONFormat')}
+            showIcon
+          />
+        )}
+        {description}
+        <BAICodeEditor
+          value={formattedJson}
+          language={'json'}
+          theme={isDarkMode ? 'dark' : 'light'}
+          editable={false}
+        />
+      </Flex>
+    </BAIModal>
+  );
+};
+
+export default BAIJSONViewerModal;

--- a/react/src/components/InferenceSessionErrorModal.tsx
+++ b/react/src/components/InferenceSessionErrorModal.tsx
@@ -32,14 +32,6 @@ const InferenceSessionErrorModal: React.FC<Props> = ({
     inferenceSessionErrorFrgmt,
   );
 
-  // const { errors } = endpoint
-  // const targetSession = errors.filter(({ session_id }) => session === session_id)
-  // if (targetSession.length > 0) {
-  //   // setErrorJSONModalSessionID(session)
-  //   // setErrorJSONModalError(targetSession[0].errors[0].repr)
-  //   // setShowErrorJSONModal(true)
-  // }
-
   const columnSetting: DescriptionsProps['column'] = {
     xxl: 1,
     xl: 1,

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -280,9 +280,12 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
 
   const mutationToCreateService = useTanMutation<
     unknown,
-    {
-      message?: string;
-    },
+    | {
+        message?: string;
+        title?: string;
+        description?: string;
+      }
+    | undefined,
     ServiceLauncherFormValue
   >({
     mutationFn: (values) => {
@@ -582,7 +585,6 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                 webuiNavigate(`/serving/${endpoint?.endpoint_id}`);
               },
               onError: (error) => {
-                console.log(error);
                 message.error(t('modelService.FailedToUpdateService'));
               },
             });

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{name}} muss maximal {{max}} sein",
     "TotalItems": "Insgesamt {{Gesamt}} Artikel",
     "ExtendLoginSession": "Eine Anmeldesitzung verlängern",
-    "Cores": "Kerne"
+    "Cores": "Kerne",
+    "InvalidJSONFormat": "Ungültiges JSON-Format."
   },
   "credential": {
     "Permission": "Genehmigung",
@@ -1606,7 +1607,8 @@
     "Resources": "Ressourcen",
     "NumberOfReplicas": "Anzahl der Replikate",
     "AutoScalingRules": "Automatische Skalierungsregeln",
-    "AddRules": "Fügen Sie Regeln hinzu"
+    "AddRules": "Fügen Sie Regeln hinzu",
+    "RouteError": "Routenfehler"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{name}} πρέπει να είναι το μέγιστο {{max}}",
     "TotalItems": "Σύνολο {{total}} στοιχείων",
     "ExtendLoginSession": "Επέκταση μιας περιόδου σύνδεσης",
-    "Cores": "πυρήνες"
+    "Cores": "πυρήνες",
+    "InvalidJSONFormat": "Μη έγκυρη μορφή JSON."
   },
   "credential": {
     "Permission": "Αδεια",
@@ -1606,7 +1607,8 @@
     "Resources": "Πόροι",
     "NumberOfReplicas": "Αριθμός αντιγράφων",
     "AutoScalingRules": "Κανόνες αυτόματης κλιμάκωσης",
-    "AddRules": "Προσθέστε κανόνες"
+    "AddRules": "Προσθέστε κανόνες",
+    "RouteError": "Σφάλμα διαδρομής"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -528,7 +528,8 @@
     "Resources": "Resources",
     "NumberOfReplicas": "Number of replicas",
     "AutoScalingRules": "Auto Scaling Rules",
-    "AddRules": "Add Rules"
+    "AddRules": "Add Rules",
+    "RouteError": "Route Error"
   },
   "button": {
     "Cancel": "Cancel",
@@ -664,7 +665,8 @@
     "MaxValueNotification": "{{name}} must be maximum {{max}}",
     "TotalItems": "Total {{total}} items",
     "ExtendLoginSession": "Extend login session",
-    "Cores": "cores"
+    "Cores": "cores",
+    "InvalidJSONFormat": "Invalid JSON format."
   },
   "credential": {
     "Permission": "Permission",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -584,7 +584,8 @@
     "MaxValueNotification": "{{name}} debe ser máximo {{max}}",
     "TotalItems": "Total {{total}} artículos",
     "ExtendLoginSession": "Prolongar una sesión de inicio de sesión",
-    "Cores": "núcleos"
+    "Cores": "núcleos",
+    "InvalidJSONFormat": "Formato JSON no válido."
   },
   "import": {
     "CleanUpImportTask": "Tarea de importación de limpieza...",
@@ -857,7 +858,8 @@
     "Resources": "Recursos",
     "NumberOfReplicas": "Número de réplicas",
     "AutoScalingRules": "Reglas de escala automática",
-    "AddRules": "Agregar reglas"
+    "AddRules": "Agregar reglas",
+    "RouteError": "Error de ruta"
   },
   "notification": {
     "Initializing": "Inicializando...",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -584,7 +584,8 @@
     "MaxValueNotification": "{{name}} on oltava maksimi {{max}}",
     "TotalItems": "Yhteensä {{total}} kohteita",
     "ExtendLoginSession": "Sisäänkirjautumisistunnon laajentaminen",
-    "Cores": "ytimet"
+    "Cores": "ytimet",
+    "InvalidJSONFormat": "Väärä JSON-muoto."
   },
   "import": {
     "CleanUpImportTask": "Tuontitehtävän siivous...",
@@ -856,7 +857,8 @@
     "Resources": "Resurssit",
     "NumberOfReplicas": "Kopioiden määrä",
     "AutoScalingRules": "Automaattiset skaalaussäännöt",
-    "AddRules": "Lisää sääntöjä"
+    "AddRules": "Lisää sääntöjä",
+    "RouteError": "Reittivirhe"
   },
   "notification": {
     "Initializing": "Aloitetaan...",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{nom}} doit être maximum {{max}}",
     "TotalItems": "Total des éléments {{total}}",
     "ExtendLoginSession": "Prolonger une session de connexion",
-    "Cores": "cœurs"
+    "Cores": "cœurs",
+    "InvalidJSONFormat": "Format JSON non valide."
   },
   "credential": {
     "Permission": "Autorisation",
@@ -1658,7 +1659,8 @@
     "Resources": "Ressources",
     "NumberOfReplicas": "Nombre de répliques",
     "AutoScalingRules": "Règles de mise à l'échelle automatique",
-    "AddRules": "Ajouter des règles"
+    "AddRules": "Ajouter des règles",
+    "RouteError": "Erreur d'itinéraire"
   },
   "modelStore": {
     "Description": "Description",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -536,7 +536,8 @@
     "MaxValueNotification": "{{nama}} harus maksimal {{max}}",
     "TotalItems": "Total item {{total}}",
     "ExtendLoginSession": "Memperpanjang sesi masuk",
-    "Cores": "core"
+    "Cores": "core",
+    "InvalidJSONFormat": "Format JSON tidak valid."
   },
   "credential": {
     "Permission": "Izin",
@@ -1658,7 +1659,8 @@
     "Resources": "Sumber daya",
     "NumberOfReplicas": "Jumlah replika",
     "AutoScalingRules": "Aturan penskalaan otomatis",
-    "AddRules": "Tambahkan aturan"
+    "AddRules": "Tambahkan aturan",
+    "RouteError": "Kesalahan Rute"
   },
   "modelStore": {
     "Description": "Keterangan",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{nome}} deve essere massimo {{max}}",
     "TotalItems": "Totale articoli {{totale}}",
     "ExtendLoginSession": "Estendere una sessione di login",
-    "Cores": "core"
+    "Cores": "core",
+    "InvalidJSONFormat": "Formato JSON non valido."
   },
   "credential": {
     "Permission": "Autorizzazione",
@@ -1604,7 +1605,8 @@
     "Resources": "Risorse",
     "NumberOfReplicas": "Numero di repliche",
     "AutoScalingRules": "Regole di ridimensionamento automatico",
-    "AddRules": "Aggiungi regole"
+    "AddRules": "Aggiungi regole",
+    "RouteError": "Errore di percorso"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{ name }}最大値は{{ max }}です",
     "TotalItems": "合計{{total}}項目",
     "ExtendLoginSession": "ログインセッションの延長",
-    "Cores": "コア"
+    "Cores": "コア",
+    "InvalidJSONFormat": "JSON形式が間違っています。"
   },
   "credential": {
     "Permission": "許可",
@@ -1606,7 +1607,8 @@
     "Resources": "リソース",
     "NumberOfReplicas": "レプリカの数",
     "AutoScalingRules": "自動スケーリングルール",
-    "AddRules": "ルールを追加します"
+    "AddRules": "ルールを追加します",
+    "RouteError": "ルートエラー"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -516,7 +516,8 @@
     "Resources": "자원",
     "NumberOfReplicas": "복제본 수",
     "AutoScalingRules": "오토스케일링 규칙",
-    "AddRules": "규칙 추가"
+    "AddRules": "규칙 추가",
+    "RouteError": "라우트 에러"
   },
   "button": {
     "Cancel": "취소",
@@ -653,7 +654,8 @@
     "TotalItems": "총 {{ total }}개",
     "ExtendLoginSession": "로그인 세션 연장",
     "Cores": "코어",
-    "Enable": "활성화"
+    "Enable": "활성화",
+    "InvalidJSONFormat": "잘못된 JSON 형식입니다."
   },
   "credential": {
     "Permission": "권한",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -536,7 +536,8 @@
     "MaxValueNotification": "{{name}} хамгийн ихдээ {{max}} байх ёстой",
     "TotalItems": "Нийт {{total}} зүйл",
     "ExtendLoginSession": "Нэвтрэх сессийг сунгах",
-    "Cores": "цөм"
+    "Cores": "цөм",
+    "InvalidJSONFormat": "Буруу JSON формат."
   },
   "credential": {
     "Permission": "Зөвшөөрөл",
@@ -1657,7 +1658,8 @@
     "Resources": "Нөөц",
     "NumberOfReplicas": "Хуулбаруудын тоо",
     "AutoScalingRules": "Автомат масштабын дүрэм",
-    "AddRules": "Дүрмийг нэмэх"
+    "AddRules": "Дүрмийг нэмэх",
+    "RouteError": "Мар Загийн алдаа"
   },
   "modelStore": {
     "Description": "Тодорхойлолт",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{nama}} mestilah maksimum {{maks}}",
     "TotalItems": "Jumlah {{total}} item",
     "ExtendLoginSession": "Lanjutkan sesi log masuk",
-    "Cores": "teras"
+    "Cores": "teras",
+    "InvalidJSONFormat": "Format JSON yang salah."
   },
   "credential": {
     "Permission": "Kebenaran",
@@ -1641,7 +1642,8 @@
     "Resources": "Sumber",
     "NumberOfReplicas": "Bilangan replika",
     "AutoScalingRules": "Peraturan penskalaan automatik",
-    "AddRules": "Tambah peraturan"
+    "AddRules": "Tambah peraturan",
+    "RouteError": "Ralat laluan"
   },
   "totp": {
     "TotpSetupCompleted": "Didayakan 2FA",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{name}} musi być maksymalna {{max}}.",
     "TotalItems": "Łącznie {{total}} pozycji",
     "ExtendLoginSession": "Przedłużanie sesji logowania",
-    "Cores": "rdzenie"
+    "Cores": "rdzenie",
+    "InvalidJSONFormat": "Nieprawidłowy format JSON."
   },
   "credential": {
     "Permission": "Pozwolenie",
@@ -1606,7 +1607,8 @@
     "Resources": "Zasoby",
     "NumberOfReplicas": "Liczba replik",
     "AutoScalingRules": "Reguły automatycznego skalowania",
-    "AddRules": "Dodaj zasady"
+    "AddRules": "Dodaj zasady",
+    "RouteError": "Błąd trasy"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{nome}} deve ser o máximo {{max}}",
     "TotalItems": "Total de itens {{total}}",
     "ExtendLoginSession": "Prolongar uma sessão de início de sessão",
-    "Cores": "núcleos"
+    "Cores": "núcleos",
+    "InvalidJSONFormat": "Formato JSON inválido."
   },
   "credential": {
     "Permission": "Permissão",
@@ -1641,7 +1642,8 @@
     "Resources": "Recursos",
     "NumberOfReplicas": "Número de réplicas",
     "AutoScalingRules": "Regras de escala automática",
-    "AddRules": "Adicione regras"
+    "AddRules": "Adicione regras",
+    "RouteError": "Erro de rota"
   },
   "totp": {
     "TotpSetupCompleted": "Ativado 2FA",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{nome}} deve ser o máximo {{max}}",
     "TotalItems": "Total de itens {{total}}",
     "ExtendLoginSession": "Prolongar uma sessão de início de sessão",
-    "Cores": "núcleos"
+    "Cores": "núcleos",
+    "InvalidJSONFormat": "Formato JSON inválido."
   },
   "credential": {
     "Permission": "Permissão",
@@ -1641,7 +1642,8 @@
     "Resources": "Recursos",
     "NumberOfReplicas": "Número de réplicas",
     "AutoScalingRules": "Regras de escala automática",
-    "AddRules": "Adicione regras"
+    "AddRules": "Adicione regras",
+    "RouteError": "Erro de rota"
   },
   "totp": {
     "TotpSetupCompleted": "Ativado 2FA",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{name}} должен быть максимальным {{max}}",
     "TotalItems": "Всего {{total}} предметов",
     "ExtendLoginSession": "Продление сеанса входа в систему",
-    "Cores": "ядра"
+    "Cores": "ядра",
+    "InvalidJSONFormat": "Неверный формат JSON."
   },
   "credential": {
     "Permission": "Разрешение",
@@ -1658,7 +1659,8 @@
     "Resources": "Ресурсы",
     "NumberOfReplicas": "Количество реплик",
     "AutoScalingRules": "Автоматические правила",
-    "AddRules": "Добавить правила"
+    "AddRules": "Добавить правила",
+    "RouteError": "Ошибка маршрута"
   },
   "modelStore": {
     "Description": "Описание",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -526,7 +526,8 @@
     "Resources": "ทรัพยากร",
     "NumberOfReplicas": "จำนวนแบบจำลอง",
     "AutoScalingRules": "กฎการปรับขนาดอัตโนมัติ",
-    "AddRules": "เพิ่มกฎ"
+    "AddRules": "เพิ่มกฎ",
+    "RouteError": "ข้อผิดพลาดเส้นทาง"
   },
   "button": {
     "Cancel": "ยกเลิก",
@@ -661,7 +662,8 @@
     "MaxValueNotification": "{{name}} ต้องมีค่าสูงสุด {{max}}",
     "TotalItems": "รวม {{total}} รายการ",
     "ExtendLoginSession": "ขยายเซสชันการเข้าสู่ระบบ",
-    "Cores": "คอร์"
+    "Cores": "คอร์",
+    "InvalidJSONFormat": "รูปแบบ JSON ไม่ถูกต้อง"
   },
   "credential": {
     "Permission": "สิทธิ์",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -534,7 +534,8 @@
     "MaxValueNotification": "{{name}} maksimum {{max}} olmalıdır",
     "TotalItems": "Toplam {{toplam}} öğe",
     "ExtendLoginSession": "Oturum açma oturumunu uzatma",
-    "Cores": "çekirdek"
+    "Cores": "çekirdek",
+    "InvalidJSONFormat": "Geçersiz JSON biçimi."
   },
   "credential": {
     "Permission": "izin",
@@ -1605,7 +1606,8 @@
     "Resources": "Kaynaklar",
     "NumberOfReplicas": "Kopya sayısı",
     "AutoScalingRules": "Otomatik Ölçeklendirme Kuralları",
-    "AddRules": "Kurallar Ekle"
+    "AddRules": "Kurallar Ekle",
+    "RouteError": "Rota Hatası"
   },
   "storageHost": {
     "quotaSettings": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{name}} phải tối đa {{max}}",
     "TotalItems": "Tổng số {{total}} mặt hàng",
     "ExtendLoginSession": "Gia hạn phiên đăng nhập",
-    "Cores": "lõi"
+    "Cores": "lõi",
+    "InvalidJSONFormat": "Định dạng JSON không chính xác."
   },
   "credential": {
     "Permission": "Sự cho phép",
@@ -1641,7 +1642,8 @@
     "Resources": "Tài nguyên",
     "NumberOfReplicas": "Số lượng bản sao",
     "AutoScalingRules": "Quy tắc mở rộng tự động",
-    "AddRules": "Thêm quy tắc"
+    "AddRules": "Thêm quy tắc",
+    "RouteError": "Lỗi tuyến đường"
   },
   "totp": {
     "TotpSetupCompleted": "Đã bật 2FA",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -535,7 +535,8 @@
     "MaxValueNotification": "{{name}} 必须是最大值 {{max}}",
     "TotalItems": "{{总计}}项目总数",
     "ExtendLoginSession": "延长登录会话",
-    "Cores": "核心"
+    "Cores": "核心",
+    "InvalidJSONFormat": "JSON 格式无效。"
   },
   "credential": {
     "Permission": "允许",
@@ -1641,7 +1642,8 @@
     "Resources": "资源",
     "NumberOfReplicas": "副本数量",
     "AutoScalingRules": "自动缩放规则",
-    "AddRules": "添加规则"
+    "AddRules": "添加规则",
+    "RouteError": "路线错误"
   },
   "totp": {
     "TotpSetupCompleted": "已启用 2FA",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -534,7 +534,8 @@
     "MaxValueNotification": "{{name}} 必须是最大值 {{max}}",
     "TotalItems": "{{总计}}项目总数",
     "ExtendLoginSession": "延长登录会话",
-    "Cores": "核心"
+    "Cores": "核心",
+    "InvalidJSONFormat": "JSON 格式无效。"
   },
   "credential": {
     "Permission": "允許",
@@ -1640,7 +1641,8 @@
     "ServiceNameCannotStartWithHyphen": "兩端不能使用連字符 (-)。",
     "Resources": "资源",
     "AutoScalingRules": "自動縮放規則",
-    "AddRules": "添加規則"
+    "AddRules": "添加規則",
+    "RouteError": "路线错误"
   },
   "totp": {
     "TotpSetupCompleted": "已启用 2FA",


### PR DESCRIPTION
resolves #3179 (FR-532)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/5e2fa753-9c82-4372-9ab4-949115819127.png)

Improves error handling and visualization in the model service UI by:

1. Adding a new JSON viewer modal component for displaying error details

    ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/bdf791a0-56ed-46ea-aeef-1e49f8d0aa4f.png)

2. Replacing question mark icons with exclamation icons for error indicators
3. Adding error data visualization for both session and route errors
4. Adding translations for JSON format errors and route errors across all languages
