### PR TITLE
fix(FR-869): fix session launcher to display appropriate type for folders

### DIFF
--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -5,6 +5,7 @@ import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
 import useControllableState from '../hooks/useControllableState';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useEventNotStable } from '../hooks/useEventNotStable';
+import UserUnionIcon from './BAIIcons/UserUnionIcon';
 import BAILink from './BAILink';
 import Flex from './Flex';
 import FolderCreateModal from './FolderCreateModal';
@@ -26,6 +27,7 @@ import {
   Table,
   TableProps,
   Tag,
+  theme,
   Tooltip,
   Typography,
 } from 'antd';
@@ -147,6 +149,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
   }, [aliasMap, internalForm, aliasBasePath]);
 
   const { t } = useTranslation();
+  const { token } = theme.useToken();
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
   const currentProject = useCurrentProjectValue();
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
@@ -447,15 +450,20 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
       title: t('data.Type'),
       dataIndex: 'type',
       sorter: (a, b) => a.type.localeCompare(b.type),
-      render: (value, record) => {
+      render: (_, record) => {
         return (
           <Flex direction="column">
-            {record.type === 'user' ? (
-              <UserOutlined title="User" />
+            {record.ownership_type === 'user' ? (
+              <Flex gap={'xs'}>
+                <Typography.Text>{t('data.User')}</Typography.Text>
+                <UserOutlined style={{ color: token.colorTextTertiary }} />
+              </Flex>
             ) : (
-              <div>Group</div>
+              <Flex gap={'xs'}>
+                <Typography.Text>{t('data.Project')}</Typography.Text>
+                <UserUnionIcon style={{ color: token.colorTextTertiary }} />
+              </Flex>
             )}
-            {record.type === 'group' && `(${record.group_name})`}
           </Flex>
         );
       },


### PR DESCRIPTION
resolves #3537 (FR-869)

**changes**
* fix showing the type of a folder in the session launcher to look the same as it does on the data page
* I'm not getting a value for `group_name`, so I've removed the part that shows it. Please let me know if you need this in your review.

|before|after|
|-----|------|
|![12eb0504-2009-4ba3-ba91-6cf06a9e364c.jpg](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/90cf0e22-239d-48c2-a61e-ab2b0b49addc.jpg) | ![CleanShot 2025-04-19 at 21.12.18@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/93f5bf78-ea26-4b21-a2a6-8f7099bbfd5c.png)|

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
