### PR TITLE
feat(FR-678): Add resourceGroup Prop to Enhance ResourcePresetSelect Composability

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -507,7 +507,7 @@ const ResourceAllocationFormItems: React.FC<
               }
             }}
             allocatablePresetNames={allocatablePresetNames}
-            perResourceGroup
+            resourceGroup={currentResourceGroupInForm}
           />
         </Form.Item>
       ) : null}

--- a/react/src/components/ResourcePresetSelect.tsx
+++ b/react/src/components/ResourcePresetSelect.tsx
@@ -2,7 +2,6 @@ import { localeCompare } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { ResourceSlotName, useResourceSlots } from '../hooks/backendai';
 import useControllableState from '../hooks/useControllableState';
-import { useCurrentResourceGroupValue } from '../hooks/useCurrentProject';
 import Flex from './Flex';
 import ResourceNumber from './ResourceNumber';
 import {
@@ -38,13 +37,13 @@ export interface ResourcePresetSelectProps
   allocatablePresetNames?: string[];
   showMinimumRequired?: boolean;
   showCustom?: boolean;
-  perResourceGroup?: boolean;
+  resourceGroup?: string;
 }
 const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
   allocatablePresetNames,
   showCustom,
   showMinimumRequired,
-  perResourceGroup,
+  resourceGroup,
   ...selectProps
 }) => {
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
@@ -64,7 +63,6 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
       updateFetchKeyThrottled();
     });
   };
-  const currentResourceGroupByProject = useCurrentResourceGroupValue();
 
   const { resource_presets } = useLazyLoadQuery<ResourcePresetSelectQuery>(
     graphql`
@@ -84,11 +82,11 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
     },
   );
 
-  const resourcePresets = perResourceGroup
+  const resourcePresets = resourceGroup
     ? _.filter(
         resource_presets,
         (preset) =>
-          preset?.scaling_group_name === currentResourceGroupByProject ||
+          preset?.scaling_group_name === resourceGroup ||
           preset?.scaling_group_name === null,
       )
     : resource_presets;


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai-webui/issues/3376 ([FR-678](https://lablup.atlassian.net/browse/FR-678))
follows #3349 

## Refactor ResourcePresetSelect to use specific resource group instead of current group

This PR changes the `ResourcePresetSelect` component to accept a specific resource group name instead of a boolean flag. This allows for more precise control over which resource presets are displayed based on the provided resource group rather than relying on the current resource group from the global context.

Changes:
- Renamed prop `perResourceGroup` to `resourceGroup` in `ResourcePresetSelect`
- Updated the component to filter presets based on the explicitly provided resource group name
- Updated the usage in `ResourceAllocationFormItems` to pass the current resource group name

**Checklist:**

- [ ] Documentation
- [x] Minium required manager version: 25.4.0
- [x] Specific setting for review (eg., KB link, endpoint or how to setup): refer #3349 
- [x] Minimum requirements to check during review: refer #3349 
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-678]: https://lablup.atlassian.net/browse/FR-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ