### PR TITLE
chore(FR-1209): change the VSCode workspace window.title pattern

### DIFF
--- a/backend.ai-webui.code-workspace
+++ b/backend.ai-webui.code-workspace
@@ -16,5 +16,6 @@
     "files.exclude": {
       "packages/backend.ai-ui": true,
     },
+    "window.title": "${activeFolderShort} (Workspace)",
   },
 }


### PR DESCRIPTION
Resolves #3904 ([FR-1209](https://lablup.atlassian.net/browse/FR-1209))

# Set custom window title for VS Code workspace

This PR adds a custom window title configuration to the VS Code workspace settings, displaying the active folder name followed by "(Workspace)" in the window title bar.


[FR-1209]: https://lablup.atlassian.net/browse/FR-1209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ