### PR TITLE
fix(FR-861): fix bug where changing mount permission would not sync with Lit component

### DIFF
--- a/react/src/components/LegacyFolderExplorer.tsx
+++ b/react/src/components/LegacyFolderExplorer.tsx
@@ -225,6 +225,8 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
                             id: vfolder_node.id,
                           },
                         ).toPromise();
+                        // @ts-ignore
+                        folderExplorerRef.current?._fetchVFolder();
                       },
                       onError: (error) => {
                         message.error(painKiller.relieve(error?.message));


### PR DESCRIPTION
resolves #3531 (FR-861)

**changes**
* modified to call the _fetchVFolder function of backend-ai-folder-explorer to update the changes when the mount permission change is successful.


![CleanShot 2025-04-17 at 16.08.13.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/574ddd90-1b08-4650-9482-63bd810d323c.gif)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
