### PR TITLE
fix: BAIModal import in SFTPConnectionInfoModal to use backend.ai-ui package

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
@@ -1,8 +1,7 @@
-import BAIModal, { BAIModalProps } from '../BAIModal';
 import SourceCodeViewer from '../SourceCodeViewer';
 import { Alert, Descriptions } from 'antd';
 import { createStyles } from 'antd-style';
-import { BAIFlex } from 'backend.ai-ui';
+import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
 import { useTranslation, Trans } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 import { SFTPConnectionInfoModalFragment$key } from 'src/__generated__/SFTPConnectionInfoModalFragment.graphql';


### PR DESCRIPTION
# Import BAIModal from backend.ai-ui instead of local component

This PR updates the import of `BAIModal` in `SFTPConnectionInfoModal.tsx` to use the component from `backend.ai-ui` package instead of the local component. It also imports `BAIModalProps` from the same package.