### PR TITLE
fix(FR-625): 404 error when using clone feature in model store

### DIFF
--- a/react/src/components/ModelCardModal.tsx
+++ b/react/src/components/ModelCardModal.tsx
@@ -388,11 +388,6 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
       <Suspense>
         <ModelCloneModal
           vfolderNode={model_card?.vfolder_node || null}
-          deprecatedVFolderInfo={{
-            id: model_card?.vfolder?.id || '',
-            host: model_card?.vfolder?.host || '',
-            name: model_card?.vfolder?.name || '',
-          }}
           title={t('modelStore.CloneAsFolder')}
           open={visibleCloneModal}
           onOk={() => {

--- a/react/src/components/ModelCloneModal.tsx
+++ b/react/src/components/ModelCloneModal.tsx
@@ -23,32 +23,26 @@ import { useFragment } from 'react-relay';
 
 interface ModelCloneModalProps extends BAIModalProps {
   vfolderNode: ModelCloneModalVFolderFragment$key | null;
-  deprecatedVFolderInfo?: {
-    id: string;
-    name: string;
-    host: string;
-  };
 }
 const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
   // sourceFolderName,
   // sourceFolderHost,
   vfolderNode,
-  deprecatedVFolderInfo,
   ...props
 }) => {
   const { t } = useTranslation();
   const baiClient = useSuspendedBackendaiClient();
-  const vfolder =
-    useFragment(
-      graphql`
-        fragment ModelCloneModalVFolderFragment on VirtualFolderNode {
-          id
-          name
-          host
-        }
-      `,
-      vfolderNode,
-    ) || deprecatedVFolderInfo;
+  const vfolder = useFragment(
+    graphql`
+      fragment ModelCloneModalVFolderFragment on VirtualFolderNode {
+        id
+        row_id
+        name
+        host
+      }
+    `,
+    vfolderNode,
+  );
 
   const formRef = useRef<
     FormInstance<{
@@ -94,11 +88,11 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
         formRef.current
           ?.validateFields()
           .then((values) => {
-            if (vfolder?.id && vfolder.host) {
+            if (vfolder?.row_id && vfolder.host) {
               mutationToClone.mutate(
                 {
                   input: values,
-                  name: vfolder.id,
+                  name: vfolder.row_id,
                 },
                 {
                   onSuccess(data) {


### PR DESCRIPTION
Resolve #3308 (FR-625)

Fixed model store clone functionality by updating the vfolder ID reference from `id` to `row_id` in the clone mutation. Removed deprecated vfolder info handling since it's no longer needed with the current API structure.

The changes ensure proper folder cloning when users select and clone items from the model store.