### PR TITLE
fix(FR-1301): remove improper key prop usage in SessionMetricGraph component

### DIFF
--- a/react/src/components/SessionMetricGraph.tsx
+++ b/react/src/components/SessionMetricGraph.tsx
@@ -62,14 +62,12 @@ interface PrometheusMetricGraphProps {
     userId: string;
     dayDiff: number;
   };
-  key: string;
   fetchKey: string;
   tooltip?: string | React.ReactNode;
 }
 
 const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
   queryProps: { startDate, endDate, metricName, userId, dayDiff },
-  key,
   fetchKey,
   tooltip,
 }) => {
@@ -185,7 +183,6 @@ const SessionMetricGraph: React.FC<PrometheusMetricGraphProps> = ({
 
   return (
     <Flex
-      key={key}
       direction="column"
       align="stretch"
       gap="sm"


### PR DESCRIPTION
Resolves #4020 ([FR-1301](https://lablup.atlassian.net/browse/FR-1301))

## Problem

The SessionMetricGraph component is causing a React warning: "`key` is not a prop. Trying to access it will result in `undefined` being returned."

## Root Cause

The component incorrectly defines `key` as a regular prop in its interface and tries to access it. In React, `key` is a reserved prop used internally for reconciliation and cannot be accessed as a regular prop within components.

## Solution

Remove the improper usage of the `key` prop:
- Remove `key` from the component's props interface
- Remove `key` parameter from function destructuring
- Remove redundant `key` usage in JSX elements

## Changes Made

- **react/src/components/SessionMetricGraph.tsx**: Removed `key: string` from `PrometheusMetricGraphProps` interface, removed `key` parameter from component function, and removed `key={key}` from Flex component JSX

## Impact

This fix eliminates console warnings and follows React best practices for prop handling.

## Testing

- [ ] No React key prop warnings in browser console
- [ ] SessionMetricGraph component functions correctly
- [ ] Code follows React prop conventions

[FR-1301]: https://lablup.atlassian.net/browse/FR-1301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ