### PR TITLE
fix(FR-921): Fix incorrect access key when terminating another user's session

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
@@ -193,6 +193,7 @@ const TerminateSessionModal: React.FC<TerminateSessionModalProps> = ({
         row_id
         name
         scaling_group @required(action: NONE)
+        access_key
         kernel_nodes {
           edges {
             node {
@@ -236,11 +237,7 @@ const TerminateSessionModal: React.FC<TerminateSessionModalProps> = ({
             (err.statusCode === 404 || err.statusCode === 500))
         ) {
           // BAI client destroy try to request 3times as default
-          return baiClient.destroy(
-            session.row_id,
-            baiClient._config.accessKey,
-            isForce,
-          );
+          return baiClient.destroy(session.row_id, session.access_key, isForce);
         } else {
           throw err;
         }


### PR DESCRIPTION
resolves #3596 (FR-921)

This PR updates the `TerminateSessionModal` component to use the session's access key directly from the session object instead of using the global access key from the BAI client configuration. This change ensures that the correct access key is used when terminating a session, particularly in cases where the session might have been created with a different access key than the one currently configured.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after