### PR TITLE
feat(FR-871): improve visibility of committed container names

### DIFF
--- a/react/src/components/AliasedImageDoubleTags.tsx
+++ b/react/src/components/AliasedImageDoubleTags.tsx
@@ -50,7 +50,7 @@ const AliasedImageDoubleTags: React.FC<AliasedImageDoubleTagsProps> = ({
         return _.isEqual(
           aliasedTag,
           preserveDotStartCase(tag.key + tagValue),
-        ) ? (
+        ) || isCustomized ? (
           <DoubleTag
             key={tag.key}
             highlightKeyword={highlightKeyword}

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -723,7 +723,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
                                   return _.isEqual(
                                     aliasedTag,
                                     preserveDotStartCase(tag.key + tagValue),
-                                  ) ? (
+                                  ) || isCustomized ? (
                                     <DoubleTag
                                       key={tag.key}
                                       highlightKeyword={versionSearch}

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -225,7 +225,7 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
               return _.isEqual(
                 aliasedTag,
                 preserveDotStartCase(tag.key + tagValue),
-              ) ? (
+              ) || isCustomized ? (
                 <DoubleTag
                   key={tag.key}
                   highlightKeyword={imageSearch}

--- a/react/src/components/ImageTags.tsx
+++ b/react/src/components/ImageTags.tsx
@@ -170,7 +170,7 @@ export const ImageTags: React.FC<ImageTagsProps> = ({
   const [, { getTags, tagAlias }] = useBackendAIImageMetaData();
   const tags = getTags(tag, labels);
   return (
-    <>
+    <React.Fragment {...props}>
       {_.map(tags, (tag: { key: string; value: string }, index) => {
         const isCustomized = tag.key === 'Customized';
         const aliasedTag = tagAlias(tag.key + tag.value);
@@ -200,6 +200,6 @@ export const ImageTags: React.FC<ImageTagsProps> = ({
           </Tag>
         );
       })}
-    </>
+    </React.Fragment>
   );
 };

--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -228,7 +228,7 @@ const SessionLauncherPreview: React.FC<{
                             return _.isEqual(
                               aliasedTag,
                               preserveDotStartCase(tag.key + tagValue),
-                            ) ? (
+                            ) || isCustomized ? (
                               <DoubleTag
                                 key={tag.key}
                                 values={[


### PR DESCRIPTION
Resolves #3543 ([FR-871](https://lablup.atlassian.net/browse/FR-871))

# Fix tag display logic to show customized tags properly

This PR modifies the tag display logic across multiple components to ensure customized tags are properly displayed. The key changes include:

1. Added a condition to show tags when `isCustomized` is true, regardless of the alias equality check
2. Updated `ImageTags` component to properly pass props to the React.Fragment

These changes ensure that customized tags are consistently displayed in the UI, fixing an issue where they might be filtered out incorrectly.

- My Environment
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/ecb41a74-e68a-4df4-aabd-044ae3e8b36f.png)
- Session launcher
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/79519d66-554a-4cb0-a1c8-826aacf1afb4.png)
- Images
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/9704c1fc-bc79-4334-9a35-c191df7df006.png)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup): 10.82.230.49
- [x] Minimum requirements to check during review: check customized name in My Environment, Session Launcher, Images page.
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-871]: https://lablup.atlassian.net/browse/FR-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ