### PR TITLE
fix(FR-949): incorrect CPU usage disaply in session usage monitor

### DIFF
--- a/react/src/components/DynamicUnitInputNumber.tsx
+++ b/react/src/components/DynamicUnitInputNumber.tsx
@@ -36,7 +36,6 @@ const DynamicUnitInputNumber: React.FC<DynamicUnitInputNumberProps> = ({
       defaultValue: '0g',
     },
   );
-  console.log(value);
   const [numValue, _unitFromValue] =
     value === null || value === undefined
       ? [null, null]

--- a/react/src/hooks/useSessionNodeLiveStat.tsx
+++ b/react/src/hooks/useSessionNodeLiveStat.tsx
@@ -39,6 +39,7 @@ export const useSessionLiveStat = (
           edges {
             node {
               live_stat
+              cluster_role
             }
           }
         }
@@ -47,10 +48,12 @@ export const useSessionLiveStat = (
     kernelFrgmt,
   );
 
-  const firstKernelNode = session?.kernel_nodes?.edges[0]?.node;
+  const mainKernelNode = _.find(session?.kernel_nodes?.edges, (edge) => {
+    return edge?.node?.cluster_role === 'main';
+  })?.node;
   const liveStat: SessionLiveStats = useMemo(() => {
-    return JSON.parse(firstKernelNode?.live_stat ?? '{}');
-  }, [firstKernelNode?.live_stat]);
+    return JSON.parse(mainKernelNode?.live_stat ?? '{}');
+  }, [mainKernelNode?.live_stat]);
 
   const sortedLiveStatArray = useMemo(
     () =>


### PR DESCRIPTION
# Remove console.log statements and fix CPU utilization calculation

This PR removes unnecessary `console.log` statements from multiple components and fixes the CPU utilization calculation in the `SessionUsageMonitor` component. The CPU utilization is now properly calculated by dividing the CPU percentage by the number of allocated CPUs.
e.g.) If you are using 1 core in a 4-core allocation session, the progress bar should only be 25% filled.

Additionally, the PR updates the session live stat hook to use the main kernel node instead of the first kernel node, ensuring more accurate resource usage reporting for multi-node sessions.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after