### PR TITLE
chore: add color to FuriosaAI icon

### DIFF
--- a/resources/icons/furiosa.svg
+++ b/resources/icons/furiosa.svg
@@ -14,6 +14,9 @@
 	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="114.6954117px"
 	 height="149.4450989px" viewBox="0 0 114.6954117 149.4450989" style="enable-background:new 0 0 114.6954117 149.4450989;"
 	 xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#E21500;}
+</style>
 <switch>
 	<foreignObject requiredExtensions="&ns_ai;" x="0" y="0" width="1" height="1">
 		<i:aipgfRef  xlink:href="#adobe_illustrator_pgf">
@@ -21,13 +24,13 @@
 	</foreignObject>
 	<g i:extraneous="self">
 		<g id="Symbol_1_">
-			<path id="Symbol" d="M114.2278366,84.8490067l-53.0622749,25.4614334v39.1346283l-7.4154549,0.0000305l-17.8930817-57.455307
+			<path id="Symbol" class="st0" d="M114.2278366,84.8490067l-53.0622749,25.4614334v39.1346283l-7.4154549,0.0000305l-17.8930817-57.455307
 				L65.0684738,78.121788H8.6048241L0,50.3970413L106.139183,0l8.5562286,27.5025711L55.4907761,55.7552147l50.5708084,2.8226471
 				L114.2278366,84.8490067z"/>
 		</g>
 	</g>
 </switch>
-<i:aipgf  id="adobe_illustrator_pgf" i:pgfEncoding="zstd/base64" i:pgfVersion="24">
+<i:aipgf id="adobe_illustrator_pgf" i:pgfEncoding="zstd/base64" i:pgfVersion="24">
 	<![CDATA[
 	KLUv/QBYxNYACq/QHyzAKqCrARvRbG1F94rmXxzPHJ7wpQP4Vfjg5SQLSxBctSa/D6YOAABA0iQ4
 HvMB7QHuAQq/yQkEPfv+zD/x96DjDR+4ZVGY5VasLL8kiYpWNWFQggrI+L3fysnDVwaNsh6+Mtzn


### PR DESCRIPTION
resolves #NNN (FR-MMM)

This PR adds a red color (#E21500) to the FuriosaAI logo SVG by:
- Adding a CSS style class `.st0` with the fill color
- Applying this class to the logo path
- Cleaning up whitespace in the SVG file

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after