### PR TITLE
feat(FR-739): add FolderInvitationResponseModal and related hooks for managing folder invitations

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -51,6 +51,9 @@ const ResourcesPage = React.lazy(() => import('./pages/ResourcesPage'));
 const FolderExplorerOpener = React.lazy(
   () => import('./components/FolderExplorerOpener'),
 );
+const FolderInvitationResponseModalOpener = React.lazy(
+  () => import('./components/FolderInvitationResponseModalOpener'),
+);
 const ServiceLauncherCreatePage = React.lazy(
   () => import('./components/ServiceLauncherPageContent'),
 );
@@ -114,6 +117,7 @@ const router = createBrowserRouter([
         <RoutingEventHandler />
         <Suspense fallback={null}>
           <FolderExplorerOpener />
+          <FolderInvitationResponseModalOpener />
         </Suspense>
       </QueryParamProvider>
     ),

--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -1,5 +1,8 @@
-import { useSuspendedBackendaiClient } from '../hooks';
-import { useVFolderInvitations } from '../hooks/backendai';
+import {
+  InvitationItem,
+  useSetVFolderInvitations,
+  useVFolderInvitationsValue,
+} from '../hooks/useVFolderInvitations';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
 import VFolderPermissionCell from './VFolderPermissionCell';
@@ -7,21 +10,6 @@ import { FolderOutlined } from '@ant-design/icons';
 import { List, Button, Typography, theme, Descriptions, App } from 'antd';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-
-interface InvitationItem {
-  id: string;
-  vfolder_id: string;
-  vfolder_name: string;
-  invitee_user_email?: string;
-  inviter_user_email?: string;
-  invitee?: string;
-  inviter?: string;
-  mount_permission: string;
-  created_at: string;
-  modified_at: string | null;
-  status: string;
-  perm: string;
-}
 
 interface FolderInvitationResponseModalProps extends BAIModalProps {
   onRequestClose?: (success: boolean) => void;
@@ -34,16 +22,16 @@ const FolderInvitationResponseModal: React.FC<
   const { token } = theme.useToken();
   const { message } = App.useApp();
   const { t } = useTranslation();
-  const baiClient = useSuspendedBackendaiClient();
-  const hasInviterEmail = baiClient.isManagerVersionCompatibleWith('25.6.0');
-  const [
-    { invitations },
-    { acceptInvitation, rejectInvitation: declineInvitation },
-  ] = useVFolderInvitations(fetchKey);
+  const { invitations } = useVFolderInvitationsValue();
+  const { acceptInvitation, rejectInvitation } = useSetVFolderInvitations();
+
+  // Memoize invitations to prevent unnecessary re-renders
+  const memoizedInvitations = React.useMemo(() => invitations, [invitations]);
 
   const renderInvitationItem = useCallback(
     (item: InvitationItem) => (
       <List.Item
+        key={item.id}
         actions={[
           <Button
             type="primary"
@@ -70,7 +58,7 @@ const FolderInvitationResponseModal: React.FC<
           <Button
             danger
             onClick={() =>
-              declineInvitation(item.id, {
+              rejectInvitation(item.id, {
                 onSuccess: () => {
                   onRequestClose?.(true);
                   message.success(
@@ -109,9 +97,7 @@ const FolderInvitationResponseModal: React.FC<
                 {
                   key: 'from',
                   label: t('data.From'),
-                  children: hasInviterEmail
-                    ? item.inviter_user_email
-                    : item.inviter,
+                  children: item.inviter_user_email,
                 },
                 {
                   key: 'permission',
@@ -124,8 +110,14 @@ const FolderInvitationResponseModal: React.FC<
         />
       </List.Item>
     ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [acceptInvitation, declineInvitation, onRequestClose],
+    [
+      acceptInvitation,
+      rejectInvitation,
+      onRequestClose,
+      message,
+      t,
+      token.paddingSM,
+    ],
   );
 
   return (
@@ -136,12 +128,8 @@ const FolderInvitationResponseModal: React.FC<
       {...baiModalProps}
     >
       <List
-        dataSource={invitations}
-        renderItem={(item) =>
-          renderInvitationItem({
-            ...item,
-          })
-        }
+        dataSource={memoizedInvitations}
+        renderItem={renderInvitationItem}
       />
     </BAIModal>
   );

--- a/react/src/components/FolderInvitationResponseModalOpener.tsx
+++ b/react/src/components/FolderInvitationResponseModalOpener.tsx
@@ -1,0 +1,28 @@
+import { useVFolderInvitationsValue } from '../hooks/useVFolderInvitations';
+import React from 'react';
+import { useQueryParam, StringParam } from 'use-query-params';
+
+const FolderInvitationResponseModal = React.lazy(
+  () => import('./FolderInvitationResponseModal'),
+);
+
+const FolderInvitationResponseModalOpener = () => {
+  const [isInvitationOpen, setIsInvitationOpen] = useQueryParam(
+    'invitation',
+    StringParam,
+  );
+  const { count } = useVFolderInvitationsValue();
+
+  return (
+    <FolderInvitationResponseModal
+      open={isInvitationOpen === 'true'}
+      onRequestClose={(success) => {
+        if (!success || count === 1) {
+          setIsInvitationOpen(null, 'replaceIn');
+        }
+      }}
+    />
+  );
+};
+
+export default FolderInvitationResponseModalOpener;

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -134,7 +134,7 @@ interface UserInfo {
   uuid: string;
 }
 
-type mutationOptions<T> = {
+export type mutationOptions<T> = {
   onSuccess?: (value: T) => void;
   onError?: (error: any) => void;
 };
@@ -359,10 +359,10 @@ export const useVFolderInvitations = (fetchKey?: string) => {
           { inv_id },
           {
             onSuccess: () => {
-              options?.onSuccess && options.onSuccess(inv_id);
+              options?.onSuccess?.(inv_id);
             },
             onError: (error: any) => {
-              options?.onError && options.onError(error);
+              options?.onError?.(error);
             },
           },
         );
@@ -372,10 +372,10 @@ export const useVFolderInvitations = (fetchKey?: string) => {
           { inv_id },
           {
             onSuccess: () => {
-              options?.onSuccess && options.onSuccess(inv_id);
+              options?.onSuccess?.(inv_id);
             },
             onError: (error: any) => {
-              options?.onError && options.onError(error);
+              options?.onError?.(error);
             },
           },
         );

--- a/react/src/hooks/useVFolderInvitations.tsx
+++ b/react/src/hooks/useVFolderInvitations.tsx
@@ -1,0 +1,97 @@
+import { useSuspendedBackendaiClient } from '.';
+import { mutationOptions } from './backendai';
+import { useTanMutation } from './reactQueryAlias';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { atomWithDefault } from 'jotai/utils';
+import { useCallback, useEffect } from 'react';
+
+export interface InvitationItem {
+  id: string;
+  vfolder_id: string;
+  vfolder_name: string;
+  invitee_user_email: string;
+  inviter_user_email: string;
+  mount_permission: string;
+  created_at: string;
+  modified_at: string | null;
+  status: string;
+  perm: string;
+}
+
+const vFolderInvitationsAtom = atomWithDefault(async () => {
+  return {
+    invitations: [] as InvitationItem[],
+    count: 0,
+  };
+});
+
+export const useVFolderInvitationsValue = () => {
+  const { updateInvitations } = useSetVFolderInvitations();
+  useEffect(() => {
+    updateInvitations();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return useAtomValue(vFolderInvitationsAtom);
+};
+
+export const useSetVFolderInvitations = () => {
+  const setInvitations = useSetAtom(vFolderInvitationsAtom);
+  const baiClient = useSuspendedBackendaiClient();
+
+  const updateInvitations = useCallback(async () => {
+    const data = await baiClient.vfolder.invitations();
+    setInvitations((prev) => ({
+      ...prev,
+      invitations: data.invitations as InvitationItem[],
+      count: data.invitations.length ?? 0,
+    }));
+  }, [baiClient, setInvitations]);
+
+  const mutationToAcceptInvitation = useTanMutation({
+    mutationFn: (values: { inv_id: string }) => {
+      return baiClient.vfolder.accept_invitation(values.inv_id);
+    },
+    onSuccess: () => {
+      updateInvitations();
+    },
+  });
+
+  const mutationToRejectInvitation = useTanMutation({
+    mutationFn: (values: { inv_id: string }) => {
+      return baiClient.vfolder.delete_invitation(values.inv_id);
+    },
+    onSuccess: () => {
+      updateInvitations();
+    },
+  });
+
+  return {
+    updateInvitations,
+    acceptInvitation: (inv_id: string, options?: mutationOptions<string>) => {
+      mutationToAcceptInvitation.mutate(
+        { inv_id },
+        {
+          onSuccess: () => {
+            options?.onSuccess?.(inv_id);
+          },
+          onError: (error: any) => {
+            options?.onError?.(error);
+          },
+        },
+      );
+    },
+    rejectInvitation: (inv_id: string, options?: mutationOptions<string>) => {
+      mutationToRejectInvitation.mutate(
+        { inv_id },
+        {
+          onSuccess: () => {
+            options?.onSuccess?.(inv_id);
+          },
+          onError: (error: any) => {
+            options?.onError?.(error);
+          },
+        },
+      );
+    },
+  };
+};

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -1,8 +1,3 @@
-import {
-  VFolderNodeListPageQuery,
-  VFolderNodeListPageQuery$data,
-  VFolderNodeListPageQuery$variables,
-} from '../__generated__/VFolderNodeListPageQuery.graphql';
 import ActionItemContent from '../components/ActionItemContent';
 import BAICard from '../components/BAICard';
 import BAIFetchKeyButton from '../components/BAIFetchKeyButton';
@@ -17,7 +12,6 @@ import BAITabs from '../components/BAITabs';
 import DeleteVFolderModal from '../components/DeleteVFolderModal';
 import Flex from '../components/Flex';
 import FolderCreateModal from '../components/FolderCreateModal';
-import FolderInvitationResponseModal from '../components/FolderInvitationResponseModal';
 import QuotaPerStorageVolumePanelCard from '../components/QuotaPerStorageVolumePanelCard';
 import RestoreVFolderModal from '../components/RestoreVFolderModal';
 import StorageStatusPanelCard from '../components/StorageStatusPanelCard';
@@ -27,11 +21,20 @@ import {
   filterNonNullItems,
   handleRowSelectionChange,
 } from '../helper';
-import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
-import { useVFolderInvitations } from '../hooks/backendai';
+import {
+  useSuspendedBackendaiClient,
+  useUpdatableState,
+  useWebUINavigate,
+} from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useDeferredQueryParams } from '../hooks/useDeferredQueryParams';
+import { useVFolderInvitationsValue } from '../hooks/useVFolderInvitations';
+import {
+  VFolderNodeListPageQuery,
+  VFolderNodeListPageQuery$data,
+  VFolderNodeListPageQuery$variables,
+} from './__generated__/VFolderNodeListPageQuery.graphql';
 import { useToggle } from 'ahooks';
 import {
   Badge,
@@ -95,6 +98,8 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   const { lg } = Grid.useBreakpoint();
   const currentProject = useCurrentProjectValue();
   const baiClient = useSuspendedBackendaiClient();
+  const webuiNavigate = useWebUINavigate();
+  const { count } = useVFolderInvitationsValue();
 
   const [selectedFolderList, setSelectedFolderList] = useState<
     Array<VFolderNodesType>
@@ -109,8 +114,6 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   const [isOpenCreateModal, { toggle: toggleCreateModal }] = useToggle(false);
   const [isOpenDeleteModal, { toggle: toggleDeleteModal }] = useToggle(false);
   const [isOpenRestoreModal, { toggle: toggleRestoreModal }] = useToggle(false);
-  const [isInvitationResponseModalOpen, setIsInvitationResponseModalOpen] =
-    useState(false);
 
   const {
     baiPaginationOption,
@@ -186,8 +189,11 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const deferredFetchKey = useDeferredValue(fetchKey);
 
-  const [{ count, isFetching, isPendingMutation }] =
-    useVFolderInvitations(deferredFetchKey);
+  useEffect(() => {
+    updateFetchKey();
+    // Update fetchKey when count changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [count]);
 
   const { vfolder_nodes, ...folderCounts } =
     useLazyLoadQuery<VFolderNodeListPageQuery>(
@@ -305,7 +311,11 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                 style={{ height: lg ? 200 : undefined }}
                 fetchKey={deferredFetchKey}
                 onRequestBadgeClick={() => {
-                  setIsInvitationResponseModalOpen(true);
+                  webuiNavigate({
+                    search: new URLSearchParams({
+                      invitation: 'true',
+                    }).toString(),
+                  });
                 }}
               />
             </Suspense>
@@ -644,25 +654,6 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
           toggleRestoreModal();
         }}
       />
-      <Suspense>
-        <FolderInvitationResponseModal
-          open={isInvitationResponseModalOpen}
-          loading={
-            isFetching || isPendingMutation || deferredFetchKey !== fetchKey
-          }
-          fetchKey={deferredFetchKey}
-          onRequestClose={(success) => {
-            if (success) {
-              if (count === 1) {
-                setIsInvitationResponseModalOpen(false);
-              }
-              updateFetchKey();
-            } else {
-              setIsInvitationResponseModalOpen(false);
-            }
-          }}
-        />
-      </Suspense>
     </Flex>
   );
 };


### PR DESCRIPTION

Resolves #3714 ([FR-739](https://lablup.atlassian.net/browse/FR-739))

# Refactor Folder Invitation System with Global Modal Access

This PR refactors the folder invitation system to use a global modal that can be accessed from anywhere in the application.

Key changes:
- Created a new `useVFolderInvitations` hook with Jotai state management for better performance and global state access
- Added `FolderInvitationResponseModalOpener` component that can be triggered via URL query parameters
- Moved invitation data model to a dedicated hook for better code organization
- Added notification for pending folder invitations on the StartPage
- Improved rendering performance with memoization of invitation items
- Fixed key prop warning in the invitation list

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-739]: https://lablup.atlassian.net/browse/FR-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ