### PR TITLE
feat(FR-598): Add permission setting button to the folder explorer

### DIFF
--- a/react/src/components/BAIModal.css
+++ b/react/src/components/BAIModal.css
@@ -6,5 +6,10 @@ div > div.ant-modal-wrap.draggable.ant-modal-centered {
   width: var(--general-modal-header-width, 26px);
   height: var(--general-modal-header-height, 26px);
   top: 22px;
+  right: 18px;
   -webkit-app-region: no-drag;
+}
+
+.ant-modal.bai-modal .ant-modal-title {
+  margin-right: 36px;
 }

--- a/react/src/components/BAIModal.tsx
+++ b/react/src/components/BAIModal.tsx
@@ -61,7 +61,7 @@ const BAIModal: React.FC<BAIModalProps> = ({
             display: 'flex',
             alignItems: 'center',
             height: 'var(--general-modal-header-height, 69px)',
-            padding: 'var(--general-modal-header-padding, 10px 20px)',
+            padding: 'var(--general-modal-header-padding, 10px 24px)',
             ...styles?.header,
           },
           body: {

--- a/react/src/components/BAISelect.tsx
+++ b/react/src/components/BAISelect.tsx
@@ -1,4 +1,4 @@
-import { Select, SelectProps } from 'antd';
+import { Select, SelectProps, Tooltip } from 'antd';
 import { createStyles } from 'antd-style';
 import classNames from 'classnames';
 import _ from 'lodash';
@@ -41,6 +41,7 @@ const useStyles = createStyles(({ css, token }) => ({
 export interface BAISelectProps extends SelectProps {
   ghost?: boolean;
   autoSelectOption?: boolean | ((options: SelectProps['options']) => any);
+  tooltip?: string;
 }
 /**
  * BAISelect component.
@@ -56,6 +57,7 @@ export interface BAISelectProps extends SelectProps {
 const BAISelect: React.FC<BAISelectProps> = ({
   autoSelectOption,
   ghost,
+  tooltip = '',
   ...selectProps
 }) => {
   const { value, options, onChange } = selectProps;
@@ -72,14 +74,16 @@ const BAISelect: React.FC<BAISelectProps> = ({
   }, [value, options, onChange, autoSelectOption]);
 
   return (
-    <Select
-      {...selectProps}
-      className={
-        ghost
-          ? classNames(styles.ghostSelect, selectProps.className)
-          : selectProps.className
-      }
-    />
+    <Tooltip title={tooltip}>
+      <Select
+        {...selectProps}
+        className={
+          ghost
+            ? classNames(styles.ghostSelect, selectProps.className)
+            : selectProps.className
+        }
+      />
+    </Tooltip>
   );
 };
 

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -97,6 +97,7 @@ export type BackendAIClient = {
     restore_from_trash_bin: (id: string) => Promise<any>;
     delete_from_trash_bin: (id: string) => Promise<any>;
     rename: (newName: string, id: string) => Promise<any>;
+    update_folder: (input: any, id: string) => Promise<any>;
   };
   supports: (feature: string) => boolean;
   [key: string]: any;

--- a/src/components/backend-ai-folder-explorer.ts
+++ b/src/components/backend-ai-folder-explorer.ts
@@ -148,6 +148,7 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
           color: #637282;
           font-size: 1em;
           margin-bottom: 10px;
+          max-width: 65%;
         }
 
         div.breadcrumb span:first-child {
@@ -207,7 +208,7 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
         mwc-icon-button {
           --mdc-icon-size: 24px;
           --mdc-icon-button-size: 28px;
-          padding: 4px;
+          padding: 0px;
         }
 
         mwc-button {
@@ -1733,7 +1734,7 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
                 <ul style="padding: 0;">
                   ${this.breadcrumb.map(
                     (item) => html`
-                      <li>
+                      <li style="white-space: nowrap;">
                         ${item === '.'
                           ? html`
                               <mwc-icon-button
@@ -1749,6 +1750,7 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
                                 path="item"
                                 @click="${(e) => this._gotoFolder(e)}"
                                 dest="${item}"
+                                style="white-space: normal; word-break: break-all;"
                               >
                                 ${item}
                               </a>


### PR DESCRIPTION
resolves #3257 (FR-598)

add permission setting to folder explorer.
replace delete, create, upload buttons.
use fragment to VFolderNameTitle instead of query.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/b98a8386-6490-4e64-82ab-54a8d9fd3a2c.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/6dac9b15-d301-4697-84aa-5b0a39d4a0e4.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
