### PR TITLE
fix(FR-1121): handle nested object for error title of log page.

### DIFF
--- a/react/src/components/ErrorLogList.tsx
+++ b/react/src/components/ErrorLogList.tsx
@@ -86,12 +86,11 @@ const ErrorLogList: React.FC<{
       key: 'errorTitle',
       render: (value) => (
         <div style={{ minWidth: 50 }}>
-          {!value ? (
+          {_.isNil(value) || (_.isObject(value) && _.isEmpty(value)) ? (
             '-'
           ) : (
             <TextHighlighter keyword={logSearch}>
-              {_.toString(value)}
-              {/* set toString because sometime value type is object */}
+              {_.isObject(value) ? JSON.stringify(value) : _.toString(value)}
             </TextHighlighter>
           )}
         </div>


### PR DESCRIPTION

Resolves #3830 ([FR-1121](https://lablup.atlassian.net/browse/FR-1121))

# Fix error title rendering in ErrorLogList component

This PR improves the rendering of error titles in the ErrorLogList component by:

1. Adding a check for empty objects using `_.isObject(value) && _.isEmpty(value)` to display a dash when the value is an empty object
2. Enhancing the display of object values by using `JSON.stringify()` for objects instead of simply using `_.toString()` for all types
3. Maintaining the existing behavior for non-object values

This change ensures that error titles are displayed in a more readable format, especially when they contain object data.

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/aa16f320-c418-4b78-9a4a-438228fb7527.png)

After:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/93d12ae1-a14b-4a43-92e9-27a359862be7.png)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1121]: https://lablup.atlassian.net/browse/FR-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ