### PR TITLE
feature(FR-1065): add: custom label on EndpointSelect component

### DIFF
--- a/react/src/components/Chat/EndpointSelect.tsx
+++ b/react/src/components/Chat/EndpointSelect.tsx
@@ -5,11 +5,14 @@ import {
 import { EndpointSelectValueQuery } from '../../__generated__/EndpointSelectValueQuery.graphql';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import BAILink from '../BAILink';
 import BAISelect from '../BAISelect';
 import TotalFooter from '../TotalFooter';
 import { useControllableValue } from 'ahooks';
-import { GetRef, SelectProps, Skeleton } from 'antd';
+import { GetRef, SelectProps, Skeleton, Tooltip } from 'antd';
+import { Flex } from 'backend.ai-ui';
 import _ from 'lodash';
+import { InfoIcon } from 'lucide-react';
 import React, { useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
@@ -149,10 +152,12 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
           label: selectedEndpoint?.name || undefined,
           value: selectedEndpoint?.endpoint_id || undefined,
         }
-      : {
-          label: controllableValue,
-          value: controllableValue,
-        },
+      : controllableValue
+        ? {
+            label: controllableValue,
+            value: controllableValue,
+          }
+        : controllableValue,
   );
 
   const isValueMatched = searchStr === deferredSearchStr;
@@ -174,6 +179,20 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
       searchValue={searchStr}
       onSearch={(v) => {
         setSearchStr(v);
+      }}
+      labelRender={({ label }: { label: React.ReactNode }) => {
+        return label ? (
+          <Flex gap="xxs">
+            {label}
+            <Tooltip title={t('general.NavigateToDetailPage')}>
+              <BAILink to={`/serving/${selectedEndpoint?.endpoint_id}`}>
+                <InfoIcon />
+              </BAILink>
+            </Tooltip>
+          </Flex>
+        ) : (
+          label
+        );
       }}
       // TODO: Need to make it work properly when autoClearSearchValue is not specified
       autoClearSearchValue

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -659,6 +659,7 @@
     "Manual": "Handbuch",
     "MaxValueNotification": "{{name}} muss maximal {{max}} sein",
     "NSelected": "{{Zahl}} ausgewählt",
+    "NavigateToDetailPage": "Zur Detailseite gehen",
     "NewPassword": "Neues Kennwort",
     "None": "Keine",
     "Password": "Passwort",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -655,6 +655,7 @@
     "Manual": "Χειροκίνητο",
     "MaxValueNotification": "{{name}} πρέπει να είναι το μέγιστο {{max}}",
     "NSelected": "{{count}} selected",
+    "NavigateToDetailPage": "Μεταβείτε στη σελίδα λεπτομερειών",
     "NewPassword": "νέος κωδικός πρόσβασης",
     "None": "Κανένα",
     "Password": "Κωδικός πρόσβασης",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -665,6 +665,7 @@
     "Manual": "Manual",
     "MaxValueNotification": "{{name}} must be maximum {{max}}",
     "NSelected": "{{count}} selected",
+    "NavigateToDetailPage": "Go to the details page",
     "NewPassword": "New Password",
     "None": "None",
     "Password": "Password",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -659,6 +659,7 @@
     "Manual": "Manual",
     "MaxValueNotification": "{{name}} debe ser máximo {{max}}",
     "NSelected": "{{cuenta}} seleccionado",
+    "NavigateToDetailPage": "Ir a la página de detalles",
     "NewPassword": "Nueva contraseña",
     "None": "Ninguno",
     "Password": "Contraseña",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -658,6 +658,7 @@
     "Manual": "Manuaalinen",
     "MaxValueNotification": "{{name}} on oltava maksimi {{max}}",
     "NSelected": "{{count}} valittu",
+    "NavigateToDetailPage": "Siirry yksityiskohtien sivulle",
     "NewPassword": "Uusi salasana",
     "None": "Ei ole",
     "Password": "Salasana",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -659,6 +659,7 @@
     "Manual": "Manuel",
     "MaxValueNotification": "{{nom}} doit être maximum {{max}}",
     "NSelected": "{{count}} sélectionné",
+    "NavigateToDetailPage": "Aller à la page de détails",
     "NewPassword": "nouveau mot de passe",
     "None": "Aucun",
     "Password": "Mot de passe",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -658,6 +658,7 @@
     "Manual": "Manual",
     "MaxValueNotification": "{{nama}} harus maksimal {{max}}",
     "NSelected": "{{count}} dipilih",
+    "NavigateToDetailPage": "Buka halaman detail",
     "NewPassword": "Kata Sandi Baru",
     "None": "Tidak ada",
     "Password": "Kata sandi",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -658,6 +658,7 @@
     "Manual": "Manuale",
     "MaxValueNotification": "{{nome}} deve essere massimo {{max}}",
     "NSelected": "{{count}} selezionato",
+    "NavigateToDetailPage": "Vai alla pagina dei dettagli",
     "NewPassword": "nuova password",
     "None": "Nessuno",
     "Password": "Parola d'ordine",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -658,6 +658,7 @@
     "Manual": "マニュアル",
     "MaxValueNotification": "{{ name }}最大値は{{ max }}です",
     "NSelected": "{count}}を選択",
+    "NavigateToDetailPage": "詳細ページへ",
     "NewPassword": "新しいパスワード",
     "None": "なし",
     "Password": "パスワード",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -662,6 +662,7 @@
     "Manual": "수동",
     "MaxValueNotification": "{{ name }} 최대 값은 {{ max }}입니다",
     "NSelected": "{{count}}개 선택됨",
+    "NavigateToDetailPage": "상세 페이지로 이동",
     "NewPassword": "새 비밀번호",
     "None": "없음",
     "Password": "비밀번호",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -657,6 +657,7 @@
     "Manual": "Гарын авлага",
     "MaxValueNotification": "{{name}} хамгийн ихдээ {{max}} байх ёстой",
     "NSelected": "{{тоолох}} сонгогдсон",
+    "NavigateToDetailPage": "Нарийвчилсан хуудсанд шилжих",
     "NewPassword": "Шинэ нууц үг",
     "None": "Байхгүй",
     "Password": "Нууц үг",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -658,6 +658,7 @@
     "Manual": "Manual",
     "MaxValueNotification": "{{nama}} mestilah maksimum {{maks}}",
     "NSelected": "{{count}} dipilih",
+    "NavigateToDetailPage": "Pindah ke halaman perincian",
     "NewPassword": "Kata laluan baharu",
     "None": "tiada",
     "Password": "Kata Laluan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -659,6 +659,7 @@
     "Manual": "Podręcznik",
     "MaxValueNotification": "{{name}} musi być maksymalna {{max}}.",
     "NSelected": "{{count}} wybrany",
+    "NavigateToDetailPage": "Przejdź do strony szczegółów",
     "NewPassword": "nowe hasło",
     "None": "Brak",
     "Password": "Hasło",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -659,6 +659,7 @@
     "Manual": "Manual",
     "MaxValueNotification": "{{nome}} deve ser o máximo {{max}}",
     "NSelected": "{{contagem}} selecionado",
+    "NavigateToDetailPage": "Ir para a página de pormenores",
     "NewPassword": "Nova Senha",
     "None": "Nenhum",
     "Password": "Senha",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -659,6 +659,7 @@
     "Manual": "Manual",
     "MaxValueNotification": "{{nome}} deve ser o máximo {{max}}",
     "NSelected": "{{contagem}} selecionado",
+    "NavigateToDetailPage": "Ir para a página de pormenores",
     "NewPassword": "Nova Senha",
     "None": "Nenhum",
     "Password": "Senha",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -659,6 +659,7 @@
     "Manual": "Руководство",
     "MaxValueNotification": "{{name}} должен быть максимальным {{max}}",
     "NSelected": "{{count}} выбран",
+    "NavigateToDetailPage": "Перейдите на страницу с подробной информацией",
     "NewPassword": "Новый пароль",
     "None": "Нет",
     "Password": "Пароль",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -648,6 +648,7 @@
     "Manual": "คู่มือ",
     "MaxValueNotification": "{{name}} ต้องมีค่าสูงสุด {{max}}",
     "NSelected": "{{count}} เลือก",
+    "NavigateToDetailPage": "ไปที่หน้าโดยละเอียด",
     "NewPassword": "รหัสผ่านใหม่",
     "None": "ไม่มี",
     "Password": "รหัสผ่าน",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -659,6 +659,7 @@
     "Manual": "El Kitabı",
     "MaxValueNotification": "{{name}} maksimum {{max}} olmalıdır",
     "NSelected": "{{count}} seçildi",
+    "NavigateToDetailPage": "Ayrıntılar sayfasına gidin",
     "NewPassword": "Yeni Şifre",
     "None": "Hiçbiri",
     "Password": "Parola",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -659,6 +659,7 @@
     "Manual": "Thủ công",
     "MaxValueNotification": "{{name}} phải tối đa {{max}}",
     "NSelected": "{{Count}} Đã chọn",
+    "NavigateToDetailPage": "Chuyển đến trang chi tiết",
     "NewPassword": "mật khẩu mới",
     "None": "Không có",
     "Password": "Mật khẩu",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -659,6 +659,7 @@
     "Manual": "手册",
     "MaxValueNotification": "{{name}} 必须是最大值 {{max}}",
     "NSelected": "{{count}}已选择",
+    "NavigateToDetailPage": "转至详细信息页面",
     "NewPassword": "新密码",
     "None": "无",
     "Password": "密码",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -659,6 +659,7 @@
     "Manual": "手册",
     "MaxValueNotification": "{{name}} 必须是最大值 {{max}}",
     "NSelected": "{{count}}已选择",
+    "NavigateToDetailPage": "转至详情页面",
     "NewPassword": "新密碼",
     "None": "无",
     "Password": "密碼",


### PR DESCRIPTION
# Add info button to endpoint select component

This PR resolves https://github.com/lablup/backend.ai-webui/issues/3746 (FR-1065) by
adding an info button next to the selected endpoint label in the endpoint select dropdown. When clicked, it will navigate to the endpoint details page (implementation pending).

**Changes:**
- Added an info button with `InfoCircleOutlined` icon to the endpoint select component
- Implemented custom label rendering to display the info button alongside the endpoint name
- Applied styling to match the UI design using theme tokens

###Screenshot(s):

[Screen Recording 2025-06-10 at 7.05.02 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Dgoz5XqHffJdivyccymr/60786a6a-cc6c-425b-87a6-3b68400a3fec.mov" />](https://app.graphite.dev/media/video/Dgoz5XqHffJdivyccymr/60786a6a-cc6c-425b-87a6-3b68400a3fec.mov)

How to test:
1. Access to the API endpoint that has at least one model service using LLM.
2. Go to Chat page.
3. Click `Info` icon with circle which is located right next to the name of model service endpoint.
4. See whether current page redirects to model service detail page.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after