### PR TITLE
fix(FR-1553): update deprecated props in antd

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIConfirmModalWithInput.tsx
+++ b/packages/backend.ai-ui/src/components/BAIConfirmModalWithInput.tsx
@@ -32,7 +32,7 @@ const BAIConfirmModalWithInput: React.FC<BAIConfirmModalWithInputProps> = ({
 
   return (
     <BAIModal
-      destroyOnClose
+      destroyOnHidden
       title={
         <BAIFlex direction="column" justify="start" align="start">
           <Text strong>

--- a/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIGraphQLPropertyFilter.tsx
@@ -545,7 +545,7 @@ const BAIGraphQLPropertyFilter: React.FC<BAIGraphQLPropertyFilterProps> = ({
             ref={autoCompleteRef}
             value={search}
             open={isOpenAutoComplete}
-            onDropdownVisibleChange={setIsOpenAutoComplete}
+            onOpenChange={setIsOpenAutoComplete}
             onSelect={addCondition}
             onChange={(value) => {
               setIsValid(true);

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
@@ -352,7 +352,7 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
             ref={autoCompleteRef}
             value={search}
             open={isOpenAutoComplete}
-            onDropdownVisibleChange={setIsOpenAutoComplete}
+            onOpenChange={setIsOpenAutoComplete}
             onSelect={onSearch}
             onChange={(value) => {
               setIsValid(true);

--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -133,12 +133,12 @@ function BAISelect<
           if (atBottomStateChange || endReached) handlePopupScroll(e);
           selectProps.onPopupScroll?.(e);
         }}
-        dropdownRender={
+        popupRender={
           footer
             ? (menu) => {
-                // Process with custom dropdownRender if provided
-                // const renderedMenu = selectProps.dropdownRender
-                //   ? selectProps.dropdownRender(menu)
+                // Process with custom popupRender if provided
+                // const renderedMenu = selectProps.popupRender
+                //   ? selectProps.popupRender(menu)
                 //   : menu;
 
                 return (

--- a/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITableSettingModal.tsx
@@ -357,7 +357,7 @@ const BAITableSettingModal: React.FC<TableSettingProps> = ({
   return (
     <Modal
       title={t('comp:BAITable.SettingTable')}
-      destroyOnClose
+      destroyOnHidden
       centered
       width={500}
       onOk={() => {

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -88,7 +88,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
         </Tooltip>
         <Dropdown
           disabled={!enableWrite}
-          dropdownRender={() => {
+          popupRender={() => {
             return (
               <BAIFlex
                 align="start"
@@ -139,7 +139,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
         </Dropdown>
       </BAIFlex>
       <DeleteSelectedItemsModal
-        destroyOnClose
+        destroyOnHidden
         open={openDeleteModal}
         selectedFiles={selectedFiles}
         onRequestClose={(success: boolean) => {
@@ -150,7 +150,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
         }}
       />
       <CreateDirectoryModal
-        destroyOnClose
+        destroyOnHidden
         open={openCreateModal}
         onRequestClose={(success: boolean) => {
           if (success) {

--- a/packages/backend.ai-ui/src/components/fragments/BAIBucketSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIBucketSelect.tsx
@@ -23,7 +23,7 @@ const BAIBucketSelect = ({
     selectProps,
     {
       valuePropName: 'open',
-      trigger: 'onDropdownVisibleChange',
+      trigger: 'onOpenChange',
     },
   );
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
@@ -122,7 +122,7 @@ const BAIBucketSelect = ({
       {...selectProps}
       endReached={() => loadNext()}
       open={controllableOpen}
-      onDropdownVisibleChange={setControllableOpen}
+      onOpenChange={setControllableOpen}
       notFoundContent={
         _.isUndefined(paginationData) ? (
           <Skeleton.Input active size="small" block />

--- a/packages/backend.ai-ui/src/components/fragments/BAIObjectStorageSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIObjectStorageSelect.tsx
@@ -24,7 +24,7 @@ const BAIObjectStorageSelect = ({
     selectPropsWithoutLoading,
     {
       valuePropName: 'open',
-      trigger: 'onDropdownVisibleChange',
+      trigger: 'onOpenChange',
     },
   );
   const selectRef = useRef<GetRef<typeof BAISelect>>(null);
@@ -102,7 +102,7 @@ const BAIObjectStorageSelect = ({
       {...selectPropsWithoutLoading}
       endReached={() => loadNext()}
       open={controllableOpen}
-      onDropdownVisibleChange={setControllableOpen}
+      onOpenChange={setControllableOpen}
       notFoundContent={
         _.isUndefined(paginationData) ? (
           <Skeleton.Input active size="small" block />

--- a/react/src/components/AboutBackendAIModal.tsx
+++ b/react/src/components/AboutBackendAIModal.tsx
@@ -46,7 +46,7 @@ const AboutBackendAIModal = ({
         />
       }
       onCancel={onRequestClose}
-      destroyOnClose
+      destroyOnHidden
       footer={null}
       width={350}
       {...props}

--- a/react/src/components/AgentDetailModal.tsx
+++ b/react/src/components/AgentDetailModal.tsx
@@ -57,7 +57,7 @@ const AgentDetailModal: React.FC<AgentDetailModalProps> = ({
       centered
       title={`${t('agent.DetailedInformation')}: ${agent?.id}`}
       onCancel={onRequestClose}
-      destroyOnClose
+      destroyOnHidden
       footer={null}
     >
       <BAIFlex direction="column" align="stretch" gap={'md'}>

--- a/react/src/components/AgentSettingModal.tsx
+++ b/react/src/components/AgentSettingModal.tsx
@@ -52,7 +52,7 @@ const AgentSettingModal: React.FC<AgentSettingModalProps> = ({
       {...modalProps}
       title={`${t('agent.AgentSetting')}: ${agent?.id}`}
       onCancel={() => onRequestClose()}
-      destroyOnClose
+      destroyOnHidden
       width={300}
       confirmLoading={isInFlightCommitModifyAgentSetting}
       onOk={() => {

--- a/react/src/components/AutoScalingRuleEditorModal.tsx
+++ b/react/src/components/AutoScalingRuleEditorModal.tsx
@@ -234,7 +234,7 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
   return (
     <BAIModal
       {...baiModalProps}
-      destroyOnClose
+      destroyOnHidden
       onOk={handleOk}
       onCancel={handleCancel}
       centered

--- a/react/src/components/BAISelect.tsx
+++ b/react/src/components/BAISelect.tsx
@@ -133,12 +133,12 @@ function BAISelect<
           if (atBottomStateChange || endReached) handlePopupScroll(e);
           selectProps.onPopupScroll?.(e);
         }}
-        dropdownRender={
+        popupRender={
           footer
             ? (menu) => {
-                // Process with custom dropdownRender if provided
-                // const renderedMenu = selectProps.dropdownRender
-                //   ? selectProps.dropdownRender(menu)
+                // Process with custom popupRender if provided
+                // const renderedMenu = selectProps.popupRender
+                //   ? selectProps.popupRender(menu)
                 //   : menu;
 
                 return (

--- a/react/src/components/Chat/EndpointSelect.tsx
+++ b/react/src/components/Chat/EndpointSelect.tsx
@@ -53,7 +53,7 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
     selectPropsWithoutLoading,
     {
       valuePropName: 'open',
-      trigger: 'onDropdownVisibleChange',
+      trigger: 'onOpenChange',
     },
   );
   const deferredOpen = useDeferredValue(controllableOpen);
@@ -217,7 +217,7 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
         loadNext();
       }}
       open={controllableOpen}
-      onDropdownVisibleChange={setControllableOpen}
+      onOpenChange={setControllableOpen}
       notFoundContent={
         _.isUndefined(paginationData) ? (
           // For the first loading options

--- a/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
@@ -122,7 +122,7 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
       width={450}
       onCancel={onRequestClose}
       footer={null}
-      destroyOnClose
+      destroyOnHidden
       {...modalProps}
     >
       <BAIFlex direction="column" gap={'md'} align="stretch">

--- a/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
@@ -101,7 +101,7 @@ const ContainerCommitModal: React.FC<ContainerCommitModalProps> = ({
       okButtonProps={{ loading: isConfirmLoading }}
       onCancel={onRequestClose}
       {...modalProps}
-      destroyOnClose
+      destroyOnHidden
     >
       <BAIFlex
         direction="column"

--- a/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
@@ -134,7 +134,7 @@ const ContainerLogModal: React.FC<ContainerLogModalProps> = ({
       }}
       {...modalProps}
       footer={null}
-      destroyOnClose
+      destroyOnHidden
     >
       <BAIFlex
         direction="column"

--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -196,7 +196,7 @@ const ContainerRegistryEditorModal: React.FC<
           .catch(() => {});
       }}
       {...modalProps}
-      destroyOnClose
+      destroyOnHidden
     >
       <Form
         ref={formRef}

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -590,7 +590,7 @@ const ContainerRegistryList: React.FC<{
         onCancel={() => {
           setDeletingRegistry(null);
         }}
-        destroyOnClose
+        destroyOnHidden
         open={!!deletingRegistry}
       >
         <BAIFlex

--- a/react/src/components/DynamicUnitInputNumber.tsx
+++ b/react/src/components/DynamicUnitInputNumber.tsx
@@ -138,7 +138,7 @@ const DynamicUnitInputNumber: React.FC<DynamicUnitInputNumberProps> = ({
           onChange={(newUnit) => {
             setValue(`${numValue}${newUnit}`);
           }}
-          onDropdownVisibleChange={(open) => {
+          onOpenChange={(open) => {
             // A null or undefined value doesn't have a unit info, so we need to set the value before setting the unit.
             if ((open && value === null) || value === undefined) {
               setValue(`0${unit}`);

--- a/react/src/components/EndpointTokenGenerationModal.tsx
+++ b/react/src/components/EndpointTokenGenerationModal.tsx
@@ -89,7 +89,7 @@ const EndpointTokenGenerationModal: React.FC<
   return (
     <BAIModal
       {...baiModalProps}
-      destroyOnClose
+      destroyOnHidden
       onOk={handleOk}
       onCancel={handleCancel}
       okText={t('modelService.Generate')}

--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -229,7 +229,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
       onCancel={() => {
         onRequestClose();
       }}
-      destroyOnClose
+      destroyOnHidden
       {...modalProps}
     >
       <Form

--- a/react/src/components/FolderExplorer.tsx
+++ b/react/src/components/FolderExplorer.tsx
@@ -151,7 +151,7 @@ const FolderExplorer: React.FC<FolderExplorerProps> = ({
       className={styles.baiModalHeader}
       width={'90%'}
       centered
-      destroyOnClose
+      destroyOnHidden
       footer={null}
       title={
         vfolder_node ? (

--- a/react/src/components/FolderExplorerOpener.tsx
+++ b/react/src/components/FolderExplorerOpener.tsx
@@ -17,7 +17,7 @@ const FolderExplorerOpener = () => {
         setFolderId(null, 'replaceIn');
         setCurrentPath(null, 'replaceIn');
       }}
-      destroyOnClose
+      destroyOnHidden
     />
   );
 };

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -595,7 +595,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
                 // autoClearSearchValue
                 optionFilterProp="filterValue"
                 // optionLabelProp="label"
-                dropdownRender={(menu) => (
+                popupRender={(menu) => (
                   <>
                     <BAIFlex
                       style={{

--- a/react/src/components/ImageInstallModal.tsx
+++ b/react/src/components/ImageInstallModal.tsx
@@ -164,7 +164,7 @@ const ImageInstallModal: React.FC<ImageInstallModalInterface> = ({
   return (
     <BAIModal
       {...modalProps}
-      destroyOnClose
+      destroyOnHidden
       maskClosable={false}
       onCancel={() => onRequestClose()}
       title={t('environment.CheckImageInstallation')}

--- a/react/src/components/ImportFromHuggingFaceModal.tsx
+++ b/react/src/components/ImportFromHuggingFaceModal.tsx
@@ -251,7 +251,7 @@ const ImportFromHuggingFaceModal: React.FC<ImportFromHuggingFaceModalProps> = ({
               huggingFaceModelInfo.data?.pipeline_tag !== 'text-generation'),
         }}
         onCancel={onRequestClose}
-        destroyOnClose
+        destroyOnHidden
         {...baiModalProps}
       >
         <Form ref={formRef} preserve={false} layout="vertical">

--- a/react/src/components/InviteFolderSettingModal.tsx
+++ b/react/src/components/InviteFolderSettingModal.tsx
@@ -164,7 +164,7 @@ const InviteFolderSettingModal: React.FC<InviteFolderSettingModalProps> = ({
       title={t('data.explorer.ShareFolder')}
       onCancel={onRequestClose}
       style={{ minWidth: 550 }}
-      destroyOnClose
+      destroyOnHidden
       footer={null}
     >
       <BAIFlex direction="column" gap="xl" align="stretch">

--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -292,7 +292,7 @@ const KeypairResourcePolicySettingModal: React.FC<
       }
       onOk={handleOk}
       onCancel={() => onRequestClose()}
-      destroyOnClose
+      destroyOnHidden
       confirmLoading={
         isInFlightCommitCreateUserSetting || isInFlightCommitModifyUserSetting
       }

--- a/react/src/components/KeypairSettingModal.tsx
+++ b/react/src/components/KeypairSettingModal.tsx
@@ -74,7 +74,7 @@ const KeypairSettingModal: React.FC<KeypairSettingModalProps> = ({
           : t('credential.AddCredential')
       }
       width={500}
-      destroyOnClose
+      destroyOnHidden
       onOk={() => {
         formRef.current
           ?.validateFields()

--- a/react/src/components/LegacyFolderExplorer.tsx
+++ b/react/src/components/LegacyFolderExplorer.tsx
@@ -120,7 +120,7 @@ const LegacyFolderExplorer: React.FC<LegacyFolderExplorerProps> = ({
       className={styles.baiModalHeader}
       centered
       width={'90%'}
-      destroyOnClose
+      destroyOnHidden
       footer={null}
       title={
         vfolder_node ? (

--- a/react/src/components/ManageAppsModal.tsx
+++ b/react/src/components/ManageAppsModal.tsx
@@ -176,7 +176,7 @@ const ManageAppsModal: React.FC<ManageAppsModalProps> = ({
 
   return (
     <BAIModal
-      destroyOnClose
+      destroyOnHidden
       open={open}
       onOk={handleOnClick}
       onCancel={() => onRequestClose(false)}

--- a/react/src/components/ManageImageResourceLimitModal.tsx
+++ b/react/src/components/ManageImageResourceLimitModal.tsx
@@ -132,7 +132,7 @@ const ManageImageResourceLimitModal: React.FC<
 
   return (
     <BAIModal
-      destroyOnClose
+      destroyOnHidden
       open={open}
       maskClosable={false}
       onOk={handleOnClick}

--- a/react/src/components/ModelCardModal.tsx
+++ b/react/src/components/ModelCardModal.tsx
@@ -103,7 +103,7 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
       }
       centered
       onCancel={onRequestClose}
-      destroyOnClose
+      destroyOnHidden
       width={
         _.isEmpty(model_card?.readme) || _.isEmpty(model_card?.description)
           ? 800
@@ -343,12 +343,14 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
                       style={{
                         width: '100%',
                       }}
-                      bodyStyle={{
-                        padding: token.paddingLG,
-                        overflowBlock: 'scroll',
-                        overflowY: 'auto',
-                        height: '300px',
-                        minHeight: 200,
+                      styles={{
+                        body: {
+                          padding: token.paddingLG,
+                          overflowBlock: 'scroll',
+                          overflowY: 'auto',
+                          height: '300px',
+                          minHeight: 200,
+                        },
                       }}
                     >
                       <Markdown>{model_card?.readme || ''}</Markdown>

--- a/react/src/components/ModelCloneModal.tsx
+++ b/react/src/components/ModelCloneModal.tsx
@@ -83,7 +83,7 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
 
   return (
     <BAIModal
-      destroyOnClose
+      destroyOnHidden
       {...props}
       okText={t('button.Clone')}
       confirmLoading={mutationToClone.isPending}

--- a/react/src/components/MyKeypairInfoModal.tsx
+++ b/react/src/components/MyKeypairInfoModal.tsx
@@ -59,7 +59,7 @@ const MyKeypairInfoModal: React.FC<MyKeypairInfoModalProps> = ({
       title={t('userSettings.MyKeypairInfo')}
       centered
       onCancel={onRequestClose}
-      destroyOnClose
+      destroyOnHidden
       width={'auto'}
       footer={[
         <Button

--- a/react/src/components/OverlayNetworkSettingModal.tsx
+++ b/react/src/components/OverlayNetworkSettingModal.tsx
@@ -92,7 +92,7 @@ const OverlayNetworkSettingModal = ({
         }
       }}
       cancelText={t('button.Cancel')}
-      destroyOnClose
+      destroyOnHidden
     >
       <Form ref={formRef} layout="vertical">
         <Form.Item label="MTU" tooltip={t('settings.MTUDescription')} required>

--- a/react/src/components/PrivacyPolicyModal.tsx
+++ b/react/src/components/PrivacyPolicyModal.tsx
@@ -44,7 +44,7 @@ const PrivacyPolicyModal = ({
     <BAIModal
       title={t('webui.menu.PrivacyPolicy')}
       onCancel={onRequestClose}
-      destroyOnClose
+      destroyOnHidden
       footer={null}
       width={'80%'}
       {...props}

--- a/react/src/components/ProjectResourcePolicySettingModal.tsx
+++ b/react/src/components/ProjectResourcePolicySettingModal.tsx
@@ -205,7 +205,7 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
       }
       onOk={handleOk}
       onCancel={() => onRequestClose()}
-      destroyOnClose
+      destroyOnHidden
       confirmLoading={
         isInFlightCommitCreateProjectResourcePolicy ||
         isInFlightCommitModifyProjectResourcePolicy

--- a/react/src/components/QuotaSettingModal.tsx
+++ b/react/src/components/QuotaSettingModal.tsx
@@ -90,7 +90,7 @@ const QuotaSettingModal: React.FC<Props> = ({
   return (
     <BAIModal
       {...baiModalProps}
-      destroyOnClose
+      destroyOnHidden
       onOk={_onOk}
       confirmLoading={isInFlightCommitSetQuotaScope}
       onCancel={onRequestClose}

--- a/react/src/components/ResetPasswordRequired.tsx
+++ b/react/src/components/ResetPasswordRequired.tsx
@@ -91,7 +91,7 @@ const ResetPasswordRequired = () => {
       maskClosable={false}
       footer={null}
       width={450}
-      destroyOnClose={true}
+      destroyOnHidden={true}
       forceRender
     >
       <BAIFlex

--- a/react/src/components/ResourceGroupSettingModal.tsx
+++ b/react/src/components/ResourceGroupSettingModal.tsx
@@ -143,7 +143,7 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
 
   return (
     <BAIModal
-      destroyOnClose
+      destroyOnHidden
       title={
         resourceGroup
           ? t('resourceGroup.ModifyResourceGroup')

--- a/react/src/components/ResourcePresetSelect.tsx
+++ b/react/src/components/ResourcePresetSelect.tsx
@@ -202,9 +202,8 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
           ? 'selectedLabel'
           : 'label'
       }
-      onDropdownVisibleChange={(open) => {
-        selectProps.onDropdownVisibleChange &&
-          selectProps.onDropdownVisibleChange(open);
+      onOpenChange={(open) => {
+        selectProps.onOpenChange && selectProps.onOpenChange(open);
         if (open) {
           updateFetchKeyUnderTransition();
         }

--- a/react/src/components/ResourcePresetSettingModal.tsx
+++ b/react/src/components/ResourcePresetSettingModal.tsx
@@ -215,7 +215,7 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
       }
       onOk={handleOk}
       onCancel={() => onRequestClose(false)}
-      destroyOnClose
+      destroyOnHidden
       confirmLoading={
         isInFlightCommitCreateResourcePreset ||
         isInFlightCommitModifyResourcePresetByName ||

--- a/react/src/components/SSHKeypairManualFormModal.tsx
+++ b/react/src/components/SSHKeypairManualFormModal.tsx
@@ -42,7 +42,7 @@ const SSHKeypairManualFormModal: React.FC<SSHKeypairManualFormModalProps> = ({
           })
           .catch(() => {});
       }}
-      destroyOnClose={true}
+      destroyOnHidden={true}
       {...baiModalProps}
     >
       <Form ref={formRef} preserve={false} layout="vertical">

--- a/react/src/components/SchedulerSettingModal.tsx
+++ b/react/src/components/SchedulerSettingModal.tsx
@@ -91,7 +91,7 @@ const SchedulerSettingModal = ({
       okButtonProps={{
         type: 'primary',
       }}
-      destroyOnClose
+      destroyOnHidden
     >
       <Form ref={formRef} layout="vertical">
         <Form.Item

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1068,7 +1068,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         width={1000}
         title={t('modelService.ValidationInfo')}
         open={isOpenServiceValidationModal}
-        destroyOnClose
+        destroyOnHidden
         onCancel={() => {
           setIsOpenServiceValidationModal(!isOpenServiceValidationModal);
         }}

--- a/react/src/components/ShellScriptEditModal.tsx
+++ b/react/src/components/ShellScriptEditModal.tsx
@@ -285,7 +285,7 @@ const ShellScriptEditModal: React.FC<BootstrapScriptEditModalProps> = ({
           </BAIFlex>
         </BAIFlex>
       }
-      destroyOnClose
+      destroyOnHidden
       {...modalProps}
     >
       <BAIFlex direction="column" align="stretch" gap={'sm'}>

--- a/react/src/components/TOTPActivateModalWithToken.tsx
+++ b/react/src/components/TOTPActivateModalWithToken.tsx
@@ -106,7 +106,7 @@ const TOTPActivateModalWithToken = () => {
       onCancel={() => {
         dispatchEvent('cancel', null);
       }}
-      destroyOnClose
+      destroyOnHidden
       onOk={_onOk}
       loading={!isSuccess}
     >

--- a/react/src/components/TableColumnsSettingModal.tsx
+++ b/react/src/components/TableColumnsSettingModal.tsx
@@ -62,7 +62,7 @@ const TableColumnsSettingModal: React.FC<TableColumnsSettingProps> = ({
     <BAIModal
       title={t('table.SettingTable')}
       open={open}
-      destroyOnClose
+      destroyOnHidden
       centered
       onOk={() => {
         formRef.current

--- a/react/src/components/TermsOfServiceModal.tsx
+++ b/react/src/components/TermsOfServiceModal.tsx
@@ -44,7 +44,7 @@ const TermsOfServiceModal = ({
     <BAIModal
       title={t('webui.menu.TermsOfService')}
       onCancel={onRequestClose}
-      destroyOnClose
+      destroyOnHidden
       footer={null}
       width={'80%'}
       {...props}

--- a/react/src/components/UserProfileSettingModal.tsx
+++ b/react/src/components/UserProfileSettingModal.tsx
@@ -136,7 +136,7 @@ const UserProfileSettingModal: React.FC<Props> = ({
         confirmLoading={userInfo.isPendingMutation}
         onOk={() => onSubmit()}
         centered
-        destroyOnClose
+        destroyOnHidden
         title={t('webui.menu.MyAccountInformation')}
       >
         <Spin spinning={isRefreshModalPending} indicator={<LoadingOutlined />}>

--- a/react/src/components/UserResourcePolicySettingModal.tsx
+++ b/react/src/components/UserResourcePolicySettingModal.tsx
@@ -200,7 +200,7 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
       }
       onOk={handleOk}
       onCancel={() => onRequestClose()}
-      destroyOnClose
+      destroyOnHidden
       confirmLoading={
         isInFlightCommitCreateUserResourcePolicy ||
         isInFlightCommitModifyUserResourcePolicy

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -293,7 +293,7 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
       title={
         user ? t('credential.ModifyUserDetail') : t('credential.CreateUser')
       }
-      destroyOnClose
+      destroyOnHidden
       onOk={handleOk}
       confirmLoading={
         isInFlightCommitModifyUserSetting || isInFlightCommitCreateUser

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -142,7 +142,7 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
           )
         }
         onChange={setValue}
-        onDropdownVisibleChange={(open) => {
+        onOpenChange={(open) => {
           if (open) {
             startTransition(() => {
               checkUpdate();

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -355,8 +355,8 @@ const UserPreferencesPage = () => {
             label: t('userSettings.Logs'),
           },
         ]}
-        bodyStyle={{
-          padding: 0,
+        styles={{
+          body: { padding: 0 },
         }}
       >
         {curTabKey === 'general' && (


### PR DESCRIPTION
Resolves #4392 ([FR-1553](https://lablup.atlassian.net/browse/FR-1553))

This PR updates the Ant Design component props to align with the latest version:

- Changed `destroyOnClose` to `destroyOnHidden` in modal components
- Replaced `onDropdownVisibleChange` with `onOpenChange` in select components
- Updated `dropdownRender` to `popupRender` in dropdown components
- Changed `bodyStyle` to `styles.body` in Card component

These changes ensure compatibility with the latest Ant Design version while maintaining the same functionality.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1553]: https://lablup.atlassian.net/browse/FR-1553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ