### PR TITLE
fix: can't access property "map", `failed_predicates` is undefined

### DIFF
--- a/src/components/backend-ai-session-list.ts
+++ b/src/components/backend-ai-session-list.ts
@@ -2436,7 +2436,7 @@ export default class BackendAISessionList extends BackendAIPage {
               ${passedCount + ` Passed`}
             </span>
             <mwc-list>
-              ${tmpSessionStatus.scheduler.failed_predicates.map((item) => {
+              ${tmpSessionStatus.scheduler.failed_predicates?.map((item) => {
                 return html`
                   ${item.name === 'reserved_time'
                     ? html`


### PR DESCRIPTION
# Fix potential undefined error in failed_predicates mapping

This PR adds a null check using the optional chaining operator (`?.`) when mapping over `tmpSessionStatus.scheduler.failed_predicates` to prevent potential errors if `failed_predicates` is undefined.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after