### PR TITLE
fix(FR-1058): handling default value in useDeferredQueryParams

### DIFF
--- a/react/src/hooks/useDeferredQueryParams.tsx
+++ b/react/src/hooks/useDeferredQueryParams.tsx
@@ -47,11 +47,20 @@ export function useDeferredQueryParams<QPCMap extends QueryParamConfigMap>(
   const isBeforeInitializingRef = useRef(true);
   const selectiveQueryAtom = useMemo(
     () => {
+      const defaultValues = _.mapValues(
+        paramConfigMap,
+        (config) => config.default,
+      );
       return atomWithDefault((get) => {
         const globalParams = get(queryParamsAtom);
         const selectedParams = _.pick(
           // Use query parameters from URL on initial render
-          isBeforeInitializingRef.current ? query : globalParams,
+          isBeforeInitializingRef.current
+            ? query
+            : {
+                ...defaultValues,
+                ...globalParams,
+              },
           Object.keys(paramConfigMap),
         );
         isBeforeInitializingRef.current = false;

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -64,7 +64,7 @@ const ComputeSessionListPage = () => {
   });
 
   const [queryParams, setQuery] = useDeferredQueryParams({
-    order: withDefault(StringParam, undefined),
+    order: withDefault(StringParam, '-created_at'),
     filter: withDefault(StringParam, undefined),
     type: withDefault(StringParam, 'all'),
     statusCategory: withDefault(StringParam, 'running'),
@@ -106,7 +106,7 @@ const ComputeSessionListPage = () => {
       offset: baiPaginationOption.offset,
       first: baiPaginationOption.first,
       filter: mergeFilterValues([statusFilter, queryParams.filter, typeFilter]),
-      order: queryParams.order || '-created_at',
+      order: queryParams.order,
     }),
     [
       currentProject.id,
@@ -382,7 +382,7 @@ const ComputeSessionListPage = () => {
                     type: 'string',
                   },
                 ]}
-                value={queryParams.filter || undefined}
+                value={queryParams.filter}
                 onChange={(value) => {
                   setQuery({ filter: value }, 'replaceIn');
                   setTablePaginationOption({ current: 1 });

--- a/react/src/pages/ServingPage.tsx
+++ b/react/src/pages/ServingPage.tsx
@@ -29,7 +29,7 @@ const ServingPage: React.FC = () => {
   const currentProject = useCurrentProjectValue();
 
   const [queryParams, setQuery] = useDeferredQueryParams({
-    order: withDefault(StringParam, undefined),
+    order: withDefault(StringParam, '-created_at'),
     filter: StringParam,
     lifecycleStage: withDefault(StringParam, 'active'),
   });
@@ -56,7 +56,7 @@ const ServingPage: React.FC = () => {
       limit: baiPaginationOption.limit,
       projectID: currentProject.id,
       filter: mergeFilterValues([lifecycleStageFilter, queryParams.filter]),
-      order: queryParams.order || '-created_at',
+      order: queryParams.order,
     }),
     [baiPaginationOption, currentProject.id, lifecycleStageFilter, queryParams],
   );

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -123,7 +123,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   });
 
   const [queryParams, setQuery] = useDeferredQueryParams({
-    order: withDefault(StringParam, undefined),
+    order: withDefault(StringParam, '-created_at'),
     filter: withDefault(StringParam, undefined),
     statusCategory: withDefault(StringParam, 'active'),
     mode: withDefault(StringParam, 'all'),
@@ -171,7 +171,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
         queryParams.filter,
         usageModeFilter,
       ]),
-      order: queryParams.order || '-created_at',
+      order: queryParams.order,
       permission: 'read_attribute',
     }),
     [


### PR DESCRIPTION
Resolves #3742 (FR-1058)

## Fix query parameter handling in useDeferredQueryParams hook

This PR updates the `useDeferredQueryParams` hook to properly handle default values for query parameters. Previously, default values were only applied when explicitly setting parameters, but not when reading from the global state. This caused issues with pagination and sorting on various list pages.

Changes:
- Modified `useDeferredQueryParams` to apply default values when reading from global state
- Updated default order parameter to `-created_at` in ComputeSessionListPage, ServingPage, and VFolderNodeListPage
- Removed redundant fallback logic for order parameters in these pages
