### PR TITLE
fix(FR-1097): Fix missing chat messages

### DIFF
--- a/react/src/components/Chat/ChatHistory.ts
+++ b/react/src/components/Chat/ChatHistory.ts
@@ -168,13 +168,15 @@ export function useHistory(id: string, provider: ChatProviderData) {
 
       chat.chats[index] = _.merge({}, chat.chats[index], data);
 
-      if (!getChatById(chat.id)) {
+      const currentChat = getChatById(chat.id);
+      if (currentChat) {
+        // If the chat is already in the cache, update it
+        currentChat.chats[index] = chat.chats[index];
+        updateHistory(currentChat);
+      } else {
         updateHistory({ ...chat });
         webuiNavigate(`/chat/${chat.id}`, { replace: true });
-        return;
       }
-
-      updateHistory({ ...chat });
     },
     [chat, updateHistory, webuiNavigate],
   );
@@ -218,13 +220,15 @@ export function useHistory(id: string, provider: ChatProviderData) {
         chat.label = chat.chats[0].messages[0].content ?? chat.label;
       }
 
-      if (!getChatById(chat.id)) {
+      const currentChat = getChatById(chat.id);
+      if (currentChat) {
+        // If the chat is already in the cache, update it
+        currentChat.chats[index] = chat.chats[index];
+        updateHistory(currentChat);
+      } else {
         updateHistory({ ...chat });
         webuiNavigate(`/chat/${chat.id}`, { replace: true });
-        return;
       }
-
-      updateHistory({ ...chat });
     },
     [chat, updateHistory, webuiNavigate],
   );

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -186,6 +186,7 @@ const PureChatPage = ({ id }: { id: string }) => {
                       }
                     },
                     text: chat.label,
+                    triggerType: ['icon', 'text'],
                   }
                 : undefined
             }
@@ -255,8 +256,8 @@ const PureChatPage = ({ id }: { id: string }) => {
                     onSaveMessage={(message) => {
                       saveChatMessage(chatData.id, message);
                     }}
-                    onClearMessage={(chat) => {
-                      clearChatMessage(chat.id);
+                    onClearMessage={(chatData) => {
+                      clearChatMessage(chatData.id);
                     }}
                     closable={isClosable(chat.chats.length)}
                     cloneable={isClonable(chat.chats.length)}


### PR DESCRIPTION
# Fix Chat History Merging and Parameter Naming

This PR addresses two issues:

1. Fixes the chat history merging logic to properly preserve existing data when updating history. Now it retrieves the existing data from the cache before merging with new data.

2. Renames a parameter in the `onClearMessage` callback from `chat` to `chatData` to better reflect its purpose and maintain consistency with other parameter names.
