### PR TITLE
style(FR-1716): The style breaks when editing the chat name

### DIFF
--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -34,7 +34,8 @@ const useStyles = createStyles(({ css }) => ({
   `,
   fixEditableVerticalAlign: css`
     & {
-      margin-top: 0px !important;
+      top: 0 !important;
+      margin: 0px !important;
       inset-inline-start: 0px !important;
     }
   `,


### PR DESCRIPTION
resolves FR-1716

# Fix chat input vertical alignment

This PR adjusts the CSS for the chat input field to properly align it vertically. It:

- Replaces `margin-top: 0px` with `top: 0 !important`
- Adds `margin: 0px !important` to ensure consistent spacing

These changes ensure the editable area is properly positioned without unwanted vertical offsets.

![image.png](https://app.graphite.com/user-attachments/assets/58d5d2aa-4724-446d-a89d-f5f49a690062.png)



**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after