### PR TITLE
e2e(FR-759): add vfolder restore test code

### DIFF
--- a/e2e/test-util.ts
+++ b/e2e/test-util.ts
@@ -122,6 +122,36 @@ export async function fillOutVaadinGridCellFilter(
   await nameInput.fill(inputValue);
 }
 
+async function removeSearchButton(page: Page, folderName: string) {
+  await page
+    .getByTestId('vfolder-filter')
+    .locator('div')
+    .filter({ hasText: `Name: ${folderName}` })
+    .locator('svg')
+    .first()
+    .click();
+}
+
+export async function verifyVFolder(
+  page: Page,
+  folderName: string,
+  statusTab: 'Created' | 'Trash' = 'Created',
+) {
+  await page.getByRole('link', { name: 'Data' }).click();
+  await page.getByRole('tab', { name: statusTab }).click();
+  await page.getByTestId('vfolder-filter').locator('div').nth(2).click();
+  await page.getByRole('option', { name: 'Name' }).locator('div').click();
+  const searchInput = page.locator('#rc_select_8');
+  await searchInput.fill(folderName);
+  await page.getByRole('button', { name: 'search' }).click();
+  await expect(
+    page
+      .getByRole('cell', { name: `VFolder Identicon ${folderName}` })
+      .filter({ hasText: folderName }),
+  ).toBeVisible();
+  await removeSearchButton(page, folderName);
+}
+
 export async function createVFolderAndVerify(
   page: Page,
   folderName: string,
@@ -129,8 +159,7 @@ export async function createVFolderAndVerify(
   type: 'user' | 'project' = 'user',
   permission: 'rw' | 'ro' = 'rw',
 ) {
-  await navigateTo(page, 'data');
-
+  await page.getByRole('link', { name: 'Data' }).click();
   await page.getByRole('button', { name: 'Create Folder' }).nth(1).click();
   await page.getByRole('textbox', { name: 'Folder name' }).fill(folderName);
 
@@ -140,63 +169,71 @@ export async function createVFolderAndVerify(
   await page.getByTestId(`${permission}-permission`).click();
 
   await page.getByRole('button', { name: 'Create', exact: true }).click();
-  await page.reload();
+  await verifyVFolder(page, folderName);
+}
+
+export async function moveToTrashAndVerify(page: Page, folderName: string) {
+  await page.getByRole('link', { name: 'Data' }).click();
   await page.getByTestId('vfolder-filter').locator('div').nth(2).click();
   await page.getByRole('option', { name: 'Name' }).locator('div').click();
-  await page.locator('#rc_select_8').fill(folderName);
+  const searchInput = page.locator('#rc_select_8');
+  await searchInput.fill(folderName);
   await page.getByRole('button', { name: 'search' }).click();
-  await page.getByRole('link', { name: folderName }).click();
+  await page
+    .getByRole('row', { name: 'VFolder Identicon e2e-test-' })
+    .getByRole('button')
+    .nth(1)
+    .click();
+  await page.getByRole('button', { name: 'Move' }).click();
+  await removeSearchButton(page, folderName);
+  await verifyVFolder(page, folderName, 'Trash');
+}
+
+export async function deleteForeverAndVerifyFromTrash(
+  page: Page,
+  folderName: string,
+) {
+  await page.getByRole('link', { name: 'Data' }).click();
+  await page.getByRole('tab', { name: 'Trash' }).click();
+  const searchInput = page.locator('#rc_select_8');
+  await searchInput.fill(folderName);
+  await page.getByRole('button', { name: 'search' }).click();
+  // Delete forever
+  await page
+    .getByRole('row', { name: 'VFolder Identicon e2e-test-' })
+    .getByRole('button')
+    .nth(1)
+    .click();
+  await page.locator('#confirmText').click();
+  await page.locator('#confirmText').fill(folderName);
+  await page.getByRole('button', { name: 'Delete forever' }).click();
+  // Verify
+  await page.getByTestId('vfolder-filter').locator('div').nth(2).click();
+  await page.getByRole('option', { name: 'Name' }).locator('div').click();
+  await searchInput.fill(folderName);
+  await page.getByRole('button', { name: 'search' }).click();
   await expect(
     page
       .getByRole('cell', { name: `VFolder Identicon ${folderName}` })
       .filter({ hasText: folderName }),
-  ).toBeVisible();
+  ).toHaveCount(0);
+  await removeSearchButton(page, folderName);
 }
 
-export async function deleteVFolderAndVerify(page: Page, folderName: string) {
-  await navigateTo(page, 'data');
-  const nameInput = page
-    .locator('#general-folder-storage vaadin-grid-cell-content')
-    .filter({ hasText: 'Name' })
-    .locator('vaadin-text-field')
-    .nth(1)
-    .locator('input');
-  await nameInput.click();
-  await nameInput.fill(folderName);
-  await page.waitForTimeout(1000);
-  await page.getByRole('button', { name: 'delete' }).first().click();
+export async function restoreVFolderAndVerify(page: Page, folderName: string) {
+  await page.getByRole('link', { name: 'Data' }).click();
+  await page.getByRole('tab', { name: 'Trash' }).click();
+  await page.locator('#react-root').getByTitle('Name').click();
+  await page.getByRole('option', { name: 'Name' }).locator('div').click();
+  const searchInput = page.locator('#rc_select_8');
+  await searchInput.fill(folderName);
+  // Restore
   await page
-    .locator('#delete-without-confirm-button')
-    .getByLabel('delete')
+    .getByRole('row', { name: 'VFolder Identicon e2e-test-' })
+    .getByRole('button')
+    .first()
     .click();
-  await page.waitForLoadState('networkidle');
-  await page.getByRole('tab', { name: 'delete' }).click();
-  const nameInputInTrash = page
-    .locator('#trash-bin-folder-storage vaadin-grid-cell-content')
-    .filter({ hasText: 'Name' })
-    .locator('vaadin-text-field')
-    .nth(1)
-    .locator('input');
-  await nameInputInTrash.fill(folderName);
-  // after filling the input, the vaadin-grid will be updated asynchronously. So we need to wait for the grid to be updated.
-  await page.waitForTimeout(1000);
-  await page
-    .locator('vaadin-grid-cell-content')
-    .filter({ hasText: folderName })
-    .locator('//following-sibling::*[7]')
-    .getByRole('button', { name: 'delete_forever' })
-    .click();
-  await page
-    .getByRole('textbox', { name: 'Type folder name to delete' })
-    .fill(folderName);
-  await page.getByRole('button', { name: 'Delete forever' }).click();
-  await expect(
-    page
-      .locator('vaadin-grid-cell-content')
-      .filter({ hasText: folderName })
-      .locator(':visible'),
-  ).toHaveCount(0);
-  await nameInputInTrash.fill('');
+  await verifyVFolder(page, folderName, 'Created');
 }
 
 export async function createSession(page: Page, sessionName: string) {

--- a/e2e/vfolder.test.ts
+++ b/e2e/vfolder.test.ts
@@ -1,21 +1,38 @@
 import {
   createVFolderAndVerify,
-  deleteVFolderAndVerify,
+  deleteForeverAndVerifyFromTrash,
   fillOutVaadinGridCellFilter,
   loginAsUser,
   loginAsUser2,
   logout,
+  moveToTrashAndVerify,
   navigateTo,
+  restoreVFolderAndVerify,
   userInfo,
 } from './test-util';
 import { test, expect } from '@playwright/test';
 
 test.describe('VFolder ', () => {
-  test('User can create and delete vFolder', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await loginAsUser(page);
-    const folderName = 'e2e-test-folder-user-creation' + new Date().getTime();
+  });
+  const folderName = 'e2e-test-folder-user-creation' + new Date().getTime();
+  test('User can create and delete, delete forever vFolder', async ({
+    page,
+  }) => {
     await createVFolderAndVerify(page, folderName);
-    await deleteVFolderAndVerify(page, folderName);
+    await moveToTrashAndVerify(page, folderName);
+    await deleteForeverAndVerifyFromTrash(page, folderName);
+  });
+
+  test('User can create, delete(move to trash), restore, delete forever vFolder', async ({
+    page,
+  }) => {
+    await createVFolderAndVerify(page, folderName);
+    await moveToTrashAndVerify(page, folderName);
+    await restoreVFolderAndVerify(page, folderName);
+    await moveToTrashAndVerify(page, folderName);
+    await deleteForeverAndVerifyFromTrash(page, folderName);
   });
 });
 
@@ -89,7 +106,8 @@ test.describe('VFolder sharing', () => {
     await page2.getByLabel('Type folder name to leave').fill(sharingFolderName);
     await page2.getByRole('button', { name: 'Leave' }).click();
     // delete folder
-    await deleteVFolderAndVerify(page, sharingFolderName);
+    await moveToTrashAndVerify(page, sharingFolderName);
+    await deleteForeverAndVerifyFromTrash(page, sharingFolderName);
     await page.close();
     await page2.close();
   });
@@ -129,7 +147,8 @@ test.describe('VFolder sharing', () => {
         .filter({ hasText: sharingFolderName }),
     ).toBeVisible();
     // Delete folder as User before User2 accept the invitation
-    await deleteVFolderAndVerify(page, sharingFolderName);
+    await moveToTrashAndVerify(page, sharingFolderName);
+    await deleteForeverAndVerifyFromTrash(page, sharingFolderName);
     // check the invitation is disappeared
     await page2.reload();
     await expect(
@@ -181,7 +200,8 @@ test.describe('VFolder sharing', () => {
         .filter({ hasText: sharingFolderName }),
     ).toBeVisible();
     // User delete the folder when User2 is trying to accept
-    await deleteVFolderAndVerify(page, sharingFolderName);
+    await moveToTrashAndVerify(page, sharingFolderName);
+    await deleteForeverAndVerifyFromTrash(page, sharingFolderName);
     // User2 accept the invitation
     await page2
       .getByText(`From ${userInfo.user.email}`)


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai-webui/issues/3450 (FR-759)

# Add VFolder Restoration Functionality and Test

This PR adds a new utility function `restoreVFolderAndVerify` to support restoring virtual folders from the trash. It also adds a comprehensive test case that verifies the complete lifecycle of a virtual folder: creation, moving to trash, restoration, and permanent deletion.

The new test ensures users can successfully restore folders from the trash before permanently deleting them, providing better test coverage for the virtual folder management workflow.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after