### PR TITLE
feat(FR-1447): add JSON sort plugin to prettier in the BUI project

### DIFF
--- a/packages/backend.ai-ui/package.json
+++ b/packages/backend.ai-ui/package.json
@@ -80,6 +80,8 @@
     "react-copy-to-clipboard": "^5.1.0"
   },
   "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "prettier-plugin-sort-json": "^4.1.1",
     "@jest/expect": "30.0.0-beta.3",
     "@jest/globals": "30.0.0-beta.3",
     "@storybook/addon-docs": "^9.1.1",

--- a/packages/backend.ai-ui/src/locale/.prettierrc
+++ b/packages/backend.ai-ui/src/locale/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "plugins": ["prettier-plugin-sort-json"],
+  "jsonRecursiveSort": true
+}

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "test"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} von {{total}} Elementen"
-  },
-  "comp:BAITable": {
-    "SettingTable": "Tabelleneinstellungen",
-    "SelectColumnToDisplay": "Wählen Sie Spalten aus, um angezeigt zu werden",
-    "SearchTableColumn": "Suchtabellenspalten"
-  },
-  "error": {
-    "UnknownError": "Ein unbekannter Fehler ist aufgetreten. \nBitte versuchen Sie es erneut."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Suche",
     "ResetFilter": "Filter zurücksetzen"
@@ -21,12 +7,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Agent"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Unbegrenzt"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Suchtabellenspalten",
+    "SelectColumnToDisplay": "Wählen Sie Spalten aus, um angezeigt zu werden",
+    "SettingTable": "Tabelleneinstellungen"
+  },
+  "comp:BAITestButton": {
+    "Test": "test"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} von {{total}} Elementen"
+  },
+  "error": {
+    "UnknownError": "Ein unbekannter Fehler ist aufgetreten. \nBitte versuchen Sie es erneut."
+  },
   "general": {
     "button": {
       "CopyAll": "Alle kopieren"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Unbegrenzt"
   }
 }

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "δοκιμή"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} των στοιχείων {{total}}"
-  },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Επιλέξτε στήλες για εμφάνιση",
-    "SearchTableColumn": "Στήλες πίνακα αναζήτησης",
-    "SettingTable": "Ρυθμίσεις πίνακα"
-  },
-  "error": {
-    "UnknownError": "Παρουσιάστηκε ένα άγνωστο σφάλμα. \nΔοκιμάστε ξανά."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Αναζήτηση",
     "ResetFilter": "Επαναφορά φίλτρων"
@@ -21,12 +7,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Μέσο"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Απεριόριστος"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Στήλες πίνακα αναζήτησης",
+    "SelectColumnToDisplay": "Επιλέξτε στήλες για εμφάνιση",
+    "SettingTable": "Ρυθμίσεις πίνακα"
+  },
+  "comp:BAITestButton": {
+    "Test": "δοκιμή"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} των στοιχείων {{total}}"
+  },
+  "error": {
+    "UnknownError": "Παρουσιάστηκε ένα άγνωστο σφάλμα. \nΔοκιμάστε ξανά."
+  },
   "general": {
     "button": {
       "CopyAll": "Αντιγράψτε όλα"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Απεριόριστος"
   }
 }

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "Test"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} of {{total}} items"
-  },
-  "comp:BAITable": {
-    "SettingTable": "Table Settings",
-    "SelectColumnToDisplay": "Select columns to display",
-    "SearchTableColumn": "Search table columns"
-  },
-  "error": {
-    "UnknownError": "An unknown error occurred. Please try again."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Search",
     "ResetFilter": "Reset filters"
@@ -21,12 +7,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Agent"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Unlimited"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Search table columns",
+    "SelectColumnToDisplay": "Select columns to display",
+    "SettingTable": "Table Settings"
+  },
+  "comp:BAITestButton": {
+    "Test": "Test"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} of {{total}} items"
+  },
+  "error": {
+    "UnknownError": "An unknown error occurred. Please try again."
+  },
   "general": {
     "button": {
       "CopyAll": "Copy All"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Unlimited"
   }
 }

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "prueba"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} de {{total}} elementos"
-  },
-  "comp:BAITable": {
-    "SettingTable": "Configuración de tabla",
-    "SelectColumnToDisplay": "Seleccionar columnas para mostrar",
-    "SearchTableColumn": "Columnas de la tabla de búsqueda"
-  },
-  "error": {
-    "UnknownError": "Ocurrió un error desconocido. \nPor favor intente de nuevo."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Buscar en",
     "ResetFilter": "Restablecer filtros"
@@ -21,12 +7,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Agente"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Ilimitado"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Columnas de la tabla de búsqueda",
+    "SelectColumnToDisplay": "Seleccionar columnas para mostrar",
+    "SettingTable": "Configuración de tabla"
+  },
+  "comp:BAITestButton": {
+    "Test": "prueba"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} de {{total}} elementos"
+  },
+  "error": {
+    "UnknownError": "Ocurrió un error desconocido. \nPor favor intente de nuevo."
+  },
   "general": {
     "button": {
       "CopyAll": "Copiar todo"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Ilimitado"
   }
 }

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "testi"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}}–{{end}} yhteensä {{total}} kohteesta"
-  },
-  "comp:BAITable": {
-    "SettingTable": "Taulukon asetukset",
-    "SelectColumnToDisplay": "Valitse näytettävä sarakkeet",
-    "SearchTableColumn": "Hakutaulukon sarakkeet"
-  },
-  "error": {
-    "UnknownError": "Tapahtui tuntematon virhe. \nYritä uudelleen."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Etsi",
     "ResetFilter": "Nollaa suodattimet"
@@ -21,12 +7,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Agentti"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Rajoittamaton"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Hakutaulukon sarakkeet",
+    "SelectColumnToDisplay": "Valitse näytettävä sarakkeet",
+    "SettingTable": "Taulukon asetukset"
+  },
+  "comp:BAITestButton": {
+    "Test": "testi"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}}–{{end}} yhteensä {{total}} kohteesta"
+  },
+  "error": {
+    "UnknownError": "Tapahtui tuntematon virhe. \nYritä uudelleen."
+  },
   "general": {
     "button": {
       "CopyAll": "Kopioida kaikki"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Rajoittamaton"
   }
 }

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "test"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} des éléments {{total}}"
-  },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Sélectionnez des colonnes à afficher",
-    "SettingTable": "Paramètres de la table",
-    "SearchTableColumn": "Colonnes de table de recherche"
-  },
-  "error": {
-    "UnknownError": "Une erreur inconnue s'est produite. \nVeuillez réessayer."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Recherche",
     "ResetFilter": "Réinitialiser les filtres"
@@ -21,12 +7,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Agent"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Illimité"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Colonnes de table de recherche",
+    "SelectColumnToDisplay": "Sélectionnez des colonnes à afficher",
+    "SettingTable": "Paramètres de la table"
+  },
+  "comp:BAITestButton": {
+    "Test": "test"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} des éléments {{total}}"
+  },
+  "error": {
+    "UnknownError": "Une erreur inconnue s'est produite. \nVeuillez réessayer."
+  },
   "general": {
     "button": {
       "CopyAll": "Copier tout"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Illimité"
   }
 }

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "tes"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} dari {{total}} item"
-  },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Pilih kolom untuk ditampilkan",
-    "SettingTable": "Pengaturan Tabel",
-    "SearchTableColumn": "Kolom Tabel Cari"
-  },
-  "error": {
-    "UnknownError": "Terjadi kesalahan yang tidak diketahui. \nTolong coba lagi."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pencarian",
     "ResetFilter": "Setel ulang filter"
@@ -21,12 +7,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Agen"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Tak terbatas"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Kolom Tabel Cari",
+    "SelectColumnToDisplay": "Pilih kolom untuk ditampilkan",
+    "SettingTable": "Pengaturan Tabel"
+  },
+  "comp:BAITestButton": {
+    "Test": "tes"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} dari {{total}} item"
+  },
+  "error": {
+    "UnknownError": "Terjadi kesalahan yang tidak diketahui. \nTolong coba lagi."
+  },
   "general": {
     "button": {
       "CopyAll": "Salin semua"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Tak terbatas"
   }
 }

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "test"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} di {{total}} elementi"
-  },
-  "comp:BAITable": {
-    "SettingTable": "Impostazioni della tabella",
-    "SelectColumnToDisplay": "Seleziona le colonne da visualizzare",
-    "SearchTableColumn": "Colonne della tabella di ricerca"
-  },
-  "error": {
-    "UnknownError": "Si è verificato un errore sconosciuto. \nPer favore riprova."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Ricerca",
     "ResetFilter": "Reimposta i filtri"
@@ -21,12 +7,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Agente"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Illimitato"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Colonne della tabella di ricerca",
+    "SelectColumnToDisplay": "Seleziona le colonne da visualizzare",
+    "SettingTable": "Impostazioni della tabella"
+  },
+  "comp:BAITestButton": {
+    "Test": "test"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} di {{total}} elementi"
+  },
+  "error": {
+    "UnknownError": "Si è verificato un errore sconosciuto. \nPer favore riprova."
+  },
   "general": {
     "button": {
       "CopyAll": "Copia tutto"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Illimitato"
   }
 }

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "テスト"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}}  -  {{end}} of {{total}}アイテム"
-  },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "表示する列を選択します",
-    "SettingTable": "テーブル設定",
-    "SearchTableColumn": "テーブル列を検索します"
-  },
-  "error": {
-    "UnknownError": "不明なエラーが発生しました。\nもう一度やり直してください。"
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "検索",
     "ResetFilter": "フィルターをリセットする"
@@ -21,12 +7,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "エージェント"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "無制限"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "テーブル列を検索します",
+    "SelectColumnToDisplay": "表示する列を選択します",
+    "SettingTable": "テーブル設定"
+  },
+  "comp:BAITestButton": {
+    "Test": "テスト"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}}  -  {{end}} of {{total}}アイテム"
+  },
+  "error": {
+    "UnknownError": "不明なエラーが発生しました。\nもう一度やり直してください。"
+  },
   "general": {
     "button": {
       "CopyAll": "すべてをコピーします"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "無制限"
   }
 }

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "테스트"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "전체 {{total}}개 중 {{start}} - {{end}}"
-  },
-  "comp:BAITable": {
-    "SettingTable": "표 설정",
-    "SelectColumnToDisplay": "표시할 열 선택",
-    "SearchTableColumn": "표시할 열 검색"
-  },
-  "error": {
-    "UnknownError": "알 수 없는 오류가 발생했습니다. 다시 시도해 주세요."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "검색",
     "ResetFilter": "필터 초기화"
@@ -21,12 +7,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "실행노드"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "제한없음"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "표시할 열 검색",
+    "SelectColumnToDisplay": "표시할 열 선택",
+    "SettingTable": "표 설정"
+  },
+  "comp:BAITestButton": {
+    "Test": "테스트"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "전체 {{total}}개 중 {{start}} - {{end}}"
+  },
+  "error": {
+    "UnknownError": "알 수 없는 오류가 발생했습니다. 다시 시도해 주세요."
+  },
   "general": {
     "button": {
       "CopyAll": "모두 복사"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "제한없음"
   }
 }

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "турших"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{{end}} {{total}}}} зүйл"
-  },
-  "comp:BAITable": {
-    "SettingTable": "Хүснэгтийн тохиргоо",
-    "SelectColumnToDisplay": "Дэлгэцийн баганыг сонгоно уу",
-    "SearchTableColumn": "Хүснэгтийн баганыг хайх"
-  },
-  "error": {
-    "UnknownError": "Үл мэдэгдэх алдаа гарлаа. \nДахин оролдоно уу."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Хайх",
     "ResetFilter": "Шүүлтүүрийг дахин тохируулах"
@@ -21,12 +7,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Агент"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Хязгааргүй"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Хүснэгтийн баганыг хайх",
+    "SelectColumnToDisplay": "Дэлгэцийн баганыг сонгоно уу",
+    "SettingTable": "Хүснэгтийн тохиргоо"
+  },
+  "comp:BAITestButton": {
+    "Test": "турших"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{{end}} {{total}}}} зүйл"
+  },
+  "error": {
+    "UnknownError": "Үл мэдэгдэх алдаа гарлаа. \nДахин оролдоно уу."
+  },
   "general": {
     "button": {
       "CopyAll": "Бүгдийг хуулбарлах"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Хязгааргүй"
   }
 }

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "ujian"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} dari {{total}} item"
-  },
-  "comp:BAITable": {
-    "SettingTable": "Tetapan Jadual",
-    "SelectColumnToDisplay": "Pilih lajur untuk dipaparkan",
-    "SearchTableColumn": "Lajur jadual carian"
-  },
-  "error": {
-    "UnknownError": "Kesalahan yang tidak diketahui berlaku. \nSila cuba lagi."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Cari",
     "ResetFilter": "Tetapkan semula penapis"
@@ -22,12 +8,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Ejen"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Tidak terhad"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Lajur jadual carian",
+    "SelectColumnToDisplay": "Pilih lajur untuk dipaparkan",
+    "SettingTable": "Tetapan Jadual"
+  },
+  "comp:BAITestButton": {
+    "Test": "ujian"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} dari {{total}} item"
+  },
+  "error": {
+    "UnknownError": "Kesalahan yang tidak diketahui berlaku. \nSila cuba lagi."
+  },
   "general": {
     "button": {
       "CopyAll": "Salin semua"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Tidak terhad"
   }
 }

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "test"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} z {{total}}"
-  },
-  "comp:BAITable": {
-    "SettingTable": "Ustawienia tabeli",
-    "SelectColumnToDisplay": "Wybierz kolumny do wyświetlenia",
-    "SearchTableColumn": "Wyszukaj kolumny tabeli"
-  },
-  "error": {
-    "UnknownError": "Wystąpił nieznany błąd. \nSpróbuj ponownie."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Wyszukiwanie",
     "ResetFilter": "Zresetuj filtry"
@@ -22,12 +8,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Agent"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Nieograniczony"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Wyszukaj kolumny tabeli",
+    "SelectColumnToDisplay": "Wybierz kolumny do wyświetlenia",
+    "SettingTable": "Ustawienia tabeli"
+  },
+  "comp:BAITestButton": {
+    "Test": "test"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} z {{total}}"
+  },
+  "error": {
+    "UnknownError": "Wystąpił nieznany błąd. \nSpróbuj ponownie."
+  },
   "general": {
     "button": {
       "CopyAll": "Kopiuj wszystko"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Nieograniczony"
   }
 }

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "teste"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} de {{total}} itens"
-  },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Selecione colunas para exibir",
-    "SettingTable": "Configurações da tabela",
-    "SearchTableColumn": "Pesquisar colunas da tabela"
-  },
-  "error": {
-    "UnknownError": "Ocorreu um erro desconhecido. \nPor favor, tente novamente."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pesquisar",
     "ResetFilter": "Redefinir filtros"
@@ -22,12 +8,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Agente"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Ilimitado"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Pesquisar colunas da tabela",
+    "SelectColumnToDisplay": "Selecione colunas para exibir",
+    "SettingTable": "Configurações da tabela"
+  },
+  "comp:BAITestButton": {
+    "Test": "teste"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} de {{total}} itens"
+  },
+  "error": {
+    "UnknownError": "Ocorreu um erro desconhecido. \nPor favor, tente novamente."
+  },
   "general": {
     "button": {
       "CopyAll": "Copie tudo"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Ilimitado"
   }
 }

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "teste"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} de {{total}} itens"
-  },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Selecione colunas para exibir",
-    "SettingTable": "Configurações da tabela",
-    "SearchTableColumn": "Pesquisar colunas da tabela"
-  },
-  "error": {
-    "UnknownError": "Ocorreu um erro desconhecido. \nPor favor, tente novamente."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Pesquisar",
     "ResetFilter": "Redefinir filtros"
@@ -22,12 +8,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Agente"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Ilimitado"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Pesquisar colunas da tabela",
+    "SelectColumnToDisplay": "Selecione colunas para exibir",
+    "SettingTable": "Configurações da tabela"
+  },
+  "comp:BAITestButton": {
+    "Test": "teste"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} de {{total}} itens"
+  },
+  "error": {
+    "UnknownError": "Ocorreu um erro desconhecido. \nPor favor, tente novamente."
+  },
   "general": {
     "button": {
       "CopyAll": "Copie tudo"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Ilimitado"
   }
 }

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "тест"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} of {{total}} элементы"
-  },
-  "comp:BAITable": {
-    "SelectColumnToDisplay": "Выберите столбцы, чтобы отобразить",
-    "SettingTable": "Настройки таблицы",
-    "SearchTableColumn": "Поиск таблицы столбцов"
-  },
-  "error": {
-    "UnknownError": "Произошла неизвестная ошибка. \nПожалуйста, попробуйте еще раз."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Поиск",
     "ResetFilter": "Сбросить фильтры"
@@ -22,12 +8,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Агент"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Неограниченный"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Поиск таблицы столбцов",
+    "SelectColumnToDisplay": "Выберите столбцы, чтобы отобразить",
+    "SettingTable": "Настройки таблицы"
+  },
+  "comp:BAITestButton": {
+    "Test": "тест"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} of {{total}} элементы"
+  },
+  "error": {
+    "UnknownError": "Произошла неизвестная ошибка. \nПожалуйста, попробуйте еще раз."
+  },
   "general": {
     "button": {
       "CopyAll": "Копировать все"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Неограниченный"
   }
 }

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "ทดสอบ"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} ของ {{total}} รายการ"
-  },
-  "comp:BAITable": {
-    "SettingTable": "การตั้งค่าตาราง",
-    "SelectColumnToDisplay": "เลือกคอลัมน์ที่จะแสดง",
-    "SearchTableColumn": "คอลัมน์ตารางค้นหา"
-  },
-  "error": {
-    "UnknownError": "เกิดข้อผิดพลาดที่ไม่รู้จัก \nโปรดลองอีกครั้ง"
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "ค้นหา",
     "ResetFilter": "รีเซ็ตตัวกรอง"
@@ -22,12 +8,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "ตัวแทน"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "ไม่ จำกัด"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "คอลัมน์ตารางค้นหา",
+    "SelectColumnToDisplay": "เลือกคอลัมน์ที่จะแสดง",
+    "SettingTable": "การตั้งค่าตาราง"
+  },
+  "comp:BAITestButton": {
+    "Test": "ทดสอบ"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} ของ {{total}} รายการ"
+  },
+  "error": {
+    "UnknownError": "เกิดข้อผิดพลาดที่ไม่รู้จัก \nโปรดลองอีกครั้ง"
+  },
   "general": {
     "button": {
       "CopyAll": "คัดลอกทั้งหมด"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "ไม่ จำกัด"
   }
 }

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "test"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} öğelerinin {{total}}"
-  },
-  "comp:BAITable": {
-    "SettingTable": "Masa Ayarları",
-    "SelectColumnToDisplay": "Görüntülemek için sütunları seçin",
-    "SearchTableColumn": "Arama Tablosu sütunları"
-  },
-  "error": {
-    "UnknownError": "Bilinmeyen bir hata oluştu. \nLütfen tekrar deneyin."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Arama",
     "ResetFilter": "Filtreleri sıfırla"
@@ -22,12 +8,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Ajan"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Sınırsız"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Arama Tablosu sütunları",
+    "SelectColumnToDisplay": "Görüntülemek için sütunları seçin",
+    "SettingTable": "Masa Ayarları"
+  },
+  "comp:BAITestButton": {
+    "Test": "test"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} öğelerinin {{total}}"
+  },
+  "error": {
+    "UnknownError": "Bilinmeyen bir hata oluştu. \nLütfen tekrar deneyin."
+  },
   "general": {
     "button": {
       "CopyAll": "Hepsini kopyala"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Sınırsız"
   }
 }

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "kiểm tra"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}} - {{end}} của {{total}}"
-  },
-  "comp:BAITable": {
-    "SettingTable": "Cài đặt bảng",
-    "SelectColumnToDisplay": "Chọn các cột để hiển thị",
-    "SearchTableColumn": "Các cột bảng tìm kiếm"
-  },
-  "error": {
-    "UnknownError": "Một lỗi không xác định xảy ra. \nHãy thử lại."
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "Tìm kiếm",
     "ResetFilter": "Đặt lại bộ lọc"
@@ -22,12 +8,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "Đại lý"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "Không giới hạn"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "Các cột bảng tìm kiếm",
+    "SelectColumnToDisplay": "Chọn các cột để hiển thị",
+    "SettingTable": "Cài đặt bảng"
+  },
+  "comp:BAITestButton": {
+    "Test": "kiểm tra"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}} - {{end}} của {{total}}"
+  },
+  "error": {
+    "UnknownError": "Một lỗi không xác định xảy ra. \nHãy thử lại."
+  },
   "general": {
     "button": {
       "CopyAll": "Sao chép tất cả"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "Không giới hạn"
   }
 }

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "测试"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}}  -  {{end}} {{total}}项目"
-  },
-  "comp:BAITable": {
-    "SettingTable": "表设置",
-    "SelectColumnToDisplay": "选择要显示的列",
-    "SearchTableColumn": "搜索表列"
-  },
-  "error": {
-    "UnknownError": "发生了未知错误。\n请重试。"
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "搜索",
     "ResetFilter": "重置过滤器"
@@ -22,12 +8,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "代理人"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "无限"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "搜索表列",
+    "SelectColumnToDisplay": "选择要显示的列",
+    "SettingTable": "表设置"
+  },
+  "comp:BAITestButton": {
+    "Test": "测试"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}}  -  {{end}} {{total}}项目"
+  },
+  "error": {
+    "UnknownError": "发生了未知错误。\n请重试。"
+  },
   "general": {
     "button": {
       "CopyAll": "复制全部"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "无限"
   }
 }

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -1,19 +1,5 @@
 {
   "$schema": "../../i18n.schema.json",
-  "comp:BAITestButton": {
-    "Test": "測試"
-  },
-  "comp:PaginationInfoText": {
-    "Total": "{{start}}  -  {{end}} {{total}}項目"
-  },
-  "comp:BAITable": {
-    "SettingTable": "表設置",
-    "SelectColumnToDisplay": "選擇要顯示的列",
-    "SearchTableColumn": "搜索表列"
-  },
-  "error": {
-    "UnknownError": "發生了未知錯誤。請重試。"
-  },
   "comp:BAIPropertyFilter": {
     "PlaceHolder": "搜索",
     "ResetFilter": "重置過濾器"
@@ -22,12 +8,26 @@
   "comp:BAISessionAgentIds": {
     "Agent": "代理人"
   },
+  "comp:BAIStatistic": {
+    "Unlimited": "無限"
+  },
+  "comp:BAITable": {
+    "SearchTableColumn": "搜索表列",
+    "SelectColumnToDisplay": "選擇要顯示的列",
+    "SettingTable": "表設置"
+  },
+  "comp:BAITestButton": {
+    "Test": "測試"
+  },
+  "comp:PaginationInfoText": {
+    "Total": "{{start}}  -  {{end}} {{total}}項目"
+  },
+  "error": {
+    "UnknownError": "發生了未知錯誤。請重試。"
+  },
   "general": {
     "button": {
       "CopyAll": "複製全部"
     }
-  },
-  "comp:BAIStatistic": {
-    "Unlimited": "無限"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,6 +537,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.2.0
         version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@trivago/prettier-plugin-sort-imports':
+        specifier: ^4.3.0
+        version: 4.3.0(@vue/compiler-sfc@3.5.13)(prettier@3.5.3)
       '@types/big.js':
         specifier: ^6.2.2
         version: 6.2.2
@@ -569,7 +572,7 @@ importers:
         version: 8.57.1
       eslint-config-react-app:
         specifier: ^7.0.1
-        version: 7.0.1(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.25.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.4.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.4.1)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 7.0.1(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(eslint@8.57.1)(jest@29.7.0(@types/node@22.4.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.4.1)(typescript@5.8.2)))(typescript@5.8.2)
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)
@@ -591,6 +594,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0(bufferutil@4.0.8)(utf-8-validate@6.0.4)
+      prettier-plugin-sort-json:
+        specifier: ^4.1.1
+        version: 4.1.1(prettier@3.5.3)
       relay-test-utils:
         specifier: ^20.1.1
         version: 20.1.1
@@ -599,7 +605,7 @@ importers:
         version: 9.1.1(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)(vite@6.3.5(@types/node@22.4.1)(jiti@1.21.6)(terser@5.31.4)(yaml@2.5.0))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.0(@babel/core@7.25.2)(@jest/transform@30.0.5)(@jest/types@30.0.5)(babel-jest@30.0.5(@babel/core@7.25.2))(esbuild@0.25.5)(jest-util@30.0.5)(jest@29.7.0(@types/node@22.4.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.4.1)(typescript@5.8.2)))(typescript@5.8.2)
+        version: 29.4.0(@babel/core@7.27.3)(@jest/transform@30.0.5)(@jest/types@30.0.5)(babel-jest@30.0.5(@babel/core@7.27.3))(esbuild@0.25.5)(jest-util@30.0.5)(jest@29.7.0(@types/node@22.4.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.4.1)(typescript@5.8.2)))(typescript@5.8.2)
       tus-js-client:
         specifier: ^4.1.0
         version: 4.1.0
@@ -849,7 +855,7 @@ importers:
         version: 7.24.7(@babel/core@7.27.3)
       '@craco/craco':
         specifier: ^7.1.0
-        version: 7.1.0(@types/node@20.17.10)(postcss@8.5.6)(react-scripts@5.0.1(patch_hash=41eb935f1b9706514c1411563c280d8adec915feeff04548ce05b23fb03bfcc8)(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.19.12)(eslint@8.57.1)(react@19.0.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.2))(type-fest@4.41.0)(typescript@5.7.2)(utf-8-validate@6.0.4)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4(webpack@5.93.0))(webpack-hot-middleware@2.26.1))(typescript@5.7.2)
+        version: 7.1.0(@types/node@20.17.10)(postcss@8.4.49)(react-scripts@5.0.1(patch_hash=41eb935f1b9706514c1411563c280d8adec915feeff04548ce05b23fb03bfcc8)(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.19.12)(eslint@8.57.1)(react@19.0.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.2))(type-fest@4.41.0)(typescript@5.7.2)(utf-8-validate@6.0.4)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4(webpack@5.93.0))(webpack-hot-middleware@2.26.1))(typescript@5.7.2)
       '@storybook/addon-essentials':
         specifier: ^8.4.5
         version: 8.4.5(@types/react@19.0.10)(storybook@8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))
@@ -867,7 +873,7 @@ importers:
         version: 8.4.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))
       '@storybook/preset-create-react-app':
         specifier: ^8.4.5
-        version: 8.4.5(react-refresh@0.17.0)(react-scripts@5.0.1(patch_hash=41eb935f1b9706514c1411563c280d8adec915feeff04548ce05b23fb03bfcc8)(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.19.12)(eslint@8.57.1)(react@19.0.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.2))(type-fest@4.41.0)(typescript@5.7.2)(utf-8-validate@6.0.4)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4(webpack@5.93.0))(webpack-hot-middleware@2.26.1))(storybook@8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(type-fest@4.41.0)(typescript@5.7.2)(webpack-dev-server@4.15.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0))))(webpack-hot-middleware@2.26.1)(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0)))
+        version: 8.4.5(react-refresh@0.11.0)(react-scripts@5.0.1(patch_hash=41eb935f1b9706514c1411563c280d8adec915feeff04548ce05b23fb03bfcc8)(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.19.12)(eslint@8.57.1)(react@19.0.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.2))(type-fest@4.41.0)(typescript@5.7.2)(utf-8-validate@6.0.4)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4(webpack@5.93.0))(webpack-hot-middleware@2.26.1))(storybook@8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(type-fest@4.41.0)(typescript@5.7.2)(webpack-dev-server@4.15.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0))))(webpack-hot-middleware@2.26.1)(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0)))
       '@storybook/react':
         specifier: ^8.4.5
         version: 8.4.5(@storybook/test@8.6.10(storybook@8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(typescript@5.7.2)
@@ -16812,11 +16818,6 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-flow@7.26.0(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.27.1
-
   '@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3)':
     dependencies:
       '@babel/core': 7.27.3
@@ -16898,11 +16899,6 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.27.3)':
     dependencies:
       '@babel/core': 7.27.3
-      '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.27.3)':
@@ -17384,17 +17380,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.3
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.25.2)
-      '@babel/types': 7.27.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3)':
     dependencies:
@@ -18197,9 +18182,9 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
-  '@craco/craco@7.1.0(@types/node@20.17.10)(postcss@8.5.6)(react-scripts@5.0.1(patch_hash=41eb935f1b9706514c1411563c280d8adec915feeff04548ce05b23fb03bfcc8)(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.19.12)(eslint@8.57.1)(react@19.0.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.2))(type-fest@4.41.0)(typescript@5.7.2)(utf-8-validate@6.0.4)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4(webpack@5.93.0))(webpack-hot-middleware@2.26.1))(typescript@5.7.2)':
+  '@craco/craco@7.1.0(@types/node@20.17.10)(postcss@8.4.49)(react-scripts@5.0.1(patch_hash=41eb935f1b9706514c1411563c280d8adec915feeff04548ce05b23fb03bfcc8)(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.19.12)(eslint@8.57.1)(react@19.0.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.2))(type-fest@4.41.0)(typescript@5.7.2)(utf-8-validate@6.0.4)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4(webpack@5.93.0))(webpack-hot-middleware@2.26.1))(typescript@5.7.2)':
     dependencies:
-      autoprefixer: 10.4.20(postcss@8.5.6)
+      autoprefixer: 10.4.20(postcss@8.4.49)
       cosmiconfig: 7.1.0
       cosmiconfig-typescript-loader: 1.0.9(@types/node@20.17.10)(cosmiconfig@7.1.0)(typescript@5.7.2)
       cross-spawn: 7.0.3
@@ -20775,22 +20760,6 @@ snapshots:
       webpack-dev-server: 4.15.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0)))
       webpack-hot-middleware: 2.26.1
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.17.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0))))(webpack-hot-middleware@2.26.1)(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0)))':
-    dependencies:
-      ansi-html: 0.0.9
-      core-js-pure: 3.39.0
-      error-stack-parser: 2.1.4
-      html-entities: 2.5.2
-      loader-utils: 2.0.4
-      react-refresh: 0.17.0
-      schema-utils: 4.2.0
-      source-map: 0.7.4
-      webpack: 5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0))
-    optionalDependencies:
-      type-fest: 4.41.0
-      webpack-dev-server: 4.15.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0)))
-      webpack-hot-middleware: 2.26.1
-
   '@polymer/polymer@3.5.1':
     dependencies:
       '@webcomponents/shadycss': 1.11.2
@@ -21534,9 +21503,9 @@ snapshots:
     dependencies:
       storybook: 8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4)
 
-  '@storybook/preset-create-react-app@8.4.5(react-refresh@0.17.0)(react-scripts@5.0.1(patch_hash=41eb935f1b9706514c1411563c280d8adec915feeff04548ce05b23fb03bfcc8)(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.19.12)(eslint@8.57.1)(react@19.0.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.2))(type-fest@4.41.0)(typescript@5.7.2)(utf-8-validate@6.0.4)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4(webpack@5.93.0))(webpack-hot-middleware@2.26.1))(storybook@8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(type-fest@4.41.0)(typescript@5.7.2)(webpack-dev-server@4.15.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0))))(webpack-hot-middleware@2.26.1)(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0)))':
+  '@storybook/preset-create-react-app@8.4.5(react-refresh@0.11.0)(react-scripts@5.0.1(patch_hash=41eb935f1b9706514c1411563c280d8adec915feeff04548ce05b23fb03bfcc8)(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(@types/babel__core@7.20.5)(bufferutil@4.0.8)(esbuild@0.19.12)(eslint@8.57.1)(react@19.0.0)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.2))(type-fest@4.41.0)(typescript@5.7.2)(utf-8-validate@6.0.4)(vue-template-compiler@2.7.16)(webpack-cli@5.1.4(webpack@5.93.0))(webpack-hot-middleware@2.26.1))(storybook@8.4.5(bufferutil@4.0.8)(prettier@3.5.3)(utf-8-validate@6.0.4))(type-fest@4.41.0)(typescript@5.7.2)(webpack-dev-server@4.15.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0))))(webpack-hot-middleware@2.26.1)(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0)))':
     dependencies:
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.17.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0))))(webpack-hot-middleware@2.26.1)(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0)))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.11.0)(type-fest@4.41.0)(webpack-dev-server@4.15.2(bufferutil@4.0.8)(utf-8-validate@6.0.4)(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0))))(webpack-hot-middleware@2.26.1)(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0)))
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.7.2)(webpack@5.97.1(esbuild@0.19.12)(webpack-cli@5.1.4(webpack@5.93.0)))
       '@types/semver': 7.5.8
       pnp-webpack-plugin: 1.7.0(typescript@5.7.2)
@@ -22015,6 +21984,20 @@ snapshots:
       javascript-natural-sort: 0.7.1
       lodash: 4.17.21
       prettier: 3.5.2
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.5.13
+    transitivePeerDependencies:
+      - supports-color
+
+  '@trivago/prettier-plugin-sort-imports@4.3.0(@vue/compiler-sfc@3.5.13)(prettier@3.5.3)':
+    dependencies:
+      '@babel/generator': 7.17.7
+      '@babel/parser': 7.25.3
+      '@babel/traverse': 7.23.2
+      '@babel/types': 7.17.0
+      javascript-natural-sort: 0.7.1
+      lodash: 4.17.21
+      prettier: 3.5.3
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.13
     transitivePeerDependencies:
@@ -24114,16 +24097,6 @@ snapshots:
       normalize-range: 0.1.2
       picocolors: 1.1.1
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-
-  autoprefixer@10.4.20(postcss@8.5.6):
-    dependencies:
-      browserslist: 4.23.3
-      caniuse-lite: 1.0.30001731
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.1.1
-      postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -26626,33 +26599,6 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.25.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.4.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.4.1)(typescript@5.8.2)))(typescript@5.8.2):
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/eslint-parser': 7.25.9(@babel/core@7.25.2)(eslint@8.57.1)
-      '@rushstack/eslint-patch': 1.10.4
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
-      babel-preset-react-app: 10.1.0
-      confusing-browser-globals: 1.0.11
-      eslint: 8.57.1
-      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.25.2))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.4.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.4.1)(typescript@5.8.2)))(typescript@5.8.2)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
-      eslint-plugin-react: 7.37.4(eslint@8.57.1)
-      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
-      eslint-plugin-testing-library: 5.11.1(eslint@8.57.1)(typescript@5.8.2)
-    optionalDependencies:
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - '@babel/plugin-syntax-flow'
-      - '@babel/plugin-transform-react-jsx'
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - jest
-      - supports-color
-
   eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(eslint@8.57.1)(jest@27.5.1(bufferutil@4.0.8)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.2))(utf-8-validate@6.0.4))(typescript@5.7.2):
     dependencies:
       '@babel/core': 7.25.2
@@ -26707,6 +26653,33 @@ snapshots:
       - jest
       - supports-color
 
+  eslint-config-react-app@7.0.1(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(eslint@8.57.1)(jest@29.7.0(@types/node@22.4.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.4.1)(typescript@5.8.2)))(typescript@5.8.2):
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/eslint-parser': 7.25.9(@babel/core@7.25.2)(eslint@8.57.1)
+      '@rushstack/eslint-patch': 1.10.4
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.8.2)
+      babel-preset-react-app: 10.1.0
+      confusing-browser-globals: 1.0.11
+      eslint: 8.57.1
+      eslint-plugin-flowtype: 8.0.3(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(jest@29.7.0(@types/node@22.4.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.4.1)(typescript@5.8.2)))(typescript@5.8.2)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
+      eslint-plugin-react: 7.37.4(eslint@8.57.1)
+      eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
+      eslint-plugin-testing-library: 5.11.1(eslint@8.57.1)(typescript@5.8.2)
+    optionalDependencies:
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - '@babel/plugin-syntax-flow'
+      - '@babel/plugin-transform-react-jsx'
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - jest
+      - supports-color
+
   eslint-import-resolver-node@0.3.9:
     dependencies:
       debug: 3.2.7
@@ -26750,14 +26723,6 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
-
-  eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.25.2))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.25.2))(eslint@8.57.1):
-    dependencies:
-      '@babel/plugin-syntax-flow': 7.26.0(@babel/core@7.25.2)
-      '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.25.2)
-      eslint: 8.57.1
-      lodash: 4.17.21
-      string-natural-compare: 3.0.1
 
   eslint-plugin-flowtype@8.0.3(@babel/plugin-syntax-flow@7.26.0(@babel/core@7.27.3))(@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.27.3))(eslint@8.57.1):
     dependencies:
@@ -32389,6 +32354,7 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+    optional: true
 
   postject@1.0.0-alpha.6:
     dependencies:
@@ -32420,6 +32386,10 @@ snapshots:
   prettier-plugin-sort-json@4.1.1(prettier@3.5.2):
     dependencies:
       prettier: 3.5.2
+
+  prettier-plugin-sort-json@4.1.1(prettier@3.5.3):
+    dependencies:
+      prettier: 3.5.3
 
   prettier@3.5.2: {}
 
@@ -35062,7 +35032,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.0(@babel/core@7.25.2)(@jest/transform@30.0.5)(@jest/types@30.0.5)(babel-jest@30.0.5(@babel/core@7.25.2))(esbuild@0.25.5)(jest-util@30.0.5)(jest@29.7.0(@types/node@22.4.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.4.1)(typescript@5.8.2)))(typescript@5.8.2):
+  ts-jest@29.4.0(@babel/core@7.27.3)(@jest/transform@30.0.5)(@jest/types@30.0.5)(babel-jest@30.0.5(@babel/core@7.27.3))(esbuild@0.25.5)(jest-util@30.0.5)(jest@29.7.0(@types/node@22.4.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.4.1)(typescript@5.8.2)))(typescript@5.8.2):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -35076,10 +35046,10 @@ snapshots:
       typescript: 5.8.2
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.27.3
       '@jest/transform': 30.0.5
       '@jest/types': 30.0.5
-      babel-jest: 30.0.5(@babel/core@7.25.2)
+      babel-jest: 30.0.5(@babel/core@7.27.3)
       esbuild: 0.25.5
       jest-util: 30.0.5
 


### PR DESCRIPTION
resolves #4254 (FR-1447)

This PR adds JSON sorting capabilities to the locale files in the backend.ai-ui package. It includes:

1. Added two Prettier plugins as dev dependencies:
   - `@trivago/prettier-plugin-sort-imports` for sorting imports
   - `prettier-plugin-sort-json` for sorting JSON keys

2. Created a `.prettierrc` configuration file in the locale directory to enable JSON sorting with:
   ```json
   {
     "plugins": ["prettier-plugin-sort-json"],
     "jsonRecursiveSort": true
   }
   ```

3. Applied sorting to all locale JSON files (de.json, el.json, en.json, etc.), organizing translation keys alphabetically for better maintainability and easier comparison between language files.

The sorted JSON files maintain the same content but with a consistent ordering pattern, making it easier to locate and manage translations across different languages.