### PR TITLE
feat(FR-1669): modify BAITable to have default size as small

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -365,7 +365,7 @@ const BAITable = <RecordType extends object = any>({
       {tableProps.pagination !== false && (
         <BAIFlex justify="end" gap={'xs'}>
           <Pagination
-            size={tableProps.size === 'small' ? 'small' : 'default'}
+            size={tableProps.pagination?.size || 'small'}
             align="end"
             pageSizeOptions={['10', '20', '50']}
             showSizeChanger={true}
@@ -396,7 +396,7 @@ const BAITable = <RecordType extends object = any>({
               type="text"
               icon={<SettingOutlined />}
               onClick={() => setIsColumnSettingModalOpen(true)}
-              size={tableProps.size}
+              size={tableProps.size || 'small'}
             />
           )}
           {tableProps.pagination && tableProps.pagination.extraContent}


### PR DESCRIPTION
resolves FR-1669

# Fix BAITable pagination and column setting button size

This PR fixes two issues in the BAITable component:

1. Updates the pagination size to use the size specified in `tableProps.pagination.size` instead of deriving it from `tableProps.size`
2. Adds a fallback to 'small' for the column setting button size when `tableProps.size` is undefined

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after