### PR TITLE
feat(FR-1761): add security exception for node-forge v1.3.2 in pnpm workspace config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,5 @@ patchedDependencies:
 
 minimumReleaseAge: 10080
 
+minimumReleaseAgeExclude:
+  - node-forge@1.3.2


### PR DESCRIPTION
Resolves #4755 ([FR-1761](https://lablup.atlassian.net/browse/FR-1761))

## Summary
A security vulnerability in older node-forge versions requires immediate upgrade to v1.3.2. However, our pnpm workspace's minimum release age policy (10080 minutes) blocks installation of recently released packages.

This PR adds a specific exception for node-forge v1.3.2 to allow the security fix while maintaining our release stability policy for other dependencies.

## Changes
- Added `minimumReleaseAgeExclude` section in `pnpm-workspace.yaml`
- Specified exception for `node-forge@1.3.2` to bypass minimum release age policy

## Expected Outcome
- Allow installation of node-forge v1.3.2 to resolve the security vulnerability
- Preserve dependency stability controls for all other packages

**Checklist:**

- [x] Documentation - Configuration change is self-documenting
- [ ] Minimum required manager version - N/A
- [ ] Specific setting for review - N/A
- [x] Minimum requirements to check during review - Verify pnpm-workspace.yaml syntax
- [x] Test case(s) to demonstrate the difference - Run `pnpm install` to verify node-forge@1.3.2 can be installed

[FR-1761]: https://lablup.atlassian.net/browse/FR-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ