### PR TITLE
feat(FR-1734): Add 'system' type to resource group setting modal

### DIFF
--- a/react/src/components/ResourceGroupSettingModal.tsx
+++ b/react/src/components/ResourceGroupSettingModal.tsx
@@ -332,6 +332,7 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
                 { label: 'Batch', value: 'batch' },
                 { label: 'Interactive', value: 'interactive' },
                 { label: 'Inference', value: 'inference' },
+                { label: 'System', value: 'system' },
               ]}
             />
           </Form.Item>


### PR DESCRIPTION
resolves FR-1734

# Add "System" option to resource group type selection

This PR adds a new "System" option to the resource group type dropdown in the ResourceGroupSettingModal component. Users can now select "System" as a resource group type alongside the existing options (Batch, Interactive, and Inference).

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after