### PR TITLE
feat(FR-1418): utilize new owner field in session GraphQL query

### DIFF
--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -129,6 +129,9 @@ const SessionDetailContent: React.FC<{
         name
         project_id
         user_id
+        owner @since(version: "25.13.0") {
+          email
+        }
         resource_opts
         status
         status_data
@@ -250,7 +253,11 @@ const SessionDetailContent: React.FC<{
           </Descriptions.Item>
           {(userRole === 'admin' || userRole === 'superadmin') && (
             <Descriptions.Item label={t('credential.UserID')} span={md ? 2 : 1}>
-              {session.user_id ? (
+              {(() => {
+                const ownerEmail = session.owner?.email;
+                return ownerEmail ? (
+                  ownerEmail
+                ) : session.user_id ? (
                 <Suspense fallback={<Skeleton.Input size="small" active />}>
                   <UNSAFELazyUserEmailView uuid={session.user_id} />
                 </Suspense>


### PR DESCRIPTION
Resolves #4205 ([FR-1418](https://lablup.atlassian.net/browse/FR-1418))

Utilize the new `owner` field (UserNode type) added in GraphQL API version 25.13.0 to display session owner information directly and reduce unnecessary API calls.

## Changes

- Add `owner { email }` field to session GraphQL query with `@since(version: "25.13.0")`
- Display owner.email directly when available, fallback to existing user_id-based lookup
- Maintain backward compatibility

## Technical Implementation

- Updated SessionDetailContent.tsx to prioritize `session.owner?.email` over user ID lookup
- Preserves existing UNSAFELazyUserEmailView fallback for older API versions

[FR-1418]: https://lablup.atlassian.net/browse/FR-1418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ