### PR TITLE
refactor(FR-583): Remove compatibility before manager version 24.09

### DIFF
--- a/react/src/components/Chat/EndpointSelect.tsx
+++ b/react/src/components/Chat/EndpointSelect.tsx
@@ -3,7 +3,6 @@ import {
   EndpointSelectQuery$data,
 } from '../../__generated__/EndpointSelectQuery.graphql';
 import { EndpointSelectValueQuery } from '../../__generated__/EndpointSelectValueQuery.graphql';
-import { useSuspendedBackendaiClient } from '../../hooks';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import BAILink from '../BAILink';
 import BAISelect from '../BAISelect';
@@ -36,7 +35,6 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
   ...selectPropsWithoutLoading
 }) => {
   const { t } = useTranslation();
-  const baiClient = useSuspendedBackendaiClient();
   const [controllableValue, setControllableValue] = useControllableValue<
     string | undefined
   >(selectPropsWithoutLoading);
@@ -114,17 +112,13 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
       limit: 10,
     },
     {
-      filter: baiClient.supports('endpoint-lifecycle-stage-filter')
-        ? [
-            lifecycleStageFilterStr,
-            deferredSearchStr
-              ? `name ilike "%${deferredSearchStr}%"`
-              : undefined,
-          ]
-            .filter(Boolean)
-            .map((v) => `(${v})`)
-            .join(' & ')
-        : undefined,
+      filter: [
+        lifecycleStageFilterStr,
+        deferredSearchStr ? `name ilike "%${deferredSearchStr}%"` : undefined,
+      ]
+        .filter(Boolean)
+        .map((v) => `(${v})`)
+        .join(' & '),
     },
     // TODO: skip fetch when the option popover is closed
     {

--- a/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
@@ -99,23 +99,6 @@ const ContainerLogModal: React.FC<ContainerLogModalProps> = ({
     staleTime: 5000,
   });
 
-  // let queryParams: Array<string> = [];
-  // if (session?.access_key != null) {
-  //   queryParams.push(`owner_access_key=${session.access_key}`);
-  // }
-  // if (baiClient.supports('per-kernel-logs') && selectedKernelId !== null) {
-  //   queryParams.push(`kernel_id=${selectedKernelId}`);
-  // }
-  // let queryString = `/session/${session?.row_id}/logs`;
-  // if (queryParams.length > 0) {
-  //   queryString += `?${queryParams.join('&')}`;
-  // }
-  // // const url = `${baiClient._endpoint}${queryString}`
-
-  // const signed = baiClient.newSignedRequest('GET', queryString, null);
-  // console.log(signed)
-  // console.log(signed.uri);
-
   const [lastLineNumbers, { resetPrevious: resetPreviousLineNumber }] =
     useMemoWithPrevious(() => logs?.split('\n').length || 0, [logs]);
 

--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -162,7 +162,6 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = (props) => {
         <Tooltip title={t('session.RequestContainerCommit')}>
           <Button
             disabled={
-              !baiClient.supports('image-commit') ||
               !baiClient._config.enableContainerCommit ||
               session.type === 'system' ||
               !isActive(session) ||

--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -48,8 +48,7 @@ const ContainerRegistryEditorModal: React.FC<
   const { message, modal } = App.useApp();
 
   const baiClient = useSuspendedBackendaiClient();
-  const isSupportExtraField =
-    baiClient.isManagerVersionCompatibleWith('24.09.3');
+  const isSupportExtraField = baiClient.supports('extra-field');
 
   const formRef = useRef<FormInstance<RegistryFormInput>>(null);
 
@@ -451,8 +450,7 @@ const ContainerRegistryEditorModal: React.FC<
 
 function useCreateContainerMutation() {
   const baiClient = useSuspendedBackendaiClient();
-  const isSupportExtraField =
-    baiClient.isManagerVersionCompatibleWith('24.09.3');
+  const isSupportExtraField = baiClient.supports('extra-field');
   const [commitCreateRegistry, isInflightCreateRegistry] =
     useMutation<ContainerRegistryEditorModalCreateMutation>(graphql`
       mutation ContainerRegistryEditorModalCreateMutation(
@@ -529,8 +527,7 @@ function useCreateContainerMutation() {
 
 function useModifyContainerMutation() {
   const baiClient = useSuspendedBackendaiClient();
-  const isSupportExtraField =
-    baiClient.isManagerVersionCompatibleWith('24.09.3');
+  const isSupportExtraField = baiClient.supports('extra-field');
 
   const [commitModifyRegistry, isInflightModifyRegistry] =
     useMutation<ContainerRegistryEditorModalModifyMutation>(graphql`

--- a/react/src/components/EndpointOwnerInfo.tsx
+++ b/react/src/components/EndpointOwnerInfo.tsx
@@ -1,5 +1,4 @@
 import { EndpointOwnerInfoFragment$key } from '../__generated__/EndpointOwnerInfoFragment.graphql';
-import { useSuspendedBackendaiClient } from '../hooks';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Button, Tooltip, theme } from 'antd';
 import React from 'react';
@@ -14,7 +13,6 @@ const EndpointOwnerInfo: React.FC<EndpointOwnerInfoProps> = ({
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const baiClient = useSuspendedBackendaiClient();
 
   const endpoint = useFragment(
     graphql`
@@ -27,8 +25,6 @@ const EndpointOwnerInfo: React.FC<EndpointOwnerInfoProps> = ({
     endpointFrgmt,
   );
 
-  if (!baiClient.supports('model-serving-endpoint-user-info'))
-    return baiClient.email || '';
   if (endpoint?.created_user_email === endpoint?.session_owner_email)
     return endpoint?.session_owner_email || '';
   else

--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -26,7 +26,7 @@ const FolderInvitationResponseModal: React.FC<
   const { invitations } = useVFolderInvitationsValue();
   const { acceptInvitation, rejectInvitation } = useSetVFolderInvitations();
   const baiClient = useSuspendedBackendaiClient();
-  const hasInviterEmail = baiClient.isManagerVersionCompatibleWith('25.6.0');
+  const hasInviterEmail = baiClient.supports('invitation-inviter-email');
 
   // Memoize invitations to prevent unnecessary re-renders
   const memoizedInvitations = React.useMemo(() => invitations, [invitations]);

--- a/react/src/components/ImageNodeSimpleTag.tsx
+++ b/react/src/components/ImageNodeSimpleTag.tsx
@@ -52,8 +52,7 @@ const ImageNodeSimpleTag: React.FC<ImageNodeSimpleTagProps> = ({
 
   const fullName = `${image.registry}/${image.namespace}:${image.tag}@${image.architecture}`;
   const legacyFullImageString = `${image.registry}/${image.name}:${image.tag}@${image.architecture}`;
-  const isSupportBaseImageName =
-    baiClient.isManagerVersionCompatibleWith('24.12.0');
+  const isSupportBaseImageName = baiClient.supports('base-image-name');
 
   return isSupportBaseImageName ? (
     <>

--- a/react/src/components/KeypairResourcePolicyInfoModal.tsx
+++ b/react/src/components/KeypairResourcePolicyInfoModal.tsx
@@ -1,6 +1,5 @@
 import { KeypairResourcePolicyInfoModalFragment$key } from '../__generated__/KeypairResourcePolicyInfoModalFragment.graphql';
 import { filterEmptyItem } from '../helper';
-import { useSuspendedBackendaiClient } from '../hooks';
 import AllowedVfolderHostsWithPermission from './AllowedVfolderHostsWithPermission';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
@@ -39,7 +38,6 @@ const KeypairResourcePolicyInfoModal: React.FC<InfoModalProps> = ({
   const { styles } = useStyles();
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const baiClient = useSuspendedBackendaiClient();
 
   const resourcePolicy = useFragment(
     graphql`
@@ -134,7 +132,7 @@ const KeypairResourcePolicyInfoModal: React.FC<InfoModalProps> = ({
       label: t('session.MaxSessionLifetime'),
       children: resourcePolicy?.max_session_lifetime || '∞',
     },
-    baiClient?.supports('max-pending-session-count') && {
+    {
       label: t('resourcePolicy.MaxPendingSessionCount'),
       children:
         _.isNull(resourcePolicy?.max_pending_session_count) ||
@@ -142,11 +140,11 @@ const KeypairResourcePolicyInfoModal: React.FC<InfoModalProps> = ({
           ? '∞'
           : resourcePolicy?.max_pending_session_count,
     },
-    baiClient?.supports('max-concurrent-sftp-sessions') && {
+    {
       label: t('resourcePolicy.MaxConcurrentSFTPSessions'),
       children: resourcePolicy?.max_concurrent_sftp_sessions || '∞',
     },
-    baiClient?.supports('max-pending-session-resource-slots') && {
+    {
       label: t('resourcePolicy.MaxPendingSessionResourceSlots'),
       children: resourcePolicy?.max_pending_session_resource_slots ? (
         !_.isEmpty(

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -12,7 +12,7 @@ import {
 } from '../helper';
 import { SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
 import { exportCSVWithFormattingRules } from '../helper/csv-util';
-import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
+import { useUpdatableState } from '../hooks';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
 import AllowedVfolderHostsWithPermission from './AllowedVfolderHostsWithPermission';
 import BAITable from './BAITable';
@@ -65,8 +65,6 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
     useState<KeypairResourcePolicyInfoModalFragment$key | null>(null);
   const [isPendingInfoModalOpen, startInfoModalOpenTransition] =
     useTransition();
-
-  const baiClient = useSuspendedBackendaiClient();
 
   const { keypair_resource_policies } =
     useLazyLoadQuery<KeypairResourcePolicyListQuery>(
@@ -200,7 +198,7 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         );
       },
     },
-    baiClient?.supports('max-pending-session-count') && {
+    {
       title: t('resourcePolicy.MaxPendingSessionCount'),
       dataIndex: 'max_pending_session_count',
       key: 'max_pending_session_count',
@@ -212,7 +210,7 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         ),
       render: (text) => (text ? text : '∞'),
     },
-    baiClient?.supports('max-concurrent-sftp-sessions') && {
+    {
       title: t('resourcePolicy.MaxConcurrentSFTPSessions'),
       dataIndex: 'max_concurrent_sftp_sessions',
       key: 'max_concurrent_sftp_sessions',

--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -61,10 +61,6 @@ const KeypairResourcePolicySettingModal: React.FC<
   const [resourceSlots] = useResourceSlots();
   const { mergedResourceSlots } = useResourceSlotsDetails();
   const baiClient = useSuspendedBackendaiClient();
-  const isDeprecatedMaxVfolderCountInKeypairResourcePolicy =
-    baiClient?.supports(
-      'deprecated-max-vfolder-count-in-keypair-resource-policy',
-    );
 
   const keypairResourcePolicy = useFragment(
     graphql`
@@ -77,7 +73,6 @@ const KeypairResourcePolicySettingModal: React.FC<
         max_containers_per_session
         idle_timeout
         allowed_vfolder_hosts
-        max_vfolder_count @deprecatedSince(version: "23.09.4")
         max_pending_session_count @since(version: "24.03.4")
         max_concurrent_sftp_sessions @since(version: "24.03.4")
       }
@@ -220,15 +215,6 @@ const KeypairResourcePolicySettingModal: React.FC<
           total_resource_slots: JSON.stringify(total_resource_slots),
           allowed_vfolder_hosts: JSON.stringify(allowed_vfolder_hosts),
         };
-        if (!isDeprecatedMaxVfolderCountInKeypairResourcePolicy) {
-          props.max_vfolder_count = values?.max_vfolder_count;
-        }
-        if (!baiClient.supports('max-pending-session-count')) {
-          delete props?.max_pending_session_count;
-        }
-        if (!baiClient.supports('max-concurrent-sftp-sessions')) {
-          delete props?.max_concurrent_sftp_sessions;
-        }
 
         if (keypairResourcePolicy === null) {
           commitCreateKeypairResourcePolicy({
@@ -553,26 +539,24 @@ const KeypairResourcePolicySettingModal: React.FC<
                   />
                 </FormItemWithUnlimited>
               </Col>
-              {baiClient.supports('max-concurrent-sftp-sessions') ? (
-                <Col
-                  xs={{ span: 12 }}
-                  md={{ span: 8 }}
-                  style={{ alignSelf: 'end' }}
+              <Col
+                xs={{ span: 12 }}
+                md={{ span: 8 }}
+                style={{ alignSelf: 'end' }}
+              >
+                <FormItemWithUnlimited
+                  name={'max_concurrent_sftp_sessions'}
+                  unlimitedValue={0}
+                  label={t('resourcePolicy.MaxConcurrentSFTPSessions')}
+                  style={{ margin: 0, width: '100%' }}
                 >
-                  <FormItemWithUnlimited
-                    name={'max_concurrent_sftp_sessions'}
-                    unlimitedValue={0}
-                    label={t('resourcePolicy.MaxConcurrentSFTPSessions')}
-                    style={{ margin: 0, width: '100%' }}
-                  >
-                    <InputNumber
-                      min={0}
-                      max={SIGNED_32BIT_MAX_INT}
-                      style={{ width: '100%' }}
-                    />
-                  </FormItemWithUnlimited>
-                </Col>
-              ) : null}
+                  <InputNumber
+                    min={0}
+                    max={SIGNED_32BIT_MAX_INT}
+                    style={{ width: '100%' }}
+                  />
+                </FormItemWithUnlimited>
+              </Col>
             </Row>
           </Card>
         </Form.Item>
@@ -584,11 +568,6 @@ const KeypairResourcePolicySettingModal: React.FC<
             >
               <AllowedHostNamesSelect mode="multiple" />
             </Form.Item>
-            {isDeprecatedMaxVfolderCountInKeypairResourcePolicy ? undefined : (
-              <Form.Item label={t('credential.Max#')} name="max_vfolder_count">
-                <InputNumber min={0} max={50} />
-              </Form.Item>
-            )}
           </Card>
         </Form.Item>
       </Form>

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -124,9 +124,6 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
   const fasttrackEndpoint = baiClient?._config?.fasttrackEndpoint ?? null;
   const blockList = baiClient?._config?.blockList ?? null;
   const inactiveList = baiClient?._config?.inactiveList ?? null;
-  const supportServing = baiClient?.supports('model-serving') ?? false;
-  const supportUserCommittedImage =
-    baiClient?.supports('user-committed-image') ?? false;
 
   const [isOpenSignoutModal, { toggle: toggleSignoutModal }] = useToggle(false);
   const [isOpenTOSModal, { toggle: toggleTOSModal }] = useToggle(false);
@@ -178,7 +175,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
       key: 'job',
       group: 'workload',
     },
-    supportServing && {
+    {
       label: <WebUILink to="/serving">{t('webui.menu.Serving')}</WebUILink>,
       icon: <EndpointsIcon style={{ color: token.colorPrimary }} />,
       key: 'serving',
@@ -214,7 +211,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
       key: 'data',
       group: 'storage',
     },
-    supportUserCommittedImage && {
+    {
       label: (
         <WebUILink to="/my-environment">
           {t('webui.menu.MyEnvironments')}

--- a/react/src/components/ManageAppsModal.tsx
+++ b/react/src/components/ManageAppsModal.tsx
@@ -1,6 +1,5 @@
 import { ManageAppsModalMutation } from '../__generated__/ManageAppsModalMutation.graphql';
 import { ManageAppsModal_image$key } from '../__generated__/ManageAppsModal_image.graphql';
-import { useSuspendedBackendaiClient } from '../hooks';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
@@ -34,7 +33,6 @@ const ManageAppsModal: React.FC<ManageAppsModalProps> = ({
   ...baiModalProps
 }) => {
   const { t } = useTranslation();
-  const baiClient = useSuspendedBackendaiClient();
   const formRef = React.useRef<FormInstance>(null);
   const app = App.useApp();
 
@@ -130,11 +128,7 @@ const ManageAppsModal: React.FC<ManageAppsModalProps> = ({
               architecture: image?.architecture,
               props: {
                 labels: labels,
-                resource_limits: baiClient.isManagerVersionCompatibleWith(
-                  '24.03.4.*',
-                )
-                  ? undefined
-                  : null,
+                resource_limits: undefined,
               },
             },
             onCompleted: (res, errors) => {

--- a/react/src/components/ManageImageResourceLimitModal.tsx
+++ b/react/src/components/ManageImageResourceLimitModal.tsx
@@ -4,7 +4,6 @@ import {
 } from '../__generated__/ManageImageResourceLimitModalMutation.graphql';
 import { ManageImageResourceLimitModal_image$key } from '../__generated__/ManageImageResourceLimitModal_image.graphql';
 import { compareNumberWithUnits } from '../helper';
-import { useSuspendedBackendaiClient } from '../hooks';
 import { useResourceSlotsDetails } from '../hooks/backendai';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import DynamicUnitInputNumber from './DynamicUnitInputNumber';
@@ -26,7 +25,6 @@ interface ManageImageResourceLimitModalProps extends BAIModalProps {
 const ManageImageResourceLimitModal: React.FC<
   ManageImageResourceLimitModalProps
 > = ({ imageFrgmt, open, onRequestClose, ...BAIModalProps }) => {
-  const baiClient = useSuspendedBackendaiClient();
   // Differentiate default max value based on manager version.
   // The difference between validating a variable type as undefined or none for an unsupplied field value.
   // [Associated PR links] : https://github.com/lablup/backend.ai/pull/1941
@@ -84,10 +82,8 @@ const ManageImageResourceLimitModal: React.FC<
         key,
         min: _.toString(value) ?? '0',
         max:
-          (image?.resource_limits?.find((item) => item?.key === key)?.max ??
-          baiClient.isManagerVersionCompatibleWith('24.03.4.*'))
-            ? undefined
-            : null,
+          image?.resource_limits?.find((item) => item?.key === key)?.max ??
+          undefined,
       }))
       .filter((item) => !_.isEmpty(item?.min));
 

--- a/react/src/components/ModelCloneModal.tsx
+++ b/react/src/components/ModelCloneModal.tsx
@@ -256,22 +256,6 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
               hidden
             >
               <Input />
-              {/* <Select
-              options={[
-                {
-                  label: 'General',
-                  value: 'general',
-                },
-                ...(baiClient.supports('inference-workload')
-                  ? [
-                      {
-                        label: 'Model',
-                        value: 'model',
-                      },
-                    ]
-                  : []),
-              ]}
-            /> */}
             </Form.Item>
           )}
           <Form.Item

--- a/react/src/components/MyKeypairInfoModal.tsx
+++ b/react/src/components/MyKeypairInfoModal.tsx
@@ -40,8 +40,6 @@ const MyKeypairInfoModal: React.FC<MyKeypairInfoModalProps> = ({
     staleTime: 0,
   });
 
-  const supportMainAccessKey = baiClient?.supports('main-access-key');
-
   const { user } = useLazyLoadQuery<MyKeypairInfoModalQuery>(
     graphql`
       query MyKeypairInfoModalQuery($email: String) {
@@ -90,7 +88,7 @@ const MyKeypairInfoModal: React.FC<MyKeypairInfoModalProps> = ({
                 <Typography.Text ellipsis copyable>
                   {value}
                 </Typography.Text>
-                {supportMainAccessKey && value === user?.main_access_key && (
+                {value === user?.main_access_key && (
                   <Tag color={'red'}>{t('credential.MainAccessKey')}</Tag>
                 )}
               </Flex>

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -59,10 +59,6 @@ const ProjectResourcePolicyList: React.FC<
     useState<ProjectResourcePolicySettingModalFragment$key | null>();
 
   const baiClient = useSuspendedBackendaiClient();
-  const supportMaxVfolderCount = baiClient?.supports(
-    'max-vfolder-count-in-user-and-project-resource-policy',
-  );
-  const supportMaxQuotaScopeSize = baiClient?.supports('max-quota-scope-size');
   const supportMaxNetworkCount = baiClient?.supports('max_network_count');
 
   const { project_resource_policies } =
@@ -111,35 +107,31 @@ const ProjectResourcePolicyList: React.FC<
       fixed: 'left',
       sorter: (a, b) => localeCompare(a?.name, b?.name),
     },
-    supportMaxVfolderCount
-      ? {
-          title: t('resourcePolicy.MaxVFolderCount'),
-          dataIndex: 'max_vfolder_count',
-          key: 'max_vfolder_count',
-          render: (text: ProjectResourcePolicies) =>
-            _.toNumber(text) === 0 ? '∞' : text,
-          sorter: (a, b) =>
-            numberSorterWithInfinityValue(
-              a?.max_vfolder_count,
-              b?.max_vfolder_count,
-              0,
-            ),
-        }
-      : {},
-    supportMaxQuotaScopeSize
-      ? {
-          title: t('resourcePolicy.MaxQuotaScopeSize'),
-          dataIndex: 'max_quota_scope_size',
-          key: 'max_quota_scope_size',
-          render: (text) => (text === -1 ? '∞' : bytesToGB(text)),
-          sorter: (a, b) =>
-            numberSorterWithInfinityValue(
-              a?.max_quota_scope_size,
-              b?.max_quota_scope_size,
-              -1,
-            ),
-        }
-      : {},
+    {
+      title: t('resourcePolicy.MaxVFolderCount'),
+      dataIndex: 'max_vfolder_count',
+      key: 'max_vfolder_count',
+      render: (text: ProjectResourcePolicies) =>
+        _.toNumber(text) === 0 ? '∞' : text,
+      sorter: (a, b) =>
+        numberSorterWithInfinityValue(
+          a?.max_vfolder_count,
+          b?.max_vfolder_count,
+          0,
+        ),
+    },
+    {
+      title: t('resourcePolicy.MaxQuotaScopeSize'),
+      dataIndex: 'max_quota_scope_size',
+      key: 'max_quota_scope_size',
+      render: (text) => (text === -1 ? '∞' : bytesToGB(text)),
+      sorter: (a, b) =>
+        numberSorterWithInfinityValue(
+          a?.max_quota_scope_size,
+          b?.max_quota_scope_size,
+          -1,
+        ),
+    },
     supportMaxNetworkCount
       ? {
           title: t('resourcePolicy.MaxNetworkCount'),

--- a/react/src/components/ProjectResourcePolicySettingModal.tsx
+++ b/react/src/components/ProjectResourcePolicySettingModal.tsx
@@ -45,10 +45,6 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
   const formRef = useRef<FormInstance>(null);
 
   const baiClient = useSuspendedBackendaiClient();
-  const supportMaxVfolderCount = baiClient?.supports(
-    'max-vfolder-count-in-user-and-project-resource-policy',
-  );
-  const supportMaxQuotaScopeSize = baiClient?.supports('max-quota-scope-size');
   const supportMaxNetworkCount = baiClient?.supports('max_network_count');
 
   const projectResourcePolicy = useFragment(
@@ -139,12 +135,6 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
               : GBToBytes(values?.max_quota_scope_size),
           max_network_count: values?.max_network_count || -1,
         };
-        if (!supportMaxVfolderCount) {
-          delete props.max_vfolder_count;
-        }
-        if (!supportMaxQuotaScopeSize) {
-          delete props.max_quota_scope_size;
-        }
         if (!supportMaxNetworkCount) {
           delete props.max_network_count;
         }
@@ -271,36 +261,32 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
           gap={'md'}
           style={{ marginBottom: token.marginMD }}
         >
-          {supportMaxVfolderCount ? (
-            <FormItemWithUnlimited
-              name={'max_vfolder_count'}
-              unlimitedValue={0}
-              label={t('resourcePolicy.MaxFolderCount')}
-              style={{ width: '100%', margin: 0 }}
-            >
-              <InputNumber
-                min={0}
-                max={SIGNED_32BIT_MAX_INT}
-                style={{ width: '100%' }}
-              />
-            </FormItemWithUnlimited>
-          ) : null}
-          {supportMaxQuotaScopeSize ? (
-            <FormItemWithUnlimited
-              name={'max_quota_scope_size'}
-              unlimitedValue={-1}
-              label={t('storageHost.MaxFolderSize')}
-              style={{ width: '100%', margin: 0 }}
-            >
-              <InputNumber
-                min={0}
-                // Maximum safe integer divided by 10^9 to prevent overflow when converting GB to bytes
-                max={Math.floor(Number.MAX_SAFE_INTEGER / Math.pow(10, 9))}
-                addonAfter="GB"
-                style={{ width: '100%' }}
-              />
-            </FormItemWithUnlimited>
-          ) : null}
+          <FormItemWithUnlimited
+            name={'max_vfolder_count'}
+            unlimitedValue={0}
+            label={t('resourcePolicy.MaxFolderCount')}
+            style={{ width: '100%', margin: 0 }}
+          >
+            <InputNumber
+              min={0}
+              max={SIGNED_32BIT_MAX_INT}
+              style={{ width: '100%' }}
+            />
+          </FormItemWithUnlimited>
+          <FormItemWithUnlimited
+            name={'max_quota_scope_size'}
+            unlimitedValue={-1}
+            label={t('storageHost.MaxFolderSize')}
+            style={{ width: '100%', margin: 0 }}
+          >
+            <InputNumber
+              min={0}
+              // Maximum safe integer divided by 10^9 to prevent overflow when converting GB to bytes
+              max={Math.floor(Number.MAX_SAFE_INTEGER / Math.pow(10, 9))}
+              addonAfter="GB"
+              style={{ width: '100%' }}
+            />
+          </FormItemWithUnlimited>
           {supportMaxNetworkCount ? (
             <FormItemWithUnlimited
               name={'max_network_count'}

--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -1503,149 +1503,146 @@ const ResourceAllocationFormItems: React.FC<
           </Flex>
         </Form.Item>
       )}
-      {baiClient.supports('multi-container') && (
-        // {false && (
-        <Form.Item
-          label={t('session.launcher.ClusterMode')}
-          tooltip={
-            <Flex direction="column" align="start">
-              {t('session.launcher.SingleNode')}
-              <Trans i18nKey={'session.launcher.DescSingleNode'} />
-              <Divider style={{ backgroundColor: token.colorBorder }} />
-              {t('session.launcher.MultiNode')}
-              <Trans i18nKey={'session.launcher.DescMultiNode'} />
-            </Flex>
-          }
-          required
-          dependencies={['agent']}
-        >
-          {({ getFieldValue }) => {
-            return (
-              <Card
-                style={{
-                  marginBottom: token.margin,
-                }}
-              >
-                <Row gutter={token.marginMD}>
-                  <Col xs={24}>
-                    {/* <Col xs={24} lg={12}> */}
-                    <Form.Item name={'cluster_mode'} required>
-                      <Radio.Group
-                        onChange={(e) => {
-                          form.validateFields().catch(() => {});
-                        }}
-                        disabled={getFieldValue('agent') !== 'auto'}
-                      >
-                        <Radio.Button value="single-node">
-                          {t('session.launcher.SingleNode')}
-                        </Radio.Button>
-                        <Radio.Button value="multi-node">
-                          {t('session.launcher.MultiNode')}
-                        </Radio.Button>
-                      </Radio.Group>
-                    </Form.Item>
-                  </Col>
-                  <Col xs={24}>
-                    <Form.Item
-                      noStyle
-                      shouldUpdate={(prev, next) =>
-                        prev.cluster_mode !== next.cluster_mode
-                      }
+      <Form.Item
+        label={t('session.launcher.ClusterMode')}
+        tooltip={
+          <Flex direction="column" align="start">
+            {t('session.launcher.SingleNode')}
+            <Trans i18nKey={'session.launcher.DescSingleNode'} />
+            <Divider style={{ backgroundColor: token.colorBorder }} />
+            {t('session.launcher.MultiNode')}
+            <Trans i18nKey={'session.launcher.DescMultiNode'} />
+          </Flex>
+        }
+        required
+        dependencies={['agent']}
+      >
+        {({ getFieldValue }) => {
+          return (
+            <Card
+              style={{
+                marginBottom: token.margin,
+              }}
+            >
+              <Row gutter={token.marginMD}>
+                <Col xs={24}>
+                  {/* <Col xs={24} lg={12}> */}
+                  <Form.Item name={'cluster_mode'} required>
+                    <Radio.Group
+                      onChange={(e) => {
+                        form.validateFields().catch(() => {});
+                      }}
+                      disabled={getFieldValue('agent') !== 'auto'}
                     >
-                      {() => {
-                        const derivedClusterSizeMaxLimit = _.min([
-                          resourceLimits.cpu?.max,
-                          keypairResourcePolicy.max_containers_per_session,
-                        ]);
-                        const clusterUnit =
-                          form.getFieldValue('cluster_mode') === 'single-node'
-                            ? t('session.launcher.Container')
-                            : t('session.launcher.Node');
-                        return (
-                          <Form.Item
-                            name={'cluster_size'}
-                            label={t('session.launcher.ClusterSize')}
-                            required
-                            rules={[
-                              {
-                                warningOnly: true,
-                                validator: async (rule, value: number) => {
-                                  if (showRemainingWarning) {
-                                    const minCPU = _.min([
-                                      remaining.cpu,
-                                      keypairResourcePolicy.max_containers_per_session,
-                                    ]);
-                                    if (_.isNumber(minCPU) && value > minCPU) {
-                                      return Promise.reject(
-                                        t(
-                                          'session.launcher.EnqueueComputeSessionWarning',
-                                        ),
-                                      );
-                                    }
+                      <Radio.Button value="single-node">
+                        {t('session.launcher.SingleNode')}
+                      </Radio.Button>
+                      <Radio.Button value="multi-node">
+                        {t('session.launcher.MultiNode')}
+                      </Radio.Button>
+                    </Radio.Group>
+                  </Form.Item>
+                </Col>
+                <Col xs={24}>
+                  <Form.Item
+                    noStyle
+                    shouldUpdate={(prev, next) =>
+                      prev.cluster_mode !== next.cluster_mode
+                    }
+                  >
+                    {() => {
+                      const derivedClusterSizeMaxLimit = _.min([
+                        resourceLimits.cpu?.max,
+                        keypairResourcePolicy.max_containers_per_session,
+                      ]);
+                      const clusterUnit =
+                        form.getFieldValue('cluster_mode') === 'single-node'
+                          ? t('session.launcher.Container')
+                          : t('session.launcher.Node');
+                      return (
+                        <Form.Item
+                          name={'cluster_size'}
+                          label={t('session.launcher.ClusterSize')}
+                          required
+                          rules={[
+                            {
+                              warningOnly: true,
+                              validator: async (rule, value: number) => {
+                                if (showRemainingWarning) {
+                                  const minCPU = _.min([
+                                    remaining.cpu,
+                                    keypairResourcePolicy.max_containers_per_session,
+                                  ]);
+                                  if (_.isNumber(minCPU) && value > minCPU) {
+                                    return Promise.reject(
+                                      t(
+                                        'session.launcher.EnqueueComputeSessionWarning',
+                                      ),
+                                    );
                                   }
-                                  return Promise.resolve();
+                                }
+                                return Promise.resolve();
+                              },
+                            },
+                          ]}
+                        >
+                          <InputNumberWithSlider
+                            inputContainerMinWidth={190}
+                            min={1}
+                            step={1}
+                            // TODO: max cluster size
+                            max={
+                              _.isNumber(derivedClusterSizeMaxLimit)
+                                ? derivedClusterSizeMaxLimit
+                                : undefined
+                            }
+                            disabled={
+                              derivedClusterSizeMaxLimit === 1 ||
+                              getFieldValue('agent') !== 'auto'
+                            }
+                            sliderProps={{
+                              marks: {
+                                1: '1',
+                                // remaining mark code should be located before max mark code to prevent overlapping when it is same value
+                                ...(remaining.cpu
+                                  ? {
+                                      [remaining.cpu]: {
+                                        label: <RemainingMark />,
+                                      },
+                                    }
+                                  : {}),
+                                ...(_.isNumber(derivedClusterSizeMaxLimit)
+                                  ? {
+                                      [derivedClusterSizeMaxLimit]:
+                                        derivedClusterSizeMaxLimit,
+                                    }
+                                  : {}),
+                              },
+                              tooltip: {
+                                formatter: (value = 0) => {
+                                  return `${value} ${clusterUnit}`;
                                 },
                               },
-                            ]}
-                          >
-                            <InputNumberWithSlider
-                              inputContainerMinWidth={190}
-                              min={1}
-                              step={1}
-                              // TODO: max cluster size
-                              max={
-                                _.isNumber(derivedClusterSizeMaxLimit)
-                                  ? derivedClusterSizeMaxLimit
-                                  : undefined
+                            }}
+                            inputNumberProps={{
+                              addonAfter: clusterUnit,
+                            }}
+                            onChange={(value) => {
+                              if (value > 1) {
+                                form.setFieldValue('num_of_sessions', 1);
                               }
-                              disabled={
-                                derivedClusterSizeMaxLimit === 1 ||
-                                getFieldValue('agent') !== 'auto'
-                              }
-                              sliderProps={{
-                                marks: {
-                                  1: '1',
-                                  // remaining mark code should be located before max mark code to prevent overlapping when it is same value
-                                  ...(remaining.cpu
-                                    ? {
-                                        [remaining.cpu]: {
-                                          label: <RemainingMark />,
-                                        },
-                                      }
-                                    : {}),
-                                  ...(_.isNumber(derivedClusterSizeMaxLimit)
-                                    ? {
-                                        [derivedClusterSizeMaxLimit]:
-                                          derivedClusterSizeMaxLimit,
-                                      }
-                                    : {}),
-                                },
-                                tooltip: {
-                                  formatter: (value = 0) => {
-                                    return `${value} ${clusterUnit}`;
-                                  },
-                                },
-                              }}
-                              inputNumberProps={{
-                                addonAfter: clusterUnit,
-                              }}
-                              onChange={(value) => {
-                                if (value > 1) {
-                                  form.setFieldValue('num_of_sessions', 1);
-                                }
-                              }}
-                            />
-                          </Form.Item>
-                        );
-                      }}
-                    </Form.Item>
-                  </Col>
-                </Row>
-              </Card>
-            );
-          }}
-        </Form.Item>
-      )}
+                            }}
+                          />
+                        </Form.Item>
+                      );
+                    }}
+                  </Form.Item>
+                </Col>
+              </Row>
+            </Card>
+          );
+        }}
+      </Form.Item>
     </>
   );
 };

--- a/react/src/components/ServiceValidationView.tsx
+++ b/react/src/components/ServiceValidationView.tsx
@@ -80,25 +80,21 @@ const ServiceValidationView: React.FC<ServiceValidationModalProps> = ({
         config: {
           model: values.vFolderID,
           model_version: 1, // FIXME: hardcoded. change it with option later
-          ...(baiClient.supports('endpoint-extra-mounts') && {
-            extra_mounts: _.reduce(
-              values.mounts,
-              (acc, key: string) => {
-                acc[key] = {
-                  ...(values.vfoldersAliasMap[key] && {
-                    mount_destination: values.vfoldersAliasMap[key],
-                  }),
-                  type: 'bind', // FIXME: hardcoded. change it with option later
-                };
-                return acc;
-              },
-              {} as Record<string, MountOptionType>,
-            ),
-          }),
+          extra_mounts: _.reduce(
+            values.mounts,
+            (acc, key: string) => {
+              acc[key] = {
+                ...(values.vfoldersAliasMap[key] && {
+                  mount_destination: values.vfoldersAliasMap[key],
+                }),
+                type: 'bind', // FIXME: hardcoded. change it with option later
+              };
+              return acc;
+            },
+            {} as Record<string, MountOptionType>,
+          ),
           model_definition_path: values.modelDefinitionPath,
-          model_mount_destination: baiClient.supports('endpoint-extra-mounts')
-            ? values.modelMountDestination
-            : '/models',
+          model_mount_destination: values.modelMountDestination,
           environ: {}, // FIXME: hardcoded. change it with option later
           scaling_group: values.resourceGroup,
           resources: {

--- a/react/src/components/StorageStatusPanel.tsx
+++ b/react/src/components/StorageStatusPanel.tsx
@@ -82,7 +82,6 @@ const StorageStatusPanel: React.FC<{
 
   // TODO: Add resolver to enable subquery and modify to call useLazyLoadQuery only once.
   const {
-    keypair,
     user,
     // currentProjectDetail
   } = useLazyLoadQuery<StorageStatusPanelKeypairQuery>(
@@ -118,7 +117,6 @@ const StorageStatusPanel: React.FC<{
   const {
     user_resource_policy,
     project_resource_policy,
-    keypair_resource_policy,
     project_quota_scope,
     user_quota_scope,
   } = useLazyLoadQuery<StorageStatusPanelQuery>(
@@ -126,7 +124,6 @@ const StorageStatusPanel: React.FC<{
       query StorageStatusPanelQuery(
         $user_RP_name: String
         $project_RP_name: String!
-        $keypair_resource_policy_name: String
         $project_quota_scope_id: String!
         $user_quota_scope_id: String!
         $storage_host_name: String!
@@ -137,11 +134,6 @@ const StorageStatusPanel: React.FC<{
         }
         project_resource_policy(name: $project_RP_name)
           @since(version: "23.09.1") {
-          max_vfolder_count
-        }
-        keypair_resource_policy(name: $keypair_resource_policy_name)
-          # use max_vfolder_count in keypair_resource_policy before adding max_vfolder_count in user_resource_policy
-          @deprecatedSince(version: "23.09.4") {
           max_vfolder_count
         }
         project_quota_scope: quota_scope(
@@ -161,7 +153,6 @@ const StorageStatusPanel: React.FC<{
     {
       user_RP_name: user?.resource_policy,
       project_RP_name: currentProject?.name ?? '',
-      keypair_resource_policy_name: keypair?.resource_policy,
       project_quota_scope_id: addQuotaScopeTypePrefix(
         'project',
         currentProject?.id,
@@ -175,17 +166,8 @@ const StorageStatusPanel: React.FC<{
     },
   );
   // Support version:
-  // keypair resource policy < 23.09.4
   // user resource policy, project resource policy >= 23.09.6
-  let maxVfolderCount;
-  if (
-    // manager version >= 23.09.6
-    baiClient?.supports('max-vfolder-count-in-user-and-project-resource-policy')
-  ) {
-    maxVfolderCount = user_resource_policy?.max_vfolder_count || 0;
-  } else {
-    maxVfolderCount = keypair_resource_policy?.max_vfolder_count || 0;
-  }
+  const maxVfolderCount = user_resource_policy?.max_vfolder_count || 0;
 
   const numberOfFolderPercent =
     maxVfolderCount || maxVfolderCount === 0

--- a/react/src/components/UserInfoModal.tsx
+++ b/react/src/components/UserInfoModal.tsx
@@ -1,5 +1,4 @@
 import { UserInfoModalQuery } from '../__generated__/UserInfoModalQuery.graphql';
-import { useSuspendedBackendaiClient } from '../hooks';
 import { useTOTPSupported } from '../hooks/backendai';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { Descriptions, DescriptionsProps, Tag, Spin } from 'antd';
@@ -19,10 +18,6 @@ const UserInfoModal: React.FC<Props> = ({
   ...baiModalProps
 }) => {
   const { t } = useTranslation();
-  const baiClient = useSuspendedBackendaiClient();
-  const sudoSessionEnabledSupported = baiClient?.supports(
-    'sudo-session-enabled',
-  );
 
   const { isTOTPSupported, isLoading: isLoadingManagerSupportingTOTP } =
     useTOTPSupported();
@@ -60,7 +55,7 @@ const UserInfoModal: React.FC<Props> = ({
     `,
     {
       email: userEmail,
-      isNotSupportSudoSessionEnabled: !sudoSessionEnabledSupported,
+      isNotSupportSudoSessionEnabled: false,
       isTOTPSupported: isTOTPSupported ?? false,
     },
   );
@@ -109,11 +104,9 @@ const UserInfoModal: React.FC<Props> = ({
         <Descriptions.Item label={t('credential.DescRequirePasswordChange')}>
           {user?.need_password_change ? t('button.Yes') : t('button.No')}
         </Descriptions.Item>
-        {sudoSessionEnabledSupported && (
-          <Descriptions.Item label={t('credential.EnableSudoSession')}>
-            {user?.sudo_session_enabled ? t('button.Yes') : t('button.No')}
-          </Descriptions.Item>
-        )}
+        <Descriptions.Item label={t('credential.EnableSudoSession')}>
+          {user?.sudo_session_enabled ? t('button.Yes') : t('button.No')}
+        </Descriptions.Item>
         {isTOTPSupported && (
           <Descriptions.Item label={t('webui.menu.TotpActivated')}>
             <Spin spinning={isLoadingManagerSupportingTOTP}>

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -12,7 +12,7 @@ import {
   numberSorterWithInfinityValue,
 } from '../helper';
 import { exportCSVWithFormattingRules } from '../helper/csv-util';
-import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
+import { useUpdatableState } from '../hooks';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
 import BAITable from './BAITable';
 import Flex from './Flex';
@@ -57,18 +57,6 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
     useState<string>();
   const [editingUserResourcePolicy, setEditingUserResourcePolicy] =
     useState<UserResourcePolicySettingModalFragment$key | null>();
-
-  const baiClient = useSuspendedBackendaiClient();
-  const supportMaxVfolderCount = baiClient?.supports(
-    'max-vfolder-count-in-user-and-project-resource-policy',
-  );
-  const supportMaxQuotaScopeSize = baiClient?.supports('max-quota-scope-size');
-  const supportMaxSessionCountPerModelSession = baiClient?.supports(
-    'max-session-count-per-model-session',
-  );
-  const supportMaxCustomizedImageCount = baiClient?.supports(
-    'max-customized-image-count',
-  );
 
   const { user_resource_policies } =
     useLazyLoadQuery<UserResourcePolicyListQuery>(
@@ -116,7 +104,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
       fixed: 'left',
       sorter: (a, b) => localeCompare(a?.name, b?.name),
     },
-    supportMaxVfolderCount && {
+    {
       title: t('resourcePolicy.MaxVFolderCount'),
       dataIndex: 'max_vfolder_count',
       key: 'max_vfolder_count',
@@ -128,7 +116,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
           0,
         ),
     },
-    supportMaxSessionCountPerModelSession && {
+    {
       title: t('resourcePolicy.MaxSessionCountPerModelSession'),
       dataIndex: 'max_session_count_per_model_session',
       key: 'max_session_count_per_model_session',
@@ -136,7 +124,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
         (a?.max_session_count_per_model_session ?? 0) -
         (b?.max_session_count_per_model_session ?? 0),
     },
-    supportMaxQuotaScopeSize && {
+    {
       title: t('resourcePolicy.MaxQuotaScopeSize'),
       dataIndex: 'max_quota_scope_size',
       key: 'max_quota_scope_size',
@@ -148,7 +136,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
           -1,
         ),
     },
-    supportMaxCustomizedImageCount && {
+    {
       title: t('resourcePolicy.MaxCustomizedImageCount'),
       key: 'max_customized_image_count',
       dataIndex: 'max_customized_image_count',

--- a/react/src/components/UserResourcePolicySettingModal.tsx
+++ b/react/src/components/UserResourcePolicySettingModal.tsx
@@ -9,7 +9,6 @@ import {
 } from '../__generated__/UserResourcePolicySettingModalModifyMutation.graphql';
 import { GBToBytes, bytesToGB } from '../helper';
 import { SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
-import { useSuspendedBackendaiClient } from '../hooks';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
 import FormItemWithUnlimited from './FormItemWithUnlimited';
@@ -44,18 +43,6 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
   const { message } = App.useApp();
 
   const formRef = useRef<FormInstance>(null);
-
-  const baiClient = useSuspendedBackendaiClient();
-  const supportMaxVfolderCount = baiClient?.supports(
-    'max-vfolder-count-in-user-and-project-resource-policy',
-  );
-  const supportMaxQuotaScopeSize = baiClient?.supports('max-quota-scope-size');
-  const supportMaxSessionCountPerModelSession = baiClient?.supports(
-    'max-session-count-per-model-session',
-  );
-  const supportMaxCustomizedImageCount = baiClient?.supports(
-    'max-customized-image-count',
-  );
 
   const userResourcePolicy = useFragment(
     graphql`
@@ -146,18 +133,6 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
             values?.max_session_count_per_model_session,
           max_customized_image_count: values?.max_customized_image_count,
         };
-        if (!supportMaxVfolderCount) {
-          delete props.max_vfolder_count;
-        }
-        if (!supportMaxQuotaScopeSize) {
-          delete props.max_quota_scope_size;
-        }
-        if (!supportMaxSessionCountPerModelSession) {
-          delete props.max_session_count_per_model_session;
-        }
-        if (!supportMaxCustomizedImageCount) {
-          delete props.max_customized_image_count;
-        }
         if (userResourcePolicy === null) {
           commitCreateUserResourcePolicy({
             variables: {
@@ -281,67 +256,59 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
           gap={'md'}
           style={{ marginBottom: token.marginMD }}
         >
-          {supportMaxVfolderCount ? (
-            <FormItemWithUnlimited
-              name={'max_vfolder_count'}
-              unlimitedValue={0}
-              label={t('resourcePolicy.MaxFolderCount')}
-              style={{ width: '100%', margin: 0 }}
-            >
-              <InputNumber
-                min={0}
-                max={SIGNED_32BIT_MAX_INT}
-                style={{ width: '100%' }}
-              />
-            </FormItemWithUnlimited>
-          ) : null}
-          {supportMaxQuotaScopeSize ? (
-            <FormItemWithUnlimited
-              name={'max_quota_scope_size'}
-              unlimitedValue={-1}
-              label={t('storageHost.MaxFolderSize')}
-              style={{ width: '100%', margin: 0 }}
-            >
-              <InputNumber
-                min={0}
-                // Maximum safe integer divided by 10^9 to prevent overflow when converting GB to bytes
-                max={Math.floor(Number.MAX_SAFE_INTEGER / Math.pow(10, 9))}
-                addonAfter="GB"
-                style={{ width: '100%' }}
-              />
-            </FormItemWithUnlimited>
-          ) : null}
+          <FormItemWithUnlimited
+            name={'max_vfolder_count'}
+            unlimitedValue={0}
+            label={t('resourcePolicy.MaxFolderCount')}
+            style={{ width: '100%', margin: 0 }}
+          >
+            <InputNumber
+              min={0}
+              max={SIGNED_32BIT_MAX_INT}
+              style={{ width: '100%' }}
+            />
+          </FormItemWithUnlimited>
+          <FormItemWithUnlimited
+            name={'max_quota_scope_size'}
+            unlimitedValue={-1}
+            label={t('storageHost.MaxFolderSize')}
+            style={{ width: '100%', margin: 0 }}
+          >
+            <InputNumber
+              min={0}
+              // Maximum safe integer divided by 10^9 to prevent overflow when converting GB to bytes
+              max={Math.floor(Number.MAX_SAFE_INTEGER / Math.pow(10, 9))}
+              addonAfter="GB"
+              style={{ width: '100%' }}
+            />
+          </FormItemWithUnlimited>
         </Flex>
-        {supportMaxSessionCountPerModelSession ? (
-          <Form.Item
-            name={'max_session_count_per_model_session'}
-            label={t('resourcePolicy.MaxSessionCountPerModelSession')}
-            rules={[
-              { required: true, message: t('data.explorer.ValueRequired') },
-            ]}
-          >
-            <InputNumber
-              min={0}
-              max={SIGNED_32BIT_MAX_INT}
-              style={{ width: '100%' }}
-            />
-          </Form.Item>
-        ) : null}
-        {supportMaxCustomizedImageCount ? (
-          <Form.Item
-            name={'max_customized_image_count'}
-            label={t('resourcePolicy.MaxCustomizedImageCount')}
-            rules={[
-              { required: true, message: t('data.explorer.ValueRequired') },
-            ]}
-          >
-            <InputNumber
-              min={0}
-              max={SIGNED_32BIT_MAX_INT}
-              style={{ width: '100%' }}
-            />
-          </Form.Item>
-        ) : null}
+        <Form.Item
+          name={'max_session_count_per_model_session'}
+          label={t('resourcePolicy.MaxSessionCountPerModelSession')}
+          rules={[
+            { required: true, message: t('data.explorer.ValueRequired') },
+          ]}
+        >
+          <InputNumber
+            min={0}
+            max={SIGNED_32BIT_MAX_INT}
+            style={{ width: '100%' }}
+          />
+        </Form.Item>
+        <Form.Item
+          name={'max_customized_image_count'}
+          label={t('resourcePolicy.MaxCustomizedImageCount')}
+          rules={[
+            { required: true, message: t('data.explorer.ValueRequired') },
+          ]}
+        >
+          <InputNumber
+            min={0}
+            max={SIGNED_32BIT_MAX_INT}
+            style={{ width: '100%' }}
+          />
+        </Form.Item>
       </Form>
     </BAIModal>
   );

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -71,9 +71,6 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
   const currentUserRole = useCurrentUserRole();
   const currentDomainName = useCurrentDomainValue();
   const baiClient = useSuspendedBackendaiClient();
-  const sudoSessionEnabledSupported = baiClient?.supports(
-    'sudo-session-enabled',
-  );
   const { isTOTPSupported, isLoading: isLoadingManagerSupportingTOTP } =
     useTOTPSupported();
   const [isOpenTOTPActivateModal, { toggle: toggleTOTPActivateModal }] =
@@ -82,11 +79,7 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
 
   const { user } = useLazyLoadQuery<UserSettingModalQuery>(
     graphql`
-      query UserSettingModalQuery(
-        $email: String
-        $isNotSupportSudoSessionEnabled: Boolean!
-        $isNotSupportTotp: Boolean!
-      ) {
+      query UserSettingModalQuery($email: String, $isNotSupportTotp: Boolean!) {
         user(email: $email) {
           email
           username
@@ -101,11 +94,7 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
             name
           }
           resource_policy
-          # TODO: reflect https://github.com/lablup/backend.ai-webui/pull/1999
-          # support from 23.09.0b1
-          # https://github.com/lablup/backend.ai/pull/1530
           sudo_session_enabled
-            @skipOnClient(if: $isNotSupportSudoSessionEnabled)
           totp_activated @skipOnClient(if: $isNotSupportTotp)
           ...TOTPActivateModalFragment
         }
@@ -113,7 +102,6 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
     `,
     {
       email: userEmail ?? '',
-      isNotSupportSudoSessionEnabled: !sudoSessionEnabledSupported,
       isNotSupportTotp: !isTOTPSupported,
     },
     {
@@ -129,7 +117,6 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
       mutation UserSettingModalModifyMutation(
         $email: String!
         $props: ModifyUserInput!
-        $isNotSupportSudoSessionEnabled: Boolean!
         $isNotSupportTotp: Boolean!
       ) {
         modify_user(email: $email, props: $props) {
@@ -150,11 +137,7 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
               name
             }
             resource_policy
-            # TODO: reflect https://github.com/lablup/backend.ai-webui/pull/1999
-            # support from 23.09.0b1
-            # https://github.com/lablup/backend.ai/pull/1530
             sudo_session_enabled
-              @skipOnClient(if: $isNotSupportSudoSessionEnabled)
             totp_activated @skipOnClient(if: $isNotSupportTotp)
             ...TOTPActivateModalFragment
           }
@@ -167,7 +150,6 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
       mutation UserSettingModalCreateMutation(
         $email: String!
         $props: UserInput!
-        $isNotSupportSudoSessionEnabled: Boolean!
         $isNotSupportTotp: Boolean!
       ) {
         create_user(email: $email, props: $props) {
@@ -189,7 +171,6 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
             }
             resource_policy
             sudo_session_enabled
-              @skipOnClient(if: $isNotSupportSudoSessionEnabled)
             totp_activated @skipOnClient(if: $isNotSupportTotp)
             ...TOTPActivateModalFragment
           }
@@ -229,7 +210,6 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
             variables: {
               email: values?.email || '',
               props: props,
-              isNotSupportSudoSessionEnabled: !sudoSessionEnabledSupported,
               isNotSupportTotp: !isTOTPSupported,
             },
             onCompleted: (res, errors) => {
@@ -275,7 +255,6 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
             variables: {
               email: values?.email || '',
               props: props,
-              isNotSupportSudoSessionEnabled: !sudoSessionEnabledSupported,
               isNotSupportTotp: !isTOTPSupported,
             },
             onCompleted: (res, errors) => {
@@ -448,15 +427,13 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
         >
           <Switch />
         </Form.Item>
-        {!!sudoSessionEnabledSupported && (
-          <Form.Item
-            name="sudo_session_enabled"
-            label={t('credential.EnableSudoSession')}
-            valuePropName="checked"
-          >
-            <Switch />
-          </Form.Item>
-        )}
+        <Form.Item
+          name="sudo_session_enabled"
+          label={t('credential.EnableSudoSession')}
+          valuePropName="checked"
+        >
+          <Switch />
+        </Form.Item>
         {!!isTOTPSupported && (
           <Form.Item
             name="totp_activated"

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -80,26 +80,19 @@ type ResourceSlotDetail = {
 export const useResourceSlotsDetails = (resourceGroupName?: string) => {
   const [key, checkUpdate] = useUpdatableState('first');
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
-  const baiClient = useSuspendedBackendaiClient();
   const { data: resourceSlotsInRG } = useTanQuery<{
     [key: string]: ResourceSlotDetail | undefined;
   }>({
     queryKey: ['useResourceSlots', resourceGroupName, key],
     queryFn: () => {
-      if (!baiClient.isManagerVersionCompatibleWith('23.09.0')) {
-        return {};
-      } else {
-        // `/resource-slots/details` is available since 23.09
-        // https://github.com/lablup/backend.ai/issues/1589
-        const search = new URLSearchParams();
-        resourceGroupName && search.set('sgroup', resourceGroupName);
-        const searchParamString = search.toString();
-        return baiRequestWithPromise({
-          method: 'GET',
-          // if `sgroup` is not provided, it will return all resource slots of all resource groups
-          url: `/config/resource-slots/details${searchParamString ? '?' + search.toString() : ''}`,
-        });
-      }
+      const search = new URLSearchParams();
+      resourceGroupName && search.set('sgroup', resourceGroupName);
+      const searchParamString = search.toString();
+      return baiRequestWithPromise({
+        method: 'GET',
+        // if `sgroup` is not provided, it will return all resource slots of all resource groups
+        url: `/config/resource-slots/details${searchParamString ? '?' + search.toString() : ''}`,
+      });
     },
     staleTime: 3000,
   });
@@ -169,13 +162,11 @@ export const useCurrentUserInfo = () => {
 
   useEffect(() => {
     const handler = (e: any) => {
-      if (baiClient.supports('change-user-name')) {
-        const input = e.detail;
-        _setUserInfo((v) => ({
-          ...v,
-          full_name: input,
-        }));
-      }
+      const input = e.detail;
+      _setUserInfo((v) => ({
+        ...v,
+        full_name: input,
+      }));
     };
     document.addEventListener('current-user-info-changed', handler);
     return () => {
@@ -288,9 +279,8 @@ export const useTOTPSupported = () => {
     },
     staleTime: 1000,
   });
-  const isTOTPSupported = baiClient.supports('2FA') && isManagerSupportingTOTP;
 
-  return { isTOTPSupported, isLoading };
+  return { isTOTPSupported: isManagerSupportingTOTP, isLoading };
 };
 
 export const useAllowedHostNames = () => {

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -457,13 +457,12 @@ export const useBackendAIImageMetaData = () => {
 export const useAppDownloadMap = () => {
   const baiClient = useSuspendedBackendaiClient();
   const appDownloadUrl = baiClient?._config?.appDownloadUrl || '';
-  const supportsWin = baiClient?.supports('use-win-instead-of-win32') || false;
 
   const appDownloadMap = {
     Linux: { os: 'linux', architecture: ['arm64', 'x64'], extension: 'zip' },
     MacOS: { os: 'macos', architecture: ['arm64', 'x64'], extension: 'dmg' },
     Windows: {
-      os: supportsWin ? 'win' : 'win32',
+      os: 'win',
       architecture: ['arm64', 'x64'],
       extension: 'zip',
     },

--- a/react/src/hooks/useSuspendedFilteredAppTemplate.ts
+++ b/react/src/hooks/useSuspendedFilteredAppTemplate.ts
@@ -102,7 +102,7 @@ export const useSuspendedFilteredAppTemplate = (
     });
   }
 
-  if (baiClient.supports('local-vscode-remote-connection') && allowTCPApps) {
+  if (allowTCPApps) {
     baseAppTemplate.push({
       name: 'vscode-desktop',
       title: 'Visual Studio Code (Desktop)',

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -9,7 +9,7 @@ import {
 } from '../components/Chat/ChatHistory';
 import { type ChatProviderData } from '../components/Chat/ChatModel';
 import Flex from '../components/Flex';
-import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useWebUINavigate } from '../hooks';
 import { Badge, Button, Card, Drawer, List, Tooltip, Typography } from 'antd';
 import { createStyles } from 'antd-style';
 import dayjs from 'dayjs';
@@ -42,7 +42,6 @@ const useStyles = createStyles(({ css }) => ({
 }));
 
 function useDefaultEndpointId() {
-  const baiClient = useSuspendedBackendaiClient();
   const { endpoint_list } = useLazyLoadQuery<ChatPageQuery>(
     graphql`
       query ChatPageQuery($filter: String) {
@@ -54,9 +53,7 @@ function useDefaultEndpointId() {
       }
     `,
     {
-      filter: baiClient.supports('endpoint-lifecycle-stage-filter')
-        ? 'lifecycle_stage == "created"'
-        : undefined,
+      filter: 'lifecycle_stage == "created"',
     },
   );
 

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -128,9 +128,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
   const webuiNavigate = useWebUINavigate();
   const { open } = useFolderExplorerOpener();
   const [selectedSessionId, setSelectedSessionId] = useState<string>();
-  const isSupportAutoScalingRule =
-    baiClient.isManagerVersionCompatibleWith('25.1.0');
-
+  const isSupportAutoScalingRule = baiClient.supports('auto-scaling-rule');
   const [errorDataForJSONModal, setErrorDataForJSONModal] = useState<string>();
   const { endpoint, endpoint_token_list, endpoint_auto_scaling_rules } =
     useLazyLoadQuery<EndpointDetailPageQuery>(
@@ -188,7 +186,6 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               human_readable_name
             }
             model
-            model_mount_destiation @deprecatedSince(version: "24.03.4")
             model_mount_destination @since(version: "24.03.4")
             model_definition_path @since(version: "24.03.4")
             extra_mounts @since(version: "24.03.4") {
@@ -434,23 +431,19 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
         <Suspense fallback={<Spin indicator={<LoadingOutlined spin />} />}>
           <Flex direction="column" align="start">
             <VFolderLazyView uuid={endpoint?.model} clickable={true} />
-            {baiClient.supports('endpoint-extra-mounts') &&
-              endpoint?.model_mount_destination && (
-                <Flex direction="row" align="center" gap={'xxs'}>
-                  <ArrowRightOutlined type="secondary" />
-                  <Typography.Text type="secondary">
-                    {endpoint?.model_mount_destination}
-                  </Typography.Text>
-                </Flex>
-              )}
+            {endpoint?.model_mount_destination && (
+              <Flex direction="row" align="center" gap={'xxs'}>
+                <ArrowRightOutlined type="secondary" />
+                <Typography.Text type="secondary">
+                  {endpoint?.model_mount_destination}
+                </Typography.Text>
+              </Flex>
+            )}
           </Flex>
         </Suspense>
       ) : null,
     },
-  ];
-
-  if (baiClient.supports('endpoint-extra-mounts')) {
-    items.push({
+    {
       label: t('modelService.AdditionalMounts'),
       children: (
         <Flex direction="column" align="start">
@@ -469,32 +462,30 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           })}
         </Flex>
       ),
-    });
-  }
-
-  items.push({
-    label: t('session.launcher.EnvironmentVariable'),
-    children: (
-      <Typography.Text style={{ fontFamily: 'monospace' }}>
-        {_.isEmpty(JSON.parse(endpoint?.environ || '{}'))
-          ? '-'
-          : endpoint?.environ}
-      </Typography.Text>
-    ),
-    span: {
-      sm: 1,
     },
-  });
-
-  items.push({
-    label: t('modelService.Image'),
-    children: endpoint?.image_object ? (
-      <ImageNodeSimpleTag imageFrgmt={endpoint.image_object} />
-    ) : null,
-    span: {
-      xl: 3,
+    {
+      label: t('session.launcher.EnvironmentVariable'),
+      children: (
+        <Typography.Text style={{ fontFamily: 'monospace' }}>
+          {_.isEmpty(JSON.parse(endpoint?.environ || '{}'))
+            ? '-'
+            : endpoint?.environ}
+        </Typography.Text>
+      ),
+      span: {
+        sm: 1,
+      },
     },
-  });
+    {
+      label: t('modelService.Image'),
+      children: endpoint?.image_object ? (
+        <ImageNodeSimpleTag imageFrgmt={endpoint.image_object} />
+      ) : null,
+      span: {
+        xl: 3,
+      },
+    },
+  ];
 
   // TODO: show current Autoscaling Rule in human-friendly way
   // items.push({

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -4,7 +4,7 @@ import KeypairResourcePolicyList from '../components/KeypairResourcePolicyList';
 import ProjectResourcePolicyList from '../components/ProjectResourcePolicyList';
 import UserResourcePolicyList from '../components/UserResourcePolicyList';
 import { filterEmptyItem } from '../helper';
-import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useWebUINavigate } from '../hooks';
 import { theme } from 'antd';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -15,13 +15,9 @@ const tabParam = withDefault(StringParam, 'keypair');
 interface ResourcePolicyPageProps {}
 const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
   const { t } = useTranslation();
+  const { token } = theme.useToken();
   const [curTabKey] = useQueryParam('tab', tabParam);
   const webUINavigate = useWebUINavigate();
-  const baiClient = useSuspendedBackendaiClient();
-  const { token } = theme.useToken();
-  const supportConfigureUserResourcePolicy = baiClient?.supports(
-    'configure-user-resource-policy',
-  );
 
   return (
     <BAICard
@@ -46,7 +42,7 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
           key: 'keypair',
           label: t('resourcePolicy.Keypair'),
         },
-        supportConfigureUserResourcePolicy && {
+        {
           key: 'user',
           label: t('resourcePolicy.User'),
         },

--- a/react/src/pages/StorageHostSettingPage.tsx
+++ b/react/src/pages/StorageHostSettingPage.tsx
@@ -2,7 +2,7 @@ import { StorageHostSettingPageQuery } from '../__generated__/StorageHostSetting
 import Flex from '../components/Flex';
 import StorageHostResourcePanel from '../components/StorageHostResourcePanel';
 import StorageHostSettingsPanel from '../components/StorageHostSettingsPanel';
-import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
+import { useWebUINavigate } from '../hooks';
 import { Breadcrumb, Card, Empty, Typography } from 'antd';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -16,7 +16,6 @@ const StorageHostSettingPage: React.FC<StorageHostSettingPageProps> = () => {
   const { hostname: storageHostId } = useParams<{
     hostname: string;
   }>();
-  const baiClient = useSuspendedBackendaiClient();
   const webuiNavigate = useWebUINavigate();
   const { t } = useTranslation();
   const { storage_volume } = useLazyLoadQuery<StorageHostSettingPageQuery>(
@@ -59,23 +58,19 @@ const StorageHostSettingPage: React.FC<StorageHostSettingPageProps> = () => {
         {storageHostId || ''}
       </Typography.Title>
       <StorageHostResourcePanel storageVolumeFrgmt={storage_volume || null} />
-      {baiClient.supports('quota-scope') && (
-        <>
-          {isQuotaSupportedStorage ? (
-            <Suspense fallback={<div>loading...</div>}>
-              <StorageHostSettingsPanel
-                storageVolumeFrgmt={storage_volume || null}
-              />
-            </Suspense>
-          ) : (
-            <Card title={t('storageHost.QuotaSettings')}>
-              <Empty
-                image={Empty.PRESENTED_IMAGE_SIMPLE}
-                description={t('storageHost.QuotaDoesNotSupported')}
-              />
-            </Card>
-          )}
-        </>
+      {isQuotaSupportedStorage ? (
+        <Suspense fallback={<div>loading...</div>}>
+          <StorageHostSettingsPanel
+            storageVolumeFrgmt={storage_volume || null}
+          />
+        </Suspense>
+      ) : (
+        <Card title={t('storageHost.QuotaSettings')}>
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description={t('storageHost.QuotaDoesNotSupported')}
+          />
+        </Card>
       )}
     </Flex>
   );

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -628,11 +628,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         }
       }
     });
-    if (
-      globalThis.backendaiclient.supports('local-vscode-remote-connection') &&
-      this.allowTCPApps &&
-      !filteredAppServices.includes('vscode-desktop')
-    ) {
+    if (this.allowTCPApps && !filteredAppServices.includes('vscode-desktop')) {
       const insertAfterIndex = this.appSupportList.findIndex(
         (item) => item.name === 'vscode',
       );

--- a/src/components/backend-ai-edu-applauncher.ts
+++ b/src/components/backend-ai-edu-applauncher.ts
@@ -250,43 +250,23 @@ export default class BackendAiEduApplauncher extends BackendAIPage {
       'service_ports',
       'mounts',
     ];
-    let statuses: string;
-    if (globalThis.backendaiclient.supports('avoid-hol-blocking')) {
-      statuses = [
-        'RUNNING',
-        'RESTARTING',
-        'TERMINATING',
-        'PENDING',
-        'SCHEDULED',
-        globalThis.backendaiclient.supports('prepared-session-status')
-          ? 'PREPARED'
-          : undefined,
-        globalThis.backendaiclient.supports('creating-session-status')
-          ? 'CREATING'
-          : undefined,
-        'PREPARING',
-        'PULLING',
-      ]
-        .filter((v) => !!v)
-        .join(',');
-    } else {
-      statuses = [
-        'RUNNING',
-        'RESTARTING',
-        'TERMINATING',
-        'PENDING',
-        globalThis.backendaiclient.supports('prepared-session-status')
-          ? 'PREPARED'
-          : undefined,
-        globalThis.backendaiclient.supports('creating-session-status')
-          ? 'CREATING'
-          : undefined,
-        'PREPARING',
-        'PULLING',
-      ]
-        .filter((v) => !!v)
-        .join(',');
-    }
+    const statuses = [
+      'RUNNING',
+      'RESTARTING',
+      'TERMINATING',
+      'PENDING',
+      'SCHEDULED',
+      globalThis.backendaiclient.supports('prepared-session-status')
+        ? 'PREPARED'
+        : undefined,
+      globalThis.backendaiclient.supports('creating-session-status')
+        ? 'CREATING'
+        : undefined,
+      'PREPARING',
+      'PULLING',
+    ]
+      .filter((v) => !!v)
+      .join(',');
 
     const accessKey = globalThis.backendaiclient._config.accessKey;
     // NOTE: There is no way to change the default group.

--- a/src/components/backend-ai-project-switcher.ts
+++ b/src/components/backend-ai-project-switcher.ts
@@ -96,10 +96,7 @@ export default class BackendAIProjectSwitcher extends LitElement {
     this.currentProject = globalThis.backendaiutils._readRecentProjectGroup();
     globalThis.backendaiclient.current_group = this.currentProject;
     this.projects = globalThis.backendaiclient.groups;
-    if (
-      globalThis.backendaiclient.supports('model-store') &&
-      globalThis.backendaiclient.is_admin
-    ) {
+    if (globalThis.backendaiclient.is_admin) {
       globalThis.backendaiclient.group
         .list(undefined, undefined, undefined, ['GENERAL', 'MODEL_STORE'])
         .then((res) => {

--- a/src/components/backend-ai-session-view.ts
+++ b/src/components/backend-ai-session-view.ts
@@ -56,8 +56,6 @@ export default class BackendAISessionView extends BackendAIPage {
   @property({ type: String }) _status = 'inactive';
   @property({ type: Boolean, reflect: true }) active = false;
   @property({ type: Boolean }) is_admin = false;
-  @property({ type: Boolean }) enableInferenceWorkload = false;
-  @property({ type: Boolean }) enableSFTPSession = false;
   @property({ type: String }) filterAccessKey = '';
   @property({ type: String }) _connectionMode = 'API';
   @property({ type: Object }) _defaultFileName = '';
@@ -171,10 +169,6 @@ export default class BackendAISessionView extends BackendAIPage {
     }
 
     const _init = () => {
-      this.enableInferenceWorkload =
-        globalThis.backendaiclient.supports('inference-workload');
-      this.enableSFTPSession =
-        globalThis.backendaiclient.supports('sftp-scaling-group');
       this.resourceMonitor.setAttribute('active', 'true');
       this.runningJobs.setAttribute('active', 'true');
       this._status = 'active';
@@ -356,9 +350,7 @@ export default class BackendAISessionView extends BackendAIPage {
     if (globalThis.backendaiclient.supports('creating-session-status')) {
       status.push('CREATING');
     }
-    if (globalThis.backendaiclient.supports('detailed-session-states')) {
-      status = status.join(',');
-    }
+    status = status.join(',');
     const fields = [
       'id',
       'name',
@@ -594,28 +586,16 @@ export default class BackendAISessionView extends BackendAIPage {
                       label="${_t('session.Batch')}"
                       @click="${(e) => this._showTab(e.target)}"
                     ></mwc-tab>
-                    ${
-                      this.enableInferenceWorkload
-                        ? html`
-                            <mwc-tab
-                              title="inference"
-                              label="${_t('session.Inference')}"
-                              @click="${(e) => this._showTab(e.target)}"
-                            ></mwc-tab>
-                          `
-                        : html``
-                    }
-                    ${
-                      this.enableSFTPSession
-                        ? html`
-                            <mwc-tab
-                              title="system"
-                              label="${_t('session.System')}"
-                              @click="${(e) => this._showTab(e.target)}"
-                            ></mwc-tab>
-                          `
-                        : html``
-                    }
+                    <mwc-tab
+                      title="inference"
+                      label="${_t('session.Inference')}"
+                      @click="${(e) => this._showTab(e.target)}"
+                    ></mwc-tab>
+                    <mwc-tab
+                      title="system"
+                      label="${_t('session.System')}"
+                      @click="${(e) => this._showTab(e.target)}"
+                    ></mwc-tab>
                     <mwc-tab
                       title="finished"
                       label="${_t('session.Finished')}"
@@ -690,38 +670,26 @@ export default class BackendAISessionView extends BackendAIPage {
                 condition="batch"
               ></backend-ai-session-list>
             </div>
-            ${
-              this.enableInferenceWorkload
-                ? html`
-                    <div
-                      id="inference-lists"
-                      class="tab-content"
-                      style="display:none;"
-                    >
-                      <backend-ai-session-list
-                        id="inference-jobs"
-                        condition="inference"
-                      ></backend-ai-session-list>
-                    </div>
-                  `
-                : html``
-            }
-            ${
-              this.enableSFTPSession
-                ? html`
-                    <div
-                      id="system-lists"
-                      class="tab-content"
-                      style="display:none;"
-                    >
-                      <backend-ai-session-list
-                        id="system-jobs"
-                        condition="system"
-                      ></backend-ai-session-list>
-                    </div>
-                  `
-                : html``
-            }
+            <div
+              id="inference-lists"
+              class="tab-content"
+              style="display:none;"
+            >
+              <backend-ai-session-list
+                id="inference-jobs"
+                condition="inference"
+              ></backend-ai-session-list>
+            </div>
+            <div
+              id="system-lists"
+              class="tab-content"
+              style="display:none;"
+            >
+              <backend-ai-session-list
+                id="system-jobs"
+                condition="system"
+              ></backend-ai-session-list>
+            </div>
             <div id="finished-lists" class="tab-content" style="display:none;">
               <backend-ai-session-list
                 id="finished-jobs"

--- a/src/components/backend-ai-summary-view.ts
+++ b/src/components/backend-ai-summary-view.ts
@@ -320,9 +320,7 @@ export default class BackendAISummary extends BackendAIPage {
             globalThis.backendaiclient._config.appDownloadUrl;
           this.allowAppDownloadPanel =
             globalThis.backendaiclient._config.allowAppDownloadPanel;
-          if (globalThis.backendaiclient.supports('use-win-instead-of-win32')) {
-            this.appDownloadMap['Windows']['os'] = 'win';
-          }
+          this.appDownloadMap['Windows']['os'] = 'win';
 
           if (this.activeConnected) {
             this._refreshConsoleUpdateInformation();
@@ -340,9 +338,7 @@ export default class BackendAISummary extends BackendAIPage {
       this.appDownloadUrl = globalThis.backendaiclient._config.appDownloadUrl;
       this.allowAppDownloadPanel =
         globalThis.backendaiclient._config.allowAppDownloadPanel;
-      if (globalThis.backendaiclient.supports('use-win-instead-of-win32')) {
-        this.appDownloadMap['Windows']['os'] = 'win';
-      }
+      this.appDownloadMap['Windows']['os'] = 'win';
       this._refreshConsoleUpdateInformation();
       this._refreshInvitations();
       // let event = new CustomEvent("backend-ai-resource-refreshed", {"detail": {}});

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -109,8 +109,6 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   @property({ type: Boolean }) auto_logout = false;
   @property({ type: Boolean }) isUserInfoMaskEnabled;
   @property({ type: Boolean }) isHideAgents = true;
-  @property({ type: Boolean }) supportServing = false;
-  @property({ type: Boolean }) supportUserCommittedImage = false;
   @property({ type: String }) lang = 'default';
   @property({ type: Array }) supportLanguageCodes = [
     'en',
@@ -361,10 +359,8 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
 
     // apply update name when user info changed via users page
     document.addEventListener('current-user-info-changed', (e: any) => {
-      if (globalThis.backendaiclient.supports('change-user-name')) {
-        const input = e.detail;
-        this.full_name = input;
-      }
+      const input = e.detail;
+      this.full_name = input;
     });
     document.addEventListener('move-to-from-react', (e) => {
       const params = (e as CustomEvent).detail.params;
@@ -623,23 +619,10 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
       this._page = 'unauthorized';
       this._moveTo('/unauthorized');
     }
-
-    this.supportServing = globalThis.backendaiclient.supports('model-serving');
-    this.supportUserCommittedImage = globalThis.backendaiclient.supports(
-      'user-committed-image',
-    );
     this.optionalPages = [
       {
         page: 'agent-summary',
         available: !this.isHideAgents,
-      },
-      {
-        page: 'serving',
-        available: this.supportServing,
-      },
-      {
-        page: 'my-environment',
-        available: this.supportUserCommittedImage,
       },
     ];
 


### PR DESCRIPTION
resolves #3236 ([FR-583](https://lablup.atlassian.net/jira/software/projects/FR/boards/21?assignee=712020%3A52c9a410-dfd2-4acd-97a6-8c6112ec8a34&selectedIssue=FR-583))
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

This PR removes feature flag checks before manager version 24.09.
The changes include:

- Removed conditional rendering based on `baiClient.supports()` checks
- Eliminated version compatibility checks in the backend client
- Removed feature-gated UI elements that were conditionally displayed
- Updated the API version to v8.20240915 for compatibility with 24.09
- Simplified logic that previously had different behavior based on manager version

These changes make the codebase more maintainable by removing the need to check for feature support before using functionality, assuming that all modern deployments will support the full feature set.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after


[FR-583]: https://lablup.atlassian.net/browse/FR-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ