### PR TITLE
chore(FR-1676): add test IDs to app launcher components for improved testability

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
@@ -129,6 +129,7 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
 
   return (
     <BAIModal
+      data-testid="app-launcher-modal"
       title={
         <BAIText
           ellipsis
@@ -150,7 +151,11 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
         {_.map(baseAppTemplate, (apps, category) => {
           return (
             <div key={category}>
-              <Typography.Title level={5} style={{ marginTop: 0 }}>
+              <Typography.Title
+                level={5}
+                style={{ marginTop: 0 }}
+                data-testid={`category-${category.split('.')[1]}`}
+              >
                 {category.split('.')[1]}
               </Typography.Title>
               <Row gutter={[24, 24]}>
@@ -158,6 +163,7 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
                   return (
                     <Col
                       key={app?.name}
+                      data-testid={`app-${app?.name}`}
                       span={6}
                       style={{ alignContent: 'center' }}
                     >

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -1776,6 +1776,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
                   ? html`
                       <h3
                         style="width:100%;padding-left:15px;border-bottom:1px solid var(--token-colorBorder, #ccc);"
+                        data-testid=${`divider-${item.title}`}
                       >
                         ${item.title}
                       </h3>
@@ -1783,6 +1784,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
                   : html`
                       <div
                         class="vertical layout center center-justified app-icon"
+                        data-testid=${`modal-item-${item.name}`}
                       >
                         <mwc-icon-button
                           class="fg apps green"
@@ -1803,7 +1805,11 @@ export default class BackendAiAppLauncher extends BackendAIPage {
           ${
             this.preOpenedPortList.length > 0
               ? html`
-                  <lablup-expansion id="preopen-ports-expansion" open>
+                  <lablup-expansion
+                    id="preopen-ports-expansion"
+                    open
+                    data-testid="checkbox-preopen-ports"
+                  >
                     <span slot="title" class="horizontal layout">
                       ${_t('session.launcher.PreOpenPortTitle')}
                     </span>
@@ -1839,7 +1845,10 @@ export default class BackendAiAppLauncher extends BackendAIPage {
               globalThis.isElectron || !this.openPortToPublic
                 ? ``
                 : html`
-                    <div class="horizontal layout center">
+                    <div
+                      class="horizontal layout center"
+                      data-testid="checkbox-open-to-public"
+                    >
                       <mwc-checkbox
                         id="chk-open-to-public"
                         style="margin-right:0.5em;"


### PR DESCRIPTION
Resolves #4631 ([FR-1676](https://lablup.atlassian.net/browse/FR-1676))

## Summary

Added test IDs to app launcher components to improve E2E testing capabilities.

## Changes

### React Component (AppLauncherModal.tsx)
- Added `data-testid` attributes to modal, category headers, and app items
- Enables better targeting of UI elements in automated tests

### Lit Element Component (backend-ai-app-launcher.ts)
- Added `data-testid` attributes to dividers, modal items, and checkboxes
- Improves testability of pre-open ports and public access options

## Test Plan

- [x] Verified test IDs are properly rendered in the DOM
- [ ] E2E tests can successfully target elements using the new test IDs
- [ ] No functional changes to the app launcher behavior

## Related

This work supports FR-1676 which aims to add functionality to hide specific applications in the session app launcher. 

[FR-1676]: https://lablup.atlassian.net/browse/FR-1676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ