### PR TITLE
feat(FR-1424): update to calculate liveStat and capacity per session

### DIFF
--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -243,7 +243,13 @@ const SessionDetailContent: React.FC<{
           </Button.Group>
         </BAIFlex>
 
-        <Descriptions bordered column={md ? 2 : 1}>
+        <Descriptions
+          bordered
+          column={md ? 2 : 1}
+          labelStyle={{
+            wordBreak: 'keep-all',
+          }}
+        >
           <Descriptions.Item label={t('session.SessionId')} span={md ? 2 : 1}>
             <Typography.Text
               ellipsis
@@ -348,7 +354,12 @@ const SessionDetailContent: React.FC<{
           <Descriptions.Item
             label={
               <BAIFlex direction="column" align="start" gap={token.marginSM}>
-                <Typography.Text style={{ color: token.colorTextSecondary }}>
+                <Typography.Text
+                  style={{
+                    color: token.colorTextSecondary,
+                    wordBreak: 'keep-all',
+                  }}
+                >
                   {t('session.ResourceUsage')}
                 </Typography.Text>
                 <Select

--- a/react/src/components/SessionUsageMonitor.tsx
+++ b/react/src/components/SessionUsageMonitor.tsx
@@ -169,14 +169,18 @@ const SessionUsageMonitor: React.FC<SessionUsageMonitorProps> = ({
         title={mergedResourceSlots?.['mem']?.human_readable_name}
         percent={
           displayTarget === 'current'
-            ? sortedLiveStat?.mem?.pct || '0'
+            ? _.toString(
+                ((convertToBinaryUnit(sortedLiveStat?.mem?.current, 'g')
+                  ?.number ?? 0) /
+                  (convertToBinaryUnit(occupiedSlots?.mem, 'g')?.number || 1)) *
+                  100,
+              )
             : _.toString(
                 ((convertToBinaryUnit(
                   sortedLiveStat?.mem?.[displayTargetName],
                   'g',
                 )?.number ?? 0) /
-                  (convertToBinaryUnit(sortedLiveStat?.mem?.capacity, 'g')
-                    ?.number || 1)) *
+                  (convertToBinaryUnit(occupiedSlots?.mem, 'g')?.number || 1)) *
                   100,
               )
         }

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1215,9 +1215,9 @@
     "PendingSessions": "대기 세션"
   },
   "session": {
-    "Agent": "실행노드",
+    "Agent": "실행 노드",
     "AgentId": "에이전트 ID",
-    "Agents": "실행노드",
+    "Agents": "실행 노드",
     "AllowedClientIps": "허용된 클라이언트 IP",
     "AlreadyTerminatingSession": "이미 종료 중인 세션입니다",
     "AnotherUserSession": "이 세션은 다른 사용자에 의해 생성되었습니다.",
@@ -1304,7 +1304,7 @@
     "RecentlyCreatedSessions": "최근 생성 세션",
     "RecentlyCreatedSessionsTooltip": "현재 프로젝트에서 가장 최근에 생성된 실행 중인 세션 {{count}}개를 표시합니다",
     "RequestContainerCommit": "컨테이너 커밋하기",
-    "Reservation": "예약시간",
+    "Reservation": "예약 시간",
     "ResourceGroup": "자원 그룹",
     "ResourceUsage": "자원 사용량",
     "Running": "실행중",


### PR DESCRIPTION
Resolves #4216 ([FR-1424](https://lablup.atlassian.net/browse/FR-1424))

# Improve Session Resource Usage Monitoring to calculate per Session

This PR enhances the session resource usage monitoring by:

1. Fixing memory usage calculation to use occupied slots instead of capacity
2. Implementing aggregated live stats across all kernel nodes instead of just the main node
3. Improving UI layout for session details with better word breaks
4. Refining Korean translations for agent-related terms

The changes ensure that resource usage percentages are calculated correctly by comparing current usage against the allocated resources rather than total capacity, providing more accurate monitoring information.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1424]: https://lablup.atlassian.net/browse/FR-1424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ