### PR TITLE
refactor(FR-1057): Refactor size unit formatting in UI components

### DIFF
--- a/react/src/components/AgentDetailModal.tsx
+++ b/react/src/components/AgentDetailModal.tsx
@@ -1,7 +1,7 @@
 import { AgentDetailModalFragment$key } from '../__generated__/AgentDetailModalFragment.graphql';
 import {
-  convertBinarySizeUnit,
-  convertDecimalSizeUnit,
+  convertToBinaryUnit,
+  convertToDecimalUnit,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
 import { useResourceSlotsDetails } from '../hooks/backendai';
@@ -99,21 +99,19 @@ const AgentDetailModal: React.FC<AgentDetailModalProps> = ({
                 <BAIProgressWithLabel
                   percent={
                     (_.toNumber(
-                      convertBinarySizeUnit(
-                        _.toString(agent?.mem_cur_bytes),
-                        'g',
-                      )?.number,
+                      convertToBinaryUnit(_.toString(agent?.mem_cur_bytes), 'g')
+                        ?.number,
                     ) /
                       _.toNumber(
-                        convertBinarySizeUnit(parsedAvailableSlots?.mem, 'g')
+                        convertToBinaryUnit(parsedAvailableSlots?.mem, 'g')
                           ?.number,
                       )) *
                       100 || 0
                   }
                   valueLabel={`${
-                    convertBinarySizeUnit(_.toString(agent?.mem_cur_bytes), 'g')
-                      ?.numberUnit
-                  }iB / ${convertBinarySizeUnit(parsedAvailableSlots?.mem, 'g')?.numberUnit}iB`}
+                    convertToBinaryUnit(_.toString(agent?.mem_cur_bytes), 'g')
+                      ?.displayValue
+                  } / ${convertToBinaryUnit(parsedAvailableSlots?.mem, 'g')?.displayValue}`}
                 />
               </Flex>
             ) : null}
@@ -126,11 +124,11 @@ const AgentDetailModal: React.FC<AgentDetailModalProps> = ({
                   <Typography.Text>TX:</Typography.Text>
                   <Typography.Text>
                     {
-                      convertDecimalSizeUnit(
+                      convertToDecimalUnit(
                         parsedLiveStat?.node?.net_tx?.current,
                         'm',
                         2,
-                      )?.numberUnit
+                      )?.displayValue
                     }
                     B
                   </Typography.Text>
@@ -139,11 +137,11 @@ const AgentDetailModal: React.FC<AgentDetailModalProps> = ({
                   <Typography.Text>RX:</Typography.Text>
                   <Typography.Text>
                     {
-                      convertDecimalSizeUnit(
+                      convertToDecimalUnit(
                         parsedLiveStat?.node?.net_rx?.current,
                         'm',
                         2,
-                      )?.numberUnit
+                      )?.displayValue
                     }
                     B
                   </Typography.Text>

--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -6,7 +6,7 @@ import {
 import { AgentSettingModalFragment$key } from '../__generated__/AgentSettingModalFragment.graphql';
 import {
   bytesToGB,
-  convertBinarySizeUnit,
+  convertToBinaryUnit,
   filterNonNullItems,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
@@ -315,17 +315,11 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
                       <Flex gap="xxs">
                         <ResourceTypeIcon type={'mem'} />
                         <Typography.Text>
-                          {convertBinarySizeUnit(
-                            parsedOccupiedSlots.mem,
-                            'g',
-                            0,
-                          )?.numberFixed ?? 0}
+                          {convertToBinaryUnit(parsedOccupiedSlots.mem, 'g', 0)
+                            ?.numberFixed ?? 0}
                           /
-                          {convertBinarySizeUnit(
-                            parsedAvailableSlots.mem,
-                            'g',
-                            0,
-                          )?.numberFixed ?? 0}
+                          {convertToBinaryUnit(parsedAvailableSlots.mem, 'g', 0)
+                            ?.numberFixed ?? 0}
                         </Typography.Text>
                         <Typography.Text
                           type="secondary"
@@ -482,12 +476,12 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
                   percent={liveStat.mem_util.ratio * 100}
                   width={120}
                   valueLabel={
-                    convertBinarySizeUnit(
+                    convertToBinaryUnit(
                       _.toString(liveStat.mem_util.current),
                       'g',
                     )?.numberFixed +
                     '/' +
-                    convertBinarySizeUnit(
+                    convertToBinaryUnit(
                       _.toString(liveStat.mem_util.capacity),
                       'g',
                     )?.numberFixed +
@@ -555,7 +549,7 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
                             100 || 0
                         }
                         valueLabel={
-                          convertBinarySizeUnit(
+                          convertToBinaryUnit(
                             _.toString(
                               liveStat[statKey as keyof typeof liveStat]
                                 .current,
@@ -563,7 +557,7 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
                             'g',
                           )?.numberFixed +
                           '/' +
-                          convertBinarySizeUnit(
+                          convertToBinaryUnit(
                             _.toString(
                               liveStat[statKey as keyof typeof liveStat]
                                 .capacity,

--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -3,7 +3,7 @@ import {
   AgentSummaryListQuery$data,
 } from '../__generated__/AgentSummaryListQuery.graphql';
 import {
-  convertBinarySizeUnit,
+  convertToBinaryUnit,
   filterNonNullItems,
   toFixedFloorWithoutTrailingZeros,
   transformSorterToOrderString,
@@ -221,17 +221,11 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
                       <Flex gap="xxs">
                         <ResourceTypeIcon type={'mem'} />
                         <Typography.Text>
-                          {convertBinarySizeUnit(
-                            parsedOccupiedSlots.mem,
-                            'g',
-                            0,
-                          )?.numberFixed ?? 0}
+                          {convertToBinaryUnit(parsedOccupiedSlots.mem, 'g', 0)
+                            ?.numberFixed ?? 0}
                           /
-                          {convertBinarySizeUnit(
-                            parsedAvailableSlots.mem,
-                            'g',
-                            0,
-                          )?.numberFixed ?? 0}
+                          {convertToBinaryUnit(parsedAvailableSlots.mem, 'g', 0)
+                            ?.numberFixed ?? 0}
                         </Typography.Text>
                         <Typography.Text
                           type="secondary"

--- a/react/src/components/AllocationHistoryStatistics.tsx
+++ b/react/src/components/AllocationHistoryStatistics.tsx
@@ -1,8 +1,4 @@
-import {
-  convertBinarySizeUnit,
-  convertDecimalSizeUnit,
-  SizeUnit,
-} from '../helper';
+import { convertToBinaryUnit, convertToDecimalUnit, SizeUnit } from '../helper';
 import {
   UserStatsData,
   UserStatsDataKey,
@@ -87,16 +83,10 @@ const getColumnConfig = ({
       return value;
     }
     if (unitType === 'byte') {
-      return (
-        convertBinarySizeUnit(value.toString() + 'B', targetUnit as SizeUnit)
-          ?.number ?? 0
-      );
+      return convertToBinaryUnit(value, targetUnit as SizeUnit)?.number ?? 0;
     }
     if (unitType === 'decimal') {
-      return (
-        convertDecimalSizeUnit(value.toString() + 'B', targetUnit as SizeUnit)
-          ?.number ?? 0
-      );
+      return convertToDecimalUnit(value, targetUnit as SizeUnit)?.number ?? 0;
     }
     return value;
   };
@@ -186,7 +176,7 @@ const AllocationHistoryStatistics: React.FC<
             data,
             key: 'mem_allocated',
             period,
-            targetUnit: 'G',
+            targetUnit: 'g',
             displayUnit: 'GiB',
             unitType: 'byte',
             isDarkMode,
@@ -216,7 +206,7 @@ const AllocationHistoryStatistics: React.FC<
                 data,
                 key: 'io_read_bytes',
                 period,
-                targetUnit: 'M',
+                targetUnit: 'm',
                 displayUnit: 'MiB',
                 unitType: 'decimal',
                 isDarkMode,
@@ -230,7 +220,7 @@ const AllocationHistoryStatistics: React.FC<
                 data,
                 key: 'io_write_bytes',
                 period,
-                targetUnit: 'M',
+                targetUnit: 'm',
                 displayUnit: 'MiB',
                 unitType: 'decimal',
                 isDarkMode,

--- a/react/src/components/AvailableResourcesCard.tsx
+++ b/react/src/components/AvailableResourcesCard.tsx
@@ -1,4 +1,4 @@
-import { convertBinarySizeUnit } from '../helper';
+import { convertToBinaryUnit } from '../helper';
 import { useResourceSlotsDetails } from '../hooks/backendai';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useResourceLimitAndRemaining } from '../hooks/useResourceLimitAndRemaining';
@@ -98,7 +98,7 @@ const AvailableResourcesCard: React.FC<AvailableResourcesCardProps> = ({
         )}
 
         {!_.isNaN(
-          convertBinarySizeUnit(checkPresetInfo?.keypair_using.mem, 'G')
+          convertToBinaryUnit(checkPresetInfo?.keypair_using.mem, 'g')
             ?.numberFixed,
         ) &&
           resourceSlotsDetails?.resourceSlotsInRG?.['mem'] && (
@@ -123,15 +123,13 @@ const AvailableResourcesCard: React.FC<AvailableResourcesCardProps> = ({
               <Col style={{ justifyItems: 'center', overflow: 'break-word' }}>
                 <ResourceWithSteppedProgress
                   current={_.toNumber(
-                    convertBinarySizeUnit(
-                      checkPresetInfo?.keypair_using.mem,
-                      'G',
-                    )?.numberFixed,
+                    convertToBinaryUnit(checkPresetInfo?.keypair_using.mem, 'g')
+                      ?.numberFixed,
                   )}
                   total={_.toNumber(
-                    convertBinarySizeUnit(
+                    convertToBinaryUnit(
                       checkPresetInfo?.keypair_limits.mem,
-                      'G',
+                      'g',
                     )?.numberFixed,
                   )}
                   title={

--- a/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
@@ -1,5 +1,5 @@
 import { SessionSlotCellFragment$key } from '../../__generated__/SessionSlotCellFragment.graphql';
-import { convertBinarySizeUnit } from '../../helper';
+import { convertToBinaryUnit } from '../../helper';
 import {
   ResourceSlotName,
   useResourceSlotsDetails,
@@ -90,7 +90,7 @@ const SessionSlotCell: React.FC<OccupiedSlotViewProps> = ({
           ),
           placement: 'left',
         }}
-        text={convertBinarySizeUnit(mem, 'G', 3)?.numberFixed + ' GiB'}
+        text={convertToBinaryUnit(mem, 'g', 3)?.displayValue}
       />
     );
   } else if (type === 'accelerator') {

--- a/react/src/components/DynamicUnitInputNumber.tsx
+++ b/react/src/components/DynamicUnitInputNumber.tsx
@@ -1,4 +1,4 @@
-import { convertBinarySizeUnit, parseUnit, SizeUnit } from '../helper';
+import { convertToBinaryUnit, parseValueWithUnit, SizeUnit } from '../helper';
 import useControllableState from '../hooks/useControllableState';
 import { usePrevious } from 'ahooks';
 import { InputNumber, InputNumberProps, Select, Typography } from 'antd';
@@ -36,19 +36,22 @@ const DynamicUnitInputNumber: React.FC<DynamicUnitInputNumberProps> = ({
       defaultValue: '0g',
     },
   );
+  console.log(value);
   const [numValue, _unitFromValue] =
-    value === null || value === undefined ? [null, null] : parseUnit(value);
+    value === null || value === undefined
+      ? [null, null]
+      : parseValueWithUnit(value);
   const previousUnit = usePrevious(_unitFromValue);
   const unit = _unitFromValue || previousUnit || units[0];
 
-  const [minNumValue, minUnit] = parseUnit(min);
-  const [maxNumValue, maxUnit] = parseUnit(max);
+  const [minNumValue, minUnit] = parseValueWithUnit(min);
+  const [maxNumValue, maxUnit] = parseValueWithUnit(max);
 
-  const minNumValueForCurrentUnit = convertBinarySizeUnit(
+  const minNumValueForCurrentUnit = convertToBinaryUnit(
     min,
     unit as SizeUnit,
   )?.number;
-  const maxNumValueForCurrentUnit = convertBinarySizeUnit(
+  const maxNumValueForCurrentUnit = convertToBinaryUnit(
     max,
     unit as SizeUnit,
   )?.number;
@@ -120,13 +123,13 @@ const DynamicUnitInputNumber: React.FC<DynamicUnitInputNumberProps> = ({
       max={
         maxUnit === unit
           ? maxNumValue
-          : convertBinarySizeUnit(max, unit as SizeUnit)?.number
+          : convertToBinaryUnit(max, unit as SizeUnit)?.number
       }
       min={
         minUnit === unit
           ? minNumValue
           : // @ts-ignore
-            convertBinarySizeUnit(min, unit).number
+            convertToBinaryUnit(min, unit).number
       }
       addonAfter={
         <Select

--- a/react/src/components/DynamicUnitInputNumberWithSlider.tsx
+++ b/react/src/components/DynamicUnitInputNumberWithSlider.tsx
@@ -1,6 +1,6 @@
 import {
   compareNumberWithUnits,
-  convertBinarySizeUnit,
+  convertToBinaryUnit,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
 import { useUpdatableState } from '../hooks';
@@ -41,10 +41,10 @@ const DynamicUnitInputNumberWithSlider: React.FC<
     },
   );
   const { token } = theme.useToken();
-  const minGiB = useMemo(() => convertBinarySizeUnit(min, 'g', 2), [min]);
-  const maxGiB = useMemo(() => convertBinarySizeUnit(max, 'g', 2), [max]);
+  const minGiB = useMemo(() => convertToBinaryUnit(min, 'g', 2), [min]);
+  const maxGiB = useMemo(() => convertToBinaryUnit(max, 'g', 2), [max]);
   const valueGiB = useMemo(
-    () => convertBinarySizeUnit(value || '0g', 'g', 2),
+    () => convertToBinaryUnit(value || '0g', 'g', 2),
     [value],
   );
 

--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -7,7 +7,7 @@ import {
   KeypairResourcePolicySettingModalModifyMutation,
   ModifyKeyPairResourcePolicyInput,
 } from '../__generated__/KeypairResourcePolicySettingModalModifyMutation.graphql';
-import { convertBinarySizeUnit } from '../helper';
+import { convertToBinaryUnit } from '../helper';
 import { MAX_CPU_QUOTA, SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useResourceSlots, useResourceSlotsDetails } from '../hooks/backendai';
@@ -132,22 +132,22 @@ const KeypairResourcePolicySettingModal: React.FC<
       keypairResourcePolicy?.total_resource_slots ?? '{}',
     );
     if (parsedTotalResourceSlots?.mem) {
-      let autoUniResult = convertBinarySizeUnit(
-        parsedTotalResourceSlots?.mem + 'b',
+      let autoUniResult = convertToBinaryUnit(
+        parsedTotalResourceSlots?.mem,
         'auto',
         2,
         true,
       );
 
-      if (autoUniResult?.unit === 'B' || autoUniResult?.unit === 'K') {
-        autoUniResult = convertBinarySizeUnit(
-          parsedTotalResourceSlots?.mem + 'b',
-          'M',
+      if (autoUniResult?.unit === '' || autoUniResult?.unit === 'k') {
+        autoUniResult = convertToBinaryUnit(
+          parsedTotalResourceSlots?.mem,
+          'm',
           3,
           true,
         );
       }
-      parsedTotalResourceSlots.mem = autoUniResult?.numberUnit || '0G';
+      parsedTotalResourceSlots.mem = autoUniResult?.value || '0g';
     }
 
     return {
@@ -180,7 +180,7 @@ const KeypairResourcePolicySettingModal: React.FC<
           ),
           (value, key) => {
             if (_.includes(key, 'mem')) {
-              return convertBinarySizeUnit(value, 'b', 0)?.numberFixed;
+              return convertToBinaryUnit(value, '', 0)?.numberFixed;
             }
             return value;
           },
@@ -423,9 +423,9 @@ const KeypairResourcePolicySettingModal: React.FC<
                                 _.includes(resourceSlotKey, 'mem') &&
                                 value &&
                                 // @ts-ignore
-                                convertBinarySizeUnit(value, 'p').number >
+                                convertToBinaryUnit(value, 'p').number >
                                   // @ts-ignore
-                                  convertBinarySizeUnit('300p', 'p').number
+                                  convertToBinaryUnit('300p', 'p').number
                               ) {
                                 return Promise.reject(
                                   new Error(

--- a/react/src/components/NumberWithUnit.tsx
+++ b/react/src/components/NumberWithUnit.tsx
@@ -1,10 +1,4 @@
-import {
-  convertBinarySizeUnit,
-  convertDecimalSizeUnit,
-  SizeUnit,
-  sizeUnitToBinarySizeUnit,
-  sizeUnitToDecimalSizeUnit,
-} from '../helper';
+import { convertToBinaryUnit, convertToDecimalUnit, SizeUnit } from '../helper';
 import Flex from './Flex';
 import { Typography } from 'antd';
 
@@ -23,12 +17,12 @@ const NumberWithUnit = ({
 }: NumberWithUnitProps) => {
   const convertedByTargetUnit =
     unitType === 'binary'
-      ? convertBinarySizeUnit(numberUnit, targetUnit, 2, true)
-      : convertDecimalSizeUnit(numberUnit, targetUnit, 2, true);
+      ? convertToBinaryUnit(numberUnit, targetUnit, 2, true)
+      : convertToDecimalUnit(numberUnit, targetUnit, 2, true);
   const convertedByAuto =
     unitType === 'binary'
-      ? convertBinarySizeUnit(numberUnit, 'auto', 2, true)
-      : convertDecimalSizeUnit(numberUnit, 'auto', 2, true);
+      ? convertToBinaryUnit(numberUnit, 'auto', 2, true)
+      : convertToDecimalUnit(numberUnit, 'auto', 2, true);
   return (
     <Flex gap="xxs">
       <Typography.Text>
@@ -36,15 +30,11 @@ const NumberWithUnit = ({
         {postfix && postfix}
       </Typography.Text>
       <Typography.Text type="secondary">
-        {unitType === 'binary'
-          ? sizeUnitToBinarySizeUnit(convertedByTargetUnit?.unit as SizeUnit)
-          : sizeUnitToDecimalSizeUnit(convertedByTargetUnit?.unit as SizeUnit)}
+        {convertedByTargetUnit?.displayUnit}
         {Number(convertedByTargetUnit?.numberFixed).toString() === '0' &&
           Number(convertedByAuto?.numberFixed).toString() !== '0' &&
           `(${Number(convertedByAuto?.numberFixed).toString()} ${
-            unitType === 'binary'
-              ? sizeUnitToBinarySizeUnit(convertedByAuto?.unit as SizeUnit)
-              : sizeUnitToDecimalSizeUnit(convertedByAuto?.unit as SizeUnit)
+            convertedByAuto?.displayUnit
           })`}
       </Typography.Text>
     </Flex>

--- a/react/src/components/QuotaPerStorageVolumePanelCard.tsx
+++ b/react/src/components/QuotaPerStorageVolumePanelCard.tsx
@@ -1,6 +1,6 @@
 import { QuotaPerStorageVolumePanelCardQuery } from '../__generated__/QuotaPerStorageVolumePanelCardQuery.graphql';
 import { QuotaPerStorageVolumePanelCardUserQuery } from '../__generated__/QuotaPerStorageVolumePanelCardUserQuery.graphql';
-import { addQuotaScopeTypePrefix, convertDecimalSizeUnit } from '../helper';
+import { addQuotaScopeTypePrefix, convertToDecimalUnit } from '../helper';
 import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import BAICard, { BAICardProps } from './BAICard';
@@ -182,12 +182,12 @@ const QuotaPerStorageVolumePanelCard: React.FC<
               used={
                 projectUsageBytes === 0
                   ? ''
-                  : `${convertDecimalSizeUnit(_.toString(projectUsageBytes), 'G')?.numberUnit}B`
+                  : `${convertToDecimalUnit(_.toString(projectUsageBytes), 'g')?.displayValue}`
               }
               total={
                 projectHardLimitBytes === 0
                   ? ''
-                  : `${convertDecimalSizeUnit(_.toString(projectHardLimitBytes), 'G')?.numberUnit}B`
+                  : `${convertToDecimalUnit(_.toString(projectHardLimitBytes), 'g')?.displayValue}`
               }
             />
           </Col>
@@ -210,12 +210,14 @@ const QuotaPerStorageVolumePanelCard: React.FC<
               used={
                 userUsageBytes === 0
                   ? ''
-                  : `${convertDecimalSizeUnit(_.toString(userUsageBytes), 'G')?.numberUnit}B`
+                  : convertToDecimalUnit(_.toString(userUsageBytes), 'g')
+                      ?.displayValue
               }
               total={
                 userHardLimitBytes === 0
                   ? ''
-                  : `${convertDecimalSizeUnit(_.toString(userHardLimitBytes), 'G')?.numberUnit}B`
+                  : convertToDecimalUnit(_.toString(userHardLimitBytes), 'g')
+                      ?.displayValue
               }
             />
           </Col>

--- a/react/src/components/ResourceNumber.tsx
+++ b/react/src/components/ResourceNumber.tsx
@@ -1,4 +1,4 @@
-import { convertBinarySizeUnit } from '../helper';
+import { convertToBinaryUnit } from '../helper';
 import {
   BaseResourceSlotName,
   KnownAcceleratorResourceSlotName,
@@ -47,7 +47,7 @@ const ResourceNumber: React.FC<ResourceNumberProps> = ({
   const formatAmount = (amount: string) => {
     return mergedResourceSlots?.[type]?.number_format.binary
       ? Number(
-          convertBinarySizeUnit(amount, 'g', 2, true)?.numberFixed,
+          convertToBinaryUnit(amount, 'g', 2, true)?.numberFixed,
         ).toString()
       : (mergedResourceSlots?.[type]?.number_format.round_length || 0) > 0
         ? parseFloat(amount).toFixed(2)
@@ -95,8 +95,7 @@ const ResourceNumber: React.FC<ResourceNumberProps> = ({
           type="secondary"
           style={{ fontSize: token.fontSizeSM }}
         >
-          (SHM:{' '}
-          {convertBinarySizeUnit(opts.shmem + 'b', 'g', 2, true)?.numberFixed}
+          (SHM: {convertToBinaryUnit(opts.shmem, 'g', 2, true)?.numberFixed}
           GiB)
         </Typography.Text>
       ) : null}

--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -102,11 +102,7 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
           return '-';
         }
         return (
-          <NumberWithUnit
-            numberUnit={text + 'b'}
-            targetUnit="g"
-            unitType="binary"
-          />
+          <NumberWithUnit numberUnit={text} targetUnit="g" unitType="binary" />
         );
       },
     },

--- a/react/src/components/ResourcePresetSettingModal.tsx
+++ b/react/src/components/ResourcePresetSettingModal.tsx
@@ -8,7 +8,7 @@ import {
   ResourcePresetSettingModalModifyByIdMutation,
 } from '../__generated__/ResourcePresetSettingModalModifyByIdMutation.graphql';
 import { ResourcePresetSettingModalModifyByNameMutation } from '../__generated__/ResourcePresetSettingModalModifyByNameMutation.graphql';
-import { convertBinarySizeUnit } from '../helper';
+import { convertToBinaryUnit } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useResourceSlots, useResourceSlotsDetails } from '../hooks/backendai';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
@@ -105,7 +105,7 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
           values?.resource_slots,
           (value, key) => {
             if (value && _.includes(key, 'mem')) {
-              return convertBinarySizeUnit(value, 'b', 0)?.numberFixed;
+              return convertToBinaryUnit(value, '', 0)?.numberFixed;
             }
             return value;
           },
@@ -116,7 +116,7 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
         const props: CreateResourcePresetInput | ModifyResourcePresetInput = {
           resource_slots: JSON.stringify(resourceSlots || {}),
           shared_memory: values?.shared_memory
-            ? convertBinarySizeUnit(values?.shared_memory, 'b', 0)?.numberFixed
+            ? convertToBinaryUnit(values?.shared_memory, '', 0)?.numberFixed
             : null,
         };
         if (baiClient?.supports('resource-presets-per-resource-group')) {
@@ -237,17 +237,17 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
                     JSON.parse(resourcePreset?.resource_slots || '{}'),
                     (value, key) =>
                       _.includes(key, 'mem')
-                        ? convertBinarySizeUnit(
-                            value + 'b',
+                        ? convertToBinaryUnit(
+                            value,
                             value === '0' ? 'g' : 'auto',
-                          )?.numberUnit
+                          )?.displayValue
                         : value,
                   ) || {},
                 shared_memory: resourcePreset?.shared_memory
-                  ? convertBinarySizeUnit(
-                      resourcePreset?.shared_memory + 'b',
+                  ? convertToBinaryUnit(
+                      resourcePreset?.shared_memory,
                       resourcePreset?.shared_memory === '0' ? 'g' : 'auto',
-                    )?.numberUnit
+                    )?.displayValue
                   : null,
               }
             : {
@@ -327,9 +327,9 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
                                 value &&
                                 _.includes(resourceSlotKey, 'mem') &&
                                 // @ts-ignore
-                                convertBinarySizeUnit(value, 'p').number >
+                                convertToBinaryUnit(value, 'p').number >
                                   // @ts-ignore
-                                  convertBinarySizeUnit('300p', 'p').number
+                                  convertToBinaryUnit('300p', 'p').number
                               ) {
                                 return Promise.reject(
                                   new Error(
@@ -374,11 +374,11 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
                       if (
                         value &&
                         getFieldValue('resource_slots')?.mem &&
-                        (convertBinarySizeUnit(
+                        (convertToBinaryUnit(
                           getFieldValue('resource_slots')?.mem,
-                          'b',
+                          '',
                         )?.number ?? 0) <
-                          (convertBinarySizeUnit(value, 'b')?.number ?? 0)
+                          (convertToBinaryUnit(value, '')?.number ?? 0)
                       ) {
                         return Promise.reject(
                           t('resourcePreset.MemoryShouldBeLargerThanSHMEM'),

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -5,7 +5,7 @@ import { ServiceLauncherPageContent_UserResourcePolicyQuery } from '../__generat
 import {
   baiSignedRequestWithPromise,
   compareNumberWithUnits,
-  convertBinarySizeUnit,
+  convertToBinaryUnit,
   useBaiSignedRequestWithPromise,
 } from '../helper';
 import {
@@ -663,19 +663,19 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         // FIXME: memory doesn't applied to resource allocation
         resource: {
           cpu: parseInt(JSON.parse(endpoint?.resource_slots || '{}')?.cpu),
-          mem: convertBinarySizeUnit(
-            JSON.parse(endpoint?.resource_slots || '{}')?.mem + 'b',
+          mem: convertToBinaryUnit(
+            JSON.parse(endpoint?.resource_slots || '{}')?.mem,
             'g',
             3,
             true,
-          )?.numberUnit,
-          shmem: convertBinarySizeUnit(
+          )?.value,
+          shmem: convertToBinaryUnit(
             JSON.parse(endpoint?.resource_opts || '{}')?.shmem ||
               AUTOMATIC_DEFAULT_SHMEM,
             'g',
             3,
             true,
-          )?.numberUnit,
+          )?.value,
           ...getAIAcceleratorWithStringifiedKey(
             _.omit(JSON.parse(endpoint?.resource_slots || '{}'), [
               'cpu',

--- a/react/src/components/SessionMetricGraph.tsx
+++ b/react/src/components/SessionMetricGraph.tsx
@@ -3,7 +3,7 @@ import {
   SessionMetricGraphQuery$data,
 } from '../__generated__/SessionMetricGraphQuery.graphql';
 import {
-  convertBinarySizeUnit,
+  convertToBinaryUnit,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
 import { useResourceSlotsDetails } from '../hooks/backendai';
@@ -282,7 +282,7 @@ const convertMetricUnit = (
     number = Number((Number(value) / 1000).toFixed(1));
     numberUnit = 's';
   } else {
-    number = Number(convertBinarySizeUnit(value ?? '0', 'g')?.numberFixed);
+    number = Number(convertToBinaryUnit(value ?? '0', 'g')?.numberFixed);
     numberUnit = 'GiB';
   }
 

--- a/react/src/components/SessionUsageMonitor.tsx
+++ b/react/src/components/SessionUsageMonitor.tsx
@@ -1,7 +1,7 @@
 import { SessionUsageMonitorFragment$key } from '../__generated__/SessionUsageMonitorFragment.graphql';
 import {
-  convertBinarySizeUnit,
-  convertDecimalSizeUnit,
+  convertToBinaryUnit,
+  convertToDecimalUnit,
   filterEmptyItem,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
@@ -173,11 +173,11 @@ const SessionUsageMonitor: React.FC<SessionUsageMonitorProps> = ({
           displayTarget === 'current'
             ? sortedLiveStat?.mem?.pct || '0'
             : _.toString(
-                ((convertBinarySizeUnit(
+                ((convertToBinaryUnit(
                   sortedLiveStat?.mem?.[displayTargetName],
                   'g',
                 )?.number ?? 0) /
-                  (convertBinarySizeUnit(sortedLiveStat?.mem?.capacity, 'g')
+                  (convertToBinaryUnit(sortedLiveStat?.mem?.capacity, 'g')
                     ?.number || 1)) *
                   100,
               )
@@ -228,9 +228,9 @@ const SessionUsageMonitor: React.FC<SessionUsageMonitorProps> = ({
                 : _.includes(key, 'util')
                   ? value?.[displayTargetName]
                   : _.toString(
-                      ((convertBinarySizeUnit(value?.[displayTargetName], 'g')
+                      ((convertToBinaryUnit(value?.[displayTargetName], 'g')
                         ?.number ?? 0) /
-                        (convertBinarySizeUnit(value?.capacity, 'g')?.number ||
+                        (convertToBinaryUnit(value?.capacity, 'g')?.number ||
                           1)) *
                         100,
                     )
@@ -283,7 +283,7 @@ const SessionUsageMonitor: React.FC<SessionUsageMonitorProps> = ({
         <Col span={24}>
           <Flex justify="end">
             <Typography.Text>
-              {`I/O Read: ${convertDecimalSizeUnit(sortedLiveStat?.io_read?.current, 'm')?.numberUnit ?? '-'}B / Write: ${convertDecimalSizeUnit(sortedLiveStat?.io_write?.current, 'm')?.numberUnit ?? '-'}B`}
+              {`I/O Read: ${convertToDecimalUnit(sortedLiveStat?.io_read?.current, 'm')?.displayValue ?? '-'} / Write: ${convertToDecimalUnit(sortedLiveStat?.io_write?.current, 'm')?.displayValue ?? '-'}`}
             </Typography.Text>
           </Flex>
         </Col>
@@ -297,8 +297,8 @@ export const displayMemoryUsage = (
   capacity: string | undefined,
   decimalSize: number = 2,
 ) => {
-  return `${convertBinarySizeUnit(current, 'g', decimalSize)?.numberFixed ?? '-'} GiB / ${
-    convertBinarySizeUnit(capacity, 'g', decimalSize)?.numberFixed ?? '-'
+  return `${convertToBinaryUnit(current, 'g', decimalSize)?.numberFixed ?? '-'} GiB / ${
+    convertToBinaryUnit(capacity, 'g', decimalSize)?.numberFixed ?? '-'
   } GiB`;
 };
 

--- a/react/src/components/VFolderNodeDescription.tsx
+++ b/react/src/components/VFolderNodeDescription.tsx
@@ -1,7 +1,7 @@
 import { VFolderNodeDescriptionFragment$key } from '../__generated__/VFolderNodeDescriptionFragment.graphql';
 import { VFolderNodeDescriptionPermissionRefreshQuery } from '../__generated__/VFolderNodeDescriptionPermissionRefreshQuery.graphql';
 import { useVirtualFolderNodePathFragment$key } from '../__generated__/useVirtualFolderNodePathFragment.graphql';
-import { convertDecimalSizeUnit, filterEmptyItem, toLocalId } from '../helper';
+import { convertToDecimalUnit, filterEmptyItem, toLocalId } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
@@ -242,7 +242,7 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
       key: 'max_size',
       label: t('data.folders.MaxSize'),
       children: vfolderNode.max_size
-        ? `${convertDecimalSizeUnit(vfolderNode.max_size, 'g', 2)?.numberUnit}B`
+        ? convertToDecimalUnit(vfolderNode.max_size, 'g', 2)?.displayValue
         : '∞',
     },
     {

--- a/react/src/helper/big-number.test.ts
+++ b/react/src/helper/big-number.test.ts
@@ -32,14 +32,14 @@ expect.extend({
 
 describe('parseUnit', () => {
   test('parses a number with a unit', () => {
-    expect(BigNumber.parseUnit('123px')).toEqualBigNumber(['123', 'px']);
-    expect(BigNumber.parseUnit('45.67em')).toEqualBigNumber(['45.67', 'em']);
-    expect(BigNumber.parseUnit('100%')).toEqualBigNumber(['100', '%']);
+    expect(BigNumber.parseUnit('123')).toEqualBigNumber(['123', '']);
+    expect(BigNumber.parseUnit('45.67k')).toEqualBigNumber(['45.67', 'k']);
+    expect(BigNumber.parseUnit('100g')).toEqualBigNumber(['100', 'g']);
   });
 
   test('parses a number without a unit', () => {
-    expect(BigNumber.parseUnit('123')).toEqualBigNumber(['123', 'b']);
-    expect(BigNumber.parseUnit('45.67')).toEqualBigNumber(['45.67', 'b']);
+    expect(BigNumber.parseUnit('123')).toEqualBigNumber(['123', '']);
+    expect(BigNumber.parseUnit('45.67')).toEqualBigNumber(['45.67', '']);
   });
 
   test('handles invalid input gracefully', () => {
@@ -48,188 +48,173 @@ describe('parseUnit', () => {
   });
 
   test('handles edge cases', () => {
-    expect(BigNumber.parseUnit('0')).toEqualBigNumber(['0', 'b']);
-    expect(BigNumber.parseUnit('0px')).toEqualBigNumber(['0', 'px']);
-    expect(BigNumber.parseUnit('.5em')).toEqualBigNumber(['0.5', 'em']);
+    expect(BigNumber.parseUnit('0')).toEqualBigNumber(['0', '']);
+    expect(BigNumber.parseUnit('0g')).toEqualBigNumber(['0', 'g']);
+    expect(BigNumber.parseUnit('.5g')).toEqualBigNumber(['0.5', 'g']);
   });
 
   test('handle a big large number', () => {
     expect(BigNumber.parseUnit(9007199254740991)).toEqualBigNumber([
       '9007199254740991',
-      'b',
+      '',
     ]);
-    expect(BigNumber.parseUnit('9007199254740991B')).toEqualBigNumber([
+    expect(BigNumber.parseUnit('9007199254740991')).toEqualBigNumber([
       '9007199254740991',
-      'b',
+      '',
     ]);
-    expect(BigNumber.parseUnit('8P')).toEqualBigNumber(['8', 'p']);
+    expect(BigNumber.parseUnit('8P')).toEqualBigNumber(['8', 'P']);
   });
 });
 
 describe('convertSizeUnit', () => {
   test('convert size units auto detect', () => {
-    expect(BigNumber.convertSizeUnit('1B')).toEqual({
+    expect(BigNumber.convertUnitValue('1')).toEqual({
       number: new Big(1),
       numberFixed: '1',
-      unit: 'B',
-      numberUnit: '1B',
+      unit: '',
+      value: '1',
     });
   });
 
   test('convert big numbers byte to high units', () => {
-    expect(BigNumber.convertSizeUnit('9007199254740991B', 'K')).toEqual({
+    expect(BigNumber.convertUnitValue('9007199254740991', 'k')).toEqual({
       number: new Big('8796093022207.9990234375'),
       numberFixed: '8796093022208',
-      unit: 'K',
-      numberUnit: '8796093022208K',
+      unit: 'k',
+      value: '8796093022208k',
     });
 
-    expect(BigNumber.convertSizeUnit('9007199254740991B', 'P')).toEqual({
+    expect(BigNumber.convertUnitValue('9007199254740991', 'p')).toEqual({
       number: new Big('7.99999999999999911182'),
       numberFixed: '8',
-      unit: 'P',
-      numberUnit: '8P',
+      unit: 'p',
+      value: '8p',
     });
 
-    expect(BigNumber.convertSizeUnit('1K')).toEqual({
-      number: new Big(1),
-      numberFixed: '1',
-      unit: 'K',
-      numberUnit: '1K',
+    expect(BigNumber.convertUnitValue('1k')).toEqual({
+      number: new Big(1024),
+      numberFixed: '1024',
+      unit: '',
+      value: '1024',
     });
   });
 });
 
 describe('convertBinarySizeUnit', () => {
   it('should convert size using binary (1024) base with default fixed value', () => {
-    const sizeWithUnit = '1K';
-    const targetSizeUnit = 'B';
-    const result = BigNumber.convertBinarySizeUnit(
-      sizeWithUnit,
-      targetSizeUnit,
-    );
+    const sizeWithUnit = '1k';
+    const result = BigNumber.convertToBinaryUnit(sizeWithUnit, '');
     expect(result).toEqual({
       number: new Big(1024),
       numberFixed: '1024',
-      unit: 'B',
-      numberUnit: '1024B',
+      unit: '',
+      displayUnit: 'BiB',
+      value: '1024',
+      displayValue: '1024 BiB',
     });
   });
 
   it('should convert binary size with fixed value of 0', () => {
-    const sizeWithUnit = '1K';
-    const targetSizeUnit = 'B';
+    const sizeWithUnit = '1k';
     const fixed = 0;
-    const result = BigNumber.convertBinarySizeUnit(
-      sizeWithUnit,
-      targetSizeUnit,
-      fixed,
-    );
-    expect(result).toEqual({
+    const result = BigNumber.convertToBinaryUnit(sizeWithUnit, '', fixed);
+    expect(result).toMatchObject({
       number: new Big(1024),
       numberFixed: '1024',
-      unit: 'B',
-      numberUnit: '1024B',
+      unit: '',
+      displayUnit: 'BiB',
+      value: '1024',
+      displayValue: '1024 BiB',
     });
   });
 
   it('should handle lowercase unit input and convert to uppercase in result', () => {
     const sizeWithUnit = '1m';
     const targetSizeUnit = 'k';
-    const result = BigNumber.convertBinarySizeUnit(
-      sizeWithUnit,
-      targetSizeUnit,
-    );
+    const result = BigNumber.convertToBinaryUnit(sizeWithUnit, targetSizeUnit);
     expect(result).toEqual({
       number: new Big(1024),
       numberFixed: '1024',
-      unit: 'K',
-      numberUnit: '1024K',
+      unit: 'k',
+      displayUnit: 'KiB',
+      value: '1024k',
+      displayValue: '1024 KiB',
     });
   });
 
   it('should convert from peta to tera bytes correctly', () => {
-    const sizeWithUnit = '1P';
-    const targetSizeUnit = 'T';
-    const result = BigNumber.convertBinarySizeUnit(
-      sizeWithUnit,
-      targetSizeUnit,
-    );
-    expect(result).toEqual({
+    const sizeWithUnit = '1p';
+    const targetSizeUnit = 't';
+    const result = BigNumber.convertToBinaryUnit(sizeWithUnit, targetSizeUnit);
+    expect(result).toMatchObject({
       number: new Big(1024),
       numberFixed: '1024',
-      unit: 'T',
-      numberUnit: '1024T',
+      unit: 't',
+      displayUnit: 'TiB',
+      value: '1024t',
+      displayValue: '1024 TiB',
     });
   });
 
   it('should throw an error for invalid size format', () => {
     const sizeWithUnit = 'invalid';
-    expect(() => BigNumber.convertBinarySizeUnit(sizeWithUnit)).toThrow();
-  });
-
-  it('should use input unit as target unit when targetSizeUnit is not provided', () => {
-    const sizeWithUnit = '1K';
-    const result = BigNumber.convertBinarySizeUnit(sizeWithUnit);
-    expect(result).toEqual({
-      number: new Big(1),
-      numberFixed: '1',
-      unit: 'K',
-      numberUnit: '1K',
-    });
+    expect(() => BigNumber.convertToBinaryUnit(sizeWithUnit)).toThrow();
   });
 
   it('should return undefined for undefined input', () => {
     const sizeWithUnit = undefined;
-    const result = BigNumber.convertBinarySizeUnit(sizeWithUnit);
+    const result = BigNumber.convertToBinaryUnit(sizeWithUnit);
     expect(result).toBeUndefined();
   });
 
   it('should handle zero input correctly', () => {
-    const result = BigNumber.convertBinarySizeUnit('0g', 'b');
+    const result = BigNumber.convertToBinaryUnit('0g', '');
     expect(result?.number.toString()).toBe('0');
-    expect(result?.unit).toBe('B');
+    expect(result?.unit).toBe('');
+    expect(result?.displayUnit).toBe('BiB');
   });
 
   describe('auto unit selection', () => {
     it('should automatically select appropriate binary units', () => {
-      expect(BigNumber.convertBinarySizeUnit('1024B', 'auto')).toEqual({
+      expect(BigNumber.convertToBinaryUnit('1024', 'auto')).toMatchObject({
         number: new Big(1),
         numberFixed: '1',
-        unit: 'K',
-        numberUnit: '1K',
+        unit: 'k',
+        displayValue: '1 KiB',
       });
 
-      expect(BigNumber.convertBinarySizeUnit('1048576B', 'auto')).toEqual({
+      expect(BigNumber.convertToBinaryUnit('1048576', 'auto')).toMatchObject({
         number: new Big(1),
         numberFixed: '1',
-        unit: 'M',
-        numberUnit: '1M',
+        unit: 'm',
+        displayValue: '1 MiB',
       });
 
-      expect(BigNumber.convertBinarySizeUnit('1073741824B', 'auto')).toEqual({
-        number: new Big(1),
-        numberFixed: '1',
-        unit: 'G',
-        numberUnit: '1G',
-      });
+      expect(BigNumber.convertToBinaryUnit('1073741824', 'auto')).toMatchObject(
+        {
+          number: new Big(1),
+          numberFixed: '1',
+          unit: 'g',
+          displayValue: '1 GiB',
+        },
+      );
     });
 
     it('should handle small values correctly', () => {
-      expect(BigNumber.convertBinarySizeUnit('900B', 'auto')).toEqual({
+      expect(BigNumber.convertToBinaryUnit('900', 'auto')).toMatchObject({
         number: new Big(900),
         numberFixed: '900',
-        unit: 'B',
-        numberUnit: '900B',
+        unit: '',
+        displayValue: '900 BiB',
       });
     });
 
     it('should handle fractional values correctly', () => {
-      expect(BigNumber.convertBinarySizeUnit('1536B', 'auto')).toEqual({
+      expect(BigNumber.convertToBinaryUnit('1536', 'auto')).toMatchObject({
         number: new Big(1.5),
         numberFixed: '1.5',
-        unit: 'K',
-        numberUnit: '1.5K',
+        unit: 'k',
+        displayValue: '1.5 KiB',
       });
     });
   });
@@ -269,63 +254,63 @@ describe('compareNumberWithUnits', () => {
 
 describe('addNumberWithUnits', () => {
   it('should add two sizes with the same unit', () => {
-    expect(BigNumber.addNumberWithUnits('1K', '2K', 'K')).toBe('3K');
-    expect(BigNumber.addNumberWithUnits('1M', '2M', 'M')).toBe('3M');
-    expect(BigNumber.addNumberWithUnits('1G', '2G', 'G')).toBe('3G');
-    expect(BigNumber.addNumberWithUnits('1T', '2T', 'T')).toBe('3T');
+    expect(BigNumber.addNumberWithUnits('1k', '2k', 'k')).toBe('3k');
+    expect(BigNumber.addNumberWithUnits('1m', '2m', 'm')).toBe('3m');
+    expect(BigNumber.addNumberWithUnits('1g', '2g', 'g')).toBe('3g');
+    expect(BigNumber.addNumberWithUnits('1t', '2t', 't')).toBe('3t');
   });
 
   it('should add two sizes with the same unit (targetUnit is `m` default Unit)', () => {
-    expect(BigNumber.addNumberWithUnits('1G', '2G')).toBe('3072M');
-    expect(BigNumber.addNumberWithUnits('1T', '2T')).toBe('3145728M');
+    expect(BigNumber.addNumberWithUnits('1g', '2g')).toBe('3072m');
+    expect(BigNumber.addNumberWithUnits('1t', '2t')).toBe('3145728m');
   });
 
   it('should add two sizes with different units', () => {
-    expect(BigNumber.addNumberWithUnits('1K', '1M', 'K')).toBe('1025K');
-    expect(BigNumber.addNumberWithUnits('1M', '1G', 'M')).toBe('1025M');
-    expect(BigNumber.addNumberWithUnits('1G', '1T', 'G')).toBe('1025G');
-    expect(BigNumber.addNumberWithUnits('1T', '1P', 'T')).toBe('1025T');
+    expect(BigNumber.addNumberWithUnits('1k', '1m', 'k')).toBe('1025k');
+    expect(BigNumber.addNumberWithUnits('1m', '1g', 'm')).toBe('1025m');
+    expect(BigNumber.addNumberWithUnits('1g', '1t', 'g')).toBe('1025g');
+    expect(BigNumber.addNumberWithUnits('1t', '1p', 't')).toBe('1025t');
   });
 });
 
 describe('subNumberWithUnits', () => {
   it('should sub two sizes with the same unit', () => {
-    expect(BigNumber.subNumberWithUnits('2K', '1K', 'K')).toBe('1K');
-    expect(BigNumber.subNumberWithUnits('2M', '1M', 'M')).toBe('1M');
-    expect(BigNumber.subNumberWithUnits('2G', '1G', 'G')).toBe('1G');
-    expect(BigNumber.subNumberWithUnits('2T', '1T', 'T')).toBe('1T');
+    expect(BigNumber.subNumberWithUnits('2k', '1k', 'k')).toBe('1k');
+    expect(BigNumber.subNumberWithUnits('2m', '1m', 'm')).toBe('1m');
+    expect(BigNumber.subNumberWithUnits('2g', '1g', 'g')).toBe('1g');
+    expect(BigNumber.subNumberWithUnits('2t', '1t', 't')).toBe('1t');
   });
 
   it('should sub two sizes with the same unit (targetUnit is `m` default Unit)', () => {
-    expect(BigNumber.subNumberWithUnits('2G', '1G')).toBe('1024M');
-    expect(BigNumber.subNumberWithUnits('2T', '1T')).toBe('1048576M');
+    expect(BigNumber.subNumberWithUnits('2g', '1g')).toBe('1024m');
+    expect(BigNumber.subNumberWithUnits('2t', '1t')).toBe('1048576m');
   });
 
   it('should sub two sizes with different units', () => {
-    expect(BigNumber.subNumberWithUnits('1M', '1K', 'K')).toBe('1023K');
-    expect(BigNumber.subNumberWithUnits('1G', '1M', 'M')).toBe('1023M');
-    expect(BigNumber.subNumberWithUnits('1T', '1G', 'G')).toBe('1023G');
-    expect(BigNumber.subNumberWithUnits('1P', '1T', 'T')).toBe('1023T');
+    expect(BigNumber.subNumberWithUnits('1m', '1k', 'k')).toBe('1023k');
+    expect(BigNumber.subNumberWithUnits('1g', '1m', 'm')).toBe('1023m');
+    expect(BigNumber.subNumberWithUnits('1t', '1g', 'g')).toBe('1023g');
+    expect(BigNumber.subNumberWithUnits('1p', '1t', 't')).toBe('1023t');
   });
 });
 
 describe('isOutsideRangeWithUnits', () => {
   it('should return true if the value is less than the minimum', () => {
-    expect(BigNumber.isOutsideRangeWithUnits('1G', '2G', '3G')).toBe(true);
-    expect(BigNumber.isOutsideRangeWithUnits('1000M', '2G', '3G')).toBe(true);
-    expect(BigNumber.isOutsideRangeWithUnits('2.5B', '2M', '3M')).toBe(true);
+    expect(BigNumber.isOutsideRangeWithUnits('1g', '2g', '3g')).toBe(true);
+    expect(BigNumber.isOutsideRangeWithUnits('1000m', '2g', '3g')).toBe(true);
+    expect(BigNumber.isOutsideRangeWithUnits('2.5', '2m', '3m')).toBe(true);
   });
 
   it('should return true if the value is greater than the maximum', () => {
     expect(BigNumber.isOutsideRangeWithUnits('4G', '2G', '3G')).toBe(true);
     expect(BigNumber.isOutsideRangeWithUnits('4000M', '2G', '3G')).toBe(true);
-    expect(BigNumber.isOutsideRangeWithUnits('4B', '2M', '3M')).toBe(true);
+    expect(BigNumber.isOutsideRangeWithUnits('4', '2M', '3M')).toBe(true);
   });
 
   it('should return false if the value is within the range', () => {
     expect(BigNumber.isOutsideRangeWithUnits('2.5G', '2G', '3G')).toBe(false);
     expect(BigNumber.isOutsideRangeWithUnits('2050M', '2G', '3G')).toBe(false);
-    expect(BigNumber.isOutsideRangeWithUnits('2100000B', '2M', '3M')).toBe(
+    expect(BigNumber.isOutsideRangeWithUnits('2100000', '2M', '3M')).toBe(
       false,
     );
   });
@@ -333,23 +318,19 @@ describe('isOutsideRangeWithUnits', () => {
   it('should return false if the value is within the range (==min)', () => {
     expect(BigNumber.isOutsideRangeWithUnits('2G', '2G', '3G')).toBe(false);
     expect(BigNumber.isOutsideRangeWithUnits('2048M', '2G', '3G')).toBe(false);
-    expect(BigNumber.isOutsideRangeWithUnits('2097152B', '2M', '3M')).toBe(
+    expect(BigNumber.isOutsideRangeWithUnits('2097152', '2M', '3M')).toBe(
       false,
     );
-    expect(BigNumber.isOutsideRangeWithUnits('2097151B', '2M', '3M')).toBe(
-      true,
-    );
+    expect(BigNumber.isOutsideRangeWithUnits('2097151', '2M', '3M')).toBe(true);
   });
 
   it('should return false if the value is within the range (==max)', () => {
     expect(BigNumber.isOutsideRangeWithUnits('3G', '2G', '3G')).toBe(false);
     expect(BigNumber.isOutsideRangeWithUnits('3072K', '2M', '3M')).toBe(false);
-    expect(BigNumber.isOutsideRangeWithUnits('3145728B', '2M', '3M')).toBe(
+    expect(BigNumber.isOutsideRangeWithUnits('3145728', '2M', '3M')).toBe(
       false,
     );
-    expect(BigNumber.isOutsideRangeWithUnits('3145729B', '2M', '3M')).toBe(
-      true,
-    );
+    expect(BigNumber.isOutsideRangeWithUnits('3145729', '2M', '3M')).toBe(true);
   });
 
   it('should treat "undefined" as no upper or lower limit', () => {

--- a/react/src/hooks/useResourceLimitAndRemaining.tsx
+++ b/react/src/hooks/useResourceLimitAndRemaining.tsx
@@ -2,7 +2,7 @@ import { useSuspendedBackendaiClient } from '.';
 import { useResourceLimitAndRemainingFragment$key } from '../__generated__/useResourceLimitAndRemainingFragment.graphql';
 import { Image } from '../components/ImageEnvironmentSelectFormItems';
 import { AUTOMATIC_DEFAULT_SHMEM } from '../components/ResourceAllocationFormItems';
-import { addNumberWithUnits, convertBinarySizeUnit } from '../helper';
+import { addNumberWithUnits, convertToBinaryUnit } from '../helper';
 import { ResourceSlotName, useResourceSlots } from '../hooks/backendai';
 import { useSuspenseTanQuery } from './reactQueryAlias';
 import { useResourceGroupsForCurrentProject } from './useCurrentProject';
@@ -197,15 +197,14 @@ export const useResourceLimitAndRemaining = ({
       !_.isEmpty(
         checkPresetInfo?.scaling_groups[currentResourceGroup]?.remaining?.mem,
       )
-        ? convertBinarySizeUnit(
+        ? convertToBinaryUnit(
             _.toNumber(
               checkPresetInfo?.scaling_groups[currentResourceGroup]?.using.mem,
             ) +
               _.toNumber(
                 checkPresetInfo?.scaling_groups[currentResourceGroup]?.remaining
                   .mem,
-              ) +
-              'b',
+              ),
             'g',
             2,
           )?.numberFixed + 'g'
@@ -282,10 +281,10 @@ export const useResourceLimitAndRemaining = ({
               //handled by 'b' unit
               addNumberWithUnits(
                 _.max([
-                  convertBinarySizeUnit(currentImageMinM, 'b')?.number,
-                  convertBinarySizeUnit(AUTOMATIC_DEFAULT_SHMEM, 'b')?.number,
+                  convertToBinaryUnit(currentImageMinM, '')?.number,
+                  convertToBinaryUnit(AUTOMATIC_DEFAULT_SHMEM, '')?.number,
                   0,
-                ]) + 'b',
+                ]) + '',
                 AUTOMATIC_DEFAULT_SHMEM,
               ),
             max:
@@ -295,17 +294,17 @@ export const useResourceLimitAndRemaining = ({
                   ? undefined
                   : baiClient._config.maxMemoryPerContainer,
                 limitParser(checkPresetInfo?.keypair_limits.mem) &&
-                  convertBinarySizeUnit(
+                  convertToBinaryUnit(
                     limitParser(checkPresetInfo?.keypair_limits.mem) + '',
                     'g',
                   )?.number,
                 limitParser(checkPresetInfo?.group_limits.mem) &&
-                  convertBinarySizeUnit(
+                  convertToBinaryUnit(
                     limitParser(checkPresetInfo?.group_limits.mem) + '',
                     'g',
                   )?.number,
                 limitParser(currentResourceGroupSlotLimits.mem) &&
-                  convertBinarySizeUnit(
+                  convertToBinaryUnit(
                     limitParser(currentResourceGroupSlotLimits.mem) + '',
                     'g',
                   )?.number,

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -34,7 +34,7 @@ import {
   compareNumberWithUnits,
   formatDuration,
   generateRandomString,
-  convertBinarySizeUnit,
+  convertToBinaryUnit,
   filterEmptyItem,
 } from '../helper';
 import {
@@ -1624,15 +1624,14 @@ export const ResourceNumbersOfSession: React.FC<FormOrResourceRequired> = ({
               type={type}
               value={
                 type === 'mem'
-                  ? (convertBinarySizeUnit(value.toString(), 'b')?.number ||
-                      0) *
+                  ? (convertToBinaryUnit(value.toString(), '')?.number || 0) *
                       containerCount +
                     ''
                   : _.toNumber(value) * containerCount + ''
               }
               opts={{
                 shmem: resource.shmem
-                  ? (convertBinarySizeUnit(resource.shmem, 'b')?.number || 0) *
+                  ? (convertToBinaryUnit(resource.shmem, '')?.number || 0) *
                     containerCount
                   : undefined,
               }}


### PR DESCRIPTION
Resolves #3741 (FR-1057)

## Refactor Size Unit Display and Conversion Functions

This PR refactors how size units are displayed across the UI by introducing more consistent formatting methods. It replaces the previous conversion functions (`convertBinarySizeUnit` and `convertDecimalSizeUnit`) with improved versions (`convertToBinaryUnit` and `convertToDecimalUnit`) that provide better formatted output.

The changes improve readability by:
1. Standardizing the display of binary units (KiB, MiB, GiB) and decimal units (KB, MB, GB)
2. Adding `displayValue` and `displayUnit` properties to conversion results
3. Simplifying unit parsing and conversion logic
4. Making the API more consistent across all components

Refactoring of Function Responsibilities:
- `convertUnitValue`: Converts the unit of a value expressed with a lowercase unit. The existing 'b' unit is removed, and cases with no unit (an empty string) are treated the same as the previous 'b'.
- `convertToBinaryUnit` & `convertToDecimalUnit`: The `displayValue` is shown with the unit in uppercase, followed by either 'iB' or 'B' (e.g., 123 GiB).

Key improvements:
- Renamed functions to better reflect their purpose (`convertToBinaryUnit` instead of `convertBinarySizeUnit`)
- Changed the return value structure to include both raw values and display-ready formatted strings
- Updated all component references to use the new properties
- Improved handling of unit-less values and automatic unit selection
- Fixed inconsistencies in how memory sizes were displayed throughout the application

These changes ensure that size units are displayed with proper formatting across agent details, resource allocation forms, storage volume panels, and other components that display size information.