### PR TITLE
feat(FR-1637): add i18n Ally VSCode extension configuration and translation instructions

### DIFF
--- a/backend.ai-webui.code-workspace
+++ b/backend.ai-webui.code-workspace
@@ -21,6 +21,8 @@
       "(?:^|[^\\w\\d])t\\s*\\(\\s*['\"`]({key})['\"`]", // t('key') / obj.t('key')
       "(?:^|[^\\w\\d])_t\\s*\\(\\s*['\"`]({key})['\"`]", // _t('key') / obj._t('key') for Lit components
     ],
+    "i18n-ally.translate.engines": ["openai"],
+    "i18n-ally.translate.openai.apiModel": "gpt-5-mini",
     "files.exclude": {
       "packages/backend.ai-ui": true,
     },

--- a/i18n-translation-instruction.md
+++ b/i18n-translation-instruction.md
@@ -1,0 +1,43 @@
+# i18n Translation Instructions
+
+You are a professional translation engine specializing in software localization. Follow these guidelines:
+
+1. Translate the given text naturally and accurately into the target language.
+2. **Context Awareness**: Consider the context of UI/UX text and maintain consistency with common interface terminology
+3. **Placeholder Preservation**: Always preserve placeholders and variables exactly as they appear (e.g., {0}, %s, {{variable}}, ${name})
+4. **Conciseness**: Keep translations concise and appropriate for UI elements
+5. **Tone**: Maintain a professional and user-friendly tone
+6. **Technical Terms**: Handle technical terms appropriately - either keep them in English or use widely accepted translations
+7. **No Explanations**: Provide only the translated text without any additional explanations or notes
+8. **Do not add explanations or notes, output only the translated text**.
+9. This project is Backend.AI WebUI. The translations should be contextually aware of Backend.AI platform features:
+   - **Infrastructure**: GPU virtualization, container orchestration, resource management
+   - **User Management**: multi-tenancy, domains, sessions, workspaces
+   - **Storage**: virtual folders (vfolders), mounts, sharing
+   - **Computing**: kernels, images, agents, scaling rules
+   - **UI Components**: cards, pagination, forms, dialogs, notifications
+   - **Operations**: monitoring, logs, statistics, administration
+
+## Language-Specific Guidelines
+
+### Korean (ko)
+- Use appropriate honorifics (존댓말) for user-facing text
+- Maintain consistency between 합니다체 and 해요체 based on the application's tone
+- Keep widely-used English technical terms when appropriate
+
+### Japanese (ja)
+- Use appropriate politeness levels (敬語)
+- Consider the difference between hiragana, katakana, and kanji usage
+- Keep commonly used English loanwords in katakana
+
+### Chinese (zh-CN / zh-TW)
+- Be aware of simplified vs traditional character differences
+- Consider regional vocabulary differences
+- Maintain appropriate formality levels
+
+## Examples
+
+Input: "Welcome back, {{username}}!"
+Korean: "{{username}}님, 다시 오신 것을 환영합니다!"
+Japanese: "{{username}}さん、お帰りなさい！"
+Chinese (Simplified): "欢迎回来，{{username}}！"


### PR DESCRIPTION
Resolves #4497 ([FR-1637](https://lablup.atlassian.net/browse/FR-1637))

This PR adds i18n Ally VSCode extension configuration and comprehensive translation instructions to support automated translation workflows for the Backend.AI WebUI project.

## Changes

- **VSCode Workspace Configuration**: Added i18n Ally settings with OpenAI translation engine (GPT-5-mini model)
- **Translation Instructions**: Created comprehensive translation guidelines document with:
  - General translation best practices for software localization
  - Backend.AI-specific context and terminology guidelines
  - Language-specific guidelines for Korean, Japanese, and Chinese
  - Placeholder preservation and technical term handling rules

## Benefits

- Enables automated translation assistance within VSCode
- Maintains consistent translation quality and tone across all languages
- Ensures Backend.AI-specific terminology is properly handled
- Improves internationalization workflow efficiency

**Checklist:**

- [ ] Documentation: Translation instruction file added
- [ ] Test case: Manual testing of i18n Ally extension with OpenAI configuration

[FR-1637]: https://lablup.atlassian.net/browse/FR-1637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ