### PR TITLE
fix(FR-571): remove `showKernelList` configuration

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -34,7 +34,6 @@ enableModelStore = false                # Enable model store feature. (From Back
 enableLLMPlayground = false             # Enable LLM Playground feature. (From Backend.AI 24.03)
 enableExtendLoginSession = false        # If true, enables login session extension UI. (From Backend.AI 24.09)
 enableImportFromHuggingFace = false     # Enable import from Hugging Face feature. (From Backend.AI 24.09)
-showKernelList = false                  # Show kernel list in the session detail panel. (From Backend.AI 24.09)
 enableInteractiveLoginAccountSwitch = true  # If false, hide the "Sign in with a different account" button from the interactive login page.
 
 [wsproxy]

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -166,7 +166,6 @@ const SessionDetailContent: React.FC<{
       .map((check) => check.remaining)
       .filter(Boolean),
   );
-  const showKernelList = baiClient._config.showKernelList;
 
   return session ? (
     <Flex direction="column" gap={'lg'} align="stretch">
@@ -353,16 +352,14 @@ const SessionDetailContent: React.FC<{
           </Descriptions.Item>
         </Descriptions>
       </Flex>
-      {showKernelList ? (
-        <Suspense fallback={<Skeleton />}>
-          <Flex direction="column" gap={'sm'} align="stretch">
-            <Typography.Title level={4} style={{ margin: 0 }}>
-              {t('kernel.Kernels')}
-            </Typography.Title>
-            <ConnectedKernelList id={id} fetchKey={fetchKey} />
-          </Flex>
-        </Suspense>
-      ) : null}
+      <Suspense fallback={<Skeleton />}>
+        <Flex direction="column" gap={'sm'} align="stretch">
+          <Typography.Title level={4} style={{ margin: 0 }}>
+            {t('kernel.Kernels')}
+          </Typography.Title>
+          <ConnectedKernelList id={id} fetchKey={fetchKey} />
+        </Flex>
+      </Suspense>
       <IdleCheckDescriptionModal
         open={openIdleCheckDescriptionModal}
         onCancel={() => setOpenIdleCheckDescriptionModal(false)}

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -459,7 +459,6 @@ type BackendAIConfig = {
   allowNonAuthTCP: boolean;
   enableExtendLoginSession: boolean;
   showNonInstalledImages: boolean;
-  showKernelList: boolean;
   enableInteractiveLoginAccountSwitch: boolean;
   debug: boolean;
   [key: string]: any;

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -145,7 +145,6 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: Boolean }) enableImportFromHuggingFace = false;
   @property({ type: Boolean }) enableExtendLoginSession = false;
   @property({ type: Boolean }) showNonInstalledImages = false;
-  @property({ type: Boolean }) showKernelList = false;
   @property({ type: Boolean }) enableInteractiveLoginAccountSwitch = true;
   @property({ type: String }) eduAppNamePrefix;
   @property({ type: String }) pluginPages;
@@ -882,12 +881,6 @@ export default class BackendAILogin extends BackendAIPage {
         value: generalConfig?.enableExtendLoginSession,
       } as ConfigValueObject,
     ) as boolean;
-
-    this.showKernelList = this._getConfigValueByExists(generalConfig, {
-      valueType: 'boolean',
-      defaultValue: false,
-      value: generalConfig?.showKernelList,
-    } as ConfigValueObject) as boolean;
 
     this.enableInteractiveLoginAccountSwitch = this._getConfigValueByExists(
       generalConfig,
@@ -1933,7 +1926,6 @@ export default class BackendAILogin extends BackendAIPage {
           this.enableImportFromHuggingFace;
         globalThis.backendaiclient._config.enableExtendLoginSession =
           this.enableExtendLoginSession;
-        globalThis.backendaiclient._config.showKernelList = this.showKernelList;
         globalThis.backendaiclient._config.enableInteractiveLoginAccountSwitch =
           this.enableInteractiveLoginAccountSwitch;
         globalThis.backendaiclient._config.pluginPages = this.pluginPages;


### PR DESCRIPTION
resolves #3214 (FR-571)

Always show kernel list in session detail panel by removing the conditional flag `showKernelList`. This change ensures users can consistently view and manage kernels within their sessions without requiring additional configuration.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after