### PR TITLE
chore: add YAML frontmatter to Claude command files

### DIFF
--- a/.claude/commands/create-jira-issue.md
+++ b/.claude/commands/create-jira-issue.md
@@ -1,10 +1,15 @@
+---
+description: Create a Jira issue for Git changes
+argument-hint: [stage, pr, branch, commit]
+model: claude-sonnet-4-20250514
+---
 
 # Create a Jira issue for Git Changes
 
 Create a Jira issue based on **Git changes** by following these instructions:
 
 ## Arguments
-This command accept"$ARGUMENTS" to specify the type of changes to analyze:
+This command accept $ARGUMENTS to specify the type of changes to analyze:
 - `stage` - Analyze staged changes
 - `pr` - Analyze changes in current graphite stack up to current branch
 - `branch` - Analyze all changes in current branch

--- a/.claude/commands/create-pr-stack-for-stage.md
+++ b/.claude/commands/create-pr-stack-for-stage.md
@@ -1,3 +1,9 @@
+---
+description: Create a PR Stack and link to Jira issue.
+argument-hint: [FR-1234, https://lablup.atlassian.net/browse/FR-1234]
+model: claude-sonnet-4-20250514
+---
+
 # Create a PR Stack for Staged Changes
 
 Create a new graphite stack branch for currently staged changes, following the project's commit message patterns and workflow.

--- a/.claude/commands/enhance-component-docs.md
+++ b/.claude/commands/enhance-component-docs.md
@@ -1,3 +1,7 @@
+---
+model: claude-sonnet-4-20250514
+---
+
 # Enhance Component Documentation
 
 Automatically enhance React component documentation with JSDoc comments, improved Storybook stories, and autodoc configuration.

--- a/.claude/commands/fill-out-i18n.md
+++ b/.claude/commands/fill-out-i18n.md
@@ -1,3 +1,7 @@
+---
+model: claude-sonnet-4-20250514
+---
+
 # Fill Out i18n Translations
 
 High-performance auto-translation of missing i18n keys using Claude AI for Backend.AI WebUI locale files based on git changes.

--- a/.claude/commands/improve-release-note.md
+++ b/.claude/commands/improve-release-note.md
@@ -1,3 +1,7 @@
+---
+model: claude-sonnet-4-20250514
+---
+
 # Improve Release Note
 
 Improve GitHub release notes by fetching the specified release and formatting it according to the project's preferred markdown format with proper categorization.

--- a/.claude/commands/update-storybook-autodoc.md
+++ b/.claude/commands/update-storybook-autodoc.md
@@ -1,3 +1,7 @@
+---
+model: claude-sonnet-4-20250514
+---
+
 # Update Storybook with Autodoc
 
 Update React components with comprehensive JSDoc documentation and enhanced Storybook stories with autodoc functionality.


### PR DESCRIPTION
# Add frontmatter to Claude commands

Adds YAML frontmatter to all Claude command files to improve command discoverability and functionality:

- Added `description` fields to provide clear purpose for each command
- Specified `argument-hint` for commands that accept arguments
- Set `model: claude-sonnet-4-20250514` for all commands
- Fixed a formatting issue in create-jira-issue.md where quotes were incorrectly surrounding $ARGUMENTS

**Checklist:**

- [x] Documentation