### PR TITLE
feat(FR-670): hide `DELETE_COMPLETE` folders

### DIFF
--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -80,6 +80,11 @@ const VFOLDER_STATUSES = [
 
 interface VFolderNodeListPageProps {}
 
+const FILTER_BY_STATUS_CATEGORY = {
+  created: 'status in ["READY", "PERFORMING", "CLONING", "MOUNTED", "ERROR"]',
+  deleted: 'status in ["DELETE_PENDING", "DELETE_ONGOING", "DELETE_ERROR"]',
+};
+
 const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   ...props
 }) => {
@@ -119,8 +124,8 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   const statusFilter =
     queryParams.statusCategory === 'created' ||
     queryParams.statusCategory === undefined
-      ? 'status in ["READY", "PERFORMING", "CLONING", "MOUNTED", "ERROR"]'
-      : 'status in ["DELETE_PENDING", "DELETE_ONGOING","DELETE_COMPLETE", "DELETE_ERROR"]';
+      ? FILTER_BY_STATUS_CATEGORY['created']
+      : FILTER_BY_STATUS_CATEGORY['deleted'];
 
   function getUsageModeFilter(mode: string) {
     switch (mode) {
@@ -170,12 +175,14 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     useLazyLoadQuery<VFolderNodeListPageQuery>(
       graphql`
         query VFolderNodeListPageQuery(
-          $projectId: UUID 
+          $projectId: UUID
           $offset: Int
           $first: Int
           $filter: String
           $order: String
           $permission: VFolderPermissionValueField
+          $filterForCreatedCount: String
+          $filterForDeletedCount: String
         ) {
           vfolder_nodes(
             project_id: $projectId
@@ -201,7 +208,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             project_id: $projectId
             first: 0
             offset: 0
-            filter: "status in [\"READY\", \"PERFORMING\", \"CLONING\", \"MOUNTED\", \"ERROR\"]"
+            filter: $filterForCreatedCount
             permission: $permission
           ) {
             count
@@ -210,14 +217,18 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             project_id: $projectId
             first: 0
             offset: 0
-            filter: "status in [\"DELETE_PENDING\", \"DELETE_ONGOING\",\"DELETE_COMPLETE\", \"DELETE_ERROR\"]",
+            filter: $filterForDeletedCount
             permission: $permission
           ) {
             count
           }
         }
       `,
-      deferredQueryVariables,
+      {
+        ...deferredQueryVariables,
+        filterForCreatedCount: FILTER_BY_STATUS_CATEGORY['created'],
+        filterForDeletedCount: FILTER_BY_STATUS_CATEGORY['deleted'],
+      },
       {
         fetchPolicy:
           deferredFetchKey === 'initial-fetch'


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai-webui/issues/3364 (FR-670)

This PR modifies the VFolder node list filtering to exclude nodes with "DELETE_COMPLETE" status from the main list view, while also removing them from the deletion status filter. **This ensures that completely deleted folders are not displayed to users**, improving the clarity of the interface. For deleting folders from DB, admin should use control panel.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after