### PR TITLE
refactor(FR-1627): remove resource monitor component from import view (#4480)

### DIFF
--- a/src/components/backend-ai-import-view.ts
+++ b/src/components/backend-ai-import-view.ts
@@ -12,8 +12,6 @@ import { SessionResources } from '../types/backend-ai-console';
 import { BackendAiStyles } from './backend-ai-general-styles';
 import { BackendAIPage } from './backend-ai-page';
 import { default as PainKiller } from './backend-ai-painkiller';
-import BackendAiResourceMonitor from './backend-ai-resource-monitor';
-import './backend-ai-resource-monitor';
 import './lablup-activity-panel';
 import LablupLoadingSpinner from './lablup-loading-spinner';
 
@@ -36,7 +34,6 @@ import { customElement, property, query } from 'lit/decorators.js';
  * This type definition is a workaround for resolving both Type error and Importing error.
  */
 // type LablupLoadingSpinner = HTMLElementTagNameMap['lablup-loading-spinner'];
-// type BackendAIResourceMonitor = HTMLElementTagNameMap['backend-ai-resource-monitor'];
 
 /**
  `<backend-ai-import-view>` is a import feature of backend.ai web UI.
@@ -69,7 +66,6 @@ export default class BackendAIImport extends BackendAIPage {
   @property({ type: String }) _helpDescriptionTitle = '';
   @property({ type: String }) _helpDescriptionIcon = '';
   @query('#loading-spinner') spinner!: LablupLoadingSpinner;
-  @query('#resource-monitor') resourceMonitor!: BackendAiResourceMonitor;
   @query('#notebook-url') notebookUrlInput!: TextField;
   @query('#notebook-badge-code') notebookBadgeCodeInput!: TextArea;
   @query('#notebook-badge-code-markdown')
@@ -194,11 +190,6 @@ export default class BackendAIImport extends BackendAIPage {
 
   async _viewStateChanged(active: boolean) {
     await this.updateComplete;
-    if (active === false) {
-      this.resourceMonitor.removeAttribute('active');
-      return;
-    }
-    this.resourceMonitor.setAttribute('active', 'true');
     if (
       typeof globalThis.backendaiclient === 'undefined' ||
       globalThis.backendaiclient === null ||
@@ -629,29 +620,10 @@ export default class BackendAIImport extends BackendAIPage {
     // language=HTML
     return html`
       <link rel="stylesheet" href="resources/custom.css" />
-      <div class="horizontal wrap layout" style="gap:24px">
-        <lablup-activity-panel
-          title="${_t('summary.ResourceStatistics')}"
-          elevation="1"
-          width="352"
-          height="490"
-          narrow
-          scrollableY
-        >
-          <div slot="message">
-            <backend-ai-resource-monitor
-              location="summary"
-              id="resource-monitor"
-              ?active="${this.active === true}"
-              direction="vertical"
-            ></backend-ai-resource-monitor>
-          </div>
-        </lablup-activity-panel>
         <lablup-activity-panel
           title="${_t('import.CreateNotebookButton')}"
           elevation="1"
-          width="352"
-          height="490"
+          horizontalsize="2x"
         >
           <div slot="message">
             <div class="vertical wrap layout center description">


### PR DESCRIPTION
Resolves #4480 ([FR-1627](https://lablup.atlassian.net/browse/FR-1627))

# Remove Resource Monitor from Import View

This PR removes the resource monitor component from the import view. The changes include:

1. Removing imports for `BackendAiResourceMonitor` and its related module
2. Removing the resource monitor query property
3. Removing the resource monitor activation/deactivation logic in `_viewStateChanged`
4. Removing the resource monitor panel from the UI layout
5. Adjusting the layout of the remaining notebook creation panel to use `horizontalsize="2x"` instead of fixed width/height

![image.png](https://app.graphite.dev/user-attachments/assets/b6600578-8f4b-447f-8e0c-04483d66db01.png)

![image.png](https://app.graphite.dev/user-attachments/assets/fc1b4bfe-2650-400f-a8f3-9663c8bcaa41.png)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup): go to import&run page
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1627]: https://lablup.atlassian.net/browse/FR-1627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ