### PR TITLE
fix(FR-1250): add error handler for 409 error to acceptoin invitaion

### DIFF
--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -46,8 +46,12 @@ const FolderInvitationResponseModal: React.FC<
                     t('data.invitation.SuccessfullyAcceptedInvitation'),
                   );
                 },
-                onError: (e) => {
+                onError: (e: any) => {
                   onRequestClose?.(false);
+                  if (e?.statusCode === 409) {
+                    message.error(t('data.FolderAlreadyExists'));
+                    return;
+                  }
                   message.error(
                     e.message || t('data.invitation.FailedToAcceptInvitation'),
                   );


### PR DESCRIPTION
resolves #3962 (FR-1250)

Improved error handling in the `FolderInvitationResponseModal` component by adding specific error messaging when a folder already exists (status code 409). Now when users attempt to accept an invitation for a folder that already exists in their account, they will see a clear error message instead of a generic failure notification.

![CleanShot 2025-07-16 at 19.40.09@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xbCemO1RqqcSjEXCRK3p/125d8a09-b6d5-47f4-9aad-a4a221078d99.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after