### PR TITLE
feat(FR-860): Introduce ImageNodeSimpleView to Endpoint detail page

### DIFF
--- a/react/src/components/ImageMetaIcon.tsx
+++ b/react/src/components/ImageMetaIcon.tsx
@@ -13,6 +13,7 @@ const ImageMetaIcon: React.FC<{
       style={{
         width: '1em',
         height: '1em',
+        verticalAlign: 'middle',
         ...style,
       }}
       alt={alt}

--- a/react/src/components/ImageNodeSimpleTag.tsx
+++ b/react/src/components/ImageNodeSimpleTag.tsx
@@ -1,0 +1,103 @@
+import { preserveDotStartCase } from '../helper';
+import { useBackendAIImageMetaData } from '../hooks';
+import DoubleTag from './DoubleTag';
+import ImageMetaIcon from './ImageMetaIcon';
+import { ImageNodeSimpleTagFragment$key } from './__generated__/ImageNodeSimpleTagFragment.graphql';
+import { Divider, Tag, Typography, theme } from 'antd';
+import graphql from 'babel-plugin-relay/macro';
+import _ from 'lodash';
+import React from 'react';
+import { useFragment } from 'react-relay';
+
+interface ImageNodeSimpleTagProps {
+  imageFrgmt: ImageNodeSimpleTagFragment$key | null;
+  copyable?: boolean;
+}
+
+const ImageNodeSimpleTag: React.FC<ImageNodeSimpleTagProps> = ({
+  imageFrgmt,
+  copyable = true,
+}) => {
+  const [, { tagAlias }] = useBackendAIImageMetaData();
+
+  const { token } = theme.useToken();
+  const image = useFragment(
+    graphql`
+      fragment ImageNodeSimpleTagFragment on ImageNode {
+        base_image_name @required(action: NONE)
+        version
+        architecture
+        tags {
+          key
+          value
+        }
+        labels {
+          key @required(action: NONE)
+          value
+        }
+        registry
+        namespace
+        tag
+      }
+    `,
+    imageFrgmt,
+  );
+
+  if (!image) return null;
+
+  const fullName = `${image.registry}/${image.namespace}:${image.tag}@${image.architecture}`;
+  return (
+    <>
+      <ImageMetaIcon
+        image={fullName}
+        style={{
+          marginRight: token.marginXS,
+        }}
+      />
+      <Typography.Text>{tagAlias(image?.base_image_name)}</Typography.Text>
+      <Divider type="vertical" />
+      <Typography.Text>{image?.version}</Typography.Text>
+      <Divider type="vertical" />
+      <Typography.Text>{image?.architecture}</Typography.Text>
+      <Divider type="vertical" />
+      {_.map(image?.tags, (tag) => {
+        const isCustomized = tag?.key && _.includes(tag.key, 'customized_');
+        const tagValue =
+          (isCustomized
+            ? _.find(image?.labels, {
+                key: 'ai.backend.customized-image.name',
+              })?.value
+            : tag?.value) || '';
+        const aliasedTag = tag?.key ? tagAlias(tag.key + tagValue) : undefined;
+        return tag?.key &&
+          _.isEqual(aliasedTag, preserveDotStartCase(tag.key + tagValue)) ? (
+          <DoubleTag
+            key={tag.key}
+            values={[
+              {
+                label: tagAlias(tag.key),
+                color: isCustomized ? 'cyan' : 'blue',
+              },
+              {
+                label: tagValue,
+                color: isCustomized ? 'cyan' : 'blue',
+              },
+            ]}
+          />
+        ) : (
+          <Tag color={isCustomized ? 'cyan' : 'blue'}>{aliasedTag}</Tag>
+        );
+      })}
+      {copyable && (
+        <Typography.Text
+          style={{ color: token.colorLink }}
+          copyable={{
+            text: fullName,
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export default ImageNodeSimpleTag;

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -2,14 +2,13 @@ import AutoScalingRuleEditorModal, {
   COMPARATOR_LABELS,
 } from '../components/AutoScalingRuleEditorModal';
 import BAIJSONViewerModal from '../components/BAIJSONViewerModal';
-import CopyableCodeText from '../components/CopyableCodeText';
 import { isEndpointInDestroyingCategory } from '../components/EndpointList';
 import EndpointOwnerInfo from '../components/EndpointOwnerInfo';
 import EndpointStatusTag from '../components/EndpointStatusTag';
 import EndpointTokenGenerationModal from '../components/EndpointTokenGenerationModal';
 import Flex from '../components/Flex';
 import { useFolderExplorerOpener } from '../components/FolderExplorerOpener';
-import ImageMetaIcon from '../components/ImageMetaIcon';
+import ImageNodeSimpleTag from '../components/ImageNodeSimpleTag';
 import InferenceSessionErrorModal from '../components/InferenceSessionErrorModal';
 import ResourceNumber from '../components/ResourceNumber';
 import SessionDetailDrawer from '../components/SessionDetailDrawer';
@@ -155,7 +154,6 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
             name
             status
             endpoint_id
-            image @deprecatedSince(version: "23.09.9")
             image_object @since(version: "23.09.9") {
               name
               namespace @since(version: "24.12.0")
@@ -176,6 +174,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               }
               size_bytes
               supported_accelerators
+              ...ImageNodeSimpleTagFragment
             }
             desired_session_count @deprecatedSince(version: "24.12.0")
             replicas @since(version: "24.12.0")
@@ -344,11 +343,6 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
     return edge?.node;
   });
 
-  const fullImageString =
-    baiClient.supports('modify-endpoint') && endpoint?.image_object
-      ? `${endpoint.image_object.registry}/${endpoint.image_object.namespace ?? endpoint.image_object.name}:${endpoint.image_object.tag}@${endpoint.image_object.architecture}`
-      : endpoint?.image;
-
   const resource_opts = JSON.parse(endpoint?.resource_opts || '{}');
 
   const items: DescriptionsItemType[] = [
@@ -490,17 +484,9 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
 
   items.push({
     label: t('modelService.Image'),
-    children: (baiClient.supports('modify-endpoint')
-      ? endpoint?.image_object
-      : endpoint?.image) && (
-      <Flex direction="row" gap={'xs'}>
-        <ImageMetaIcon image={fullImageString || null} />
-        <CopyableCodeText>{fullImageString}</CopyableCodeText>
-        {endpoint?.runtime_variant?.human_readable_name ? (
-          <Tag>{endpoint?.runtime_variant?.human_readable_name}</Tag>
-        ) : null}
-      </Flex>
-    ),
+    children: endpoint?.image_object ? (
+      <ImageNodeSimpleTag imageFrgmt={endpoint.image_object} />
+    ) : null,
     span: {
       xl: 3,
     },


### PR DESCRIPTION
Resolves #3526 (FR-860)

# Add ImageNodeSimpleView component for better image display

This PR introduces a new `ImageNodeSimpleView` component that provides a standardized way to display image information with proper formatting and styling. The component:

- Shows image metadata including base name, version, architecture, and tags
- Supports customized image tags with different styling
- Includes a copy button for the full image name
- Uses the existing `ImageMetaIcon` component with improved vertical alignment

The component is implemented in the `EndpointDetailPage` to replace the previous image display logic, providing a more consistent and feature-rich presentation of image information.
