### PR TITLE
refactor(FR-851): remove custom duration for message

### DIFF
--- a/react/src/components/AutoScalingRuleEditorModal.tsx
+++ b/react/src/components/AutoScalingRuleEditorModal.tsx
@@ -181,7 +181,7 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
               if (errors && errors.length > 0) {
                 const errorMsgList = _.map(errors, (error) => error.message);
                 for (const error of errorMsgList) {
-                  message.error(error, 2.5);
+                  message.error(error);
                 }
                 onRequestClose(false);
                 return;
@@ -209,7 +209,7 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
               if (errors && errors.length > 0) {
                 const errorMsgList = _.map(errors, (error) => error.message);
                 for (const error of errorMsgList) {
-                  message.error(error, 2.5);
+                  message.error(error);
                 }
                 onRequestClose(false);
                 return;

--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -116,7 +116,7 @@ const ContainerRegistryEditorModal: React.FC<
                 if (errors && errors.length > 0) {
                   const errorMsgList = _.map(errors, (error) => error.message);
                   for (const error of errorMsgList) {
-                    message.error(error, 2.5);
+                    message.error(error);
                   }
                 } else {
                   onOk && onOk('modify');
@@ -146,7 +146,7 @@ const ContainerRegistryEditorModal: React.FC<
               if (errors && errors?.length > 0) {
                 const errorMsgList = _.map(errors, (error) => error.message);
                 for (const error of errorMsgList) {
-                  message.error(error, 2.5);
+                  message.error(error);
                 }
               } else {
                 onOk && onOk('create');

--- a/react/src/components/ContainerRegistryEditorModalBefore2409.tsx
+++ b/react/src/components/ContainerRegistryEditorModalBefore2409.tsx
@@ -129,7 +129,7 @@ const ContainerRegistryEditorModal: React.FC<
               if (errors && errors.length > 0) {
                 const errorMsgList = _.map(errors, (error) => error.message);
                 for (const error of errorMsgList) {
-                  message.error(error, 2.5);
+                  message.error(error);
                 }
               } else {
                 onOk && onOk('modify');
@@ -152,7 +152,7 @@ const ContainerRegistryEditorModal: React.FC<
               if (errors && errors?.length > 0) {
                 const errorMsgList = _.map(errors, (error) => error.message);
                 for (const error of errorMsgList) {
-                  message.error(error, 2.5);
+                  message.error(error);
                 }
               } else {
                 onOk && onOk('create');

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -369,7 +369,7 @@ const ContainerRegistryList: React.FC<{
                       (error) => error.message,
                     );
                     for (const error of errorMsgList) {
-                      message.error(error, 2.5);
+                      message.error(error);
                     }
                   } else {
                     startReloadTransition(() => {

--- a/react/src/components/ContainerRegistryListBefore2409.tsx
+++ b/react/src/components/ContainerRegistryListBefore2409.tsx
@@ -363,7 +363,7 @@ const ContainerRegistryListBefore2409: React.FC<{
                             (error) => error.message,
                           );
                           for (const error of errorMsgList) {
-                            message.error(error, 2.5);
+                            message.error(error);
                           }
                         } else {
                           startReloadTransition(() => {

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -378,7 +378,7 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
                         (error) => error.message,
                       );
                       for (const error of errorMsgList) {
-                        message.error(error, 2.5);
+                        message.error(error);
                       }
                       return;
                     }

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -304,7 +304,7 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
                             (error) => error.message,
                           );
                           for (const error of errorMsgList) {
-                            message.error(error, 2.5);
+                            message.error(error);
                           }
                         } else {
                           startRefetchTransition(() =>

--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -279,7 +279,7 @@ const KeypairResourcePolicySettingModal: React.FC<
                 return;
               }
               if (errors && errors.length > 0) {
-                errors.forEach((error) => message.error(error.message, 2.5));
+                errors.forEach((error) => message.error(error.message));
                 onRequestClose(false);
                 return;
               }

--- a/react/src/components/ManageAppsModal.tsx
+++ b/react/src/components/ManageAppsModal.tsx
@@ -146,7 +146,7 @@ const ManageAppsModal: React.FC<ManageAppsModalProps> = ({
               if (errors && errors?.length > 0) {
                 const errorMsgList = _.map(errors, (error) => error.message);
                 for (const error of errorMsgList) {
-                  message.error(error, 2.5);
+                  message.error(error);
                 }
               } else {
                 message.success(t('environment.DescImagePortsModified'));

--- a/react/src/components/ManageImageResourceLimitModal.tsx
+++ b/react/src/components/ManageImageResourceLimitModal.tsx
@@ -98,7 +98,7 @@ const ManageImageResourceLimitModal: React.FC<
           if (errors && errors?.length > 0) {
             const errorMsgList = _.map(errors, (error) => error.message);
             for (const error of errorMsgList) {
-              message.error(error, 2.5);
+              message.error(error);
             }
           } else {
             message.success(t('environment.DescImageResourceModified'));

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -209,7 +209,7 @@ const ProjectResourcePolicyList: React.FC<
                         (error) => error.message,
                       );
                       for (const error of errorMsgList) {
-                        message.error(error, 2.5);
+                        message.error(error);
                       }
                     } else {
                       startRefetchTransition(() =>

--- a/react/src/components/ResourcePresetSettingModal.tsx
+++ b/react/src/components/ResourcePresetSettingModal.tsx
@@ -135,7 +135,7 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
               } else if (errors && errors?.length > 0) {
                 const errorMsgList = _.map(errors, (err) => err.message);
                 _.forEach(errorMsgList, (err) => {
-                  message.error(err, 2.5);
+                  message.error(err);
                 });
                 onRequestClose(false);
               } else {
@@ -161,7 +161,7 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
                 } else if (errors && errors?.length > 0) {
                   const errorMsgList = _.map(errors, (err) => err?.message);
                   _.forEach(errorMsgList, (err) => {
-                    message.error(err, 2.5);
+                    message.error(err);
                   });
                   onRequestClose(false);
                 } else {
@@ -187,7 +187,7 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
                 } else if (errors && errors?.length > 0) {
                   const errorMsgList = _.map(errors, (err) => err?.message);
                   _.forEach(errorMsgList, (err) => {
-                    message.error(err, 2.5);
+                    message.error(err);
                   });
                   onRequestClose(false);
                 } else {

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -554,7 +554,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                 if (errors && errors?.length > 0) {
                   const errorMsgList = _.map(errors, (error) => error.message);
                   for (const error of errorMsgList) {
-                    message.error(error, 2.5);
+                    message.error(error);
                   }
                 } else {
                   const updatedEndpoint = res.modify_endpoint?.endpoint;

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -205,7 +205,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
                     if (errors && errors.length > 0) {
                       const errorMsgList = errors.map((error) => error.message);
                       for (const error of errorMsgList) {
-                        message.error(error, 2.5);
+                        message.error(error);
                       }
                       return;
                     }

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -244,7 +244,7 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
               if (errors && errors.length > 0) {
                 const errorMsgList = _.map(errors, (error) => error.message);
                 for (const error of errorMsgList) {
-                  message.error(error, 2.5);
+                  message.error(error);
                 }
                 onRequestClose(false);
               }
@@ -294,7 +294,7 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
               if (errors && errors.length > 0) {
                 const errorMsgList = _.map(errors, (error) => error.message);
                 for (const error of errorMsgList) {
-                  message.error(error, 2.5);
+                  message.error(error);
                 }
                 onRequestClose(false);
               }

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -686,7 +686,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
                                     error.message || t('dialog.ErrorOccurred'),
                                 );
                                 for (const error of errorMsgList) {
-                                  message.error(error, 2.5);
+                                  message.error(error);
                                 }
                               } else {
                                 setEditingAutoScalingRule(null);


### PR DESCRIPTION
resolves #3520 (FR-851)
Remove the duration value set to custom for `message` in that PR to use the value set to global. And when I modified the `duration` option of the message in the `DefaultProvider`, I made sure that the value was reflected.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
