### PR TITLE
fix(FR-1359): hide empty accelerator resource section in BaseResourceItem

### DIFF
--- a/react/src/components/BaseResourceItem.tsx
+++ b/react/src/components/BaseResourceItem.tsx
@@ -230,23 +230,25 @@ const BaseResourceItem: React.FC<BaseResourceItemProps> = ({
                 </BAIStatisticItemWrap>
               )}
             </BAIRowWrapWithDividers>
-            <BAIRowWrapWithDividers
-              rowGap={token.marginXL}
-              columnGap={token.marginXXL}
-              dividerColor={token.colorBorder}
-              dividerWidth={1}
-              style={{
-                backgroundColor: token.colorSuccessBg,
-                borderRadius: token.borderRadiusLG,
-                padding: token.padding,
-              }}
-            >
-              {_.map(visibleAccelerators, ({ key, resourceSlot, values }) => (
-                <BAIStatisticItemWrap key={key}>
-                  {renderResourceProgress(values, resourceSlot)}
-                </BAIStatisticItemWrap>
-              ))}
-            </BAIRowWrapWithDividers>
+            {visibleAccelerators.length > 0 && (
+              <BAIRowWrapWithDividers
+                rowGap={token.marginXL}
+                columnGap={token.marginXXL}
+                dividerColor={token.colorBorder}
+                dividerWidth={1}
+                style={{
+                  backgroundColor: token.colorSuccessBg,
+                  borderRadius: token.borderRadiusLG,
+                  padding: token.padding,
+                }}
+              >
+                {_.map(visibleAccelerators, ({ key, resourceSlot, values }) => (
+                  <BAIStatisticItemWrap key={key}>
+                    {renderResourceProgress(values, resourceSlot)}
+                  </BAIStatisticItemWrap>
+                ))}
+              </BAIRowWrapWithDividers>
+            )}
           </BAIFlex>
         )}
       </BAIFlex>


### PR DESCRIPTION
Resolves #4123 ([FR-1359](https://lablup.atlassian.net/browse/FR-1359))

# Hide accelerator section when no accelerators are visible

This PR adds a conditional check to only render the accelerator section when there are visible accelerators. Previously, the section would always render even when empty, creating unnecessary visual space.

Before

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/35157b1b-62ba-4b13-a5e3-3d17b676088a.png)

After

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/2HueYSdFvL8pOB5mgrUQ/291f1996-3b76-427d-9743-c13c6ceedb86.png)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1359]: https://lablup.atlassian.net/browse/FR-1359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ