### PR TITLE
feat(FR-326): dashboard layout

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,3 +1,4 @@
+// import AnnouncementAlert from './components/AnnouncementAlert';
 import BAICard from './components/BAICard';
 import BAIErrorBoundary, { ErrorView } from './components/BAIErrorBoundary';
 import {
@@ -35,6 +36,7 @@ const EndpointDetailPage = React.lazy(
   () => import('./pages/EndpointDetailPage'),
 );
 const StartPage = React.lazy(() => import('./pages/StartPage'));
+const DashboardPage = React.lazy(() => import('./pages/DashboardPage'));
 const EnvironmentPage = React.lazy(() => import('./pages/EnvironmentPage'));
 const MyEnvironmentPage = React.lazy(() => import('./pages/MyEnvironmentPage'));
 const StorageHostSettingPage = React.lazy(
@@ -125,6 +127,15 @@ const router = createBrowserRouter([
         handle: { labelKey: 'webui.menu.Start' },
       },
       {
+        path: '/dashboard',
+        element: (
+          <BAIErrorBoundary>
+            <DashboardPage />
+          </BAIErrorBoundary>
+        ),
+        handle: { labelKey: 'webui.menu.Dashboard' },
+      },
+      {
         //for electron dev mode
         path: '/build/electron-app/app/index.html',
         element: <WebUINavigate to="/start" replace />,
@@ -149,10 +160,24 @@ const router = createBrowserRouter([
           );
         },
       },
-      {
-        path: '/summary',
-        handle: { labelKey: 'webui.menu.Summary' },
-      },
+      // {
+      //   path: '/summary',
+      //   Component: () => {
+      //     const { token } = theme.useToken();
+      //     return (
+      //       <>
+      //         <AnnouncementAlert
+      //           showIcon
+      //           icon={undefined}
+      //           banner={false}
+      //           style={{ marginBottom: token.paddingContentVerticalLG }}
+      //           closable
+      //         />
+      //       </>
+      //     );
+      //   },
+      //   handle: { labelKey: 'webui.menu.Summary' },
+      // },
       {
         path: '/job',
         handle: { labelKey: 'webui.menu.Sessions' },

--- a/react/src/components/AvailableResourcesCard.tsx
+++ b/react/src/components/AvailableResourcesCard.tsx
@@ -21,10 +21,11 @@ const AvailableResourcesCard: React.FC<AvailableResourcesCardProps> = ({
   const currentProject = useCurrentProjectValue();
   const [selectedResourceGroup, setSelectedResourceGroup] = useState();
   const deferredSelectedResourceGroup = useDeferredValue(selectedResourceGroup);
-  const [{ checkPresetInfo }, { refetch }] = useResourceLimitAndRemaining({
-    currentProjectName: currentProject.name,
-    currentResourceGroup: deferredSelectedResourceGroup || 'default',
-  });
+  const [{ checkPresetInfo, isRefetching }, { refetch }] =
+    useResourceLimitAndRemaining({
+      currentProjectName: currentProject.name,
+      currentResourceGroup: deferredSelectedResourceGroup || 'default',
+    });
   const resourceSlotsDetails = useResourceSlotsDetails(
     deferredSelectedResourceGroup || 'default',
   );
@@ -69,6 +70,10 @@ const AvailableResourcesCard: React.FC<AvailableResourcesCardProps> = ({
             type="text"
             onClick={() => {
               refetch();
+            }}
+            loading={isRefetching}
+            style={{
+              backgroundColor: 'transparent',
             }}
           />
         </Flex>

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -117,11 +117,17 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
       group: 'none',
     },
     {
-      label: <WebUILink to="/summary">{t('webui.menu.Summary')}</WebUILink>,
+      label: <WebUILink to="/dashboard">{t('webui.menu.Dashboard')}</WebUILink>,
       icon: <DashboardOutlined style={{ color: token.colorPrimary }} />,
-      key: 'summary',
+      key: 'dashboard',
       group: 'none',
     },
+    // {
+    //   label: <WebUILink to="/summary">{t('webui.menu.Summary')}</WebUILink>,
+    //   icon: <DashboardOutlined style={{ color: token.colorPrimary }} />,
+    //   key: 'summary',
+    //   group: 'none',
+    // },
     {
       label: (
         <WebUILink to={experimentalNeoSessionList ? '/session' : '/job'}>

--- a/react/src/components/MySessionCard.tsx
+++ b/react/src/components/MySessionCard.tsx
@@ -1,6 +1,7 @@
 import BAICard, { BAICardProps } from './BAICard';
 import BAIFetchKeyButton from './BAIFetchKeyButton';
 import BAIPanelItem from './BAIPanelItem';
+import Flex from './Flex';
 import { MySessionCardQueryFragment$key } from './__generated__/MySessionCardQueryFragment.graphql';
 import { Col, Divider, Row, theme } from 'antd';
 import graphql from 'babel-plugin-relay/macro';
@@ -66,24 +67,35 @@ const MySessionCard: React.FC<MySessionCardProps> = ({
       {...props}
       title={t('session.MySessions')}
       extra={
-        <BAIFetchKeyButton
-          loading={isPendingRefetch}
-          autoUpdateDelay={15_000}
-          value=""
-          onChange={(newFetchKey) => {
-            startRefetchTransition(() => {
-              refetch(
-                {},
-                {
-                  fetchPolicy: 'network-only',
-                },
-              );
-            });
+        <Flex
+          direction="row"
+          gap="sm"
+          style={{
+            marginRight: -8,
           }}
-          buttonProps={{
-            type: 'text',
-          }}
-        />
+        >
+          <BAIFetchKeyButton
+            loading={isPendingRefetch}
+            autoUpdateDelay={15_000}
+            value=""
+            onChange={(newFetchKey) => {
+              startRefetchTransition(() => {
+                refetch(
+                  {},
+                  {
+                    fetchPolicy: 'network-only',
+                  },
+                );
+              });
+            }}
+            buttonProps={{
+              type: 'text',
+              style: {
+                backgroundColor: 'transparent',
+              },
+            }}
+          />
+        </Flex>
       }
     >
       <Row gutter={[24, 16]}>

--- a/react/src/components/RecentlyCreatedSessionCard.tsx
+++ b/react/src/components/RecentlyCreatedSessionCard.tsx
@@ -1,6 +1,7 @@
 import { filterNonNullItems, toLocalId } from '../helper';
 import BAICard, { BAICardProps } from './BAICard';
 import BAIFetchKeyButton from './BAIFetchKeyButton';
+import Flex from './Flex';
 import SessionDetailDrawer from './SessionDetailDrawer';
 import SessionNodes from './SessionNodes';
 import { RecentlyCreatedSessionCardFragment$key } from './__generated__/RecentlyCreatedSessionCardFragment.graphql';
@@ -55,24 +56,35 @@ const RecentlyCreatedSessionCard: React.FC<RecentlyCreatedSessionCardProps> = ({
       <BAICard
         title={t('session.RecentlyCreatedSessions')}
         extra={
-          <BAIFetchKeyButton
-            loading={isPendingRefetch}
-            autoUpdateDelay={15_000}
-            value=""
-            onChange={(newFetchKey) => {
-              startRefetchTransition(() => {
-                refetch(
-                  {},
-                  {
-                    fetchPolicy: 'network-only',
-                  },
-                );
-              });
+          <Flex
+            direction="row"
+            gap="sm"
+            style={{
+              marginRight: -8,
             }}
-            buttonProps={{
-              type: 'text',
-            }}
-          />
+          >
+            <BAIFetchKeyButton
+              loading={isPendingRefetch}
+              autoUpdateDelay={15_000}
+              value=""
+              onChange={(newFetchKey) => {
+                startRefetchTransition(() => {
+                  refetch(
+                    {},
+                    {
+                      fetchPolicy: 'network-only',
+                    },
+                  );
+                });
+              }}
+              buttonProps={{
+                type: 'text',
+                style: {
+                  backgroundColor: 'transparent',
+                },
+              }}
+            />
+          </Flex>
         }
         {...props}
       >

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -1,0 +1,109 @@
+import AvailableResourcesCard from '../components/AvailableResourcesCard';
+import MySessionCard from '../components/MySessionCard';
+import RecentlyCreatedSessionCard from '../components/RecentlyCreatedSessionCard';
+import { filterEmptyItem } from '../helper';
+import { useSuspendedBackendaiClient } from '../hooks';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { DashboardPageQuery } from './__generated__/DashboardPageQuery.graphql';
+import { Col, Grid, Row } from 'antd';
+import graphql from 'babel-plugin-relay/macro';
+import _ from 'lodash';
+import { useLazyLoadQuery } from 'react-relay';
+
+const DashboardPage: React.FC = () => {
+  const { lg } = Grid.useBreakpoint();
+
+  // to avoid flickering
+  useSuspendedBackendaiClient();
+
+  const currentProject = useCurrentProjectValue();
+
+  const queryRef = useLazyLoadQuery<DashboardPageQuery>(
+    graphql`
+      query DashboardPageQuery($projectId: UUID) {
+        ...MySessionCardQueryFragment @arguments(projectId: $projectId)
+        ...RecentlyCreatedSessionCardFragment @arguments(projectId: $projectId)
+      }
+    `,
+    {
+      projectId: currentProject.id,
+    },
+    {},
+  );
+
+  const items = filterEmptyItem([
+    {
+      id: 'mySession',
+      rowSpan: 3,
+      columnSpan: 1,
+      columnOffset: { 6: 0, 4: 0 },
+      data: {
+        content: (
+          <MySessionCard
+            queryRef={queryRef}
+            style={{ minHeight: lg ? 200 : undefined }}
+          />
+        ),
+      },
+    },
+    {
+      id: 'allocatedResources',
+      rowSpan: 3,
+      columnSpan: 1,
+      columnOffset: { 6: 1, 4: 1 },
+      data: {
+        content: (
+          <AvailableResourcesCard
+            style={{
+              width: '100%',
+              minHeight: lg ? 200 : undefined,
+            }}
+          />
+        ),
+      },
+    },
+    {
+      id: 'recentlyCreatedSession',
+      rowSpan: 3,
+      columnSpan: 2,
+      columnOffset: { 6: 0, 4: 0 },
+      data: {
+        content: <RecentlyCreatedSessionCard queryRef={queryRef} />,
+      },
+    },
+    // {
+    //   id: 'mostResourceAllocatedSession',
+    //   rowSpan: 3,
+    //   columnSpan: 2,
+    //   columnOffset: { 6: 0, 4: 0 },
+    //   data: {
+    //     content: <></>,
+    //   },
+    // },
+    // {
+    //   id: 'pipelineStatus',
+    //   rowSpan: 3,
+    //   columnSpan: 2,
+    //   columnOffset: { 6: 0, 4: 0 },
+    //   data: {
+    //     content: <></>,
+    //   },
+    // },
+  ]);
+
+  return (
+    <>
+      <Row gutter={[16, 16]}>
+        {_.map(items, (item) => {
+          return (
+            <Col xs={24} lg={item.columnSpan === 2 ? 24 : 12}>
+              {item.data.content}
+            </Col>
+          );
+        })}
+      </Row>
+    </>
+  );
+};
+
+export default DashboardPage;

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -145,6 +145,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   @property({ type: Object }) supports = Object();
   @property({ type: Array }) availablePages = [
     'start',
+    'dashboard',
     'summary',
     'verify-email',
     'change-password',


### PR DESCRIPTION
resolves [FR-326](https://lablup.atlassian.net/browse/FR-326)

# Add Dashboard Page
This PR adds a new Dashboard page to replace the Summary page in the WebUI. The changes include:

- Created a new `DashboardPage` component with cards for:
  - My Sessions
  - Available Resources
  - Recently Created Sessions
- Added the Dashboard page to the router configuration
- Updated the sidebar navigation to link to the Dashboard instead of Summary
- Commented out the Summary page code for potential future removal

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/6d720255-e110-40cf-913a-b0ef2b5b4394.png)


**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup): go to dashboard page
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-326]: https://lablup.atlassian.net/browse/FR-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ