### PR TITLE
feat(FR-663): Set default category if app is not included app template.

### DIFF
--- a/react/src/hooks/useSuspendedFilteredAppTemplate.ts
+++ b/react/src/hooks/useSuspendedFilteredAppTemplate.ts
@@ -78,11 +78,11 @@ export const useSuspendedFilteredAppTemplate = (
         if (app.name === 'sshd' && !allowTCPApps) {
           return null;
         }
-        // They are default apps from Backend.AI agent.
+        // They are custom apps from Backend.AI agent.
         return {
           name: app.name,
           title: template?.title || app.name,
-          category: template?.category || '0.Default',
+          category: template?.category || '99.Custom',
           redirect: template?.redirect || '',
           src: template?.src || './resources/icons/default_app.svg',
         };
@@ -96,7 +96,7 @@ export const useSuspendedFilteredAppTemplate = (
     baseAppTemplate.push({
       name: appTemplate['ttyd'][0].name,
       title: appTemplate['ttyd'][0].title,
-      category: '0.Default',
+      category: '99.Custom',
       redirect: appTemplate['ttyd'][0].redirect,
       src: appTemplate['ttyd'][0].src,
     });

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -541,7 +541,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         // Force push terminal
         name: 'ttyd',
         title: 'Console',
-        category: '0.Default',
+        category: '99.Custom',
         redirect: '',
         src: './resources/icons/terminal.svg',
       });
@@ -561,7 +561,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         this.appTemplate[elm].push({
           name: elm,
           title: elm,
-          category: '99.',
+          category: '99.Custom',
           redirect: '',
           src: './resources/icons/default_app.svg',
         });
@@ -585,8 +585,8 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         if (elm !== 'sshd' || (elm === 'sshd' && this.allowTCPApps)) {
           if (interText !== this.appTemplate[elm][0].category) {
             this.appSupportList.push({
-              name: this.appTemplate[elm][0].category.substring(2),
-              title: this.appTemplate[elm][0].category.substring(2),
+              name: this.appTemplate[elm][0].category?.split('.')[1],
+              title: this.appTemplate[elm][0].category?.split('.')[1],
               category: 'divider',
               redirect: '',
               src: '',
@@ -599,11 +599,11 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         }
       } else {
         if (!['ttyd', 'ipython'].includes(elm)) {
-          // They are default apps from Backend.AI agent.
+          // They are custom apps from Backend.AI agent.
           this.appSupportList.push({
             name: elm,
             title: elm,
-            category: 'Default',
+            category: 'Custom',
             redirect: '',
             src: './resources/icons/default_app.svg',
           });


### PR DESCRIPTION
# Change default app category from '0.Default' to '99.Custom'

This PR changes the default category for custom applications from '0.Default' to '99.Custom' in the app launcher component. This change ensures that custom applications from Backend.AI agent are properly categorized and displayed at the end of the application list rather than at the beginning.

The PR also fixes the category name extraction logic by using a split method to properly extract the category name after the dot notation.

Before
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b6a12119-b4ee-4d7e-ad69-796eb709b618" />

<img width="300" alt="image" src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/bdf57ca8-df46-47c6-af4e-0294b761a3eb.png" />

After

<img width="300" alt="image" src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/1421b06d-7ba1-43f2-b274-ab71d5001b28.png"/>

<img width="300" alt="image" src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/2f6ca025-d388-4ca2-bbb4-f008678e76d8.png" />



**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after