### PR TITLE
feat(FR-558): display human readable file size on folder explorer

### DIFF
--- a/src/components/backend-ai-folder-explorer.ts
+++ b/src/components/backend-ai-folder-explorer.ts
@@ -348,7 +348,11 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
                 <span class="monospace">-</span>
               `
             : html`
-                <span>${rowData.item.size}</span>
+                <span>
+                  ${globalThis.backendaiutils._humanReadableFileSize(
+                    rowData.item.size,
+                  )}
+                </span>
               `}
         </div>
       `,


### PR DESCRIPTION
resolves #NNN (FR-558)
In this PR, make the file sizes that appear in folder explorer human-readable.

**changes** 
* make the file sizes that appear in folder explorer human-readable in the `backend-ai-folder-exporer`

![CleanShot 2025-04-17 at 13.16.33@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/d23e61e4-d58f-4fe4-b23a-be342516e14c.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
