### PR TITLE
fix(FR-850): typo error - folder creation and file upload

### DIFF
--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -216,7 +216,7 @@
     "Create": "생성",
     "CreateANewStorageFolder": "새 폴더 추가",
     "CreateFolder": "폴더 생성",
-    "CreateFolderAndUploadFiles": "폴더\b 생성 및 파일 업로드",
+    "CreateFolderAndUploadFiles": "폴더 생성 및 파일 업로드",
     "Created": "생성됨",
     "CreatedFolders": "생성된 폴더",
     "Deleted": "삭제됨",


### PR DESCRIPTION

Resolves #3518 ([FR-850](https://lablup.atlassian.net/browse/FR-850))

Fixed a typo in the Korean translation by removing an invisible control character (backspace) in the "CreateFolderAndUploadFiles" string.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-850]: https://lablup.atlassian.net/browse/FR-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ