### PR TITLE
feature(FR-569): add Rebellions image metadata

### DIFF
--- a/resources/image_metadata.json
+++ b/resources/image_metadata.json
@@ -1,5 +1,36 @@
 {
   "imageInfo": {
+	  "rbln-ubuntu": {
+      "name": "Rebellions Ubuntu",
+      "description": "Rebellions Ubuntu is a basic image for Rebellions NPU.",
+      "group": "NPU",
+      "tags": [],
+      "icon": "rebel.svg",
+      "label": [
+        {
+          "tag": "Rebellions NPU",
+          "color": "gray"
+        }
+      ]
+    },
+    "rbln-triton": {
+      "name": "Rebellions Triton Server",
+      "description": "Triton Inference Server for Rebellions NPU, high-performance server that simplifies the deployment of AI models for inference in production environments.",
+      "group": "NPU",
+      "tags": [],
+      "icon": "rebel.svg",
+      "label": [
+        {
+          "category": "Env",
+          "tag": "Triton",
+          "color": "blue"
+        },
+        {
+          "tag": "Rebellions NPU",
+          "color": "gray"
+        }
+      ]
+    },
     "python": {
       "name": "Python",
       "description": "Python is a programming language that lets you work quickly and integrate systems more effectively.",


### PR DESCRIPTION
resolves #3213 (FR-569)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/05d9b13d-85c3-454f-8757-1bc309087037.png)

Added Rebellions NPU support by introducing two new image templates:
- `rbln-ubuntu`: Basic Ubuntu-based image for Rebellions NPU
- `rbln-triton`: Triton Inference Server image optimized for Rebellions NPU deployment