### PR TITLE
feat(FR-1304): enhance PR workflow to auto-assign issues to active sprints

### DIFF
--- a/.claude/commands/create-pr-stack-for-stage.md
+++ b/.claude/commands/create-pr-stack-for-stage.md
@@ -38,8 +38,22 @@ The associated Jira issue is specified by `$ARGUMENTS`.
 - Ensure PR description includes `Resolves #YYYY ([FR-XXXX](https://lablup.atlassian.net/browse/FR-XXXX))` on top. (YYYY is a number of "GitHub Issue URL" custom filed in related Jira item)
 
 6. **Update Jira issue after PR creation**
-   - If Sprint is empty, assign it to the currently active sprint in the project
+   - If Sprint is empty, find and assign it to the currently active (open) sprint in the FR project
    - If Assignee is empty, assign it to the current Jira MCP connected account
+   - Use Atlassian MCP commands to update the issue:
+     ```
+     # First, get current user info for assignee
+     mcp__Atlassian__atlassianUserInfo
+     
+     # Search for issues in active sprint to find the sprint ID
+     mcp__Atlassian__searchJiraIssuesUsingJql with JQL:
+     "project = FR AND sprint in openSprints() ORDER BY created DESC"
+     
+     # Update the issue with sprint and assignee
+     mcp__Atlassian__editJiraIssue with fields:
+     - customfield_10020: sprint_id (Sprint field - use numeric ID only)
+     - assignee: {accountId: "user_account_id"}
+     ```
 
 ## Example Workflow
 ```bash


### PR DESCRIPTION
Resolves #4026 ([FR-1304](https://lablup.atlassian.net/browse/FR-1304))

## Summary
This PR enhances the Claude Code PR creation workflow to automatically assign newly created Jira issues to the currently active sprint in the FR project, improving workflow efficiency.

## Changes
- ✅ Enhanced `/create-pr-stack-for-stage` command documentation
- ✅ Added Atlassian MCP integration instructions for automatic sprint assignment
- ✅ Specified correct sprint field format (`customfield_10020` with numeric ID)
- ✅ Added JQL query examples for finding active sprints
- ✅ Included step-by-step MCP command usage for user and sprint assignment

## Technical Implementation
- Integrates `mcp__Atlassian__searchJiraIssuesUsingJql` for active sprint detection
- Uses `mcp__Atlassian__editJiraIssue` for automatic issue assignment
- Maintains backward compatibility with existing workflow

## Benefits
- Eliminates manual sprint assignment steps
- Improves development workflow efficiency
- Ensures proper organization of work items within sprint planning
- Provides comprehensive documentation for MCP integration

## Testing
- [x] Command documentation updated with correct field formats
- [x] MCP command integration tested and verified
- [x] Sprint auto-assignment functionality validated

[FR-1304]: https://lablup.atlassian.net/browse/FR-1304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ