### PR TITLE
fix(FR-1332): remove try-catch wrapper from use hook in useConnectedBAIClient

### DIFF
--- a/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useConnectedBAIClient.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIClientProvider/hooks/useConnectedBAIClient.ts
@@ -3,17 +3,12 @@ import { BAIClient } from '../types';
 import { use, useContext } from 'react';
 
 const useConnectedBAIClient = (): BAIClient => {
-  try {
-    const baiClientPromise = useContext(BAIClientContext);
-    if (!baiClientPromise) {
-      throw new Error('useBAIClient must be used within a BAIClientProvider');
-    }
-    const baiClient = use(baiClientPromise);
-    return baiClient;
-  } catch (error) {
-    console.error('Error using BAI Client:', error);
-    throw error;
+  const baiClientPromise = useContext(BAIClientContext);
+  if (!baiClientPromise) {
+    throw new Error('useBAIClient must be used within a BAIClientProvider');
   }
+  const baiClient = use(baiClientPromise);
+  return baiClient;
 };
 
 export default useConnectedBAIClient;


### PR DESCRIPTION
### Simplify error handling in useConnectedBAIClient hook

Removes the try-catch block from the `useConnectedBAIClient` hook, simplifying the code while maintaining the same functionality. The error handling was redundant since React's error boundaries would catch any errors thrown during the hook's execution.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after