### PR TITLE
fix(FR-1517): fix to ensure the gpu accelerator value is loaded correctly

### DIFF
--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -183,6 +183,9 @@ const ResourceAllocationFormItems: React.FC<
 
   // Get supported accelerator types in resource group by image
   const supportedAcceleratorTypesInRGByImage = useMemo(() => {
+    if (_.isUndefined(acceleratorSlotsInRG) || _.isNil(currentImage)) {
+      return undefined;
+    }
     return _.keys(acceleratorSlotsInRG).filter((acceleratorTypeName) => {
       // '*' means all types of accelerators are supported
       return (
@@ -201,7 +204,7 @@ const ResourceAllocationFormItems: React.FC<
   }, [currentImage, acceleratorSlotsInRG, currentEnvironmentManual]);
 
   useEffect(() => {
-    if (supportedAcceleratorTypesInRGByImage.length === 0) {
+    if (supportedAcceleratorTypesInRGByImage?.length === 0) {
       form.setFieldsValue({
         resource: {
           accelerator: 0,
@@ -1072,14 +1075,14 @@ const ResourceAllocationFormItems: React.FC<
                                 return `${value} ${mergedResourceSlots?.[currentAcceleratorType]?.display_unit || ''}`;
                               },
                               open:
-                                supportedAcceleratorTypesInRGByImage.length ===
+                                supportedAcceleratorTypesInRGByImage?.length ===
                                 0
                                   ? false
                                   : undefined,
                             },
                           }}
                           disabled={
-                            supportedAcceleratorTypesInRGByImage.length === 0
+                            supportedAcceleratorTypesInRGByImage?.length === 0
                           }
                           min={0}
                           max={
@@ -1099,7 +1102,7 @@ const ResourceAllocationFormItems: React.FC<
                                   _.keys(acceleratorSlotsInRG),
                                 )}
                                 hidden={
-                                  supportedAcceleratorTypesInRGByImage.length ===
+                                  supportedAcceleratorTypesInRGByImage?.length ===
                                   0
                                 }
                               >


### PR DESCRIPTION
resolves #4338 (FR-1517)

This PR fixes an issue in the `ResourceAllocationFormItems` component where it was not properly handling undefined values for `acceleratorSlotsInRG` and `currentImage`. The changes add null/undefined checks to prevent potential runtime errors.

Key changes:
- Added a guard clause in the `supportedAcceleratorTypesInRGByImage` useMemo to return undefined when required dependencies are missing
- Updated conditional checks to use optional chaining (`?.length`) when accessing properties of potentially undefined objects

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after