### PR TITLE
feat(FR-1161): Apply BAIBoard component to Start Page

### DIFF
--- a/react/src/components/ActionItemContent.tsx
+++ b/react/src/components/ActionItemContent.tsx
@@ -63,13 +63,20 @@ const ActionItemContent: React.FC<StartItemContentProps> = ({
       justify="between"
       direction="column"
       style={{
-        height: '100%',
+        height: 328,
         textAlign: 'center',
         overflowY: 'auto',
-        padding: token.marginMD,
       }}
     >
-      <Flex direction="column" gap={type === 'default' ? 'sm' : 'xxs'}>
+      <Flex
+        direction="column"
+        gap={type === 'default' ? 'sm' : 'xxs'}
+        style={{
+          overflow: 'hidden',
+          padding: token.marginMD,
+          paddingBottom: 0,
+        }}
+      >
         <Flex
           align="center"
           justify="center"
@@ -112,19 +119,20 @@ const ActionItemContent: React.FC<StartItemContentProps> = ({
       </Flex>
       <Flex
         direction="column"
+        align="stretch"
         style={{
           width: '100%',
           position: 'sticky',
           bottom: 0,
           backgroundColor:
             type === 'default' ? token.colorBgContainer : undefined,
-          marginTop: type === 'default' ? token.marginSM : undefined,
-          paddingBottom: type === 'default' ? token.marginMD : undefined,
+          padding: type === 'default' ? token.paddingMD : undefined,
+          paddingTop: 0,
         }}
       >
         {description && (
           <Divider
-            style={{ margin: token.marginSM, marginTop: 0, borderWidth: 2 }}
+            style={{ margin: 0, marginBottom: token.marginMD, borderWidth: 1 }}
           />
         )}
         {to ? <WebUILink to={to}>{actionButton}</WebUILink> : actionButton}

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -19,6 +19,7 @@ interface UserSettings {
   pinnedSessionHistory?: Array<SessionHistory>;
   experimental_neo_session_list?: boolean;
   start_board_items?: Array<Omit<BAIBoardItem, 'data'>>;
+  start_page_board_items?: Array<Omit<BAIBoardItem, 'data'>>;
   experimental_ai_agents?: boolean;
   experimental_dashboard?: boolean;
   session_metrics_board_items?: Array<Omit<BAIBoardItem, 'data'>>;


### PR DESCRIPTION
resolves #3866 (FR-1161)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lSyr8xXz1wdXALkJKzVx/a9512d3f-432a-437a-95c9-54c4df163358.png)

This PR enhances the Start Page by:

1. Replacing the static card grid with a movable BAIBoard component, allowing users to rearrange start page items
2. Implementing persistent layout storage in user settings via `start_page_board_items`
3. Improving the ActionItemContent component's layout and styling:
   - Fixed overflow handling with proper flex structure
   - Enhanced text alignment and spacing
   - Improved divider styling
   - Better responsiveness for different content types

The changes provide a more customizable and visually consistent start page experience.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after