### PR TITLE
feat(FR-966): Custom view beside of BAITable's pagination

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -3,7 +3,6 @@ import {
   convertBinarySizeUnit,
   filterNonNullItems,
   toFixedFloorWithoutTrailingZeros,
-  transformSorterToOrderString,
 } from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import { ResourceSlotName, useResourceSlotsDetails } from '../hooks/backendai';
@@ -16,6 +15,7 @@ import BAIIntervalView from './BAIIntervalView';
 import BAIProgressWithLabel from './BAIProgressWithLabel';
 import BAIPropertyFilter from './BAIPropertyFilter';
 import BAIRadioGroup from './BAIRadioGroup';
+import BAITable from './BAITable';
 import DoubleTag from './DoubleTag';
 import Flex from './Flex';
 import { ResourceTypeIcon } from './ResourceNumber';
@@ -29,21 +29,12 @@ import { AgentSettingModalFragment$key } from './__generated__/AgentSettingModal
 import {
   CheckCircleOutlined,
   InfoCircleOutlined,
-  LoadingOutlined,
   MinusCircleOutlined,
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import {
-  Button,
-  Table,
-  TableProps,
-  Tag,
-  theme,
-  Tooltip,
-  Typography,
-} from 'antd';
+import { Button, TableProps, Tag, theme, Tooltip, Typography } from 'antd';
 import { AnyObject } from 'antd/es/_util/type';
 import { ColumnsType, ColumnType } from 'antd/es/table';
 import graphql from 'babel-plugin-relay/macro';
@@ -51,7 +42,7 @@ import dayjs from 'dayjs';
 import _ from 'lodash';
 import React, { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FetchPolicy, useLazyLoadQuery } from 'react-relay';
+import { useLazyLoadQuery } from 'react-relay';
 
 type Agent = NonNullable<AgentListQuery$data['agent_list']>['items'][number];
 
@@ -96,7 +87,6 @@ const AgentList: React.FC<AgentListProps> = ({
   const [order, setOrder] = useState<string>();
 
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
-  const [fetchPolicy] = useState<FetchPolicy>('network-only');
   const updateFetchKeyInTransition = () =>
     startRefreshTransition(() => {
       updateFetchKey();
@@ -152,7 +142,7 @@ const AgentList: React.FC<AgentListProps> = ({
     },
     {
       fetchKey,
-      fetchPolicy,
+      fetchPolicy: fetchKey === 'first' ? 'store-and-network' : 'network-only',
     },
   );
 
@@ -752,14 +742,8 @@ const AgentList: React.FC<AgentListProps> = ({
     useHiddenColumnKeysSetting('AgentList');
 
   return (
-    <Flex direction="column" align="stretch" style={containerStyle}>
-      <Flex
-        justify="between"
-        align="start"
-        gap="xs"
-        style={{ padding: token.paddingXS }}
-        wrap="wrap"
-      >
+    <Flex direction="column" align="stretch" style={containerStyle} gap={'sm'}>
+      <Flex justify="between" align="start" gap="xs" wrap="wrap">
         <Flex
           direction="row"
           gap={'sm'}
@@ -837,8 +821,10 @@ const AgentList: React.FC<AgentListProps> = ({
           </Tooltip>
         </Flex>
       </Flex>
-      <Table
+      <BAITable
         bordered
+        size="small"
+        neoStyle
         scroll={{ x: 'max-content' }}
         rowKey={'id'}
         dataSource={filterNonNullItems(agent_list?.items)}
@@ -858,40 +844,34 @@ const AgentList: React.FC<AgentListProps> = ({
             return `${range[0]}-${range[1]} of ${total} items`;
           },
           pageSizeOptions: ['10', '20', '50'],
-          style: { marginRight: token.marginXS },
+          extraContent: (
+            <Button
+              type="text"
+              icon={<SettingOutlined />}
+              onClick={() => {
+                toggleColumnSettingModal();
+              }}
+            />
+          ),
+          onChange(current, pageSize) {
+            startPageChangeTransition(() => {
+              if (_.isNumber(current) && _.isNumber(pageSize)) {
+                setTablePaginationOption({
+                  current,
+                  pageSize,
+                });
+              }
+            });
+          },
         }}
-        onChange={({ pageSize, current }, filters, sorter) => {
+        onChangeOrder={(order) => {
           startPageChangeTransition(() => {
-            if (_.isNumber(current) && _.isNumber(pageSize)) {
-              setTablePaginationOption({
-                current,
-                pageSize,
-              });
-            }
-            setOrder(transformSorterToOrderString(sorter));
+            setOrder(order);
           });
         }}
-        loading={{
-          spinning:
-            isPendingPageChange || isPendingStatusFetch || isPendingFilter,
-          indicator: <LoadingOutlined />,
-        }}
+        loading={isPendingPageChange || isPendingStatusFetch || isPendingFilter}
         {...tableProps}
       />
-      <Flex
-        justify="end"
-        style={{
-          padding: token.paddingXXS,
-        }}
-      >
-        <Button
-          type="text"
-          icon={<SettingOutlined />}
-          onClick={() => {
-            toggleColumnSettingModal();
-          }}
-        />
-      </Flex>
       <AgentDetailModal
         agentDetailModalFrgmt={currentAgentInfo}
         open={!!currentAgentInfo}

--- a/react/src/components/BAICard.tsx
+++ b/react/src/components/BAICard.tsx
@@ -61,7 +61,7 @@ const BAICard: React.FC<BAICardProps> = ({
                 borderBottom: 'none',
               },
               body: {
-                paddingTop: token.marginXS,
+                paddingTop: cardProps.tabList ? token.margin : token.marginXS,
               },
             },
         styles,

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -133,7 +133,7 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
 
   return (
     <>
-      <BAITable<(typeof filteredSessions)[0]>
+      <BAITable
         resizable
         neoStyle
         rowKey={'id'}

--- a/react/src/components/SessionTemplateModal.tsx
+++ b/react/src/components/SessionTemplateModal.tsx
@@ -34,6 +34,13 @@ interface SessionTemplateModalProps
   extends Omit<BAIModalProps, 'onOk' | 'onCancel'> {
   onRequestClose: (formValue?: SessionLauncherFormValue) => void;
 }
+
+interface ParsedSessionHistory
+  extends SessionLauncherFormValue,
+    SessionHistory {
+  pinned?: boolean;
+}
+
 const SessionTemplateModal: React.FC<SessionTemplateModalProps> = ({
   ...modalProps
 }) => {
@@ -50,7 +57,7 @@ const SessionTemplateModal: React.FC<SessionTemplateModalProps> = ({
   const [, setSelectedHistoryId] = useState<string>();
   const { token } = theme.useToken();
 
-  const parsedSessionHistory = useMemo(() => {
+  const parsedSessionHistory: Array<ParsedSessionHistory> = useMemo(() => {
     const parseToFormValues = (history: SessionHistory, isPinned: boolean) => {
       const params = new URLSearchParams(history.params);
       const formValues: SessionLauncherFormValue = JSON.parse(
@@ -98,7 +105,7 @@ const SessionTemplateModal: React.FC<SessionTemplateModalProps> = ({
         <Typography.Text>
           {t('session.launcher.YouCanStartWithHistory')}
         </Typography.Text>
-        <BAITable
+        <BAITable<ParsedSessionHistory>
           rowSelection={{
             selectedRowKeys: pinnedSessionHistory?.map((item) => item.id),
             columnWidth: 0,

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -5,7 +5,6 @@ import {
 } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
-import BAICard from './BAICard';
 import BAIFetchKeyButton from './BAIFetchKeyButton';
 import CephIcon from './BAIIcons/CephIcon';
 import PureStorageIcon from './BAIIcons/PureStorageIcon';
@@ -264,17 +263,9 @@ const StorageProxyList = () => {
   }, [storage_volume_list]);
 
   return (
-    <BAICard
-      variant="borderless"
-      styles={{
-        header: {
-          borderBottom: 'none',
-        },
-      }}
-    >
-      <Flex direction="column" align="stretch" gap="sm">
-        <Flex justify="end" wrap="wrap" gap="sm">
-          {/* // TODO: implement filter when filter and order are supported
+    <Flex direction="column" align="stretch" gap="sm">
+      <Flex justify="end" wrap="wrap" gap="sm">
+        {/* // TODO: implement filter when filter and order are supported
           <BAIPropertyFilter
             filterProperties={[
               {
@@ -284,51 +275,50 @@ const StorageProxyList = () => {
               },
             ]}
           /> */}
-          <BAIFetchKeyButton
-            loading={
-              deferredFetchKey !== fetchKey ||
-              deferredQueryVariables !== queryVariables
-            }
-            autoUpdateDelay={15_000}
-            value={fetchKey}
-            onChange={() => {
-              updateFetchKey();
-            }}
-          />
-        </Flex>
-        <BAITable
-          resizable
-          neoStyle
-          size="small"
-          scroll={{ x: 'max-content' }}
-          rowKey={'id'}
-          dataSource={filterNonNullItems(storage_volume_list?.items)}
-          columns={columns}
+        <BAIFetchKeyButton
           loading={
-            deferredQueryVariables !== queryVariables ||
-            deferredFetchKey !== fetchKey
+            deferredFetchKey !== fetchKey ||
+            deferredQueryVariables !== queryVariables
           }
-          pagination={{
-            pageSize: tablePaginationOption.pageSize,
-            current: tablePaginationOption.current,
-            total: storage_volume_list?.total_count ?? 0,
-            showTotal: (total) => (
-              <Typography.Text type="secondary">
-                {t('general.TotalItems', { total: total })}
-              </Typography.Text>
-            ),
+          autoUpdateDelay={15_000}
+          value={fetchKey}
+          onChange={() => {
+            updateFetchKey();
           }}
-          onChange={({ pageSize, current }) => {
+        />
+      </Flex>
+      <BAITable
+        resizable
+        neoStyle
+        size="small"
+        scroll={{ x: 'max-content' }}
+        rowKey={'id'}
+        dataSource={filterNonNullItems(storage_volume_list?.items)}
+        columns={columns}
+        loading={
+          deferredQueryVariables !== queryVariables ||
+          deferredFetchKey !== fetchKey
+        }
+        pagination={{
+          pageSize: tablePaginationOption.pageSize,
+          current: tablePaginationOption.current,
+          total: storage_volume_list?.total_count ?? 0,
+          showTotal: (total) => (
+            <Typography.Text type="secondary">
+              {t('general.TotalItems', { total: total })}
+            </Typography.Text>
+          ),
+          onChange(current, pageSize) {
             if (_.isNumber(current) && _.isNumber(pageSize)) {
               setTablePaginationOption({
                 pageSize,
                 current,
               });
             }
-          }}
-        />
-      </Flex>
-    </BAICard>
+          },
+        }}
+      />
+    </Flex>
   );
 };
 

--- a/react/src/components/UserCredentialList.tsx
+++ b/react/src/components/UserCredentialList.tsx
@@ -1,8 +1,4 @@
-import {
-  filterEmptyItem,
-  filterNonNullItems,
-  transformSorterToOrderString,
-} from '../helper';
+import { filterEmptyItem, filterNonNullItems } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import BAIPropertyFilter from './BAIPropertyFilter';
@@ -555,16 +551,20 @@ const UserCredentialList: React.FC = () => {
           // TODO: need to set more options to export CSV in current page's data
           pageSizeOptions: ['10', '20', '50'],
           style: { marginRight: token.marginXS },
+          onChange(current, pageSize) {
+            startPageChangeTransition(() => {
+              if (_.isNumber(current) && _.isNumber(pageSize)) {
+                setTablePaginationOption({
+                  current,
+                  pageSize,
+                });
+              }
+            });
+          },
         }}
-        onChange={({ pageSize, current }, filters, sorter) => {
+        onChangeOrder={(nextOrder) => {
           startPageChangeTransition(() => {
-            if (_.isNumber(current) && _.isNumber(pageSize)) {
-              setTablePaginationOption({
-                current,
-                pageSize,
-              });
-            }
-            setOrder(transformSorterToOrderString(sorter));
+            setOrder(nextOrder);
           });
         }}
       />

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -130,7 +130,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
 
   return (
     <>
-      <BAITable<(typeof filteredVFolders)[0]>
+      <BAITable
         resizable
         neoStyle
         showSorterTooltip={false}

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -12,11 +12,7 @@ import BAITabs from '../components/BAITabs';
 import TerminateSessionModal from '../components/ComputeSessionNodeItems/TerminateSessionModal';
 import Flex from '../components/Flex';
 import SessionNodes from '../components/SessionNodes';
-import {
-  filterNonNullItems,
-  handleRowSelectionChange,
-  transformSorterToOrderString,
-} from '../helper';
+import { filterNonNullItems, handleRowSelectionChange } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
@@ -416,7 +412,7 @@ const ComputeSessionListPage = () => {
             </Flex>
           </Flex>
           <SessionNodes
-            orderString={queryParams.order}
+            order={queryParams.order}
             onClickSessionName={(session) => {
               setSessionDetailId(session.row_id);
             }}
@@ -454,15 +450,14 @@ const ComputeSessionListPage = () => {
                   {t('general.TotalItems', { total: total })}
                 </Typography.Text>
               ),
+              onChange: (current, pageSize) => {
+                if (_.isNumber(current) && _.isNumber(pageSize)) {
+                  setTablePaginationOption({ current, pageSize });
+                }
+              },
             }}
-            onChange={({ current, pageSize }, filters, sorter) => {
-              if (_.isNumber(current) && _.isNumber(pageSize)) {
-                setTablePaginationOption({ current, pageSize });
-              }
-              setQuery(
-                { order: transformSorterToOrderString(sorter) },
-                'replaceIn',
-              );
+            onChangeOrder={(order) => {
+              setQuery({ order }, 'replaceIn');
             }}
           />
         </Flex>

--- a/react/src/pages/ResourcesPage.tsx
+++ b/react/src/pages/ResourcesPage.tsx
@@ -1,6 +1,7 @@
 import AgentList from '../components/AgentList';
+import BAICard from '../components/BAICard';
 import StorageProxyList from '../components/StorageProxyList';
-import { Card, Skeleton, theme } from 'antd';
+import { Skeleton, theme } from 'antd';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
@@ -20,7 +21,7 @@ const ResourcesPage: React.FC<ResourcesPageProps> = (props) => {
   const { token } = theme.useToken();
 
   return (
-    <Card
+    <BAICard
       activeTabKey={curTabKey}
       onTabChange={(key) => setCurTabKey(key as TabKey)}
       tabList={[
@@ -37,13 +38,6 @@ const ResourcesPage: React.FC<ResourcesPageProps> = (props) => {
           tab: t('general.ResourceGroup'),
         },
       ]}
-      styles={{
-        body: {
-          padding: 0,
-          paddingTop: 1,
-          overflow: 'hidden',
-        },
-      }}
     >
       {curTabKey === 'agents' ? (
         // To remove duplicated border in the bordered table, we need to remove margin of the container.
@@ -55,7 +49,7 @@ const ResourcesPage: React.FC<ResourcesPageProps> = (props) => {
             />
           }
         >
-          <AgentList containerStyle={{ marginLeft: -1, marginRight: -1 }} />
+          <AgentList />
         </Suspense>
       ) : null}
       {curTabKey === 'storages' ? (
@@ -74,7 +68,7 @@ const ResourcesPage: React.FC<ResourcesPageProps> = (props) => {
         // @ts-ignore
         <backend-ai-resource-group-list active />
       ) : null}
-    </Card>
+    </BAICard>
   );
 };
 

--- a/react/src/pages/ServingPage.tsx
+++ b/react/src/pages/ServingPage.tsx
@@ -6,7 +6,7 @@ import BAIPropertyFilter, {
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import EndpointList from '../components/EndpointList';
 import Flex from '../components/Flex';
-import { filterEmptyItem, transformSorterToOrderString } from '../helper';
+import { filterEmptyItem } from '../helper';
 import { useUpdatableState, useWebUINavigate } from '../hooks';
 import { useCurrentUserRole } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
@@ -201,17 +201,16 @@ const ServingPage: React.FC = () => {
                     {t('general.TotalItems', { total: total })}
                   </Typography.Text>
                 ),
+                onChange(current, pageSize) {
+                  if (_.isNumber(current) && _.isNumber(pageSize)) {
+                    setTablePaginationOption({ current, pageSize });
+                  }
+                },
               }}
-              orderString={queryParams.order}
+              order={queryParams.order}
               loading={deferredQueryVariables !== queryVariables}
-              onChange={({ current, pageSize }, filters, sorter) => {
-                if (_.isNumber(current) && _.isNumber(pageSize)) {
-                  setTablePaginationOption({ current, pageSize });
-                }
-                setQuery(
-                  { order: transformSorterToOrderString(sorter) },
-                  'replaceIn',
-                );
+              onChangeOrder={(order) => {
+                setQuery({ order }, 'replaceIn');
               }}
               onDeleted={() => {
                 updateFetchKey();

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -20,7 +20,6 @@ import {
   filterEmptyItem,
   filterNonNullItems,
   handleRowSelectionChange,
-  transformSorterToOrderString,
 } from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
@@ -539,7 +538,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             </Flex>
           </Flex>
           <VFolderNodes
-            orderString={queryParams.order}
+            order={queryParams.order}
             loading={deferredQueryVariables !== queryVariables}
             vfoldersFrgmt={filterNonNullItems(
               _.map(vfolder_nodes?.edges, 'node'),
@@ -576,15 +575,14 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                   {t('general.TotalItems', { total: total })}
                 </Typography.Text>
               ),
+              onChange(current, pageSize) {
+                if (_.isNumber(current) && _.isNumber(pageSize)) {
+                  setTablePaginationOption({ current, pageSize });
+                }
+              },
             }}
-            onChange={({ current, pageSize }, filters, sorter) => {
-              if (_.isNumber(current) && _.isNumber(pageSize)) {
-                setTablePaginationOption({ current, pageSize });
-              }
-              setQuery(
-                { order: transformSorterToOrderString(sorter) },
-                'replaceIn',
-              );
+            onChangeOrder={(order) => {
+              setQuery({ order }, 'replaceIn');
             }}
             onRequestChange={(updatedFolderId) => {
               setSelectedFolderList((prevSelected) =>


### PR DESCRIPTION
Resolves #3625 (FR-966)

Refactored the BAITable component to provide better pagination control and flexibility. The main changes include:

- Separated pagination from the Table component to allow for custom content next to pagination
- Added support for extra content in the pagination area through a new `extraContent` property
- Improved the sorting mechanism by replacing `orderString` with `order` and `onChangeOrder` props
- Fixed TypeScript types for better type safety and developer experience
- Updated all component implementations to use the new API pattern
- Apply `BAITable` with `extraContent` prop to AgentList

These changes make the BAITable component more versatile while maintaining its existing functionality.