### PR TITLE
hotfix: Move Chat menu under Serving menu

### DIFF
--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -110,14 +110,14 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
       key: 'serving',
     },
     {
-      label: <WebUILink to="/import">{t('webui.menu.Import&Run')}</WebUILink>,
-      icon: <PlayIcon style={{ color: token.colorPrimary }} />,
-      key: 'import',
-    },
-    {
       label: <WebUILink to="/chat">{t('webui.menu.Chat')}</WebUILink>,
       icon: <MessageOutlined style={{ color: token.colorPrimary }} />,
       key: 'chat',
+    },
+    {
+      label: <WebUILink to="/import">{t('webui.menu.Import&Run')}</WebUILink>,
+      icon: <PlayIcon style={{ color: token.colorPrimary }} />,
+      key: 'import',
     },
     {
       label: <WebUILink to="/data">{t('webui.menu.Data&Storage')}</WebUILink>,


### PR DESCRIPTION
Reorders the navigation menu items in the WebUI sidebar to place the Chat option before Import & Run, providing a more intuitive menu flow for users.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after