### PR TITLE
feat(FR-952): TOTP registration before login

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -232,6 +232,8 @@ function MainLayout() {
                 </Flex>
               </Suspense>
               <Suspense>
+                {/* ForceTOTPChecker is a component for previous version of manager which don't support TOTP registration before login.  */}
+                {/* https://github.com/lablup/backend.ai/pull/4354 */}
                 <ForceTOTPChecker />
               </Suspense>
               <Suspense>

--- a/react/src/components/TOTPActivateModalWithToken.tsx
+++ b/react/src/components/TOTPActivateModalWithToken.tsx
@@ -1,0 +1,127 @@
+import { useAnonymousBackendaiClient } from '../hooks';
+import { useTanMutation } from '../hooks/reactQueryAlias';
+import BAIModal from './BAIModal';
+import { useWebComponentInfo } from './DefaultProviders';
+import Flex from './Flex';
+import { TOTPActivateForm, TOTPActivateFormData } from './TOTPActivateModal';
+import { FormInstance, message } from 'antd';
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const TOTPActivateModalWithToken = () => {
+  const { t } = useTranslation();
+  const formRef = useRef<FormInstance<TOTPActivateFormData>>(null);
+  const { value, dispatchEvent } = useWebComponentInfo();
+  let parsedValue: {
+    open: boolean;
+    totp_registration_token: string;
+    api_endpoint: string;
+  };
+  try {
+    parsedValue = JSON.parse(value || '');
+  } catch (error) {
+    parsedValue = {
+      open: false,
+      totp_registration_token: '',
+      api_endpoint: '',
+    };
+  }
+
+  const { api_endpoint, open, totp_registration_token } = parsedValue;
+  const anonBaiClient = useAnonymousBackendaiClient({
+    api_endpoint,
+  });
+
+  const {
+    data: initializedTotp,
+    isSuccess,
+    isError,
+    mutate,
+  } = useTanMutation<
+    {
+      totp_key: string;
+      totp_uri: string;
+    },
+    null,
+    {
+      registration_token: string;
+    }
+  >({
+    mutationFn: ({ registration_token }) => {
+      return anonBaiClient.initialize_totp_anon({
+        registration_token,
+      });
+    },
+  });
+
+  useEffect(() => {
+    if (open) {
+      mutate({
+        registration_token: totp_registration_token,
+      });
+    }
+  }, [open, mutate, totp_registration_token]);
+
+  const mutationToActivateTotp = useTanMutation<
+    {},
+    null,
+    {
+      registration_token: string;
+      otp: number;
+    }
+  >({
+    mutationFn: (values: TOTPActivateFormData) => {
+      return anonBaiClient.activate_totp_anon(values);
+    },
+  });
+
+  const _onOk = () => {
+    formRef.current
+      ?.validateFields()
+      .then((values) => {
+        mutationToActivateTotp.mutate(
+          {
+            otp: values.otp,
+            registration_token: totp_registration_token,
+          },
+          {
+            onSuccess: () => {
+              message.success(t('totp.TotpSetupCompleted'));
+              dispatchEvent('ok', null);
+            },
+            onError: () => {
+              message.error(t('totp.InvalidTotpCode'));
+            },
+          },
+        );
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <BAIModal
+      title={t('webui.menu.SetupTotp')}
+      maskClosable={false}
+      confirmLoading={mutationToActivateTotp.isPending}
+      open={open}
+      onCancel={() => {
+        dispatchEvent('cancel', null);
+      }}
+      destroyOnClose
+      onOk={_onOk}
+      loading={!isSuccess}
+    >
+      {isError || !initializedTotp?.totp_uri || !initializedTotp?.totp_key ? (
+        <Flex>{t('totp.TotpSetupNotAvailable')}</Flex>
+      ) : (
+        <TOTPActivateForm
+          ref={formRef}
+          totp_uri={initializedTotp?.totp_uri}
+          totp_key={initializedTotp?.totp_key}
+        />
+      )}
+    </BAIModal>
+  );
+};
+
+export default TOTPActivateModalWithToken;

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -56,6 +56,21 @@ const BatchSessionScheduledTimeSetting = React.lazy(
   () => import('./components/BatchSessionScheduledTimeSetting'),
 );
 
+const TOTPActivateModalWithToken = React.lazy(
+  () => import('./components/TOTPActivateModalWithToken'),
+);
+
+customElements.define(
+  'backend-ai-react-totp-registration-modal-before-login',
+  reactToWebComponent((props) => {
+    return (
+      <DefaultProviders {...props}>
+        <TOTPActivateModalWithToken />
+      </DefaultProviders>
+    );
+  }),
+);
+
 customElements.define(
   'backend-ai-react-reset-password-required-modal',
   reactToWebComponent((props) => (

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -888,7 +888,7 @@ class Client {
         // Authentication failed.
         localStorage.removeItem('backendaiwebui.sessionid');
         if (result.data && result.data.details) {
-          return Promise.resolve({ fail_reason: result.data.details });
+          return Promise.resolve({ fail_reason: result.data.details, data: result.data });
         } else {
           return Promise.resolve(false);
         }
@@ -1030,8 +1030,24 @@ class Client {
     return this._wrapWithPromise(rqst);
   }
 
+  async initialize_totp_anon({
+    registration_token,
+  }): Promise<any> {
+    let rqst = this.newSignedRequest('POST', '/totp/anon', {
+      registration_token
+    }, null);
+    return this._wrapWithPromise(rqst);
+  }
+
   async activate_totp(otp): Promise<any> {
     let rqst = this.newSignedRequest('POST', '/totp/verify', { otp }, null);
+    return this._wrapWithPromise(rqst);
+  }
+  async activate_totp_anon({
+    otp,
+    registration_token,
+  }): Promise<any> {
+    let rqst = this.newSignedRequest('POST', '/totp/anon/verify', { otp, registration_token }, null);
     return this._wrapWithPromise(rqst);
   }
 


### PR DESCRIPTION
Resolves #3614 (FR-952)

## TOTP Registration Flow for Forced 2FA

This PR implements a TOTP registration flow for users who are required to set up two-factor authentication before they can log in. The implementation includes:

- Added a new React component `TOTPActivateModalWithToken` that handles TOTP registration before login
- Refactored `TOTPActivateModal` to extract the form into a reusable component
- Added backend client methods for anonymous TOTP initialization and verification
- Updated the login component to detect when TOTP registration is required and show the registration modal

The flow now properly handles the case where the server returns "TOTP key registration required" during login attempts, allowing users to set up 2FA without being logged in first.

### How to test
You can use a [test server](https://teams.microsoft.com/l/message/19:3c0acc0825024daeb2211f55c4e7f4aa@thread.skype/1746702452186?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=74ae2c4d-ec4d-4fdf-b2c2-f5041d1e8631&parentMessageId=1746581769686&teamName=devops&channelName=Backend.AI%20Talks&createdTime=1746702452186). If you want to set up on your local machine:
- You need to checkout https://github.com/lablup/backend.ai/pull/4354 for testing
- Please set `force_2FA` and `enable_2FA` in `webserver.conf`

**Test Cases:**
**[s1. Core does not have the 2FA authentication plugin installed.]**
- All users can log in regardless of the `enable2FA` `force2FA` setting in webserver or webui config. 

**[s2. if the server was using TOTP Plugin before the change]**
- The login process was not validating 2FA and preventing users from using the WebUI by opening an unclosable modal on the main screen after login. [There was a recent TOTP Plugin fix](https://github.com/lablup/backend.ai/pull/4354) due to a security issue in this process.
- If the `enable2FA` setting is false, login is possible regardless of whether `force2FA` is enabled. However, if you have previously enabled 2FA, you will need to disable it through the control panel settings.
- If the `enable2FA` setting is true, login is possible regard of whether  `force2FA` is enabled. If `force2FA` is disabled, user can login and set 2FA via `MyAccountModal`. If `force2FA` is enabled, all users must register for 2FA authentication.
- Users who are not 2FA enrolled will see a 2FA enrollment modal, and after initial enrollment, they will see a field to enter an OTP code without the enrollment modal.

**[s3.If the server was using TOTP Plugin **after the change**]**
- Perform 2FA validation during the login process. All test scenarios are the same as in item 2. The difference is the timing of when the verification process is performed.