### PR TITLE
fix(FR-1406):fix to enalbe pagination for ConnectedKernelList compnent

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -184,7 +184,6 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
         dataSource={filterOutNullAndUndefined(kernelNodes)}
         style={{ width: '100%' }}
         // TODO: implement pagination when compute_session_node query supports pagination
-        pagination={false}
       />
 
       <BAIUnmountAfterClose>


### PR DESCRIPTION
resolves #4185 (FR-1406)

Removed the explicit `pagination={false}` prop from the Table component in ConnectedKernelList, as it's redundant when pagination is already disabled by default.

![CleanShot 2025-08-26 at 16.30.01@2x.png](https://app.graphite.dev/user-attachments/assets/7e466ef8-f290-4115-a7a1-79e81f2800bf.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after