### PR TITLE
chore: Bump version to 25.9.0-alpha.0

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend.ai-webui",
   "productName": "Backend.AI Desktop",
-  "version": "25.5.0-alpha.0",
+  "version": "25.9.0-alpha.0",
   "repository": "https://github.com/lablup/backend.ai-webui.git",
   "author": "Lablup Inc. <contact@lablup.com>",
   "license": "LGPL-3.0-or-later",

--- a/index.html
+++ b/index.html
@@ -32,8 +32,8 @@
         NODE_ENV: 'production'
       }
     };
-    globalThis.packageVersion = "25.5.0-alpha.0";
-    globalThis.buildNumber = "6552";
+    globalThis.packageVersion = "25.9.0-alpha.0";
+    globalThis.buildNumber = "6700";
     globalThis.litNonce = "{{nonce}}";
     globalThis.baiNonce = "{{nonce}}";
   </script>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": 9,
   "name": "Backend.AI Web UI",
   "short_name": "BackendAIWebUI",
-  "version": "25.5.0-alpha.0",
+  "version": "25.9.0-alpha.0",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#fff",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend.ai-webui",
   "productName": "Backend.AI Desktop",
-  "version": "25.5.0-alpha.0",
+  "version": "25.9.0-alpha.0",
   "repository": "https://github.com/lablup/backend.ai-webui.git",
   "author": "Lablup Inc. <contact@lablup.com>",
   "license": "LGPL-3.0-or-later",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-ai-webui-react",
-  "version": "25.5.0-alpha.0",
+  "version": "25.9.0-alpha.0",
   "private": true,
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "25.5.0-alpha.0", "buildNumber": "6552", "buildDate": "250314.150338", "revision": "e618e654f" }
+{ "package": "25.9.0-alpha.0", "buildNumber": "6700", "buildDate": "250522.130550", "revision": "c51fa09e7" }


### PR DESCRIPTION
This PR updates the package version from 25.5.0-alpha.0 to 25.9.0-alpha.0 across all configuration files. The build number has also been updated from 6552 to 6700, and the build date is now set to 250522.130550 with revision c51fa09e7.