### PR TITLE
fix(FR-1219): Support responsive session metric graph

### DIFF
--- a/react/src/components/SessionMetricGraph.tsx
+++ b/react/src/components/SessionMetricGraph.tsx
@@ -62,12 +62,14 @@ interface PrometheusMetricGraphProps {
     userId: string;
     dayDiff: number;
   };
+  key: string;
   fetchKey: string;
   tooltip?: string | React.ReactNode;
 }
 
 const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
   queryProps: { startDate, endDate, metricName, userId, dayDiff },
+  key,
   fetchKey,
   tooltip,
 }) => {
@@ -183,6 +185,7 @@ const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
 
   return (
     <Flex
+      key={key}
       direction="column"
       align="stretch"
       gap="sm"


### PR DESCRIPTION
resolves #3918 ([FR-1219](https://lablup.atlassian.net/jira/software/projects/FR/boards/21?assignee=712020%3A52c9a410-dfd2-4acd-97a6-8c6112ec8a34&selectedIssue=FR-1219))

### Fix Session Metric Graph Rendering on Resize

This PR adds a `key` prop to the `SessionMetricGraph` component to ensure proper re-rendering when metrics are resized in the dashboard. When a user resizes a metric graph, the component now regenerates with a unique key based on the item ID and timestamp, forcing a complete re-render of the graph with the new dimensions.

The changes include:
- Added a required `key` prop to the `SessionMetricGraph` component interface
- Implemented special handling for resized items in the board's `onItemsChange` event
- Regenerated graph content with fresh keys when resizing occurs

How to test:
- Move to `User Session History` page. 
- Increase the vertical size of the card, and then decrease the vertical size again.
- After changing the size, make sure that there is no scrolling inside the card.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1219]: https://lablup.atlassian.net/browse/FR-1219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ