### PR TITLE
fix(FR-899): fix to display success message when deleting a resource preset

### DIFF
--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -37,7 +37,7 @@ interface ResourcePresetListProps {}
 const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const { modal } = App.useApp();
+  const { modal, message } = App.useApp();
   const [isRefetchPending, startRefetchTransition] = useTransition();
   const [resourcePresetsFetchKey, updateResourcePresetsFetchKey] =
     useUpdatableState('initial-fetch');
@@ -171,10 +171,24 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
                       variables: {
                         name: record?.name ?? '',
                       },
-                      onCompleted: () => {
-                        startRefetchTransition(() => {
-                          updateResourcePresetsFetchKey();
-                        });
+                      onCompleted: (res, errors) => {
+                        if (!res?.delete_resource_preset?.ok) {
+                          message.error(res?.delete_resource_preset?.msg);
+                        } else if (errors && errors?.length > 0) {
+                          const errorMsgList = _.map(
+                            errors,
+                            (err) => err?.message,
+                          );
+                          _.forEach(errorMsgList, (err) => message.error(err));
+                        } else {
+                          message.success(t('resourcePreset.Deleted'));
+                          startRefetchTransition(() => {
+                            updateResourcePresetsFetchKey();
+                          });
+                        }
+                      },
+                      onError: (error) => {
+                        message.error(error?.message);
                       },
                     });
                   },


### PR DESCRIPTION
resolves #3575 (FR-899)

**changes**
* add `message.success` when deleting is completed.

![CleanShot 2025-04-24 at 15.55.55@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/4e5571e9-de78-46e7-b269-e67d19f2a04e.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
