### PR TITLE
fix(FR-547): fix calculate logic for agent list memory usage progress percent

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -507,7 +507,7 @@ const AgentList: React.FC<AgentListProps> = ({
                   {mergedResourceSlots?.mem?.human_readable_name}
                 </Typography.Text>
                 <BAIProgressWithLabel
-                  percent={liveStat.mem_util.ratio}
+                  percent={liveStat.mem_util.ratio * 100}
                   width={120}
                   valueLabel={
                     convertBinarySizeUnit(


### PR DESCRIPTION
resolves #3196 (FR-547)

Fixed memory utilization display in agent list by multiplying the ratio by 100 to show correct percentage values in the progress bar.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after