### PR TITLE
style(FR-1601): remove unnecessary padding override from ConfigurationsPage Card component

### DIFF
--- a/react/src/pages/ConfigurationsPage.tsx
+++ b/react/src/pages/ConfigurationsPage.tsx
@@ -21,7 +21,6 @@ const ConfigurationsPage = () => {
           tab: t('webui.menu.Configurations'),
         },
       ]}
-      styles={{ body: { padding: 0 } }}
     >
       {curTabKey === 'configurations' && <ConfigurationsSettingList />}
     </Card>

--- a/react/src/pages/MaintenancePage.tsx
+++ b/react/src/pages/MaintenancePage.tsx
@@ -21,7 +21,6 @@ const MaintenancePage = () => {
           tab: t('webui.menu.Maintenance'),
         },
       ]}
-      styles={{ body: { padding: 0 } }}
     >
       {curTabKey === 'maintenance' && <MaintenanceSettingList />}
     </Card>


### PR DESCRIPTION
Resolves #4445 ([FR-1601](https://lablup.atlassian.net/browse/FR-1601))

## Summary
This PR removes an unnecessary padding override from the ConfigurationsPage Card component that is no longer needed with the current Ant Design defaults.

## Background
Previously, the Card component may not have had default padding applied to its body, requiring manual style overrides. However, with recent updates to the Ant Design library or our component styling system, the Card component now has appropriate default padding applied to the body. This makes the explicit `styles={{ body: { padding: 0 } }}` prop redundant and potentially problematic as it removes the now-desired default padding.

## Changes
- Removed `styles={{ body: { padding: 0 } }}` prop from the Card component in ConfigurationsPage
- This allows the Card to use its proper default padding, ensuring consistent styling across the application

## Testing
- [ ] Verified that the ConfigurationsPage displays correctly with default Card body padding
- [ ] Checked consistency with other Card components in the application

[FR-1601]: https://lablup.atlassian.net/browse/FR-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ