### PR TITLE
feat(FR-1700): implement automatic fallback to auto agent when invalid

### DIFF
--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -1243,6 +1243,7 @@ const ResourceAllocationFormItems: React.FC<
                   resourceGroup={currentResourceGroupInForm}
                   fetchKey={agentFetchKey}
                   mode={supportMultiAgents ? 'multiple' : undefined}
+                  fallbackToAuto
                   labelRender={
                     supportMultiAgents
                       ? ({ label, value }) => {


### PR DESCRIPTION
Resolves #4672 ([FR-1700](https://lablup.atlassian.net/browse/FR-1700))

This PR adds a new `fallbackToAuto` prop to the AgentSelect component, replacing the previous `autoSelectDefault` prop. When enabled, this feature automatically switches to "Auto" selection when the current agent value becomes invalid (e.g., when the agent is no longer available in the options list).

The implementation includes:
- Adding a new effect hook that monitors changes to the value and available agent options
- Using `useEffectEvent` to handle the fallback logic
- Enabling this feature in ResourceAllocationFormItems by setting `fallbackToAuto` prop

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1700]: https://lablup.atlassian.net/browse/FR-1700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ