### PR TITLE
fix(FR-1760): Remove duplicated onclick handler assignments of `useBAINotification`

### DIFF
--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -477,14 +477,12 @@ export const useSetBAINotification = () => {
 
       const notification = new Notification(title, options);
       notification.onclick = () => {
-        notification.onclick = () => {
-          if (params.to) {
-            window.focus();
-            const href =
-              typeof params.to === 'string' ? params.to : createPath(params.to);
-            window.location.href = href;
-          }
-        };
+        if (params.to) {
+          window.focus();
+          const href =
+            typeof params.to === 'string' ? params.to : createPath(params.to);
+          window.location.href = href;
+        }
       };
     },
     [t],


### PR DESCRIPTION
Resolves #4752 ([FR-1760](https://lablup.atlassian.net/browse/FR-1760))

# Fix duplicate notification click handler

This PR fixes a bug in the notification click handler where the `onclick` function was being defined twice, causing nested handlers. The redundant inner handler has been removed, simplifying the code and ensuring the notification click behavior works correctly.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1760]: https://lablup.atlassian.net/browse/FR-1760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ