### PR TITLE
fix(FR-1511): fix FolderExplorer modal buttons and implement mount-by-id support

### DIFF
--- a/react/src/components/FolderExplorer.tsx
+++ b/react/src/components/FolderExplorer.tsx
@@ -184,6 +184,14 @@ const FolderExplorer: React.FC<FolderExplorerProps> = ({
             {vFolderDescriptionElement}
           </BAIFlex>
         )}
+        <div style={{ display: 'none' }}>
+          {/* @ts-ignore  TODO: delete below after https://lablup.atlassian.net/browse/FR-1150 */}
+          <backend-ai-folder-explorer
+            ref={folderExplorerRef}
+            active
+            vfolderID={vfolderID}
+          />
+        </div>
       </BAIFlex>
     </BAIModal>
   );

--- a/src/components/backend-ai-folder-explorer.ts
+++ b/src/components/backend-ai-folder-explorer.ts
@@ -1536,7 +1536,11 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
       preferredImage['tag'];
 
     resources.config = {};
-    resources.config.mounts = [this.vfolderName];
+    if (globalThis.backendaiclient.supports('mount-by-id')) {
+      resources.config.mount_ids = [this.vfolderID];
+    } else {
+      resources.config.mounts = [this.vfolderName];
+    }
     resources.config.resources = {
       cpu: 1,
       mem: this.minimumResource.mem + 'g',
@@ -1676,7 +1680,13 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
       resources.domain = globalThis.backendaiclient._config.domainName;
       resources.type = 'system';
       resources.config = {};
-      resources.config.mounts = [this.vfolderName];
+
+      if (globalThis.backendaiclient.supports('mount-by-id')) {
+        resources.config.mount_ids = [this.vfolderID];
+      } else {
+        resources.config.mounts = [this.vfolderName];
+      }
+
       resources.config.scaling_group =
         this.volumeInfo[this.vhost]?.sftp_scaling_groups[0] || '';
       resources.config.resources = {

--- a/src/types/backend-ai-console.d.ts
+++ b/src/types/backend-ai-console.d.ts
@@ -154,6 +154,7 @@ export interface SessionResources {
       allow_fractional_resource_fragmentation?: boolean;
     };
     mounts?: string[];
+    mount_ids?: string[];
     mount_map?: {
       [key: string]: string;
     };


### PR DESCRIPTION
Resolves #4330 ([FR-1511](https://lablup.atlassian.net/browse/FR-1511))

## Summary
This PR fixes two critical issues in the FolderExplorer modal:
1. Non-functional filebrowser and SFTP server creation buttons
2. Incompatibility with ID-based managers due to vfolder name-based mounting

## Changes
- Added hidden `backend-ai-folder-explorer` component to FolderExplorer React component to restore button functionality
- Implemented mount-by-id support in `backend-ai-folder-explorer.ts` for both filebrowser and SFTP server creation
- Added `mount_ids` field to SessionResources type definition

## Technical Details
The fix checks for backend support of `mount-by-id` capability and uses:
- `mount_ids` array with vfolder IDs when supported
- Falls back to `mounts` array with vfolder names for backward compatibility

This ensures compatibility with both ID-based and name-based vfolder managers.

[FR-1511]: https://lablup.atlassian.net/browse/FR-1511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ