### PR TITLE
feat(FR-1287): Optimize session detail navigation with state caching and GraphQL fragment improvements

### DIFF
--- a/react/src/components/LegacyFolderExplorer.tsx
+++ b/react/src/components/LegacyFolderExplorer.tsx
@@ -80,6 +80,7 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
           id
           user
           permission
+          permissions
           unmanaged_path @since(version: "25.04.0")
           ...FolderExplorerHeaderFragment
           ...VFolderNodeDescriptionFragment
@@ -95,6 +96,10 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
     },
   );
 
+  // TODO: Skip permission check due to inaccurate API response. Update when API is fixed.
+  const hasNoPermissions = false;
+  // !vfolder_node || (vfolder_node.permissions?.length || 0) === 0;
+
   const legacyFolderExplorerPane = vfolder_node && (
     <Flex direction="column" align="stretch">
       {vfolder_node?.unmanaged_path ? (
@@ -102,7 +107,7 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
           message={t('explorer.NoExplorerSupportForUnmanagedFolder')}
           showIcon
         />
-      ) : (
+      ) : !hasNoPermissions ? (
         <>
           <FolderExplorerActions
             isSelected={isSelected}
@@ -117,7 +122,7 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
             vfolderID={vfolderID}
           />
         </>
-      )}
+      ) : null}
     </Flex>
   );
 
@@ -150,6 +155,15 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
       }}
       {...modalProps}
     >
+      {!vfolder_node ? (
+        <Alert
+          message={t('explorer.FolderNotFoundOrNoAccess')}
+          type="error"
+          showIcon
+        />
+      ) : hasNoPermissions ? (
+        <Alert message={t('explorer.NoPermissions')} type="error" showIcon />
+      ) : null}
       {vfolder_node ? (
         xl ? (
           <Splitter
@@ -171,13 +185,7 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
             {vfolderDescription}
           </Flex>
         )
-      ) : (
-        <Alert
-          message={t('explorer.FolderNotFoundOrNoAccess')}
-          type="error"
-          showIcon
-        />
-      )}
+      ) : null}
     </BAIModal>
   );
 };

--- a/react/src/components/MountedVFolderLinks.tsx
+++ b/react/src/components/MountedVFolderLinks.tsx
@@ -1,0 +1,110 @@
+import { MountedVFolderLinksFragment$key } from '../__generated__/MountedVFolderLinksFragment.graphql';
+import { MountedVFolderLinksLegacyLazyFolderLinkFragment$key } from '../__generated__/MountedVFolderLinksLegacyLazyFolderLinkFragment.graphql';
+import { MountedVFolderLinksQuery } from '../__generated__/MountedVFolderLinksQuery.graphql';
+import { useSuspendedBackendaiClient } from '../hooks';
+import FolderLink from './FolderLink';
+import { Skeleton } from 'antd';
+import _ from 'lodash';
+import React, { Suspense } from 'react';
+import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
+
+interface MountedVFolderLinksProps {
+  sessionFrgmt: MountedVFolderLinksFragment$key; // Replace with actual type if available
+}
+
+const MountedVFolderLinks: React.FC<MountedVFolderLinksProps> = ({
+  sessionFrgmt,
+}) => {
+  const baiClient = useSuspendedBackendaiClient();
+
+  const session = useFragment(
+    graphql`
+      fragment MountedVFolderLinksFragment on ComputeSessionNode {
+        row_id
+        vfolder_nodes @since(version: "25.4.0") {
+          edges {
+            node {
+              ...FolderLink_vfolderNode
+            }
+          }
+        }
+        ...MountedVFolderLinksLegacyLazyFolderLinkFragment
+      }
+    `,
+    sessionFrgmt,
+  );
+
+  return baiClient.supports('vfolder_nodes_in_session_node') ? (
+    _.map(session.vfolder_nodes?.edges, (vfolder, idx) => {
+      return (
+        vfolder?.node && (
+          <FolderLink
+            key={`mounted-vfolder-${idx}`}
+            showIcon
+            vfolderNodeFragment={vfolder.node}
+            // TODO: For now, disable state using VirtualFolderNode permissions in FolderLink component.
+            // Currently shows Alert.error in Folder Explorer instead due to related bugs
+          />
+        )
+      );
+    })
+  ) : session.row_id ? (
+    // TODO: This part can be removed once compatibility with v25.4.0 is no longer needed.
+    <Suspense fallback={<Skeleton.Input size="small" active block />}>
+      <LegacyLazyMountedVFolderLinks sessionFrgmt={session} />
+    </Suspense>
+  ) : null;
+};
+
+export default MountedVFolderLinks;
+
+const LegacyLazyMountedVFolderLinks: React.FC<{
+  sessionFrgmt: MountedVFolderLinksLegacyLazyFolderLinkFragment$key;
+}> = ({ sessionFrgmt }) => {
+  const baiClient = useSuspendedBackendaiClient();
+  const session = useFragment(
+    graphql`
+      fragment MountedVFolderLinksLegacyLazyFolderLinkFragment on ComputeSessionNode {
+        row_id
+        vfolder_mounts
+      }
+    `,
+    sessionFrgmt,
+  );
+
+  const { legacy_session } = useLazyLoadQuery<MountedVFolderLinksQuery>(
+    graphql`
+      query MountedVFolderLinksQuery($uuid: UUID!) {
+        legacy_session: compute_session(id: $uuid) {
+          mounts
+        }
+      }
+    `,
+    {
+      uuid: session.row_id || '',
+    },
+    {
+      fetchPolicy: session.row_id ? 'store-and-network' : 'store-only',
+    },
+  );
+
+  return baiClient.supports('vfolder-mounts')
+    ? _.map(
+        // compute_session_node query's vfolder_mounts is not include name.
+        // To provide vfolder name in compute_session_node, schema must be changed.
+        // legacy_session.mounts (name) and session.vfolder_mounts (id) give vfolder information in same order.
+        _.zip(legacy_session?.mounts, session?.vfolder_mounts),
+        (mountInfo) => {
+          const [name, id] = mountInfo;
+          return (
+            <FolderLink
+              key={id}
+              folderId={id ?? ''}
+              folderName={name ?? ''}
+              showIcon
+            />
+          );
+        },
+      )
+    : legacy_session?.mounts?.join(', ');
+};

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -41,6 +41,7 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
         ...SessionReservationFragment
         ...SessionSlotCellFragment
         ...SessionUsageMonitorFragment
+        ...SessionDetailDrawerFragment
       }
     `,
     sessionsFrgmt,

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -637,6 +637,7 @@
     "FolderNotFoundOrNoAccess": "Ordner, der nicht gefunden oder zugänglich ist verweigert",
     "InputTooShort": "EingabeTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Nicht verwaltete Ordner unterstützen den Datei -Explorer nicht.",
+    "NoPermissions": "Keine Berechtigungen für den Zugriff auf diesen Ordner",
     "ValueRequired": "WertErforderlich"
   },
   "general": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -633,6 +633,7 @@
     "FolderNotFoundOrNoAccess": "Ο φάκελος δεν βρέθηκε ή απορρίφθηκε η πρόσβαση",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Οι μη διαχειριζόμενοι φάκελοι δεν υποστηρίζουν τον εξερευνητή αρχείων.",
+    "NoPermissions": "Δεν υπάρχουν δικαιώματα πρόσβασης σε αυτόν τον φάκελο",
     "ValueRequired": "Απαιτούμενη τιμή"
   },
   "general": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -641,6 +641,7 @@
     "FolderNotFoundOrNoAccess": "Folder not found or access denied",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Unmanaged folders do not support the file explorer.",
+    "NoPermissions": "No permissions to access this folder",
     "ValueRequired": "ValueRequired"
   },
   "general": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -637,6 +637,7 @@
     "FolderNotFoundOrNoAccess": "Carpeta no encontrada ni de acceso denegada",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Las carpetas no administradas no admiten el explorador de archivos.",
+    "NoPermissions": "No hay permisos para acceder a esta carpeta",
     "ValueRequired": "ValorRequerido"
   },
   "general": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -637,6 +637,7 @@
     "FolderNotFoundOrNoAccess": "Kansiota ei löydy tai pääsy kielletty",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Hallitsemattomat kansiot eivät tue tiedostotutkijaa.",
+    "NoPermissions": "Ei oikeuksia käyttää tätä kansiota",
     "ValueRequired": "ValueRequired"
   },
   "general": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -637,6 +637,7 @@
     "FolderNotFoundOrNoAccess": "Dossier non trouvé ou accès refusé",
     "InputTooShort": "Entrée Trop Courte",
     "NoExplorerSupportForUnmanagedFolder": "Les dossiers non gérés ne prennent pas en charge l'explorateur de fichiers.",
+    "NoPermissions": "Aucune autorisation pour accéder à ce dossier",
     "ValueRequired": "ValeurRequis"
   },
   "general": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -636,6 +636,7 @@
     "FolderNotFoundOrNoAccess": "Folder tidak ditemukan atau akses ditolak",
     "InputTooShort": "MasukanTerlaluPendek",
     "NoExplorerSupportForUnmanagedFolder": "Folder yang tidak dikelola tidak mendukung file explorer.",
+    "NoPermissions": "Tidak ada izin untuk mengakses folder ini",
     "ValueRequired": "NilaiDiperlukan"
   },
   "general": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -636,6 +636,7 @@
     "FolderNotFoundOrNoAccess": "Cartella non trovata o accesso negata",
     "InputTooShort": "Inputtroppo corto",
     "NoExplorerSupportForUnmanagedFolder": "Le cartelle non gestite non supportano l'esploratore dei file.",
+    "NoPermissions": "Nessuna autorizzazione per accedere a questa cartella",
     "ValueRequired": "ValoreRichiesto"
   },
   "general": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -636,6 +636,7 @@
     "FolderNotFoundOrNoAccess": "フォルダーが見つかりませんまたはアクセスが拒否されません",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "管理されていないフォルダーは、ファイルエクスプローラーをサポートしていません。",
+    "NoPermissions": "このフォルダーにアクセスする権限はありません",
     "ValueRequired": "ValueRequired"
   },
   "general": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -639,6 +639,7 @@
     "FolderNotFoundOrNoAccess": "존재하지 않거나 접근할 수 없는 폴더입니다.",
     "InputTooShort": "입력값이 너무 짧습니다.",
     "NoExplorerSupportForUnmanagedFolder": "Unmanaged 폴더는 파일 탐색기를 지원하지 않습니다.",
+    "NoPermissions": "이 폴더에 접근할 권한이 없습니다",
     "ValueRequired": "값이 필요합니다."
   },
   "general": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -635,6 +635,7 @@
     "FolderNotFoundOrNoAccess": "Фолдер олдсонгүй эсвэл хандалтыг үгүйсгэв",
     "InputTooShort": "Хэт богино байна",
     "NoExplorerSupportForUnmanagedFolder": "НҮБ-нээгүй хавтас нь файлын Explorer-ийг дэмждэггүй.",
+    "NoPermissions": "Энэ хавтсанд нэвтрэх зөвшөөрөл байхгүй байна",
     "ValueRequired": "Утга Шаардлагатай"
   },
   "general": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -636,6 +636,7 @@
     "FolderNotFoundOrNoAccess": "Folder tidak dijumpai atau akses ditolak",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Folder yang tidak dikendalikan tidak menyokong penjelajah fail.",
+    "NoPermissions": "Tiada kebenaran untuk mengakses folder ini",
     "ValueRequired": "Nilai Diperlukan"
   },
   "general": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -637,6 +637,7 @@
     "FolderNotFoundOrNoAccess": "Pasta não encontrada ou acesso negado",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Pastas não gerenciadas não suportam o File Explorer.",
+    "NoPermissions": "Sem permissões para acessar esta pasta",
     "ValueRequired": "ValueRequired"
   },
   "general": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -637,6 +637,7 @@
     "FolderNotFoundOrNoAccess": "Pasta não encontrada ou acesso negado",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Pastas não gerenciadas não suportam o File Explorer.",
+    "NoPermissions": "Sem permissões para acessar esta pasta",
     "ValueRequired": "ValueRequired"
   },
   "general": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -626,6 +626,7 @@
     "FolderNotFoundOrNoAccess": "ไม่พบโฟลเดอร์หรือถูกปฏิเสธการเข้าถึง",
     "InputTooShort": "ข้อมูลที่ป้อนสั้นเกินไป",
     "NoExplorerSupportForUnmanagedFolder": "โฟลเดอร์ที่ไม่มีการจัดการไม่รองรับ File Explorer",
+    "NoPermissions": "ไม่มีสิทธิ์ในการเข้าถึงโฟลเดอร์นี้",
     "ValueRequired": "ต้องระบุค่า"
   },
   "general": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -637,6 +637,7 @@
     "FolderNotFoundOrNoAccess": "Klasör bulunamadı veya erişim reddedildi",
     "InputTooShort": "GirişÇok Kısa",
     "NoExplorerSupportForUnmanagedFolder": "Yönetilmeyen klasörler Dosya Gezgini'ni desteklemez.",
+    "NoPermissions": "Bu klasöre erişmek için izin yok",
     "ValueRequired": "DeğerGerekli"
   },
   "general": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -637,6 +637,7 @@
     "FolderNotFoundOrNoAccess": "Thư mục không tìm thấy hoặc truy cập bị từ chối",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Các thư mục không được quản lý không hỗ trợ trình thám hiểm tệp.",
+    "NoPermissions": "Không có quyền truy cập thư mục này",
     "ValueRequired": "Giá trị bắt buộc"
   },
   "general": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -637,6 +637,7 @@
     "FolderNotFoundOrNoAccess": "未找到或拒绝访问的文件夹",
     "InputTooShort": "输入太短",
     "NoExplorerSupportForUnmanagedFolder": "未管理的文件夹不支持文件资源管理器。",
+    "NoPermissions": "无权访问此文件夹",
     "ValueRequired": "需要值"
   },
   "general": {

--- a/src/components/backend-ai-folder-explorer.ts
+++ b/src/components/backend-ai-folder-explorer.ts
@@ -786,12 +786,12 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
     const vfolder = allowedVFolders.find((vfolder) => {
       return vfolder.id === this.vfolderID;
     });
-    this.vfolderName = vfolder.name;
+    this.vfolderName = vfolder?.name;
     this.vfolder = globalThis.backendaiclient.supports('vfolder-id-based')
-      ? vfolder.id
-      : vfolder.name;
-    this.vhost = vfolder.host;
-    this.isWritable = vfolder.permission.includes('w');
+      ? vfolder?.id
+      : vfolder?.name;
+    this.vhost = vfolder?.host;
+    this.isWritable = vfolder?.permission?.includes('w');
 
     document.dispatchEvent(
       new CustomEvent('folderExplorer:connected', { detail: this.isWritable }),

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -785,6 +785,7 @@ class Client {
     }
     if (this.isManagerVersionCompatibleWith('25.4.0')) {
       this._features['resource-presets-per-resource-group'] = true;
+      this._features['vfolder_nodes_in_session_node'] = true;
     }
     if (this.isManagerVersionCompatibleWith('25.5.0')) {
       this._features['custom-accelerator-quantum-size'] = true;


### PR DESCRIPTION
# Improve Folder Explorer and Session Detail Drawer Performance

This PR enhances the folder explorer and session detail drawer with several improvements:

1. Added permissions field to folder explorer GraphQL query to prepare for permission-based access control
2. Created a new `MountedVFolderLinks` component to handle folder mounting display in sessions
3. Improved session detail drawer performance by:
   - Passing session fragment data via location state to avoid redundant fetches
   - Adding timestamp to determine when to refresh cached data
4. Added error handling for folders with no permissions
5. Added translations for "No permissions to access this folder" message in all supported languages

The changes optimize data fetching patterns and improve the user experience when viewing session details and folder contents.