### PR TITLE
feat(FR-576): Add TCP connection guidance dialog

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1236,7 +1236,8 @@
       "NoExistingConnectionExample": "Keine Verbindung Zu kopierendes Beispiel.",
       "OpenVSCodeRemote": "Lokalen Visual Studio Code öffnen",
       "Prepared": "Bereit",
-      "SSHConnectionExampleClipboardCopy": "SSH Connection Example wurde in die Zwischenablage kopiert."
+      "SSHConnectionExampleClipboardCopy": "SSH Connection Example wurde in die Zwischenablage kopiert.",
+      "TCPConnection": "TCP -Verbindung"
     },
     "launcher": {
       "AIAccelerator": "KI-Beschleuniger",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1232,7 +1232,8 @@
       "NoExistingConnectionExample": "Δεν υπάρχει σύνδεση Παράδειγμα προς αντιγραφή.",
       "OpenVSCodeRemote": "Ανοίξτε τον τοπικό κώδικα του Visual Studio",
       "Prepared": "Ετοιμος",
-      "SSHConnectionExampleClipboardCopy": "Το παράδειγμα σύνδεσης SSH έχει αντιγραφεί στο πρόχειρο."
+      "SSHConnectionExampleClipboardCopy": "Το παράδειγμα σύνδεσης SSH έχει αντιγραφεί στο πρόχειρο.",
+      "TCPConnection": "Σύνδεση TCP"
     },
     "launcher": {
       "AIAccelerator": "Επιταχυντής AI",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1242,7 +1242,8 @@
       "NoExistingConnectionExample": "No Connection Example to be copied.",
       "OpenVSCodeRemote": "Open local Visual Studio Code",
       "Prepared": "Prepared",
-      "SSHConnectionExampleClipboardCopy": "SSH Connection Example has been copied to the clipboard."
+      "SSHConnectionExampleClipboardCopy": "SSH Connection Example has been copied to the clipboard.",
+      "TCPConnection": "TCP connection"
     },
     "launcher": {
       "AIAccelerator": "AI Accelerator",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1236,7 +1236,8 @@
       "NoExistingConnectionExample": "No hay conexión Ejemplo a copiar.",
       "OpenVSCodeRemote": "Abrir código local de Visual Studio",
       "Prepared": "Preparado",
-      "SSHConnectionExampleClipboardCopy": "El ejemplo de conexión SSH se ha copiado en el portapapeles."
+      "SSHConnectionExampleClipboardCopy": "El ejemplo de conexión SSH se ha copiado en el portapapeles.",
+      "TCPConnection": "Conexión TCP"
     },
     "launcher": {
       "AIAccelerator": "Acelerador de IA",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1234,7 +1234,8 @@
       "NoExistingConnectionExample": "Ei yhteyttä Kopioitava esimerkki.",
       "OpenVSCodeRemote": "Avaa paikallinen Visual Studio Code",
       "Prepared": "Valmisteltu",
-      "SSHConnectionExampleClipboardCopy": "SSH-yhteys Esimerkki on kopioitu leikepöydälle."
+      "SSHConnectionExampleClipboardCopy": "SSH-yhteys Esimerkki on kopioitu leikepöydälle.",
+      "TCPConnection": "TCP -yhteys"
     },
     "launcher": {
       "AIAccelerator": "AI-kiihdyttämö",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1236,7 +1236,8 @@
       "NoExistingConnectionExample": "Aucun exemple de connexion à copier.",
       "OpenVSCodeRemote": "Ouvrir le code local de Visual Studio",
       "Prepared": "Préparé",
-      "SSHConnectionExampleClipboardCopy": "L'exemple de connexion SSH a été copié dans le presse-papiers."
+      "SSHConnectionExampleClipboardCopy": "L'exemple de connexion SSH a été copié dans le presse-papiers.",
+      "TCPConnection": "Connexion TCP"
     },
     "launcher": {
       "AIAccelerator": "Accélérateur d'IA",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1234,7 +1234,8 @@
       "NoExistingConnectionExample": "Tidak Ada Koneksi Contoh untuk disalin.",
       "OpenVSCodeRemote": "Buka kode Visual Studio lokal",
       "Prepared": "Siap",
-      "SSHConnectionExampleClipboardCopy": "Contoh Koneksi SSH telah disalin ke clipboard."
+      "SSHConnectionExampleClipboardCopy": "Contoh Koneksi SSH telah disalin ke clipboard.",
+      "TCPConnection": "Koneksi TCP"
     },
     "launcher": {
       "AIAccelerator": "Akselerator AI",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1233,7 +1233,8 @@
       "NoExistingConnectionExample": "Nessun esempio di connessione da copiare.",
       "OpenVSCodeRemote": "Aprire il codice locale di Visual Studio",
       "Prepared": "Preparato",
-      "SSHConnectionExampleClipboardCopy": "L'esempio di connessione SSH è stato copiato negli appunti."
+      "SSHConnectionExampleClipboardCopy": "L'esempio di connessione SSH è stato copiato negli appunti.",
+      "TCPConnection": "Connessione TCP"
     },
     "launcher": {
       "AIAccelerator": "Acceleratore AI",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1235,7 +1235,8 @@
       "NoExistingConnectionExample": "コピーする接続例がありません。",
       "OpenVSCodeRemote": "ローカルVisual Studio Codeを開く",
       "Prepared": "準備",
-      "SSHConnectionExampleClipboardCopy": "SSH接続例がクリップボードにコピーされました。"
+      "SSHConnectionExampleClipboardCopy": "SSH接続例がクリップボードにコピーされました。",
+      "TCPConnection": "TCP接続"
     },
     "launcher": {
       "AIAccelerator": "AIアクセラレータ",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1239,7 +1239,8 @@
       "NoExistingConnectionExample": "복사할 접속 예제가 없습니다.",
       "OpenVSCodeRemote": "로컬 Visual Studio Code 열기",
       "Prepared": "준비되었습니다",
-      "SSHConnectionExampleClipboardCopy": "SSH 접속 예제가 클립보드에 복사되었습니다."
+      "SSHConnectionExampleClipboardCopy": "SSH 접속 예제가 클립보드에 복사되었습니다.",
+      "TCPConnection": "TCP 연결"
     },
     "launcher": {
       "AIAccelerator": "AI 가속기",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1233,7 +1233,8 @@
       "NoExistingConnectionExample": "Хуулбарлах холболтын жишээ байхгүй.",
       "OpenVSCodeRemote": "Орон нутгийн Visual Studio кодыг нээнэ үү",
       "Prepared": "Бэлтгэсэн",
-      "SSHConnectionExampleClipboardCopy": "SSH холболтын жишээг санах ой руу хуулсан."
+      "SSHConnectionExampleClipboardCopy": "SSH холболтын жишээг санах ой руу хуулсан.",
+      "TCPConnection": "TCP холболт"
     },
     "launcher": {
       "AIAccelerator": "AI хурдасгуур",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1235,7 +1235,8 @@
       "NoExistingConnectionExample": "Tiada Contoh Sambungan untuk disalin.",
       "OpenVSCodeRemote": "Buka Kod Visual Studio tempatan",
       "Prepared": "Bersedia",
-      "SSHConnectionExampleClipboardCopy": "Contoh Sambungan SSH telah disalin ke papan keratan."
+      "SSHConnectionExampleClipboardCopy": "Contoh Sambungan SSH telah disalin ke papan keratan.",
+      "TCPConnection": "Sambungan TCP"
     },
     "launcher": {
       "AIAccelerator": "Pemecut AI",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1236,7 +1236,8 @@
       "NoExistingConnectionExample": "Brak przykładu połączenia do skopiowania.",
       "OpenVSCodeRemote": "Otwórz lokalny kod Visual Studio",
       "Prepared": "Przygotowany",
-      "SSHConnectionExampleClipboardCopy": "Przykład połączenia SSH został skopiowany do schowka."
+      "SSHConnectionExampleClipboardCopy": "Przykład połączenia SSH został skopiowany do schowka.",
+      "TCPConnection": "Połączenie TCP"
     },
     "launcher": {
       "AIAccelerator": "Akcelerator AI",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1236,7 +1236,8 @@
       "NoExistingConnectionExample": "Não há exemplo de ligação a copiar.",
       "OpenVSCodeRemote": "Abrir o código local do Visual Studio",
       "Prepared": "Preparado",
-      "SSHConnectionExampleClipboardCopy": "O exemplo de ligação SSH foi copiado para a área de transferência."
+      "SSHConnectionExampleClipboardCopy": "O exemplo de ligação SSH foi copiado para a área de transferência.",
+      "TCPConnection": "Conexão TCP"
     },
     "launcher": {
       "AIAccelerator": "Acelerador de IA",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1236,7 +1236,8 @@
       "NoExistingConnectionExample": "Não há exemplo de ligação a copiar.",
       "OpenVSCodeRemote": "Abrir o código local do Visual Studio",
       "Prepared": "Preparado",
-      "SSHConnectionExampleClipboardCopy": "O exemplo de ligação SSH foi copiado para a área de transferência."
+      "SSHConnectionExampleClipboardCopy": "O exemplo de ligação SSH foi copiado para a área de transferência.",
+      "TCPConnection": "Conexão TCP"
     },
     "launcher": {
       "AIAccelerator": "Acelerador de IA",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1236,7 +1236,8 @@
       "NoExistingConnectionExample": "Нет примера подключения для копирования.",
       "OpenVSCodeRemote": "Открыть локальный Visual Studio Code",
       "Prepared": "Готовый",
-      "SSHConnectionExampleClipboardCopy": "Пример подключения SSH скопирован в буфер обмена."
+      "SSHConnectionExampleClipboardCopy": "Пример подключения SSH скопирован в буфер обмена.",
+      "TCPConnection": "Соединение TCP"
     },
     "launcher": {
       "AIAccelerator": "Ускоритель искусственного интеллекта",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1224,7 +1224,8 @@
       "NoExistingConnectionExample": "ไม่มีตัวอย่างการเชื่อมต่อที่จะคัดลอก",
       "OpenVSCodeRemote": "เปิด Visual Studio Code ในเครื่อง",
       "Prepared": "เตรียมพร้อมแล้ว",
-      "SSHConnectionExampleClipboardCopy": "คัดลอกตัวอย่างการเชื่อมต่อ SSH ไปยังคลิปบอร์ดแล้ว"
+      "SSHConnectionExampleClipboardCopy": "คัดลอกตัวอย่างการเชื่อมต่อ SSH ไปยังคลิปบอร์ดแล้ว",
+      "TCPConnection": "การเชื่อมต่อ TCP"
     },
     "launcher": {
       "AIAccelerator": "ตัวเร่ง AI",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1235,7 +1235,8 @@
       "NoExistingConnectionExample": "Kopyalanacak Bağlantı Örneği Yok.",
       "OpenVSCodeRemote": "Yerel Visual Studio Kodunu açın",
       "Prepared": "Hazırlanmış",
-      "SSHConnectionExampleClipboardCopy": "SSH Bağlantı Örneği panoya kopyalandı."
+      "SSHConnectionExampleClipboardCopy": "SSH Bağlantı Örneği panoya kopyalandı.",
+      "TCPConnection": "TCP bağlantısı"
     },
     "launcher": {
       "AIAccelerator": "Yapay Zeka Hızlandırıcı",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1236,7 +1236,8 @@
       "NoExistingConnectionExample": "Không có ví dụ kết nối nào được sao chép.",
       "OpenVSCodeRemote": "Mở mã Visual Studio cục bộ",
       "Prepared": "Chuẩn bị",
-      "SSHConnectionExampleClipboardCopy": "Ví dụ về kết nối SSH đã được sao chép vào bảng nhớ tạm."
+      "SSHConnectionExampleClipboardCopy": "Ví dụ về kết nối SSH đã được sao chép vào bảng nhớ tạm.",
+      "TCPConnection": "Kết nối TCP"
     },
     "launcher": {
       "AIAccelerator": "Máy gia tốc AI",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1236,7 +1236,8 @@
       "NoExistingConnectionExample": "无连接示例可复制。",
       "OpenVSCodeRemote": "打开本地 Visual Studio 代码",
       "Prepared": "准备好了",
-      "SSHConnectionExampleClipboardCopy": "SSH 连接示例已复制到剪贴板。"
+      "SSHConnectionExampleClipboardCopy": "SSH 连接示例已复制到剪贴板。",
+      "TCPConnection": "TCP连接"
     },
     "launcher": {
       "AIAccelerator": "人工智能加速器",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1235,7 +1235,8 @@
       "NoExistingConnectionExample": "无连接示例可复制。",
       "OpenVSCodeRemote": "打开本地 Visual Studio 代码",
       "Prepared": "準備好了",
-      "SSHConnectionExampleClipboardCopy": "SSH 连接示例已复制到剪贴板。"
+      "SSHConnectionExampleClipboardCopy": "SSH 连接示例已复制到剪贴板。",
+      "TCPConnection": "TCP連接"
     },
     "launcher": {
       "AIAccelerator": "人工智能加速器",


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai-webui/issues/3218 ([FR-576](https://lablup.atlassian.net/browse/FR-576))

# Add TCP connection dialog for TCP-based applications

This PR adds a new dialog for TCP-based applications that displays connection information (host and port) when a TCP connection is established. The dialog shows the application name, host, and port information to help users connect to TCP-based services.

The implementation includes:
- Added a new "TCPConnection" string to all language translation files
- Created a new TCP dialog component with connection information display
- Enhanced the app launcher to detect TCP connections and show the appropriate dialog
- Added logic to extract host and port information from redirect URLs

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/c10011f7-9433-4d12-b6b8-7bdb47a3eb11.png)

### How to test
1. Log in in dogbowl
2. Create a session with `cr.backend.ai/testing/python-tcp-app:3.9-ubuntu20.04@x86_64` image
3. Click the `testapp` from the App Dialog
4. You can check tcp connection: `curl -v telnet://<HOST>:<PORT>/`
  - If you receive like this message, the tcp is successfully connected.
  ```
$ curl -v telnet://proxy.asia03t.app.backend.ai:10305
* Host proxy.asia03t.app.backend.ai:10305 was resolved.
* IPv6: (none)
* IPv4: 110.45.167.85
*   Trying 110.45.167.85:10305...
* Connected to proxy.asia03t.app.backend.ai (110.45.167.85) port 10305
```

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-576]: https://lablup.atlassian.net/browse/FR-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ