### PR TITLE
feat(FR-777): use resource limit of resource group

### DIFF
--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -9,6 +9,37 @@ type Queries {
     """The ID of the object"""
     id: ID!
   ): Node
+
+  """Added in 25.6.0."""
+  audit_log_schema: AuditLogSchema
+
+  """Added in 25.6.0."""
+  audit_log_nodes(
+    """
+    Specifies the criteria used to narrow down the query results based on certain conditions.
+    """
+    filter: String
+
+    """Specifies the sorting order of the query result."""
+    order: String
+
+    """Specifies how many items to skip before beginning to return result."""
+    offset: Int
+
+    """If this value is provided, the query will be limited to that value."""
+    before: String
+
+    """Queries the `last` number of results from the query result from last."""
+    after: String
+
+    """
+    Queries the `first` number of results from the query result from first.
+    """
+    first: Int
+
+    """If the given value is provided, the query will start from that value."""
+    last: Int
+  ): AuditLogConnection
   agent(agent_id: String!): Agent
   agent_list(limit: Int!, offset: Int!, filter: String, order: String, scaling_group: String, status: String): AgentList
   agents(scaling_group: String, status: String): [Agent]
@@ -245,6 +276,23 @@ type Queries {
   compute_container_list(limit: Int!, offset: Int!, filter: String, order: String, session_id: ID!, role: String): ComputeContainerList
   legacy_compute_session_list(limit: Int!, offset: Int!, order_key: String, order_asc: Boolean, domain_name: String, group_id: String, access_key: String, status: String): LegacyComputeSessionList
   legacy_compute_session(sess_id: String!, domain_name: String, access_key: String): LegacyComputeSession
+
+  """Added in 25.5.0."""
+  total_resource_slot(
+    """
+    `statuses` argument is an array of session statuses. Only sessions with the specified statuses will be queried to calculate the sum of total resource slots. The argument should be an array of the following valid status values: ['PENDING', 'SCHEDULED', 'PREPARING', 'PULLING', 'PREPARED', 'CREATING', 'RUNNING', 'RESTARTING', 'RUNNING_DEGRADED', 'TERMINATING', 'TERMINATED', 'ERROR', 'CANCELLED'].
+    Default value is null.
+    """
+    statuses: [String] = null
+
+    """
+    `filter` argument is a string that is parsed into query conditions. It works in the same way as the `filter` argument in the `compute_session` query schema, meaning the values are parsed into an identical SQL query expression.
+    Default value is `null`.
+    """
+    filter: String
+    domain_name: String
+    resource_group_name: String
+  ): TotalResourceSlot
   vfolder_host_permissions: PredefinedAtomicPermission
   endpoint(endpoint_id: UUID!): Endpoint
   endpoint_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: String, user_uuid: String, project: UUID): EndpointList
@@ -290,6 +338,108 @@ interface Node {
   id: ID!
 }
 
+"""
+A schema that contains metadata related to the AuditLogNode.
+It provides a list of values, such as entity_type and status, that can be used in the AuditLog, allowing clients to retrieve them.
+
+Added in 25.6.0.
+"""
+type AuditLogSchema {
+  """
+  Possible values of "AuditLogNode.entity_type"
+  """
+  entity_type_variants: [String]
+
+  """
+  Possible values of "AuditLogNode.status"
+  """
+  status_variants: [String]
+}
+
+"""Added in 25.6.0."""
+type AuditLogConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [AuditLogEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""
+The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
+"""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+}
+
+"""Added in 25.6.0. A Relay edge containing a `AuditLog` and its cursor."""
+type AuditLogEdge {
+  """The item at the end of the edge"""
+  node: AuditLogNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Added in 25.6.0."""
+type AuditLogNode implements Node {
+  """The ID of the object"""
+  id: ID!
+
+  """UUID of the audit log row"""
+  row_id: UUID!
+
+  """Entity ID of the AuditLog"""
+  entity_type: String!
+
+  """Entity type of the AuditLog"""
+  operation: String!
+
+  """Operation type of the AuditLog"""
+  entity_id: String!
+
+  """The time the AuditLog was reported"""
+  created_at: DateTime!
+
+  """RequestID of the AuditLog"""
+  request_id: UUID!
+
+  """Description of the AuditLog"""
+  description: String!
+
+  """Duration taken to perform the operation"""
+  duration: String!
+
+  """Status of the AuditLog"""
+  status: String!
+}
+
+"""
+Leverages the internal Python implementation of UUID (uuid.UUID) to provide native UUID objects
+in fields, resolvers and input.
+"""
+scalar UUID
+
+"""
+The `DateTime` scalar type represents a DateTime
+value as specified by
+[iso8601](https://en.wikipedia.org/wiki/ISO_8601).
+"""
+scalar DateTime
+
 type Agent implements Item {
   id: ID
   status: String
@@ -329,13 +479,6 @@ type Agent implements Item {
 interface Item {
   id: ID
 }
-
-"""
-The `DateTime` scalar type represents a DateTime
-value as specified by
-[iso8601](https://en.wikipedia.org/wiki/ISO_8601).
-"""
-scalar DateTime
 
 """
 Allows use of a JSON String for input / output from the GraphQL schema.
@@ -390,12 +533,6 @@ type ComputeContainer implements Item {
   last_stat: JSONString
   preopen_ports: [Int]
 }
-
-"""
-Leverages the internal Python implementation of UUID (uuid.UUID) to provide native UUID objects
-in fields, resolvers and input.
-"""
-scalar UUID
 
 type ImageNode implements Node {
   """The ID of the object"""
@@ -520,23 +657,6 @@ type ScalinGroupConnection {
 
   """Total count of the GQL nodes of the query."""
   count: Int
-}
-
-"""
-The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
-"""
-type PageInfo {
-  """When paginating forwards, are there more items?"""
-  hasNextPage: Boolean!
-
-  """When paginating backwards, are there more items?"""
-  hasPreviousPage: Boolean!
-
-  """When paginating backwards, the cursor to continue."""
-  startCursor: String
-
-  """When paginating forwards, the cursor to continue."""
-  endCursor: String
 }
 
 """
@@ -836,6 +956,9 @@ type UserNode implements Node {
   Added in 25.2.0. Supplementary group IDs assigned to processes running inside the container.
   """
   container_gids: [Int]
+
+  """Added in 25.5.0."""
+  project_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): GroupConnection
 }
 
 """Added in 24.03.0"""
@@ -1245,6 +1368,9 @@ type ScalingGroup {
     status: String = "ALIVE"
   ): JSONString
 
+  """Added in 25.6.0. The resource slot hard-limit of the resource group."""
+  resource_slot_limit: JSONString
+
   """
   Added in 25.4.0. The sum of occupied slots across compute sessions that occupying agent's resources. Only includes sessions owned by the user.
   """
@@ -1513,6 +1639,13 @@ type LegacyComputeSession implements Item {
   io_write_bytes: BigInt
   io_max_scratch_size: BigInt
   io_cur_scratch_size: BigInt
+}
+
+"""Added in 25.5.0."""
+type TotalResourceSlot implements Item {
+  id: ID
+  occupied_slots: JSONString
+  requested_slots: JSONString
 }
 
 type PredefinedAtomicPermission {
@@ -1992,7 +2125,7 @@ type Mutations {
   clear_images(registry: String): ClearImages
 
   """Added in 25.4.0"""
-  purge_images(agent_id: String!, images: [ImageRefType]!): PurgeImages
+  purge_images(keys: [PurgeImagesKey]!, options: PurgeImagesOptions = {force: false, noprune: false}): PurgeImagesPayload
 
   """Added in 24.09.0."""
   modify_compute_session(input: ModifyComputeSessionInput!): ModifyComputeSessionPayload
@@ -2592,15 +2725,32 @@ type ClearImages {
   msg: String
 }
 
-"""Added in 25.4.0."""
-type PurgeImages {
+"""Added in 25.6.0."""
+type PurgeImagesPayload {
   task_id: String
+}
+
+"""Added in 25.6.0."""
+input PurgeImagesKey {
+  agent_id: String!
+  images: [ImageRefType]!
 }
 
 input ImageRefType {
   name: String!
   registry: String
   architecture: String
+}
+
+"""Added in 25.6.0."""
+input PurgeImagesOptions {
+  """
+  Remove the images even if it is being used by stopped containers or has other tags, Added in 25.6.0.
+  """
+  force: Boolean = false
+
+  """Don't delete untagged parent images, Added in 25.6.0."""
+  noprune: Boolean = false
 }
 
 """Added in 24.09.0."""

--- a/react/src/components/DynamicUnitInputNumberWithSlider.tsx
+++ b/react/src/components/DynamicUnitInputNumberWithSlider.tsx
@@ -1,4 +1,8 @@
-import { compareNumberWithUnits, convertBinarySizeUnit } from '../helper';
+import {
+  compareNumberWithUnits,
+  convertBinarySizeUnit,
+  toFixedFloorWithoutTrailingZeros,
+} from '../helper';
 import { useUpdatableState } from '../hooks';
 import useControllableState from '../hooks/useControllableState';
 import DynamicUnitInputNumber, {
@@ -222,8 +226,12 @@ const DynamicUnitInputNumberWithSlider: React.FC<
                     maxGiB.number === 0
                       ? maxGiB.number
                       : maxGiB.number >= 1
-                        ? maxGiB.number + 'g'
-                        : maxGiB.number * 1024 + 'm',
+                        ? toFixedFloorWithoutTrailingZeros(maxGiB.number, 2) +
+                          'g'
+                        : toFixedFloorWithoutTrailingZeros(
+                            maxGiB.number * 1024,
+                            2,
+                          ) + 'm',
                 },
               }),
             })}

--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -128,6 +128,7 @@ const ResourceAllocationFormItems: React.FC<
             accelerator_quantum_size
             name
             is_active
+            ...useResourceLimitAndRemainingFragment
           }
         }
       `,
@@ -164,6 +165,7 @@ const ResourceAllocationFormItems: React.FC<
     useResourceLimitAndRemaining({
       currentProjectName: currentProject.name,
       currentResourceGroup: currentResourceGroupInForm || undefined, // global currentResourceGroup can be null
+      currentResourceGroupFrgmtForLimit: currentResourceGroupInfo,
       currentImage: currentImage,
     });
 


### PR DESCRIPTION
Resolves #3463 (FR-777)

To conduct the test, you must use the environment at https://github.com/lablup/backend.ai/pull/4108. There is a test server for this PR, and related details can be found at the following [link](https://teams.microsoft.com/l/message/19:acd1be4236b94664b814f4d4e5c84da6@thread.skype/1744025901127?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=74ae2c4d-ec4d-4fdf-b2c2-f5041d1e8631&parentMessageId=1744011801142&teamName=devops&channelName=JIRA%20Issue%20Notification&createdTime=1744025901127).

This PR adds several new GraphQL types and queries:

1. (Key change) **Enhanced resource limit calculation to consider scaling group resource limits**
2. Update schema for `resource_slot_limit` field to the ScalingGroup type to expose resource limits
3. Fixed number formatting in DynamicUnitInputNumberWithSlider to prevent trailing zeros
