### PR TITLE
fix(FR-1252): Separate untag and forget queries

### DIFF
--- a/data/merged_schema.graphql
+++ b/data/merged_schema.graphql
@@ -328,11 +328,23 @@ type Queries {
   """Added in 25.1.0."""
   endpoint_auto_scaling_rule_nodes(endpoint: String!, filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): EndpointAutoScalingRuleConnection
 
-  """Added in 25.5.0."""
+  """Added in 25.6.0."""
   user_utilization_metric(user_id: UUID!, props: UserUtilizationMetricQueryInput!): UserUtilizationMetric
 
-  """Added in 25.5.0."""
+  """Added in 25.6.0."""
   container_utilization_metric_metadata: ContainerUtilizationMetricMetadata
+
+  """Added in 25.8.0."""
+  available_service: AvailableServiceNode
+
+  """Added in 25.8.0."""
+  available_services(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): AvailableServiceConnection
+
+  """Added in 25.8.0."""
+  service_config(service: String!): ServiceConfigNode
+
+  """Added in 25.8.0."""
+  service_configs(services: [String]!, filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ServiceConfigConnection
 }
 
 """
@@ -405,32 +417,32 @@ type AuditLogNode implements Node {
   """The ID of the object"""
   id: ID!
 
-  """UUID of the audit log row"""
+  """UUID of the AuditLog row"""
   row_id: UUID!
 
   """Added in 25.6.0. UUID of the action"""
   action_id: UUID!
 
-  """Entity ID of the AuditLog"""
+  """Entity type of the AuditLog"""
   entity_type: String!
 
-  """Entity type of the AuditLog"""
+  """Operation type of the AuditLog"""
   operation: String!
 
-  """Operation type of the AuditLog"""
-  entity_id: String!
+  """Entity ID of the AuditLog"""
+  entity_id: String
 
   """The time the AuditLog was reported"""
   created_at: DateTime!
 
-  """RequestID of the AuditLog"""
-  request_id: UUID!
+  """Request ID of the AuditLog"""
+  request_id: String
 
   """Description of the AuditLog"""
   description: String!
 
   """Duration taken to perform the operation"""
-  duration: String!
+  duration: String
 
   """Status of the AuditLog"""
   status: String!
@@ -586,6 +598,9 @@ type ImageNode implements Node {
   Added in 25.3.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
   """
   permissions: [ImagePermissionValueField]
+
+  """Added in 25.11.0. Indicates if the image is installed on any Agent."""
+  installed: Boolean
 }
 
 type KVPair {
@@ -2041,19 +2056,19 @@ type EndpointAutoScalingRuleEdge {
   cursor: String!
 }
 
-"""Added in 25.5.0."""
+"""Added in 25.6.0."""
 type UserUtilizationMetric {
   user_id: UUID
   metrics: [ContainerUtilizationMetric]
 }
 
-"""Added in 25.5.0."""
+"""Added in 25.6.0."""
 type ContainerUtilizationMetric {
   metric_name: String
 
-  """One of 'current', 'capacity', 'pct'."""
+  """One of 'current', 'capacity'."""
   value_type: String
-  values: [MetircResultValue]
+  values: [MetricResultValue]
 
   """The maximum value of the metric in given time range. null if no data."""
   max_value: String
@@ -2062,16 +2077,16 @@ type ContainerUtilizationMetric {
   avg_value: String
 }
 
-"""Added in 25.5.0. A pair of timestamp and value."""
-type MetircResultValue {
+"""Added in 25.6.0. A pair of timestamp and value."""
+type MetricResultValue {
   timestamp: Float
   value: String
 }
 
-"""Added in 25.5.0."""
+"""Added in 25.6.0."""
 input UserUtilizationMetricQueryInput {
-  """One of 'current', 'capacity', 'pct'. Default value is 'null'."""
-  value_type: String = null
+  """One of 'current', 'capacity'. Default value is 'current'."""
+  value_type: String = "current"
 
   """metric name of container utilization. For example, 'cpu_util', 'mem'."""
   metric_name: String!
@@ -2088,9 +2103,81 @@ input UserUtilizationMetricQueryInput {
   step: String!
 }
 
-"""Added in 25.5.0."""
+"""Added in 25.6.0."""
 type ContainerUtilizationMetricMetadata {
   metric_names: [String]
+}
+
+"""Available services for configuration. Added in 25.8.0."""
+type AvailableServiceNode implements Node {
+  """The ID of the object"""
+  id: ID!
+
+  """Possible values of "Config.service". Added in 25.8.0."""
+  service_variants: [String]!
+}
+
+"""Added in 25.8.0."""
+type AvailableServiceConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [AvailableServiceEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""
+Added in 25.8.0. A Relay edge containing a `AvailableService` and its cursor.
+"""
+type AvailableServiceEdge {
+  """The item at the end of the edge"""
+  node: AvailableServiceNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Configuration data for a specific service. Added in 25.8.0."""
+type ServiceConfigNode implements Node {
+  """The ID of the object"""
+  id: ID!
+
+  """
+  Service name. See AvailableService.service_variants for possible values. Added in 25.8.0.
+  """
+  service: String!
+
+  """Configuration data. Added in 25.8.0."""
+  configuration: JSONString!
+
+  """JSON schema of the configuration. Added in 25.8.0."""
+  schema: JSONString!
+}
+
+"""Added in 25.8.0."""
+type ServiceConfigConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [ServiceConfigEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""
+Added in 25.8.0. A Relay edge containing a `ServiceConfig` and its cursor.
+"""
+type ServiceConfigEdge {
+  """The item at the end of the edge"""
+  node: ServiceConfigNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
 }
 
 """All available GraphQL mutations."""
@@ -2172,6 +2259,9 @@ type Mutations {
   unload_image(references: [String]!, target_agents: [String]!): UnloadImage
   modify_image(architecture: String = "x86_64", props: ModifyImageInput!, target: String!): ModifyImage
 
+  """Added in 25.6.0"""
+  clear_image_custom_resource_limit(key: ClearImageCustomResourceLimitKey!): ClearImageCustomResourceLimitPayload
+
   """Added in 24.03.0"""
   forget_image_by_id(image_id: String!): ForgetImageById
 
@@ -2179,7 +2269,12 @@ type Mutations {
   forget_image(architecture: String = "x86_64", reference: String!): ForgetImage @deprecated(reason: "Deprecated since 25.4.0. Use `forget_image_by_id` instead.")
 
   """Added in 25.4.0"""
-  purge_image_by_id(image_id: String!): PurgeImageById
+  purge_image_by_id(
+    image_id: String!
+
+    """Added in 25.10.0."""
+    options: PurgeImageOptions = {remove_from_registry: false}
+  ): PurgeImageById
 
   """Added in 24.03.1"""
   untag_image_from_registry(image_id: String!): UntagImageFromRegistry
@@ -2213,6 +2308,12 @@ type Mutations {
     id: UUID = null
     name: String = null @deprecated(reason: "Deprecated since 25.4.0.")
   ): DeleteResourcePreset
+
+  """Updates configuration for a given service. Added in 25.8.0."""
+  modify_service_config(
+    """Added in 25.8.0."""
+    input: ModifyServiceConfigNodeInput!
+  ): ModifyServiceConfigNodePayload
   create_scaling_group(name: String!, props: CreateScalingGroupInput!): CreateScalingGroup
   modify_scaling_group(name: String!, props: ModifyScalingGroupInput!): ModifyScalingGroup
   delete_scaling_group(name: String!): DeleteScalingGroup
@@ -2741,6 +2842,17 @@ input ResourceLimitInput {
   max: String
 }
 
+"""Added in 25.6.0."""
+type ClearImageCustomResourceLimitPayload {
+  image_node: ImageNode
+}
+
+"""Added in 25.6.0."""
+input ClearImageCustomResourceLimitKey {
+  image_canonical: String!
+  architecture: String! = "x86_64"
+}
+
 """Added in 24.03.0."""
 type ForgetImageById {
   ok: Boolean
@@ -2764,7 +2876,17 @@ type PurgeImageById {
   image: ImageNode
 }
 
-"""Added in 24.03.1"""
+"""Added in 25.10.0."""
+input PurgeImageOptions {
+  """
+  Untag the deleted image from the registry. Only available in the HarborV2 registry.
+  """
+  remove_from_registry: Boolean = false
+}
+
+"""
+Deprecated since 25.10.0. Use `purge_image_by_id` with `remove_from_registry` option instead.
+"""
 type UntagImageFromRegistry {
   ok: Boolean
   msg: String
@@ -3034,6 +3156,29 @@ input ModifyResourcePresetInput {
 type DeleteResourcePreset {
   ok: Boolean
   msg: String
+}
+
+"""
+Payload for the ModifyServiceConfigNode mutation.
+Added in 25.8.0.
+"""
+type ModifyServiceConfigNodePayload {
+  """ServiceConfiguration Node. Added in 25.8.0."""
+  service_config: ServiceConfigNode!
+}
+
+"""
+Input data for modifying configuration.
+Added in 25.8.0.
+"""
+input ModifyServiceConfigNodeInput {
+  """
+  Service name. See AvailableService.service_variants for possible values. Added in 25.8.0.
+  """
+  service: String!
+
+  """Service configuration data to mutate. Added in 25.8.0."""
+  configuration: JSONString!
 }
 
 type CreateScalingGroup {

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -328,11 +328,23 @@ type Queries {
   """Added in 25.1.0."""
   endpoint_auto_scaling_rule_nodes(endpoint: String!, filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): EndpointAutoScalingRuleConnection
 
-  """Added in 25.5.0."""
+  """Added in 25.6.0."""
   user_utilization_metric(user_id: UUID!, props: UserUtilizationMetricQueryInput!): UserUtilizationMetric
 
-  """Added in 25.5.0."""
+  """Added in 25.6.0."""
   container_utilization_metric_metadata: ContainerUtilizationMetricMetadata
+
+  """Added in 25.8.0."""
+  available_service: AvailableServiceNode
+
+  """Added in 25.8.0."""
+  available_services(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): AvailableServiceConnection
+
+  """Added in 25.8.0."""
+  service_config(service: String!): ServiceConfigNode
+
+  """Added in 25.8.0."""
+  service_configs(services: [String]!, filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ServiceConfigConnection
 }
 
 """
@@ -405,32 +417,32 @@ type AuditLogNode implements Node {
   """The ID of the object"""
   id: ID!
 
-  """UUID of the audit log row"""
+  """UUID of the AuditLog row"""
   row_id: UUID!
 
   """Added in 25.6.0. UUID of the action"""
   action_id: UUID!
 
-  """Entity ID of the AuditLog"""
+  """Entity type of the AuditLog"""
   entity_type: String!
 
-  """Entity type of the AuditLog"""
+  """Operation type of the AuditLog"""
   operation: String!
 
-  """Operation type of the AuditLog"""
-  entity_id: String!
+  """Entity ID of the AuditLog"""
+  entity_id: String
 
   """The time the AuditLog was reported"""
   created_at: DateTime!
 
-  """RequestID of the AuditLog"""
-  request_id: UUID!
+  """Request ID of the AuditLog"""
+  request_id: String
 
   """Description of the AuditLog"""
   description: String!
 
   """Duration taken to perform the operation"""
-  duration: String!
+  duration: String
 
   """Status of the AuditLog"""
   status: String!
@@ -586,6 +598,9 @@ type ImageNode implements Node {
   Added in 25.3.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
   """
   permissions: [ImagePermissionValueField]
+
+  """Added in 25.11.0. Indicates if the image is installed on any Agent."""
+  installed: Boolean
 }
 
 type KVPair {
@@ -2041,19 +2056,19 @@ type EndpointAutoScalingRuleEdge {
   cursor: String!
 }
 
-"""Added in 25.5.0."""
+"""Added in 25.6.0."""
 type UserUtilizationMetric {
   user_id: UUID
   metrics: [ContainerUtilizationMetric]
 }
 
-"""Added in 25.5.0."""
+"""Added in 25.6.0."""
 type ContainerUtilizationMetric {
   metric_name: String
 
-  """One of 'current', 'capacity', 'pct'."""
+  """One of 'current', 'capacity'."""
   value_type: String
-  values: [MetircResultValue]
+  values: [MetricResultValue]
 
   """The maximum value of the metric in given time range. null if no data."""
   max_value: String
@@ -2062,16 +2077,16 @@ type ContainerUtilizationMetric {
   avg_value: String
 }
 
-"""Added in 25.5.0. A pair of timestamp and value."""
-type MetircResultValue {
+"""Added in 25.6.0. A pair of timestamp and value."""
+type MetricResultValue {
   timestamp: Float
   value: String
 }
 
-"""Added in 25.5.0."""
+"""Added in 25.6.0."""
 input UserUtilizationMetricQueryInput {
-  """One of 'current', 'capacity', 'pct'. Default value is 'null'."""
-  value_type: String = null
+  """One of 'current', 'capacity'. Default value is 'current'."""
+  value_type: String = "current"
 
   """metric name of container utilization. For example, 'cpu_util', 'mem'."""
   metric_name: String!
@@ -2088,9 +2103,81 @@ input UserUtilizationMetricQueryInput {
   step: String!
 }
 
-"""Added in 25.5.0."""
+"""Added in 25.6.0."""
 type ContainerUtilizationMetricMetadata {
   metric_names: [String]
+}
+
+"""Available services for configuration. Added in 25.8.0."""
+type AvailableServiceNode implements Node {
+  """The ID of the object"""
+  id: ID!
+
+  """Possible values of "Config.service". Added in 25.8.0."""
+  service_variants: [String]!
+}
+
+"""Added in 25.8.0."""
+type AvailableServiceConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [AvailableServiceEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""
+Added in 25.8.0. A Relay edge containing a `AvailableService` and its cursor.
+"""
+type AvailableServiceEdge {
+  """The item at the end of the edge"""
+  node: AvailableServiceNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
+}
+
+"""Configuration data for a specific service. Added in 25.8.0."""
+type ServiceConfigNode implements Node {
+  """The ID of the object"""
+  id: ID!
+
+  """
+  Service name. See AvailableService.service_variants for possible values. Added in 25.8.0.
+  """
+  service: String!
+
+  """Configuration data. Added in 25.8.0."""
+  configuration: JSONString!
+
+  """JSON schema of the configuration. Added in 25.8.0."""
+  schema: JSONString!
+}
+
+"""Added in 25.8.0."""
+type ServiceConfigConnection {
+  """Pagination data for this connection."""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection."""
+  edges: [ServiceConfigEdge]!
+
+  """Total count of the GQL nodes of the query."""
+  count: Int
+}
+
+"""
+Added in 25.8.0. A Relay edge containing a `ServiceConfig` and its cursor.
+"""
+type ServiceConfigEdge {
+  """The item at the end of the edge"""
+  node: ServiceConfigNode
+
+  """A cursor for use in pagination"""
+  cursor: String!
 }
 
 """All available GraphQL mutations."""
@@ -2172,6 +2259,9 @@ type Mutations {
   unload_image(references: [String]!, target_agents: [String]!): UnloadImage
   modify_image(architecture: String = "x86_64", props: ModifyImageInput!, target: String!): ModifyImage
 
+  """Added in 25.6.0"""
+  clear_image_custom_resource_limit(key: ClearImageCustomResourceLimitKey!): ClearImageCustomResourceLimitPayload
+
   """Added in 24.03.0"""
   forget_image_by_id(image_id: String!): ForgetImageById
 
@@ -2179,7 +2269,12 @@ type Mutations {
   forget_image(architecture: String = "x86_64", reference: String!): ForgetImage @deprecated(reason: "Deprecated since 25.4.0. Use `forget_image_by_id` instead.")
 
   """Added in 25.4.0"""
-  purge_image_by_id(image_id: String!): PurgeImageById
+  purge_image_by_id(
+    image_id: String!
+
+    """Added in 25.10.0."""
+    options: PurgeImageOptions = {remove_from_registry: false}
+  ): PurgeImageById
 
   """Added in 24.03.1"""
   untag_image_from_registry(image_id: String!): UntagImageFromRegistry
@@ -2213,6 +2308,12 @@ type Mutations {
     id: UUID = null
     name: String = null @deprecated(reason: "Deprecated since 25.4.0.")
   ): DeleteResourcePreset
+
+  """Updates configuration for a given service. Added in 25.8.0."""
+  modify_service_config(
+    """Added in 25.8.0."""
+    input: ModifyServiceConfigNodeInput!
+  ): ModifyServiceConfigNodePayload
   create_scaling_group(name: String!, props: CreateScalingGroupInput!): CreateScalingGroup
   modify_scaling_group(name: String!, props: ModifyScalingGroupInput!): ModifyScalingGroup
   delete_scaling_group(name: String!): DeleteScalingGroup
@@ -2741,6 +2842,17 @@ input ResourceLimitInput {
   max: String
 }
 
+"""Added in 25.6.0."""
+type ClearImageCustomResourceLimitPayload {
+  image_node: ImageNode
+}
+
+"""Added in 25.6.0."""
+input ClearImageCustomResourceLimitKey {
+  image_canonical: String!
+  architecture: String! = "x86_64"
+}
+
 """Added in 24.03.0."""
 type ForgetImageById {
   ok: Boolean
@@ -2764,7 +2876,17 @@ type PurgeImageById {
   image: ImageNode
 }
 
-"""Added in 24.03.1"""
+"""Added in 25.10.0."""
+input PurgeImageOptions {
+  """
+  Untag the deleted image from the registry. Only available in the HarborV2 registry.
+  """
+  remove_from_registry: Boolean = false
+}
+
+"""
+Deprecated since 25.10.0. Use `purge_image_by_id` with `remove_from_registry` option instead.
+"""
 type UntagImageFromRegistry {
   ok: Boolean
   msg: String
@@ -3034,6 +3156,29 @@ input ModifyResourcePresetInput {
 type DeleteResourcePreset {
   ok: Boolean
   msg: String
+}
+
+"""
+Payload for the ModifyServiceConfigNode mutation.
+Added in 25.8.0.
+"""
+type ModifyServiceConfigNodePayload {
+  """ServiceConfiguration Node. Added in 25.8.0."""
+  service_config: ServiceConfigNode!
+}
+
+"""
+Input data for modifying configuration.
+Added in 25.8.0.
+"""
+input ModifyServiceConfigNodeInput {
+  """
+  Service name. See AvailableService.service_variants for possible values. Added in 25.8.0.
+  """
+  service: String!
+
+  """Service configuration data to mutate. Added in 25.8.0."""
+  configuration: JSONString!
 }
 
 type CreateScalingGroup {

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -548,6 +548,7 @@
     "Digest": "Verdauen",
     "Disabled": "deaktiviert",
     "ErrorMinimumValue": "{{key}} muss mindestens {{value}} sein",
+    "FailedToDeleteCustomizedImage": "Das kundenspezifische Bild nicht löschen.",
     "FullImagePath": "Vollständiger Bildpfad",
     "ImageReinstallationRequired": "Bild neu installation erforderlich",
     "Images": "Bilder",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -544,6 +544,7 @@
     "Digest": "Σύνοψη",
     "Disabled": "άτομα με ειδικές ανάγκες",
     "ErrorMinimumValue": "{{key}} πρέπει να είναι τουλάχιστον {{value}}",
+    "FailedToDeleteCustomizedImage": "Αποτυχία διαγραφής προσαρμοσμένης εικόνας.",
     "FullImagePath": "Πλήρης διαδρομή εικόνας",
     "ImageReinstallationRequired": "Απαιτείται επανεγκατάσταση εικόνας",
     "Images": "Εικόνες",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -550,6 +550,7 @@
     "Digest": "Digest",
     "Disabled": "disabled",
     "ErrorMinimumValue": "{{ key }} must be at least {{ value }}",
+    "FailedToDeleteCustomizedImage": "Failed to delete customized image.",
     "FullImagePath": "Full image path",
     "ImageReinstallationRequired": "Image reinstallation required",
     "Images": "Images",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -548,6 +548,7 @@
     "Digest": "Digerir",
     "Disabled": "desactivado",
     "ErrorMinimumValue": "{{ key }} debe ser al menos {{value}}",
+    "FailedToDeleteCustomizedImage": "No se pudo eliminar la imagen personalizada.",
     "FullImagePath": "Ruta de imagen completa",
     "ImageReinstallationRequired": "Requerir la reinstalación de la imagen",
     "Images": "Imágenes",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -548,6 +548,7 @@
     "Digest": "Digest",
     "Disabled": "disabled",
     "ErrorMinimumValue": "{{key}} on oltava vähintään {{value}}",
+    "FailedToDeleteCustomizedImage": "Mukautetun kuvan poistaminen epäonnistui.",
     "FullImagePath": "Koko kuvan polku",
     "ImageReinstallationRequired": "Kuvan uudelleenasentaminen vaaditaan",
     "Images": "Kuvat",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -548,6 +548,7 @@
     "Digest": "Digérer",
     "Disabled": "désactivée",
     "ErrorMinimumValue": "{{key}} doit être au moins {{value}}",
+    "FailedToDeleteCustomizedImage": "Échec de la suppression de l'image personnalisée.",
     "FullImagePath": "Chemin d'accès complet à l'image",
     "ImageReinstallationRequired": "Réinstallation d'image requise",
     "Images": "Images",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -547,6 +547,7 @@
     "Digest": "Intisari",
     "Disabled": "di-nonaktifkan",
     "ErrorMinimumValue": "{{key}} harus setidaknya {{value}}",
+    "FailedToDeleteCustomizedImage": "Gagal menghapus gambar yang disesuaikan.",
     "FullImagePath": "Jalur gambar penuh",
     "ImageReinstallationRequired": "Diperlukan pemasangan ulang gambar",
     "Images": "Image",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -547,6 +547,7 @@
     "Digest": "digerire",
     "Disabled": "Disabilitato",
     "ErrorMinimumValue": "{{ key }} deve essere almeno {{ value }}",
+    "FailedToDeleteCustomizedImage": "Impossibile eliminare l'immagine personalizzata.",
     "FullImagePath": "Percorso completo dell'immagine",
     "ImageReinstallationRequired": "Richiesta di reinstallazione dell'immagine",
     "Images": "immagini",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -547,6 +547,7 @@
     "Digest": "ダイジェスト",
     "Disabled": "無効",
     "ErrorMinimumValue": "{{key}}は、少なくとも{{value}}でなければなりません",
+    "FailedToDeleteCustomizedImage": "カスタマイズされた画像を削除できませんでした。",
     "FullImagePath": "完全な画像パス",
     "ImageReinstallationRequired": "画像の再インストールが必要です",
     "Images": "画像",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -550,6 +550,7 @@
     "Digest": "Digest",
     "Disabled": "사용 안함",
     "ErrorMinimumValue": "{{key}}는 {{value}} 이상이어야합니다.",
+    "FailedToDeleteCustomizedImage": "사용자 정의된 이미지를 삭제하는 데 실패했습니다.",
     "FullImagePath": "전체 이미지 경로",
     "ImageReinstallationRequired": "이미지 재설치가 필요합니다",
     "Images": "이미지",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -546,6 +546,7 @@
     "Digest": "Хоол боловсруулах",
     "Disabled": "Идэвхгүй",
     "ErrorMinimumValue": "{{ key }} нь дор хаяж {{ value }} байх ёстой",
+    "FailedToDeleteCustomizedImage": "Өөрчлөгдсөн зургийг устгах ажиллагаа амжилтгүй боллоо.",
     "FullImagePath": "Зургийн бүрэн зам",
     "ImageReinstallationRequired": "Зургийг дахин суулгах шаардлагатай",
     "Images": "Image",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -547,6 +547,7 @@
     "Digest": "Pencernaan",
     "Disabled": "kurang upaya",
     "ErrorMinimumValue": "{{key}} mestilah sekurang -kurangnya {{value}}",
+    "FailedToDeleteCustomizedImage": "Gagal memadam imej tersuai.",
     "FullImagePath": "Laluan imej penuh",
     "ImageReinstallationRequired": "Pemasaran imej diperlukan",
     "Images": "Gambar",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -548,6 +548,7 @@
     "Digest": "strawić",
     "Disabled": "niepełnosprawny",
     "ErrorMinimumValue": "{{key}} musi być co najmniej {{value}}",
+    "FailedToDeleteCustomizedImage": "Nie udało się usunąć dostosowanego obrazu.",
     "FullImagePath": "Pełna ścieżka obrazu",
     "ImageReinstallationRequired": "Wymagana ponowna instalacja obrazu",
     "Images": "Obrazy",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -548,6 +548,7 @@
     "Digest": "Digerir",
     "Disabled": "Desativado",
     "ErrorMinimumValue": "{{key}} deve ser pelo menos {{value}}",
+    "FailedToDeleteCustomizedImage": "Falha ao excluir a imagem personalizada.",
     "FullImagePath": "Caminho completo da imagem",
     "ImageReinstallationRequired": "Reinstalação de imagem necessária",
     "Images": "Imagens",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -548,6 +548,7 @@
     "Digest": "Digerir",
     "Disabled": "Desativado",
     "ErrorMinimumValue": "{{key}} deve ser pelo menos {{value}}",
+    "FailedToDeleteCustomizedImage": "Falha ao excluir a imagem personalizada.",
     "FullImagePath": "Caminho completo da imagem",
     "ImageReinstallationRequired": "Reinstalação de imagem necessária",
     "Images": "Imagens",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -548,6 +548,7 @@
     "Digest": "Дайджест",
     "Disabled": "отключен",
     "ErrorMinimumValue": "{{key}} должен быть как минимум {{value}}",
+    "FailedToDeleteCustomizedImage": "Не удалось удалить индивидуальное изображение.",
     "FullImagePath": "Полный путь к изображению",
     "ImageReinstallationRequired": "Требуется переустановка изображения",
     "Images": "Изображений",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -539,6 +539,7 @@
     "Digest": "ไดเจสต์",
     "Disabled": "ปิดใช้งาน",
     "ErrorMinimumValue": "{{key}} ต้องมีอย่างน้อย {{value}}",
+    "FailedToDeleteCustomizedImage": "ไม่สามารถลบภาพที่กำหนดเองได้",
     "FullImagePath": "เส้นทางภาพเต็ม",
     "ImageReinstallationRequired": "จำเป็นต้องติดตั้งรูปภาพใหม่",
     "Images": "อิมเมจ",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -548,6 +548,7 @@
     "Digest": "sindirmek",
     "Disabled": "engelli",
     "ErrorMinimumValue": "{{key}} en azından {{value}} olmalıdır.",
+    "FailedToDeleteCustomizedImage": "Özelleştirilmiş görüntüyü silemedi.",
     "FullImagePath": "Tam görüntü yolu",
     "ImageReinstallationRequired": "Resim Yeniden Yükleme Gerekli",
     "Images": "Görüntüler",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -548,6 +548,7 @@
     "Digest": "Tiêu",
     "Disabled": "tàn tật",
     "ErrorMinimumValue": "{{key}} phải ít nhất {{value}}",
+    "FailedToDeleteCustomizedImage": "Không thể xóa hình ảnh tùy chỉnh.",
     "FullImagePath": "Đường dẫn hình ảnh đầy đủ",
     "ImageReinstallationRequired": "Cài đặt lại hình ảnh cần thiết",
     "Images": "Hình ảnh",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -548,6 +548,7 @@
     "Digest": "消化",
     "Disabled": "残疾",
     "ErrorMinimumValue": "{{key}}必须至少为{{value}}",
+    "FailedToDeleteCustomizedImage": "无法删除自定义图像。",
     "FullImagePath": "完整图像路径",
     "ImageReinstallationRequired": "需要恢复图像",
     "Images": "图片",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -549,6 +549,7 @@
     "Digest": "消化",
     "Disabled": "殘疾",
     "ErrorMinimumValue": "{{key}}必須至少為{{value}}",
+    "FailedToDeleteCustomizedImage": "無法刪除自定義圖像。",
     "FullImagePath": "完整影像路徑",
     "ImageReinstallationRequired": "需要恢復圖像",
     "Images": "圖片",

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -797,6 +797,9 @@ class Client {
       this._features['image_rescan_by_project'] = true
       this._features['auto-scaling-rule'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('25.10.0')) {
+      this._features['purge_image_by_id'] = true;
+    }
   }
 
   /**


### PR DESCRIPTION
resolves #3968 [(FR-1252)](https://lablup.atlassian.net/browse/FR-1252)

This PR updates the GraphQL schema and image management functionality with several improvements:

1. Updates the version annotations for user utilization metrics from 25.5.0 to 25.6.0
2. Fixes a typo in `MetircResultValue` to `MetricResultValue`
3. Adds new service configuration queries and mutations in version 25.8.0:
   - `available_service`, `available_services`
   - `service_config`, `service_configs`
   - `modify_service_config`
4. Enhances image management:
   - Adds `installed` boolean field to `ImageNode` in version 25.11.0
   - Adds `clear_image_custom_resource_limit` mutation in version 25.6.0
   - Updates `purge_image_by_id` to support registry removal option in version 25.10.0
5. Refactors the image deletion process in `CustomizedImageList.tsx`:
   - Splits the combined forget and untag mutation into separate mutations
   - Adds support for the new `purge_image_by_id` with `remove_from_registry` option
   - Improves error handling and loading states

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after