### PR TITLE
fix(FR-576): remove hyperlink in sftp/ftp link on app launcher dialog

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -1840,16 +1840,8 @@ export default class BackendAiAppLauncher extends BackendAIPage {
               work
             </div>
             <div>
-              <span>SSH URL:</span>
-              <a href="ssh://${this.tcpHost}:${this.tcpPort}">
-                ssh://${this.tcpHost}
-              </a>
-            </div>
-            <div>
-              <span>SFTP URL:</span>
-              <a href="sftp://${this.tcpHost}:${this.tcpPort}">
-                sftp://${this.tcpHost}
-              </a>
+              <span>Host: </span>
+                ${`${this.tcpHost}`}
             </div>
             <div>
               <span>Port:</span>


### PR DESCRIPTION
resolves #3218 (FR-576).

simplify informing "Host info" by get rid of unnecessary hyperlinks which confuses users whether it tend to click or not.

| After | Before|
|------|--------|
| ![Screenshot 2025-02-26 at 3.38.01 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/db9dee27-7eec-46a0-8538-eb706d33b220.png) | ![Screenshot 2025-02-26 at 2.49.04 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/bc637646-339a-4e92-9177-20715b66e213.png) |

How to test:
1. Create a session.
2. Click app dialog.
3. Click SSH / SFTP icon inside the app dialog.
4. See the changes.


**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minimum required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [] Test case(s) to demonstrate the difference of before/after
