### PR TITLE
fix(FR-819): Fix share unit of resource preset.

### DIFF
--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -103,7 +103,7 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
       title: t('resourcePreset.SharedMemory'),
       dataIndex: 'shared_memory',
       render: (text) =>
-        text ? convertBinarySizeUnit(text + '', 'g')?.number : '-',
+        text ? convertBinarySizeUnit(text + '', 'g')?.numberFixed : '-',
     },
     baiClient?.supports('resource-presets-per-resource-group') && {
       title: t('general.ResourceGroup'),

--- a/react/src/components/ResourcePresetSettingModal.tsx
+++ b/react/src/components/ResourcePresetSettingModal.tsx
@@ -331,6 +331,7 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
                           <DynamicUnitInputNumber />
                         ) : (
                           <InputNumber
+                            stringMode
                             min={resourceSlotKey === 'cpu' ? 1 : 0}
                             step={
                               _.includes(resourceSlotKey, '.shares') ? 0.1 : 1


### PR DESCRIPTION
Resolves #3485 ([FR-819](https://lablup.atlassian.net/browse/FR-819))

## Add `stringMode` to InputNumber for Resource Preset Settings

This PR adds the `stringMode` prop to the InputNumber component in the ResourcePresetSettingModal. This change ensures that decimal values are properly handled when users input resource allocation values, particularly for fields with fractional values.

**Changes:**
- Added `stringMode={true}` to the InputNumber component to preserve decimal precision in resource preset settings

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-819]: https://lablup.atlassian.net/browse/FR-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ