### PR TITLE
fix(FR-612): Increase max-old-space-size to 4096 of package.yml

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -61,6 +61,8 @@ jobs:
           BAI_APP_SIGN_KEYCHAIN_PASSWORD: ${{ secrets.BAI_APP_SIGN_KEYCHAIN_PASSWORD }}
       - name: Bundle static resources into zip package
         run: make bundle
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
       - name: Upload application to latest release
         run: node upload-release.js app
         env:

--- a/react/src/components/DomainSelector.test.tsx
+++ b/react/src/components/DomainSelector.test.tsx
@@ -38,20 +38,16 @@ describe('DomainSelect', () => {
 
     expect(screen.getByText('loading...')).toBeInTheDocument();
 
-    act(() => {
-      environment.mock.resolveMostRecentOperation((operation) =>
-        MockPayloadGenerator.generate(operation, {
-          String() {
-            return 'abcd';
-          },
-        }),
-      );
-    });
+    environment.mock.resolveMostRecentOperation((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        String() {
+          return 'abcd';
+        },
+      }),
+    );
 
     expect(await screen.findByText('Please select domain')).toBeInTheDocument();
-    await act(async () => {
-      await userEvent.click(screen.getByRole('combobox'));
-    });
+    await userEvent.click(screen.getByRole('combobox'));
     expect(screen.getAllByText('abcd')[0]).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
   });


### PR DESCRIPTION
resolves #3291 (FR-612)

Increases Node.js memory allocation limit to resolve heap out of memory errors during static resource bundling. Additionally removes unnecessary `act` wrapper in DomainSelector tests as the operations are already wrapped in async functions.

Fixes the following error during GitHub Actions build:
```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```