### PR TITLE
feat(FR-1632): Set the schedulable field in the agent setting modal to required.

### DIFF
--- a/react/src/components/AgentSettingModal.tsx
+++ b/react/src/components/AgentSettingModal.tsx
@@ -88,6 +88,7 @@ const AgentSettingModal: React.FC<AgentSettingModalProps> = ({
           name="schedulable"
           label={t('agent.Schedulable')}
           valuePropName="checked"
+          required={true}
         >
           <Switch />
         </Form.Item>


### PR DESCRIPTION
Resolves #4485 ([FR-1632](https://lablup.atlassian.net/browse/FR-1632))

# Make the Schedulable field required in AgentSettingModal

This PR adds the `required={true}` attribute to the Schedulable field in the AgentSettingModal component, ensuring that users must specify whether an agent is schedulable before submitting the form.

![image.png](https://app.graphite.dev/user-attachments/assets/3bca2019-e25b-4135-86ef-d250f8fe4708.png)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1632]: https://lablup.atlassian.net/browse/FR-1632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ