### PR TITLE
fix(FR-1170): make BAITable to controll correct pagination values

### DIFF
--- a/react/src/components/BAITable.tsx
+++ b/react/src/components/BAITable.tsx
@@ -151,13 +151,16 @@ const BAITable = <RecordType extends object = any>({
   const [resizedColumnWidths, setResizedColumnWidths] = useState<
     Record<string, number>
   >(generateResizedColumnWidths(columns));
-  const [currentPage, setCurrentPage] = useControllableValue(tableProps, {
-    valuePropName: 'current',
-    defaultValue: 1,
-    trigger: 'no-trigger',
-  });
+  const [currentPage, setCurrentPage] = useControllableValue(
+    tableProps.pagination ? tableProps.pagination : {},
+    {
+      valuePropName: 'current',
+      defaultValue: 1,
+      trigger: 'no-trigger',
+    },
+  );
   const [currentPageSize, setCurrentPageSize] = useControllableValue(
-    tableProps,
+    tableProps.pagination ? tableProps.pagination : {},
     {
       valuePropName: 'pageSize',
       defaultValue: 10,


### PR DESCRIPTION
resolves #3873 [(FR-1170)](https://lablup.atlassian.net/browse/FR-1170)

Fixed BAITable pagination by checking if pagination prop exists before accessing it. Previously, the component was trying to access pagination properties directly from tableProps, which could cause errors if pagination was not provided. Now it safely checks if tableProps.pagination exists before using it with useControllableValue.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after