### PR TITLE
fix(FR-1625): Visibility on the dashboard page is poor when dark mode is enabled

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIStatistic.tsx
+++ b/packages/backend.ai-ui/src/components/BAIStatistic.tsx
@@ -94,7 +94,7 @@ const BAIStatistic: React.FC<BAIStatisticProps> = ({
               style={{
                 fontSize: 32,
                 lineHeight: '1em',
-                color: 'inherit',
+                color: style?.color ?? 'inherit',
               }}
             >
               {displayCurrent}


### PR DESCRIPTION
Resolves #4479 ([FR-1625](https://lablup.atlassian.net/browse/FR-1625))

# Fix color inheritance in BAIStatistic component

This PR fixes the color styling in the BAIStatistic component by properly applying the color from the style prop to the displayed value. Previously, the component was using `color: 'inherit'` which ignored any custom color passed through the style prop to support dark mode.

![image.png](https://app.graphite.dev/user-attachments/assets/ddecbabe-4ae7-4a58-8571-edf007dc0814.png)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1625]: https://lablup.atlassian.net/browse/FR-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ