### PR TITLE
fix(FR-1501): fix file upload status tracking and error handling

### DIFF
--- a/react/src/components/FolderExplorerModal.tsx
+++ b/react/src/components/FolderExplorerModal.tsx
@@ -69,7 +69,7 @@ const FolderExplorerModal: React.FC<FolderExplorerProps> = ({
   const bodyRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (uploadStatus && _.isEmpty(uploadStatus.pending)) {
+    if (uploadStatus && _.isEmpty(uploadStatus?.pendingFiles)) {
       updateFetchKey();
     }
   }, [uploadStatus, updateFetchKey]);

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -652,17 +652,18 @@
     "Title": "Es ist ein Fehler aufgetreten."
   },
   "explorer": {
-    "FileInProgress": "Hochladen von '{{fileName}}' ...",
     "FileUploadCancelled": "Das Datei -Upload wurde durch Benutzeranforderung storniert.",
     "FileUploadFailed": "Es wurden einige Dateien nicht in Ordner '{{folderName}}' hochgeladen.",
+    "Filename": "Dateiname",
     "FolderNotFoundOrNoAccess": "Ordner, der nicht gefunden oder zugänglich ist verweigert",
     "InputTooShort": "EingabeTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Nicht verwaltete Ordner unterstützen den Datei -Explorer nicht.",
     "NoPermissions": "Keine Berechtigungen für den Zugriff auf diesen Ordner",
     "ProcessingUpload": "Ihre Datei wird hochgeladen. \nBitte warten.",
-    "SuccessfullyUploadedToFolder": "Dateien, die erfolgreich in Ordner '{{folderName}}' hochgeladen wurden",
+    "SuccessfullyUploadedToFolder": "Dateien erfolgreich hochgeladen.",
     "UploadFailed": "Upload fehlgeschlagen in '{{folderName}}' '",
-    "UploadToFolder": "Hochladen auf '{{folderName}}'",
+    "UploadingFiles": "Dateien werden hochgeladen...",
+    "VFolder": "Ordner",
     "ValueRequired": "WertErforderlich"
   },
   "general": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -649,17 +649,18 @@
     "Title": "Εμφανίστηκε σφάλμα."
   },
   "explorer": {
-    "FileInProgress": "Μεταφόρτωση '{{fileName}}' ...",
     "FileUploadCancelled": "Η μεταφόρτωση αρχείων ακυρώθηκε με αίτημα χρήστη.",
     "FileUploadFailed": "Απέτυχε να ανεβάσει κάποια αρχεία στο φάκελο '{{folderName}}'.",
+    "Filename": "Όνομα αρχείου",
     "FolderNotFoundOrNoAccess": "Ο φάκελος δεν βρέθηκε ή απορρίφθηκε η πρόσβαση",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Οι μη διαχειριζόμενοι φάκελοι δεν υποστηρίζουν τον εξερευνητή αρχείων.",
     "NoPermissions": "Δεν υπάρχουν δικαιώματα πρόσβασης σε αυτόν τον φάκελο",
     "ProcessingUpload": "Το αρχείο σας μεταφορτώνεται. \nΠεριμένετε.",
-    "SuccessfullyUploadedToFolder": "Αρχεία που μεταφορτώθηκαν με επιτυχία στο φάκελο '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "Τα αρχεία μεταφορτώθηκαν με επιτυχία.",
     "UploadFailed": "Η μεταφόρτωση απέτυχε στο '{{folderName}}'",
-    "UploadToFolder": "Μεταφόρτωση στο '{{folderName}}'",
+    "UploadingFiles": "Μεταφόρτωση αρχείων...",
+    "VFolder": "Ντοσιέ",
     "ValueRequired": "Απαιτούμενη τιμή"
   },
   "general": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -657,17 +657,18 @@
     "Title": "An error has occurred."
   },
   "explorer": {
-    "FileInProgress": "Uploading '{{fileName}}'...",
     "FileUploadCancelled": "The file upload was canceled by user request.",
     "FileUploadFailed": "Failed to upload some files in folder '{{folderName}}'.",
+    "Filename": "File Name",
     "FolderNotFoundOrNoAccess": "Folder not found or access denied",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Unmanaged folders do not support the file explorer.",
     "NoPermissions": "No permissions to access this folder",
     "ProcessingUpload": "Your file is being uploaded. Please wait.",
-    "SuccessfullyUploadedToFolder": "Files uploaded successfully in folder '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "Files uploaded successfully.",
     "UploadFailed": "Upload failed in '{{folderName}}'",
-    "UploadToFolder": "Uploading to '{{folderName}}'",
+    "UploadingFiles": "Uploading files...",
+    "VFolder": "Folder",
     "ValueRequired": "ValueRequired"
   },
   "general": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -652,17 +652,18 @@
     "Title": "Se ha producido un error."
   },
   "explorer": {
-    "FileInProgress": "Cargando '{{fileName}}' ...",
     "FileUploadCancelled": "La carga de archivo fue cancelada por solicitud del usuario.",
     "FileUploadFailed": "No se pudo cargar algunos archivos en la carpeta '{{folderName}}'.",
+    "Filename": "Nombre del archivo",
     "FolderNotFoundOrNoAccess": "Carpeta no encontrada ni de acceso denegada",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Las carpetas no administradas no admiten el explorador de archivos.",
     "NoPermissions": "No hay permisos para acceder a esta carpeta",
     "ProcessingUpload": "Se está cargando su archivo. \nEspere por favor.",
-    "SuccessfullyUploadedToFolder": "Archivos cargados correctamente en la carpeta '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "Archivos cargados exitosamente.",
     "UploadFailed": "La carga falló en '{{folderName}}'",
-    "UploadToFolder": "Cargar a '{{folderName}}'",
+    "UploadingFiles": "Subiendo archivos...",
+    "VFolder": "Carpeta",
     "ValueRequired": "ValorRequerido"
   },
   "general": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -652,17 +652,18 @@
     "Title": "On tapahtunut virhe."
   },
   "explorer": {
-    "FileInProgress": "Lataaminen '{{fileName}}' ...",
     "FileUploadCancelled": "Tiedoston lataus peruutettiin käyttäjäpyynnöllä.",
     "FileUploadFailed": "Joidenkin tiedostojen lähettäminen kansioon '{{folderName}}'.",
+    "Filename": "Tiedoston nimi",
     "FolderNotFoundOrNoAccess": "Kansiota ei löydy tai pääsy kielletty",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Hallitsemattomat kansiot eivät tue tiedostotutkijaa.",
     "NoPermissions": "Ei oikeuksia käyttää tätä kansiota",
     "ProcessingUpload": "Tiedostosi ladataan. \nOdota.",
-    "SuccessfullyUploadedToFolder": "Tiedostot ladataan onnistuneesti kansioon '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "Tiedostot on ladattu onnistuneesti.",
     "UploadFailed": "Lähettäminen epäonnistui '{{folderName}}'",
-    "UploadToFolder": "Lataaminen '{{folderName}}'",
+    "UploadingFiles": "Ladataan tiedostoja...",
+    "VFolder": "Kansio",
     "ValueRequired": "ValueRequired"
   },
   "general": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -652,17 +652,18 @@
     "Title": "Une erreur s'est produite."
   },
   "explorer": {
-    "FileInProgress": "Téléchargement '{{fileName}}' ...",
     "FileUploadCancelled": "Le téléchargement du fichier a été annulé par demande de l'utilisateur.",
     "FileUploadFailed": "Échec pour télécharger certains fichiers dans le dossier '{{folderName}}'.",
+    "Filename": "Nom de fichier",
     "FolderNotFoundOrNoAccess": "Dossier non trouvé ou accès refusé",
     "InputTooShort": "Entrée Trop Courte",
     "NoExplorerSupportForUnmanagedFolder": "Les dossiers non gérés ne prennent pas en charge l'explorateur de fichiers.",
     "NoPermissions": "Aucune autorisation pour accéder à ce dossier",
     "ProcessingUpload": "Votre fichier est téléchargé. \nS'il vous plaît, attendez.",
-    "SuccessfullyUploadedToFolder": "Fichiers téléchargés avec succès dans le dossier '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "Fichiers téléchargés avec succès.",
     "UploadFailed": "Le téléchargement a échoué dans '{{folderName}}'",
-    "UploadToFolder": "Téléchargement sur '{{folderName}}'",
+    "UploadingFiles": "Téléchargement de fichiers...",
+    "VFolder": "Dossier",
     "ValueRequired": "ValeurRequis"
   },
   "general": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -651,17 +651,18 @@
     "Title": "Telah terjadi kesalahan."
   },
   "explorer": {
-    "FileInProgress": "Mengunggah '{{fileName}}' ...",
     "FileUploadCancelled": "Unggah file dibatalkan dengan permintaan pengguna.",
     "FileUploadFailed": "Gagal mengunggah beberapa file di folder '{{folderName}}'.",
+    "Filename": "Nama File",
     "FolderNotFoundOrNoAccess": "Folder tidak ditemukan atau akses ditolak",
     "InputTooShort": "MasukanTerlaluPendek",
     "NoExplorerSupportForUnmanagedFolder": "Folder yang tidak dikelola tidak mendukung file explorer.",
     "NoPermissions": "Tidak ada izin untuk mengakses folder ini",
     "ProcessingUpload": "File Anda sedang diunggah. \nHarap tunggu.",
-    "SuccessfullyUploadedToFolder": "File berhasil diunggah di folder '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "File berhasil diunggah.",
     "UploadFailed": "Unggah gagal di '{{folderName}}'",
-    "UploadToFolder": "Mengunggah ke '{{folderName}}'",
+    "UploadingFiles": "Mengunggah file...",
+    "VFolder": "Map",
     "ValueRequired": "NilaiDiperlukan"
   },
   "general": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -651,17 +651,18 @@
     "Title": "Si è verificato un errore."
   },
   "explorer": {
-    "FileInProgress": "Caricamento '{{fileName}}' ...",
     "FileUploadCancelled": "Il caricamento del file è stato cancellato dalla richiesta dell'utente.",
     "FileUploadFailed": "Impossibile caricare alcuni file nella cartella '{{folderName}}'.",
+    "Filename": "Nome del file",
     "FolderNotFoundOrNoAccess": "Cartella non trovata o accesso negata",
     "InputTooShort": "Inputtroppo corto",
     "NoExplorerSupportForUnmanagedFolder": "Le cartelle non gestite non supportano l'esploratore dei file.",
     "NoPermissions": "Nessuna autorizzazione per accedere a questa cartella",
     "ProcessingUpload": "Il tuo file viene caricato. \nAttendere prego.",
-    "SuccessfullyUploadedToFolder": "File caricati correttamente nella cartella '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "File caricati correttamente.",
     "UploadFailed": "Caricamento non riuscito in '{{folderName}'",
-    "UploadToFolder": "Caricamento su '{{folderName}}'",
+    "UploadingFiles": "Caricamento file...",
+    "VFolder": "Cartella",
     "ValueRequired": "ValoreRichiesto"
   },
   "general": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -651,17 +651,18 @@
     "Title": "エラーが発生しました。"
   },
   "explorer": {
-    "FileInProgress": "'{{fileName}}'のアップロード...",
     "FileUploadCancelled": "ファイルのアップロードは、ユーザーリクエストによってキャンセルされました。",
     "FileUploadFailed": "Folder '{{folderName}}'にいくつかのファイルをアップロードできませんでした。",
+    "Filename": "ファイル名",
     "FolderNotFoundOrNoAccess": "フォルダーが見つかりませんまたはアクセスが拒否されません",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "管理されていないフォルダーは、ファイルエクスプローラーをサポートしていません。",
     "NoPermissions": "このフォルダーにアクセスする権限はありません",
     "ProcessingUpload": "ファイルがアップロードされています。\nお待ちください。",
-    "SuccessfullyUploadedToFolder": "FilesがFolder '{{folderName}}'に正常にアップロードされました '",
+    "SuccessfullyUploadedToFolder": "ファイルは正常にアップロードされました。",
     "UploadFailed": "'{{folderName}}'で故障したアップロード",
-    "UploadToFolder": "'{{folderName}}にアップロードする",
+    "UploadingFiles": "ファイルをアップロードしています...",
+    "VFolder": "フォルダ",
     "ValueRequired": "ValueRequired"
   },
   "general": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -654,17 +654,18 @@
     "Title": "에러가 발생했습니다."
   },
   "explorer": {
-    "FileInProgress": "'{{fileName}}' 파일 업로드 중...",
     "FileUploadCancelled": "사용자 요청에 따라 파일 업로드가 취소되었습니다.",
     "FileUploadFailed": "'{{folderName}}' 폴더에서 일부 파일 업로드에 실패했습니다. ",
+    "Filename": "파일 이름",
     "FolderNotFoundOrNoAccess": "존재하지 않거나 접근할 수 없는 폴더입니다.",
     "InputTooShort": "입력값이 너무 짧습니다.",
     "NoExplorerSupportForUnmanagedFolder": "Unmanaged 폴더는 파일 탐색기를 지원하지 않습니다.",
     "NoPermissions": "이 폴더에 접근할 권한이 없습니다",
     "ProcessingUpload": "파일을 업로드하는 중입니다. 잠시만 기다려주세요.",
-    "SuccessfullyUploadedToFolder": "'{{folderName}}' 폴더에 파일 업로드가 완료되었습니다. ",
+    "SuccessfullyUploadedToFolder": "파일 업로드가 완료되었습니다. ",
     "UploadFailed": "'{{folderName}}'에 업로드 실패",
-    "UploadToFolder": "'{{folderName}}'에 업로드 중",
+    "UploadingFiles": "파일 업로드 중...",
+    "VFolder": "폴더",
     "ValueRequired": "값이 필요합니다."
   },
   "general": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -650,17 +650,18 @@
     "Title": "Алдаа гарсан байна."
   },
   "explorer": {
-    "FileInProgress": "Файлуудыг '{{fileName}}}' ...",
     "FileUploadCancelled": "Файлын байршуулалтыг хэрэглэгчийн хүсэлтээр цуцлагдсан.",
     "FileUploadFailed": "'{{folderName}}' Файлд файл байршуулж чадсангүй.",
+    "Filename": "Хөдөлгөөний нэр",
     "FolderNotFoundOrNoAccess": "Фолдер олдсонгүй эсвэл хандалтыг үгүйсгэв",
     "InputTooShort": "Хэт богино байна",
     "NoExplorerSupportForUnmanagedFolder": "НҮБ-нээгүй хавтас нь файлын Explorer-ийг дэмждэггүй.",
     "NoPermissions": "Энэ хавтсанд нэвтрэх зөвшөөрөл байхгүй байна",
     "ProcessingUpload": "Таны файлыг байршуулж байна. \nТүр хүлээнэ үү",
-    "SuccessfullyUploadedToFolder": "Файлууд '{{folderName}}' хавтасанд амжилттай байршуулсан файлууд.",
+    "SuccessfullyUploadedToFolder": "Файлуудыг амжилттай байршуулсан.",
     "UploadFailed": "'{{folderName}} -д бүтэлгүйтсэн.",
-    "UploadToFolder": "'{{folderName}}' руу байршуулж байна.",
+    "UploadingFiles": "Файл байршуулах ...",
+    "VFolder": "Хавтас",
     "ValueRequired": "Утга Шаардлагатай"
   },
   "general": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -651,17 +651,18 @@
     "Title": "Ralat telah berlaku."
   },
   "explorer": {
-    "FileInProgress": "Memuat naik '{{fileName}}' ...",
     "FileUploadCancelled": "Muat naik fail dibatalkan oleh permintaan pengguna.",
     "FileUploadFailed": "Gagal memuat naik beberapa fail dalam folder '{{folderName}}'.",
+    "Filename": "Nama fail",
     "FolderNotFoundOrNoAccess": "Folder tidak dijumpai atau akses ditolak",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Folder yang tidak dikendalikan tidak menyokong penjelajah fail.",
     "NoPermissions": "Tiada kebenaran untuk mengakses folder ini",
     "ProcessingUpload": "Fail anda sedang dimuat naik. \nTolong tunggu.",
-    "SuccessfullyUploadedToFolder": "Fail yang dimuat naik dengan jayanya dalam folder '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "Fail dimuat naik dengan jayanya.",
     "UploadFailed": "Muat naik gagal dalam '{{folderName}}'",
-    "UploadToFolder": "Memuat naik ke '{{folderName}}'",
+    "UploadingFiles": "Memuat naik fail ...",
+    "VFolder": "Folder",
     "ValueRequired": "Nilai Diperlukan"
   },
   "general": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -652,16 +652,17 @@
     "Title": "Wystąpił błąd."
   },
   "explorer": {
-    "FileInProgress": "Przesyłanie „{{fileName}}” ...",
     "FileUploadCancelled": "Przesłanie pliku zostało anulowane na żądanie użytkownika.",
     "FileUploadFailed": "Nie udało się przesłać niektórych plików w folderze „{{folderName}}”.",
+    "Filename": "Nazwa pliku",
     "FolderNotFoundOrNoAccess": "Folder nie został znaleziony ani nie ma dostępu",
     "InputTooShort": "Wejście zbyt krótkie",
     "NoExplorerSupportForUnmanagedFolder": "Foldery niezarządzane nie obsługują eksploratora plików.",
     "ProcessingUpload": "Twój plik jest przesyłany. \nProszę poczekaj.",
-    "SuccessfullyUploadedToFolder": "Pliki przesłane pomyślnie w folderze '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "Pliki przesłane pomyślnie.",
     "UploadFailed": "Przesyłanie nie powiodło się w '{{folderName}}' '",
-    "UploadToFolder": "Przesyłanie do „{{folderName}}”",
+    "UploadingFiles": "Przesyłanie plików...",
+    "VFolder": "Falcówka",
     "ValueRequired": "Wymagana wartość"
   },
   "general": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -652,17 +652,18 @@
     "Title": "Ocorreu um erro."
   },
   "explorer": {
-    "FileInProgress": "Upload '{{fileName}}' ...",
     "FileUploadCancelled": "O upload do arquivo foi cancelado por solicitação do usuário.",
     "FileUploadFailed": "Falha ao fazer upload de alguns arquivos na pasta '{{folderName}}'.",
+    "Filename": "Nome do arquivo",
     "FolderNotFoundOrNoAccess": "Pasta não encontrada ou acesso negado",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Pastas não gerenciadas não suportam o File Explorer.",
     "NoPermissions": "Sem permissões para acessar esta pasta",
     "ProcessingUpload": "Seu arquivo está sendo carregado. \nPor favor, aguarde.",
-    "SuccessfullyUploadedToFolder": "Arquivos enviados com sucesso na pasta '{{folderName}}''",
+    "SuccessfullyUploadedToFolder": "Arquivos enviados com sucesso.",
     "UploadFailed": "O upload falhou em '{{folderName}}'",
-    "UploadToFolder": "Upload para '{{folderName}}'",
+    "UploadingFiles": "Fazendo upload de arquivos...",
+    "VFolder": "Pasta",
     "ValueRequired": "ValueRequired"
   },
   "general": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -652,17 +652,18 @@
     "Title": "Ocorreu um erro."
   },
   "explorer": {
-    "FileInProgress": "Upload '{{fileName}}' ...",
     "FileUploadCancelled": "O upload do arquivo foi cancelado por solicitação do usuário.",
     "FileUploadFailed": "Falha ao fazer upload de alguns arquivos na pasta '{{folderName}}'.",
+    "Filename": "Nome do arquivo",
     "FolderNotFoundOrNoAccess": "Pasta não encontrada ou acesso negado",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Pastas não gerenciadas não suportam o File Explorer.",
     "NoPermissions": "Sem permissões para acessar esta pasta",
     "ProcessingUpload": "Seu arquivo está sendo carregado. \nPor favor, aguarde.",
-    "SuccessfullyUploadedToFolder": "Arquivos enviados com sucesso na pasta '{{folderName}}''",
+    "SuccessfullyUploadedToFolder": "Arquivos enviados com sucesso.",
     "UploadFailed": "O upload falhou em '{{folderName}}'",
-    "UploadToFolder": "Upload para '{{folderName}}'",
+    "UploadingFiles": "Fazendo upload de arquivos...",
+    "VFolder": "Pasta",
     "ValueRequired": "ValueRequired"
   },
   "general": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -652,16 +652,17 @@
     "Title": "Произошла ошибка."
   },
   "explorer": {
-    "FileInProgress": "Загрузка '{{fileName}}' ...",
     "FileUploadCancelled": "Загрузка файла была отменена пользовательским запросом.",
     "FileUploadFailed": "Не удалось загрузить некоторые файлы в папке '{{folderName}}'.",
+    "Filename": "Имя файла",
     "FolderNotFoundOrNoAccess": "Папка не найдена или доступа отказана",
     "InputTooShort": "ВводОченьКороток",
     "NoExplorerSupportForUnmanagedFolder": "Неуправляемые папки не поддерживают исследователь файлов.",
     "ProcessingUpload": "Ваш файл загружается. \nПожалуйста, подождите.",
-    "SuccessfullyUploadedToFolder": "Файлы успешно загружены в папке '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "Файлы успешно загружены.",
     "UploadFailed": "Загрузка не удалась в '{{folderName}}'",
-    "UploadToFolder": "Загрузка на '{{folderName}}'",
+    "UploadingFiles": "Загрузка файлов...",
+    "VFolder": "Папка",
     "ValueRequired": "НужноЗначение"
   },
   "general": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -641,17 +641,18 @@
     "Title": "เกิดข้อผิดพลาด"
   },
   "explorer": {
-    "FileInProgress": "การอัปโหลด '{{fileName}}' ...",
     "FileUploadCancelled": "การอัปโหลดไฟล์ถูกยกเลิกโดยคำขอผู้ใช้",
     "FileUploadFailed": "ไม่สามารถอัปโหลดไฟล์บางไฟล์ในโฟลเดอร์ '{{folderName}}'",
+    "Filename": "ชื่อไฟล์",
     "FolderNotFoundOrNoAccess": "ไม่พบโฟลเดอร์หรือถูกปฏิเสธการเข้าถึง",
     "InputTooShort": "ข้อมูลที่ป้อนสั้นเกินไป",
     "NoExplorerSupportForUnmanagedFolder": "โฟลเดอร์ที่ไม่มีการจัดการไม่รองรับ File Explorer",
     "NoPermissions": "ไม่มีสิทธิ์ในการเข้าถึงโฟลเดอร์นี้",
     "ProcessingUpload": "ไฟล์ของคุณกำลังถูกอัปโหลด \nโปรดรอ.",
-    "SuccessfullyUploadedToFolder": "ไฟล์อัปโหลดสำเร็จในโฟลเดอร์ '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "อัปโหลดไฟล์เรียบร้อยแล้ว",
     "UploadFailed": "การอัปโหลดล้มเหลวใน '{{folderName}}'",
-    "UploadToFolder": "การอัปโหลดไปยัง '{{folderName}}'",
+    "UploadingFiles": "กำลังอัพโหลดไฟล์...",
+    "VFolder": "โฟลเดอร์",
     "ValueRequired": "ต้องระบุค่า"
   },
   "general": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -652,17 +652,18 @@
     "Title": "Bir hata oluştu."
   },
   "explorer": {
-    "FileInProgress": "'{{fileName}}' yükleme ...",
     "FileUploadCancelled": "Dosya yükleme kullanıcı isteği ile iptal edildi.",
     "FileUploadFailed": "Bazı dosyaları '{{{folderName}}' klasörüne yükleyemedi.",
+    "Filename": "Dosya adı",
     "FolderNotFoundOrNoAccess": "Klasör bulunamadı veya erişim reddedildi",
     "InputTooShort": "GirişÇok Kısa",
     "NoExplorerSupportForUnmanagedFolder": "Yönetilmeyen klasörler Dosya Gezgini'ni desteklemez.",
     "NoPermissions": "Bu klasöre erişmek için izin yok",
     "ProcessingUpload": "Dosyanız yükleniyor. \nLütfen bekleyin.",
-    "SuccessfullyUploadedToFolder": "Dosyalar '{{folderName}}' klasörüne başarıyla yüklendi",
+    "SuccessfullyUploadedToFolder": "Dosyalar başarıyla yüklendi.",
     "UploadFailed": "Yükleme başarısız oldu '{{folderName}}'",
-    "UploadToFolder": "'{{folderName}}' adresine yükleme",
+    "UploadingFiles": "Dosyalar yükleniyor...",
+    "VFolder": "Dosya",
     "ValueRequired": "DeğerGerekli"
   },
   "general": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -652,17 +652,18 @@
     "Title": "Một lỗi đã xảy ra."
   },
   "explorer": {
-    "FileInProgress": "Tải lên '{{fileName}}' ...",
     "FileUploadCancelled": "Tải lên tệp đã bị hủy bởi yêu cầu người dùng.",
     "FileUploadFailed": "Không thể tải lên một số tệp trong thư mục '{{folderName}}'.",
+    "Filename": "Tên tệp",
     "FolderNotFoundOrNoAccess": "Thư mục không tìm thấy hoặc truy cập bị từ chối",
     "InputTooShort": "InputTooShort",
     "NoExplorerSupportForUnmanagedFolder": "Các thư mục không được quản lý không hỗ trợ trình thám hiểm tệp.",
     "NoPermissions": "Không có quyền truy cập thư mục này",
     "ProcessingUpload": "Tệp của bạn đang được tải lên. \nVui lòng chờ.",
-    "SuccessfullyUploadedToFolder": "Các tệp được tải lên thành công trong thư mục '{{folderName}}'",
+    "SuccessfullyUploadedToFolder": "Các tập tin được tải lên thành công.",
     "UploadFailed": "Tải lên không thành công trong '{{folderName}}'",
-    "UploadToFolder": "Tải lên '{{folderName}}'",
+    "UploadingFiles": "Đang tải tệp lên...",
+    "VFolder": "Thư mục",
     "ValueRequired": "Giá trị bắt buộc"
   },
   "general": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -652,17 +652,18 @@
     "Title": "发生错误。"
   },
   "explorer": {
-    "FileInProgress": "上传'{{fileName}}'...",
     "FileUploadCancelled": "文件上传已通过用户请求取消。",
     "FileUploadFailed": "无法将某些文件上传到文件夹'{{folderName}}'中。",
+    "Filename": "文件名",
     "FolderNotFoundOrNoAccess": "未找到或拒绝访问的文件夹",
     "InputTooShort": "输入太短",
     "NoExplorerSupportForUnmanagedFolder": "未管理的文件夹不支持文件资源管理器。",
     "NoPermissions": "无权访问此文件夹",
     "ProcessingUpload": "您的文件正在上传。\n请稍等。",
-    "SuccessfullyUploadedToFolder": "文件在文件夹'{{folderName}}'中成功上传",
+    "SuccessfullyUploadedToFolder": "文件上传成功。",
     "UploadFailed": "上传失败在'{{folderName}}'中",
-    "UploadToFolder": "上传到'{{folderName}}'",
+    "UploadingFiles": "正在上传文件...",
+    "VFolder": "文件夹",
     "ValueRequired": "需要值"
   },
   "general": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -652,16 +652,17 @@
     "Title": "发生错误。"
   },
   "explorer": {
-    "FileInProgress": "上傳'{{fileName}}'...",
     "FileUploadCancelled": "文件上傳已通過用戶請求取消。",
     "FileUploadFailed": "無法將某些文件上傳到文件夾'{{folderName}}'中。",
+    "Filename": "文件名",
     "FolderNotFoundOrNoAccess": "未找到或拒絕訪問的文件夾",
     "InputTooShort": "輸入太短",
     "NoExplorerSupportForUnmanagedFolder": "未管理的文件夾不支持文件資源管理器。",
     "ProcessingUpload": "您的文件正在上傳。請稍等。",
-    "SuccessfullyUploadedToFolder": "文件在文件夾'{{folderName}}'中成功上傳",
+    "SuccessfullyUploadedToFolder": "文件上傳成功。",
     "UploadFailed": "上傳失敗在'{{folderName}}'中",
-    "UploadToFolder": "上傳到'{{folderName}}'",
+    "UploadingFiles": "正在上傳文件...",
+    "VFolder": "文件夾",
     "ValueRequired": "需要值"
   },
   "general": {


### PR DESCRIPTION
Resolves #4316 ([FR-1501](https://lablup.atlassian.net/browse/FR-1501))

## Changes

Fixes file upload status tracking and progress  calculation issues, particularly for concurrent  uploads. Refactored the upload state management to  properly track upload progress using bytes instead of  just file counts.

### Key Changes

1. Enhanced State Management Structure

  2. Fixed Progress Calculation

  - Problem: Progress was only tracked by file count, not actual bytes uploaded
  - Solution:
    - Added completedBytes to track actual upload progress
    - Added totalExpectedSize for accurate percentage calculation
    - Progress now shows: completedBytes /  totalExpectedSize * 100

  3.  Fixed Cumulative Bytes Issue

  - Problem: onProgress callback provides cumulative bytesUploaded, not incremental
  - Solution: Calculate delta bytes for each progress update
```
  let previousBytesUploaded = 0;
  const deltaBytes = bytesUploaded - previousBytesUploaded;
  previousBytesUploaded = bytesUploaded;
```

4. Improved Concurrent Upload Handling

  - Problem: When starting new uploads while others are in progress, total size wasn't properly accumulated
  - Solution:
    - totalExpectedSize accumulates across all upload requests
    - All progress callbacks reference the same total from state
    - Proper reset when all uploads complete

  5. Better Upload Status Notifications

  - Progress notifications now show both file count and byte-based percentage
  - More accurate progress tracking during uploads
  - Proper cleanup of state after completion

  Testing

  - Single file upload progress tracking
  - Multiple files upload (folder) progress tracking
  - Concurrent uploads (starting new upload while another
   is in progress)
  - Upload failure handling
  - Progress percentage accuracy

  Technical Details

  The main issue was that the original implementation only tracked file names without considering actual bytes uploaded. This led to inaccurate progress reporting, especially for files of varying sizes. The new implementation:

  1. Tracks both file counts and bytes for comprehensive progress reporting
  2. Properly handles cumulative vs incremental byte reporting from the TUS upload library
  3. Maintains a single source of truth (totalExpectedSize) for all concurrent uploads
  4. Correctly accumulates sizes when new uploads are added

**Checklist:**

- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [x] Test case: Upload multiple files and verify status tracking works correctly

[FR-1501]: https://lablup.atlassian.net/browse/FR-1501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ