### PR TITLE
bugifx(FR-626): Card component's css bug

### DIFF
--- a/src/components/lablup-activity-panel.ts
+++ b/src/components/lablup-activity-panel.ts
@@ -68,7 +68,6 @@ export default class LablupActivityPanel extends LitElement {
           line-height: 1.1;
           color: var(--token-colorText);
           border: 1px solid var(--token-colorBorderSecondary, #424242);
-          overflow: hidden;
         }
 
         div.card > h4 {
@@ -79,7 +78,8 @@ export default class LablupActivityPanel extends LitElement {
           height: 48px;
           padding: 5px 15px 5px 20px;
           margin: 0 0 10px 0;
-          border-radius: 5px 5px 0 0;
+          border-radius: var(--token-borderRadiusLG) var(--token-borderRadiusLG)
+            0 0;
           border-bottom: 1px solid var(--token-colorBorderSecondary, #ddd);
           display: flex;
           white-space: nowrap;


### PR DESCRIPTION
resolves #3310(FR-626)

**chagens**
* using `border-radius` instead of `overflow: hidden`
before
![스크린샷 2025-03-05 오후 4.00.38.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/9abd668f-5084-453e-9026-89dfa8e4049d.png)
after
![스크린샷 2025-03-05 오후 5.29.25.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/86e766ed-395b-47e8-8094-159c481ba199.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
