### PR TITLE
fix(FR-578): fix resource panel i18n key error.

### DIFF
--- a/src/components/backend-ai-resource-panel.ts
+++ b/src/components/backend-ai-resource-panel.ts
@@ -789,7 +789,7 @@ export default class BackendAIResourcePanel extends BackendAIPage {
                                           this.cuda_fgpu_total,
                                           2,
                                         )} CUDA FGPUs ${_t(
-                                          'summary.reserved',
+                                          'summary.Reserved',
                                         )}."
                                       ></lablup-progress-bar>
                                       <lablup-progress-bar


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai-webui/issues/3220 (FR-578)

Fix the mismatch key in the CUDA FGPU progress bar.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after