### PR TITLE
fix(FR-1645): correct folder selection count after partial deletion

### DIFF
--- a/packages/backend.ai-ui/src/helper/index.ts
+++ b/packages/backend.ai-ui/src/helper/index.ts
@@ -318,7 +318,12 @@ export const localeCompare = (a?: string | null, b?: string | null) => {
   return a.localeCompare(b);
 };
 
-export const toGlobalId = (type: string, id: string): string => {
+type KnownGlobalIdType =
+  | 'VirtualFolderNode'
+  | 'ComputeSessionNode'
+  | 'UserNode';
+
+export const toGlobalId = (type: KnownGlobalIdType, id: string): string => {
   return btoa(`${type}:${id}`);
 };
 

--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -162,7 +162,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
         mutationToCreateFolder.mutate(input, {
           onSuccess: (result) => {
             upsertNotification({
-              key: 'folder-create-success',
+              key: `folder-create-success-${result.id}`,
               icon: 'folder',
               message: `${result.name}: ${t('data.folders.FolderCreated')}`,
               toText: t('data.folders.OpenAFolder'),

--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -15,6 +15,7 @@ import {
 } from 'backend.ai-ui';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSetBAINotification } from 'src/hooks/useBAINotification';
 
 interface FolderInvitationResponseModalProps extends BAIModalProps {}
 
@@ -32,6 +33,7 @@ const FolderInvitationResponseModal: React.FC<
   const baiClient = useSuspendedBackendaiClient();
   const hasInviterEmail = baiClient.supports('invitation-inviter-email');
   const { getErrorMessage } = useErrorMessageResolver();
+  const { upsertNotification } = useSetBAINotification();
 
   useEffect(() => {
     updateInvitations();
@@ -49,6 +51,19 @@ const FolderInvitationResponseModal: React.FC<
               message.success(
                 t('data.invitation.SuccessfullyAcceptedInvitation'),
               );
+
+              upsertNotification({
+                key: `folder-invitation-success-${item.id}`,
+                icon: 'folder',
+                message: `${item.vfolder_name}: ${t('data.invitation.SuccessfullyAcceptedInvitation')}`,
+                toText: t('data.folders.OpenAFolder'),
+                to: {
+                  search: new URLSearchParams({
+                    folder: item.vfolder_id,
+                  }).toString(),
+                },
+                open: true,
+              });
             } catch (e: any) {
               if (
                 e?.statusCode === 409 ||

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -677,12 +677,9 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             onChangeOrder={(order) => {
               setQuery({ order }, 'replaceIn');
             }}
-            onRequestChange={(updatedFolderId) => {
+            onRemoveRow={(removedId) => {
               setSelectedFolderList((prevSelected) =>
-                _.filter(
-                  prevSelected,
-                  (folder) => folder.id !== updatedFolderId,
-                ),
+                _.filter(prevSelected, (folder) => folder.id !== removedId),
               );
               updateFetchKey();
             }}


### PR DESCRIPTION
Resolves #4578 ([FR-1645](https://lablup.atlassian.net/browse/FR-1645))

## 🐛 Problem
Users experienced incorrect selected folder counts in multiple scenarios:
1. After partially deleting folders (moving to trash or permanent deletion)
2. After leaving a shared folder invitation
3. After restoring folders from trash

This led to confusion when users tried to select all items again, as the count would not match the actual selection state.

## 💡 Solution
This PR fixes the folder selection count mismatch by properly managing the selection state when folders are removed from the current view.

### Key Changes

#### 1. Improved Callback Naming and Semantics
- Renamed `onRequestChange` prop to `onRemoveRow` for better semantic clarity
- The new name clearly indicates that the callback is triggered when a row is removed from the current list

#### 2. Fixed Selection State Management
- **Delete to Trash**: Properly removes deleted folders from selection
- **Permanent Delete**: Correctly updates selection when folders are permanently deleted
- **Restore from Trash**: Updates selection state when folders are restored
- **Leave Shared Folder**: Now correctly removes the folder from selection when user leaves a shared folder invitation

#### 3. Enhanced Code Readability
- Renamed `currentVFolder` state to `deletingVFolder` for clearer intent
- Added descriptive comment for the `onRemoveRow` prop

#### 4. Improved User Notifications
- Success messages now properly display after each operation
- Consistent notification handling across all folder operations

## 📝 Changes in Detail

### VFolderNodes.tsx
- Renamed callback prop from `onRequestChange` to `onRemoveRow`
- Updated all mutation success handlers to use the new callback with correct parameters
- Fixed SharedFolderPermissionInfoModal's `onLeaveFolder` to properly trigger row removal
- Improved variable naming for better code clarity

### VFolderNodeListPage.tsx
- Updated to use the new `onRemoveRow` prop
- Simplified the folder removal logic for better readability
- Ensures selection list is properly updated when folders are removed

## ✅ Testing Checklist
- [ ] Select multiple folders and delete them (move to trash) - verify count updates correctly
- [ ] Permanently delete folders from trash - verify selection count remains accurate
- [ ] Restore folders from trash - verify selection state updates properly
- [ ] Select a shared folder and leave the invitation - verify the folder is removed from selection
- [ ] Select all folders, then partially delete some - verify "Select All" works correctly afterward
- [ ] Verify success notifications appear for all operations

## 🎯 Impact
This fix ensures a consistent and predictable user experience when managing folder selections, eliminating the confusion caused by mismatched selection counts after various folder operations.

[FR-1645]: https://lablup.atlassian.net/browse/FR-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ