### PR TITLE
feat(FR-887): hide model service card on start page if enableModelFolders is false

### DIFF
--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -96,7 +96,7 @@ const StartPage: React.FC = () => {
         ),
       },
     },
-    {
+    baiClient._config.enableModelFolders && {
       id: 'modelService',
       rowSpan: 3,
       requiredMenuKey: 'serving',


### PR DESCRIPTION

Resolves #3561 ([FR-887](https://lablup.atlassian.net/browse/FR-887))

# Conditionally render model service based on enableModelFolders flag

This PR modifies the StartPage component to conditionally render the model service section based on the `enableModelFolders` configuration flag from the BAI client. When this flag is disabled, the model service section will not be displayed in the UI.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-887]: https://lablup.atlassian.net/browse/FR-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ