### PR TITLE
chore(FR-1153): replace CPU and MEM icons in React

### DIFF
--- a/react/src/components/ResourceNumber.tsx
+++ b/react/src/components/ResourceNumber.tsx
@@ -6,7 +6,7 @@ import ImageWithFallback from './ImageWithFallback';
 import NumberWithUnit from './NumberWithUnit';
 import { Tooltip, Typography, theme } from 'antd';
 import _ from 'lodash';
-import { MicrochipIcon } from 'lucide-react';
+import { CpuIcon, MemoryStickIcon, MicrochipIcon } from 'lucide-react';
 import React, { ReactElement } from 'react';
 
 export type ResourceOpts = {
@@ -95,24 +95,6 @@ const ResourceNumber: React.FC<ResourceNumberProps> = ({
   );
 };
 
-const MWCIconWrap: React.FC<{ size?: number; children: string }> = ({
-  size = 16,
-  children,
-}) => {
-  return (
-    // @ts-ignore
-    <mwc-icon
-      style={{
-        '--mdc-icon-size': `${size + 2}px`,
-        width: size,
-        height: size,
-      }}
-    >
-      {children}
-      {/* @ts-ignore */}
-    </mwc-icon>
-  );
-};
 interface AccTypeIconProps
   extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'src'> {
   type: ResourceSlotName | string;
@@ -135,7 +117,7 @@ export const ResourceTypeIcon: React.FC<AccTypeIconProps> = ({
     if (type === 'cpu') {
       return (
         <Flex style={{ width: 16, height: 16 }}>
-          <MWCIconWrap size={size}>developer_board</MWCIconWrap>
+          <CpuIcon />
         </Flex>
       );
     }
@@ -143,7 +125,7 @@ export const ResourceTypeIcon: React.FC<AccTypeIconProps> = ({
     if (type === 'mem') {
       return (
         <Flex style={{ width: 16, height: 16 }}>
-          <MWCIconWrap size={size}>memory</MWCIconWrap>
+          <MemoryStickIcon />
         </Flex>
       );
     }


### PR DESCRIPTION
Resolves #3860 ([FR-1153](https://lablup.atlassian.net/browse/FR-1153))

# Replace Material Web Component Icons with Lucide Icons

|  Before  | After    |
|---------|--------|
| ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/4d1155f1-c416-47ed-b2db-447e512a1328.png)               |     ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/a7edac83-0906-4d36-84de-713de081304b.png)        |

This PR replaces the deprecated Material Web Component icons with Lucide icons for CPU and memory resources. Specifically:

- Removes the `MWCIconWrap` component that was using the deprecated `mwc-icon` element
- Imports `CpuIcon` and `MemoryStickIcon` from Lucide React
- Updates the resource type icons to use these Lucide components instead of the MWC icons


[FR-1153]: https://lablup.atlassian.net/browse/FR-1153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ