### PR TITLE
feat(FR-920): set `minimum-required` resources when no available preset

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -468,10 +468,12 @@ const ResourceAllocationFormItems: React.FC<
           });
           updateResourceFieldsBasedOnPreset(autoSelectedPreset);
         } else {
-          // if the current preset is not available in the current resource group, set to custom
-          form.setFieldsValue({
-            allocationPreset: 'custom',
-          });
+          // if the current preset is not available in the current resource group, set to "minimum-required".
+          if (baiClient._config.allowCustomResourceAllocation) {
+            form.setFieldValue('allocationPreset', 'minimum-required');
+          } else {
+            form.setFieldValue('allocationPreset', null);
+          }
         }
       }
       ensureValidAcceleratorType();
@@ -492,6 +494,7 @@ const ResourceAllocationFormItems: React.FC<
     // below are functions wrapped by useEventNotStable
     ensureValidAcceleratorType,
     updateResourceFieldsBasedOnPreset,
+    baiClient._config.allowCustomResourceAllocation,
   ]);
 
   // This effect is for auto updating the resource fields when minimum-required preset is selected
@@ -519,8 +522,12 @@ const ResourceAllocationFormItems: React.FC<
         <Form.Item
           label={t('resourcePreset.ResourcePresets')}
           name="allocationPreset"
-          required
           style={{ marginBottom: token.marginXS }}
+          rules={[
+            {
+              required: true,
+            },
+          ]}
         >
           <ResourcePresetSelect
             showCustom={baiClient._config.allowCustomResourceAllocation}


### PR DESCRIPTION
Resolves #3595 (FR-920)



This PR modifies the behavior of resource allocation preset selection in the ResourceAllocationFormItems component:

1. When a preset becomes unavailable in the current resource group:
   - If custom resource allocation is allowed, it now defaults to 'minimum-required' instead of 'custom'
   - If custom resource allocation is not allowed, it sets the value to null

2. Added dependency on `baiClient._config.allowCustomResourceAllocation` to the useEffect to ensure proper re-rendering when this configuration changes

3. Changed the form validation to make it work in preview step:
   - Removed the `required` prop from Form.Item
   - Added explicit validation rules to maintain the required behavior