### PR TITLE
fix(FR-1701): disabled style is not applied to the upload button in folder explorer

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -139,7 +139,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
           }}
         >
           <Tooltip title={!lg && t('general.button.Upload')}>
-            <Button icon={<UploadOutlined />}>
+            <Button icon={<UploadOutlined />} disabled={!enableWrite}>
               {lg && t('general.button.Upload')}
             </Button>
           </Tooltip>


### PR DESCRIPTION
resolves #4676 (FR-1701)

This PR disables the upload button in the file explorer when the user doesn't have write permissions, preventing users from attempting actions they don't have permission to perform.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after