### PR TITLE
feat(FR-997): Linking the correct documentation page for a model service start/update

### DIFF
--- a/react/src/components/WEBUIHelpButton.tsx
+++ b/react/src/components/WEBUIHelpButton.tsx
@@ -15,6 +15,7 @@ const WEBUIHelpButton: React.FC<WEBUIHelpButtonProps> = ({ ...props }) => {
     summary: 'summary/summary.html',
     job: 'sessions_all/sessions_all.html',
     serving: 'model_serving/model_serving.html',
+    service: 'model_serving/model_serving.html',
     import: 'import_run/import_run.html',
     data: 'vfolder/vfolder.html',
     statistics: 'statistics/statistics.html',


### PR DESCRIPTION
https://lablup.atlassian.net/browse/FR-997
Resolves #3666 (FR-997)

# Add service page to help button mapping

This PR adds a mapping for the "service" page to the "model_serving/model_serving.html" help document, allowing users to access the appropriate help documentation when using the service page.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after