### PR TITLE
style(FR-1386): change invite folder modal title from 'Modify Permissions' to 'Share Folder'

### DIFF
--- a/react/src/components/InviteFolderSettingModal.tsx
+++ b/react/src/components/InviteFolderSettingModal.tsx
@@ -163,7 +163,7 @@ const InviteFolderSettingModal: React.FC<InviteFolderSettingModalProps> = ({
   return (
     <BAIModal
       {...baiModalProps}
-      title={t('data.explorer.ModifyPermissions')}
+      title={t('data.explorer.ShareFolder')}
       onCancel={onRequestClose}
       style={{ minWidth: 550 }}
       destroyOnClose

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "Eingeladene E-Mail",
       "KeepFileExtension": "Behalten",
       "LessThan10Sec": "Weniger als 10 Sekunden",
-      "ModifyPermissions": "Berechtigungen ändern",
       "MoreThanADay": "Mehr als ein Tag",
       "Name": "Name",
       "NewFileName": "Neuer Dateiname",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -299,7 +299,6 @@
       "InviteeEmail": "Πρόσκληση e-mail",
       "KeepFileExtension": "Διατήρηση",
       "LessThan10Sec": "Λιγότερο από 10 δευτερόλεπτα",
-      "ModifyPermissions": "Τροποποίηση δικαιωμάτων",
       "MoreThanADay": "Περισσότερο από μια μέρα",
       "Name": "Ονομα",
       "NewFileName": "Νέο όνομα αρχείου",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -303,7 +303,6 @@
       "InviteeEmail": "Invitee email",
       "KeepFileExtension": "Keep ",
       "LessThan10Sec": "Less than 10 seconds",
-      "ModifyPermissions": "Modify Permissions",
       "MoreThanADay": "More than a day",
       "Name": "Name",
       "NewFileName": "New file name",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "Correo electrónico del invitado",
       "KeepFileExtension": "Visite",
       "LessThan10Sec": "Menos de 10 segundos",
-      "ModifyPermissions": "Modificar permisos",
       "MoreThanADay": "Más de un día",
       "Name": "Nombre",
       "NewFileName": "Nuevo nombre de archivo",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "Kutsutun sähköpostiosoite",
       "KeepFileExtension": "Pidä",
       "LessThan10Sec": "Alle 10 sekuntia",
-      "ModifyPermissions": "Muokkaa käyttöoikeuksia",
       "MoreThanADay": "Yli päivä",
       "Name": "Nimi",
       "NewFileName": "Uusi tiedostonimi",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "Courriel de l'invité",
       "KeepFileExtension": "Garder",
       "LessThan10Sec": "Moins de 10 secondes",
-      "ModifyPermissions": "Modifier les autorisations",
       "MoreThanADay": "Plus d'un jour",
       "Name": "Nom",
       "NewFileName": "Nouveau nom de fichier",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -300,7 +300,6 @@
       "InviteeEmail": "Email Undangan",
       "KeepFileExtension": "Jaga",
       "LessThan10Sec": "Kurang dari 10 detik",
-      "ModifyPermissions": "Ubah Perizinan",
       "MoreThanADay": "Lebih dari sehari",
       "Name": "Nama",
       "NewFileName": "Nama file baru",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -300,7 +300,6 @@
       "InviteeEmail": "E-mail di invito",
       "KeepFileExtension": "Mantenere",
       "LessThan10Sec": "Meno di 10 secondi",
-      "ModifyPermissions": "Modifica autorizzazioni",
       "MoreThanADay": "Più di un giorno",
       "Name": "Nome",
       "NewFileName": "Nuovo nome file",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -300,7 +300,6 @@
       "InviteeEmail": "招待者の電子メール",
       "KeepFileExtension": "保つ",
       "LessThan10Sec": "10秒未満",
-      "ModifyPermissions": "権限の変更",
       "MoreThanADay": "1日以上",
       "Name": "名前",
       "NewFileName": "新しいファイル名",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -303,7 +303,6 @@
       "InviteeEmail": "초대한 이메일",
       "KeepFileExtension": " 유지",
       "LessThan10Sec": "10초 이하의 시간 소요",
-      "ModifyPermissions": "권한 수정",
       "MoreThanADay": "최소 1일 이상 소요",
       "Name": "이름",
       "NewFileName": "새로운 파일 이름",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -300,7 +300,6 @@
       "InviteeEmail": "Уригдсан имэйл",
       "KeepFileExtension": "Хадгалах",
       "LessThan10Sec": "10 секундээс бага",
-      "ModifyPermissions": "Зөвшөөрлийг өөрчлөх",
       "MoreThanADay": "Өдөр гаруй",
       "Name": "Нэр",
       "NewFileName": "Шинэ файлын нэр",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -300,7 +300,6 @@
       "InviteeEmail": "E-mel Jemputan",
       "KeepFileExtension": "Jaga",
       "LessThan10Sec": "Tidak sampai 10 saat",
-      "ModifyPermissions": "Ubahsuai Kebenaran",
       "MoreThanADay": "Lebih dari sehari",
       "Name": "Nama",
       "NewFileName": "Nama fail baru",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "E-mail z zaproszeniem",
       "KeepFileExtension": "Trzymać",
       "LessThan10Sec": "Mniej niż 10 sekund",
-      "ModifyPermissions": "Modyfikuj uprawnienia",
       "MoreThanADay": "Więcej niż dzień",
       "Name": "Nazwa",
       "NewFileName": "Nowa nazwa pliku",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "E-mail do convidado",
       "KeepFileExtension": "Manter",
       "LessThan10Sec": "Menos de 10 segundos",
-      "ModifyPermissions": "Modificar permissões",
       "MoreThanADay": "Mais de um dia",
       "Name": "Nome",
       "NewFileName": "Novo nome de arquivo",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "E-mail do convidado",
       "KeepFileExtension": "Manter",
       "LessThan10Sec": "Menos de 10 segundos",
-      "ModifyPermissions": "Modificar permissões",
       "MoreThanADay": "Mais de um dia",
       "Name": "Nome",
       "NewFileName": "Novo nome de arquivo",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "Электронная почта приглашенного",
       "KeepFileExtension": "Хранить",
       "LessThan10Sec": "Менее 10 секунд",
-      "ModifyPermissions": "Изменить разрешения",
       "MoreThanADay": "Больше суток",
       "Name": "Имя",
       "NewFileName": "Новое имя файла",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "อีเมลผู้รับเชิญ",
       "KeepFileExtension": "เก็บ ",
       "LessThan10Sec": "น้อยกว่า 10 วินาที",
-      "ModifyPermissions": "แก้ไขสิทธิ์",
       "MoreThanADay": "มากกว่าหนึ่งวัน",
       "Name": "ชื่อ",
       "NewFileName": "ชื่อไฟล์ใหม่",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "Davet E-postası",
       "KeepFileExtension": "Tut",
       "LessThan10Sec": "10 saniyeden az",
-      "ModifyPermissions": "İzinleri Değiştir",
       "MoreThanADay": "bir günden fazla",
       "Name": "isim",
       "NewFileName": "Yeni dosya adı",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "Thư điện tử của Người được mời",
       "KeepFileExtension": "Giữ",
       "LessThan10Sec": "Dưới 10 giây",
-      "ModifyPermissions": "Sửa đổi quyền",
       "MoreThanADay": "Hơn một ngày",
       "Name": "Tên",
       "NewFileName": "Tên tệp mới",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "受邀者电子邮件",
       "KeepFileExtension": "保持",
       "LessThan10Sec": "不到 10 秒",
-      "ModifyPermissions": "修改权限",
       "MoreThanADay": "一天多",
       "Name": "名称",
       "NewFileName": "新文件名",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -301,7 +301,6 @@
       "InviteeEmail": "受邀者電子郵件",
       "KeepFileExtension": "保持",
       "LessThan10Sec": "不到 10 秒",
-      "ModifyPermissions": "修改權限",
       "MoreThanADay": "一天多",
       "Name": "名稱",
       "NewFileName": "新文件名",


### PR DESCRIPTION
Resolves #4169 ([FR-1386](https://lablup.atlassian.net/browse/FR-1386))

## Summary
Updates the folder sharing modal title from "Modify Permissions" to "Share Folder" for improved clarity and better user understanding.

## Changes
- Changed modal title in `InviteFolderSettingModal.tsx` from "Modify Permissions" to "Share Folder"
- Removed unused "ModifyPermissions" translation key from all 21 language files
- Improves user experience by using more descriptive and accurate modal title

## Test plan
- [ ] Verify the folder sharing modal displays "Share Folder" as the title
- [ ] Confirm all functionality remains unchanged
- [ ] Check that no translation keys are broken across different languages

[FR-1386]: https://lablup.atlassian.net/browse/FR-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ