### PR TITLE
fix(FR-1698): fix session creation failure when agent is set to auto

### DIFF
--- a/react/src/hooks/useStartSession.tsx
+++ b/react/src/hooks/useStartSession.tsx
@@ -256,7 +256,7 @@ export const useStartSession = () => {
           ...(baiClient.supports('agent-select') &&
           !baiClient?._config?.hideAgents &&
           values.agent !== undefined &&
-          !_.isEqual(values.agent, ['auto'])
+          !_.isEqual(_.castArray(values.agent), ['auto'])
             ? {
                 // Filter out undefined values
                 agent_list: _.chain(values.agent)


### PR DESCRIPTION
resolves #4670 (FR-1698)

This PR fixes an issue in the `useStartSession` hook where the agent selection logic wasn't properly handling both array and non-array values. The fix uses `_.castArray()` to ensure the agent value is always treated as an array before comparing it to `['auto']`.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after