### PR TITLE
feat(FR-1004): use server provided session resource setting in launching session

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -54,6 +54,9 @@ interface SessionActionButtonsProps {
 }
 
 const isActive = (session: SessionActionButtonsFragment$data) => {
+  if (session?.type === 'system') {
+    return session?.status === 'RUNNING';
+  }
   return !['TERMINATED', 'CANCELLED', 'TERMINATING'].includes(
     session?.status || '',
   );
@@ -283,9 +286,7 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = ({
           <Tooltip title={t('data.explorer.RunSSH/SFTPserver')}>
             <Button
               type="primary"
-              disabled={
-                !isAppSupported(session) || !isActive(session) || !isOwner
-              }
+              disabled={!isActive(session) || !isOwner}
               size={size}
               icon={<BAISftpIcon />}
               onClick={() => {

--- a/react/src/components/FileBrowserButton.tsx
+++ b/react/src/components/FileBrowserButton.tsx
@@ -12,12 +12,10 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 import { FileBrowserButtonFragment$key } from 'src/__generated__/FileBrowserButtonFragment.graphql';
 import { useCurrentDomainValue, useSuspendedBackendaiClient } from 'src/hooks';
-import { useSetBAINotification } from 'src/hooks/useBAINotification';
 import { useCurrentProjectValue } from 'src/hooks/useCurrentProject';
 import { useDefaultFileBrowserImageWithFallback } from 'src/hooks/useDefaultImagesWithFallback';
 import { useMergedAllowedStorageHostPermission } from 'src/hooks/useMergedAllowedStorageHostPermission';
 import {
-  startSessionErrorCodes,
   StartSessionWithDefaultValue,
   useStartSession,
 } from 'src/hooks/useStartSession';
@@ -50,7 +48,6 @@ const FileBrowserButton: React.FC<FileBrowserButtonProps> = ({
   const { getErrorMessage } = useErrorMessageResolver();
   const { startSessionWithDefault, upsertSessionNotification } =
     useStartSession();
-  const { upsertNotification } = useSetBAINotification();
 
   const filebrowserImage = useDefaultFileBrowserImageWithFallback();
 
@@ -104,6 +101,8 @@ const FileBrowserButton: React.FC<FileBrowserButtonProps> = ({
             return;
           }
           const fileBrowserFormValue: StartSessionWithDefaultValue = {
+            // If the resource setting is not included when the session is created,
+            // it is created with the value determined by the server.
             sessionName: `filebrowser-${vfolder.row_id}`,
             sessionType: 'interactive',
             // use default file browser image if configured and allowed
@@ -114,10 +113,6 @@ const FileBrowserButton: React.FC<FileBrowserButtonProps> = ({
             cluster_mode: 'single-node',
             cluster_size: 1,
             mount_ids: [vfolder.row_id?.replaceAll('-', '') || ''],
-            resource: {
-              cpu: 1,
-              mem: '0.5g',
-            },
           };
 
           await startSessionWithDefault(fileBrowserFormValue)
@@ -125,6 +120,7 @@ const FileBrowserButton: React.FC<FileBrowserButtonProps> = ({
               if (results?.fulfilled && results.fulfilled.length > 0) {
                 upsertSessionNotification(results.fulfilled, [
                   {
+                    key: `filebrowser-${vfolder.row_id}`,
                     extraData: {
                       appName: 'filebrowser',
                     } as PrimaryAppOption,
@@ -133,22 +129,10 @@ const FileBrowserButton: React.FC<FileBrowserButtonProps> = ({
               }
               if (results?.rejected && results.rejected.length > 0) {
                 const error = results.rejected[0].reason;
-                if (
-                  _.includes(
-                    error.message,
-                    startSessionErrorCodes.DUPLICATED_SESSION,
-                  )
-                ) {
-                  upsertNotification({
-                    key: `filebrowser-${vfolder.row_id}`,
-                    open: true,
-                  });
-                } else {
-                  modal.error({
-                    title: error?.title,
-                    content: getErrorMessage(error),
-                  });
-                }
+                modal.error({
+                  title: error?.title,
+                  content: getErrorMessage(error),
+                });
               }
             })
             .catch((error) => {

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -138,6 +138,7 @@ const ResourceAllocationFormItems: React.FC<
     accessible_scaling_groups,
     (group) => group?.name === currentResourceGroupInForm,
   );
+  const currentResourceValue = Form.useWatch(['resource']);
   const currentImage = Form.useWatch(['environments', 'image'], {
     form,
     preserve: true,
@@ -205,6 +206,11 @@ const ResourceAllocationFormItems: React.FC<
   }, [currentImage, acceleratorSlotsInRG, currentEnvironmentManual]);
 
   useEffect(() => {
+    if (!currentResourceValue) {
+      form.setFieldsValue({
+        allocationPreset: 'auto-select',
+      });
+    }
     if (supportedAcceleratorTypesInRGByImage?.length === 0) {
       form.setFieldsValue({
         resource: {
@@ -212,7 +218,7 @@ const ResourceAllocationFormItems: React.FC<
         },
       });
     }
-  }, [supportedAcceleratorTypesInRGByImage, form]);
+  }, [supportedAcceleratorTypesInRGByImage, form, currentResourceValue]);
 
   const sessionSliderLimitAndRemaining = {
     min: 1,

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -279,7 +279,7 @@ const SessionLauncherPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const mergedInitialValues = useMemo(() => {
+  const mergedInitialValues: SessionLauncherFormValue = useMemo(() => {
     return _.merge({}, defaultFormValues, formValuesFromQueryParams);
   }, [defaultFormValues, formValuesFromQueryParams]);
 


### PR DESCRIPTION
### Removed resource values for filebrowser and sftp session

resolves #3673([FR-1004](https://lablup.atlassian.net/browse/FR-1004))

This PR removes explicit resource requirements when creating system sessions (like SFTP and file browser sessions), allowing the server to determine appropriate resource allocation. Key changes:

### Features
- Modified `useStartSession` to make resource specifications optional (The session launcher side uses ResourceAllocationFormItems, so no separate modifications are needed. Instead, the useStartSession side, which imports the type, is modified to allow the resource to be optional. )
- Removed hardcoded resource requirements from `FileBrowserButton` and `SFTPServerButton`
### Fixed Bugs
- Added handling for system session status checking
- Removed unnecessary SFTP button disabling condition
### How to test
- folder explorer 에서 filebrowser 혹은 sftp session 을 생성합니다. 
- 네트워크 payload 에 resource 설정이 비어있는지 확인합니다.
- 생성된 세션에 자원이 잘 할당되었는지 확인합니다. 

These changes ensure system sessions use server-defined resource allocations rather than client-specified values, which improves resource management and prevents potential issues with insufficient resources.

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1004]: https://lablup.atlassian.net/browse/FR-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ