### PR TITLE
refactor(FR-1554): fix Wrapper component typing and prop passing in SessionActionButtons

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -21,7 +21,7 @@ import {
   BAIUnmountAfterClose,
 } from 'backend.ai-ui';
 import _ from 'lodash';
-import React, { Suspense, useState, PropsWithChildren } from 'react';
+import React, { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
@@ -52,6 +52,13 @@ const isAppSupported = (session: SessionActionButtonsFragment$data) => {
       session?.type || '',
     ) && !_.isEmpty(JSON.parse(session?.service_ports ?? '{}'))
   );
+};
+
+const Wrapper: React.FC<{ compact?: boolean; children?: React.ReactNode }> = ({
+  children,
+  compact,
+}) => {
+  return compact ? <Space.Compact>{children}</Space.Compact> : <>{children}</>;
 };
 
 const SessionActionButtons: React.FC<SessionActionButtonsProps> = ({
@@ -124,20 +131,12 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = ({
     return !hiddenButtons.has(key);
   };
 
-  const Wrapper: React.FC<PropsWithChildren> = ({ children }) => {
-    return compact ? (
-      <Space.Compact>{children}</Space.Compact>
-    ) : (
-      <>{children}</>
-    );
-  };
-
   // When size is 'small', use the button's title attribute instead of a Tooltip
   const isButtonTitleMode = size === 'small';
 
   return session ? (
     <>
-      <Wrapper>
+      <Wrapper compact={compact}>
         {isVisible('appLauncher') && (
           <>
             <Tooltip


### PR DESCRIPTION
Resolves #4394 ([FR-1554](https://lablup.atlassian.net/browse/FR-1554))

## Summary
This PR fixes the Wrapper component definition in SessionActionButtons to prevent potential infinite re-rendering issues.

## Changes
- Moved the `Wrapper` component outside of the main component function to avoid recreating it on every render
- Added proper TypeScript typing with explicit `compact` prop
- Fixed prop passing by explicitly passing `compact={compact}` instead of using implicit children props
- Removed unused `PropsWithChildren` import

## Impact
This refactoring prevents unnecessary component re-creation during renders, which could lead to performance issues and potential infinite rendering loops.

[FR-1554]: https://lablup.atlassian.net/browse/FR-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ