### PR TITLE
fix(FR-1126): Duplicated port number in generating URL

### DIFF
--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -68,11 +68,10 @@ const useStyles = createStyles(({ token, css }) => ({
 }));
 
 function createModelsURL(baseURL: string) {
-  const { origin, port, pathname: path } = new URL(baseURL.trim());
-  const host = port.length > 0 ? `${origin}:${port}` : origin;
+  const { origin, pathname: path } = new URL(baseURL.trim());
   const normalizedPath = path === '/' ? '/models' : `${path}/models`;
 
-  return new URL(normalizedPath, host).toString();
+  return new URL(normalizedPath, origin).toString();
 }
 
 function useModels(

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -311,11 +311,7 @@ const ChatPage: React.FC = () => {
     webuiNavigate(`/chat`, { replace: true });
   }
 
-  return (
-    <>
-      <PureChatPage id={id || generateChatId()} />
-    </>
-  );
+  return <PureChatPage id={id || generateChatId()} />;
 };
 
 export default ChatPage;


### PR DESCRIPTION
resolves #3844 (FR-1126)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

### Simplify URL handling in Chat components

Resolves the issue of not being able to access the CHAT page if the service endpoint already has a port.
This PR refactors URL handling in two components:

1. In `ChatCard.tsx`, simplifies the `createModelsURL` function by:
   - Removing unnecessary port extraction and handling
   - Using the `origin` property directly which already includes the port information
   - Streamlining the URL construction process

2. In `ChatPage.tsx`, removes unnecessary fragment wrapper around the `PureChatPage` component

These changes make the code more concise while maintaining the same functionality.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
