### PR TITLE
fix(FR-1540): remove use-query-params dependency from FileExplorer

### DIFF
--- a/packages/backend.ai-ui/package.json
+++ b/packages/backend.ai-ui/package.json
@@ -83,10 +83,7 @@
     "lucide-react": "^0.484.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-draggable": "^4.4.6",
-    "react-resizable": "^3.0.5",
-    "react-router-dom": "^6.30.0",
-    "relay-runtime": "^20.1.0",
-    "use-query-params": "^2.2.1"
+    "react-resizable": "^3.0.5"
   },
   "devDependencies": {
     "@jest/expect": "30.0.0-beta.3",

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/hooks.ts
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/hooks.ts
@@ -7,15 +7,10 @@ import { RcFile } from 'antd/es/upload';
 import _ from 'lodash';
 import { use, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 export const useSearchVFolderFiles = (vfolder: string, fetchKey?: string) => {
   const baiClient = useConnectedBAIClient();
   const [currentPath, setCurrentPath] = useState<string>('.');
-  const [, setCurrentPathParam] = useQueryParam(
-    'path',
-    withDefault(StringParam, '.'),
-  );
   const [directoryTree, setDirectoryTree] = useState<
     Record<string, Array<VFolderFile>>
   >({});
@@ -24,26 +19,19 @@ export const useSearchVFolderFiles = (vfolder: string, fetchKey?: string) => {
     const newPath =
       currentPath === '.' ? folderName : `${currentPath}/${folderName}`;
     setCurrentPath(newPath);
-    setCurrentPathParam(newPath);
   };
 
   const navigateUp = () => {
     const pathParts = currentPath.split('/');
     if (pathParts.length > 1) {
-      const newPath = pathParts.join('/');
       pathParts.pop();
+      const newPath = pathParts.join('/');
       setCurrentPath(newPath || '.');
-      newPath === '.'
-        ? setCurrentPathParam(null, 'replaceIn')
-        : setCurrentPathParam(newPath);
     }
   };
 
   const navigateToPath = (path: string) => {
     setCurrentPath(path);
-    path === '.'
-      ? setCurrentPathParam(null, 'replaceIn')
-      : setCurrentPathParam(path);
   };
 
   const {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -521,9 +521,6 @@ importers:
       relay-runtime:
         specifier: ^20.1.0
         version: 20.1.0
-      use-query-params:
-        specifier: ^2.2.1
-        version: 2.2.1(react-dom@19.0.0(react@19.0.0))(react-router-dom@6.30.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
     devDependencies:
       '@jest/expect':
         specifier: 30.0.0-beta.3


### PR DESCRIPTION
Resolves #4382 ([FR-1540](https://lablup.atlassian.net/browse/FR-1540))

## Summary

This PR removes the problematic `use-query-params` and unused `react-router-dom` dependencies from the FileExplorer component that were causing the folder explorer to be unusable.

## Changes

- **Removed dependencies**: `use-query-params` and `react-router-dom` from `packages/backend.ai-ui/package.json`
- **Removed URL query parameter synchronization**: Cleaned up the FileExplorer hooks to remove the query param sync logic (`useQueryParam`, `setCurrentPathParam`)
- **Updated lockfile**: `pnpm-lock.yaml` reflects the dependency removal

## Rationale

The `use-query-params` package dependency was blocking the folder explorer functionality. Since the `backend.ai-ui` project currently doesn't use this package and plans to implement this functionality externally in future work, we're removing it now to unblock the folder explorer.

## Testing Notes

⚠️ **Please test this change in the public build environment** to ensure:
- The folder explorer is now functional
- Navigation between folders works correctly
- No regressions in folder browsing functionality

## Checklist

- [x] Documentation: Not required (dependency removal)
- [ ] Minimum required manager version: No change
- [ ] Specific setting for review: Test in public build environment
- [x] Test case: Verify folder explorer navigation works without URL query params


[FR-1540]: https://lablup.atlassian.net/browse/FR-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ