### PR TITLE
fix(FR-1285): StorageStatusPanel is too large.

### DIFF
--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -276,7 +276,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
         align={'stretch'}
         style={{ minHeight: lg ? CARD_MIN_HEIGHT : undefined }}
       >
-        <Col xs={24} md={8} xl={4} style={{ display: 'flex' }}>
+        <Col xs={24} md={8} lg={4} style={{ display: 'flex' }}>
           <BAICard
             style={{
               width: '100%',
@@ -304,7 +304,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             />
           </BAICard>
         </Col>
-        <Col xs={24} md={16} xl={8} style={{ display: 'flex' }}>
+        <Col xs={24} md={16} lg={8} style={{ display: 'flex' }}>
           <Suspense
             fallback={
               <BAICard
@@ -333,7 +333,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             />
           </Suspense>
         </Col>
-        <Col xs={24} md={24} xl={12} style={{ display: 'flex' }}>
+        <Col xs={24} lg={12} style={{ display: 'flex' }}>
           <Suspense
             fallback={
               <BAICard


### PR DESCRIPTION
# Adjusted responsive column breakpoints for VFolderNodeListPage

This PR adjusts the responsive column breakpoints in the VFolderNodeListPage component to improve the layout across different screen sizes:

- Changed first column from `lg={8} xxl={4}` to `md={8} lg={4}`
- Changed second column from `lg={16} xxl={8}` to `md={16} lg={8}`
- Changed third column from `xxl={12}` to `lg={12}`

These changes allow the layout to respond better at medium screen sizes and create a more balanced distribution of space across different viewport widths.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after