### PR TITLE
feat(FR-603): Add folder creation notification with an open button

### DIFF
--- a/react/src/components/BAINotificationItem.tsx
+++ b/react/src/components/BAINotificationItem.tsx
@@ -8,6 +8,7 @@ import {
 import { Card, List, Progress, Typography, theme } from 'antd';
 import dayjs from 'dayjs';
 import _ from 'lodash';
+import { FolderIcon } from 'lucide-react';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -22,6 +23,21 @@ const BAINotificationItem: React.FC<{
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const [showExtraDescription, setShowExtraDescription] = useState(false);
+
+  const explicitIcon = notification.icon === 'folder' ? <FolderIcon /> : null;
+  const icon =
+    explicitIcon ||
+    (notification.backgroundTask &&
+      {
+        pending: <ClockCircleOutlined style={{ color: token.colorInfo }} />,
+        resolved: <CheckCircleOutlined style={{ color: token.colorSuccess }} />,
+        rejected: <CloseCircleOutlined style={{ color: token.colorError }} />,
+      }[notification.backgroundTask.status]) ||
+    (notification.type === 'error' ? (
+      <CloseCircleOutlined style={{ color: token.colorError }} />
+    ) : notification.type === 'success' ? (
+      <CheckCircleOutlined style={{ color: token.colorSuccess }} />
+    ) : null);
   return (
     <List.Item>
       <Flex direction="column" align="stretch" gap={'xxs'}>
@@ -33,25 +49,7 @@ const BAINotificationItem: React.FC<{
             paddingRight: token.paddingMD,
           }}
         >
-          <Flex style={{ height: 22 }}>
-            {notification.backgroundTask &&
-              {
-                pending: (
-                  <ClockCircleOutlined style={{ color: token.colorInfo }} />
-                ),
-                resolved: (
-                  <CheckCircleOutlined style={{ color: token.colorSuccess }} />
-                ),
-                rejected: (
-                  <CloseCircleOutlined style={{ color: token.colorError }} />
-                ),
-              }[notification.backgroundTask.status]}
-            {notification.type === 'error' ? (
-              <CloseCircleOutlined style={{ color: token.colorError }} />
-            ) : notification.type === 'success' ? (
-              <CheckCircleOutlined style={{ color: token.colorSuccess }} />
-            ) : null}
-          </Flex>
+          {icon && <Flex style={{ height: 22 }}>{icon}</Flex>}
           <Typography.Paragraph
             style={{
               fontWeight: 500,

--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -2,6 +2,7 @@ import { useBaiSignedRequestWithPromise } from '../helper';
 import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserRole } from '../hooks/backendai';
 import { useTanMutation, useTanQuery } from '../hooks/reactQueryAlias';
+import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
@@ -93,6 +94,8 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
   const currentDomain = useCurrentDomainValue();
   const currentProject = useCurrentProjectValue();
 
+  const { upsertNotification } = useSetBAINotification();
+
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
 
   const { data: allowedTypes, isFetching: isFetchingAllowedTypes } =
@@ -141,7 +144,16 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
       .then((values) => {
         mutationToCreateFolder.mutate(values, {
           onSuccess: (result) => {
-            message.success(t('data.folders.FolderCreated'));
+            upsertNotification({
+              key: 'folder-create-success',
+              icon: 'folder',
+              message: `${result.name}: ${t('data.folders.FolderCreated')}`,
+              toText: t('data.folders.OpenAFolder'),
+              to: {
+                search: `?folder=${result.id}`,
+              },
+              open: true,
+            });
             document.dispatchEvent(
               new CustomEvent('backend-ai-folder-list-changed'),
             );

--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -11,13 +11,14 @@ import { v4 as uuidv4 } from 'uuid';
 const _activeNotificationKeys: Key[] = [];
 
 export interface NotificationState
-  extends Omit<ArgsProps, 'placement' | 'key'> {
+  extends Omit<ArgsProps, 'placement' | 'key' | 'icon'> {
   key: React.Key;
   created?: string;
   toTextKey?: string;
   toText?: string;
   to?: string | To;
   open?: boolean;
+  icon?: 'folder';
   backgroundTask?: {
     taskId?: string;
     percent?: number;
@@ -351,6 +352,7 @@ export const useSetBAINotification = () => {
           }
           app.notification.open({
             ...newNotification,
+            icon: undefined, // override icon to remove default icon from notification, icon displayed in BAINotificationItem
             type: undefined, // override type to remove default icon from notification, icon displayed in BAINotificationItem
             placement: 'bottomRight',
             message: undefined,


### PR DESCRIPTION
Resolves #3269(FR-603)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/2b86c7a5-4a15-4987-a85e-42bbc4ee450c.png)

Adds folder creation notification with navigation link

Enhances the folder creation notification system. When a folder is created, users now receive a notification with a direct link to navigate to the newly created folder. The notification includes a folder icon and displays success message with the folder name.


