### PR TITLE
fix(FR-1378): improve error handling logic in service update flow

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -274,20 +274,6 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
     };
   };
 
-  const legacyMutationToUpdateService = useTanMutation({
-    mutationFn: (values: ServiceLauncherFormValue) => {
-      const body = {
-        to: values.replicas,
-      };
-      return baiSignedRequestWithPromise({
-        method: 'POST',
-        url: `/services/${endpoint?.endpoint_id}/scale`,
-        body,
-        client: baiClient,
-      });
-    },
-  });
-
   const mutationToCreateService = useTanMutation<
     unknown,
     | {
@@ -492,108 +478,91 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
       .validateFields()
       .then((values) => {
         if (endpoint) {
-          if (baiClient.supports('modify-endpoint')) {
-            const mutationVariables: ServiceLauncherPageContentModifyMutation['variables'] =
-              {
-                endpoint_id: endpoint?.endpoint_id || '',
-                props: {
-                  resource_slots: JSON.stringify({
-                    cpu: values.resource.cpu,
-                    mem: values.resource.mem,
-                    ...(values.resource.accelerator > 0
-                      ? {
-                          [values.resource.acceleratorType]:
-                            values.resource.accelerator,
-                        }
-                      : undefined),
-                  }),
-                  resource_opts: JSON.stringify({
-                    shmem: values.resource.shmem,
-                  }),
-                  // FIXME: temporarily convert cluster mode string according to server-side type
-                  cluster_mode:
-                    'single-node' === values.cluster_mode
-                      ? 'SINGLE_NODE'
-                      : 'MULTI_NODE',
-                  cluster_size: values.cluster_size,
-                  ...(baiClient.supports('replicas')
-                    ? { replicas: values.replicas }
-                    : {
-                        desired_session_count: values.replicas,
-                      }),
-                  ...getImageInfoFromInputInEditing(
-                    checkManualImageAllowed(
-                      baiClient._config.allow_manual_image_name_for_session,
-                      values.environments?.manual,
-                    ),
-                    values,
-                  ),
-                  extra_mounts: _.map(values.mount_ids, (vfolder) => {
-                    return {
-                      vfolder_id: vfolder,
-                      ...(values.mount_id_map[vfolder] && {
-                        mount_destination: values.mount_id_map[vfolder],
-                      }),
-                    };
-                  }),
-                  name: values.serviceName,
-                  resource_group: values.resourceGroup,
-                  model_definition_path: values.modelDefinitionPath,
-                  runtime_variant: values.runtimeVariant,
-                },
-              };
-            const newEnvirons: { [key: string]: string } = {};
-            if (values.envvars) {
-              values.envvars.forEach(
-                (v) => (newEnvirons[v.variable] = v.value),
-              );
-            }
-            mutationVariables.props.environ = JSON.stringify(newEnvirons);
-            commitModifyEndpoint({
-              variables: mutationVariables,
-              onCompleted: (res, errors) => {
-                if (!res.modify_endpoint?.ok) {
-                  message.error(res.modify_endpoint?.msg);
-                  return;
-                }
-                if (errors && errors?.length > 0) {
-                  const errorMsgList = _.map(errors, (error) => error.message);
-                  for (const error of errorMsgList) {
-                    message.error(error);
-                  }
-                } else {
-                  const updatedEndpoint = res.modify_endpoint?.endpoint;
-                  message.success(
-                    t('modelService.ServiceUpdated', {
-                      name: updatedEndpoint?.name,
+          const mutationVariables: ServiceLauncherPageContentModifyMutation['variables'] =
+            {
+              endpoint_id: endpoint?.endpoint_id || '',
+              props: {
+                resource_slots: JSON.stringify({
+                  cpu: values.resource.cpu,
+                  mem: values.resource.mem,
+                  ...(values.resource.accelerator > 0
+                    ? {
+                        [values.resource.acceleratorType]:
+                          values.resource.accelerator,
+                      }
+                    : undefined),
+                }),
+                resource_opts: JSON.stringify({
+                  shmem: values.resource.shmem,
+                }),
+                // FIXME: temporarily convert cluster mode string according to server-side type
+                cluster_mode:
+                  'single-node' === values.cluster_mode
+                    ? 'SINGLE_NODE'
+                    : 'MULTI_NODE',
+                cluster_size: values.cluster_size,
+                ...(baiClient.supports('replicas')
+                  ? { replicas: values.replicas }
+                  : {
+                      desired_session_count: values.replicas,
                     }),
-                  );
-                  webuiNavigate(`/serving/${endpoint?.endpoint_id}`);
-                }
+                ...getImageInfoFromInputInEditing(
+                  checkManualImageAllowed(
+                    baiClient._config.allow_manual_image_name_for_session,
+                    values.environments?.manual,
+                  ),
+                  values,
+                ),
+                extra_mounts: _.map(values.mount_ids, (vfolder) => {
+                  return {
+                    vfolder_id: vfolder,
+                    ...(values.mount_id_map[vfolder] && {
+                      mount_destination: values.mount_id_map[vfolder],
+                    }),
+                  };
+                }),
+                name: values.serviceName,
+                resource_group: values.resourceGroup,
+                model_definition_path: values.modelDefinitionPath,
+                runtime_variant: values.runtimeVariant,
               },
-              onError: (error) => {
-                if (error.message) {
-                  message.error(error.message);
-                } else {
-                  message.error(t('modelService.FailedToUpdateService'));
-                }
-              },
-            });
-          } else {
-            legacyMutationToUpdateService.mutate(values, {
-              onSuccess: () => {
+            };
+          const newEnvirons: { [key: string]: string } = {};
+          if (values.envvars) {
+            values.envvars.forEach((v) => (newEnvirons[v.variable] = v.value));
+          }
+          mutationVariables.props.environ = JSON.stringify(newEnvirons);
+          commitModifyEndpoint({
+            variables: mutationVariables,
+            onCompleted: (res, errors) => {
+              if (res.modify_endpoint?.ok) {
+                const updatedEndpoint = res.modify_endpoint?.endpoint;
                 message.success(
                   t('modelService.ServiceUpdated', {
-                    name: endpoint.name, // FIXME: temporally get name from endpoint, not input value
+                    name: updatedEndpoint?.name,
                   }),
                 );
                 webuiNavigate(`/serving/${endpoint?.endpoint_id}`);
-              },
-              onError: (error) => {
+                return;
+              }
+
+              if (res.modify_endpoint?.msg) {
+                message.error(res.modify_endpoint?.msg);
+              } else if (errors && errors?.length > 0) {
+                const errorMsgList = _.map(errors, (error) => error.message);
+                for (const error of errorMsgList) {
+                  message.error(error);
+                }
+              }
+            },
+            onError: (error) => {
+              if (error.message) {
+                message.error(error.message);
+              } else {
                 message.error(t('modelService.FailedToUpdateService'));
-              },
-            });
-          }
+              }
+            },
+          });
         } else {
           // create service
           mutationToCreateService.mutate(values, {


### PR DESCRIPTION
Resolves #4153 ([FR-1378](https://lablup.atlassian.net/browse/FR-1378))

## Summary

Improves error handling logic in the service update flow to properly display server error messages when endpoint modification fails.

## Changes

- Removed unused legacy mutation function `legacyMutationToUpdateService`
- Simplified conditional logic by removing `baiClient.supports('modify-endpoint')` check
- Streamlined error handling to ensure server error messages are properly displayed
- Consolidated success/error message flow for better user experience

## Test Plan

- [ ] Test endpoint modification with invalid image name format to verify proper error message display
- [ ] Verify successful endpoint updates still show success messages correctly
- [ ] Ensure all existing functionality remains intact

**Type:** Bug Fix
**Component:** Service Launcher

[FR-1378]: https://lablup.atlassian.net/browse/FR-1378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ