### PR TITLE
fix(FR-1597): exclude name field from KeypairResourcePolicySettingModal props

### DIFF
--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -210,7 +210,7 @@ const KeypairResourcePolicySettingModal: React.FC<
         const props:
           | CreateKeyPairResourcePolicyInput
           | ModifyKeyPairResourcePolicyInput = {
-          ..._.omit(restValues, 'parsedTotalResourceSlots'),
+          ..._.omit(restValues, 'parsedTotalResourceSlots', 'name'),
           total_resource_slots: JSON.stringify(total_resource_slots),
           allowed_vfolder_hosts: JSON.stringify(allowed_vfolder_hosts),
         };


### PR DESCRIPTION
Resolves #4442 ([FR-1597](https://lablup.atlassian.net/browse/FR-1597))

## Summary
This PR fixes a bug in the KeypairResourcePolicySettingModal component where the 'name' field was being incorrectly passed in the props object when updating keypair resource policies.

## Changes
- Added 'name' to the `_.omit()` function to exclude it from the props object in the `handleOk` method
- This prevents the 'name' field from being included in the modification payload sent to the API

## Why this fix is needed
The 'name' field should not be included in the modification payload when updating keypair resource policies, as it's not a modifiable field and causes issues with the API.

## Testing
- Verify that creating/modifying keypair resource policies works correctly
- Ensure the 'name' field is not included in the API payload
- Confirm no regression in existing functionality

[FR-1597]: https://lablup.atlassian.net/browse/FR-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ