### PR TITLE
fix(FR-941): prevent suspense fallback when Allocated resource card is auto-refreshing

### DIFF
--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -255,7 +255,8 @@ const ComputeSessionListPage = () => {
               style={{
                 height: lg ? 200 : undefined,
               }}
-              fetchKey={fetchKey}
+              isRefetching={deferredFetchKey !== fetchKey}
+              fetchKey={deferredFetchKey}
             />
           </Suspense>
         </Col>


### PR DESCRIPTION
Resolves #3603 (FR-941)

The allocated resources card falls back to a skeleton every time it auto refetches, which decreases usability. This PR changes it so that only the refresh button shows a loading state during auto refetching.