### PR TITLE
feat(FR-1329): add a github action for regression test

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,127 @@
+# .github/workflows/playwright.yml
+name: Playwright Tests
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: "ubuntu-latest"
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        lts:
+          - name: "main"
+            apiEndpoint: "https://19d3c8.poc.isla-sorna.backend.ai/"
+          - name: "v25.15" # Please update according to the latest LTS versions
+            apiEndpoint: "https://99dfef.poc.isla-sorna.backend.ai/"
+
+    name: E2E Playwright Tests for LTS ${{ matrix.lts.name }}
+    env:
+      E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
+      E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
+      E2E_USER2_PASSWORD: ${{ secrets.E2E_USER2_PASSWORD }}
+      E2E_MONITOR_PASSWORD: ${{ secrets.E2E_MONITOR_PASSWORD }}
+      E2E_DOMAIN_ADMIN_PASSWORD: ${{ secrets.E2E_DOMAIN_ADMIN_PASSWORD }}
+      E2E_API_ENDPOINT: ${{ matrix.lts.apiEndpoint }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: latest
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        name: Install Node.js
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright Browsers
+        run: pnpm exec playwright install --with-deps
+
+      - name: Copy config.toml.sample to config.toml
+        run: |
+          awk '
+            /^[[:space:]]*$/ { next }
+            /^\[.*\]$/ { if (n++) print ""; print; next }
+            /^[[:space:]]*#[^=]/ { print; next }
+            {
+              line = $0
+              sub(/#.*/, "", line)
+              sub(/[[:space:]]+$/, "", line)
+              if (line != "") print line
+            }
+          ' config.toml.sample > config-cleaned.toml
+
+      - name: Inject apiEndpoint and allowChangeSigninMode into config.toml
+        run: |
+          EP="${{ matrix.lts.apiEndpoint }}"
+          awk -v ep="$EP" '
+            {
+              if ($0 ~ /^apiEndpoint[[:space:]]*=/) {
+                print "apiEndpoint = \"" ep "\""
+              } else if ($0 ~ /^allowChangeSigninMode[[:space:]]*=/) {
+                print "allowChangeSigninMode = true"
+              } else {
+                print
+              }
+            }
+          ' config-cleaned.toml > config.toml
+
+      # - name: Upload config.toml artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: config-toml-${{ matrix.lts.name }}
+      #     path: config.toml
+
+      - name: Build project
+        run: pnpm run build
+
+      - name: Serve build at port 9081 (background)
+        run: |
+          pnpm server:p -s -l 9081 > /dev/null 2>&1 &
+          echo "Waiting for server to start..."
+          for i in {1..30}; do
+            if curl -s http://127.0.0.1:9081 > /dev/null; then
+              echo "Server is up!"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Run Playwright Tests
+        run: pnpm playwright test
+
+      - name: Upload HTML report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.lts.name }}
+          path: playwright-report/

--- a/e2e/login.test.ts
+++ b/e2e/login.test.ts
@@ -1,7 +1,6 @@
 import {
-  login,
   loginAsAdmin,
-  userInfo,
+  getUserInfo,
   webServerEndpoint,
 } from './utils/test-util';
 import { test, expect } from '@playwright/test';
@@ -53,10 +52,10 @@ test.describe('Login failure cases', () => {
   test('should display error message for incorrect password', async ({
     page,
   }) => {
-    await page.getByLabel('Email or Username').fill(userInfo.admin.email);
+    await page.getByLabel('Email or Username').fill(getUserInfo().admin.email);
     await page
       .getByRole('textbox', { name: 'Password' })
-      .fill(userInfo.admin.password + 'wrong');
+      .fill(getUserInfo().admin.password + 'wrong');
     await page
       .getByRole('textbox', { name: 'Endpoint' })
       .fill(webServerEndpoint);

--- a/e2e/vfolder.test.ts
+++ b/e2e/vfolder.test.ts
@@ -8,7 +8,7 @@ import {
   moveToTrashAndVerify,
   restoreVFolderAndVerify,
   shareVFolderAndVerify,
-  userInfo,
+  getUserInfo,
 } from './utils/test-util';
 import { test, expect } from '@playwright/test';
 
@@ -132,7 +132,11 @@ test.describe('VFolder sharing', () => {
   });
 
   test('User can share vFolder', async ({ page, browser }) => {
-    await shareVFolderAndVerify(page, sharingFolderName, userInfo.user2.email);
+    await shareVFolderAndVerify(
+      page,
+      sharingFolderName,
+      getUserInfo().user2.email,
+    );
     const user2_page = await browser.newPage();
     await loginAsUser2(user2_page);
     await acceptAllInvitationAndVerifySpecificFolder(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  // workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI
     ? [["html", { open: "never" }], ["github"]]
@@ -74,9 +74,11 @@ export default defineConfig({
     // },
   ],
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  // webServer: process.env.CI
+  //   ? {
+  //       command: "pnpm run server:p -s -l 9081",
+  //       url: "http://127.0.0.1:9081",
+  //       timeout: 1000 * 60 * 5,
+  //     }
+  //   : undefined,
 });

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -2139,6 +2139,7 @@ export default class BackendAILogin extends BackendAIPage {
               ? html`
                   <div
                     id="change-signin-area"
+                    data-testid="change-login-mode-button"
                     class="vertical center-justified layout"
                     style="flex: 1; text-align: right;"
                   >

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,11 @@
     "lib": ["es6", "dom", "es2016", "es2017", "es2020"],
     "preserveWatchOutput": true
   },
-  "include": ["src/components/*", "src/plugins/*", "src/reducers/*", "src/*"]
+  "include": [
+    "src/components/*",
+    "src/plugins/*",
+    "src/reducers/*",
+    "src/*",
+    "playwright.config.ts"
+  ]
 }


### PR DESCRIPTION
# Add E2E Testing with Playwright for CI

This PR adds end-to-end testing capabilities using Playwright that run automatically on pull requests. The implementation:

- Creates a new GitHub workflow for running Playwright tests against different LTS versions
- Enhances the login utility to support different sign-in modes
- Configures Playwright to work properly in CI environments
- Adds a helper function to switch between IAM and ID sign-in modes
- Updates the login component with a data-testid attribute for better test targeting
- Adjusts timeout and reporter settings for CI compatibility

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after