### PR TITLE
feat(FR-1105): Improve session metrics layout and remove CPU used metric

### DIFF
--- a/react/src/components/UserSessionsMetrics.tsx
+++ b/react/src/components/UserSessionsMetrics.tsx
@@ -4,7 +4,7 @@ import { useCurrentUserInfo } from '../hooks/backendai';
 import BAIFetchKeyButton from './BAIFetchKeyButton';
 import Flex from './Flex';
 import SessionMetricGraph from './SessionMetricGraph';
-import { Alert, DatePicker, Empty, Skeleton, theme } from 'antd';
+import { Alert, Col, DatePicker, Empty, Row, Skeleton, theme } from 'antd';
 import dayjs from 'dayjs';
 import _ from 'lodash';
 import { Suspense, useTransition } from 'react';
@@ -47,21 +47,47 @@ const UserSessionsMetrics: React.FC<PrometheusMetricProps> = () => {
         fetchPolicy: 'store-and-network',
       },
     );
-  const sortedMetricMetadata = [
-    ..._.filter(
-      container_utilization_metric_metadata?.metric_names,
-      (metric) => metric && _.startsWith(metric, 'cpu'),
-    ),
-    ..._.filter(
-      container_utilization_metric_metadata?.metric_names,
-      (metric) => metric && _.startsWith(metric, 'mem'),
-    ),
-    ..._.filter(
-      container_utilization_metric_metadata?.metric_names,
-      (metric) =>
-        metric && !_.startsWith(metric, 'cpu') && !_.startsWith(metric, 'mem'),
-    ),
-  ];
+
+  const sortedMetricMetadata = (() => {
+    const metrics = container_utilization_metric_metadata?.metric_names || [];
+
+    const { cpuUtil, memory, acceleratorGroups, rest } = _.reduce(
+      metrics,
+      (acc, metric) => {
+        if (!metric || metric === 'cpu_used') return acc;
+
+        if (metric === 'cpu_util') {
+          acc.cpuUtil.push(metric);
+        } else if (metric === 'mem') {
+          acc.memory.push(metric);
+        } else if (
+          (metric.endsWith('_util') || metric.endsWith('_mem')) &&
+          !_.startsWith(metric, 'cpu') &&
+          !_.startsWith(metric, 'mem')
+        ) {
+          const prefix = metric.split('_').slice(0, -1).join('_');
+          if (!acc.acceleratorGroups[prefix]) {
+            acc.acceleratorGroups[prefix] = [];
+          }
+          acc.acceleratorGroups[prefix].push(metric);
+        } else {
+          acc.rest.push(metric);
+        }
+        return acc;
+      },
+      {
+        cpuUtil: [] as string[],
+        memory: [] as string[],
+        acceleratorGroups: {} as Record<string, string[]>,
+        rest: [] as string[],
+      },
+    );
+    const sortedAccelMetrics = _.flatMap(_.values(acceleratorGroups), (group) =>
+      _.sortBy(group, (metric) => (metric.endsWith('_util') ? 0 : 1)),
+    );
+
+    return [...cpuUtil, ...memory, ...sortedAccelMetrics, ...rest];
+  })();
 
   return (
     <Flex
@@ -139,26 +165,30 @@ const UserSessionsMetrics: React.FC<PrometheusMetricProps> = () => {
         />
       )}
       <Suspense fallback={<Skeleton active />}>
-        {_.isEmpty(container_utilization_metric_metadata?.metric_names) ? (
+        {_.isEmpty(sortedMetricMetadata) ? (
           <Empty
             image={Empty.PRESENTED_IMAGE_SIMPLE}
             description={t('statistics.prometheus.NoMetricsToDisplay')}
           />
         ) : (
-          _.map(_.omit(sortedMetricMetadata), (metric: string) => {
-            return metric ? (
-              <SessionMetricGraph
-                queryProps={{
-                  startDate: dayjs(startDate).unix().toString(),
-                  endDate: dayjs(endDate).unix().toString(),
-                  metricName: metric,
-                  userId: userInfo[0]?.uuid ?? '',
-                  dayDiff: dayDiff,
-                }}
-                fetchKey={usageFetchKey}
-              />
-            ) : null;
-          })
+          <Row gutter={[16, 16]}>
+            {_.map(sortedMetricMetadata, (metric: string) => {
+              return (
+                <Col key={metric} xs={24} md={24} xl={12} xxl={12}>
+                  <SessionMetricGraph
+                    queryProps={{
+                      startDate: dayjs(startDate).unix().toString(),
+                      endDate: dayjs(endDate).unix().toString(),
+                      metricName: metric,
+                      userId: userInfo[0]?.uuid ?? '',
+                      dayDiff: dayDiff,
+                    }}
+                    fetchKey={usageFetchKey}
+                  />
+                </Col>
+              );
+            })}
+          </Row>
         )}
       </Suspense>
     </Flex>


### PR DESCRIPTION
### Enhanced User Sessions Metrics Display

This PR improves the user sessions metrics display by:

1. Implementing a responsive grid layout using Ant Design's Row and Col components to display metrics in a two-column format on larger screens
2. Enhancing metric sorting logic to group related metrics together:
   - Prioritizing CPU utilization and memory metrics
   - Grouping accelerator metrics by type (e.g., GPU)
   - Sorting accelerator metrics to show utilization before memory metrics
3. Excluding 'cpu_used' metric from display

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/9b72e5cf-df00-4652-88b3-7b3ab642d6d9.png)

The new layout provides a more organized view of metrics, making better use of screen space while maintaining readability on both desktop and mobile devices.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after