### PR TITLE
fix(FR-839):Handle rename functionality when update_attribute is absent

### DIFF
--- a/react/src/components/EditableVFolderName.tsx
+++ b/react/src/components/EditableVFolderName.tsx
@@ -152,6 +152,7 @@ const EditableVFolderName: React.FC<EditableVFolderNameProps> = ({
                   ).toPromise();
                 },
                 onError: (error) => {
+                  onEditEnd?.();
                   message.error(painKiller.relieve(error?.message));
                   setOptimisticName(vfolder.name);
                 },

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -157,7 +157,8 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
                       style={{ color: token.colorLink }}
                       editable={
                         !isDeletedCategory(vfolder?.status) &&
-                        vfolder?.id !== editingColumn
+                        vfolder?.id !== editingColumn &&
+                        _.includes(vfolder?.permissions, 'update_attribute')
                       }
                       onEditEnd={() => {
                         setEditingColumn(null);


### PR DESCRIPTION
Resolves #3504 ([FR-839](https://lablup.atlassian.net/browse/FR-839))

## Restrict folder name editing based on user permissions

This PR adds a permission check to prevent users from editing virtual folder names when they don't have the 'update_attribute' permission. It also ensures the edit mode is properly exited when an error occurs during editing.

Changes:
- Added permissions to the GraphQL query in VFolderNodes
- Added a permission check to only allow editing folder names when the user has 'update_attribute' permission
- Fixed a bug where the edit mode wasn't properly exited when an error occurred during name editing

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-839]: https://lablup.atlassian.net/browse/FR-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ