### PR TITLE
feat(FR-1070): Include new accelerator information in session creation payload

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -507,7 +507,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                   resource_opts: JSON.stringify({
                     shmem: values.resource.shmem,
                   }),
-                  // FIXME: temporally convert cluster mode string according to server-side type
+                  // FIXME: temporarily convert cluster mode string according to server-side type
                   cluster_mode:
                     'single-node' === values.cluster_mode
                       ? 'SINGLE_NODE'

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -291,7 +291,6 @@ const SessionDetailContent: React.FC<{
             <Flex gap="xs" wrap="wrap">
               {session.vfolder_nodes
                 ? session.vfolder_nodes.edges.map((vfolder, idx) => {
-                    console.log(vfolder?.node);
                     return (
                       vfolder?.node && (
                         <FolderLink

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -96,29 +96,38 @@ import {
   withDefault,
 } from 'use-query-params';
 
-interface SessionConfig {
-  group_name: string;
-  domain: string;
-  scaling_group: string;
-  type: string;
-  cluster_mode: string;
+interface SessionResources {
+  group_name?: string;
+  domain?: string;
+  type?: 'interactive' | 'batch' | 'inference' | 'system';
+  cluster_mode: 'single-node' | 'multi-node';
   cluster_size: number;
   maxWaitSeconds: number;
-  cpu: number;
-  mem: string;
-  shmem: string;
-  mounts: string[];
-  mount_map: {
-    [key: string]: string;
-  };
-  env: {
-    [key: string]: string;
-  };
-  preopen_ports: number[];
-  startsAt?: string;
+  starts_at?: string;
   startupCommand?: string;
   bootstrap_script?: string;
-  agent_list?: string[];
+  owner_access_key?: string;
+  config?: {
+    resources?: {
+      cpu: number;
+      mem: string;
+      [key: string]: number | string;
+    };
+    resource_opts?: {
+      shmem?: string;
+      allow_fractional_resource_fragmentation?: boolean;
+    };
+    mounts?: string[];
+    mount_map?: {
+      [key: string]: string;
+    };
+    environ?: {
+      [key: string]: string;
+    };
+    scaling_group?: string;
+    preopen_ports?: number[];
+    agent_list?: string[];
+  };
 }
 
 interface CreateSessionInfo {
@@ -126,7 +135,7 @@ interface CreateSessionInfo {
   sessionName: string;
   architecture: string;
   batchTimeout?: string;
-  config: SessionConfig;
+  resources: SessionResources;
 }
 
 interface SessionLauncherValue {
@@ -433,91 +442,114 @@ const SessionLauncherPage = () => {
           : values.sessionName;
 
         const sessionInfo: CreateSessionInfo = {
+          // Basic session information
+          sessionName: sessionName,
           kernelName,
           architecture,
-          sessionName: sessionName,
-          ...(supportBatchTimeout &&
-          values?.batch?.timeoutEnabled &&
-          !_.isUndefined(values?.batch?.timeout)
-            ? {
-                batchTimeout:
-                  _.toString(values.batch.timeout) + values?.batch?.timeoutUnit,
-              }
-            : undefined),
-          config: {
-            ...(baiClient.supports('agent-select') &&
-            !baiClient?._config?.hideAgents &&
-            values.agent !== 'auto'
-              ? {
-                  agent_list: [values.agent].filter(
-                    (agent): agent is string => !!agent,
-                  ),
-                } // Filter out undefined values
-              : undefined),
+          resources: {
+            // Project and domain settings
+            group_name: values.owner?.enabled
+              ? values.owner.project
+              : currentProject.name,
+            domain: values.owner?.enabled
+              ? values.owner.domainName
+              : baiClient._config.domainName,
+
+            // Session configuration
             type: values.sessionType,
-            ...(_.isEmpty(values.bootstrap_script)
-              ? {}
-              : {
-                  bootstrap_script: values.bootstrap_script,
-                }),
+            cluster_mode: values.cluster_mode,
+            cluster_size: values.cluster_size,
+            maxWaitSeconds: 15,
+
+            // Owner settings (optional)
+            // FYI, `config.scaling_group` also changes based on owner settings
+            ...(values.owner?.enabled
+              ? {
+                  owner_access_key: values.owner.accesskey,
+                }
+              : {}),
+
+            // Batch mode settings (optional)
             ...(values.sessionType === 'batch'
               ? {
-                  startsAt: values.batch.enabled
+                  starts_at: values.batch.enabled
                     ? values.batch.scheduleDate
                     : undefined,
                   startupCommand: values.batch.command,
                 }
               : {}),
 
-            // TODO: support change owner
-            ...(values.owner?.enabled
-              ? {
-                  group_name: values.owner.project,
-                  domain: values.owner.domainName,
-                  scaling_group: values.owner.project,
-                  owner_access_key: values.owner.accesskey,
-                }
-              : {
-                  group_name: currentProject.name,
-                  domain: baiClient._config.domainName,
-                  scaling_group: values.resourceGroup,
-                }),
-            cluster_mode: values.cluster_mode,
-            cluster_size: values.cluster_size,
-            maxWaitSeconds: 15,
-            cpu: values.resource.cpu,
-            mem: values.resource.mem,
-            shmem:
-              compareNumberWithUnits(values.resource.mem, '4g') > 0 &&
-              compareNumberWithUnits(values.resource.shmem, '1g') < 0
-                ? '1g'
-                : values.resource.shmem,
-            ...(values.resource.accelerator > 0
-              ? {
-                  [values.resource.acceleratorType]:
-                    values.resource.accelerator,
-                }
-              : undefined),
-            mounts: values.mounts,
-            mount_map: values.vfoldersAliasMap,
+            // Bootstrap script (optional)
+            ...(values.bootstrap_script
+              ? { bootstrap_script: values.bootstrap_script }
+              : {}),
 
-            env: {
-              ..._.fromPairs(values.envvars.map((v) => [v.variable, v.value])),
-              // set hpcOptimization options: "OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS"
-              ...(values.hpcOptimization.autoEnabled
-                ? {}
-                : _.omit(values.hpcOptimization, 'autoEnabled')),
-            },
-            preopen_ports: transformPortValuesToNumbers(values.ports),
-            ...(baiClient.supports('agent-select') &&
-            !baiClient?._config?.hideAgents &&
-            values.agent !== 'auto'
+            // Batch timeout configuration (optional)
+            ...(supportBatchTimeout &&
+            values?.batch?.timeoutEnabled &&
+            !_.isUndefined(values?.batch?.timeout)
               ? {
-                  agent_list: [values.agent].filter(
-                    (agent): agent is string => !!agent,
-                  ),
-                } // Filter out undefined values
+                  batchTimeout:
+                    _.toString(values.batch.timeout) +
+                    values?.batch?.timeoutUnit,
+                }
               : undefined),
+
+            config: {
+              // Resource allocation
+              resources: {
+                cpu: values.resource.cpu,
+                mem: values.resource.mem,
+                // Add accelerator only if specified
+                ...(values.resource.accelerator > 0
+                  ? {
+                      [values.resource.acceleratorType]:
+                        values.resource.accelerator,
+                    }
+                  : undefined),
+              },
+              scaling_group: values.owner?.enabled
+                ? values.owner.project
+                : values.resourceGroup,
+              resource_opts: {
+                shmem:
+                  compareNumberWithUnits(values.resource.mem, '4g') > 0 &&
+                  compareNumberWithUnits(values.resource.shmem, '1g') < 0
+                    ? '1g'
+                    : values.resource.shmem,
+                // allow_fractional_resource_fragmentation can be added here if needed
+              },
+
+              // Storage configuration
+              mounts: values.mounts,
+              mount_map: values.vfoldersAliasMap,
+
+              // Environment variables
+              environ: {
+                ..._.fromPairs(
+                  values.envvars.map((v) => [v.variable, v.value]),
+                ),
+                // set hpcOptimization options: "OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS"
+                ...(values.hpcOptimization.autoEnabled
+                  ? {}
+                  : _.omit(values.hpcOptimization, 'autoEnabled')),
+              },
+
+              // Networking
+              preopen_ports: transformPortValuesToNumbers(values.ports),
+
+              // Agent selection (optional)
+              ...(baiClient.supports('agent-select') &&
+              !baiClient?._config?.hideAgents &&
+              values.agent !== 'auto'
+                ? {
+                    // Filter out undefined values
+                    agent_list: [values.agent].filter(
+                      (agent): agent is string => !!agent,
+                    ),
+                  }
+                : undefined),
+            },
           },
         };
         const sessionPromises = _.map(
@@ -531,10 +563,9 @@ const SessionLauncherPage = () => {
               .createIfNotExists(
                 sessionInfo.kernelName,
                 formattedSessionName,
-                sessionInfo.config,
+                sessionInfo.resources,
                 undefined,
                 sessionInfo.architecture,
-                sessionInfo.batchTimeout,
               )
               .then((res: { created: boolean; status: string }) => {
                 // // When session is already created with the same name, the status code

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -806,7 +806,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
 
     // Apply v1 when executing in electron mode
     const wsproxyVersion = await this._getWSProxyVersion(sessionUuid);
-    let uri =
+    const uri =
       wsproxyVersion == 'v1'
         ? await this._resolveV1ProxyUri(sessionUuid, app)
         : await this._resolveV2ProxyUri(sessionUuid, app, null, envs, args);

--- a/src/components/backend-ai-splash.ts
+++ b/src/components/backend-ai-splash.ts
@@ -15,7 +15,7 @@ import { customElement, property, query } from 'lit/decorators.js';
  `backend-ai-splash` shows simple summary about current app / web application.
 
  Example:
- 
+
  ```
  <backend-ai-splash></backend-ai-splash>
  ...

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -9,6 +9,7 @@ Licensed under MIT
 import CryptoES from 'crypto-es';
 //var CryptoES = require("crypto-js"); /* Exclude for ES6 */
 import { comparePEP440Versions, isCompatibleMultipleConditions} from './pep440';
+import { SessionResources } from '../types/backend-ai-console';
 type requestInfo = {
   method: string;
   headers: Headers;
@@ -1090,10 +1091,14 @@ class Client {
   async createIfNotExists(
     kernelType: string,
     sessionId: string,
-    resources = {},
+    resources: SessionResources = {
+      type: 'interactive',
+      cluster_mode: 'single-node',
+      cluster_size: 1,
+      maxWaitSeconds: 0,
+    },
     timeout?: number,
     architecture: string = 'x86_64',
-    batchTimeout?: string,
   ) {
     if (
       typeof sessionId === 'undefined' ||
@@ -1102,133 +1107,12 @@ class Client {
     ) {
       sessionId = this.generateSessionId();
     }
-    let params = {
+    const params = {
       lang: kernelType,
       clientSessionToken: sessionId,
       architecture: architecture,
+      ...resources
     };
-    if (batchTimeout) {
-      params['batch_timeout'] = batchTimeout;
-    }
-    if (resources && Object.keys(resources).length !== 0) {
-      let config = {};
-      if (resources['cpu']) {
-        config['cpu'] = resources['cpu'];
-      }
-      if (resources['mem']) {
-        config['mem'] = resources['mem'];
-      }
-      if (resources['gpu']) {
-        // Legacy support (till 19.09)
-        config['cuda.device'] = parseInt(resources['gpu']);
-      }
-      if (resources['cuda.device']) {
-        // Generalized device information from 20.03
-        config['cuda.device'] = parseInt(resources['cuda.device']);
-      }
-      if (resources['vgpu']) {
-        // Legacy support (till 19.09)
-        config['cuda.shares'] = parseFloat(resources['vgpu']).toFixed(2); // under 19.03
-      } else if (resources['fgpu']) {
-        config['cuda.shares'] = parseFloat(resources['fgpu']).toFixed(2); // 19.09 and above
-      }
-      if (resources['cuda.shares']) {
-        // Generalized device information from 20.03
-        config['cuda.shares'] = parseFloat(resources['cuda.shares']).toFixed(2);
-      }
-      if (resources['rocm.device']) {
-        config['rocm.device'] = parseInt(resources['rocm.device']);
-      }
-      if (resources['tpu.device']) {
-        config['tpu.device'] = parseInt(resources['tpu.device']);
-      }
-      if (resources['ipu.device']) {
-        config['ipu.device'] = parseInt(resources['ipu.device']);
-      }
-      if (resources['atom.device']) {
-        config['atom.device'] = parseInt(resources['atom.device']);
-      }
-      if (resources['atom-plus.device']) {
-        config['atom-plus.device'] = parseInt(resources['atom-plus.device']);
-      }
-      if (resources['gaudi2.device']) {
-        config['gaudi2.device'] = parseInt(resources['gaudi2.device']);
-      }
-      if (resources['warboy.device']) {
-        config['warboy.device'] = parseInt(resources['warboy.device']);
-      }
-      if (resources['rngd.device']) {
-        config['rngd.device'] = parseInt(resources['rngd.device']);
-      }
-      if (resources['hyperaccel-lpu.device']) {
-        config['hyperaccel-lpu.device'] = parseInt(resources['hyperaccel-lpu.device']);
-      }
-      if (resources['cluster_size']) {
-        params['cluster_size'] = resources['cluster_size'];
-      }
-      if (resources['cluster_mode']) {
-        params['cluster_mode'] = resources['cluster_mode'];
-      }
-      if (resources['group_name']) {
-        params['group_name'] = resources['group_name'];
-      }
-      if (resources['domain']) {
-        params['domain'] = resources['domain'];
-      }
-      if (resources['type']) {
-        params['type'] = resources['type'];
-      }
-      if (resources['startsAt']) {
-        params['starts_at'] = resources['startsAt'];
-      }
-      if (resources['enqueueOnly']) {
-        params['enqueueOnly'] = resources['enqueueOnly'];
-      }
-      if (resources['maxWaitSeconds']) {
-        params['maxWaitSeconds'] = resources['maxWaitSeconds'];
-      }
-      if (resources['reuseIfExists']) {
-        params['reuseIfExists'] = resources['reuseIfExists'];
-      }
-      if (resources['startupCommand']) {
-        params['startupCommand'] = resources['startupCommand'];
-      }
-      if (resources['bootstrapScript']) {
-        params['bootstrapScript'] = resources['bootstrapScript'];
-      }
-      if (resources['bootstrap_script']) {
-        params['bootstrap_script'] = resources['bootstrap_script'];
-      }
-      if (resources['owner_access_key']) {
-        params['owner_access_key'] = resources['owner_access_key'];
-      }
-      if (resources['batch_timeout']) {
-        params['batch_timeout'] = resources['batch_timeout'];
-      }
-      params['config'] = { resources: config };
-      if (resources['mounts']) {
-        params['config'].mounts = resources['mounts'];
-      }
-      if (resources['mount_map']) {
-        params['config'].mount_map = resources['mount_map'];
-      }
-      if (resources['scaling_group']) {
-        params['config'].scaling_group = resources['scaling_group'];
-      }
-      if (resources['shmem']) {
-        params['config'].resource_opts = {};
-        params['config'].resource_opts.shmem = resources['shmem'];
-      }
-      if (resources['env']) {
-        params['config'].environ = resources['env'];
-      }
-      if (resources['preopen_ports']) {
-        params['config'].preopen_ports = resources['preopen_ports'];
-      }
-      if (resources['agent_list']) {
-        params['config'].agent_list = resources['agent_list'];
-      }
-    }
     let rqst;
     if (this._apiVersionMajor < 5) {
       // For V3/V4 API compatibility

--- a/src/types/backend-ai-console.d.ts
+++ b/src/types/backend-ai-console.d.ts
@@ -131,3 +131,37 @@ declare global {
   }
 }
 export {};
+
+export interface SessionResources {
+  group_name?: string;
+  domain?: string;
+  type?: 'interactive' | 'batch' | 'inference' | 'system';
+  cluster_mode: 'single-node' | 'multi-node';
+  cluster_size: number;
+  maxWaitSeconds: number;
+  starts_at?: string;
+  startupCommand?: string;
+  bootstrap_script?: string;
+  owner_access_key?: string;
+  config?: {
+    resources?: {
+      cpu: number;
+      mem: string;
+      [key: string]: number | string;
+    };
+    resource_opts?: {
+      shmem?: string;
+      allow_fractional_resource_fragmentation?: boolean;
+    };
+    mounts?: string[];
+    mount_map?: {
+      [key: string]: string;
+    };
+    environ?: {
+      [key: string]: string;
+    };
+    scaling_group?: string;
+    preopen_ports?: number[];
+    agent_list?: string[];
+  };
+}


### PR DESCRIPTION
Resolves #3751 ([FR-1070](https://lablup.atlassian.net/browse/FR-1070))

# Refactor session creation API to include new accelerator info to payloader.

This PR refactors the session creation API to handle the parsing and check logic in react component.

1. Restructures `SessionConfig` into `SessionResources` with a nested `config` object
2. Renames fields to match backend API conventions:
   - `startsAt` → `starts_at`
   - `env` → `environ`
   - Moves resource specifications into appropriate nested objects
3. Removes console.log statement in SessionDetailContent
4. Simplifies the client's `createIfNotExists` method by removing redundant parameter transformations
5. Fixes a typo in ServiceLauncherPageContent ("temporally" → "temporarily")

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1070]: https://lablup.atlassian.net/browse/FR-1070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ