### PR TITLE
fix(FR-1021): Set Tooltip popup container to document.body via ConfigProvider to fix layout shift

### DIFF
--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -12,7 +12,7 @@ import { useSuspendedBackendaiClient } from './hooks';
 import { useCurrentResourceGroupValue } from './hooks/useCurrentProject';
 import { ThemeModeProvider } from './hooks/useThemeMode';
 import '@ant-design/v5-patch-for-react-19';
-import { Tag, theme } from 'antd';
+import { ConfigProvider, Tag, theme } from 'antd';
 import dayjs from 'dayjs';
 import { Provider as JotaiProvider } from 'jotai';
 import _ from 'lodash';
@@ -70,7 +70,12 @@ customElements.define(
   reactToWebComponent((props) => {
     return (
       <DefaultProviders {...props}>
-        <CopyableCodeText text={props.value || ''} />
+        {/* FIXME: When rendered inside a Shadow DOM, Tooltip may affect layout flow.
+                   Force portal to shadowRoot to prevent layout shift.*/}
+        {/* @ts-ignore */}
+        <ConfigProvider getPopupContainer={() => props.shadowRoot}>
+          <CopyableCodeText text={props.value || ''} />
+        </ConfigProvider>
       </DefaultProviders>
     );
   }),


### PR DESCRIPTION
resolves #3698 (FR-1021)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

### Fixed portal not working properly when using tooltip inside shadow dom

> This is only an issue with EDGE BROWSER. If you are using a MAC environment, please [INSTALL EDGE BROWSER ](https://www.microsoft.com/ko-kr/edge/mac?form=MA13UX&cs=2282084340) for MAC.

Ant Design's Tooltip renders its children as DOM nodes outside of the parent component's DOM hierarchy. If a React Component is used inside a Lit Element, the portal will not behave properly and will be trapped inside the shadow DOM, causing layout deformations due to the tooltip.

Modify the portal to work properly by setting a ConfigProvider on the `CopyableCodeText.tsx` component.

**How to test:**
- Run WebUI with edge browser, and run vscode in a running session.
- Run the browser inspector, and modify the text inside the SSH password tag to make the button wrap. [Teams](https://teams.microsoft.com/l/message/19:fceea950220e430ca12c3040d152efe9@thread.tacv2/1747874830877?tenantId=13c6a44d-9b52-4b9e-aa34-0513ee7131f2&groupId=b1f3bcf4-facf-40d3-94ab-169abb4f0f52&parentMessageId=1747016387327&teamName=customers%20%26%20clients&channelName=KT%20Cloud&createdTime=1747874830877)
- Hover the button to run the test.



<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
