### PR TITLE
fix(FR-1346): show descriptive text for model store folder creation

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -345,6 +345,7 @@
       "CloneFolder": "Ordner klonen",
       "Cloneable": "klonbar",
       "Control": "Steuerung",
+      "CreateModelFolderOnlyInExclusiveProject": "Modellprojektordner können nur in Model Store -Exclusive -Projekten erstellt werden.",
       "CreatedAt": "Erstellt at",
       "Delete": "Löschen",
       "DeleteAFolder": "Einen Ordner löschen",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -342,6 +342,7 @@
       "CloneFolder": "Φάκελος κλωνοποίησης",
       "Cloneable": "Κλωνοποιήσιμο",
       "Control": "Ελεγχος",
+      "CreateModelFolderOnlyInExclusiveProject": "Οι φακέλοι έργων μοντέλων μπορούν να δημιουργηθούν μόνο σε αποκλειστικά έργα Model Store.",
       "CreatedAt": "Δημιουργήθηκε στο",
       "Delete": "Διαγράφω",
       "DeleteAFolder": "Διαγραφή φακέλου",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -347,6 +347,7 @@
       "CloneFolder": "Clone folder",
       "Cloneable": "Cloneable",
       "Control": "Controls",
+      "CreateModelFolderOnlyInExclusiveProject": "Model project folders can only be created in model store–exclusive projects.",
       "CreatedAt": "Created At",
       "Delete": "Delete",
       "DeleteAFolder": "Delete folder",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -345,6 +345,7 @@
       "CloneFolder": "Clonar carpeta",
       "Cloneable": "Clonable",
       "Control": "Controlar",
+      "CreateModelFolderOnlyInExclusiveProject": "Las carpetas de proyectos modelo solo se pueden crear en proyectos exclusivos de Model Store.",
       "CreatedAt": "Creado a",
       "Delete": "Borrar",
       "DeleteAFolder": "Eliminar una carpeta",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -345,6 +345,7 @@
       "CloneFolder": "Kloonattu kansio",
       "Cloneable": "Kloonattavissa",
       "Control": "Valvonta",
+      "CreateModelFolderOnlyInExclusiveProject": "Malliprojektin kansiot voidaan luoda vain Model Store - Exclusive -projekteihin.",
       "CreatedAt": "Luotu jhk",
       "Delete": "Poista",
       "DeleteAFolder": "Poista kansio",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -345,6 +345,7 @@
       "CloneFolder": "Cloner un dossier",
       "Cloneable": "Clonable",
       "Control": "Contrôler",
+      "CreateModelFolderOnlyInExclusiveProject": "Les dossiers de projets modèles ne peuvent être créés que dans des projets exclusifs en magasin de modèles.",
       "CreatedAt": "Créé à",
       "Delete": "Effacer",
       "DeleteAFolder": "Supprimer un dossier",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -344,6 +344,7 @@
       "CloneFolder": "Folder klon",
       "Cloneable": "Dapat diklon",
       "Control": "Kontrol",
+      "CreateModelFolderOnlyInExclusiveProject": "Folder Proyek Model hanya dapat dibuat di proyek Model Store -Eksklusif.",
       "CreatedAt": "Dibuat di",
       "Delete": "Hapus",
       "DeleteAFolder": "Hapus folder",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -344,6 +344,7 @@
       "CloneFolder": "Clona la cartella",
       "Cloneable": "Clonabile",
       "Control": "Controllo",
+      "CreateModelFolderOnlyInExclusiveProject": "Le cartelle del progetto di modello possono essere create solo in progetti esclusivi del negozio di modelli.",
       "CreatedAt": "Creato a",
       "Delete": "Elimina",
       "DeleteAFolder": "Elimina una cartella",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -344,6 +344,7 @@
       "CloneFolder": "フォルダクローン",
       "Cloneable": "クローン可能",
       "Control": "コントロール",
+      "CreateModelFolderOnlyInExclusiveProject": "モデルプロジェクトフォルダーは、モデルストアと独占プロジェクトでのみ作成できます。",
       "CreatedAt": "で作成されました",
       "Delete": "削除",
       "DeleteAFolder": "フォルダを削除する",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -347,6 +347,7 @@
       "CloneFolder": "폴더 클론",
       "Cloneable": "복사 가능 여부",
       "Control": "제어",
+      "CreateModelFolderOnlyInExclusiveProject": "모델 스토어 전용 프로젝트에서만 모델용 프로젝트 폴더 생성이 가능합니다.",
       "CreatedAt": "생성 시간",
       "Delete": "삭제",
       "DeleteAFolder": "폴더 삭제",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -344,6 +344,7 @@
       "CloneFolder": "Фолдерыг хувилах",
       "Cloneable": "Cloneable",
       "Control": "Хяналт",
+      "CreateModelFolderOnlyInExclusiveProject": "Загвар төслийн фолдеруудыг зөвхөн загвар дэлгүүрийн онцгой төсөлд бий болгож болно.",
       "CreatedAt": "Бүтэмж дээр бүтсэн",
       "Delete": "Устгах",
       "DeleteAFolder": "Фолдер устгах",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -344,6 +344,7 @@
       "CloneFolder": "Klon folder",
       "Cloneable": "Boleh diklon",
       "Control": "Kawal",
+      "CreateModelFolderOnlyInExclusiveProject": "Folder projek model hanya boleh dibuat dalam projek eksklusif kedai model.",
       "CreatedAt": "Dicipta di",
       "Delete": "Padam",
       "DeleteAFolder": "Padamkan folder",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -345,6 +345,7 @@
       "CloneFolder": "Klonowanie folderu",
       "Cloneable": "Możliwość klonowania",
       "Control": "Kontrola",
+      "CreateModelFolderOnlyInExclusiveProject": "Modelowe foldery projektu można tworzyć tylko w projektach ekskluzywnych w magazynie modeli.",
       "CreatedAt": "Utworzony w",
       "Delete": "Kasować",
       "DeleteAFolder": "Usuń folder",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -345,6 +345,7 @@
       "CloneFolder": "Clonar pasta",
       "Cloneable": "Clonável",
       "Control": "Ao controle",
+      "CreateModelFolderOnlyInExclusiveProject": "As pastas de projeto modelo só podem ser criadas em projetos exclusivos da loja de modelos.",
       "CreatedAt": "Criado em",
       "Delete": "Excluir",
       "DeleteAFolder": "Excluir uma pasta",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -345,6 +345,7 @@
       "CloneFolder": "Clonar pasta",
       "Cloneable": "Clonável",
       "Control": "Ao controle",
+      "CreateModelFolderOnlyInExclusiveProject": "As pastas de projeto modelo só podem ser criadas em projetos exclusivos da loja de modelos.",
       "CreatedAt": "Criado em",
       "Delete": "Excluir",
       "DeleteAFolder": "Excluir uma pasta",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -345,6 +345,7 @@
       "CloneFolder": "Клонировать папку",
       "Cloneable": "Клонируемый",
       "Control": "Контроль",
+      "CreateModelFolderOnlyInExclusiveProject": "Папки моделей проектов могут быть созданы только в эксклюзивных проектах Model Store.",
       "CreatedAt": "Создан в",
       "Delete": "Удалить",
       "DeleteAFolder": "Удалить папку",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -345,6 +345,7 @@
       "CloneFolder": "โคลนโฟลเดอร์",
       "Cloneable": "สามารถโคลนได้",
       "Control": "ควบคุม",
+      "CreateModelFolderOnlyInExclusiveProject": "โมเดลโฟลเดอร์โครงการสามารถสร้างขึ้นได้ในโครงการโมเดล - โครงการพิเศษเท่านั้น",
       "CreatedAt": "สร้างขึ้นที่",
       "Delete": "ลบ",
       "DeleteAFolder": "ลบโฟลเดอร์",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -345,6 +345,7 @@
       "CloneFolder": "Klasör klonlama",
       "Cloneable": "klonlanabilir",
       "Control": "Kontrol",
+      "CreateModelFolderOnlyInExclusiveProject": "Model proje klasörleri yalnızca model mağaza özel projelerinde oluşturulabilir.",
       "CreatedAt": "Yaratılmış",
       "Delete": "Sil",
       "DeleteAFolder": "Klasörü sil",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -345,6 +345,7 @@
       "CloneFolder": "Sao chép thư mục",
       "Cloneable": "Có thể nhân bản",
       "Control": "Điều khiển",
+      "CreateModelFolderOnlyInExclusiveProject": "Các thư mục mô hình dự án chỉ có thể được tạo trong các dự án độc quyền của mô hình lưu trữ.",
       "CreatedAt": "Được tạo ra tại",
       "Delete": "Xóa bỏ",
       "DeleteAFolder": "Xóa một thư mục",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -345,6 +345,7 @@
       "CloneFolder": "克隆文件夹",
       "Cloneable": "可克隆",
       "Control": "控制",
+      "CreateModelFolderOnlyInExclusiveProject": "模型项目文件夹只能在模型商店的独家项目中创建。",
       "CreatedAt": "创建在",
       "Delete": "删除",
       "DeleteAFolder": "删除文件夹",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -345,6 +345,7 @@
       "CloneFolder": "克隆文件夹",
       "Cloneable": "可克隆",
       "Control": "控制",
+      "CreateModelFolderOnlyInExclusiveProject": "模型項目文件夾只能在模型商店的獨家項目中創建。",
       "CreatedAt": "創建在",
       "Delete": "刪除",
       "DeleteAFolder": "刪除文件夾",


### PR DESCRIPTION
  Resolves #4098 ([FR-1346](https://lablup.atlassian.net/browse/FR-1346))

## Summary

- Add help text for user type when creating model folders in non-exclusive projects
- Update conditional logic to always show appropriate help text based on folder type and project context
- Add new i18n key `CreateModelFolderOnlyInExclusiveProject` for user type model folders
- Fix missing descriptive text issue in FolderCreateModal

## Problem

When creating folders in the FolderCreateModal, descriptive text was missing for user type folders, particularly when dealing with model store scenarios. Users should see helpful guidance text even when the folder type is "user", but it wasn't appearing.

## Solution

- **Fixed conditional logic**: Updated the help text display logic to show appropriate messages for both `user` and `project` folder types
- **Added missing help text**: Now displays "Model project folders can only be created in model store–exclusive projects." for user type when attempting to create model folders in non-exclusive projects
- **Improved user guidance**: Users now receive clear instructions regardless of their folder type selection
- **Internationalization**: Added the new help text across all supported languages (21 language files updated)

## Changes Made

- **`FolderCreateModal.tsx`**: Updated conditional logic for help text display
- **i18n files**: Added `CreateModelFolderOnlyInExclusiveProject` translation key across all languages

## Test plan

- [ ] Test folder creation with user type in model store exclusive project - should show appropriate help text
- [ ] Test folder creation with user type in non-model store project - should show model store restriction message
- [ ] Test folder creation with project type - should show project-specific help text
- [ ] Verify all language translations display correctly
- [ ] Test that help text appears consistently without flickering

[FR-1346]: https://lablup.atlassian.net/browse/FR-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ