### PR TITLE
feat(FR-1697): add a claude skill references the backend.ai docs

### DIFF
--- a/.claude/skills/backend-ai-guide/SKILL.md
+++ b/.claude/skills/backend-ai-guide/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: backend-ai-guide
+description: |
+  Expert guide for Backend.AI distributed computing platform. Automatically
+  activates when users ask about:
+  - Backend.AI architecture, components (Manager, Agent, Storage Proxy, Webserver, App Proxy)
+  - Features (session scheduling, Sokovan orchestrator, multi-tenancy, resource allocation)
+  - APIs (REST, GraphQL), authentication, RBAC authorization
+  - Container runtime (kernels, jail sandbox, hook library, virtual folders)
+  - Accelerator support (CUDA, ROCm, TPU, NPU, Graphcore IPU)
+  - Client SDKs (Python, Java, JavaScript, PHP)
+  - Setup, requirements (Python 3.13+, Docker, PostgreSQL, Redis, etcd)
+  - How WebUI connects to/interacts with Backend.AI backend
+  - Plugin interfaces, development setup, infrastructure
+  Use when user mentions "Backend.AI", "backend.ai", "Sokovan", component names,
+  or asks about the backend platform this WebUI connects to.
+ allowed-tools: WebFetch, Read
+---
+
+# Backend.AI Guide Skill
+
+## Purpose
+
+This skill provides expert-level information about the Backend.AI platform by:
+
+- Fetching official documentation from the Backend.AI GitHub repository
+- Recursively exploring Major Components documentation links
+- Following relevant links to gather comprehensive technical details
+- Providing accurate, source-backed answers about Backend.AI architecture and features
+
+## When to Use
+
+Activate this skill when the user asks about:
+
+- Backend.AI platform overview or architecture
+- Backend.AI components (Manager, Agent, Storage Proxy, Webserver, App Proxy)
+- Backend.AI setup, requirements, or infrastructure
+- Backend.AI APIs (REST, GraphQL)
+- Backend.AI features (session scheduling, resource allocation, multi-tenancy)
+- Backend.AI kernels, containers, or runtime elements
+- How the WebUI connects to or interacts with Backend.AI backend
+- Differences between Backend.AI components
+
+## Primary Documentation Sources
+
+1. **Main README**: https://github.com/lablup/backend.ai/blob/main/README.md
+
+   - Overview and architecture
+   - Major Components section with component links
+   - Requirements and setup information
+
+2. **Major Component READMEs**: Follow links from the Major Components section
+
+   - Manager component details
+   - Agent component details
+   - Storage Proxy details
+   - Webserver details
+   - App Proxy details
+   - And other components
+
+3. **Recursive Link Following**: When a component README references additional documentation, follow those links to gather comprehensive information
+
+## Instructions
+
+### Step 1: Identify the Question Scope
+
+- Determine what aspect of Backend.AI the user is asking about
+- Identify which components or features are relevant
+
+### Step 2: Fetch the Main README
+
+- Always start by fetching: https://github.com/lablup/backend.ai/blob/main/README.md
+- Extract key information relevant to the question
+- Identify links to Major Components that need to be explored
+
+### Step 3: Recursively Fetch Component Documentation
+
+- For questions about specific components, fetch their individual READMEs
+- Component README links are found in the "Major Components" section
+- Example component paths (adjust based on actual links):
+  - Manager: `src/ai/backend/manager/README.md`
+  - Agent: `src/ai/backend/agent/README.md`
+  - Storage Proxy: `src/ai/backend/storage/README.md`
+  - Webserver: `src/ai/backend/web/README.md`
+  - App Proxy: `src/ai/backend/appproxy/README.md`
+
+### Step 4: Follow Additional Links
+
+- If component READMEs reference additional documentation, follow those links
+- Common additional documentation types:
+  - Architecture diagrams
+  - API documentation
+  - Configuration guides
+  - Development guides
+- **Important**: Only follow links that are relevant to answering the user's question
+
+### Step 5: Synthesize and Present Information
+
+- Combine information from all fetched sources
+- Structure the answer logically:
+  1. Direct answer to the user's question
+  2. Supporting details from official documentation
+  3. Related component interactions (if applicable)
+  4. Links to source documentation for further reading
+- Use clear headings and formatting
+- Include code examples or configuration snippets when relevant
+
+## Best Practices
+
+1. **Always Cite Sources**
+
+   - Reference the specific documentation URLs you fetched
+   - Help users find more detailed information
+
+2. **Stay Current**
+
+   - Fetch documentation fresh each time (don't rely on cached knowledge)
+   - Note version requirements (Python, Docker, PostgreSQL, etc.)
+
+3. **Explain Component Interactions**
+
+   - Backend.AI is a distributed system - explain how components work together
+   - Clarify the relationship between WebUI (this project) and Backend.AI backend
+
+4. **Be Precise with Technical Details**
+
+   - Include version numbers, requirements, and configuration details
+   - Distinguish between different API types (REST vs GraphQL)
+
+5. **Limit Recursion Depth**
+   - Fetch main README + relevant component READMEs
+   - Only follow 1-2 additional link levels unless user needs deep details
+   - Balance thoroughness with response time
+
+## Example Question Types
+
+**Architecture Questions**
+
+- "How does Backend.AI work?"
+- "What is the architecture of Backend.AI?"
+- "What are the main components of Backend.AI?"
+
+**Component Questions**
+
+- "What does the Backend.AI Manager do?"
+- "How does the Agent component work?"
+- "What is the Storage Proxy?"
+
+**Integration Questions**
+
+- "How does this WebUI connect to Backend.AI?"
+- "What APIs does Backend.AI expose?"
+- "How do I authenticate with Backend.AI?"
+
+**Setup Questions**
+
+- "What are the requirements for Backend.AI?"
+- "How do I set up Backend.AI?"
+- "What infrastructure does Backend.AI need?"
+
+## Response Format
+
+Structure answers as follows:
+
+```markdown
+## [Direct Answer to Question]
+
+[Concise, direct answer based on official documentation]
+
+## Details
+
+[Supporting information from fetched documentation]
+
+### Component Interactions (if applicable)
+
+[How different components work together]
+
+## Technical Specifications (if applicable)
+
+- Requirements: [versions, dependencies]
+- Configuration: [relevant settings]
+- APIs: [REST/GraphQL endpoints]
+
+## Source Documentation
+
+- Main: [URL to main README]
+- Component: [URLs to component READMEs]
+- Additional: [URLs to other relevant docs]
+```
+
+## Notes
+
+- Backend.AI is the **backend platform** that this WebUI project connects to
+- This WebUI (backend.ai-webui) is a **client application** that uses Backend.AI's APIs
+- When users ask about "the backend" in this project context, they likely mean Backend.AI
+- Distinguish between WebUI code (this project) and Backend.AI platform code (separate repo)
+
+## Limitations
+
+- This skill only fetches publicly available GitHub documentation
+- For questions requiring internal documentation or specific deployment details, direct users to Backend.AI team
+- Cannot access private repositories or non-public documentation

--- a/.claude/skills/backend-ai-guide/common-questions.md
+++ b/.claude/skills/backend-ai-guide/common-questions.md
@@ -1,0 +1,551 @@
+# Backend.AI Common Questions
+
+Frequently asked questions about Backend.AI platform. Use this as a quick reference for common inquiries.
+
+---
+
+## Architecture & Components
+
+### Q: What is Backend.AI?
+
+**A**: Backend.AI is a streamlined, container-based computing cluster platform that hosts popular computing/ML frameworks and diverse programming languages, with pluggable heterogeneous accelerator support. It allocates computing resources for multi-tenant sessions on-demand or in batches through its orchestrator called "Sokovan".
+
+**Key Characteristics**:
+- Container-based isolation
+- Multi-tenant resource allocation
+- Heterogeneous accelerator support (CUDA, ROCm, TPU, NPU)
+- REST and GraphQL APIs for all operations
+- Built for ML/AI workloads and scientific computing
+
+---
+
+### Q: What are the main components of Backend.AI?
+
+**A**: Backend.AI consists of 5 major server-side components:
+
+1. **Manager** - Central API gateway, orchestrator, session scheduler, authentication
+2. **Agent** - Kernel lifecycle management on compute nodes, container management
+3. **Storage Proxy** - Virtual folder and storage backend abstraction
+4. **Webserver** - Hosts the WebUI, manages web sessions
+5. **App Proxy** - Routes traffic to in-container services (Jupyter, VSCode, SSH)
+
+**Container Runtime Elements**:
+- **Kernels** - Dockerfile recipes for computing environments
+- **Jail** - Rust-based ptrace sandbox for security
+- **Hook** - In-container runtime library for resource control
+
+---
+
+### Q: How do the components communicate with each other?
+
+**A**: Component communication flow:
+
+```
+User → Webserver → Manager → Agent → Storage Proxy
+                       ↓
+                  App Proxy
+```
+
+1. **User** accesses via WebUI or Client SDK
+2. **Webserver** hosts WebUI, signs API requests
+3. **Manager** receives requests, orchestrates operations, schedules sessions
+4. **Agent** executes container operations, manages kernels
+5. **Storage Proxy** provides virtual folder access
+6. **App Proxy** routes traffic to in-container services
+
+All communication uses REST/GraphQL APIs with authentication tokens.
+
+---
+
+### Q: What is Sokovan?
+
+**A**: Sokovan is Backend.AI's built-in orchestrator responsible for:
+- Session scheduling and resource allocation
+- Multi-tenant resource isolation
+- Priority-based and fair-share scheduling
+- Resource quota management
+- Custom scheduling policies via plugins
+
+It's named after the warehouse keeper puzzle game (Sokoban), reflecting its role in organizing and managing resources efficiently.
+
+---
+
+## WebUI Integration
+
+### Q: How does this WebUI project connect to Backend.AI?
+
+**A**: The Backend.AI WebUI is a **client application** that connects to the Backend.AI backend platform:
+
+1. **WebUI** (this project) runs as a Single Page Application (SPA)
+2. **Webserver** component hosts the WebUI and manages web sessions
+3. **Manager** component provides REST/GraphQL APIs
+4. **WebUI** uses APIs to:
+   - Authenticate users
+   - Create/manage compute sessions
+   - Access virtual folders
+   - Monitor resources
+   - Configure settings
+
+**Connection Flow**:
+```
+WebUI Code (React/Lit) → API Calls → Manager API → Backend Operations
+```
+
+---
+
+### Q: What APIs does the WebUI use?
+
+**A**: The WebUI uses both REST and GraphQL APIs:
+
+**REST API**: For operations like:
+- Authentication (`/auth/login`)
+- Session management (`/session`)
+- Kernel operations (`/kernel`)
+- File uploads/downloads
+
+**GraphQL API**: For complex queries like:
+- User information (`query user`)
+- Session details (`query compute_session`)
+- Group/project data (`query group`)
+- Aggregated statistics
+
+**Authentication**: API keys or JWT tokens signed by the Webserver component.
+
+---
+
+## Features & Capabilities
+
+### Q: What accelerators does Backend.AI support?
+
+**A**: Backend.AI supports heterogeneous accelerators through the Agent's plugin system:
+
+**GPU**:
+- NVIDIA CUDA GPUs
+- AMD ROCm GPUs
+
+**NPU (Neural Processing Units)**:
+- Rebellions NPU
+- FuriosaAI NPU
+
+**Other Accelerators**:
+- HyperAccel LPU (Language Processing Unit)
+- Google TPU (Tensor Processing Unit)
+- Graphcore IPU (Intelligence Processing Unit)
+
+New accelerators can be added via the `backendai_accelerator_v21` plugin interface.
+
+---
+
+### Q: What is multi-tenancy in Backend.AI?
+
+**A**: Multi-tenancy means Backend.AI can:
+- **Isolate resources** between different users/organizations
+- **Allocate quotas** for CPU, memory, GPU, storage
+- **Enforce permissions** via RBAC (Role-Based Access Control)
+- **Share infrastructure** while maintaining security boundaries
+
+**Organizational Hierarchy**:
+```
+Domain (Organization)
+  └─ Group/Project
+      └─ User
+          └─ Session (Kernel)
+```
+
+Each level has resource quotas and permission policies.
+
+---
+
+### Q: What are virtual folders (vfolders)?
+
+**A**: Virtual folders are Backend.AI's abstraction for persistent storage:
+
+**Features**:
+- **Cross-session persistence** - Data survives kernel restarts
+- **Multi-backend support** - Local FS, NFS, Ceph, S3, Azure Blob, GCS
+- **Permission management** - Share folders between users/groups
+- **Quota enforcement** - Size limits per folder
+- **Performance monitoring** - Real-time I/O metrics
+
+**Use Cases**:
+- Store datasets across multiple training sessions
+- Share code/data between team members
+- Persist model checkpoints
+- Mount cloud storage into containers
+
+---
+
+### Q: What are kernels in Backend.AI?
+
+**A**: Kernels are containerized computing environments:
+
+**Definition**: Docker containers running specific frameworks/languages with intrinsic service support.
+
+**Intrinsic Services**:
+- Jupyter Notebook/Lab
+- Terminal (ttyd)
+- SSH/SFTP/SCP
+- VSCode Server
+
+**Popular Kernels**:
+- Python (TensorFlow, PyTorch, JAX)
+- R (with statistical packages)
+- Julia, C/C++, Java, Go, Rust, Node.js
+
+**Kernel Lifecycle**: Manager schedules → Agent creates container → User interacts → Agent destroys container
+
+---
+
+## Development & Setup
+
+### Q: What are the system requirements to run Backend.AI?
+
+**A**: Development/Production Requirements:
+
+**Software**:
+- Python 3.13.x (CPython 3.13.7)
+- Pantsbuild 2.27.x
+- Docker 20.10+ (with Compose v2)
+- PostgreSQL 16+
+- Redis 7.2+
+- etcd 3.5+
+- Prometheus 3.x
+
+**OS**:
+- Linux (Debian/RHEL-based distributions)
+- macOS (with sudo access)
+
+**Hardware** (recommended):
+- Multi-core CPU
+- 16GB+ RAM for development
+- SSD storage
+- GPU optional (for accelerator support)
+
+---
+
+### Q: How do I start developing with Backend.AI?
+
+**A**: Quick development setup:
+
+```bash
+# Clone repository
+git clone https://github.com/lablup/backend.ai.git
+cd backend.ai
+
+# Install development dependencies
+./scripts/install-dev.sh
+
+# Start components (in separate terminals)
+./backend.ai mgr start-server --debug    # Manager
+./backend.ai ag start-server --debug     # Agent
+./py -m ai.backend.storage.server        # Storage Proxy
+./py -m ai.backend.web.server            # Webserver
+
+# Access WebUI
+open http://localhost:8090
+```
+
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/README.md
+
+---
+
+### Q: How do I use Backend.AI from my application?
+
+**A**: Use one of the official Client SDKs:
+
+**Python**:
+```bash
+pip install backend.ai-client
+
+# CLI usage
+backend.ai session create python:3.11
+backend.ai run python -c "print('Hello')"
+
+# SDK usage
+from ai.backend.client import Session
+async with Session() as session:
+    result = await session.execute("print('Hello')")
+```
+
+**JavaScript**:
+```bash
+npm install backend.ai-client
+
+// SDK usage
+import BackendAIClient from 'backend.ai-client';
+const client = new BackendAIClient(config);
+await client.session.create('python:3.11');
+```
+
+**Java**: Download from https://github.com/lablup/backend.ai-client-java
+**PHP**: Coming soon - https://github.com/lablup/backend.ai-client-php
+
+---
+
+## Plugin System
+
+### Q: What plugins does Backend.AI support?
+
+**A**: Backend.AI has a rich plugin system for extensibility:
+
+**Manager Plugins**:
+- `backendai_scheduler_v10` - Custom schedulers (e.g., FIFO, priority, fair-share)
+- `backendai_agentselector_v10` - Agent selection strategies
+- `backendai_hook_v20` - Lifecycle hooks (pre/post operations)
+- `backendai_webapp_v20` - Web app extensions
+- `backendai_monitor_stats_v10` - Statistics monitoring
+- `backendai_monitor_error_v10` - Error monitoring
+
+**Agent Plugins**:
+- `backendai_accelerator_v21` - Hardware accelerator support
+- `backendai_monitor_stats_v10` - Statistics monitoring
+- `backendai_monitor_error_v10` - Error monitoring
+
+**Use Cases**:
+- Add custom GPU support
+- Implement organization-specific scheduling policies
+- Integrate monitoring systems (Prometheus, Grafana)
+- Add custom authentication backends
+
+---
+
+## Security & Isolation
+
+### Q: How does Backend.AI ensure security and isolation?
+
+**A**: Multi-layered security approach:
+
+**Container Isolation**:
+- Docker container boundaries
+- Resource limits (CPU, memory, GPU)
+- Network isolation per session
+
+**Jail Sandbox**:
+- Rust-based ptrace system call filtering
+- Prevents dangerous system calls
+- Fine-grained access control
+
+**Hook Library**:
+- Resource monitoring and limits
+- Standard input control
+- Environment variable management
+
+**RBAC (Role-Based Access Control)**:
+- User/group/domain hierarchy
+- Permission policies per resource
+- API key management
+
+**Quota Enforcement**:
+- CPU/memory/GPU limits
+- Storage quota per vfolder
+- Rate limiting on API calls
+
+---
+
+## Performance & Scaling
+
+### Q: How does Backend.AI handle scaling?
+
+**A**: Horizontal and vertical scaling strategies:
+
+**Horizontal Scaling**:
+- Add more **Agent** nodes for compute capacity
+- Add **Storage Proxy** instances for I/O throughput
+- Load balance via **App Proxy** for service routing
+
+**Vertical Scaling**:
+- Increase resources on existing nodes
+- Add more GPUs/accelerators per Agent
+
+**Architecture Benefits**:
+- **Stateless Manager** - Scale API gateway independently
+- **Self-registering Agents** - Add nodes dynamically via heartbeats
+- **Distributed Storage** - Backends like Ceph scale independently
+- **Sokovan Orchestrator** - Efficient resource allocation across cluster
+
+---
+
+## Troubleshooting
+
+### Q: Where can I find logs and metrics?
+
+**A**: Observability stack integration:
+
+**Logs**:
+- Component logs in stdout/stderr
+- Structured logging (JSON format)
+- **Loki** integration for log aggregation
+
+**Metrics**:
+- **Prometheus** metrics endpoint on each component
+- Resource usage (CPU, memory, GPU, I/O)
+- Session statistics
+- **Grafana** dashboards for visualization
+
+**Tracing**:
+- **OpenTelemetry** instrumentation
+- **Tempo** for distributed tracing
+- Request flow across components
+
+**Default Monitoring URL**: http://localhost:9090 (Prometheus)
+
+---
+
+### Q: How do I debug Backend.AI issues?
+
+**A**: Debugging strategies:
+
+**Check Component Logs**:
+```bash
+./backend.ai mgr start-server --debug    # Verbose Manager logs
+./backend.ai ag start-server --debug     # Verbose Agent logs
+```
+
+**Verify Component Status**:
+```bash
+# Check if services are running
+docker ps                    # Container status
+etcdctl member list          # etcd cluster health
+redis-cli ping               # Redis connectivity
+psql -h localhost -U backend.ai  # PostgreSQL connection
+```
+
+**API Testing**:
+```bash
+# Test REST API
+curl -X POST http://localhost:8090/auth/login
+
+# Test GraphQL API
+curl -X POST http://localhost:8090/admin/graphql \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"query": "{ user { id email } }"}'
+```
+
+**Common Issues**:
+- **Agent not registering**: Check etcd connectivity, verify heartbeat config
+- **Session creation fails**: Check Agent resources, Docker daemon status
+- **Storage access fails**: Verify Storage Proxy config, backend credentials
+- **WebUI not loading**: Check Webserver logs, CORS settings
+
+---
+
+## Migration & Updates
+
+### Q: How do I migrate between Backend.AI versions?
+
+**A**: Follow the official migration guide:
+
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/MIGRATION.md
+
+**General Process**:
+1. **Backup databases** (PostgreSQL, etcd, Redis)
+2. **Review release notes** for breaking changes
+3. **Update dependencies** (Python packages, system libraries)
+4. **Run database migrations** (via Alembic)
+5. **Restart components** in order (Manager → Agent → Storage → Web)
+6. **Verify functionality** (test sessions, API calls)
+
+**Compatibility**:
+- Manager/Agent versions should match
+- Client SDKs compatible within major version
+- Kernel images updated separately
+
+---
+
+## Additional Resources
+
+### Q: Where can I find more information?
+
+**A**: Official resources:
+
+**Documentation**:
+- Main Docs: http://docs.backend.ai
+- GitHub: https://github.com/lablup/backend.ai
+- Contributing: https://github.com/lablup/backend.ai/blob/main/.github/CONTRIBUTING.md
+
+**Development**:
+- Development Setup: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/README.md
+- Claude Agent Guide: https://github.com/lablup/backend.ai/blob/main/CLAUDE.md
+- Migration Guide: https://github.com/lablup/backend.ai/blob/main/MIGRATION.md
+
+**Client SDKs**:
+- Python: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/client
+- Java: https://github.com/lablup/backend.ai-client-java
+- JavaScript: https://github.com/lablup/backend.ai-client-js
+- PHP: https://github.com/lablup/backend.ai-client-php
+
+**Container Runtime**:
+- Kernels: https://github.com/lablup/backend.ai-kernels
+- Jail: https://github.com/lablup/backend.ai-jail
+- Hook: https://github.com/lablup/backend.ai-hook
+
+---
+
+## WebUI-Specific Questions
+
+### Q: What's the difference between React and Lit-Element code in this WebUI?
+
+**A**: This WebUI is a **hybrid architecture**:
+
+**Lit-Element (`/src`)**:
+- Legacy web components
+- Material Web Components
+- Older features and pages
+
+**React (`/react`)**:
+- Modern UI components
+- Ant Design + Relay (GraphQL)
+- New features and pages
+
+**Integration**: Both coexist, gradually migrating from Lit to React.
+
+---
+
+### Q: How does the WebUI handle state management?
+
+**A**: Different strategies for different frameworks:
+
+**React Components**:
+- **Relay** for GraphQL-backed state
+- **Recoil** for global client state
+- **React hooks** for local state
+
+**Lit-Element Components**:
+- **Redux** for global state
+- Component properties for local state
+
+**Recommendation**: New features should use React + Relay + Recoil pattern.
+
+---
+
+### Q: How do I fetch Backend.AI data in the WebUI?
+
+**A**: Use appropriate method for the framework:
+
+**React + Relay** (preferred):
+```typescript
+const data = useLazyLoadQuery(
+  graphql`
+    query MyComponentQuery {
+      compute_session {
+        id
+        status
+      }
+    }
+  `,
+  {}
+);
+```
+
+**REST API** (when GraphQL not available):
+```typescript
+const response = await fetch('/session', {
+  headers: {
+    'Authorization': `Bearer ${token}`
+  }
+});
+```
+
+**Refer to**: `@.github/instructions/react.instructions.md` for React patterns.
+
+---

--- a/.claude/skills/backend-ai-guide/component-overview.md
+++ b/.claude/skills/backend-ai-guide/component-overview.md
@@ -1,0 +1,341 @@
+# Backend.AI Component Overview
+
+Quick reference guide for Backend.AI's major components. This document provides at-a-glance summaries for fast lookups.
+
+---
+
+## Server-Side Components
+
+### Manager
+**Repository**: `src/ai/backend/manager/`
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/manager/README.md
+
+**Purpose**: Central API gateway and cluster orchestrator
+
+**Key Responsibilities**:
+- Routes REST and GraphQL API requests
+- Orchestrates cluster-wide operations
+- Session scheduling via **Sokovan** orchestrator
+- User authentication and RBAC authorization
+- Plugin management and extensibility
+
+**Plugin Interfaces**:
+- `backendai_scheduler_v10` - Custom schedulers
+- `backendai_agentselector_v10` - Agent selection strategies
+- `backendai_hook_v20` - Lifecycle hooks
+- `backendai_webapp_v20` - Web app extensions
+- `backendai_monitor_stats_v10` - Statistics monitoring
+- `backendai_monitor_error_v10` - Error monitoring
+
+**Start Command**: `./backend.ai mgr start-server --debug`
+
+---
+
+### Agent
+**Repository**: `src/ai/backend/agent/`
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/agent/README.md
+
+**Purpose**: Kernel lifecycle management on compute nodes
+
+**Key Responsibilities**:
+- Manages Docker containers on individual nodes
+- Self-registers to cluster via heartbeat mechanism
+- Monitors container health and resource usage
+- Executes kernel operations (create, destroy, restart)
+
+**Plugin Interfaces**:
+- `backendai_accelerator_v21` - Hardware accelerator support
+- `backendai_monitor_stats_v10` - Statistics monitoring
+- `backendai_monitor_error_v10` - Error monitoring
+
+**Supported Accelerators**:
+- CUDA GPU (NVIDIA)
+- ROCm GPU (AMD)
+- Rebellions NPU
+- FuriosaAI NPU
+- HyperAccel LPU
+- Google TPU
+- Graphcore IPU
+
+**Start Command**: `./backend.ai ag start-server --debug`
+
+---
+
+### Storage Proxy
+**Repository**: `src/ai/backend/storage/`
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/storage/README.md
+
+**Purpose**: Virtual folder and storage backend abstraction
+
+**Key Responsibilities**:
+- Provides unified interface for multiple storage backends
+- Manages virtual folders (vfolders) for data persistence
+- Real-time performance metrics and monitoring
+- Storage acceleration APIs for optimized I/O
+
+**Supported Backends**:
+- Local filesystem
+- NFS
+- Ceph
+- AWS S3
+- Azure Blob Storage
+- Google Cloud Storage
+
+**Start Command**: `./py -m ai.backend.storage.server`
+
+---
+
+### Webserver
+**Repository**: `src/ai/backend/web/`
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/web/README.md
+
+**Purpose**: Web UI hosting and session management
+
+**Key Responsibilities**:
+- Hosts Backend.AI WebUI (Single Page Application)
+- Manages web sessions and cookies
+- API request signing for authentication
+- Serves static assets
+
+**Default URL**: http://localhost:8090
+
+**Start Command**: `./py -m ai.backend.web.server`
+
+---
+
+### App Proxy
+**Repository**: `src/ai/backend/appproxy/coordinator/`
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/appproxy/coordinator/README.md
+
+**Purpose**: Service routing and load balancing for in-container services
+
+**Key Responsibilities**:
+- Routes traffic to in-container services (Jupyter, VSCode, SSH, etc.)
+- Dynamic circuit provisioning between external clients and containers
+- Health monitoring and automatic failover
+- Load balancing across multiple container instances
+
+**Supported Services**:
+- Jupyter Notebook/Lab
+- VSCode Server
+- Terminal (ttyd)
+- SSH/SFTP/SCP
+- Custom web applications
+
+---
+
+## Container Runtime Elements
+
+### Kernels
+**Repository**: https://github.com/lablup/backend.ai-kernels
+
+**Purpose**: Container image recipes for computing environments
+
+**Description**: Dockerfile-based recipes that define computing environments with specific frameworks, languages, and tools.
+
+**Intrinsic Support**:
+- Jupyter Notebook/Lab
+- Terminal (ttyd)
+- SSH/SFTP/SCP
+- VSCode Server
+
+**Popular Kernel Images**:
+- Python (TensorFlow, PyTorch, JAX)
+- R (with statistical packages)
+- Julia
+- C/C++ (with compilers)
+- Java, Go, Rust, Node.js
+
+---
+
+### Jail
+**Repository**: https://github.com/lablup/backend.ai-jail
+
+**Purpose**: Programmable sandbox for security isolation
+
+**Description**: Rust-based ptrace-based system call filtering mechanism that provides fine-grained control over container operations.
+
+**Features**:
+- System call filtering and interception
+- Resource access control
+- Security policy enforcement
+- Process isolation
+
+---
+
+### Hook
+**Repository**: https://github.com/lablup/backend.ai-hook
+
+**Purpose**: In-container runtime library for resource control
+
+**Description**: Library with libc overrides that provides resource monitoring and control from within containers.
+
+**Features**:
+- Resource usage monitoring
+- Standard input (stdin) support for batch jobs
+- Environment variable management
+- Inter-process communication hooks
+
+---
+
+## Client SDKs
+
+### Python Client
+**Package**: `backend.ai-client`
+**Repository**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/client
+**Install**: `pip install backend.ai-client`
+
+**Features**:
+- Full REST and GraphQL API support
+- Command-line interface (CLI)
+- Session management
+- Virtual folder operations
+- Async/await support
+
+---
+
+### Java Client
+**Repository**: https://github.com/lablup/backend.ai-client-java
+**Install**: Available via releases
+
+**Features**:
+- REST API support
+- Session lifecycle management
+- Type-safe API bindings
+
+---
+
+### JavaScript Client
+**Package**: `backend.ai-client`
+**Repository**: https://github.com/lablup/backend.ai-client-js
+**Install**: `npm install backend.ai-client`
+
+**Features**:
+- Browser and Node.js support
+- Promise-based API
+- WebSocket support for streaming
+
+---
+
+### PHP Client
+**Package**: `lablup/backend.ai-client`
+**Repository**: https://github.com/lablup/backend.ai-client-php
+**Install**: `composer require lablup/backend.ai-client` (under preparation)
+
+**Status**: Under development
+
+---
+
+## Architecture Concepts
+
+### Sokovan Orchestrator
+**Purpose**: Custom job scheduler and resource orchestrator
+
+**Description**: Backend.AI's built-in orchestrator that handles session scheduling, resource allocation, and cluster-wide coordination.
+
+**Features**:
+- Multi-tenant resource isolation
+- Priority-based scheduling
+- Fair-share scheduling
+- Resource quota management
+- Custom scheduling policies via plugins
+
+---
+
+### Virtual Folders (vfolders)
+**Purpose**: Cloud storage abstraction for data persistence
+
+**Description**: Abstraction layer over various storage backends that provides consistent API for file operations across sessions.
+
+**Features**:
+- Cross-session data sharing
+- Permission management
+- Quota enforcement
+- Multiple storage backend support
+- Performance monitoring
+
+---
+
+## API Types
+
+### REST API
+**Purpose**: Primary interface for cluster operations
+
+**Features**:
+- Standard HTTP methods (GET, POST, PUT, DELETE)
+- JSON request/response format
+- Authentication via API keys
+- Rate limiting and quotas
+
+**Common Endpoints**:
+- `/auth/login` - User authentication
+- `/session` - Session management
+- `/kernel` - Kernel operations
+- `/vfolder` - Virtual folder operations
+- `/admin` - Administrative operations
+
+---
+
+### GraphQL API
+**Purpose**: Flexible query interface for complex data retrieval
+
+**Features**:
+- Single endpoint for all queries
+- Precise data fetching (no over-fetching)
+- Type-safe schema
+- Real-time subscriptions
+
+**Common Queries**:
+- `compute_session` - Session information
+- `user` - User details
+- `group` - Group and project information
+- `keypair` - API key management
+
+---
+
+## Infrastructure Requirements
+
+### Development Setup
+
+**Python**: 3.13.x (CPython 3.13.7 for main branch)
+**Pantsbuild**: 2.27.x
+**Docker**: 20.10+ (with Compose v2)
+**PostgreSQL**: 16+ (tested with 16.3)
+**Redis**: 7.2+ (tested with 7.2.11)
+**etcd**: 3.5+ (tested with 3.5.14)
+**Prometheus**: 3.x (tested with 3.1.0)
+
+### Recommended Observability Stack
+
+**Grafana**: 11.x (tested with 11.4.0)
+**Loki**: 3.x (tested with 3.5.0)
+**Tempo**: 2.x (tested with 2.7.2)
+**OpenTelemetry Collector**: Latest
+
+---
+
+## Quick Reference: Component Communication
+
+```
+User/Client
+    ↓
+Webserver (hosts WebUI, signs requests)
+    ↓
+Manager (API gateway, orchestration, scheduling)
+    ↓ (allocates resources)
+Agent (manages containers on compute nodes)
+    ↓ (provisions storage)
+Storage Proxy (virtual folder access)
+    ↓ (routes app traffic)
+App Proxy (Jupyter, VSCode, SSH access)
+```
+
+---
+
+## Additional Resources
+
+- **Official Documentation**: http://docs.backend.ai
+- **Main Repository**: https://github.com/lablup/backend.ai
+- **Contributing Guidelines**: https://github.com/lablup/backend.ai/blob/main/.github/CONTRIBUTING.md
+- **Migration Guide**: https://github.com/lablup/backend.ai/blob/main/MIGRATION.md
+- **Development Agent Guide**: https://github.com/lablup/backend.ai/blob/main/CLAUDE.md

--- a/.claude/skills/backend-ai-guide/examples/architecture-example.md
+++ b/.claude/skills/backend-ai-guide/examples/architecture-example.md
@@ -1,0 +1,212 @@
+# Example: Backend.AI Architecture Question
+
+## User Question
+"Can you explain Backend.AI's architecture? How do the components work together?"
+
+---
+
+## Ideal Response Format
+
+### Backend.AI Distributed Computing Platform Architecture
+
+Backend.AI is a container-based distributed computing platform where 5 major server components collaborate to provide seamless resource orchestration.
+
+---
+
+## Major Components and Roles
+
+### 1. Manager (Central Gateway)
+**Role**: The brain of the cluster
+- Routes REST/GraphQL API requests
+- Session scheduling via **Sokovan** orchestrator
+- User authentication and RBAC authorization
+- Orchestrates cluster-wide operations
+
+**Start Command**: `./backend.ai mgr start-server --debug`
+
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/manager/README.md
+
+---
+
+### 2. Agent (Compute Node Manager)
+**Role**: Manages containers on individual nodes
+- Creates/destroys/monitors Docker containers
+- Self-registers to cluster via heartbeat mechanism
+- Manages hardware accelerators (GPU/NPU)
+- Handles kernel lifecycle operations
+
+**Start Command**: `./backend.ai ag start-server --debug`
+
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/agent/README.md
+
+---
+
+### 3. Storage Proxy (Storage Abstraction)
+**Role**: Virtual folder and storage backend management
+- Unified interface for multiple storage backends (Local FS, NFS, Ceph, S3, Azure Blob, GCS)
+- Virtual folder (vfolder) creation and permission management
+- Real-time I/O performance metrics
+- Storage acceleration APIs
+
+**Start Command**: `./py -m ai.backend.storage.server`
+
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/storage/README.md
+
+---
+
+### 4. Webserver (WebUI Hosting)
+**Role**: Provides web interface
+- Hosts Backend.AI WebUI (Single Page Application)
+- Web session and cookie management
+- API request signing
+- Serves static assets
+
+**Start Command**: `./py -m ai.backend.web.server`
+**Default URL**: http://localhost:8090
+
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/web/README.md
+
+---
+
+### 5. App Proxy (Service Routing)
+**Role**: Access to in-container services
+- Routes traffic to in-container services (Jupyter, VSCode, SSH, etc.)
+- Dynamic circuit provisioning
+- Health monitoring and automatic failover
+- Load balancing
+
+**Documentation**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/appproxy/coordinator/README.md
+
+---
+
+## Component Communication Flow
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   User / Client                          │
+└────────────────────┬────────────────────────────────────┘
+                     │
+                     ↓
+         ┌───────────────────────┐
+         │     Webserver         │  Web session management, request signing
+         │   (WebUI Hosting)     │
+         └───────────┬───────────┘
+                     │
+                     ↓
+         ┌───────────────────────┐
+         │      Manager          │  API gateway, orchestration
+         │   (Central Coord)     │  Sokovan scheduler
+         └─────┬─────────────┬───┘
+               │             │
+       ┌───────┘             └───────┐
+       ↓                             ↓
+┌──────────────┐              ┌──────────────┐
+│    Agent     │ ← Heartbeat → │    Agent     │  Container management
+│  (Node #1)   │              │  (Node #2)   │  GPU/NPU allocation
+└──────┬───────┘              └──────┬───────┘
+       │                             │
+       │         ┌───────────────────┘
+       │         │
+       ↓         ↓
+┌────────────────────────┐
+│   Storage Proxy        │  Virtual folder access
+│  (Storage Backend)     │  Data persistence
+└────────────────────────┘
+       │
+       ↓
+┌────────────────────────┐
+│    App Proxy           │  Jupyter, VSCode access
+│  (Service Routing)     │  SSH/SFTP connections
+└────────────────────────┘
+```
+
+---
+
+## Key Workflow Example
+
+### Session Creation Flow
+1. **User**: Requests "Create Python kernel" via WebUI
+2. **Webserver**: Signs request and forwards to Manager
+3. **Manager**:
+   - Verifies user authentication
+   - Sokovan scheduler decides resource allocation
+   - Selects appropriate Agent
+4. **Agent**:
+   - Creates Docker container
+   - Allocates required GPU/NPU
+   - Mounts vfolder via Storage Proxy
+5. **User**: Accesses Jupyter routed through App Proxy
+
+---
+
+## Container Runtime Elements
+
+Backend.AI provides additional functionality at the container level:
+
+### Kernels
+- Dockerfile-based computing environment recipes
+- Various frameworks: TensorFlow, PyTorch, R, Julia
+- Repository: https://github.com/lablup/backend.ai-kernels
+
+### Jail (Sandbox)
+- Rust-based ptrace system call filtering
+- Enforces security policies
+- Repository: https://github.com/lablup/backend.ai-jail
+
+### Hook (Runtime Library)
+- Resource control via libc overrides
+- stdin support, environment variable management
+- Repository: https://github.com/lablup/backend.ai-hook
+
+---
+
+## Scalability and High Availability
+
+### Horizontal Scaling
+- **Add Agent nodes**: Increases compute capacity
+- **Add Storage Proxy instances**: Increases I/O throughput
+- **App Proxy load balancing**: Distributes service routing
+
+### High Availability
+- **Manager**: Stateless design allows replication
+- **Agent**: Auto-removal on heartbeat failure, re-registration
+- **etcd**: Distributed storage of cluster state
+- **PostgreSQL**: HA configuration support (replication, failover)
+
+---
+
+## Required Infrastructure Components
+
+Backend.AI cluster requires the following infrastructure:
+
+| Component | Version | Role |
+|-----------|---------|------|
+| Python | 3.13.x | Backend.AI codebase |
+| Docker | 20.10+ | Container runtime |
+| PostgreSQL | 16+ | Metadata storage |
+| Redis | 7.2+ | Caching and session management |
+| etcd | 3.5+ | Cluster state management |
+| Prometheus | 3.x | Metrics collection |
+
+---
+
+## Source Documentation
+
+- **Main README**: https://github.com/lablup/backend.ai/blob/main/README.md
+- **Component Architecture**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/README.md
+- **Manager README**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/manager/README.md
+- **Agent README**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/agent/README.md
+- **Storage Proxy README**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/storage/README.md
+- **Official Docs**: http://docs.backend.ai
+
+---
+
+## Key Takeaways
+
+✅ **Distributed Architecture**: 5 major components collaborating
+✅ **Sokovan Orchestrator**: Intelligent resource scheduling
+✅ **Diverse Accelerator Support**: CUDA, ROCm, TPU, NPU
+✅ **Multi-tenancy**: User/group/domain isolation
+✅ **REST + GraphQL APIs**: All functions programmable
+✅ **Container-based**: Docker + custom runtime elements
+✅ **Horizontally Scalable**: Dynamic Agent node addition

--- a/.claude/skills/backend-ai-guide/examples/component-example.md
+++ b/.claude/skills/backend-ai-guide/examples/component-example.md
@@ -1,0 +1,282 @@
+# Example: Component-Specific Question
+
+## User Question
+"What does the Backend.AI Manager component do? How is it different from the Agent?"
+
+---
+
+## Ideal Response Format
+
+### Backend.AI Manager Component
+
+The **Manager** is the central API gateway and orchestrator of the Backend.AI cluster. It serves as the brain that coordinates all operations across the distributed system.
+
+---
+
+## Manager's Key Responsibilities
+
+### 1. API Gateway
+- Routes all REST and GraphQL API requests
+- Validates authentication tokens
+- Enforces rate limiting and quotas
+- Exposes unified API interface to clients
+
+### 2. Session Scheduling (Sokovan Orchestrator)
+- Decides when and where to create compute sessions
+- Implements scheduling policies:
+  - **FIFO** (First In, First Out)
+  - **Priority-based** scheduling
+  - **Fair-share** scheduling
+- Manages session queues
+- Resource allocation decisions
+
+### 3. Authentication & Authorization
+- User authentication via API keys or JWT
+- **RBAC** (Role-Based Access Control)
+- Permission checks for all operations
+- Domain/group/user hierarchy management
+
+### 4. Cluster Orchestration
+- Monitors Agent heartbeats
+- Tracks cluster-wide resource availability
+- Manages virtual folders (vfolders)
+- Coordinates multi-component operations
+
+### 5. Plugin Management
+- Loads and manages plugins:
+  - Custom schedulers (`backendai_scheduler_v10`)
+  - Agent selectors (`backendai_agentselector_v10`)
+  - Lifecycle hooks (`backendai_hook_v20`)
+  - Web app extensions (`backendai_webapp_v20`)
+  - Monitoring plugins (`backendai_monitor_stats_v10`, `backendai_monitor_error_v10`)
+
+---
+
+## Manager vs Agent: Key Differences
+
+| Aspect | Manager | Agent |
+|--------|---------|-------|
+| **Scope** | Cluster-wide coordination | Single compute node |
+| **Primary Role** | API gateway & orchestrator | Container lifecycle management |
+| **Deployment** | Centralized (1-few instances) | Distributed (many nodes) |
+| **State** | Stateless (uses PostgreSQL/etcd) | Stateful (manages local containers) |
+| **Responsibilities** | Scheduling, auth, API routing | Docker operations, resource monitoring |
+| **Hardware** | No accelerator requirements | Direct GPU/NPU access |
+| **API Exposure** | REST + GraphQL endpoints | Internal communication only |
+| **Plugin Types** | Scheduler, hook, webapp | Accelerator, monitoring |
+
+---
+
+## How They Work Together
+
+### Session Creation Example
+
+```
+User Request: "Create Python kernel with 2 GPUs"
+       ↓
+┌──────────────────┐
+│    Manager       │  1. Receives API request
+│                  │  2. Authenticates user
+│                  │  3. Checks resource quotas
+└────────┬─────────┘
+         │
+         │  4. Sokovan scheduler finds available resources
+         │
+         ↓
+┌──────────────────┐
+│    Agent #3      │  5. Selected Agent with 2 free GPUs
+│                  │  6. Creates Docker container
+│                  │  7. Allocates GPUs
+│                  │  8. Reports status back to Manager
+└──────────────────┘
+         │
+         ↓
+    Container running with 2 GPUs
+```
+
+### Key Interaction Points
+
+1. **Heartbeat Mechanism**
+   - Agents send periodic heartbeats to Manager
+   - Manager tracks Agent availability and resources
+   - Failed heartbeats trigger Agent removal
+
+2. **Resource Tracking**
+   - Agents report available CPU, memory, GPU to Manager
+   - Manager maintains cluster-wide resource view
+   - Scheduling decisions based on real-time data
+
+3. **Container Operations**
+   - Manager issues container commands (create, destroy, restart)
+   - Agent executes commands via Docker API
+   - Agent reports operation results to Manager
+
+---
+
+## Manager Architecture Details
+
+### Technology Stack
+- **Python 3.13.x** - Core implementation
+- **PostgreSQL** - Metadata storage
+- **Redis** - Caching and rate limiting
+- **etcd** - Cluster state coordination
+- **aiohttp** - Async HTTP server
+
+### API Endpoints
+
+**REST API Examples**:
+- `POST /auth/login` - User authentication
+- `POST /session` - Create compute session
+- `GET /session/:id` - Get session status
+- `DELETE /session/:id` - Destroy session
+- `GET /resource` - Check resource availability
+
+**GraphQL API Examples**:
+```graphql
+query {
+  compute_session(id: "session-id") {
+    id
+    status
+    kernels {
+      id
+      image
+      resource_opts
+    }
+  }
+}
+```
+
+---
+
+## Plugin System
+
+The Manager's plugin system enables extensibility:
+
+### Scheduler Plugins (`backendai_scheduler_v10`)
+Custom scheduling algorithms:
+```python
+class MyScheduler:
+    async def schedule_session(self, session_ctx):
+        # Custom logic to select Agent
+        return selected_agent
+```
+
+### Hook Plugins (`backendai_hook_v20`)
+Lifecycle hooks for custom actions:
+```python
+class MyHook:
+    async def on_session_created(self, session_ctx):
+        # Custom logic after session creation
+        pass
+```
+
+---
+
+## Agent Component (For Comparison)
+
+### Agent's Key Responsibilities
+
+1. **Container Management**
+   - Creates/destroys Docker containers
+   - Monitors container health
+   - Manages container networking
+
+2. **Resource Monitoring**
+   - Tracks CPU, memory, GPU usage
+   - Reports real-time metrics to Manager
+   - Enforces resource limits
+
+3. **Accelerator Management**
+   - Direct GPU/NPU access
+   - Allocates accelerators to containers
+   - Supports multiple accelerator types via plugins
+
+4. **Self-Registration**
+   - Discovers Manager via etcd
+   - Sends heartbeat every few seconds
+   - Auto-registers on startup
+
+---
+
+## Deployment Patterns
+
+### Typical Cluster Setup
+
+```
+┌─────────────────────────────────────────┐
+│  Load Balancer                          │
+└────────────┬────────────────────────────┘
+             │
+    ┌────────┴────────┐
+    ↓                 ↓
+┌─────────┐      ┌─────────┐
+│ Manager │      │ Manager │  (HA setup)
+│  #1     │      │  #2     │
+└────┬────┘      └────┬────┘
+     │                │
+     └────────┬───────┘
+              │ (orchestrates)
+    ┌─────────┼─────────────┐
+    ↓         ↓             ↓
+┌────────┐ ┌────────┐  ┌────────┐
+│ Agent  │ │ Agent  │  │ Agent  │
+│  #1    │ │  #2    │  │  #3    │
+│ 4 GPUs │ │ 8 GPUs │  │ 2 TPUs │
+└────────┘ └────────┘  └────────┘
+```
+
+**Manager**: Centralized, stateless, can be replicated
+**Agent**: Distributed across compute nodes, stateful
+
+---
+
+## Performance Considerations
+
+### Manager Bottlenecks
+- API request throughput
+- Database query performance
+- Scheduling algorithm complexity
+
+**Solutions**:
+- Horizontal scaling (multiple Manager instances)
+- Database connection pooling
+- Caching frequently accessed data (Redis)
+
+### Agent Bottlenecks
+- Docker daemon performance
+- Network I/O for container images
+- GPU allocation overhead
+
+**Solutions**:
+- Pre-pull container images
+- Optimize Docker storage driver
+- Use local image registry
+
+---
+
+## Source Documentation
+
+- **Manager README**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/manager/README.md
+- **Agent README**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/agent/README.md
+- **Main README**: https://github.com/lablup/backend.ai/blob/main/README.md
+- **Plugin Development**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/README.md
+
+---
+
+## Quick Summary
+
+**Manager**:
+- 🧠 Cluster brain - makes decisions
+- 🚪 API gateway - handles all client requests
+- 📅 Sokovan scheduler - resource allocation
+- 🔐 Auth & RBAC - security enforcement
+- 📊 Cluster orchestrator - coordinates operations
+
+**Agent**:
+- 🐳 Container manager - Docker operations
+- 💪 Resource executor - runs actual workloads
+- 🎮 GPU/NPU handler - accelerator management
+- 💓 Heartbeat sender - self-registration
+- 📈 Metrics reporter - real-time monitoring
+
+**Key Difference**: Manager decides **what** and **where**, Agent executes **how** and **monitors**.

--- a/.claude/skills/backend-ai-guide/examples/webui-integration-example.md
+++ b/.claude/skills/backend-ai-guide/examples/webui-integration-example.md
@@ -1,0 +1,509 @@
+# Example: WebUI Integration Question
+
+## User Question
+"How does this Backend.AI WebUI connect to and communicate with the Backend.AI backend? What APIs does it use?"
+
+---
+
+## Ideal Response Format
+
+### Backend.AI WebUI Integration Architecture
+
+The **Backend.AI WebUI** (this project) is a **client application** that communicates with the Backend.AI backend platform through well-defined APIs. It's a hybrid Single Page Application (SPA) using both Lit-Element and React frameworks.
+
+---
+
+## WebUI to Backend.AI Connection Flow
+
+```
+┌─────────────────────────────────────────────┐
+│  Backend.AI WebUI (this project)            │
+│  - React components (/react)                │
+│  - Lit-Element components (/src)            │
+│  - Ant Design + Relay (GraphQL)             │
+└──────────────────┬──────────────────────────┘
+                   │
+                   │ API Calls (REST + GraphQL)
+                   │ Authentication: API Key / JWT
+                   │
+                   ↓
+┌─────────────────────────────────────────────┐
+│  Backend.AI Webserver Component             │
+│  - Hosts the WebUI SPA                      │
+│  - Manages web sessions                     │
+│  - Signs API requests                       │
+│  - Default: http://localhost:8090           │
+└──────────────────┬──────────────────────────┘
+                   │
+                   │ Forwarded Requests
+                   │
+                   ↓
+┌─────────────────────────────────────────────┐
+│  Backend.AI Manager Component               │
+│  - REST API endpoints                       │
+│  - GraphQL API endpoint                     │
+│  - Authentication & Authorization (RBAC)    │
+│  - Orchestrates backend operations          │
+└─────────────────────────────────────────────┘
+```
+
+---
+
+## API Communication Methods
+
+### 1. REST API
+**Used for**: Direct operations, file uploads/downloads, authentication
+
+**Common Endpoints**:
+```javascript
+// Authentication
+POST /auth/login
+{
+  "username": "user@example.com",
+  "password": "password"
+}
+→ Response: { "access_token": "...", "refresh_token": "..." }
+
+// Session Management
+POST /session
+{
+  "image": "python:3.11",
+  "resources": {
+    "cpu": "2",
+    "mem": "8g",
+    "cuda.shares": "1"
+  }
+}
+→ Response: { "session_id": "...", "status": "pending" }
+
+// Get Session Status
+GET /session/{session_id}
+→ Response: { "id": "...", "status": "running", "kernels": [...] }
+
+// Virtual Folder Operations
+GET /vfolder
+POST /vfolder/create
+DELETE /vfolder/{vfolder_name}
+POST /vfolder/{vfolder_name}/upload
+GET /vfolder/{vfolder_name}/download/{file_path}
+```
+
+---
+
+### 2. GraphQL API
+**Used for**: Complex queries, nested data fetching, real-time subscriptions
+
+**Endpoint**: `POST /admin/graphql`
+
+**Common Queries in WebUI**:
+
+```graphql
+# User Information
+query GetUserInfo {
+  user {
+    id
+    email
+    username
+    role
+    domain_name
+    groups {
+      id
+      name
+    }
+  }
+}
+
+# Compute Sessions
+query GetComputeSessions($status: String) {
+  compute_session_list(status: $status) {
+    items {
+      id
+      name
+      image
+      status
+      created_at
+      terminated_at
+      kernels {
+        id
+        occupied_slots
+        live_stat
+      }
+    }
+    total_count
+  }
+}
+
+# Resource Presets
+query GetResourcePresets {
+  keypair_resource_policies {
+    name
+    default_for_unspecified
+    total_resource_slots
+    max_concurrent_sessions
+  }
+}
+
+# Virtual Folders (with Fragment)
+fragment VFolderInfo on VirtualFolder {
+  id
+  name
+  host
+  quota
+  used_bytes
+  max_size
+  created_at
+  permission
+}
+
+query GetVirtualFolders {
+  vfolders {
+    ...VFolderInfo
+  }
+}
+```
+
+---
+
+## Authentication Flow
+
+### Initial Login
+```
+1. User enters credentials in WebUI
+   ↓
+2. WebUI sends POST /auth/login to Webserver
+   ↓
+3. Webserver forwards to Manager
+   ↓
+4. Manager validates credentials
+   ↓
+5. Manager returns JWT tokens (access + refresh)
+   ↓
+6. WebUI stores tokens (localStorage/sessionStorage)
+   ↓
+7. All subsequent requests include: Authorization: Bearer <token>
+```
+
+### API Request Signing (Alternative Method)
+Some deployments use API key signing:
+```javascript
+// WebUI generates signed request
+const signature = generateSignature({
+  method: 'POST',
+  url: '/session',
+  body: requestBody,
+  accessKey: userAccessKey,
+  secretKey: userSecretKey,
+  timestamp: Date.now()
+});
+
+// Request includes signature headers
+fetch('/session', {
+  method: 'POST',
+  headers: {
+    'X-BackendAI-Version': 'v5.20240101',
+    'X-BackendAI-Date': timestamp,
+    'Authorization': `BackendAI signedToken=${signature}`
+  },
+  body: JSON.stringify(requestBody)
+});
+```
+
+---
+
+## WebUI Technology Stack
+
+### Framework Architecture
+```
+Backend.AI WebUI (Hybrid)
+├── React Components (/react)
+│   ├── Ant Design UI Library
+│   ├── Relay (GraphQL Client)
+│   ├── Recoil (Global State)
+│   └── Modern features (new development)
+└── Lit-Element Components (/src)
+    ├── Material Web Components
+    ├── Redux (Legacy State)
+    └── Legacy features (maintenance mode)
+```
+
+### React + Relay Pattern (Preferred)
+```typescript
+// Modern WebUI pattern using Relay
+import { useLazyLoadQuery, graphql } from 'react-relay';
+
+const SessionList: React.FC = () => {
+  const data = useLazyLoadQuery(
+    graphql`
+      query SessionListQuery {
+        compute_session_list(status: "RUNNING") {
+          items {
+            id
+            name
+            status
+            ...SessionCard_session
+          }
+        }
+      }
+    `,
+    {}
+  );
+
+  return (
+    <div>
+      {data.compute_session_list.items.map(session => (
+        <SessionCard key={session.id} sessionRef={session} />
+      ))}
+    </div>
+  );
+};
+```
+
+---
+
+## Key WebUI-Backend Interactions
+
+### 1. Session Creation
+```typescript
+// WebUI initiates session creation
+const createSession = async () => {
+  const response = await fetch('/session', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      image: 'python:3.11-tensorflow',
+      resources: {
+        cpu: '4',
+        mem: '16g',
+        'cuda.shares': '2'
+      },
+      mounts: ['my-dataset-vfolder'],
+      env: {
+        'JUPYTER_TOKEN': 'secret'
+      }
+    })
+  });
+
+  const session = await response.json();
+  // session.id can now be used to access the kernel
+};
+```
+
+**Backend Flow**:
+1. Webserver receives request
+2. Manager validates token, checks quotas
+3. Sokovan scheduler selects Agent
+4. Agent creates Docker container
+5. Storage Proxy mounts vfolders
+6. Manager returns session ID to WebUI
+
+---
+
+### 2. Service Access (Jupyter, VSCode, Terminal)
+```typescript
+// WebUI generates service URL
+const jupyterUrl = `/proxy/${sessionId}/jupyter/`;
+const vscodeUrl = `/proxy/${sessionId}/vscode/`;
+const terminalUrl = `/proxy/${sessionId}/ttyd/`;
+
+// User clicks "Open Jupyter"
+// Browser navigates to proxy URL
+// App Proxy routes request to container's Jupyter service
+```
+
+**Backend Flow**:
+1. WebUI requests service access
+2. App Proxy receives request
+3. App Proxy looks up session ID → container IP
+4. App Proxy establishes circuit to container
+5. Traffic flows: Browser ↔ App Proxy ↔ Container
+
+---
+
+### 3. Virtual Folder File Operations
+```typescript
+// List files in vfolder
+const listFiles = async (vfolderName: string) => {
+  const response = await fetch(`/vfolder/${vfolderName}/files`, {
+    headers: { 'Authorization': `Bearer ${accessToken}` }
+  });
+  return await response.json();
+};
+
+// Upload file
+const uploadFile = async (vfolderName: string, file: File) => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  await fetch(`/vfolder/${vfolderName}/upload`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${accessToken}` },
+    body: formData
+  });
+};
+
+// Download file
+const downloadFile = (vfolderName: string, filePath: string) => {
+  const url = `/vfolder/${vfolderName}/download/${filePath}?token=${accessToken}`;
+  window.open(url, '_blank');
+};
+```
+
+**Backend Flow**:
+1. WebUI sends vfolder operation request
+2. Manager authenticates and checks permissions
+3. Storage Proxy performs actual file operation
+4. Result returned to WebUI
+
+---
+
+## Real-Time Updates
+
+### WebSocket Connections
+```typescript
+// WebUI establishes WebSocket for real-time updates
+const ws = new WebSocket(
+  `wss://${host}/events?token=${accessToken}`
+);
+
+ws.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+
+  switch (data.type) {
+    case 'session_status_changed':
+      // Update session status in UI
+      updateSessionStatus(data.session_id, data.status);
+      break;
+
+    case 'resource_usage_updated':
+      // Update resource metrics
+      updateMetrics(data.session_id, data.metrics);
+      break;
+  }
+};
+```
+
+---
+
+## Configuration
+
+### WebUI Config (`config.toml`)
+```toml
+[general]
+apiEndpoint = "https://api.backend.ai"  # Manager API endpoint
+webserverUrl = "https://console.backend.ai"  # Webserver URL
+
+[wsproxy]
+proxyURL = "wss://api.backend.ai/events"  # WebSocket endpoint
+
+[authorization]
+enableSignature = true  # Use signature-based auth
+```
+
+### Connection Setup
+```typescript
+// WebUI initializes connection
+import { BackendAIClient } from './backend-ai-client';
+
+const client = new BackendAIClient({
+  endpoint: config.apiEndpoint,
+  accessKey: userAccessKey,
+  secretKey: userSecretKey
+});
+
+// Client handles:
+// - Request signing
+// - Token refresh
+// - Error handling
+// - Rate limiting
+```
+
+---
+
+## WebUI Source Code Structure
+
+```
+backend.ai-webui/
+├── react/                    # React components (modern)
+│   ├── src/
+│   │   ├── components/       # UI components
+│   │   ├── hooks/            # Custom React hooks
+│   │   ├── __generated__/    # Relay generated files
+│   │   └── App.tsx           # Main React app
+│   └── relay.config.js       # Relay compiler config
+│
+├── src/                      # Lit-Element components (legacy)
+│   ├── components/           # Web components
+│   ├── lib/                  # Shared libraries
+│   └── backend-ai-client.ts  # API client implementation
+│
+└── resources/
+    ├── config.toml.sample    # Configuration template
+    └── i18n/                 # Translations
+```
+
+---
+
+## Development Workflow
+
+### Running WebUI Locally
+```bash
+# Terminal 1: Build and serve WebUI
+pnpm run server:d   # Watch mode, auto-reload
+
+# Terminal 2: WebSocket proxy (for desktop app)
+pnpm run wsproxy
+
+# Terminal 3: Backend.AI components (if running locally)
+./backend.ai mgr start-server --debug
+./backend.ai ag start-server --debug
+```
+
+### API Testing
+```bash
+# Test REST API
+curl -X POST http://localhost:8090/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": "admin@lablup.com", "password": "password"}'
+
+# Test GraphQL API
+curl -X POST http://localhost:8090/admin/graphql \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ user { email } }"}'
+```
+
+---
+
+## Source Documentation
+
+- **WebUI Repository**: https://github.com/lablup/backend.ai-webui
+- **Webserver Component**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/web/README.md
+- **Manager API**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/manager/README.md
+- **Client SDK (Python)**: https://github.com/lablup/backend.ai/blob/main/src/ai/backend/client
+- **Client SDK (JavaScript)**: https://github.com/lablup/backend.ai-client-js
+
+---
+
+## Summary: WebUI-Backend Communication
+
+**Key Points**:
+✅ **Hybrid Architecture**: React (modern) + Lit-Element (legacy)
+✅ **Dual API Support**: REST for operations, GraphQL for queries
+✅ **Authentication**: JWT tokens or signed requests
+✅ **Hosted by**: Backend.AI Webserver component
+✅ **State Management**: Relay (GraphQL) + Recoil (global) for React
+✅ **Real-time Updates**: WebSocket connections for live data
+✅ **Service Access**: App Proxy routes to in-container services
+✅ **File Operations**: Storage Proxy handles vfolder operations
+
+**Communication Flow**:
+```
+WebUI → Webserver (session mgmt) → Manager (API) → Agent (execution)
+                                  ↓
+                          Storage Proxy (files)
+                                  ↓
+                          App Proxy (services)
+```


### PR DESCRIPTION
resolves #4668 (FR-1697)

This PR adds a new Claude skill to provide expert-level information about the [Backend.AI](http://Backend.AI) platform. The skill automatically activates when users ask about:

- [Backend.AI](http://Backend.AI) architecture and components (Manager, Agent, Storage Proxy, Webserver, App Proxy)
- Platform features (session scheduling, Sokovan orchestrator, multi-tenancy, resource allocation)
- APIs (REST, GraphQL), authentication, and RBAC authorization
- Container runtime elements (kernels, jail sandbox, hook library, virtual folders)
- Accelerator support (CUDA, ROCm, TPU, NPU, Graphcore IPU)
- Client SDKs (Python, Java, JavaScript, PHP)
- Setup requirements and infrastructure
- WebUI integration with [Backend.AI](http://Backend.AI) backend

The skill includes:

- Detailed instructions for fetching and synthesizing documentation
- Common questions reference guide
- Component overview for quick lookups
- Example responses for architecture, component, and WebUI integration questions

**how to test**
Ask Claude Code about [backend.ai](http://backend.ai)!

**Checklist:** (if applicable)

- [x] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after