### PR TITLE
fix(FR-978): Comprehensive backward compatibility check (24.09.x) before 25.8.0 release

### DIFF
--- a/react/src/components/MySessionCard.tsx
+++ b/react/src/components/MySessionCard.tsx
@@ -27,7 +27,7 @@ const MySessionCard: React.FC<MySessionCardProps> = ({
     graphql`
         fragment  MySessionCardQueryFragment on Queries
         @argumentDefinitions(
-          projectId: { type: UUID }
+          projectId: { type: "UUID!" }
         ) 
         @refetchable(queryName: "MySessionCardQueryFragmentRefetchQuery") {
           myInteractive: compute_session_nodes(

--- a/react/src/components/RecentlyCreatedSessionCard.tsx
+++ b/react/src/components/RecentlyCreatedSessionCard.tsx
@@ -32,7 +32,7 @@ const RecentlyCreatedSessionCard: React.FC<RecentlyCreatedSessionCardProps> = ({
     graphql`
       fragment RecentlyCreatedSessionCardFragment on Queries
       @argumentDefinitions(
-        projectId: { type: "UUID" }
+        projectId: { type: "UUID!" }
       )
       @refetchable(queryName: "RecentlyCreatedSessionCardRefetchQuery") {
         compute_session_nodes(

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -23,7 +23,7 @@ const DashboardPage: React.FC = () => {
   const [isPendingRefetch, startRefetchTransition] = useTransition();
   const queryRef = useLazyLoadQuery<DashboardPageQuery>(
     graphql`
-      query DashboardPageQuery($projectId: UUID) {
+      query DashboardPageQuery($projectId: UUID!) {
         ...MySessionCardQueryFragment @arguments(projectId: $projectId)
         ...RecentlyCreatedSessionCardFragment @arguments(projectId: $projectId)
       }


### PR DESCRIPTION
https://lablup.atlassian.net/browse/FR-978
Resolves #3643 (FR-978)

Updated the `projectId` parameter in the `DashboardPageQuery` GraphQL query to be non-nullable by changing its type from `UUID` to `UUID!`. This ensures that the query will always require a project ID to be provided, preventing potential null reference issues.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after