### PR TITLE
feat(FR-1530): Implement window focus check for automatic refresh interval

### DIFF
--- a/react/src/components/BAIFetchKeyButton.tsx
+++ b/react/src/components/BAIFetchKeyButton.tsx
@@ -16,6 +16,7 @@ interface BAIAutoRefetchButtonProps
   size?: ButtonProps['size'];
   onChange: (fetchKey: string) => void;
   hidden?: boolean;
+  pauseWhenHidden?: boolean;
 }
 const BAIFetchKeyButton: React.FC<BAIAutoRefetchButtonProps> = ({
   value,
@@ -26,6 +27,7 @@ const BAIFetchKeyButton: React.FC<BAIAutoRefetchButtonProps> = ({
   size,
   hidden,
   lastLoadTime: lastLoadTimeProp,
+  pauseWhenHidden = true,
   ...buttonProps
 }) => {
   const { t } = useTranslation();
@@ -65,6 +67,7 @@ const BAIFetchKeyButton: React.FC<BAIAutoRefetchButtonProps> = ({
     },
     showLastLoadTime ? 5_000 : null,
     lastLoadTime.toISOString(),
+    pauseWhenHidden,
   );
 
   // remember when loading is done to display when the last fetch was done
@@ -80,6 +83,7 @@ const BAIFetchKeyButton: React.FC<BAIAutoRefetchButtonProps> = ({
     },
     // only start auto-updating after the previous loading is false(done).
     loading ? null : autoUpdateDelay,
+    pauseWhenHidden,
   );
 
   const tooltipTitle = showLastLoadTime ? loadTimeMessage : undefined;


### PR DESCRIPTION
Resolves #4357 ([FR-1530](https://lablup.atlassian.net/browse/FR-1530))

# Add pauseWhenHidden option to interval hooks

This PR adds a `pauseWhenHidden` option to the `useInterval` and `useIntervalValue` hooks, allowing intervals to be paused when the page is hidden (tab not in focus). The feature is enabled by default but can be disabled by setting `pauseWhenHidden={false}`.

When enabled:
- Intervals pause when the page is hidden
- Callbacks execute immediately when the page becomes visible again
- Reduces unnecessary background processing

The `BAIFetchKeyButton` component has been updated to support this new option, with the default behavior maintaining backward compatibility.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1530]: https://lablup.atlassian.net/browse/FR-1530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ