### PR TITLE
fix(FR-1020): Change session name update method to use REST API

### DIFF
--- a/react/src/components/SessionNameFormItem.tsx
+++ b/react/src/components/SessionNameFormItem.tsx
@@ -10,7 +10,9 @@ export interface SessionNameFormItemValue {
   sessionName: string;
 }
 
-export const getSessionNameRules = (t: TFunction): FormItemProps['rules'] => [
+export const getSessionNameRules = (
+  t: TFunction,
+): Exclude<FormItemProps['rules'], undefined> => [
   {
     min: 4,
     message: t('session.validation.SessionNameTooShort'),


### PR DESCRIPTION
resolves #3695 (FR-1020)

### Refactor Session Rename Functionality to Use REST API

This PR refactors the session rename functionality to use the REST API instead of GraphQL mutation. The implementation now:

1. Uses `useTanMutation` with the REST API endpoint `/session/${session.name}/rename`
2. Adds validation to check for existing session names before attempting to rename
3. Improves the optimistic UI updates during rename operations
4. Adds proper transition states for better user experience

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after