### PR TITLE
style(FR-1487): improve layout and spacing for ImageNodeSimpleTag component

### DIFF
--- a/react/src/components/ImageNodeSimpleTag.tsx
+++ b/react/src/components/ImageNodeSimpleTag.tsx
@@ -57,21 +57,31 @@ const ImageNodeSimpleTag: React.FC<ImageNodeSimpleTagProps> = ({
   const isSupportBaseImageName = baiClient.supports('base-image-name');
 
   return isSupportBaseImageName ? (
-    <>
-      <ImageMetaIcon
-        image={fullName}
+    <BAIFlex direction="row" gap={'xs'} wrap="wrap">
+      <ImageMetaIcon image={fullName} />
+      <Typography.Text>{tagAlias(image.base_image_name || '')}</Typography.Text>
+      <Divider
+        type="vertical"
         style={{
-          marginRight: token.marginXS,
+          marginInline: 0,
         }}
       />
-      <Typography.Text>{tagAlias(image.base_image_name || '')}</Typography.Text>
-      <Divider type="vertical" />
       <Typography.Text>{image.version}</Typography.Text>
-      <Divider type="vertical" />
+      <Divider
+        type="vertical"
+        style={{
+          marginInline: 0,
+        }}
+      />
       <Typography.Text>{image.architecture}</Typography.Text>
       {withoutTag ? null : (
         <>
-          <Divider type="vertical" />
+          <Divider
+            type="vertical"
+            style={{
+              marginInline: 0,
+            }}
+          />
           {_.map(image.tags, (tag, index) => {
             if (!tag) return null;
             const isCustomized = tag.key && _.includes(tag.key, 'customized_');
@@ -106,6 +116,9 @@ const ImageNodeSimpleTag: React.FC<ImageNodeSimpleTagProps> = ({
               <Tag
                 key={`${tag.key}-${index}`}
                 color={isCustomized ? 'cyan' : 'blue'}
+                style={{
+                  marginRight: 0,
+                }}
               >
                 {aliasedTag}
               </Tag>
@@ -121,7 +134,7 @@ const ImageNodeSimpleTag: React.FC<ImageNodeSimpleTagProps> = ({
           }}
         />
       )}
-    </>
+    </BAIFlex>
   ) : (
     <BAIFlex direction="row" gap={'xs'}>
       <ImageMetaIcon image={legacyFullImageString || null} />


### PR DESCRIPTION
Resolves #4296 ([FR-1487](https://lablup.atlassian.net/browse/FR-1487))

## Summary
Refactor the ImageNodeSimpleTag component to use BAIFlex layout container for better visual organization and consistent spacing.

## Changes
- Replace fragment wrapper with BAIFlex container for better layout control
- Add consistent spacing between image metadata elements (icon, base image name, version, architecture)  
- Improve divider positioning with proper margin control
- Enhance tag spacing by removing default margins
- Maintain existing functionality while improving visual presentation

## Test Plan
- [ ] Verify ImageNodeSimpleTag displays correctly with new layout
- [ ] Check spacing and alignment of all elements
- [ ] Ensure dividers display properly without extra margins
- [ ] Confirm tags are properly spaced without overlapping
- [ ] Test with different image configurations (with/without tags)

[FR-1487]: https://lablup.atlassian.net/browse/FR-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ