### PR TITLE
fix(FR-877): Enable project folder mount permissions editing for admins

### DIFF
--- a/react/src/components/VFolderNodeDescription.tsx
+++ b/react/src/components/VFolderNodeDescription.tsx
@@ -1,7 +1,7 @@
 import { convertDecimalSizeUnit, filterEmptyItem, toLocalId } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useVirtualFolderNodePathFragment$key } from '../hooks/__generated__/useVirtualFolderNodePathFragment.graphql';
-import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
+import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { usePainKiller } from '../hooks/usePainKiller';
@@ -44,7 +44,6 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
 
   const relayEnv = useRelayEnvironment();
   const currentProject = useCurrentProjectValue();
-  const userRole = useCurrentUserRole();
   const painKiller = usePainKiller();
   const baiClient = useSuspendedBackendaiClient();
   const [currentUser] = useCurrentUserInfo();
@@ -95,13 +94,6 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
   }
 
   const vfolderId = toLocalId(vfolderNode?.id);
-  // const quotaScopeId = _.split(vfolderNode?.quota_scope_id, ':')?.[1];
-  // const [vfolderIdPrefix1, vfolderIdPrefix2, ...vfolderIdRest] = [
-  //   vfolderId.slice(0, 2),
-  //   vfolderId.slice(2, 4),
-  //   vfolderId.slice(4),
-  // ];
-  // const vfolderPath = `${quotaScopeId}/${vfolderIdPrefix1}/${vfolderIdPrefix2}/${vfolderIdRest}`;
 
   const items: DescriptionsProps['items'] = filterEmptyItem([
     {
@@ -158,7 +150,8 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
           </Flex>
         ),
     },
-    vfolderNode?.user === currentUser.uuid && {
+    (vfolderNode?.user === currentUser.uuid ||
+      (baiClient.is_admin && vfolderNode?.group === currentProject?.id)) && {
       key: 'permission',
       label: t('data.folders.MountPermission'),
       children: (
@@ -214,7 +207,7 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
       label: t('data.folders.Owner'),
       children:
         vfolderNode?.user === currentUser?.uuid ||
-        (vfolderNode?.group === currentProject?.id && userRole === 'admin') ? (
+        (baiClient.is_admin && vfolderNode?.group === currentProject?.id) ? (
           <Flex justify="start">
             <CheckCircleOutlined />
           </Flex>

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -1,6 +1,6 @@
 import { filterNonNullItems, toLocalId } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
-import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
+import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
@@ -73,7 +73,6 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
   const { message } = App.useApp();
 
   const currentProject = useCurrentProjectValue();
-  const userRole = useCurrentUserRole();
   const baiClient = useSuspendedBackendaiClient();
   const painKiller = usePainKiller();
   const [currentUser] = useCurrentUserInfo();
@@ -410,8 +409,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
             title: t('data.folders.Owner'),
             render: (__, vfolder) =>
               vfolder?.user === currentUser?.uuid ||
-              (vfolder?.group === currentProject?.id &&
-                userRole === 'admin') ? (
+              (vfolder?.group === currentProject?.id && baiClient.is_admin) ? (
                 <Flex justify="center">
                   <CheckCircleOutlined />
                 </Flex>

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -279,6 +279,9 @@ class Client {
     } else {
       this._loginSessionId = '';
     }
+    this.email = '';
+    this.full_name = '';
+    this.user_uuid = '';
     //if (this._config.connectionMode === 'API') {
     //this.getManagerVersion();
     //}


### PR DESCRIPTION

Resolves #3548 ([FR-877](https://lablup.atlassian.net/browse/FR-877))

## Allow admins to change permission of group folders

This PR enables project admins to change the permission of group folders. Previously, only the owner of a folder could change its permission. Now, project admins can also change the permission of folders that belong to their project.

The changes include:
- Adding the `group` field to the GraphQL query for both legacy and new vfolder APIs
- Using the current project context to determine if the user is an admin of the project
- Allowing permission changes when the folder belongs to the current project and the user is an admin
- Using `baiClient.is_admin` instead of `userRole === 'admin'` for consistency

### Specific setting for review
1. make a new project folder with admin user.
2. click the folder name to change the project mount permission.

### Minimum requirements to check during review
- [ ] If current project id is same with group id of project folder, you can see the mount permission selector in the folder explorer.
- [ ] If current project id is not same with group id of project folder or current user role is not admin, you cannot see the mount permission selector in the folder explorer.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup)
- [x] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-877]: https://lablup.atlassian.net/browse/FR-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ