### PR TITLE
feat(FR-1437): enhance session display with owner information and improved date formatting

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionReservation.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionReservation.tsx
@@ -2,6 +2,7 @@ import { SessionReservationFragment$key } from '../../__generated__/SessionReser
 import { formatDurationAsDays } from '../../helper';
 import BAIIntervalView from '../BAIIntervalView';
 import DoubleTag from '../DoubleTag';
+import { Typography } from 'antd';
 import dayjs from 'dayjs';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -24,9 +25,12 @@ const SessionReservation: React.FC<{
     sessionFrgmt,
   );
 
+  const formattedCreatedAt = dayjs(session.created_at).format('lll');
   return (
     <>
-      {mode !== 'simple-elapsed' && dayjs(session.created_at).format('lll')}
+      {mode !== 'simple-elapsed' && (
+        <Typography.Text>{formattedCreatedAt}</Typography.Text>
+      )}
       <BAIIntervalView
         key={session.id}
         callback={() => {
@@ -38,7 +42,9 @@ const SessionReservation: React.FC<{
         delay={1000}
         render={(intervalValue) =>
           mode === 'simple-elapsed' ? (
-            intervalValue
+            <Typography.Text title={formattedCreatedAt || ''}>
+              {intervalValue}
+            </Typography.Text>
           ) : (
             <DoubleTag
               values={[

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -63,6 +63,9 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
             }
           }
         }
+        owner @since(version: "25.13.0") {
+          email
+        }
       }
     `,
     sessionsFrgmt,
@@ -171,6 +174,13 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
         defaultHidden: false,
         render: (__, session) => <BAISessionAgentIds sessionFrgmt={session} />,
       },
+      userRole === 'superadmin' &&
+        baiClient.isManagerVersionCompatibleWith('25.13.0') && {
+          key: 'owner',
+          title: t('session.launcher.OwnerEmail'),
+          defaultHidden: false,
+          render: (__, session) => session.owner?.email || '-',
+        },
     ]),
     (column) => {
       return disableSorter ? _.omit(column, 'sorter') : column;


### PR DESCRIPTION
Resolves #4237 ([FR-1437](https://lablup.atlassian.net/browse/FR-1437))

![image.png](https://app.graphite.dev/user-attachments/assets/48fc1bf5-c47e-4d4e-b438-9a123b772c3c.png)

## Summary

Enhanced session display capabilities with owner information and improved date formatting for better user experience and administrative visibility.

## Changes

- **SessionReservation.tsx**: Enhanced date display with Typography.Text components and added tooltips for better UX
- **SessionNodes.tsx**: Added owner email column display for superadmin users when [Backend.AI](http://Backend.AI) manager version 25.13.0+ is available

## Key Features

- Improved UI consistency with proper Typography components for session dates
- Date tooltips provide better context when viewing elapsed time
- Owner email visibility for superadmin users to better manage session ownership
- Conditional rendering based on user role and manager version compatibility
- Maintains backwards compatibility with existing functionality

## Testing

- [x] UI displays properly formatted dates with tooltips
- [x] Owner email column appears for superadmin users with compatible manager version
- [x] Backwards compatibility maintained for older manager versions
- [x] No breaking changes to existing session display functionality

## Technical Notes

- Requires [Backend.AI](http://Backend.AI) manager version 25.13.0 or higher for owner email functionality
- Uses conditional rendering based on user role (userRole === "superadmin") and version check

[FR-1437]: https://lablup.atlassian.net/browse/FR-1437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ