### PR TITLE
fix(FR-1191): seperate traceback from error message

### DIFF
--- a/packages/backend.ai-ui/src/hooks/index.ts
+++ b/packages/backend.ai-ui/src/hooks/index.ts
@@ -32,3 +32,7 @@ export function useMemoizedJSONParse<T = any>(
     }
   }, [jsonString, fallbackValue]);
 }
+
+export { default as useErrorMessageResolver } from './useErrorMessageResolver';
+export type { ErrorResponse } from './useErrorMessageResolver';
+export type { ESMClientErrorResponse } from './useErrorMessageResolver';

--- a/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.ts
+++ b/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.ts
@@ -1,0 +1,61 @@
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+
+export type ErrorResponse = {
+  type: string;
+  title: string;
+  msg?: string;
+  error_code?: string;
+  traceback?: string;
+};
+
+export type ESMClientErrorResponse = {
+  isError: true;
+  timestamp: string;
+  type: string;
+  requestUrl: string;
+  requestMethod: string;
+  requestParameters: any;
+  statusCode: number;
+  statusText: string;
+  title: string;
+  msg: string;
+  description: string;
+  error_code?: string;
+  traceback?: string;
+};
+
+const useErrorMessageResolver = () => {
+  const { t } = useTranslation();
+
+  /**
+   * Resolves the error message for a given error object.
+   * @param error - The error object to resolve.
+   * @param defaultMessage - (optional) The default message to return if no specific message is found.
+   * @returns - The resolved error message (string).
+   */
+  const getErrorMessage = (
+    error: Partial<ErrorResponse & Error> | undefined | null,
+    defaultMessage?: string,
+  ): string => {
+    let errorMsg = defaultMessage || t('error.UnknownError');
+    if (!error) return errorMsg;
+
+    if (error?.msg) {
+      errorMsg = !_.includes(error?.msg, 'Traceback') ? error.msg : errorMsg;
+    } else if (error.title) {
+      errorMsg = error.title;
+    }
+    if (error?.error_code) {
+      errorMsg = _.join([errorMsg, `(${error.error_code})`], ' ');
+    }
+
+    return errorMsg;
+  };
+
+  return {
+    getErrorMessage,
+  };
+};
+
+export default useErrorMessageResolver;

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "Wählen Sie Spalten aus, um angezeigt zu werden",
     "SearchTableColumn": "Suchtabellenspalten"
   },
+  "error": {
+    "UnknownError": "Ein unbekannter Fehler ist aufgetreten. \nBitte versuchen Sie es erneut."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Suche",
     "ResetFilter": "Filter zurücksetzen"

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -11,6 +11,9 @@
     "SearchTableColumn": "Στήλες πίνακα αναζήτησης",
     "SettingTable": "Ρυθμίσεις πίνακα"
   },
+  "error": {
+    "UnknownError": "Παρουσιάστηκε ένα άγνωστο σφάλμα. \nΔοκιμάστε ξανά."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Αναζήτηση",
     "ResetFilter": "Επαναφορά φίλτρων"

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "Select columns to display",
     "SearchTableColumn": "Search table columns"
   },
+  "error": {
+    "UnknownError": "An unknown error occurred. Please try again."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Search",
     "ResetFilter": "Reset filters"

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "Seleccionar columnas para mostrar",
     "SearchTableColumn": "Columnas de la tabla de búsqueda"
   },
+  "error": {
+    "UnknownError": "Ocurrió un error desconocido. \nPor favor intente de nuevo."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Buscar en",
     "ResetFilter": "Restablecer filtros"

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "Valitse näytettävä sarakkeet",
     "SearchTableColumn": "Hakutaulukon sarakkeet"
   },
+  "error": {
+    "UnknownError": "Tapahtui tuntematon virhe. \nYritä uudelleen."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Etsi",
     "ResetFilter": "Nollaa suodattimet"

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -11,6 +11,9 @@
     "SettingTable": "Paramètres de la table",
     "SearchTableColumn": "Colonnes de table de recherche"
   },
+  "error": {
+    "UnknownError": "Une erreur inconnue s'est produite. \nVeuillez réessayer."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Recherche",
     "ResetFilter": "Réinitialiser les filtres"

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -11,6 +11,9 @@
     "SettingTable": "Pengaturan Tabel",
     "SearchTableColumn": "Kolom Tabel Cari"
   },
+  "error": {
+    "UnknownError": "Terjadi kesalahan yang tidak diketahui. \nTolong coba lagi."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pencarian",
     "ResetFilter": "Setel ulang filter"

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "Seleziona le colonne da visualizzare",
     "SearchTableColumn": "Colonne della tabella di ricerca"
   },
+  "error": {
+    "UnknownError": "Si è verificato un errore sconosciuto. \nPer favore riprova."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Ricerca",
     "ResetFilter": "Reimposta i filtri"

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -11,6 +11,9 @@
     "SettingTable": "テーブル設定",
     "SearchTableColumn": "テーブル列を検索します"
   },
+  "error": {
+    "UnknownError": "不明なエラーが発生しました。\nもう一度やり直してください。"
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "検索",
     "ResetFilter": "フィルターをリセットする"

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "표시할 열 선택",
     "SearchTableColumn": "표시할 열 검색"
   },
+  "error": {
+    "UnknownError": "알 수 없는 오류가 발생했습니다. 다시 시도해 주세요."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "검색",
     "ResetFilter": "필터 초기화"

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "Дэлгэцийн баганыг сонгоно уу",
     "SearchTableColumn": "Хүснэгтийн баганыг хайх"
   },
+  "error": {
+    "UnknownError": "Үл мэдэгдэх алдаа гарлаа. \nДахин оролдоно уу."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Хайх",
     "ResetFilter": "Шүүлтүүрийг дахин тохируулах"

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "Pilih lajur untuk dipaparkan",
     "SearchTableColumn": "Lajur jadual carian"
   },
+  "error": {
+    "UnknownError": "Kesalahan yang tidak diketahui berlaku. \nSila cuba lagi."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Cari",
     "ResetFilter": "Tetapkan semula penapis"

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "Wybierz kolumny do wyświetlenia",
     "SearchTableColumn": "Wyszukaj kolumny tabeli"
   },
+  "error": {
+    "UnknownError": "Wystąpił nieznany błąd. \nSpróbuj ponownie."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Wyszukiwanie",
     "ResetFilter": "Zresetuj filtry"

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -11,6 +11,9 @@
     "SettingTable": "Configurações da tabela",
     "SearchTableColumn": "Pesquisar colunas da tabela"
   },
+  "error": {
+    "UnknownError": "Ocorreu um erro desconhecido. \nPor favor, tente novamente."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pesquisar",
     "ResetFilter": "Redefinir filtros"

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -11,6 +11,9 @@
     "SettingTable": "Configurações da tabela",
     "SearchTableColumn": "Pesquisar colunas da tabela"
   },
+  "error": {
+    "UnknownError": "Ocorreu um erro desconhecido. \nPor favor, tente novamente."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pesquisar",
     "ResetFilter": "Redefinir filtros"

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -11,6 +11,9 @@
     "SettingTable": "Настройки таблицы",
     "SearchTableColumn": "Поиск таблицы столбцов"
   },
+  "error": {
+    "UnknownError": "Произошла неизвестная ошибка. \nПожалуйста, попробуйте еще раз."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Поиск",
     "ResetFilter": "Сбросить фильтры"

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "เลือกคอลัมน์ที่จะแสดง",
     "SearchTableColumn": "คอลัมน์ตารางค้นหา"
   },
+  "error": {
+    "UnknownError": "เกิดข้อผิดพลาดที่ไม่รู้จัก \nโปรดลองอีกครั้ง"
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "ค้นหา",
     "ResetFilter": "รีเซ็ตตัวกรอง"

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "Görüntülemek için sütunları seçin",
     "SearchTableColumn": "Arama Tablosu sütunları"
   },
+  "error": {
+    "UnknownError": "Bilinmeyen bir hata oluştu. \nLütfen tekrar deneyin."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Arama",
     "ResetFilter": "Filtreleri sıfırla"

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "Chọn các cột để hiển thị",
     "SearchTableColumn": "Các cột bảng tìm kiếm"
   },
+  "error": {
+    "UnknownError": "Một lỗi không xác định xảy ra. \nHãy thử lại."
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Tìm kiếm",
     "ResetFilter": "Đặt lại bộ lọc"

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "选择要显示的列",
     "SearchTableColumn": "搜索表列"
   },
+  "error": {
+    "UnknownError": "发生了未知错误。\n请重试。"
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "搜索",
     "ResetFilter": "重置过滤器"

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -11,6 +11,9 @@
     "SelectColumnToDisplay": "選擇要顯示的列",
     "SearchTableColumn": "搜索表列"
   },
+  "error": {
+    "UnknownError": "發生了未知錯誤。請重試。"
+  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "搜索",
     "ResetFilter": "重置過濾器"

--- a/react/src/components/DeleteVFolderModal.tsx
+++ b/react/src/components/DeleteVFolderModal.tsx
@@ -2,11 +2,9 @@ import { DeleteVFolderModalFragment$key } from '../__generated__/DeleteVFolderMo
 import { VFolderNodesFragment$data } from '../__generated__/VFolderNodesFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
-import { useSetBAINotification } from '../hooks/useBAINotification';
-import { usePainKiller } from '../hooks/usePainKiller';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { Typography, message } from 'antd';
-import { toLocalId } from 'backend.ai-ui';
+import { toLocalId, useErrorMessageResolver } from 'backend.ai-ui';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,9 +23,8 @@ const DeleteVFolderModal: React.FC<DeleteVFolderModalProps> = ({
   ...baiModalProps
 }) => {
   const { t } = useTranslation();
-  const { upsertNotification } = useSetBAINotification();
   const baiClient = useSuspendedBackendaiClient();
-  const painKiller = usePainKiller();
+  const { getErrorMessage } = useErrorMessageResolver();
 
   const vfolders = useFragment(
     graphql`
@@ -56,11 +53,8 @@ const DeleteVFolderModal: React.FC<DeleteVFolderModalProps> = ({
       onOk={() => {
         const promises = _.map(vfolders, (vfolder: VFolderType) =>
           deleteMutation.mutateAsync(vfolder.id).catch((error) => {
-            upsertNotification({
-              message: painKiller.relieve(error?.title),
-              description: error?.description,
-              open: true,
-            });
+            message.error(getErrorMessage(error));
+            return Promise.reject();
           }),
         );
         Promise.allSettled(promises).then((results) => {

--- a/react/src/components/EditableVFolderName.tsx
+++ b/react/src/components/EditableVFolderName.tsx
@@ -4,14 +4,13 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
-import { usePainKiller } from '../hooks/usePainKiller';
 import { isDeletedCategory } from '../pages/VFolderNodeListPage';
 import BAILink from './BAILink';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import { theme, Form, Input, App } from 'antd';
 import Text, { TextProps } from 'antd/es/typography/Text';
 import Title, { TitleProps } from 'antd/es/typography/Title';
-import { toLocalId } from 'backend.ai-ui';
+import { toLocalId, useErrorMessageResolver } from 'backend.ai-ui';
 import _ from 'lodash';
 import { CornerDownLeftIcon } from 'lucide-react';
 import React, { useState } from 'react';
@@ -67,11 +66,11 @@ const EditableVFolderName: React.FC<EditableVFolderNameProps> = ({
     },
   });
   const relayEnv = useRelayEnvironment();
-  const painKiller = usePainKiller();
 
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
   const { generateFolderPath } = useFolderExplorerOpener();
   const [isEditing, setIsEditing] = useState(false);
 
@@ -157,7 +156,7 @@ const EditableVFolderName: React.FC<EditableVFolderNameProps> = ({
                 },
                 onError: (error) => {
                   onEditEnd?.();
-                  message.error(painKiller.relieve(error?.message));
+                  message.error(getErrorMessage(error));
                   setOptimisticName(vfolder.name);
                 },
               },

--- a/react/src/components/EndpointTokenGenerationModal.tsx
+++ b/react/src/components/EndpointTokenGenerationModal.tsx
@@ -3,7 +3,7 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { Alert, DatePicker, Form, FormInstance, message } from 'antd';
-import { BAIFlex } from 'backend.ai-ui';
+import { BAIFlex, ESMClientErrorResponse } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -29,9 +29,7 @@ const EndpointTokenGenerationModal: React.FC<
 
   const mutationToGenerateToken = useTanMutation<
     unknown,
-    {
-      message?: string;
-    },
+    ESMClientErrorResponse,
     EndpointTokenGenerationInput
   >({
     mutationFn: (values) => {
@@ -61,7 +59,7 @@ const EndpointTokenGenerationModal: React.FC<
             onRequestClose(true);
           },
           onError: (err) => {
-            if (err?.message?.includes('valid_until is older than now')) {
+            if (err?.msg?.includes('valid_until is older than now')) {
               message.error(t('modelService.TokenExpiredDateError'));
               return;
             } else {

--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -21,7 +21,11 @@ import {
 } from 'antd';
 import { createStyles } from 'antd-style';
 import { FormInstance } from 'antd/lib';
-import { BAIFlex } from 'backend.ai-ui';
+import {
+  BAIFlex,
+  ESMClientErrorResponse,
+  useErrorMessageResolver,
+} from 'backend.ai-ui';
 import _ from 'lodash';
 import { TriangleAlertIcon } from 'lucide-react';
 import { Suspense, useRef } from 'react';
@@ -106,6 +110,8 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
 
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
 
+  const { getErrorMessage } = useErrorMessageResolver();
+
   const { data: allowedTypes, isFetching: isFetchingAllowedTypes } =
     useTanQuery({
       queryKey: ['allowedTypes', modalProps.open],
@@ -116,7 +122,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
 
   const mutationToCreateFolder = useTanMutation<
     FolderCreationResponse,
-    { message?: string },
+    ESMClientErrorResponse,
     FolderCreateFormItemsType
   >({
     mutationFn: (values) => {
@@ -179,7 +185,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
             onRequestClose(result);
           },
           onError: (error) => {
-            message.error(error.message);
+            message.error(getErrorMessage(error));
           },
         });
       })

--- a/react/src/components/ImportFromHuggingFaceModal.tsx
+++ b/react/src/components/ImportFromHuggingFaceModal.tsx
@@ -26,7 +26,7 @@ import {
   Tooltip,
   Typography,
 } from 'antd';
-import { BAIFlex } from 'backend.ai-ui';
+import { BAIFlex, useErrorMessageResolver } from 'backend.ai-ui';
 import _ from 'lodash';
 import { CheckIcon } from 'lucide-react';
 import Markdown from 'markdown-to-jsx';
@@ -92,6 +92,7 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
   const baiClient = useSuspendedBackendaiClient();
   const formRef = useRef<FormInstance<Service>>(null);
   const currentProject = useCurrentProjectValue();
@@ -208,7 +209,7 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
               onRequestClose();
             },
             onError(e) {
-              message.error(e.message || t('dialog.ErrorOccurred'));
+              message.error(getErrorMessage(e));
             },
           },
         );
@@ -400,7 +401,7 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
                     folderName: importResult?.folder?.name,
                     serviceName: importResult?.service?.name,
                   })
-              : importAndStartService?.error?.message
+              : getErrorMessage(importAndStartService?.error)
           }
           extra={
             importAndStartService?.isSuccess && (

--- a/react/src/components/InviteFolderSettingModal.tsx
+++ b/react/src/components/InviteFolderSettingModal.tsx
@@ -1,7 +1,6 @@
 import { localeCompare, useBaiSignedRequestWithPromise } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation, useTanQuery } from '../hooks/reactQueryAlias';
-import { usePainKiller } from '../hooks/usePainKiller';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { CloseCircleOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import {
@@ -17,7 +16,7 @@ import {
   Typography,
   theme,
 } from 'antd';
-import { BAITable, BAIFlex } from 'backend.ai-ui';
+import { BAITable, BAIFlex, useErrorMessageResolver } from 'backend.ai-ui';
 import _ from 'lodash';
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -46,7 +45,7 @@ const InviteFolderSettingModal: React.FC<InviteFolderSettingModalProps> = ({
   const baiClient = useSuspendedBackendaiClient();
   const inviteFormRef = useRef<FormInstance>(null);
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
-  const painKiller = usePainKiller();
+  const { getErrorMessage } = useErrorMessageResolver();
   const { token } = theme.useToken();
 
   const {
@@ -126,10 +125,7 @@ const InviteFolderSettingModal: React.FC<InviteFolderSettingModalProps> = ({
                 );
                 return;
               }
-              message.error(
-                painKiller.relieve(err?.message) ||
-                  t('data.invitation.FolderSharingNotAvailableToUser'),
-              );
+              message.error(getErrorMessage(err));
             },
           },
         );
@@ -150,10 +146,7 @@ const InviteFolderSettingModal: React.FC<InviteFolderSettingModalProps> = ({
           refetch();
         },
         onError: (err) => {
-          message.error(
-            painKiller.relieve(err?.message) ||
-              t('data.permission.FailedToModifyPermission'),
-          );
+          message.error(getErrorMessage(err));
         },
       },
     );

--- a/react/src/components/ModelCloneModal.tsx
+++ b/react/src/components/ModelCloneModal.tsx
@@ -2,7 +2,6 @@ import { ModelCloneModalVFolderFragment$key } from '../__generated__/ModelCloneM
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
-import { usePainKiller } from '../hooks/usePainKiller';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import StorageSelect from './StorageSelect';
 import {
@@ -15,7 +14,11 @@ import {
   Switch,
   message,
 } from 'antd';
-import { BAIFlex } from 'backend.ai-ui';
+import {
+  BAIFlex,
+  ESMClientErrorResponse,
+  useErrorMessageResolver,
+} from 'backend.ai-ui';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
@@ -53,7 +56,7 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
       usage_mode: string;
     }>
   >(null);
-  const painKiller = usePainKiller();
+  const { getErrorMessage } = useErrorMessageResolver();
   const { upsertNotification } = useSetBAINotification();
 
   const [extraNameError, setExtraNameError] = useState<
@@ -65,7 +68,7 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
       bgtask_id: string;
       id: string;
     },
-    { type?: string; title?: string; message?: string },
+    ESMClientErrorResponse,
     {
       input: any;
       name: string;
@@ -122,7 +125,7 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
                   },
                   onError(error) {
                     if (
-                      error.message?.includes(
+                      error.msg?.includes(
                         'The virtual folder already exists with the same name',
                       )
                     ) {
@@ -131,12 +134,7 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
                         help: t('modelStore.FolderAlreadyExists'),
                       });
                     } else {
-                      const messageStr = painKiller.relieve(
-                        error?.message || '',
-                      );
-                      message.error({
-                        content: messageStr,
-                      });
+                      message.error(getErrorMessage(error));
                     }
                   },
                 },

--- a/react/src/components/ModelTryContentButton.tsx
+++ b/react/src/components/ModelTryContentButton.tsx
@@ -23,6 +23,7 @@ import {
   ServiceLauncherFormValue,
 } from './ServiceLauncherPageContent';
 import { Button } from 'antd';
+import { ESMClientErrorResponse } from 'backend.ai-ui';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -133,7 +134,7 @@ const ModelTryContentButton: React.FC<ModelTryContentButtonProps> = ({
       bgtask_id: string;
       id: string;
     },
-    { type?: string; title?: string; message?: string },
+    ESMClientErrorResponse,
     {
       input: any;
       name: string;

--- a/react/src/components/ServiceValidationView.tsx
+++ b/react/src/components/ServiceValidationView.tsx
@@ -15,7 +15,11 @@ import {
 import ValidationStatusTag from './ValidationStatusTag';
 import { AnsiUp } from 'ansi_up';
 import { App, Tag, theme } from 'antd';
-import { BAIFlex } from 'backend.ai-ui';
+import {
+  BAIFlex,
+  ESMClientErrorResponse,
+  useErrorMessageResolver,
+} from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
 import React, { Suspense, useEffect, useRef, useState } from 'react';
@@ -37,6 +41,7 @@ const ServiceValidationView: React.FC<ServiceValidationModalProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
   const [validationStatus, setValidationStatus] = useState('');
   const [containerLogSummary, setContainerLogSummary] = useState('');
   const [validationTime, setValidationTime] = useState('Before validation');
@@ -55,9 +60,7 @@ const ServiceValidationView: React.FC<ServiceValidationModalProps> = ({
 
   const mutationsToValidateService = useTanMutation<
     unknown,
-    {
-      message?: string;
-    },
+    ESMClientErrorResponse,
     ServiceLauncherFormValue
   >({
     mutationFn: (values) => {
@@ -183,9 +186,7 @@ const ServiceValidationView: React.FC<ServiceValidationModalProps> = ({
       })
       .catch((error) => {
         message.error(
-          error?.message
-            ? _.truncate(error?.message, { length: 200 })
-            : t('modelService.FormValidationFailed'),
+          getErrorMessage(error) || t('modelService.FormValidationFailed'),
         );
       })
       .finally(() => {

--- a/react/src/components/SharedFolderPermissionInfoModal.tsx
+++ b/react/src/components/SharedFolderPermissionInfoModal.tsx
@@ -5,7 +5,6 @@ import {
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
-import { usePainKiller } from '../hooks/usePainKiller';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import VFolderPermissionCell from './VFolderPermissionCell';
 import { UserOutlined } from '@ant-design/icons';
@@ -24,6 +23,7 @@ import {
   BAITable,
   BAIUserUnionIcon,
   BAIFlex,
+  useErrorMessageResolver,
 } from 'backend.ai-ui';
 import { LogOut } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -42,9 +42,9 @@ const SharedFolderPermissionInfoModal: React.FC<
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
   const [currentUser] = useCurrentUserInfo();
   const baiClient = useSuspendedBackendaiClient();
-  const painKiller = usePainKiller();
 
   const vfolder = useFragment(
     graphql`
@@ -157,10 +157,7 @@ const SharedFolderPermissionInfoModal: React.FC<
                                 onRequestClose(true);
                               },
                               onError: (err) => {
-                                message.error(
-                                  painKiller.relieve(err?.message) ||
-                                    t('general.ErrorOccurred'),
-                                );
+                                message.error(getErrorMessage(err));
                                 onRequestClose();
                               },
                             },

--- a/react/src/components/ShellScriptEditModal.tsx
+++ b/react/src/components/ShellScriptEditModal.tsx
@@ -5,7 +5,7 @@ import BAICodeEditor from './BAICodeEditor';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { DeleteOutlined } from '@ant-design/icons';
 import { App, Button, Dropdown, Form, Select, Typography } from 'antd';
-import { BAIFlex } from 'backend.ai-ui';
+import { BAIFlex, useErrorMessageResolver } from 'backend.ai-ui';
 import _ from 'lodash';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -27,7 +27,8 @@ const ShellScriptEditModal: React.FC<BootstrapScriptEditModalProps> = ({
   ...modalProps
 }) => {
   const { t } = useTranslation();
-  const app = App.useApp();
+  const { message, modal } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
   const [rcfileNames, setRcfileNames] = useState<string>('.bashrc');
   const [script, setScript] = useState<string>('');
   const [userConfigScript, setUserConfigScript] = useState<
@@ -114,16 +115,16 @@ const ShellScriptEditModal: React.FC<BootstrapScriptEditModalProps> = ({
   const saveScript = ({ closeAfter = true } = {}) => {
     if (shellInfo === 'bootstrap') {
       if (!script) {
-        app.message.error(t('userSettings.BootstrapScriptEmpty'));
+        message.error(t('userSettings.BootstrapScriptEmpty'));
         return;
       }
       updateBootStrapScriptMutation.mutate(script, {
         onSuccess: (result) => {
-          app.message.success(t('userSettings.BootstrapScriptUpdated'));
+          message.success(t('userSettings.BootstrapScriptUpdated'));
           closeAfter && onRequestClose();
         },
-        onError: (error: any) => {
-          app.message.error(error.message);
+        onError: (error) => {
+          message.error(getErrorMessage(error));
           console.error(error);
         },
       });
@@ -134,30 +135,30 @@ const ShellScriptEditModal: React.FC<BootstrapScriptEditModalProps> = ({
       if (existValidator) {
         updateUserConfigScriptMutation.mutate(script, {
           onSuccess: (result) => {
-            app.message.success(t('userSettings.DescScriptUpdated'));
+            message.success(t('userSettings.DescScriptUpdated'));
             if (closeAfter) {
               onRequestClose();
             } else {
               fetchScript();
             }
           },
-          onError: (error: any) => {
-            app.message.error(t('userSettings.DescNewUserConfigFileCreated'));
+          onError: (error) => {
+            message.error(getErrorMessage(error));
             console.error(error);
           },
         });
       } else {
         createUserConfigScriptMutation.mutate(script, {
           onSuccess: (result) => {
-            app.message.success(t('userSettings.DescScriptCreated'));
+            message.success(t('userSettings.DescScriptCreated'));
             if (closeAfter) {
               onRequestClose();
             } else {
               fetchScript();
             }
           },
-          onError: (error: any) => {
-            app.message.error(t('userSettings.DescNewUserConfigFileCreated'));
+          onError: (error) => {
+            message.error(getErrorMessage(error));
             console.error(error);
           },
         });
@@ -169,11 +170,11 @@ const ShellScriptEditModal: React.FC<BootstrapScriptEditModalProps> = ({
     if (shellInfo === 'bootstrap') {
       updateBootStrapScriptMutation.mutate('', {
         onSuccess: (result) => {
-          app.message.success(t('userSettings.BootstrapScriptDeleted'));
+          message.success(t('userSettings.BootstrapScriptDeleted'));
           onRequestClose();
         },
-        onError: (error: any) => {
-          app.message.error(error.message);
+        onError: (error) => {
+          message.error(getErrorMessage(error));
           console.error(error);
         },
       });
@@ -181,13 +182,13 @@ const ShellScriptEditModal: React.FC<BootstrapScriptEditModalProps> = ({
     if (shellInfo === 'userconfig') {
       deleteUserConfigScriptMutation.mutate(undefined, {
         onSuccess: (result) => {
-          app.message.success(
+          message.success(
             `${t('userSettings.DescScriptDeleted')}${rcfileNames}`,
           );
           onRequestClose();
         },
-        onError: (error: any) => {
-          app.message.error(error.message);
+        onError: (error) => {
+          message.error(getErrorMessage(error));
           console.error(error);
         },
       });
@@ -217,7 +218,7 @@ const ShellScriptEditModal: React.FC<BootstrapScriptEditModalProps> = ({
                     key: 'reset',
                     label: t('button.Reset'),
                     onClick: () => {
-                      app.modal.confirm({
+                      modal.confirm({
                         title: t('dialog.title.LetsDouble-Check'),
                         content: t('dialog.ask.DoYouWantToResetChanges'),
                         onOk: () => {
@@ -235,7 +236,7 @@ const ShellScriptEditModal: React.FC<BootstrapScriptEditModalProps> = ({
                 ],
               }}
               onClick={() => {
-                app.modal.confirm({
+                modal.confirm({
                   title: t('dialog.title.LetsDouble-Check'),
                   content: t('dialog.ask.DoYouWantToDeleteSomething', {
                     name:

--- a/react/src/components/SignoutModal.tsx
+++ b/react/src/components/SignoutModal.tsx
@@ -2,6 +2,7 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { Form, Input, message, Alert, FormInstance } from 'antd';
+import { useErrorMessageResolver } from 'backend.ai-ui';
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -17,6 +18,7 @@ const SignoutModal: React.FC<SignoutModalProps> = ({
 }) => {
   const formRef = useRef<FormInstance>(null);
   const { t } = useTranslation();
+  const { getErrorMessage } = useErrorMessageResolver();
   const [messageApi, contextHolder] = message.useMessage();
   const baiClient = useSuspendedBackendaiClient();
   const signoutMutation = useTanMutation({
@@ -38,10 +40,10 @@ const SignoutModal: React.FC<SignoutModalProps> = ({
               const event = new CustomEvent('backend-ai-logout');
               document.dispatchEvent(event);
             },
-            onError: (e: any) => {
+            onError: (e) => {
               messageApi.open({
                 type: 'error',
-                content: e.message,
+                content: getErrorMessage(e),
               });
             },
           },

--- a/react/src/components/SummaryPageItems/SummaryItemInvitation.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemInvitation.tsx
@@ -8,13 +8,14 @@ import {
   useTanMutation,
 } from '../../hooks/reactQueryAlias';
 import { App, Button, Descriptions, Empty, Tag, Typography, theme } from 'antd';
-import { BAICard, BAIFlex } from 'backend.ai-ui';
+import { BAICard, BAIFlex, useErrorMessageResolver } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';
 
 const SummaryItemInvitation: React.FC = () => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const app = App.useApp();
+  const { message } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
 
   const baiClient = useSuspendedBackendaiClient();
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
@@ -106,15 +107,13 @@ const SummaryItemInvitation: React.FC = () => {
                     terminateInvitationsMutation.mutate(invitation.id, {
                       onSuccess() {
                         refetch();
-                        app.message.success(
+                        message.success(
                           t('summary.DeclineSharedVFolder') +
                             invitation.vfolder_name,
                         );
                       },
-                      onError(error: any) {
-                        app.message.error(
-                          error.message || t('dialog.ErrorOccurred'),
-                        );
+                      onError(error) {
+                        message.error(getErrorMessage(error));
                       },
                     })
                   }
@@ -136,14 +135,14 @@ const SummaryItemInvitation: React.FC = () => {
                     acceptInvitationsMutation.mutate(invitation.id, {
                       onSuccess() {
                         refetch();
-                        app.message.success(
+                        message.success(
                           t('summary.AcceptSharedVFolder') +
                             invitation.vfolder_name,
                         );
                       },
-                      onError(error: any) {
-                        app.message.error(
-                          error.message || t('dialog.ErrorOccurred'),
+                      onError(error) {
+                        message.error(
+                          getErrorMessage(error) || t('dialog.ErrorOccurred'),
                         );
                       },
                     })

--- a/react/src/components/UserProfileSettingModal.tsx
+++ b/react/src/components/UserProfileSettingModal.tsx
@@ -22,6 +22,7 @@ import {
   Spin,
   FormInstance,
 } from 'antd';
+import { useErrorMessageResolver } from 'backend.ai-ui';
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PreloadedQuery, usePreloadedQuery } from 'react-relay';
@@ -59,7 +60,7 @@ const UserProfileSettingModal: React.FC<Props> = ({
   const baiClient = useSuspendedBackendaiClient();
   const userRole = useCurrentUserRole();
   const [userInfo, userMutations] = useCurrentUserInfo();
-  // const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
+  const { getErrorMessage } = useErrorMessageResolver();
 
   const { user } = usePreloadedQuery(UserProfileQuery, queryRef);
 
@@ -258,8 +259,8 @@ const UserProfileSettingModal: React.FC<Props> = ({
                                   false,
                                 );
                               },
-                              onError: (error: any) => {
-                                message.error(error.message);
+                              onError: (error) => {
+                                message.error(getErrorMessage(error));
                               },
                             });
                           },

--- a/react/src/components/VFolderNodeDescription.tsx
+++ b/react/src/components/VFolderNodeDescription.tsx
@@ -6,7 +6,6 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
-import { usePainKiller } from '../hooks/usePainKiller';
 import { useVirtualFolderPath } from '../hooks/useVirtualFolderNodePath';
 import BAISelect from './BAISelect';
 import BAITag from './BAITag';
@@ -25,6 +24,7 @@ import {
   BAIUserUnionIcon,
   toLocalId,
   BAIFlex,
+  useErrorMessageResolver,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
@@ -49,10 +49,10 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
 
   const relayEnv = useRelayEnvironment();
   const currentProject = useCurrentProjectValue();
-  const painKiller = usePainKiller();
   const baiClient = useSuspendedBackendaiClient();
   const [currentUser] = useCurrentUserInfo();
 
@@ -197,8 +197,8 @@ const VFolderNodeDescription: React.FC<VFolderNodeDescriptionProps> = ({
                   ).toPromise();
                   onRequestRefresh?.();
                 },
-                onError: (error: { message: string }) => {
-                  message.error(painKiller.relieve(error?.message));
+                onError: (error) => {
+                  message.error(getErrorMessage(error));
                 },
               },
             );

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -7,7 +7,6 @@ import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
-import { usePainKiller } from '../hooks/usePainKiller';
 import { isDeletedCategory } from '../pages/VFolderNodeListPage';
 import BAIConfirmModalWithInput from './BAIConfirmModalWithInput';
 import BAILink from './BAILink';
@@ -38,6 +37,7 @@ import {
   BAITableProps,
   BAIFlex,
   toLocalId,
+  useErrorMessageResolver,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import React, { useState } from 'react';
@@ -76,13 +76,13 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
   const { message } = App.useApp();
   const currentProject = useCurrentProjectValue();
   const baiClient = useSuspendedBackendaiClient();
-  const painKiller = usePainKiller();
   const [currentUser] = useCurrentUserInfo();
   const [hoveredColumn, setHoveredColumn] = useState<string | null>();
   const [editingColumn, setEditingColumn] = useState<string | null>(null);
   const [inviteFolderId, setInviteFolderId] = useState<string | null>(null);
   const { upsertNotification } = useSetBAINotification();
   const { generateFolderPath } = useFolderExplorerOpener();
+  const { getErrorMessage } = useErrorMessageResolver();
 
   const [currentVFolder, setCurrentVFolder] =
     useState<VFolderNodeInList | null>(null);
@@ -275,7 +275,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
                             },
                             onError: (error) => {
                               upsertNotification({
-                                description: painKiller.relieve(error?.message),
+                                description: getErrorMessage(error),
                                 open: true,
                               });
                             },
@@ -300,7 +300,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
                           },
                           onError: (error) => {
                             upsertNotification({
-                              description: painKiller.relieve(error?.message),
+                              description: getErrorMessage(error),
                               open: true,
                             });
                           },
@@ -454,7 +454,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
             },
             onError: (error) => {
               upsertNotification({
-                description: painKiller.relieve(error?.message),
+                description: getErrorMessage(error),
                 open: true,
               });
             },

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -324,6 +324,8 @@ class Client {
     let errorTitle = '';
     let errorMsg;
     let errorDesc = '';
+    let errorCode = '';
+    let traceback = '';
     let resp, body, requestTimer, requestTimerForSoftTimeout;
     let isSoftTimeoutTriggered = false;
     try {
@@ -384,6 +386,8 @@ class Client {
         body = await resp.json(); // Formatted error message from manager
         errorType = body.type;
         errorTitle = body.title;
+        errorCode = body?.error_code;
+        traceback = body?.traceback;
       } else if (!rawFile && contentType?.startsWith('text/')) {
         body = await resp.text();
       } else {
@@ -495,8 +499,10 @@ class Client {
         statusCode: resp.status,
         statusText: resp.statusText,
         title: errorTitle,
-        message: errorMsg,
+        msg: errorMsg,
         description: errorDesc,
+        error_code: errorCode,
+        traceback: traceback,
       };
     }
 


### PR DESCRIPTION
### Add useErrorMessageResolver hook for consistent error handling

resolves #3887 ([FR-1191](https://lablup.atlassian.net/browse/FR-1191))

This PR adds a new `useErrorMessageResolver` hook to standardize error message handling across the application. The hook provides a `getErrorMessage` function that extracts the most relevant error message from error objects, with support for internationalization.

Key changes:
- Created new `useErrorMessageResolver` hook with TypeScript interfaces for error responses
- Added "UnknownError" translation strings to all locale files
- Refactored error handling in multiple components to use the new hook
- Standardized error response types in API client and mutation hooks

This implementation ensures consistent error message display throughout the application, improving user experience by providing clearer error messages with proper localization.

**Checklist:**

- [x] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1191]: https://lablup.atlassian.net/browse/FR-1191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ