### PR TITLE
fix(FR-568): remove whitespace and update CoolDown text in autoscaling UI

### DIFF
--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -787,7 +787,6 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
                   </Flex>
                 ),
               },
-
               {
                 title: t('autoScalingRule.StepSize'),
                 dataIndex: 'step_size',

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1779,7 +1779,7 @@
     "MetricSource": "Metric Source",
     "MetricName": "Metric Name",
     "Comparator": "Comparator",
-    "CoolDownSeconds": "Cool Down Seconds",
+    "CoolDownSeconds": "CoolDown Seconds",
     "MinReplicas": "Min Replicas",
     "MaxReplicas": "Max Replicas",
     "Threshold": "Threshold",


### PR DESCRIPTION
resolves #1234 (FR-568)

Update "Cool Down Seconds" translation to "CoolDown Seconds" to align with standard industry terminology.

**Checklist:**
- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after