### PR TITLE
fix(FR-727): Modify ChatSender's style to follow Antd's design system

### DIFF
--- a/react/src/components/Chat/ChatInput.tsx
+++ b/react/src/components/Chat/ChatInput.tsx
@@ -44,9 +44,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const { token } = theme.useToken();
 
   const ChatInputStyle = {
-    background: '#ffffff',
-    borderTop: '1px solid #f0f0f0',
-    borderRadius: '0 0 8px 8px',
+    borderTop: `1px solid ${token.colorBorderSecondary}`,
     padding: token.paddingContentVertical,
   };
 


### PR DESCRIPTION
resolves #3419 (FR-727)
This PR resolves dark mode bug in the `ChatSender` component.

**changes**
* remove the `background` style to enable dark mode
* remove unnecessary `border-radius` style

|before|after|
|------|-----|
| ![Microsoft Teams 2025-03-27 23.33.42.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/d506a714-3d49-4b49-991a-95b737a8edcb.png)| ![CleanShot 2025-03-28 at 00.46.08@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/a052b02a-fa2a-46ba-907c-186b2be920dc.png) |



**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
