### PR TITLE
feat(FR-1539): add keyboard shortcut and tooltip to notification button

### DIFF
--- a/react/src/components/BAINotificationButton.tsx
+++ b/react/src/components/BAINotificationButton.tsx
@@ -5,11 +5,13 @@ import {
 import ReverseThemeProvider from './ReverseThemeProvider';
 import WEBUINotificationDrawer from './WEBUINotificationDrawer';
 import { BellOutlined } from '@ant-design/icons';
-import { Badge, Button, Typography } from 'antd';
+import { Badge, Button, Tooltip, Typography } from 'antd';
 import type { ButtonProps } from 'antd';
+import { t } from 'i18next';
 import { atom, useAtom } from 'jotai';
 import _ from 'lodash';
 import React, { useEffect } from 'react';
+import useKeyboardShortcut from 'src/hooks/useKeyboardShortcut';
 
 export const isOpenDrawerState = atom(false);
 
@@ -28,6 +30,18 @@ const BAINotificationButton: React.FC<ButtonProps> = ({ ...props }) => {
     };
   }, [upsertNotification]);
 
+  useKeyboardShortcut(
+    (event) => {
+      if (event.key === ']') {
+        event.preventDefault();
+        setIsOpenDrawer((v) => !v);
+      }
+    },
+    {
+      skipShortcutOnMetaKey: true,
+    },
+  );
+
   const hasRunningBackgroundTask = _.some(notifications, (n) => {
     return n.backgroundTask?.status === 'pending';
   });
@@ -36,22 +50,39 @@ const BAINotificationButton: React.FC<ButtonProps> = ({ ...props }) => {
   return (
     <>
       <ReverseThemeProvider>
-        <Button
-          icon={
-            <ReverseThemeProvider>
-              <Badge color="red" dot={hasRunningBackgroundTask}>
-                <ReverseThemeProvider>
-                  <Typography.Text>
-                    <BellOutlined />
-                  </Typography.Text>
-                </ReverseThemeProvider>
-              </Badge>
-            </ReverseThemeProvider>
+        <Tooltip
+          title={
+            <>
+              {t('notification.Notifications')}
+              <Typography.Text
+                keyboard
+                style={{
+                  color: 'inherit',
+                }}
+              >
+                ]
+              </Typography.Text>
+            </>
           }
-          type="text"
-          onClick={() => setIsOpenDrawer((v) => !v)}
-          {...props}
-        />
+          placement="left"
+        >
+          <Button
+            icon={
+              <ReverseThemeProvider>
+                <Badge color="red" dot={hasRunningBackgroundTask}>
+                  <ReverseThemeProvider>
+                    <Typography.Text>
+                      <BellOutlined />
+                    </Typography.Text>
+                  </ReverseThemeProvider>
+                </Badge>
+              </ReverseThemeProvider>
+            }
+            type="text"
+            onClick={() => setIsOpenDrawer((v) => !v)}
+            {...props}
+          />
+        </Tooltip>
       </ReverseThemeProvider>
       <WEBUINotificationDrawer
         open={isOpenDrawer}


### PR DESCRIPTION
Resolves #4377 ([FR-1539](https://lablup.atlassian.net/browse/FR-1539))

## Summary
This PR adds keyboard shortcut functionality and tooltip to the notification button to improve accessibility and user experience.

## Changes
- Added keyboard shortcut (']' key) to toggle notification drawer open/close
- Integrated useKeyboardShortcut hook with skipShortcutOnMetaKey option to avoid conflicts
- Added tooltip displaying "Notifications ]" to inform users about the available shortcut
- Tooltip positioned on the left side of the button for better visibility

## Benefits
- Improved accessibility through keyboard navigation
- Better user experience with clear visual hints about available shortcuts
- Enhanced productivity for power users who prefer keyboard shortcuts

## Acceptance Criteria
- [x] Users can press the ']' key to open/close the notification drawer
- [x] The keyboard shortcut is disabled when meta key is pressed to avoid conflicts
- [x] A tooltip displays "Notifications ]" to inform users about the available keyboard shortcut
- [x] The tooltip appears on the left side of the button for better visibility
- [x] The keyboard shortcut functionality integrates seamlessly with existing notification button behavior

[FR-1539]: https://lablup.atlassian.net/browse/FR-1539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ