### PR TITLE
hotfix(FR-802): Disable Delete Button for Users with 'User' Role

### DIFF
--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -1,6 +1,6 @@
 import { filterNonNullItems, toLocalId } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
-import { useCurrentUserInfo } from '../hooks/backendai';
+import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
@@ -72,6 +72,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
   const { message } = App.useApp();
 
   const currentProject = useCurrentProjectValue();
+  const userRole = useCurrentUserRole();
   const baiClient = useSuspendedBackendaiClient();
   const painKiller = usePainKiller();
   const [currentUser] = useCurrentUserInfo();
@@ -120,6 +121,10 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
       return baiClient.vfolder.delete_from_trash_bin(toLocalId(id));
     },
   });
+
+  const isMoveToTrashDisabled = (vfolder: VFolderNodeInList) => {
+    return userRole === 'user' && vfolder?.ownership_type === 'group';
+  };
 
   return (
     <>
@@ -280,18 +285,30 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
                       }}
                       okText={t('button.Move')}
                       okButtonProps={{ danger: true }}
+                      disabled={isMoveToTrashDisabled(vfolder)}
                     >
                       <Tooltip
-                        title={t('data.folders.MoveToTrash')}
+                        title={
+                          isMoveToTrashDisabled(vfolder)
+                            ? t(
+                                'data.folders.ProjectFolderDeletionRequiresAdmin',
+                              )
+                            : t('data.folders.MoveToTrash')
+                        }
                         placement="right"
                       >
                         <Button
                           size="small"
                           type="text"
                           icon={<TrashBinIcon />}
+                          disabled={isMoveToTrashDisabled(vfolder)}
                           style={{
-                            color: token.colorError,
-                            background: token.colorErrorBg,
+                            color: isMoveToTrashDisabled(vfolder)
+                              ? token.colorTextDisabled
+                              : token.colorError,
+                            background: isMoveToTrashDisabled(vfolder)
+                              ? token.colorBgContainerDisabled
+                              : token.colorErrorBg,
                           }}
                         />
                       </Tooltip>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -371,6 +371,7 @@
       "Owner": "Inhaber",
       "Ownership": "Eigentum",
       "Permission": "Genehmigung",
+      "ProjectFolderDeletionRequiresAdmin": "Für die Löschung des Projektordners erfordert die Genehmigung des Projektmanagers.",
       "Rename": "Umbenennen",
       "Restore": "Wiederherstellen",
       "RestoreDescription": "Möchten Sie \"{{ folderName }}\" -Fordner wiederherstellen?",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -368,6 +368,7 @@
       "Owner": "Ιδιοκτήτης",
       "Ownership": "Ιδιοκτησία",
       "Permission": "Αδεια",
+      "ProjectFolderDeletionRequiresAdmin": "Η διαγραφή του φακέλου του έργου απαιτεί την εξουσιοδότηση του διαχειριστή έργου.",
       "Rename": "Μετονομάζω",
       "Restore": "Επαναφέρω",
       "RestoreDescription": "Θέλετε να επαναφέρετε \"{{ folderName }}\" \"Φάκελος;",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -373,6 +373,7 @@
       "Owner": "Owner",
       "Ownership": "Ownership",
       "Permission": "Permission",
+      "ProjectFolderDeletionRequiresAdmin": "The project folder deletion requires project manager authorization.",
       "Rename": "Rename",
       "Restore": "Restore",
       "RestoreDescription": "Do you want to restore \"{{ folderName }}\" folder?",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -371,6 +371,7 @@
       "Owner": "Propietario",
       "Ownership": "Propiedad",
       "Permission": "Permiso",
+      "ProjectFolderDeletionRequiresAdmin": "La eliminación de la carpeta del proyecto requiere la autorización del administrador del proyecto.",
       "Rename": "Cambie el nombre de",
       "Restore": "Restaurar",
       "RestoreDescription": "¿Quieres restaurar la carpeta \"{{ folderName }}\"?",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -370,6 +370,7 @@
       "Owner": "Omistaja",
       "Ownership": "Omistus",
       "Permission": "Lupa",
+      "ProjectFolderDeletionRequiresAdmin": "Projektikansioiden poisto vaatii projektipäällikön valtuutusta.",
       "Rename": "Nimeä uudelleen",
       "Restore": "Palauttaa",
       "RestoreDescription": "Haluatko palauttaa \"{{ folderName }}\" -kansio?",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -371,6 +371,7 @@
       "Owner": "Propriétaire",
       "Ownership": "La possession",
       "Permission": "Autorisation",
+      "ProjectFolderDeletionRequiresAdmin": "La suppression du dossier du projet nécessite une autorisation de gestionnaire de projet.",
       "Rename": "Renommer",
       "Restore": "Restaurer",
       "RestoreDescription": "Voulez-vous restaurer le dossier \"{{ folderName }}\"?",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -370,6 +370,7 @@
       "Owner": "Pemilik",
       "Ownership": "Kepemilikan",
       "Permission": "Izin",
+      "ProjectFolderDeletionRequiresAdmin": "Penghapusan folder proyek membutuhkan otorisasi manajer proyek.",
       "Rename": "Ganti nama",
       "Restore": "Memulihkan",
       "RestoreDescription": "Apakah Anda ingin mengembalikan \"{{ folderName }}\"?",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -370,6 +370,7 @@
       "Owner": "Proprietario",
       "Ownership": "Proprietà",
       "Permission": "Autorizzazione",
+      "ProjectFolderDeletionRequiresAdmin": "La cancellazione della cartella del progetto richiede l'autorizzazione del project manager.",
       "Rename": "Rinominare",
       "Restore": "Ristabilire",
       "RestoreDescription": "Vuoi ripristinare la cartella \"{{ folderName }}\"?",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -370,6 +370,7 @@
       "Owner": "オーナー",
       "Ownership": "所有",
       "Permission": "許可",
+      "ProjectFolderDeletionRequiresAdmin": "プロジェクトフォルダーの削除には、プロジェクトマネージャーの承認が必要です。",
       "Rename": "名前を変更",
       "Restore": "復元する",
       "RestoreDescription": "\"{{ folderName }}\"フォルダーを復元しますか？",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -373,6 +373,7 @@
       "Owner": "소유자 여부",
       "Ownership": "소유",
       "Permission": "권한",
+      "ProjectFolderDeletionRequiresAdmin": "프로젝트 폴더 삭제는 프로젝트 관리자 승인이 필요합니다.",
       "Rename": "이름 변경",
       "Restore": "복원",
       "RestoreDescription": "\"{{ folderName }}\" 폴더를 복원 하시겠습니까?",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -370,6 +370,7 @@
       "Owner": "Эзэмшигч",
       "Ownership": "Эзэмшил",
       "Permission": "Зөвшөөрөл",
+      "ProjectFolderDeletionRequiresAdmin": "Төслийн хавтас устгах нь төслийн менежерийн зөвшөөрлийг шаарддаг.",
       "Rename": "Нэрийг нь өөрчлөх",
       "Restore": "Сэргээх",
       "RestoreDescription": "Та сэргээхийг хүсч байна уу \"{{ folderName }}\" хавтас?",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -370,6 +370,7 @@
       "Owner": "Pemilik",
       "Ownership": "Pemilikan",
       "Permission": "Kebenaran",
+      "ProjectFolderDeletionRequiresAdmin": "Penghapusan folder projek memerlukan kebenaran Pengurus Projek.",
       "Rename": "Namakan semula",
       "Restore": "Pulihkan",
       "RestoreDescription": "Adakah anda mahu memulihkan folder \"{{ folderName }}\"?",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -371,6 +371,7 @@
       "Owner": "Właściciel",
       "Ownership": "Własność",
       "Permission": "Pozwolenie",
+      "ProjectFolderDeletionRequiresAdmin": "Usunięcie folderu projektu wymaga autoryzacji menedżera projektu.",
       "Rename": "Przemianować",
       "Restore": "Przywrócić",
       "RestoreDescription": "Czy chcesz przywrócić folder \"{{ folderName }}\"?",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -371,6 +371,7 @@
       "Owner": "Proprietário",
       "Ownership": "Propriedade",
       "Permission": "Permissão",
+      "ProjectFolderDeletionRequiresAdmin": "A exclusão da pasta do projeto requer autorização do gerente de projeto.",
       "Rename": "Renomear",
       "Restore": "Restaurar",
       "RestoreDescription": "Deseja restaurar a pasta \"{{ folderName }}\"?",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -371,6 +371,7 @@
       "Owner": "Proprietário",
       "Ownership": "Propriedade",
       "Permission": "Permissão",
+      "ProjectFolderDeletionRequiresAdmin": "A exclusão da pasta do projeto requer autorização do gerente de projeto.",
       "Rename": "Renomear",
       "Restore": "Restaurar",
       "RestoreDescription": "Deseja restaurar a pasta \"{{ folderName }}\"?",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -371,6 +371,7 @@
       "Owner": "Владелец",
       "Ownership": "Владение",
       "Permission": "Разрешение",
+      "ProjectFolderDeletionRequiresAdmin": "Удаление папки проекта требует авторизации менеджера проекта.",
       "Rename": "Переименовать",
       "Restore": "Восстановить",
       "RestoreDescription": "Вы хотите восстановить \"{{ folderName }}\" папка?",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -371,6 +371,7 @@
       "Owner": "เจ้าของ",
       "Ownership": "ความเป็นเจ้าของ",
       "Permission": "สิทธิ์",
+      "ProjectFolderDeletionRequiresAdmin": "การลบโฟลเดอร์โครงการต้องการการอนุญาตผู้จัดการโครงการ",
       "Rename": "เปลี่ยนชื่อ",
       "Restore": "กู้คืน",
       "RestoreDescription": "คุณต้องการกู้คืนโฟลเดอร์ \"{{ folderName }}\" หรือไม่?",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -371,6 +371,7 @@
       "Owner": "Sahip",
       "Ownership": "Mülkiyet",
       "Permission": "izin",
+      "ProjectFolderDeletionRequiresAdmin": "Proje klasörü silme, proje yöneticisi yetkilendirilmesini gerektirir.",
       "Rename": "Adını değiştirmek",
       "Restore": "Eski haline getirmek",
       "RestoreDescription": "\"{{ folderName }}\" klasörünü geri yüklemek istiyor musunuz?",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -371,6 +371,7 @@
       "Owner": "Chủ nhân",
       "Ownership": "Quyền sở hữu",
       "Permission": "Sự cho phép",
+      "ProjectFolderDeletionRequiresAdmin": "Việc xóa thư mục dự án yêu cầu ủy quyền quản lý dự án.",
       "Rename": "Đổi tên",
       "Restore": "Khôi phục",
       "RestoreDescription": "Bạn có muốn khôi phục thư mục \"{{ folderName }}\" không?",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -371,6 +371,7 @@
       "Owner": "所有者",
       "Ownership": "所有权",
       "Permission": "允许",
+      "ProjectFolderDeletionRequiresAdmin": "项目文件夹删除需要项目经理授权。",
       "Rename": "改名",
       "Restore": "恢复",
       "RestoreDescription": "您要还原“{{ folderName }}”文件夹？",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -371,6 +371,7 @@
       "Owner": "所有者",
       "Ownership": "所有權",
       "Permission": "允許",
+      "ProjectFolderDeletionRequiresAdmin": "項目文件夾刪除需要項目經理授權。",
       "Rename": "改名",
       "RenameAFolder": "重命名文件夾",
       "Restore": "恢復",


### PR DESCRIPTION
Resolves #3476 ([FR-802](https://lablup.atlassian.net/browse/FR-802))

# Disable "Move to Trash" button for users on group-owned folders

This PR prevents users from moving project folders to trash by disabling the "Move to Trash" button for group-owned folders when the current user has a 'user' role. The button is visually disabled and shows a tooltip explaining that users cannot delete project folders.

- project folder with 'user' role
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/b4bf8c27-6cad-4ccb-898c-c62b5f9c8127.png)

- general folder
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/13ba5723-af38-4863-bd97-0659cbf61e70.png)

**Checklist:**

- [x] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-802]: https://lablup.atlassian.net/browse/FR-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ