### PR TITLE
hotfix(FR-618): use Grid component instead of BAIBoard to fix broken layout in Electron

### DIFF
--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -1,15 +1,17 @@
 import ActionItemContent from '../components/ActionItemContent';
-import BAIBoard, { BAIBoardItem } from '../components/BAIBoard';
+// import BAIBoard, { BAIBoardItem } from '../components/BAIBoard';
 import FolderCreateModal from '../components/FolderCreateModal';
 import ThemeSecondaryProvider from '../components/ThemeSecondaryProvider';
+import { filterEmptyItem } from '../helper';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
-import { useBAISettingUserState } from '../hooks/useBAISetting';
+// import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { SessionLauncherFormValue } from './SessionLauncherPage';
 import {
   AppstoreAddOutlined,
   FolderAddOutlined,
   LinkOutlined,
 } from '@ant-design/icons';
+import { Card, Col, Grid, Row } from 'antd';
 import _ from 'lodash';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -21,147 +23,140 @@ const StartPage: React.FC = () => {
   useSuspendedBackendaiClient();
 
   const webuiNavigate = useWebUINavigate();
-
   const [isOpenCreateModal, setIsOpenCreateModal] = useState<boolean>(false);
+  const { xl } = Grid.useBreakpoint();
 
-  const [itemSettings, setItemSettings] =
-    useBAISettingUserState('start_board_items');
-
-  const [items, setItems] = useState<Array<BAIBoardItem>>(() => {
-    const defaultItems: Array<BAIBoardItem> = [
-      {
-        id: 'createFolder',
-        rowSpan: 3,
-        columnSpan: 1,
-        columnOffset: { 6: 0, 4: 0 },
-        data: {
-          content: (
-            <ActionItemContent
-              title={t('start.CreateFolder')}
-              description={t('start.CreateFolderDesc')}
-              buttonText={t('start.button.CreateFolder')}
-              icon={<FolderAddOutlined />}
-              onClick={() => setIsOpenCreateModal(true)}
-            />
-          ),
-        },
+  const items = filterEmptyItem([
+    {
+      id: 'createFolder',
+      rowSpan: 3,
+      columnSpan: 1,
+      columnOffset: { 6: 0, 4: 0 },
+      data: {
+        content: (
+          <ActionItemContent
+            title={t('start.CreateFolder')}
+            description={t('start.CreateFolderDesc')}
+            buttonText={t('start.button.CreateFolder')}
+            icon={<FolderAddOutlined />}
+            onClick={() => setIsOpenCreateModal(true)}
+          />
+        ),
       },
-      {
-        id: 'startSession',
-        rowSpan: 3,
-        columnSpan: 1,
-        columnOffset: { 6: 1, 4: 1 },
-        data: {
-          content: (
+    },
+    {
+      id: 'startSession',
+      rowSpan: 3,
+      columnSpan: 1,
+      columnOffset: { 6: 1, 4: 1 },
+      data: {
+        content: (
+          <ActionItemContent
+            title={t('start.StartSession')}
+            description={t('start.StartSessionDesc')}
+            buttonText={t('start.button.StartSession')}
+            icon={<AppstoreAddOutlined />}
+            onClick={() => webuiNavigate('/session/start')}
+          />
+        ),
+      },
+    },
+    {
+      id: 'startBatchSession',
+      rowSpan: 3,
+      columnSpan: 1,
+      columnOffset: { 6: 2, 4: 2 },
+      data: {
+        content: (
+          <ActionItemContent
+            title={t('start.StartBatchSession')}
+            description={t('start.StartBatchSessionDesc')}
+            buttonText={t('start.button.StartSession')}
+            icon={<AppstoreAddOutlined />}
+            onClick={() => {
+              const launcherValue: DeepPartial<SessionLauncherFormValue> = {
+                sessionType: 'batch',
+              };
+              const params = new URLSearchParams();
+              params.set('step', '0');
+              params.set('formValues', JSON.stringify(launcherValue));
+              webuiNavigate(`/session/start?${params.toString()}`);
+            }}
+          />
+        ),
+      },
+    },
+    xl && {
+      id: 'empty',
+      rowSpan: 3,
+      columnSpan: 1,
+      columnOffset: { 6: 0, 4: 0 },
+      data: {
+        content: <></>,
+      },
+    },
+    {
+      id: 'modelService',
+      rowSpan: 3,
+      columnSpan: 1,
+      columnOffset: { 6: 0, 4: 0 },
+      data: {
+        content: (
+          <ThemeSecondaryProvider>
             <ActionItemContent
-              title={t('start.StartSession')}
-              description={t('start.StartSessionDesc')}
-              buttonText={t('start.button.StartSession')}
+              title={t('start.ModelService')}
+              description={t('start.ModelServiceDesc')}
+              buttonText={t('start.button.ModelService')}
               icon={<AppstoreAddOutlined />}
-              onClick={() => webuiNavigate('/session/start')}
+              onClick={() => webuiNavigate('/service/start')}
             />
-          ),
-        },
+          </ThemeSecondaryProvider>
+        ),
       },
-      {
-        id: 'startBatchSession',
-        rowSpan: 3,
-        columnSpan: 1,
-        columnOffset: { 6: 2, 4: 2 },
-        data: {
-          content: (
+    },
+    {
+      id: 'startFromURL',
+      rowSpan: 3,
+      columnSpan: 1,
+      columnOffset: { 6: 1, 4: 1 },
+      data: {
+        content: (
+          <ThemeSecondaryProvider>
             <ActionItemContent
-              title={t('start.StartBatchSession')}
-              description={t('start.StartBatchSessionDesc')}
-              buttonText={t('start.button.StartSession')}
-              icon={<AppstoreAddOutlined />}
-              onClick={() => {
-                const launcherValue: DeepPartial<SessionLauncherFormValue> = {
-                  sessionType: 'batch',
-                };
-                const params = new URLSearchParams();
-                params.set('step', '0');
-                params.set('formValues', JSON.stringify(launcherValue));
-                webuiNavigate(`/session/start?${params.toString()}`);
-              }}
+              title={t('start.StartFromURL')}
+              description={t('start.StartFromURLDesc')}
+              buttonText={t('start.button.StartNow')}
+              icon={<LinkOutlined />}
+              onClick={() => webuiNavigate('/import')}
             />
-          ),
-        },
+          </ThemeSecondaryProvider>
+        ),
       },
-      {
-        id: 'modelService',
-        rowSpan: 3,
-        columnSpan: 1,
-        columnOffset: { 6: 0, 4: 0 },
-        data: {
-          content: (
-            <ThemeSecondaryProvider>
-              <ActionItemContent
-                title={t('start.ModelService')}
-                description={t('start.ModelServiceDesc')}
-                buttonText={t('start.button.ModelService')}
-                icon={<AppstoreAddOutlined />}
-                onClick={() => webuiNavigate('/service/start')}
-              />
-            </ThemeSecondaryProvider>
-          ),
-        },
-      },
-      {
-        id: 'startFromURL',
-        rowSpan: 3,
-        columnSpan: 1,
-        columnOffset: { 6: 1, 4: 1 },
-        data: {
-          content: (
-            <ThemeSecondaryProvider>
-              <ActionItemContent
-                title={t('start.StartFromURL')}
-                description={t('start.StartFromURLDesc')}
-                buttonText={t('start.button.StartNow')}
-                icon={<LinkOutlined />}
-                onClick={() => webuiNavigate('/import')}
-              />
-            </ThemeSecondaryProvider>
-          ),
-        },
-      },
-      // {
-      //   id: 'startFromExample',
-      //   rowSpan: 3,
-      //   columnSpan: 1,
-      //   columnOffset: { 6:2, 4: 2 },
-      //   data: {
-      //     content: (
-      //       <ThemeSecondaryProvider>
-      //         <ActionItemContent
-      //           title={t('start.StartFromExample')}
-      //           description={t('start.StartFromExampleDesc')}
-      //           buttonText={t('start.button.StartNow')}
-      //           icon={<PlaySquareOutlined />}
-      //           onClick={() => webuiNavigate('/import')}
-      //         />
-      //       </ThemeSecondaryProvider>
-      //     ),
-      //   },
-      // },
-    ];
-
-    if (itemSettings) {
-      return defaultItems.map((item) => {
-        const savedSetting = itemSettings.find(
-          (setting) => setting.id === item.id,
-        );
-        return savedSetting ? { ...item, ...savedSetting } : item;
-      });
-    }
-
-    return defaultItems;
-  });
+    },
+    // {
+    //   id: 'startFromExample',
+    //   rowSpan: 3,
+    //   columnSpan: 1,
+    //   columnOffset: { 6:2, 4: 2 },
+    //   data: {
+    //     content: (
+    //       <ThemeSecondaryProvider>
+    //         <ActionItemContent
+    //           title={t('start.StartFromExample')}
+    //           description={t('start.StartFromExampleDesc')}
+    //           buttonText={t('start.button.StartNow')}
+    //           icon={<PlaySquareOutlined />}
+    //           onClick={() => webuiNavigate('/import')}
+    //         />
+    //       </ThemeSecondaryProvider>
+    //     ),
+    //   },
+    // },
+  ]);
 
   return (
     <>
-      <BAIBoard
+      {/* <BAIBoard
         items={items}
         onItemsChange={(event) => {
           // use spread operator to ignore readonly type error
@@ -169,7 +164,28 @@ const StartPage: React.FC = () => {
           setItems(changedItems);
           setItemSettings(_.map(changedItems, (item) => _.omit(item, 'data')));
         }}
-      />
+      /> */}
+      <Row gutter={[16, 16]}>
+        {_.map(items, (item) => {
+          return item.id === 'empty' ? (
+            <Col xs={24} md={12} xl={6}></Col>
+          ) : (
+            <Col xs={24} md={12} xl={6}>
+              <Card
+                style={{ height: 340 }}
+                styles={{
+                  body: {
+                    height: '100%',
+                    padding: 0,
+                  },
+                }}
+              >
+                {item.data.content}
+              </Card>
+            </Col>
+          );
+        })}
+      </Row>
       <FolderCreateModal
         open={isOpenCreateModal}
         onRequestClose={(response) => {


### PR DESCRIPTION
Resolves #3298 (FR-618)

The BAIBoard displayed a broken UI in the Electron environment. To fix this, the draggable BAIBoard component has been replaced with a fixed grid layout on the StartPage. The new layout uses Ant Design's Row and Col components to create a responsive grid system that adapts to different screen sizes:
- Small screens: 1 card per row
- Medium screens: 2 cards per row
- Large screens: 4 cards per row

Each action item is now displayed in a fixed-height Card component, maintaining consistent spacing and alignment across the page.