### PR TITLE
chore(FR-1558): refactor code related to #4404

### DIFF
--- a/packages/backend.ai-ui/package.json
+++ b/packages/backend.ai-ui/package.json
@@ -24,7 +24,7 @@
     "test": "NODE_OPTIONS='--no-deprecation' jest",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "lint": "eslint ./src --ignore-pattern '*.test.*' --ignore-pattern '**.graphql.**' --max-warnings=0"
+    "lint": "eslint ./src --ignore-pattern '**.graphql.**' --max-warnings=0"
   },
   "eslintConfig": {
     "extends": [

--- a/react/package.json
+++ b/react/package.json
@@ -82,7 +82,7 @@
     "eject": "react-scripts eject",
     "relay": "relay-compiler",
     "relay:watch": "nodemon --watch schema.graphql --watch client-directives.graphql --exec 'pnpm run relay --watch'",
-    "lint": "eslint ./src '../resources/i18n/*.json' '../resources/device_metadata.json' --ignore-pattern '*.test.*' --max-warnings=0",
+    "lint": "eslint ./src '../resources/i18n/*.json' '../resources/device_metadata.json' --max-warnings=0",
     "format": "pnpm dlx prettier --check 'src/**/*.{js,jsx,ts,tsx}'",
     "format-fix": "pnpm dlx prettier --write './src/**/*.{js,jsx,ts,tsx}'",
     "storybook": "storybook dev -p 6006",

--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -46,7 +46,7 @@ import {
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
-import React, { useState, useDeferredValue, useMemo } from 'react';
+import React, { useState, useDeferredValue } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { StringParam, useQueryParams, withDefault } from 'use-query-params';
@@ -88,22 +88,13 @@ const AgentList: React.FC<AgentListProps> = ({ tableProps }) => {
 
   const [fetchKey, updateFetchKey] = useFetchKey();
 
-  const queryVariables = useMemo(
-    () => ({
-      limit: baiPaginationOption.limit,
-      offset: baiPaginationOption.offset,
-      filter: queryParams.filter,
-      order: queryParams.order,
-      status: queryParams.status,
-    }),
-    [
-      baiPaginationOption.limit,
-      baiPaginationOption.offset,
-      queryParams.filter,
-      queryParams.order,
-      queryParams.status,
-    ],
-  );
+  const queryVariables = {
+    limit: baiPaginationOption.limit,
+    offset: baiPaginationOption.offset,
+    filter: queryParams.filter,
+    order: queryParams.order,
+    status: queryParams.status,
+  };
 
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const deferredFetchKey = useDeferredValue(fetchKey);

--- a/react/src/components/AnnouncementAlert.tsx
+++ b/react/src/components/AnnouncementAlert.tsx
@@ -7,10 +7,7 @@ import Markdown from 'markdown-to-jsx';
 import React from 'react';
 
 interface Props extends BAIAlertProps {}
-const AnnouncementAlert: React.FC<Props> = ({
-  style: _style,
-  ...otherProps
-}) => {
+const AnnouncementAlert: React.FC<Props> = ({ ...otherProps }) => {
   const baiClient = useSuspendedBackendaiClient();
   const { token } = theme.useToken();
   const { data: announcement } = useSuspenseTanQuery({

--- a/react/src/components/BAICodeEditor.tsx
+++ b/react/src/components/BAICodeEditor.tsx
@@ -1,4 +1,4 @@
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import { loadLanguage, LanguageName } from '@uiw/codemirror-extensions-langs';
 import CodeMirror, {
   ReactCodeMirrorProps,
@@ -23,7 +23,7 @@ const BAICodeEditor: React.FC<BAICodeEditorProps> = ({
   lineWrapping = false,
   ...CodeMirrorProps
 }) => {
-  const [script, setScript] = useControllableState<string>({
+  const [script, setScript] = useControllableState_deprecated<string>({
     defaultValue: '',
     value,
     onChange,

--- a/react/src/components/BAIFetchKeyButton.tsx
+++ b/react/src/components/BAIFetchKeyButton.tsx
@@ -1,4 +1,4 @@
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import { useInterval, useIntervalValue } from '../hooks/useIntervalValue';
 import { ReloadOutlined } from '@ant-design/icons';
 import { Button, ButtonProps, Tooltip } from 'antd';
@@ -19,7 +19,6 @@ interface BAIAutoRefetchButtonProps
   pauseWhenHidden?: boolean;
 }
 const BAIFetchKeyButton: React.FC<BAIAutoRefetchButtonProps> = ({
-  value: _value,
   loading,
   onChange,
   showLastLoadTime,
@@ -31,7 +30,7 @@ const BAIFetchKeyButton: React.FC<BAIAutoRefetchButtonProps> = ({
   ...buttonProps
 }) => {
   const { t } = useTranslation();
-  const [lastLoadTime, setLastLoadTime] = useControllableState(
+  const [lastLoadTime, setLastLoadTime] = useControllableState_deprecated(
     {
       value: lastLoadTimeProp,
     },

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -40,7 +40,7 @@ export type CommittedImage = NonNullable<
   CustomizedImageListQuery$data['customized_images']
 >[number];
 
-const CustomizedImageList = () => {
+const CustomizedImageList: React.FC = () => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();

--- a/react/src/components/DynamicStepInputNumber.tsx
+++ b/react/src/components/DynamicStepInputNumber.tsx
@@ -1,5 +1,5 @@
 import { useUpdatableState } from '../hooks';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import { InputNumber, InputNumberProps } from 'antd';
 import _ from 'lodash';
 import React, { useEffect } from 'react';
@@ -21,9 +21,12 @@ const DynamicInputNumber: React.FC<DynamicInputNumberProps> = ({
   // onChange,
   ...inputNumberProps
 }) => {
-  const [value, setValue] = useControllableState<number>(inputNumberProps, {
-    defaultValue: dynamicSteps[0],
-  });
+  const [value, setValue] = useControllableState_deprecated<number>(
+    inputNumberProps,
+    {
+      defaultValue: dynamicSteps[0],
+    },
+  );
 
   // FIXME: this is a workaround to fix the issue that the value is not updated when the value is controlled
   const [key, updateKey] = useUpdatableState('first');

--- a/react/src/components/DynamicUnitInputNumber.tsx
+++ b/react/src/components/DynamicUnitInputNumber.tsx
@@ -1,5 +1,5 @@
 import { convertToBinaryUnit, parseValueWithUnit, SizeUnit } from '../helper';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import { usePrevious } from 'ahooks';
 import { InputNumber, InputNumberProps, Select, Typography } from 'antd';
 import _ from 'lodash';
@@ -30,12 +30,11 @@ const DynamicUnitInputNumber: React.FC<DynamicUnitInputNumberProps> = ({
   roundStep,
   ...inputNumberProps
 }) => {
-  const [value, setValue] = useControllableState<string | null | undefined>(
-    inputNumberProps,
-    {
-      defaultValue: '0g',
-    },
-  );
+  const [value, setValue] = useControllableState_deprecated<
+    string | null | undefined
+  >(inputNumberProps, {
+    defaultValue: '0g',
+  });
   const [numValue, _unitFromValue] =
     value === null || value === undefined
       ? [null, null]

--- a/react/src/components/DynamicUnitInputNumberWithSlider.tsx
+++ b/react/src/components/DynamicUnitInputNumberWithSlider.tsx
@@ -4,7 +4,7 @@ import {
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
 import { useUpdatableState } from '../hooks';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import DynamicUnitInputNumber, {
   DynamicUnitInputNumberProps,
 } from './DynamicUnitInputNumber';
@@ -34,12 +34,11 @@ const DynamicUnitInputNumberWithSlider: React.FC<
   step = 0.05,
   ...otherProps
 }) => {
-  const [value, setValue] = useControllableState<string | undefined | null>(
-    otherProps,
-    {
-      defaultValue: '0g',
-    },
-  );
+  const [value, setValue] = useControllableState_deprecated<
+    string | undefined | null
+  >(otherProps, {
+    defaultValue: '0g',
+  });
   const { token } = theme.useToken();
   const minGiB = useMemo(() => convertToBinaryUnit(min, 'g', 2), [min]);
   const maxGiB = useMemo(() => convertToBinaryUnit(max, 'g', 2), [max]);

--- a/react/src/components/EditableVFolderName.tsx
+++ b/react/src/components/EditableVFolderName.tsx
@@ -30,7 +30,6 @@ import {
 type EditableVFolderNameProps = {
   vfolderFrgmt: EditableVFolderNameFragment$key;
   enableLink?: boolean;
-  existingNames?: Array<string>;
   inputProps?: InputProps;
   onEditEnd?: () => void;
   onEditStart?: () => void;

--- a/react/src/components/InputNumberWithSlider.tsx
+++ b/react/src/components/InputNumberWithSlider.tsx
@@ -1,5 +1,5 @@
 import { useUpdatableState } from '../hooks';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import { InputNumber, Slider, InputNumberProps, SliderSingleProps } from 'antd';
 import { SliderRangeProps } from 'antd/es/slider';
 import { BAIFlex } from 'backend.ai-ui';
@@ -33,7 +33,7 @@ const InputNumberWithSlider: React.FC<InputNumberWithSliderProps> = ({
   inputContainerMinWidth,
   ...otherProps
 }) => {
-  const [value, setValue] = useControllableState(otherProps);
+  const [value, setValue] = useControllableState_deprecated(otherProps);
   const inputRef = React.useRef<HTMLInputElement>(null);
   useEffect(() => {
     if (!allowNegative) {

--- a/react/src/components/KeypairResourcePolicySelector.tsx
+++ b/react/src/components/KeypairResourcePolicySelector.tsx
@@ -1,6 +1,6 @@
 import { KeypairResourcePolicySelectorQuery } from '../__generated__/KeypairResourcePolicySelectorQuery.graphql';
 import { localeCompare } from '../helper';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import { Select, SelectProps } from 'antd';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
@@ -12,7 +12,7 @@ const KeypairResourcePolicySelector: React.FC<
   KeypairResourcePolicySelectorProps
 > = ({ ...selectProps }) => {
   const { t } = useTranslation();
-  const [value, setValue] = useControllableState<string>({
+  const [value, setValue] = useControllableState_deprecated<string>({
     value: selectProps.value,
     onChange: selectProps.onChange,
   });

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -218,7 +218,6 @@ function MainLayout() {
                 >
                   <WebUIHeader
                     onClickMenuIcon={() => setSideCollapsed((v) => !v)}
-                    containerElement={contentScrollFlexRef.current}
                   />
                   {/* sticky Alert components with banner props */}
                   <Suspense fallback={null}>

--- a/react/src/components/MainLayout/WebUIHeader.tsx
+++ b/react/src/components/MainLayout/WebUIHeader.tsx
@@ -34,7 +34,6 @@ const useStyles = createStyles(({ css }) => ({
 
 export interface WebUIHeaderProps extends BAIFlexProps {
   onClickMenuIcon?: () => void;
-  containerElement?: HTMLDivElement | null;
 }
 
 const WebUIHeader: React.FC<WebUIHeaderProps> = ({ onClickMenuIcon }) => {

--- a/react/src/components/ManageAppsModal.tsx
+++ b/react/src/components/ManageAppsModal.tsx
@@ -84,10 +84,9 @@ const ManageAppsModal: React.FC<ManageAppsModalProps> = ({
           item !== null && item?.key === 'ai.backend.service-ports',
       );
       if (servicePortsIdx !== -1) {
-        // eslint-disable-next-line
-        servicePorts = image?.labels[servicePortsIdx]
-          ?.value!?.split(',')
-          .map((e: string): ServicePort => {
+        const rawValue = image.labels[servicePortsIdx]?.value;
+        if (rawValue) {
+          servicePorts = rawValue.split(',').map((e: string): ServicePort => {
             const sp = e.split(':');
             return {
               app: sp[0],
@@ -95,6 +94,7 @@ const ManageAppsModal: React.FC<ManageAppsModalProps> = ({
               port: Number(sp[2]),
             };
           });
+        }
       }
     }
     return servicePorts;

--- a/react/src/components/NonLinearSlider.tsx
+++ b/react/src/components/NonLinearSlider.tsx
@@ -1,4 +1,4 @@
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import { Slider, SliderSingleProps } from 'antd';
 import _, { isNumber } from 'lodash';
 import React from 'react';
@@ -15,7 +15,7 @@ interface NonLinearSliderProps
   steps: StepType[];
   value?: number | string;
   defaultValue?: number | string;
-  showAllMarkLabels?: boolean;
+  // showAllMarkLabels?: boolean;
   onChange?: (value: number | string, label: string) => void;
 }
 const NonLinearSlider: React.FC<NonLinearSliderProps> = ({
@@ -35,11 +35,13 @@ const NonLinearSlider: React.FC<NonLinearSliderProps> = ({
     return step;
   });
 
-  const [controlledValue, setControlledValue] = useControllableState({
-    value,
-    defaultValue: defaultValue ?? normalizedSteps[0]?.value,
-    onChange,
-  });
+  const [controlledValue, setControlledValue] = useControllableState_deprecated(
+    {
+      value,
+      defaultValue: defaultValue ?? normalizedSteps[0]?.value,
+      onChange,
+    },
+  );
 
   const isFirstAndLast = (index: number) =>
     index === 0 || index === normalizedSteps.length - 1;

--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -1,7 +1,7 @@
 import { ProjectSelectorQuery } from '../__generated__/ProjectSelectorQuery.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import BAISelect, { BAISelectProps } from './BAISelect';
 import _ from 'lodash';
 import React from 'react';
@@ -33,7 +33,7 @@ const ProjectSelect: React.FC<ProjectSelectProps> = ({
   const baiClient = useSuspendedBackendaiClient();
   const blockList = baiClient?._config?.blockList ?? null;
 
-  const [value, setValue] = useControllableState(selectProps);
+  const [value, setValue] = useControllableState_deprecated(selectProps);
   const userRole = useCurrentUserRole();
   const { groups, user } = useLazyLoadQuery<ProjectSelectorQuery>(
     graphql`

--- a/react/src/components/ResourceGroupSelect.tsx
+++ b/react/src/components/ResourceGroupSelect.tsx
@@ -1,7 +1,7 @@
 import { useBaiSignedRequestWithPromise } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import BAISelect, { BAISelectProps } from './BAISelect';
 import TextHighlighter from './TextHighlighter';
 import { SelectProps } from 'antd';
@@ -39,13 +39,13 @@ const ResourceGroupSelect: React.FC<ResourceGroupSelectProps> = ({
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
   const [fetchKey] = useUpdatableState('first');
   const [controllableSearchValue, setControllableSearchValue] =
-    useControllableState<string>({
+    useControllableState_deprecated<string>({
       value: searchValue,
       onChange: onSearch,
     });
 
   const [controllableValue, setControllableValueDoNotUseWithoutTransition] =
-    useControllableState(selectProps);
+    useControllableState_deprecated(selectProps);
   const [isPendingChangeTransition, startChangeTransition] = useTransition();
 
   const [optimisticValue, setOptimisticValue] = useState();

--- a/react/src/components/ResourcePresetSelect.tsx
+++ b/react/src/components/ResourcePresetSelect.tsx
@@ -5,7 +5,7 @@ import {
 import { localeCompare } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { ResourceSlotName, useResourceSlots } from '../hooks/backendai';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import ResourceNumber from './ResourceNumber';
 import { EditOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import { useThrottleFn } from 'ahooks';
@@ -56,7 +56,7 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
   const { token } = theme.useToken();
   const [isPendingUpdate, _startTransition] = useTransition();
   const [controllableValue, setControllableValue] =
-    useControllableState(selectProps);
+    useControllableState_deprecated(selectProps);
   const updateFetchKeyUnderTransition = () => {
     _startTransition(() => {
       updateFetchKeyThrottled();

--- a/react/src/components/SharedResourceGroupSelectForCurrentProject.tsx
+++ b/react/src/components/SharedResourceGroupSelectForCurrentProject.tsx
@@ -1,5 +1,5 @@
 import { useSuspendedBackendaiClient } from '../hooks';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import {
   useCurrentResourceGroupState,
   useResourceGroupsForCurrentProject,
@@ -30,7 +30,7 @@ const SharedResourceGroupSelectForCurrentProject: React.FC<
 }) => {
   useSuspendedBackendaiClient(); // To make sure the client is ready
   const [controllableSearchValue, setControllableSearchValue] =
-    useControllableState<string>({
+    useControllableState_deprecated<string>({
       value: searchValue,
       onChange: onSearch,
     });

--- a/react/src/components/StorageSelect.tsx
+++ b/react/src/components/StorageSelect.tsx
@@ -1,7 +1,7 @@
 import { usageIndicatorColor } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import BAISelect, { BAISelectProps } from './BAISelect';
 import TextHighlighter from './TextHighlighter';
 import { Badge, Tooltip } from 'antd';
@@ -57,13 +57,14 @@ const StorageSelect: React.FC<Props> = ({
       },
     });
 
-  const [controllableState, setControllableState] = useControllableState({
-    value,
-    onChange,
-    defaultValue,
-  });
+  const [controllableState, setControllableState] =
+    useControllableState_deprecated({
+      value,
+      onChange,
+      defaultValue,
+    });
   const [controllableSearchValue, setControllableSearchValue] =
-    useControllableState({ value: searchValue, onChange: onSearch });
+    useControllableState_deprecated({ value: searchValue, onChange: onSearch });
   useEffect(() => {
     if (!autoSelectType || !vhostInfo) return; // Return early if vhostInfo is null
     let nextHost = vhostInfo?.default ?? vhostInfo?.allowed[0] ?? '';

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -1,7 +1,7 @@
 import { useBaiSignedRequestWithPromise } from '../helper';
 import { useUpdatableState } from '../hooks';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import FolderCreateModal from './FolderCreateModal';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
@@ -55,7 +55,7 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
   const { generateFolderPath } = useFolderExplorerOpener();
   const { t } = useTranslation();
-  const [value, setValue] = useControllableState(selectProps);
+  const [value, setValue] = useControllableState_deprecated(selectProps);
   const [key, checkUpdate] = useUpdatableState('first');
   const [isOpenCreateModal, setIsOpenCreateModal] = useState(false);
   // const { vfolder_list } = useLazyLoadQuery<VFolderSelectQuery>(

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -3,7 +3,7 @@ import { useBaiSignedRequestWithPromise } from '../helper';
 import { useSuspendedBackendaiClient, useUpdatableState } from '../hooks';
 import { useKeyPairLazyLoadQuery } from '../hooks/hooksUsingRelay';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
-import useControllableState from '../hooks/useControllableState';
+import useControllableState_deprecated from '../hooks/useControllableState';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useEventNotStable } from '../hooks/useEventNotStable';
 import FolderCreateModal from './FolderCreateModal';
@@ -112,7 +112,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
 
   const [isOpenCreateModal, setIsOpenCreateModal] = useState(false);
 
-  const [selectedRowKeys, setSelectedRowKeys] = useControllableState<
+  const [selectedRowKeys, setSelectedRowKeys] = useControllableState_deprecated<
     VFolderKey[]
   >(
     {
@@ -129,7 +129,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
     },
   );
 
-  const [aliasMap, setAliasMap] = useControllableState<AliasMap>(
+  const [aliasMap, setAliasMap] = useControllableState_deprecated<AliasMap>(
     {
       value: controlledAliasMap,
       onChange: onChangeAliasMap,

--- a/react/src/helper/big-number.test.ts
+++ b/react/src/helper/big-number.test.ts
@@ -1,6 +1,5 @@
 import { BigNumber } from './big-number';
 import { expect } from '@jest/globals';
-import '@jest/globals';
 import Big from 'big.js';
 
 declare module '@jest/expect' {

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -21,16 +21,17 @@ export const useBackendAIAppLauncher = (
       // @ts-ignore
       globalThis.appLauncher.runTerminal(session.row_id);
     },
-    showLauncher: (_params: {
-      'session-uuid'?: string;
-      'access-key'?: string;
-      'app-services'?: string;
-      mode?: string;
-      'app-services-option'?: string;
-      'service-ports'?: string;
-      runtime?: string;
-      filename?: string;
-      arguments?: string;
-    }) => {},
+    // TODO: implement below function
+    // showLauncher: (params: {
+    //   'session-uuid'?: string;
+    //   'access-key'?: string;
+    //   'app-services'?: string;
+    //   mode?: string;
+    //   'app-services-option'?: string;
+    //   'service-ports'?: string;
+    //   runtime?: string;
+    //   filename?: string;
+    //   arguments?: string;
+    // }) => {},
   };
 };

--- a/react/src/hooks/useBackendAIImageMetaData.test.tsx
+++ b/react/src/hooks/useBackendAIImageMetaData.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable testing-library/render-result-naming-convention */
 import { useBackendAIImageMetaData } from '.';
 import { getImageFullName } from '../helper';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/react/src/hooks/useControllableState.test.ts
+++ b/react/src/hooks/useControllableState.test.ts
@@ -1,11 +1,13 @@
-/* eslint-disable testing-library/render-result-naming-convention */
-import useControllableState, { Options, Props } from './useControllableState';
+import useControllableState_deprecated, {
+  Options,
+  Props,
+} from './useControllableState';
 import { renderHook } from '@testing-library/react';
 import { act } from 'react';
 
 describe('useControllableState', () => {
   const setUp = (props?: Props, options?: Options<any>): any =>
-    renderHook(() => useControllableState(props, options));
+    renderHook(() => useControllableState_deprecated(props, options));
 
   it('defaultValue should work', () => {
     const hook = setUp({ defaultValue: 1 });
@@ -88,7 +90,7 @@ describe('useControllableState', () => {
       },
       onChange: () => {},
     };
-    const hook = renderHook(() => useControllableState(props));
+    const hook = renderHook(() => useControllableState_deprecated(props));
     const [v] = hook.result.current;
     expect(v.foo).toBe(123);
   });

--- a/react/src/hooks/useControllableState.ts
+++ b/react/src/hooks/useControllableState.ts
@@ -22,14 +22,14 @@ export interface StandardProps<T> {
  * However if the value is undefined, the component is treated as an uncontrolled component
  */
 
-function useControllableState<T = any>(
+function useControllableState_deprecated<T = any>(
   props: StandardProps<T>,
 ): [T, (v: SetStateAction<T>) => void];
-function useControllableState<T = any>(
+function useControllableState_deprecated<T = any>(
   props?: Props,
   options?: Options<T>,
 ): [T, (v: SetStateAction<T>, ...args: any[]) => void];
-function useControllableState<T = any>(
+function useControllableState_deprecated<T = any>(
   props: Props = {},
   options: Options<T> = {},
 ) {
@@ -82,7 +82,7 @@ function useControllableState<T = any>(
   return [stateRef.current, useMemoizedFn(setState)] as const;
 }
 
-export default useControllableState;
+export default useControllableState_deprecated;
 
 type noop = (this: any, ...args: any[]) => any;
 

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -107,7 +107,7 @@ customElements.define(
   }),
 );
 
-const SourceCodeViewerInWebComponent = (_props: ReactWebComponentProps) => {
+const SourceCodeViewerInWebComponent: React.FC<ReactWebComponentProps> = () => {
   const {
     parsedValue: { children, language, wordWrap } = {
       children: '',
@@ -237,7 +237,7 @@ customElements.define(
   }),
 );
 
-const ReservationTimeCounter = (_props: ReactWebComponentProps) => {
+const ReservationTimeCounter: React.FC<ReactWebComponentProps> = () => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
 


### PR DESCRIPTION
This PR 
- removes the `--ignore-pattern '*.test.*'` flag from ESLint configuration in both `backend.ai-ui` and `react` packages, allowing test files to be properly linted.
- Renames `useControllableState` to `useControllableState_deprecated` to prepare for future refactoring
- Removes unused parameters and variables from various components
- Adds proper React.FC type annotations to components that were missing them
- Replaces a potentially unsafe optional chaining with a proper null check in ManageAppsModal
- Simplifies the queryVariables in AgentList by removing unnecessary useMemo
