### PR TITLE
fix(FR-1051): show only status info name and hide status info detail

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionStatusDetailModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionStatusDetailModal.tsx
@@ -102,7 +102,7 @@ const SessionStatusDetailModal: React.FC<SessionStatusDetailModalProps> = ({
                 style: { fontWeight: 'normal' },
               },
               {
-                label: session.status_info ?? '',
+                label: _.split(session.status_info, ' ')[0] ?? '',
                 color: session.status_info
                   ? _.get(statusInfoTagColor, session.status_info)
                   : undefined,

--- a/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
@@ -114,7 +114,7 @@ const SessionStatusTag: React.FC<SessionStatusTagProps> = ({
               : undefined
           }
         >
-          {session.status_info}
+          {_.split(session.status_info, ' ')[0]}
         </Tag>
       </Flex>
     )


### PR DESCRIPTION
resolves #3728 (FR-1051)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

There are two forms of `status_info`. One has only an info_name representing the info, and the other has both an info_name and a status_detail. Since `status_detail` is shown in `SessionStatusDetailModal`, modify the Status Tag to show only `Info_name` without detail.

case 1)  "status_info": "image-pull-failed". `HcNzqkij-session` in finished tab in dogbowl
case 2)   "status_info": "other-error (SerializationError('could not serialize access due to read/write dependencies among transactions'))". `gemma-3-1b-it-ad31e508-343e-42b6-a472-c3b29187044a` session in running tab in dogbowl

|before|after|
|---|---|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/9ccf50ac-85c0-43c5-b04b-3adc3c3b6d6b.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/a90f8da2-405e-4c27-91b2-93318e5562d9.png)|
|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/5f2ee441-1262-455a-bbd9-8bdd368efe77.png)|![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/6e0e6ca1-0e10-44ca-b84f-15986399d376.png)|

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
