### PR TITLE
fix(FR-957): Display device name in upper case on prometheus metrics

### DIFF
--- a/react/src/components/SessionMetricGraph.tsx
+++ b/react/src/components/SessionMetricGraph.tsx
@@ -12,6 +12,7 @@ import { Empty, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import _ from 'lodash';
+import { useMemo } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import {
   LineChart,
@@ -143,17 +144,29 @@ const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
     dayDiff < 7 ? '5m' : dayDiff < 30 ? '1h' : '1d',
   );
 
+  const resourceSlotKey = useMemo(() => {
+    const [key] = _.split(metricName, '_');
+    return (
+      _.find(_.keys(mergedResourceSlots), (slotKey) =>
+        _.startsWith(slotKey, key),
+      ) ?? ''
+    );
+  }, [mergedResourceSlots, metricName]);
+  const deviceDescription = mergedResourceSlots[resourceSlotKey]?.description;
+
   const getMetricTitle = () => {
-    const [key, ...rest] = _.split(metricName, '_');
+    const [, ...rest] = _.split(metricName, '_');
     const restLabel = _.startCase(rest.join(' '));
 
-    if (_.has(mergedResourceSlots, key)) {
-      return `${mergedResourceSlots[key]?.human_readable_name} ${restLabel}`;
+    // TODO: Modify to use display name when display name is added to device metadata.
+    // Currently, cuda and rocm have the same human_readable_name in device_metadata.
+    if (deviceDescription) {
+      return `${deviceDescription} ${restLabel}`;
+    } else if (_.includes(metricName, 'io')) {
+      return `${_.startCase(metricName.replaceAll('io', 'IO').replaceAll('_', ' '))}`;
+    } else {
+      return `${_.startCase(metricName.replaceAll('_', ' '))}`;
     }
-    if (_.includes(metricName, 'io')) {
-      return `${_.upperCase(key)} ${restLabel}`;
-    }
-    return `${_.startCase(metricName.replaceAll('_', ' '))}`;
   };
 
   return (


### PR DESCRIPTION
### Improve metric title display in SessionMetricGraph component

This PR enhances the `getMetricTitle` function in the SessionMetricGraph component to better handle different types of metrics. It adds special handling for 'cuda', 'rocm', and 'io' metrics to display them in uppercase, and improves the resource slot key lookup by searching for partial matches instead of exact matches.

**How to test:**
- Connect to endpoints that support devices like CUDA or ROCm or etc.
- Access the STATISTICS page and verify that the device name is capitalized on the card in USER SESSION HISTORY.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after