### PR TITLE
feat(FR-1572): improve keyboard interaction and focus management for editable name components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,5 @@ CLAUDE.local.md
 # ignore merged schema
 data/merged_schema.graphql
 
-# webui release download temp directories
-temp-webui-*
-backend.ai-webui-bundle-*.zip
+# webui release download temp directories (safe to delete)
+scripts/temp-releases/

--- a/react/src/components/FolderExplorerModal.tsx
+++ b/react/src/components/FolderExplorerModal.tsx
@@ -150,6 +150,7 @@ const FolderExplorerModal: React.FC<FolderExplorerProps> = ({
       className={styles.baiModalHeader}
       width={'90%'}
       centered
+      keyboard
       destroyOnHidden
       footer={null}
       title={


### PR DESCRIPTION
Resolves #4420 ([FR-1572](https://lablup.atlassian.net/browse/FR-1572))

## Summary
This PR improves keyboard interaction and focus management for editable name components in the session detail drawer and folder explorer modal.

## Changes
- Added focus management using useRef and focus fallback functions to EditableFileName, EditableSessionName, and EditableVFolderName components
- Implemented event.stopPropagation() for ESC key during editing to prevent modal closing
- Added proper tabIndex and focus handling after editing completes
- Enabled keyboard modal closing (keyboard prop) for FolderExplorer modal
- Added 'use memo' directive for React compiler optimization

## Technical Details
- When editing name fields, ESC key now cancels editing without closing the parent modal/drawer
- After editing completes (either by confirmation or cancellation), focus returns to the text element with proper tabIndex
- This ensures ESC key can properly close modals when not in editing mode
- All editable name components now have consistent keyboard interaction behavior

## Testing
- Test editing names in session detail drawer - ESC should cancel editing without closing drawer
- Test editing names in folder explorer modal - ESC should cancel editing without closing modal  
- After editing, ESC should properly close the modal/drawer
- Verify focus management works correctly when switching between editing and view modes

[FR-1572]: https://lablup.atlassian.net/browse/FR-1572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ