### PR TITLE
fix(FR-1623): Labels misaligned in resource group midification modal

### DIFF
--- a/react/src/components/ResourceGroupSettingModal.tsx
+++ b/react/src/components/ResourceGroupSettingModal.tsx
@@ -393,55 +393,43 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
           </Form.Item>
           <Form.Item label={t('resourceGroup.SchedulerOptions')}>
             <BAICard styles={{ body: { paddingBottom: 0 } }}>
-              <Row gutter={[24, 24]}>
-                <Col
-                  span={12}
-                  style={{
-                    alignSelf: 'end',
-                  }}
-                >
-                  <Form.Item
-                    labelCol={{ span: 24 }}
-                    label={
-                      <BAIFlex gap="xxs">
-                        {t('resourceGroup.PendingTimeout')}
-                        <Tooltip
-                          title={newLineToBrElement(
-                            t('resourceGroup.PendingTimeoutDesc'),
-                          )}
-                        >
-                          <QuestionCircleOutlined
-                            style={{ color: token.colorTextSecondary }}
-                          />
-                        </Tooltip>
-                      </BAIFlex>
-                    }
-                    name="pendingTimeout"
-                  >
-                    <InputNumber
-                      style={{ width: '100%' }}
-                      addonAfter={t('resourceGroup.TimeoutSeconds')}
-                      min={0}
-                    />
-                  </Form.Item>
-                </Col>
-                <Col span={12}>
-                  <Form.Item
-                    label={
-                      <BAIFlex style={{ whiteSpace: 'pre' }}>
-                        {t('resourceGroup.RetriesToSkipDesc')}
-                      </BAIFlex>
-                    }
-                    name="retriesToSkip"
-                  >
-                    <InputNumber
-                      style={{ width: '100%' }}
-                      addonAfter={t('resourceGroup.RetriesToSkip')}
-                      min={0}
-                    />
-                  </Form.Item>
-                </Col>
-              </Row>
+              <Form.Item
+                label={
+                  <BAIFlex gap="xxs">
+                    {t('resourceGroup.PendingTimeout')}
+                    <Tooltip
+                      title={newLineToBrElement(
+                        t('resourceGroup.PendingTimeoutDesc'),
+                      )}
+                    >
+                      <QuestionCircleOutlined
+                        style={{ color: token.colorTextSecondary }}
+                      />
+                    </Tooltip>
+                  </BAIFlex>
+                }
+                name="pendingTimeout"
+              >
+                <InputNumber
+                  style={{ width: '100%' }}
+                  addonAfter={t('resourceGroup.TimeoutSeconds')}
+                  min={0}
+                />
+              </Form.Item>
+              <Form.Item
+                label={
+                  <BAIFlex style={{ whiteSpace: 'pre' }}>
+                    {t('resourceGroup.RetriesToSkipDesc')}
+                  </BAIFlex>
+                }
+                name="retriesToSkip"
+              >
+                <InputNumber
+                  style={{ width: '100%' }}
+                  addonAfter={t('resourceGroup.RetriesToSkip')}
+                  min={0}
+                />
+              </Form.Item>
             </BAICard>
           </Form.Item>
         </Form>


### PR DESCRIPTION
Resolves #4474 ([FR-1623](https://lablup.atlassian.net/browse/FR-1623))

# Simplified Resource Group Settings Layout

Removes the Row and Col components from the scheduler options section in the ResourceGroupSettingModal, simplifying the layout structure while maintaining the same functionality. This change improves code readability and removes unnecessary nesting without affecting the user interface.

![image.png](https://app.graphite.dev/user-attachments/assets/1d57d6fc-4333-498a-936b-3ed2558ab360.png)

![image.png](https://app.graphite.dev/user-attachments/assets/269f1b52-df37-44b5-943c-02ba6f1e718d.png)

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1623]: https://lablup.atlassian.net/browse/FR-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ