### PR TITLE
fix(FR-1461): show error message for session commit as notifiaction

### DIFF
--- a/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.ts
+++ b/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.ts
@@ -19,7 +19,7 @@ export type ESMClientErrorResponse = {
   statusCode: number;
   statusText: string;
   title: string;
-  msg: string;
+  message: string;
   description: string;
   error_code?: string;
   traceback?: string;
@@ -41,8 +41,11 @@ const useErrorMessageResolver = () => {
     let errorMsg = defaultMessage || t('error.UnknownError');
     if (!error) return errorMsg;
 
-    if (error?.msg) {
-      errorMsg = !_.includes(error?.msg, 'Traceback') ? error.msg : errorMsg;
+    if (error?.msg || error?.message) {
+      const integratedErrorMsg = error?.msg || error?.message || '';
+      errorMsg = !_.includes(integratedErrorMsg, 'Traceback')
+        ? integratedErrorMsg
+        : errorMsg;
     } else if (error.title) {
       errorMsg = error.title;
     }

--- a/react/src/components/EndpointTokenGenerationModal.tsx
+++ b/react/src/components/EndpointTokenGenerationModal.tsx
@@ -59,7 +59,7 @@ const EndpointTokenGenerationModal: React.FC<
             onRequestClose(true);
           },
           onError: (err) => {
-            if (err?.msg?.includes('valid_until is older than now')) {
+            if (err?.message?.includes('valid_until is older than now')) {
               message.error(t('modelService.TokenExpiredDateError'));
               return;
             } else {

--- a/react/src/components/ModelCloneModal.tsx
+++ b/react/src/components/ModelCloneModal.tsx
@@ -125,7 +125,7 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
                   },
                   onError(error) {
                     if (
-                      error.msg?.includes(
+                      error.message?.includes(
                         'The virtual folder already exists with the same name',
                       )
                     ) {

--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -1647,9 +1647,9 @@ export default class BackendAISessionList extends BackendAIPage {
           this.workDialog.show();
         })
         .catch((err) => {
-          if (err && err.message) {
+          if (err && err.msg) {
             this.notification.text = PainKiller.relieve(err.title);
-            this.notification.detail = err.message;
+            this.notification.detail = err.msg;
             this.notification.show(true, err);
           } else if (err && err.title) {
             this.notification.text = PainKiller.relieve(err.title);

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -499,7 +499,7 @@ class Client {
         statusCode: resp.status,
         statusText: resp.statusText,
         title: errorTitle,
-        msg: errorMsg,
+        message: errorMsg,
         description: errorDesc,
         error_code: errorCode,
         traceback: traceback,


### PR DESCRIPTION
resolves #4274 (FR-1461)

Fix error handling in session commit functionality by changing `err.message` to `err.msg` in the error condition check. This ensures that error notifications are properly displayed when session commit operations fail.

![CleanShot 2025-09-12 at 14.20.10@2x.png](https://app.graphite.dev/user-attachments/assets/be7685df-3bcb-4647-ba11-f36dd197a35e.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after