### PR TITLE
fix(FR-1348): correct RAM unit display in resource monitoring

### DIFF
--- a/packages/backend.ai-ui/src/helper/index.ts
+++ b/packages/backend.ai-ui/src/helper/index.ts
@@ -49,6 +49,19 @@ export const bytesToGB = (
 export type InputSizeUnit = '' | 'k' | 'm' | 'g' | 't' | 'p' | 'e';
 export type SizeUnit = InputSizeUnit;
 
+export const getDisplayUnitToInputSizeUnit = (
+  displayUnit: string | undefined,
+): InputSizeUnit => {
+  if (!displayUnit) return '';
+  const unit = displayUnit.toLowerCase();
+  if (['kib', 'ki'].includes(unit)) return 'k';
+  if (['mib', 'mi'].includes(unit)) return 'm';
+  if (['gib', 'gi'].includes(unit)) return 'g';
+  if (['tib', 'ti'].includes(unit)) return 't';
+  if (['pib', 'pi'].includes(unit)) return 'p';
+  if (['eib', 'ei'].includes(unit)) return 'e';
+  return '';
+};
 /**
  * Converts a value with a unit to a different unit or automatically selects the most appropriate unit.
  *

--- a/react/src/components/BaseResourceItem.tsx
+++ b/react/src/components/BaseResourceItem.tsx
@@ -7,6 +7,8 @@ import {
   BAIResourceWithSteppedProgress,
   BAIResourceWithSteppedProgressProps,
   compareNumberWithUnits,
+  convertToBinaryUnit,
+  getDisplayUnitToInputSizeUnit,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { ReactNode } from 'react';
@@ -61,10 +63,20 @@ const BaseResourceItem: React.FC<BaseResourceItemProps> = ({
     values: ResourceValues,
     resourceSlot: ResourceSlotDetail,
   ) => {
+    const convertedBinaryValues =
+      resourceSlot.slot_name === 'ram'
+        ? convertToBinaryUnit(
+            values.current,
+            getDisplayUnitToInputSizeUnit(resourceSlot.display_unit),
+          )
+        : undefined;
     const progressProps: BAIResourceWithSteppedProgressProps = {
-      current: values.current,
+      current: convertedBinaryValues?.value || values.current,
       title: resourceSlot.human_readable_name,
-      displayUnit: values.displayUnit || resourceSlot.display_unit,
+      displayUnit:
+        convertedBinaryValues?.displayUnit ||
+        values.displayUnit ||
+        resourceSlot.display_unit,
     };
 
     if (showProgress && !_.isUndefined(values.total)) {

--- a/react/src/components/MyResource.tsx
+++ b/react/src/components/MyResource.tsx
@@ -14,7 +14,7 @@ import BaseResourceItem, {
   AcceleratorSlotDetail,
   ResourceValues,
 } from './BaseResourceItem';
-import { BAICardProps, convertToBinaryUnit } from 'backend.ai-ui';
+import { BAICardProps } from 'backend.ai-ui';
 import _ from 'lodash';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -58,15 +58,9 @@ const getResourceValue = (
   };
   const currentValue = getCurrentValue();
 
-  const displayValue = type === 'usage' ? currentValue : totalValue;
-
   return {
     current: currentValue || 0,
     total: totalValue,
-    displayUnit:
-      resource === 'mem' && displayValue
-        ? convertToBinaryUnit(displayValue, 'auto')?.displayUnit
-        : undefined,
   };
 };
 

--- a/react/src/components/MyResourceWithinResourceGroup.tsx
+++ b/react/src/components/MyResourceWithinResourceGroup.tsx
@@ -1,4 +1,3 @@
-import { convertToBinaryUnit } from '../helper';
 import { useResourceSlotsDetails } from '../hooks/backendai';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import {
@@ -34,13 +33,7 @@ const getResourceValue = (
         checkPresetInfo?.scaling_groups?.[resourceGroup]?.using,
         resource,
       );
-
-      if (resource === 'mem') {
-        const converted = convertToBinaryUnit(value, 'auto');
-        return _.toNumber(converted?.numberFixed);
-      }
-
-      return _.toNumber(value);
+      return value;
     }
 
     const remaining = _.get(
@@ -48,17 +41,11 @@ const getResourceValue = (
       resource,
     );
     if (remaining === Number.MAX_SAFE_INTEGER) return Number.MAX_SAFE_INTEGER;
-
-    if (resource === 'mem') {
-      const converted = convertToBinaryUnit(remaining, 'auto');
-      return _.toNumber(converted?.numberFixed);
-    }
-
-    return _.toNumber(remaining);
+    return remaining;
   };
 
   return {
-    current: getCurrentValue(),
+    current: getCurrentValue() || 0,
   };
 };
 


### PR DESCRIPTION
## Summary
Resolves #4101 ([FR-1348](https://lablup.atlassian.net/browse/FR-1348))

- Fix incorrect RAM unit display in My/Total Resource panels
- Move RAM binary unit conversion from data processing to display layer in `BaseResourceItem`
- Remove duplicate binary conversion in `MyResourceWithinResourceGroup` component
- Ensure consistent RAM unit display (MB, GB, etc.) across resource monitoring components

## Problem

There was an issue with incorrect RAM unit display in the My/Total Resource panels within resource groups. RAM values were being converted to binary units (MB, GB, etc.) at the wrong layer, which caused inconsistent or incorrect unit displays in the resource monitoring UI.

## Solution

- **Moved conversion logic:** Relocated RAM binary unit conversion from the data processing layer to the display layer in `BaseResourceItem`.
- **Removed duplicate logic:** Eliminated redundant binary conversion in `MyResourceWithinResourceGroup` that was occurring too early in the data flow.
- **Consistent display:** All RAM values are now consistently converted to the appropriate binary unit (MB, GB, TB, etc.) only when being displayed.
- **Better separation of concerns:** Data processing now handles only raw values, while display components handle unit formatting.

## Changes Made

- **`BaseResourceItem.tsx`:** Added RAM-specific binary unit conversion logic for display.
- **`MyResourceWithinResourceGroup.tsx`:** Removed duplicate binary conversion logic and unused import.

## Test Plan

- [ ] Verify RAM units display correctly in My Resource within Resource Group panel
- [ ] Verify RAM units display correctly in Total Resource within Resource Group panel
- [ ] Test with various RAM values (KB, MB, GB, TB ranges) to ensure proper unit conversion
- [ ] Confirm no regression in other resource types (CPU, GPU, etc.)
- [ ] Check consistency across different resource group selections


[FR-1348]: https://lablup.atlassian.net/browse/FR-1348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ