### PR TITLE
hotfix(FR-619): set default order to '-created_at' for

### DIFF
--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -68,7 +68,7 @@ const ComputeSessionListPage = () => {
   });
 
   const [queryParams, setQuery] = useDeferredQueryParams({
-    order: StringParam,
+    order: withDefault(StringParam, '-created_at'),
     filter: StringParam,
     type: withDefault(StringParam, 'all'),
     statusCategory: withDefault(StringParam, 'running'),

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -93,7 +93,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   });
 
   const [queryParams, setQuery] = useDeferredQueryParams({
-    order: StringParam,
+    order: withDefault(StringParam, '-created_at'),
     filter: StringParam,
     statusCategory: withDefault(StringParam, 'created'),
     mode: withDefault(StringParam, 'all'),
@@ -249,7 +249,13 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
           </Col>
           <Col xs={24} lg={16} xl={8}>
             <Suspense
-              fallback={<BAICard style={{height: 200}} title={t('data.StorageStatus')} loading />}
+              fallback={
+                <BAICard
+                  style={{ height: 200 }}
+                  title={t('data.StorageStatus')}
+                  loading
+                />
+              }
             >
               <StorageStatusPanelCard
                 style={{ height: lg ? 200 : undefined }}
@@ -259,7 +265,11 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
           <Col xs={24} xl={12}>
             <Suspense
               fallback={
-                <BAICard style={{height: 200}} title={t('data.QuotaPerStorageVolume')} loading />
+                <BAICard
+                  style={{ height: 200 }}
+                  title={t('data.QuotaPerStorageVolume')}
+                  loading
+                />
               }
             >
               <QuotaPerStorageVolumePanelCard


### PR DESCRIPTION
resolves #3299 (FR-619)

Sets default sorting order to '-created_at' for both compute sessions and VFolder node lists, ensuring consistent display of newest items first. Additionally improves loading state presentation in VFolder storage status cards by fixing style formatting.