### PR TITLE
fix(FR-703): Add word-break to mounted folders on session detail modal

### DIFF
--- a/react/src/components/FolderLink.tsx
+++ b/react/src/components/FolderLink.tsx
@@ -1,0 +1,60 @@
+import BAILink from './BAILink';
+import { useFolderExplorerOpener } from './FolderExplorerOpener';
+import { FolderLink_vfolderNode$key } from './__generated__/FolderLink_vfolderNode.graphql';
+import { FolderOutlined } from '@ant-design/icons';
+import graphql from 'babel-plugin-relay/macro';
+import { useFragment } from 'react-relay';
+
+interface FolderLinkBase {
+  showIcon?: boolean;
+}
+
+interface FolderLinkWithFragment extends FolderLinkBase {
+  vfolderNodeFragment: FolderLink_vfolderNode$key;
+  folderId?: never;
+  folderName?: never;
+}
+
+interface FolderLinkWithIdAndName extends FolderLinkBase {
+  vfolderNodeFragment?: never;
+  folderId: string;
+  folderName: string;
+}
+
+type FolderLinkProps = FolderLinkWithFragment | FolderLinkWithIdAndName;
+
+const FolderLink = ({
+  vfolderNodeFragment,
+  folderId,
+  folderName,
+  showIcon,
+}: FolderLinkProps) => {
+  const { generateFolderPath } = useFolderExplorerOpener();
+  const vfolderNode = useFragment(
+    graphql`
+      fragment FolderLink_vfolderNode on VirtualFolderNode {
+        row_id
+        name
+      }
+    `,
+    vfolderNodeFragment,
+  );
+
+  return (
+    <BAILink
+      to={generateFolderPath(folderId ?? vfolderNode?.row_id ?? '')}
+      style={{
+        wordBreak: 'break-all',
+      }}
+    >
+      {showIcon && (
+        <>
+          <FolderOutlined /> &nbsp;
+        </>
+      )}
+      {folderName ?? vfolderNode?.name ?? ''}
+    </BAILink>
+  );
+};
+
+export default FolderLink;


### PR DESCRIPTION
resolves #3406 (FR-703)
this PR resolves layout bug in mounted folder section on session detail modal

**changes**
* add `FolderLink` component using `BAILink`
* remove `flex` style from session status item

|before|after|
|-------|-----|
| ![스크린샷 2025-03-25 오후 4.22.14.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/909fc9d6-6f03-4d3d-a80f-c59ce1a4602a.png) |![스크린샷 2025-03-27 오후 1.27.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/88ff37e2-5699-4e93-ae23-3b853bb812b3.png) |

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
