### PR TITLE
fix(FR-821): display unique agent IDs with comma separation

### DIFF
--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -303,7 +303,7 @@ const SessionDetailContent: React.FC<{
             </Flex>
           </Descriptions.Item>
           <Descriptions.Item label={t('session.Agent')}>
-            {session.agent_ids || '-'}
+            {_.uniq(session.agent_ids).join(', ') || '-'}
           </Descriptions.Item>
           <Descriptions.Item label={t('session.Reservation')} span={md ? 2 : 1}>
             <Flex gap={'xs'} wrap={'wrap'}>


### PR DESCRIPTION
Resolves #3493 (FR-821)

This PR modifies the display of agent IDs in the session detail view. Instead of showing potentially duplicate agent IDs, it now displays a unique, comma-separated list of agent IDs by using Lodash's `uniq` function and joining the results.

### How to test:
dogbowl `/session?order=-created_at&type=all&statusCategory=finished&current=1&sessionDetail=6ff414fb-1a2a-4c25-ae09-654a516bda16`

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-821]: https://lablup.atlassian.net/browse/FR-821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ