### PR TITLE
fix(FR-823): log message scroll bar is too wide when logs are empty.

### DIFF
--- a/react/src/components/ErrorLogList.tsx
+++ b/react/src/components/ErrorLogList.tsx
@@ -277,7 +277,13 @@ const ErrorLogList: React.FC<{
               }
             : false
         }
-        scroll={{ x: 'max-content', y: 'calc(100vh - 400px)' }}
+        scroll={{
+          x: 'max-content',
+          y:
+            _.filter(filteredLogData, (log) => log.isError).length === 0
+              ? undefined
+              : 'calc(100vh - 400px)',
+        }}
         dataSource={
           checkedShowOnlyError
             ? _.filter(filteredLogData, (log) => {


### PR DESCRIPTION
Resolves #3486 ([FR-823](https://lablup.atlassian.net/browse/FR-823))

# Conditionally set table scroll height in ErrorLogList

This PR modifies the `ErrorLogList` component to conditionally set the vertical scroll height. When there are no error logs to display (filtered log data with `isError` is empty), the vertical scroll height is set to `undefined` instead of a fixed calculation. This prevents unnecessary scrollbars from appearing when there's no error data to scroll through.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-823]: https://lablup.atlassian.net/browse/FR-823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ