### PR TITLE
feat(FR-1414): allow shmem adjustment when allowCustomResourceAllocation is disabled

### DIFF
--- a/react/src/components/ResourceAllocationFormItems.tsx
+++ b/react/src/components/ResourceAllocationFormItems.tsx
@@ -564,14 +564,7 @@ const ResourceAllocationFormItems: React.FC<
           />
         </Form.Item>
       ) : null}
-      <Card
-        style={{
-          marginBottom: token.margin,
-          display: baiClient._config.allowCustomResourceAllocation
-            ? 'block'
-            : 'none',
-        }}
-      >
+      <Card style={{ marginBottom: token.margin }}>
         <Form.Item
           shouldUpdate={(prev, cur) =>
             prev.allocationPreset !== cur.allocationPreset
@@ -585,6 +578,7 @@ const ResourceAllocationFormItems: React.FC<
                 {resourceSlotsInRG?.cpu && (
                   <Form.Item
                     name={['resource', 'cpu']}
+                    hidden={!baiClient._config.allowCustomResourceAllocation}
                     // initialValue={0}
                     label={
                       mergedResourceSlots?.cpu?.human_readable_name || 'CPU'
@@ -709,6 +703,7 @@ const ResourceAllocationFormItems: React.FC<
                       shouldUpdate={(prev, next) =>
                         prev.resource.shmem !== next.resource.shmem
                       }
+                      hidden={!baiClient._config.allowCustomResourceAllocation}
                     >
                       {() => {
                         return (
@@ -1046,10 +1041,15 @@ const ResourceAllocationFormItems: React.FC<
                                       width: 200,
                                     }}
                                     onChange={() => {
-                                      form.setFieldValue(
-                                        'allocationPreset',
-                                        'custom',
-                                      );
+                                      if (
+                                        baiClient._config
+                                          .allowCustomResourceAllocation
+                                      ) {
+                                        form.setFieldValue(
+                                          'allocationPreset',
+                                          'custom',
+                                        );
+                                      }
                                     }}
                                   />
                                 </Form.Item>
@@ -1073,10 +1073,15 @@ const ResourceAllocationFormItems: React.FC<
                                             ]) || '0g',
                                           );
                                         }
-                                        form.setFieldValue(
-                                          'allocationPreset',
-                                          'custom',
-                                        );
+                                        if (
+                                          baiClient._config
+                                            .allowCustomResourceAllocation
+                                        ) {
+                                          form.setFieldValue(
+                                            'allocationPreset',
+                                            'custom',
+                                          );
+                                        }
                                       }}
                                     />
                                   </Form.Item>
@@ -1130,6 +1135,7 @@ const ResourceAllocationFormItems: React.FC<
                       prev.cluster_size !== next.cluster_size
                     );
                   }}
+                  hidden={!baiClient._config.allowCustomResourceAllocation}
                 >
                   {({ getFieldValue }) => {
                     const currentAcceleratorType = getFieldValue([


### PR DESCRIPTION
Resolves #4194 ([FR-1414](https://lablup.atlassian.net/browse/FR-1414))  
![image.png](https://app.graphite.dev/user-attachments/assets/517121e2-8804-4b36-8c31-8617ace82723.png)  
This PR modifies the resource allocation form to properly handle the `allowCustomResourceAllocation` configuration setting. Instead of hiding the entire card when custom allocation is disabled, it now:

1. Always shows the resource allocation card
2. Hides specific form items (CPU, mem, cluster size) when custom allocation is disabled
3. Only sets the allocation preset to 'custom' when custom allocation is allowed

This approach provides better UX by maintaining consistent layout while respecting configuration settings.

[FR-1414]: https://lablup.atlassian.net/browse/FR-1414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ