### PR TITLE
feat(FR-706): preserving pagination and filter state of VFolder list

### DIFF
--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -24,7 +24,7 @@ import {
   transformSorterToOrderString,
 } from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
-import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useDeferredQueryParams } from '../hooks/useDeferredQueryParams';
 import {
@@ -106,7 +106,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionState({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 10,
   });
@@ -119,9 +119,12 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   });
 
   const queryMapRef = useRef({
-    [queryParams.statusCategory]: queryParams,
+    [queryParams.statusCategory]: { queryParams, tablePaginationOption },
   });
-  queryMapRef.current[queryParams.statusCategory] = queryParams;
+  queryMapRef.current[queryParams.statusCategory] = {
+    queryParams,
+    tablePaginationOption,
+  };
 
   const statusFilter =
     queryParams.statusCategory === 'created' ||
@@ -343,10 +346,15 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
               mode: 'all',
             };
             setQuery(
-              { ...storedQuery, statusCategory: key as 'created' | 'deleted' },
+              {
+                ...storedQuery.queryParams,
+                statusCategory: key as 'created' | 'deleted',
+              },
               'replace',
             );
-            setTablePaginationOption({ current: 1 });
+            setTablePaginationOption(
+              storedQuery.tablePaginationOption || { current: 1 },
+            );
             setSelectedFolderList([]);
           }}
           items={_.map(


### PR DESCRIPTION
Resolves #3404 (FR-706)

# Preserve pagination state when switching between folder status tabs

This PR enhances the user experience in the VFolderNodeListPage by preserving the pagination state when switching between the "created" and "deleted" folder tabs. Previously, the pagination would reset to page 1 when switching tabs, causing users to lose their position in the list. Additionally, the pagination state is now maintained even after refreshing the browser.

Now, the pagination state is stored separately for each tab and restored when switching back to a previously visited tab.

**Changes:**
- Switched from `useBAIPaginationOptionState` to `useBAIPaginationOptionStateOnSearchParam` to better handle pagination state
- Modified the `queryMapRef` to store both query parameters and pagination state for each tab
- Updated the tab switching logic to restore the saved pagination state when changing tabs