### PR TITLE
feat(FR-1662): use checkbox for `openToPublic` option in model service form

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -776,7 +776,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                           <Input disabled={!!endpoint} />
                         </Form.Item>
                         <Form.Item name="openToPublic" valuePropName="checked">
-                          <Checkbox>{t('modelService.OpenToPublic')}</Checkbox>
+                          <Checkbox disabled={!!endpoint}>{t('modelService.OpenToPublic')}</Checkbox>
                         </Form.Item>
                         {!endpoint ? (
                           <Form.Item


### PR DESCRIPTION
resolves #4605 (FR-1662)

| Before | After |
| ------- | ----- |
| <img width="713" height="342" alt="image" src="https://github.com/user-attachments/assets/337cfa82-bafe-4f58-a1bf-5bc508c7c765" /> | <img width="713" height="342" alt="image" src="https://github.com/user-attachments/assets/7d842b39-c55d-4f1e-b432-003bd28753db" /> |

This pull request updates the UI component for the "Open to Public" option on the `ServiceLauncherPageContent` form. The main change is replacing the `Switch` component with a `Checkbox`, and updating the logic to handle its state within the form.

**UI Component Changes:**

* Replaced the `Switch` component with a `Checkbox` for the "Open to Public" field, updating the import and usage in `ServiceLauncherPageContent.tsx`. [[1]](diffhunk://#diff-958c893fc385a72308862262e53baed65dc7412d599125ed3c4efe331ef7bc47R43-L47) [[2]](diffhunk://#diff-958c893fc385a72308862262e53baed65dc7412d599125ed3c4efe331ef7bc47L779-R797)
* Updated the form logic to use a render function for the "Open to Public" field, allowing direct control of the checked state and value changes with `getFieldValue` and `setFieldValue`.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
