### PR TITLE
fix(FR-843): Users with a user role are incorrectly identified as the owner of the project folder.

### DIFF
--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -398,7 +398,8 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
             title: t('data.folders.Owner'),
             render: (__, vfolder) =>
               vfolder?.user === currentUser?.uuid ||
-              vfolder?.group === currentProject?.id ? (
+              (vfolder?.group === currentProject?.id &&
+                userRole === 'admin') ? (
                 <Flex justify="center">
                   <CheckCircleOutlined />
                 </Flex>


### PR DESCRIPTION
Resolves #3508 ([FR-843](https://lablup.atlassian.net/browse/FR-843))

# Update owner check in VFolderNodes component

This PR modifies the owner check in the VFolderNodes component to only display the owner checkmark for group-owned folders when the user has an admin role. Previously, the checkmark would appear for any user if the folder belonged to the current project group.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/2ec7c819-f91b-488d-94f0-f23b5484d531.png)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-843]: https://lablup.atlassian.net/browse/FR-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ