### PR TITLE
feat(FR-976): Session live stat badge

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
@@ -1,10 +1,24 @@
 import { convertBinarySizeUnit } from '../../helper';
-import { useResourceSlotsDetails } from '../../hooks/backendai';
+import {
+  ResourceSlotName,
+  useResourceSlotsDetails,
+} from '../../hooks/backendai';
+import { useSessionLiveStat } from '../../hooks/useSessionNodeLiveStat';
+import Flex from '../Flex';
+import { displayMemoryUsage } from '../SessionUsageMonitor';
 import { SessionSlotCellFragment$key } from './__generated__/SessionSlotCellFragment.graphql';
-import { Divider, Typography } from 'antd';
+import {
+  Badge,
+  BadgeProps,
+  Divider,
+  theme,
+  Tooltip,
+  TooltipProps,
+  Typography,
+} from 'antd';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
-import React, { Fragment } from 'react';
+import React from 'react';
 import { useFragment } from 'react-relay';
 
 interface OccupiedSlotViewProps {
@@ -22,25 +36,64 @@ const SessionSlotCell: React.FC<OccupiedSlotViewProps> = ({
     graphql`
       fragment SessionSlotCellFragment on ComputeSessionNode {
         id
+        status
         occupied_slots
         requested_slots
+        ...useSessionNodeLiveStatSessionFragment
       }
     `,
     sessionFrgmt,
   );
 
-  const slots = JSON.parse(
+  const { liveStat } = useSessionLiveStat(session);
+
+  const slots: {
+    [key in ResourceSlotName]?: string;
+  } = JSON.parse(
     (mode === 'occupied' ? session.occupied_slots : session.requested_slots) ||
       '{}',
   );
 
   if (type === 'cpu') {
-    return slots.cpu ?? '-';
+    const displayPercent =
+      (liveStat.cpu_util?.pct ? parseFloat(liveStat.cpu_util?.pct) : 0) /
+      parseFloat(slots.cpu ?? '1');
+    const cpuUtilPercentNumber = liveStat.cpu_util?.pct
+      ? parseFloat(liveStat.cpu_util.pct)
+      : 0;
+    const maxPercent = parseFloat(slots.cpu ?? '1') * 100;
+    return slots.cpu ? (
+      <UsageBadge
+        percent={displayPercent}
+        text={slots.cpu}
+        tooltip={{
+          title: liveStat.cpu_util
+            ? `${cpuUtilPercentNumber.toFixed(1)}% / ${maxPercent}%`
+            : undefined,
+          placement: 'left',
+        }}
+      />
+    ) : (
+      '-'
+    );
   } else if (type === 'mem') {
     const mem = slots.mem ?? '-';
-    return mem === '-'
-      ? mem
-      : convertBinarySizeUnit(mem, 'G', 3)?.numberFixed + ' GiB';
+    return mem === '-' ? (
+      mem
+    ) : (
+      <UsageBadge
+        percent={liveStat.mem?.pct ? parseFloat(liveStat.mem.pct) : 0}
+        tooltip={{
+          // title: liveStat.mem ? `${liveStat.mem.pct} %` : undefined,
+          title: displayMemoryUsage(
+            liveStat.mem?.current,
+            liveStat.mem?.capacity,
+          ),
+          placement: 'left',
+        }}
+        text={convertBinarySizeUnit(mem, 'G', 3)?.numberFixed + ' GiB'}
+      />
+    );
   } else if (type === 'accelerator') {
     const occupiedAccelerators = _.omit(slots, ['cpu', 'mem']);
 
@@ -48,20 +101,83 @@ const SessionSlotCell: React.FC<OccupiedSlotViewProps> = ({
       occupiedAccelerators,
       (value) => _.toNumber(value) <= 0 || _.isNaN(_.toNumber(value)),
     );
-    return _.every(filteredAccelerators, (value) => value === 0)
+    return _.every(filteredAccelerators, (value) => parseFloat(value) === 0)
       ? '-'
       : _.map(filteredAccelerators, (value, key) => {
+          const statKey = key.split('.')[0];
+          const memStat = liveStat[statKey + '_mem'];
+
+          const percentNumber = memStat?.pct ? parseFloat(memStat.pct) : 0;
           return (
-            <Fragment key={key}>
-              <Typography.Text>{value}</Typography.Text>
+            <Flex
+              direction="row"
+              key={key}
+              align="start"
+              style={{ minWidth: 100 }}
+            >
+              <UsageBadge
+                percent={percentNumber}
+                tooltip={{
+                  // title: memStat ? `${memStat.pct} %` : undefined,
+                  title:
+                    displayMemoryUsage(memStat?.current, memStat?.capacity) +
+                    (memStat?.pct !== undefined
+                      ? ` (${percentNumber.toFixed(1)} %)`
+                      : ''),
+                  placement: 'left',
+                }}
+                text={value}
+              />
               <Divider type="vertical" />
               <Typography.Text>
                 {mergedResourceSlots?.[key]?.display_unit}
               </Typography.Text>
-            </Fragment>
+            </Flex>
           );
         });
   }
+};
+
+interface UsageBadgeProps extends Omit<BadgeProps, 'color' | 'status'> {
+  percent: number;
+  tooltip?: TooltipProps;
+}
+const UsageBadge: React.FC<UsageBadgeProps> = ({
+  tooltip,
+  percent,
+  ...badgeProps
+}) => {
+  const { token } = theme.useToken();
+  const extraProps: Pick<BadgeProps, 'status' | 'color' | 'styles'> = !percent
+    ? {
+        status: 'default',
+        styles: {
+          indicator: {
+            border: '1px solid',
+            borderColor: token.colorTextDisabled,
+            backgroundColor: 'transparent',
+          },
+        },
+      }
+    : percent < 50
+      ? {
+          status: 'default',
+        }
+      : percent < 80
+        ? {
+            status: 'warning',
+          }
+        : {
+            status: 'processing',
+            color: 'red',
+          };
+  return (
+    <Tooltip {...tooltip}>
+      <div>
+        <Badge {...badgeProps} {...extraProps} />
+      </div>
+    </Tooltip>
+  );
 };
 
 export default SessionSlotCell;

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -4,14 +4,11 @@ import BAITable, { BAITableProps } from './BAITable';
 import SessionReservation from './ComputeSessionNodeItems/SessionReservation';
 import SessionSlotCell from './ComputeSessionNodeItems/SessionSlotCell';
 import SessionStatusTag from './ComputeSessionNodeItems/SessionStatusTag';
-import Flex from './Flex';
-import SessionUsageMonitor from './SessionUsageMonitor';
 import {
   SessionNodesFragment$data,
   SessionNodesFragment$key,
 } from './__generated__/SessionNodesFragment.graphql';
 import { ColumnType } from 'antd/es/table';
-import { theme } from 'antd/lib';
 import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React from 'react';
@@ -33,7 +30,6 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
   ...tableProps
 }) => {
   const { t } = useTranslation();
-  const { token } = theme.useToken();
 
   const sessions = useFragment(
     graphql`
@@ -46,8 +42,6 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
         ...SessionReservationFragment
         ...SessionSlotCellFragment
         ...SessionUsageMonitorFragment
-        # fix: This fragment is not used in this component, but it is required by the SessionStatusDetailModal.
-        # It might be a bug in relay
       }
     `,
     sessionsFrgmt,
@@ -85,21 +79,22 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
           return <SessionStatusTag sessionFrgmt={session} />;
         },
       },
-      {
-        key: 'utils',
-        title: t('session.Utilization'),
-        render: (__, session) => {
-          return (
-            <Flex
-              style={{
-                paddingLeft: token.paddingXS,
-              }}
-            >
-              <SessionUsageMonitor size="small" sessionFrgmt={session} />
-            </Flex>
-          );
-        },
-      },
+      // This column will be added back when the session list column setting ui is ready
+      // {
+      //   key: 'utils',
+      //   title: t('session.Utilization'),
+      //   render: (__, session) => {
+      //     return (
+      //       <Flex
+      //         style={{
+      //           paddingLeft: token.paddingXS,
+      //         }}
+      //       >
+      //         <SessionUsageMonitor size="small" sessionFrgmt={session} />
+      //       </Flex>
+      //     );
+      //   },
+      // },
       {
         key: 'accelerator',
         title: t('session.launcher.AIAccelerator'),

--- a/react/src/components/SessionUsageMonitor.tsx
+++ b/react/src/components/SessionUsageMonitor.tsx
@@ -148,16 +148,6 @@ const SessionUsageMonitor: React.FC<SessionUsageMonitorProps> = ({
     [liveStat],
   );
 
-  const displayMemoryUsage = (
-    current: string,
-    capacity: string,
-    decimalSize: number = 2,
-  ) => {
-    return `${convertBinarySizeUnit(current, 'g', decimalSize)?.numberFixed ?? '-'} / ${
-      convertBinarySizeUnit(capacity, 'g', decimalSize)?.numberFixed ?? '-'
-    } GiB`;
-  };
-
   const displayTargetName =
     displayTarget === 'current'
       ? 'current'
@@ -301,6 +291,16 @@ const SessionUsageMonitor: React.FC<SessionUsageMonitorProps> = ({
       )}
     </Row>
   );
+};
+
+export const displayMemoryUsage = (
+  current: string | undefined,
+  capacity: string | undefined,
+  decimalSize: number = 2,
+) => {
+  return `${convertBinarySizeUnit(current, 'g', decimalSize)?.numberFixed ?? '-'} GiB / ${
+    convertBinarySizeUnit(capacity, 'g', decimalSize)?.numberFixed ?? '-'
+  } GiB`;
 };
 
 export default SessionUsageMonitor;

--- a/react/src/hooks/useSessionNodeLiveStat.tsx
+++ b/react/src/hooks/useSessionNodeLiveStat.tsx
@@ -1,0 +1,80 @@
+import { useSessionNodeLiveStatSessionFragment$key } from './__generated__/useSessionNodeLiveStatSessionFragment.graphql';
+import graphql from 'babel-plugin-relay/macro';
+import _ from 'lodash';
+import { useMemo } from 'react';
+import { useFragment } from 'react-relay';
+
+interface ResourceStatItem {
+  current: string;
+  capacity: string;
+  pct: string;
+  unit_hint: string;
+  'stats.max'?: string;
+  'stats.avg'?: string;
+  'stats.rate'?: string;
+  [key: string]: string | undefined; // For any other potential stats fields
+}
+
+interface SessionLiveStats {
+  cuda_util?: ResourceStatItem;
+  cpu_util?: ResourceStatItem;
+  cuda_mem?: ResourceStatItem;
+  cpu_used?: ResourceStatItem;
+  mem?: ResourceStatItem;
+  io_read?: ResourceStatItem;
+  io_write?: ResourceStatItem;
+  net_rx?: ResourceStatItem;
+  net_tx?: ResourceStatItem;
+  io_scratch_size?: ResourceStatItem;
+  [key: string]: ResourceStatItem | undefined; // For any other resource metrics that may be present
+}
+
+export const useSessionLiveStat = (
+  kernelFrgmt: useSessionNodeLiveStatSessionFragment$key,
+) => {
+  const session = useFragment(
+    graphql`
+      fragment useSessionNodeLiveStatSessionFragment on ComputeSessionNode {
+        id
+        kernel_nodes {
+          edges {
+            node {
+              live_stat
+            }
+          }
+        }
+      }
+    `,
+    kernelFrgmt,
+  );
+
+  const firstKernelNode = session?.kernel_nodes?.edges[0]?.node;
+  const liveStat: SessionLiveStats = useMemo(() => {
+    return JSON.parse(firstKernelNode?.live_stat ?? '{}');
+  }, [firstKernelNode?.live_stat]);
+
+  const sortedLiveStatArray = useMemo(
+    () =>
+      _.keys(liveStat)
+        .sort((a, b) => {
+          const aUtil = a.includes('_util');
+          const bUtil = b.includes('_util');
+          const aMem = a.includes('_mem');
+          const bMem = b.includes('_mem');
+
+          if (aUtil && !bUtil) return -1;
+          if (!aUtil && bUtil) return 1;
+          if (aMem && !bMem) return -1;
+          if (!aMem && bMem) return 1;
+
+          return 0;
+        })
+        .map((key) => ({
+          key,
+          value: liveStat[key],
+        })),
+    [liveStat],
+  );
+
+  return { liveStat, sortedLiveStatArray };
+};


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/82729b10-c38e-4473-898d-33b5b38081a8.png)

# Add Usage Badge Indicators to Session Slot Cells

This PR enhances the session resource monitoring by adding visual indicators that show resource usage directly in the session slot cells. It adds colored status badges that change based on usage percentage thresholds (warning at 50%, critical at 80%).

Key changes:
- Added usage badges to CPU, memory, and accelerator resource displays
- Implemented tooltips showing detailed usage information (current/capacity)
- Moved session usage monitoring logic from a separate component into the slot cells
- Added a new `useSessionLiveStat` hook to handle resource statistics
- Enhanced `BAISelect` component with optional title support in dropdown


The badge changes based on the percentage value:
- At 0%, it displays as a gray circle with only a border.
- For values below 50%, it appears as a filled gray circle.
- For values from 50% to below 80%, it appears as a yellow circle.
- At 80% and above, it appears as a red circle.