### PR TITLE
fix(FR-1132): hide unmanaged path in vfolder description

### DIFF
--- a/react/src/components/VFolderNodeDescription.tsx
+++ b/react/src/components/VFolderNodeDescription.tsx
@@ -81,6 +81,7 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
         cloneable
         status
         permissions @since(version: "24.09.0")
+        unmanaged_path @since(version: "25.04.0")
         ...VFolderPermissionCellFragment
         ...useVirtualFolderNodePathFragment
       }
@@ -100,7 +101,7 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
   const vfolderId = toLocalId(vfolderNode?.id);
 
   const items: DescriptionsProps['items'] = filterEmptyItem([
-    {
+    !vfolderNode?.unmanaged_path && {
       key: 'path',
       label: (
         <Typography.Text


### PR DESCRIPTION

Resolves #3848 ([FR-1132](https://lablup.atlassian.net/browse/FR-1132))

# Hide path field for unmanaged virtual folders

This PR hides the path field in the virtual folder description when the folder is unmanaged (has an `unmanaged_path`). It also adds the `unmanaged_path` field to the GraphQL query to support this functionality.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/908fe830-e1aa-4005-b997-66df1215343b.png)

**Checklist:**

- [ ] Documentation
- [x] Minium required manager version: 25.04.0
- [x] Specific setting for review: http://10.82.230.49:8090/data?order=-created_at&statusCategory=active&mode=all&folder=a1029325-ad12-4c08-8d7a-d20373b21564
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1132]: https://lablup.atlassian.net/browse/FR-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ