### PR TITLE
fix(FR-1155): Set DynamicUnitInputNumber to stringMode

### DIFF
--- a/react/src/components/DynamicUnitInputNumber.tsx
+++ b/react/src/components/DynamicUnitInputNumber.tsx
@@ -85,6 +85,7 @@ const DynamicUnitInputNumber: React.FC<DynamicUnitInputNumberProps> = ({
         ref.current = node;
         return _.isFunction(inputNumberProps.ref) && inputNumberProps.ref(node);
       }}
+      stringMode
       onBlur={() => {
         if (_.isNumber(roundStep) && roundStep > 0) {
           const nextRoundedNumValue =

--- a/react/src/components/DynamicUnitInputNumberWithSlider.stories.tsx
+++ b/react/src/components/DynamicUnitInputNumberWithSlider.stories.tsx
@@ -68,7 +68,7 @@ export const AllowOlnyGiB: Story = {
   args: {
     min: '0.5g',
     max: '45g',
-    units: ['m', 'g'],
+    units: ['g'],
   },
 };
 

--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -728,7 +728,7 @@ const ResourceAllocationFormItems: React.FC<
                                     _.isString(value) &&
                                     resourceLimits.mem?.max &&
                                     compareNumberWithUnits(
-                                      value,
+                                      value || '0g',
                                       resourceLimits.mem?.max,
                                     ) > 0
                                   ) {
@@ -764,7 +764,7 @@ const ResourceAllocationFormItems: React.FC<
                                     !_.isEmpty(value) &&
                                     resourceLimits.mem?.min &&
                                     compareNumberWithUnits(
-                                      value,
+                                      value || '0g',
                                       resourceLimits.mem?.min || '0g',
                                     ) < 0
                                   ) {
@@ -800,7 +800,7 @@ const ResourceAllocationFormItems: React.FC<
                                       !_.isElement(value) &&
                                       resourceLimits.mem &&
                                       compareNumberWithUnits(
-                                        value,
+                                        value || '0g',
                                         remaining.mem,
                                       ) > 0
                                     ) {
@@ -842,7 +842,7 @@ const ResourceAllocationFormItems: React.FC<
                                 if (
                                   form.getFieldValue('enabledAutomaticShmem')
                                 ) {
-                                  runShmemAutomationRule(M_plus_S);
+                                  runShmemAutomationRule(M_plus_S || '0g');
                                 }
                               }}
                             />
@@ -1006,7 +1006,6 @@ const ResourceAllocationFormItems: React.FC<
                                         }
                                       },
                                     },
-
                                     {
                                       validator: async (
                                         rule,


### PR DESCRIPTION
resoves #3862 (FR-1155)

# Fix memory input validation in ResourceAllocationFormItems

This PR adds `stringMode` to `DynamicUnitInputNumber` component to ensure proper handling of string values. It also fixes memory validation in `ResourceAllocationFormItems` by providing fallback values (`'0g'`) when comparing memory values, preventing potential errors when dealing with empty or undefined values.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after