### PR TITLE
fix(FR-1101): Missing Sender Information in User Invitation Email

### DIFF
--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -1,3 +1,4 @@
+import { useSuspendedBackendaiClient } from '../hooks';
 import {
   InvitationItem,
   useSetVFolderInvitations,
@@ -24,6 +25,8 @@ const FolderInvitationResponseModal: React.FC<
   const { t } = useTranslation();
   const { invitations } = useVFolderInvitationsValue();
   const { acceptInvitation, rejectInvitation } = useSetVFolderInvitations();
+  const baiClient = useSuspendedBackendaiClient();
+  const hasInviterEmail = baiClient.isManagerVersionCompatibleWith('25.6.0');
 
   // Memoize invitations to prevent unnecessary re-renders
   const memoizedInvitations = React.useMemo(() => invitations, [invitations]);
@@ -97,7 +100,9 @@ const FolderInvitationResponseModal: React.FC<
                 {
                   key: 'from',
                   label: t('data.From'),
-                  children: item.inviter_user_email,
+                  children: hasInviterEmail
+                    ? item.inviter_user_email
+                    : item.inviter,
                 },
                 {
                   key: 'permission',
@@ -117,6 +122,7 @@ const FolderInvitationResponseModal: React.FC<
       message,
       t,
       token.paddingSM,
+      hasInviterEmail,
     ],
   );
 

--- a/react/src/hooks/useVFolderInvitations.tsx
+++ b/react/src/hooks/useVFolderInvitations.tsx
@@ -9,8 +9,10 @@ export interface InvitationItem {
   id: string;
   vfolder_id: string;
   vfolder_name: string;
-  invitee_user_email: string;
-  inviter_user_email: string;
+  invitee_user_email?: string;
+  inviter_user_email?: string;
+  invitee?: string;
+  inviter?: string;
   mount_permission: string;
   created_at: string;
   modified_at: string | null;


### PR DESCRIPTION

Resolves #3800 ([FR-1101](https://lablup.atlassian.net/browse/FR-1101))


# Add support for backward compatibility with older manager versions in folder invitations

This PR enhances the folder invitation system to support both new and old manager API versions:

- Adds compatibility with manager versions before 25.6.0 by supporting both `inviter_user_email` and legacy `inviter` fields
- Uses `useSuspendedBackendaiClient` to check manager version compatibility
- Conditionally displays the appropriate inviter information based on the manager version
- Updates the `InvitationItem` interface to make email fields optional and include legacy fields

**Checklist:**

- [x] Minmium required manager version
- [x] Specific setting for review (Test with both manager versions before and after 25.6.0)

[FR-1101]: https://lablup.atlassian.net/browse/FR-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ