### PR TITLE
feat(FR-1727): customizing optional text in form

### DIFF
--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -15,7 +15,7 @@ import { StyleProvider, createCache } from '@ant-design/cssinjs';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useSessionStorageState, useUpdateEffect } from 'ahooks';
 import { App, AppProps, theme, Typography } from 'antd';
-import { BAIConfigProvider } from 'backend.ai-ui';
+import { BAIConfigProvider, BAIText } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import 'dayjs/locale/de';
 import 'dayjs/locale/el';
@@ -208,6 +208,8 @@ const DefaultProvidersForWebComponent: React.FC<DefaultProvidersProps> = ({
 }) => {
   const cache = useMemo(() => createCache(), []);
   const [lang] = useCurrentLanguage();
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
 
   const [userCustomThemeConfig] = useBAISettingUserState('custom_theme_config');
   const [isThemePreviewMode] = useSessionStorageState('isThemePreviewMode', {
@@ -287,7 +289,22 @@ const DefaultProvidersForWebComponent: React.FC<DefaultProvidersProps> = ({
                       }}
                       clientPromise={backendaiClientPromise}
                       form={{
-                        requiredMark: 'optional',
+                        requiredMark: (label, { required }) => (
+                          <>
+                            {label}
+                            {!required && (
+                              <BAIText
+                                type="secondary"
+                                style={{
+                                  marginLeft: token.marginXXS,
+                                  wordBreak: 'keep-all',
+                                }}
+                              >
+                                {`(${t('general.Optional')})`}
+                              </BAIText>
+                            )}
+                          </>
+                        ),
                       }}
                       anonymousClientFactory={createAnonymousBackendaiClient}
                     >
@@ -355,6 +372,8 @@ export const DefaultProvidersForReactRoot: React.FC<
   Partial<DefaultProvidersProps>
 > = ({ children }) => {
   const [lang] = useCurrentLanguage();
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
   const { isDarkMode } = useThemeMode();
 
   const [userCustomThemeConfig] = useBAISettingUserState('custom_theme_config');
@@ -408,7 +427,22 @@ export const DefaultProvidersForReactRoot: React.FC<
               clientPromise={backendaiClientPromise}
               anonymousClientFactory={createAnonymousBackendaiClient}
               form={{
-                requiredMark: 'optional',
+                requiredMark: (label, { required }) => (
+                  <>
+                    {label}
+                    {!required && (
+                      <BAIText
+                        type="secondary"
+                        style={{
+                          marginLeft: token.marginXXS,
+                          wordBreak: 'keep-all',
+                        }}
+                      >
+                        {`(${t('general.Optional')})`}
+                      </BAIText>
+                    )}
+                  </>
+                ),
               }}
             >
               <QueryParamProvider adapter={ReactRouter6Adapter}>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -706,6 +706,7 @@
     "NavigateToDetailPage": "Zur Detailseite gehen",
     "NewPassword": "Neues Kennwort",
     "None": "Keine",
+    "Optional": "Optional",
     "Password": "Passwort",
     "RemainingLoginSessionTime": "Zeit bis zur automatischen Abmeldung",
     "ResourceGroup": "Ressourcengruppe",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -703,6 +703,7 @@
     "NavigateToDetailPage": "Μεταβείτε στη σελίδα λεπτομερειών",
     "NewPassword": "νέος κωδικός πρόσβασης",
     "None": "Κανένα",
+    "Optional": "Προαιρετικό",
     "Password": "Κωδικός πρόσβασης",
     "RemainingLoginSessionTime": "Χρόνος μέχρι την αυτόματη αποσύνδεση",
     "ResourceGroup": "Ομάδα πόρων",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -711,6 +711,7 @@
     "NavigateToDetailPage": "Go to the details page",
     "NewPassword": "New Password",
     "None": "None",
+    "Optional": "optional",
     "Password": "Password",
     "RemainingLoginSessionTime": "Time until auto logout",
     "ResourceGroup": "Resource Group",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -706,6 +706,7 @@
     "NavigateToDetailPage": "Ir a la página de detalles",
     "NewPassword": "Nueva contraseña",
     "None": "Ninguno",
+    "Optional": "opcional",
     "Password": "Contraseña",
     "RemainingLoginSessionTime": "Tiempo hasta el cierre de sesión automático",
     "ResourceGroup": "Grupo de recursos",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -706,6 +706,7 @@
     "NavigateToDetailPage": "Siirry yksityiskohtien sivulle",
     "NewPassword": "Uusi salasana",
     "None": "Ei ole",
+    "Optional": "valinnainen",
     "Password": "Salasana",
     "RemainingLoginSessionTime": "Aika automaattiseen uloskirjautumiseen asti",
     "ResourceGroup": "Resurssiryhmä",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -706,6 +706,7 @@
     "NavigateToDetailPage": "Aller à la page de détails",
     "NewPassword": "nouveau mot de passe",
     "None": "Aucun",
+    "Optional": "facultatif",
     "Password": "Mot de passe",
     "RemainingLoginSessionTime": "Délai avant déconnexion automatique",
     "ResourceGroup": "Groupe de ressources",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -705,6 +705,7 @@
     "NavigateToDetailPage": "Buka halaman detail",
     "NewPassword": "Kata Sandi Baru",
     "None": "Tidak ada",
+    "Optional": "opsional",
     "Password": "Kata sandi",
     "RemainingLoginSessionTime": "Waktu Hingga Keluar Otomatis",
     "ResourceGroup": "Grup Sumber Daya",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -705,6 +705,7 @@
     "NavigateToDetailPage": "Vai alla pagina dei dettagli",
     "NewPassword": "nuova password",
     "None": "Nessuno",
+    "Optional": "opzionale",
     "Password": "Parola d'ordine",
     "RemainingLoginSessionTime": "Tempo fino alla disconnessione automatica",
     "ResourceGroup": "Gruppo di risorse",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -705,6 +705,7 @@
     "NavigateToDetailPage": "詳細ページへ",
     "NewPassword": "新しいパスワード",
     "None": "なし",
+    "Optional": "任意",
     "Password": "パスワード",
     "RemainingLoginSessionTime": "自動ログアウトまでの時間",
     "ResourceGroup": "リソースグループ",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -709,6 +709,7 @@
     "NavigateToDetailPage": "상세 페이지로 이동",
     "NewPassword": "새 비밀번호",
     "None": "없음",
+    "Optional": "선택",
     "Password": "비밀번호",
     "RemainingLoginSessionTime": "자동 로그아웃까지 남은 시간",
     "ResourceGroup": "자원 그룹",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -704,6 +704,7 @@
     "NavigateToDetailPage": "Нарийвчилсан хуудсанд шилжих",
     "NewPassword": "Шинэ нууц үг",
     "None": "Байхгүй",
+    "Optional": "заавал биш",
     "Password": "Нууц үг",
     "RemainingLoginSessionTime": "Автоматаар гарах хүртэл хугацаа",
     "ResourceGroup": "Нөөцийн бүлэг",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -705,6 +705,7 @@
     "NavigateToDetailPage": "Pindah ke halaman perincian",
     "NewPassword": "Kata laluan baharu",
     "None": "tiada",
+    "Optional": "pilihan",
     "Password": "Kata Laluan",
     "RemainingLoginSessionTime": "__NOT_TRANSLATED__",
     "ResourceGroup": "Kumpulan Sumber",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -705,6 +705,7 @@
     "NavigateToDetailPage": "Przejdź do strony szczegółów",
     "NewPassword": "nowe hasło",
     "None": "Brak",
+    "Optional": "Opcjonalne",
     "Password": "Hasło",
     "RemainingLoginSessionTime": "Czas do automatycznego wylogowania",
     "ResourceGroup": "Grupa zasobów",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -706,6 +706,7 @@
     "NavigateToDetailPage": "Ir para a página de pormenores",
     "NewPassword": "Nova Senha",
     "None": "Nenhum",
+    "Optional": "opcional",
     "Password": "Senha",
     "RemainingLoginSessionTime": "Tempo até ao encerramento automático da sessão",
     "ResourceGroup": "Grupo de Recursos",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -706,6 +706,7 @@
     "NavigateToDetailPage": "Ir para a página de pormenores",
     "NewPassword": "Nova Senha",
     "None": "Nenhum",
+    "Optional": "opcional",
     "Password": "Senha",
     "RemainingLoginSessionTime": "Tempo até ao encerramento automático da sessão",
     "ResourceGroup": "Grupo de Recursos",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -705,6 +705,7 @@
     "NavigateToDetailPage": "Перейдите на страницу с подробной информацией",
     "NewPassword": "Новый пароль",
     "None": "Нет",
+    "Optional": "необязательно",
     "Password": "Пароль",
     "RemainingLoginSessionTime": "Время до автоматического выхода из системы",
     "ResourceGroup": "Группа ресурсов",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -695,6 +695,7 @@
     "NavigateToDetailPage": "ไปที่หน้าโดยละเอียด",
     "NewPassword": "รหัสผ่านใหม่",
     "None": "ไม่มี",
+    "Optional": "ไม่บังคับ",
     "Password": "รหัสผ่าน",
     "RemainingLoginSessionTime": "เวลาจนกระทั่งออกจากระบบอัตโนมัติ",
     "ResourceGroup": "กลุ่มทรัพยากร",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -706,6 +706,7 @@
     "NavigateToDetailPage": "Ayrıntılar sayfasına gidin",
     "NewPassword": "Yeni Şifre",
     "None": "Hiçbiri",
+    "Optional": "İsteğe bağlı",
     "Password": "Parola",
     "RemainingLoginSessionTime": "Otomatik Çıkışa Kadar Geçen Süre",
     "ResourceGroup": "Kaynak Grubu",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -706,6 +706,7 @@
     "NavigateToDetailPage": "Chuyển đến trang chi tiết",
     "NewPassword": "mật khẩu mới",
     "None": "Không có",
+    "Optional": "Không bắt buộc",
     "Password": "Mật khẩu",
     "RemainingLoginSessionTime": "Thời gian cho đến khi tự động đăng xuất",
     "ResourceGroup": "Nhóm tài nguyên",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -706,6 +706,7 @@
     "NavigateToDetailPage": "转至详细信息页面",
     "NewPassword": "新密码",
     "None": "无",
+    "Optional": "可选",
     "Password": "密码",
     "RemainingLoginSessionTime": "自动注销前的时间",
     "ResourceGroup": "资源组",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -705,6 +705,7 @@
     "NavigateToDetailPage": "转至详情页面",
     "NewPassword": "新密碼",
     "None": "无",
+    "Optional": "選填",
     "Password": "密碼",
     "RemainingLoginSessionTime": "自动注销前的时间",
     "ResourceGroup": "資源組",


### PR DESCRIPTION
resolves #4711 (FR-1727)


This PR enhances the form field labeling by explicitly marking optional fields with "(optional)" text instead of using the default Ant Design approach. The changes include:

1. Updated the `requiredMark` configuration in `BAIConfigProvider` to display "(optional)" text for non-required fields
2. Added a new translation key "Optional" across all language files
3. Improved the layout of the Resource Preset Setting form by:
   - Using vertical layout for better readability
   - Adding consistent styling for input fields
   - Removing unnecessary Row/Col structure

These changes make it clearer to users which fields are optional vs. required in forms throughout the application.

![CleanShot 2025-11-26 at 12.50.59@2x.png](https://app.graphite.com/user-attachments/assets/4d77b838-bdcd-4eac-9680-9af3e524b7d5.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after