### PR TITLE
fix(FR-1431): URL-based state persistence for pagination and filters

### DIFF
--- a/react/src/components/PendingSessionNodeList.tsx
+++ b/react/src/components/PendingSessionNodeList.tsx
@@ -76,8 +76,7 @@ const PendingSessionNodeList: React.FC = () => {
       `,
       deferredQueryVariables,
       {
-        fetchKey:
-          deferredFetchKey === INITIAL_FETCH_KEY ? undefined : deferredFetchKey,
+        fetchKey: deferredFetchKey,
         fetchPolicy:
           deferredFetchKey === INITIAL_FETCH_KEY
             ? 'store-and-network'

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -4,7 +4,7 @@ import {
   convertUnitValue,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
-import { useUpdatableState } from '../hooks';
+import { INITIAL_FETCH_KEY, useFetchKey } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import BAIFetchKeyButton from './BAIFetchKeyButton';
 import BAILink from './BAILink';
@@ -81,7 +81,7 @@ const StorageProxyList = () => {
     current: 1,
     pageSize: 10,
   });
-  const [fetchKey, updateFetchKey] = useUpdatableState('first');
+  const [fetchKey, updateFetchKey] = useFetchKey();
   const queryVariables = useMemo(
     () => ({
       offset: baiPaginationOption.offset,
@@ -111,8 +111,10 @@ const StorageProxyList = () => {
     deferredQueryVariables,
     {
       fetchPolicy:
-        deferredFetchKey === 'first' ? 'store-and-network' : 'network-only',
-      fetchKey: deferredFetchKey === 'first' ? undefined : deferredFetchKey,
+        deferredFetchKey === INITIAL_FETCH_KEY
+          ? 'store-and-network'
+          : 'network-only',
+      fetchKey: deferredFetchKey,
     },
   );
 

--- a/react/src/hooks/reactPaginationQueryOptions.tsx
+++ b/react/src/hooks/reactPaginationQueryOptions.tsx
@@ -1,6 +1,5 @@
 // import { offset_to_cursor } from "../helper";
 import { LazyLoadQueryOptions } from '../helper/types';
-import { useDeferredQueryParams } from './useDeferredQueryParams';
 import { SorterResult } from 'antd/lib/table/interface';
 import _ from 'lodash';
 import { useMemo, useState } from 'react';
@@ -15,6 +14,7 @@ import {
   ObjectParam,
   StringParam,
   useQueryParams,
+  withDefault,
 } from 'use-query-params';
 
 export type SorterInterface = Pick<SorterResult<any>, 'field' | 'order'>;
@@ -342,14 +342,11 @@ export const useBAIPaginationOptionState = (
 export const useBAIPaginationOptionStateOnSearchParam = (
   initialOptions: InitialPaginationOption,
 ): BAIPaginationOptionState => {
-  const [options, setOptions] = useDeferredQueryParams({
-    current: NumberParam,
-    pageSize: NumberParam,
+  const [{ pageSize, current }, setOptions] = useQueryParams({
+    current: withDefault(NumberParam, initialOptions.current),
+    pageSize: withDefault(NumberParam, initialOptions.pageSize),
   });
 
-  const mergeOptions = _.merge(initialOptions, options);
-
-  const { pageSize, current } = mergeOptions;
   const memoizedOptions = useMemo<{
     baiPaginationOption: BAIPaginationOption;
     tablePaginationOption: AntdBasicPaginationOption;

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -16,7 +16,6 @@ import { INITIAL_FETCH_KEY, useFetchKey, useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAINotificationState } from '../hooks/useBAINotification';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
-import { useDeferredQueryParams } from '../hooks/useDeferredQueryParams';
 import { SESSION_LAUNCHER_NOTI_PREFIX } from './SessionLauncherPage';
 import { useUpdateEffect } from 'ahooks';
 import {
@@ -53,7 +52,7 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useLocation } from 'react-router-dom';
 import { useBAISettingUserState } from 'src/hooks/useBAISetting';
-import { StringParam, withDefault } from 'use-query-params';
+import { StringParam, useQueryParams, withDefault } from 'use-query-params';
 
 type TypeFilterType = 'all' | 'interactive' | 'batch' | 'inference' | 'system';
 type SessionNode = NonNullableNodeOnEdges<
@@ -87,7 +86,7 @@ const ComputeSessionListPage = () => {
     pageSize: 10,
   });
 
-  const [queryParams, setQuery] = useDeferredQueryParams({
+  const [queryParams, setQuery] = useQueryParams({
     order: withDefault(StringParam, '-created_at'),
     filter: withDefault(StringParam, undefined),
     type: withDefault(StringParam, 'all'),
@@ -219,8 +218,7 @@ const ComputeSessionListPage = () => {
         deferredFetchKey === INITIAL_FETCH_KEY
           ? 'store-and-network'
           : 'network-only',
-      fetchKey:
-        deferredFetchKey === INITIAL_FETCH_KEY ? undefined : deferredFetchKey,
+      fetchKey: deferredFetchKey,
     },
   );
 

--- a/react/src/pages/ServingPage.tsx
+++ b/react/src/pages/ServingPage.tsx
@@ -6,7 +6,6 @@ import { useUpdatableState, useWebUINavigate } from '../hooks';
 import { useCurrentUserRole } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
-import { useDeferredQueryParams } from '../hooks/useDeferredQueryParams';
 import { Button, Skeleton, theme } from 'antd';
 import {
   filterOutEmpty,
@@ -19,7 +18,7 @@ import _ from 'lodash';
 import React, { Suspense, useDeferredValue, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { StringParam, withDefault } from 'use-query-params';
+import { StringParam, useQueryParams, withDefault } from 'use-query-params';
 
 const ServingPage: React.FC = () => {
   const { t } = useTranslation();
@@ -28,7 +27,7 @@ const ServingPage: React.FC = () => {
   const webuiNavigate = useWebUINavigate();
   const currentProject = useCurrentProjectValue();
 
-  const [queryParams, setQuery] = useDeferredQueryParams({
+  const [queryParams, setQuery] = useQueryParams({
     order: withDefault(StringParam, '-created_at'),
     filter: StringParam,
     lifecycleStage: withDefault(StringParam, 'active'),

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -19,9 +19,7 @@ import {
   useUpdatableState,
   useWebUINavigate,
 } from '../hooks';
-import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
-import { useDeferredQueryParams } from '../hooks/useDeferredQueryParams';
 import { useVFolderInvitationsValue } from '../hooks/useVFolderInvitations';
 import { useToggle } from 'ahooks';
 import {
@@ -58,8 +56,9 @@ import React, {
 import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
+import { useBAIPaginationOptionStateOnSearchParam } from 'src/hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from 'src/hooks/useBAISetting';
-import { StringParam, withDefault } from 'use-query-params';
+import { StringParam, useQueryParams, withDefault } from 'use-query-params';
 
 export const isDeletedCategory = (status?: string | null) => {
   return _.includes(
@@ -132,7 +131,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     pageSize: 10,
   });
 
-  const [queryParams, setQuery] = useDeferredQueryParams({
+  const [queryParams, setQuery] = useQueryParams({
     order: withDefault(StringParam, '-created_at'),
     filter: withDefault(StringParam, undefined),
     statusCategory: withDefault(StringParam, 'active'),
@@ -146,12 +145,6 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     queryParams,
     tablePaginationOption,
   };
-
-  const statusFilter =
-    queryParams.statusCategory === 'active' ||
-    queryParams.statusCategory === undefined
-      ? FILTER_BY_STATUS_CATEGORY['active']
-      : FILTER_BY_STATUS_CATEGORY['deleted'];
 
   function getUsageModeFilter(mode: string) {
     switch (mode) {
@@ -175,23 +168,28 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     () => ({
       projectId: currentProject.id,
       offset: baiPaginationOption.offset,
-      first: baiPaginationOption.first ?? 20,
+      first: baiPaginationOption.first,
       filter: mergeFilterValues([
-        statusFilter,
+        queryParams.statusCategory === 'active' ||
+        queryParams.statusCategory === undefined
+          ? FILTER_BY_STATUS_CATEGORY['active']
+          : FILTER_BY_STATUS_CATEGORY['deleted'],
         queryParams.filter,
         usageModeFilter,
       ]),
       order: queryParams.order,
       permission: 'read_attribute',
+      filterForActiveCount: FILTER_BY_STATUS_CATEGORY['active'],
+      filterForDeletedCount: FILTER_BY_STATUS_CATEGORY['deleted'],
     }),
     [
       currentProject.id,
       baiPaginationOption.offset,
       baiPaginationOption.first,
-      statusFilter,
+      queryParams.statusCategory,
       queryParams.filter,
-      usageModeFilter,
       queryParams.order,
+      usageModeFilter,
     ],
   );
   const deferredQueryVariables = useDeferredValue(queryVariables);
@@ -258,11 +256,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
           }
         }
       `,
-      {
-        ...deferredQueryVariables,
-        filterForActiveCount: FILTER_BY_STATUS_CATEGORY['active'],
-        filterForDeletedCount: FILTER_BY_STATUS_CATEGORY['deleted'],
-      },
+      deferredQueryVariables,
       {
         fetchPolicy:
           deferredFetchKey === 'initial-fetch'


### PR DESCRIPTION
Resolves #4225 ([FR-1431](https://lablup.atlassian.net/browse/FR-1431))

# URL-Based State Persistence for List Components

This PR implements URL-based state persistence for pagination, filtering, and sorting across multiple list components. When users refresh the page, their current view state (including filters, sorting, and pagination) is now preserved.

## Technical Background

`useDeferredQueryParams`​ had known bugs. To resolve this issue, we migrated to the stable hooks provided by the `use-query-params`​ library (`useQueryParams`​).

However, the  hooks have a limitation when used with  `useTransition`​, state changes don't occur within the transition, causing UI inconsistencies. To address this, we are following the same pattern used in other list page components throughout the codebase.

## Key Changes

- **State Management**: Replaced  with  and  for persistent state management
- **Performance Optimization**: Implemented  to handle state changes smoothly without transition conflicts
- **Pagination**: Switched from  to  for URL-based pagination
- **Loading States**: Simplified loading state management by comparing deferred values with current values
- **Code Consistency**: Aligned implementation patterns with other list components in the codebase

## Components Updated

- AgentList.tsx
- AgentSummaryList.tsx
- ContainerRegistryList.tsx
- StorageProxyList.tsx
- UserCredentialList.tsx
- UserNodeList.tsx
- ServingPage.tsx
- VFolderNodeListPage.tsx

## Benefits

- **Persistent State**: Filter values, pagination, and sorting preferences survive page refreshes
- **Better UX**: Users maintain their context when navigating or refreshing pages
- **Performance**: Deferred value updates prevent unnecessary re-renders during rapid state changes
- **Consistency**: All list components now follow the same state management pattern

This implementation ensures reliable state persistence while maintaining smooth user interactions across all list components.

[FR-1431]: https://lablup.atlassian.net/browse/FR-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ