### PR TITLE
feat(FR-1480): display cluster mode in session detail panel

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAISessionClusterMode.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionClusterMode.tsx
@@ -1,5 +1,5 @@
 import { BAISessionClusterModeFragment$key } from '../../__generated__/BAISessionClusterModeFragment.graphql';
-import { Typography } from 'antd';
+import { Tag, theme, Typography } from 'antd';
 import _ from 'lodash';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -7,12 +7,17 @@ import { useFragment, graphql } from 'react-relay';
 
 export interface BAISessionClusterModeProps {
   sessionFrgmt: BAISessionClusterModeFragment$key;
+  showSize?: boolean;
+  mode?: 'text' | 'tag';
 }
 
 const BAISessionClusterMode: React.FC<BAISessionClusterModeProps> = ({
   sessionFrgmt,
+  showSize = true,
+  mode = 'text',
 }) => {
   const { t } = useTranslation();
+  const { token } = theme.useToken();
   const session = useFragment(
     graphql`
       fragment BAISessionClusterModeFragment on ComputeSessionNode {
@@ -31,13 +36,35 @@ const BAISessionClusterMode: React.FC<BAISessionClusterModeProps> = ({
     : _.startsWith(session.cluster_mode?.toUpperCase() || '', 'MULTI')
       ? t('comp:BAISessionClusterMode.MultiNodeShort')
       : '-';
-  return (
+  return mode === 'text' ? (
     <Typography.Text>
-      {modeTitle}&nbsp;
-      <Typography.Text type="secondary">
-        ({session.cluster_size})
-      </Typography.Text>
+      {modeTitle}
+      {showSize && (
+        <>
+          &nbsp;
+          <Typography.Text type="secondary">
+            ({session.cluster_size})
+          </Typography.Text>
+        </>
+      )}
     </Typography.Text>
+  ) : (
+    <Tag>
+      {modeTitle}
+      {showSize && (
+        <>
+          &nbsp;
+          <Typography.Text
+            type="secondary"
+            style={{
+              fontSize: token.fontSizeSM,
+            }}
+          >
+            ({session.cluster_size})
+          </Typography.Text>
+        </>
+      )}
+    </Tag>
   );
 };
 

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -41,6 +41,7 @@ import {
   useMemoizedJSONParse,
   BAIFlex,
   BAISessionAgentIds,
+  BAISessionClusterMode,
 } from 'backend.ai-ui';
 // import { graphql } from 'react-relay';
 import _ from 'lodash';
@@ -176,6 +177,7 @@ const SessionDetailContent: React.FC<{
         ...AppLauncherModalFragment
         ...MountedVFolderLinksFragment
         ...BAISessionAgentIdsFragment
+        ...BAISessionClusterModeFragment
       }
     `,
     (internalLoadedSession as SessionDetailContentFragment$key) || sessionFrgmt,
@@ -319,10 +321,13 @@ const SessionDetailContent: React.FC<{
           <Descriptions.Item label={t('session.Agent')}>
             <BAISessionAgentIds sessionFrgmt={session} />
           </Descriptions.Item>
-          <Descriptions.Item label={t('session.Reservation')} span={md ? 2 : 1}>
+          <Descriptions.Item label={t('session.Reservation')}>
             <BAIFlex gap={'xs'} wrap={'wrap'}>
               <SessionReservation sessionFrgmt={session} />
             </BAIFlex>
+          </Descriptions.Item>
+          <Descriptions.Item label={t('session.ClusterMode')}>
+            <BAISessionClusterMode sessionFrgmt={session} showSize />
           </Descriptions.Item>
           {baiClient.supports('idle-checks-gql') &&
           session.status === 'RUNNING' &&


### PR DESCRIPTION
Resolves #4290 ([FR-1480](https://lablup.atlassian.net/browse/FR-1480))

## Summary

This PR improves the session detail panel to clearly display the cluster mode (single-node vs multi-node), addressing the issue where users mistakenly created single-node sessions when they intended to create multi-node sessions.

## Changes

- Enhanced `BAISessionClusterMode` component with new props:
  - `showSize`: Optional prop to control whether cluster size is displayed (default: true)
  - `display`: Optional prop to render as 'text' or 'tag' format (default: 'text')
  
- Updated `SessionDetailContent` to display cluster mode as a tag in the Agent section, making it visually prominent and easy to identify

|||
|---|---|
|![image.png](https://app.graphite.dev/user-attachments/assets/66962165-69c1-4604-8790-7dbeca46f399.png)|![image.png](https://app.graphite.dev/user-attachments/assets/5fbd4572-c07a-4d8d-824e-a5eb7f72e085.png)|

## Impact

Users can now clearly see at a glance whether a session is single-node or multi-node in the session detail panel, reducing confusion and mistakes when creating sessions.

**Checklist:**

- [x] Code changes align with acceptance criteria
- [x] UI changes improve clarity and user experience
- [ ] Documentation (if needed)
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1480]: https://lablup.atlassian.net/browse/FR-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ