### PR TITLE
feat(FR-1451): add lint rule to restrict imports from backend.ai-ui

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/index.ts
+++ b/packages/backend.ai-ui/src/components/Table/index.ts
@@ -5,6 +5,7 @@ export type {
   BAIColumnsType,
   BAITableSettings,
   BAITableColumnOverrideItem,
+  BAITableColumnOverrideRecord,
 } from './BAITable';
 export {
   isColumnVisible,

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -30,6 +30,7 @@ export { default as BAIRowWrapWithDividers } from './BAIRowWrapWithDividers';
 export { default as BAIStatistic } from './BAIStatistic';
 export type { BAIStatisticProps } from './BAIStatistic';
 export { default as ResourceStatistics } from './ResourceStatistics';
+export { processMemoryValue, convertToNumber } from './ResourceStatistics';
 export { default as BAIUnmountAfterClose } from './BAIUnmountAfterClose';
 export { default as BAIAlertIconWithTooltip } from './BAIAlertIconWithTooltip';
 export * from './Table';

--- a/react/package.json
+++ b/react/package.json
@@ -104,7 +104,16 @@
       "import/no-duplicates": "error",
       "relay/graphql-syntax": "off",
       "relay/unused-fields": "off",
-      "relay/must-colocate-fragment-spreads": "off"
+      "relay/must-colocate-fragment-spreads": "off",
+      "no-restricted-imports": [
+        "error",
+        {
+          "patterns": [
+            "backend.ai-ui/*",
+            "!backend.ai-ui/dist"
+          ]
+        }
+      ]
     }
   },
   "browserslist": {

--- a/react/src/components/MyResource.tsx
+++ b/react/src/components/MyResource.tsx
@@ -4,11 +4,13 @@ import { useResourceLimitAndRemaining } from '../hooks/useResourceLimitAndRemain
 import BAIFetchKeyButton from './BAIFetchKeyButton';
 import { useControllableValue } from 'ahooks';
 import { Segmented, theme } from 'antd';
-import { BAIBoardItemTitle, BAIFlex, ResourceStatistics } from 'backend.ai-ui';
 import {
+  BAIBoardItemTitle,
+  BAIFlex,
+  ResourceStatistics,
   convertToNumber,
   processMemoryValue,
-} from 'backend.ai-ui/components/ResourceStatistics';
+} from 'backend.ai-ui';
 import _ from 'lodash';
 import { ReactNode, useMemo, useTransition } from 'react';
 import { Trans, useTranslation } from 'react-i18next';

--- a/react/src/components/MyResourceWithinResourceGroup.tsx
+++ b/react/src/components/MyResourceWithinResourceGroup.tsx
@@ -8,11 +8,13 @@ import BAIFetchKeyButton from './BAIFetchKeyButton';
 import SharedResourceGroupSelectForCurrentProject from './SharedResourceGroupSelectForCurrentProject';
 import { useControllableValue } from 'ahooks';
 import { Segmented, Skeleton, theme, Typography } from 'antd';
-import { BAIFlex, BAIBoardItemTitle, ResourceStatistics } from 'backend.ai-ui';
 import {
+  BAIFlex,
+  BAIBoardItemTitle,
+  ResourceStatistics,
   convertToNumber,
   processMemoryValue,
-} from 'backend.ai-ui/components/ResourceStatistics';
+} from 'backend.ai-ui';
 import _ from 'lodash';
 import { ReactNode, useDeferredValue, useMemo, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/TotalResourceWithinResourceGroup.tsx
+++ b/react/src/components/TotalResourceWithinResourceGroup.tsx
@@ -14,11 +14,9 @@ import {
   addNumberWithUnits,
   BAIBoardItemTitle,
   ResourceStatistics,
-} from 'backend.ai-ui';
-import {
   convertToNumber,
   processMemoryValue,
-} from 'backend.ai-ui/components/ResourceStatistics';
+} from 'backend.ai-ui';
 import _ from 'lodash';
 import {
   useMemo,

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -1,6 +1,6 @@
 import { BAIBoardItem } from '../components/BAIBoard';
 import { jotaiStore } from '../components/DefaultProviders';
-import { BAITableColumnOverrideRecord } from 'backend.ai-ui/components/Table/BAITable';
+import { BAITableColumnOverrideRecord } from 'backend.ai-ui';
 import { atom, useAtom } from 'jotai';
 import { atomFamily } from 'jotai/utils';
 


### PR DESCRIPTION
resolves #4262 (FR-1451)

This PR exports additional types and utility functions from the backend.ai-ui package to make them properly accessible to consuming applications:

1. Exports `BAITableColumnOverrideRecord` type from Table component
2. Exports utility functions `processMemoryValue` and `convertToNumber` from ResourceStatistics
3. Adds ESLint rule to prevent importing from internal paths (enforcing imports from the main entry point)
4. Updates import statements in components to use the proper exported paths:
   - MyResource
   - MyResourceWithinResourceGroup
   - TotalResourceWithinResourceGroup
   - useBAISetting

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after