### PR TITLE
fix(FR-1254): Add desktop notification localstorage setting to callback dependency array

### DIFF
--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -360,6 +360,7 @@ export const useSetBAINotification = () => {
           ) {
             _activeNotificationKeys.push(newNotification.key);
           }
+
           if (!skipDesktopNotification && desktopNotification) {
             upsertDesktopNotification(newNotification);
           }
@@ -410,7 +411,12 @@ export const useSetBAINotification = () => {
     },
     // webuiNavigate is not a dependency because it is not used in the callback of useCallback
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [app.notification, setNotifications, destroyNotification],
+    [
+      app.notification,
+      setNotifications,
+      destroyNotification,
+      desktopNotification,
+    ],
   );
 
   const upsertDesktopNotification = useCallback(


### PR DESCRIPTION
### Add `desktopNotification` to dependency array in `useSetBAINotification`

This PR adds `desktopNotification` to the dependency array of the `useCallback` hook in `useSetBAINotification`. This ensures that the callback is properly updated when the `desktopNotification` value changes, fixing a potential bug where desktop notifications might not reflect the current state of the `desktopNotification` setting.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after