### PR TITLE
fix(FR-1112): remove unnecessary form reset effect in VFolderTableFormItem

### DIFF
--- a/react/src/components/VFolderTableFormItem.tsx
+++ b/react/src/components/VFolderTableFormItem.tsx
@@ -7,7 +7,7 @@ import VFolderTable, {
 } from './VFolderTable';
 import { Form, FormItemProps, Input } from 'antd';
 import _ from 'lodash';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface VFolderTableFormItemProps extends Omit<FormItemProps, 'name'> {
@@ -30,14 +30,6 @@ const VFolderTableFormItem: React.FC<VFolderTableFormItemProps> = ({
 }) => {
   const form = Form.useFormInstance();
   const { t } = useTranslation();
-
-  useEffect(() => {
-    form.setFieldsValue({
-      mounts: [],
-      vfoldersAliasMap: {},
-      autoMountedFolderNames: [],
-    });
-  }, [tableProps?.ownerEmail, form]);
 
   return (
     <>
@@ -91,6 +83,7 @@ const VFolderTableFormItem: React.FC<VFolderTableFormItemProps> = ({
         trigger="onChangeSelectedRowKeys"
       >
         <VFolderTable
+          key={tableProps?.ownerEmail}
           rowKey={rowKey}
           showAliasInput
           aliasMap={form.getFieldValue('vfoldersAliasMap')}


### PR DESCRIPTION
# Remove unnecessary useEffect in VFolderTableFormItem

This PR resolves #3825 (FR-1112) by removing an unnecessary `useEffect` hook that was resetting form values (`mounts`, `vfoldersAliasMap`, and `autoMountedFolderNames`) whenever the `tableProps.ownerEmail` changed. This initialization is likely handled elsewhere in the application flow.

### How to test
> Prerequisite:
> - Backend.AI Core version from 24.09~
> - two users(one is admin, and the other is userA)
> - at least one or more user-owned automount folder. (starts with `.`(dot))

#### Case 1: Create a session with user account.
1. Login with user account
2. Go to Data page
3. Create a `general` usage-mode user type folder, a name starts with `.`(dot).
4. Go to Session page.
5. Click `Start` button.
6. Go to `Data & Storage` section.
7. See automount folder just created in step 2 displayed properly.
8. Go to preview section and create session.
9. See the automount folder you just created mounted properly to the session.

#### Case 2: Create a session with admin account.
1. Login with admin account.
2. Go to Data page
3. Create a `general` usage-mode user type folder, a name starts with `.`(dot).
4. Go to Session page.
5. Click `Start` button.
6. Go to `Data & Storage` section.
7. See automount folder just created in step 2 displayed properly.
8. Go to preview section and create session.
9. See the automount folder you just created mounted properly to the session.

#### Case 3: Create a session with admin account on behalf of user account.
1. Login with admin account.
2. Go to Session page.
3. Click `Start` button.
4. Enable `Session owner` switch.
5. Input user account that you just created automount folder (in Case 1)
6. Go to `Data & Storage` section.
7. See automount folder just created in step 2 displayed properly.
8. Go to preview section and create session.
9. See the automount folder you just created mounted properly to the session.

### Screenshot(s)
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/18ec35cd-9c1e-4ba2-85fa-b4d8b10d11e8.png)

![Screenshot 2025-06-20 at 4.08.43 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/0f8afc4e-50d6-4249-a9ce-2ed2bb17c1d0.png)

![Screenshot 2025-06-20 at 4.09.14 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/2e52e64e-ee5b-4d1c-b1bc-aaa67023230e.png)

**Checklist:**

- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [x] Test case(s) to demonstrate the difference of before/after