### PR TITLE
e2e(FR-1337): refactor brokend e2e test of vfolder and add auto mount vfolder test case

### DIFF
--- a/e2e/.eslintrc.json
+++ b/e2e/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "root": true,
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:relay/recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "settings": {
+    "react": {
+      "version": "^19.0.0"
+    }
+  },
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["relay", "import", "@typescript-eslint"],
+  "rules": {
+    "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off",
+    "import/no-duplicates": "error",
+    "relay/graphql-syntax": "off",
+    "relay/unused-fields": "off",
+    "relay/must-colocate-fragment-spreads": "off",
+    "@typescript-eslint/no-explicit-any": "off"
+  }
+}

--- a/e2e/utils/classes/FolderCreationModal.ts
+++ b/e2e/utils/classes/FolderCreationModal.ts
@@ -122,9 +122,14 @@ export class FolderCreationModal {
 
   async getModelUsageModeRadio(): Promise<Locator> {
     const usageModeFormItem = await this.getUsageModeFormItem();
-    return usageModeFormItem.getByLabel('Model', {
+    return usageModeFormItem.getByLabel('Models', {
       exact: true,
     });
+  }
+
+  async getAutoMountUsageModeRadio(): Promise<Locator> {
+    const usageModeFormItem = await this.getUsageModeFormItem();
+    return usageModeFormItem.getByLabel('Auto Mount', { exact: true });
   }
 
   async getUserTypeRadio(): Promise<Locator> {
@@ -150,7 +155,7 @@ export class FolderCreationModal {
 
   async getReadOnlyPermissionRadio(): Promise<Locator> {
     const permissionFormItem = await this.getPermissionFormItem();
-    return permissionFormItem.getByLabel('Read Only', {
+    return permissionFormItem.getByLabel('Read only', {
       exact: true,
     });
   }

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -1,12 +1,5 @@
 import TOML from '@iarna/toml';
-import {
-  APIRequestContext,
-  Locator,
-  Page,
-  Request,
-  expect,
-  request,
-} from '@playwright/test';
+import { APIRequestContext, Locator, Page, expect } from '@playwright/test';
 
 export const webuiEndpoint = 'http://127.0.0.1:9081';
 export const webServerEndpoint = 'http://127.0.0.1:8090';
@@ -180,7 +173,7 @@ export async function moveToTrashAndVerify(page: Page, folderName: string) {
   await searchInput.fill(folderName);
   await page.getByRole('button', { name: 'search' }).click();
   await page
-    .getByRole('row', { name: 'VFolder Identicon e2e-test-' })
+    .getByRole('row', { name: `VFolder Identicon ${folderName}` })
     .getByRole('button')
     .nth(1)
     .click();
@@ -200,7 +193,7 @@ export async function deleteForeverAndVerifyFromTrash(
   await page.getByRole('button', { name: 'search' }).click();
   // Delete forever
   await page
-    .getByRole('row', { name: 'VFolder Identicon e2e-test-' })
+    .getByRole('row', { name: `VFolder Identicon ${folderName}` })
     .getByRole('button')
     .nth(1)
     .click();

--- a/e2e/vfolder.test.ts
+++ b/e2e/vfolder.test.ts
@@ -87,12 +87,26 @@ test.describe('VFolder ', () => {
       await (await folderCreationModal.getCreateButton()).click();
     });
   });
-  test('User can create and delete, delete forever vFolder', async ({
-    page,
-  }) => {
-    await createVFolderAndVerify(page, folderName);
-    await moveToTrashAndVerify(page, folderName);
-    await deleteForeverAndVerifyFromTrash(page, folderName);
+  test.describe('Auto Mount vFolder Creation', () => {
+    const folderName = '.e2e-test-folder-auto-mount' + new Date().getTime();
+    test.beforeEach(async ({ page }) => {
+      await page.getByRole('link', { name: 'Data' }).click();
+      await page.getByRole('button', { name: 'Create Folder' }).nth(1).click();
+    });
+    test.afterEach(async ({ page }) => {
+      await moveToTrashAndVerify(page, folderName);
+      await deleteForeverAndVerifyFromTrash(page, folderName);
+    });
+    test('User can create Auto Mount vFolder', async ({ page }) => {
+      const folderCreationModal = new FolderCreationModal(page);
+      await folderCreationModal.modalToBeVisible();
+      await folderCreationModal.fillFolderName(folderName);
+      await (await folderCreationModal.getAutoMountUsageModeRadio()).check();
+      await expect(
+        await folderCreationModal.getAutoMountUsageModeRadio(),
+      ).toBeChecked();
+      await (await folderCreationModal.getCreateButton()).click();
+    });
   });
 
   test('User can create, delete(move to trash), restore, delete forever vFolder', async ({


### PR DESCRIPTION
resolves #4086 [(FR-1337)](https://lablup.atlassian.net/browse/FR-1337) (FR-1338)
# Add ESLint configuration for e2e tests and update folder creation tests

This PR adds an ESLint configuration file for the e2e test directory and updates the folder creation tests to support Auto Mount folders. It also fixes several UI label references in the test utilities to match the actual UI text.

Changes include:
- Added new `.eslintrc.json` configuration for e2e tests
- Updated label references in `FolderCreationModal.ts` from "Model" to "Models" and "Read Only" to "Read only"
- Added a new method `getAutoMountUsageModeRadio()` to support Auto Mount folder testing
- Fixed folder name references in trash verification functions to use the actual folder name
- Added a test case for Auto Mount vFolder creation
- Added logic to handle cleanup of Auto Mount folders

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after