### PR TITLE
fix(FR-1633): Success message shows `{{folderlength}}` template variable instead of actual count

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -402,7 +402,7 @@
       "MoveToTrashMultipleDescription": "Sind Sie sicher, dass Sie {{folderLength}} Ordner in Müll bin verschieben möchten?",
       "MovedToTrashBin": "Der Ordner {{ folderName }} wurde in den Papierkorb verschoben.",
       "MultipleFilesDeleted": "Mehrere Dateien gelöscht",
-      "MultipleFolderDeleted": "Ausgewählte {{OrdnerLength}} Ordner wurden gelöscht.",
+      "MultipleFolderDeleted": "Ausgewählte {{folderLength}} Ordner wurden gelöscht.",
       "MultipleFolderRestored": "Ausgewählte {{ folderLength }} Ordner wurden wiederhergestellt.",
       "Name": "Name",
       "NoDeletePermission": "Keine Löschberechtigung",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -400,7 +400,7 @@
       "MoveToTrashMultipleDescription": "Είστε σίγουροι ότι θέλετε να μετακινήσετε τους φακέλους {{ folderLength }} στον κάδο απορριμμάτων;",
       "MovedToTrashBin": "Ο φάκελος {{ folderName }} έχει μετακινηθεί στον κάδο απορριμμάτων.",
       "MultipleFilesDeleted": "Διαγράφηκαν πολλά αρχεία",
-      "MultipleFolderDeleted": "Επιλεγμένα {{FolderLength}} Φάκελοι έχει διαγραφεί.",
+      "MultipleFolderDeleted": "Επιλεγμένα {{folderLength}} Φάκελοι έχει διαγραφεί.",
       "MultipleFolderRestored": "Επιλεγμένα {{ folderLength }} Φάκελοι έχει αποκατασταθεί.",
       "Name": "Ονομα",
       "NoDeletePermission": "Δεν υπάρχει δικαίωμα διαγραφής",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -405,7 +405,7 @@
       "MoveToTrashMultipleDescription": "Are you sure you want to move {{ folderLength }} folders to trash bin?",
       "MovedToTrashBin": "The {{ folderName }} folder has been moved to the trash bin.",
       "MultipleFilesDeleted": "Multiple Files deleted",
-      "MultipleFolderDeleted": "Selected {{ folderLength }} folders has been deleted.",
+      "MultipleFolderDeleted": "Selected {{folderLength}} folders has been deleted.",
       "MultipleFolderRestored": "Selected {{ folderLength }} folders has been restored.",
       "Name": "Name",
       "NoDeletePermission": "No delete permission",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -402,7 +402,7 @@
       "MoveToTrashMultipleDescription": "¿Estás seguro de que quieres mover las carpetas {{folderLength}} a la basura?",
       "MovedToTrashBin": "La carpeta {{ folderName }} se ha movido a la papelera.",
       "MultipleFilesDeleted": "Múltiples archivos eliminados",
-      "MultipleFolderDeleted": "Se han eliminado las carpetas seleccionadas {{FolderLength}}.",
+      "MultipleFolderDeleted": "Se han eliminado las carpetas seleccionadas {{folderLength}}.",
       "MultipleFolderRestored": "Se han restaurado las carpetas seleccionadas {{ folderLength }}.",
       "Name": "Nombre",
       "NoDeletePermission": "Sin permiso de eliminación",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -402,7 +402,7 @@
       "MoveToTrashMultipleDescription": "Haluatko varmasti liikuttaa {{folderLength}} kansioita roskakoriin?",
       "MovedToTrashBin": "Kansio {{ folderName }} on siirretty roskakoriin.",
       "MultipleFilesDeleted": "Useita tiedostoja poistettu",
-      "MultipleFolderDeleted": "Valitut {{kansiota}} kansiot on poistettu.",
+      "MultipleFolderDeleted": "Valitut {{folderLength}} kansiot on poistettu.",
       "MultipleFolderRestored": "Valitut {{ folderLength }} kansiot on palautettu.",
       "Name": "Nimi",
       "NoDeletePermission": "Ei poistolupaa",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -402,7 +402,7 @@
       "MoveToTrashMultipleDescription": "Êtes-vous sûr de vouloir déplacer des dossiers {{folderLength}} aux déchets?",
       "MovedToTrashBin": "Le dossier {{ folderName }} a été déplacé vers la corbeille.",
       "MultipleFilesDeleted": "Plusieurs fichiers supprimés",
-      "MultipleFolderDeleted": "Les dossiers sélectionnés {{FolderLength}} ont été supprimés.",
+      "MultipleFolderDeleted": "Les dossiers sélectionnés {{folderLength}} ont été supprimés.",
       "MultipleFolderRestored": "Les dossiers sélectionnés {{ folderLength }} ont été restaurés.",
       "Name": "Nom",
       "NoDeletePermission": "Pas d'autorisation de suppression",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -401,7 +401,7 @@
       "MoveToTrashMultipleDescription": "Sei sicuro di voler spostare le cartelle {{folderLength}} per spazzare via?",
       "MovedToTrashBin": "La cartella {{ folderName }} è stata spostata nel cestino.",
       "MultipleFilesDeleted": "Più file eliminati",
-      "MultipleFolderDeleted": "Le cartelle selezionate {{CartederLength}} sono state eliminate.",
+      "MultipleFolderDeleted": "Le cartelle selezionate {{folderLength}} sono state eliminate.",
       "MultipleFolderRestored": "Le cartelle selezionate {{ folderLength }} sono state ripristinate.",
       "Name": "Nome",
       "NoDeletePermission": "Nessun permesso di cancellazione",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -404,7 +404,7 @@
       "MoveToTrashMultipleDescription": "{{folderLength}}개의 폴더를 휴지통으로 이동하시겠습니까?",
       "MovedToTrashBin": "{{ folderName }} 폴더가 휴지통으로 이동되었습니다.",
       "MultipleFilesDeleted": "다수의 파일이 삭제되었습니다",
-      "MultipleFolderDeleted": "선택된 {{folderlength}}개 폴더가 삭제되었습니다.",
+      "MultipleFolderDeleted": "선택된 {{folderLength}}개 폴더가 삭제되었습니다.",
       "MultipleFolderRestored": "선택한 {{ folderLength }} 폴더가 복원되었습니다.",
       "Name": "이름",
       "NoDeletePermission": "삭제 권한이 없습니다",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -401,7 +401,7 @@
       "MoveToTrashMultipleDescription": "Та {{folderLength}} хавтас руу зөөхийг хүсч байна уу?",
       "MovedToTrashBin": "{{ folderName }} фолдерыг хогийн сав руу зөөв.",
       "MultipleFilesDeleted": "Олон файл устгасан",
-      "MultipleFolderDeleted": "Сонгосон {{follenlength}} хавтас устсан байна.",
+      "MultipleFolderDeleted": "Сонгосон {{folderLength}} хавтас устсан байна.",
       "MultipleFolderRestored": "Сонгосон {{ folderLength }} хавтасыг сэргээв.",
       "Name": "Нэр",
       "NoDeletePermission": "Устгах зөвшөөрөл байхгүй байна",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -401,7 +401,7 @@
       "MoveToTrashMultipleDescription": "Adakah anda pasti mahu bergerak {{folderLength}} folder ke sampah tong?",
       "MovedToTrashBin": "Folder {{ folderName }} telah dialihkan ke tong sampah.",
       "MultipleFilesDeleted": "Berbilang Fail dipadamkan",
-      "MultipleFolderDeleted": "Dipilih {{folderlength}} Folder telah dipadam.",
+      "MultipleFolderDeleted": "Dipilih {{folderLength}} Folder telah dipadam.",
       "MultipleFolderRestored": "Dipilih {{ folderLength }} Folder telah dipulihkan.",
       "Name": "Nama",
       "NoDeletePermission": "Tiada kebenaran memadam",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -402,7 +402,7 @@
       "MoveToTrashMultipleDescription": "Tem certeza de que deseja mover {{folderLength}} pastas para a lixeira?",
       "MovedToTrashBin": "A pasta {{ folderName }} foi movida para a lixeira.",
       "MultipleFilesDeleted": "Vários arquivos excluídos",
-      "MultipleFolderDeleted": "As pastas selecionadas {{pasherLength}} foram excluídas.",
+      "MultipleFolderDeleted": "As pastas selecionadas {{folderLength}} foram excluídas.",
       "MultipleFolderRestored": "As pastas selecionadas {{ folderLength }} foram restauradas.",
       "Name": "Nome",
       "NoDeletePermission": "Sem permissão de eliminação",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -402,7 +402,7 @@
       "MoveToTrashMultipleDescription": "Tem certeza de que deseja mover {{folderLength}} pastas para lixo?",
       "MovedToTrashBin": "A pasta {{ folderName }} foi movida para a lixeira.",
       "MultipleFilesDeleted": "Vários arquivos excluídos",
-      "MultipleFolderDeleted": "As pastas selecionadas {{pasherLength}} foram excluídas.",
+      "MultipleFolderDeleted": "As pastas selecionadas {{folderLength}} foram excluídas.",
       "MultipleFolderRestored": "As pastas selecionadas {{ folderLength }} foram restauradas.",
       "Name": "Nome",
       "NoDeletePermission": "Sem permissão de eliminação",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -402,7 +402,7 @@
       "MoveToTrashMultipleDescription": "Bạn có chắc là bạn muốn di chuyển {{folderLength}} các thư mục sang thùng rác không?",
       "MovedToTrashBin": "Thư mục {{ folderName }} đã được chuyển vào thùng rác.",
       "MultipleFilesDeleted": "Nhiều tệp đã bị xóa",
-      "MultipleFolderDeleted": "Đã chọn {{thư mục}} Các thư mục đã bị xóa.",
+      "MultipleFolderDeleted": "Đã chọn {{folderLength}} Các thư mục đã bị xóa.",
       "MultipleFolderRestored": "Đã chọn {{ folderLength }} Các thư mục đã được khôi phục.",
       "Name": "Tên",
       "NoDeletePermission": "Không xóa quyền",


### PR DESCRIPTION
Resolves #4493 ([FR-1633](https://lablup.atlassian.net/browse/FR-1633))

# Fix variable name inconsistencies in i18n translation files

This PR fixes inconsistent variable names in the `MultipleFolderDeleted` translation strings across multiple language files. The variable name has been standardized to `folderLength` in all affected files:

- German (de.json): Changed `OrdnerLength` to `folderLength`
- Greek (el.json): Changed `FolderLength` to `folderLength`
- English (en.json): Standardized spacing around `folderLength`
- Spanish (es.json): Changed `FolderLength` to `folderLength`
- Finnish (fi.json): Changed `kansiota` to `folderLength`
- French (fr.json): Changed `FolderLength` to `folderLength`
- Italian (it.json): Changed `CartederLength` to `folderLength`
- Korean (ko.json): Changed `folderlength` to `folderLength`
- Mongolian (mn.json): Changed `follenlength` to `folderLength`
- Malay (ms.json): Changed `folderlength` to `folderLength`
- Portuguese (pt-BR.json and pt.json): Changed `pasherLength` to `folderLength`
- Vietnamese (vi.json): Changed `thư mục` to `folderLength`

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1633]: https://lablup.atlassian.net/browse/FR-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ