### PR TITLE
fix(FR-1351): replace useUpdatableState with useFetchKey in ComputeSessionListPage

### DIFF
--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -17,8 +17,8 @@ import SessionNodes from '../components/SessionNodes';
 import { filterOutNullAndUndefined, handleRowSelectionChange } from '../helper';
 import {
   INITIAL_FETCH_KEY,
+  useFetchKey,
   useSuspendedBackendaiClient,
-  useUpdatableState,
   useWebUINavigate,
 } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
@@ -124,7 +124,7 @@ const ComputeSessionListPage = () => {
     return status === 'TERMINATED' || status === 'CANCELLED';
   };
 
-  const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
+  const [fetchKey, updateFetchKey] = useFetchKey();
 
   const queryVariables: ComputeSessionListPageQuery$variables = useMemo(
     () => ({


### PR DESCRIPTION
# Replace `useUpdatableState` with `useFetchKey` in ComputeSessionListPage

This PR replaces the usage of `useUpdatableState` with the more specific `useFetchKey` hook in the ComputeSessionListPage component. The change simplifies the code by using a dedicated hook for managing fetch key state.