### PR TITLE
feat(FR-1652): implement npm tag assignment from git tags

### DIFF
--- a/.github/workflows/publish-backend.ai-ui.yml
+++ b/.github/workflows/publish-backend.ai-ui.yml
@@ -50,14 +50,31 @@ jobs:
         run: |
           cd packages/backend.ai-ui
           ./scripts/update-canary-version.sh
+
       - name: Publish to npm (canary)
         if: github.ref_type == 'branch'
         run: |
           cd packages/backend.ai-ui
           npm publish --tag canary --access public --no-git-checks
 
-      - name: Publish to npm (latest)
+      - name: Determine npm tag from git tag
+        if: github.ref_type == 'tag'
+        id: determine-tag
+        run: |
+          GIT_TAG="${GITHUB_REF#refs/tags/v}"
+
+          if [[ "$GIT_TAG" == *"-rc"* ]]; then
+            NPM_TAG="rc"
+          elif [[ "$GIT_TAG" == *"-beta"* ]]; then
+            NPM_TAG="beta"
+          else
+            NPM_TAG="latest"
+          fi
+
+          echo "npm_tag=${NPM_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Publish to npm
         if: github.ref_type == 'tag'
         run: |
           cd packages/backend.ai-ui
-          npm publish --tag latest --access public --no-git-checks
+          npm publish --tag ${{ steps.determine-tag.outputs.npm_tag }} --access public --no-git-checks


### PR DESCRIPTION
resolves #4589 (FR-1652)

This PR enhances the GitHub workflow for publishing the backend.ai-ui package by automatically determining the appropriate npm tag based on the git tag format:

- Tags containing `-rc` will be published with the `rc` npm tag
- Tags containing `-beta` will be published with the `beta` npm tag
- All other tags will continue to use the `latest` npm tag

This allows for better versioning control and release management by properly categorizing pre-releases in npm.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after