### PR TITLE
fix(FR-1049):modify to display the inviter’s email

### DIFF
--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -1,3 +1,4 @@
+import { useSuspendedBackendaiClient } from '../hooks';
 import { useVFolderInvitations } from '../hooks/backendai';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
@@ -11,8 +12,10 @@ interface InvitationItem {
   id: string;
   vfolder_id: string;
   vfolder_name: string;
-  invitee_user_email: string;
-  inviter_user_email: string;
+  invitee_user_email?: string;
+  inviter_user_email?: string;
+  invitee?: string;
+  inviter?: string;
   mount_permission: string;
   created_at: string;
   modified_at: string | null;
@@ -31,6 +34,8 @@ const FolderInvitationResponseModal: React.FC<
   const { token } = theme.useToken();
   const { message } = App.useApp();
   const { t } = useTranslation();
+  const baiClient = useSuspendedBackendaiClient();
+  const hasInviterEmail = baiClient.isManagerVersionCompatibleWith('25.6.0');
   const [
     { invitations },
     { acceptInvitation, rejectInvitation: declineInvitation },
@@ -104,7 +109,9 @@ const FolderInvitationResponseModal: React.FC<
                 {
                   key: 'from',
                   label: t('data.From'),
-                  children: item.inviter_user_email,
+                  children: hasInviterEmail
+                    ? item.inviter_user_email
+                    : item.inviter,
                 },
                 {
                   key: 'permission',


### PR DESCRIPTION
resolves #3731 (FR-1049)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR resolves an issue that prevented some versions from showing invited users.

In version 25.6.0 and later, `invitee` and `inviter` are followed by `_user_email`.

**changes**
* Fixed to work with Manager version 25.6.0 and earlier

![CleanShot 2025-05-30 at 19.25.17@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/4361283d-f3c0-4f49-a9aa-500d89044800.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
