### PR TITLE
feat(FR-1107): Apply BAIBoard to customize prometheus metrics display

### DIFF
--- a/react/src/components/BAIBoard.tsx
+++ b/react/src/components/BAIBoard.tsx
@@ -19,9 +19,14 @@ const useStyles = createStyles(({ css, token }) => {
         // FIXME: global token doesn't exist, so opacity fits color
         opacity: 0.3;
       }
-
       .bai_board_handle button span {
         color: ${token.colorTextTertiary} !important;
+      }
+      .bai_board_container-override
+        > div:first-child
+        > div:nth-child(2)
+        > div:first-child {
+        padding: 0 !important;
       }
     `,
     disableResize: css`
@@ -39,16 +44,21 @@ const useStyles = createStyles(({ css, token }) => {
     `,
     boardItems: css`
       & > div:first-child {
-        border: none !important ;
-        border-radius: var(--token-borderRadius) !important ;
-        background-color: var(--token-colorBgContainer) !important ;
+        border-radius: var(--token-borderRadius) !important;
+        background-color: var(--token-colorBgContainer) !important;
+        border: 1px solid ${token.colorBorderSecondary} !important;
       }
 
       & > div:first-child > div:first-child > div:first-child {
         margin-bottom: var(--token-margin);
-        background-color: var(--token-colorBgContainer) !important ;
+        background-color: var(--token-colorBgContainer) !important;
         position: absolute;
         z-index: 1;
+      }
+    `,
+    disableBorder: css`
+      & > div:first-child {
+        border: none !important;
       }
     `,
   };
@@ -64,12 +74,14 @@ export interface BAIBoardProps<T extends BAIBoardDataType = BAIBoardDataType> {
   onItemsChange: (event: CustomEvent<BoardProps.ItemsChangeDetail<T>>) => void;
   resizable?: boolean;
   movable?: boolean;
+  bordered?: boolean;
 }
 
 const BAIBoard = <T extends BAIBoardDataType>({
   items,
   resizable = false,
   movable = false,
+  bordered = false,
   ...BoardProps
 }: BAIBoardProps<T>) => {
   const { styles } = useStyles();
@@ -84,7 +96,10 @@ const BAIBoard = <T extends BAIBoardDataType>({
       renderItem={(item: BoardProps.Item<T>) => {
         return (
           <BoardItem
-            className={styles.boardItems}
+            className={classNames(
+              styles.boardItems,
+              !bordered && styles.disableBorder,
+            )}
             key={item.id}
             i18nStrings={{
               dragHandleAriaLabel: '',

--- a/react/src/components/SessionMetricGraph.tsx
+++ b/react/src/components/SessionMetricGraph.tsx
@@ -8,8 +8,8 @@ import {
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
 import { useResourceSlotsDetails } from '../hooks/backendai';
-import BAICard from './BAICard';
-import { Empty, theme } from 'antd';
+import Flex from './Flex';
+import { Empty, Typography, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import _ from 'lodash';
@@ -171,20 +171,28 @@ const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
   };
 
   return (
-    <BAICard
-      title={getMetricTitle()}
-      type="inner"
-      styles={{
-        body: {
-          padding: `${token.marginMD}px ${token.marginMD}px ${token.marginXS}px ${token.marginMD}px`,
-        },
+    <Flex
+      direction="column"
+      align="stretch"
+      gap="sm"
+      style={{
+        height: '100%',
+        overflow: 'hidden',
       }}
     >
+      <Flex align="center" style={{ height: 56, marginLeft: 52 }}>
+        <Typography.Text style={{ fontSize: token.fontSizeHeading5 }} strong>
+          {getMetricTitle()}
+        </Typography.Text>
+      </Flex>
       {_.isEmpty(capacity_metric?.metrics) &&
       _.isEmpty(current_metric?.metrics) ? (
-        <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          style={{ height: '100%', alignContent: 'center' }}
+        />
       ) : (
-        <ResponsiveContainer width="100%" height={350}>
+        <ResponsiveContainer style={{ paddingRight: token.marginXL }}>
           <LineChart data={metricData} className={styles.recharts}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="timestamp" minTickGap={token.marginMD} />
@@ -224,7 +232,7 @@ const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
           </LineChart>
         </ResponsiveContainer>
       )}
-    </BAICard>
+    </Flex>
   );
 };
 

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -21,6 +21,7 @@ interface UserSettings {
   start_board_items?: Array<Omit<BAIBoardItem, 'data'>>;
   experimental_ai_agents?: boolean;
   experimental_dashboard?: boolean;
+  session_metrics_board_items?: Array<Omit<BAIBoardItem, 'data'>>;
   [key: `hiddenColumnKeys.${string}`]: Array<string>;
 }
 


### PR DESCRIPTION
resolves #3810 (FR-1107)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

> **!Notice**
There is a bug with changing the vertical size of a card. If you increase the card vertically and then decrease the size vertically again, the graphs inside the card do not shrink.

This PR implements a draggable and resizable metrics board in the User Sessions Metrics page. Users can now customize the layout of their metrics graphs by dragging and resizing them according to their preferences. The layout is persisted in local storage so it's maintained between sessions.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/4cc01643-5af0-4d07-b498-b84cf4fd43bb.png)

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
