### PR TITLE
fix(FR-1629): fix language reset to work properly

### DIFF
--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -173,7 +173,16 @@ const UserPreferencesPage = () => {
           },
           defaultValue: defaultLanguage,
           value: selectedLanguage || defaultLanguage,
-          setValue: setSelectedLanguage,
+          setValue: (value: any) => {
+            setSelectedLanguage(value);
+            const event = new CustomEvent('language-changed', {
+              detail: {
+                language: value,
+              },
+            });
+            setLanguage(value);
+            document.dispatchEvent(event);
+          },
           onChange: (value: any) => {
             setSelectedLanguage(value);
             const event = new CustomEvent('language-changed', {


### PR DESCRIPTION
resolves #4488 (FR-1629)

This PR enhances the language selection functionality in the UserSettingsPage by:

1. Updating the `setValue` function to not only set the selected language but also:
   - Dispatch a custom 'language-changed' event with the new language value
   - Call `setLanguage()` to apply the language change immediately

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after