### PR TITLE
style(FR-1257): broken UI of create session panel

### DIFF
--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -43,6 +43,9 @@ type TypeFilterType = 'all' | 'interactive' | 'batch' | 'inference' | 'system';
 type SessionNode = NonNullableNodeOnEdges<
   ComputeSessionListPageQuery$data['compute_session_nodes']
 >;
+
+const CARD_MIN_HEIGHT = 200;
+
 const ComputeSessionListPage = () => {
   const currentProject = useCurrentProjectValue();
 
@@ -207,16 +210,17 @@ const ComputeSessionListPage = () => {
 
   return (
     <Flex direction="column" align="stretch" gap={'md'}>
-      <Row gutter={[16, 16]}>
-        <Col xs={24} lg={8} xl={4}>
+      <Row
+        gutter={[16, 16]}
+        align={'stretch'}
+        style={{ minHeight: lg ? CARD_MIN_HEIGHT : undefined }}
+      >
+        <Col xs={24} lg={8} xl={4} style={{ display: 'flex' }}>
           <BAICard
-            styles={{
-              body: {
-                padding: 0,
-              },
+            style={{
+              width: '100%',
+              minHeight: lg ? CARD_MIN_HEIGHT : undefined,
             }}
-            style={{ height: lg ? 200 : undefined }}
-            // size={lg ? undefined : 'small'}
           >
             <ActionItemContent
               title={
@@ -233,14 +237,20 @@ const ComputeSessionListPage = () => {
               icon={<SessionsIcon />}
               type="simple"
               to={'/session/start'}
+              style={{
+                height: '100%',
+              }}
             />
           </BAICard>
         </Col>
-        <Col xs={24} lg={16} xl={20}>
+        <Col xs={24} lg={16} xl={20} style={{ display: 'flex' }}>
           <Suspense
             fallback={
               <BAICard
-                style={{ height: 200 }}
+                style={{
+                  width: '100%',
+                  minHeight: lg ? CARD_MIN_HEIGHT : undefined,
+                }}
                 title={t('Allocated Resources')}
                 loading
               />
@@ -248,7 +258,8 @@ const ComputeSessionListPage = () => {
           >
             <AvailableResourcesCard
               style={{
-                height: lg ? 200 : undefined,
+                width: '100%',
+                minHeight: lg ? CARD_MIN_HEIGHT : undefined,
               }}
               isRefetching={deferredFetchKey !== fetchKey}
               fetchKey={deferredFetchKey}

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -90,6 +90,8 @@ const FILTER_BY_STATUS_CATEGORY = {
   deleted: 'status in ["DELETE_PENDING", "DELETE_ONGOING", "DELETE_ERROR"]',
 };
 
+const CARD_MIN_HEIGHT = 200;
+
 const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   ...props
 }) => {
@@ -270,10 +272,15 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
       <Row
         gutter={[16, 16]}
         align={'stretch'}
-        style={{ minHeight: lg ? 200 : undefined }}
+        style={{ minHeight: lg ? CARD_MIN_HEIGHT : undefined }}
       >
         <Col xs={24} lg={8} xxl={4} style={{ display: 'flex' }}>
-          <BAICard style={{ width: '100%', minHeight: lg ? 200 : undefined }}>
+          <BAICard
+            style={{
+              width: '100%',
+              minHeight: lg ? CARD_MIN_HEIGHT : undefined,
+            }}
+          >
             <ActionItemContent
               title={
                 <Typography.Text
@@ -299,14 +306,20 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
           <Suspense
             fallback={
               <BAICard
-                style={{ width: '100%', minHeight: lg ? 200 : undefined }}
+                style={{
+                  width: '100%',
+                  minHeight: lg ? CARD_MIN_HEIGHT : undefined,
+                }}
                 title={t('data.StorageStatus')}
                 loading
               />
             }
           >
             <StorageStatusPanelCard
-              style={{ width: '100%', minHeight: lg ? 200 : undefined }}
+              style={{
+                width: '100%',
+                minHeight: lg ? CARD_MIN_HEIGHT : undefined,
+              }}
               fetchKey={deferredFetchKey}
               onRequestBadgeClick={() => {
                 webuiNavigate({
@@ -322,14 +335,20 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
           <Suspense
             fallback={
               <BAICard
-                style={{ width: '100%', minHeight: lg ? 200 : undefined }}
+                style={{
+                  width: '100%',
+                  minHeight: lg ? CARD_MIN_HEIGHT : undefined,
+                }}
                 title={t('data.QuotaPerStorageVolume')}
                 loading
               />
             }
           >
             <QuotaPerStorageVolumePanelCard
-              style={{ width: '100%', minHeight: lg ? 200 : undefined }}
+              style={{
+                width: '100%',
+                minHeight: lg ? CARD_MIN_HEIGHT : undefined,
+              }}
             />
           </Suspense>
         </Col>


### PR DESCRIPTION
https://lablup.atlassian.net/browse/FR-1257
Resolves #3970 (FR-1257)

# Improved layout of Compute Session List Page

This PR enhances the layout of the Compute Session List Page by:

- Making cards stretch to fill their container height
- Using flexbox display for columns to ensure proper alignment
- Setting consistent `minHeight` instead of fixed `height` for better responsiveness
- Applying width of 100% to cards to ensure they fill their containers
- Ensuring the ActionItemContent component stretches to full height

These changes improve the visual consistency of the page, especially in different screen sizes.

Before

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/038e8309-16af-4121-a693-c960650c3c9b.png)

After
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/e2f5e986-4df1-4305-a31d-693b1fa46e19.png)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after