### PR TITLE
fix(FR-733): use isActive function for session termination button disable condition

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -182,7 +182,7 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = (props) => {
         />
         <Tooltip title={t('session.TerminateSession')}>
           <Button
-            disabled={session.status !== 'RUNNING'}
+            disabled={!isActive(session)}
             icon={
               <TerminateIcon
                 style={{


### PR DESCRIPTION
This PR resolves #3433 (FR-733)

This PR modifies the session termination button to be enabled for all active sessions, not just those in the "RUNNING" state. This change allows users to terminate sessions that are in other active states, such as "PREPARING" or "RESTARTING".

### How to test
1. Login with user/admin.
2. Go to session page.
3. Create a session with random name.
4. Click the session name
5. Detail page showed up.
6. Change the status of the session just created in step 3.
> NOTE: For now, testing in Core server in local, scheduler changes the status of session too fast, therefore It status should be changed manually using manager.
```
$ ./backend.ai mgr dbshell 
$ UPDATE sessions SET status='CREATING' WHERE name='<created-session-name>'
```
7. Check status whether terminate session button is enabled or not.

### Screenshot(s)
| After | Before |
|------|--------|
| ![Screenshot 2025-03-31 at 6.20.41 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/8fde6064-3617-47c3-b3dc-e8e2f3327e57.png) | ![Screenshot 2025-03-31 at 5.05.31 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/c98eab1f-e44b-4e2b-b29f-45787ed1942f.png) |


**Checklist:**

- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after