### PR TITLE
chore(FR-653): comment out StartFromURL card from startpage

### DIFF
--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -6,11 +6,7 @@ import { filterEmptyItem } from '../helper';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 // import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { SessionLauncherFormValue } from './SessionLauncherPage';
-import {
-  AppstoreAddOutlined,
-  FolderAddOutlined,
-  LinkOutlined,
-} from '@ant-design/icons';
+import { AppstoreAddOutlined, FolderAddOutlined } from '@ant-design/icons';
 import { Card, Col, Grid, Row } from 'antd';
 import _ from 'lodash';
 import { useState } from 'react';
@@ -114,25 +110,25 @@ const StartPage: React.FC = () => {
         ),
       },
     },
-    {
-      id: 'startFromURL',
-      rowSpan: 3,
-      columnSpan: 1,
-      columnOffset: { 6: 1, 4: 1 },
-      data: {
-        content: (
-          <ThemeSecondaryProvider>
-            <ActionItemContent
-              title={t('start.StartFromURL')}
-              description={t('start.StartFromURLDesc')}
-              buttonText={t('start.button.StartNow')}
-              icon={<LinkOutlined />}
-              onClick={() => webuiNavigate('/import')}
-            />
-          </ThemeSecondaryProvider>
-        ),
-      },
-    },
+    // {
+    //   id: 'startFromURL',
+    //   rowSpan: 3,
+    //   columnSpan: 1,
+    //   columnOffset: { 6: 1, 4: 1 },
+    //   data: {
+    //     content: (
+    //       <ThemeSecondaryProvider>
+    //         <ActionItemContent
+    //           title={t('start.StartFromURL')}
+    //           description={t('start.StartFromURLDesc')}
+    //           buttonText={t('start.button.StartNow')}
+    //           icon={<LinkOutlined />}
+    //           onClick={() => webuiNavigate('/import')}
+    //         />
+    //       </ThemeSecondaryProvider>
+    //     ),
+    //   },
+    // },
     // {
     //   id: 'startFromExample',
     //   rowSpan: 3,


### PR DESCRIPTION
resolves #3333 (FR-653)
This pr comment out the StartFromURL card on the start page and then check if the layout is not broken afterward.

**changes**
* comment out the startFromURL card on the startpage


![스크린샷 2025-03-11 오후 5.37.13.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/d817bd61-b9a3-4aed-baed-e0aa30c3d8d0.png)

![스크린샷 2025-03-11 오후 5.37.20.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/0573b784-e52c-492c-be63-677d7bab9b08.png)

![스크린샷 2025-03-11 오후 5.37.37.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/7804a368-e913-41d6-98f9-d705e637c773.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
