### PR TITLE
fix(FR-801): update reset button to hide cloneable toggle

### DIFF
--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -182,7 +182,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
           <Button
             danger
             onClick={() => {
-              formRef.current?.setFieldsValue(INITIAL_FORM_VALUES);
+              formRef.current?.resetFields();
             }}
           >
             {t('button.Reset')}


### PR DESCRIPTION
resolves #3475 (FR-801)
Reset button can hide cloneable toggle button

**changes**
* Change `setFieldsValue` to `resetFields` in the reset button

![CleanShot 2025-04-10 at 12 46 27](https://github.com/user-attachments/assets/e6c73c4d-6bea-4414-86b0-21992a7d9228)


**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
