### PR TITLE
fix(FR-1625): update default text color in BAIStatistic component for dark mode

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIStatistic.tsx
+++ b/packages/backend.ai-ui/src/components/BAIStatistic.tsx
@@ -94,7 +94,7 @@ const BAIStatistic: React.FC<BAIStatisticProps> = ({
               style={{
                 fontSize: 32,
                 lineHeight: '1em',
-                color: style?.color ?? 'inherit',
+                color: style?.color ?? token.colorText,
               }}
             >
               {displayCurrent}


### PR DESCRIPTION
Follows https://github.com/lablup/backend.ai-webui/pull/4478
Resolves #4479 ([FR-1625](https://lablup.atlassian.net/browse/FR-1625))


# Fix text color in BAIStatistic component

This PR updates the default text color in the BAIStatistic component to use the theme token's `colorText` value instead of 'inherit' when no specific color is provided. This ensures consistent text coloring that properly respects the current theme.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1625]: https://lablup.atlassian.net/browse/FR-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ