### PR TITLE
fix(FR-915): fix error when deleting or restoring single folder after multi-check

### DIFF
--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -60,7 +60,7 @@ export type VFolderNodeInList = NonNullable<VFolderNodesFragment$data[number]>;
 interface VFolderNodesProps
   extends Omit<BAITableProps<VFolderNodeInList>, 'dataSource' | 'columns'> {
   vfoldersFrgmt: VFolderNodesFragment$key;
-  onRequestChange?: () => void;
+  onRequestChange?: (updatedFolderId?: string) => void;
 }
 
 const VFolderNodes: React.FC<VFolderNodesProps> = ({
@@ -250,8 +250,8 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
                         disabled={vfolder?.status !== 'delete-pending'}
                         onClick={() => {
                           restoreMutation.mutate(vfolder?.id, {
-                            onSuccess: (result) => {
-                              onRequestChange?.();
+                            onSuccess: (result, variables) => {
+                              onRequestChange?.(variables);
                               message.success(
                                 t('data.folders.FolderRestored', {
                                   folderName: vfolder?.name,
@@ -275,8 +275,8 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
                       title={t('data.folders.MoveToTrash')}
                       onConfirm={() => {
                         deleteMutation.mutate(vfolder?.id, {
-                          onSuccess: () => {
-                            onRequestChange?.();
+                          onSuccess: (result, variables) => {
+                            onRequestChange?.(variables);
                             message.success(
                               t('data.folders.MovedToTrashBin', {
                                 folderName: vfolder?.name,

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -586,7 +586,13 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                 'replaceIn',
               );
             }}
-            onRequestChange={() => {
+            onRequestChange={(updatedFolderId) => {
+              setSelectedFolderList((prevSelected) =>
+                _.filter(
+                  prevSelected,
+                  (folder) => folder.id !== updatedFolderId,
+                ),
+              );
               updateFetchKey();
             }}
           />


### PR DESCRIPTION
https://lablup.atlassian.net/browse/FR-915
Resolves #3588 (FR-915)

# Improve folder selection handling after restore/delete operations

This PR enhances the folder selection behavior when restoring or deleting folders. When a folder is moved to trash or restored, the updated folder ID is now passed to the `onRequestChange` callback, allowing the parent component to update its selected folder list accordingly. This can resolve the selectedFolder mismatch when deleting or restoring single folder after multi-check.

The main changes:
- Updated the `onRequestChange` callback signature to accept an optional folder ID parameter
- Modified the restore and delete mutation success handlers to pass the folder ID to the callback
- Added logic in `VFolderNodeListPage` to remove the updated folder from the selected folder list

This prevents issues where deleted/restored folders would remain in the selection state after the operation is complete.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after