### PR TITLE
refactor(FR-1664): refactor the container registry components to use the v2 api

### DIFF
--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -156,7 +156,7 @@ const ContainerRegistryList: React.FC<{
   const [commitDeleteMutation, isInFlightDeleteMutation] =
     useMutation<ContainerRegistryListDeleteMutation>(graphql`
       mutation ContainerRegistryListDeleteMutation($id: String!) {
-        delete_container_registry_node(id: $id) {
+        delete_container_registry_node_v2(id: $id) {
           container_registry {
             id
           }


### PR DESCRIPTION
resolves #4609 (FR-1665)

This PR updates the Container Registry Editor Modal to use the V2 API endpoints for container registry operations. The changes include:

1. Replacing multiple mutation variants with simplified V2 mutations
2. Updating the mutation structure to use the new input types
3. Updating response field references to match the V2 API structure
4. Updating the delete mutation in ContainerRegistryList to use the V2 endpoint

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after