### PR TITLE
fix(FR-1457): fix dashboard resource panel access based on version compatibility

### DIFF
--- a/react/src/components/ConfigurableResourceCard.tsx
+++ b/react/src/components/ConfigurableResourceCard.tsx
@@ -1,7 +1,9 @@
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import MyResource from './MyResource';
 import MyResourceWithinResourceGroup from './MyResourceWithinResourceGroup';
-import TotalResourceWithinResourceGroup from './TotalResourceWithinResourceGroup';
+import TotalResourceWithinResourceGroup, {
+  useIsAvailableTotalResourceWithinResourceGroup,
+} from './TotalResourceWithinResourceGroup';
 import { SettingOutlined } from '@ant-design/icons';
 import { Button, Dropdown, MenuProps, Skeleton, theme } from 'antd';
 import { filterOutEmpty, BAICard, BAICardProps } from 'backend.ai-ui';
@@ -10,7 +12,6 @@ import React, { Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { ConfigurableResourceCardQuery } from 'src/__generated__/ConfigurableResourceCardQuery.graphql';
-import { useSuspendedBackendaiClient } from 'src/hooks';
 import { useCurrentUserRole } from 'src/hooks/backendai';
 import { useCurrentResourceGroupValue } from 'src/hooks/useCurrentProject';
 
@@ -32,13 +33,11 @@ const ConfigurableResourceCard: React.FC<ConfigurableResourceCardProps> = ({
   const [selectedPanelType, setSelectedPanelType] = useBAISettingUserState(
     'resource_panel_type',
   );
-  const baiClient = useSuspendedBackendaiClient();
   const userRole = useCurrentUserRole();
 
+  const isAvailableTotalResourcePanel =
+    useIsAvailableTotalResourceWithinResourceGroup();
   const currentResourceGroup = useCurrentResourceGroupValue();
-
-  const isHiddenAgents =
-    baiClient?._config?.hideAgents && userRole !== 'superadmin';
 
   const queryRefForTotalResource =
     useLazyLoadQuery<ConfigurableResourceCardQuery>(
@@ -62,7 +61,10 @@ const ConfigurableResourceCard: React.FC<ConfigurableResourceCardProps> = ({
         agentNodeFilter: `schedulable == true & status == "ALIVE" & scaling_group == "${currentResourceGroup}"`,
       },
       {
-        fetchPolicy: isHiddenAgents ? 'store-only' : 'network-only',
+        // if TotalResourceWithinResourceGroup is not available, do not fetch the query
+        fetchPolicy: isAvailableTotalResourcePanel
+          ? 'network-only'
+          : 'store-only',
         fetchKey: fetchKey,
       },
     );
@@ -78,7 +80,7 @@ const ConfigurableResourceCard: React.FC<ConfigurableResourceCardProps> = ({
       label: t('webui.menu.MyResourcesInResourceGroup'),
       value: 'MyResourceWithinResourceGroup' as ResourcePanelType,
     },
-    !isHiddenAgents && {
+    isAvailableTotalResourcePanel && {
       label: t('webui.menu.TotalResourcesInResourceGroup'),
       value: 'TotalResourceWithinResourceGroup' as ResourcePanelType,
     },
@@ -86,7 +88,7 @@ const ConfigurableResourceCard: React.FC<ConfigurableResourceCardProps> = ({
 
   useEffect(() => {
     if (
-      isHiddenAgents &&
+      !isAvailableTotalResourcePanel &&
       currentPanelType === 'TotalResourceWithinResourceGroup'
     ) {
       setSelectedPanelType('MyResource');
@@ -144,7 +146,7 @@ const ConfigurableResourceCard: React.FC<ConfigurableResourceCardProps> = ({
         return <MyResourceWithinResourceGroup {...commonProps} />;
       case 'TotalResourceWithinResourceGroup':
         return (
-          !isHiddenAgents && (
+          isAvailableTotalResourcePanel && (
             <TotalResourceWithinResourceGroup
               {...commonProps}
               queryRef={queryRefForTotalResource}

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -4,12 +4,10 @@ import MyResource from '../components/MyResource';
 import MyResourceWithinResourceGroup from '../components/MyResourceWithinResourceGroup';
 import MySession from '../components/MySession';
 import RecentlyCreatedSession from '../components/RecentlyCreatedSession';
-import TotalResourceWithinResourceGroup from '../components/TotalResourceWithinResourceGroup';
-import {
-  INITIAL_FETCH_KEY,
-  useFetchKey,
-  useSuspendedBackendaiClient,
-} from '../hooks';
+import TotalResourceWithinResourceGroup, {
+  useIsAvailableTotalResourceWithinResourceGroup,
+} from '../components/TotalResourceWithinResourceGroup';
+import { INITIAL_FETCH_KEY, useFetchKey } from '../hooks';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   useCurrentProjectValue,
@@ -24,7 +22,6 @@ import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useCurrentUserRole } from 'src/hooks/backendai';
 
 const DashboardPage: React.FC = () => {
-  const baiClient = useSuspendedBackendaiClient();
   const { token } = theme.useToken();
 
   const currentProject = useCurrentProjectValue();
@@ -38,8 +35,8 @@ const DashboardPage: React.FC = () => {
   const [localStorageBoardItems, setLocalStorageBoardItems] =
     useBAISettingUserState('dashboard_board_items');
 
-  const skipTotalResourceWithinResourceGroup =
-    baiClient?._config?.hideAgents && userRole !== 'superadmin';
+  const isAvailableTotalResourcePanel =
+    useIsAvailableTotalResourceWithinResourceGroup();
 
   const queryRef = useLazyLoadQuery<DashboardPageQuery>(
     graphql`
@@ -65,7 +62,7 @@ const DashboardPage: React.FC = () => {
     {
       projectId: currentProject.id,
       resourceGroup: currentResourceGroup || 'default',
-      skipTotalResourceWithinResourceGroup,
+      skipTotalResourceWithinResourceGroup: !isAvailableTotalResourcePanel,
       isSuperAdmin: _.isEqual(userRole, 'superadmin'),
       agentNodeFilter: `schedulable == true & status == "ALIVE" & scaling_group == "${currentResourceGroup}"`,
     },
@@ -140,7 +137,7 @@ const DashboardPage: React.FC = () => {
         ),
       },
     },
-    !skipTotalResourceWithinResourceGroup && {
+    isAvailableTotalResourcePanel && {
       id: 'totalResourceWithinResourceGroup',
       rowSpan: 2,
       columnSpan: 2,


### PR DESCRIPTION
# Fix TotalResourceWithinResourceGroup availability check

This PR refactors how we determine whether the TotalResourceWithinResourceGroup component should be available to users. Instead of directly checking `hideAgents` config and user role in multiple places, it introduces a dedicated hook `useIsAvailableTotalResourceWithinResourceGroup()` that centralizes this logic.

The hook now considers:

- Whether the user is a superadmin
- Whether the `hideAgents` config is enabled
- Whether the manager version is compatible with v24.12.0 (which provides the `agent_nodes` field)

This allows superadmins to access the total resource panel even when `hideAgents` is true, as long as the manager version supports the required GraphQL field.