### PR TITLE
refactor(FR-967): migrate list components in resources page to Neo Style

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -47,14 +47,10 @@ import { useLazyLoadQuery } from 'react-relay';
 type Agent = NonNullable<AgentListQuery$data['agent_list']>['items'][number];
 
 interface AgentListProps {
-  containerStyle?: React.CSSProperties;
   tableProps?: Omit<TableProps, 'dataSource'>;
 }
 
-const AgentList: React.FC<AgentListProps> = ({
-  containerStyle,
-  tableProps,
-}) => {
+const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { isDarkMode } = useThemeMode();
@@ -742,8 +738,8 @@ const AgentList: React.FC<AgentListProps> = ({
     useHiddenColumnKeysSetting('AgentList');
 
   return (
-    <Flex direction="column" align="stretch" style={containerStyle} gap={'sm'}>
-      <Flex justify="between" align="start" gap="xs" wrap="wrap">
+    <Flex direction="column" align="stretch" gap="sm">
+      <Flex justify="between" align="start" wrap="wrap">
         <Flex
           direction="row"
           gap={'sm'}

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -1,0 +1,188 @@
+import { filterEmptyItem, filterNonNullItems } from '../helper';
+import { useUpdatableState } from '../hooks';
+import BAIFetchKeyButton from './BAIFetchKeyButton';
+import BAIRadioGroup from './BAIRadioGroup';
+import BAITable from './BAITable';
+import Flex from './Flex';
+import {
+  ResourceGroupListQuery,
+  ResourceGroupListQuery$data,
+} from './__generated__/ResourceGroupListQuery.graphql';
+import {
+  CheckOutlined,
+  CloseOutlined,
+  DeleteOutlined,
+  InfoCircleOutlined,
+  SettingOutlined,
+} from '@ant-design/icons';
+import { Button, theme } from 'antd';
+import { ColumnsType } from 'antd/es/table';
+import graphql from 'babel-plugin-relay/macro';
+import _ from 'lodash';
+import { useState, useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLazyLoadQuery } from 'react-relay';
+
+type ResourceGroup = NonNullable<
+  NonNullable<
+    NonNullable<ResourceGroupListQuery$data>['scaling_groups']
+  >[number]
+>;
+
+const ResourceGroupList: React.FC = () => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const [activeType, setActiveType] = useState<'active' | 'inactive'>('active');
+  const [fetchKey, updateFetchKey] = useUpdatableState('first');
+  const [isActiveTypePending, startActiveTypeTransition] = useTransition();
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+
+  const { scaling_groups } = useLazyLoadQuery<ResourceGroupListQuery>(
+    graphql`
+      query ResourceGroupListQuery($is_active: Boolean) {
+        scaling_groups(is_active: $is_active) {
+          name
+          description
+          is_public
+          driver
+          scheduler
+          wsproxy_addr
+        }
+      }
+    `,
+    {
+      is_active: activeType === 'active',
+    },
+    {
+      fetchPolicy: 'store-and-network',
+      fetchKey,
+    },
+  );
+
+  const columns: ColumnsType<ResourceGroup> = filterEmptyItem([
+    {
+      key: 'name',
+      title: t('resourceGroup.Name'),
+      dataIndex: 'name',
+    },
+    {
+      key: 'description',
+      title: t('resourceGroup.Description'),
+      dataIndex: 'description',
+      render: (value) => value || '-',
+    },
+    {
+      key: 'is_public',
+      title: t('resourceGroup.Public'),
+      dataIndex: 'is_public',
+      render: (value) => {
+        return value ? (
+          <CheckOutlined style={{ color: token.colorSuccess }} />
+        ) : (
+          <CloseOutlined style={{ color: token.colorTextSecondary }} />
+        );
+      },
+    },
+    {
+      key: 'driver',
+      title: t('resourceGroup.Driver'),
+      dataIndex: 'driver',
+    },
+    {
+      key: 'scheduler',
+      title: t('resourceGroup.Scheduler'),
+      dataIndex: 'scheduler',
+      render: (value) => _.toUpper(value),
+    },
+    {
+      key: 'wsproxy_addr',
+      title: t('resourceGroup.WsproxyAddress'),
+      dataIndex: 'wsproxy_addr',
+      render: (value) => value || '-',
+    },
+    {
+      key: 'controls',
+      title: t('general.Control'),
+      fixed: 'right',
+      render: () => {
+        return (
+          <Flex>
+            <Button
+              type="text"
+              size="large"
+              icon={<InfoCircleOutlined />}
+              style={{ color: token.colorSuccess }}
+            />
+            <Button
+              type="text"
+              size="large"
+              icon={<SettingOutlined />}
+              style={{
+                color: token.colorInfo,
+              }}
+            />
+            <Button
+              type="text"
+              size="large"
+              icon={
+                <DeleteOutlined
+                  style={{
+                    color: token.colorError,
+                  }}
+                />
+              }
+            />
+          </Flex>
+        );
+      },
+    },
+  ]);
+
+  return (
+    <Flex direction="column" align="stretch" gap="sm">
+      <Flex justify="between">
+        <BAIRadioGroup
+          value={activeType}
+          onChange={(value) => {
+            startActiveTypeTransition(() => {
+              setActiveType(value.target.value);
+            });
+          }}
+          optionType="button"
+          options={[
+            {
+              label: 'Active',
+              value: 'active',
+            },
+            {
+              label: 'Inactive',
+              value: 'inactive',
+            },
+          ]}
+        />
+        <BAIFetchKeyButton
+          loading={isPendingRefetch}
+          value={fetchKey}
+          onChange={() => {
+            startRefetchTransition(() => {
+              updateFetchKey();
+            });
+          }}
+        />
+      </Flex>
+
+      <BAITable
+        rowKey={'name'}
+        neoStyle
+        resizable
+        size="small"
+        scroll={{ x: 'max-content' }}
+        columns={columns}
+        dataSource={filterNonNullItems(scaling_groups)}
+        loading={isActiveTypePending}
+      />
+    </Flex>
+  );
+};
+
+export default ResourceGroupList;

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -123,55 +123,6 @@ const StorageProxyList = () => {
       },
     },
     {
-      title: t('general.Control'),
-      key: 'control',
-      width: 100,
-      render: (value, record) => {
-        let perfMetricDisabled;
-        try {
-          const performanceMetric = JSON.parse(record.performance_metric);
-          perfMetricDisabled = _.isEmpty(performanceMetric);
-        } catch (e) {
-          perfMetricDisabled = true;
-        }
-        return (
-          <>
-            <Button
-              size="large"
-              disabled={perfMetricDisabled}
-              style={{
-                color: perfMetricDisabled
-                  ? token.colorTextDisabled
-                  : token.colorSuccess,
-              }}
-              icon={<InfoCircleOutlined />}
-              onClick={() => {
-                // This event is being listened to by the plugin
-                const event = new CustomEvent(
-                  'backend-ai-selected-storage-proxy',
-                  {
-                    detail: record.id,
-                  },
-                );
-                document.dispatchEvent(event);
-              }}
-              type="text"
-            />
-            <BAILink to={`/storage-settings/${record.id}`}>
-              <Button
-                size="large"
-                style={{
-                  color: token.colorInfo,
-                }}
-                icon={<SettingOutlined />}
-                type="text"
-              />
-            </BAILink>
-          </>
-        );
-      },
-    },
-    {
       title: t('agent.BackendType'),
       key: 'backend',
       dataIndex: 'backend',
@@ -249,6 +200,56 @@ const StorageProxyList = () => {
               </Tag>
             ))}
           </Flex>
+        );
+      },
+    },
+    {
+      title: t('general.Control'),
+      key: 'control',
+      width: 100,
+      fixed: 'right',
+      render: (value, record) => {
+        let perfMetricDisabled;
+        try {
+          const performanceMetric = JSON.parse(record.performance_metric);
+          perfMetricDisabled = _.isEmpty(performanceMetric);
+        } catch (e) {
+          perfMetricDisabled = true;
+        }
+        return (
+          <>
+            <Button
+              size="large"
+              disabled={perfMetricDisabled}
+              style={{
+                color: perfMetricDisabled
+                  ? token.colorTextDisabled
+                  : token.colorSuccess,
+              }}
+              icon={<InfoCircleOutlined />}
+              onClick={() => {
+                // This event is being listened to by the plugin
+                const event = new CustomEvent(
+                  'backend-ai-selected-storage-proxy',
+                  {
+                    detail: record.id,
+                  },
+                );
+                document.dispatchEvent(event);
+              }}
+              type="text"
+            />
+            <BAILink to={`/storage-settings/${record.id}`}>
+              <Button
+                size="large"
+                style={{
+                  color: token.colorInfo,
+                }}
+                icon={<SettingOutlined />}
+                type="text"
+              />
+            </BAILink>
+          </>
         );
       },
     },

--- a/react/src/pages/ResourcesPage.tsx
+++ b/react/src/pages/ResourcesPage.tsx
@@ -1,5 +1,6 @@
 import AgentList from '../components/AgentList';
 import BAICard from '../components/BAICard';
+import ResourceGroupList from '../components/ResourceGroupList';
 import StorageProxyList from '../components/StorageProxyList';
 import { Skeleton, theme } from 'antd';
 import React, { Suspense } from 'react';
@@ -38,35 +39,30 @@ const ResourcesPage: React.FC<ResourcesPageProps> = (props) => {
           tab: t('general.ResourceGroup'),
         },
       ]}
+      styles={{
+        body: {
+          padding: `${token.paddingSM}px ${token.paddingLG}px ${token.paddingLG}px ${token.paddingLG}px`,
+        },
+      }}
     >
       {curTabKey === 'agents' ? (
-        // To remove duplicated border in the bordered table, we need to remove margin of the container.
-        <Suspense
-          fallback={
-            <Skeleton
-              active
-              style={{ padding: token.paddingContentVerticalLG }}
-            />
-          }
-        >
+        <Suspense fallback={<Skeleton active />}>
           <AgentList />
         </Suspense>
       ) : null}
       {curTabKey === 'storages' ? (
-        <Suspense
-          fallback={
-            <Skeleton
-              active
-              style={{ padding: token.paddingContentVerticalLG }}
-            />
-          }
-        >
+        <Suspense fallback={<Skeleton active />}>
           <StorageProxyList />
         </Suspense>
       ) : null}
       {curTabKey === 'resourceGroup' ? (
-        // @ts-ignore
-        <backend-ai-resource-group-list active />
+        <>
+          <Suspense fallback={<Skeleton active />}>
+            <ResourceGroupList />
+          </Suspense>
+          {/* @ts-ignore */}
+          {/* <backend-ai-resource-group-list active /> */}
+        </>
       ) : null}
     </BAICard>
   );


### PR DESCRIPTION
### Refactor Resource Page to Neo UI
resolves #3462 (FR-967)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/ebf7f27f-4b5d-42b7-9522-6bff5c1791ef.png)

> The controls and generate functions are worked on separate stacks.

This PR updates the Resource Page UI by:

1. Replacing standard Ant Design Table with BAITable component in AgentList and StorageProxyList
2. Adding a new ResourceGroupList component using BAITable instead of the web component
3. Improving layout consistency across all resource list components
4. Fixing table styling with proper padding and spacing
5. Moving control buttons to the right side of tables with fixed positioning
6. Standardizing pagination display format across tables

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after