### PR TITLE
fix(FR-1717): fix long text overflow in chat message paragraphs

### DIFF
--- a/react/src/components/Chat/ChatMessageContent.tsx
+++ b/react/src/components/Chat/ChatMessageContent.tsx
@@ -250,7 +250,12 @@ const ChatMessageContentBlock = memo<{ block?: string; isStreaming?: boolean }>(
     );
 
     const renderParagraph = useCallback(({ node: _node, ...props }: any) => {
-      return <p {...props} style={{ whiteSpace: 'pre-wrap' }} />;
+      return (
+        <p
+          {...props}
+          style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+        />
+      );
     }, []);
 
     const renderBlockquote = useCallback(


### PR DESCRIPTION
Resolves [FR-1717](https://lablup.atlassian.net/browse/FR-1717)

## Summary
- Fix text overflow issue in chat message paragraphs by adding `word-break: break-word` CSS property
- Prevents long words and URLs from breaking the chat message layout

## Changes
- Updated `ChatMessageContent.tsx` to add `wordBreak: 'break-word'` style to paragraph elements

## Test Plan
- [ ] Verify long URLs in chat messages wrap properly
- [ ] Verify long continuous text breaks correctly
- [ ] Test in both light and dark themes
- [ ] Check that existing message formatting still works

[FR-1717]: https://lablup.atlassian.net/browse/FR-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ