### PR TITLE
fix(FR-1404): ensure BAIUnmountAfterClose always unmounts after close animations

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIUnmountAfterClose.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUnmountAfterClose.tsx
@@ -28,32 +28,26 @@ const BAIUnmountAfterClose: React.FC<BAIUnmountModalAfterCloseProps> = ({
   children,
 }) => {
   // Ensure there is only one child element
-  const modalElement = React.Children.only(children);
-  const isModalOpen = modalElement.props.open;
+  const childElement = React.Children.only(children);
+  const isOpen = childElement.props.open;
 
   // Manage internal rendering state
-  const [isMount, setIsMount] = useState(isModalOpen);
+  const [isMount, setIsMount] = useState(isOpen);
 
   // Update internal state when the child's open prop becomes true
   useLayoutEffect(() => {
-    if (isModalOpen) {
+    if (isOpen) {
       setIsMount(true);
     }
-  }, [isModalOpen]);
+  }, [isOpen]);
 
   // Return null if the modal should not be rendered
   if (!isMount) {
     return null;
   }
 
-  // Type guards to check if the element is a Modal or Drawer
-  const hasAfterClose = 'afterClose' in modalElement.props;
-  const hasAfterOpenChange = 'afterOpenChange' in modalElement.props;
-
   // Preserve the original afterClose callback if it exists
-  const originalAfterClose = hasAfterClose
-    ? (modalElement.props as ModalProps).afterClose
-    : undefined;
+  const originalAfterClose = (childElement.props as ModalProps).afterClose;
 
   // New handler to intercept afterClose
   const handleModalAfterClose: ModalProps['afterClose'] = (...args) => {
@@ -65,9 +59,7 @@ const BAIUnmountAfterClose: React.FC<BAIUnmountModalAfterCloseProps> = ({
   };
 
   // Preserve the original afterOpenChange callback if it exists
-  const originalAfterOpenChange = hasAfterOpenChange
-    ? modalElement.props.afterOpenChange
-    : undefined;
+  const originalAfterOpenChange = childElement.props.afterOpenChange;
 
   // New handler to intercept afterOpenChange
   const handleModalAfterOpenChange: DrawerProps['afterOpenChange'] = (open) => {
@@ -81,11 +73,11 @@ const BAIUnmountAfterClose: React.FC<BAIUnmountModalAfterCloseProps> = ({
   };
 
   // Clone the child element with proper typing
-  const clonedChild = React.cloneElement(modalElement, {
+  const clonedChild = React.cloneElement(childElement, {
     // for Modal
-    ...(hasAfterClose && { afterClose: handleModalAfterClose }),
+    afterClose: handleModalAfterClose,
     // for Drawer
-    ...(hasAfterOpenChange && { afterOpenChange: handleModalAfterOpenChange }),
+    afterOpenChange: handleModalAfterOpenChange,
   });
 
   return clonedChild;


### PR DESCRIPTION
Resolves #4183 ([FR-1404](https://lablup.atlassian.net/browse/FR-1404))

## Summary

Fixes the BAIUnmountAfterClose component to ensure it always properly unmounts Modal and Drawer components after close animations complete, regardless of whether parent components provide afterClose or afterOpenChange callback props.

## Problem

The component was using type guards to conditionally add unmounting handlers only when original props existed. This caused the component to fail to unmount when parents didn't provide these callbacks, leading to memory leaks.

## Solution

- Removed conditional type guards (`hasAfterClose`, `hasAfterOpenChange`)
- Always add our own unmounting handlers (`afterClose`, `afterOpenChange`)
- Preserve any existing callbacks while ensuring proper unmounting behavior
- Ensures component unmounts after close animations in all scenarios

## Changes

- Simplified prop handling by always applying unmounting handlers
- Reduced code complexity by removing unnecessary conditional logic
- Maintains backward compatibility with existing callback preservation

[FR-1404]: https://lablup.atlassian.net/browse/FR-1404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ