### PR TITLE
feat(FR-732): Unified dashboard refetch mechanism and UI improvements

### DIFF
--- a/react/src/components/AvailableResourcesCard.tsx
+++ b/react/src/components/AvailableResourcesCard.tsx
@@ -3,38 +3,38 @@ import { useResourceSlotsDetails } from '../hooks/backendai';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useResourceLimitAndRemaining } from '../hooks/useResourceLimitAndRemaining';
 import BAICard, { BAICardProps } from './BAICard';
+import BAIFetchKeyButton from './BAIFetchKeyButton';
 import Flex from './Flex';
 import ResourceGroupSelectForCurrentProject from './ResourceGroupSelectForCurrentProject';
-import { ReloadOutlined } from '@ant-design/icons';
 import { Row, Col, Divider } from 'antd';
-import { Button, theme, Tooltip, Typography } from 'antd';
+import { theme, Tooltip, Typography } from 'antd';
 import _ from 'lodash';
-import React, { useDeferredValue, useEffect, useState } from 'react';
+import React, { useDeferredValue, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface AvailableResourcesCardProps extends BAICardProps {
   fetchKey?: string;
+  isRefetching?: boolean;
 }
 const AvailableResourcesCard: React.FC<AvailableResourcesCardProps> = ({
   fetchKey,
+  isRefetching,
   ...props
 }) => {
   const { token } = theme.useToken();
   const currentProject = useCurrentProjectValue();
   const [selectedResourceGroup, setSelectedResourceGroup] = useState();
   const deferredSelectedResourceGroup = useDeferredValue(selectedResourceGroup);
-  const [{ checkPresetInfo, isRefetching }, { refetch }] =
+  const { t } = useTranslation();
+  const [{ checkPresetInfo, isRefetching: internalIsRefetching }, { refetch }] =
     useResourceLimitAndRemaining({
       currentProjectName: currentProject.name,
       currentResourceGroup: deferredSelectedResourceGroup || 'default',
+      fetchKey,
     });
   const resourceSlotsDetails = useResourceSlotsDetails(
     deferredSelectedResourceGroup || 'default',
   );
-
-  useEffect(() => {
-    refetch();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchKey]);
 
   const acceleratorSlotsDetails = _.chain(
     resourceSlotsDetails?.resourceSlotsInRG,
@@ -54,7 +54,6 @@ const AvailableResourcesCard: React.FC<AvailableResourcesCardProps> = ({
       extra={
         <Flex
           direction="row"
-          gap="sm"
           style={{
             marginRight: -8,
           }}
@@ -65,14 +64,16 @@ const AvailableResourcesCard: React.FC<AvailableResourcesCardProps> = ({
             onChange={(v) => setSelectedResourceGroup(v)}
             loading={selectedResourceGroup !== deferredSelectedResourceGroup}
             popupMatchSelectWidth={false}
+            variant="borderless"
+            tooltip={t('general.ResourceGroup')}
           />
-          <Button
-            icon={<ReloadOutlined />}
-            type="text"
-            onClick={() => {
+          <BAIFetchKeyButton
+            loading={isRefetching || internalIsRefetching}
+            value={''}
+            onChange={(newFetchKey) => {
               refetch();
             }}
-            loading={isRefetching}
+            type="text"
             style={{
               backgroundColor: 'transparent',
             }}

--- a/react/src/components/BAIFetchKeyButton.tsx
+++ b/react/src/components/BAIFetchKeyButton.tsx
@@ -6,7 +6,8 @@ import dayjs from 'dayjs';
 import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-interface BAIAutoRefetchButtonProps {
+interface BAIAutoRefetchButtonProps
+  extends Omit<ButtonProps, 'value' | 'onChange' | 'loading'> {
   value: string;
   loading?: boolean;
   lastLoadTime?: Date;
@@ -15,7 +16,6 @@ interface BAIAutoRefetchButtonProps {
   size?: ButtonProps['size'];
   onChange: (fetchKey: string) => void;
   hidden?: boolean;
-  buttonProps?: ButtonProps;
 }
 const BAIFetchKeyButton: React.FC<BAIAutoRefetchButtonProps> = ({
   value,
@@ -25,13 +25,13 @@ const BAIFetchKeyButton: React.FC<BAIAutoRefetchButtonProps> = ({
   autoUpdateDelay = null,
   size,
   hidden,
-  buttonProps,
-  ...props
+  lastLoadTime: lastLoadTimeProp,
+  ...buttonProps
 }) => {
   const { t } = useTranslation();
   const [lastLoadTime, setLastLoadTime] = useControllableState(
     {
-      value: props.lastLoadTime,
+      value: lastLoadTimeProp,
     },
     {
       defaultValue: new Date(),

--- a/react/src/components/MySessionCard.tsx
+++ b/react/src/components/MySessionCard.tsx
@@ -11,10 +11,12 @@ import { useRefetchableFragment } from 'react-relay';
 
 interface MySessionCardProps extends BAICardProps {
   queryRef: MySessionCardQueryFragment$key;
+  isRefetching?: boolean;
 }
 
 const MySessionCard: React.FC<MySessionCardProps> = ({
   queryRef,
+  isRefetching,
   ...props
 }) => {
   const { t } = useTranslation();
@@ -75,8 +77,7 @@ const MySessionCard: React.FC<MySessionCardProps> = ({
           }}
         >
           <BAIFetchKeyButton
-            loading={isPendingRefetch}
-            autoUpdateDelay={15_000}
+            loading={isPendingRefetch || isRefetching}
             value=""
             onChange={(newFetchKey) => {
               startRefetchTransition(() => {
@@ -88,11 +89,9 @@ const MySessionCard: React.FC<MySessionCardProps> = ({
                 );
               });
             }}
-            buttonProps={{
-              type: 'text',
-              style: {
-                backgroundColor: 'transparent',
-              },
+            type="text"
+            style={{
+              backgroundColor: 'transparent',
             }}
           />
         </Flex>

--- a/react/src/components/QuotaPerStorageVolumePanelCard.tsx
+++ b/react/src/components/QuotaPerStorageVolumePanelCard.tsx
@@ -132,16 +132,22 @@ const QuotaPerStorageVolumePanelCard: React.FC<
         </Flex>
       }
       extra={
-        <StorageSelect
-          value={selectedVolumeInfo?.id}
-          onChange={(__, vInfo) => {
-            setSelectedVolumeInfo(vInfo);
+        <Flex
+          style={{
+            marginRight: -8,
           }}
-          autoSelectType="usage"
-          showUsageStatus
-          showSearch
-          allowClear
-        />
+        >
+          <StorageSelect
+            value={selectedVolumeInfo?.id}
+            onChange={(__, vInfo) => {
+              setSelectedVolumeInfo(vInfo);
+            }}
+            autoSelectType="usage"
+            showUsageStatus
+            showSearch
+            variant="borderless"
+          />
+        </Flex>
       }
       styles={{
         body: {

--- a/react/src/components/RecentlyCreatedSessionCard.tsx
+++ b/react/src/components/RecentlyCreatedSessionCard.tsx
@@ -13,10 +13,12 @@ import { useQueryParam, StringParam } from 'use-query-params';
 
 interface RecentlyCreatedSessionCardProps extends BAICardProps {
   queryRef: RecentlyCreatedSessionCardFragment$key;
+  isRefetching?: boolean;
 }
 
 const RecentlyCreatedSessionCard: React.FC<RecentlyCreatedSessionCardProps> = ({
   queryRef,
+  isRefetching,
   ...props
 }) => {
   const { t } = useTranslation();
@@ -64,8 +66,7 @@ const RecentlyCreatedSessionCard: React.FC<RecentlyCreatedSessionCardProps> = ({
             }}
           >
             <BAIFetchKeyButton
-              loading={isPendingRefetch}
-              autoUpdateDelay={15_000}
+              loading={isPendingRefetch || isRefetching}
               value=""
               onChange={(newFetchKey) => {
                 startRefetchTransition(() => {
@@ -77,11 +78,9 @@ const RecentlyCreatedSessionCard: React.FC<RecentlyCreatedSessionCardProps> = ({
                   );
                 });
               }}
-              buttonProps={{
-                type: 'text',
-                style: {
-                  backgroundColor: 'transparent',
-                },
+              type="text"
+              style={{
+                backgroundColor: 'transparent',
               }}
             />
           </Flex>
@@ -96,7 +95,7 @@ const RecentlyCreatedSessionCard: React.FC<RecentlyCreatedSessionCardProps> = ({
             setSessionDetailId(toLocalId(session.id));
           }}
           pagination={false}
-          isSorterDisabled
+          disableSorter
         />
         <SessionDetailDrawer
           open={!!sessionDetailId}

--- a/react/src/components/ResourceGroupSelectForCurrentProject.tsx
+++ b/react/src/components/ResourceGroupSelectForCurrentProject.tsx
@@ -4,14 +4,15 @@ import {
   useCurrentResourceGroupState,
   useResourceGroupsForCurrentProject,
 } from '../hooks/useCurrentProject';
+import BAISelect, { BAISelectProps } from './BAISelect';
 import TextHighlighter from './TextHighlighter';
-import { Select, SelectProps } from 'antd';
+import { SelectProps } from 'antd';
 import _ from 'lodash';
 import React, { useEffect, useState, useTransition } from 'react';
 
 interface ResourceGroupSelectForCurrentProjectProps
   extends Omit<
-    SelectProps,
+    BAISelectProps,
     'defaultValue' | 'value' | 'allowClear' | 'onClear'
   > {
   // filter?: (projectName: string) => boolean;
@@ -64,7 +65,7 @@ const ResourceGroupSelectForCurrentProject: React.FC<
     : {};
 
   return (
-    <Select
+    <BAISelect
       defaultActiveFirstOption
       loading={isPendingLoading}
       options={_.map(resourceGroups, (resourceGroup) => {

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -23,13 +23,13 @@ interface SessionNodesProps
   extends Omit<TableProps<SessionNodeInList>, 'dataSource' | 'columns'> {
   sessionsFrgmt: SessionNodesFragment$key;
   onClickSessionName?: (session: SessionNodeInList) => void;
-  isSorterDisabled?: boolean;
+  disableSorter?: boolean;
 }
 
 const SessionNodes: React.FC<SessionNodesProps> = ({
   sessionsFrgmt,
   onClickSessionName,
-  isSorterDisabled,
+  disableSorter,
   ...tableProps
 }) => {
   const { t } = useTranslation();
@@ -132,7 +132,7 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
       },
     ]),
     (column) => {
-      return isSorterDisabled ? _.omit(column, 'sorter') : column;
+      return disableSorter ? _.omit(column, 'sorter') : column;
     },
   );
 

--- a/react/src/components/StorageSelect.tsx
+++ b/react/src/components/StorageSelect.tsx
@@ -2,9 +2,10 @@ import { usageIndicatorColor } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
 import useControllableState from '../hooks/useControllableState';
+import BAISelect, { BAISelectProps } from './BAISelect';
 import Flex from './Flex';
 import TextHighlighter from './TextHighlighter';
-import { Select, SelectProps, Badge, Tooltip } from 'antd';
+import { Badge, Tooltip } from 'antd';
 import _ from 'lodash';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,7 +19,7 @@ export type VolumeInfo = {
   };
   sftp_scaling_groups: string[];
 };
-interface Props extends Omit<SelectProps, 'value' | 'onChange'> {
+interface Props extends Omit<BAISelectProps, 'value' | 'onChange'> {
   autoSelectType?: 'usage' | 'default';
   showUsageStatus?: boolean;
   value?: string;
@@ -87,7 +88,7 @@ const StorageSelect: React.FC<Props> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [vhostInfo]);
   return (
-    <Select
+    <BAISelect
       filterOption={true}
       placeholder={t('data.SelectStorageHost')}
       loading={isLoadingVhostInfo}

--- a/react/src/hooks/useResourceLimitAndRemaining.tsx
+++ b/react/src/hooks/useResourceLimitAndRemaining.tsx
@@ -97,6 +97,7 @@ interface Props {
   currentImage?: Image;
   currentResourceGroup?: string;
   ignorePerContainerConfig?: boolean;
+  fetchKey?: string;
 }
 
 // determine resource limits and remaining for current resource group and current image in current project
@@ -105,6 +106,7 @@ export const useResourceLimitAndRemaining = ({
   currentResourceGroup = '',
   currentProjectName,
   ignorePerContainerConfig = false,
+  fetchKey,
 }: Props) => {
   const baiClient = useSuspendedBackendaiClient();
   const [resourceSlots] = useResourceSlots();
@@ -116,7 +118,12 @@ export const useResourceLimitAndRemaining = ({
     refetch,
     isRefetching,
   } = useSuspenseTanQuery<ResourceAllocation | null>({
-    queryKey: ['check-presets', currentProjectName, currentResourceGroup],
+    queryKey: [
+      'check-presets',
+      currentProjectName,
+      currentResourceGroup,
+      fetchKey,
+    ],
     queryFn: () => {
       if (
         currentResourceGroup &&


### PR DESCRIPTION

Resolves #3426 (FR-732)
This PR enhances the dashboard components with a unified refresh mechanism and improves UI consistency:

- Implements a centralized refresh approach for dashboard cards using a shared fetch key
- Refactors `BAIFetchKeyButton` to properly extend button props
- Improves resource group and storage selection UI with borderless variants
- Standardizes refresh button behavior across all dashboard cards
- Adds automatic 15-second refresh interval for dashboard components
- Renames `isSorterDisabled` prop to more intuitive `disableSorter` in SessionNodes
- Fixes resource limit and remaining hook to properly handle fetch key changes