### PR TITLE
fix(FR-1282): modify service name rule to validate only when create and apply field name change

### DIFF
--- a/react/src/components/ModelTryContentButton.tsx
+++ b/react/src/components/ModelTryContentButton.tsx
@@ -256,7 +256,7 @@ const ModelTryContentButton: React.FC<ModelTryContentButtonProps> = ({
       vFolderID: vfolderID, // TODO: add cloned folder result
       modelMountDestination: '/models',
       modelDefinitionPath: '',
-      vfoldersAliasMap: {},
+      mount_id_map: {},
       envvars: modelCardMetadata?.envvars || [],
       enabledAutomaticShmem: false,
     };

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -116,7 +116,7 @@ interface ServiceLauncherInput extends ImageEnvironmentFormInput {
   openToPublic: boolean;
   modelMountDestination: string;
   modelDefinitionPath: string;
-  vfoldersAliasMap: Record<string, string>;
+  mount_id_map: Record<string, string>;
   mounts?: Array<string>;
   envvars: EnvVarFormListValue[];
   runtimeVariant: string;
@@ -312,8 +312,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
             values.mounts,
             (acc, key: string) => {
               acc[key] = {
-                ...(values.vfoldersAliasMap[key] && {
-                  mount_destination: values.vfoldersAliasMap[key],
+                ...(values.mount_id_map[key] && {
+                  mount_destination: values.mount_id_map[key],
                 }),
                 type: 'bind', // FIXME: hardcoded. change it with option later
               };
@@ -516,8 +516,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                   extra_mounts: _.map(values.mounts, (vfolder) => {
                     return {
                       vfolder_id: vfolder,
-                      ...(values.vfoldersAliasMap[vfolder] && {
-                        mount_destination: values.vfoldersAliasMap[vfolder],
+                      ...(values.mount_id_map[vfolder] && {
+                        mount_destination: values.mount_id_map[vfolder],
                       }),
                     };
                   }),
@@ -737,7 +737,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                         label={t('modelService.ServiceName')}
                         name="serviceName"
                         validateDebounce={500}
-                        rules={validationRules}
+                        rules={!!endpoint ? [] : validationRules}
                       >
                         <Input disabled={!!endpoint} />
                       </Form.Item>

--- a/react/src/components/ServiceValidationView.tsx
+++ b/react/src/components/ServiceValidationView.tsx
@@ -84,8 +84,8 @@ const ServiceValidationView: React.FC<ServiceValidationModalProps> = ({
             values.mounts,
             (acc, key: string) => {
               acc[key] = {
-                ...(values.vfoldersAliasMap[key] && {
-                  mount_destination: values.vfoldersAliasMap[key],
+                ...(values.mount_id_map[key] && {
+                  mount_destination: values.mount_id_map[key],
                 }),
                 type: 'bind', // FIXME: hardcoded. change it with option later
               };


### PR DESCRIPTION
resolves FR-1282

This PR fixes the validation rule to only be applied when creating a service. It also addresses the issue by reflecting the changed field names.
(`vfoldersAliasMap` -> `mount_id_map`)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
