### PR TITLE
fix(FR-883): Implement consistent sorting behavior across table components

### DIFF
--- a/react/src/components/EndpointList.tsx
+++ b/react/src/components/EndpointList.tsx
@@ -6,7 +6,7 @@ import {
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
-import BAITable from './BAITable';
+import BAITable, { BAITableProps } from './BAITable';
 import EndpointOwnerInfo from './EndpointOwnerInfo';
 import EndpointStatusTag from './EndpointStatusTag';
 import Flex from './Flex';
@@ -27,7 +27,6 @@ import {
   App,
   TablePaginationConfig,
   Tooltip,
-  TableProps,
 } from 'antd';
 import { ColumnType } from 'antd/lib/table';
 import graphql from 'babel-plugin-relay/macro';
@@ -42,7 +41,7 @@ import { Link } from 'react-router-dom';
 type Endpoint = EndpointListFragment$data[number];
 
 interface EndpointListProps
-  extends Omit<TableProps<Endpoint>, 'dataSource' | 'columns'> {
+  extends Omit<BAITableProps<Endpoint>, 'dataSource' | 'columns'> {
   endpointsFrgmt: EndpointListFragment$key;
   loading?: boolean;
   pagination: TablePaginationConfig;
@@ -261,8 +260,6 @@ const EndpointList: React.FC<EndpointListProps> = ({
       render: (created_at) => {
         return dayjs(created_at).format('ll LT');
       },
-      defaultSortOrder: 'descend',
-      sortDirections: ['descend', 'ascend', 'descend'],
       sorter: (a, b) => {
         const date1 = dayjs(a.created_at);
         const date2 = dayjs(b.created_at);
@@ -324,7 +321,6 @@ const EndpointList: React.FC<EndpointListProps> = ({
       rowKey={'endpoint_id'}
       dataSource={filterNonNullItems(endpoints)}
       columns={columns}
-      sortDirections={['descend', 'ascend', 'descend']}
       pagination={pagination}
       {...tableProps}
     />

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -550,7 +550,6 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
             },
           })}
           showSorterTooltip={false}
-          sortDirections={['descend', 'ascend', 'descend']}
         />
         <Flex
           justify="end"

--- a/react/src/components/InviteFolderSettingModal.tsx
+++ b/react/src/components/InviteFolderSettingModal.tsx
@@ -236,7 +236,6 @@ const InviteFolderSettingModal: React.FC<InviteFolderSettingModalProps> = ({
               pagination={false}
               showSorterTooltip={false}
               loading={isFetching}
-              sortDirections={['descend', 'ascend', 'descend']}
               dataSource={shared || []}
               scroll={{ x: 'max-content' }}
               rowKey={(record) => record.shared_to.uuid}

--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -247,7 +247,6 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
         dataSource={filterNonNullItems(resource_presets)}
         scroll={{ x: 'max-content' }}
         pagination={false}
-        sortDirections={['descend', 'ascend', 'descend']}
         showSorterTooltip={false}
         columns={columns}
       />

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -1,6 +1,6 @@
 import { filterEmptyItem, filterNonNullItems } from '../helper';
 import BAILink from './BAILink';
-import BAITable from './BAITable';
+import BAITable, { BAITableProps } from './BAITable';
 import SessionReservation from './ComputeSessionNodeItems/SessionReservation';
 import SessionSlotCell from './ComputeSessionNodeItems/SessionSlotCell';
 import SessionStatusTag from './ComputeSessionNodeItems/SessionStatusTag';
@@ -11,7 +11,7 @@ import {
   SessionNodesFragment$key,
 } from './__generated__/SessionNodesFragment.graphql';
 import { ColumnType } from 'antd/es/table';
-import { TableProps, theme } from 'antd/lib';
+import { theme } from 'antd/lib';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React from 'react';
@@ -20,7 +20,7 @@ import { useFragment } from 'react-relay';
 
 export type SessionNodeInList = NonNullable<SessionNodesFragment$data[number]>;
 interface SessionNodesProps
-  extends Omit<TableProps<SessionNodeInList>, 'dataSource' | 'columns'> {
+  extends Omit<BAITableProps<SessionNodeInList>, 'dataSource' | 'columns'> {
   sessionsFrgmt: SessionNodesFragment$key;
   onClickSessionName?: (session: SessionNodeInList) => void;
   disableSorter?: boolean;

--- a/react/src/components/UserNodeList.tsx
+++ b/react/src/components/UserNodeList.tsx
@@ -371,7 +371,6 @@ const UserNodeList: React.FC<UserNodeListProps> = () => {
           },
         ])}
         showSorterTooltip={false}
-        sortDirections={['descend', 'ascend', 'descend']}
         pagination={{
           pageSize: tablePaginationOption.pageSize,
           showSizeChanger: true,

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -134,7 +134,6 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
         resizable
         neoStyle
         showSorterTooltip={false}
-        sortDirections={['descend', 'ascend', 'descend']}
         rowKey={(record) => record.id}
         size="small"
         dataSource={filteredVFolders}

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -595,7 +595,6 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
               },
             };
           }}
-          sortDirections={['ascend', 'descend']}
           {...tableProps}
         />
       </Form>

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -68,8 +68,8 @@ const ComputeSessionListPage = () => {
   });
 
   const [queryParams, setQuery] = useDeferredQueryParams({
-    order: withDefault(StringParam, '-created_at'),
-    filter: StringParam,
+    order: withDefault(StringParam, undefined),
+    filter: withDefault(StringParam, undefined),
     type: withDefault(StringParam, 'all'),
     statusCategory: withDefault(StringParam, 'running'),
   });
@@ -110,7 +110,7 @@ const ComputeSessionListPage = () => {
       offset: baiPaginationOption.offset,
       first: baiPaginationOption.first,
       filter: mergeFilterValues([statusFilter, queryParams.filter, typeFilter]),
-      order: queryParams.order,
+      order: queryParams.order || '-created_at',
     }),
     [
       currentProject.id,
@@ -415,6 +415,7 @@ const ComputeSessionListPage = () => {
             </Flex>
           </Flex>
           <SessionNodes
+            orderString={queryParams.order}
             onClickSessionName={(session) => {
               setSessionDetailId(session.row_id);
             }}

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -801,7 +801,6 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               },
             ]}
             pagination={false}
-            sortDirections={['descend', 'ascend', 'descend']}
             showSorterTooltip={false}
             dataSource={autoScalingRules}
             bordered
@@ -872,7 +871,6 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               sorter: dayDiff,
             },
           ]}
-          sortDirections={['descend', 'ascend', 'descend']}
           showSorterTooltip={false}
           pagination={false}
           dataSource={filterNonNullItems(endpoint_token_list?.items)}

--- a/react/src/pages/ServingPage.tsx
+++ b/react/src/pages/ServingPage.tsx
@@ -29,7 +29,7 @@ const ServingPage: React.FC = () => {
   const currentProject = useCurrentProjectValue();
 
   const [queryParams, setQuery] = useDeferredQueryParams({
-    order: StringParam,
+    order: withDefault(StringParam, undefined),
     filter: StringParam,
     lifecycleStage: withDefault(StringParam, 'active'),
   });
@@ -56,7 +56,7 @@ const ServingPage: React.FC = () => {
       limit: baiPaginationOption.limit,
       projectID: currentProject.id,
       filter: mergeFilterValues([lifecycleStageFilter, queryParams.filter]),
-      order: queryParams.order,
+      order: queryParams.order || '-created_at',
     }),
     [baiPaginationOption, currentProject.id, lifecycleStageFilter, queryParams],
   );
@@ -202,6 +202,7 @@ const ServingPage: React.FC = () => {
                   </Typography.Text>
                 ),
               }}
+              orderString={queryParams.order}
               loading={deferredQueryVariables !== queryVariables}
               onChange={({ current, pageSize }, filters, sorter) => {
                 if (_.isNumber(current) && _.isNumber(pageSize)) {

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -111,8 +111,8 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   });
 
   const [queryParams, setQuery] = useDeferredQueryParams({
-    order: withDefault(StringParam, '-created_at'),
-    filter: StringParam,
+    order: withDefault(StringParam, undefined),
+    filter: withDefault(StringParam, undefined),
     statusCategory: withDefault(StringParam, 'active'),
     mode: withDefault(StringParam, 'all'),
   });
@@ -159,7 +159,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
         queryParams.filter,
         usageModeFilter,
       ]),
-      order: queryParams.order,
+      order: queryParams.order || '-created_at',
       permission: 'read_attribute',
     }),
     [
@@ -539,6 +539,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             </Flex>
           </Flex>
           <VFolderNodes
+            orderString={queryParams.order}
             loading={deferredQueryVariables !== queryVariables}
             vfoldersFrgmt={filterNonNullItems(
               _.map(vfolder_nodes?.edges, 'node'),


### PR DESCRIPTION
Resolves #3587 (FR-883)

This PR fixes inconsistent sorting behavior in table components that caused NEO session and NEO folder lists to appear differently when first loaded compared to when navigating between pages.

The key changes include:

- Added `orderString` prop to `BAITable` component to control sort direction based on URL parameters
- Modified table components to use this prop for consistent sorting
- Removed hardcoded `sortDirections` and `defaultSortOrder` properties that were causing inconsistencies
- Updated `ComputeSessionListPage`, `ServingPage`, and `VFolderNodeListPage` to properly handle default sorting
- Ensured sort indicators are correctly displayed based on the current sort order

These changes ensure that tables maintain consistent sorting behavior throughout the application, regardless of navigation patterns.