### PR TITLE
feat(FR-1525): introduce switch type setting item

### DIFF
--- a/react/src/components/SettingItem.tsx
+++ b/react/src/components/SettingItem.tsx
@@ -1,4 +1,12 @@
-import { Badge, Checkbox, Select, SelectProps, Typography, theme } from 'antd';
+import {
+  Badge,
+  Checkbox,
+  Select,
+  type SelectProps,
+  Switch,
+  Typography,
+  theme,
+} from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIFlex } from 'backend.ai-ui';
 import _ from 'lodash';
@@ -6,7 +14,7 @@ import React, { ReactElement, ReactNode } from 'react';
 
 export interface SettingItemProps {
   'data-testid'?: string;
-  type: 'custom' | 'checkbox' | 'select';
+  type: 'custom' | 'checkbox' | 'select' | 'switch';
   title: string;
   description?: string | ReactElement;
   children?: ReactNode;
@@ -94,7 +102,13 @@ const SettingItem: React.FC<SettingItemProps> = ({
               ...selectProps?.style,
             }}
             {..._.omit(selectProps, ['style'])}
-          ></Select>
+          />
+        </>
+      )}
+      {type === 'switch' && (
+        <>
+          {description}
+          <Switch checked={value} onChange={onChange} />
         </>
       )}
     </BAIFlex>


### PR DESCRIPTION
Follow-up of #2212 and resolves #4347 (FR-1525)

This pull request enhances the `SettingItem` component by adding support for a new "switch" type, allowing it to render an Ant Design `Switch` in addition to the existing types. The most important changes are:

Component enhancements:

* Added `Switch` from Ant Design to the imports and updated the `SettingItemProps` type to accept a new `'switch'` value for the `type` prop. (`react/src/components/SettingItem.tsx`)
* Updated the `SettingItem` component to render a `Switch` when the `type` prop is set to `'switch'`, displaying the description and passing the correct props to the `Switch` component. (`react/src/components/SettingItem.tsx`)
