### PR TITLE
feat(FR-1681): implement automatic shared memory calculation in session creation

### DIFF
--- a/react/src/hooks/useStartSession.tsx
+++ b/react/src/hooks/useStartSession.tsx
@@ -154,7 +154,7 @@ export const useStartSession = () => {
       const mem = mergedValue.resource.mem;
 
       // Apply the same logic as ResourceAllocationFormItems
-      // If mem > 4G, set shmem to 1G, otherwise use AUTOMATIC_DEFAULT_SHMEM (64m)
+      // If mem >= 4G, set shmem to 1G, otherwise use AUTOMATIC_DEFAULT_SHMEM (64m)
       if (compareNumberWithUnits(mem, '4g') >= 0) {
         mergedValue.resource.shmem = '1g';
       } else {


### PR DESCRIPTION
Resolves ([FR-1681](https://lablup.atlassian.net/browse/FR-1681))

## Summary
Implement automatic shared memory (shmem) calculation in the `startSessionWithDefault` function to ensure consistency with UI-based session creation.

## Changes
- Added automatic shmem calculation logic in `useStartSession.tsx`
- When `enabledAutomaticShmem` is enabled and memory is allocated:
  - If memory ≥ 4GB → shmem = 1GB
  - If memory < 4GB → shmem = 64MB (default)
- Imports `AUTOMATIC_DEFAULT_SHMEM` constant and `compareNumberWithUnits` helper

## Background
Previously, the `ResourceAllocationFormItems` component had automatic shmem calculation logic, but programmatic session creation through `useStartSession` hook did not apply the same logic. This created inconsistency between UI-based and programmatic session creation, potentially leading to suboptimal resource allocation.

## Test Plan
- Verify shmem is automatically set to 1GB when memory ≥ 4GB
- Verify shmem is automatically set to 64MB when memory < 4GB
- Confirm consistency with ResourceAllocationFormItems behavior

[FR-1681]: https://lablup.atlassian.net/browse/FR-1681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ