### PR TITLE
feat(FR-513): NEO quota per storage volume card

### DIFF
--- a/react/src/components/BAIProgress.tsx
+++ b/react/src/components/BAIProgress.tsx
@@ -1,0 +1,125 @@
+import Flex from './Flex';
+import { ProgressProps, theme, Typography } from 'antd';
+import _ from 'lodash';
+import React, { ReactNode } from 'react';
+
+interface BAIProgressProps extends ProgressProps {
+  title?: ReactNode;
+  used?: number | string;
+  total?: number | string;
+  progressStyle?: React.CSSProperties;
+}
+
+const BAIProgress: React.FC<BAIProgressProps> = ({
+  title,
+  used,
+  total,
+  progressStyle,
+  ...baiProgressProps
+}) => {
+  const { token } = theme.useToken();
+
+  return (
+    <Flex direction="column" align="stretch" gap={'xs'}>
+      <Flex align="stretch" justify={title ? 'between' : 'end'}>
+        <Typography.Text style={{ alignContent: 'end' }}>
+          {title}
+        </Typography.Text>
+        <Typography.Text
+          style={{
+            fontSize: token.fontSizeHeading3,
+            color: _.isString(baiProgressProps.strokeColor)
+              ? baiProgressProps.strokeColor
+              : token.Layout?.headerBg,
+            alignContent: 'end',
+          }}
+        >
+          {baiProgressProps.percent ?? 0}%
+        </Typography.Text>
+      </Flex>
+      <Flex
+        style={{
+          padding: 1,
+          backgroundColor: token.colorFillSecondary,
+          height: _.isNumber(baiProgressProps.size)
+            ? baiProgressProps.size
+            : token.size,
+          ...progressStyle,
+        }}
+        direction="column"
+        align="stretch"
+      >
+        <Flex
+          style={{
+            height: _.isNumber(baiProgressProps.size)
+              ? baiProgressProps.size
+              : token.size,
+            width: `${!baiProgressProps.percent || _.isNaN(baiProgressProps.percent) ? 0 : _.min([baiProgressProps.percent, 100])}%`,
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            backgroundColor: _.isString(baiProgressProps.strokeColor)
+              ? (baiProgressProps.strokeColor ??
+                token.Layout?.headerBg ??
+                token.colorPrimary)
+              : (token.Layout?.headerBg ?? token.colorPrimary),
+            zIndex: 0,
+            overflow: 'hidden',
+          }}
+        ></Flex>
+        {/* Hide used text to avoid overlapping */}
+        {used && baiProgressProps.percent && baiProgressProps.percent < 70 ? (
+          <div
+            style={{
+              position: 'absolute',
+              left:
+                !baiProgressProps.percent || _.isNaN(baiProgressProps.percent)
+                  ? 0
+                  : `calc(${_.min([baiProgressProps.percent, 100])}% - ${token.size}px)`,
+              bottom: -(token.size + token.fontSize),
+              textAlign: 'center',
+            }}
+          >
+            <Typography.Text
+              style={{
+                color: _.isString(baiProgressProps.strokeColor)
+                  ? (baiProgressProps.strokeColor ??
+                    token.Layout?.headerBg ??
+                    token.colorPrimary)
+                  : (token.Layout?.headerBg ?? token.colorPrimary),
+              }}
+            >
+              {used}
+            </Typography.Text>
+          </div>
+        ) : null}
+      </Flex>
+      <Flex justify="end">
+        {used &&
+        total &&
+        baiProgressProps.percent &&
+        baiProgressProps.percent >= 70 ? (
+          <Flex gap={'xxs'}>
+            <Typography.Text
+              style={{
+                color: _.isString(baiProgressProps.strokeColor)
+                  ? (baiProgressProps.strokeColor ??
+                    token.Layout?.headerBg ??
+                    token.colorPrimary)
+                  : (token.Layout?.headerBg ?? token.colorPrimary),
+              }}
+            >
+              {used}
+            </Typography.Text>
+            <Typography.Text>/</Typography.Text>
+            <Typography.Text>{total}</Typography.Text>
+          </Flex>
+        ) : total ? (
+          <Typography.Text>{total}</Typography.Text>
+        ) : null}
+      </Flex>
+    </Flex>
+  );
+};
+
+export default BAIProgress;

--- a/react/src/components/QuotaPerStorageVolumePanelCard.tsx
+++ b/react/src/components/QuotaPerStorageVolumePanelCard.tsx
@@ -1,0 +1,229 @@
+import { addQuotaScopeTypePrefix, convertDecimalSizeUnit } from '../helper';
+import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import BAICard, { BAICardProps } from './BAICard';
+import BAIProgress from './BAIProgress';
+import Flex from './Flex';
+import FlexActivityIndicator from './FlexActivityIndicator';
+import StorageSelect from './StorageSelect';
+import { QuotaPerStorageVolumePanelCardQuery } from './__generated__/QuotaPerStorageVolumePanelCardQuery.graphql';
+import { QuotaPerStorageVolumePanelCardUserQuery } from './__generated__/QuotaPerStorageVolumePanelCardUserQuery.graphql';
+import { QuestionCircleOutlined } from '@ant-design/icons';
+import { Col, Empty, Row, theme, Tooltip, Typography } from 'antd';
+import graphql from 'babel-plugin-relay/macro';
+import _ from 'lodash';
+import React, { useDeferredValue, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLazyLoadQuery } from 'react-relay';
+
+export type VolumeInfo = {
+  id: string;
+  backend: string;
+  capabilities: string[];
+  usage: {
+    percentage: number;
+  };
+  sftp_scaling_groups: string[];
+};
+
+interface QuotaPerStorageVolumePanelCardProps extends BAICardProps {}
+
+const QuotaPerStorageVolumePanelCard: React.FC<
+  QuotaPerStorageVolumePanelCardProps
+> = ({ ...baiCardProps }) => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const [selectedVolumeInfo, setSelectedVolumeInfo] = useState<VolumeInfo>();
+  const deferredSelectedVolumeInfo = useDeferredValue(selectedVolumeInfo);
+  const currentProject = useCurrentProjectValue();
+  const baiClient = useSuspendedBackendaiClient();
+
+  // TODO: Add resolver to enable subquery and modify to call useLazyLoadQuery only once.
+  const { user } = useLazyLoadQuery<QuotaPerStorageVolumePanelCardUserQuery>(
+    graphql`
+      query QuotaPerStorageVolumePanelCardUserQuery(
+        $domain_name: String
+        $email: String
+      ) {
+        user(domain_name: $domain_name, email: $email) {
+          id
+        }
+      }
+    `,
+    {
+      domain_name: useCurrentDomainValue(),
+      email: baiClient?.email,
+    },
+  );
+  const { project_quota_scope, user_quota_scope } =
+    useLazyLoadQuery<QuotaPerStorageVolumePanelCardQuery>(
+      graphql`
+        query QuotaPerStorageVolumePanelCardQuery(
+          $project_quota_scope_id: String!
+          $user_quota_scope_id: String!
+          $storage_host_name: String!
+          $skipQuotaScope: Boolean!
+        ) {
+          project_quota_scope: quota_scope(
+            quota_scope_id: $project_quota_scope_id
+            storage_host_name: $storage_host_name
+          ) @skip(if: $skipQuotaScope) {
+            details {
+              usage_bytes
+              hard_limit_bytes
+            }
+          }
+          user_quota_scope: quota_scope(
+            quota_scope_id: $user_quota_scope_id
+            storage_host_name: $storage_host_name
+          ) @skip(if: $skipQuotaScope) {
+            details {
+              usage_bytes
+              hard_limit_bytes
+            }
+          }
+        }
+      `,
+      {
+        project_quota_scope_id: addQuotaScopeTypePrefix(
+          'project',
+          currentProject?.id,
+        ),
+        user_quota_scope_id: addQuotaScopeTypePrefix('user', user?.id || ''),
+        storage_host_name: deferredSelectedVolumeInfo?.id || '',
+        skipQuotaScope:
+          currentProject?.id === undefined ||
+          user?.id === undefined ||
+          !deferredSelectedVolumeInfo?.id,
+      },
+    );
+
+  const projectUsageBytes = _.toFinite(
+    project_quota_scope?.details?.usage_bytes,
+  );
+  const projectHardLimitBytes = _.toFinite(
+    project_quota_scope?.details?.hard_limit_bytes,
+  );
+  const projectPercent = projectHardLimitBytes
+    ? _.toFinite(
+        ((projectUsageBytes / projectHardLimitBytes) * 100)?.toFixed(2),
+      )
+    : 0;
+
+  const userUsageBytes = _.toFinite(user_quota_scope?.details?.usage_bytes);
+  const userHardLimitBytes = _.toFinite(
+    user_quota_scope?.details?.hard_limit_bytes,
+  );
+  const userPercent = userHardLimitBytes
+    ? _.toFinite(((userUsageBytes / userHardLimitBytes) * 100)?.toFixed(2))
+    : 0;
+
+  return (
+    <BAICard
+      {...baiCardProps}
+      title={
+        <Flex gap={'xs'} align="center">
+          {t('data.QuotaPerStorageVolume')}
+          <Tooltip title={t('data.HostDetails')}>
+            <QuestionCircleOutlined
+              style={{ color: token.colorTextDescription }}
+            />
+          </Tooltip>
+        </Flex>
+      }
+      extra={
+        <StorageSelect
+          value={selectedVolumeInfo?.id}
+          onChange={(__, vInfo) => {
+            setSelectedVolumeInfo(vInfo);
+          }}
+          autoSelectType="usage"
+          showUsageStatus
+          showSearch
+          allowClear
+        />
+      }
+      styles={{
+        body: {
+          paddingTop: token.paddingLG,
+        },
+      }}
+    >
+      {selectedVolumeInfo !== deferredSelectedVolumeInfo ? (
+        <FlexActivityIndicator style={{ minHeight: 120 }} />
+      ) : selectedVolumeInfo?.capabilities?.includes('quota') ? (
+        <Row gutter={[24, 16]}>
+          <Col
+            span={12}
+            style={{
+              borderRight: `1px solid ${token.colorBorderSecondary}`,
+            }}
+          >
+            <BAIProgress
+              title={
+                <Flex direction="column" align="start">
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: token.fontSizeSM }}
+                  >
+                    {t('data.Project')}
+                  </Typography.Text>
+                  <Typography.Text style={{ fontSize: token.fontSize }}>
+                    {currentProject?.name}
+                  </Typography.Text>
+                </Flex>
+              }
+              percent={projectPercent}
+              used={
+                projectUsageBytes === 0
+                  ? ''
+                  : `${convertDecimalSizeUnit(_.toString(projectUsageBytes), 'G')?.numberUnit}B`
+              }
+              total={
+                projectHardLimitBytes === 0
+                  ? ''
+                  : `${convertDecimalSizeUnit(_.toString(projectHardLimitBytes), 'G')?.numberUnit}B`
+              }
+            />
+          </Col>
+          <Col span={12}>
+            <BAIProgress
+              percent={userPercent}
+              title={
+                <Flex direction="column" align="start">
+                  <Typography.Text
+                    type="secondary"
+                    style={{ fontSize: token.fontSizeSM }}
+                  >
+                    {t('data.User')}
+                  </Typography.Text>
+                  <Typography.Text style={{ fontSize: token.fontSize }}>
+                    {baiClient?.full_name}
+                  </Typography.Text>
+                </Flex>
+              }
+              used={
+                userUsageBytes === 0
+                  ? ''
+                  : `${convertDecimalSizeUnit(_.toString(userUsageBytes), 'G')?.numberUnit}B`
+              }
+              total={
+                userHardLimitBytes === 0
+                  ? ''
+                  : `${convertDecimalSizeUnit(_.toString(userHardLimitBytes), 'G')?.numberUnit}B`
+              }
+            />
+          </Col>
+        </Row>
+      ) : (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={t('storageHost.QuotaDoesNotSupported')}
+          style={{ margin: 'auto 25px' }}
+        />
+      )}
+    </BAICard>
+  );
+};
+
+export default QuotaPerStorageVolumePanelCard;

--- a/resources/theme.json
+++ b/resources/theme.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./theme.schema.json",
-  "light" : {
+  "light": {
     "token": {
       "fontFamily": "'Ubuntu', Roboto, sans-serif",
       "colorPrimary": "#FF7A00",
@@ -8,7 +8,8 @@
       "colorText": "#141414",
       "colorInfo": "#028DF2",
       "colorError": "#FF4D4F",
-      "colorSuccess": "#00BD9B"
+      "colorSuccess": "#00BD9B",
+      "colorFillSecondary": "#D9D9D9"
     },
     "components": {
       "Tag": {
@@ -32,7 +33,8 @@
       "colorText": "#FFF",
       "colorInfo": "#009BDD",
       "colorError": "#DC4446",
-      "colorSuccess": "#03A487"
+      "colorSuccess": "#03A487",
+      "colorFillSecondary": "#262626"
     },
     "components": {
       "Tag": {
@@ -59,8 +61,7 @@
       "height": 34
     }
   },
-  "sider": {
-  },
+  "sider": {},
   "branding": {
     "companyName": "Lablup Inc.",
     "brandName": "Backend.AI"


### PR DESCRIPTION
resolves #3151 (FR-513)

Adds a new quota per storage volume panel card to display project and user storage quotas. The panel shows usage percentages and storage limits for both project and user quotas when a storage volume is selected. The card includes:

- Progress bars showing usage percentages
- Storage usage in GB for both project and user quotas
- Support for volumes with quota capability
- Empty state for volumes without quota support
- Integration with existing storage volume selection

### How to test:
checkout #3232

### Screenshots
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/2abd90c7-ab03-47ee-82ea-8e685791ba23.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/7dfa05a2-d418-4657-9292-e7c53fa5b97d.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/efa37fb7-9033-45eb-9f61-2085f5aafa4d.png)

**Checklist:**
- [ ] Documentation
- [ ] Test case to verify quota display accuracy
- [ ] Verify empty state handling for non-quota volumes
- [ ] Check progress bar behavior at different usage levels
- [ ] Validate storage unit conversion logic