### PR TITLE
fix(FR-994): Validate that TCP APPs are allowed when open app laucnher on session detail panel

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -349,6 +349,27 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         }
       },
     );
+    if (
+      typeof globalThis.backendaiclient === 'undefined' ||
+      globalThis.backendaiclient === null ||
+      globalThis.backendaiclient.ready === false
+    ) {
+      document.addEventListener(
+        'backend-ai-connected',
+        () => {
+          this.allowTCPApps =
+            globalThis.isElectron ||
+            globalThis.backendaiclient._config.allowNonAuthTCP;
+        },
+        {
+          once: true,
+        },
+      );
+    } else {
+      this.allowTCPApps =
+        globalThis.isElectron ||
+        globalThis.backendaiclient._config.allowNonAuthTCP;
+    }
   }
 
   async _viewStateChanged(active) {
@@ -576,9 +597,6 @@ export default class BackendAiAppLauncher extends BackendAIPage {
     if (Object.keys(appServicesOption).length > 0) {
       this.appSupportOption = appServicesOption;
     }
-    this.allowTCPApps =
-      globalThis.isElectron ||
-      globalThis.backendaiclient._config.allowNonAuthTCP;
 
     filteredAppServices.forEach((elm) => {
       if (elm in this.appTemplate) {
@@ -1197,7 +1215,6 @@ export default class BackendAiAppLauncher extends BackendAIPage {
               urlPostfix,
               TCP_APPS.indexOf(appName) === -1 || globalThis.isElectron,
             );
-
           // eligiblity for spawning TCP-based apps are already verified when first loading the app launcher icons, so here we assume that either non-auth TCP mode is enabled on system or user is using electron app
           if (TCP_APPS.indexOf(appName) !== -1 && this.allowTCPApps) {
             if (globalThis.isElectron) {


### PR DESCRIPTION
resolves #3660 (FR-994)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

### Fixed an issue where port information was not displayed correctly in connected info when running an ssh/sftp session from the session detail panel.

The app launcher running in the session detail panel is using the `backend-ai-app-launcher`. The `backend-ai-app-launcher` validates the tcp-based app spawn eligibility when the app launcher dialog is displayed on the screen. However, this process is missing when opening the app launcher in the session detail panel.

**Bug report:**
When refreshing after creating a new session but before the APP DIALOG was displayed, the port information was not displayed in the INFORMATION MODAL when executing SSH/SFTP through the SESSION DETAIL PANEL.

**How to test:**
- Connect to a test server with SSH/SFTP enabled (e.g. dogbowl).
- Create a new session and refresh the browser before opening the app launcher dialog
- Open the `session detail panel` and run ssh/sftp 
- Verify that information modal shows correct `user/host/port` 

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
