### PR TITLE
feat(FR-1575): merge admin dashboard into user dashboard

### DIFF
--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -260,18 +260,19 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
   ]);
 
   const adminMenu: MenuProps['items'] = filterOutEmpty([
+    // TODO: Enable the menu item when the page is ready.
     // WARN: Currently only superadmins can access AdminDashboardPage.
     // To place the Admin Dashboard menu item at the top of adminMenu,
     // add it to adminMenu instead of superAdminMenu:
-    currentUserRole === 'superadmin' && {
-      label: (
-        <WebUILink to="/admin-dashboard">
-          {t('webui.menu.AdminDashboard')}
-        </WebUILink>
-      ),
-      icon: <DashboardOutlined style={{ color: token.colorInfo }} />,
-      key: 'admin-dashboard',
-    },
+    // currentUserRole === 'superadmin' && {
+    //   label: (
+    //     <WebUILink to="/admin-dashboard">
+    //       {t('webui.menu.AdminDashboard')}
+    //     </WebUILink>
+    //   ),
+    //   icon: <DashboardOutlined style={{ color: token.colorInfo }} />,
+    //   key: 'admin-dashboard',
+    // },
     {
       label: <WebUILink to="/credential">{t('webui.menu.Users')}</WebUILink>,
       icon: <UserOutlined style={{ color: token.colorInfo }} />,


### PR DESCRIPTION
Resolves #4424 ([FR-1575](https://lablup.atlassian.net/browse/FR-1575))

# Disable Admin Dashboard Menu Item and Enhance Dashboard Page for Superadmins

This PR temporarily disables the Admin Dashboard menu item with a TODO comment to re-enable it when the page is ready. It also enhances the Dashboard page for superadmins by:

1. Renaming "My Sessions" to "Active Sessions" for superadmins
2. Adding Agent Stats component for superadmins when supported by the backend
3. Adding Active Agents component for superadmins

These changes provide superadmins with a more comprehensive view of system activity directly from the dashboard.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1575]: https://lablup.atlassian.net/browse/FR-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ