### PR TITLE
fix(FR-1486): correct plugin import path from relative to parent directory

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,13 @@
     }
     globalThis.enableSW = true;
 
-    globalThis.process = {
-      env: {
-        NODE_ENV: 'production'
-      }
-    };
     globalThis.packageVersion = "25.14.0-alpha.0";
     globalThis.buildNumber = "6927";
     globalThis.litNonce = "{{nonce}}";
     globalThis.baiNonce = "{{nonce}}";
+
+    // DO NOT CHANGE BELOW LINE
+    // DEV_JS_INJECTING
   </script>
   <!-- DO NOT CHANGE BELOW LINE -->
   <!-- REACT_BUNDLE_INJECTING FOR DEV-->

--- a/react/craco.config.js
+++ b/react/craco.config.js
@@ -1,5 +1,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+const fs = require('fs');
 
 const {
   getLoader,
@@ -165,9 +166,17 @@ module.exports = {
       webpackConfig.plugins = webpackConfig.plugins.map((plugin) => {
         if (plugin.constructor.name === 'HtmlWebpackPlugin') {
           if (env === 'development') {
+            const content = fs.readFileSync(webuiIndexHtml, {
+              encoding: 'utf-8',
+            });
+
             plugin = new HtmlWebpackPlugin({
               inject: true,
               template: webuiIndexHtml,
+              templateContent: content.replace(
+                '// DEV_JS_INJECTING',
+                'globalThis.process = {env: {NODE_ENV: "development"}};',
+              ),
             });
           } else {
             plugin = new HtmlWebpackPlugin({

--- a/src/backend-ai-app.ts
+++ b/src/backend-ai-app.ts
@@ -129,7 +129,11 @@ const loadPage =
         if (typeof globalThis.backendaiPages !== 'undefined') {
           for (const item of globalThis.backendaiPages) {
             if ('url' in item) {
-              import('./plugins/' + item.url + '.js');
+              const path =
+                process.env.NODE_ENV === 'development'
+                  ? './plugins/'
+                  : '../plugins/';
+              import(path + item.url + '.js');
             }
           }
           break;


### PR DESCRIPTION
Resolves #4294 ([FR-1486](https://lablup.atlassian.net/browse/FR-1486))

### Fix plugin import path and improve development environment setup

## Changes
- Fixed plugin import path in `backend-ai-app.ts` to conditionally use the correct path based on environment
- Added dynamic NODE_ENV injection for development environment in `index.html`
- Removed hardcoded `process.env` from `index.html` and moved it to be injected during development
- Implemented template content replacement in `craco.config.js` to inject development environment variables

## How to test
- Run the application in development mode and verify plugins load correctly
- Build the application and verify plugins load correctly in production mode
- Check console for any plugin loading errors in both environments

This change ensures plugins are loaded from the correct path in both development and production environments, preventing console errors during plugin loading.

[FR-1486]: https://lablup.atlassian.net/browse/FR-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ