### PR TITLE
feat(FR-1331): setup Jest testing environment for BAIFlex component

### DIFF
--- a/packages/backend.ai-ui/package.json
+++ b/packages/backend.ai-ui/package.json
@@ -57,10 +57,10 @@
     "@ant-design/icons": "^5.6.1",
     "ahooks": "^3.8.4",
     "antd": "^5.24.5",
-    "big.js": "^7.0.1",
-    "dayjs": "^1.11.13",
     "antd-style": "^3.7.1",
+    "big.js": "^7.0.1",
     "classnames": "^2.5.1",
+    "dayjs": "^1.11.13",
     "graphql": "^16.10.0",
     "i18next": "^24.2.3",
     "lodash": "^4.17.21",
@@ -69,8 +69,8 @@
     "react-dom": "^19.0.0",
     "react-i18next": "^15.4.1",
     "react-relay": "^20.1.0",
-    "relay-runtime": "^20.1.0",
-    "react-resizable": "^3.0.5"
+    "react-resizable": "^3.0.5",
+    "relay-runtime": "^20.1.0"
   },
   "devDependencies": {
     "@jest/expect": "30.0.0-beta.3",
@@ -81,6 +81,7 @@
     "@storybook/addon-links": "^8.4.5",
     "@storybook/addon-onboarding": "^9.0.0",
     "@storybook/react-vite": "^9.0.0",
+    "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@types/big.js": "^6.2.2",
     "@types/lodash": "^4.17.13",
@@ -99,6 +100,7 @@
     "fast-glob": "^3.3.3",
     "graphql": "^16.10.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "storybook": "^9.0.0",
     "ts-jest": "^29.2.5",
     "tus-js-client": "^4.1.0",
@@ -125,6 +127,10 @@
           }
         }
       ]
-    }
+    },
+    "setupFilesAfterEnv": [
+      "./setupTests.ts"
+    ],
+    "testEnvironment": "jsdom"
   }
 }

--- a/packages/backend.ai-ui/setupTests.ts
+++ b/packages/backend.ai-ui/setupTests.ts
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+import '@testing-library/jest-dom';

--- a/packages/backend.ai-ui/src/components/BAIFlex.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIFlex.test.tsx
@@ -1,0 +1,65 @@
+import BAIFlex from './BAIFlex';
+import { describe, expect, test, jest } from '@jest/globals';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+// Mock antd's theme hook
+jest.mock('antd', () => ({
+  theme: {
+    useToken: () => ({
+      token: {
+        sizeXXS: 4,
+        sizeXS: 8,
+        sizeSM: 12,
+        sizeMS: 16,
+        sizeMD: 20,
+        sizeLG: 24,
+        sizeXL: 32,
+        sizeXXL: 48,
+      },
+    }),
+  },
+}));
+
+describe('BAIFlex', () => {
+  test('default render', () => {
+    const { baseElement } = render(<BAIFlex />);
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  test('render with custom props', () => {
+    const { baseElement } = render(
+      <BAIFlex
+        direction="column"
+        wrap="wrap-reverse"
+        justify="center"
+        align="start"
+        gap="sm"
+        style={{ backgroundColor: 'blue' }}
+      />,
+    );
+    expect(baseElement).toMatchSnapshot();
+  });
+
+  test('render with children', () => {
+    const { baseElement } = render(
+      <BAIFlex>
+        <div data-testid="firstChildComponent">
+          <h1> First Child </h1>
+          <div data-testid="nestedChildComponent">
+            <h1> Nested Child </h1>
+          </div>
+        </div>
+        <div data-testid="secondChildComponent">
+          <h1> Second Child </h1>
+        </div>
+      </BAIFlex>,
+    );
+    expect(screen.getByTestId('firstChildComponent')).toBeInTheDocument();
+    expect(screen.getByTestId('secondChildComponent')).toBeInTheDocument();
+    expect(screen.getByTestId('nestedChildComponent')).toBeInTheDocument();
+
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/packages/backend.ai-ui/src/components/__snapshots__/BAIFlex.test.tsx.snap
+++ b/packages/backend.ai-ui/src/components/__snapshots__/BAIFlex.test.tsx.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BAIFlex default render 1`] = `
+<body>
+  <div>
+    <div
+      style="align-items: center; border: 0px solid black; box-sizing: border-box; display: flex; flex-basis: auto; flex-direction: row; flex-shrink: 0; list-style: none; margin: 0px; min-height: 0; min-width: 0; padding: 0px; position: relative; text-decoration: none; gap: 0; flex-wrap: nowrap; justify-content: flex-start;"
+    />
+  </div>
+</body>
+`;
+
+exports[`BAIFlex render with children 1`] = `
+<body>
+  <div>
+    <div
+      style="align-items: center; border: 0px solid black; box-sizing: border-box; display: flex; flex-basis: auto; flex-direction: row; flex-shrink: 0; list-style: none; margin: 0px; min-height: 0; min-width: 0; padding: 0px; position: relative; text-decoration: none; gap: 0; flex-wrap: nowrap; justify-content: flex-start;"
+    >
+      <div
+        data-testid="firstChildComponent"
+      >
+        <h1>
+           First Child 
+        </h1>
+        <div
+          data-testid="nestedChildComponent"
+        >
+          <h1>
+             Nested Child 
+          </h1>
+        </div>
+      </div>
+      <div
+        data-testid="secondChildComponent"
+      >
+        <h1>
+           Second Child 
+        </h1>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`BAIFlex render with custom props 1`] = `
+<body>
+  <div>
+    <div
+      style="align-items: flex-start; border: 0px solid black; box-sizing: border-box; display: flex; flex-basis: auto; flex-direction: column; flex-shrink: 0; list-style: none; margin: 0px; min-height: 0; min-width: 0; padding: 0px; position: relative; text-decoration: none; gap: 12px; flex-wrap: wrap-reverse; justify-content: center; background-color: blue;"
+    />
+  </div>
+</body>
+`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,10 +472,10 @@ importers:
         version: 0.484.0(react@19.0.0)
       react:
         specifier: ^19.0.0
-        version: 19.0.0
+        version: 18.3.1
       react-dom:
         specifier: ^19.0.0
-        version: 19.0.0(react@19.0.0)
+        version: 18.3.1(react@18.3.1)
       react-i18next:
         specifier: ^15.4.1
         version: 15.4.1(i18next@24.2.3(typescript@5.8.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -506,16 +506,19 @@ importers:
         version: 8.4.5(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))
       '@storybook/addon-links':
         specifier: ^8.4.5
-        version: 8.4.5(react@19.0.0)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))
+        version: 8.4.5(react@18.3.1)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))
       '@storybook/addon-onboarding':
         specifier: ^9.0.0
         version: 9.0.0(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))
       '@storybook/react-vite':
         specifier: ^9.0.0
-        version: 9.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.41.1)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(typescript@5.8.2)(vite@6.3.5(@types/node@22.4.1)(jiti@1.21.6)(terser@5.31.4)(yaml@2.5.0))
+        version: 9.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(typescript@5.8.2)(vite@6.3.5(@types/node@22.4.1)(jiti@1.21.6)(terser@5.31.4)(yaml@2.5.0))
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.6.3
       '@testing-library/react':
         specifier: ^16.2.0
-        version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/big.js':
         specifier: ^6.2.2
         version: 6.2.2
@@ -539,7 +542,7 @@ importers:
         version: 4.5.0(vite@6.3.5(@types/node@22.4.1)(jiti@1.21.6)(terser@5.31.4)(yaml@2.5.0))
       ahooks:
         specifier: ^3.8.4
-        version: 3.8.4(react@19.0.0)
+        version: 3.8.4(react@18.3.1)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -567,6 +570,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.4.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.4.1)(typescript@5.8.2))
+      jest-environment-jsdom:
+        specifier: ^29.7.0
+        version: 29.7.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
       storybook:
         specifier: ^9.0.0
         version: 9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)
@@ -22334,20 +22340,20 @@ snapshots:
       storybook: 9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)
       ts-dedent: 2.2.0
 
+  '@storybook/addon-links@8.4.5(react@18.3.1)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))':
+    dependencies:
+      '@storybook/csf': 0.1.11
+      '@storybook/global': 5.0.0
+      storybook: 9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      react: 18.3.1
+
   '@storybook/addon-links@8.4.5(react@19.0.0)(storybook@8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))':
     dependencies:
       '@storybook/csf': 0.1.11
       '@storybook/global': 5.0.0
       storybook: 8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)
-      ts-dedent: 2.2.0
-    optionalDependencies:
-      react: 19.0.0
-
-  '@storybook/addon-links@8.4.5(react@19.0.0)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))':
-    dependencies:
-      '@storybook/csf': 0.1.11
-      '@storybook/global': 5.0.0
-      storybook: 9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 19.0.0
@@ -22646,23 +22652,29 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       storybook: 8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)
 
+  '@storybook/react-dom-shim@9.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)
+
   '@storybook/react-dom-shim@9.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))':
     dependencies:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       storybook: 9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)
 
-  '@storybook/react-vite@9.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rollup@4.41.1)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(typescript@5.8.2)(vite@6.3.5(@types/node@22.4.1)(jiti@1.21.6)(terser@5.31.4)(yaml@2.5.0))':
+  '@storybook/react-vite@9.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.41.1)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(typescript@5.8.2)(vite@6.3.5(@types/node@22.4.1)(jiti@1.21.6)(terser@5.31.4)(yaml@2.5.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.0(typescript@5.8.2)(vite@6.3.5(@types/node@22.4.1)(jiti@1.21.6)(terser@5.31.4)(yaml@2.5.0))
       '@rollup/pluginutils': 5.1.4(rollup@4.41.1)
       '@storybook/builder-vite': 9.0.0(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(vite@6.3.5(@types/node@22.4.1)(jiti@1.21.6)(terser@5.31.4)(yaml@2.5.0))
-      '@storybook/react': 9.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(typescript@5.8.2)
+      '@storybook/react': 9.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(typescript@5.8.2)
       find-up: 5.0.0
       magic-string: 0.30.17
-      react: 19.0.0
+      react: 18.3.1
       react-docgen: 8.0.0
-      react-dom: 19.0.0(react@19.0.0)
+      react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.10
       storybook: 9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)
       tsconfig-paths: 4.2.0
@@ -22707,12 +22719,12 @@ snapshots:
       '@storybook/test': 8.6.10(storybook@8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))
       typescript: 5.7.2
 
-  '@storybook/react@9.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(typescript@5.8.2)':
+  '@storybook/react@9.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(typescript@5.8.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
+      '@storybook/react-dom-shim': 9.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       storybook: 9.0.0(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)
     optionalDependencies:
       typescript: 5.8.2
@@ -23004,12 +23016,22 @@ snapshots:
   '@testing-library/jest-dom@6.6.3':
     dependencies:
       '@adobe/css-tools': 4.4.1
-      aria-query: 5.3.0
+      aria-query: 5.3.2
       chalk: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
+
+  '@testing-library/react@16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.27.0
+      '@testing-library/dom': 10.4.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
 
   '@testing-library/react@16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
@@ -24753,6 +24775,19 @@ snapshots:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
+
+  ahooks@3.8.4(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.27.0
+      dayjs: 1.11.13
+      intersection-observer: 0.12.2
+      js-cookie: 3.0.5
+      lodash: 4.17.21
+      react: 18.3.1
+      react-fast-compare: 3.2.2
+      resize-observer-polyfill: 1.5.1
+      screenfull: 5.2.0
+      tslib: 2.8.1
 
   ahooks@3.8.4(react@19.0.0):
     dependencies:

--- a/react/tsconfig.json
+++ b/react/tsconfig.json
@@ -22,5 +22,10 @@
       "backend.ai-ui/dist/locale/*": ["../packages/backend.ai-ui/src/locale/*"]
     }
   },
-  "include": ["src", "../packages/backend.ai-ui/src"]
+  "include": ["src", "../packages/backend.ai-ui/src"],
+  "exclude": [
+    "../packages/backend.ai-ui/src/**/*.test.*",
+    "../packages/backend.ai-ui/src/**/*.stories.*",
+    "../packages/backend.ai-ui/src/**/*.spec.*"
+  ]
 }


### PR DESCRIPTION
Resolves #4069 ([FR-1331](https://lablup.atlassian.net/browse/FR-1331))

This PR sets up Jest testing environment to support testing of React components in the backend.ai-ui package, specifically for the BAIFlex component.

## Background

The backend.ai-ui package needs proper testing infrastructure to ensure component reliability and maintainability. This includes setting up Jest with proper DOM testing capabilities and implementing comprehensive tests for the BAIFlex component.

## Changes

* Configure Jest testing environment with jsdom support in package.json
* Add setupTests.ts file with jest-dom extensions
* Implement comprehensive unit tests for BAIFlex component with various scenarios:
  - Default render
  - Custom props (direction, wrap, justify, align, gap, style)
  - Children components
* Move and update test snapshots for the renamed component (Flex → BAIFlex)
* Update pnpm-lock.yaml with new testing dependencies
* Update tsconfig.json configuration

## Test Coverage

The BAIFlex component now has comprehensive test coverage including:
- Default render behavior
- Custom prop combinations
- Child component rendering
- Snapshot testing for regression detection

## Acceptance Criteria

- [x] Jest configuration is properly set up in package.json
- [x] setupTests.ts file configures testing environment with jest-dom extensions
- [x] BAIFlex component has comprehensive test coverage including default render, custom props, and children scenarios
- [x] Test snapshots are correctly maintained for component regression testing

[FR-1331]: https://lablup.atlassian.net/browse/FR-1331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ