### PR TITLE
fix(FR-777): Update  `resource_slot_limit` to `resource_allocation_limit_for_sessions`

### DIFF
--- a/react/data/schema.graphql
+++ b/react/data/schema.graphql
@@ -402,6 +402,9 @@ type AuditLogNode implements Node {
   """UUID of the audit log row"""
   row_id: UUID!
 
+  """Added in 25.6.0. UUID of the action"""
+  action_id: UUID!
+
   """Entity ID of the AuditLog"""
   entity_type: String!
 
@@ -1368,8 +1371,10 @@ type ScalingGroup {
     status: String = "ALIVE"
   ): JSONString
 
-  """Added in 25.6.0. The resource slot hard-limit of the resource group."""
-  resource_slot_limit: JSONString
+  """
+  Added in 25.6.0. The limit of computing resources that can be allocated to each compute session created within this resource group.
+  """
+  resource_allocation_limit_for_sessions: JSONString
 
   """
   Added in 25.4.0. The sum of occupied slots across compute sessions that occupying agent's resources. Only includes sessions owned by the user.

--- a/react/src/hooks/useResourceLimitAndRemaining.tsx
+++ b/react/src/hooks/useResourceLimitAndRemaining.tsx
@@ -122,7 +122,7 @@ export const useResourceLimitAndRemaining = ({
     graphql`
       fragment useResourceLimitAndRemainingFragment on ScalingGroup {
         name
-        resource_slot_limit @since(version: "25.6.0")
+        resource_allocation_limit_for_sessions @since(version: "25.6.0")
       }
     `,
     currentResourceGroupFrgmt,
@@ -130,7 +130,8 @@ export const useResourceLimitAndRemaining = ({
 
   const currentResourceGroupSlotLimits = useMemo(() => {
     return JSON.parse(
-      currentResourceGroupForLimit?.resource_slot_limit || '{}',
+      currentResourceGroupForLimit?.resource_allocation_limit_for_sessions ||
+        '{}',
     ) as ResourceSlots;
   }, [currentResourceGroupForLimit]);
 


### PR DESCRIPTION
## Rename `resource_slot_limit` to `resource_allocation_limit_for_sessions`

This PR renames the GraphQL field `resource_slot_limit` to `resource_allocation_limit_for_sessions` in the ScalingGroup type to better reflect its purpose.