### PR TITLE
fix(FR-585): apply conditional rendering by using ternary operator on VFolderLazyView

### DIFF
--- a/react/src/components/VFolderLazyView.tsx
+++ b/react/src/components/VFolderLazyView.tsx
@@ -36,7 +36,7 @@ const VFolderLazyView: React.FC<VFolderLazyViewProps> = ({
 
   const vFolder = vFolders?.find(
     // `id` of `/folders` API is not UUID, but UUID without `-`
-    (vFolder) => vFolder.id === uuid.replaceAll('-', ''),
+    (vFolder) => vFolder.id === uuid?.replaceAll('-', ''),
   );
 
   return (

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -429,13 +429,10 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
     },
     {
       label: t('session.launcher.ModelStorage'),
-      children: (
+      children: endpoint?.model ? (
         <Suspense fallback={<Spin indicator={<LoadingOutlined spin />} />}>
           <Flex direction="column" align="start">
-            <VFolderLazyView
-              uuid={endpoint?.model as string}
-              clickable={true}
-            />
+            <VFolderLazyView uuid={endpoint?.model} clickable={true} />
             {baiClient.supports('endpoint-extra-mounts') &&
               endpoint?.model_mount_destination && (
                 <Flex direction="row" align="center" gap={'xxs'}>
@@ -447,7 +444,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               )}
           </Flex>
         </Suspense>
-      ),
+      ) : null,
     },
   ];
 


### PR DESCRIPTION
**Changes:**
Adds null-safety checks for UUID handling in virtual folder components and endpoint model storage display. The endpoint model storage tab now only renders when an endpoint model exists, preventing potential rendering issues with undefined values.

**How to test:**
- Connect to the bogbowl endpoint.
- Access the 19ce39ca-ada3-4f63-8b83-19fc2eb3d69a model service detail page and verify that the replaceAll error does not occur.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after