### PR TITLE
feat(FR-561): add percentage suffix for kernel metric threshold

### DIFF
--- a/react/src/components/AutoScalingRuleEditorModal.tsx
+++ b/react/src/components/AutoScalingRuleEditorModal.tsx
@@ -384,7 +384,12 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
                   rules={[{ required: true }]}
                   noStyle
                 >
-                  <Input placeholder={t('autoScalingRule.Threshold')} />
+                  <Input
+                    suffix={
+                      getFieldValue('metric_source') === 'KERNEL' ? '%' : ''
+                    }
+                    placeholder={t('autoScalingRule.Threshold')}
+                  />
                 </Form.Item>
               </Space.Compact>
             );

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -665,6 +665,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
                       '-'
                     )}
                     {row?.threshold}
+                    {row?.metric_source === 'KERNEL' ? '%' : ''}
                   </Flex>
                 ),
               },


### PR DESCRIPTION
resolves #3204 (FR-561)

Added percentage symbol (%) display for kernel-based auto-scaling rule thresholds in both the rule editor modal and endpoint detail page. This provides clearer indication when threshold values represent percentages for kernel metrics.

In Form
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/9b3e18b7-147f-4329-98dd-d26eed455b70.png)

In List
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/367f7419-a650-4792-943d-9f3e339dfddc.png)

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after