### PR TITLE
fix(FR-1686): fix edit button not reappearing after no-change submission in folder name editor

### DIFF
--- a/react/src/components/EditableVFolderName.tsx
+++ b/react/src/components/EditableVFolderName.tsx
@@ -157,6 +157,7 @@ const EditableVFolderName: React.FC<EditableVFolderNameProps> = ({
             setIsEditing(false);
             focusFallback();
             if (values.vfolderName === vfolder.name) {
+              onEditEnd?.();
               return;
             }
             setOptimisticName(values.vfolderName);


### PR DESCRIPTION
Resolves #4650 ([FR-1686](https://lablup.atlassian.net/browse/FR-1686))

## Changes

Fixed a bug where the inline edit button (hover edit icon) for folder names would not reappear after:
1. Clicking the edit button to enter edit mode
2. Pressing Enter without making any changes

### Root Cause
When the form was submitted with no changes, the `onEditEnd` callback was not being called, leaving the `editingColumn` state in VFolderNodes in an inconsistent state. This prevented the hover edit button from being displayed again.

### Solution
Added `onEditEnd?.()` callback invocation in the form submission handler when the folder name hasn't changed, ensuring proper cleanup of the editing state.

## Test Case
1. Navigate to the Data & Storage page
2. Hover over a folder name to see the edit button
3. Click the edit button to enter edit mode
4. Press Enter without making any changes
5. Hover over the folder name again
6. ✅ The edit button should reappear (previously it would not)

**Checklist:**

- [x] Test case verified: Edit button now reappears correctly after no-change submission

[FR-1686]: https://lablup.atlassian.net/browse/FR-1686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ