### PR TITLE
feat(FR-1579): add customizable sorting for image environment groups

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -273,6 +273,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
         .map((images, groupName) => {
           return {
             groupName,
+            groupSortKey: metadata?.groupSortKeyMap?.[groupName] || groupName,
             environmentGroups: _.chain(images)
               // sub group by using (environment) `name` property of image info
               .groupBy((image) => {
@@ -288,13 +289,12 @@ const ImageEnvironmentSelectFormItems: React.FC<
               .map((images, environmentName) => {
                 const imageKey = environmentName.split('/')?.[2];
                 const displayName =
-                  imageKey && metadata?.imageInfo[imageKey]?.name;
+                  (imageKey && metadata?.imageInfo[imageKey]?.name) ||
+                  (_.last(environmentName.split('/')) as string);
 
                 return {
                   environmentName,
-                  displayName:
-                    displayName ||
-                    (_.last(environmentName.split('/')) as string),
+                  displayName,
                   prefix: _.chain(environmentName)
                     .split('/')
                     .drop(1)
@@ -316,7 +316,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
               .value(),
           };
         })
-        .sortBy((item) => item.groupName)
+        .sortBy((item) => item.groupSortKey)
         .value(),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [images, metadata, filter, showPrivate],

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -343,6 +343,7 @@ export const useBackendAIImageMetaData = () => {
     tagReplace: {
       [key: string]: string;
     };
+    groupSortKeyMap?: { [key: string]: string };
   }>({
     queryKey: ['backendai-metadata-for-suspense'],
     queryFn: () => {

--- a/resources/image_metadata.json
+++ b/resources/image_metadata.json
@@ -1,6 +1,7 @@
 {
+  "$schema": "./image_metadata.schema.json",
   "imageInfo": {
-	  "rbln-ubuntu": {
+    "rbln-ubuntu": {
       "name": "Rebellions Ubuntu",
       "description": "Rebellions Ubuntu is a basic image for Rebellions NPU.",
       "group": "NPU",
@@ -860,9 +861,9 @@
     "python": "Python",
     "tensorflow": "TensorFlow",
     "pytorch": "PyTorch",
-    "pytorch2.1":"PyTorch 2.1",
-    "pytorch2.0":"PyTorch 2.0",
-    "pytorch2.2":"PyTorch 2.2",
+    "pytorch2.1": "PyTorch 2.1",
+    "pytorch2.0": "PyTorch 2.0",
+    "pytorch2.2": "PyTorch 2.2",
     "lua": "Lua",
     "r": "R",
     "r-base": "R",
@@ -986,5 +987,8 @@
     "^gromacs*$": "GROMACS",
     "^(customized)_.*$": "Customized",
     "^(-_)$": " "
+  },
+  "groupSortKeyMap": {
+    "Custom Environments": "00000"
   }
 }

--- a/resources/image_metadata.schema.json
+++ b/resources/image_metadata.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "imageInfo": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9.-]+$": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Display name of the image"
+            },
+            "description": {
+              "type": "string",
+              "description": "Detailed description of the image"
+            },
+            "group": {
+              "type": "string",
+              "description": "Category group for the image",
+              "enum": [
+                "Language",
+                "Machine Learning / Deep Learning",
+                "Scientific Language",
+                "Big Data",
+                "Desktop Environment",
+                "Application",
+                "Benchmarks",
+                "Inference",
+                "Framework",
+                "Molecular Dynamics",
+                "NPU",
+                "Scientific Environment",
+                "Scientific Toolkit",
+                "Deep Learning Toolkit",
+                "Utilities"
+              ]
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Additional tags for the image"
+            },
+            "icon": {
+              "type": "string",
+              "description": "Icon filename for the image"
+            },
+            "label": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "category": {
+                    "type": "string",
+                    "description": "Label category (e.g., Env)",
+                    "enum": ["Env"]
+                  },
+                  "tag": {
+                    "type": "string",
+                    "description": "Label tag text"
+                  },
+                  "color": {
+                    "type": "string",
+                    "description": "Label color",
+                    "enum": ["blue", "green", "yellow", "gray", "red"]
+                  }
+                },
+                "required": ["tag", "color"]
+              },
+              "description": "Labels to display for the image"
+            }
+          },
+          "required": ["name", "description", "group", "tags", "label"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "tagAlias": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9.-]+$": {
+          "type": "string",
+          "description": "Human-readable alias for the tag"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Mapping of tag names to their display aliases"
+    },
+    "tagReplace": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "type": "string",
+          "description": "Replacement pattern for matching tags"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Regular expression patterns for tag replacement"
+    },
+    "groupSortKeyMap": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "type": "string",
+          "description": "Sort order key for the group"
+        }
+      },
+      "additionalProperties": false,
+      "description": "Mapping of group names to their sort order"
+    }
+  },
+  "required": ["imageInfo", "tagAlias", "tagReplace"]
+}


### PR DESCRIPTION
Resolves [FR-1579](https://lablup.atlassian.net/browse/FR-1579)

<img width="713" height="359" alt="image" src="https://github.com/user-attachments/assets/8713e037-18eb-4f08-af82-c9a8cef72dca" />


## Summary

This PR adds support for customizable sorting of image environment groups in the session launcher. Previously, groups were only sorted alphabetically, which made it difficult for users to prioritize frequently used or important groups.

## Changes

- Added `groupSortKeyMap` configuration to `resources/image_metadata.json`
- Modified `ImageEnvironmentSelectFormItems.tsx` to use custom sort keys instead of alphabetical sorting
- Created JSON schema for `image_metadata.json` validation
- Updated type definitions to include the new `groupSortKeyMap` property

## How to Use `groupSortKeyMap`

The `groupSortKeyMap` allows administrators to customize the display order of image environment groups in the session launcher.

### Configuration

Edit `resources/image_metadata.json` and add sort keys for each group you want to reorder:

```
"groupSortKeyMap": {
  "Custom Environments": "00000",
  "Language": "00001",
  "Machine Learning / Deep Learning": "00002", 
  "Scientific Language": "00003",
  "Big Data": "00004",
  "Desktop Environment": "00005"
}
```

### Sort Key Guidelines

- Use string values for sort keys (e.g., "00000", "00001")
- Lower values appear first in the list
- Groups without a sort key will use their group name as the sort key (alphabetical)
- Leading zeros help maintain consistent ordering (e.g., "00001" vs "1")

### Example Use Cases

1. **Prioritize custom environments**: Set "Custom Environments" to "00000" to show it first
2. **Group related categories**: Use sequential numbers for related groups
3. **Push rarely used groups down**: Assign higher numbers to less frequently used groups

## Testing

- Verify that groups appear in the custom order when `groupSortKeyMap` is configured
- Confirm that groups without sort keys still appear alphabetically after the custom-sorted ones
- Check that the session launcher UI updates correctly when the configuration changes

[FR-1579]: https://lablup.atlassian.net/browse/FR-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ