### PR TITLE
fix(FR-1526): apply disabled color to `DynamicUnitInputNumber` unit text when disabled

### DIFF
--- a/react/src/components/DynamicUnitInputNumber.tsx
+++ b/react/src/components/DynamicUnitInputNumber.tsx
@@ -1,7 +1,7 @@
 import { convertToBinaryUnit, parseValueWithUnit, SizeUnit } from '../helper';
 import useControllableState from '../hooks/useControllableState';
 import { usePrevious } from 'ahooks';
-import { InputNumber, InputNumberProps, Select, Typography } from 'antd';
+import { InputNumber, InputNumberProps, Select, theme, Typography } from 'antd';
 import _ from 'lodash';
 import React, { RefObject, useEffect, useRef } from 'react';
 
@@ -30,6 +30,7 @@ const DynamicUnitInputNumber: React.FC<DynamicUnitInputNumberProps> = ({
   roundStep,
   ...inputNumberProps
 }) => {
+  const { token } = theme.useToken();
   const [value, setValue] = useControllableState<string | null | undefined>(
     inputNumberProps,
     {
@@ -149,6 +150,9 @@ const DynamicUnitInputNumber: React.FC<DynamicUnitInputNumberProps> = ({
             label: (
               <Typography.Text
                 style={{
+                  color: ref.current?.disabled
+                    ? token.colorTextDisabled
+                    : token.colorText,
                   fontFamily:
                     "'SFMono-Regular',Consolas,'Liberation Mono',Menlo,Courier,monospace",
                 }}


### PR DESCRIPTION
Follow-up of #1953 and resolves #4349 (FR-1526)

| Before | After |
| ------- | ----- |
| <img width="852" height="259" alt="image" src="https://github.com/user-attachments/assets/91f258aa-c9b9-4f96-afec-7122da0813b1" /> | <img width="852" height="259" alt="image" src="https://github.com/user-attachments/assets/45d8fe85-c9d3-4684-95af-b36b619ef3b2" /> |

This pull request updates the `DynamicUnitInputNumber` component to improve its handling of disabled states and theme integration. The main change is the use of Ant Design's theme tokens to ensure consistent styling based on the component's state.

Styling and theme integration improvements:

* Imported `theme` from Ant Design and used its `useToken` hook to access theme tokens for dynamic styling. (`react/src/components/DynamicUnitInputNumber.tsx`) [[1]](diffhunk://#diff-ccca1c3642f7c617c2c4400f026db1b16b8d7d44b296ad5820f394adde603de0L4-R4) [[2]](diffhunk://#diff-ccca1c3642f7c617c2c4400f026db1b16b8d7d44b296ad5820f394adde603de0R33)
* Updated the color of the unit label to use `token.colorTextDisabled` when the input is disabled, and `token.colorText` otherwise, ensuring proper visual feedback. (`react/src/components/DynamicUnitInputNumber.tsx`)
