### PR TITLE
fix(FR-842): storage status mismatch with virtual nodes total count.

### DIFF
--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -246,7 +246,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     );
 
   return (
-    <Flex direction="column" align="stretch" gap={'md'}>
+    <Flex direction="column" align="stretch" gap={'md'} {...props}>
       <Flex direction="column" align="stretch">
         <Row gutter={[16, 16]}>
           <Col xs={24} lg={8} xl={4}>
@@ -289,6 +289,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             >
               <StorageStatusPanelCard
                 style={{ height: lg ? 200 : undefined }}
+                fetchKey={fetchKey}
               />
             </Suspense>
           </Col>


### PR DESCRIPTION

Resolves #3507 ([FR-842](https://lablup.atlassian.net/browse/FR-842))


### Pass props to VFolderNodeListPage and add fetchKey to StorageStatusPanelCard

This PR passes the props to the root Flex component in VFolderNodeListPage and adds the fetchKey prop to the StorageStatusPanelCard component to ensure proper data fetching and refresh behavior.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-842]: https://lablup.atlassian.net/browse/FR-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ