### PR TITLE
feat(FR-1334): implement drag-and-drop file upload functionality

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -350,13 +350,17 @@ const BAITable = <RecordType extends object = any>({
             }
           }
         }}
-        pagination={{
-          style: {
-            display: 'none', // Hide default pagination as we're using custom Pagination component below
-          },
-          current: currentPage,
-          pageSize: currentPageSize,
-        }}
+        pagination={
+          tableProps.pagination === false
+            ? false
+            : {
+                style: {
+                  display: 'none', // Hide default pagination as we're using custom Pagination component below
+                },
+                current: currentPage,
+                pageSize: currentPageSize,
+              }
+        }
       />
       {tableProps.pagination !== false && (
         <BAIFlex justify="end" gap={'xs'}>

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/DragAndDrop.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/DragAndDrop.tsx
@@ -1,0 +1,56 @@
+import { useUploadVFolderFiles } from './hooks';
+import { InboxOutlined } from '@ant-design/icons';
+import { theme, Typography, Upload } from 'antd';
+import { RcFile } from 'antd/es/upload';
+import { useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+
+interface DragAndDropProps {
+  onUpload: (files: Array<RcFile>, currentPath: string) => void;
+  /** Optional container element for portal rendering */
+  portalContainer?: HTMLElement | null;
+}
+
+const DragAndDrop: React.FC<DragAndDropProps> = ({
+  onUpload,
+  portalContainer,
+}) => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { uploadFiles } = useUploadVFolderFiles();
+  const lastFileListRef = useRef<Array<RcFile>>([]);
+
+  const overlay = (
+    <Upload.Dragger
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: token.zIndexPopupBase + 1,
+        backdropFilter: 'blur(4px)',
+        borderWidth: 3,
+      }}
+      multiple
+      directory
+      showUploadList={false}
+      beforeUpload={(_, fileList) => {
+        if (fileList !== lastFileListRef.current) {
+          uploadFiles(fileList, onUpload);
+        }
+        lastFileListRef.current = fileList;
+        return false;
+      }}
+    >
+      <p>
+        <InboxOutlined style={{ fontSize: token.fontSizeHeading1 }} />
+      </p>
+      <Typography.Text style={{ fontSize: token.fontSizeHeading4 }}>
+        {t('comp:FileExplorer.DragAndDropDesc')}
+      </Typography.Text>
+    </Upload.Dragger>
+  );
+
+  return portalContainer ? createPortal(overlay, portalContainer) : overlay;
+};
+
+export default DragAndDrop;

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} von {{total}} Elementen"
   },
-  "comp:BAITable": {
-    "SettingTable": "Tabelleneinstellungen",
-    "SelectColumnToDisplay": "Wählen Sie Spalten aus, um angezeigt zu werden",
-    "SearchTableColumn": "Suchtabellenspalten"
-  },
   "error": {
     "UnknownError": "Ein unbekannter Fehler ist aufgetreten. \nBitte versuchen Sie es erneut."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "Die Dateigröße überschreitet die Hochladungsgrenze."
     },
     "DuplicatedFilesDesc": "Die Datei oder der Ordner mit demselben Namen existieren bereits. \nMöchten Sie überschreiben?",
-    "DuplicatedFiles": "Überschreibung der Bestätigung"
+    "DuplicatedFiles": "Überschreibung der Bestätigung",
+    "DragAndDropDesc": "Ziehen Sie Dateien in diesen Bereich zum Hochladen."
+  },
+  "comp:BAITable": {
+    "SettingTable": "Tabelleneinstellungen",
+    "SelectColumnToDisplay": "Wählen Sie Spalten aus, um angezeigt zu werden",
+    "SearchTableColumn": "Suchtabellenspalten"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Suche",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} των στοιχείων {{total}}"
   },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Επιλέξτε στήλες για εμφάνιση",
-    "SearchTableColumn": "Στήλες πίνακα αναζήτησης",
-    "SettingTable": "Ρυθμίσεις πίνακα"
-  },
   "error": {
     "UnknownError": "Παρουσιάστηκε ένα άγνωστο σφάλμα. \nΔοκιμάστε ξανά."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "Το μέγεθος του αρχείου υπερβαίνει το όριο μεγέθους μεταφόρτωσης."
     },
     "DuplicatedFilesDesc": "Το αρχείο ή ο φάκελος με το ίδιο όνομα υπάρχει ήδη. \nΘέλετε να αντικαταστήσετε;",
-    "DuplicatedFiles": "Αντιπροσώπηση επιβεβαίωσης"
+    "DuplicatedFiles": "Αντιπροσώπηση επιβεβαίωσης",
+    "DragAndDropDesc": "Σύρετε και αποθέστε αρχεία σε αυτήν την περιοχή για μεταφόρτωση."
+  },
+  "comp:BAITable": {
+    "SelectColumnToDisplay": "Επιλέξτε στήλες για εμφάνιση",
+    "SearchTableColumn": "Στήλες πίνακα αναζήτησης",
+    "SettingTable": "Ρυθμίσεις πίνακα"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Αναζήτηση",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} of {{total}} items"
   },
-  "comp:BAITable": {
-    "SettingTable": "Table Settings",
-    "SelectColumnToDisplay": "Select columns to display",
-    "SearchTableColumn": "Search table columns"
-  },
   "error": {
     "UnknownError": "An unknown error occurred. Please try again."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "File size exceeds upload size limit."
     },
     "DuplicatedFilesDesc": "The file or folder with the same name already exists. Do you want to overwrite?",
-    "DuplicatedFiles": "Overwrite Confirmation"
+    "DuplicatedFiles": "Overwrite Confirmation",
+    "DragAndDropDesc": "Drag and drop files to this area to upload."
+  },
+  "comp:BAITable": {
+    "SettingTable": "Table Settings",
+    "SelectColumnToDisplay": "Select columns to display",
+    "SearchTableColumn": "Search table columns"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Search",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} de {{total}} elementos"
   },
-  "comp:BAITable": {
-    "SettingTable": "Configuración de tabla",
-    "SelectColumnToDisplay": "Seleccionar columnas para mostrar",
-    "SearchTableColumn": "Columnas de la tabla de búsqueda"
-  },
   "error": {
     "UnknownError": "Ocurrió un error desconocido. \nPor favor intente de nuevo."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "El tamaño del archivo excede el límite de tamaño de carga."
     },
     "DuplicatedFilesDesc": "El archivo o carpeta con el mismo nombre ya existe. \n¿Quieres sobrescribir?",
-    "DuplicatedFiles": "Confirmación de sobrescribencia"
+    "DuplicatedFiles": "Confirmación de sobrescribencia",
+    "DragAndDropDesc": "Arrastre y suelte archivos a esta área para cargar."
+  },
+  "comp:BAITable": {
+    "SettingTable": "Configuración de tabla",
+    "SelectColumnToDisplay": "Seleccionar columnas para mostrar",
+    "SearchTableColumn": "Columnas de la tabla de búsqueda"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Buscar en",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}}–{{end}} yhteensä {{total}} kohteesta"
   },
-  "comp:BAITable": {
-    "SettingTable": "Taulukon asetukset",
-    "SelectColumnToDisplay": "Valitse näytettävä sarakkeet",
-    "SearchTableColumn": "Hakutaulukon sarakkeet"
-  },
   "error": {
     "UnknownError": "Tapahtui tuntematon virhe. \nYritä uudelleen."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "Tiedoston koko ylittää lähetyskoon rajan."
     },
     "DuplicatedFilesDesc": "Tiedosto tai kansio, jolla on sama nimi, on jo olemassa. \nHaluatko korvata?",
-    "DuplicatedFiles": "Korvata vahvistus"
+    "DuplicatedFiles": "Korvata vahvistus",
+    "DragAndDropDesc": "Vedä ja pudota tiedostoja tälle alueelle ladataksesi."
+  },
+  "comp:BAITable": {
+    "SettingTable": "Taulukon asetukset",
+    "SelectColumnToDisplay": "Valitse näytettävä sarakkeet",
+    "SearchTableColumn": "Hakutaulukon sarakkeet"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Etsi",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} des éléments {{total}}"
   },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Sélectionnez des colonnes à afficher",
-    "SettingTable": "Paramètres de la table",
-    "SearchTableColumn": "Colonnes de table de recherche"
-  },
   "error": {
     "UnknownError": "Une erreur inconnue s'est produite. \nVeuillez réessayer."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "La taille du fichier dépasse la limite de taille de téléchargement."
     },
     "DuplicatedFilesDesc": "Le fichier ou le dossier avec le même nom existe déjà. \nVoulez-vous écraser?",
-    "DuplicatedFiles": "Écran de confirmation"
+    "DuplicatedFiles": "Écran de confirmation",
+    "DragAndDropDesc": "Faites glisser et déposez les fichiers dans cette zone pour télécharger."
+  },
+  "comp:BAITable": {
+    "SelectColumnToDisplay": "Sélectionnez des colonnes à afficher",
+    "SettingTable": "Paramètres de la table",
+    "SearchTableColumn": "Colonnes de table de recherche"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Recherche",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} dari {{total}} item"
   },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Pilih kolom untuk ditampilkan",
-    "SettingTable": "Pengaturan Tabel",
-    "SearchTableColumn": "Kolom Tabel Cari"
-  },
   "error": {
     "UnknownError": "Terjadi kesalahan yang tidak diketahui. \nTolong coba lagi."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "Ukuran file melebihi batas ukuran unggahan."
     },
     "DuplicatedFilesDesc": "File atau folder dengan nama yang sama sudah ada. \nApakah Anda ingin menimpa?",
-    "DuplicatedFiles": "Timpa konfirmasi"
+    "DuplicatedFiles": "Timpa konfirmasi",
+    "DragAndDropDesc": "Seret dan jatuhkan file ke area ini untuk diunggah."
+  },
+  "comp:BAITable": {
+    "SelectColumnToDisplay": "Pilih kolom untuk ditampilkan",
+    "SettingTable": "Pengaturan Tabel",
+    "SearchTableColumn": "Kolom Tabel Cari"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pencarian",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} di {{total}} elementi"
   },
-  "comp:BAITable": {
-    "SettingTable": "Impostazioni della tabella",
-    "SelectColumnToDisplay": "Seleziona le colonne da visualizzare",
-    "SearchTableColumn": "Colonne della tabella di ricerca"
-  },
   "error": {
     "UnknownError": "Si è verificato un errore sconosciuto. \nPer favore riprova."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "La dimensione del file supera il limite di dimensione del caricamento."
     },
     "DuplicatedFilesDesc": "Il file o la cartella con lo stesso nome esiste già. \nVuoi sovrascrivere?",
-    "DuplicatedFiles": "Sovrascrivere la conferma"
+    "DuplicatedFiles": "Sovrascrivere la conferma",
+    "DragAndDropDesc": "Trascina i file in quest'area da caricare."
+  },
+  "comp:BAITable": {
+    "SettingTable": "Impostazioni della tabella",
+    "SelectColumnToDisplay": "Seleziona le colonne da visualizzare",
+    "SearchTableColumn": "Colonne della tabella di ricerca"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Ricerca",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}}  -  {{end}} of {{total}}アイテム"
   },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "表示する列を選択します",
-    "SettingTable": "テーブル設定",
-    "SearchTableColumn": "テーブル列を検索します"
-  },
   "error": {
     "UnknownError": "不明なエラーが発生しました。\nもう一度やり直してください。"
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "ファイルサイズはアップロードサイズの制限を超えています。"
     },
     "DuplicatedFilesDesc": "同じ名前のファイルまたはフォルダーはすでに存在しています。\n上書きしますか？",
-    "DuplicatedFiles": "確認の上書き"
+    "DuplicatedFiles": "確認の上書き",
+    "DragAndDropDesc": "このエリアにファイルをドラッグアンドドロップしてアップロードします。"
+  },
+  "comp:BAITable": {
+    "SelectColumnToDisplay": "表示する列を選択します",
+    "SettingTable": "テーブル設定",
+    "SearchTableColumn": "テーブル列を検索します"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "検索",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "전체 {{total}}개 중 {{start}} - {{end}}"
   },
-  "comp:BAITable": {
-    "SettingTable": "표 설정",
-    "SelectColumnToDisplay": "표시할 열 선택",
-    "SearchTableColumn": "표시할 열 검색"
-  },
   "error": {
     "UnknownError": "알 수 없는 오류가 발생했습니다. 다시 시도해 주세요."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "업로드 가능한 단일 파일 사이즈 제한을 초과했습니다."
     },
     "DuplicatedFilesDesc": "업로드 하려는 파일 또는 폴더가 이미 존재합니다. 덮어쓰시겠습니까?",
-    "DuplicatedFiles": "덮어쓰기 확인"
+    "DuplicatedFiles": "덮어쓰기 확인",
+    "DragAndDropDesc": "파일을 이곳에 드래그하여 업로드하세요."
+  },
+  "comp:BAITable": {
+    "SettingTable": "표 설정",
+    "SelectColumnToDisplay": "표시할 열 선택",
+    "SearchTableColumn": "표시할 열 검색"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "검색",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{{end}} {{total}}}} зүйл"
   },
-  "comp:BAITable": {
-    "SettingTable": "Хүснэгтийн тохиргоо",
-    "SelectColumnToDisplay": "Дэлгэцийн баганыг сонгоно уу",
-    "SearchTableColumn": "Хүснэгтийн баганыг хайх"
-  },
   "error": {
     "UnknownError": "Үл мэдэгдэх алдаа гарлаа. \nДахин оролдоно уу."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "Файлын хэмжээ байршуулах хэмжээнээс хэтэрсэн байна."
     },
     "DuplicatedFilesDesc": "Ижил нэртэй файл эсвэл хавтас аль хэдийн байна. \nТа дарж бичихийг хүсч байна уу?",
-    "DuplicatedFiles": "Баталгаажуулалтыг дарж бичих"
+    "DuplicatedFiles": "Баталгаажуулалтыг дарж бичих",
+    "DragAndDropDesc": "Байршуулахын тулд энэ газарт файлуудыг чирч, буулгана уу."
+  },
+  "comp:BAITable": {
+    "SettingTable": "Хүснэгтийн тохиргоо",
+    "SelectColumnToDisplay": "Дэлгэцийн баганыг сонгоно уу",
+    "SearchTableColumn": "Хүснэгтийн баганыг хайх"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Хайх",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} dari {{total}} item"
   },
-  "comp:BAITable": {
-    "SettingTable": "Tetapan Jadual",
-    "SelectColumnToDisplay": "Pilih lajur untuk dipaparkan",
-    "SearchTableColumn": "Lajur jadual carian"
-  },
   "error": {
     "UnknownError": "Kesalahan yang tidak diketahui berlaku. \nSila cuba lagi."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "Saiz fail melebihi had saiz muat naik."
     },
     "DuplicatedFilesDesc": "Fail atau folder dengan nama yang sama sudah ada. \nAdakah anda mahu menimpa?",
-    "DuplicatedFiles": "Pengesahan Pengesahan"
+    "DuplicatedFiles": "Pengesahan Pengesahan",
+    "DragAndDropDesc": "Seret dan lepaskan fail ke kawasan ini untuk dimuat naik."
+  },
+  "comp:BAITable": {
+    "SettingTable": "Tetapan Jadual",
+    "SelectColumnToDisplay": "Pilih lajur untuk dipaparkan",
+    "SearchTableColumn": "Lajur jadual carian"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Cari",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} z {{total}}"
   },
-  "comp:BAITable": {
-    "SettingTable": "Ustawienia tabeli",
-    "SelectColumnToDisplay": "Wybierz kolumny do wyświetlenia",
-    "SearchTableColumn": "Wyszukaj kolumny tabeli"
-  },
   "error": {
     "UnknownError": "Wystąpił nieznany błąd. \nSpróbuj ponownie."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "Rozmiar pliku przekracza limit rozmiaru przesyłania."
     },
     "DuplicatedFilesDesc": "Plik lub folder o tej samej nazwie już istnieje. \nChcesz zastąpić?",
-    "DuplicatedFiles": "Nadpisz potwierdzenie"
+    "DuplicatedFiles": "Nadpisz potwierdzenie",
+    "DragAndDropDesc": "Przeciągnij i upuść pliki do tego obszaru, aby przesłać."
+  },
+  "comp:BAITable": {
+    "SettingTable": "Ustawienia tabeli",
+    "SelectColumnToDisplay": "Wybierz kolumny do wyświetlenia",
+    "SearchTableColumn": "Wyszukaj kolumny tabeli"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Wyszukiwanie",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} de {{total}} itens"
   },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Selecione colunas para exibir",
-    "SettingTable": "Configurações da tabela",
-    "SearchTableColumn": "Pesquisar colunas da tabela"
-  },
   "error": {
     "UnknownError": "Ocorreu um erro desconhecido. \nPor favor, tente novamente."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "O tamanho do arquivo excede o limite de tamanho de upload."
     },
     "DuplicatedFilesDesc": "O arquivo ou pasta com o mesmo nome já existe. \nVocê quer substituir?",
-    "DuplicatedFiles": "Substituição de substituição"
+    "DuplicatedFiles": "Substituição de substituição",
+    "DragAndDropDesc": "Arraste e solte arquivos para esta área para fazer upload."
+  },
+  "comp:BAITable": {
+    "SelectColumnToDisplay": "Selecione colunas para exibir",
+    "SettingTable": "Configurações da tabela",
+    "SearchTableColumn": "Pesquisar colunas da tabela"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pesquisar",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} de {{total}} itens"
   },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Selecione colunas para exibir",
-    "SettingTable": "Configurações da tabela",
-    "SearchTableColumn": "Pesquisar colunas da tabela"
-  },
   "error": {
     "UnknownError": "Ocorreu um erro desconhecido. \nPor favor, tente novamente."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "O tamanho do arquivo excede o limite de tamanho de upload."
     },
     "DuplicatedFilesDesc": "O arquivo ou pasta com o mesmo nome já existe. \nVocê quer substituir?",
-    "DuplicatedFiles": "Substituição de substituição"
+    "DuplicatedFiles": "Substituição de substituição",
+    "DragAndDropDesc": "Arraste e solte arquivos para esta área para fazer upload."
+  },
+  "comp:BAITable": {
+    "SelectColumnToDisplay": "Selecione colunas para exibir",
+    "SettingTable": "Configurações da tabela",
+    "SearchTableColumn": "Pesquisar colunas da tabela"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pesquisar",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} of {{total}} элементы"
   },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Выберите столбцы, чтобы отобразить",
-    "SettingTable": "Настройки таблицы",
-    "SearchTableColumn": "Поиск таблицы столбцов"
-  },
   "error": {
     "UnknownError": "Произошла неизвестная ошибка. \nПожалуйста, попробуйте еще раз."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "Размер файла превышает ограничение размера загрузки."
     },
     "DuplicatedFilesDesc": "Файл или папка с тем же именем уже существует. \nВы хотите перезаписать?",
-    "DuplicatedFiles": "Перезаписать подтверждение"
+    "DuplicatedFiles": "Перезаписать подтверждение",
+    "DragAndDropDesc": "Перетащите файлы в эту область, чтобы загрузить."
+  },
+  "comp:BAITable": {
+    "SelectColumnToDisplay": "Выберите столбцы, чтобы отобразить",
+    "SettingTable": "Настройки таблицы",
+    "SearchTableColumn": "Поиск таблицы столбцов"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Поиск",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} ของ {{total}} รายการ"
   },
-  "comp:BAITable": {
-    "SettingTable": "การตั้งค่าตาราง",
-    "SelectColumnToDisplay": "เลือกคอลัมน์ที่จะแสดง",
-    "SearchTableColumn": "คอลัมน์ตารางค้นหา"
-  },
   "error": {
     "UnknownError": "เกิดข้อผิดพลาดที่ไม่รู้จัก \nโปรดลองอีกครั้ง"
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "ขนาดไฟล์เกินขีด จำกัด ขนาดการอัปโหลด"
     },
     "DuplicatedFilesDesc": "ไฟล์หรือโฟลเดอร์ที่มีชื่อเดียวกันมีอยู่แล้ว \nคุณต้องการเขียนทับ?",
-    "DuplicatedFiles": "การยืนยันการเขียนทับ"
+    "DuplicatedFiles": "การยืนยันการเขียนทับ",
+    "DragAndDropDesc": "ลากและวางไฟล์ไปยังพื้นที่นี้เพื่ออัปโหลด"
+  },
+  "comp:BAITable": {
+    "SettingTable": "การตั้งค่าตาราง",
+    "SelectColumnToDisplay": "เลือกคอลัมน์ที่จะแสดง",
+    "SearchTableColumn": "คอลัมน์ตารางค้นหา"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "ค้นหา",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} öğelerinin {{total}}"
   },
-  "comp:BAITable": {
-    "SettingTable": "Masa Ayarları",
-    "SelectColumnToDisplay": "Görüntülemek için sütunları seçin",
-    "SearchTableColumn": "Arama Tablosu sütunları"
-  },
   "error": {
     "UnknownError": "Bilinmeyen bir hata oluştu. \nLütfen tekrar deneyin."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "Dosya boyutu yükleme boyutu sınırını aşar."
     },
     "DuplicatedFilesDesc": "Aynı ada sahip dosya veya klasör zaten mevcuttur. \nÜzerine yazmak ister misin?",
-    "DuplicatedFiles": "Üzerine Yazın Onay"
+    "DuplicatedFiles": "Üzerine Yazın Onay",
+    "DragAndDropDesc": "Yüklemek için dosyaları bu alana sürükleyin ve bırakın."
+  },
+  "comp:BAITable": {
+    "SettingTable": "Masa Ayarları",
+    "SelectColumnToDisplay": "Görüntülemek için sütunları seçin",
+    "SearchTableColumn": "Arama Tablosu sütunları"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Arama",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}} - {{end}} của {{total}}"
   },
-  "comp:BAITable": {
-    "SettingTable": "Cài đặt bảng",
-    "SelectColumnToDisplay": "Chọn các cột để hiển thị",
-    "SearchTableColumn": "Các cột bảng tìm kiếm"
-  },
   "error": {
     "UnknownError": "Một lỗi không xác định xảy ra. \nHãy thử lại."
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "Kích thước tệp vượt quá giới hạn kích thước tải lên."
     },
     "DuplicatedFilesDesc": "Tệp hoặc thư mục có cùng tên đã tồn tại. \nBạn có muốn ghi đè lên?",
-    "DuplicatedFiles": "Ghi đè xác nhận"
+    "DuplicatedFiles": "Ghi đè xác nhận",
+    "DragAndDropDesc": "Kéo và thả các tập tin vào khu vực này để tải lên."
+  },
+  "comp:BAITable": {
+    "SettingTable": "Cài đặt bảng",
+    "SelectColumnToDisplay": "Chọn các cột để hiển thị",
+    "SearchTableColumn": "Các cột bảng tìm kiếm"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Tìm kiếm",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}}  -  {{end}} {{total}}项目"
   },
-  "comp:BAITable": {
-    "SettingTable": "表设置",
-    "SelectColumnToDisplay": "选择要显示的列",
-    "SearchTableColumn": "搜索表列"
-  },
   "error": {
     "UnknownError": "发生了未知错误。\n请重试。"
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "文件大小超过上传大小限制。"
     },
     "DuplicatedFilesDesc": "具有相同名称的文件或文件夹已经存在。\n你想覆盖吗？",
-    "DuplicatedFiles": "覆盖确认"
+    "DuplicatedFiles": "覆盖确认",
+    "DragAndDropDesc": "将文件拖到此区域上传。"
+  },
+  "comp:BAITable": {
+    "SettingTable": "表设置",
+    "SelectColumnToDisplay": "选择要显示的列",
+    "SearchTableColumn": "搜索表列"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "搜索",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -6,11 +6,6 @@
   "comp:PaginationInfoText": {
     "Total": "{{start}}  -  {{end}} {{total}}項目"
   },
-  "comp:BAITable": {
-    "SettingTable": "表設置",
-    "SelectColumnToDisplay": "選擇要顯示的列",
-    "SearchTableColumn": "搜索表列"
-  },
   "error": {
     "UnknownError": "發生了未知錯誤。請重試。"
   },
@@ -44,7 +39,13 @@
       "FileUploadSizeLimit": "文件大小超過上傳大小限制。"
     },
     "DuplicatedFilesDesc": "具有相同名稱的文件或文件夾已經存在。你想覆蓋嗎？",
-    "DuplicatedFiles": "覆蓋確認"
+    "DuplicatedFiles": "覆蓋確認",
+    "DragAndDropDesc": "將文件拖到此區域上傳。"
+  },
+  "comp:BAITable": {
+    "SettingTable": "表設置",
+    "SelectColumnToDisplay": "選擇要顯示的列",
+    "SearchTableColumn": "搜索表列"
   },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "搜索",

--- a/react/src/components/FolderExplorerHeader.tsx
+++ b/react/src/components/FolderExplorerHeader.tsx
@@ -9,11 +9,13 @@ import { graphql, useFragment } from 'react-relay';
 interface FolderExplorerHeaderProps {
   vfolderNodeFrgmt?: FolderExplorerHeaderFragment$key | null;
   folderExplorerRef: LegacyRef<HTMLDivElement>;
+  titleStyle?: React.CSSProperties;
 }
 
 const FolderExplorerHeader: React.FC<FolderExplorerHeaderProps> = ({
   vfolderNodeFrgmt,
   folderExplorerRef,
+  titleStyle,
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
@@ -42,7 +44,7 @@ const FolderExplorerHeader: React.FC<FolderExplorerHeaderProps> = ({
       <BAIFlex
         data-testid="folder-explorer-title"
         gap={token.marginMD}
-        style={{ flex: 1 }}
+        style={{ flex: 1, ...titleStyle }}
       >
         <Suspense fallback={<Skeleton.Input active />}>
           <VFolderNameTitle vfolderNodeFrgmt={vfolderNode} />


### PR DESCRIPTION
resolves #4077 ([FR-1334](https://lablup.atlassian.net/browse/FR-1334))

This PR adds drag and drop file upload functionality to the file explorer. Users can now drag files directly into the file explorer area to upload them, providing a more intuitive and convenient way to manage files.

Key changes:
- Created a new `DragAndDrop` component that appears when files are dragged over the file explorer
- Extracted file upload logic into a reusable hook `useUploadVFolderFiles` to avoid code duplication
- Added event listeners to detect drag and drop events at the document level
- Added translations for the drag and drop feature in all supported languages
- Simplified the file upload process in the `ActionItems` component by using the new hook

**Checklist:**

- [x] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1334]: https://lablup.atlassian.net/browse/FR-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ