### PR TITLE
feat(FR-1343): BAIUnmountAfterClose in BUI

### DIFF
--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -7,6 +7,7 @@ export type { BAICardProps } from './BAICard';
 export { default as BAIResourceWithSteppedProgress } from './BAIResourceWithSteppedProgress';
 export { default as BAIRowWrapWithDividers } from './BAIRowWrapWithDividers';
 export type { BAIResourceWithSteppedProgressProps } from './BAIResourceWithSteppedProgress';
+export { default as BAIUnmountAfterClose } from './BAIUnmountAfterClose';
 export * from './Table';
 export * from './fragments';
 export * from './provider';

--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -6,11 +6,10 @@ import { ContainerLogModalFragment$key } from '../../__generated__/ContainerLogM
 import { filterOutEmpty, filterOutNullAndUndefined } from '../../helper';
 // import BAIPropertyFilter from '../BAIPropertyFilter';
 import DoubleTag from '../DoubleTag';
-import UnmountAfterClose from '../UnmountAfterClose';
 import ContainerLogModal from './ContainerLogModal';
 import { Button, Tag, theme, Tooltip, Typography } from 'antd';
 import { ColumnType } from 'antd/lib/table';
-import { BAITable, BAIFlex } from 'backend.ai-ui';
+import { BAITable, BAIFlex, BAIUnmountAfterClose } from 'backend.ai-ui';
 import _ from 'lodash';
 import { ScrollTextIcon } from 'lucide-react';
 import { useState } from 'react';
@@ -183,7 +182,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
         pagination={false}
       />
 
-      <UnmountAfterClose>
+      <BAIUnmountAfterClose>
         <ContainerLogModal
           open={!!kernelIdForLogModal}
           sessionFrgmt={sessionFrgmtForLogModal || null}
@@ -192,7 +191,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
             setKernelIdForLogModal(undefined);
           }}
         />
-      </UnmountAfterClose>
+      </BAIUnmountAfterClose>
     </BAIFlex>
   );
 };

--- a/react/src/components/FolderInvitationResponseModalOpener.tsx
+++ b/react/src/components/FolderInvitationResponseModalOpener.tsx
@@ -1,5 +1,5 @@
 import { useVFolderInvitationsValue } from '../hooks/useVFolderInvitations';
-import UnmountAfterClose from './UnmountAfterClose';
+import { BAIUnmountAfterClose } from 'backend.ai-ui';
 import React from 'react';
 import { useQueryParam, StringParam } from 'use-query-params';
 
@@ -15,7 +15,7 @@ const FolderInvitationResponseModalOpener = () => {
   const { count } = useVFolderInvitationsValue();
 
   return (
-    <UnmountAfterClose>
+    <BAIUnmountAfterClose>
       <FolderInvitationResponseModal
         open={isInvitationOpen === 'true'}
         onRequestClose={(success) => {
@@ -24,7 +24,7 @@ const FolderInvitationResponseModalOpener = () => {
           }
         }}
       />
-    </UnmountAfterClose>
+    </BAIUnmountAfterClose>
   );
 };
 

--- a/react/src/components/RecentlyCreatedSession.tsx
+++ b/react/src/components/RecentlyCreatedSession.tsx
@@ -3,9 +3,13 @@ import { filterOutNullAndUndefined } from '../helper';
 import BAIFetchKeyButton from './BAIFetchKeyButton';
 import SessionDetailDrawer from './SessionDetailDrawer';
 import SessionNodes from './SessionNodes';
-import UnmountAfterClose from './UnmountAfterClose';
 import { theme } from 'antd';
-import { toLocalId, BAIFlex, BAIBoardItemTitle } from 'backend.ai-ui';
+import {
+  toLocalId,
+  BAIFlex,
+  BAIUnmountAfterClose,
+  BAIBoardItemTitle,
+} from 'backend.ai-ui';
 import { useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useRefetchableFragment } from 'react-relay';
@@ -112,7 +116,7 @@ const RecentlyCreatedSession: React.FC<RecentlyCreatedSessionProps> = ({
           />
         </BAIFlex>
       </BAIFlex>
-      <UnmountAfterClose>
+      <BAIUnmountAfterClose>
         <SessionDetailDrawer
           open={!!sessionDetailId}
           sessionId={sessionDetailId || undefined}
@@ -120,7 +124,7 @@ const RecentlyCreatedSession: React.FC<RecentlyCreatedSessionProps> = ({
             setSessionDetailId(undefined, 'pushIn');
           }}
         />
-      </UnmountAfterClose>
+      </BAIUnmountAfterClose>
     </>
   );
 };

--- a/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
+++ b/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
@@ -1,7 +1,7 @@
 import { useSuspendedBackendaiClient } from '../hooks';
 import ContainerLogModalWithLazyQueryLoader from './ComputeSessionNodeItems/ContainerLogModalWithLazyQueryLoader';
 import SessionDetailDrawer from './SessionDetailDrawer';
-import UnmountAfterClose from './UnmountAfterClose';
+import { BAIUnmountAfterClose } from 'backend.ai-ui';
 import { useState, useEffect, useTransition } from 'react';
 import { useQueryParam, StringParam } from 'use-query-params';
 
@@ -29,7 +29,7 @@ const SessionDetailAndContainerLogOpenerLegacy = () => {
   return (
     <>
       {supportSessionDetailPanel ? (
-        <UnmountAfterClose>
+        <BAIUnmountAfterClose>
           <SessionDetailDrawer
             open={!!sessionId}
             sessionId={sessionId || undefined}
@@ -37,7 +37,7 @@ const SessionDetailAndContainerLogOpenerLegacy = () => {
               setSessionId(null, 'replaceIn');
             }}
           />
-        </UnmountAfterClose>
+        </BAIUnmountAfterClose>
       ) : null}
       <ContainerLogModalWithLazyQueryLoader
         open={!!containerLogModalSessionId || isPendingLogModalOpen}

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -18,7 +18,6 @@ import ImageNodeSimpleTag from '../components/ImageNodeSimpleTag';
 import InferenceSessionErrorModal from '../components/InferenceSessionErrorModal';
 import ResourceNumber from '../components/ResourceNumber';
 import SessionDetailDrawer from '../components/SessionDetailDrawer';
-import UnmountAfterClose from '../components/UnmountAfterClose';
 import VFolderLazyView from '../components/VFolderLazyView';
 import {
   baiSignedRequestWithPromise,
@@ -60,7 +59,7 @@ import {
   theme,
 } from 'antd';
 import { DescriptionsItemType } from 'antd/es/descriptions';
-import { BAIFlex } from 'backend.ai-ui';
+import { BAIFlex, BAIUnmountAfterClose } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
 import _ from 'lodash';
 import {
@@ -1010,7 +1009,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
         endpoint_id={endpoint?.endpoint_id || ''}
       ></EndpointTokenGenerationModal>
       {isSupportAutoScalingRule && (
-        <UnmountAfterClose>
+        <BAIUnmountAfterClose>
           <AutoScalingRuleEditorModal
             open={isOpenAutoScalingRuleModal}
             endpoint_id={endpoint?.endpoint_id as string}
@@ -1025,9 +1024,9 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               }
             }}
           />
-        </UnmountAfterClose>
+        </BAIUnmountAfterClose>
       )}
-      <UnmountAfterClose>
+      <BAIUnmountAfterClose>
         <SessionDetailDrawer
           open={!!selectedSessionId}
           sessionId={selectedSessionId}
@@ -1035,7 +1034,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
             setSelectedSessionId(undefined);
           }}
         />
-      </UnmountAfterClose>
+      </BAIUnmountAfterClose>
       <BAIJSONViewerModal
         open={!!errorDataForJSONModal}
         title={t('modelService.RouteError')}


### PR DESCRIPTION
Resolves #4094 ([FR-1343](https://lablup.atlassian.net/browse/FR-1343))

## Summary

This PR refactors the `UnmountAfterClose` component to improve its organization and reusability within the codebase. The component has been moved from the React-specific directory to the shared backend.ai-ui package and renamed to follow the BAI naming convention.

## Changes Made

- **Moved** `UnmountAfterClose` component from `react/src/components/` to `packages/backend.ai-ui/src/components/`
- **Renamed** component from `UnmountAfterClose` to `BAIUnmountAfterClose`
- **Enhanced** component interface to be more generic and work with both Modal and Drawer components
- **Added** proper type guards for safe handling of Modal and Drawer props
- **Updated** all import statements throughout the codebase to use the new component location and name
- **Exported** the component from backend.ai-ui package index
- **Maintained** backward compatibility and existing functionality

## Benefits

This refactoring improves code organization by moving the component to the shared UI package where it can be reused across different parts of the application, and follows the established BAI naming convention for consistency.

**Checklist:** (if applicable)

- [x] Documentation - Component is properly documented with JSDoc
- [ ] Minimum required manager version - No changes to manager requirements
- [ ] Specific setting for review - No special setup required
- [x] Minimum requirements to check during review - Verify all imports work correctly
- [x] Test case(s) to demonstrate the difference of before/after - All existing usage points updated

[FR-1343]: https://lablup.atlassian.net/browse/FR-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ