### PR TITLE
feat(FR-647): set NEO vfolder as a default.

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -17,7 +17,6 @@ import ModelStoreListPage from './pages/ModelStoreListPage';
 import Page401 from './pages/Page401';
 import Page404 from './pages/Page404';
 import ServingPage from './pages/ServingPage';
-import VFolderListPage from './pages/VFolderListPage';
 import VFolderNodeListPage from './pages/VFolderNodeListPage';
 import { Skeleton, theme } from 'antd';
 import React, { Suspense } from 'react';
@@ -368,16 +367,9 @@ const router = createBrowserRouter([
         path: '/data',
         handle: { labelKey: 'webui.menu.Data' },
         Component: () => {
-          const [experimentalNeoDataPage] = useBAISettingUserState(
-            'experimental_neo_data_page',
-          );
           return (
             <BAIErrorBoundary>
-              {experimentalNeoDataPage ? (
-                <VFolderNodeListPage />
-              ) : (
-                <VFolderListPage />
-              )}
+              <VFolderNodeListPage />
             </BAIErrorBoundary>
           );
         },

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -20,7 +20,6 @@ interface UserSettings {
   experimental_neo_session_list?: boolean;
   start_board_items?: Array<Omit<BAIBoardItem, 'data'>>;
   experimental_ai_agents?: boolean;
-  experimental_neo_data_page?: boolean;
   [key: `hiddenColumnKeys.${string}`]: Array<string>;
 }
 

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -49,8 +49,6 @@ const UserPreferencesPage = () => {
     useBAISettingUserState('experimental_neo_session_list');
   const [experimentalAIAgents, setExperimentalAIAgents] =
     useBAISettingUserState('experimental_ai_agents');
-  const [experimentalNeoDataPage, setExperimentalNeoDataPage] =
-    useBAISettingUserState('experimental_neo_data_page');
   const [shellInfo, setShellInfo] = useState<ShellScriptType>('bootstrap');
   const [isOpenShellScriptEditModal, { toggle: toggleShellScriptEditModal }] =
     useToggle(false);
@@ -268,17 +266,6 @@ const UserPreferencesPage = () => {
           setValue: setExperimentalAIAgents,
           onChange: (e) => {
             setExperimentalAIAgents(e.target.checked);
-          },
-        },
-        {
-          type: 'checkbox',
-          title: t('userSettings.NEODataPage'),
-          description: t('general.Enabled'),
-          defaultValue: false,
-          value: experimentalNeoDataPage,
-          setValue: setExperimentalNeoDataPage,
-          onChange: (e) => {
-            setExperimentalNeoDataPage(e.target.checked);
           },
         },
       ],


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai-webui/issues/3148 ([FR-647](https://lablup.atlassian.net/browse/FR-647))

# Make the Neo Data Page the Default

This PR removes the experimental flag for the Neo Data Page, making it the default view for all users. The changes include:

1. Removing the `experimental_neo_data_page` setting from the user settings interface
2. Updating the Data page route to always render the `VFolderNodeListPage` component
3. Removing the `experimental_neo_data_page` property from the UserSettings interface

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-647]: https://lablup.atlassian.net/browse/FR-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ