### PR TITLE
style(FR-1190): enhance the ux for resource display on the agent page

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -5,8 +5,9 @@ import {
 } from '../__generated__/AgentListQuery.graphql';
 import { AgentSettingModalFragment$key } from '../__generated__/AgentSettingModalFragment.graphql';
 import {
-  bytesToGB,
   convertToBinaryUnit,
+  convertToDecimalUnit,
+  convertUnitValue,
   filterNonNullItems,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
@@ -273,7 +274,7 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
                             parsedOccupiedSlots.cpu || 0,
                             0,
                           )}
-                          /
+                          &nbsp;/&nbsp;
                           {toFixedFloorWithoutTrailingZeros(
                             parsedAvailableSlots.cpu || 0,
                             0,
@@ -317,7 +318,7 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
                         <Typography.Text>
                           {convertToBinaryUnit(parsedOccupiedSlots.mem, 'g', 0)
                             ?.numberFixed ?? 0}
-                          /
+                          &nbsp;/&nbsp;
                           {convertToBinaryUnit(parsedAvailableSlots.mem, 'g', 0)
                             ?.numberFixed ?? 0}
                         </Typography.Text>
@@ -362,7 +363,7 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
                             parsedOccupiedSlots[key] || 0,
                             2,
                           )}
-                          /
+                          &nbsp;/&nbsp;
                           {toFixedFloorWithoutTrailingZeros(
                             parsedAvailableSlots[key],
                             2,
@@ -451,6 +452,9 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
               };
             }
           });
+          const baseUnit =
+            convertUnitValue(_.toString(liveStat.mem_util.capacity), 'auto')
+              ?.unit || 'g';
           return (
             <Flex direction="column" gap="xxs">
               <Flex justify="between" style={{ minWidth: 200 }}>
@@ -478,14 +482,13 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
                   valueLabel={
                     convertToBinaryUnit(
                       _.toString(liveStat.mem_util.current),
-                      'g',
+                      baseUnit,
                     )?.numberFixed +
-                    '/' +
+                    ' / ' +
                     convertToBinaryUnit(
                       _.toString(liveStat.mem_util.capacity),
-                      'g',
-                    )?.numberFixed +
-                    ' GiB'
+                      baseUnit,
+                    )?.displayValue
                   }
                 />
               </Flex>
@@ -529,6 +532,13 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
                 }
                 if (_.includes(statKey, '_mem')) {
                   const deviceName = _.split(statKey, '_')[0] + '.device';
+                  const baseUnit =
+                    convertUnitValue(
+                      _.toString(
+                        liveStat[statKey as keyof typeof liveStat].capacity,
+                      ),
+                      'auto',
+                    )?.unit || 'g';
                   return (
                     <Flex
                       key={statKey}
@@ -554,17 +564,16 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
                               liveStat[statKey as keyof typeof liveStat]
                                 .current,
                             ),
-                            'g',
+                            baseUnit,
                           )?.numberFixed +
-                          '/' +
+                          ' / ' +
                           convertToBinaryUnit(
                             _.toString(
                               liveStat[statKey as keyof typeof liveStat]
                                 .capacity,
                             ),
-                            'g',
-                          )?.numberFixed +
-                          ' GiB'
+                            baseUnit,
+                          )?.displayValue
                         }
                       />
                     </Flex>
@@ -587,6 +596,10 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
         const pctValue = _.toFinite(parsedDisk.pct) || 0;
         const pct = _.toFinite(toFixedFloorWithoutTrailingZeros(pctValue, 2));
         const color = pct > 80 ? token.colorError : token.colorSuccess;
+        const baseUnit =
+          convertUnitValue(parsedDisk?.capacity, 'auto', {
+            base: 1000,
+          })?.unit || 'g';
         return (
           <Flex direction="column">
             <BAIProgressWithLabel
@@ -596,8 +609,12 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
               width={120}
             />
             <Typography.Text style={{ fontSize: token.fontSizeSM }}>
-              {bytesToGB(parsedDisk?.current)}GB /{' '}
-              {bytesToGB(parsedDisk?.capacity)}GB
+              {convertToDecimalUnit(parsedDisk?.current, baseUnit)?.numberFixed}
+              &nbsp;/&nbsp;
+              {
+                convertToDecimalUnit(parsedDisk?.capacity, baseUnit)
+                  ?.displayValue
+              }
             </Typography.Text>
           </Flex>
         );

--- a/react/src/components/StorageHostResourcePanel.tsx
+++ b/react/src/components/StorageHostResourcePanel.tsx
@@ -1,5 +1,5 @@
 import { StorageHostResourcePanelFragment$key } from '../__generated__/StorageHostResourcePanelFragment.graphql';
-import { humanReadableDecimalSize, usageIndicatorColor } from '../helper/index';
+import { convertToDecimalUnit, usageIndicatorColor } from '../helper/index';
 import { Progress, Descriptions, Typography, Tag } from 'antd';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -52,12 +52,15 @@ const StorageHostResourcePanel: React.FC<{
         <Typography.Text type="secondary">
           {t('storageHost.Used')}:{' '}
         </Typography.Text>
-        {humanReadableDecimalSize(storageUsage?.used_bytes)}
+        {convertToDecimalUnit(storageUsage?.used_bytes, 'auto')?.displayValue}
         <Typography.Text type="secondary">{' / '}</Typography.Text>
         <Typography.Text type="secondary">
           {t('storageHost.Total')}:{' '}
         </Typography.Text>
-        {humanReadableDecimalSize(storageUsage?.capacity_bytes)}
+        {
+          convertToDecimalUnit(storageUsage?.capacity_bytes, 'auto')
+            ?.displayValue
+        }
       </Descriptions.Item>
       <Descriptions.Item label={t('agent.Endpoint')}>
         {resource?.path}

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -1,7 +1,8 @@
 import { StorageProxyListQuery } from '../__generated__/StorageProxyListQuery.graphql';
 import {
+  convertToDecimalUnit,
+  convertUnitValue,
   filterNonNullItems,
-  humanReadableDecimalSize,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
 import { useUpdatableState } from '../hooks';
@@ -169,7 +170,10 @@ const StorageProxyList = () => {
           toFixedFloorWithoutTrailingZeros(ratio * 100, 2),
         );
         const color = percent > 80 ? token.colorError : token.colorSuccess;
-
+        const baseUnit =
+          convertUnitValue(_.toString(usage?.capacity_bytes), 'auto', {
+            base: 1000,
+          })?.unit || 'g';
         return (
           <>
             <BAIProgressWithLabel
@@ -180,11 +184,12 @@ const StorageProxyList = () => {
             />
             <Typography.Text style={{ fontSize: token.fontSizeSM }}>
               {usage.used_bytes
-                ? humanReadableDecimalSize(usage.used_bytes)
+                ? convertToDecimalUnit(usage.used_bytes, baseUnit)?.numberFixed
                 : '-'}
               &nbsp;/&nbsp;
               {usage.capacity_bytes
-                ? humanReadableDecimalSize(usage.capacity_bytes)
+                ? convertToDecimalUnit(usage.capacity_bytes, baseUnit)
+                    ?.displayValue
                 : '-'}
             </Typography.Text>
           </>

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -55,25 +55,6 @@ export const useBaiSignedRequestWithPromise = () => {
 };
 
 /**
- * Convert file size with binary unit to human readable unit and value
- *
- * @param {number} bytes
- * @param {number} decimalPoint decimal point set to 2 as a default
- * @return {string} converted file size to human readable value
- */
-export const humanReadableDecimalSize = (bytes = 0, decimalPoint = 2) => {
-  if (bytes === 0) return '0 Bytes';
-  const k = Math.pow(10, 3);
-  decimalPoint = decimalPoint < 0 ? 0 : decimalPoint;
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
-  let i = Math.floor(Math.log(Math.round(bytes)) / Math.log(k));
-  i = i < 0 ? 0 : i; // avoid negative value
-  return (
-    parseFloat((bytes / Math.pow(k, i)).toFixed(decimalPoint)) + ' ' + sizes[i]
-  );
-};
-
-/**
  * Change date of any type to human readable date time.
  *
  * @param {Date} d   - string or DateTime object to convert
@@ -129,7 +110,7 @@ export type SizeUnit = InputSizeUnit;
  * convertUnitValue('1048576', 'auto', { fixed: 1 })
  * // => { number: 1, numberFixed: "1", unit: "m", value: "1m" }
  */
-function convertUnitValue(
+export function convertUnitValue(
   inputValue: string | undefined,
   targetUnit: InputSizeUnit | 'auto',
   options?: {


### PR DESCRIPTION
resolves #3885 (FR-1190)

This PR enhances how resource metrics are displayed throughout the UI by:

1. Adding proper spacing around division symbols (`/`) in resource usage displays
2. Using dynamic base units for memory and storage metrics instead of hardcoded units
3. Replacing the deprecated `bytesToGB` function with more flexible conversion utilities:
   - `convertToDecimalUnit` for decimal-based conversions (storage)
   - `convertToBinaryUnit` for binary-based conversions (memory)
   - `convertUnitValue` for determining appropriate display units
4. remove `humanReadableDecimalSize` function.

These changes make resource metrics more readable and ensure consistent formatting across the application.

![CleanShot 2025-07-09 at 10.56.28@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/f77c323e-2db9-4d17-a101-0b4ed53e50e9.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after