### PR TITLE
fix(FR-1682): remove hardcoded password from noVNC redirect URL

### DIFF
--- a/resources/app_template.json
+++ b/resources/app_template.json
@@ -151,7 +151,7 @@
         "name": "novnc",
         "title": "VNC (Web)",
         "category": "6.Desktop Environment",
-        "redirect": "/vnc.html?autoconnect=true&amp;password=backendai",
+        "redirect": "/vnc.html?autoconnect=true",
         "src": "./resources/icons/novnc.svg"
       }
     ],


### PR DESCRIPTION
resolves ([FR-1682](https://lablup.atlassian.net/browse/FR-1682))
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

This addresses the security issue where the password used for authentication during noVNC connections is included in the redirect URL. 

Removing the password portion from the URL requires users to manually enter their password when accessing via noVMC. 

![image.png](https://app.graphite.com/user-attachments/assets/bf63cef7-77a2-4965-8482-aef3573f21a4.png)

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after


[FR-1682]: https://lablup.atlassian.net/browse/FR-1682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ