### PR TITLE
feat(FR-735): apply NEO style to existing pages using Tabs or Table

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -78,7 +78,7 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
     setTablePaginationOption,
   } = useBAIPaginationOptionState({
     current: 1,
-    pageSize: 20,
+    pageSize: 10,
   });
   const [order, setOrder] = useState<string>();
 
@@ -721,7 +721,6 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
         return (
           <Flex>
             <Button
-              size="large"
               style={{
                 color: token.colorSuccess,
               }}
@@ -730,7 +729,6 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
               onClick={() => setCurrentAgentInfo(record)}
             />
             <Button
-              size="large"
               style={{
                 color: token.colorInfo,
               }}
@@ -828,7 +826,6 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
         </Flex>
       </Flex>
       <BAITable
-        bordered
         size="small"
         neoStyle
         scroll={{ x: 'max-content' }}
@@ -843,13 +840,8 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
         }
         pagination={{
           pageSize: tablePaginationOption.pageSize,
-          showSizeChanger: true,
           total: agent_list?.total_count,
           current: tablePaginationOption.current,
-          showTotal(total, range) {
-            return `${range[0]}-${range[1]} of ${total} items`;
-          },
-          pageSizeOptions: ['10', '20', '50'],
           extraContent: (
             <Button
               type="text"

--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -6,7 +6,6 @@ import {
   convertToBinaryUnit,
   filterNonNullItems,
   toFixedFloorWithoutTrailingZeros,
-  transformSorterToOrderString,
 } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { ResourceSlotName, useResourceSlotsDetails } from '../hooks/backendai';
@@ -16,18 +15,18 @@ import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting'
 import BAIProgressWithLabel from './BAIProgressWithLabel';
 import BAIPropertyFilter from './BAIPropertyFilter';
 import BAIRadioGroup from './BAIRadioGroup';
+import BAITable from './BAITable';
 import Flex from './Flex';
 import { ResourceTypeIcon } from './ResourceNumber';
 import TableColumnsSettingModal from './TableColumnsSettingModal';
 import {
   CheckCircleOutlined,
-  LoadingOutlined,
   MinusCircleOutlined,
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { Button, Table, TableProps, theme, Tooltip, Typography } from 'antd';
+import { Button, TableProps, theme, Tooltip, Typography } from 'antd';
 import { AnyObject } from 'antd/es/_util/type';
 import { ColumnsType, ColumnType } from 'antd/es/table';
 import _ from 'lodash';
@@ -338,14 +337,8 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
     useHiddenColumnKeysSetting('AgentSummaryList');
 
   return (
-    <Flex direction="column" align="stretch" style={containerStyle}>
-      <Flex
-        justify="between"
-        align="start"
-        gap="xs"
-        style={{ padding: token.paddingXS }}
-        wrap="wrap"
-      >
+    <Flex direction="column" align="stretch" style={containerStyle} gap="sm">
+      <Flex justify="between" align="start" gap="xs" wrap="wrap">
         <Flex
           direction="row"
           gap={'sm'}
@@ -418,7 +411,9 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
           </Tooltip>
         </Flex>
       </Flex>
-      <Table
+      <BAITable
+        neoStyle
+        size="small"
         bordered
         scroll={{ x: 'max-content' }}
         rowKey={'id'}
@@ -432,47 +427,36 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
         }
         pagination={{
           pageSize: tablePaginationOption.pageSize,
-          showSizeChanger: true,
           total: filteredAgentSummaryList?.length || 0,
           current: tablePaginationOption.current,
-          showTotal(total, range) {
-            return `${range[0]}-${range[1]} of ${total} items`;
+          onChange(page, pageSize) {
+            startPageChangeTransition(() => {
+              if (_.isNumber(page) && _.isNumber(pageSize)) {
+                setTablePaginationOption({
+                  current: page,
+                  pageSize,
+                });
+              }
+            });
           },
-          pageSizeOptions: ['10', '20', '50'],
-          style: { marginRight: token.marginXS },
+          extraContent: (
+            <Button
+              type="text"
+              icon={<SettingOutlined />}
+              onClick={() => {
+                toggleColumnSettingModal();
+              }}
+            />
+          ),
         }}
-        onChange={({ pageSize, current }, filters, sorter) => {
+        onChangeOrder={(order) => {
           startPageChangeTransition(() => {
-            if (_.isNumber(current) && _.isNumber(pageSize)) {
-              setTablePaginationOption({
-                current,
-                pageSize,
-              });
-            }
-            setOrder(transformSorterToOrderString(sorter));
+            setOrder(order);
           });
         }}
-        loading={{
-          spinning:
-            isPendingPageChange || isPendingStatusFetch || isPendingFilter,
-          indicator: <LoadingOutlined />,
-        }}
+        loading={isPendingPageChange || isPendingStatusFetch || isPendingFilter}
         {...tableProps}
       />
-      <Flex
-        justify="end"
-        style={{
-          padding: token.paddingXXS,
-        }}
-      >
-        <Button
-          type="text"
-          icon={<SettingOutlined />}
-          onClick={() => {
-            toggleColumnSettingModal();
-          }}
-        />
-      </Flex>
       <TableColumnsSettingModal
         open={visibleColumnSettingModal}
         onRequestClose={(values) => {

--- a/react/src/components/BAIFetchKeyButton.tsx
+++ b/react/src/components/BAIFetchKeyButton.tsx
@@ -82,12 +82,11 @@ const BAIFetchKeyButton: React.FC<BAIAutoRefetchButtonProps> = ({
     loading ? null : autoUpdateDelay,
   );
 
+  const tooltipTitle = showLastLoadTime ? loadTimeMessage : undefined;
   return hidden ? null : (
-    <Tooltip
-      title={showLastLoadTime ? loadTimeMessage : undefined}
-      placement="topLeft"
-    >
+    <Tooltip title={tooltipTitle} placement="topLeft">
       <Button
+        title={tooltipTitle ? undefined : t('general.Refresh')}
         loading={displayLoading}
         size={size}
         icon={<ReloadOutlined />}

--- a/react/src/components/BAITable.tsx
+++ b/react/src/components/BAITable.tsx
@@ -1,6 +1,7 @@
 import { transformSorterToOrderString } from '../helper';
 import { useThemeMode } from '../hooks/useThemeMode';
 import Flex from './Flex';
+import PaginationInfoText from './PaginationInfoText';
 import { useControllableValue, useDebounce } from 'ahooks';
 import { ConfigProvider, GetProps, Pagination, Table, theme } from 'antd';
 import { createStyles } from 'antd-style';
@@ -283,6 +284,15 @@ const BAITable = <RecordType extends object = any>({
             <Pagination
               size={tableProps.size === 'small' ? 'small' : 'default'}
               align="end"
+              pageSizeOptions={['10', '20', '50']}
+              showSizeChanger={true}
+              showTotal={(total, range) => (
+                <PaginationInfoText
+                  start={range[0]}
+                  end={range[1]}
+                  total={total}
+                />
+              )}
               {...tableProps.pagination}
               // override props for controlled values
               total={

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -420,9 +420,9 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
   );
 
   return (
-    <Flex direction="column" align="stretch" gap={'xs'}>
-      <Flex direction="column" align="stretch">
-        <Flex justify="end" style={{ padding: token.paddingSM }} gap="xs">
+    <Flex direction="column" align="stretch">
+      <Flex direction="column" align="stretch" gap="sm">
+        <Flex justify="between" gap="xs" wrap="wrap">
           <Input
             allowClear
             prefix={<SearchOutlined />}
@@ -440,11 +440,11 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
             onClick={() => {
               startRefetchTransition(() => updateCustomizedImageListFetchKey());
             }}
-          >
-            {t('button.Refresh')}
-          </Button>
+          />
         </Flex>
         <BAITable
+          neoStyle
+          size="small"
           resizable
           loading={isPendingSearchTransition}
           columns={
@@ -457,22 +457,18 @@ const CustomizedImageList: React.FC<PropsWithChildren> = ({ children }) => {
           dataSource={filterNonNullItems(filteredImageData)}
           rowKey="id"
           scroll={{ x: 'max-content' }}
-          pagination={false}
-        />
-        <Flex
-          justify="end"
-          style={{
-            padding: token.paddingXXS,
+          pagination={{
+            extraContent: (
+              <Button
+                type="text"
+                icon={<SettingOutlined />}
+                onClick={() => {
+                  toggleColumnSettingModal();
+                }}
+              />
+            ),
           }}
-        >
-          <Button
-            type="text"
-            icon={<SettingOutlined />}
-            onClick={() => {
-              toggleColumnSettingModal();
-            }}
-          />
-        </Flex>
+        />
       </Flex>
       <TableColumnsSettingModal
         open={visibleColumnSettingModal}

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -33,7 +33,7 @@ import {
   VerticalAlignBottomOutlined,
 } from '@ant-design/icons';
 import { useToggle, useDebounceFn } from 'ahooks';
-import { App, Button, Input, Tag, theme, Typography } from 'antd';
+import { App, Button, Input, Tag, theme, Tooltip, Typography } from 'antd';
 import { ColumnType } from 'antd/es/table';
 import _ from 'lodash';
 import { Key, useMemo, useState, useTransition } from 'react';
@@ -109,10 +109,11 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
     `,
     {},
     {
-      fetchPolicy:
-        environmentFetchKey === 'initial-fetch'
-          ? 'store-and-network'
-          : 'network-only',
+      // fetchPolicy:
+      //   environmentFetchKey === 'initial-fetch'
+      //     ? 'store-and-network'
+      //     : 'network-only',
+      fetchPolicy: 'store-and-network',
       fetchKey: environmentFetchKey,
     },
   );
@@ -489,18 +490,11 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
         align="stretch"
         style={{
           flex: 1,
-          paddingBottom: token.paddingSM,
           ...style,
         }}
+        gap="sm"
       >
-        <Flex justify="end" style={{ padding: token.paddingSM }} gap={'xs'}>
-          {selectedRows.length > 0 ? (
-            <Typography.Text>
-              {t('general.NSelected', {
-                count: selectedRows.length,
-              })}
-            </Typography.Text>
-          ) : null}
+        <Flex justify="between">
           <Input
             allowClear
             prefix={<SearchOutlined />}
@@ -512,50 +506,54 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
               width: 200,
             }}
           />
-          <Button
-            icon={<ReloadOutlined />}
-            loading={isPendingRefreshTransition}
-            onClick={() => {
-              setSelectedRows([]);
-              startRefreshTransition(() => updateEnvironmentFetchKey());
-            }}
-          >
-            {t('button.Refresh')}
-          </Button>
+          <Flex gap={'xs'}>
+            {selectedRows.length > 0 ? (
+              <Typography.Text>
+                {t('general.NSelected', {
+                  count: selectedRows.length,
+                })}
+              </Typography.Text>
+            ) : null}
+            <Tooltip title={t('button.Refresh')}>
+              <Button
+                icon={<ReloadOutlined />}
+                loading={isPendingRefreshTransition}
+                onClick={() => {
+                  setSelectedRows([]);
+                  startRefreshTransition(() => updateEnvironmentFetchKey());
+                }}
+              />
+            </Tooltip>
 
-          <Button
-            icon={<VerticalAlignBottomOutlined />}
-            style={{ backgroundColor: token.colorPrimary, color: 'white' }}
-            onClick={() => {
-              if (selectedRows.length === 0) {
-                message.error(t('environment.NoImagesAreSelected'));
-                return;
-              }
-              if (selectedRows.some((image) => !image.installed)) {
-                setIsOpenInstallModal(true);
-                return;
-              }
-              message.error(t('environment.AlreadyInstalledImage'));
-            }}
-          >
-            {t('environment.Install')}
-          </Button>
+            <Button
+              icon={<VerticalAlignBottomOutlined />}
+              style={{ backgroundColor: token.colorPrimary, color: 'white' }}
+              onClick={() => {
+                if (selectedRows.length === 0) {
+                  message.error(t('environment.NoImagesAreSelected'));
+                  return;
+                }
+                if (selectedRows.some((image) => !image.installed)) {
+                  setIsOpenInstallModal(true);
+                  return;
+                }
+                message.error(t('environment.AlreadyInstalledImage'));
+              }}
+            >
+              {t('environment.Install')}
+            </Button>
+          </Flex>
         </Flex>
         <BAITable
+          neoStyle
+          size="small"
           resizable
           rowKey="id"
           scroll={{ x: 'max-content' }}
           pagination={{
-            showTotal(total, range) {
-              return `${range[0]}-${range[1]} of ${total} items`;
-            },
-            pageSizeOptions: ['10', '20', '50'],
             extraContent: (
               <Button
                 type="text"
-                style={{
-                  marginRight: token.marginXS,
-                }}
                 icon={<SettingOutlined />}
                 onClick={() => {
                   toggleColumnSettingModal();
@@ -592,20 +590,6 @@ const ImageList: React.FC<{ style?: React.CSSProperties }> = ({ style }) => {
           })}
           showSorterTooltip={false}
         />
-        {/* <Flex
-          justify="end"
-          style={{
-            padding: token.paddingXXS,
-          }}
-        >
-          <Button
-            type="text"
-            icon={<SettingOutlined />}
-            onClick={() => {
-              toggleColumnSettingModal();
-            }}
-          />
-        </Flex> */}
       </Flex>
       <ManageImageResourceLimitModal
         open={!!managingResourceLimit}

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -15,6 +15,7 @@ import { exportCSVWithFormattingRules } from '../helper/csv-util';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
 import AllowedVfolderHostsWithPermission from './AllowedVfolderHostsWithPermission';
+import BAITable from './BAITable';
 import Flex from './Flex';
 import KeypairResourcePolicyInfoModal from './KeypairResourcePolicyInfoModal';
 import KeypairResourcePolicySettingModal from './KeypairResourcePolicySettingModal';
@@ -22,17 +23,17 @@ import ResourceNumber from './ResourceNumber';
 import TableColumnsSettingModal from './TableColumnsSettingModal';
 import {
   DeleteOutlined,
-  DownOutlined,
   InfoCircleOutlined,
   PlusOutlined,
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { App, Button, Dropdown, Space, Table, theme, Typography } from 'antd';
+import { App, Button, Dropdown, theme, Tooltip, Typography } from 'antd';
 import { AnyObject } from 'antd/es/_util/type';
 import { ColumnsType, ColumnType } from 'antd/es/table';
 import _ from 'lodash';
+import { EllipsisIcon } from 'lucide-react';
 import React, { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
@@ -231,7 +232,6 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         <Flex direction="row" align="stretch">
           <Button
             type="text"
-            size="large"
             icon={<InfoCircleOutlined style={{ color: token.colorSuccess }} />}
             onClick={() => {
               startInfoModalOpenTransition(() => {
@@ -241,7 +241,6 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
           />
           <Button
             type="text"
-            size="large"
             icon={<SettingOutlined />}
             style={{
               color: token.colorInfo,
@@ -252,7 +251,6 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
           />
           <Button
             type="text"
-            size="large"
             icon={
               <DeleteOutlined
                 style={{
@@ -377,55 +375,37 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
   };
 
   return (
-    <Flex direction="column" align="stretch" {...props}>
-      <Flex
-        direction="row"
-        justify="between"
-        wrap="wrap"
-        gap={'xs'}
-        style={{
-          padding: token.paddingContentVertical,
-          paddingLeft: token.paddingContentHorizontalSM,
-          paddingRight: token.paddingContentHorizontalSM,
-        }}
-      >
-        <Flex direction="column" align="start">
-          <Dropdown
-            menu={{
-              items: [
-                {
-                  key: 'exportCSV',
-                  label: t('resourcePolicy.ExportCSV'),
-                  onClick: () => {
-                    handleExportCSV();
-                  },
+    <Flex direction="column" align="stretch" gap="sm" {...props}>
+      <Flex direction="row" justify="end" wrap="wrap" gap={'xs'}>
+        <Dropdown
+          menu={{
+            items: [
+              {
+                key: 'exportCSV',
+                label: t('resourcePolicy.ExportCSV'),
+                onClick: () => {
+                  handleExportCSV();
                 },
-              ],
-            }}
-          >
-            <Button
-              type="link"
-              style={{ padding: 0 }}
-              onClick={(e) => e.preventDefault()}
-            >
-              <Space style={{ color: token.colorLinkHover }}>
-                {t('resourcePolicy.Tools')}
-                <DownOutlined />
-              </Space>
-            </Button>
-          </Dropdown>
-        </Flex>
+              },
+            ],
+          }}
+          trigger={['click']}
+        >
+          <Button icon={<EllipsisIcon />} />
+        </Dropdown>
         <Flex direction="row" gap={'xs'} wrap="wrap" style={{ flexShrink: 1 }}>
           <Flex gap={'xs'}>
-            <Button
-              icon={<ReloadOutlined />}
-              loading={isRefetchPending}
-              onClick={() => {
-                startRefetchTransition(() =>
-                  updateKeypairResourcePolicyFetchKey(),
-                );
-              }}
-            />
+            <Tooltip title={t('button.Refresh')}>
+              <Button
+                icon={<ReloadOutlined />}
+                loading={isRefetchPending}
+                onClick={() => {
+                  startRefetchTransition(() =>
+                    updateKeypairResourcePolicyFetchKey(),
+                  );
+                }}
+              />
+            </Tooltip>
             <Button
               type="primary"
               icon={<PlusOutlined />}
@@ -438,7 +418,9 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
           </Flex>
         </Flex>
       </Flex>
-      <Table
+      <BAITable
+        neoStyle
+        size="small"
         columns={
           _.filter(
             columns,
@@ -450,23 +432,19 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         }
         rowKey="name"
         scroll={{ x: 'max-content' }}
-        pagination={false}
+        pagination={{
+          extraContent: (
+            <Button
+              type="text"
+              icon={<SettingOutlined />}
+              onClick={() => {
+                toggleColumnSettingModal();
+              }}
+            />
+          ),
+        }}
         showSorterTooltip={false}
       />
-      <Flex
-        justify="end"
-        style={{
-          padding: token.paddingXXS,
-        }}
-      >
-        <Button
-          type="text"
-          icon={<SettingOutlined />}
-          onClick={() => {
-            toggleColumnSettingModal();
-          }}
-        />
-      </Flex>
       <TableColumnsSettingModal
         open={visibleColumnSettingModal}
         onRequestClose={(values) => {

--- a/react/src/components/PaginationInfoText.tsx
+++ b/react/src/components/PaginationInfoText.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from 'react-i18next';
+
+export interface PaginationInfoTextProps {
+  start: number;
+  end: number;
+  total: number;
+}
+
+const PaginationInfoText = ({ start, end, total }: PaginationInfoTextProps) => {
+  const { t } = useTranslation();
+
+  return t('pagination.Total', {
+    start,
+    end,
+    total,
+  });
+};
+
+export default PaginationInfoText;

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -14,36 +14,31 @@ import {
 import { exportCSVWithFormattingRules } from '../helper/csv-util';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
+import BAITable from './BAITable';
 import Flex from './Flex';
 import ProjectResourcePolicySettingModal from './ProjectResourcePolicySettingModal';
 import TableColumnsSettingModal from './TableColumnsSettingModal';
 import {
   DeleteOutlined,
-  DownOutlined,
   PlusOutlined,
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import {
-  Button,
-  Dropdown,
-  message,
-  Popconfirm,
-  Space,
-  Table,
-  theme,
-} from 'antd';
+import { Button, Dropdown, message, Popconfirm, theme, Tooltip } from 'antd';
 import { ColumnType } from 'antd/es/table';
 import dayjs from 'dayjs';
 import _ from 'lodash';
+import { EllipsisIcon } from 'lucide-react';
 import React, { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 
 type ProjectResourcePolicies = NonNullable<
-  ProjectResourcePolicyListQuery$data['project_resource_policies']
->[number];
+  NonNullable<
+    ProjectResourcePolicyListQuery$data['project_resource_policies']
+  >[number]
+>;
 
 interface ProjectResourcePolicyListProps {}
 
@@ -282,19 +277,9 @@ const ProjectResourcePolicyList: React.FC<
   };
 
   return (
-    <Flex direction="column" align="stretch">
-      <Flex
-        direction="row"
-        justify="between"
-        wrap="wrap"
-        gap={'xs'}
-        style={{
-          padding: token.paddingContentVertical,
-          paddingLeft: token.paddingContentHorizontalSM,
-          paddingRight: token.paddingContentHorizontalSM,
-        }}
-      >
-        <Flex direction="column" align="start">
+    <Flex direction="column" align="stretch" gap="sm">
+      <Flex direction="row" justify="end" wrap="wrap" gap={'xs'}>
+        <Flex direction="row" gap={'xs'} wrap="wrap" style={{ flexShrink: 1 }}>
           <Dropdown
             menu={{
               items: [
@@ -307,30 +292,22 @@ const ProjectResourcePolicyList: React.FC<
                 },
               ],
             }}
+            trigger={['click']}
           >
-            <Button
-              type="link"
-              style={{ padding: 0 }}
-              onClick={(e) => e.preventDefault()}
-            >
-              <Space style={{ color: token.colorLinkHover }}>
-                {t('resourcePolicy.Tools')}
-                <DownOutlined />
-              </Space>
-            </Button>
+            <Button icon={<EllipsisIcon />} />
           </Dropdown>
-        </Flex>
-        <Flex direction="row" gap={'xs'} wrap="wrap" style={{ flexShrink: 1 }}>
           <Flex gap={'xs'}>
-            <Button
-              icon={<ReloadOutlined />}
-              loading={isRefetchPending}
-              onClick={() => {
-                startRefetchTransition(() =>
-                  updateProjectResourcePolicyFetchKey(),
-                );
-              }}
-            />
+            <Tooltip title={t('button.Refresh')}>
+              <Button
+                icon={<ReloadOutlined />}
+                loading={isRefetchPending}
+                onClick={() => {
+                  startRefetchTransition(() =>
+                    updateProjectResourcePolicyFetchKey(),
+                  );
+                }}
+              />
+            </Tooltip>
             <Button
               type="primary"
               icon={<PlusOutlined />}
@@ -343,7 +320,9 @@ const ProjectResourcePolicyList: React.FC<
           </Flex>
         </Flex>
       </Flex>
-      <Table
+      <BAITable
+        neoStyle
+        size="small"
         rowKey="id"
         showSorterTooltip={false}
         columns={_.filter(
@@ -352,22 +331,18 @@ const ProjectResourcePolicyList: React.FC<
         )}
         dataSource={filterNonNullItems(project_resource_policies)}
         scroll={{ x: 'max-content' }}
-        pagination={false}
-      />
-      <Flex
-        justify="end"
-        style={{
-          padding: token.paddingXXS,
+        pagination={{
+          extraContent: (
+            <Button
+              type="text"
+              icon={<SettingOutlined />}
+              onClick={() => {
+                toggleColumnSettingModal();
+              }}
+            />
+          ),
         }}
-      >
-        <Button
-          type="text"
-          icon={<SettingOutlined />}
-          onClick={() => {
-            toggleColumnSettingModal();
-          }}
-        />
-      </Flex>
+      />
       <TableColumnsSettingModal
         open={visibleColumnSettingModal}
         onRequestClose={(values) => {

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -168,7 +168,6 @@ const ResourceGroupList: React.FC = () => {
           <Flex>
             <Button
               type="text"
-              size="large"
               icon={<InfoCircleOutlined />}
               style={{ color: token.colorSuccess }}
               onClick={() => {
@@ -178,7 +177,6 @@ const ResourceGroupList: React.FC = () => {
             />
             <Button
               type="text"
-              size="large"
               icon={<SettingOutlined />}
               style={{
                 color: token.colorInfo,
@@ -254,7 +252,6 @@ const ResourceGroupList: React.FC = () => {
             <Tooltip title={t('button.Delete')}>
               <Button
                 type="text"
-                size="large"
                 icon={
                   <DeleteOutlined
                     style={{

--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -4,8 +4,9 @@ import {
   ResourcePresetListQuery$data,
 } from '../__generated__/ResourcePresetListQuery.graphql';
 import { ResourcePresetSettingModalFragment$key } from '../__generated__/ResourcePresetSettingModalFragment.graphql';
-import { filterNonNullItems, localeCompare, filterEmptyItem } from '../helper';
+import { filterEmptyItem, filterNonNullItems, localeCompare } from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
+import BAITable from './BAITable';
 import Flex from './Flex';
 import NumberWithUnit from './NumberWithUnit';
 import ResourceNumber from './ResourceNumber';
@@ -16,16 +17,22 @@ import {
   SettingOutlined,
   DeleteOutlined,
 } from '@ant-design/icons';
-import { Tooltip, Button, theme, Table, App, Typography } from 'antd';
-import { ColumnType } from 'antd/es/table';
+import {
+  Tooltip,
+  Button,
+  theme,
+  App,
+  Typography,
+  TableColumnsType,
+} from 'antd';
 import _ from 'lodash';
 import React, { Suspense, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 
 type ResourcePreset = NonNullable<
-  ResourcePresetListQuery$data['resource_presets']
->[number];
+  NonNullable<ResourcePresetListQuery$data['resource_presets']>[number]
+>;
 
 interface ResourcePresetListProps {}
 
@@ -75,7 +82,7 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
       }
     `);
 
-  const columns = filterEmptyItem<ColumnType<ResourcePreset>>([
+  const columns: TableColumnsType<ResourcePreset> = filterEmptyItem([
     {
       title: t('resourcePreset.Name'),
       dataIndex: 'name',
@@ -122,7 +129,6 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
           <Tooltip title={t('button.Edit')}>
             <Button
               type="text"
-              size="large"
               icon={<SettingOutlined />}
               style={{
                 color: token.colorInfo,
@@ -137,7 +143,6 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
           <Tooltip title={t('button.Delete')}>
             <Button
               type="text"
-              size="large"
               icon={
                 <DeleteOutlined
                   style={{
@@ -208,18 +213,8 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
   ]);
 
   return (
-    <Flex direction="column" align="stretch">
-      <Flex
-        direction="row"
-        gap={'xs'}
-        justify="end"
-        wrap="wrap"
-        style={{
-          padding: token.paddingContentVertical,
-          paddingLeft: token.paddingContentHorizontalSM,
-          paddingRight: token.paddingContentHorizontalSM,
-        }}
-      >
+    <Flex direction="column" align="stretch" gap="sm">
+      <Flex direction="row" gap={'xs'} justify="end" wrap="wrap">
         <Flex direction="row" gap={'xs'} wrap="wrap" style={{ flexShrink: 1 }}>
           <Tooltip title={t('button.Refresh')}>
             <Button
@@ -243,11 +238,12 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
           </Button>
         </Flex>
       </Flex>
-      <Table
+      <BAITable
+        neoStyle
+        size="small"
         rowKey={'name'}
         dataSource={filterNonNullItems(resource_presets)}
         scroll={{ x: 'max-content' }}
-        pagination={false}
         showSorterTooltip={false}
         columns={columns}
       />

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -231,7 +231,6 @@ const StorageProxyList = () => {
         return (
           <>
             <Button
-              size="large"
               disabled={perfMetricDisabled}
               style={{
                 color: perfMetricDisabled
@@ -253,7 +252,6 @@ const StorageProxyList = () => {
             />
             <BAILink to={`/storage-settings/${record.id}`}>
               <Button
-                size="large"
                 style={{
                   color: token.colorInfo,
                 }}
@@ -316,11 +314,6 @@ const StorageProxyList = () => {
           pageSize: tablePaginationOption.pageSize,
           current: tablePaginationOption.current,
           total: storage_volume_list?.total_count ?? 0,
-          showTotal: (total) => (
-            <Typography.Text type="secondary">
-              {t('general.TotalItems', { total: total })}
-            </Typography.Text>
-          ),
           onChange(current, pageSize) {
             if (_.isNumber(current) && _.isNumber(pageSize)) {
               setTablePaginationOption({

--- a/react/src/components/UserCredentialList.tsx
+++ b/react/src/components/UserCredentialList.tsx
@@ -7,7 +7,7 @@ import {
 } from '../__generated__/UserCredentialListQuery.graphql';
 import { filterEmptyItem, filterNonNullItems } from '../helper';
 import { useUpdatableState } from '../hooks';
-import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import BAIPropertyFilter from './BAIPropertyFilter';
 import BAIRadioGroup from './BAIRadioGroup';
 import BAITable from './BAITable';
@@ -69,7 +69,7 @@ const UserCredentialList: React.FC = () => {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionState({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 20,
   });
@@ -146,14 +146,8 @@ const UserCredentialList: React.FC = () => {
     `);
 
   return (
-    <Flex direction="column" align="stretch">
-      <Flex
-        justify="between"
-        align="start"
-        gap="xs"
-        style={{ padding: token.paddingSM }}
-        wrap="wrap"
-      >
+    <Flex direction="column" align="stretch" gap="sm">
+      <Flex justify="between" align="start" gap="xs" wrap="wrap">
         <Flex gap={'sm'} align="start">
           <BAIRadioGroup
             value={activeType}
@@ -246,6 +240,8 @@ const UserCredentialList: React.FC = () => {
         </Flex>
       </Flex>
       <BAITable<Keypair>
+        neoStyle
+        size="small"
         // resizable
         rowKey={'id'}
         scroll={{ x: 'max-content' }}
@@ -541,15 +537,9 @@ const UserCredentialList: React.FC = () => {
         showSorterTooltip={false}
         pagination={{
           pageSize: tablePaginationOption.pageSize,
-          showSizeChanger: true,
           total: keypair_list?.total_count || 0,
           current: tablePaginationOption.current,
-          showTotal: (total, range) => {
-            return `${range[0]}-${range[1]} of ${total} items`;
-          },
           // TODO: need to set more options to export CSV in current page's data
-          pageSizeOptions: ['10', '20', '50'],
-          style: { marginRight: token.marginXS },
           onChange(current, pageSize) {
             startPageChangeTransition(() => {
               if (_.isNumber(current) && _.isNumber(pageSize)) {

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -14,28 +14,31 @@ import {
 import { exportCSVWithFormattingRules } from '../helper/csv-util';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
+import BAITable from './BAITable';
 import Flex from './Flex';
 import TableColumnsSettingModal from './TableColumnsSettingModal';
 import UserResourcePolicySettingModal from './UserResourcePolicySettingModal';
 import {
   DeleteOutlined,
-  DownOutlined,
   PlusOutlined,
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { App, Button, Dropdown, Popconfirm, Space, Table, theme } from 'antd';
+import { App, Button, Dropdown, Popconfirm, theme, Tooltip } from 'antd';
 import { ColumnType } from 'antd/es/table';
 import dayjs from 'dayjs';
 import _ from 'lodash';
+import { EllipsisIcon } from 'lucide-react';
 import React, { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 
 type UserResourcePolicies = NonNullable<
-  UserResourcePolicyListQuery$data['user_resource_policies']
->[number];
+  NonNullable<
+    UserResourcePolicyListQuery$data['user_resource_policies']
+  >[number]
+>;
 
 interface UserResourcePolicyListProps {}
 
@@ -281,19 +284,9 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
   };
 
   return (
-    <Flex direction="column" align="stretch">
-      <Flex
-        direction="row"
-        justify="between"
-        wrap="wrap"
-        gap={'xs'}
-        style={{
-          padding: token.paddingContentVertical,
-          paddingLeft: token.paddingContentHorizontalSM,
-          paddingRight: token.paddingContentHorizontalSM,
-        }}
-      >
-        <Flex direction="column" align="start">
+    <Flex direction="column" align="stretch" gap="sm">
+      <Flex direction="row" justify="end" wrap="wrap" gap={'xs'}>
+        <Flex direction="row" gap={'xs'} wrap="wrap" style={{ flexShrink: 1 }}>
           <Dropdown
             menu={{
               items: [
@@ -306,30 +299,22 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
                 },
               ],
             }}
+            trigger={['click']}
           >
-            <Button
-              type="link"
-              style={{ padding: 0 }}
-              onClick={(e) => e.preventDefault()}
-            >
-              <Space style={{ color: token.colorLinkHover }}>
-                {t('resourcePolicy.Tools')}
-                <DownOutlined />
-              </Space>
-            </Button>
+            <Button icon={<EllipsisIcon />} />
           </Dropdown>
-        </Flex>
-        <Flex direction="row" gap={'xs'} wrap="wrap" style={{ flexShrink: 1 }}>
           <Flex gap={'xs'}>
-            <Button
-              icon={<ReloadOutlined />}
-              loading={isRefetchPending}
-              onClick={() => {
-                startRefetchTransition(() =>
-                  updateUserResourcePolicyFetchKey(),
-                );
-              }}
-            />
+            <Tooltip title={t('button.Refresh')}>
+              <Button
+                icon={<ReloadOutlined />}
+                loading={isRefetchPending}
+                onClick={() => {
+                  startRefetchTransition(() =>
+                    updateUserResourcePolicyFetchKey(),
+                  );
+                }}
+              />
+            </Tooltip>
             <Button
               type="primary"
               icon={<PlusOutlined />}
@@ -342,7 +327,9 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
           </Flex>
         </Flex>
       </Flex>
-      <Table
+      <BAITable
+        neoStyle
+        size="small"
         rowKey="id"
         showSorterTooltip={false}
         columns={_.filter(
@@ -351,22 +338,18 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
         )}
         dataSource={filterNonNullItems(user_resource_policies)}
         scroll={{ x: 'max-content' }}
-        pagination={false}
-      />
-      <Flex
-        justify="end"
-        style={{
-          padding: token.paddingXXS,
+        pagination={{
+          extraContent: (
+            <Button
+              type="text"
+              icon={<SettingOutlined />}
+              onClick={() => {
+                toggleColumnSettingModal();
+              }}
+            />
+          ),
         }}
-      >
-        <Button
-          type="text"
-          icon={<SettingOutlined />}
-          onClick={() => {
-            toggleColumnSettingModal();
-          }}
-        />
-      </Flex>
+      />
       <TableColumnsSettingModal
         open={visibleColumnSettingModal}
         onRequestClose={(values) => {

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -292,6 +292,7 @@ export const useBackendAIImageMetaData = () => {
       );
     },
     retry: false,
+    staleTime: 1000 * 60 * 60 * 24, // 24 hours
   });
 
   const getImageMeta = (imageName: string) => {

--- a/react/src/pages/AgentSummaryPage.tsx
+++ b/react/src/pages/AgentSummaryPage.tsx
@@ -1,5 +1,6 @@
 import AgentSummaryList from '../components/AgentSummaryList';
-import { Card, Skeleton, theme } from 'antd';
+import BAICard from '../components/BAICard';
+import { Skeleton, theme } from 'antd';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
@@ -19,7 +20,7 @@ const ResourcesPage: React.FC<ResourcesPageProps> = (props) => {
   const { token } = theme.useToken();
 
   return (
-    <Card
+    <BAICard
       activeTabKey={curTabKey}
       onTabChange={(key) => setCurTabKey(key as TabKey)}
       tabList={[
@@ -30,9 +31,7 @@ const ResourcesPage: React.FC<ResourcesPageProps> = (props) => {
       ]}
       styles={{
         body: {
-          padding: 0,
-          paddingTop: 1,
-          overflow: 'hidden',
+          padding: `${token.paddingSM}px ${token.paddingLG}px ${token.paddingLG}px ${token.paddingLG}px`,
         },
       }}
     >
@@ -46,12 +45,10 @@ const ResourcesPage: React.FC<ResourcesPageProps> = (props) => {
             />
           }
         >
-          <AgentSummaryList
-            containerStyle={{ marginLeft: -1, marginRight: -1 }}
-          />
+          <AgentSummaryList />
         </Suspense>
       ) : null}
-    </Card>
+    </BAICard>
   );
 };
 

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -444,11 +444,6 @@ const ComputeSessionListPage = () => {
               pageSize: tablePaginationOption.pageSize,
               current: tablePaginationOption.current,
               total: compute_session_nodes?.count ?? 0,
-              showTotal: (total) => (
-                <Typography.Text type="secondary">
-                  {t('general.TotalItems', { total: total })}
-                </Typography.Text>
-              ),
               onChange: (current, pageSize) => {
                 if (_.isNumber(current) && _.isNumber(pageSize)) {
                   setTablePaginationOption({ current, pageSize });

--- a/react/src/pages/EnvironmentPage.tsx
+++ b/react/src/pages/EnvironmentPage.tsx
@@ -1,9 +1,10 @@
+import BAICard from '../components/BAICard';
 import ContainerRegistryList from '../components/ContainerRegistryList';
 import FlexActivityIndicator from '../components/FlexActivityIndicator';
 import ImageList from '../components/ImageList';
 import ResourcePresetList from '../components/ResourcePresetList';
 import { useSuspendedBackendaiClient } from '../hooks';
-import Card from 'antd/es/card/Card';
+import { theme } from 'antd';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
@@ -14,9 +15,10 @@ const EnvironmentPage = () => {
   const { t } = useTranslation();
   const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
   const baiClient = useSuspendedBackendaiClient();
+  const { token } = theme.useToken();
 
   return (
-    <Card
+    <BAICard
       activeTabKey={curTabKey}
       onTabChange={setCurTabKey}
       tabList={[
@@ -39,9 +41,7 @@ const EnvironmentPage = () => {
       ]}
       styles={{
         body: {
-          padding: 0,
-          paddingTop: 1,
-          overflow: 'hidden',
+          padding: `${token.paddingSM}px ${token.paddingLG}px ${token.paddingLG}px ${token.paddingLG}px`,
         },
       }}
     >
@@ -57,7 +57,7 @@ const EnvironmentPage = () => {
         {curTabKey === 'preset' && <ResourcePresetList />}
         {curTabKey === 'registry' && <ContainerRegistryList />}
       </Suspense>
-    </Card>
+    </BAICard>
   );
 };
 

--- a/react/src/pages/MyEnvironmentPage.tsx
+++ b/react/src/pages/MyEnvironmentPage.tsx
@@ -1,6 +1,7 @@
+import BAICard from '../components/BAICard';
 import CustomizedImageList from '../components/CustomizedImageList';
 import FlexActivityIndicator from '../components/FlexActivityIndicator';
-import Card from 'antd/es/card/Card';
+import { theme } from 'antd';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
@@ -10,9 +11,10 @@ const tabParam = withDefault(StringParam, 'image');
 const MyEnvironmentPage = () => {
   const { t } = useTranslation();
   const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+  const { token } = theme.useToken();
 
   return (
-    <Card
+    <BAICard
       activeTabKey={curTabKey}
       onTabChange={setCurTabKey}
       tabList={[
@@ -23,9 +25,7 @@ const MyEnvironmentPage = () => {
       ]}
       styles={{
         body: {
-          padding: 0,
-          paddingTop: 1,
-          overflow: 'hidden',
+          padding: `${token.paddingSM}px ${token.paddingLG}px ${token.paddingLG}px ${token.paddingLG}px`,
         },
       }}
     >
@@ -39,7 +39,7 @@ const MyEnvironmentPage = () => {
       >
         {curTabKey === 'image' && <CustomizedImageList />}
       </Suspense>
-    </Card>
+    </BAICard>
   );
 };
 

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -1,10 +1,11 @@
+import BAICard from '../components/BAICard';
 import FlexActivityIndicator from '../components/FlexActivityIndicator';
 import KeypairResourcePolicyList from '../components/KeypairResourcePolicyList';
 import ProjectResourcePolicyList from '../components/ProjectResourcePolicyList';
 import UserResourcePolicyList from '../components/UserResourcePolicyList';
 import { filterEmptyItem } from '../helper';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
-import { Card } from 'antd';
+import { theme } from 'antd';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { withDefault, StringParam, useQueryParam } from 'use-query-params';
@@ -17,12 +18,13 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
   const [curTabKey] = useQueryParam('tab', tabParam);
   const webUINavigate = useWebUINavigate();
   const baiClient = useSuspendedBackendaiClient();
+  const { token } = theme.useToken();
   const supportConfigureUserResourcePolicy = baiClient?.supports(
     'configure-user-resource-policy',
   );
 
   return (
-    <Card
+    <BAICard
       activeTabKey={curTabKey}
       onTabChange={(key) => {
         webUINavigate(
@@ -55,9 +57,7 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
       ])}
       styles={{
         body: {
-          padding: 0,
-          paddingTop: 1,
-          overflow: 'hidden',
+          padding: `${token.paddingSM}px ${token.paddingLG}px ${token.paddingLG}px ${token.paddingLG}px`,
         },
       }}
     >
@@ -66,7 +66,7 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
         {curTabKey === 'user' && <UserResourcePolicyList />}
         {curTabKey === 'project' && <ProjectResourcePolicyList />}
       </Suspense>
-    </Card>
+    </BAICard>
   );
 };
 

--- a/react/src/pages/ServingPage.tsx
+++ b/react/src/pages/ServingPage.tsx
@@ -13,7 +13,7 @@ import { useCurrentUserRole } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useDeferredQueryParams } from '../hooks/useDeferredQueryParams';
-import { Button, Skeleton, theme, Typography } from 'antd';
+import { Button, Skeleton, theme } from 'antd';
 import _ from 'lodash';
 import React, { Suspense, useDeferredValue, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -195,11 +195,6 @@ const ServingPage: React.FC = () => {
                 pageSize: tablePaginationOption.pageSize,
                 current: tablePaginationOption.current,
                 total: endpoint_list?.total_count,
-                showTotal: (total) => (
-                  <Typography.Text type="secondary">
-                    {t('general.TotalItems', { total: total })}
-                  </Typography.Text>
-                ),
                 onChange(current, pageSize) {
                   if (_.isNumber(current) && _.isNumber(pageSize)) {
                     setTablePaginationOption({ current, pageSize });

--- a/react/src/pages/UserCredentialsPage.tsx
+++ b/react/src/pages/UserCredentialsPage.tsx
@@ -3,11 +3,12 @@ import Flex from '../components/Flex';
 import FlexActivityIndicator from '../components/FlexActivityIndicator';
 import UserCredentialList from '../components/UserCredentialList';
 import UserNodeList from '../components/UserNodeList';
+import { theme } from 'antd';
 import { createStyles } from 'antd-style';
 import { CardTabListType } from 'antd/es/card';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 const useStyles = createStyles(({ css }) => ({
   card: css`
@@ -17,12 +18,13 @@ const useStyles = createStyles(({ css }) => ({
   `,
 }));
 
-const tabParam = withDefault(StringParam, 'users');
-
 const UserCredentialsPage: React.FC = () => {
   const { t } = useTranslation();
   const { styles } = useStyles();
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+  const { token } = theme.useToken();
+  const [searchParams] = useSearchParams();
+  const currentTab = searchParams.get('tab') || 'users';
+  const navigate = useNavigate();
   const tabItems: CardTabListType[] = [
     {
       key: 'users',
@@ -38,9 +40,19 @@ const UserCredentialsPage: React.FC = () => {
     <BAICard
       showDivider
       className={styles.card}
-      activeTabKey={curTabKey}
-      onTabChange={setCurTabKey}
+      activeTabKey={currentTab}
+      onTabChange={(key) =>
+        navigate({
+          pathname: '/credential',
+          search: `?tab=${key}`,
+        })
+      }
       tabList={tabItems}
+      styles={{
+        body: {
+          padding: `${token.paddingSM}px ${token.paddingLG}px ${token.paddingLG}px ${token.paddingLG}px`,
+        },
+      }}
     >
       <Suspense
         fallback={
@@ -50,12 +62,12 @@ const UserCredentialsPage: React.FC = () => {
           />
         }
       >
-        {curTabKey === 'users' && (
+        {currentTab === 'users' && (
           <Flex direction="column" align="stretch">
             <UserNodeList />
           </Flex>
         )}
-        {curTabKey === 'credentials' && (
+        {currentTab === 'credentials' && (
           <Flex direction="column" align="stretch">
             <UserCredentialList />
           </Flex>

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -596,11 +596,6 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
               pageSize: tablePaginationOption.pageSize,
               current: tablePaginationOption.current,
               total: vfolder_nodes?.count ?? 0,
-              showTotal: (total) => (
-                <Typography.Text type="secondary">
-                  {t('general.TotalItems', { total: total })}
-                </Typography.Text>
-              ),
               onChange(current, pageSize) {
                 if (_.isNumber(current) && _.isNumber(pageSize)) {
                   setTablePaginationOption({ current, pageSize });

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1014,6 +1014,9 @@
     "SuccessfullyUpdated": "Erfolgreich aktualisiert",
     "Visit": "Besuch"
   },
+  "pagination": {
+    "Total": "{{Start}} - {{end}} von {{Total}} Elementen"
+  },
   "propertyFilter": {
     "PlaceHolder": "Suche",
     "ResetFilter": "Filter zurücksetzen"

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1010,6 +1010,9 @@
     "SuccessfullyUpdated": "Ενημερώθηκε με επιτυχία",
     "Visit": "Επίσκεψη"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} των στοιχείων {{Total}}"
+  },
   "propertyFilter": {
     "PlaceHolder": "Αναζήτηση",
     "ResetFilter": "Επαναφορά φίλτρων"

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1018,6 +1018,9 @@
     "SuccessfullyUpdated": "Successfully Updated",
     "Visit": "Visit"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} of {{total}} items"
+  },
   "propertyFilter": {
     "PlaceHolder": "Search",
     "ResetFilter": "Reset filters"

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1014,6 +1014,9 @@
     "SuccessfullyUpdated": "Actualizado con éxito",
     "Visit": "Visite"
   },
+  "pagination": {
+    "Total": "{{inicio}} - {{end}} de {{Total}} elementos"
+  },
   "propertyFilter": {
     "PlaceHolder": "Buscar en",
     "ResetFilter": "Restablecer filtros"

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1013,6 +1013,9 @@
     "SuccessfullyUpdated": "Päivitetty onnistuneesti",
     "Visit": "Käy osoitteessa"
   },
+  "pagination": {
+    "Total": "{{start}}–{{end}} yhteensä {{total}} kohteesta"
+  },
   "propertyFilter": {
     "PlaceHolder": "Etsi",
     "ResetFilter": "Nollaa suodattimet"

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1014,6 +1014,9 @@
     "SuccessfullyUpdated": "Mise à jour réussie",
     "Visit": "Visite"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} des éléments {{total}}"
+  },
   "propertyFilter": {
     "PlaceHolder": "Recherche",
     "ResetFilter": "Réinitialiser les filtres"

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1012,6 +1012,9 @@
     "SuccessfullyUpdated": "Berhasil Diperbarui",
     "Visit": "Kunjungi"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} dari {{total}} item"
+  },
   "propertyFilter": {
     "PlaceHolder": "Pencarian",
     "ResetFilter": "Setel ulang filter"

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1012,6 +1012,9 @@
     "SuccessfullyUpdated": "Aggiornato con successo",
     "Visit": "Visitare"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} di {{total}} elementi"
+  },
   "propertyFilter": {
     "PlaceHolder": "Ricerca",
     "ResetFilter": "Reimposta i filtri"

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1013,6 +1013,9 @@
     "SuccessfullyUpdated": "正常に更新されました",
     "Visit": "訪問"
   },
+  "pagination": {
+    "Total": "{{start}}  -  {{end}} of {{attol}}アイテム"
+  },
   "propertyFilter": {
     "PlaceHolder": "検索",
     "ResetFilter": "フィルターをリセットする"

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1017,6 +1017,9 @@
     "SuccessfullyUpdated": "수정되었습니다.",
     "Visit": "방문"
   },
+  "pagination": {
+    "Total": "전체 {{total}}개 중 {{start}} - {{end}}"
+  },
   "propertyFilter": {
     "PlaceHolder": "검색",
     "ResetFilter": "필터 초기화"

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1012,6 +1012,9 @@
     "SuccessfullyUpdated": "Амжилттай шинэчлэгдсэн",
     "Visit": "Айлчлах"
   },
+  "pagination": {
+    "Total": "{{start}} - {{{End}} {{нийт}}}} зүйл"
+  },
   "propertyFilter": {
     "PlaceHolder": "Хайх",
     "ResetFilter": "Шүүлтүүрийг дахин тохируулах"

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1013,6 +1013,9 @@
     "SuccessfullyUpdated": "Berjaya Dikemas kini",
     "Visit": "Lawati"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} {{total}} item"
+  },
   "propertyFilter": {
     "PlaceHolder": "Cari",
     "ResetFilter": "Tetapkan semula penapis"

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1014,6 +1014,9 @@
     "SuccessfullyUpdated": "Pomyślnie zaktualizowano",
     "Visit": "Wizyta"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} z {{total}}"
+  },
   "propertyFilter": {
     "PlaceHolder": "Wyszukiwanie",
     "ResetFilter": "Zresetuj filtry"

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1014,6 +1014,9 @@
     "SuccessfullyUpdated": "Atualizado com sucesso",
     "Visit": "Visita"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} de {{total}} itens"
+  },
   "propertyFilter": {
     "PlaceHolder": "Pesquisar",
     "ResetFilter": "Redefinir filtros"

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1014,6 +1014,9 @@
     "SuccessfullyUpdated": "Atualizado com sucesso",
     "Visit": "Visita"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} de {{total}} itens"
+  },
   "propertyFilter": {
     "PlaceHolder": "Pesquisar",
     "ResetFilter": "Redefinir filtros"

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1014,6 +1014,9 @@
     "SuccessfullyUpdated": "Успешно обновлено",
     "Visit": "Посещение"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} of {{total}} элементы"
+  },
   "propertyFilter": {
     "PlaceHolder": "Поиск",
     "ResetFilter": "Сбросить фильтры"

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1003,6 +1003,9 @@
     "SuccessfullyUpdated": "อัปเดตสำเร็จแล้ว",
     "Visit": "เยี่ยมชม"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} ของ {{total}} รายการ"
+  },
   "propertyFilter": {
     "PlaceHolder": "ค้นหา",
     "ResetFilter": "รีเซ็ตตัวกรอง"

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1014,6 +1014,9 @@
     "SuccessfullyUpdated": "Başarıyla güncellendi",
     "Visit": "Ziyaret etmek"
   },
+  "pagination": {
+    "Total": "{{start}} - {{total}} öğelerinin {{end}}"
+  },
   "propertyFilter": {
     "PlaceHolder": "Arama",
     "ResetFilter": "Filtreleri sıfırla"

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1014,6 +1014,9 @@
     "SuccessfullyUpdated": "Cập nhật thành công",
     "Visit": "Chuyến thăm"
   },
+  "pagination": {
+    "Total": "{{start}} - {{end}} của {{Total}}"
+  },
   "propertyFilter": {
     "PlaceHolder": "Tìm kiếm",
     "ResetFilter": "Đặt lại bộ lọc"

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1014,6 +1014,9 @@
     "SuccessfullyUpdated": "成功更新",
     "Visit": "访问"
   },
+  "pagination": {
+    "Total": "{{start}}  -  {{end}} {{total}}项目"
+  },
   "propertyFilter": {
     "PlaceHolder": "搜索",
     "ResetFilter": "重置过滤器"

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1014,6 +1014,9 @@
     "SuccessfullyUpdated": "成功更新",
     "Visit": "訪問"
   },
+  "pagination": {
+    "Total": "{{start}}  -  {{end}} {{total}}項目"
+  },
   "propertyFilter": {
     "PlaceHolder": "搜索",
     "ResetFilter": "重置過濾器"


### PR DESCRIPTION
resolves #3429 [(FR-735)](https://lablup.atlassian.net/browse/FR-735)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

In this PR, modify the Card' Tab or Table to be a BAICard, BAITable with NEO styling.

**changes**
* All tables have been modified to include `pagination`.
* Unified the showTotal text in pagination.
* From now on, `BAITable` has `showSizeChanger`, `pageSizeOptions` and `showTotal` set as default values.

**how to test**
Make sure the pages you use tabs and tables on are NEO-styled. Table and Tab should look like the following photo.

![CleanShot 2025-06-26 at 12.03.51@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/c07a198f-5f61-4b5c-8c44-d5f899d26354.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
