### PR TITLE
Fix: change separator between image name & tag

### DIFF
--- a/react/src/components/ImageInstallModal.tsx
+++ b/react/src/components/ImageInstallModal.tsx
@@ -169,7 +169,7 @@ const ImageInstallModal: React.FC<ImageInstallModalInterface> = ({
             size="small"
             dataSource={imagesToInstall.map(
               (image) =>
-                `${image?.registry}/${image?.namespace ?? image?.name}/${image?.tag}`,
+                `${image?.registry}/${image?.namespace ?? image?.name}:${image?.tag}`,
             )}
             style={{
               width: '100%',


### PR DESCRIPTION
fix separator between image name & tag

On the environment page, fix seperator between image name & tag. originally use `:` seperator between image name and tag

incorrect: `correct: cr.backend.ai/stable/r-base/3.6`
correct: `cr.backend.ai/stable/r-base:3.6`

resolves #3610 

resolves #NNN (FR-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
