### PR TITLE
chore(FR-1513): Disable user selection in `BAIMenu` component

### DIFF
--- a/react/src/components/BAIMenu.tsx
+++ b/react/src/components/BAIMenu.tsx
@@ -52,6 +52,7 @@ const BAIMenu: React.FC<BAIMenuProps> = ({ collapsed, ...props }) => {
           backgroundColor: 'transparent',
           borderRight: 'none',
           // paddingRight: 4,
+          userSelect: 'none',
         }}
         // mode=""
         {...props}


### PR DESCRIPTION
resolves #4333 (FR-1513)

This pull request introduces a minor UI improvement to the `BAIMenu` component. The change prevents users from accidentally selecting text in the menu by disabling text selection.

* UI enhancement:
  * [`react/src/components/BAIMenu.tsx`](diffhunk://#diff-886488963e4493ccbe130276981d3c42c9bf0fd0f47a752f7da6691ad53a5105R55): Added `userSelect: 'none'` to the menu's style to prevent text selection.
