### PR TITLE
misc(FR-1035): remove unused pnpm command for test using jest framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "format-fix:all": "prettier --write 'src/**/*.{js,jsx,ts,tsx,json,css,scss,md}' 'react/src/**/*.{js,jsx,ts,tsx,json,css,scss,md}'",
     "format-fix:i18n": "prettier --write 'resources/i18n/*.json'",
     "test": "jest",
-    "test:react": "pnpm test --prefix ./react test",
     "wsproxy": "node ./src/wsproxy/local_proxy.js",
     "build": "rm -rf build/rollup && mkdir -p build/rollup/src/components && pnpm run copyindex && pnpm run copywc && pnpm run copywa && pnpm run copyresource && pnpm run copyconfig && rollup -c rollup.config.ts --configPlugin typescript && pnpm run --prefix ./react build:copy",
     "build:react-only": "pnpm run --prefix ./react build",


### PR DESCRIPTION

# Remove `test:react` script from package.json

This PR resolves #3712 (FR-1035) by removing the `test:react` script from the package.json file, which was previously used to run tests in the React subdirectory.

**Checklist:**

- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after