### PR TITLE
fix(FR-1605): resolve plugin page activation issue on initial browser load

### DIFF
--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -360,7 +360,8 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
       _.map(value, (name) => {
         // Find page item belonging to each of menuitem-user, menuitem-admin, menuitem-superadmin in webuiplugins.page
         const page = _.find(pluginPages, { name: name }) as PluginPage;
-        if (page) {
+        // if menuitem is empty, skip adding menu item
+        if (page && page.menuitem) {
           const menuItem: MenuItem = {
             label: <WebUILink to={`/${page?.url}`}>{page?.menuitem}</WebUILink>,
             icon: pluginIconMap[page.icon || ''] || <ApiOutlined />,

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -553,6 +553,17 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
           );
           document.dispatchEvent(event);
           this.requestUpdate();
+
+          // After loading plugin, activate the current page component if exists (only for initial load)
+          if (this.plugins['page'].find((item) => item.name === this._page)) {
+            const component = this.shadowRoot?.querySelector(
+              this._page,
+            ) as BackendAIPage;
+            if (component) {
+              component.active = true;
+              component.requestUpdate();
+            }
+          }
         });
       }
     }


### PR DESCRIPTION
Resolves #4449 ([FR-1605](https://lablup.atlassian.net/browse/FR-1605))

## Description
This PR fixes an issue where plugin pages do not become active when the browser initially loads with a plugin page as the starting page. 

## Problem
When users bookmark or directly navigate to plugin pages, those pages were not displaying properly on initial load because the plugin activation logic runs after the initial page load but doesn't trigger the activation of the current page component.

## Solution
1. Added check in WebUISider to skip menu items with empty menuitem fields
2. Added logic in backend-ai-webui to properly activate the current page component after plugins are loaded during initial page load

## Changes Made
- **WebUISider.tsx**: Skip adding menu items when menuitem field is empty
- **backend-ai-webui.ts**: Activate current page component after plugin loading completes for initial load

[FR-1605]: https://lablup.atlassian.net/browse/FR-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ