### PR TITLE
style(FR-1622): fix clipped home icon of filebrowser

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
@@ -4,6 +4,7 @@ import {
   localeCompare,
 } from '../../../helper';
 import BAIFlex from '../../BAIFlex';
+import BAILink from '../../BAILink';
 import BAIUnmountAfterClose from '../../BAIUnmountAfterClose';
 import { BAITable, BAITableProps } from '../../Table';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
@@ -15,7 +16,7 @@ import ExplorerActionControls from './ExplorerActionControls';
 import FileItemControls from './FileItemControls';
 import { useSearchVFolderFiles } from './hooks';
 import { FolderOutlined } from '@ant-design/icons';
-import { Breadcrumb, Skeleton, TableColumnsType, Typography } from 'antd';
+import { Breadcrumb, Skeleton, TableColumnsType, theme } from 'antd';
 import { ItemType } from 'antd/es/breadcrumb/Breadcrumb';
 import { RcFile } from 'antd/es/upload';
 import dayjs from 'dayjs';
@@ -56,6 +57,8 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
   style,
 }) => {
   const { t } = useTranslation();
+  const { token } = theme.useToken();
+
   const [isDragMode, setIsDragMode] = useState(false);
   const [selectedItems, setSelectedItems] = useState<Array<VFolderFile>>([]);
   const [selectedSingleItem, setSelectedSingleItem] =
@@ -88,7 +91,11 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
 
     const items: Array<ItemType> = [
       {
-        title: <HouseIcon />,
+        title: (
+          <BAILink style={{ color: 'inherit' }}>
+            <HouseIcon />
+          </BAILink>
+        ),
         onClick: () => {
           navigateToPath('.');
           setSelectedItems([]);
@@ -125,7 +132,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
       }));
 
       items.push({
-        title: part,
+        title: <BAILink style={{ color: 'inherit' }}>{part}</BAILink>,
         onClick: () => {
           navigateToPath(navigatePath);
           setSelectedItems([]);
@@ -258,11 +265,9 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
         <BAIFlex align="center" justify="between">
           <Breadcrumb
             items={breadCrumbItems}
-            itemRender={(item) => (
-              <Typography.Link onClick={item.onClick}>
-                {item.title}
-              </Typography.Link>
-            )}
+            style={{
+              marginLeft: token.marginXXS,
+            }}
           />
           <ExplorerActionControls
             selectedFiles={selectedItems}


### PR DESCRIPTION
Resolves #4476 ([FR-1622](https://lablup.atlassian.net/browse/FR-1622))

# Add margin to home icon in file explorer breadcrumb

This PR adds a left margin to the home icon in the file explorer breadcrumb navigation to improve visual spacing and alignment. The margin is applied using the theme token system to maintain consistency with the design system.

**Changes:**
- Import the theme from antd
- Use theme.useToken() to access design tokens
- Apply marginXS token to the HouseIcon in the breadcrumb

Before
![image.png](https://app.graphite.dev/user-attachments/assets/9d1b7952-b152-447a-b354-bc84d41f10c7.png)
After
![image.png](https://app.graphite.dev/user-attachments/assets/b728c0e9-ff3a-449c-b7d7-27cafedee904.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1622]: https://lablup.atlassian.net/browse/FR-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ