### PR TITLE
fix: handle optional chaining for allowed_vfolder_hosts in resource policy

### DIFF
--- a/react/src/components/VFolderNodeIdenticon.tsx
+++ b/react/src/components/VFolderNodeIdenticon.tsx
@@ -26,6 +26,8 @@ const VFolderNodeIdenticon: React.FC<VFolderNodeIdenticonProps> = ({
 
   return (
     <img
+      draggable={false}
+      onDragStart={(e) => e.preventDefault()}
       style={{
         borderRadius: '0.25em',
         width: '1em',
@@ -33,6 +35,7 @@ const VFolderNodeIdenticon: React.FC<VFolderNodeIdenticonProps> = ({
         borderWidth: 0.5,
         borderStyle: 'solid',
         borderColor: token.colorBorder,
+        userSelect: 'none',
         ...style,
       }}
       src={createAvatar(shapes, {

--- a/src/components/backend-ai-folder-explorer.ts
+++ b/src/components/backend-ai-folder-explorer.ts
@@ -752,7 +752,7 @@ export default class BackendAIFolderExplorer extends BackendAIPage {
       mergedData?.group?.allowed_vfolder_hosts || '{}',
     );
     const allowedPermissionForResourcePolicyByVolume = JSON.parse(
-      mergedData?.keypair_resource_policy.allowed_vfolder_hosts || '{}',
+      mergedData?.keypair_resource_policy?.allowed_vfolder_hosts || '{}',
     );
 
     const _mergeDedupe = (arr) => [...new Set([].concat(...arr))];


### PR DESCRIPTION
# Prevent Dragging of VFolder Node Identicons and Fix Resource Policy Access

This PR makes two changes:

1. Prevents dragging of VFolder node identicons by adding `draggable={false}`, a drag prevention handler, and `userSelect: 'none'` to the image style.
2. Fixes a potential undefined error when accessing `keypair_resource_policy.allowed_vfolder_hosts` by adding an optional chaining operator (`?.`).