### PR TITLE
feat(FR-1287): Show "No Access" in Explorer, not disable Session Detail

### DIFF
--- a/react/src/components/LegacyFolderExplorer.tsx
+++ b/react/src/components/LegacyFolderExplorer.tsx
@@ -95,7 +95,7 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
     },
   );
 
-  const legacyFolderExplorerPane = (
+  const legacyFolderExplorerPane = vfolder_node && (
     <Flex direction="column" align="stretch">
       {vfolder_node?.unmanaged_path ? (
         <Alert
@@ -120,7 +120,8 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
       )}
     </Flex>
   );
-  const vfolderDescription = (
+
+  const vfolderDescription = vfolder_node && (
     <VFolderNodeDescription
       vfolderNodeFrgmt={vfolder_node}
       onRequestRefresh={() => {
@@ -128,6 +129,7 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
       }}
     />
   );
+
   return (
     <BAIModal
       className={styles.baiModalHeader}
@@ -136,35 +138,45 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
       destroyOnClose
       footer={null}
       title={
-        <FolderExplorerHeader
-          vfolderNodeFrgmt={vfolder_node}
-          folderExplorerRef={folderExplorerRef}
-        />
+        vfolder_node ? (
+          <FolderExplorerHeader
+            vfolderNodeFrgmt={vfolder_node}
+            folderExplorerRef={folderExplorerRef}
+          />
+        ) : null
       }
       onCancel={() => {
         onRequestClose();
       }}
       {...modalProps}
     >
-      {xl ? (
-        <Splitter
-          style={{
-            gap: token.size,
-            alignSelf: 'stretch',
-          }}
-        >
-          <Splitter.Panel resizable={false}>
+      {vfolder_node ? (
+        xl ? (
+          <Splitter
+            style={{
+              gap: token.size,
+              alignSelf: 'stretch',
+            }}
+          >
+            <Splitter.Panel resizable={false}>
+              {legacyFolderExplorerPane}
+            </Splitter.Panel>
+            <Splitter.Panel defaultSize={500} min={300} max={'40%'}>
+              {vfolderDescription}
+            </Splitter.Panel>
+          </Splitter>
+        ) : (
+          <Flex direction="column" align="stretch" gap={'md'}>
             {legacyFolderExplorerPane}
-          </Splitter.Panel>
-          <Splitter.Panel defaultSize={500} min={300} max={'40%'}>
             {vfolderDescription}
-          </Splitter.Panel>
-        </Splitter>
+          </Flex>
+        )
       ) : (
-        <Flex direction="column" align="stretch" gap={'md'}>
-          {legacyFolderExplorerPane}
-          {vfolderDescription}
-        </Flex>
+        <Alert
+          message={t('explorer.FolderNotFoundOrNoAccess')}
+          type="error"
+          showIcon
+        />
       )}
     </BAIModal>
   );

--- a/react/src/components/VFolderNodeDescription.tsx
+++ b/react/src/components/VFolderNodeDescription.tsx
@@ -33,7 +33,7 @@ import {
 } from 'react-relay';
 
 interface VFolderNodeDescriptionProps extends DescriptionsProps {
-  vfolderNodeFrgmt?: VFolderNodeDescriptionFragment$key | null;
+  vfolderNodeFrgmt: VFolderNodeDescriptionFragment$key;
   onRequestRefresh?: () => void;
 }
 
@@ -94,11 +94,7 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
     vfolderNode as useVirtualFolderNodePathFragment$key,
   );
 
-  if (!vfolderNode) {
-    return null;
-  }
-
-  const vfolderId = toLocalId(vfolderNode?.id);
+  const vfolderId = toLocalId(vfolderNode.id);
 
   const items: DescriptionsProps['items'] = filterEmptyItem([
     !vfolderNode?.unmanaged_path && {

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -634,6 +634,7 @@
     "Title": "Es ist ein Fehler aufgetreten."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Ordner, der nicht gefunden oder zugänglich ist verweigert",
     "InputTooShort": "EingabeTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Nicht verwaltete Ordner unterstützen den Datei -Explorer nicht.",
     "ValueRequired": "WertErforderlich"

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -630,6 +630,7 @@
     "Title": "Εμφανίστηκε σφάλμα."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Ο φάκελος δεν βρέθηκε ή απορρίφθηκε η πρόσβαση",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Οι μη διαχειριζόμενοι φάκελοι δεν υποστηρίζουν τον εξερευνητή αρχείων.",
     "ValueRequired": "Απαιτούμενη τιμή"

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -638,6 +638,7 @@
     "Title": "An error has occurred."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Folder not found or access denied",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Unmanaged folders do not support the file explorer.",
     "ValueRequired": "ValueRequired"

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -634,6 +634,7 @@
     "Title": "Se ha producido un error."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Carpeta no encontrada ni de acceso denegada",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Las carpetas no administradas no admiten el explorador de archivos.",
     "ValueRequired": "ValorRequerido"

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -634,6 +634,7 @@
     "Title": "On tapahtunut virhe."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Kansiota ei löydy tai pääsy kielletty",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Hallitsemattomat kansiot eivät tue tiedostotutkijaa.",
     "ValueRequired": "ValueRequired"

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -634,6 +634,7 @@
     "Title": "Une erreur s'est produite."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Dossier non trouvé ou accès refusé",
     "InputTooShort": "Entrée Trop Courte",
     "NoExplorerSupportForUnmanagedFolder": "Les dossiers non gérés ne prennent pas en charge l'explorateur de fichiers.",
     "ValueRequired": "ValeurRequis"

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -633,6 +633,7 @@
     "Title": "Telah terjadi kesalahan."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Folder tidak ditemukan atau akses ditolak",
     "InputTooShort": "MasukanTerlaluPendek",
     "NoExplorerSupportForUnmanagedFolder": "Folder yang tidak dikelola tidak mendukung file explorer.",
     "ValueRequired": "NilaiDiperlukan"

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -633,6 +633,7 @@
     "Title": "Si è verificato un errore."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Cartella non trovata o accesso negata",
     "InputTooShort": "Inputtroppo corto",
     "NoExplorerSupportForUnmanagedFolder": "Le cartelle non gestite non supportano l'esploratore dei file.",
     "ValueRequired": "ValoreRichiesto"

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -633,6 +633,7 @@
     "Title": "エラーが発生しました。"
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "フォルダーが見つかりませんまたはアクセスが拒否されません",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "管理されていないフォルダーは、ファイルエクスプローラーをサポートしていません。",
     "ValueRequired": "ValueRequired"

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -636,6 +636,7 @@
     "Title": "에러가 발생했습니다."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "존재하지 않거나 접근할 수 없는 폴더입니다.",
     "InputTooShort": "입력값이 너무 짧습니다.",
     "NoExplorerSupportForUnmanagedFolder": "Unmanaged 폴더는 파일 탐색기를 지원하지 않습니다.",
     "ValueRequired": "값이 필요합니다."

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -632,6 +632,7 @@
     "Title": "Алдаа гарсан байна."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Фолдер олдсонгүй эсвэл хандалтыг үгүйсгэв",
     "InputTooShort": "Хэт богино байна",
     "NoExplorerSupportForUnmanagedFolder": "НҮБ-нээгүй хавтас нь файлын Explorer-ийг дэмждэггүй.",
     "ValueRequired": "Утга Шаардлагатай"

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -633,6 +633,7 @@
     "Title": "Ralat telah berlaku."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Folder tidak dijumpai atau akses ditolak",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Folder yang tidak dikendalikan tidak menyokong penjelajah fail.",
     "ValueRequired": "Nilai Diperlukan"

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -634,6 +634,7 @@
     "Title": "Wystąpił błąd."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Folder nie został znaleziony ani nie ma dostępu",
     "InputTooShort": "Wejście zbyt krótkie",
     "NoExplorerSupportForUnmanagedFolder": "Foldery niezarządzane nie obsługują eksploratora plików.",
     "ValueRequired": "Wymagana wartość"

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -634,6 +634,7 @@
     "Title": "Ocorreu um erro."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Pasta não encontrada ou acesso negado",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Pastas não gerenciadas não suportam o File Explorer.",
     "ValueRequired": "ValueRequired"

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -634,6 +634,7 @@
     "Title": "Ocorreu um erro."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Pasta não encontrada ou acesso negado",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Pastas não gerenciadas não suportam o File Explorer.",
     "ValueRequired": "ValueRequired"

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -634,6 +634,7 @@
     "Title": "Произошла ошибка."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Папка не найдена или доступа отказана",
     "InputTooShort": "ВводОченьКороток",
     "NoExplorerSupportForUnmanagedFolder": "Неуправляемые папки не поддерживают исследователь файлов.",
     "ValueRequired": "НужноЗначение"

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -623,6 +623,7 @@
     "Title": "เกิดข้อผิดพลาด"
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "ไม่พบโฟลเดอร์หรือถูกปฏิเสธการเข้าถึง",
     "InputTooShort": "ข้อมูลที่ป้อนสั้นเกินไป",
     "NoExplorerSupportForUnmanagedFolder": "โฟลเดอร์ที่ไม่มีการจัดการไม่รองรับ File Explorer",
     "ValueRequired": "ต้องระบุค่า"

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -634,6 +634,7 @@
     "Title": "Bir hata oluştu."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Klasör bulunamadı veya erişim reddedildi",
     "InputTooShort": "GirişÇok Kısa",
     "NoExplorerSupportForUnmanagedFolder": "Yönetilmeyen klasörler Dosya Gezgini'ni desteklemez.",
     "ValueRequired": "DeğerGerekli"

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -634,6 +634,7 @@
     "Title": "Một lỗi đã xảy ra."
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "Thư mục không tìm thấy hoặc truy cập bị từ chối",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Các thư mục không được quản lý không hỗ trợ trình thám hiểm tệp.",
     "ValueRequired": "Giá trị bắt buộc"

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -634,6 +634,7 @@
     "Title": "发生错误。"
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "未找到或拒绝访问的文件夹",
     "InputTooShort": "输入太短",
     "NoExplorerSupportForUnmanagedFolder": "未管理的文件夹不支持文件资源管理器。",
     "ValueRequired": "需要值"

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -634,6 +634,7 @@
     "Title": "发生错误。"
   },
   "explorer": {
+    "FolderNotFoundOrNoAccess": "未找到或拒絕訪問的文件夾",
     "InputTooShort": "輸入太短",
     "NoExplorerSupportForUnmanagedFolder": "未管理的文件夾不支持文件資源管理器。",
     "ValueRequired": "需要值"


### PR DESCRIPTION
# Fix folder explorer error handling and remove unnecessary folder access checks

This PR improves error handling in the LegacyFolderExplorer component by adding proper null checks for the vfolder_node and displaying an error message when a folder is not found or access is denied. It also removes unnecessary folder access checks in the SessionDetailContent component that were causing issues.

Key changes:
- Added conditional rendering in LegacyFolderExplorer to handle cases where vfolder_node is null
- Added an error message when folder is not found or access is denied
- Removed unnecessary folder invitation checks in SessionDetailContent
- Updated VFolderNodeDescription to properly type its props
- Added translations for the new error message in all supported languages