### PR TITLE
fix(FR-1519): Endpoint lifecycle state change from created to ready not reflected

### DIFF
--- a/react/src/components/Chat/EndpointSelect.tsx
+++ b/react/src/components/Chat/EndpointSelect.tsx
@@ -3,6 +3,7 @@ import {
   EndpointSelectQuery$data,
 } from '../../__generated__/EndpointSelectQuery.graphql';
 import { EndpointSelectValueQuery } from '../../__generated__/EndpointSelectValueQuery.graphql';
+import { useSuspendedBackendaiClient } from '../../hooks';
 import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
 import BAISelect from '../BAISelect';
 import TotalFooter from '../TotalFooter';
@@ -25,15 +26,26 @@ export interface EndpointSelectProps
   lifecycleStageFilter?: LifecycleStage[];
 }
 
-type LifecycleStage = 'created' | 'destroying' | 'destroyed';
+type LifecycleStage =
+  | 'pending'
+  | 'created' // Deprecated, use READY instead from 25.13.0
+  | 'scaling'
+  | 'ready'
+  | 'destroying'
+  | 'destroyed';
 
 const EndpointSelect: React.FC<EndpointSelectProps> = ({
   fetchKey,
-  lifecycleStageFilter = ['created'],
+  lifecycleStageFilter = ['ready', 'created'],
   loading,
   ...selectPropsWithoutLoading
 }) => {
   const { t } = useTranslation();
+  const baiClient = useSuspendedBackendaiClient();
+  lifecycleStageFilter = baiClient.supports('endpoint-lifecycle-ready-stage')
+    ? ['ready', 'created']
+    : ['created'];
+
   const [controllableValue, setControllableValue] = useControllableValue<
     string | undefined
   >(selectPropsWithoutLoading);

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -7,7 +7,7 @@ import {
   useHistory,
 } from '../components/Chat/ChatHistory';
 import { type ChatProviderData } from '../components/Chat/ChatModel';
-import { useWebUINavigate } from '../hooks';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { Badge, Button, Card, Drawer, List, Tooltip, Typography } from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIFlex, BAICard } from 'backend.ai-ui';
@@ -41,6 +41,8 @@ const useStyles = createStyles(({ css }) => ({
 }));
 
 function useDefaultEndpointId() {
+  const baiClient = useSuspendedBackendaiClient();
+
   const { endpoint_list } = useLazyLoadQuery<ChatPageQuery>(
     graphql`
       query ChatPageQuery($filter: String) {
@@ -52,7 +54,9 @@ function useDefaultEndpointId() {
       }
     `,
     {
-      filter: 'lifecycle_stage == "created"',
+      filter: baiClient.supports('endpoint-lifecycle-ready-stage')
+        ? 'lifecycle_stage == "ready" | lifecycle_stage == "created"'
+        : 'lifecycle_stage == "created"',
     },
   );
 

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -816,6 +816,7 @@ class Client {
     }
     if (this.isManagerVersionCompatibleWith('25.13.0')) {
       this._features['pending-session-list'] = true;
+      this._features['endpoint-lifecycle-ready-stage'] = true;
     }
     if (this.isManagerVersionCompatibleWith('25.12.0')) {
       this._features['reservoir'] = true;


### PR DESCRIPTION
Resolves #4341 ([FR-1519](https://lablup.atlassian.net/browse/FR-1519))

# Update lifecycle stages for endpoint selection

This PR expands the `LifecycleStage` type to include new states: 'pending', 'scaling', and 'ready', while marking 'created' as deprecated. The default lifecycle stage filter now includes both 'ready' and 'created' states to ensure backward compatibility while adopting the new 'ready' state.

The filter in ChatPage has also been updated to match endpoints with either 'ready' or 'created' lifecycle stages.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1519]: https://lablup.atlassian.net/browse/FR-1519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ