### PR TITLE
fix(FR-1003): Add scroll overflow to code blocks in chat messages

### DIFF
--- a/react/src/components/Chat/ChatMessageContent.tsx
+++ b/react/src/components/Chat/ChatMessageContent.tsx
@@ -98,6 +98,7 @@ const ChatMessageContentBlock = memo<{ block?: string; isStreaming?: boolean }>(
                 padding: token.paddingSM,
                 borderRadius: `0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px`,
                 margin: '-0.5em 0',
+                overflow: 'scroll',
               }}
             >
               <CodeBlock
@@ -113,14 +114,24 @@ const ChatMessageContentBlock = memo<{ block?: string; isStreaming?: boolean }>(
             </Flex>
           </Flex>
         ) : (
-          <code
-            {...rest}
-            style={{ whiteSpace: 'pre-wrap' }}
-            className={className}
+          <Flex
+            style={{
+              width: '100%',
+              padding: token.paddingSM,
+              borderRadius: `0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px`,
+              margin: '-0.5em 0',
+              overflow: 'scroll',
+            }}
           >
-            {/* @ts-ignore */}
-            {children}
-          </code>
+            <code
+              {...rest}
+              style={{ whiteSpace: 'pre-wrap' }}
+              className={className}
+            >
+              {/* @ts-ignore */}
+              {children}
+            </code>
+          </Flex>
         );
       },
       [isStreaming],


### PR DESCRIPTION
resolves #3672 (FR-1003)

# Add horizontal scrolling to code blocks in chat messages

This PR adds horizontal scrolling capability to code blocks in chat messages by:

1. Adding `overflow: 'scroll'` to the existing code block container
2. Wrapping inline code elements in a Flex container with the same styling as code blocks, including the overflow scroll property

These changes ensure that code content that exceeds the width of the chat message container can be scrolled horizontally rather than wrapping or being cut off.

![Screenshot 2025-05-16 at 11.00.05 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/JFysNkoR8J15CnzOUuvH/ca4cc625-2620-44f5-9d65-a4fefe70de7a.png)

![Screenshot 2025-05-16 at 11.00.03 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/JFysNkoR8J15CnzOUuvH/435abd3a-5f51-4b79-a522-2466ade410ba.png)

