### PR TITLE
feat(FR-1472): implement GraphQL viewer query for current user information

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -180,21 +180,21 @@ input AllowedGroups
   remove: [String] = []
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input ApproveArtifactInput
   @join__type(graph: STRAWBERRY)
 {
   artifactRevisionId: ID!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type ApproveArtifactPayload
   @join__type(graph: STRAWBERRY)
 {
   artifactRevision: ArtifactRevision!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type Artifact implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
   @join__type(graph: STRAWBERRY)
@@ -207,11 +207,20 @@ type Artifact implements Node
   registry: SourceInfo!
   source: SourceInfo!
   readonly: Boolean!
+  scannedAt: DateTime!
+  updatedAt: DateTime!
+  availability: ArtifactAvailability!
   revisions(filter: ArtifactRevisionFilter = null, orderBy: [ArtifactRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ArtifactRevisionConnection!
-  updatedAt: DateTime
 }
 
-"""Added in 25.13.0"""
+enum ArtifactAvailability
+  @join__type(graph: STRAWBERRY)
+{
+  ALIVE @join__enumValue(graph: STRAWBERRY)
+  DELETED @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in 25.14.0"""
 type ArtifactConnection
   @join__type(graph: STRAWBERRY)
 {
@@ -234,7 +243,7 @@ type ArtifactEdge
   node: Artifact!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input ArtifactFilter
   @join__type(graph: STRAWBERRY)
 {
@@ -242,13 +251,13 @@ input ArtifactFilter
   name: StringFilter = null
   registry: StringFilter = null
   source: StringFilter = null
+  availability: [ArtifactAvailability!] = null
   AND: [ArtifactFilter!] = null
   OR: [ArtifactFilter!] = null
   NOT: [ArtifactFilter!] = null
-  DISTINCT: Boolean = null
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type ArtifactImportProgressUpdatedPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -257,7 +266,7 @@ type ArtifactImportProgressUpdatedPayload
   status: ArtifactStatus!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input ArtifactOrderBy
   @join__type(graph: STRAWBERRY)
 {
@@ -271,9 +280,29 @@ enum ArtifactOrderField
   NAME @join__enumValue(graph: STRAWBERRY)
   TYPE @join__enumValue(graph: STRAWBERRY)
   SIZE @join__enumValue(graph: STRAWBERRY)
+  SCANNED_AT @join__enumValue(graph: STRAWBERRY)
+  UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
+type ArtifactRegistry
+  @join__type(graph: STRAWBERRY)
+{
+  """Name of the default artifact registry."""
+  name: String!
+
+  """Type of the default artifact registry."""
+  type: ArtifactRegistryType!
+}
+
+enum ArtifactRegistryType
+  @join__type(graph: STRAWBERRY)
+{
+  HUGGINGFACE @join__enumValue(graph: STRAWBERRY)
+  RESERVOIR @join__enumValue(graph: STRAWBERRY)
+}
+
+"""Added in 25.14.0"""
 type ArtifactRevision implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
   @join__type(graph: STRAWBERRY)
@@ -286,9 +315,10 @@ type ArtifactRevision implements Node
   size: ByteSize
   createdAt: DateTime
   updatedAt: DateTime
+  artifact: Artifact!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type ArtifactRevisionConnection
   @join__type(graph: STRAWBERRY)
 {
@@ -311,20 +341,28 @@ type ArtifactRevisionEdge
   node: ArtifactRevision!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input ArtifactRevisionFilter
   @join__type(graph: STRAWBERRY)
 {
   status: ArtifactRevisionStatusFilter = null
   version: StringFilter = null
   artifactId: ID = null
+  size: IntFilter = null
   AND: [ArtifactRevisionFilter!] = null
   OR: [ArtifactRevisionFilter!] = null
   NOT: [ArtifactRevisionFilter!] = null
-  DISTINCT: Boolean = null
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
+type ArtifactRevisionImportTask
+  @join__type(graph: STRAWBERRY)
+{
+  taskId: ID!
+  artifactRevision: ArtifactRevision!
+}
+
+"""Added in 25.14.0"""
 input ArtifactRevisionOrderBy
   @join__type(graph: STRAWBERRY)
 {
@@ -342,7 +380,7 @@ enum ArtifactRevisionOrderField
   STATUS @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input ArtifactRevisionStatusFilter
   @join__type(graph: STRAWBERRY)
 {
@@ -363,14 +401,14 @@ enum ArtifactStatus
   REJECTED @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input ArtifactStatusChangedInput
   @join__type(graph: STRAWBERRY)
 {
   artifactRevisionIds: [ID!]!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type ArtifactStatusChangedPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -590,7 +628,7 @@ scalar Bytes
 scalar ByteSize
   @join__type(graph: STRAWBERRY)
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input CancelArtifactInput
   @join__type(graph: STRAWBERRY)
 {
@@ -600,7 +638,7 @@ input CancelArtifactInput
 type CancelImportArtifactPayload
   @join__type(graph: STRAWBERRY)
 {
-  artifactRevisionId: ID!
+  artifactRevision: ArtifactRevision!
 }
 
 """Added in 24.12.0"""
@@ -617,6 +655,20 @@ input CheckAndTransitStatusInput
 {
   ids: [GlobalIDField]!
   client_mutation_id: String
+}
+
+"""Added in 25.14.0"""
+input CleanupArtifactRevisionsInput
+  @join__type(graph: STRAWBERRY)
+{
+  artifactRevisionIds: [ID!]!
+}
+
+"""Added in 25.14.0"""
+type CleanupArtifactRevisionsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  artifactRevisions: ArtifactRevisionConnection!
 }
 
 """Added in 25.6.0."""
@@ -1139,7 +1191,7 @@ type CreateGroup
   group: Group
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input CreateHuggingFaceRegistryInput
   @join__type(graph: STRAWBERRY)
 {
@@ -1148,7 +1200,7 @@ input CreateHuggingFaceRegistryInput
   token: String = null
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type CreateHuggingFaceRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -1235,7 +1287,7 @@ type CreateNetwork
   network: NetworkNode
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input CreateObjectStorageInput
   @join__type(graph: STRAWBERRY)
 {
@@ -1247,7 +1299,7 @@ input CreateObjectStorageInput
   region: String!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type CreateObjectStoragePayload
   @join__type(graph: STRAWBERRY)
 {
@@ -1280,6 +1332,24 @@ input CreateProjectResourcePolicyInput
   Added in 24.12.0. Limitation of the number of networks created on behalf of project. Set as -1 to allow creating unlimited networks.
   """
   max_network_count: Int
+}
+
+"""Added in 25.14.0"""
+input CreateReservoirRegistryInput
+  @join__type(graph: STRAWBERRY)
+{
+  name: String!
+  endpoint: String!
+  accessKey: String!
+  secretKey: String!
+  apiVersion: String!
+}
+
+"""Added in 25.14.0"""
+type CreateReservoirRegistryPayload
+  @join__type(graph: STRAWBERRY)
+{
+  reservoir: ReservoirRegistry!
 }
 
 type CreateResourcePreset
@@ -1382,26 +1452,18 @@ type DealiasImage
   msg: String
 }
 
-"""Added in 25.13.0"""
-input DeleteArtifactRevisionsInput
+"""Added in 25.15.0"""
+input DeleteArtifactsInput
   @join__type(graph: STRAWBERRY)
 {
-  targets: [DeleteArtifactRevisionTarget!]!
+  artifactIds: [ID!]!
 }
 
-"""Added in 25.13.0"""
-type DeleteArtifactRevisionsPayload
+"""Added in 25.15.0"""
+type DeleteArtifactsPayload
   @join__type(graph: STRAWBERRY)
 {
-  artifactRevisionIds: [ID!]!
-}
-
-"""Added in 25.13.0"""
-input DeleteArtifactRevisionTarget
-  @join__type(graph: STRAWBERRY)
-{
-  artifactRevisionId: ID!
-  storageNamespaceId: ID!
+  artifacts: [Artifact!]!
 }
 
 """Deprecated since 24.09.0. use `DeleteContainerRegistryNode` instead"""
@@ -1457,14 +1519,14 @@ type DeleteGroup
   msg: String
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input DeleteHuggingFaceRegistryInput
   @join__type(graph: STRAWBERRY)
 {
   id: ID!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type DeleteHuggingFaceRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -1505,14 +1567,14 @@ type DeleteNetwork
   msg: String
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input DeleteObjectStorageInput
   @join__type(graph: STRAWBERRY)
 {
   id: ID!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type DeleteObjectStoragePayload
   @join__type(graph: STRAWBERRY)
 {
@@ -1524,6 +1586,20 @@ type DeleteProjectResourcePolicy
 {
   ok: Boolean
   msg: String
+}
+
+"""Added in 25.14.0"""
+input DeleteReservoirRegistryInput
+  @join__type(graph: STRAWBERRY)
+{
+  id: ID!
+}
+
+"""Added in 25.14.0"""
+type DeleteReservoirRegistryPayload
+  @join__type(graph: STRAWBERRY)
+{
+  id: ID!
 }
 
 type DeleteResourcePreset
@@ -1964,36 +2040,31 @@ type ForgetImageById
   image: ImageNode
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input GetPresignedDownloadURLInput
   @join__type(graph: STRAWBERRY)
 {
   artifactRevisionId: ID!
-  storageNamespaceId: ID!
   key: String!
+  expiration: Int = null
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type GetPresignedDownloadURLPayload
   @join__type(graph: STRAWBERRY)
 {
   presignedUrl: String!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input GetPresignedUploadURLInput
   @join__type(graph: STRAWBERRY)
 {
   artifactRevisionId: ID!
-  storageNamespaceId: ID!
   key: String!
-  contentType: String = null
-  expiration: Int = null
-  minSize: Int = null
-  maxSize: Int = null
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type GetPresignedUploadURLPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -2110,7 +2181,7 @@ Added in 25.3.0. One of ['read_attribute', 'read_sensitive_attribute', 'update_a
 scalar GroupPermissionField
   @join__type(graph: GRAPHENE)
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type HuggingFaceRegistry implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
   @join__type(graph: STRAWBERRY)
@@ -2122,7 +2193,7 @@ type HuggingFaceRegistry implements Node
   token: String
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type HuggingFaceRegistryConnection
   @join__type(graph: STRAWBERRY)
 {
@@ -2302,20 +2373,19 @@ enum ImageType
   SERVICE @join__enumValue(graph: GRAPHENE)
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input ImportArtifactsInput
   @join__type(graph: STRAWBERRY)
 {
   artifactRevisionIds: [ID!]!
-  storageNamespaceId: ID!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type ImportArtifactsPayload
   @join__type(graph: STRAWBERRY)
 {
   artifactRevisions: ArtifactRevisionConnection!
-  taskIds: [UUID!]!
+  tasks: [ArtifactRevisionImportTask!]!
 }
 
 type InferenceSessionError
@@ -2331,6 +2401,17 @@ type InferenceSessionErrorInfo
   src: String!
   name: String!
   repr: String!
+}
+
+input IntFilter
+  @join__type(graph: STRAWBERRY)
+{
+  equals: Int = null
+  notEquals: Int = null
+  greaterThan: Int = null
+  greaterThanOrEqual: Int = null
+  lessThan: Int = null
+  lessThanOrEqual: Int = null
 }
 
 interface Item
@@ -2864,6 +2945,14 @@ input ModelRuntimeConfigInput
   runtimeVariant: String!
   serviceConfig: JSONString = null
   environ: JSONString = null
+}
+
+"""Added in 25.14.0"""
+input ModelTarget
+  @join__type(graph: STRAWBERRY)
+{
+  modelId: String!
+  revision: String = null
 }
 
 type ModifyAgent
@@ -3668,59 +3757,77 @@ type Mutation
   """Added in 24.12.0."""
   delete_network(network: String!): DeleteNetwork @join__field(graph: GRAPHENE)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   scanArtifacts(input: ScanArtifactsInput!): ScanArtifactsPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
+  scanArtifactModels(input: ScanArtifactModelsInput!): ScanArtifactModelsPayload! @join__field(graph: STRAWBERRY)
+
+  """Added in 25.14.0"""
   importArtifacts(input: ImportArtifactsInput!): ImportArtifactsPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   updateArtifact(input: UpdateArtifactInput!): UpdateArtifactPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
-  deleteArtifactRevisions(input: DeleteArtifactRevisionsInput!): DeleteArtifactRevisionsPayload! @join__field(graph: STRAWBERRY)
+  """Added in 25.15.0"""
+  deleteArtifacts(input: DeleteArtifactsInput!): DeleteArtifactsPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.15.0"""
+  restoreArtifacts(input: RestoreArtifactsInput!): RestoreArtifactsPayload! @join__field(graph: STRAWBERRY)
+
+  """Added in 25.14.0"""
+  cleanupArtifactRevisions(input: CleanupArtifactRevisionsInput!): CleanupArtifactRevisionsPayload! @join__field(graph: STRAWBERRY)
+
+  """Added in 25.14.0"""
   cancelImportArtifact(input: CancelArtifactInput!): CancelImportArtifactPayload! @join__field(graph: STRAWBERRY)
   createModelDeployment(input: CreateModelDeploymentInput!): CreateModelDeploymentPayload! @join__field(graph: STRAWBERRY)
   updateModelDeployment(input: UpdateModelDeploymentInput!): UpdateModelDeploymentPayload! @join__field(graph: STRAWBERRY)
   deleteModelDeployment(input: DeleteModelDeploymentInput!): DeleteModelDeploymentPayload! @join__field(graph: STRAWBERRY)
   createModelRevision(input: CreateModelRevisionInput!): CreateModelRevisionPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   createObjectStorage(input: CreateObjectStorageInput!): CreateObjectStoragePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   updateObjectStorage(input: UpdateObjectStorageInput!): UpdateObjectStoragePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   deleteObjectStorage(input: DeleteObjectStorageInput!): DeleteObjectStoragePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   registerObjectStorageBucket(input: RegisterObjectStorageBucketInput!): RegisterObjectStorageBucketPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   unregisterObjectStorageBucket(input: UnregisterObjectStorageBucketInput!): UnregisterObjectStorageBucketPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   createHuggingfaceRegistry(input: CreateHuggingFaceRegistryInput!): CreateHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   updateHuggingfaceRegistry(input: UpdateHuggingFaceRegistryInput!): UpdateHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   deleteHuggingfaceRegistry(input: DeleteHuggingFaceRegistryInput!): DeleteHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
+  createReservoirRegistry(input: CreateReservoirRegistryInput!): CreateReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
+
+  """Added in 25.14.0"""
+  updateReservoirRegistry(input: UpdateReservoirRegistryInput!): UpdateReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
+
+  """Added in 25.14.0"""
+  deleteReservoirRegistry(input: DeleteReservoirRegistryInput!): DeleteReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
+
+  """Added in 25.14.0"""
   getPresignedDownloadUrl(input: GetPresignedDownloadURLInput!): GetPresignedDownloadURLPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   getPresignedUploadUrl(input: GetPresignedUploadURLInput!): GetPresignedUploadURLPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   approveArtifactRevision(input: ApproveArtifactInput!): ApproveArtifactPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   rejectArtifactRevision(input: RejectArtifactInput!): RejectArtifactPayload! @join__field(graph: STRAWBERRY)
 }
 
@@ -3779,7 +3886,7 @@ interface Node
   id: ID!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type ObjectStorage implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
   @join__type(graph: STRAWBERRY)
@@ -3792,10 +3899,10 @@ type ObjectStorage implements Node
   secretKey: String!
   endpoint: String!
   region: String!
-  namespaces: [ObjectStorageNamespace!]!
+  namespaces(before: String, after: String, first: Int, last: Int, limit: Int, offset: Int): ObjectStorageNamespaceConnection!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type ObjectStorageConnection
   @join__type(graph: STRAWBERRY)
 {
@@ -3818,7 +3925,7 @@ type ObjectStorageEdge
   node: ObjectStorage!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type ObjectStorageNamespace implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
   @join__type(graph: STRAWBERRY)
@@ -3827,6 +3934,29 @@ type ObjectStorageNamespace implements Node
   id: ID!
   storageId: ID!
   bucket: String!
+}
+
+"""Added in 25.14.0"""
+type ObjectStorageNamespaceConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [ObjectStorageNamespaceEdge!]!
+  count: Int!
+}
+
+"""An edge in a connection."""
+type ObjectStorageNamespaceEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: ObjectStorageNamespace!
 }
 
 enum OrderDirection
@@ -4170,6 +4300,9 @@ type Query
     first: Int
     last: Int
   ): ImageConnection @join__field(graph: GRAPHENE)
+
+  """Added in 25.14.2. Returns information about the current user."""
+  viewer: Viewer @join__field(graph: GRAPHENE)
   user(domain_name: String, email: String): User @join__field(graph: GRAPHENE)
   user_from_uuid(domain_name: String, user_id: ID): User @join__field(graph: GRAPHENE)
   users(domain_name: String, group_id: UUID, is_active: Boolean, status: String): [User] @join__field(graph: GRAPHENE)
@@ -4372,16 +4505,16 @@ type Query
   """Added in 25.8.0."""
   service_configs(services: [String]!, filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ServiceConfigConnection @join__field(graph: GRAPHENE)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   artifact(id: ID!): Artifact @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
-  artifacts(filter: ArtifactFilter = null, orderBy: [ArtifactOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ArtifactConnection! @join__field(graph: STRAWBERRY)
+  """Added in 25.14.0"""
+  artifacts(filter: ArtifactFilter = {type: null, name: null, registry: null, source: null, availability: [ALIVE], AND: null, OR: null, NOT: null}, orderBy: [ArtifactOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ArtifactConnection! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   artifactRevision(id: ID!): ArtifactRevision @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   artifactRevisions(filter: ArtifactRevisionFilter = null, orderBy: [ArtifactRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ArtifactRevisionConnection! @join__field(graph: STRAWBERRY)
   deployments(
     filter: DeploymentFilter = null
@@ -4419,17 +4552,26 @@ type Query
   revision(id: ID!): ModelRevision @join__field(graph: STRAWBERRY)
   replica(id: ID!): ModelReplica @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   objectStorage(id: ID!): ObjectStorage @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   objectStorages(before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ObjectStorageConnection! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   huggingfaceRegistry(id: ID!): HuggingFaceRegistry @join__field(graph: STRAWBERRY)
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   huggingfaceRegistries(before: String = null, after: String = null, first: Int = null, last: Int = null, offset: Int = null, limit: Int = null): HuggingFaceRegistryConnection! @join__field(graph: STRAWBERRY)
+
+  """Added in 25.14.0"""
+  reservoirRegistry(id: ID!): ReservoirRegistry @join__field(graph: STRAWBERRY)
+
+  """Added in 25.14.0"""
+  reservoirRegistries(before: String = null, after: String = null, first: Int = null, last: Int = null, offset: Int = null, limit: Int = null): ReservoirRegistryConnection! @join__field(graph: STRAWBERRY)
+
+  """Added in 25.14.0"""
+  defaultArtifactRegistry(artifactType: ArtifactType!): ArtifactRegistry @join__field(graph: STRAWBERRY)
 }
 
 type QuotaDetails
@@ -4463,7 +4605,7 @@ type RawServiceConfig
   extraCliParameters: String
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input RegisterObjectStorageBucketInput
   @join__type(graph: STRAWBERRY)
 {
@@ -4471,21 +4613,21 @@ input RegisterObjectStorageBucketInput
   bucketName: String!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type RegisterObjectStorageBucketPayload
   @join__type(graph: STRAWBERRY)
 {
   id: UUID!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input RejectArtifactInput
   @join__type(graph: STRAWBERRY)
 {
   artifactRevisionId: ID!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type RejectArtifactPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -4527,6 +4669,43 @@ type RescanImages
   task_id: UUID
 }
 
+"""Added in 25.14.0"""
+type ReservoirRegistry implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+  name: String!
+  endpoint: String!
+  accessKey: String!
+  secretKey: String!
+  apiVersion: String!
+}
+
+"""Added in 25.14.0"""
+type ReservoirRegistryConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [ReservoirRegistryEdge!]!
+  count: Int!
+}
+
+"""An edge in a connection."""
+type ReservoirRegistryEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: ReservoirRegistry!
+}
+
 type ResourceConfig
   @join__type(graph: STRAWBERRY)
 {
@@ -4554,7 +4733,7 @@ type ResourceLimit
 {
   key: String
   min: String
-  max: String
+  max: String @deprecated(reason: "Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete.")
 }
 
 input ResourceLimitInput
@@ -4562,7 +4741,7 @@ input ResourceLimitInput
 {
   key: String
   min: String
-  max: String
+  max: String @deprecated(reason: "Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete.")
 }
 
 type ResourcePreset
@@ -4578,6 +4757,20 @@ type ResourcePreset
   Added in 25.4.0. A name of scaling group(=resource group) of the resource preset associated with.
   """
   scaling_group_name: String
+}
+
+"""Added in 25.15.0"""
+input RestoreArtifactsInput
+  @join__type(graph: STRAWBERRY)
+{
+  artifactIds: [ID!]!
+}
+
+"""Added in 25.15.0"""
+type RestoreArtifactsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  artifacts: [Artifact!]!
 }
 
 type Routing implements Item
@@ -4729,17 +4922,34 @@ type ScalingRule
   autoScalingRules: [EndpointAutoScalingRuleNode!]!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
+input ScanArtifactModelsInput
+  @join__type(graph: STRAWBERRY)
+{
+  models: [ModelTarget!]!
+  registryId: UUID = null
+}
+
+"""Added in 25.14.0"""
+type ScanArtifactModelsPayload
+  @join__type(graph: STRAWBERRY)
+{
+  artifactRevision: ArtifactRevisionConnection!
+}
+
+"""Added in 25.14.0"""
 input ScanArtifactsInput
   @join__type(graph: STRAWBERRY)
 {
-  registryId: ID!
-  storageNamespaceId: ID!
+  registryId: ID = null
+
+  """Maximum number of artifacts to scan (max: 500)"""
   limit: Int!
+  artifactType: ArtifactType = null
   search: String = null
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type ScanArtifactsPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -4844,7 +5054,7 @@ type SetQuotaScope
   quota_scope: QuotaScope
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type SourceInfo
   @join__type(graph: STRAWBERRY)
 {
@@ -4898,10 +5108,10 @@ input StringFilter
 type Subscription
   @join__type(graph: STRAWBERRY)
 {
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   artifactStatusChanged(input: ArtifactStatusChangedInput!): ArtifactStatusChangedPayload!
 
-  """Added in 25.13.0"""
+  """Added in 25.14.0"""
   artifactImportProgressUpdated(artifactRevisionId: ID!): ArtifactImportProgressUpdatedPayload!
   deploymentStatusChanged(deploymentId: ID!): DeploymentStatusChangedPayload!
   replicaStatusChanged(revisionId: ID!): ReplicaStatusChangedPayload!
@@ -4925,7 +5135,7 @@ type UnloadImage
   task_id: String
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input UnregisterObjectStorageBucketInput
   @join__type(graph: STRAWBERRY)
 {
@@ -4933,7 +5143,7 @@ input UnregisterObjectStorageBucketInput
   bucketName: String!
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type UnregisterObjectStorageBucketPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -4959,7 +5169,7 @@ type UntagImageFromRegistry
   image: ImageNode
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input UpdateArtifactInput
   @join__type(graph: STRAWBERRY)
 {
@@ -4967,7 +5177,7 @@ input UpdateArtifactInput
   readonly: Boolean
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type UpdateArtifactPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -4982,7 +5192,7 @@ type UpdateContainerRegistryQuota
   msg: String
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input UpdateHuggingFaceRegistryInput
   @join__type(graph: STRAWBERRY)
 {
@@ -4992,7 +5202,7 @@ input UpdateHuggingFaceRegistryInput
   token: String
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type UpdateHuggingFaceRegistryPayload
   @join__type(graph: STRAWBERRY)
 {
@@ -5015,7 +5225,7 @@ type UpdateModelDeploymentPayload
   deployment: ModelDeployment
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 input UpdateObjectStorageInput
   @join__type(graph: STRAWBERRY)
 {
@@ -5028,11 +5238,30 @@ input UpdateObjectStorageInput
   region: String
 }
 
-"""Added in 25.13.0"""
+"""Added in 25.14.0"""
 type UpdateObjectStoragePayload
   @join__type(graph: STRAWBERRY)
 {
   objectStorage: ObjectStorage!
+}
+
+"""Added in 25.14.0"""
+input UpdateReservoirRegistryInput
+  @join__type(graph: STRAWBERRY)
+{
+  id: ID!
+  name: String
+  endpoint: String
+  accessKey: String
+  secretKey: String
+  apiVersion: String
+}
+
+"""Added in 25.14.0"""
+type UpdateReservoirRegistryPayload
+  @join__type(graph: STRAWBERRY)
+{
+  reservoir: ReservoirRegistry!
 }
 
 type User implements Item
@@ -5297,6 +5526,15 @@ Added in 24.09.0. One of ['clone', 'assign_permission_to_others', 'read_attribut
 """
 scalar VFolderPermissionValueField
   @join__type(graph: GRAPHENE)
+
+"""Added in 25.14.2."""
+type Viewer
+  @join__type(graph: GRAPHENE)
+{
+  user: UserNode
+  user_id: UUID
+  encoded_user_role: String
+}
 
 type VirtualFolder implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")

--- a/packages/backend.ai-ui/src/components/provider/BAIClientProvider/index.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIClientProvider/index.ts
@@ -1,3 +1,5 @@
+export { default as useConnectedBAIClient } from './hooks/useConnectedBAIClient';
+
 export { default as BAIClientProvider } from './BAIClientProvider';
 export type { BAIClientProviderProps } from './BAIClientProvider';
 export { BAIClientContext, BAIAnonymousClientContext } from './context';

--- a/packages/backend.ai-ui/src/components/provider/BAIClientProvider/types.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIClientProvider/types.ts
@@ -4,6 +4,7 @@ export interface BAIClient {
   // Example:
   // request: (endpoint: string, options?: RequestInit) => Promise<any>;
   // Add more methods as needed based on the actual Backend.AI client API
+  isManagerVersionCompatibleWith: (version: string) => boolean;
   vfolder: {
     list_files: (path: string, id: string) => Promise<any>;
   };

--- a/packages/backend.ai-ui/src/hooks/index.ts
+++ b/packages/backend.ai-ui/src/hooks/index.ts
@@ -34,5 +34,6 @@ export function useMemoizedJSONParse<T = any>(
 }
 
 export { default as useErrorMessageResolver } from './useErrorMessageResolver';
+export { default as useViewer } from './useViewer';
 export type { ErrorResponse } from './useErrorMessageResolver';
 export type { ESMClientErrorResponse } from './useErrorMessageResolver';

--- a/packages/backend.ai-ui/src/hooks/useViewer.ts
+++ b/packages/backend.ai-ui/src/hooks/useViewer.ts
@@ -1,0 +1,33 @@
+import { useConnectedBAIClient } from '..';
+import { useViewerQuery } from '../__generated__/useViewerQuery.graphql';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+const useViewer = () => {
+  const baiClient = useConnectedBAIClient();
+  const isViewerAvailable = baiClient.isManagerVersionCompatibleWith('25.14.2');
+  const { viewer } = useLazyLoadQuery<useViewerQuery>(
+    graphql`
+      query useViewerQuery {
+        viewer {
+          user {
+            email
+          }
+          encoded_user_role
+        }
+      }
+    `,
+    {},
+    {
+      fetchPolicy: isViewerAvailable ? 'store-or-network' : 'store-only',
+    },
+  );
+
+  return {
+    viewer,
+    decodedUserRole: viewer?.encoded_user_role
+      ? atob(viewer.encoded_user_role)
+      : null,
+  };
+};
+
+export default useViewer;

--- a/react/src/hooks/backendai.test.tsx
+++ b/react/src/hooks/backendai.test.tsx
@@ -1,6 +1,7 @@
-// import json
 import deviceMetadata from '../../../resources/device_metadata.json';
+// import json
 import schema from '../../../resources/device_metadata.schema.json';
+import '../../__test__/matchMedia.mock.js';
 import {
   knownAcceleratorResourceSlotNames,
   baseResourceSlotNames,

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -5,6 +5,7 @@ import {
   useTanMutation,
   useTanQuery,
 } from './reactQueryAlias';
+import { useViewer } from 'backend.ai-ui';
 import _ from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -256,6 +257,9 @@ export const useCurrentUserInfo = () => {
 export const useCurrentUserRole = () => {
   const [userInfo] = useCurrentUserInfo();
   const baiClient = useSuspendedBackendaiClient();
+
+  const { decodedUserRole } = useViewer();
+
   const { data: roleData } = useTanQuery<{
     user: {
       role: 'superadmin' | 'admin' | 'user' | 'monitor';
@@ -266,10 +270,10 @@ export const useCurrentUserRole = () => {
       return baiClient.user.get(userInfo.email, ['role']);
     },
     staleTime: Infinity,
+    enabled: decodedUserRole === null,
   });
-  const userRole = roleData?.user.role;
 
-  return userRole;
+  return decodedUserRole ?? roleData?.user.role;
 };
 
 export const useTOTPSupported = () => {


### PR DESCRIPTION
Resolves #4279 ([FR-1472](https://lablup.atlassian.net/browse/FR-1472))

## Summary
Implements GraphQL `viewer` query functionality to handle current user information and determine user roles.

## Changes
- Added `Viewer` type to GraphQL schema with user information fields
- Created `useViewer` hook for accessing current user data via GraphQL
- Enhanced BAI Client Provider with viewer-related hooks and type definitions  
- Integrated viewer functionality into React hooks system

## Context
This implementation is based on the backend changes from https://github.com/lablup/backend.ai/pull/5728, which introduces the Viewer functionality for retrieving authenticated user information.

## Test Plan
- [ ] Verify `useViewer` hook returns current user information correctly
- [ ] Confirm user role is properly determined from viewer query
- [ ] Test integration with existing authentication system
- [ ] Ensure GraphQL schema updates are compatible with backend

[FR-1472]: https://lablup.atlassian.net/browse/FR-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ