### PR TITLE
fix(FR-690): browser freezing during user inputs chat message

### DIFF
--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -215,6 +215,7 @@ const ChatCard: React.FC<ChatCardProps> = ({
     body: {
       modelId: modelId,
     },
+    experimental_throttle: 100,
     fetch: async (input, init) => {
       if (fetchOnClient || modelId === 'custom') {
         const body = JSON.parse(init?.body as string);

--- a/react/src/components/Chat/ChatMessage.tsx
+++ b/react/src/components/Chat/ChatMessage.tsx
@@ -9,7 +9,7 @@ import dayjs from 'dayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import _ from 'lodash';
-import React from 'react';
+import React, { useDeferredValue } from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -36,10 +36,8 @@ const ChatMessage: React.FC<{
   const { t } = useTranslation();
   const [isHovered, setIsHovered] = useState(false);
 
-  const throttledMessageReasoning = useThrottle(message.reasoning, {
-    wait: 50,
-  });
-  const throttledMessageContent = useThrottle(message.content, { wait: 50 });
+  const deferredReasoning = useDeferredValue(message.reasoning);
+  const deferredContent = useDeferredValue(message.content);
 
   return (
     <Flex
@@ -130,7 +128,7 @@ const ChatMessage: React.FC<{
               items={[
                 {
                   key: 'reasoning',
-                  label: _.isEmpty(throttledMessageContent) ? (
+                  label: _.isEmpty(deferredContent) ? (
                     <Flex gap="xs">
                       <Typography.Text>{t('chatui.Thinking')}</Typography.Text>
                       <Spin size="small" />
@@ -141,16 +139,14 @@ const ChatMessage: React.FC<{
                     </Typography.Text>
                   ),
                   children: (
-                    <ChatMessageContent>
-                      {throttledMessageReasoning}
-                    </ChatMessageContent>
+                    <ChatMessageContent>{deferredReasoning}</ChatMessageContent>
                   ),
                 },
               ]}
             />
           )}
           <ChatMessageContent>
-            {throttledMessageContent + (isStreaming ? '\n●' : '')}
+            {deferredContent + (isStreaming ? '\n●' : '')}
           </ChatMessageContent>
         </Flex>
         <Flex


### PR DESCRIPTION
resolves #3398 (FR-690)

This PR improves the performance of the Chat UI by:

1. Replacing `useThrottle` with React's native `useDeferredValue` in ChatMessage component for better rendering performance of message content and reasoning
2. Adding experimental throttling (100ms) to the chat fetch request to reduce unnecessary network calls during rapid state changes


To reproduce browser freezing:
1. create two chat windows on the Chat page, set "Sync" input  in both chat
2.  Send a question that will generate a lot of markdown (e.g. "Let me know the JavaScript sort function"). 
3. While waiting for a response, quickly type in the chat message input.