### PR TITLE
fix(FR-1320): prevent sending empty system prompt in Chat API requests

### DIFF
--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -260,7 +260,7 @@ const PureChatCard: React.FC<ChatCardProps> = ({
             middleware: extractReasoningMiddleware({ tagName: 'think' }),
           }),
           messages: body?.messages,
-          system: agent ? (agent.config.system_prompt ?? '') : '',
+          system: agent?.config.system_prompt || undefined,
           ...(chat.usingParameters ? chat.parameters : {}),
         });
 


### PR DESCRIPTION
Resolves #4052 ([FR-1320](https://lablup.atlassian.net/browse/FR-1320))

## Summary
Fixes Chat system prompt compatibility issue with vision models by preventing empty system prompt from being sent in API requests.

## Changes
- Modified react/src/components/Chat/ChatCard.tsx to use undefined instead of empty string for system prompt when no agent is selected
- This ensures the system field is omitted from the API request payload entirely when empty

## Background
When no agent is selected in the Chat feature, an empty string was being sent as the system prompt parameter, causing compatibility issues with certain AI models like Llama 3 Vision which throw errors when receiving empty system prompts.

[FR-1320]: https://lablup.atlassian.net/browse/FR-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ