### PR TITLE
fix(FR-1706): file list does not update when files have been updated

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/BAIFileExplorer.tsx
@@ -23,7 +23,14 @@ import { RcFile } from 'antd/es/upload';
 import dayjs from 'dayjs';
 import _ from 'lodash';
 import { HouseIcon } from 'lucide-react';
-import { createContext, Suspense, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  Suspense,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 
 export const FolderInfoContext = createContext<{
@@ -33,6 +40,10 @@ export const FolderInfoContext = createContext<{
   targetVFolderId: '',
   currentPath: '.',
 });
+
+export interface BAIFileExplorerRef {
+  refetch: () => void;
+}
 
 export interface BAIFileExplorerProps {
   targetVFolderId: string;
@@ -45,6 +56,7 @@ export interface BAIFileExplorerProps {
   enableDelete?: boolean;
   enableWrite?: boolean;
   onChangeFetchKey?: (fetchKey: string) => void;
+  ref?: React.Ref<BAIFileExplorerRef>;
 }
 
 const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
@@ -57,6 +69,7 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
   enableDelete = false,
   enableWrite = false,
   style,
+  ref,
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
@@ -78,6 +91,14 @@ const BAIFileExplorer: React.FC<BAIFileExplorerProps> = ({
     navigateToPath,
     refetch,
   } = useSearchVFolderFiles(targetVFolderId, fetchKey);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch,
+    }),
+    [refetch],
+  );
 
   const breadCrumbItems: Array<ItemType> = useMemo(() => {
     const pathParts = currentPath === '.' ? [] : currentPath.split('/');

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/index.ts
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/index.ts
@@ -1,2 +1,6 @@
 export { default as BAIFileExplorer } from './BAIFileExplorer';
+export type {
+  BAIFileExplorerProps,
+  BAIFileExplorerRef,
+} from './BAIFileExplorer';
 export { useSearchVFolderFiles } from './hooks';

--- a/react/src/components/FileUploadManager.tsx
+++ b/react/src/components/FileUploadManager.tsx
@@ -347,7 +347,7 @@ export const useFileUploadManager = (id?: string, folderName?: string) => {
   const setUploadRequests = useSetAtom(uploadRequestAtom);
 
   const [uploadStatus, setUploadStatus] = useUploadStatusAtomStatus(
-    id ? toLocalId(id) : '',
+    id ? toLocalId(id).replace(/-/g, '') : '', // since jotai atom doesn't use '-' in key, we need to replace it
   );
 
   const validateUploadRequest = (

--- a/react/src/hooks/useDefaultImagesWithFallback.ts
+++ b/react/src/hooks/useDefaultImagesWithFallback.ts
@@ -141,7 +141,6 @@ export const useDefaultSystemSSHImageWithFallback = () => {
         )
         .then(async (sshImages) => {
           const firstImage = _.first(sshImages);
-          console.log(firstImage);
           setSystemSSHImage(firstImage ? getImageFullName(firstImage) : null);
           setSystemSSHImageInfo(firstImage || undefined);
         })


### PR DESCRIPTION
resolves #4681 (FR-1706)

This PR makes several improvements to React hooks and fixes issues with file upload status tracking:

1. Refactors `useIntervalValue` and `useInterval` hooks to use `useEffectEvent` instead of `useRef` for better handling of callback functions
2. Fixes upload status tracking by removing hyphens from local IDs since Jotai atoms don't support hyphens in keys
3. Adds polling mechanism in `FolderExplorerModal` to update fetch key when there are pending uploads
4. Removes a console.log statement from `useDefaultSystemSSHImageWithFallback`

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after