### PR TITLE
refactor(FR-992): migrate Privacy Policy modal to NEO Style react component

### DIFF
--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -13,6 +13,7 @@ import SessionsIcon from '../BAIIcons/SessionsIcon';
 import BAIMenu from '../BAIMenu';
 import BAISider, { BAISiderProps } from '../BAISider';
 import Flex from '../Flex';
+import PrivacyPolicyModal from '../PrivacyPolicyModal';
 import ThemeReverseProvider from '../ReverseThemeProvider';
 import SiderToggleButton from '../SiderToggleButton';
 import SignoutModal from '../SignoutModal';
@@ -128,6 +129,8 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
 
   const [isOpenSignoutModal, { toggle: toggleSignoutModal }] = useToggle(false);
   const [isOpenTOSModal, { toggle: toggleTOSModal }] = useToggle(false);
+  const [isOpenPrivacyPolicyModal, { toggle: togglePrivacyPolicyModal }] =
+    useToggle(false);
 
   const siderRef = useRef<HTMLDivElement>(null);
   const isSiderHover = useHover(siderRef);
@@ -585,9 +588,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
                   type="secondary"
                   style={{ fontSize: 11 }}
                   onClick={() => {
-                    document.dispatchEvent(
-                      new CustomEvent('show-PP-agreement'),
-                    );
+                    togglePrivacyPolicyModal();
                   }}
                 >
                   {t('webui.menu.PrivacyPolicy')}
@@ -641,6 +642,10 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
       <TermsOfServiceModal
         open={isOpenTOSModal}
         onRequestClose={toggleTOSModal}
+      />
+      <PrivacyPolicyModal
+        open={isOpenPrivacyPolicyModal}
+        onRequestClose={togglePrivacyPolicyModal}
       />
     </BAISider>
   );

--- a/react/src/components/PrivacyPolicyModal.tsx
+++ b/react/src/components/PrivacyPolicyModal.tsx
@@ -1,0 +1,59 @@
+import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
+import BAIModal, { BAIModalProps } from './BAIModal';
+import { Skeleton } from 'antd';
+import { Suspense, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface PrivacyPolicyModalProps extends BAIModalProps {
+  onRequestClose: () => void;
+}
+
+const RenderPrivacyPolicyHtml = () => {
+  const [selectedLanguage] = useBAISettingUserState('selected_language');
+  const defaultLanguage =
+    globalThis.navigator.language &&
+    globalThis.navigator.language.split('-')[0] === 'ko'
+      ? 'ko'
+      : 'en';
+  const language = useMemo(() => {
+    if (!selectedLanguage) {
+      return defaultLanguage;
+    }
+    return selectedLanguage === 'ko' ? 'ko' : 'en';
+  }, [selectedLanguage, defaultLanguage]);
+
+  const { data } = useSuspenseTanQuery({
+    queryKey: ['termsOfService', language],
+    staleTime: 1000 * 60 * 30,
+    gcTime: 1000 * 60 * 60,
+    queryFn: () =>
+      fetch(`/resources/documents/privacy-policy.${language}.html`).then(
+        (response) => response.text(),
+      ),
+  });
+  return <div dangerouslySetInnerHTML={{ __html: data }} />;
+};
+
+const PrivacyPolicyModal = ({
+  onRequestClose,
+  ...props
+}: PrivacyPolicyModalProps) => {
+  const { t } = useTranslation();
+  return (
+    <BAIModal
+      title={t('webui.menu.PrivacyPolicy')}
+      onCancel={onRequestClose}
+      destroyOnClose
+      footer={null}
+      width={'80%'}
+      {...props}
+    >
+      <Suspense fallback={<Skeleton active />}>
+        <RenderPrivacyPolicyHtml />
+      </Suspense>
+    </BAIModal>
+  );
+};
+
+export default PrivacyPolicyModal;


### PR DESCRIPTION
resolves #NNN (FR-992)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

Migrate the `Privacy Policy` modal from that PR to a React component in NEO Style. This modal is only visible in React.

**changes**
* add `PrivacyPolicyModal`
* If the language is anything other than Korean, it will be displayed in English.

You can view this modal by clicking the `privacy policy` button at the bottom of the side menu.

![CleanShot 2025-05-14 at 13.16.20@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/c9ec3597-1676-47f9-80ff-99403205550d.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
