### PR TITLE
fix(FR-1483): correct queryKey from 'termsOfService' to 'privacyPolicy'

### DIFF
--- a/react/src/components/PrivacyPolicyModal.tsx
+++ b/react/src/components/PrivacyPolicyModal.tsx
@@ -24,7 +24,7 @@ const RenderPrivacyPolicyHtml = () => {
   }, [selectedLanguage, defaultLanguage]);
 
   const { data } = useSuspenseTanQuery({
-    queryKey: ['termsOfService', language],
+    queryKey: ['privacyPolicy', language],
     staleTime: 1000 * 60 * 30,
     gcTime: 1000 * 60 * 60,
     queryFn: () =>


### PR DESCRIPTION
# Fix incorrect query key in PrivacyPolicyModal

Resolves #4292 ([FR-1483](https://lablup.atlassian.net/browse/FR-1483))


This PR fixes a bug in the `PrivacyPolicyModal` component where the query key was incorrectly set to `'termsOfService'` instead of `'privacyPolicy'`. This ensures that the privacy policy content is properly cached and retrieved with the correct key.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1483]: https://lablup.atlassian.net/browse/FR-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ