### PR TITLE
fix(FR-1408): fix property mapping for default session environment configuration

### DIFF
--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -234,7 +234,7 @@ const SessionLauncherPage = () => {
       // set default_session_environment only if set
       ...(baiClient._config?.default_session_environment && {
         environments: {
-          environment: baiClient._config?.default_session_environment,
+          version: baiClient._config?.default_session_environment,
         },
       }),
       ...RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,


### PR DESCRIPTION
Resolves ([FR-1408](https://lablup.atlassian.net/browse/FR-1408))

## Summary
Fixed property mapping for default session environment configuration. Changed incorrect property name from `environment:` to `version:` in the default session environment configuration object.

## Changes
- Fixed line 237 in `react/src/pages/SessionLauncherPage.tsx`
- Changed `environment: baiClient._config?.default_session_environment` to `version: baiClient._config?.default_session_environment`

This ensures that the default session environment configuration is properly applied when launching new sessions.

[FR-1408]: https://lablup.atlassian.net/browse/FR-1408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ