### PR TITLE
fix(FR-1104): Improve backward compatibility in ResourcePresetSelect

### DIFF
--- a/react/src/components/ResourcePresetSelect.tsx
+++ b/react/src/components/ResourcePresetSelect.tsx
@@ -86,7 +86,7 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
         resource_presets,
         (preset) =>
           preset?.scaling_group_name === resourceGroup ||
-          preset?.scaling_group_name === null,
+          _.isEmpty(preset?.scaling_group_name),
       )
     : resource_presets;
 


### PR DESCRIPTION
# Fix resource preset filtering logic

This PR changes the condition for filtering resource presets by replacing a null check with `_.isEmpty()`. This ensures that resource presets with empty scaling group names are properly included in the filtered results, fixing an issue where some valid presets might not appear in the selection.

Before this PR, Resource preset select can not display any presets with Manager v24.09.x.
This PR is related to https://github.com/lablup/backend.ai-webui/pull/3349 PR