### PR TITLE
refactor(FR-896): chat card state managment and naming convention

### DIFF
--- a/react/src/components/Chat/AIAgentSelect.tsx
+++ b/react/src/components/Chat/AIAgentSelect.tsx
@@ -1,14 +1,11 @@
-import { AIAgent } from '../../hooks/useAIAgent';
+import { AIAgent, useAIAgent } from '../../hooks/useAIAgent';
 import Flex from '../Flex';
 import { FluentEmojiIcon } from '../FluentEmojiIcon';
 import { useControllableValue } from 'ahooks';
 import { Select, SelectProps, theme } from 'antd';
 import React, { useState, useTransition } from 'react';
 
-interface ChatAgentSelectProps extends Omit<SelectProps, 'options'> {
-  agents: AIAgent[];
-  selectedAgent?: AIAgent;
-}
+interface ChatAgentSelectProps extends Omit<SelectProps, 'options'> {}
 
 function makeAgentOptions(agents: AIAgent[], filter?: string) {
   return agents
@@ -24,20 +21,16 @@ function makeAgentOptions(agents: AIAgent[], filter?: string) {
 
 const AIAgentSelect: React.FC<ChatAgentSelectProps> = ({
   loading,
-  agents,
-  selectedAgent,
   ...props
 }) => {
   const { token } = theme.useToken();
-  const [controllableValue, setControllableValue] =
-    useControllableValue<AIAgent>(props, {
-      valuePropName: 'value',
-      trigger: 'onChange',
-      defaultValue: props.value,
-    });
+  const [controllableValue, setControllableValue] = useControllableValue(props);
 
   const [searchAgent, setSearchAgent] = useState<string>();
   const [isSearchPending, startSearchTransition] = useTransition();
+
+  const { agents } = useAIAgent();
+  const selectedAgent = agents.find((agent) => agent.id === controllableValue);
 
   return (
     <>

--- a/react/src/components/Chat/ChatHeader.tsx
+++ b/react/src/components/Chat/ChatHeader.tsx
@@ -4,20 +4,18 @@ import { AIAgent } from '../../hooks/useAIAgent';
 import { useBAISettingUserState } from '../../hooks/useBAISetting';
 import Flex from '../Flex';
 import AIAgentSelect from './AIAgentSelect';
-import { BAIModel, ChatLifecycleEventType, ChatType } from './ChatModel';
-import EndpointSelect from './EndpointSelect';
+import { BAIModel } from './ChatModel';
+import EndpointSelect, { EndpointSelectProps } from './EndpointSelect';
 import ModelSelect from './ModelSelect';
-import {
-  ChatCard_endpoint$data,
-  ChatCard_endpoint$key,
-} from './__generated__/ChatCard_endpoint.graphql';
-import { Message } from '@ai-sdk/react';
+import { ChatHeader_Endpoint$key } from './__generated__/ChatHeader_Endpoint.graphql';
 import { CloseOutlined, MoreOutlined, PlusOutlined } from '@ant-design/icons';
 import { Dropdown, Button, theme, MenuProps, Typography, Switch } from 'antd';
+import graphql from 'babel-plugin-relay/macro';
 import { isEmpty } from 'lodash';
 import { Scale as ScaleIcon, Eraser as EraserIcon } from 'lucide-react';
-import React, { useState, startTransition } from 'react';
+import React, { startTransition, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useFragment } from 'react-relay';
 
 interface SyncSwitchProps {
   sync: boolean;
@@ -38,48 +36,60 @@ const SyncSwitch: React.FC<SyncSwitchProps> = ({ sync, onClick }) => {
   );
 };
 
-interface ChatHeaderProps extends ChatLifecycleEventType {
-  chat: ChatType;
+interface ChatHeaderProps {
   showCompareMenuItem?: boolean;
   closable?: boolean;
   models: BAIModel[];
   modelId: string;
-  setModelId: (modelId: string) => void;
-  endpoint?: ChatCard_endpoint$data | null;
-  setEndpoint: (endpoint: ChatCard_endpoint$key) => void;
+  onChangeModel: (modelId: string) => void;
+  endpointFrgmt?: ChatHeader_Endpoint$key | null;
+  onChangeEndpoint: EndpointSelectProps['onChange'];
   agents: AIAgent[];
   agent?: AIAgent;
-  setAgent: (agent: AIAgent) => void;
+  onChangeAgent: (agent: AIAgent) => void;
   sync: boolean;
-  setSync: (sync: boolean) => void;
+  onChangeSync: (sync: boolean) => void;
   fetchKey: string;
-  setMessages: (messages: Message[]) => void;
+  onClickDeleteChatHistory?: () => void;
+  onClickClose?: () => void;
+  onClickCreate?: () => void;
 }
 
 const ChatHeader: React.FC<ChatHeaderProps> = ({
-  chat,
   showCompareMenuItem,
   closable,
   models,
   modelId,
-  setModelId,
-  endpoint,
-  setEndpoint,
+  onChangeModel,
+  endpointFrgmt,
+  onChangeEndpoint,
   agents,
   agent,
-  setAgent,
+  onChangeAgent,
   sync,
-  setSync,
-  onRequestClose,
-  onCreateNewChat,
+  onChangeSync,
+  onClickClose,
+  onClickCreate,
   fetchKey,
-  setMessages,
+  onClickDeleteChatHistory,
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const webuiNavigate = useWebUINavigate();
 
-  const [promisingEndpoint, setPromisingEndpoint] = useState(endpoint);
+  const [isPendingEndpointTransition, startEndpointTransition] =
+    useTransition();
+  const [isPendingAgentTransition, startAgentTransition] = useTransition();
+
+  // Using fragment instead of just endpoint_id to support future EndpointSelect extensions
+  const endpoint = useFragment(
+    graphql`
+      fragment ChatHeader_Endpoint on Endpoint {
+        endpoint_id
+      }
+    `,
+    endpointFrgmt,
+  );
 
   const items: MenuProps['items'] = filterEmptyItem([
     showCompareMenuItem && {
@@ -100,7 +110,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
       label: t('chatui.DeleteChatHistory'),
       icon: <EraserIcon />,
       onClick: () => {
-        setMessages([]);
+        onClickDeleteChatHistory?.();
       },
     },
     closable && {
@@ -112,7 +122,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
       label: t('chatui.DeleteChattingSession'),
       icon: <CloseOutlined />,
       onClick: () => {
-        onRequestClose?.(chat);
+        onClickClose?.();
       },
     },
   ]);
@@ -146,23 +156,21 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
       >
         {experimentalAIAgents && (
           <AIAgentSelect
-            agents={agents}
-            selectedAgent={agent}
+            loading={isPendingAgentTransition}
             value={agent?.id}
             onChange={(_, agent: any) => {
-              startTransition(() => {
-                setAgent(agent);
+              startAgentTransition(() => {
+                onChangeAgent(agent);
               });
             }}
           />
         )}
         <EndpointSelect
           fetchKey={fetchKey}
-          loading={promisingEndpoint?.endpoint_id !== endpoint?.endpoint_id}
-          onChange={(_, endpoint: any) => {
-            setPromisingEndpoint(endpoint);
-            startTransition(() => {
-              setEndpoint(endpoint);
+          loading={isPendingEndpointTransition}
+          onChange={(id) => {
+            startEndpointTransition(() => {
+              onChangeEndpoint?.(id);
             });
           }}
           value={endpoint?.endpoint_id}
@@ -174,7 +182,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
             value={modelId}
             onChange={(modelId) => {
               startTransition(() => {
-                setModelId(modelId);
+                onChangeModel(modelId);
               });
             }}
           />
@@ -186,12 +194,12 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
             sync={sync}
             onClick={(checked) => {
               startTransition(() => {
-                setSync(checked);
+                onChangeSync(checked);
               });
             }}
           />
         )}
-        <Button onClick={() => onCreateNewChat?.()} icon={<PlusOutlined />} />
+        <Button onClick={() => onClickCreate?.()} icon={<PlusOutlined />} />
         <Dropdown menu={{ items }} trigger={['click']}>
           <Button
             type="link"

--- a/react/src/components/Chat/ChatModel.tsx
+++ b/react/src/components/Chat/ChatModel.tsx
@@ -1,8 +1,4 @@
 import { AIAgent } from '../../hooks/useAIAgent';
-import {
-  ChatCard_endpoint$data,
-  ChatCard_endpoint$key,
-} from './__generated__/ChatCard_endpoint.graphql';
 import i18n from 'i18next';
 
 export type ChatProviderType = {
@@ -69,41 +65,3 @@ export type BAIModel = {
   created?: string;
   description?: string;
 };
-
-export type ChatOptions = {
-  models: BAIModel[];
-  modelId: string;
-  endpoint?: ChatCard_endpoint$data | null;
-  endpointKey?: ChatCard_endpoint$key | null;
-  agents: AIAgent[];
-  agentId?: string;
-};
-
-export class ChatModelError extends Error {
-  status: number;
-
-  constructor(status: number) {
-    super(ChatModelError.errorMessage(status));
-    this.name = 'ModelsError';
-    this.status = status;
-  }
-
-  static errorMessage(status: number) {
-    const messageKey = (() => {
-      switch (status) {
-        case 401:
-          return 'error.UnauthorizedToken';
-        case 404:
-          return 'error.NotFoundBasePath';
-        case 500:
-          return 'error.InternalServerError';
-        case 503:
-          return 'error.ServiceUnavailable';
-        default:
-          return 'error.UnknownError';
-      }
-    })();
-
-    return i18n.t(messageKey, { status });
-  }
-}

--- a/react/src/components/Chat/EndpointSelect.tsx
+++ b/react/src/components/Chat/EndpointSelect.tsx
@@ -11,14 +11,25 @@ import React, { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLazyLoadQuery } from 'react-relay';
 
-interface EndpointSelectProps extends Omit<SelectProps, 'options'> {
+export type Endpoint = NonNullable<
+  NonNullableItem<EndpointSelectQuery$data['endpoint_list']>
+>;
+
+export interface EndpointSelectProps
+  extends Omit<
+    SelectProps<
+      string,
+      {
+        label?: string | null;
+        value?: string | null;
+        endpoint?: Endpoint | null;
+      }
+    >,
+    'options'
+  > {
   fetchKey?: string;
   lifecycleStageFilter?: LifecycleStage[];
 }
-
-export type Endpoint = NonNullableItem<
-  EndpointSelectQuery$data['endpoint_list']
->;
 
 type LifecycleStage = 'created' | 'destroying' | 'destroyed';
 
@@ -60,13 +71,12 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
             name
             endpoint_id
             url
-            ...ChatCard_endpoint
           }
         }
         endpoint(endpoint_id: $endpoint_id) @skipOnClient(if: $skipEndpoint) {
           name
           endpoint_id
-          ...ChatCard_endpoint
+          url
         }
       }
     `,


### PR DESCRIPTION
Resolves #3574 (FR-896)

# Refactor Chat Components for Better State Management

- Refactored `AIAgentSelect` to use the `useAIAgent` hook directly instead of requiring agents to be passed as props
- Simplified `ChatCard` component by removing redundant state management and using controlled components
- Added `onUpdateChat` callback to `ChatCard` to propagate changes to parent components
- Improved `ChatHeader` component by making it more declarative with explicit callbacks
- Enhanced `Conversation` component to properly update chat state using the new callback pattern
-Fetch default endpoint selection in `ChatPage` to improve initial user experience
- Removed unnecessary state variables and transitions for better performance
- Fixed prop types and interfaces across components for better type safety