### PR TITLE
fix(FR-870): invalid sorter for file size in folder explorer

### DIFF
--- a/react/src/components/FolderExplorer.tsx
+++ b/react/src/components/FolderExplorer.tsx
@@ -211,7 +211,7 @@ const FolderExplorer: React.FC<Props> = ({
             title: 'Size',
             dataIndex: 'size',
             align: 'right',
-            sorter: (a, b) => dayjs(a.size).diff(b.size),
+            sorter: (a, b) => a.size - b.size,
             // render: (text) => {
           },
           {


### PR DESCRIPTION
Follow-up to #1896 and resolves #3541 (FR-870)

This pull request suggests to use raw number comparison instead of `date` comparison for file size in folder explorer.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
