### PR TITLE
fix(FR-1450): correct Electron app development mode path configuration

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -39,11 +39,11 @@ let es6Path;
 let electronPath;
 let mainIndex;
 if (process.env.serveMode == 'dev') {
-  ProxyManager = require('./build/electron-app/app/wsproxy/wsproxy.js');
-  versions = require('./version');
-  es6Path = npjoin(__dirname, 'build/electron-app/app'); // ES6 module loader with custom protocol
-  electronPath = npjoin(__dirname, 'build/electron-app');
-  mainIndex = 'build/electron-app/app/index.html';
+  ProxyManager = require(path.join(__dirname, 'app/wsproxy/wsproxy.js'));
+  versions = require(path.join(__dirname, 'app/version'));
+  es6Path = npjoin(__dirname, 'app'); // ES6 module loader with custom protocol
+  electronPath = npjoin(__dirname);
+  mainIndex = 'app/index.html';
 } else {
   ProxyManager = require('./app/wsproxy/wsproxy.js');
   versions = require('./app/version');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "server:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && PORT=$BAI_WEBUI_DEV_REACT_PORT PROXY=http://localhost:$BAI_WEBUI_DEV_WEBDEV_PORT pnpm --prefix ./react run start",
     "server:d-ie11": "web-dev-server --node-resolve --open --watch --port 3081 --hostname $BAI_WEBUI_DEV_HOST --esbuild-target auto --app-index demo/index.html --file-extensions .ts",
     "build:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && concurrently -c \"auto\" --names \"webcomponent,react-relay,webdev\" \"./node_modules/typescript/bin/tsc --watch\" \"cd react && pnpm run relay:watch\" \"web-dev-server --node-resolve --port $BAI_WEBUI_DEV_WEBDEV_PORT --hostname localhost --esbuild-target auto --app-index index.html --file-extensions .ts\"",
-    "electron:d": "electron . --dev",
+    "electron:d": "electron build/electron-app --dev",
     "relay": "relay-compiler",
     "copywc": "mkdir -p build/rollup/src/lib && cp -r node_modules/@webcomponents/webcomponentsjs/bundles build/rollup/src/lib && cp -r node_modules/@webcomponents/webcomponentsjs/bundles src/lib && cp node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js build/rollup/src/lib && cp -r node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js src/lib",
     "copywa": "mkdir -p build/rollup/src/lib/web-animations-js && mkdir -p src/lib/web-animations-js && cp node_modules/web-animations-js/web-animations-next-lite.min.js src/lib/web-animations-js && cp src/lib/web-animations-js/web-animations-next-lite.min.js build/rollup/src/lib/web-animations-js",


### PR DESCRIPTION
Resolves ([FR-1450](https://lablup.atlassian.net/browse/FR-1450))

## Summary
This PR fixes the Electron app's development mode path configuration issues. The current paths in `main.js` were incorrectly referencing `build/electron-app/app` directories when in development mode, but these should be pointing to the correct relative paths within the Electron app structure.

## Changes
- **electron-app/main.js**: Fixed development mode path references to use correct relative paths with `path.join(__dirname, 'app/...')` instead of hardcoded build paths
- **package.json**: Updated `electron:d` script to launch from `build/electron-app` directory

## Impact
- Fixes Electron app development mode startup issues
- Ensures proper module loading in development environment
- Aligns development and production path configurations

## Test Plan
- Verify Electron app launches correctly in development mode with `pnpm run electron:d` after `make clean & make dep`
- Verify that it operates without issues in the production environment. 
- Confirm all required modules and resources are properly loaded
- Test both development and production modes work as expected

[FR-1450]: https://lablup.atlassian.net/browse/FR-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ