### PR TITLE
fix(FR-1671): add required field indicators to FolderCreateModal form

### DIFF
--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -238,7 +238,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
         initialValues={INITIAL_FORM_VALUES}
         labelCol={{ span: 8 }}
       >
-        <Form.Item label={t('data.UsageMode')} name={'usage_mode'}>
+        <Form.Item label={t('data.UsageMode')} name={'usage_mode'} required>
           <Radio.Group
             onChange={() => {
               // Only validate name field if it has a value to prevent excessive validation
@@ -316,7 +316,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
         </Form.Item>
         <Divider />
 
-        <Form.Item label={t('data.folders.Location')} name={'host'}>
+        <Form.Item label={t('data.folders.Location')} name={'host'} required>
           <Suspense fallback={<Skeleton.Input active />}>
             <StorageSelect
               onChange={(value) => {
@@ -329,7 +329,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
           </Suspense>
         </Form.Item>
         <Divider />
-        <Form.Item dependencies={['usage_mode']} noStyle>
+        <Form.Item dependencies={['usage_mode']} noStyle required>
           {({ getFieldValue }) => {
             const usageMode = getFieldValue('usage_mode');
             const shouldDisableProject =
@@ -340,6 +340,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
               <Form.Item
                 label={t('data.Type')}
                 name={'type'}
+                required
                 style={{ flex: 1, marginBottom: 0 }}
                 rules={[
                   ({ getFieldValue }) => ({
@@ -423,7 +424,7 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
 
         <Form.Item hidden name={'group'} />
 
-        <Form.Item label={t('data.Permission')} name={'permission'}>
+        <Form.Item label={t('data.Permission')} name={'permission'} required>
           <Radio.Group>
             <Radio value={'rw'} data-testid="rw-permission">
               {t('data.ReadWrite')}


### PR DESCRIPTION
Resolves #4623 ([FR-1671](https://lablup.atlassian.net/browse/FR-1671))

## What this PR changes

This PR fixes missing required field indicators in the FolderCreateModal form. The form was not clearly showing which fields are mandatory, causing user confusion.

## Changes made

- Added `required` prop to Usage Mode field
- Added `required` prop to Location field  
- Added `required` prop to Type field
- Added `required` prop to Permission field

## How it affects users

Users will now see clear asterisk (*) indicators next to required fields in the Folder Create Modal, improving the user experience by making it obvious which fields must be filled out before folder creation can proceed.

**Checklist:** (if applicable)

- [x] Documentation - No documentation changes needed for UI indicators
- [x] Minimum required manager version - No backend changes required
- [x] Specific setting for review - Open Folder Create Modal in Storage section
- [x] Minimum requirements to check during review - Verify asterisks appear next to required fields
- [x] Test case(s) to demonstrate the difference of before/after - Check that Usage Mode, Location, Type, and Permission fields show required indicators

[FR-1671]: https://lablup.atlassian.net/browse/FR-1671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ