### PR TITLE
fix(FR-1648): fix quota overlapping text

### DIFF
--- a/react/src/components/BAIProgress.tsx
+++ b/react/src/components/BAIProgress.tsx
@@ -69,38 +69,9 @@ const BAIProgress: React.FC<BAIProgressProps> = ({
             overflow: 'hidden',
           }}
         ></BAIFlex>
-        {/* Hide used text to avoid overlapping */}
-        {used && baiProgressProps.percent && baiProgressProps.percent < 70 ? (
-          <div
-            style={{
-              position: 'absolute',
-              left:
-                !baiProgressProps.percent || _.isNaN(baiProgressProps.percent)
-                  ? 0
-                  : `calc(${_.min([baiProgressProps.percent, 100])}% - ${token.size}px)`,
-              bottom: -(token.size + token.fontSize),
-              textAlign: 'center',
-            }}
-          >
-            <Typography.Text
-              style={{
-                color: _.isString(baiProgressProps.strokeColor)
-                  ? (baiProgressProps.strokeColor ??
-                    primaryColors.primary5 ??
-                    token.colorPrimary)
-                  : (primaryColors.primary5 ?? token.colorPrimary),
-              }}
-            >
-              {used}
-            </Typography.Text>
-          </div>
-        ) : null}
       </BAIFlex>
       <BAIFlex justify="end">
-        {used &&
-        total &&
-        baiProgressProps.percent &&
-        baiProgressProps.percent >= 70 ? (
+        {used && total && baiProgressProps.percent ? (
           <BAIFlex gap={'xxs'}>
             <Typography.Text
               style={{

--- a/react/src/components/QuotaPerStorageVolumePanelCard.tsx
+++ b/react/src/components/QuotaPerStorageVolumePanelCard.tsx
@@ -209,13 +209,13 @@ const QuotaPerStorageVolumePanelCard: React.FC<
               used={
                 userUsageBytes === 0
                   ? ''
-                  : convertToDecimalUnit(_.toString(userUsageBytes), 'g')
+                  : convertToDecimalUnit(_.toString(userUsageBytes), 'auto')
                       ?.displayValue
               }
               total={
                 userHardLimitBytes === 0
                   ? ''
-                  : convertToDecimalUnit(_.toString(userHardLimitBytes), 'g')
+                  : convertToDecimalUnit(_.toString(userHardLimitBytes), 'auto')
                       ?.displayValue
               }
             />


### PR DESCRIPTION
Resolves [FR-1648](https://lablup.atlassian.net/browse/FR-1648)

# Refactor BAIProgress component to use a constant for overlapping threshold

This PR introduces a constant `OVERLAPPING_THRESHOLD_PERCENT` set to 50 to determine when text should be displayed inside or outside the progress bar. Previously, this threshold was hardcoded as 70 in two different places, making it difficult to maintain consistency.

- progress < 50 (without slash between used and total)
![image.png](https://app.graphite.dev/user-attachments/assets/3fc3111e-a5cb-4bd4-ac93-3530259f6133.png)

- progress >= 50 (with slash between used and total)
![image.png](https://app.graphite.dev/user-attachments/assets/98cd552e-9c4f-469d-932b-b1f67d321883.png)

## How to test
Modify total, used, percent in `QuotaPerStorageVolumePanelCard.tsx` (dogbowl)

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1648]: https://lablup.atlassian.net/browse/FR-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ