### PR TITLE
fix(FR-1631): truncate session name in session notification

### DIFF
--- a/packages/backend.ai-ui/src/components/BAILink.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.tsx
@@ -1,4 +1,3 @@
-import BAIFlex from './BAIFlex';
 import { Typography } from 'antd';
 import { createStyles } from 'antd-style';
 import React from 'react';
@@ -24,51 +23,40 @@ const useStyles = createStyles(({ css, token }) => ({
 export interface BAILinkProps extends Omit<LinkProps, 'to'> {
   type?: 'hover' | 'disabled' | undefined;
   to?: LinkProps['to'];
-  icon?: React.ReactNode;
   ellipsis?: boolean | { tooltip?: string };
   children?: string | React.ReactNode;
 }
 const BAILink: React.FC<BAILinkProps> = ({
   type,
   to,
-  icon,
   ellipsis,
   children,
   ...linkProps
 }) => {
   const { styles } = useStyles();
-  return (
-    <BAIFlex gap="xs" style={{ display: 'inline-flex' }}>
-      {icon && icon}
-      {type !== 'disabled' && to ? (
-        <Link
+  return type !== 'disabled' && to ? (
+    <Link className={type ? styles?.[type] : undefined} to={to} {...linkProps}>
+      {children}
+    </Link>
+  ) : (
+    <Typography.Link
+      className={type ? styles?.[type] : undefined}
+      onClick={linkProps.onClick}
+      disabled={type === 'disabled'}
+      ellipsis={!!ellipsis}
+      {...linkProps}
+    >
+      {typeof ellipsis === 'object' && ellipsis.tooltip ? (
+        <Typography.Text
           className={type ? styles?.[type] : undefined}
-          to={to}
-          {...linkProps}
+          ellipsis={ellipsis}
         >
           {children}
-        </Link>
+        </Typography.Text>
       ) : (
-        <Typography.Link
-          className={type ? styles?.[type] : undefined}
-          onClick={linkProps.onClick}
-          disabled={type === 'disabled'}
-          ellipsis={!!ellipsis}
-          {...linkProps}
-        >
-          {typeof ellipsis === 'object' && ellipsis.tooltip ? (
-            <Typography.Text
-              className={type ? styles?.[type] : undefined}
-              ellipsis={ellipsis}
-            >
-              {children}
-            </Typography.Text>
-          ) : (
-            children
-          )}
-        </Typography.Link>
+        children
       )}
-    </BAIFlex>
+    </Typography.Link>
   );
 };
 

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/EditableFileName.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/EditableFileName.tsx
@@ -150,10 +150,10 @@ const EditableFileName: React.FC<EditableNameProps> = ({
                   ? token.colorTextTertiary
                   : undefined,
               }}
-              icon={<FolderOutlined style={{ color: token.colorLink }} />}
               ellipsis
               title={fileInfo.name}
             >
+              <FolderOutlined style={{ color: token.colorLink }} /> &nbsp;
               {isPendingRenamingAndRefreshing ? optimisticName : fileInfo.name}
             </BAILink>
           ) : (

--- a/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
+++ b/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
@@ -1,7 +1,7 @@
 import SessionActionButtons from './ComputeSessionNodeItems/SessionActionButtons';
 import SessionStatusTag from './ComputeSessionNodeItems/SessionStatusTag';
 import { useUpdateEffect } from 'ahooks';
-import { BAIFlex, BAILink, BAINotificationItem } from 'backend.ai-ui';
+import { BAIFlex, BAILink, BAINotificationItem, BAIText } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -11,6 +11,7 @@ import {
   useFragment,
   useRelayEnvironment,
 } from 'react-relay';
+import { useNavigate } from 'react-router-dom';
 import { BAIComputeSessionNodeNotificationItemFragment$key } from 'src/__generated__/BAIComputeSessionNodeNotificationItemFragment.graphql';
 import { BAIComputeSessionNodeNotificationItemRefreshQuery } from 'src/__generated__/BAIComputeSessionNodeNotificationItemRefreshQuery.graphql';
 import {
@@ -29,6 +30,7 @@ const BAIComputeSessionNodeNotificationItem: React.FC<
 > = ({ sessionFrgmt, showDate, notification }) => {
   const { destroyNotification } = useSetBAINotification();
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const node = useFragment(
     graphql`
       fragment BAIComputeSessionNodeNotificationItemFragment on ComputeSessionNode {
@@ -73,25 +75,23 @@ const BAIComputeSessionNodeNotificationItem: React.FC<
     node && (
       <BAINotificationItem
         title={
-          <span>
+          <BAIText ellipsis>
             {t('general.Session')}:&nbsp;
             <BAILink
               style={{
                 fontWeight: 'normal',
               }}
-              to={{
-                pathname: '/session',
-                search: node.row_id
-                  ? new URLSearchParams({
-                      sessionDetail: node.row_id,
-                    }).toString()
-                  : undefined,
-              }}
+              title={node.name || ''}
               onClick={() => {
+                navigate(
+                  `/session${node.row_id ? `?${new URLSearchParams({ sessionDetail: node.row_id }).toString()}` : ''}`,
+                );
                 destroyNotification(notification.key);
               }}
-            >{`${node.name}`}</BAILink>
-          </span>
+            >
+              {node.name}
+            </BAILink>
+          </BAIText>
         }
         description={
           <BAIFlex justify="between">

--- a/react/src/components/SessionNameFormItem.tsx
+++ b/react/src/components/SessionNameFormItem.tsx
@@ -24,7 +24,14 @@ const SessionNameFormItem: React.FC<SessionNameFormItemProps> = ({
       rules={validationRules}
       {...formItemProps}
     >
-      <Input allowClear autoComplete="off" />
+      <Input
+        allowClear
+        autoComplete="off"
+        count={{
+          max: 64,
+          show: true,
+        }}
+      />
     </Form.Item>
   );
 };


### PR DESCRIPTION
resolves #4491 (FR-1631)

This PR replaces the custom `BAILink` component with Ant Design's `Typography.Link` in the session notification item. The change also:

- Adds ellipsis functionality to the session name link
- Adds a `title` attribute to show the full name on hover
- Uses `useNavigate` hook from react-router-dom for navigation

![CleanShot 2025-10-30 at 10.12.47@2x.png](https://app.graphite.dev/user-attachments/assets/5bcc35cb-697a-4107-a7b1-040dc7a2d74d.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after