### PR TITLE
fix(FR-1251): folder invitation response modal doesn't show latest data.

### DIFF
--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -14,12 +14,11 @@ import { useTranslation } from 'react-i18next';
 
 interface FolderInvitationResponseModalProps extends BAIModalProps {
   onRequestClose?: (success: boolean) => void;
-  fetchKey?: string;
 }
 
 const FolderInvitationResponseModal: React.FC<
   FolderInvitationResponseModalProps
-> = ({ onRequestClose, fetchKey, ...baiModalProps }) => {
+> = ({ onRequestClose, ...baiModalProps }) => {
   const { token } = theme.useToken();
   const { message } = App.useApp();
   const { t } = useTranslation();

--- a/react/src/components/FolderInvitationResponseModalOpener.tsx
+++ b/react/src/components/FolderInvitationResponseModalOpener.tsx
@@ -1,4 +1,5 @@
 import { useVFolderInvitationsValue } from '../hooks/useVFolderInvitations';
+import UnmountModalAfterClose from './UnmountModalAfterClose';
 import React from 'react';
 import { useQueryParam, StringParam } from 'use-query-params';
 
@@ -14,14 +15,16 @@ const FolderInvitationResponseModalOpener = () => {
   const { count } = useVFolderInvitationsValue();
 
   return (
-    <FolderInvitationResponseModal
-      open={isInvitationOpen === 'true'}
-      onRequestClose={(success) => {
-        if (!success || count === 1) {
-          setIsInvitationOpen(null, 'replaceIn');
-        }
-      }}
-    />
+    <UnmountModalAfterClose>
+      <FolderInvitationResponseModal
+        open={isInvitationOpen === 'true'}
+        onRequestClose={(success) => {
+          if (!success || count === 1) {
+            setIsInvitationOpen(null, 'replaceIn');
+          }
+        }}
+      />
+    </UnmountModalAfterClose>
   );
 };
 


### PR DESCRIPTION

Resolves #3959 ([FR-1251](https://lablup.atlassian.net/browse/FR-1251))

# Enhance folder invitation refresh mechanism

This PR improves the folder invitation handling by automatically refreshing invitation data when the invitation modal is opened. The implementation:

1. Modifies `useVFolderInvitationsValue` hook to accept an optional `shouldRefresh` parameter
2. Adds a new effect that triggers invitation data refresh when `shouldRefresh` becomes true
3. Removes the unused `fetchKey` prop from `FolderInvitationResponseModal`
4. Updates the modal to pass its `open` state to the hook to trigger refreshes

These changes ensure that users always see the most up-to-date invitation data when opening the invitation modal.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1251]: https://lablup.atlassian.net/browse/FR-1251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ