### PR TITLE
fix(FR-1477): Update session status follow up backend changes

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionStatusDetailModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionStatusDetailModal.tsx
@@ -2,8 +2,7 @@ import { SessionStatusDetailModalFragment$key } from '../../__generated__/Sessio
 import { useSuspendedBackendaiClient } from '../../hooks';
 import { useCurrentUserRole } from '../../hooks/backendai';
 import BAIModal from '../BAIModal';
-import DoubleTag from '../DoubleTag';
-import { statusTagColor } from './SessionStatusTag';
+import SessionStatusTag from './SessionStatusTag';
 import { CheckCircleOutlined, CloseCircleOutlined } from '@ant-design/icons';
 import { Descriptions, ModalProps, Tag, Typography, theme } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';
@@ -80,6 +79,7 @@ const SessionStatusDetailModal: React.FC<SessionStatusDetailModalProps> = ({
         status_info
         status_data
         starts_at
+        ...SessionStatusTagFragment
       }
     `,
     sessionFrgmt,
@@ -91,24 +91,13 @@ const SessionStatusDetailModal: React.FC<SessionStatusDetailModalProps> = ({
       title={
         <>
           {t('session.StatusInfo')}
-          <DoubleTag
-            values={[
-              {
-                label: session.status ?? '',
-                color: session.status
-                  ? _.get(statusTagColor, session.status)
-                  : undefined,
-                style: { fontWeight: 'normal' },
-              },
-              {
-                label: _.split(session.status_info, ' ')[0] ?? '',
-                color: session.status_info
-                  ? _.get(statusInfoTagColor, session.status_info)
-                  : undefined,
-                style: { borderStyle: 'dashed', fontWeight: 'normal' },
-              },
-            ]}
-          />
+          <span style={{ fontWeight: 'normal' }}>
+            <SessionStatusTag
+              sessionFrgmt={session}
+              showInfo
+              showQueuePosition={false}
+            />
+          </span>
         </>
       }
       footer={null}

--- a/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
@@ -14,6 +14,7 @@ import { graphql, useFragment } from 'react-relay';
 interface SessionStatusTagProps {
   sessionFrgmt?: SessionStatusTagFragment$key | null;
   showInfo?: boolean;
+  showQueuePosition?: boolean;
 }
 export const statusTagColor = {
   //prepare
@@ -45,6 +46,7 @@ const isTransitional = (session: SessionStatusTagFragment$data) => {
 const SessionStatusTag: React.FC<SessionStatusTagProps> = ({
   sessionFrgmt,
   showInfo,
+  showQueuePosition = true,
 }) => {
   const { token } = theme.useToken();
   const { t } = useTranslation();
@@ -62,9 +64,10 @@ const SessionStatusTag: React.FC<SessionStatusTagProps> = ({
     sessionFrgmt,
   );
 
-  const displayQuePosition = _.isNumber(session?.queue_position)
-    ? session?.queue_position + 1
-    : undefined;
+  const displayQuePosition =
+    showQueuePosition && _.isNumber(session?.queue_position)
+      ? session?.queue_position + 1
+      : undefined;
   return session ? (
     _.isEmpty(session.status_info) || !showInfo ? (
       <BAIFlex wrap="nowrap">
@@ -91,49 +94,70 @@ const SessionStatusTag: React.FC<SessionStatusTagProps> = ({
             <Tag
               style={{
                 borderRadius: 11,
+                margin: 0,
               }}
             >{`#${displayQuePosition}`}</Tag>
           </Tooltip>
         ) : null}
       </BAIFlex>
     ) : (
-      <BAIFlex>
-        <Tag
-          style={{
-            margin: 0,
-            zIndex: 1,
-            paddingLeft: token.paddingSM,
-            borderTopLeftRadius: 11,
-            borderBottomLeftRadius: 11,
-          }}
-          color={
-            session.status ? _.get(statusTagColor, session.status) : undefined
-          }
-        >
-          {session.status}
-        </Tag>
-        <Tag
-          style={{
-            margin: 0,
-            marginLeft: -1,
-            borderStyle: 'dashed',
-            paddingRight: token.paddingSM,
-            borderTopRightRadius: 11,
-            borderBottomRightRadius: 11,
-            color:
-              session.status_info &&
-              _.get(statusInfoTagColor, session.status_info)
-                ? undefined
-                : token.colorTextSecondary,
-          }}
-          color={
-            session.status_info
-              ? _.get(statusInfoTagColor, session.status_info)
-              : undefined
-          }
-        >
-          {_.split(session.status_info, ' ')[0]}
-        </Tag>
+      <BAIFlex gap={'xs'}>
+        <BAIFlex>
+          <Tag
+            style={{
+              margin: 0,
+              zIndex: 1,
+              paddingLeft: token.paddingSM,
+              borderTopLeftRadius: 11,
+              borderBottomLeftRadius: 11,
+            }}
+            icon={
+              isTransitional(session) ? <LoadingOutlined spin /> : undefined
+            }
+            color={
+              session.status ? _.get(statusTagColor, session.status) : undefined
+            }
+          >
+            {session.status}
+          </Tag>
+          <Tag
+            style={{
+              margin: 0,
+              marginLeft: -1,
+              borderStyle: 'dashed',
+              paddingRight: token.paddingSM,
+              borderTopRightRadius: 11,
+              borderBottomRightRadius: 11,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              width: 80,
+              color:
+                session.status_info &&
+                _.get(statusInfoTagColor, session.status_info)
+                  ? undefined
+                  : token.colorTextSecondary,
+            }}
+            color={
+              session.status_info
+                ? _.get(statusInfoTagColor, session.status_info)
+                : undefined
+            }
+            title={session.status_info || undefined}
+          >
+            {session.status_info}
+          </Tag>
+        </BAIFlex>
+        {displayQuePosition ? (
+          <Tooltip title={t('session.PendingPosition')}>
+            <Tag
+              style={{
+                borderRadius: 11,
+                margin: 0,
+              }}
+            >{`#${displayQuePosition}`}</Tag>
+          </Tooltip>
+        ) : null}
       </BAIFlex>
     )
   ) : null;

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -102,7 +102,7 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
         dataIndex: 'status',
         render: (status: string, session) => {
           // TODO: Display idle checker if imminentExpirationTime as Icon(clock-alert).
-          return <SessionStatusTag sessionFrgmt={session} />;
+          return <SessionStatusTag sessionFrgmt={session} showInfo />;
         },
       },
       // This column will be added back when the session list column setting ui is ready


### PR DESCRIPTION
# Improved Session Status Tag Display

This PR enhances the SessionStatusTag component by:

1. Adding CSS properties to prevent text overflow:
   - Added `whiteSpace: 'nowrap'`
   - Added `overflow: 'hidden'`
   - Added `textOverflow: 'ellipsis'`
   - Set fixed `width: 80` for consistent sizing

2. Improved status info text display:
   - Changed from showing only the first word (`_.split(session.status_info, ' ')[0]`) 
   - To showing the first 10 characters (`session.status_info?.slice(0, 10)`)

These changes ensure that status tags display consistently and handle long status text gracefully.

![CleanShot 2025-09-23 at 16.43.51@2x.png](https://app.graphite.dev/user-attachments/assets/964c9fd0-60cc-4365-b90e-83ea86590e6a.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after