### PR TITLE
chore: improve description of image_metadata.schema.json

### DIFF
--- a/resources/image_metadata.schema.json
+++ b/resources/image_metadata.schema.json
@@ -105,11 +105,11 @@
       "patternProperties": {
         ".*": {
           "type": "string",
-          "description": "Sort order key for the group"
+          "description": "Sort key value that determines the display order of this group. Uses string comparison for sorting, so padding numbers with leading zeros is recommended for consistent ordering"
         }
       },
       "additionalProperties": false,
-      "description": "Mapping of group names to their sort order"
+      "description": "Controls the display order of image groups in the UI. The keys in this map must match the 'group' property values defined in imageInfo entries (e.g., 'NPU', 'Language', 'Machine Learning / Deep Learning'). The values are sort keys that determine each group's position in the UI. Groups not defined in this map are sorted alphabetically by their group name after the mapped groups"
     }
   },
   "required": ["imageInfo", "tagAlias", "tagReplace"]


### PR DESCRIPTION
# Improved Documentation for Image Group Sorting in Schema

This PR enhances the documentation for the `groupSort` property in the image metadata schema to provide clearer guidance on how image groups are sorted in the UI. The updated descriptions explain:

1. That the keys in the `groupSort` map must match the 'group' property values defined in imageInfo entries
2. How string comparison is used for sorting (recommending zero-padding for numbers)
3. The fallback behavior for groups not defined in the map (alphabetical sorting)

**Checklist:**

- [x] Documentation