### PR TITLE
fix(FR-1602): update CodeMirror language option from 'shell' to 'sh'

### DIFF
--- a/react/src/components/BAICodeEditor.tsx
+++ b/react/src/components/BAICodeEditor.tsx
@@ -17,7 +17,7 @@ interface BAICodeEditorProps extends Omit<ReactCodeMirrorProps, 'language'> {
 const BAICodeEditor: React.FC<BAICodeEditorProps> = ({
   value,
   onChange,
-  language = 'shell',
+  language = 'sh',
   editable = false,
   showLineNumbers = true,
   lineWrapping = false,

--- a/react/src/components/ShellScriptEditModal.tsx
+++ b/react/src/components/ShellScriptEditModal.tsx
@@ -323,7 +323,7 @@ const ShellScriptEditModal: React.FC<BootstrapScriptEditModalProps> = ({
         )}
         <BAICodeEditor
           onChange={(value) => setScript(value)}
-          language="shell"
+          language="sh"
           editable
           value={script}
         />


### PR DESCRIPTION
resolves #4447 (FR-1602)

This PR changes the language identifier in the `ShellScriptEditModal` component from "shell" to "sh" for the code editor. This ensures proper syntax highlighting when editing shell scripts in the UI.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after