### PR TITLE
fix(FR-1008): Simplify EndpointSelectProps type and remove unused resource import

### DIFF
--- a/react/src/components/Chat/EndpointSelect.tsx
+++ b/react/src/components/Chat/EndpointSelect.tsx
@@ -20,17 +20,7 @@ export type Endpoint = NonNullable<
 >;
 
 export interface EndpointSelectProps
-  extends Omit<
-    SelectProps<
-      string,
-      {
-        label?: string | null;
-        value?: string | null;
-        endpoint?: Endpoint | null;
-      }
-    >,
-    'options' | 'labelInValue'
-  > {
+  extends Omit<SelectProps, 'options' | 'labelInValue'> {
   fetchKey?: string;
   lifecycleStageFilter?: LifecycleStage[];
 }
@@ -175,7 +165,6 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
     }
   }, [isValueMatched]);
   return (
-    // @ts-ignore
     <BAISelect
       ref={selectRef}
       placeholder={t('chatui.SelectEndpoint')}

--- a/src/backend-ai-app.ts
+++ b/src/backend-ai-app.ts
@@ -104,8 +104,6 @@ const loadPage =
         import('./components/backend-ai-serving-view.js');
         break;
       case 'agent':
-      case 'resource':
-        import('./components/backend-ai-resource-group-list.js');
         break;
       case 'verify-email':
         import('./components/backend-ai-email-verification-view.js');


### PR DESCRIPTION
Resolves #3679 (FR-1008)
## Fix TypeScript errors in EndpointSelect component and remove unused resource import

This PR fixes TypeScript errors in the EndpointSelect component by simplifying the type definition for EndpointSelectProps. It also removes an unused import for the resource group list component.

**Changes:**
- Simplified the EndpointSelectProps interface to extend from SelectProps directly
- Removed a @ts-ignore comment that is no longer needed
- Removed the 'resource' case and its associated import in backend-ai-app.ts

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after