### PR TITLE
feat(FR-55): support ai.backend.accelerators image label's * value

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -140,6 +140,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
             value
           }
           version @since(version: "24.12.0")
+          supported_accelerators
         }
       }
     `,

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
@@ -49,6 +49,7 @@ describe('getAllocatablePresetNames', () => {
     base_image_name: undefined,
     tags: undefined,
     version: undefined,
+    supported_accelerators: undefined,
   };
 
   it('should return presets when currentImage has accelerator limits', () => {

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -166,6 +166,7 @@ describe('getImageFullName', () => {
           },
         ],
         base_image_name: 'def/training',
+        supported_accelerators: undefined,
         tags: [
           {
             key: 'py3',
@@ -223,6 +224,7 @@ describe('getImageFullName', () => {
           },
         ],
         base_image_name: 'def/training',
+        supported_accelerators: undefined,
         tags: [
           {
             key: 'py3',
@@ -281,6 +283,7 @@ describe('getImageFullName', () => {
           },
         ],
         base_image_name: 'def/training',
+        supported_accelerators: undefined,
         tags: [
           {
             key: 'py3',

--- a/react/src/hooks/useBackendAIImageMetaData.test.tsx
+++ b/react/src/hooks/useBackendAIImageMetaData.test.tsx
@@ -148,6 +148,7 @@ describe('useBackendAIImageMetaData', () => {
         base_image_name: undefined,
         tags: undefined,
         version: undefined,
+        supported_accelerators: undefined,
       }) || '',
     );
     expect(key).toBe('training');


### PR DESCRIPTION
Resolves #2781 ([FR-55](https://lablup.atlassian.net/browse/FR-55))

This PR enhances accelerator selection by using the `supported_accelerators` field from images instead of relying on accelerator limits. The implementation:

1. Adds `supported_accelerators` to the GraphQL query in ImageEnvironmentSelectFormItems
2. Replaces the previous accelerator filtering logic with a new approach that:
   - Checks if an accelerator type is supported by the image using the `supported_accelerators` field
   - Supports wildcard matching with '*' or empty string to indicate all accelerators are supported
   - Allows prefix matching for accelerator types
   - Maintains backward compatibility with manual image input

This change improves the user experience by showing only relevant accelerator options based on what the selected image actually supports.

[FR-55]: https://lablup.atlassian.net/browse/FR-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ