### PR TITLE
style(FR-1672): set resource preset all input width to 100%

### DIFF
--- a/react/src/components/ResourcePresetSettingModal.tsx
+++ b/react/src/components/ResourcePresetSettingModal.tsx
@@ -354,6 +354,7 @@ const ResourcePresetSettingModal: React.FC<ResourcePresetSettingModalProps> = ({
                               _.get(mergedResourceSlots, resourceSlotKey)
                                 ?.display_unit
                             }
+                            style={{ width: '100%' }}
                           />
                         )}
                       </Form.Item>


### PR DESCRIPTION
resolves FR-1672

# Set width to 100% for resource slot input in ResourcePresetSettingModal

This PR adds a style property to set the width of the resource slot input to 100% in the ResourcePresetSettingModal component, ensuring the input field properly fills its container.

![image.png](https://app.graphite.com/user-attachments/assets/d02d828b-dabf-47fe-9760-d05548addea1.png)



**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after