### PR TITLE
fix(FR-1558): Unable to upload multiple files in file explorer

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -103,9 +103,13 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
               >
                 <Upload
                   beforeUpload={(_, fileList) => {
-                    uploadFiles(fileList, onUpload);
+                    if (fileList !== lastFileListRef.current) {
+                      uploadFiles(fileList, onUpload);
+                    }
+                    lastFileListRef.current = fileList;
                     return false; // Prevent default upload behavior
                   }}
+                  multiple
                   showUploadList={false}
                 >
                   <Button type="text" icon={<FileAddOutlined />}>


### PR DESCRIPTION
resolves #4401 (FR-1558)

This PR addresses an issue with file uploads in the `ExplorerActionControls` component by:

1. Adding a check to prevent duplicate file uploads by comparing the current file list with the previously uploaded one
2. Enabling multiple file selection by adding the `multiple` attribute to the Upload component

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after