### PR TITLE
fix(FR-1759): remove `startWithReasoning` to avoid stuck on reasoning cycle.

### DIFF
--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -264,7 +264,6 @@ const PureChatCard: React.FC<ChatCardProps> = ({
                 model: provider.chat(modelId),
                 middleware: extractReasoningMiddleware({
                   tagName: 'think',
-                  startWithReasoning: true,
                 }),
               }),
               messages: convertToModelMessages(body?.messages),


### PR DESCRIPTION
resolves FR-1759

# Remove `startWithReasoning: true` from extractReasoningMiddleware

This PR removes the `startWithReasoning: true` parameter from the `extractReasoningMiddleware` configuration in the ChatCard component. This change modifies how the reasoning middleware processes chat messages.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after