### PR TITLE
fix(FR-1645): Mismatch in Selected Count After Partial Folder Deletion

### DIFF
--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -416,8 +416,8 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
         open={!!currentVFolder}
         onOk={() => {
           deleteFromTrashBinMutation.mutate(currentVFolder?.id ?? '', {
-            onSuccess: () => {
-              onRequestChange?.();
+            onSuccess: (_result, variables) => {
+              onRequestChange?.(variables);
               message.success(
                 t('data.folders.FolderDeletedForever', {
                   folderName: currentVFolder?.name,

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -653,13 +653,15 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                 };
               },
               onChange: (selectedRowKeys) => {
-                // Using selectedRowKeys to retrieve selected rows since selectedRows lack nested fragment types
+                // Using improved handleRowSelectionChange with preserveOtherPageSelections enabled
                 handleRowSelectionChange(
                   selectedRowKeys,
                   filterOutNullAndUndefined(
                     _.map(vfolder_nodes?.edges, 'node'),
                   ),
                   setSelectedFolderList,
+                  'id',
+                  true, // Enable preserveOtherPageSelections
                 );
               },
               selectedRowKeys: _.map(selectedFolderList, (i) => i.id),


### PR DESCRIPTION
Resolves #4578 ([FR-1645](https://lablup.atlassian.net/browse/FR-1645))

# Improve folder selection handling and deletion callback

This PR enhances two key aspects of folder management:

1. Adds a `preserveOtherPageSelections` parameter to `handleRowSelectionChange` function, allowing selections to persist across different pages
2. Updates the deletion callback in `VFolderNodes` to pass the deleted folder ID to the parent component

## Changes:

- Enhanced `handleRowSelectionChange` to properly maintain selections when navigating between pages
- Implemented the improved selection handling in `VFolderNodeListPage` with cross-page selection preservation
- Modified the deletion success callback to pass the deleted folder ID to the parent component

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1645]: https://lablup.atlassian.net/browse/FR-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ