### PR TITLE
chore(FR-656) Modify the icon-related design on the session page

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -11,7 +11,7 @@ import {
   ConnectedKernelListQuery,
   ConnectedKernelListQuery$data,
 } from './__generated__/ConnectedKernelListQuery.graphql';
-import { Button, Tag, Tooltip, Typography } from 'antd';
+import { Button, Tag, theme, Tooltip, Typography } from 'antd';
 import { ColumnType } from 'antd/lib/table';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
@@ -62,6 +62,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
   const { t } = useTranslation();
   const currentProject = useCurrentProjectValue();
   const [kernelIdForLogModal, setKernelIdForLogModal] = useState<string>();
+  const { token } = theme.useToken();
 
   // get the project id of the session for <= v24.12.0.
   const { session_for_project_id } =
@@ -140,7 +141,12 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
               onClick={() => {
                 setKernelIdForLogModal(row_id);
               }}
-              style={{ width: 22 }}
+              style={{
+                width: 'auto',
+                height: 'auto',
+                marginInlineStart: token.marginXXS,
+                border: 'none',
+              }}
             />
           </Tooltip>
         </>
@@ -183,11 +189,14 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
       onCell: () => ({
         style: { maxWidth: 250 },
       }),
-      render: (id) => (
-        <Typography.Text copyable ellipsis>
-          {id}
-        </Typography.Text>
-      ),
+      render: (id) =>
+        _.isEmpty(id) ? (
+          '-'
+        ) : (
+          <Typography.Text copyable ellipsis>
+            {id}
+          </Typography.Text>
+        ),
     },
     {
       title: t('kernel.AgentId'),


### PR DESCRIPTION
resolves #3337 (FR-656)
This PR modify the icon-related design on the session page.

**changes**
* modify the spacing between the copyable icon and the log icon.
before
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/0a81f740-b03e-4360-abb5-eda1f2c46eb1.png)
after
![스크린샷 2025-03-12 오전 11.20.28.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/3f10ea7e-ca49-4592-ad4d-1acace171d28.png)

* display '-' if container ID is not available.
before
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/c52257b1-ec81-4c73-ba26-7ed18893a2dd.png)
after
![스크린샷 2025-03-12 오전 11.21.58.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/3e1b9931-9720-4189-b9fa-2cc5d5c513e6.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
