### PR TITLE
feat(FR-1719): use async file deletion api to handle timeout error

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIConfirmModalWithInput.tsx
+++ b/packages/backend.ai-ui/src/components/BAIConfirmModalWithInput.tsx
@@ -1,7 +1,7 @@
 import BAIFlex from './BAIFlex';
 import BAIModal, { BAIModalProps } from './BAIModal';
 import { ExclamationCircleFilled } from '@ant-design/icons';
-import { Form, Input, Typography } from 'antd';
+import { Form, Input, InputProps, theme, Typography } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -14,6 +14,7 @@ export interface BAIConfirmModalWithInputProps
   title: React.ReactNode;
   icon?: React.ReactNode;
   okButtonProps?: Omit<BAIModalProps['okButtonProps'], 'disabled' | 'danger'>;
+  inputProps?: InputProps;
 }
 
 const BAIConfirmModalWithInput: React.FC<BAIConfirmModalWithInputProps> = ({
@@ -23,9 +24,11 @@ const BAIConfirmModalWithInput: React.FC<BAIConfirmModalWithInputProps> = ({
   icon,
   onOk,
   onCancel,
-  ...props
+  inputProps,
+  ...modalProps
 }) => {
   const { t } = useTranslation();
+  const { token } = theme.useToken();
   const [form] = Form.useForm();
   const typedText = Form.useWatch('confirmText', form);
 
@@ -37,7 +40,7 @@ const BAIConfirmModalWithInput: React.FC<BAIConfirmModalWithInputProps> = ({
           <Text strong>
             {icon ?? (
               <ExclamationCircleFilled
-                style={{ color: '#faad14', marginRight: 5 }}
+                style={{ color: token.colorWarning, marginRight: 5 }}
               />
             )}
             {title}
@@ -52,9 +55,9 @@ const BAIConfirmModalWithInput: React.FC<BAIConfirmModalWithInputProps> = ({
         form.resetFields();
         onCancel?.(e);
       }}
-      {...props}
+      {...modalProps}
       okButtonProps={{
-        ...props.okButtonProps,
+        ...modalProps.okButtonProps,
         disabled: confirmText !== typedText,
         danger: true,
       }}
@@ -83,9 +86,11 @@ const BAIConfirmModalWithInput: React.FC<BAIConfirmModalWithInputProps> = ({
               autoFocus
               autoComplete="off"
               allowClear
+              {...inputProps}
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
+                inputProps?.onClick?.(e);
               }}
             />
           </Form.Item>

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -2,7 +2,9 @@ import { BAITrashBinIcon } from '../../../icons';
 import BAIFlex from '../../BAIFlex';
 import { VFolderFile } from '../../provider/BAIClientProvider/types';
 import CreateDirectoryModal from './CreateDirectoryModal';
-import DeleteSelectedItemsModal from './DeleteSelectedItemsModal';
+import DeleteSelectedItemsModal, {
+  DeleteSelectedItemsModalProps,
+} from './DeleteSelectedItemsModal';
 import { useUploadVFolderFiles } from './hooks';
 import {
   FileAddOutlined,
@@ -36,6 +38,7 @@ interface ExplorerActionControlsProps {
     modifiedItems?: Array<VFolderFile>,
   ) => void;
   onUpload: (files: Array<RcFile>, currentPath: string) => void;
+  onDeleteFilesInBackground: DeleteSelectedItemsModalProps['onDeleteFilesInBackground'];
   enableDelete?: boolean;
   enableWrite?: boolean;
   // onClickRefresh?: (key: string) => void;
@@ -46,6 +49,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
   selectedFiles,
   onRequestClose,
   onUpload,
+  onDeleteFilesInBackground,
   enableDelete = false,
   enableWrite = false,
   extra,
@@ -149,6 +153,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
         destroyOnHidden
         open={openDeleteModal}
         selectedFiles={selectedFiles}
+        onDeleteFilesInBackground={onDeleteFilesInBackground}
         onRequestClose={(success: boolean) => {
           if (success) {
             onRequestClose(true, selectedFiles);

--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
@@ -1,4 +1,5 @@
 import { BAITrashBinIcon } from '../../../icons';
+import { BAIButtonProps } from '../../BAIButton';
 import BAIFlex from '../../BAIFlex';
 import useConnectedBAIClient from '../../provider/BAIClientProvider/hooks/useConnectedBAIClient';
 import { VFolderFile } from '../../provider/BAIClientProvider/types';
@@ -14,6 +15,8 @@ interface FileItemControlsProps {
   onClickDelete: () => void;
   enableDownload?: boolean;
   enableDelete?: boolean;
+  downloadButtonProps?: BAIButtonProps;
+  deleteButtonProps?: BAIButtonProps;
 }
 
 const FileItemControls: React.FC<FileItemControlsProps> = ({
@@ -21,6 +24,8 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
   onClickDelete,
   enableDownload = false,
   enableDelete = false,
+  downloadButtonProps,
+  deleteButtonProps,
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
@@ -90,6 +95,7 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
           e.stopPropagation();
           handleDownload();
         }}
+        {...downloadButtonProps}
       />
       <Button
         type="text"
@@ -100,6 +106,7 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
           e.stopPropagation();
           onClickDelete();
         }}
+        {...deleteButtonProps}
       />
     </BAIFlex>
   );

--- a/packages/backend.ai-ui/src/components/provider/BAIClientProvider/types.ts
+++ b/packages/backend.ai-ui/src/components/provider/BAIClientProvider/types.ts
@@ -47,6 +47,7 @@ export interface BAIClient {
   email: string;
   accessKey: string;
   _config: BackendAIConfig;
+  supports: (feature: string) => boolean;
 }
 
 export type BackendAIConfig = {

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -659,6 +659,7 @@
     "Title": "Es ist ein Fehler aufgetreten."
   },
   "explorer": {
+    "DeletingSelectedItems": "Die ausgewählten Dateien werden gelöscht. Bitte warten.",
     "FileUploadCancelled": "Das Datei -Upload wurde durch Benutzeranforderung storniert.",
     "FileUploadFailed": "Es wurden einige Dateien nicht in Ordner '{{folderName}}' hochgeladen.",
     "Filename": "Dateiname",
@@ -667,6 +668,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Nicht verwaltete Ordner unterstützen den Datei -Explorer nicht.",
     "NoPermissions": "Keine Berechtigungen für den Zugriff auf diesen Ordner",
     "ProcessingUpload": "Ihre Datei wird hochgeladen. \nBitte warten.",
+    "SelectedItemsDeletedSuccessfully": "Die ausgewählte Datei wurde erfolgreich gelöscht.",
+    "SelectedItemsDeletionFailed": "Beim Löschen der Dateien ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
     "SuccessfullyUploadedToFolder": "Dateien erfolgreich hochgeladen.",
     "UploadFailed": "Upload fehlgeschlagen in '{{folderName}}' '",
     "UploadingFiles": "Dateien werden hochgeladen...",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -656,6 +656,7 @@
     "Title": "Εμφανίστηκε σφάλμα."
   },
   "explorer": {
+    "DeletingSelectedItems": "Διαγράφονται τα επιλεγμένα αρχεία. Παρακαλώ περιμένετε.",
     "FileUploadCancelled": "Η μεταφόρτωση αρχείων ακυρώθηκε με αίτημα χρήστη.",
     "FileUploadFailed": "Απέτυχε να ανεβάσει κάποια αρχεία στο φάκελο '{{folderName}}'.",
     "Filename": "Όνομα αρχείου",
@@ -664,6 +665,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Οι μη διαχειριζόμενοι φάκελοι δεν υποστηρίζουν τον εξερευνητή αρχείων.",
     "NoPermissions": "Δεν υπάρχουν δικαιώματα πρόσβασης σε αυτόν τον φάκελο",
     "ProcessingUpload": "Το αρχείο σας μεταφορτώνεται. \nΠεριμένετε.",
+    "SelectedItemsDeletedSuccessfully": "Το επιλεγμένο αρχείο διαγράφηκε με επιτυχία.",
+    "SelectedItemsDeletionFailed": "Προέκυψε σφάλμα κατά τη διαγραφή των αρχείων. Παρακαλώ δοκιμάστε ξανά.",
     "SuccessfullyUploadedToFolder": "Τα αρχεία μεταφορτώθηκαν με επιτυχία.",
     "UploadFailed": "Η μεταφόρτωση απέτυχε στο '{{folderName}}'",
     "UploadingFiles": "Μεταφόρτωση αρχείων...",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -664,6 +664,7 @@
     "Title": "An error has occurred."
   },
   "explorer": {
+    "DeletingSelectedItems": "Deleting the selected files. Please wait.",
     "FileUploadCancelled": "The file upload was canceled by user request.",
     "FileUploadFailed": "Failed to upload some files in folder '{{folderName}}'.",
     "Filename": "File Name",
@@ -672,6 +673,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Unmanaged folders do not support the file explorer.",
     "NoPermissions": "No permissions to access this folder",
     "ProcessingUpload": "Your file is being uploaded. Please wait.",
+    "SelectedItemsDeletedSuccessfully": "The selected files have been successfully deleted.",
+    "SelectedItemsDeletionFailed": "An error occurred while deleting the files. Please try again.",
     "SuccessfullyUploadedToFolder": "Files uploaded successfully.",
     "UploadFailed": "Upload failed in '{{folderName}}'",
     "UploadingFiles": "Uploading files...",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -659,6 +659,7 @@
     "Title": "Se ha producido un error."
   },
   "explorer": {
+    "DeletingSelectedItems": "Eliminando los archivos seleccionados. Por favor, espere.",
     "FileUploadCancelled": "La carga de archivo fue cancelada por solicitud del usuario.",
     "FileUploadFailed": "No se pudo cargar algunos archivos en la carpeta '{{folderName}}'.",
     "Filename": "Nombre del archivo",
@@ -667,6 +668,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Las carpetas no administradas no admiten el explorador de archivos.",
     "NoPermissions": "No hay permisos para acceder a esta carpeta",
     "ProcessingUpload": "Se está cargando su archivo. \nEspere por favor.",
+    "SelectedItemsDeletedSuccessfully": "El archivo seleccionado se ha eliminado correctamente.",
+    "SelectedItemsDeletionFailed": "Se produjo un error al eliminar los archivos. Por favor, inténtalo de nuevo.",
     "SuccessfullyUploadedToFolder": "Archivos cargados exitosamente.",
     "UploadFailed": "La carga falló en '{{folderName}}'",
     "UploadingFiles": "Subiendo archivos...",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -659,6 +659,7 @@
     "Title": "On tapahtunut virhe."
   },
   "explorer": {
+    "DeletingSelectedItems": "Poistetaan valittuja tiedostoja. Odota hetki.",
     "FileUploadCancelled": "Tiedoston lataus peruutettiin käyttäjäpyynnöllä.",
     "FileUploadFailed": "Joidenkin tiedostojen lähettäminen kansioon '{{folderName}}'.",
     "Filename": "Tiedoston nimi",
@@ -667,6 +668,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Hallitsemattomat kansiot eivät tue tiedostotutkijaa.",
     "NoPermissions": "Ei oikeuksia käyttää tätä kansiota",
     "ProcessingUpload": "Tiedostosi ladataan. \nOdota.",
+    "SelectedItemsDeletedSuccessfully": "Valittu tiedosto on poistettu onnistuneesti.",
+    "SelectedItemsDeletionFailed": "Tiedostojen poistossa tapahtui virhe. Yritä uudelleen.",
     "SuccessfullyUploadedToFolder": "Tiedostot on ladattu onnistuneesti.",
     "UploadFailed": "Lähettäminen epäonnistui '{{folderName}}'",
     "UploadingFiles": "Ladataan tiedostoja...",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -659,6 +659,7 @@
     "Title": "Une erreur s'est produite."
   },
   "explorer": {
+    "DeletingSelectedItems": "Suppression des fichiers sélectionnés. Veuillez patienter.",
     "FileUploadCancelled": "Le téléchargement du fichier a été annulé par demande de l'utilisateur.",
     "FileUploadFailed": "Échec pour télécharger certains fichiers dans le dossier '{{folderName}}'.",
     "Filename": "Nom de fichier",
@@ -667,6 +668,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Les dossiers non gérés ne prennent pas en charge l'explorateur de fichiers.",
     "NoPermissions": "Aucune autorisation pour accéder à ce dossier",
     "ProcessingUpload": "Votre fichier est téléchargé. \nS'il vous plaît, attendez.",
+    "SelectedItemsDeletedSuccessfully": "Le fichier sélectionné a été supprimé avec succès.",
+    "SelectedItemsDeletionFailed": "Une erreur s'est produite lors de la suppression des fichiers. Veuillez réessayer.",
     "SuccessfullyUploadedToFolder": "Fichiers téléchargés avec succès.",
     "UploadFailed": "Le téléchargement a échoué dans '{{folderName}}'",
     "UploadingFiles": "Téléchargement de fichiers...",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -658,6 +658,7 @@
     "Title": "Telah terjadi kesalahan."
   },
   "explorer": {
+    "DeletingSelectedItems": "Menghapus file yang dipilih. Mohon tunggu.",
     "FileUploadCancelled": "Unggah file dibatalkan dengan permintaan pengguna.",
     "FileUploadFailed": "Gagal mengunggah beberapa file di folder '{{folderName}}'.",
     "Filename": "Nama File",
@@ -666,6 +667,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Folder yang tidak dikelola tidak mendukung file explorer.",
     "NoPermissions": "Tidak ada izin untuk mengakses folder ini",
     "ProcessingUpload": "File Anda sedang diunggah. \nHarap tunggu.",
+    "SelectedItemsDeletedSuccessfully": "File terpilih berhasil dihapus.",
+    "SelectedItemsDeletionFailed": "Terjadi kesalahan saat menghapus file. Silakan coba lagi.",
     "SuccessfullyUploadedToFolder": "File berhasil diunggah.",
     "UploadFailed": "Unggah gagal di '{{folderName}}'",
     "UploadingFiles": "Mengunggah file...",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -658,6 +658,7 @@
     "Title": "Si è verificato un errore."
   },
   "explorer": {
+    "DeletingSelectedItems": "Eliminazione dei file selezionati in corso. Attendere...",
     "FileUploadCancelled": "Il caricamento del file è stato cancellato dalla richiesta dell'utente.",
     "FileUploadFailed": "Impossibile caricare alcuni file nella cartella '{{folderName}}'.",
     "Filename": "Nome del file",
@@ -666,6 +667,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Le cartelle non gestite non supportano l'esploratore dei file.",
     "NoPermissions": "Nessuna autorizzazione per accedere a questa cartella",
     "ProcessingUpload": "Il tuo file viene caricato. \nAttendere prego.",
+    "SelectedItemsDeletedSuccessfully": "Il file selezionato è stato eliminato con successo.",
+    "SelectedItemsDeletionFailed": "Si è verificato un errore durante l'eliminazione dei file. Riprova.",
     "SuccessfullyUploadedToFolder": "File caricati correttamente.",
     "UploadFailed": "Caricamento non riuscito in '{{folderName}'",
     "UploadingFiles": "Caricamento file...",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -658,6 +658,7 @@
     "Title": "エラーが発生しました。"
   },
   "explorer": {
+    "DeletingSelectedItems": "選択したファイルを削除しています。しばらくお待ちください。",
     "FileUploadCancelled": "ファイルのアップロードは、ユーザーリクエストによってキャンセルされました。",
     "FileUploadFailed": "Folder '{{folderName}}'にいくつかのファイルをアップロードできませんでした。",
     "Filename": "ファイル名",
@@ -666,6 +667,8 @@
     "NoExplorerSupportForUnmanagedFolder": "管理されていないフォルダーは、ファイルエクスプローラーをサポートしていません。",
     "NoPermissions": "このフォルダーにアクセスする権限はありません",
     "ProcessingUpload": "ファイルがアップロードされています。\nお待ちください。",
+    "SelectedItemsDeletedSuccessfully": "選択したファイルは正常に削除されました。",
+    "SelectedItemsDeletionFailed": "ファイルの削除中にエラーが発生しました。もう一度お試しください。",
     "SuccessfullyUploadedToFolder": "ファイルは正常にアップロードされました。",
     "UploadFailed": "'{{folderName}}'で故障したアップロード",
     "UploadingFiles": "ファイルをアップロードしています...",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -661,6 +661,7 @@
     "Title": "에러가 발생했습니다."
   },
   "explorer": {
+    "DeletingSelectedItems": "선택한 파일을 삭제하는 중입니다. 잠시만 기다려 주세요.",
     "FileUploadCancelled": "사용자 요청에 따라 파일 업로드가 취소되었습니다.",
     "FileUploadFailed": "'{{folderName}}' 폴더에서 일부 파일 업로드에 실패했습니다. ",
     "Filename": "파일 이름",
@@ -669,6 +670,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Unmanaged 폴더는 파일 탐색기를 지원하지 않습니다.",
     "NoPermissions": "이 폴더에 접근할 권한이 없습니다",
     "ProcessingUpload": "파일을 업로드하는 중입니다. 잠시만 기다려주세요.",
+    "SelectedItemsDeletedSuccessfully": "선택한 파일이 정상적으로 삭제되었습니다.",
+    "SelectedItemsDeletionFailed": "파일을 삭제하는 동안 문제가 발생했습니다. 다시 시도해 주세요.",
     "SuccessfullyUploadedToFolder": "파일 업로드가 완료되었습니다. ",
     "UploadFailed": "'{{folderName}}'에 업로드 실패",
     "UploadingFiles": "파일 업로드 중...",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -657,6 +657,7 @@
     "Title": "Алдаа гарсан байна."
   },
   "explorer": {
+    "DeletingSelectedItems": "Сонгосон файлуудыг устгаж байна. Түр хүлээнэ үү.",
     "FileUploadCancelled": "Файлын байршуулалтыг хэрэглэгчийн хүсэлтээр цуцлагдсан.",
     "FileUploadFailed": "'{{folderName}}' Файлд файл байршуулж чадсангүй.",
     "Filename": "Хөдөлгөөний нэр",
@@ -665,6 +666,8 @@
     "NoExplorerSupportForUnmanagedFolder": "НҮБ-нээгүй хавтас нь файлын Explorer-ийг дэмждэггүй.",
     "NoPermissions": "Энэ хавтсанд нэвтрэх зөвшөөрөл байхгүй байна",
     "ProcessingUpload": "Таны файлыг байршуулж байна. \nТүр хүлээнэ үү",
+    "SelectedItemsDeletedSuccessfully": "Сонгосон файл амжилттай устгагдсан.",
+    "SelectedItemsDeletionFailed": "Файлуудыг устгах явцад алдаа гарлаа. Дахин оролдоно уу.",
     "SuccessfullyUploadedToFolder": "Файлуудыг амжилттай байршуулсан.",
     "UploadFailed": "'{{folderName}} -д бүтэлгүйтсэн.",
     "UploadingFiles": "Файл байршуулах ...",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -658,6 +658,7 @@
     "Title": "Ralat telah berlaku."
   },
   "explorer": {
+    "DeletingSelectedItems": "Sedang memadam fail yang dipilih. Sila tunggu.",
     "FileUploadCancelled": "Muat naik fail dibatalkan oleh permintaan pengguna.",
     "FileUploadFailed": "Gagal memuat naik beberapa fail dalam folder '{{folderName}}'.",
     "Filename": "Nama fail",
@@ -666,6 +667,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Folder yang tidak dikendalikan tidak menyokong penjelajah fail.",
     "NoPermissions": "Tiada kebenaran untuk mengakses folder ini",
     "ProcessingUpload": "Fail anda sedang dimuat naik. \nTolong tunggu.",
+    "SelectedItemsDeletedSuccessfully": "Fail yang dipilih telah berjaya dipadam.",
+    "SelectedItemsDeletionFailed": "Ralat berlaku semasa memadam fail. Sila cuba lagi.",
     "SuccessfullyUploadedToFolder": "Fail dimuat naik dengan jayanya.",
     "UploadFailed": "Muat naik gagal dalam '{{folderName}}'",
     "UploadingFiles": "Memuat naik fail ...",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -659,6 +659,7 @@
     "Title": "Wystąpił błąd."
   },
   "explorer": {
+    "DeletingSelectedItems": "Usuwanie wybranych plików. Proszę czekać.",
     "FileUploadCancelled": "Przesłanie pliku zostało anulowane na żądanie użytkownika.",
     "FileUploadFailed": "Nie udało się przesłać niektórych plików w folderze „{{folderName}}”.",
     "Filename": "Nazwa pliku",
@@ -666,6 +667,8 @@
     "InputTooShort": "Wejście zbyt krótkie",
     "NoExplorerSupportForUnmanagedFolder": "Foldery niezarządzane nie obsługują eksploratora plików.",
     "ProcessingUpload": "Twój plik jest przesyłany. \nProszę poczekaj.",
+    "SelectedItemsDeletedSuccessfully": "Wybrany plik został pomyślnie usunięty.",
+    "SelectedItemsDeletionFailed": "Wystąpił błąd podczas usuwania plików. Spróbuj ponownie.",
     "SuccessfullyUploadedToFolder": "Pliki przesłane pomyślnie.",
     "UploadFailed": "Przesyłanie nie powiodło się w '{{folderName}}' '",
     "UploadingFiles": "Przesyłanie plików...",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -659,6 +659,7 @@
     "Title": "Ocorreu um erro."
   },
   "explorer": {
+    "DeletingSelectedItems": "Excluindo os arquivos selecionados. Por favor, aguarde.",
     "FileUploadCancelled": "O upload do arquivo foi cancelado por solicitação do usuário.",
     "FileUploadFailed": "Falha ao fazer upload de alguns arquivos na pasta '{{folderName}}'.",
     "Filename": "Nome do arquivo",
@@ -667,6 +668,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Pastas não gerenciadas não suportam o File Explorer.",
     "NoPermissions": "Sem permissões para acessar esta pasta",
     "ProcessingUpload": "Seu arquivo está sendo carregado. \nPor favor, aguarde.",
+    "SelectedItemsDeletedSuccessfully": "O arquivo selecionado foi excluído com sucesso.",
+    "SelectedItemsDeletionFailed": "Ocorreu um erro ao excluir os arquivos. Por favor, tente novamente.",
     "SuccessfullyUploadedToFolder": "Arquivos enviados com sucesso.",
     "UploadFailed": "O upload falhou em '{{folderName}}'",
     "UploadingFiles": "Fazendo upload de arquivos...",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -659,6 +659,7 @@
     "Title": "Ocorreu um erro."
   },
   "explorer": {
+    "DeletingSelectedItems": "Excluindo os arquivos selecionados. Aguarde, por favor.",
     "FileUploadCancelled": "O upload do arquivo foi cancelado por solicitação do usuário.",
     "FileUploadFailed": "Falha ao fazer upload de alguns arquivos na pasta '{{folderName}}'.",
     "Filename": "Nome do arquivo",
@@ -667,6 +668,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Pastas não gerenciadas não suportam o File Explorer.",
     "NoPermissions": "Sem permissões para acessar esta pasta",
     "ProcessingUpload": "Seu arquivo está sendo carregado. \nPor favor, aguarde.",
+    "SelectedItemsDeletedSuccessfully": "O ficheiro selecionado foi eliminado com sucesso.",
+    "SelectedItemsDeletionFailed": "Ocorreu um erro ao excluir os arquivos. Por favor, tente novamente.",
     "SuccessfullyUploadedToFolder": "Arquivos enviados com sucesso.",
     "UploadFailed": "O upload falhou em '{{folderName}}'",
     "UploadingFiles": "Fazendo upload de arquivos...",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -659,6 +659,7 @@
     "Title": "Произошла ошибка."
   },
   "explorer": {
+    "DeletingSelectedItems": "Удаление выбранных файлов. Пожалуйста, подождите.",
     "FileUploadCancelled": "Загрузка файла была отменена пользовательским запросом.",
     "FileUploadFailed": "Не удалось загрузить некоторые файлы в папке '{{folderName}}'.",
     "Filename": "Имя файла",
@@ -666,6 +667,8 @@
     "InputTooShort": "ВводОченьКороток",
     "NoExplorerSupportForUnmanagedFolder": "Неуправляемые папки не поддерживают исследователь файлов.",
     "ProcessingUpload": "Ваш файл загружается. \nПожалуйста, подождите.",
+    "SelectedItemsDeletedSuccessfully": "Выбранный файл успешно удалён.",
+    "SelectedItemsDeletionFailed": "Произошла ошибка при удалении файлов. Пожалуйста, попробуйте ещё раз.",
     "SuccessfullyUploadedToFolder": "Файлы успешно загружены.",
     "UploadFailed": "Загрузка не удалась в '{{folderName}}'",
     "UploadingFiles": "Загрузка файлов...",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -648,6 +648,7 @@
     "Title": "เกิดข้อผิดพลาด"
   },
   "explorer": {
+    "DeletingSelectedItems": "กำลังลบไฟล์ที่เลือก โปรดรอ",
     "FileUploadCancelled": "การอัปโหลดไฟล์ถูกยกเลิกโดยคำขอผู้ใช้",
     "FileUploadFailed": "ไม่สามารถอัปโหลดไฟล์บางไฟล์ในโฟลเดอร์ '{{folderName}}'",
     "Filename": "ชื่อไฟล์",
@@ -656,6 +657,8 @@
     "NoExplorerSupportForUnmanagedFolder": "โฟลเดอร์ที่ไม่มีการจัดการไม่รองรับ File Explorer",
     "NoPermissions": "ไม่มีสิทธิ์ในการเข้าถึงโฟลเดอร์นี้",
     "ProcessingUpload": "ไฟล์ของคุณกำลังถูกอัปโหลด \nโปรดรอ.",
+    "SelectedItemsDeletedSuccessfully": "ไฟล์ที่เลือกถูกลบเรียบร้อยแล้ว",
+    "SelectedItemsDeletionFailed": "เกิดข้อผิดพลาดขณะลบไฟล์ กรุณาลองอีกครั้ง",
     "SuccessfullyUploadedToFolder": "อัปโหลดไฟล์เรียบร้อยแล้ว",
     "UploadFailed": "การอัปโหลดล้มเหลวใน '{{folderName}}'",
     "UploadingFiles": "กำลังอัพโหลดไฟล์...",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -659,6 +659,7 @@
     "Title": "Bir hata oluştu."
   },
   "explorer": {
+    "DeletingSelectedItems": "Seçili dosyalar siliniyor. Lütfen bekleyin.",
     "FileUploadCancelled": "Dosya yükleme kullanıcı isteği ile iptal edildi.",
     "FileUploadFailed": "Bazı dosyaları '{{{folderName}}' klasörüne yükleyemedi.",
     "Filename": "Dosya adı",
@@ -667,6 +668,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Yönetilmeyen klasörler Dosya Gezgini'ni desteklemez.",
     "NoPermissions": "Bu klasöre erişmek için izin yok",
     "ProcessingUpload": "Dosyanız yükleniyor. \nLütfen bekleyin.",
+    "SelectedItemsDeletedSuccessfully": "Seçili dosya başarıyla silindi.",
+    "SelectedItemsDeletionFailed": "Dosyalar silinirken bir hata oluştu. Lütfen tekrar deneyin.",
     "SuccessfullyUploadedToFolder": "Dosyalar başarıyla yüklendi.",
     "UploadFailed": "Yükleme başarısız oldu '{{folderName}}'",
     "UploadingFiles": "Dosyalar yükleniyor...",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -659,6 +659,7 @@
     "Title": "Một lỗi đã xảy ra."
   },
   "explorer": {
+    "DeletingSelectedItems": "Đang xóa các tệp đã chọn. Vui lòng chờ.",
     "FileUploadCancelled": "Tải lên tệp đã bị hủy bởi yêu cầu người dùng.",
     "FileUploadFailed": "Không thể tải lên một số tệp trong thư mục '{{folderName}}'.",
     "Filename": "Tên tệp",
@@ -667,6 +668,8 @@
     "NoExplorerSupportForUnmanagedFolder": "Các thư mục không được quản lý không hỗ trợ trình thám hiểm tệp.",
     "NoPermissions": "Không có quyền truy cập thư mục này",
     "ProcessingUpload": "Tệp của bạn đang được tải lên. \nVui lòng chờ.",
+    "SelectedItemsDeletedSuccessfully": "Tệp được chọn đã được xóa thành công.",
+    "SelectedItemsDeletionFailed": "Đã xảy ra lỗi khi xóa các tệp. Vui lòng thử lại.",
     "SuccessfullyUploadedToFolder": "Các tập tin được tải lên thành công.",
     "UploadFailed": "Tải lên không thành công trong '{{folderName}}'",
     "UploadingFiles": "Đang tải tệp lên...",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -659,6 +659,7 @@
     "Title": "发生错误。"
   },
   "explorer": {
+    "DeletingSelectedItems": "正在删除所选文件，请稍候。",
     "FileUploadCancelled": "文件上传已通过用户请求取消。",
     "FileUploadFailed": "无法将某些文件上传到文件夹'{{folderName}}'中。",
     "Filename": "文件名",
@@ -667,6 +668,8 @@
     "NoExplorerSupportForUnmanagedFolder": "未管理的文件夹不支持文件资源管理器。",
     "NoPermissions": "无权访问此文件夹",
     "ProcessingUpload": "您的文件正在上传。\n请稍等。",
+    "SelectedItemsDeletedSuccessfully": "所选文件已成功删除。",
+    "SelectedItemsDeletionFailed": "删除文件时出错，请重试。",
     "SuccessfullyUploadedToFolder": "文件上传成功。",
     "UploadFailed": "上传失败在'{{folderName}}'中",
     "UploadingFiles": "正在上传文件...",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -659,6 +659,7 @@
     "Title": "发生错误。"
   },
   "explorer": {
+    "DeletingSelectedItems": "正在刪除所選檔案，請稍候。",
     "FileUploadCancelled": "文件上傳已通過用戶請求取消。",
     "FileUploadFailed": "無法將某些文件上傳到文件夾'{{folderName}}'中。",
     "Filename": "文件名",
@@ -666,6 +667,8 @@
     "InputTooShort": "輸入太短",
     "NoExplorerSupportForUnmanagedFolder": "未管理的文件夾不支持文件資源管理器。",
     "ProcessingUpload": "您的文件正在上傳。請稍等。",
+    "SelectedItemsDeletedSuccessfully": "已成功刪除所選檔案。",
+    "SelectedItemsDeletionFailed": "刪除檔案時發生錯誤。請再試一次。",
     "SuccessfullyUploadedToFolder": "文件上傳成功。",
     "UploadFailed": "上傳失敗在'{{folderName}}'中",
     "UploadingFiles": "正在上傳文件...",

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -828,6 +828,9 @@ class Client {
     if (this.isManagerVersionCompatibleWith('25.16.0')) {
       this._features['multi-agents'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('25.17.0')) {
+      this._features['background-file-delete'] = true;
+    }
   }
 
   /**
@@ -2453,9 +2456,12 @@ class VFolder {
       files: files,
       recursive: recursive,
     };
+    
     let rqst = this.client.newSignedRequest(
-      this.client._managerVersion >= '24.03.7' ? 'POST' : 'DELETE',
-      `${this.urlPrefix}/${name}/delete-files`,
+      'POST',
+      this.client.supports('background-file-delete') 
+        ? `${this.urlPrefix}/${name}/delete-files-async` 
+        : `${this.urlPrefix}/${name}/delete-files`,
       body,
     );
     return this.client._wrapWithPromise(rqst);


### PR DESCRIPTION
resolves #4688 ([FR-1719](https://lablup.atlassian.net/browse/FR-1719))

### Implement Background File Deletion in File Explorer using Background API

This PR enhances the file deletion functionality in the File Explorer by implementing background file deletion. When users delete files, especially large ones or directories, the operation now runs asynchronously in the background, providing a better user experience.

Key changes:
- Added support for the new `delete-files-async` API endpoint when available
- Implemented visual indicators for files being deleted (loading state on delete buttons)
- Added notification system to track background deletion progress
- Added translations for deletion status messages across all supported languages
- Made the confirmation input field disabled during deletion to prevent multiple submissions

**Checklist:**
- [x] Documentation
- [x] Minium required manager version: 25.17.0 for background file deletion
- [x] Specific setting for review: Test with large file/folder deletion
- [x] Minimum requirements to check during review: Verify loading indicators appear and notifications show progress
- [x] Test case(s): Delete a large folder and verify the UI remains responsive

[FR-1719]: https://lablup.atlassian.net/browse/FR-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ