### PR TITLE
feat(FR-1002): Infinite scrolling of EndpointSelect

### DIFF
--- a/react/src/components/TotalFooter.tsx
+++ b/react/src/components/TotalFooter.tsx
@@ -1,0 +1,33 @@
+import Flex from './Flex';
+import { LoadingOutlined } from '@ant-design/icons';
+import { theme, Typography } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+const TotalFooter: React.FC<{
+  loading?: boolean;
+  total?: number;
+}> = ({ loading, total }) => {
+  const { token } = theme.useToken();
+  const { t } = useTranslation();
+  return (
+    <Flex justify="end" gap={'xs'}>
+      {loading ? (
+        <LoadingOutlined
+          spin
+          style={{
+            color: token.colorTextSecondary,
+          }}
+        />
+      ) : (
+        <div />
+      )}
+      <Typography.Text type="secondary">
+        {t('general.TotalItems', {
+          total: total,
+        })}
+      </Typography.Text>
+    </Flex>
+  );
+};
+
+export default TotalFooter;

--- a/react/src/hooks/usePaginatedQuery.ts
+++ b/react/src/hooks/usePaginatedQuery.ts
@@ -1,0 +1,87 @@
+import { useEventNotStable } from './useEventNotStable';
+import _ from 'lodash';
+import { useState, useTransition, useMemo, useRef, useEffect } from 'react';
+import { GraphQLTaggedNode, useLazyLoadQuery } from 'react-relay';
+import { OperationType } from 'relay-runtime';
+
+type extraOptions<Result, ItemType> = {
+  getItem: (result: Result) => any;
+  getTotal: (result: Result) => number | undefined;
+  getId: (item: ItemType) => string | undefined | null;
+};
+export function useLazyPaginatedQuery<
+  T extends OperationType & {
+    variables: { limit: number; offset: number };
+  },
+  ItemType,
+>(
+  query: GraphQLTaggedNode,
+  initialPaginationVariables: Pick<T['variables'], 'limit'>,
+  otherVariables: Omit<Partial<T['variables']>, 'limit' | 'offset'>,
+  options: Parameters<typeof useLazyLoadQuery<T>>[2],
+  { getItem, getId, getTotal }: extraOptions<T['response'], ItemType>,
+) {
+  const previousResult = useRef<T['response'][]>([]);
+  const [isLoadingNext, startLoadingNextTransition] = useTransition();
+
+  // limit doesn't change after the first render
+  const [limit] = useState(initialPaginationVariables.limit);
+  const [offset, setOffset] = useState(0);
+
+  const previousOtherVariablesRef = useRef(otherVariables);
+
+  const isNewOtherVariables = !_.isEqual(
+    previousOtherVariablesRef.current,
+    otherVariables,
+  );
+
+  // Fetch the initial data using useLazyLoadQuery
+  const result = useLazyLoadQuery<T>(
+    query,
+    {
+      limit: isNewOtherVariables ? initialPaginationVariables.limit : limit,
+      offset: isNewOtherVariables ? 0 : offset,
+      ...otherVariables,
+    },
+    options,
+  );
+
+  const data = useMemo(() => {
+    const items = getItem(result);
+    if (isNewOtherVariables) {
+      previousResult.current = [];
+    }
+    return items
+      ? _.uniqBy([...previousResult.current, ...items], getId)
+      : undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [result]);
+
+  const hasNext = offset + limit < (getTotal(result) as number);
+
+  const loadNext = useEventNotStable(() => {
+    if (isLoadingNext || !hasNext) return;
+    previousResult.current = data || [];
+    startLoadingNextTransition(() => {
+      const nextOffset = offset + limit;
+      setOffset(nextOffset);
+    });
+  });
+
+  useEffect(() => {
+    // Reset the offset and limit when otherVariables change after success rendering
+    if (isNewOtherVariables) {
+      previousOtherVariablesRef.current = otherVariables;
+      setOffset(0);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isNewOtherVariables]);
+
+  return {
+    paginationData: data,
+    result,
+    loadNext,
+    hasNext,
+    isLoadingNext,
+  };
+}


### PR DESCRIPTION
Resolves #3669 (FR-1002)

## Enhanced BAISelect Component with Infinite Scrolling and Improved EndpointSelect

This PR enhances the BAISelect component with infinite scrolling capabilities and improves the EndpointSelect component to leverage these new features.

## Key Changes:

- Added infinite scrolling support to BAISelect with `endReached` callback
- Implemented scroll position tracking to detect when users reach the bottom of the dropdown
- Added footer support to display loading state and total item count
- Created a new `TotalFooter` component to show loading state and item counts
- Implemented `useLazyPaginatedQuery` hook for efficient data pagination
- Enhanced EndpointSelect to use the new pagination features
- Added optimistic UI updates for better user experience
- Improved search functionality with deferred value handling

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/458b9070-8fcb-4056-89df-f37150f0dfdf.png)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after