### PR TITLE
feat(FR-564): Allow create folder and explorer for vfolder select

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -799,6 +799,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                             valuePropName="id"
                             autoSelectDefault={!model}
                             disabled={!!endpoint}
+                            allowFolderExplorer
+                            allowCreateFolder
                           />
                         </Form.Item>
                       ) : (


### PR DESCRIPTION
resolves #3207 ([FR-564](https://lablup.atlassian.net/jira/software/projects/FR/boards/21?assignee=712020:52c9a410-dfd2-4acd-97a6-8c6112ec8a34&selectedIssue=FR-564))

### Add folder creation and exploration capabilities to VFolderSelect component

This PR enhances the `VFolderSelect` component by adding two new features:
1. Folder exploration - allows users to navigate to the selected folder
2. Folder creation - enables users to create new folders directly from the select component

The component now accepts two new props:
- `allowFolderExplorer`: Enables folder navigation links
- `allowCreateFolder`: Adds a button to create new folders

These features are implemented in the Service Launcher page to improve the user experience when working with folders.

**How to test:**
- Go to serving page
- Create a new service and check the `model storage to mount' field to create a new model type folder and use Explorer.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-564]: https://lablup.atlassian.net/browse/FR-564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ