### PR TITLE
hotfix(FR-726): plugin menu item doesn't work

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -25,6 +25,8 @@ export type PluginPage = {
   name: string;
   url: string;
   menuitem: string;
+  icon?: string;
+  group?: string;
 };
 
 export type WebUIPluginType = {

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -44,14 +44,15 @@ import {
 } from 'antd';
 import { MenuItemType } from 'antd/lib/menu/interface';
 import _ from 'lodash';
-import { BotMessageSquare } from 'lucide-react';
-import React, { useContext, useRef } from 'react';
+import { BotMessageSquare, ExternalLinkIcon, LinkIcon } from 'lucide-react';
+import React, { ReactNode, useContext, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
 type MenuItem = {
-  label: string;
+  label: ReactNode;
   icon: React.ReactNode;
+  group?: string;
   key: string;
 };
 interface WebUISiderProps
@@ -265,6 +266,12 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
     'menuitem-superadmin': superAdminMenu,
   };
 
+  const pluginIconMap: {
+    [key: string]: React.ReactNode;
+  } = {
+    link: <LinkIcon />,
+    externalLink: <ExternalLinkIcon />,
+  };
   // Add plugin pages according to the user role.
   // Iterates over own enumerable string keyed properties of an object and invokes iteratee for each property.
   _.forOwn(props.webuiplugins, (value, key) => {
@@ -277,9 +284,10 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
         const page = _.find(pluginPages, { name: name }) as PluginPage;
         if (page) {
           const menuItem: MenuItem = {
-            label: page?.menuitem,
-            icon: <ApiOutlined />,
+            label: <WebUILink to={`/${page?.url}`}>{page?.menuitem}</WebUILink>,
+            icon: pluginIconMap[page.icon || ''] || <ApiOutlined />,
             key: page?.url,
+            group: page.group || 'none',
           };
           menu?.push(menuItem);
         }

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -360,6 +360,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
 
   return (
     <BAISider
+      className="webui-sider"
       ref={siderRef}
       logo={
         <img
@@ -507,6 +508,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
       {props.collapsed ? null : (
         <Flex
           justify="center"
+          className="sider-footer-wrap"
           direction="column"
           style={{
             width: '100%',

--- a/src/components/backend-ai-page.ts
+++ b/src/components/backend-ai-page.ts
@@ -34,6 +34,8 @@ export class BackendAIPage extends LitElement {
   @property({ type: Boolean }) hasLoadedStrings = false;
   @property({ type: String }) permission; // Reserved for plugin pages
   @property({ type: String }) menuitem; // Reserved for plugin pages
+  @property({ type: String }) icon; // Reserved for plugin pages
+  @property({ type: String }) group; // Reserved for plugin pages
   @property({ type: Boolean }) isDarkMode;
 
   constructor() {

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -539,6 +539,8 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
                 name: page,
                 url: page,
                 menuitem: pageItem.menuitem,
+                icon: pageItem.icon,
+                group: pageItem.group,
               });
               return Promise.resolve(true);
             }),


### PR DESCRIPTION
Resolves #3418 (FR-726)

This PR resolve the bug related plugin's menu item. When users click the plugin menu item, it should be move to the plugin page.

Additionally, this PR enhances the plugin page system by adding two new optional properties:

1. `icon`: Allows specifying custom icons for plugin menu items
2. `group`: Enables grouping of plugin menu items

The changes include:
- Adding the new properties to the `PluginPage` type definition
- Updating the `MenuItem` type to support the new properties
- Implementing an icon mapping system with support for `link` and `externalLink` icons
- Adding the properties to the `BackendAIPage` component
- Ensuring the properties are passed through from plugin pages to the menu system

These additions provide more flexibility for plugin developers to customize how their plugins appear in the navigation menu.

=