### PR TITLE
fix(FR-752): e2e for showNonInstalledImages and login

### DIFF
--- a/e2e/config.test.ts
+++ b/e2e/config.test.ts
@@ -53,7 +53,7 @@ test.describe.parallel('config.toml', () => {
   );
 
   test(
-    'showNonInstalledImages',
+    'showNonInstalledImages: Allow users to select non-installed images when creating sessions',
     { tag: ['@session'] },
     async ({ page, context, request }) => {
       // modify config.toml to show non-installed images
@@ -66,7 +66,10 @@ test.describe.parallel('config.toml', () => {
 
       await loginAsAdmin(page);
 
-      await page.getByRole('group').getByText('Environments').click();
+      await page
+        .getByRole('group')
+        .getByText('Environments', { exact: true })
+        .click();
       await page
         .getByRole('columnheader', { name: 'Status' })
         .locator('div')
@@ -81,7 +84,8 @@ test.describe.parallel('config.toml', () => {
       ).jsonValue();
 
       await page.goto(webuiEndpoint);
-      await page.getByLabel('power_settings_new').click();
+      // await page.getByLabel('power_settings_new').click();
+      await page.getByRole('button', { name: 'Start Session' }).first().click();
       await page
         .getByRole('button', { name: '2 Environments & Resource' })
         .click();

--- a/e2e/login.test.ts
+++ b/e2e/login.test.ts
@@ -19,9 +19,9 @@ test.describe('Login using the admin account', () => {
   });
 
   test('should redirect to the Summary', async ({ page }) => {
-    await expect(page).toHaveURL(/\/summary/);
+    await expect(page).toHaveURL(/\/start/);
     await expect(
-      page.getByTestId('webui-breadcrumb').getByText('Summary'),
+      page.getByTestId('webui-breadcrumb').getByText('Start'),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
Resolves #3444 (FR-752)

# Update E2E tests for UI changes

This PR updates E2E tests to reflect recent UI changes:

1. Improves the test description for `showNonInstalledImages` to better describe its functionality
2. Updates element selectors to be more precise:
   - Uses `exact: true` for the Environments text selector
   - Replaces the icon selector with a more reliable button selector for "Start Session"
3. Updates login test to reflect that users are now redirected to the `/start` page instead of `/summary` after login

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after