### PR TITLE
fix(FR-620): folder permission refresh folder list after updating folder permission in FolderExplorer

### DIFF
--- a/react/src/components/InviteFolderSettingModal.tsx
+++ b/react/src/components/InviteFolderSettingModal.tsx
@@ -270,8 +270,8 @@ const InviteFolderSettingModal: React.FC<InviteFolderSettingModalProps> = ({
                             { label: t('data.folders.Edit'), value: 'rw' },
                           ]}
                           defaultValue={perm}
-                          onChange={() => {
-                            handlePermission(record.shared_to.uuid, perm);
+                          onChange={(nextPerm) => {
+                            handlePermission(record.shared_to.uuid, nextPerm);
                           }}
                         />
                         <Popconfirm

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -994,6 +994,9 @@ export default class BackendAiStorageList extends BackendAIPage {
     document.addEventListener('backend-ai-folder-created', (e) =>
       this._refreshFolderList(true, 'folder-updated'),
     );
+    document.addEventListener('backend-ai-folder-updated', (e) =>
+      this._refreshFolderList(true, 'folder-updated'),
+    );
   }
 
   _isUncontrollableStatus(status: VFolderOperationStatus) {


### PR DESCRIPTION
resolves #3330 (FR-620)

Adds a new event listener to refresh the folder list when folder permissions are modified in the legacy folder explorer. This ensures the storage list view stays synchronized with permission changes made through the UI.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after