### PR TITLE
feat(FR-1435): exclude project type folder from folder selector of service creation page.

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -803,7 +803,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                             <VFolderSelect
                               filter={(vf) =>
                                 vf.usage_mode === 'model' &&
-                                vf.status === 'ready'
+                                vf.status === 'ready' &&
+                                vf.ownership_type !== 'group'
                               }
                               valuePropName="id"
                               autoSelectDefault={


### PR DESCRIPTION

Resolves #4233 ([FR-1435](https://lablup.atlassian.net/browse/FR-1435))

# Exclude group-owned vfolders from model selection in service launcher


This PR modifies the vfolder selection filter in the service launcher to exclude group-owned vfolders. Now, only model vfolders that are ready and not owned by a group will be available for selection when launching a service.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1435]: https://lablup.atlassian.net/browse/FR-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ