### PR TITLE
refactor(FR-1432): Fix user email conditional rendering and remove Korean comments

### DIFF
--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -253,11 +253,9 @@ const SessionDetailContent: React.FC<{
           </Descriptions.Item>
           {(userRole === 'admin' || userRole === 'superadmin') && (
             <Descriptions.Item label={t('credential.UserID')} span={md ? 2 : 1}>
-              {(() => {
-                const ownerEmail = session.owner?.email;
-                return ownerEmail ? (
-                  ownerEmail
-                ) : session.user_id ? (
+              {session.owner?.email ? (
+                session.owner.email
+              ) : session.user_id ? (
                 <Suspense fallback={<Skeleton.Input size="small" active />}>
                   <UNSAFELazyUserEmailView uuid={session.user_id} />
                 </Suspense>

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -804,7 +804,6 @@ class Client {
     if (this.isManagerVersionCompatibleWith('25.12.0')) {
       this._features['mount-by-id'] = true;
     }
-    // TODO: 버전 25.13.0
     if (this.isManagerVersionCompatibleWith('25.13.0')) {
       this._features['pending-session-list'] = true;
     }


### PR DESCRIPTION
Resolves #(FR-1432)

## Summary
- Refactored SessionDetailContent to simplify owner email display logic by removing unnecessary IIFE (Immediately Invoked Function Expression)
- Cleaned up backend.ai-client-esm.ts by removing Korean TODO comment

## Changes
- **react/src/components/SessionDetailContent.tsx**: Simplified conditional rendering for session owner email display
- **src/lib/backend.ai-client-esm.ts**: Removed TODO comment for cleaner code

## Test Plan
- [ ] Verify session owner email displays correctly in session detail view
- [ ] Ensure no functional changes in session detail behavior