### PR TITLE
feat(FR-1660): add action buttons column to SessionNodes table

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -326,6 +326,7 @@ const BAITable = <RecordType extends object = any>({
           styles.neoHeader,
           tableProps.rowSelection?.columnWidth === 0 &&
             styles.zeroWithSelectionColumn,
+          styles.adjustZIndex,
         )}
         style={{
           opacity: loading ? 0.7 : 1,
@@ -470,6 +471,11 @@ const useStyles = createStyles(({ token, css }) => ({
     .ant-table-selection-column {
       /* display: none !important; */
       padding: 0 !important;
+    }
+  `,
+  adjustZIndex: css`
+    td.ant-table-cell.ant-table-cell-fix-left {
+      z-index: 4;
     }
   `,
 }));

--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -47,6 +47,7 @@ interface SessionActionButtonsProps {
   hiddenButtonKeys?: SessionActionButtonKey[];
   onAction?: (action: SessionActionButtonKey) => void;
   primaryAppOption?: PrimaryAppOption;
+  noPrimaryButton?: boolean;
 }
 
 const isActive = (session: SessionActionButtonsFragment$data) => {
@@ -76,6 +77,7 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = ({
   hiddenButtonKeys,
   primaryAppOption,
   onAction,
+  noPrimaryButton: noPrimaryColor,
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
@@ -158,7 +160,7 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = ({
           >
             <Button
               size={size}
-              type={'primary'}
+              type={noPrimaryColor ? undefined : 'primary'}
               disabled={
                 !isAppSupported(session) || !isActive(session) || !isOwner
               }
@@ -192,7 +194,9 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = ({
             >
               <Button
                 size={size}
-                type={primaryAppOption ? undefined : 'primary'}
+                type={
+                  primaryAppOption || noPrimaryColor ? undefined : 'primary'
+                }
                 disabled={
                   !isAppSupported(session) || !isActive(session) || !isOwner
                 }

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -4,6 +4,7 @@ import {
 } from '../__generated__/SessionNodesFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserRole } from '../hooks/backendai';
+import SessionActionButtons from './ComputeSessionNodeItems/SessionActionButtons';
 import SessionReservation from './ComputeSessionNodeItems/SessionReservation';
 import SessionSlotCell from './ComputeSessionNodeItems/SessionSlotCell';
 import SessionStatusTag from './ComputeSessionNodeItems/SessionStatusTag';
@@ -60,6 +61,7 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
         ...BAISessionAgentIdsFragment
         ...BAISessionTypeTagFragment
         ...BAISessionClusterModeFragment
+        ...SessionActionButtonsFragment
         kernel_nodes {
           edges {
             node {
@@ -113,6 +115,20 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
           // TODO: Display idle checker if imminentExpirationTime as Icon(clock-alert).
           return <SessionStatusTag sessionFrgmt={session} />;
         },
+      },
+      {
+        key: 'actionButtons',
+        title: t('general.Control'),
+        defaultHidden: true,
+        sorter: false,
+        render: (__, session) => (
+          <SessionActionButtons
+            size="small"
+            sessionFrgmt={session}
+            compact
+            noPrimaryButton
+          />
+        ),
       },
       // This column will be added back when the session list column setting ui is ready
       // {


### PR DESCRIPTION
Resolves #4603 ([FR-1660](https://lablup.atlassian.net/browse/FR-1660))

## Summary
Add a new control column with action buttons to the SessionNodes table for improved session management accessibility.

## Changes
- Added new 'Control' column to SessionNodes table with action buttons
- Enhanced SessionActionButtons component with `noPrimaryButton` prop for neutral styling in table contexts  
- Fixed z-index issues in BAITable for proper column stacking with fixed columns

## Notes
- The column is hidden by default but can be enabled through table settings
- Action buttons display in compact mode without primary button styling

[FR-1660]: https://lablup.atlassian.net/browse/FR-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ