### PR TITLE
fix(FR-1735): sftp application is always disabled.

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -60,7 +60,7 @@ const isActive = (session: SessionActionButtonsFragment$data) => {
 };
 const isAppSupported = (session: SessionActionButtonsFragment$data) => {
   return (
-    ['batch', 'interactive', 'inference', 'running'].includes(
+    ['batch', 'interactive', 'inference', 'system', 'running'].includes(
       session?.type || '',
     ) && !_.isEmpty(JSON.parse(session?.service_ports ?? '{}'))
   );


### PR DESCRIPTION
Resolves #4725 ([FR-1735](https://lablup.atlassian.net/browse/FR-1735))

# Add `system` session type to app launch check to prevent SFTP app from being falsely reported as disabled.

This PR adds 'system' to the list of session types that support app launching. Previously, only 'batch', 'interactive', 'inference', and 'running' session types were considered for app support.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1735]: https://lablup.atlassian.net/browse/FR-1735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ