### PR TITLE
fix(FR-820): compact sidebar doesn't work when refreshing.

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -162,8 +162,8 @@ function MainLayout() {
               !compactSidebarActive && setSideCollapsed(false);
             }
           }}
-          onCollapse={(collapsed) => {
-            setSideCollapsed(collapsed);
+          onCollapse={(collapsed, type) => {
+            type === 'clickTrigger' && setSideCollapsed(collapsed);
           }}
           webuiplugins={webUIPlugins}
         />

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -56,9 +56,11 @@ type MenuItem = {
   key: string;
 };
 interface WebUISiderProps
-  extends Pick<BAISiderProps, 'collapsed' | 'collapsedWidth' | 'onBreakpoint'> {
+  extends Pick<
+    BAISiderProps,
+    'collapsed' | 'collapsedWidth' | 'onBreakpoint' | 'onCollapse'
+  > {
   webuiplugins?: WebUIPluginType;
-  onCollapse?: (collapsed: boolean) => void;
 }
 
 type GroupName =
@@ -443,7 +445,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
         buttonTop={68}
         // buttonTop={18}
         onClick={(collapsed) => {
-          props.onCollapse?.(collapsed);
+          props.onCollapse?.(collapsed, 'clickTrigger');
         }}
         hidden={!gridBreakpoint.sm || !isSiderHover}
       />


### PR DESCRIPTION
resolves https://github.com/lablup/backend.ai-webui/issues/3340, https://github.com/lablup/backend.ai-webui/issues/3496 ([FR-820](https://lablup.atlassian.net/browse/FR-820))

## Remove redundant `onCollapse` handler in MainLayout to keep sidebar collapse after refreshing

This PR removes the redundant `onCollapse` handler from the MainLayout component. The handler was setting the `sideCollapsed` state, which is already being handled by the existing `onBreakpoint` function.

### Minimum requirements to check during review
- wide screen
  - [ ] if compact sidebar is true, keep compact sidebar after refreshing.
  - [ ] if compact sidebar is false, sidebar always expanded.
- middle screen
  - [ ] always compact sidebar
- narrow screen
  - [ ] always hidden sidebar

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review: toggle `Use Compact Sidebar by default` in usersettings page.
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-820]: https://lablup.atlassian.net/browse/FR-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ