### PR TITLE
fix(FR-579): The contents of the credential list appear blurry.

### DIFF
--- a/react/src/components/UserCredentialList.tsx
+++ b/react/src/components/UserCredentialList.tsx
@@ -21,7 +21,6 @@ import {
 import {
   DeleteOutlined,
   InfoCircleOutlined,
-  LoadingOutlined,
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
@@ -255,14 +254,12 @@ const UserCredentialList: React.FC = () => {
         // resizable
         rowKey={'id'}
         scroll={{ x: 'max-content' }}
-        loading={{
-          spinning:
-            isActiveTypePending ||
-            isPendingRefresh ||
-            isPendingPageChange ||
-            isPendingFilter,
-          indicator: <LoadingOutlined />,
-        }}
+        loading={
+          isActiveTypePending ||
+          isPendingRefresh ||
+          isPendingPageChange ||
+          isPendingFilter
+        }
         dataSource={filterNonNullItems(keypair_list?.items)}
         columns={filterEmptyItem([
           {


### PR DESCRIPTION
resolves #3227 (FR-579)

Simplifies the loading indicator in the UserCredentialList component by removing the custom LoadingOutlined indicator and using the default loading state. This maintains the same loading behavior while reducing unnecessary configuration.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review: go to Users - Credentials tab
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after