### PR TITLE
chore(FR-1197): modify validation message in environments select

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -364,7 +364,14 @@ const ImageEnvironmentSelectFormItems: React.FC<
             {t('session.launcher.Version')}
           </Typography.Text>
         }
-        rules={[{ required: _.isEmpty(environments?.manual) }]}
+        rules={[
+          {
+            required: _.isEmpty(environments?.manual),
+            message: t('general.ValueRequired', {
+              name: t('session.launcher.Environments'),
+            }),
+          },
+        ]}
         style={{ marginBottom: 10 }}
       >
         <Select
@@ -564,7 +571,14 @@ const ImageEnvironmentSelectFormItems: React.FC<
             <Form.Item
               className="image-environment-select-form-item"
               name={['environments', 'version']}
-              rules={[{ required: _.isEmpty(environments?.manual) }]}
+              rules={[
+                {
+                  required: _.isEmpty(environments?.manual),
+                  message: t('general.ValueRequired', {
+                    name: t('session.launcher.Version'),
+                  }),
+                },
+              ]}
             >
               <Select
                 ref={versionSelectRef}


### PR DESCRIPTION
resolves #3896 (FR-1197)

## description 
In the "Environments & Resource allocation" step of the session page, the validation message for the Environments select item has been updated. Previously, the validation relied on the default behavior provided by antd, but now a custom message has been specified in the rules to display a more appropriate text. The updated messages are confi
rmed to appear correctly in both Korean, English and other languages.

<img width="450" alt="Screenshot 2025-07-04 at 15 40 34" src="https://github.com/user-attachments/assets/d4831a1a-499d-4931-b44b-ce40855dab8e" />

<img width="450" alt="Screenshot 2025-07-04 at 15 41 07" src="https://github.com/user-attachments/assets/070d2a9f-eec4-438e-affb-184491d01b70" />

<br><br><br>

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
