### PR TITLE
feat(FR-1263): show pending sessions in the session list immediately aftercreation

### DIFF
--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -20,8 +20,11 @@ import SessionNodes from '../components/SessionNodes';
 import { filterNonNullItems, handleRowSelectionChange } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { useBAINotificationState } from '../hooks/useBAINotification';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useDeferredQueryParams } from '../hooks/useDeferredQueryParams';
+import { SESSION_LAUNCHER_NOTI_PREFIX } from './SessionLauncherPage';
+import { useUpdateEffect } from 'ahooks';
 import {
   Badge,
   Button,
@@ -34,7 +37,14 @@ import {
 } from 'antd';
 import _ from 'lodash';
 import { PowerOffIcon } from 'lucide-react';
-import { Suspense, useDeferredValue, useMemo, useRef, useState } from 'react';
+import {
+  Suspense,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
@@ -144,6 +154,7 @@ const ComputeSessionListPage = () => {
             edges @required(action: THROW) {
               node @required(action: THROW) {
                 id @required(action: THROW)
+                name @required(action: THROW)
                 ...SessionNodesFragment
                 ...TerminateSessionModalFragment
               }
@@ -207,6 +218,58 @@ const ComputeSessionListPage = () => {
       },
     );
   const { lg } = Grid.useBreakpoint();
+
+  const [notifications] = useBAINotificationState();
+
+  const sessionNotifications = _.filter(notifications, (n) =>
+    _.startsWith(n.key.toString(), SESSION_LAUNCHER_NOTI_PREFIX),
+  );
+
+  const pendingSessionNames = _.filter(
+    sessionNotifications,
+    (n) => n.backgroundTask?.status === 'pending',
+  ).map((notifications) =>
+    notifications.key.toString().replace(SESSION_LAUNCHER_NOTI_PREFIX, ''),
+  );
+
+  const resolvedSessionNames = _.filter(
+    sessionNotifications,
+    (n) => n.backgroundTask?.status === 'resolved',
+  ).map((notifications) =>
+    notifications.key.toString().replace(SESSION_LAUNCHER_NOTI_PREFIX, ''),
+  );
+
+  // Monkey patch to show pending sessions in the list immediately when navigating to this page
+  // before receiving the response after session creation request
+  // TODO: Remove this effect when the session creation API response right after creation
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | null = null;
+    if (queryParams.type === 'all' && pendingSessionNames.length > 0) {
+      if (
+        !_.some(compute_session_nodes?.edges, (e) => {
+          return e?.node.name && pendingSessionNames.includes(e.node.name);
+        })
+      ) {
+        timeoutId = setTimeout(() => {
+          updateFetchKey();
+        }, 500);
+      }
+    }
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(pendingSessionNames), queryParams.type]);
+
+  // Update fetch key when session creation notifications are resolved
+  // TODO: Remove this effect when the session creation API supports bg_task or GraphQL subscriptions
+  useUpdateEffect(() => {
+    if (resolvedSessionNames.length > 0) {
+      updateFetchKey();
+    }
+  }, [resolvedSessionNames.length, updateFetchKey]);
 
   return (
     <Flex direction="column" align="stretch" gap={'md'}>

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -186,9 +186,12 @@ export type SessionLauncherStepKey =
   | 'storage'
   | 'network'
   | 'review';
+
 interface StepPropsWithKey extends StepProps {
   key: SessionLauncherStepKey;
 }
+
+export const SESSION_LAUNCHER_NOTI_PREFIX = 'session-launcher:';
 
 const SessionLauncherPage = () => {
   const app = App.useApp();
@@ -598,7 +601,7 @@ const SessionLauncherPage = () => {
         const backupTo = window.location.pathname + window.location.search;
         webuiNavigate(redirectTo || '/job');
         upsertNotification({
-          key: 'session-launcher:' + sessionName,
+          key: SESSION_LAUNCHER_NOTI_PREFIX + sessionName,
           backgroundTask: {
             promise: Promise.all(sessionPromises),
             status: 'pending',


### PR DESCRIPTION
Resolves #3981 ([FR-1263](https://lablup.atlassian.net/browse/FR-1263))

### TL;DR

Added automatic refresh of the compute session list when sessions are created or pending.

### What changed?

- Added monitoring of session creation notifications in the ComputeSessionListPage
- Implemented two effects to refresh the session list:
  1. A timeout-based refresh when pending sessions are detected but not yet visible in the list
  2. An immediate refresh when session creation notifications are resolved
- Added session name to the GraphQL query to properly track sessions
- Exported the SESSION_LAUNCHER_NOTI_PREFIX constant for consistent notification key management

### How to test?

1. Create a new compute session from the Session Launcher page
2. After creation, it will be navigated to the Compute Session List page
3. Verify that pending sessions appear in the list immediately
4. Verify that the list automatically refreshes when session creation completes (App modal is opened)

### Why make this change?

This improves the user experience by providing immediate feedback when sessions are created. Previously, users had to manually refresh the page to see newly created sessions, which could lead to confusion about whether the session creation was successful.

[FR-1263]: https://lablup.atlassian.net/browse/FR-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ