### PR TITLE
chore: Update alpha version index to 25.14.0-alpha.0

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend.ai-webui",
   "productName": "Backend.AI Desktop",
-  "version": "25.12.0-alpha.0",
+  "version": "25.14.0-alpha.0",
   "repository": "https://github.com/lablup/backend.ai-webui.git",
   "author": "Lablup Inc. <contact@lablup.com>",
   "license": "LGPL-3.0-or-later",

--- a/index.html
+++ b/index.html
@@ -32,8 +32,8 @@
         NODE_ENV: 'production'
       }
     };
-    globalThis.packageVersion = "25.12.0-alpha.0";
-    globalThis.buildNumber = "6785";
+    globalThis.packageVersion = "25.14.0-alpha.0";
+    globalThis.buildNumber = "6927";
     globalThis.litNonce = "{{nonce}}";
     globalThis.baiNonce = "{{nonce}}";
   </script>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": 9,
   "name": "Backend.AI Web UI",
   "short_name": "BackendAIWebUI",
-  "version": "25.12.0-alpha.0",
+  "version": "25.14.0-alpha.0",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#fff",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend.ai-webui",
   "productName": "Backend.AI Desktop",
-  "version": "25.12.0-alpha.0",
+  "version": "25.14.0-alpha.0",
   "repository": "https://github.com/lablup/backend.ai-webui.git",
   "author": "Lablup Inc. <contact@lablup.com>",
   "license": "LGPL-3.0-or-later",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-ai-webui-react",
-  "version": "25.12.0-alpha.0",
+  "version": "25.14.0-alpha.0",
   "private": true,
   "dependencies": {
     "@ai-sdk/openai": "^1.3.22",

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "25.12.0-alpha.0", "buildNumber": "6785", "buildDate": "250704.230743", "revision": "764155849" }
+{ "package": "25.14.0-alpha.0", "buildNumber": "6927", "buildDate": "250903.170919", "revision": "0ebf9d2fd" }


### PR DESCRIPTION
# Bump version to 25.14.0-alpha.0

Updates the package version from 25.12.0-alpha.0 to 25.14.0-alpha.0 across all configuration files. Also updates the build number from 6785 to 6927 and revision hash in version.json.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after