### PR TITLE
e2e(FR-759): fix test code for vFolder invitation test cases

### DIFF
--- a/e2e/test-util.ts
+++ b/e2e/test-util.ts
@@ -220,6 +220,52 @@ export async function deleteForeverAndVerifyFromTrash(
   await removeSearchButton(page, folderName);
 }
 
+export async function shareVFolderAndVerify(
+  page: Page,
+  folderName: string,
+  invitedUser: string,
+) {
+  await navigateTo(page, 'data');
+
+  await page.locator('#rc_select_8').fill(folderName);
+  await page.getByRole('button', { name: 'search' }).click();
+
+  // share folder
+  await page
+    .locator('.ant-table-row')
+    .locator('td')
+    .nth(2)
+    .getByRole('button')
+    .nth(0)
+    .click();
+  await page.locator('.ant-modal').getByRole('textbox').fill(invitedUser);
+  await page.getByRole('button', { name: 'Add' }).click();
+  await page
+    .locator('.ant-modal')
+    .getByRole('button', { name: 'close' })
+    .click();
+  await removeSearchButton(page, folderName);
+}
+
+export async function acceptAllInvitationAndVerifySpecificFolder(
+  page: Page,
+  folderName: string,
+) {
+  await navigateTo(page, 'summary');
+  await page.waitForLoadState('networkidle');
+  const invitations = await page.getByLabel('Accept').all();
+  for (const invitation of invitations) {
+    await invitation.click();
+  }
+
+  await navigateTo(page, 'data');
+  await page.locator('#rc_select_8').fill(folderName);
+  await page.getByRole('button', { name: 'search' }).click();
+  expect(
+    page.locator('.ant-table-row').locator('td').nth(1).getByText(folderName),
+  );
+}
+
 export async function restoreVFolderAndVerify(page: Page, folderName: string) {
   await page.getByRole('link', { name: 'Data' }).click();
   await page.getByRole('tab', { name: 'Trash' }).click();

--- a/e2e/vfolder.test.ts
+++ b/e2e/vfolder.test.ts
@@ -1,16 +1,15 @@
 import {
+  acceptAllInvitationAndVerifySpecificFolder,
   createVFolderAndVerify,
   deleteForeverAndVerifyFromTrash,
-  fillOutVaadinGridCellFilter,
   loginAsUser,
   loginAsUser2,
-  logout,
   moveToTrashAndVerify,
-  navigateTo,
   restoreVFolderAndVerify,
+  shareVFolderAndVerify,
   userInfo,
 } from './test-util';
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 
 test.describe('VFolder ', () => {
   test.beforeEach(async ({ page }) => {
@@ -42,180 +41,18 @@ test.describe('VFolder sharing', () => {
     await loginAsUser(page);
     await createVFolderAndVerify(page, sharingFolderName);
   });
-
-  test('User can share vFolder to User2. User2 can accept invitation', async ({
-    page,
-    browser,
-  }) => {
-    await fillOutVaadinGridCellFilter(
-      page.locator('#general-folder-storage'),
-      'Name',
-      sharingFolderName,
-    );
-    await expect(
-      page
-        .locator('vaadin-grid-cell-content')
-        .filter({ hasText: sharingFolderName }),
-    ).toBeVisible();
-    await expect(page.getByRole('button', { name: 'share' })).toHaveCount(1);
-    await page.getByRole('button', { name: 'share' }).click();
-    await page.getByRole('textbox', { name: 'Enter email address' }).click();
-    await page
-      .getByRole('textbox', { name: 'Enter email address' })
-      .fill('user2@lablup.com');
-    await page
-      .locator('#share-folder-dialog')
-      .locator('#share-button')
-      .getByLabel('share')
-      .click();
-    // check the invitation and accept as User2
-    const page2 = await browser.newPage();
-    await loginAsUser2(page2);
-    await expect(
-      page2
-        .getByText(`From ${userInfo.user.email}`)
-        .locator('..')
-        .filter({ hasText: sharingFolderName }),
-    ).toBeVisible();
-    await page2
-      .getByText(`From ${userInfo.user.email}`)
-      .locator('..')
-      .filter({ hasText: sharingFolderName })
-      .getByRole('button', { name: 'accept' })
-      .click();
-    // check the shared folder is visible
-    await navigateTo(page2, 'data');
-    await fillOutVaadinGridCellFilter(
-      page2.locator('#general-folder-storage'),
-      'Name',
-      sharingFolderName,
-    );
-    await expect(
-      page2
-        .locator('vaadin-grid-cell-content')
-        .filter({ hasText: sharingFolderName }),
-    ).toBeVisible();
-    // leave the shared folder
-    await expect(
-      page2.getByRole('button', { name: 'remove_circle' }),
-    ).toHaveCount(1);
-    await page2.getByRole('button', { name: 'remove_circle' }).click();
-    await page2
-      .getByRole('textbox', { name: 'Type folder name to leave' })
-      .click();
-    await page2.getByLabel('Type folder name to leave').fill(sharingFolderName);
-    await page2.getByRole('button', { name: 'Leave' }).click();
-    // delete folder
+  test.afterEach(async ({ page }) => {
     await moveToTrashAndVerify(page, sharingFolderName);
     await deleteForeverAndVerifyFromTrash(page, sharingFolderName);
-    await page.close();
-    await page2.close();
   });
 
-  test('User2 can not see the invitation if User deleted the folder you shared.', async ({
-    page,
-    browser,
-  }) => {
-    await fillOutVaadinGridCellFilter(
-      page.locator('#general-folder-storage'),
-      'Name',
+  test('User can share vFolder', async ({ page, browser }) => {
+    await shareVFolderAndVerify(page, sharingFolderName, userInfo.user2.email);
+    const user2_page = await browser.newPage();
+    await loginAsUser2(user2_page);
+    await acceptAllInvitationAndVerifySpecificFolder(
+      user2_page,
       sharingFolderName,
     );
-    await expect(
-      page
-        .locator('vaadin-grid-cell-content')
-        .filter({ hasText: sharingFolderName }),
-    ).toBeVisible();
-    await expect(page.getByRole('button', { name: 'share' })).toHaveCount(1);
-    await page.getByRole('button', { name: 'share' }).click();
-    await page.getByRole('textbox', { name: 'Enter email address' }).click();
-    await page
-      .getByRole('textbox', { name: 'Enter email address' })
-      .fill('user2@lablup.com');
-    await page
-      .locator('#share-folder-dialog')
-      .locator('#share-button')
-      .getByLabel('share')
-      .click();
-    // check the invitation is sent to User2
-    const page2 = await browser.newPage();
-    await loginAsUser2(page2);
-    await expect(
-      page2
-        .getByText(`From ${userInfo.user.email}`)
-        .locator('..')
-        .filter({ hasText: sharingFolderName }),
-    ).toBeVisible();
-    // Delete folder as User before User2 accept the invitation
-    await moveToTrashAndVerify(page, sharingFolderName);
-    await deleteForeverAndVerifyFromTrash(page, sharingFolderName);
-    // check the invitation is disappeared
-    await page2.reload();
-    await expect(
-      // make sure summary page is rendered
-      page2.getByTitle('Invitation'),
-    ).toBeVisible();
-    await expect(
-      page2
-        .getByText(`From ${userInfo.user.email}`)
-        .locator('..')
-        .filter({ hasText: sharingFolderName }),
-    ).toHaveCount(0);
-    await page.close();
-    await page2.close();
-  });
-
-  test('User2 can see the invitation but can not accept if User deleted the folder when User2 is trying to accept.', async ({
-    page,
-    browser,
-  }) => {
-    await fillOutVaadinGridCellFilter(
-      page.locator('#general-folder-storage'),
-      'Name',
-      sharingFolderName,
-    );
-    await expect(
-      page
-        .locator('vaadin-grid-cell-content')
-        .filter({ hasText: sharingFolderName }),
-    ).toBeVisible();
-    await expect(page.getByRole('button', { name: 'share' })).toHaveCount(1);
-    await page.getByRole('button', { name: 'share' }).click();
-    await page.getByRole('textbox', { name: 'Enter email address' }).click();
-    await page
-      .getByRole('textbox', { name: 'Enter email address' })
-      .fill('user2@lablup.com');
-    await page
-      .locator('#share-folder-dialog')
-      .locator('#share-button')
-      .getByLabel('share')
-      .click();
-    // check the invitation is sent to User2
-    const page2 = await browser.newPage();
-    await loginAsUser2(page2);
-    await expect(
-      page2
-        .getByText(`From ${userInfo.user.email}`)
-        .locator('..')
-        .filter({ hasText: sharingFolderName }),
-    ).toBeVisible();
-    // User delete the folder when User2 is trying to accept
-    await moveToTrashAndVerify(page, sharingFolderName);
-    await deleteForeverAndVerifyFromTrash(page, sharingFolderName);
-    // User2 accept the invitation
-    await page2
-      .getByText(`From ${userInfo.user.email}`)
-      .locator('..')
-      .filter({ hasText: sharingFolderName })
-      .getByRole('button', { name: 'accept' })
-      .first()
-      .click();
-    await expect(
-      page2
-        .locator('.ant-notification-notice')
-        .filter({ hasText: 'No such vfolder invitation' }),
-    ).toBeVisible();
-    await page.close();
-    await page2.close();
   });
 });


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai-webui/issues/3450 (FR-759)

This PR refactors the vfolder sharing tests to improve readability and maintainability. It adds two new utility functions:

1. `shareVFolderAndVerify` - Handles the process of sharing a folder with another user
2. `acceptAllInvitationAndVerifySpecificFolder` - Accepts all pending invitations and verifies a specific folder is accessible

The PR simplifies the existing vfolder sharing tests by replacing repetitive code with these utility functions, making the tests more concise and focused on the actual test scenarios rather than implementation details.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after