### PR TITLE
add(FR-638): NoResourceGroupBanner to show warning when no resource group is assigned

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -8,6 +8,7 @@ import BAISider from '../BAISider';
 import Flex from '../Flex';
 import ForceTOTPChecker from '../ForceTOTPChecker';
 import NetworkStatusBanner from '../NetworkStatusBanner';
+import NoResourceGroupBanner from '../NoResourceGroupBanner';
 import PasswordChangeRequestAlert from '../PasswordChangeRequestAlert';
 import { DRAWER_WIDTH } from '../WEBUINotificationDrawer';
 import WebUIBreadcrumb from '../WebUIBreadcrumb';
@@ -192,6 +193,7 @@ function MainLayout() {
                     containerElement={contentScrollFlexRef.current}
                   />
                   <NetworkStatusBanner />
+                  <NoResourceGroupBanner />
                 </div>
               </Suspense>
               <Suspense>

--- a/react/src/components/NoResourceGroupBanner.tsx
+++ b/react/src/components/NoResourceGroupBanner.tsx
@@ -1,0 +1,24 @@
+import { useCurrentResourceGroupValue } from '../hooks/useCurrentProject';
+import { Alert, theme } from 'antd';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const NoResourceGroupBanner: React.FC = () => {
+  const currentResourceGroup = useCurrentResourceGroupValue();
+  const { token } = theme.useToken();
+  const { t } = useTranslation();
+
+  return (
+    <>
+      {currentResourceGroup === null || currentResourceGroup === '' ? (
+        <Alert
+          style={{ margin: token.paddingContentHorizontalLG }}
+          message={t('resourceGroup.NoScalingGroupAssignedToThisProject')}
+          showIcon
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default NoResourceGroupBanner;

--- a/react/src/hooks/useCurrentProject.tsx
+++ b/react/src/hooks/useCurrentProject.tsx
@@ -21,6 +21,7 @@ export const useCurrentProjectValue = () => {
 const previousSelectedResourceGroupNameAtom = atom<string | null>(null);
 
 export const useCurrentResourceGroupValue = () => {
+  useSuspendedBackendaiClient();
   const { resourceGroups } = useAtomValue(resourceGroupsForCurrentProjectAtom);
   const [prevSelectedRGName, setPrevSelectedRGName] = useAtom(
     previousSelectedResourceGroupNameAtom,
@@ -63,6 +64,7 @@ export const useCurrentResourceGroupState = () => {
 };
 
 const resourceGroupsForCurrentProjectAtom = atom(async (get) => {
+  // NOTE: cannot use hook inside atom
   const currentProject = get(currentProjectAtom);
   const [resourceGroups, vhostInfo] = await Promise.all([
     // @ts-ignore

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -15,6 +15,7 @@ import '@ant-design/v5-patch-for-react-19';
 import { Tag, theme } from 'antd';
 import dayjs from 'dayjs';
 import { Provider as JotaiProvider } from 'jotai';
+import _ from 'lodash';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { useTranslation } from 'react-i18next';
@@ -147,7 +148,10 @@ const ResourceGroupSelectInWebComponent = (props: ReactWebComponentProps) => {
         size="large"
         showSearch
         disabled={currentResourceGroupByProject !== props.value}
-        loading={currentResourceGroupByProject !== props.value}
+        loading={
+          !_.isEmpty(currentResourceGroupByProject) &&
+          currentResourceGroupByProject !== props.value
+        }
         onChange={(value) => {
           // setValue(value);
           props.dispatchEvent('change', value);

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1010,6 +1010,7 @@
     "Name": "Name",
     "NoChangesMade": "Keine Änderungen vorgenommen",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Dieses Projekt wird keine Ressourcengruppe zugewiesen. \nDie Erstellung der Sitzung und die Erstellung von Modelldienstleistungen werden eingeschränkt.",
     "Public": "Öffentlich",
     "PublicStatus": "Öffentlicher Status",
     "ResourceGroupAlreadyExist": "Eine Ressourcengruppe mit demselben Namen ist bereits vorhanden.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1006,6 +1006,7 @@
     "Name": "Ονομα",
     "NoChangesMade": "Δεν έγιναν αλλαγές",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Καμία ομάδα πόρων δεν έχει ανατεθεί σε αυτό το έργο. \nΗ δημιουργία συνόδων και η δημιουργία υπηρεσιών μοντέλων θα περιοριστεί.",
     "Public": "Δημόσιο",
     "PublicStatus": "Δημόσια κατάσταση",
     "ResourceGroupAlreadyExist": "Υπάρχει ήδη μια ομάδα πόρων με το ίδιο όνομα.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1016,6 +1016,7 @@
     "Name": "Name",
     "NoChangesMade": "No changes made",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "No resource group is assigned to this project. Session creation and model service creation will be restricted.",
     "Public": "Public",
     "PublicStatus": "Public Status",
     "ResourceGroupAlreadyExist": "A resource group with the same name already exists.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1010,6 +1010,7 @@
     "Name": "Nombre",
     "NoChangesMade": "No se han realizado cambios",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "No se asigna ningún grupo de recursos a este proyecto. \nLa creación de sesiones y la creación de servicios de modelo estarán restringidos.",
     "Public": "Público",
     "PublicStatus": "Estado público",
     "ResourceGroupAlreadyExist": "Ya existe un grupo de recursos con el mismo nombre.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1008,6 +1008,7 @@
     "Name": "Nimi",
     "NoChangesMade": "Ei muutoksia",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Resurssiryhmää ei ole osoitettu tähän projektiin. \nIstunnon luominen ja mallipalvelun luominen rajoitetaan.",
     "Public": "Julkinen",
     "PublicStatus": "Julkinen asema",
     "ResourceGroupAlreadyExist": "Samanniminen resurssiryhmä on jo olemassa.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1010,6 +1010,7 @@
     "Name": "Nom",
     "NoChangesMade": "Aucune modification apportée",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Aucun groupe de ressources n'est affecté à ce projet. \nLa création de session et la création de services de modèle seront restreintes.",
     "Public": "Public",
     "PublicStatus": "Statut public",
     "ResourceGroupAlreadyExist": "Un groupe de ressources du même nom existe déjà.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1008,6 +1008,7 @@
     "Name": "Nama",
     "NoChangesMade": "Tidak ada perubahan yang dilakukan",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Tidak ada grup sumber daya yang ditugaskan untuk proyek ini. \nPembuatan Sesi dan Pembuatan Layanan Model akan dibatasi.",
     "Public": "Publik",
     "PublicStatus": "Status Publik",
     "ResourceGroupAlreadyExist": "Grup sumber daya dengan nama yang sama sudah ada.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1008,6 +1008,7 @@
     "Name": "Nome",
     "NoChangesMade": "Nessuna modifica effettuata",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Nessun gruppo di risorse è assegnato a questo progetto. \nLa creazione di sessione e la creazione del servizio modello saranno limitate.",
     "Public": "Pubblico",
     "PublicStatus": "Stato pubblico",
     "ResourceGroupAlreadyExist": "Esiste già un gruppo di risorse con lo stesso nome.",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1009,6 +1009,7 @@
     "Name": "名前",
     "NoChangesMade": "変更はありません",
     "NoGroupToDisplay": "グループがありません。",
+    "NoScalingGroupAssignedToThisProject": "このプロジェクトにはリソースグループが割り当てられていません。\nセッションの作成とモデルサービスの作成は制限されます。",
     "Public": "公開",
     "PublicStatus": "公開状況",
     "ResourceGroupAlreadyExist": "同じ名前のリソースグループがすでに存在します。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1013,6 +1013,7 @@
     "Name": "이름",
     "NoChangesMade": "변경사항이 없습니다",
     "NoGroupToDisplay": "그룹이 없습니다.",
+    "NoScalingGroupAssignedToThisProject": "이 프로젝트에 할당된 자원그룹이 없습니다. 세션 및 모델 서비스 생성이 제한됩니다.",
     "Public": "공개",
     "PublicStatus": "공개 상태",
     "ResourceGroupAlreadyExist": "같은 이름의 자원 그룹이 이미 있습니다.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1008,6 +1008,7 @@
     "Name": "Нэр",
     "NoChangesMade": "Өөрчлөлт оруулаагүй болно",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Энэ төсөлд нөөцийн бүлэгт хуваарилагдаагүй байна. \nХуралдаан үүсгэх ба загвар үйлчилгээний үйлдвэрлэлийг хязгаарлах болно.",
     "Public": "Олон нийтийн",
     "PublicStatus": "Олон нийтийн статус",
     "ResourceGroupAlreadyExist": "Ижил нэртэй нөөцийн бүлэг аль хэдийн бий болсон.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1009,6 +1009,7 @@
     "Name": "Nama",
     "NoChangesMade": "Tidak ada perubahan yang dibuat",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Tiada kumpulan sumber yang diberikan kepada projek ini. \nPenciptaan sesi dan penciptaan perkhidmatan model akan dihadkan.",
     "Public": "Awam",
     "PublicStatus": "Status Awam",
     "ResourceGroupAlreadyExist": "Kumpulan sumber dengan nama yang sama sudah ada.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1010,6 +1010,7 @@
     "Name": "Nazwa",
     "NoChangesMade": "Nie wprowadzono żadnych zmian",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Do tego projektu nie jest przypisywana grupa zasobów. \nTworzenie sesji i tworzenie usług modelowych będą ograniczone.",
     "Public": "Publiczny",
     "PublicStatus": "Status publiczny",
     "ResourceGroupAlreadyExist": "Grupa zasobów o tej samej nazwie już istnieje.",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1010,6 +1010,7 @@
     "Name": "Nome",
     "NoChangesMade": "Nenhuma mudança feita",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Nenhum grupo de recursos é atribuído a este projeto. A criação de sessões e a criação de serviços modelo serão restringidas.",
     "Public": "Público",
     "PublicStatus": "Estado público",
     "ResourceGroupAlreadyExist": "Já existe um grupo de recursos com o mesmo nome.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1010,6 +1010,7 @@
     "Name": "Nome",
     "NoChangesMade": "Nenhuma mudança feita",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Nenhum grupo de recursos é atribuído a este projeto. \nA criação de sessões e a criação de serviços de modelo serão restritos.",
     "Public": "Público",
     "PublicStatus": "Estado público",
     "ResourceGroupAlreadyExist": "Já existe um grupo de recursos com o mesmo nome.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1010,6 +1010,7 @@
     "Name": "Имя",
     "NoChangesMade": "Никаких изменений не внесено",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Никакая группа ресурсов не назначена в этот проект. \nСоздание сеанса и создание моделей службы будет ограничено.",
     "Public": "Публичный",
     "PublicStatus": "Общественный статус",
     "ResourceGroupAlreadyExist": "Группа ресурсов с таким именем уже существует.",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -999,6 +999,7 @@
     "Name": "ชื่อ",
     "NoChangesMade": "ไม่มีการเปลี่ยนแปลง",
     "NoGroupToDisplay": "ไม่มีกลุ่มที่จะแสดง",
+    "NoScalingGroupAssignedToThisProject": "ไม่มีกลุ่มทรัพยากรที่ได้รับมอบหมายให้โครงการนี้ \nการสร้างเซสชันและการสร้างบริการแบบจำลองจะถูก จำกัด",
     "Public": "สาธารณะ",
     "PublicStatus": "สถานะสาธารณะ",
     "ResourceGroupAlreadyExist": "มีกลุ่มทรัพยากรชื่อเดียวกันอยู่แล้ว",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1010,6 +1010,7 @@
     "Name": "isim",
     "NoChangesMade": "Değişiklik yapılmadı",
     "NoGroupToDisplay": "NoGroupToDisplay",
+    "NoScalingGroupAssignedToThisProject": "Bu projeye hiçbir kaynak grubu atanmadı. \nOturum oluşturma ve model hizmeti oluşturma kısıtlanacaktır.",
     "Public": "Kamu",
     "PublicStatus": "Kamu Statüsü",
     "ResourceGroupAlreadyExist": "Aynı ada sahip bir kaynak grubu zaten var.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1010,6 +1010,7 @@
     "Name": "Tên",
     "NoChangesMade": "Không có thay đổi nào được thực hiện",
     "NoGroupToDisplay": "Không có nhóm để hiển thị",
+    "NoScalingGroupAssignedToThisProject": "Không có nhóm tài nguyên nào được gán cho dự án này. \nTạo phiên và tạo dịch vụ mô hình sẽ bị hạn chế.",
     "Public": "Công cộng",
     "PublicStatus": "Trạng thái công khai",
     "ResourceGroupAlreadyExist": "Một nhóm tài nguyên có cùng tên đã tồn tại.",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1010,6 +1010,7 @@
     "Name": "名称",
     "NoChangesMade": "未做任何更改",
     "NoGroupToDisplay": "无组显示",
+    "NoScalingGroupAssignedToThisProject": "没有资源组分配给该项目。\n会话创建和模型服务创建将受到限制。",
     "Public": "公众",
     "PublicStatus": "公众地位",
     "ResourceGroupAlreadyExist": "已存在同名的资源组。",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1010,6 +1010,7 @@
     "Name": "名稱",
     "NoChangesMade": "未做任何更改",
     "NoGroupToDisplay": "无组显示",
+    "NoScalingGroupAssignedToThisProject": "沒有資源組分配給該項目。\n會話創建和模型服務創建將受到限制。",
     "Public": "公众",
     "PublicStatus": "公众地位",
     "ResourceGroupAlreadyExist": "已存在同名的資源組。",

--- a/src/components/backend-ai-resource-broker.ts
+++ b/src/components/backend-ai-resource-broker.ts
@@ -549,6 +549,9 @@ export default class BackendAiResourceBroker extends BackendAIPage {
         }
         param['scaling_group'] = this.scaling_group;
       }
+      if (!param['scaling_group']) {
+        delete param['scaling_group'];
+      }
       const resourcePresetInfo =
         await globalThis.backendaiclient.resourcePreset.check(param);
       const resource_remaining = resourcePresetInfo.keypair_remaining;


### PR DESCRIPTION
# Add warning notification when no resource group is assigned to a project

This PR introduces showing warning notification when current selected project doesn't contains resource group, such as `model-store`.

Backend.AI applied new type of project(group), so called "model-store", which doesn't contain any resource group, but to only contains and manages each model card(metadata of model itself). The problem is that, When a user with superadmin role, who has an access to see those project(group) in WebUI, changes the current project to `model-store`, things gets in trouble, since our logic is based on one rule, "Every project(group) has resource group, and resource group mostly has certain amount of resource(if not then it will display zero)."
To avoid those confusions, we decided to show warning notification on every pages "No resource group assigned in this project, session creation and model service creation is restricted.", as is.

Key changes:
- Added a new `NoResourceGroupBanner` component to display a warning when no resource group is assigned
- Integrated the banner into the main layout to show on all pages
- Fixed resource group selection loading state to properly handle empty resource groups
- Added translations for the "No resource group assigned" message in multiple languages
- Fixed resource preset checking to handle cases when scaling_group is empty

## Screenshots:
* current project(group) doesn't have resource group:

![Screenshot 2025-03-21 at 7.12.01 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/bd4095d0-6ce0-442d-8885-5495b0779373.png)

![Screenshot 2025-03-21 at 7.12.16 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/742eb68a-12ef-4002-a8bd-8fd04fe066cf.png)

![Screenshot 2025-03-21 at 7.12.23 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/318963ea-5ffb-41f2-bfba-19a463a21b1f.png)

