### PR TITLE
misc(FR-1124): fix import error by correcting right path and library

### DIFF
--- a/react/src/components/AllowedVfolderHostsWithPermission.tsx
+++ b/react/src/components/AllowedVfolderHostsWithPermission.tsx
@@ -1,16 +1,15 @@
+import { AllowedVfolderHostsWithPermissionFragment$key } from '../__generated__/AllowedVfolderHostsWithPermissionFragment.graphql';
+import { AllowedVfolderHostsWithPermissionQuery } from '../__generated__/AllowedVfolderHostsWithPermissionQuery.graphql';
 import BAILink from './BAILink';
 import BAIModal from './BAIModal';
 import BAITable from './BAITable';
 import Flex from './Flex';
-import { AllowedVfolderHostsWithPermissionFragment$key } from './__generated__/AllowedVfolderHostsWithPermissionFragment.graphql';
-import { AllowedVfolderHostsWithPermissionQuery } from './__generated__/AllowedVfolderHostsWithPermissionQuery.graphql';
 import { CheckCircleFilled, StopFilled } from '@ant-design/icons';
 import { Badge, theme } from 'antd';
-import graphql from 'babel-plugin-relay/macro';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useFragment, useLazyLoadQuery } from 'react-relay';
+import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 
 interface AllowedVfolderHostsWithPermissionProps {
   allowedVfolderHostsWithPermissionFrgmt: AllowedVfolderHostsWithPermissionFragment$key;

--- a/react/src/components/KeypairResourcePolicyInfoModal.tsx
+++ b/react/src/components/KeypairResourcePolicyInfoModal.tsx
@@ -1,18 +1,17 @@
+import { KeypairResourcePolicyInfoModalFragment$key } from '../__generated__/KeypairResourcePolicyInfoModalFragment.graphql';
 import { filterEmptyItem } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import AllowedVfolderHostsWithPermission from './AllowedVfolderHostsWithPermission';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
 import ResourceNumber from './ResourceNumber';
-import { KeypairResourcePolicyInfoModalFragment$key } from './__generated__/KeypairResourcePolicyInfoModalFragment.graphql';
 import { Descriptions, theme, Typography } from 'antd';
 import { createStyles } from 'antd-style';
 import { DescriptionsItemType } from 'antd/es/descriptions';
-import graphql from 'babel-plugin-relay/macro';
 import dayjs from 'dayjs';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useFragment } from 'react-relay';
+import { useFragment, graphql } from 'react-relay';
 
 const useStyles = createStyles(({ css }) => ({
   description: css`


### PR DESCRIPTION
# Update import paths for Relay GraphQL components

This PR resolves #3838 (FR-1124) the import paths for Relay GraphQL generated files in two components:

1. `AllowedVfolderHostsWithPermission.tsx`: 
   - Moves generated type imports from local `./__generated__` to `../`
   - Updates Relay imports to use direct `react-relay` instead of `babel-plugin-relay/macro`

2. `KeypairResourcePolicyInfoModal.tsx`:
   - Moves generated type imports from local `./__generated__` to `../`
   - Updates Relay imports to use direct `react-relay` instead of `babel-plugin-relay/macro`

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after