### PR TITLE
refactor(FR-593): Endpoint list loading state management

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,4 +1,5 @@
 import AnnouncementAlert from './components/AnnouncementAlert';
+import BAICard from './components/BAICard';
 import BAIErrorBoundary, { ErrorView } from './components/BAIErrorBoundary';
 import {
   DefaultProvidersForReactRoot,
@@ -15,6 +16,7 @@ import VFolderListPage from './pages/VFolderListPage';
 import { Skeleton, theme } from 'antd';
 import React, { Suspense } from 'react';
 import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   IndexRouteObject,
   RouterProvider,
@@ -176,14 +178,13 @@ const router = createBrowserRouter([
               const [experimentalNeoSessionList] = useBAISettingUserState(
                 'experimental_neo_session_list',
               );
+              const { t } = useTranslation();
 
               return experimentalNeoSessionList ? (
                 <BAIErrorBoundary>
                   <Suspense
                     fallback={
-                      <Flex direction="column" style={{ maxWidth: 700 }}>
-                        <Skeleton active />
-                      </Flex>
+                      <BAICard title={t('webui.menu.Sessions')} loading />
                     }
                   >
                     <ComputeSessionListPage />
@@ -231,11 +232,20 @@ const router = createBrowserRouter([
         children: [
           {
             path: '',
-            element: (
-              <BAIErrorBoundary>
-                <ServingPage />
-              </BAIErrorBoundary>
-            ),
+            Component: () => {
+              const { t } = useTranslation();
+              return (
+                <BAIErrorBoundary>
+                  <Suspense
+                    fallback={
+                      <BAICard title={t('webui.menu.Serving')} loading />
+                    }
+                  >
+                    <ServingPage />
+                  </Suspense>
+                </BAIErrorBoundary>
+              );
+            },
           },
           {
             path: '/serving/:serviceId',

--- a/react/src/components/EndpointList.tsx
+++ b/react/src/components/EndpointList.tsx
@@ -2,60 +2,52 @@ import {
   baiSignedRequestWithPromise,
   filterEmptyItem,
   filterNonNullItems,
-  transformSorterToOrderString,
 } from '../helper';
-import {
-  useSuspendedBackendaiClient,
-  useUpdatableState,
-  useWebUINavigate,
-} from '../hooks';
-import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
-import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
-// import { getSortOrderByName } from '../hooks/reactPaginationQueryOptions';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
-import { useCurrentProjectValue } from '../hooks/useCurrentProject';
-import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
-import BAIPropertyFilter from './BAIPropertyFilter';
-import BAIRadioGroup from './BAIRadioGroup';
 import BAITable from './BAITable';
 import EndpointOwnerInfo from './EndpointOwnerInfo';
 import EndpointStatusTag from './EndpointStatusTag';
 import Flex from './Flex';
-import TableColumnsSettingModal from './TableColumnsSettingModal';
 import {
-  EndpointListQuery,
-  EndpointListQuery$data,
-} from './__generated__/EndpointListQuery.graphql';
+  EndpointListFragment$data,
+  EndpointListFragment$key,
+} from './__generated__/EndpointListFragment.graphql';
 import {
   CheckOutlined,
   CloseOutlined,
   DeleteOutlined,
-  ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
-import { useRafInterval, useToggle } from 'ahooks';
-import { Button, Typography, theme, App, Tooltip } from 'antd';
+import {
+  Button,
+  Typography,
+  theme,
+  App,
+  TablePaginationConfig,
+  Tooltip,
+  TableProps,
+} from 'antd';
 import { ColumnType } from 'antd/lib/table';
 import graphql from 'babel-plugin-relay/macro';
-import { default as dayjs } from 'dayjs';
+import dayjs from 'dayjs';
 import _ from 'lodash';
 import { InfoIcon } from 'lucide-react';
-import React, {
-  PropsWithChildren,
-  useState,
-  useTransition,
-  startTransition as startTransitionWithoutPendingState,
-} from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLazyLoadQuery } from 'react-relay';
+import { useFragment } from 'react-relay';
 import { Link } from 'react-router-dom';
-import { StringParam, useQueryParam } from 'use-query-params';
 
-export type Endpoint = NonNullable<
-  NonNullable<
-    NonNullable<NonNullable<EndpointListQuery$data>['endpoint_list']>['items']
-  >[0]
->;
+type Endpoint = EndpointListFragment$data[number];
+
+interface EndpointListProps
+  extends Omit<TableProps<Endpoint>, 'dataSource' | 'columns'> {
+  endpointsFrgmt: EndpointListFragment$key;
+  loading?: boolean;
+  pagination: TablePaginationConfig;
+  onDeleted?: (endpoint: Endpoint) => void;
+}
 
 export const isEndpointInDestroyingCategory = (
   endpoint?: {
@@ -71,49 +63,58 @@ export const isEndpointInDestroyingCategory = (
   );
 };
 
-type LifecycleStage = 'created&destroying' | 'destroyed';
-
-interface EndpointListProps extends PropsWithChildren {
-  style?: React.CSSProperties;
-}
-const EndpointList: React.FC<EndpointListProps> = ({ style, children }) => {
+const EndpointList: React.FC<EndpointListProps> = ({
+  endpointsFrgmt,
+  loading,
+  pagination,
+  // onPaginationChange,
+  // onOrderChange,
+  onDeleted,
+  ...tableProps
+}) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message, modal } = App.useApp();
-  const [visibleColumnSettingModal, { toggle: toggleColumnSettingModal }] =
-    useToggle();
-  const [selectedLifecycleStage, setSelectedLifecycleStage] =
-    useState<LifecycleStage>('created&destroying');
-
-  const {
-    baiPaginationOption,
-    tablePaginationOption,
-    setTablePaginationOption,
-  } = useBAIPaginationOptionState({
-    current: 1,
-    pageSize: 10,
-  });
-  const lifecycleStageFilter =
-    selectedLifecycleStage === 'created&destroying'
-      ? `lifecycle_stage == "created" | lifecycle_stage == "destroying"`
-      : `lifecycle_stage == "${selectedLifecycleStage}"`;
-
-  const [isRefetchPending, startRefetchTransition] = useTransition();
-  const [isFilterPending, startFilterTransition] = useTransition();
-  const [isPendingPageChange, startPageChangeTransition] = useTransition();
-  const [servicesFetchKey, updateServicesFetchKey] =
-    useUpdatableState('initial-fetch');
-  const [optimisticDeletingId, setOptimisticDeletingId] = useState<
-    string | null
-  >();
-
-  const [filterStr, setFilterStr] = useQueryParam('filter', StringParam);
-  const [order, setOrder] = useState<string>();
   const [currentUser] = useCurrentUserInfo();
-  const currentUserRole = useCurrentUserRole();
-  const curProject = useCurrentProjectValue();
   const baiClient = useSuspendedBackendaiClient();
+  const [optimisticDeletingId, setOptimisticDeletingId] = useState<string>();
   const webuiNavigate = useWebUINavigate();
+
+  const endpoints = useFragment(
+    graphql`
+      fragment EndpointListFragment on Endpoint @relay(plural: true) {
+        name
+        endpoint_id
+        status
+        url
+        open_to_public
+        created_at
+        replicas
+        desired_session_count
+        routings {
+          status
+        }
+        created_user_email
+        ...EndpointOwnerInfoFragment
+        ...EndpointStatusTagFragment
+      }
+    `,
+    endpointsFrgmt,
+  );
+
+  const terminateModelServiceMutation = useTanMutation<
+    { success?: boolean },
+    unknown,
+    string
+  >({
+    mutationFn: (endpoint_id) => {
+      return baiSignedRequestWithPromise({
+        method: 'DELETE',
+        url: '/services/' + endpoint_id,
+        client: baiClient,
+      });
+    },
+  });
 
   const columns = filterEmptyItem<ColumnType<Endpoint>>([
     {
@@ -207,14 +208,12 @@ const EndpointList: React.FC<EndpointListProps> = ({ style, children }) => {
                   type: 'primary',
                 },
                 onOk: () => {
-                  setOptimisticDeletingId(row?.endpoint_id);
+                  setOptimisticDeletingId(row?.endpoint_id || undefined);
                   // FIXME: any better idea for handling result?
                   row.endpoint_id &&
                     terminateModelServiceMutation.mutate(row?.endpoint_id, {
                       onSuccess: (res) => {
-                        startRefetchTransition(() => {
-                          updateServicesFetchKey();
-                        });
+                        onDeleted?.(row);
                         // FIXME: temporally refer to mutate input to message
                         if (res.success) {
                           message.success(
@@ -315,276 +314,20 @@ const EndpointList: React.FC<EndpointListProps> = ({ style, children }) => {
         ),
     },
   ]);
-  const [hiddenColumnKeys, setHiddenColumnKeys] =
-    useHiddenColumnKeysSetting('EndpointListPage');
-
-  useRafInterval(() => {
-    startTransitionWithoutPendingState(() => {
-      updateServicesFetchKey();
-    });
-  }, 7000);
-
-  const { endpoint_list: modelServiceList } =
-    useLazyLoadQuery<EndpointListQuery>(
-      graphql`
-        query EndpointListQuery(
-          $offset: Int!
-          $limit: Int!
-          $projectID: UUID
-          $filter: String
-          $order: String
-        ) {
-          endpoint_list(
-            offset: $offset
-            limit: $limit
-            project: $projectID
-            filter: $filter
-            order: $order
-          ) {
-            total_count
-            items {
-              name
-              endpoint_id
-              model
-              domain
-              status
-              project
-              resource_group
-              resource_slots
-              url
-              open_to_public
-              created_at @since(version: "23.09.0")
-              desired_session_count @deprecatedSince(version: "24.12.0")
-              replicas @since(version: "24.12.0")
-              routings {
-                routing_id
-                endpoint
-                session
-                traffic_ratio
-                status
-              }
-              runtime_variant @since(version: "24.03.5") {
-                name
-                human_readable_name
-              }
-              created_user_email @since(version: "23.09.8")
-              ...EndpointOwnerInfoFragment
-              ...EndpointStatusTagFragment
-            }
-          }
-        }
-      `,
-      {
-        offset: baiPaginationOption.offset,
-        limit: baiPaginationOption.limit,
-        projectID: curProject.id,
-        filter: baiClient.supports('endpoint-lifecycle-stage-filter')
-          ? [lifecycleStageFilter, filterStr]
-              .filter(Boolean)
-              .map((v) => `(${v})`)
-              .join(' & ')
-          : undefined,
-        order,
-      },
-      {
-        fetchPolicy: 'network-only',
-        fetchKey: servicesFetchKey,
-      },
-    );
-
-  // FIXME: struggling with sending data when active tab changes!
-  // const runningModelServiceList = modelServiceList?.filter(
-  //   (item: any) => item.desired_session_count >= 0
-  // );
-
-  // const terminatedModelServiceList = modelServiceList?.filter(
-  //   (item: any) => item.desired_session_count < 0
-  // );
-
-  const terminateModelServiceMutation = useTanMutation<
-    {
-      success?: boolean;
-    },
-    unknown,
-    string
-  >({
-    mutationFn: (endpoint_id) => {
-      return baiSignedRequestWithPromise({
-        method: 'DELETE',
-        url: '/services/' + endpoint_id,
-        client: baiClient,
-      });
-    },
-  });
 
   return (
-    <Flex direction="column" align="stretch" style={style} gap={'sm'}>
-      <Flex
-        direction="row"
-        justify="between"
-        align="start"
-        wrap="wrap"
-        gap={'xs'}
-      >
-        <Flex
-          direction="row"
-          gap={'sm'}
-          align="start"
-          wrap="wrap"
-          style={{ flexShrink: 1 }}
-        >
-          {baiClient.supports('endpoint-lifecycle-stage-filter') && (
-            <>
-              <BAIRadioGroup
-                value={selectedLifecycleStage}
-                onChange={(e) => {
-                  startPageChangeTransition(() => {
-                    setSelectedLifecycleStage(e.target?.value);
-                    setTablePaginationOption({
-                      current: 1,
-                      pageSize: 10,
-                    });
-                  });
-                }}
-                optionType="button"
-                buttonStyle="solid"
-                options={[
-                  {
-                    label: 'Active',
-                    value: 'created&destroying',
-                  },
-                  {
-                    label: 'Destroyed',
-                    value: 'destroyed',
-                  },
-                ]}
-              />
-              <BAIPropertyFilter
-                value={filterStr || undefined}
-                onChange={(v) => {
-                  startFilterTransition(() => {
-                    setFilterStr(v, 'replaceIn');
-                  });
-                }}
-                loading={isFilterPending}
-                filterProperties={filterEmptyItem([
-                  // https://github.com/lablup/backend.ai/blob/main/src/ai/backend/manager/models/endpoint.py#L766-L773
-                  {
-                    key: 'name',
-                    type: 'string',
-                    propertyLabel: t('modelService.EndpointName'),
-                  },
-                  {
-                    key: 'url',
-                    type: 'string',
-                    propertyLabel: t('modelService.ServiceEndpoint'),
-                  },
-                  currentUserRole === 'admin' ||
-                  currentUserRole === 'superadmin'
-                    ? {
-                        key: 'created_user_email',
-                        type: 'string',
-                        propertyLabel: t('modelService.Owner'),
-                      }
-                    : undefined,
-                  // not supported yet
-                  // {
-                  //   key: 'open_to_public',
-                  //   propertyLabel: t('modelService.Public'),
-                  //   type: 'boolean',
-                  //   options: [
-                  //     {
-                  //       value: 'true',
-                  //     },
-                  //     {
-                  //       value:'false'
-                  //     }
-                  //   ]
-                  // }
-                ])}
-              />
-            </>
-          )}
-        </Flex>
-        <Flex direction="row" gap={'xs'}>
-          <Flex gap={'xs'}>
-            <Button
-              icon={<ReloadOutlined />}
-              loading={isRefetchPending}
-              onClick={() => {
-                startRefetchTransition(() => updateServicesFetchKey());
-              }}
-            />
-            <Button
-              type="primary"
-              onClick={() => {
-                webuiNavigate('/service/start');
-              }}
-            >
-              {t('modelService.StartService')}
-            </Button>
-          </Flex>
-        </Flex>
-      </Flex>
-      <Flex direction="column" align="stretch">
-        <BAITable
-          neoStyle
-          size="small"
-          loading={isFilterPending || isPendingPageChange}
-          scroll={{ x: 'max-content' }}
-          rowKey={'endpoint_id'}
-          dataSource={filterNonNullItems(modelServiceList?.items)}
-          columns={_.filter(
-            columns,
-            (column) => !_.includes(hiddenColumnKeys, _.toString(column?.key)),
-          )}
-          sortDirections={['descend', 'ascend', 'descend']}
-          pagination={{
-            pageSize: tablePaginationOption.pageSize,
-            current: tablePaginationOption.current,
-            pageSizeOptions: ['10', '20', '50'],
-            total: modelServiceList?.total_count || 0,
-            showSizeChanger: true,
-            style: { marginRight: token.marginXS },
-          }}
-          onChange={({ pageSize, current }, filter, sorter) => {
-            startPageChangeTransition(() => {
-              if (_.isNumber(current) && _.isNumber(pageSize)) {
-                setTablePaginationOption({
-                  current,
-                  pageSize,
-                });
-              }
-              setOrder(transformSorterToOrderString(sorter));
-            });
-          }}
-        />
-        <Flex justify="end">
-          <Button
-            type="text"
-            icon={<SettingOutlined />}
-            onClick={() => {
-              toggleColumnSettingModal();
-            }}
-          />
-        </Flex>
-        <TableColumnsSettingModal
-          open={visibleColumnSettingModal}
-          onRequestClose={(values) => {
-            values?.selectedColumnKeys &&
-              setHiddenColumnKeys(
-                _.difference(
-                  columns.map((column) => _.toString(column.key)),
-                  values?.selectedColumnKeys,
-                ),
-              );
-            toggleColumnSettingModal();
-          }}
-          columns={columns}
-          hiddenColumnKeys={hiddenColumnKeys}
-        />
-      </Flex>
-    </Flex>
+    <BAITable
+      neoStyle
+      size="small"
+      loading={loading}
+      scroll={{ x: 'max-content' }}
+      rowKey={'endpoint_id'}
+      dataSource={filterNonNullItems(endpoints)}
+      columns={columns}
+      sortDirections={['descend', 'ascend', 'descend']}
+      pagination={pagination}
+      {...tableProps}
+    />
   );
 };
 

--- a/react/src/hooks/reactPaginationQueryOptions.tsx
+++ b/react/src/hooks/reactPaginationQueryOptions.tsx
@@ -2,7 +2,7 @@
 import { LazyLoadQueryOptions } from '../helper/types';
 import { SorterResult } from 'antd/lib/table/interface';
 import _ from 'lodash';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   fetchQuery,
   GraphQLTaggedNode,
@@ -293,35 +293,45 @@ interface AntdBasicPaginationOption {
 interface InitialPaginationOption
   extends AntdBasicPaginationOption,
     Omit<BAIPaginationOption, 'limit' | 'offset'> {}
-export const useBAIPaginationOptionState = (
-  initialOptions: InitialPaginationOption,
-): {
+
+interface BAIPaginationOptionState {
   baiPaginationOption: BAIPaginationOption;
   tablePaginationOption: AntdBasicPaginationOption;
   setTablePaginationOption: (
     pagination: Partial<AntdBasicPaginationOption>,
   ) => void;
-} => {
+}
+export const useBAIPaginationOptionState = (
+  initialOptions: InitialPaginationOption,
+): BAIPaginationOptionState => {
   const [options, setOptions] =
     useState<AntdBasicPaginationOption>(initialOptions);
-  return {
-    baiPaginationOption: {
-      limit: options.pageSize,
-      first: options.pageSize,
-      offset:
-        options.current > 1 ? (options.current - 1) * options.pageSize : 0,
-    },
-    tablePaginationOption: {
-      pageSize: options.pageSize,
-      current: options.current,
-    },
-    setTablePaginationOption: (pagination) => {
-      if (!_.isEqual(pagination, options)) {
-        setOptions((current) => ({
-          ...current,
-          ...pagination,
-        }));
-      }
-    },
-  };
+
+  const { pageSize, current } = options;
+  return useMemo<BAIPaginationOptionState>(() => {
+    return {
+      baiPaginationOption: {
+        limit: pageSize,
+        first: pageSize,
+        offset: current > 1 ? (current - 1) * pageSize : 0,
+      },
+      tablePaginationOption: {
+        pageSize: pageSize,
+        current: current,
+      },
+      setTablePaginationOption: (pagination) => {
+        if (
+          !_.isEqual(pagination, {
+            pageSize,
+            current,
+          })
+        ) {
+          setOptions((current) => ({
+            ...current,
+            ...pagination,
+          }));
+        }
+      },
+    };
+  }, [pageSize, current]);
 };

--- a/react/src/hooks/useDeferredQueryParams.tsx
+++ b/react/src/hooks/useDeferredQueryParams.tsx
@@ -1,6 +1,7 @@
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { atomWithDefault } from 'jotai/utils';
 import _ from 'lodash';
+import { useRef } from 'react';
 import { useCallback, useMemo } from 'react';
 import {
   useQueryParams,
@@ -9,29 +10,54 @@ import {
   UrlUpdateType,
 } from 'use-query-params';
 
-// Create a global atom to store query params
 const queryParamsAtom = atom<Record<string, any>>({});
 
+/**
+ * A custom hook that synchronizes URL search parameters with application state while handling React transitions.
+ * This hook solves the issue where URL parameter changes within React transitions are not properly reflected
+ * in the rendering cycle, as search parameter changes are detected through events rather than React's state system.
+ *
+ * @template QPCMap - Type extending QueryParamConfigMap that defines the structure of URL parameters
+ * @param {QPCMap} paramConfigMap - Configuration object that defines the URL parameters to be managed
+ *
+ * @returns {[
+ *   DecodedValueMap<QPCMap>,
+ *   (nextQuery: Partial<DecodedValueMap<QPCMap>> | ((prevQuery: DecodedValueMap<QPCMap>) => Partial<DecodedValueMap<QPCMap>>),
+ *    updateType: UrlUpdateType) => void,
+ *   boolean
+ * ]} A tuple containing:
+ *   - localQuery: The current state of the URL parameters
+ *   - setDeferredQuery: Function to update URL parameters with transition support
+ *   - isPending: Boolean indicating if a transition is in progress
+ *
+ * @example
+ * const [query, setQuery, isPending] = useDeferredQueryParams({
+ *   page: NumberParam,
+ *   search: StringParam
+ * });
+ *
+ * // Update URL parameters
+ * setQuery({ page: 2 }, 'pushIn');
+ */
 export function useDeferredQueryParams<QPCMap extends QueryParamConfigMap>(
   paramConfigMap: QPCMap,
 ) {
   const [query, setQuery] = useQueryParams(paramConfigMap);
 
+  const isBeforeInitializingRef = useRef(true);
   const selectiveQueryAtom = useMemo(
-    () =>
-      atomWithDefault((get) => {
+    () => {
+      return atomWithDefault((get) => {
         const globalParams = get(queryParamsAtom);
         const selectedParams = _.pick(
-          globalParams,
+          // Use query parameters from URL on initial render
+          isBeforeInitializingRef.current ? query : globalParams,
           Object.keys(paramConfigMap),
         );
-        if (_.isEmpty(selectedParams)) {
-          // If the global state is empty, return the query
-          return query;
-        }
-        // Use the value from the global state if it exists
+        isBeforeInitializingRef.current = false;
         return selectedParams as DecodedValueMap<QPCMap>;
-      }),
+      });
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [JSON.stringify(paramConfigMap)],
   );
@@ -57,8 +83,15 @@ export function useDeferredQueryParams<QPCMap extends QueryParamConfigMap>(
       } else {
         setLocalQuery(newQuery as DecodedValueMap<QPCMap>);
       }
-      // Update URL params
-      setQuery(newQuery, updateType);
+
+      // Sync all(merged) query parameters with URL
+      setQuery(
+        {
+          ...localQuery,
+          ...newQuery,
+        },
+        updateType,
+      );
     },
     [localQuery, setQuery, setLocalQuery],
   );

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -1,9 +1,11 @@
-import BAIFetchKeyButton from '../components/BAIFetchKeyButton';
 import BAICard from '../components/BAICard';
+import BAIFetchKeyButton from '../components/BAIFetchKeyButton';
 import BAILink from '../components/BAILink';
 import BAIPropertyFilter, {
   mergeFilterValues,
 } from '../components/BAIPropertyFilter';
+import BAIRadioGroup from '../components/BAIRadioGroup';
+import BAITabs from '../components/BAITabs';
 import TerminateSessionModal from '../components/ComputeSessionNodeItems/TerminateSessionModal';
 import Flex from '../components/Flex';
 import SessionNodes from '../components/SessionNodes';
@@ -29,8 +31,6 @@ import { useDeferredValue, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyLoadQuery } from 'react-relay';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
-import BAITabs from '../components/BAITabs';
-import BAIRadioGroup from '../components/BAIRadioGroup';
 
 type TypeFilterType = 'all' | 'interactive' | 'batch' | 'inference' | 'system';
 type SessionNode = NonNullableNodeOnEdges<
@@ -84,7 +84,7 @@ const ComputeSessionListPage = () => {
     return status === 'TERMINATED' || status === 'CANCELLED';
   };
 
-  const [fetchKey, updateFetchKey] = useUpdatableState('first');
+  const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
 
   const queryVariables: ComputeSessionListPageQuery$variables = useMemo(
     () => ({
@@ -178,8 +178,15 @@ const ComputeSessionListPage = () => {
       `,
       deferredQueryVariables,
       {
-        fetchPolicy: 'network-only',
-        fetchKey: deferredFetchKey,
+        // fetchPolicy: 'network-only',
+        // fetchKey: deferredFetchKey,
+
+        fetchPolicy:
+          deferredFetchKey === 'initial-fetch'
+            ? 'store-and-network'
+            : 'network-only',
+        fetchKey:
+          deferredFetchKey === 'initial-fetch' ? undefined : deferredFetchKey,
       },
     );
 


### PR DESCRIPTION
resolves #3250 (FR-593)

Refactors the Serving page and Endpoint list components to improve performance and maintainability:

- Extracts endpoint list into a reusable component with Relay fragment
- Adds loading states and suspense boundaries with skeleton placeholders
- Implements deferred query params to prevent UI jank during filtering/pagination
- Optimizes pagination state management with memoization
- Adds proper type safety for endpoint data structures
- Improves filter and lifecycle stage handling
- Implements proper loading states during data fetches

**How to test:**
  - Navigate to Serving page
  - Test filtering, pagination, and lifecycle stage toggles
  - Verify loading states and transitions
  - Filter endpoints by name/url/owner
  - Toggle between Active/Destroyed views
  - Paginate through results
  - Delete endpoints and verify list updates