### PR TITLE
feature(FR-604): remove deprecated inference request metrics

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -3021,7 +3021,6 @@ export default class BackendAISessionList extends BackendAIPage {
    * @param {Object} rowData - the object with the properties related with the rendered item
    */
   sessionTypeRenderer(root, column?, rowData?) {
-    const inferenceMetrics = JSON.parse(rowData.item.inference_metrics || '{}');
     render(
       html`
         <div class="layout vertical start">
@@ -3030,17 +3029,6 @@ export default class BackendAISessionList extends BackendAIPage {
             description="${rowData.item.type}"
             ui="round"
           ></lablup-shields>
-          ${rowData.item.type === 'INFERENCE'
-            ? html`
-                <span style="font-size:12px;margin-top:5px;">
-                  Inference requests: ${inferenceMetrics.requests}
-                </span>
-                <span style="font-size:12px;">
-                  Inference API last response time (ms):
-                  ${inferenceMetrics.last_response_ms}
-                </span>
-              `
-            : ``}
         </div>
       `,
       root,


### PR DESCRIPTION
resolves FR-605

Removes inference metrics display (request count and last response time) from the session type column in the session list view. The session type badge remains unchanged.


### Before

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/d1798e4c-e1be-4736-bc75-93c76a9cad92.png)

### After

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/8eb5b34b-2bf9-4d04-8e1f-f71b1fdf7658.png)

