### PR TITLE
feat(FR-1426): conditionally show terminal guide based on copy feature support

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -1548,7 +1548,9 @@ export default class BackendAiAppLauncher extends BackendAIPage {
    * Open a guide for terminal
    */
   _openTerminalGuideDialog() {
-    this.terminalGuideDialog.show();
+    if (!globalThis.backendaiclient.supports('copy-on-terminal')) {
+      this.terminalGuideDialog.show();
+    }
   }
 
   /**

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -813,13 +813,14 @@ class Client {
     }
     if (this.isManagerVersionCompatibleWith('25.12.0')) {
       this._features['mount-by-id'] = true;
+      this._features['reservoir'] = true;
     }
     if (this.isManagerVersionCompatibleWith('25.13.0')) {
       this._features['pending-session-list'] = true;
       this._features['endpoint-lifecycle-ready-stage'] = true;
     }
-    if (this.isManagerVersionCompatibleWith('25.12.0')) {
-      this._features['reservoir'] = true;
+    if (this.isManagerVersionCompatibleWith('25.13.2')) {
+      this._features['copy-on-terminal'] = true;
     }
     if (this.isManagerVersionCompatibleWith('25.15.0')) {
       this._features['agent-stats'] = true;


### PR DESCRIPTION
Resolves #4220 ([FR-1426](https://lablup.atlassian.net/browse/FR-1426))

## Changes

This PR implements conditional display of the terminal guide dialog based on the new copy-on-terminal feature support.

### Key Changes

1. **Added copy-on-terminal feature flag**
   - New feature flag for manager version 25.13.2+
   - Indicates support for clipboard copy via mouse selection in tmux

2. **Conditional terminal guide display**
   - Terminal guide dialog now only shows when `copy-on-terminal` feature is NOT supported
   - Provides backward compatibility for older manager versions
   - Improves UX by removing unnecessary popup when copy feature is available

3. **Code organization**
   - Moved `reservoir` feature flag to correct version section (25.12.0)

### Files Changed
- `src/components/backend-ai-app-launcher.ts` - Conditional terminal guide dialog display
- `src/lib/backend.ai-client-esm.ts` - Added feature flags for version compatibility

### Background
With the new copy-on-terminal feature (manager v25.13.2+), users can copy text by simply selecting it with the mouse when tmux mouse setting is enabled. This makes the terminal guide popup unnecessary for newer versions.

**Checklist:**

- [ ] Documentation
- [ ] Minimum required manager version: 25.13.2 for copy-on-terminal feature
- [ ] Specific setting for review: Test with both old and new manager versions
- [ ] Minimum requirements to check during review: Verify guide shows only on older versions
- [x] Test case: Terminal guide should not appear with manager v25.13.2+, should appear with older versions

[FR-1426]: https://lablup.atlassian.net/browse/FR-1426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ