### PR TITLE
feat(FR-1016): change using folderId instead of folderName when leaving a shared folder

### DIFF
--- a/react/src/components/SharedFolderPermissionInfoModal.tsx
+++ b/react/src/components/SharedFolderPermissionInfoModal.tsx
@@ -50,6 +50,7 @@ const SharedFolderPermissionInfoModal: React.FC<
       fragment SharedFolderPermissionInfoModalFragment on VirtualFolderNode {
         id
         name
+        row_id
         creator
         ownership_type
         user_email
@@ -62,8 +63,8 @@ const SharedFolderPermissionInfoModal: React.FC<
   );
 
   const leaveFolder = useTanMutation({
-    mutationFn: ({ folderName }: { folderName: string }) => {
-      return baiClient.vfolder.leave_invited(folderName);
+    mutationFn: ({ folderId }: { folderId: string }) => {
+      return baiClient.vfolder.leave_invited(folderId);
     },
   });
 
@@ -143,7 +144,7 @@ const SharedFolderPermissionInfoModal: React.FC<
                         onConfirm={() => {
                           leaveFolder.mutate(
                             {
-                              folderName: data?.name,
+                              folderId: data?.row_id,
                             },
                             {
                               onSuccess: () => {


### PR DESCRIPTION
resolves #3689 [(FR-1016)](https://lablup.atlassian.net/browse/FR-1016)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

Change the `leave` API to use `vfolderId` instead of `vfolderName` in the `leave` API to leave an invited folder. 

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
