### PR TITLE
feat(FR-1506): hide terminal and app buttons for system sessions

### DIFF
--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -230,6 +230,7 @@ const SessionDetailContent: React.FC<{
             level={3}
             style={{
               margin: 0,
+              lineHeight: '1.6em',
               color: ['TERMINATED', 'CANCELLED'].includes(session.status || '')
                 ? token.colorTextTertiary
                 : undefined,
@@ -238,9 +239,7 @@ const SessionDetailContent: React.FC<{
               !['TERMINATED', 'CANCELLED'].includes(session.status || '')
             }
           />
-          <Button.Group size="large">
-            <SessionActionButtons sessionFrgmt={session} />
-          </Button.Group>
+          <SessionActionButtons size={'large'} compact sessionFrgmt={session} />
         </BAIFlex>
 
         <Descriptions


### PR DESCRIPTION
Resolves #4324 ([FR-1506](https://lablup.atlassian.net/browse/FR-1506))

## Summary
Disable terminal and app launcher buttons for system sessions (like SFTP) to prevent inappropriate access attempts.

## Changes
- Modified SessionActionButtons.tsx to add session.type === 'system' condition
- Applied to both terminal button and app launcher button
- Ensures system sessions cannot access terminal or app functionality

## Test Plan
- [ ] Verify SFTP sessions show disabled terminal/app buttons
- [ ] Confirm regular compute sessions still have functional buttons
- [ ] Test across different session states (active, inactive, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

[FR-1506]: https://lablup.atlassian.net/browse/FR-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ