### PR TITLE
style: Remove require marks from Chat paramerter sliders

### DIFF
--- a/react/src/components/Chat/ChatParametersSliders.tsx
+++ b/react/src/components/Chat/ChatParametersSliders.tsx
@@ -142,6 +142,7 @@ export const ChatParametersSliders = ({
       <Form
         size="small"
         layout="vertical"
+        requiredMark={false}
         initialValues={
           Object.keys(parameters).length > 0
             ? parameters


### PR DESCRIPTION
# Remove required mark from chat parameters form

This PR removes the required mark (red asterisk) from the chat parameters form by setting `requiredMark={false}` in the Form component. This provides a cleaner interface since none of the parameters are actually required.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after