### PR TITLE
chore: update cron schedule for daily workflows to run at 9am KST

### DIFF
--- a/.github/workflows/daily-team-status.lock.yml
+++ b/.github/workflows/daily-team-status.lock.yml
@@ -172,7 +172,7 @@
 name: "Daily Team Status"
 "on":
   schedule:
-  - cron: "0 9 * * 1-5"
+  - cron: "0 0 * * 1-5"
   workflow_dispatch: null
 
 permissions:

--- a/.github/workflows/daily-team-status.md
+++ b/.github/workflows/daily-team-status.md
@@ -1,7 +1,7 @@
 ---
 on:
   schedule:
-  - cron: 0 9 * * 1-5
+  - cron: 0 0 * * 1-5
   stop-after: +1mo
   workflow_dispatch: null
 permissions:

--- a/.github/workflows/daily-test-improver.lock.yml
+++ b/.github/workflows/daily-test-improver.lock.yml
@@ -217,7 +217,7 @@
 name: "Daily Test Coverage Improver"
 "on":
   schedule:
-  - cron: "0 2 * * 1-5"
+  - cron: "0 0 * * 1-5"
   workflow_dispatch: null
 
 permissions:

--- a/.github/workflows/daily-test-improver.md
+++ b/.github/workflows/daily-test-improver.md
@@ -9,7 +9,7 @@ on:
     workflow_dispatch:
     schedule:
         # Run daily at 2am UTC, all days except Saturday and Sunday
-        - cron: "0 2 * * 1-5"
+        - cron: "0 0 * * 1-5"
     stop-after: +1mo # workflow will no longer trigger after 1 month
 
 timeout-minutes: 30


### PR DESCRIPTION
# Update cron schedules for daily workflows

This PR updates the cron schedules for the daily team status and test coverage improver workflows to run at midnight UTC 0:00 (KST 9am) on weekdays instead of their previous times (9:00 and 2:00 UTC respectively).
