### PR TITLE
fix(FR-1403): improve lifecycle stage filter logic for active serving instances

### DIFF
--- a/react/src/pages/ServingPage.tsx
+++ b/react/src/pages/ServingPage.tsx
@@ -47,7 +47,7 @@ const ServingPage: React.FC = () => {
 
   const lifecycleStageFilter =
     queryParams.lifecycleStage === 'active'
-      ? `lifecycle_stage == "created" | lifecycle_stage == "destroying"`
+      ? `lifecycle_stage != "destroyed"`
       : `lifecycle_stage == "${queryParams.lifecycleStage}"`;
 
   const queryVariables = useMemo(


### PR DESCRIPTION
Resolves ([FR-1403](https://lablup.atlassian.net/browse/FR-1403))

This PR improves the lifecycle stage filter logic for active serving instances in the ServingPage component.

## Changes
- Updated lifecycle stage filter from specific inclusion logic (`lifecycle_stage == "created" | lifecycle_stage == "destroying"`) to exclusion logic (`lifecycle_stage != "destroyed"`)
- This provides better coverage of all non-destroyed lifecycle stages when filtering for "active" serving instances

## Impact
- Users will see a more comprehensive view of active serving instances
- Improves accuracy of filtering serving instances by their lifecycle stage
- Better alignment with the intended behavior of showing all active (non-destroyed) services

**Checklist:**

- [x] Code follows project conventions
- [x] Changes are focused and minimal
- [ ] Documentation (not applicable)
- [ ] Test coverage (existing tests cover this logic)

[FR-1403]: https://lablup.atlassian.net/browse/FR-1403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ