### PR TITLE
e2e(FR-1337): refactor broken e2e test of session and create a class for start page

### DIFF
--- a/e2e/session.test.ts
+++ b/e2e/session.test.ts
@@ -1,10 +1,11 @@
+import { StartPage } from './utils/classes/StartPage';
 import {
   deleteSession,
   loginAsAdmin,
   loginAsUser,
   navigateTo,
 } from './utils/test-util';
-import { getCardItemByCardTitle, getMenuItem } from './utils/test-util-antd';
+import { getMenuItem } from './utils/test-util-antd';
 import { test, expect, Page } from '@playwright/test';
 
 const getStartSessionButton = (page: Page) => {
@@ -119,16 +120,16 @@ test.describe('Session Creation', () => {
   test('User can create interactive session on the Start page', async ({
     page,
   }) => {
-    // move to start page
-    await getMenuItem(page, 'start').click();
+    const startPage = new StartPage(page);
+    await startPage.goto();
     await expect(page).toHaveURL(/\/start/);
-    // click Start Session button and move to session start page
-    const card = getCardItemByCardTitle(page, 'Start Interactive Session');
-    expect(card).toBeVisible();
-    const creationButton = card.getByRole('button', {
-      name: 'Start Session',
-    });
+    const interactiveSessionCard = startPage.getInteractiveSessionCard();
+    await expect(interactiveSessionCard).toBeVisible();
+    const creationButton = startPage.getStartButtonFromCard(
+      interactiveSessionCard,
+    );
     await creationButton.click();
+
     await expect(page).toHaveURL(/\/session\/start/);
     await page.waitForLoadState('networkidle');
     // interactive radio button is selected by default
@@ -150,15 +151,12 @@ test.describe('Session Creation', () => {
   });
 
   test('User can create batch session on the Start page', async ({ page }) => {
-    // move to start page
-    await getMenuItem(page, 'start').click();
+    const startPage = new StartPage(page);
+    await startPage.goto();
     await expect(page).toHaveURL(/\/start/);
-    // click Start Session button and move to session start page
-    const card = getCardItemByCardTitle(page, 'Start Batch Session');
-    expect(card).toBeVisible();
-    const creationButton = card.getByRole('button', {
-      name: 'Start Session',
-    });
+    const batchSessionCard = startPage.getBatchSessionCard();
+    await expect(batchSessionCard).toBeVisible();
+    const creationButton = startPage.getStartButtonFromCard(batchSessionCard);
     await creationButton.click();
     await expect(page).toHaveURL(/\/session\/start/);
     await page.waitForLoadState('networkidle');

--- a/e2e/utils/classes/StartPage.ts
+++ b/e2e/utils/classes/StartPage.ts
@@ -1,0 +1,33 @@
+import { getMenuItem } from '../test-util-antd';
+import { Locator, Page } from '@playwright/test';
+
+export class StartPage {
+  private readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async goto(): Promise<void> {
+    await getMenuItem(this.page, 'Start').click();
+  }
+
+  private getCardByTitle(title: string) {
+    return this.page.locator(`.bai_grid_item:has-text("${title}")`);
+  }
+  getStorageFolderCard() {
+    return this.getCardByTitle('Create New Storage Folder');
+  }
+  getInteractiveSessionCard() {
+    return this.getCardByTitle('Start Interactive Session');
+  }
+  getBatchSessionCard() {
+    return this.getCardByTitle('Start Batch Session');
+  }
+  getModelServiceCard() {
+    return this.getCardByTitle('Start Model Service');
+  }
+  getStartButtonFromCard(card: Locator) {
+    return card.getByRole('button', { name: 'Start' });
+  }
+}


### PR DESCRIPTION
resolves #4088 (FR-1337) (FR-1341)

# Refactor Start Page in E2E Tests with Page Object Model

This PR introduces a new `StartPage` class that implements the Page Object Model pattern for E2E tests. The class encapsulates the functionality of the Start page, providing methods to navigate to the page and interact with its various card elements.

The implementation:
- Creates a new `StartPage` class with methods to access different cards (Interactive Session, Batch Session, etc.)
- Refactors existing session tests to use this new class
- Improves test readability by abstracting page interaction details

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after