### PR TITLE
chore(FR-616): Remove unnecessary # column from table and unused codes

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -158,19 +158,6 @@ const AgentList: React.FC<AgentListProps> = ({
 
   const columns: ColumnsType<Agent> = [
     {
-      title: '#',
-      fixed: 'left',
-      render: (id, record, index) => {
-        return (
-          index +
-          1 +
-          (tablePaginationOption.current - 1) * tablePaginationOption.pageSize
-        );
-      },
-      showSorterTooltip: false,
-      rowScope: 'row',
-    },
-    {
       title: <>ID / {t('agent.Endpoint')}</>,
       key: 'id',
       dataIndex: 'id',

--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -132,19 +132,6 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
 
   const columns: ColumnsType<AgentSummary> = [
     {
-      title: '#',
-      fixed: 'left',
-      render: (id, record, index) => {
-        return (
-          index +
-          1 +
-          (tablePaginationOption.current - 1) * tablePaginationOption.pageSize
-        );
-      },
-      showSorterTooltip: false,
-      rowScope: 'row',
-    },
-    {
       title: <>ID</>,
       key: 'id',
       dataIndex: 'id',

--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -117,15 +117,6 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
 
   const columns = filterEmptyItem<ColumnType<Kernel>>([
     {
-      title: '#',
-      fixed: 'left',
-      render: (id, record, index) => {
-        return index + 1;
-      },
-      showSorterTooltip: false,
-      rowScope: 'row',
-    },
-    {
       title: t('kernel.KernelId'),
       fixed: 'left',
       dataIndex: 'row_id',

--- a/react/src/components/InviteFolderSettingModal.tsx
+++ b/react/src/components/InviteFolderSettingModal.tsx
@@ -242,16 +242,6 @@ const InviteFolderSettingModal: React.FC<InviteFolderSettingModalProps> = ({
               rowKey={(record) => record.shared_to.uuid}
               columns={[
                 {
-                  title: '#',
-                  fixed: 'left',
-                  render: (text, record, index) => {
-                    ++index;
-                    return index;
-                  },
-                  showSorterTooltip: false,
-                  rowScope: 'row',
-                },
-                {
                   title: t('data.explorer.InviteeEmail'),
                   dataIndex: ['shared_to', 'email'],
                   sorter: (a, b) =>

--- a/react/src/components/MyKeypairInfoModal.tsx
+++ b/react/src/components/MyKeypairInfoModal.tsx
@@ -82,15 +82,6 @@ const MyKeypairInfoModal: React.FC<MyKeypairInfoModalProps> = ({
         dataSource={keypairs}
         columns={[
           {
-            title: '#',
-            fixed: 'left',
-            render: (id, record, index) => {
-              ++index;
-              return index;
-            },
-            rowScope: 'row',
-          },
-          {
             title: t('general.AccessKey'),
             key: 'accessKey',
             dataIndex: 'access_key',

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -134,22 +134,6 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
         scroll={{ x: 'max-content' }}
         columns={[
           {
-            key: '#',
-            title: '#',
-            render: (id, record, index) => {
-              const [current, pageSize] =
-                tableProps.pagination &&
-                tableProps.pagination.current &&
-                tableProps.pagination.pageSize
-                  ? [
-                      tableProps.pagination.current,
-                      tableProps.pagination.pageSize,
-                    ]
-                  : [1, 0];
-              return index + 1 + (current - 1) * pageSize;
-            },
-          },
-          {
             key: 'name',
             title: t('data.folders.Name'),
             dataIndex: 'name',

--- a/src/components/backend-ai-folder-explorer.ts
+++ b/src/components/backend-ai-folder-explorer.ts
@@ -92,7 +92,6 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
   // [SSH / SFTP]
   @property({ type: Object }) volumeInfo = Object();
   // [renderers]
-  @property({ type: Object }) _boundIndexRenderer = Object();
   @property({ type: Object }) _boundFileNameRenderer = Object();
   @property({ type: Object }) _boundCreatedTimeRenderer = Object();
   @property({ type: Object }) _boundSizeRenderer = Object();
@@ -225,7 +224,6 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
 
   constructor() {
     super();
-    this._boundIndexRenderer = this.indexRenderer.bind(this);
     this._boundFileNameRenderer = this.fileNameRenderer.bind(this);
     this._boundCreatedTimeRenderer = this.createdTimeRenderer.bind(this);
     this._boundSizeRenderer = this.sizeRenderer.bind(this);
@@ -268,16 +266,6 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
         new CustomEvent('folderExplorer:columnSelected', { detail: false }),
       );
     }
-  }
-
-  indexRenderer(root, column?, rowData?) {
-    render(
-      // language=HTML
-      html`
-        ${this._indexFrom1(rowData.index)}
-      `,
-      root,
-    );
   }
 
   closeDialog(id) {
@@ -1772,13 +1760,6 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
           <vaadin-grid-selection-column
             auto-select
           ></vaadin-grid-selection-column>
-          <vaadin-grid-column
-            width="40px"
-            flex-grow="0"
-            resizable
-            header="#"
-            .renderer="${this._boundIndexRenderer}"
-          ></vaadin-grid-column>
           <vaadin-grid-sort-column
             auto-width
             resizable

--- a/src/components/backend-ai-registry-list.ts
+++ b/src/components/backend-ai-registry-list.ts
@@ -563,23 +563,6 @@ class BackendAIRegistryList extends BackendAIPage {
   }
 
   /**
-   * Render index of each row corresponding to element in registry list. Starts from 1.
-   *
-   * @param {Element} root - the row details content DOM element
-   * @param {Element} column - the column element that controls the state of the host element
-   * @param {Object} rowData - the object with the properties related with the rendered item
-   */
-  private _indexRenderer(root: HTMLElement, column: HTMLElement, rowData) {
-    const idx = rowData.index + 1;
-    render(
-      html`
-        <div>${idx}</div>
-      `,
-      root,
-    );
-  }
-
-  /**
    * Render hostname (string) usually represented by string without protocol of registry url.
    *
    * @param {Element} root - the row details content DOM element
@@ -737,13 +720,6 @@ class BackendAIRegistryList extends BackendAIPage {
           aria-label="Registry list"
           .items="${this._registryList}"
         >
-          <vaadin-grid-column
-            flex-grow="0"
-            width="40px"
-            header="#"
-            text-align="center"
-            .renderer=${this._indexRenderer}
-          ></vaadin-grid-column>
           <vaadin-grid-column
             flex-grow="1"
             auto-width

--- a/src/components/backend-ai-resource-group-list.ts
+++ b/src/components/backend-ai-resource-group-list.ts
@@ -301,16 +301,6 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
     );
   }
 
-  _indexRenderer(root, column, rowData) {
-    const idx = rowData.index + 1;
-    render(
-      html`
-        <div>${idx}</div>
-      `,
-      root,
-    );
-  }
-
   _launchDialogById(id: string) {
     (this.shadowRoot?.querySelector(id) as BackendAIDialog).show();
   }
@@ -755,13 +745,6 @@ export default class BackendAIResourceGroupList extends BackendAIPage {
           aria-label="Job list"
           .items="${this.resourceGroups}"
         >
-          <vaadin-grid-column
-            frozen
-            flex-grow="0"
-            header="#"
-            width="40px"
-            .renderer=${this._indexRenderer}
-          ></vaadin-grid-column>
           <vaadin-grid-column
             frozen
             flex-grow="1"

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1525,23 +1525,6 @@ export default class BackendAISessionList extends BackendAIPage {
   }
 
   /**
-   * Render index of rowData
-   *
-   * @param {Element} root - the row details content DOM element
-   * @param {Element} column - the column element that controls the state of the host element
-   * @param {Object} rowData - the object with the properties related with the rendered item
-   * */
-  _indexRenderer(root, column, rowData) {
-    const idx = rowData.index + 1;
-    render(
-      html`
-        <div>${idx}</div>
-      `,
-      root,
-    );
-  }
-
-  /**
    * Send request according to rqst method.
    *
    * @param {XMLHttpRequest} rqst
@@ -4926,13 +4909,6 @@ export default class BackendAISessionList extends BackendAIPage {
                         ></vaadin-grid-selection-column>
                       `
                     : html``}
-                  <vaadin-grid-column
-                    frozen
-                    width="40px"
-                    flex-grow="0"
-                    header="#"
-                    .renderer="${this._indexRenderer}"
-                  ></vaadin-grid-column>
                   ${this.is_admin
                     ? html`
                         <lablup-grid-sort-filter-column

--- a/src/components/backend-ai-storage-list.ts
+++ b/src/components/backend-ai-storage-list.ts
@@ -116,7 +116,6 @@ export default class BackendAiStorageList extends BackendAIPage {
   @property({ type: Object }) notification = Object();
   @property({ type: String }) listCondition: StatusCondition = 'loading';
   @property({ type: Array }) allowed_folder_type = [];
-  @property({ type: Object }) _boundIndexRenderer = Object();
   @property({ type: Object }) _boundTypeRenderer = Object();
   @property({ type: Object }) _boundFolderListRenderer = Object();
   @property({ type: Object }) _boundControlFolderListRenderer = Object();
@@ -184,7 +183,6 @@ export default class BackendAiStorageList extends BackendAIPage {
   @state() private _unionedAllowedPermissionByVolume = Object();
   constructor() {
     super();
-    this._boundIndexRenderer = this.indexRenderer.bind(this);
     this._boundTypeRenderer = this.typeRenderer.bind(this);
     this._boundControlFolderListRenderer =
       this.controlFolderListRenderer.bind(this);
@@ -454,14 +452,6 @@ export default class BackendAiStorageList extends BackendAIPage {
           aria-label="Folder list"
           .items="${this.folders}"
         >
-          <vaadin-grid-column
-            width="40px"
-            flex-grow="0"
-            resizable
-            header="#"
-            text-align="center"
-            .renderer="${this._boundIndexRenderer}"
-          ></vaadin-grid-column>
           <lablup-grid-sort-filter-column
             path="name"
             width="80px"
@@ -1193,16 +1183,6 @@ export default class BackendAiStorageList extends BackendAIPage {
           description="${rowData.item.status}"
           ui="flat"
         ></lablup-shields>
-      `,
-      root,
-    );
-  }
-
-  indexRenderer(root, column?, rowData?) {
-    render(
-      // language=HTML
-      html`
-        ${this._indexFrom1(rowData.index)}
       `,
       root,
     );

--- a/src/components/backend-ai-storage-proxy-list.ts
+++ b/src/components/backend-ai-storage-proxy-list.ts
@@ -261,23 +261,6 @@ export default class BackendAIStorageProxyList extends BackendAIPage {
   }
 
   /**
-   * Render an index.
-   *
-   * @param {DOMelement} root
-   * @param {object} column (<vaadin-grid-column> element)
-   * @param {object} rowData
-   */
-  _indexRenderer(root, column, rowData) {
-    const idx = rowData.index + 1;
-    render(
-      html`
-        <div>${idx}</div>
-      `,
-      root,
-    );
-  }
-
-  /**
    * Render endpoint with IP and name.
    *
    * @param {DOMelement} root
@@ -516,13 +499,6 @@ export default class BackendAIStorageProxyList extends BackendAIPage {
           aria-label="Job list"
           .items="${this.storages}"
         >
-          <vaadin-grid-column
-            width="40px"
-            flex-grow="0"
-            header="#"
-            text-align="center"
-            .renderer="${this._indexRenderer}"
-          ></vaadin-grid-column>
           <vaadin-grid-column
             resizable
             width="80px"


### PR DESCRIPTION
resolves #3330 (FR-616)

this PR removed unnecessary # column from table

**changes**
* remove from `/data`, `/agent`, `/job`, `/agent-summary`, `/sessionDetail`, `myKeyPairInfoModal`, `InvteFolderSettingModal`, `vfolder-explorer` and experimental `/data`
* delete unused functions and variables
* The `backend-ai-resource-preset-list` and `backend-ai-scaling-group-list` files also use the # column, but these components are no longer in use. Therefore, these files are being deleted in a different PR #3352, so I will exclude them from this PR.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
