### PR TITLE
fix(fr-1120): Use decimal size for I/O metrics

### DIFF
--- a/react/src/components/SessionMetricGraph.tsx
+++ b/react/src/components/SessionMetricGraph.tsx
@@ -4,6 +4,7 @@ import {
 } from '../__generated__/SessionMetricGraphQuery.graphql';
 import {
   convertToBinaryUnit,
+  convertToDecimalUnit,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
 import { useResourceSlotsDetails } from '../hooks/backendai';
@@ -162,7 +163,7 @@ const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
     // Currently, cuda and rocm have the same human_readable_name in device_metadata.
     if (deviceDescription) {
       return `${deviceDescription} ${restLabel}`;
-    } else if (_.includes(metricName, 'io')) {
+    } else if (_.includes(metricName.toLowerCase(), 'io')) {
       return `${_.startCase(metricName.replaceAll('io', 'IO').replaceAll('_', ' '))}`;
     } else {
       return `${_.startCase(metricName.replaceAll('_', ' '))}`;
@@ -251,7 +252,7 @@ const getMetricData = (
 
   const timeUnits = { s: 1, m: 60, h: 3600, d: 86400 };
   const stepUnit = step.slice(-1) as keyof typeof timeUnits;
-  const stepValue = parseInt(step.slice(0, -1));
+  const stepValue = parseInt(step.slice(0, -1), 10);
   const stepSeconds = stepValue * timeUnits[stepUnit];
 
   const filledData = [];
@@ -288,18 +289,22 @@ const convertMetricUnit = (
       numberUnit,
     };
 
-  if (metricName.includes('util')) {
+  if (_.includes(metricName.toLowerCase(), 'util')) {
     number = Number(toFixedFloorWithoutTrailingZeros(value ?? 0, 1));
     numberUnit = '%';
-  } else if (metricName.includes('used')) {
+  } else if (_.includes(metricName.toLowerCase(), 'used')) {
     number = Number((Number(value) / 1000).toFixed(1));
     numberUnit = 's';
   } else {
-    number = Number(convertToBinaryUnit(value ?? '0', 'g')?.numberFixed);
-    numberUnit = 'GiB';
+    number = Number(
+      _.includes(metricName.toLowerCase(), 'io')
+        ? convertToDecimalUnit(value ?? '0', 'g')?.numberFixed
+        : convertToBinaryUnit(value ?? '0', 'g')?.numberFixed,
+    );
+    numberUnit = _.includes(metricName.toLowerCase(), 'io') ? 'GB' : 'GiB';
   }
 
-  if (metricName.includes('net')) {
+  if (_.includes(metricName.toLowerCase(), 'net')) {
     numberUnit = 'GiB/s';
   }
   number = value ? number : undefined;


### PR DESCRIPTION
resolves #3829 (FR-1120)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->
 This PR modifies the unit conversion logic in SessionMetricGraph to use decimal units (GB) for I/O metrics instead of binary units (GiB). This ensures that I/O metrics are displayed with the correct units that match industry standards for I/O measurements.

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
