### PR TITLE
feat(FR-889): Add resource group column to agent summary

### DIFF
--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -308,6 +308,12 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
       },
     },
     {
+      title: t('general.ResourceGroup'),
+      key: 'scaling_group',
+      dataIndex: 'scaling_group',
+      sorter: true,
+    },
+    {
       title: t('agent.Schedulable'),
       key: 'schedulable',
       dataIndex: 'schedulable',


### PR DESCRIPTION

Resolves #3564 ([FR-889](https://lablup.atlassian.net/browse/FR-889))

Added Resource Group column to the Agent Summary List table. The new column displays the scaling group information for each agent, and supports sorting functionality.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-889]: https://lablup.atlassian.net/browse/FR-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ