### PR TITLE
fix(FR-867): incorrect permission value display for 'wd' permission

### DIFF
--- a/react/src/components/LegacyFolderExplorer.tsx
+++ b/react/src/components/LegacyFolderExplorer.tsx
@@ -126,6 +126,8 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
     },
   );
 
+  const permission = vfolder_node?.permission || vfolder?.permission;
+
   const updateMutation = useTanMutation({
     mutationFn: ({ permission, id }: { permission: string; id: string }) => {
       return baiClient.vfolder.update_folder({ permission }, id);
@@ -191,7 +193,7 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
             {vfolder_node?.user === currentUser.uuid && (
               <BAISelect
                 tooltip={t('data.folders.MountPermission')}
-                defaultValue={vfolder_node?.permission || vfolder?.permission}
+                defaultValue={permission === 'wd' ? 'rw' : permission}
                 options={[
                   { value: 'ro', label: t('data.ReadOnly') },
                   { value: 'rw', label: t('data.ReadWrite') },

--- a/react/src/components/ModelCloneModal.tsx
+++ b/react/src/components/ModelCloneModal.tsx
@@ -288,10 +288,6 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
                   label: 'Read-Only',
                   value: 'ro',
                 },
-                {
-                  label: 'Delete',
-                  value: 'wd',
-                },
               ]}
             />
           </Form.Item>

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -2194,7 +2194,7 @@ class VFolder {
    *
    * @param {json} input - parameters for cloning Vfolder
    * @param {boolean} input.cloneable - whether new cloned Vfolder is cloneable or not
-   * @param {string} input.permission - permission for new cloned Vfolder. permission should one of the following: 'ro', 'rw', 'wd'
+   * @param {string} input.permission - permission for new cloned Vfolder. permission should one of the following: 'ro', 'rw'
    * @param {string} input.target_host - target_host for new cloned Vfolder
    * @param {string} input.target_name - name for new cloned Vfolder
    * @param {string} input.usage_mode - Cloned virtual folder's purpose of use. Can be "general" (normal folders), "data" (data storage), and "model" (pre-trained model storage).
@@ -2215,7 +2215,7 @@ class VFolder {
    *
    * @param {json} input - parameters for updating folder options of Vfolder
    * @param {boolean} input.cloneable - whether Vfolder is cloneable or not
-   * @param {string} input.permission - permission for Vfolder. permission should one of the following: 'ro', 'rw', 'wd'
+   * @param {string} input.permission - permission for Vfolder. permission should one of the following: 'ro', 'rw'
    * @param name - source Vfolder name
    */
   async update_folder(input, name = null): Promise<any> {
@@ -2717,7 +2717,7 @@ class VFolder {
    * Modify an invitee's permission to a shared vfolder
    *
    * @param {json} input - parameters for permission modification
-   * @param {string} input.perm - invitee's new permission. permission should one of the following: 'ro', 'rw', 'wd'
+   * @param {string} input.perm - invitee's new permission. permission should one of the following: 'ro', 'rw'
    * @param {string} input.user - invitee's uuid
    * @param {string} input.vfolder - id of the vfolder that has been shared to the invitee
    */


### PR DESCRIPTION

Resolves #3534 ([FR-867](https://lablup.atlassian.net/browse/FR-867))

# Remove 'wd' permission option from folder permissions

This PR removes the 'wd' (write-delete) permission option from folder permissions throughout the application:

1. Updates `LegacyFolderExplorer.tsx` to handle 'wd' permission by converting it to 'rw' in the UI
2. Removes the 'Delete' permission option from the ModelCloneModal dropdown
3. Updates documentation in backend.ai-client-esm.ts to reflect that only 'ro' and 'rw' permissions are valid options

### Specific setting for review
1. update folder permission to 'wd' in DB.
```
update vfolders set permission='wd' where name='<vfolder name>';
```
2. check vfolder explorer


**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-867]: https://lablup.atlassian.net/browse/FR-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ