### PR TITLE
refactor(FR-1287): remove image infomation in legacy session fragment

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionIdleChecks.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionIdleChecks.tsx
@@ -9,6 +9,7 @@ import DoubleTag from '../DoubleTag';
 import Flex from '../Flex';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { Tooltip, Typography, theme } from 'antd';
+import { useMemoizedJSONParse } from 'backend.ai-ui';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
@@ -157,8 +158,11 @@ const SessionIdleChecks: React.FC<SessionIdleChecksProps> = ({
     },
   );
 
-  const idleChecks: IdleChecks = JSON.parse(
-    sessionNode?.idle_checks || session?.idle_checks || '{}',
+  const idleChecks: IdleChecks = useMemoizedJSONParse(
+    sessionNode?.idle_checks || session?.idle_checks,
+    {
+      fallbackValue: {},
+    },
   );
 
   const getIdleCheckTitle = (key: keyof IdleChecks) => {

--- a/react/src/components/LegacyFolderExplorer.tsx
+++ b/react/src/components/LegacyFolderExplorer.tsx
@@ -75,8 +75,8 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
 
   const { vfolder_node } = useLazyLoadQuery<LegacyFolderExplorerQuery>(
     graphql`
-      query LegacyFolderExplorerQuery($vfolderUUID: String!) {
-        vfolder_node(id: $vfolderUUID) @since(version: "24.03.4") {
+      query LegacyFolderExplorerQuery($vfolderGlobalId: String!) {
+        vfolder_node(id: $vfolderGlobalId) @since(version: "24.03.4") {
           id
           user
           permission
@@ -88,7 +88,7 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
       }
     `,
     {
-      vfolderUUID: toGlobalId('VirtualFolderNode', vfolderID),
+      vfolderGlobalId: toGlobalId('VirtualFolderNode', vfolderID),
     },
     {
       fetchPolicy: modalProps.open ? 'network-only' : 'store-only',


### PR DESCRIPTION
# Refactor Image Tags Component and Add UNSAFELazySessionImageTag

This PR refactors the ImageTags component and adds a new component for fetching session image information via GraphQL.

Key changes:
- Added `UNSAFELazySessionImageTag` component that lazily loads session image data
- Made several ImageTags subcomponents non-exported as they're only used internally
- Refactored SessionDetailContent to use the new image tag components
- Updated variable name in LegacyFolderExplorer from `vfolderUUID` to `vfolderGlobal` for clarity
- Removed redundant components like `BaseVersionTags`, `LangTags`, and `ConstraintTags`
- Reorganized SessionKernelTags to be a memoized component