### PR TITLE
fix(FR-1474): handle infinity values in resource progress calculation

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIStatistic.tsx
+++ b/packages/backend.ai-ui/src/components/BAIStatistic.tsx
@@ -43,7 +43,7 @@ const BAIStatistic: React.FC<BAIStatisticProps> = ({
 
   // Calculate progress position
   const calculateProgress = (): number => {
-    if (!showProgress || total === undefined) return 0;
+    if (!showProgress || total === undefined || total === Infinity) return 0;
     if (!_.isFinite(current) || !isFinite(total) || total === 0)
       return progressSteps;
     return _.isUndefined(current)


### PR DESCRIPTION
Resolves #4281 ([FR-1474](https://lablup.atlassian.net/browse/FR-1474))

# Fix progress calculation in BAIStatistic component

This PR fixes the progress calculation in the BAIStatistic component by adding a check for `total === Infinity`. When the total value is Infinity, the progress will now correctly return 0 instead of attempting to calculate a progress value.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1474]: https://lablup.atlassian.net/browse/FR-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ