### PR TITLE
feat(FR-679): Add optional description attribute to SettingGroup

### DIFF
--- a/react/src/components/SettingList.tsx
+++ b/react/src/components/SettingList.tsx
@@ -16,7 +16,7 @@ import {
 } from 'antd';
 import { createStyles } from 'antd-style';
 import _ from 'lodash';
-import { useState } from 'react';
+import { useState, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const useStyles = createStyles(({ css, token }) => ({
@@ -32,6 +32,7 @@ const useStyles = createStyles(({ css, token }) => ({
 
 export type SettingGroup = {
   title: string;
+  description?: ReactNode;
   settingItems: SettingItemProps[];
 };
 
@@ -87,6 +88,14 @@ const GroupSettingItems: React.FC<{
           {group.title}
         </Typography.Title>
         <Divider style={{ marginTop: 0, marginBottom: 0 }} />
+        {group.description && (
+          <Typography.Text
+            type="secondary"
+            style={{ marginTop: token.marginSM }}
+          >
+            {group.description}
+          </Typography.Text>
+        )}
       </Flex>
       <Flex direction="column" align="start" gap={'lg'}>
         {group.settingItems.map((item) => (


### PR DESCRIPTION
resolves #3378 (FR-679)
this PR adds optional `description` attribute to `SettingGroup` as `ReactNode`

**changes**
* add optional `description` attribute to `SettingGroup` component

It is supposed to display the description following the image.

![스크린샷 2025-03-18 오후 2.52.15.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/adffc887-e0a3-4225-b5c7-0a44942a1889.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
