### PR TITLE
fix(FR-1728): update scheduler label (ko)

### DIFF
--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2135,7 +2135,7 @@
       "Reservoir": "리저버",
       "ResourcePolicy": "자원 정책",
       "Resources": "자원",
-      "Scheduler": "스케쥴러",
+      "Scheduler": "스케줄러",
       "Serving": "모델 서빙",
       "Sessions": "세션",
       "Settings": "설정",


### PR DESCRIPTION
resolves FR-1728

# Fix Korean translation of "Scheduler" in UI

Corrects the Korean translation of "Scheduler" from "스케쥴러" to "스케줄러" in the Korean localization file.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after