### PR TITLE
feat(FR-1313): improve inline code rendering and styling in ChatMessageContent

### DIFF
--- a/react/src/components/Chat/ChatMessageContent.tsx
+++ b/react/src/components/Chat/ChatMessageContent.tsx
@@ -62,12 +62,18 @@ CodeHead.displayName = 'CodeHead';
 
 const ChatMessageContentBlock = memo<{ block?: string; isStreaming?: boolean }>(
   ({ block, isStreaming }) => {
+    const renderPre = useCallback((props: React.HTMLProps<HTMLPreElement>) => {
+      return <pre {...props} style={{ overflow: 'auto' }} />;
+    }, []);
+
     const renderCode = useCallback(
       (props: any) => {
         const { children, className, node, ref, ...rest } = props;
         const match = /language-(\w+)/.exec(className || '');
         const content = String(children ?? '').replace(/\n$/, '');
         const { token } = theme.useToken();
+
+        const isOneLine = node.position?.start?.line === node.position?.end?.line || false;
 
         return match ? (
           <Flex
@@ -114,24 +120,25 @@ const ChatMessageContentBlock = memo<{ block?: string; isStreaming?: boolean }>(
             </Flex>
           </Flex>
         ) : (
-          <Flex
+          <code
+            {...rest}
             style={{
-              width: '100%',
-              padding: token.paddingSM,
-              borderRadius: `0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px`,
-              margin: '-0.5em 0',
-              overflow: 'scroll',
+              whiteSpace: 'pre-wrap',
+              ...(isOneLine
+                ? {
+                    backgroundColor: token.colorBgContainerDisabled,
+                    border: `1px solid ${token.colorBorder}`,
+                    padding: '2px 6px',
+                    borderRadius: token.borderRadiusSM,
+                    fontSize: '0.875em',
+                  }
+                : {}),
             }}
+            className={className}
           >
-            <code
-              {...rest}
-              style={{ whiteSpace: 'pre-wrap' }}
-              className={className}
-            >
-              {/* @ts-ignore */}
-              {children}
-            </code>
-          </Flex>
+            {/* @ts-ignore */}
+            {children}
+          </code>
         );
       },
       [isStreaming],
@@ -145,7 +152,7 @@ const ChatMessageContentBlock = memo<{ block?: string; isStreaming?: boolean }>(
       <Markdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex]}
-        components={{ p: renderParagraph, code: renderCode }}
+        components={{ p: renderParagraph, code: renderCode, pre: renderPre }}
       >
         {block}
       </Markdown>


### PR DESCRIPTION
Resolves #4041 ([FR-1313](https://lablup.atlassian.net/browse/FR-1313))

Fix a rendering bug in ChatMessageContent component where inline code was not properly displayed and was causing content below it to be hidden or overlapped.

## Problem
- Inline code snippets were not rendering correctly in chat messages
- Code content was being wrapped in unnecessary Flex containers
- Content below inline code was being hidden or overlapped
- Poor visual distinction between inline code and code blocks

## Solution
- Remove unnecessary Flex wrapper for inline code
- Apply proper styling for single-line inline code (background, border, padding)  
- Add overflow handling for code blocks with `renderPre` callback
- Improve visual distinction between inline and block code

## Changes
- Added `renderPre` callback with overflow auto styling
- Enhanced `renderCode` to differentiate single-line vs multi-line code
- Applied special styling for single-line inline code (background, border, padding)
- Simplified multi-line code block rendering


|  Before  | After    |
|---------|--------|
|    ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/a6f6c47c-c4fe-4a5f-a1d0-5d31faa3e29e.png)    |     ![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/XqC2uNFuj0wg8I60sMUh/af63507f-1ed3-489c-9a42-fb3d98b330c3.png) |

[FR-1313]: https://lablup.atlassian.net/browse/FR-1313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ