### PR TITLE
refactor(FR-1358): separate filtering concerns in VFolderTable to fix auto-mount detection

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -933,7 +933,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                               <VFolderTableFormItem
                                 rowKey={'id'}
                                 label={t('modelService.AdditionalMounts')}
-                                filter={(vf) =>
+                                rowFilter={(vf) =>
                                   vf.id !== getFieldValue('vFolderID') &&
                                   vf.status === 'ready' &&
                                   vf.usage_mode !== 'model' &&

--- a/react/src/components/VFolderTableFormItem.tsx
+++ b/react/src/components/VFolderTableFormItem.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface VFolderTableFormItemProps extends Omit<FormItemProps, 'name'> {
-  filter?: VFolderTableProps['filter'];
+  rowFilter?: VFolderTableProps['rowFilter'];
   rowKey?: keyof VFolder;
   tableProps?: Partial<VFolderTableProps>;
 }
@@ -27,7 +27,7 @@ export interface VFolderTableFormValues {
 }
 
 const VFolderTableFormItem: React.FC<VFolderTableFormItemProps> = ({
-  filter,
+  rowFilter,
   rowKey = 'name',
   tableProps,
   ...formItemProps
@@ -105,7 +105,7 @@ const VFolderTableFormItem: React.FC<VFolderTableFormItemProps> = ({
           })}
           // TODO: implement pagination
           pagination={false}
-          filter={filter}
+          rowFilter={rowFilter}
           showAutoMountedFoldersSection
           onChangeAutoMountedFolders={useEventNotStable((names) => {
             form.setFieldValue('autoMountedFolderNames', names);

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1423,7 +1423,7 @@ const SessionLauncherPage = () => {
                       return (
                         <VFolderTableFormItem
                           rowKey={!!supportsMountById ? 'id' : 'name'}
-                          filter={(vfolder) => {
+                          rowFilter={(vfolder) => {
                             return (
                               vfolder.status === 'ready' &&
                               !vfolder.name?.startsWith('.')


### PR DESCRIPTION
Resolves #4121 ([FR-1358](https://lablup.atlassian.net/browse/FR-1358))

## Summary

Fixed a structural issue in the VFolderTable component that caused auto-mounted folder lists to be incorrectly filtered by the display rowFilter, resulting in empty arrays being passed to parent components via the onChangeAutoMountedFolders callback.

## Changes

### Filtering Concern Separation
- **Permission-based filtering**: Separated into , , and 
- **Auto-mount folder extraction**: Now only depends on permission-filtered folders, not display filters
- **Display filtering**: Isolated to  with both external rowFilter and search keywords

### Props Refactoring  
- Renamed  prop to  to clarify its purpose as a display-only filter
- Updated prop destructuring to maintain backward compatibility

### Variable Naming Improvements
-  →  (clearer purpose)
-  →  (more concise)

## Impact

This fix ensures that auto-mounted folders (folders starting with  in ready status) are correctly detected and reported to parent components in:
- 
- 

## Technical Details

The previous implementation applied the display rowFilter to all filtering operations, including auto-mount detection. This caused issues where the rowFilter would exclude auto-mountable folders from being detected, even though they should be identified regardless of display preferences.

The refactored implementation clearly separates:
1. **Data access layer**: Permission and project-based filtering
2. **Business logic layer**: Auto-mount folder identification
3. **Presentation layer**: Display filtering with search and external filters

[FR-1358]: https://lablup.atlassian.net/browse/FR-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ