### PR TITLE
fix(FR-1498): remove hyphens from VirtualFolder storage paths

### DIFF
--- a/react/src/components/VirtualFolderNodeItems/VirtualFolderPath.tsx
+++ b/react/src/components/VirtualFolderNodeItems/VirtualFolderPath.tsx
@@ -40,7 +40,9 @@ const VirtualFolderPath: React.FC<VirtualFolderPathProps> = ({
           }}
           style={{ fontSize: '0.9em' }}
         >
-          {_.truncate(quotaScopeIdWithoutType, { length: 15 })}
+          {_.truncate(quotaScopeIdWithoutType.replaceAll('-', ''), {
+            length: 15,
+          })}
         </BAIText>
         <BAIText
           type="secondary"
@@ -75,7 +77,7 @@ const VirtualFolderPath: React.FC<VirtualFolderPathProps> = ({
             }}
             style={{ fontSize: '0.9em' }}
           >
-            {_.truncate(vfolderIdRest.join(''), { length: 7 })}
+            {_.truncate(vfolderIdRest.replaceAll('-', ''), { length: 7 })}
           </BAIText>
         </BAIFlex>
         <BAIText

--- a/react/src/hooks/useVirtualFolderNodePath.ts
+++ b/react/src/hooks/useVirtualFolderNodePath.ts
@@ -41,8 +41,8 @@ export const useVirtualFolderPath = (
   const vfolderId = toLocalId(vfolderNode?.id);
   const vfolderIdPrefix1 = vfolderId.slice(0, 2);
   const vfolderIdPrefix2 = vfolderId.slice(2, 4);
-  const vfolderIdRest = [vfolderId.slice(4)];
-  const vfolderPath = `${quotaScopeIdWithoutType}/${vfolderIdPrefix1}/${vfolderIdPrefix2}/${vfolderIdRest}`;
+  const vfolderIdRest = vfolderId.slice(4);
+  const vfolderPath = `${quotaScopeIdWithoutType.replaceAll('-', '')}/${vfolderIdPrefix1}/${vfolderIdPrefix2}/${vfolderIdRest.replaceAll('-', '')}`;
 
   return {
     quotaScopeType,


### PR DESCRIPTION
Resolves #4311 ([FR-1498](https://lablup.atlassian.net/browse/FR-1498))

## Summary
This PR fixes a bug where VirtualFolder storage paths incorrectly included hyphens from quota scope IDs and vfolder IDs, causing issues with storage location mapping.

The full path format should be like below:
```
f38dea2350fa42a0b5ae338f5f4693f4/bd/6e/e89fa47145a1b2d00ea0ef9b9051
```

## Changes
- Remove hyphens from quota scope IDs when constructing storage paths in `useVirtualFolderNodePath.ts`
- Remove hyphens from vfolder IDs when constructing storage paths  
- Update UI display in `VirtualFolderPath.tsx` to show truncated paths without hyphens

## Why This Fix Is Needed
VirtualFolder storage paths should not contain hyphens (-) from the various ID values when used as actual filesystem paths. The hyphens were causing mismatches between expected and actual storage locations.

## Testing
- Verify that VirtualFolder paths are correctly generated without hyphens
- Ensure path display in UI shows properly truncated paths
- Confirm storage operations work correctly with the new path format

[FR-1498]: https://lablup.atlassian.net/browse/FR-1498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ