### PR TITLE
fix(FR-1479): remove forced automatic shmem adjustment during session creation

### DIFF
--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -31,7 +31,6 @@ import VFolderTableFormItem, {
   VFolderTableFormValues,
 } from '../components/VFolderTableFormItem';
 import {
-  compareNumberWithUnits,
   formatDuration,
   generateRandomString,
   convertToBinaryUnit,
@@ -521,11 +520,7 @@ const SessionLauncherPage = () => {
                 ? values.owner.project
                 : values.resourceGroup,
               resource_opts: {
-                shmem:
-                  compareNumberWithUnits(values.resource.mem, '4g') > 0 &&
-                  compareNumberWithUnits(values.resource.shmem, '1g') < 0
-                    ? '1g'
-                    : values.resource.shmem,
+                shmem: values.resource.shmem,
                 // allow_fractional_resource_fragmentation can be added here if needed
               },
 


### PR DESCRIPTION
Resolves [FR-1479](https://lablup.atlassian.net/browse/FR-1479)

## Summary
Fix a bug where shmem (shared memory) values are being automatically adjusted during session creation API request, regardless of the `enabledAutomaticShmem` setting.

## Changes
- Remove forced automatic shmem adjustment logic from SessionLauncherPage
- Remove unused `compareNumberWithUnits` import
- Ensure shmem values are passed as configured by the user

## Background
The ResourceAllocationFormItems component properly handles automatic shmem adjustment through the `enabledAutomaticShmem` flag. However, SessionLauncherPage was applying automatic adjustment unconditionally during the API request, overriding the user's preference and causing unexpected behavior.

[FR-1479]: https://lablup.atlassian.net/browse/FR-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ