### PR TITLE
fix(FR-1352): catch baseURL check errors in useModels

### DIFF
--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -101,13 +101,13 @@ function useModels(
   }>({
     queryKey: ['models', fetchKey, baseURL, provider.apiKey],
     queryFn: async () => {
-      if (!baseURL) {
-        return { data: [] };
-      }
-
-      const url = createModelsURL(baseURL);
-      const authToken = provider.apiKey;
       try {
+        if (!baseURL) {
+          return { data: [] };
+        }
+
+        const url = createModelsURL(baseURL);
+        const authToken = provider.apiKey;
         const response = await fetch(url, {
           headers: {
             Authorization: authToken ? `Bearer ${authToken}` : '',


### PR DESCRIPTION
Moved the try block to wrap the entire function body in the `useModels` query function. This ensures that any errors occurring during the function execution, including those from conditional checks and URL creation, are properly caught and handled by the error handling mechanism.