### PR TITLE
fix(FR-695): match resource preset sorting

### DIFF
--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -84,7 +84,7 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
     {
       title: t('resourcePreset.Name'),
       dataIndex: 'name',
-      sorter: true,
+      sorter: (a, b) => localeCompare(a?.name, b?.name),
     },
     {
       title: t('resourcePreset.Resources'),
@@ -104,7 +104,6 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
       dataIndex: 'shared_memory',
       render: (text) =>
         text ? convertBinarySizeUnit(text + '', 'g')?.number : '-',
-      sorter: true,
     },
     baiClient?.supports('resource-presets-per-resource-group') && {
       title: t('general.ResourceGroup'),


### PR DESCRIPTION
# Fix sorting in ResourcePresetList component


resolves https://github.com/lablup/backend.ai-webui/issues/3395 (FR-695)

This PR updates the sorting functionality in the ResourcePresetList component:

1. Replaces the generic `sorter: true` with a proper locale-aware string comparison function for the "Name" column
2. Removes the unnecessary sorting capability from the "Shared Memory" column

These changes ensure that resource preset names are sorted correctly according to the user's locale.


**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after