### PR TITLE
fix(FR-1300): improve data page storage panel responsive layout

### DIFF
--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -276,7 +276,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
         align={'stretch'}
         style={{ minHeight: lg ? CARD_MIN_HEIGHT : undefined }}
       >
-        <Col xs={24} lg={8} xxl={4} style={{ display: 'flex' }}>
+        <Col xs={24} md={8} xl={4} style={{ display: 'flex' }}>
           <BAICard
             style={{
               width: '100%',
@@ -304,7 +304,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             />
           </BAICard>
         </Col>
-        <Col xs={24} lg={16} xxl={8} style={{ display: 'flex' }}>
+        <Col xs={24} md={16} xl={8} style={{ display: 'flex' }}>
           <Suspense
             fallback={
               <BAICard
@@ -333,7 +333,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             />
           </Suspense>
         </Col>
-        <Col xs={24} xxl={12} style={{ display: 'flex' }}>
+        <Col xs={24} md={24} xl={12} style={{ display: 'flex' }}>
           <Suspense
             fallback={
               <BAICard


### PR DESCRIPTION
Resolves #4018 ([FR-1300](https://lablup.atlassian.net/browse/FR-1300))

## Summary
Improves data page responsive layout by updating breakpoints from lg/xxl to md/xl system.

## Changes
- Updated all three panels' responsive breakpoints:
  - Panel 1: `xs={24} lg={8} xxl={4}` → `xs={24} md={8} xl={4}`
  - Panel 2: `xs={24} lg={16} xxl={8}` → `xs={24} md={16} xl={8}`  
  - Panel 3: `xs={24} lg={8} xxl={12}` → `xs={24} md={24} xl={12}`

## Result
- **Large screens (xl+)**: 3-column layout in single row
- **Medium screens (md-lg)**: 2-column layout (2 panels + 1 panel)
- **Small screens (xs-sm)**: single column layout

[FR-1300]: https://lablup.atlassian.net/browse/FR-1300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ