### PR TITLE
feat(FR-563): Set model usage mode when selected tab is model.

### DIFF
--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -62,6 +62,7 @@ interface FolderCreateFormItemsType {
 
 interface FolderCreateModalProps extends BAIModalProps {
   onRequestClose: (response?: FolderCreationResponse) => void;
+  usageMode?: 'general' | 'model';
 }
 export interface FolderCreationResponse {
   id: string;
@@ -81,6 +82,7 @@ export interface FolderCreationResponse {
 
 const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
   onRequestClose,
+  usageMode,
   ...modalProps
 }) => {
   const { t } = useTranslation();
@@ -132,7 +134,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
     name: '',
     host: undefined,
     group: currentProject.name,
-    usage_mode: 'general',
+    usage_mode: usageMode ?? 'general',
     type: 'user',
     permission: 'rw',
     cloneable: false,

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -582,6 +582,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
           }
           toggleCreateModal();
         }}
+        usageMode={queryParams.mode === 'model' ? 'model' : undefined}
       />
       <DeleteVFolderModal
         vfolderFrgmts={selectedFolderList}


### PR DESCRIPTION
# Add `usageMode` prop to FolderCreateModal for model-specific folder creation

This PR adds a new `usageMode` prop to the `FolderCreateModal` component, allowing the caller to specify whether the folder being created is for general use or specifically for models. When the modal is opened from the VFolder list page with the `mode=model` query parameter, it will now automatically set the folder's usage mode to 'model'.

### How to test
1. create a folder
2. select model tab 

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/79e5afe7-ba42-4314-af33-3943ebd9ddbf.png)

3. check usage mode is model

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/b9172c7b-8a2a-41b3-9449-950c227d2b89.png)

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after