### PR TITLE
fix(FR-1198): endpoint token select is not calculating timezone correctly

### DIFF
--- a/react/src/components/Chat/EndpointTokenSelect.tsx
+++ b/react/src/components/Chat/EndpointTokenSelect.tsx
@@ -21,7 +21,8 @@ function sortEndpointTokenList(
     (item) => ({
       label: item?.token,
       value: item?.token,
-      disabled: !dayjs(item?.valid_until).tz().isAfter(now),
+      // FIXME: temporally parse UTC and change to timezone (timezone need to be added in server side)
+      disabled: !dayjs.utc(item?.valid_until).tz().isAfter(now),
     }),
   );
 }


### PR DESCRIPTION
resolves #3894 [(FR-1198)](https://lablup.atlassian.net/browse/FR-1198)

# Fix timezone handling in EndpointTokenSelect

This PR fixes the timezone handling in the `EndpointTokenSelect` component by using `dayjs.utc()` instead of `dayjs()` when checking if a token is valid. This ensures that token expiration dates are correctly interpreted regardless of the user's local timezone.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after