### PR TITLE
fix(FR-1703): Fix invitation acceptance workflow in E2E tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ data/merged_schema.graphql
 
 # webui release download temp directories (safe to delete)
 scripts/temp-releases/
+
+# ignore playwright mcp test files
+.playwright-mcp/

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -267,15 +267,25 @@ export async function acceptAllInvitationAndVerifySpecificFolder(
   page: Page,
   folderName: string,
 ) {
-  await navigateTo(page, 'summary');
+  await page
+    .locator('.ant-notification-notice')
+    .getByText('See Detail')
+    .click();
+
   await page.waitForLoadState('networkidle');
-  const invitations = await page.getByLabel('Accept').all();
-  for (const invitation of invitations) {
-    await invitation.click();
+  // Accept all invitations one by one
+  const acceptButtons = await page
+    .getByRole('button', { name: 'Accept' })
+    .all();
+  for (const acceptButton of acceptButtons) {
+    await acceptButton.click();
   }
+  await page.waitForLoadState('networkidle');
 
   await navigateTo(page, 'data');
-  await page.locator('#rc_select_8').fill(folderName);
+  // Select the search input - use type="search" with ant-input class for the folder search
+  const searchInput = page.locator('input.ant-input[type="search"]');
+  await searchInput.fill(folderName);
   await page.getByRole('button', { name: 'search' }).click();
   expect(
     page.locator('.ant-table-row').locator('td').nth(1).getByText(folderName),


### PR DESCRIPTION
**Changes:**

- Updated the `acceptAllInvitationAndVerifySpecificFolder` function to use a more reliable approach for accepting invitations
- Changed the invitation acceptance flow to click "See Detail" on notifications instead of navigating to summary page
- Improved folder search by using a more specific selector for the search input
- Added `.playwright-mcp/` to `.gitignore` to exclude Playwright MCP test files

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after