### PR TITLE
feat(FR-1503):Adopt pnpm minimumReleaseAge for security

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - packages/backend.ai-ui
 
 ignoredBuiltDependencies:
-  - '@vaadin/vaadin-usage-statistics'
+  - "@vaadin/vaadin-usage-statistics"
 
 onlyBuiltDependencies:
   - bufferutil
@@ -16,6 +16,8 @@ onlyBuiltDependencies:
   - utf-8-validate
 
 patchedDependencies:
-  '@cloudscape-design/board-components@3.0.60': react/patches/@cloudscape-design__board-components@3.0.60.patch
+  "@cloudscape-design/board-components@3.0.60": react/patches/@cloudscape-design__board-components@3.0.60.patch
   rc-field-form@2.7.0: react/patches/rc-field-form.patch
   react-scripts@5.0.1: react/patches/react-scripts@5.0.1.patch
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
# Add minimumReleaseAge to pnpm-workspace.yaml 

This PR adds a `minimumReleaseAge` setting of 1440 minutes (24 hours) to the pnpm-workspace.yaml file. This setting helps ensure we only use package versions that have been available for at least 24 hours, reducing the risk of using packages that might be quickly yanked due to issues.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after