### PR TITLE
feat(FR-1507): add a value to config.toml to enalbe reservoir page

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -32,6 +32,7 @@ enableExtendLoginSession = false        # If true, enables login session extensi
 enableImportFromHuggingFace = false     # Enable import from Hugging Face feature. (From Backend.AI 24.09)
 enableInteractiveLoginAccountSwitch = true  # If false, hide the "Sign in with a different account" button from the interactive login page.
 enableModelFolders = true               # Enable model folders feature. (From Backend.AI 23.03)
+enableReservoir = false                 # Enable reservoir page
 
 [wsproxy]
 proxyURL = "[Proxy URL]"

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactTable.tsx
@@ -159,11 +159,9 @@ const BAIArtifactTable = ({
             <Button
               title={t('comp:BAIArtifactTable.Deactivate')}
               size="small"
-              type="text"
-              style={{
-                color: token.colorError,
-                background: token.colorErrorBg,
-              }}
+              // type="text"
+              color={'red'}
+              variant="filled"
               icon={<BanIcon />}
               onClick={() => onClickDelete(record.id)}
             />
@@ -173,12 +171,10 @@ const BAIArtifactTable = ({
             <Button
               title={t('comp:BAIArtifactTable.Activate')}
               size="small"
-              type="text"
+              color="blue"
+              variant="filled"
+              // type="text"
               icon={<UndoIcon />}
-              style={{
-                color: token.colorInfo,
-                background: token.colorInfoBg,
-              }}
               onClick={() => onClickRestore(record.id)}
             />
           );

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -287,11 +287,14 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
       icon: <SolutionOutlined style={{ color: token.colorInfo }} />,
       key: 'resource-policy',
     },
-    baiClient?.supports('reservoir') && {
-      label: <WebUILink to="/reservoir">{t('webui.menu.Reservoir')}</WebUILink>,
-      icon: <PackagePlus style={{ color: token.colorInfo }} />,
-      key: 'reservoir',
-    },
+    baiClient?.supports('reservoir') &&
+      baiClient?._config.enableReservoir && {
+        label: (
+          <WebUILink to="/reservoir">{t('webui.menu.Reservoir')}</WebUILink>
+        ),
+        icon: <PackagePlus style={{ color: token.colorInfo }} />,
+        key: 'reservoir',
+      },
   ]);
 
   const superAdminMenu: MenuProps['items'] = [

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -605,6 +605,7 @@ type BackendAIConfig = {
   showNonInstalledImages: boolean;
   enableInteractiveLoginAccountSwitch: boolean;
   isDirectorySizeVisible: boolean;
+  enableReservoir: boolean;
   debug: boolean;
   [key: string]: any;
 };

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -144,6 +144,7 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: Boolean }) enableExtendLoginSession = false;
   @property({ type: Boolean }) enableModelFolders = true;
   @property({ type: Boolean }) showNonInstalledImages = false;
+  @property({ type: Boolean }) enableReservoir = false;
   @property({ type: Boolean }) enableInteractiveLoginAccountSwitch = true;
   @property({ type: String }) eduAppNamePrefix;
   @property({ type: String }) pluginPages;
@@ -866,6 +867,12 @@ export default class BackendAILogin extends BackendAIPage {
       valueType: 'boolean',
       defaultValue: true,
       value: generalConfig?.enableModelFolders,
+    } as ConfigValueObject) as boolean;
+    // Enable reservoir feature
+    this.enableReservoir = this._getConfigValueByExists(generalConfig, {
+      valueType: 'boolean',
+      defaultValue: false,
+      value: generalConfig?.enableReservoir,
     } as ConfigValueObject) as boolean;
   }
 
@@ -1937,6 +1944,8 @@ export default class BackendAILogin extends BackendAIPage {
         globalThis.backendaiclient._config.inactiveList = this.inactiveList;
         globalThis.backendaiclient._config.allowSignout = this.allow_signout;
         globalThis.backendaiclient.ready = true;
+        globalThis.backendaiclient._config.enableReservoir =
+          this.enableReservoir;
         if (
           this.endpoints.indexOf(
             globalThis.backendaiclient._config.endpoint as string,


### PR DESCRIPTION
# Add configuration option to enable/disable Reservoir page

resolves #4326 (FR-1507)

This PR adds a new configuration option `enableReservoir` to control the visibility of the Reservoir page in the UI. By default, this feature is disabled (`false`).

The changes include:
- Adding the `enableReservoir` configuration option to the sample config file
- Updating the WebUISider component to check this configuration before displaying the Reservoir menu item
- Adding the configuration property to the BackendAIConfig type
- Implementing the property in the login component and passing it to the client configuration

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after