### PR TITLE
fix(FR-1626): fix folder name truncation

### DIFF
--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -21,7 +21,6 @@ import {
   Descriptions,
   Form,
   Input,
-  Table,
   TableProps,
   Tag,
   theme,
@@ -29,7 +28,7 @@ import {
   Typography,
 } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
-import { BAIUserUnionIcon, BAIFlex, BAILink } from 'backend.ai-ui';
+import { BAIUserUnionIcon, BAIFlex, BAILink, BAITable } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
 import { PlusIcon } from 'lucide-react';
@@ -631,7 +630,7 @@ const VFolderTable: React.FC<VFolderTableProps> = ({
         </Tooltip>
       </BAIFlex>
       <Form form={internalForm} component={false} preserve={false}>
-        <Table
+        <BAITable
           // size="small"
           scroll={{ x: 'max-content' }}
           rowKey={getRowKey}


### PR DESCRIPTION
resolves #4489 (FR-1626)

change `Table` to `BAITable` to fix folder name truncation issue.

before

![fe5e5ffa-9a9b-47dd-9f38-7a6cd5630525.png](https://app.graphite.dev/user-attachments/assets/cff97e62-f250-4a0f-8a6e-7c4fffe029ad.png)
after

![CleanShot 2025-10-29 at 17.24.47@2x.png](https://app.graphite.dev/user-attachments/assets/0c708ff3-c34e-479a-b469-5c17f75c5a83.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
