### PR TITLE
e2e(FR-759): fix create test code

### DIFF
--- a/e2e/test-util.ts
+++ b/e2e/test-util.ts
@@ -127,36 +127,30 @@ export async function createVFolderAndVerify(
   folderName: string,
   usageMode: 'general' | 'model' = 'general',
   type: 'user' | 'project' = 'user',
-  permission: 'rw' | 'ro' | 'wd' = 'rw',
+  permission: 'rw' | 'ro' = 'rw',
 ) {
-  const permissionMap = {
-    rw: 'Read & Write',
-    ro: 'Read only',
-    wd: 'Delete',
-  };
   await navigateTo(page, 'data');
 
-  await page.getByRole('button', { name: 'plus Add' }).click();
+  await page.getByRole('button', { name: 'Create Folder' }).nth(1).click();
   await page.getByRole('textbox', { name: 'Folder name' }).fill(folderName);
+
   // select parsed parameters in create modal form
-  await page.getByRole('radio', { name: usageMode }).click();
-  await page.getByRole('radio', { name: type }).click();
-  await page.getByRole('radio', { name: permissionMap[permission] }).click();
+  await page.getByTestId(`${usageMode}-usage-mode`).click();
+  await page.getByTestId(`${type}-type`).click();
+  await page.getByTestId(`${permission}-permission`).click();
 
   await page.getByRole('button', { name: 'Create', exact: true }).click();
   await page.reload();
-  const nameInput = page
-    .locator('#general-folder-storage vaadin-grid-cell-content')
-    .filter({ hasText: 'Name' })
-    .locator('vaadin-text-field')
-    .nth(1)
-    .locator('input');
-  await nameInput.click();
-  await nameInput.fill(folderName);
+  await page.getByTestId('vfolder-filter').locator('div').nth(2).click();
+  await page.getByRole('option', { name: 'Name' }).locator('div').click();
+  await page.locator('#rc_select_8').fill(folderName);
+  await page.getByRole('button', { name: 'search' }).click();
+  await page.getByRole('link', { name: folderName }).click();
   await expect(
-    page.locator('vaadin-grid-cell-content').filter({ hasText: folderName }),
+    page
+      .getByRole('cell', { name: `VFolder Identicon ${folderName}` })
+      .filter({ hasText: folderName }),
   ).toBeVisible();
-  await nameInput.fill('');
 }
 
 export async function deleteVFolderAndVerify(page: Page, folderName: string) {

--- a/react/src/components/BAIPropertyFilter.tsx
+++ b/react/src/components/BAIPropertyFilter.tsx
@@ -244,7 +244,7 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
   };
 
   return (
-    <Flex direction="column" gap={'xs'} align="start">
+    <Flex direction="column" gap={'xs'} align="start" {...containerProps}>
       <Space.Compact>
         <Select
           popupMatchSelectWidth={false}

--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -255,9 +255,13 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
 
         <Form.Item label={t('data.UsageMode')} name={'usage_mode'}>
           <Radio.Group>
-            <Radio value={'general'}>General</Radio>
+            <Radio value={'general'} data-testid="general-usage-mode">
+              General
+            </Radio>
             {baiClient._config.enableModelFolders ? (
-              <Radio value={'model'}>Model</Radio>
+              <Radio value={'model'} data-testid="model-usage-mode">
+                Model
+              </Radio>
             ) : null}
           </Radio.Group>
         </Form.Item>
@@ -276,11 +280,15 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
              * so we need both checks for proper access control
              */}
             {_.includes(allowedTypes, 'user') ? (
-              <Radio value={'user'}>User</Radio>
+              <Radio value={'user'} data-testid="user-type">
+                User
+              </Radio>
             ) : null}
             {(userRole === 'admin' || userRole === 'superadmin') &&
             _.includes(allowedTypes, 'group') ? (
-              <Radio value={'project'}>Project</Radio>
+              <Radio value={'project'} data-testid="project-type">
+                Project
+              </Radio>
             ) : null}
           </Radio.Group>
         </Form.Item>
@@ -305,8 +313,12 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
 
         <Form.Item label={t('data.Permission')} name={'permission'}>
           <Radio.Group>
-            <Radio value={'rw'}>Read & Write</Radio>
-            <Radio value={'ro'}>Read Only</Radio>
+            <Radio value={'rw'} data-testid="rw-permission">
+              Read & Write
+            </Radio>
+            <Radio value={'ro'} data-testid="ro-permission">
+              Read Only
+            </Radio>
           </Radio.Group>
         </Form.Item>
 

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -436,6 +436,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                 ])}
               />
               <BAIPropertyFilter
+                data-testid="vfolder-filter"
                 filterProperties={[
                   {
                     key: 'name',


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai-webui/issues/3450 (FR-759)

>[!NOTE]
> This PR only handles creation.

## Update folder creation test and add data-testid attributes

This PR updates the folder creation test in `e2e/test-util.ts` to work with the new UI components. The changes include:

1. Removing the 'wd' (Delete) permission option as it's no longer supported
2. Updating the folder creation workflow to use the "Create Folder" button
3. Adding data-testid attributes to radio buttons in FolderCreateModal for better test targeting
4. Updating the folder verification process to work with the new UI components

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after