### PR TITLE
chore: change temp directory path of serve-release.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,5 @@ CLAUDE.local.md
 # ignore merged schema
 data/merged_schema.graphql
 
-# webui release download temp directories
-temp-webui-*
-backend.ai-webui-bundle-*.zip
+# webui release download temp directories (safe to delete)
+scripts/temp-releases/


### PR DESCRIPTION
# Improve WebUI Release Serving Script

This PR reorganizes the WebUI release download and serving process:

1. Creates a dedicated `scripts/temp-releases/` directory for all downloaded WebUI releases
2. Updates `.gitignore` to reflect the new directory structure
3. Improves the `serve-release.sh` script with:
   - Better path handling using script directory detection
   - Automatic cleanup of downloaded zip files
   - Proper copying of config.toml from project root
   - Adds copying of plugins directory to the extracted WebUI