### PR TITLE
fix(FR-1667): improve type safety and fix CUDA device config bug

### DIFF
--- a/react/src/components/UserDropdownMenu.tsx
+++ b/react/src/components/UserDropdownMenu.tsx
@@ -31,7 +31,7 @@ import {
   Typography,
   theme,
 } from 'antd';
-import { BAIUnmountAfterClose } from 'backend.ai-ui';
+import { BAIUnmountAfterClose, filterOutEmpty } from 'backend.ai-ui';
 import _ from 'lodash';
 import React, { CSSProperties, Suspense, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -68,7 +68,7 @@ const UserDropdownMenu: React.FC<{
     isPendingInitializeSettingModal,
     startInitializeSettingModalTransition,
   ] = useTransition();
-  const items: MenuProps['items'] = [
+  const items: MenuProps['items'] = filterOutEmpty([
     {
       'data-testid': 'dropdown-user-name',
       label: <Typography.Text>{userInfo.username}</Typography.Text>, //To display properly when the user name is too long.
@@ -185,7 +185,7 @@ const UserDropdownMenu: React.FC<{
         document.dispatchEvent(event);
       },
     },
-  ];
+  ]);
 
   const [userProfileSettingQueryRef, loadUserProfileSettingQuery] =
     useQueryLoader<UserProfileSettingModalQuery>(UserProfileQuery);

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -609,5 +609,7 @@ type BackendAIConfig = {
   isDirectorySizeVisible: boolean;
   enableReservoir: boolean;
   debug: boolean;
-  [key: string]: any;
+  proxyURL: string;
+  allowCustomResourceAllocation: boolean;
+  allowAppDownloadPanel: boolean;
 };

--- a/react/src/hooks/useResourceLimitAndRemaining.tsx
+++ b/react/src/hooks/useResourceLimitAndRemaining.tsx
@@ -244,7 +244,9 @@ export const useResourceLimitAndRemaining = ({
     () =>
       _.omitBy(baiClient._config, (_value, key) => {
         return !maxPerContainerRegex.test(key);
-      }),
+      }) as {
+        [key: string]: number;
+      },
     [baiClient._config],
   );
 
@@ -326,7 +328,7 @@ export const useResourceLimitAndRemaining = ({
         const perContainerLimit =
           _.find(perContainerConfigs, (_configValue, configName) => {
             return isMatchingMaxPerContainer(configName, key);
-          }) ?? baiClient._config['cuda.device']; // FIXME: temporally `cuda.device` config, when undefined
+          }) ?? baiClient._config.maxCUDADevicesPerContainer; // NOTE: Fallback to maxCUDADevicesPerContainer if no specific config found
 
         result[key] = {
           min: parseInt(


### PR DESCRIPTION
Resolves [FR-1667](https://lablup.atlassian.net/browse/FR-1667)

## Background
Improve TypeScript type safety and fix CUDA device configuration bug.

## Problems
- Reduced type safety due to `[key: string]: any` in BackendAIConfig interface
- Incorrect config property reference in useResourceLimitAndRemaining (cuda.device → maxCUDADevicesPerContainer)

## Changes
- Add explicit property definitions to BackendAIConfig interface
- Fix CUDA device configuration to use correct property name  
- Apply filterOutEmpty utility to UserDropdownMenu

## Test Plan
- [ ] Verify TypeScript compilation passes without errors
- [ ] Test resource limit calculations work correctly with CUDA devices
- [ ] Ensure UserDropdownMenu displays correctly with filtered items

[FR-1667]: https://lablup.atlassian.net/browse/FR-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ