### PR TITLE
chore: update workspace window.title to use folderName variable

### DIFF
--- a/backend.ai-webui.code-workspace
+++ b/backend.ai-webui.code-workspace
@@ -16,6 +16,6 @@
     "files.exclude": {
       "packages/backend.ai-ui": true,
     },
-    "window.title": "${activeFolderShort} (Workspace)",
+    "window.title": "${folderName} (Workspace)",
   },
 }


### PR DESCRIPTION
This pull request makes a small change to the `backend.ai-webui.code-workspace` file. The change updates the `window.title` configuration to use `${folderName}` instead of `${activeFolderShort}` for better clarity in the workspace title.