### PR TITLE
fix(FR-1537): refactor file explorer to use prop-based permissions instead of GraphQL fragments

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/EditableFileName.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/EditableFileName.tsx
@@ -1,4 +1,3 @@
-import { EditableFileNameFragment$key } from '../../../__generated__/EditableFileNameFragment.graphql';
 import BAIFlex from '../../BAIFlex';
 import BAILink from '../../BAILink';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
@@ -12,7 +11,6 @@ import _ from 'lodash';
 import { CornerDownLeftIcon } from 'lucide-react';
 import { use, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useFragment } from 'react-relay';
 
 interface ServerError extends Error {
   title?: string;
@@ -39,7 +37,6 @@ const useStyles = createStyles(({ css }) => ({
 }));
 
 type EditableNameProps = {
-  vfolderNodeFrgmt?: EditableFileNameFragment$key | null;
   fileInfo: VFolderFile;
   existingFiles: Array<VFolderFile>;
   onEndEdit?: () => void;
@@ -56,9 +53,9 @@ type EditableNameProps = {
 );
 
 const EditableFileName: React.FC<EditableNameProps> = ({
-  vfolderNodeFrgmt,
   fileInfo,
   existingFiles,
+  disabled = false,
   onEndEdit,
   onStartEdit,
   component: Component = Typography.Text,
@@ -95,17 +92,6 @@ const EditableFileName: React.FC<EditableNameProps> = ({
     },
   });
 
-  const vFolderNode = useFragment(
-    graphql`
-      fragment EditableFileNameFragment on VirtualFolderNode {
-        permissions
-      }
-    `,
-    vfolderNodeFrgmt,
-  );
-  const hasWritePermission =
-    vFolderNode?.permissions?.includes('write_content');
-
   // filter existing file names but exclude the current file name
   const existingFileNames = existingFiles
     .filter((file) => file.name !== fileInfo.name)
@@ -123,7 +109,7 @@ const EditableFileName: React.FC<EditableNameProps> = ({
       {!isEditing || isPendingRenamingAndRefreshing ? (
         <Component
           editable={
-            hasWritePermission && !isPendingRenamingAndRefreshing
+            !disabled && !isPendingRenamingAndRefreshing
               ? {
                   onStart: () => {
                     setIsEditing(true);
@@ -136,7 +122,7 @@ const EditableFileName: React.FC<EditableNameProps> = ({
                 }
               : false
           }
-          className={hasWritePermission ? styles.hoverEdit : undefined}
+          className={!disabled ? styles.hoverEdit : undefined}
           style={style}
           {...props}
         >

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -1,4 +1,3 @@
-import { ExplorerActionControlsFragment$key } from '../../../__generated__/ExplorerActionControlsFragment.graphql';
 import { BAITrashBinIcon } from '../../../icons';
 import BAIFlex from '../../BAIFlex';
 import { VFolderFile } from '../../provider/BAIClientProvider/types';
@@ -16,7 +15,6 @@ import { createStyles } from 'antd-style';
 import { RcFile } from 'antd/es/upload';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useFragment } from 'react-relay';
 
 const useStyles = createStyles(({ css }) => ({
   upload: css`
@@ -33,19 +31,21 @@ const useStyles = createStyles(({ css }) => ({
 
 interface ExplorerActionControlsProps {
   selectedFiles: Array<VFolderFile>;
-  vFolderNodeFrgmt?: ExplorerActionControlsFragment$key | null;
   onRequestClose: (
     success: boolean,
     modifiedItems?: Array<VFolderFile>,
   ) => void;
   onUpload: (files: Array<RcFile>, currentPath: string) => void;
+  enableDelete?: boolean;
+  enableWrite?: boolean;
 }
 
 const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
   selectedFiles,
-  vFolderNodeFrgmt,
   onRequestClose,
   onUpload,
+  enableDelete = false,
+  enableWrite = false,
 }) => {
   const { t } = useTranslation();
   const { lg } = Grid.useBreakpoint();
@@ -55,20 +55,6 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
   const [openCreateModal, { toggle: toggleCreateModal }] = useToggle(false);
   const [openDeleteModal, { toggle: toggleDeleteModal }] = useToggle(false);
   const lastFileListRef = useRef<Array<RcFile>>([]);
-
-  const virtualFolderNodeFrgmt = useFragment(
-    graphql`
-      fragment ExplorerActionControlsFragment on VirtualFolderNode {
-        permissions
-      }
-    `,
-    vFolderNodeFrgmt,
-  );
-
-  const hasWritePermission =
-    virtualFolderNodeFrgmt?.permissions?.includes('write_content');
-  const hasDeletePermission =
-    virtualFolderNodeFrgmt?.permissions?.includes('delete_content');
 
   return (
     <BAIFlex gap="xs">
@@ -80,7 +66,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
             })}
             <Tooltip title={t('general.button.Delete')} placement="topLeft">
               <Button
-                disabled={!hasDeletePermission}
+                disabled={!enableDelete}
                 icon={<BAITrashBinIcon style={{ color: token.colorError }} />}
                 onClick={() => {
                   toggleDeleteModal();
@@ -91,7 +77,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
         )}
         <Tooltip title={!lg && t('general.button.Create')}>
           <Button
-            disabled={!hasWritePermission}
+            disabled={!enableWrite}
             icon={<FolderAddOutlined />}
             onClick={() => {
               toggleCreateModal();
@@ -101,7 +87,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
           </Button>
         </Tooltip>
         <Dropdown
-          disabled={!hasWritePermission}
+          disabled={!enableWrite}
           dropdownRender={() => {
             return (
               <BAIFlex

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
@@ -1,5 +1,3 @@
-import { FileItemControlsFragment$key } from '../../../__generated__/FileItemControlsFragment.graphql';
-import { useMergedAllowedStorageHostPermission } from '../../../hooks';
 import { BAITrashBinIcon } from '../../../icons';
 import BAIFlex from '../../BAIFlex';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
@@ -7,46 +5,28 @@ import { VFolderFile } from '../../provider/BAIClientProvider/types';
 import { FolderInfoContext } from './BAIFileExplorer';
 import { useMutation } from '@tanstack/react-query';
 import { App, Button, theme } from 'antd';
-import _ from 'lodash';
 import { DownloadIcon } from 'lucide-react';
 import { use } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useFragment } from 'react-relay';
 
 interface FileItemControlsProps {
-  vfolderNodeFrgmt?: FileItemControlsFragment$key | null;
   selectedItem: VFolderFile;
   onClickDelete: () => void;
+  enableDownload?: boolean;
+  enableDelete?: boolean;
 }
 
 const FileItemControls: React.FC<FileItemControlsProps> = ({
-  vfolderNodeFrgmt,
   selectedItem,
   onClickDelete,
+  enableDownload = false,
+  enableDelete = false,
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
-  const { targetVFolderId } = use(FolderInfoContext);
-  const { unitedAllowedPermissionByVolume } =
-    useMergedAllowedStorageHostPermission();
+  const { targetVFolderId, currentPath } = use(FolderInfoContext);
   const baiClient = useConnectedBAIClient();
-
-  const vFolderNode = useFragment(
-    graphql`
-      fragment FileItemControlsFragment on VirtualFolderNode {
-        permissions
-        host @required(action: THROW)
-      }
-    `,
-    vfolderNodeFrgmt,
-  );
-  const hasDeletePermission =
-    vFolderNode?.permissions?.includes('delete_content');
-  const hasDownloadPermission = _.includes(
-    unitedAllowedPermissionByVolume[vFolderNode?.host ?? ''],
-    'download-file',
-  );
 
   const downloadFileMutation = useMutation({
     mutationFn: async ({
@@ -92,7 +72,7 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
     if (!selectedItem || downloadFileMutation.isPending) return;
 
     downloadFileMutation.mutate({
-      fileName: selectedItem.name,
+      fileName: `${currentPath}/${selectedItem.name}`,
       currentFolder: targetVFolderId,
       archive: selectedItem.type === 'DIRECTORY',
     });
@@ -104,7 +84,7 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
         type="text"
         size="small"
         icon={<DownloadIcon color={token.colorInfo} />}
-        disabled={!hasDownloadPermission || downloadFileMutation.isPending}
+        disabled={!enableDownload || downloadFileMutation.isPending}
         loading={downloadFileMutation.isPending}
         onClick={(e) => {
           e.stopPropagation();
@@ -115,7 +95,7 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
         type="text"
         size="small"
         icon={<BAITrashBinIcon style={{ color: token.colorError }} />}
-        disabled={!hasDeletePermission}
+        disabled={!enableDelete}
         onClick={(e) => {
           e.stopPropagation();
           onClickDelete();

--- a/packages/backend.ai-ui/src/hooks/index.ts
+++ b/packages/backend.ai-ui/src/hooks/index.ts
@@ -33,7 +33,6 @@ export function useMemoizedJSONParse<T = any>(
   }, [jsonString, fallbackValue]);
 }
 
-export { useMergedAllowedStorageHostPermission } from './useMergedAllowedStorageHostPermission';
 export { default as useErrorMessageResolver } from './useErrorMessageResolver';
 export { default as useViewer } from './useViewer';
 export type { ErrorResponse } from './useErrorMessageResolver';

--- a/react/src/components/LegacyFolderExplorer.tsx
+++ b/react/src/components/LegacyFolderExplorer.tsx
@@ -73,7 +73,6 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
           ...FolderExplorerHeaderFragment
           ...VFolderNodeDescriptionFragment
           ...VFolderNameTitleNodeFragment
-          ...BAIFileExplorerFragment
         }
       }
     `,
@@ -97,7 +96,6 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
         />
       ) : !hasNoPermissions ? (
         <BAIFileExplorer
-          vfolderNodeFrgmt={vfolder_node}
           targetVFolderId={vfolderID}
           onUpload={(files: RcFile[], currentPath: string) => {
             uploadFiles(files, vfolderID, currentPath);

--- a/react/src/hooks/useMergedAllowedStorageHostPermission.ts
+++ b/react/src/hooks/useMergedAllowedStorageHostPermission.ts
@@ -1,15 +1,15 @@
-import { useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery } from '../__generated__/useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery.graphql';
-import { useMergedAllowedStorageHostPermission_KeypairQuery } from '../__generated__/useMergedAllowedStorageHostPermission_KeypairQuery.graphql';
-import useConnectedBAIClient from '../components/provider/BAIClientProvider/hooks/useConnectedBAIClient';
+import { useSuspendedBackendaiClient } from '.';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { graphql, useLazyLoadQuery } from 'react-relay';
+import { useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery } from 'src/__generated__/useMergedAllowedStorageHostPermission_AllowedVFolderHostsQuery.graphql';
+import { useMergedAllowedStorageHostPermission_KeypairQuery } from 'src/__generated__/useMergedAllowedStorageHostPermission_KeypairQuery.graphql';
 
-export const useMergedAllowedStorageHostPermission = () => {
-  const baiClient = useConnectedBAIClient();
-  const userAccessKey = baiClient?.accessKey;
-  const domainName = baiClient?._config?.domainName;
-  const projectId = baiClient?.current_group_id();
-
+export const useMergedAllowedStorageHostPermission = (
+  domain: string,
+  projectId: string,
+  userAccessKey: string,
+) => {
+  const baiClient = useSuspendedBackendaiClient();
   const { keypair } =
     useLazyLoadQuery<useMergedAllowedStorageHostPermission_KeypairQuery>(
       graphql`
@@ -24,7 +24,7 @@ export const useMergedAllowedStorageHostPermission = () => {
         }
       `,
       {
-        domainName,
+        domainName: domain,
         accessKey: userAccessKey,
       },
       {
@@ -51,7 +51,7 @@ export const useMergedAllowedStorageHostPermission = () => {
         }
       `,
       {
-        domainName,
+        domainName: domain,
         projectId,
         resourcePolicyName: keypair?.resource_policy,
       },


### PR DESCRIPTION
resolves #4375 ([FR-1537](https://lablup.atlassian.net/browse/FR-1537))
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

### refactor file explorer to use prop-based permissions instead of GQL fragments

Resolves an issue where BAIFileExplorer fails to retrieve the project ID for the model_store project when using internal values from baiClient, preventing explorer usage. BAIFileExplorer now receives permissions via Prop and modifies the behavior so that permission checks are performed on the using side. 

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after


[FR-1537]: https://lablup.atlassian.net/browse/FR-1537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ