### PR TITLE
fix(FR-1186): update okButtonProps to include disabled and danger in BAIConfirmModalWithInput component

### DIFF
--- a/react/src/components/BAIConfirmModalWithInput.tsx
+++ b/react/src/components/BAIConfirmModalWithInput.tsx
@@ -8,11 +8,13 @@ import { useTranslation } from 'react-i18next';
 
 const { Text } = Typography;
 
-interface BAIConfirmModalWithInputProps extends Omit<BAIModalProps, 'icon'> {
+interface BAIConfirmModalWithInputProps
+  extends Omit<BAIModalProps, 'icon' | 'okButtonProps'> {
   confirmText: string;
   content: React.ReactNode;
   title: React.ReactNode;
   icon?: React.ReactNode;
+  okButtonProps?: Omit<BAIModalProps['okButtonProps'], 'disabled' | 'danger'>;
 }
 
 const BAIConfirmModalWithInput: React.FC<BAIConfirmModalWithInputProps> = ({
@@ -51,8 +53,12 @@ const BAIConfirmModalWithInput: React.FC<BAIConfirmModalWithInputProps> = ({
         form.resetFields();
         _.isFunction(onCancel) && onCancel(e);
       }}
-      okButtonProps={{ disabled: confirmText !== typedText, danger: true }}
       {...props}
+      okButtonProps={{
+        ...props.okButtonProps,
+        disabled: confirmText !== typedText,
+        danger: true,
+      }}
     >
       <Flex direction="column" justify="start" align="start">
         {content}


### PR DESCRIPTION
resolves #3884 (FR-1186)

### Fix `okButtonProps` in `BAIConfirmModalWithInput` component

This PR fixes an issue with the `okButtonProps` in the `BAIConfirmModalWithInput` component. Previously, the component was overriding any `okButtonProps` passed through the `props` object. Now, it properly spreads the existing `okButtonProps` before applying the required `disabled` and `danger` properties.

This change ensures that custom button properties (like `loading`, `className`, etc.) can be passed to the OK button while still maintaining the required confirmation behavior.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after