### PR TITLE
feat(FR-1425): implement BAISessionAgentIds component to improve agent display

### DIFF
--- a/packages/backend.ai-ui/package.json
+++ b/packages/backend.ai-ui/package.json
@@ -53,6 +53,9 @@
       "import/no-duplicates": "error"
     }
   },
+  "dependencies": {
+    "react-copy-to-clipboard": "^5.1.0"
+  },
   "peerDependencies": {
     "@ant-design/icons": "^5.6.1",
     "antd": "^5.24.5",
@@ -91,6 +94,7 @@
     "@types/big.js": "^6.2.2",
     "@types/lodash": "^4.17.13",
     "@types/react": "^19.0.0",
+    "@types/react-copy-to-clipboard": "^5.0.7",
     "@types/react-dom": "^19.0.3",
     "@types/react-relay": "^18.2.1",
     "@types/react-resizable": "^3.0.8",

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.tsx
@@ -1,0 +1,81 @@
+import { BAISessionAgentIdsFragment$key } from '../../__generated__/BAISessionAgentIdsFragment.graphql';
+import BAIFlex from '../BAIFlex';
+import { CopyOutlined } from '@ant-design/icons';
+import { Popover, Typography, Button, theme } from 'antd';
+import _ from 'lodash';
+import React, { useMemo } from 'react';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment } from 'react-relay';
+
+interface BAISessionAgentIdsProps {
+  sessionFrgmt: BAISessionAgentIdsFragment$key;
+  maxInline?: number; // New prop to control max inline display
+  emptyText?: string; // New prop for empty state text
+}
+export const BAISessionAgentIds: React.FC<BAISessionAgentIdsProps> = ({
+  sessionFrgmt,
+  maxInline = 3,
+  emptyText = '-',
+}) => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const session = useFragment(
+    graphql`
+      fragment BAISessionAgentIdsFragment on ComputeSessionNode {
+        agent_ids
+      }
+    `,
+    sessionFrgmt,
+  );
+
+  const agents = useMemo(
+    () => _.uniq(session.agent_ids ?? []),
+    [session.agent_ids],
+  );
+
+  const inline = agents.slice(0, maxInline).join(', ');
+  const rest = agents.slice(maxInline);
+  const restCount = _.max([agents.length - maxInline, 0]) || 0;
+
+  return agents.length === 0 ? (
+    emptyText
+  ) : (
+    <span>
+      <Typography.Text>{inline}</Typography.Text>
+      {restCount > 0 && (
+        <>
+          &nbsp;
+          <Popover
+            trigger="click"
+            title={
+              <BAIFlex justify="between">
+                <span>
+                  {t('comp:BAISessionAgentIds.Agent')} ({agents.length})
+                </span>
+                <CopyToClipboard text={agents.join(', ')}>
+                  <Button size="small" type="text" icon={<CopyOutlined />}>
+                    {t('general.button.CopyAll')}
+                  </Button>
+                </CopyToClipboard>
+              </BAIFlex>
+            }
+            content={
+              <div style={{ maxHeight: 240, overflow: 'auto', minWidth: 260 }}>
+                <ul style={{ paddingLeft: token.padding, margin: 0 }}>
+                  {rest.map((id) => (
+                    <li key={id} style={{ listStyle: 'disc' }}>
+                      <Typography.Text>{id}</Typography.Text>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            }
+          >
+            <Typography.Link>+{restCount}</Typography.Link>
+          </Popover>
+        </>
+      )}
+    </span>
+  );
+};

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Unbegrenzt"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Agent"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Alle kopieren"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Απεριόριστος"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Μέσο"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Αντιγράψτε όλα"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Unlimited"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Agent"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Copy All"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Ilimitado"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Agente"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Copiar todo"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Rajoittamaton"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Agentti"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Kopioida kaikki"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Illimité"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Agent"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Copier tout"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Tak terbatas"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Agen"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Salin semua"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Illimitato"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Agente"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Copia tutto"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "無制限"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "エージェント"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "すべてをコピーします"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "제한없음"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "실행노드"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "모두 복사"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Хязгааргүй"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Агент"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Бүгдийг хуулбарлах"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Tidak terhad"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Ejen"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Salin semua"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Nieograniczony"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Agent"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Kopiuj wszystko"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Ilimitado"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Agente"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Copie tudo"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Ilimitado"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Agente"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Copie tudo"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Неограниченный"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Агент"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Копировать все"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "ไม่ จำกัด"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "ตัวแทน"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "คัดลอกทั้งหมด"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Sınırsız"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Ajan"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Hepsini kopyala"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Không giới hạn"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "Đại lý"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "Sao chép tất cả"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "无限"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "代理人"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "复制全部"
+    }
   }
 }

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -17,5 +17,13 @@
   },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "無限"
+  },
+  "comp:BAISessionAgentIds": {
+    "Agent": "代理人"
+  },
+  "general": {
+    "button": {
+      "CopyAll": "複製全部"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,6 +543,9 @@ importers:
       '@types/react':
         specifier: ^19.0.0
         version: 19.0.10
+      '@types/react-copy-to-clipboard':
+        specifier: ^5.0.7
+        version: 5.0.7
       '@types/react-dom':
         specifier: ^19.0.3
         version: 19.0.4(@types/react@19.0.10)

--- a/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
@@ -155,6 +155,7 @@ const UsageBadge: React.FC<UsageBadgeProps> = ({
             border: '1px solid',
             borderColor: token.colorTextDisabled,
             backgroundColor: 'transparent',
+            flexWrap: 'nowrap',
           },
         },
       }

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -41,6 +41,7 @@ import {
   useMemoizedJSONParse,
   BAIFlex,
 } from 'backend.ai-ui';
+import { BAISessionAgentIds } from 'backend.ai-ui/components/fragments/BAISessionAgentIds';
 // import { graphql } from 'react-relay';
 import _ from 'lodash';
 import { Suspense, useState } from 'react';
@@ -174,6 +175,7 @@ const SessionDetailContent: React.FC<{
         ...SessionStatusDetailModalFragment
         ...AppLauncherModalFragment
         ...MountedVFolderLinksFragment
+        ...BAISessionAgentIdsFragment
       }
     `,
     (internalLoadedSession as SessionDetailContentFragment$key) || sessionFrgmt,
@@ -310,7 +312,7 @@ const SessionDetailContent: React.FC<{
             </BAIFlex>
           </Descriptions.Item>
           <Descriptions.Item label={t('session.Agent')}>
-            {_.uniq(session.agent_ids).join(', ') || '-'}
+            <BAISessionAgentIds sessionFrgmt={session} />
           </Descriptions.Item>
           <Descriptions.Item label={t('session.Reservation')} span={md ? 2 : 1}>
             <BAIFlex gap={'xs'} wrap={'wrap'}>

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -16,6 +16,7 @@ import {
   BAITable,
   BAITableProps,
 } from 'backend.ai-ui';
+import { BAISessionAgentIds } from 'backend.ai-ui/components/fragments/BAISessionAgentIds';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -52,6 +53,7 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
         ...SessionSlotCellFragment
         ...SessionUsageMonitorFragment
         ...SessionDetailDrawerFragment
+        ...BAISessionAgentIdsFragment
         kernel_nodes {
           edges {
             node {
@@ -167,11 +169,7 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
         key: 'agent',
         title: t('session.Agent'),
         defaultHidden: false,
-        render: (__, session) => {
-          return session?.agent_ids?.length
-            ? _.uniq(session.agent_ids).join(', ') || '-'
-            : '-';
-        },
+        render: (__, session) => <BAISessionAgentIds sessionFrgmt={session} />,
       },
     ]),
     (column) => {


### PR DESCRIPTION
Resolves #4218 ([FR-1425](https://lablup.atlassian.net/browse/FR-1425))

# Add BAISessionAgentIds component for better agent ID display

This PR adds a new `BAISessionAgentIds` component to improve the display of agent IDs in session details. The component:

- Shows a limited number of agent IDs inline (default: 3)
- Displays remaining IDs in a popover when clicked
- Includes a "Copy All" button for easy copying of all agent IDs
- Handles empty states gracefully

The component is integrated in both the session detail view and session nodes table, replacing the previous simple string display.

**Checklist:**

- [x] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1425]: https://lablup.atlassian.net/browse/FR-1425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ