### PR TITLE
refactor(FR-1445): rename ResourceGroupSelectForCurrentProject to SharedResourceGroupSelectForCurrentProject and add onChangeInTransition

### DIFF
--- a/react/src/components/MyResourceWithinResourceGroup.tsx
+++ b/react/src/components/MyResourceWithinResourceGroup.tsx
@@ -5,7 +5,7 @@ import {
 } from '../hooks/useCurrentProject';
 import { useResourceLimitAndRemaining } from '../hooks/useResourceLimitAndRemaining';
 import BAIFetchKeyButton from './BAIFetchKeyButton';
-import ResourceGroupSelectForCurrentProject from './ResourceGroupSelectForCurrentProject';
+import SharedResourceGroupSelectForCurrentProject from './SharedResourceGroupSelectForCurrentProject';
 import { useControllableValue } from 'ahooks';
 import { Segmented, Skeleton, theme, Typography } from 'antd';
 import { BAIFlex, BAIBoardItemTitle, ResourceStatistics } from 'backend.ai-ui';
@@ -169,7 +169,7 @@ const MyResourceWithinResourceGroup: React.FC<
             >
               {t('webui.menu.MyResourcesIn')}
             </Typography.Text>
-            <ResourceGroupSelectForCurrentProject
+            <SharedResourceGroupSelectForCurrentProject
               size="small"
               showSearch
               loading={currentResourceGroup !== deferredCurrentResourceGroup}

--- a/react/src/components/PendingSessionNodeList.tsx
+++ b/react/src/components/PendingSessionNodeList.tsx
@@ -1,10 +1,10 @@
 import BAIFetchKeyButton from './BAIFetchKeyButton';
-import ResourceGroupSelectForCurrentProject from './ResourceGroupSelectForCurrentProject';
 import SessionNodes from './SessionNodes';
+import SharedResourceGroupSelectForCurrentProject from './SharedResourceGroupSelectForCurrentProject';
 import { Form } from 'antd';
 import { BAIFlex, filterOutNullAndUndefined } from 'backend.ai-ui';
 import _ from 'lodash';
-import { useDeferredValue, useMemo, useState } from 'react';
+import { useDeferredValue, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useLocation } from 'react-router-dom';
@@ -15,13 +15,15 @@ import {
 import { INITIAL_FETCH_KEY, useFetchKey, useWebUINavigate } from 'src/hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from 'src/hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from 'src/hooks/useBAISetting';
+import { useCurrentResourceGroupValue } from 'src/hooks/useCurrentProject';
 
 const PendingSessionNodeList: React.FC = () => {
   const { t } = useTranslation();
   const [fetchKey, updateFetchKey] = useFetchKey();
-  const [selectedResourceGroup, setSelectedResourceGroup] = useState<string>();
+  // const [selectedResourceGroup, setSelectedResourceGroup] = useState<string>();
+  const currentResourceGroup = useCurrentResourceGroupValue();
   const deferredFetchKey = useDeferredValue(fetchKey);
-  const deferredSelectedResourceGroup = useDeferredValue(selectedResourceGroup);
+  const deferredCurrentResourceGroup = useDeferredValue(currentResourceGroup);
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.PendingSessionNodeList',
@@ -41,11 +43,11 @@ const PendingSessionNodeList: React.FC = () => {
 
   const queryVariables: PendingSessionNodeListQuery$variables = useMemo(
     () => ({
-      resource_group_id: deferredSelectedResourceGroup || 'default',
+      resource_group_id: deferredCurrentResourceGroup || 'default',
       first: baiPaginationOption.first,
       offset: baiPaginationOption.offset,
     }),
-    [deferredSelectedResourceGroup, baiPaginationOption],
+    [deferredCurrentResourceGroup, baiPaginationOption],
   );
   const deferredQueryVariables = useDeferredValue(queryVariables);
 
@@ -90,14 +92,13 @@ const PendingSessionNodeList: React.FC = () => {
           label={t('session.ResourceGroup')}
           style={{ marginBottom: 0 }}
         >
-          <ResourceGroupSelectForCurrentProject
+          <SharedResourceGroupSelectForCurrentProject
             showSearch
             style={{ minWidth: 100 }}
-            onChange={(v) => {
-              setSelectedResourceGroup(v);
+            onChangeInTransition={(v) => {
               setTablePaginationOption({ current: 1 });
             }}
-            loading={selectedResourceGroup !== deferredSelectedResourceGroup}
+            loading={currentResourceGroup !== deferredCurrentResourceGroup}
             popupMatchSelectWidth={false}
             tooltip={t('general.ResourceGroup')}
           />

--- a/react/src/components/TotalResourceWithinResourceGroup.tsx
+++ b/react/src/components/TotalResourceWithinResourceGroup.tsx
@@ -4,7 +4,7 @@ import {
   useResourceSlotsDetails,
 } from '../hooks/backendai';
 import BAIFetchKeyButton from './BAIFetchKeyButton';
-import ResourceGroupSelectForCurrentProject from './ResourceGroupSelectForCurrentProject';
+import SharedResourceGroupSelectForCurrentProject from './SharedResourceGroupSelectForCurrentProject';
 import { useControllableValue } from 'ahooks';
 import { Segmented, theme, Typography } from 'antd';
 import {
@@ -272,7 +272,7 @@ const TotalResourceWithinResourceGroup: React.FC<
             >
               {t('webui.menu.TotalResourcesIn')}
             </Typography.Text>
-            <ResourceGroupSelectForCurrentProject
+            <SharedResourceGroupSelectForCurrentProject
               size="small"
               showSearch
               style={{ minWidth: 100 }}

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -1,7 +1,7 @@
 import App from './App';
 import BAIIntervalView from './components/BAIIntervalView';
 import { jotaiStore, useWebComponentInfo } from './components/DefaultProviders';
-import ResourceGroupSelectForCurrentProject from './components/ResourceGroupSelectForCurrentProject';
+import SharedResourceGroupSelectForCurrentProject from './components/SharedResourceGroupSelectForCurrentProject';
 import SourceCodeViewer from './components/SourceCodeViewer';
 import { loadCustomThemeConfig } from './helper/customThemeConfig';
 import reactToWebComponent, {
@@ -164,7 +164,7 @@ const ResourceGroupSelectInWebComponent = (props: ReactWebComponentProps) => {
       style={{ minWidth: 200, maxWidth: 310 }}
     >
       {t('session.launcher.ResourceGroup')}
-      <ResourceGroupSelectForCurrentProject
+      <SharedResourceGroupSelectForCurrentProject
         size="large"
         showSearch
         disabled={currentResourceGroupByProject !== props.value}
@@ -172,7 +172,7 @@ const ResourceGroupSelectInWebComponent = (props: ReactWebComponentProps) => {
           !_.isEmpty(currentResourceGroupByProject) &&
           currentResourceGroupByProject !== props.value
         }
-        onChange={(value) => {
+        onChangeInTransition={(value) => {
           // setValue(value);
           props.dispatchEvent('change', value);
         }}


### PR DESCRIPTION
Resolves #4247 ([FR-1445](https://lablup.atlassian.net/browse/FR-1445))

## Rename ResourceGroupSelectForCurrentProject to SharedResourceGroupSelectForCurrentProject and add onChangeInTransition prop

This PR renames `ResourceGroupSelectForCurrentProject` to `SharedResourceGroupSelectForCurrentProject` and adds a new `onChangeInTransition` prop to handle changes during transition state. The component now properly handles loading states and optimistic updates when changing resource groups.

In `PendingSessionNodeList`, the component now uses the global resource group state instead of maintaining its own local state, improving consistency across the application.

[FR-1445]: https://lablup.atlassian.net/browse/FR-1445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ