### PR TITLE
hotfix(FR-1110): place tooltip of chat parameter to left side to avoid overflow

### DIFF
--- a/react/src/components/Chat/ChatHeader.tsx
+++ b/react/src/components/Chat/ChatHeader.tsx
@@ -243,7 +243,7 @@ const ChatHeader: React.FC<ChatHeaderProps> = ({
             />
           }
           trigger="click"
-          placement="bottom"
+          placement="bottomLeft"
           style={{
             padding: token.paddingXS,
           }}


### PR DESCRIPTION
# Change Popover Placement from "bottom" to "bottomLeft" in ChatHeader

This PR resolves #3827 (FR-1110) by changing the placement property of the Popover component in ChatHeader.tsx from "bottom" to "bottomLeft" to better align the popover with its trigger element. 
(Please refer to antd component description: https://ant.design/components/tooltip#common-api)

### Screenshot(s:

| After | Before |
|-------|-------|
| ![Screenshot 2025-06-20 at 4.39.11 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/7c2ab094-f7ac-45a6-a72c-ccee19998f81.png) |  ![Screenshot 2025-06-20 at 4.39.22 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Dgoz5XqHffJdivyccymr/066e5d03-be0d-4b6f-9fd9-2812eed34c3e.png) | 

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after