### PR TITLE
feat: move the announcement component to the start page

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,4 +1,3 @@
-import AnnouncementAlert from './components/AnnouncementAlert';
 import BAICard from './components/BAICard';
 import BAIErrorBoundary, { ErrorView } from './components/BAIErrorBoundary';
 import {
@@ -152,20 +151,6 @@ const router = createBrowserRouter([
       },
       {
         path: '/summary',
-        Component: () => {
-          const { token } = theme.useToken();
-          return (
-            <>
-              <AnnouncementAlert
-                showIcon
-                icon={undefined}
-                banner={false}
-                style={{ marginBottom: token.paddingContentVerticalLG }}
-                closable
-              />
-            </>
-          );
-        },
         handle: { labelKey: 'webui.menu.Summary' },
       },
       {

--- a/react/src/components/AnnouncementAlert.tsx
+++ b/react/src/components/AnnouncementAlert.tsx
@@ -1,12 +1,12 @@
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
-import { Alert, theme } from 'antd';
-import { AlertProps } from 'antd/lib';
+import BAIAlert, { BAIAlertProps } from './BAIAlert';
+import { theme } from 'antd';
 import _ from 'lodash';
 import Markdown from 'markdown-to-jsx';
 import React from 'react';
 
-interface Props extends AlertProps {}
+interface Props extends BAIAlertProps {}
 const AnnouncementAlert: React.FC<Props> = ({ style, ...otherProps }) => {
   const baiClient = useSuspendedBackendaiClient();
   const { token } = theme.useToken();
@@ -18,21 +18,7 @@ const AnnouncementAlert: React.FC<Props> = ({ style, ...otherProps }) => {
   });
 
   return !_.isEmpty(announcement.message) ? (
-    <Alert
-      banner
-      style={{
-        // alignItems: 'flex-start',
-        // overflow: 'auto',
-        ...style,
-      }}
-      // icon={
-      //   //use <> because tag border is not displayed normally when Tag component is used only
-      //   <>
-      //     <Tag color="error" style={{ fontSize: token.fontSize }}>
-      //       Notice
-      //     </Tag>
-      //   </>
-      // }
+    <BAIAlert
       description={
         <div style={{ marginBottom: token.marginSM * -1 }}>
           <Markdown

--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -1,4 +1,6 @@
 import ActionItemContent from '../components/ActionItemContent';
+import AnnouncementAlert from '../components/AnnouncementAlert';
+import Flex from '../components/Flex';
 // import BAIBoard, { BAIBoardItem } from '../components/BAIBoard';
 import FolderCreateModal from '../components/FolderCreateModal';
 import ThemeSecondaryProvider from '../components/ThemeSecondaryProvider';
@@ -151,7 +153,7 @@ const StartPage: React.FC = () => {
   ]);
 
   return (
-    <>
+    <Flex direction="column" gap={'md'} align="stretch">
       {/* <BAIBoard
         items={items}
         onItemsChange={(event) => {
@@ -161,6 +163,7 @@ const StartPage: React.FC = () => {
           setItemSettings(_.map(changedItems, (item) => _.omit(item, 'data')));
         }}
       /> */}
+      <AnnouncementAlert showIcon closable />
       <Row gutter={[16, 16]}>
         {_.map(items, (item, idx) => {
           return item.id === 'empty' ? (
@@ -191,7 +194,7 @@ const StartPage: React.FC = () => {
           }
         }}
       />
-    </>
+    </Flex>
   );
 };
 export default StartPage;


### PR DESCRIPTION
Resolves #3411 (FR-716)

# Move Announcement Alert from Summary Page to Start Page

This PR moves the `AnnouncementAlert` component from the Summary page to the Start page. The changes:

1. Remove the `AnnouncementAlert` component from the Summary page route in `App.tsx`
2. Add the `AnnouncementAlert` component to the Start page
3. Wrap the Start page content in a `Flex` component with column direction to properly display the alert