### PR TITLE
feat(FR-1218): Add a css custom variable for backend-ai-dialog title.

### DIFF
--- a/src/components/backend-ai-dialog.ts
+++ b/src/components/backend-ai-dialog.ts
@@ -89,6 +89,7 @@ export default class BackendAIDialog extends LitElement {
 
         mwc-dialog > div.card > h3 {
           background-color: var(
+            --header-background-color,
             --token-colorBgElevated,
             --general-dialog-background-color,
             #ffffff


### PR DESCRIPTION
https://lablup.atlassian.net/browse/FR-1218
Resolves #3916 (FR-1218)

# Add fallback header background color for dialogs

This PR adds a fallback variable `--header-background-color` to the dialog header styling, ensuring proper background color rendering when the primary token variables are not available.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after