### PR TITLE
refactor(FR-1287): remove `service_port` in legacy session fragment

### DIFF
--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -9,3 +9,4 @@ export * from './Table';
 export * from './fragments';
 export * from './tests';
 export * from './provider';
+export * from './unsafe';

--- a/packages/backend.ai-ui/src/components/unsafe/UNSAFELazyUserEmailView.tsx
+++ b/packages/backend.ai-ui/src/components/unsafe/UNSAFELazyUserEmailView.tsx
@@ -1,0 +1,48 @@
+import { UNSAFELazyUserEmailViewQuery } from '../../__generated__/UNSAFELazyUserEmailViewQuery.graphql';
+import { toGlobalId } from '../../helper';
+import { GetProps, Typography } from 'antd';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export interface UNSAFELazyUserEmailViewProps
+  extends Omit<GetProps<typeof Typography.Text>, 'children'> {
+  uuid?: string;
+  fetchKey?: string;
+}
+
+/**
+ * @warning This component should only be used as a last resort.
+ * @internal
+ */
+const UNSAFELazyUserEmailView: React.FC<UNSAFELazyUserEmailViewProps> = ({
+  uuid,
+  fetchKey,
+  ...textProps
+}) => {
+  const { user_node } = useLazyLoadQuery<UNSAFELazyUserEmailViewQuery>(
+    graphql`
+      query UNSAFELazyUserEmailViewQuery($uuid: String!) {
+        user_node(id: $uuid) {
+          email
+        }
+      }
+    `,
+    {
+      uuid: uuid ? toGlobalId('UserNode', uuid) : '',
+    },
+    {
+      fetchPolicy: !uuid
+        ? 'store-only'
+        : fetchKey === undefined
+          ? 'store-or-network'
+          : 'network-only',
+      fetchKey,
+    },
+  );
+  return (
+    user_node?.email && (
+      <Typography.Text {...textProps}>{user_node?.email}</Typography.Text>
+    )
+  );
+};
+
+export default UNSAFELazyUserEmailView;

--- a/packages/backend.ai-ui/src/components/unsafe/index.ts
+++ b/packages/backend.ai-ui/src/components/unsafe/index.ts
@@ -1,0 +1,1 @@
+export { default as UNSAFELazyUserEmailView } from './UNSAFELazyUserEmailView';

--- a/packages/backend.ai-ui/src/helper/index.ts
+++ b/packages/backend.ai-ui/src/helper/index.ts
@@ -293,3 +293,11 @@ export function divideNumberWithUnits(size1: string, size2: string) {
   if (num2 === 0) return undefined; // Avoid division by zero
   return convertToBinaryUnit(num1 / num2, '')?.value;
 }
+
+export const toGlobalId = (type: string, id: string): string => {
+  return btoa(`${type}:${id}`);
+};
+
+export const toLocalId = (globalId: string): string => {
+  return atob(globalId).split(':')?.[1];
+};

--- a/packages/backend.ai-ui/src/hooks/index.ts
+++ b/packages/backend.ai-ui/src/hooks/index.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+
+type UseMemoizedJsonParseOptions<T> = {
+  fallbackValue: T;
+};
+
+/**
+ * A custom React hook that memoizes the result of parsing a JSON string.
+ *
+ * @template T The expected type of the parsed JSON object.
+ * @param jsonString - The JSON string to parse. If `undefined` or `null`, the `fallbackValue` is returned.
+ * @param options - Optional configuration object.
+ * @param options.fallbackValue - The value to return if parsing fails or if `jsonString` is not a string.
+ * @returns The parsed JSON object of type `T`, or the `fallbackValue` if parsing fails.
+ *
+ * @example
+ * const data = useMemoizedJSONParse<MyType>(jsonString, { fallbackValue: defaultValue });
+ */
+export function useMemoizedJSONParse<T = any>(
+  jsonString: string | undefined | null,
+  options?: UseMemoizedJsonParseOptions<T>,
+): T {
+  const { fallbackValue } = options || {};
+
+  return useMemo(() => {
+    if (typeof jsonString !== 'string') return fallbackValue;
+
+    try {
+      return JSON.parse(jsonString);
+    } catch (err) {
+      return fallbackValue;
+    }
+  }, [jsonString, fallbackValue]);
+}

--- a/packages/backend.ai-ui/src/index.ts
+++ b/packages/backend.ai-ui/src/index.ts
@@ -1,3 +1,4 @@
 export * from './components';
 export * from './helper';
+export * from './hooks';
 export * from './icons';

--- a/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
@@ -1,5 +1,4 @@
 import { AppLauncherModalFragment$key } from '../../__generated__/AppLauncherModalFragment.graphql';
-import { AppLauncherModalLegacyFragment$key } from '../../__generated__/AppLauncherModalLegacyFragment.graphql';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import {
   ServicePort,
@@ -31,13 +30,11 @@ import { graphql, useFragment } from 'react-relay';
 interface AppLauncherModalProps extends ModalProps {
   onRequestClose: () => void;
   sessionFrgmt: AppLauncherModalFragment$key | null;
-  legacySessionFrgmt?: AppLauncherModalLegacyFragment$key | null;
 }
 
 const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
   onRequestClose,
   sessionFrgmt,
-  legacySessionFrgmt,
   ...modalProps
 }) => {
   const { t } = useTranslation();
@@ -61,20 +58,8 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
     sessionFrgmt,
   );
 
-  const legacySession = useFragment(
-    graphql`
-      fragment AppLauncherModalLegacyFragment on ComputeSession {
-        id
-        session_id
-        service_ports
-        access_key
-      }
-    `,
-    legacySessionFrgmt,
-  );
-
   const servicePorts: ServicePort[] = JSON.parse(
-    session?.service_ports ?? legacySession?.service_ports ?? '{}',
+    session?.service_ports ?? '{}',
   );
 
   const { preOpenAppTemplate, baseAppTemplate } =

--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -2,10 +2,6 @@ import {
   SessionActionButtonsFragment$data,
   SessionActionButtonsFragment$key,
 } from '../../__generated__/SessionActionButtonsFragment.graphql';
-import {
-  SessionActionButtonsLegacyFragment$data,
-  SessionActionButtonsLegacyFragment$key,
-} from '../../__generated__/SessionActionButtonsLegacyFragment.graphql';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import { useCurrentUserInfo } from '../../hooks/backendai';
 import { useBackendAIAppLauncher } from '../../hooks/useBackendAIAppLauncher';
@@ -28,7 +24,6 @@ import { graphql, useFragment } from 'react-relay';
 
 interface SessionActionButtonsProps {
   sessionFrgmt: SessionActionButtonsFragment$key | null;
-  legacySessionFrgmt?: SessionActionButtonsLegacyFragment$key | null;
 }
 
 const isActive = (session: SessionActionButtonsFragment$data) => {
@@ -36,19 +31,11 @@ const isActive = (session: SessionActionButtonsFragment$data) => {
     session?.status || '',
   );
 };
-const isAppSupported = (
-  session: SessionActionButtonsFragment$data,
-  legacy_session: SessionActionButtonsLegacyFragment$data | null | undefined,
-) => {
+const isAppSupported = (session: SessionActionButtonsFragment$data) => {
   return (
     ['batch', 'interactive', 'inference', 'system', 'running'].includes(
       session?.type || '',
-    ) &&
-    !_.isEmpty(
-      JSON.parse(
-        session?.service_ports ?? legacy_session?.service_ports ?? '{}',
-      ),
-    )
+    ) && !_.isEmpty(JSON.parse(session?.service_ports ?? '{}'))
   );
 };
 
@@ -78,17 +65,6 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = (props) => {
     props.sessionFrgmt,
   );
 
-  const legacySession = useFragment(
-    graphql`
-      fragment SessionActionButtonsLegacyFragment on ComputeSession {
-        id
-        service_ports
-        ...AppLauncherModalLegacyFragment
-      }
-    `,
-    props.legacySessionFrgmt,
-  );
-
   const [openAppLauncherModal, setOpenAppLauncherModal] = useState(false);
   const [openTerminateModal, setOpenTerminateModal] = useState(false);
   const [openLogModal, setOpenLogModal] = useState(false);
@@ -104,9 +80,7 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = (props) => {
         <Tooltip title={t('session.SeeAppDialog')}>
           <Button
             disabled={
-              !isAppSupported(session, legacySession) ||
-              !isActive(session) ||
-              !isOwner
+              !isAppSupported(session) || !isActive(session) || !isOwner
             }
             icon={<BAIAppIcon />}
             onClick={() => {
@@ -117,7 +91,6 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = (props) => {
         <Suspense fallback={null}>
           <AppLauncherModal
             sessionFrgmt={session}
-            legacySessionFrgmt={legacySession}
             open={openAppLauncherModal}
             onRequestClose={() => {
               setOpenAppLauncherModal(false);
@@ -127,9 +100,7 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = (props) => {
         <Tooltip title={t('session.ExecuteTerminalApp')}>
           <Button
             disabled={
-              !isAppSupported(session, legacySession) ||
-              !isActive(session) ||
-              !isOwner
+              !isAppSupported(session) || !isActive(session) || !isOwner
             }
             icon={<BAITerminalAppIcon />}
             onClick={() => {

--- a/react/src/components/DeleteVFolderModal.tsx
+++ b/react/src/components/DeleteVFolderModal.tsx
@@ -1,12 +1,12 @@
 import { DeleteVFolderModalFragment$key } from '../__generated__/DeleteVFolderModalFragment.graphql';
 import { VFolderNodesFragment$data } from '../__generated__/VFolderNodesFragment.graphql';
-import { toLocalId } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { usePainKiller } from '../hooks/usePainKiller';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { Typography, message } from 'antd';
+import { toLocalId } from 'backend.ai-ui';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/EditableVFolderName.tsx
+++ b/react/src/components/EditableVFolderName.tsx
@@ -1,6 +1,5 @@
 import { EditableVFolderNameFragment$key } from '../__generated__/EditableVFolderNameFragment.graphql';
 import { EditableVFolderNameRefetchQuery } from '../__generated__/EditableVFolderNameRefetchQuery.graphql';
-import { toLocalId } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
@@ -12,6 +11,7 @@ import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import { theme, Form, Input, App } from 'antd';
 import Text, { TextProps } from 'antd/es/typography/Text';
 import Title, { TitleProps } from 'antd/es/typography/Title';
+import { toLocalId } from 'backend.ai-ui';
 import _ from 'lodash';
 import { CornerDownLeftIcon } from 'lucide-react';
 import React, { useState } from 'react';

--- a/react/src/components/LegacyFolderExplorer.tsx
+++ b/react/src/components/LegacyFolderExplorer.tsx
@@ -1,5 +1,4 @@
 import { LegacyFolderExplorerQuery } from '../__generated__/LegacyFolderExplorerQuery.graphql';
-import { toGlobalId } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import Flex from './Flex';
@@ -8,6 +7,7 @@ import FolderExplorerHeader from './FolderExplorerHeader';
 import VFolderNodeDescription from './VFolderNodeDescription';
 import { Alert, Grid, Splitter, theme } from 'antd';
 import { createStyles } from 'antd-style';
+import { toGlobalId } from 'backend.ai-ui';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';

--- a/react/src/components/RecentlyCreatedSession.tsx
+++ b/react/src/components/RecentlyCreatedSession.tsx
@@ -1,11 +1,12 @@
 import { RecentlyCreatedSessionFragment$key } from '../__generated__/RecentlyCreatedSessionFragment.graphql';
-import { filterNonNullItems, toLocalId } from '../helper';
+import { filterNonNullItems } from '../helper';
 import BAIFetchKeyButton from './BAIFetchKeyButton';
 import Flex from './Flex';
 import SessionDetailDrawer from './SessionDetailDrawer';
 import SessionNodes from './SessionNodes';
 import UnmountAfterClose from './UnmountAfterClose';
 import { theme, Typography } from 'antd';
+import { toLocalId } from 'backend.ai-ui';
 import { useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useRefetchableFragment } from 'react-relay';

--- a/react/src/components/RestoreVFolderModal.tsx
+++ b/react/src/components/RestoreVFolderModal.tsx
@@ -1,12 +1,12 @@
 import { RestoreVFolderModalFragment$key } from '../__generated__/RestoreVFolderModalFragment.graphql';
 import { VFolderNodesFragment$data } from '../__generated__/VFolderNodesFragment.graphql';
-import { toLocalId } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { usePainKiller } from '../hooks/usePainKiller';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { Typography, message } from 'antd';
+import { toLocalId } from 'backend.ai-ui';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/VFolderNodeDescription.tsx
+++ b/react/src/components/VFolderNodeDescription.tsx
@@ -1,7 +1,7 @@
 import { VFolderNodeDescriptionFragment$key } from '../__generated__/VFolderNodeDescriptionFragment.graphql';
 import { VFolderNodeDescriptionPermissionRefreshQuery } from '../__generated__/VFolderNodeDescriptionPermissionRefreshQuery.graphql';
 import { useVirtualFolderNodePathFragment$key } from '../__generated__/useVirtualFolderNodePathFragment.graphql';
-import { convertToDecimalUnit, filterEmptyItem, toLocalId } from '../helper';
+import { convertToDecimalUnit, filterEmptyItem } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
@@ -21,7 +21,7 @@ import {
   Typography,
   type DescriptionsProps,
 } from 'antd';
-import { BAIUserUnionIcon } from 'backend.ai-ui';
+import { BAIUserUnionIcon, toLocalId } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -2,7 +2,7 @@ import {
   VFolderNodesFragment$data,
   VFolderNodesFragment$key,
 } from '../__generated__/VFolderNodesFragment.graphql';
-import { filterNonNullItems, toLocalId } from '../helper';
+import { filterNonNullItems } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
@@ -37,6 +37,7 @@ import {
   BAIUserUnionIcon,
   BAITable,
   BAITableProps,
+  toLocalId,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import React, { useState } from 'react';

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -476,14 +476,6 @@ export function formatToUUID(str: string) {
   return `${str.slice(0, 8)}-${str.slice(8, 12)}-${str.slice(12, 16)}-${str.slice(16, 20)}-${str.slice(20)}`;
 }
 
-export const toGlobalId = (type: string, id: string): string => {
-  return btoa(`${type}:${id}`);
-};
-
-export const toLocalId = (globalId: string): string => {
-  return atob(globalId).split(':')?.[1];
-};
-
 export function preserveDotStartCase(str: string = '') {
   // Temporarily replace periods with a unique placeholder
   const placeholder = '<<<DOT>>>';

--- a/react/src/hooks/useVirtualFolderNodePath.ts
+++ b/react/src/hooks/useVirtualFolderNodePath.ts
@@ -1,5 +1,5 @@
 import { useVirtualFolderNodePathFragment$key } from '../__generated__/useVirtualFolderNodePathFragment.graphql';
-import { toLocalId } from '../helper';
+import { toLocalId } from 'backend.ai-ui';
 import _ from 'lodash';
 import { graphql, useFragment } from 'react-relay';
 


### PR DESCRIPTION
# Add UNSAFELazyUserEmailView component and utility functions

This PR adds a new component `UNSAFELazyUserEmailView` that safely fetches and displays user email addresses. It also:

- Adds utility functions `toGlobalId` and `toLocalId` for GraphQL ID conversion
- Creates a new `useMemoizedJSONParse` hook for efficient JSON parsing
- Refactors session components to use the new email view component
- Removes legacy session fragments that are no longer needed
  - FYI, `service_ports` of ComputeSessionNode is available since v24.09.0
- Updates the SessionIdleChecks component to use lazy loading
  -  FYI, `idle_checks` of ComputeSessionNode is available since v24.12.0

The changes improve code organization and provide a safer way to display user emails in the UI.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after