### PR TITLE
fix(FR-1582): enable full visibility of long option text in select dropdowns

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -378,8 +378,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
         <Select
           ref={envSelectRef}
           showSearch
-          // open={true}
-          // autoClearSearchValue
+          popupMatchSelectWidth={false}
           searchValue={environmentSearch}
           onSearch={setEnvironmentSearch}
           defaultActiveFirstOption={true}
@@ -582,6 +581,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
             >
               <Select
                 ref={versionSelectRef}
+                popupMatchSelectWidth={false}
                 onChange={(value) => {
                   const selectedImage = _.find(images, (image) => {
                     return getImageFullName(image) === value;

--- a/react/src/components/ResourcePresetSelect.tsx
+++ b/react/src/components/ResourcePresetSelect.tsx
@@ -93,6 +93,7 @@ const ResourcePresetSelect: React.FC<ResourcePresetSelectProps> = ({
   return (
     <Select
       loading={isPendingUpdate}
+      popupMatchSelectWidth={false}
       options={[
         ...(showCustom
           ? [


### PR DESCRIPTION
Resolves #4435 ([FR-1582](https://lablup.atlassian.net/browse/FR-1582))

Added `popupMatchSelectWidth={false}` to Select components in ImageEnvironmentSelectFormItems and ResourcePresetSelect to prevent dropdown menus from being constrained to the width of the select input. This allows dropdown content to display properly without being cut off when content is wider than the select input.

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.dev/user-attachments/assets/5eb1b211-c39c-4348-a629-b29f537addc3.png) | ![image.png](https://app.graphite.dev/user-attachments/assets/8cf62a2c-b11e-4b25-b679-140db4bca468.png) |



[FR-1582]: https://lablup.atlassian.net/browse/FR-1582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ