### PR TITLE
fix(FR-951): Add white-space pre-wrap to code blocks

### DIFF
--- a/react/src/components/Chat/ChatMessageContent.tsx
+++ b/react/src/components/Chat/ChatMessageContent.tsx
@@ -113,7 +113,11 @@ const ChatMessageContentBlock = memo<{ block?: string; isStreaming?: boolean }>(
             </Flex>
           </Flex>
         ) : (
-          <code {...rest} className={className}>
+          <code
+            {...rest}
+            style={{ whiteSpace: 'pre-wrap' }}
+            className={className}
+          >
             {/* @ts-ignore */}
             {children}
           </code>

--- a/react/src/components/Chat/SyntaxHighight.tsx
+++ b/react/src/components/Chat/SyntaxHighight.tsx
@@ -14,7 +14,7 @@ export const SyntaxHighlighter = memo<SyntaxHighlighterProps>(
       <>
         {isLoading || !data ? (
           <pre>
-            <code>{children}</code>
+            <code style={{ whiteSpace: 'pre-wrap' }}>{children}</code>
           </pre>
         ) : (
           <div dangerouslySetInnerHTML={{ __html: data as string }} dir="ltr" />


### PR DESCRIPTION
resolves #3613 (FR-951)

# Fix code block wrapping in chat messages

This PR adds `whiteSpace: 'pre-wrap'` styling to code elements in both `ChatMessageContent.tsx` and `SyntaxHighight.tsx` to ensure that code blocks properly wrap text instead of overflowing their containers.
