### PR TITLE
refactor(FR-844): migrate Terms of Service modal to react component

### DIFF
--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -16,6 +16,7 @@ import Flex from '../Flex';
 import ThemeReverseProvider from '../ReverseThemeProvider';
 import SiderToggleButton from '../SiderToggleButton';
 import SignoutModal from '../SignoutModal';
+import TermsOfServiceModal from '../TermsOfServiceModal';
 import WebUILink from '../WebUILink';
 import { PluginPage, WebUIPluginType } from './MainLayout';
 import {
@@ -126,6 +127,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
     baiClient?.supports('user-committed-image') ?? false;
 
   const [isOpenSignoutModal, { toggle: toggleSignoutModal }] = useToggle(false);
+  const [isOpenTOSModal, { toggle: toggleTOSModal }] = useToggle(false);
 
   const siderRef = useRef<HTMLDivElement>(null);
   const isSiderHover = useHover(siderRef);
@@ -573,9 +575,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
                   type="secondary"
                   style={{ fontSize: 11 }}
                   onClick={() => {
-                    document.dispatchEvent(
-                      new CustomEvent('show-TOS-agreement'),
-                    );
+                    toggleTOSModal();
                   }}
                 >
                   {t('webui.menu.TermsOfService')}
@@ -638,6 +638,10 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
           </Typography.Text>
         </Flex>
       )}
+      <TermsOfServiceModal
+        open={isOpenTOSModal}
+        onRequestClose={toggleTOSModal}
+      />
     </BAISider>
   );
 };

--- a/react/src/components/TermsOfServiceModal.tsx
+++ b/react/src/components/TermsOfServiceModal.tsx
@@ -1,0 +1,59 @@
+import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import BAIModal, { BAIModalProps } from './BAIModal';
+import { Skeleton } from 'antd';
+import { Suspense, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface TermsOfServiceModalProps extends BAIModalProps {
+  onRequestClose: () => void;
+}
+
+const RenderTOSHtml = () => {
+  const [selectedLanguage] = useBAISettingUserState('selected_language');
+  const defaultLanguage =
+    globalThis.navigator.language &&
+    globalThis.navigator.language.split('-')[0] === 'ko'
+      ? 'ko'
+      : 'en';
+  const language = useMemo(() => {
+    if (!selectedLanguage) {
+      return defaultLanguage;
+    }
+    return selectedLanguage === 'ko' ? 'ko' : 'en';
+  }, [selectedLanguage, defaultLanguage]);
+
+  const { data } = useSuspenseTanQuery({
+    queryKey: ['termsOfService', language],
+    staleTime: 1000 * 60 * 30,
+    gcTime: 1000 * 60 * 60,
+    queryFn: () =>
+      fetch(`/resources/documents/terms-of-service.${language}.html`).then(
+        (response) => response.text(),
+      ),
+  });
+  return <div dangerouslySetInnerHTML={{ __html: data }} />;
+};
+
+const TermsOfServiceModal = ({
+  onRequestClose,
+  ...props
+}: TermsOfServiceModalProps) => {
+  const { t } = useTranslation();
+  return (
+    <BAIModal
+      title={t('webui.menu.TermsOfService')}
+      onCancel={onRequestClose}
+      destroyOnClose
+      footer={null}
+      width={'80%'}
+      {...props}
+    >
+      <Suspense fallback={<Skeleton active />}>
+        <RenderTOSHtml />
+      </Suspense>
+    </BAIModal>
+  );
+};
+
+export default TermsOfServiceModal;


### PR DESCRIPTION
resolves #3512 [(FR-844)](https://lablup.atlassian.net/browse/FR-844)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->
Migrate the Terms of Service to a React modal in that PR. This modal is only active in parts that are written in React.

**changes** 
* add `TermsOfServiceModal.tsx`
* The modal has a width of `80%` and I'm not sure if that value is appropriate.

You can enable the modal by clicking on Terms of Service at the bottom of the side menu.

![CleanShot 2025-05-14 at 11.51.24@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/642284a6-05b9-490a-bb06-7c43e9b6309e.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
