### PR TITLE
feat(FR-1763): combine configurations and maintenance into single page.

### DIFF
--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -22,12 +22,10 @@ import {
   FileDoneOutlined,
   SolutionOutlined,
   ControlOutlined,
-  ToolOutlined,
   InfoCircleOutlined,
   ApiOutlined,
   TeamOutlined,
 } from '@ant-design/icons';
-import { useSessionStorageState } from 'ahooks';
 import { type MenuProps, theme, Typography } from 'antd';
 import { GetProp } from 'antd/lib';
 import { MenuItemType } from 'antd/lib/menu/interface';
@@ -47,7 +45,6 @@ import {
   PackagePlus,
   LinkIcon,
   ExternalLinkIcon,
-  Palette,
 } from 'lucide-react';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -91,8 +88,6 @@ export type MenuKeys =
   | 'admin-dashboard'
   | 'agent'
   | 'settings'
-  | 'maintenance'
-  | 'branding'
   | 'information';
 
 // Convert menu key to URL path
@@ -141,10 +136,6 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   const [experimentalAIAgents] = useBAISettingUserState(
     'experimental_ai_agents',
   );
-
-  const [isThemePreviewMode] = useSessionStorageState('isThemePreviewMode', {
-    defaultValue: false,
-  });
 
   // Helper to create menu item with labelText reused in label
   const createMenuItem = (
@@ -327,18 +318,6 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
       ),
       icon: <ControlOutlined style={{ color: token.colorInfo }} />,
       key: 'settings',
-    },
-    {
-      label: (
-        <WebUILink to="/maintenance">{t('webui.menu.Maintenance')}</WebUILink>
-      ),
-      icon: <ToolOutlined style={{ color: token.colorInfo }} />,
-      key: 'maintenance',
-    },
-    !isThemePreviewMode && {
-      label: <WebUILink to="/branding">{t('webui.menu.Branding')}</WebUILink>,
-      icon: <Palette style={{ color: token.colorInfo }} />,
-      key: 'branding',
     },
     {
       label: (

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -76,7 +76,6 @@ const UserCredentialsPage = React.lazy(
 );
 
 const AgentSummaryPage = React.lazy(() => import('./pages/AgentSummaryPage'));
-const MaintenancePage = React.lazy(() => import('./pages/MaintenancePage'));
 const StatisticsPage = React.lazy(() => import('./pages/StatisticsPage'));
 const ConfigurationsPage = React.lazy(
   () => import('./pages/ConfigurationsPage'),
@@ -95,7 +94,6 @@ const ReservoirArtifactDetailPage = React.lazy(
 );
 
 const SchedulerPage = React.lazy(() => import('./pages/SchedulerPage'));
-const BrandingPage = React.lazy(() => import('./pages/BrandingPage'));
 const AdminSessionPage = React.lazy(() => import('./pages/AdminSessionPage'));
 const EmailVerificationPage = React.lazy(
   () => import('./pages/EmailVerificationPage'),
@@ -445,14 +443,34 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     handle: { labelKey: 'webui.menu.Configurations' },
   },
   {
+    // Redirect paths for backward compatibility
     path: '/maintenance',
-    element: <MaintenancePage />,
-    handle: { labelKey: 'webui.menu.Maintenance' },
+    Component: () => {
+      const location = useLocation();
+      const params = new URLSearchParams(location.search);
+      params.set('tab', 'maintenance');
+      return (
+        <WebUINavigate
+          to={`/settings?${params.toString()}${location.hash}`}
+          replace
+        />
+      );
+    },
   },
   {
+    // Redirect paths for backward compatibility
     path: '/branding',
-    element: <BrandingPage />,
-    handle: { labelKey: 'webui.menu.Branding' },
+    Component: () => {
+      const location = useLocation();
+      const params = new URLSearchParams(location.search);
+      params.set('tab', 'branding');
+      return (
+        <WebUINavigate
+          to={`/settings?${params.toString()}${location.hash}`}
+          replace
+        />
+      );
+    },
   },
   {
     path: '/project',


### PR DESCRIPTION
Resolves #4766 ([FR-1763](https://lablup.atlassian.net/browse/FR-1763))

# Move Maintenance Page to Settings Tab

This PR moves the Maintenance page functionality to the Settings page as a new tab. The standalone Maintenance page has been removed, and a redirect has been added for backward compatibility.

Changes include:

- Removed the dedicated MaintenancePage component
- Added Maintenance as a tab in the ConfigurationsPage
- Removed the Maintenance item from the sidebar menu
- Added a redirect from the old `/maintenance` path to `/settings?tab=maintenance`

![image.png](https://app.graphite.com/user-attachments/assets/c02a0c3f-c46e-45fc-aa8c-3c8fffb22194.png)





**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1763]: https://lablup.atlassian.net/browse/FR-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ