### PR TITLE
fix(FR-890): Fix pagination count issue in agent summary table

### DIFF
--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -440,7 +440,7 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
         pagination={{
           pageSize: tablePaginationOption.pageSize,
           showSizeChanger: true,
-          total: agent_summary_list?.total_count,
+          total: filteredAgentSummaryList?.length || 0,
           current: tablePaginationOption.current,
           showTotal(total, range) {
             return `${range[0]}-${range[1]} of ${total} items`;


### PR DESCRIPTION

Resolves #3566 ([FR-890](https://lablup.atlassian.net/browse/FR-890))

# Fix pagination total count in AgentSummaryList

This PR updates the pagination total count in the AgentSummaryList component to use the length of the filtered agent summary list instead of the total count from the agent summary list. This ensures that the pagination accurately reflects the number of items currently being displayed after filtering.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup): dogbowl
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-890]: https://lablup.atlassian.net/browse/FR-890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ