### PR TITLE
fix(FR-895): change resource statistics panel on the Import & Run page to be scrollable

### DIFF
--- a/src/components/backend-ai-import-view.ts
+++ b/src/components/backend-ai-import-view.ts
@@ -748,6 +748,7 @@ export default class BackendAIImport extends BackendAIPage {
           width="352"
           height="490"
           narrow
+          scrollableY
         >
           <div slot="message">
             <backend-ai-resource-monitor


### PR DESCRIPTION
resolves #3572 (FR-895)
In that PR, change the `resource statistics panel` on the `Import & Run` page to be scrollable.

![CleanShot 2025-04-29 at 15.31.13@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/2a456041-21c1-4e71-8a0a-337bea7c1d15.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
