### PR TITLE
feat(FR-567): preserve pagination/filter/order data in session/endpoint page

### DIFF
--- a/react/src/hooks/useDeferredQueryParams.tsx
+++ b/react/src/hooks/useDeferredQueryParams.tsx
@@ -63,7 +63,7 @@ export function useDeferredQueryParams<QPCMap extends QueryParamConfigMap>(
   );
 
   let localQuery = useAtomValue(selectiveQueryAtom);
-  const setLocalQuery = useSetAtom(queryParamsAtom);
+  const setSharedQuery = useSetAtom(queryParamsAtom);
 
   const setDeferredQuery = useCallback(
     (
@@ -79,9 +79,16 @@ export function useDeferredQueryParams<QPCMap extends QueryParamConfigMap>(
 
       // Update Jotai state
       if (updateType === 'replaceIn' || updateType === 'pushIn') {
-        setLocalQuery({ ...localQuery, ...newQuery });
+        setSharedQuery((prev) => ({
+          ...prev,
+          ...localQuery,
+          ...newQuery,
+        }));
       } else {
-        setLocalQuery(newQuery as DecodedValueMap<QPCMap>);
+        setSharedQuery((prev) => ({
+          ...prev,
+          ...(newQuery as DecodedValueMap<QPCMap>),
+        }));
       }
 
       // Sync all(merged) query parameters with URL
@@ -93,7 +100,7 @@ export function useDeferredQueryParams<QPCMap extends QueryParamConfigMap>(
         updateType,
       );
     },
-    [localQuery, setQuery, setLocalQuery],
+    [localQuery, setQuery, setSharedQuery],
   );
 
   return [localQuery, setDeferredQuery] as const;

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -15,7 +15,7 @@ import {
   transformSorterToOrderString,
 } from '../helper';
 import { useUpdatableState } from '../hooks';
-import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useDeferredQueryParams } from '../hooks/useDeferredQueryParams';
 import {
@@ -50,7 +50,7 @@ const ComputeSessionListPage = () => {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionState({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 10,
   });
@@ -64,10 +64,16 @@ const ComputeSessionListPage = () => {
 
   const [, setSessionDetailId] = useQueryParam('sessionDetail', StringParam);
   const queryMapRef = useRef({
-    [queryParams.type]: queryParams,
+    [queryParams.type]: {
+      queryParams,
+      tablePaginationOption,
+    },
   });
-  //
-  queryMapRef.current[queryParams.type] = queryParams;
+
+  queryMapRef.current[queryParams.type] = {
+    queryParams,
+    tablePaginationOption,
+  };
 
   const typeFilter =
     queryParams.type === 'all' || queryParams.type === undefined
@@ -230,13 +236,17 @@ const ComputeSessionListPage = () => {
           activeKey={queryParams.type}
           onChange={(key) => {
             const storedQuery = queryMapRef.current[key] || {
-              statusCategory: 'running',
+              queryParams: {
+                statusCategory: 'running',
+              },
             };
             setQuery(
-              { ...storedQuery, type: key as TypeFilterType },
+              { ...storedQuery.queryParams, type: key as TypeFilterType },
               'replace',
             );
-            setTablePaginationOption({ current: 1 });
+            setTablePaginationOption(
+              storedQuery.tablePaginationOption || { current: 1 },
+            );
             setSelectedSessionList([]);
           }}
           items={_.map(

--- a/react/src/pages/ServingPage.tsx
+++ b/react/src/pages/ServingPage.tsx
@@ -9,7 +9,7 @@ import Flex from '../components/Flex';
 import { filterEmptyItem, transformSorterToOrderString } from '../helper';
 import { useUpdatableState, useWebUINavigate } from '../hooks';
 import { useCurrentUserRole } from '../hooks/backendai';
-import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useDeferredQueryParams } from '../hooks/useDeferredQueryParams';
 import { ServingPageQuery } from './__generated__/ServingPageQuery.graphql';
@@ -31,14 +31,14 @@ const ServingPage: React.FC = () => {
   const [queryParams, setQuery] = useDeferredQueryParams({
     order: StringParam,
     filter: StringParam,
-    lifecycleStage: withDefault(StringParam, 'created&destroying'),
+    lifecycleStage: withDefault(StringParam, 'active'),
   });
 
   const {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionState({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 10,
   });
@@ -46,7 +46,7 @@ const ServingPage: React.FC = () => {
   const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
 
   const lifecycleStageFilter =
-    queryParams.lifecycleStage === 'created&destroying'
+    queryParams.lifecycleStage === 'active'
       ? `lifecycle_stage == "created" | lifecycle_stage == "destroying"`
       : `lifecycle_stage == "${queryParams.lifecycleStage}"`;
 
@@ -153,7 +153,7 @@ const ServingPage: React.FC = () => {
                 options={[
                   {
                     label: 'Active',
-                    value: 'created&destroying',
+                    value: 'active',
                   },
                   {
                     label: 'Destroyed',


### PR DESCRIPTION
resolves #3210 (FR-567)

Adds URL search parameter persistence for pagination state in ComputeSession and Serving pages. When users navigate between different tabs or return to these pages, their pagination settings (page size and current page) are now preserved through the URL.

Key changes:
- Added `useBAIPaginationOptionStateOnSearchParam` to store pagination state in URL
- Fixed query parameter sharing in `useDeferredQueryParams` to properly merge states
- Updated ComputeSession page to maintain pagination state across tab switches
- Changed default lifecycle stage filter in Serving page from 'created&destroying' to 'active'