### PR TITLE
fix(FR-1295): Preserve necessary GraphQL fragments after client directive filtering

### DIFF
--- a/react/src/helper/graphql-transformer.test.ts
+++ b/react/src/helper/graphql-transformer.test.ts
@@ -141,4 +141,161 @@ describe('graphql-transformer', () => {
       'query MyQuery {\n  testQuery(props: {name: "asdf", age: 32}) {\n    deprecatedField3\n  }\n}',
     );
   });
+
+  it('should preserve necessary fragments after field filtering', () => {
+    const result = manipulateGraphQLQueryWithClientDirectives(
+      `
+    query SessionDetailDrawerQuery(
+      $id: GlobalIDField!
+      $project_id: UUID!
+    ) {
+      compute_session_node(id: $id, project_id: $project_id) {
+        ...SessionDetailContentFragment
+        id
+      }
+    }
+
+    fragment SessionDetailContentFragment on ComputeSessionNode {
+      id
+      row_id
+      name
+      vfolder_nodes @since(version: "2504") {
+        edges {
+          node {
+            ...FolderLink_vfolderNode
+            id
+          }
+        }
+        count
+      }
+      idle_checks @since(version: "2403")
+      kernel_nodes {
+        edges {
+          node {
+            image {
+              ...ImageNodeSimpleTagFragment 
+              id
+            }
+            ...ConnectedKernelListFragment
+            id
+          }
+        }
+      }
+      ...SessionActionButtonsFragment
+      ...ContainerLogModalFragment
+    }
+
+    fragment FolderLink_vfolderNode on VirtualFolderNode {
+      row_id
+      name
+    }
+
+    fragment ImageNodeSimpleTagFragment on ImageNode {
+      base_image_name @since(version: "2412")
+      version @since(version: "2412")
+      architecture
+      name
+      tags @since(version: "2412") {
+        key
+        value
+      }
+      registry
+      namespace @since(version: "2412")
+      tag
+    }
+
+    fragment ConnectedKernelListFragment on KernelNode {
+      id
+      row_id
+      cluster_role
+      status
+      status_info
+      agent_id
+      container_id
+    }
+
+    fragment SessionActionButtonsFragment on ComputeSessionNode {
+      id
+      row_id
+      type
+      status
+      access_key
+      service_ports
+      ...ContainerLogModalFragment
+    }
+
+    fragment ContainerLogModalFragment on ComputeSessionNode {
+      id
+      row_id
+      name
+      status
+      access_key
+      kernel_nodes {
+        edges {
+          node {
+            id
+            row_id
+            container_id
+            cluster_idx
+            cluster_role
+          }
+        }
+      }
+    }
+  `,
+      {},
+      (version) => {
+        // Simulate version 24.03.0 - some @since fields should be removed
+        return version < '2412';
+      },
+    );
+
+    // Verify that necessary fragments are preserved even when some fields are removed
+    expect(result).toContain('fragment FolderLink_vfolderNode');
+    expect(result).toContain('fragment ImageNodeSimpleTagFragment');
+    expect(result).toContain('fragment ConnectedKernelListFragment');
+    expect(result).toContain('fragment SessionActionButtonsFragment');
+    expect(result).toContain('fragment ContainerLogModalFragment');
+    expect(result).toContain('fragment SessionDetailContentFragment');
+
+    // Verify that fields with @since directives were properly handled
+    expect(result).not.toContain('@since');
+    expect(result).not.toMatch(/idle_checks/); // idle_checks field should be removed
+    expect(result).toMatch(/vfolder_nodes\s*{/); // vfolder_nodes field should remain but without @since
+  });
+
+  it('should remove fragments that are truly unused after transformation', () => {
+    const result = manipulateGraphQLQueryWithClientDirectives(
+      `
+    query TestQuery {
+      node {
+        ...UsedFragment
+        field @since(version: "99.0.0") {
+          ...UnusedFragment
+        }
+      }
+    }
+
+    fragment UsedFragment on Node {
+      id
+      name
+    }
+
+    fragment UnusedFragment on Node {
+      description
+      metadata
+    }
+  `,
+      {},
+      (version) => {
+        // Remove field that uses UnusedFragment
+        return version >= '50.0.0';
+      },
+    );
+
+    // UsedFragment should be preserved
+    expect(result).toContain('fragment UsedFragment');
+    // UnusedFragment should be removed because the field using it was removed
+    expect(result).not.toContain('fragment UnusedFragment');
+  });
 });


### PR DESCRIPTION
Resolves #4002 (FR-1295)

# Improve GraphQL fragment handling in client directive transformer

This PR enhances the GraphQL transformer to properly handle fragments after field filtering. The implementation now:

1. Uses a multi-pass approach to correctly identify and preserve necessary fragments
2. Removes truly unused fragments after transformation
3. Properly handles `@since` directives while maintaining fragment references

The changes split the transformation process into three distinct passes:
- First pass: Remove fields with client directives and clean up directives
- Second pass: Collect fragment spreads from the transformed AST
- Third pass: Remove unused fragment definitions

This prevents the "Fragment is never used" error while ensuring we don't keep unnecessary fragments in the final query.