### PR TITLE
fix(FR-1628): user profile setting modal's labels are too narrow

### DIFF
--- a/react/src/components/UserProfileSettingModal.tsx
+++ b/react/src/components/UserProfileSettingModal.tsx
@@ -143,7 +143,6 @@ const UserProfileSettingModal: React.FC<Props> = ({
           <Form
             ref={formRef}
             layout="vertical"
-            labelCol={{ span: 8 }}
             initialValues={{
               full_name: userInfo.full_name,
               totp_activated: user?.totp_activated || false,


### PR DESCRIPTION
Resolves #4482 ([FR-1628](https://lablup.atlassian.net/browse/FR-1628))

# Remove `labelCol` prop from UserProfileSettingModal form

Removes the `labelCol={{ span: 8 }}` property from the Form component in UserProfileSettingModal, allowing the form to use default label column styling.

Before
![image.png](https://app.graphite.dev/user-attachments/assets/061d36d4-a0e5-41f1-8f9a-f86607bc33f5.png)

After
![image.png](https://app.graphite.dev/user-attachments/assets/ffa0c949-542d-469e-a76b-fc6d360d7bb8.png)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1628]: https://lablup.atlassian.net/browse/FR-1628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ