### PR TITLE
style(FR-816): Improve Start page grid size for XXL screen

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,4 +1,3 @@
-import AnnouncementAlert from './components/AnnouncementAlert';
 import BAICard from './components/BAICard';
 import BAIErrorBoundary, { ErrorView } from './components/BAIErrorBoundary';
 import {
@@ -70,7 +69,9 @@ const UserCredentialsPage = React.lazy(
 const AgentSummaryPage = React.lazy(() => import('./pages/AgentSummaryPage'));
 const MaintenancePage = React.lazy(() => import('./pages/MaintenancePage'));
 const StatisticsPage = React.lazy(() => import('./pages/StatisticsPage'));
-const ConfigurationsPage = React.lazy(() => import('./pages/ConfigurationsPage'));
+const ConfigurationsPage = React.lazy(
+  () => import('./pages/ConfigurationsPage'),
+);
 const SessionDetailAndContainerLogOpenerLegacy = React.lazy(
   () => import('./components/SessionDetailAndContainerLogOpenerLegacy'),
 );
@@ -155,25 +156,13 @@ const router = createBrowserRouter([
       {
         path: '/summary',
         Component: () => {
-          const { token } = theme.useToken();
           const location = useLocation();
           const [experimentalDashboard] = useBAISettingUserState(
             'experimental_dashboard',
           );
-          return (
-            <>
-              <AnnouncementAlert
-                showIcon
-                icon={undefined}
-                banner={false}
-                style={{ marginBottom: token.paddingContentVerticalLG }}
-                closable
-              />
-              {experimentalDashboard ? (
-                <WebUINavigate to={'/dashboard' + location.search} replace />
-              ) : null}
-            </>
-          );
+          return experimentalDashboard ? (
+            <WebUINavigate to={'/dashboard' + location.search} replace />
+          ) : null;
         },
         handle: { labelKey: 'webui.menu.Summary' },
       },

--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -178,7 +178,7 @@ const StartPage: React.FC = () => {
       <Row gutter={[16, 16]}>
         {_.map(items, (item, idx) => {
           return (
-            <Col key={item.id} xs={24} md={12} xl={6}>
+            <Col key={item.id} xs={24} md={12} xl={6} xxl={4}>
               <Card
                 style={{ height: 340 }}
                 styles={{

--- a/resources/theme.json
+++ b/resources/theme.json
@@ -9,7 +9,10 @@
       "colorInfo": "#028DF2",
       "colorError": "#FF4D4F",
       "colorSuccess": "#00BD9B",
-      "colorFillSecondary": "#D9D9D9"
+      "colorFillSecondary": "#D9D9D9",
+      "screenXLMax": 1919,
+      "screenXXLMin": 1920,
+      "screenXXL": 1920
     },
     "components": {
       "Tag": {
@@ -34,7 +37,10 @@
       "colorInfo": "#009BDD",
       "colorError": "#DC4446",
       "colorSuccess": "#03A487",
-      "colorFillSecondary": "#262626"
+      "colorFillSecondary": "#262626",
+      "screenXLMax": 1919,
+      "screenXXLMin": 1920,
+      "screenXXL": 1920
     },
     "components": {
       "Tag": {


### PR DESCRIPTION
Resolves #3482 (FR-816)

This PR adds support for the XXL breakpoint in the responsive design system. It includes:

1. Added `screenXLMax`, `screenXXLMin`, and `screenXXL` values to both light and dark themes in `theme.json`
2. Added `xxl={4}` column sizing to the card layout in StartPage, allowing for better use of screen space on larger displays
3. Removed the `AnnouncementAlert` component from the summary page

These changes improve the UI layout on larger screens by allowing more cards to be displayed in a row when sufficient screen space is available.