### PR TITLE
feat(FR-1720): implement theme color reset functionality

### DIFF
--- a/react/src/components/BrandingSettingItems/ThemeColorPicker.tsx
+++ b/react/src/components/BrandingSettingItems/ThemeColorPicker.tsx
@@ -12,7 +12,7 @@ import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 
 type TokenPath = `token.${keyof AliasToken & string}`;
 type ComponentPath = `components.${keyof ComponentTokenMap & string}.${string}`;
-type ThemeConfigPath = TokenPath | ComponentPath;
+export type ThemeConfigPath = TokenPath | ComponentPath;
 
 interface ThemeColorPickerSettingItemProps extends ColorPickerProps {
   tokenName?: ThemeConfigPath;

--- a/react/src/components/BrandingSettingList.tsx
+++ b/react/src/components/BrandingSettingList.tsx
@@ -1,5 +1,7 @@
 import BAIAlert from './BAIAlert';
-import ThemeColorPicker from './BrandingSettingItems/ThemeColorPicker';
+import ThemeColorPicker, {
+  ThemeConfigPath,
+} from './BrandingSettingItems/ThemeColorPicker';
 import SettingList, { SettingGroup } from './SettingList';
 import { ExportOutlined } from '@ant-design/icons';
 import { App } from 'antd';
@@ -7,6 +9,7 @@ import { BAIButton, BAIFlex } from 'backend.ai-ui';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { downloadBlob } from 'src/helper/csv-util';
+import { useCustomThemeConfig } from 'src/helper/customThemeConfig';
 import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 
 interface BrandingSettingListProps {}
@@ -15,8 +18,27 @@ const BrandingSettingList: React.FC<BrandingSettingListProps> = () => {
   const { t } = useTranslation();
   const { message } = App.useApp();
 
+  const themeConfig = useCustomThemeConfig();
+
   const [userCustomThemeConfig, setUserCustomThemeConfig] =
     useBAISettingUserState('custom_theme_config');
+
+  const resetThemeConfig = (tokenName: ThemeConfigPath) => {
+    if (!themeConfig) return;
+
+    setUserCustomThemeConfig((prev: typeof userCustomThemeConfig) => {
+      const newCustomThemeConfig = _.cloneDeep({
+        ...themeConfig,
+        ...prev,
+      });
+      const lightDefaultValue = _.get(themeConfig, `light.${tokenName}`);
+      const darkDefaultValue = _.get(themeConfig, `dark.${tokenName}`);
+
+      _.set(newCustomThemeConfig, `light.${tokenName}`, lightDefaultValue);
+      _.set(newCustomThemeConfig, `dark.${tokenName}`, darkDefaultValue);
+      return newCustomThemeConfig;
+    });
+  };
 
   const settingGroups: Array<SettingGroup> = [
     {
@@ -40,57 +62,63 @@ const BrandingSettingList: React.FC<BrandingSettingListProps> = () => {
           title: t('userSettings.theme.PrimaryColor'),
           description: t('userSettings.theme.PrimaryColorDesc'),
           children: <ThemeColorPicker tokenName="token.colorPrimary" />,
-          // for reset feature
-          defaultValue: {},
-          setValue: setUserCustomThemeConfig,
+          onReset: () => {
+            resetThemeConfig('token.colorPrimary');
+          },
         },
         {
           type: 'custom',
           title: t('userSettings.theme.HeaderBg'),
           description: t('userSettings.theme.HeaderBgDesc'),
           children: <ThemeColorPicker tokenName="components.Layout.headerBg" />,
-          defaultValue: {},
-          setValue: setUserCustomThemeConfig,
+          onReset: () => {
+            resetThemeConfig('components.Layout.headerBg');
+          },
         },
         {
           type: 'custom',
           title: t('userSettings.theme.LinkColor'),
           description: t('userSettings.theme.LinkColorDesc'),
           children: <ThemeColorPicker tokenName="token.colorLink" />,
-          defaultValue: {},
-          setValue: setUserCustomThemeConfig,
+          onReset: () => {
+            resetThemeConfig('token.colorLink');
+          },
         },
         {
           type: 'custom',
           title: t('userSettings.theme.InfoColor'),
           description: t('userSettings.theme.InfoColorDesc'),
           children: <ThemeColorPicker tokenName="token.colorInfo" />,
-          defaultValue: {},
-          setValue: setUserCustomThemeConfig,
+          onReset: () => {
+            resetThemeConfig('token.colorInfo');
+          },
         },
         {
           type: 'custom',
           title: t('userSettings.theme.ErrorColor'),
           description: t('userSettings.theme.ErrorColorDesc'),
           children: <ThemeColorPicker tokenName="token.colorError" />,
-          defaultValue: {},
-          setValue: setUserCustomThemeConfig,
+          onReset: () => {
+            resetThemeConfig('token.colorError');
+          },
         },
         {
           type: 'custom',
           title: t('userSettings.theme.SuccessColor'),
           description: t('userSettings.theme.SuccessColorDesc'),
           children: <ThemeColorPicker tokenName="token.colorSuccess" />,
-          defaultValue: {},
-          setValue: setUserCustomThemeConfig,
+          onReset: () => {
+            resetThemeConfig('token.colorSuccess');
+          },
         },
         {
           type: 'custom',
           title: t('userSettings.theme.TextColor'),
           description: t('userSettings.theme.TextColorDesc'),
           children: <ThemeColorPicker tokenName="token.colorText" />,
-          defaultValue: {},
-          setValue: setUserCustomThemeConfig,
+          onReset: () => {
+            resetThemeConfig('token.colorText');
+          },
         },
       ],
     },

--- a/react/src/components/ConfigurationsSettingList.tsx
+++ b/react/src/components/ConfigurationsSettingList.tsx
@@ -157,10 +157,9 @@ const ConfigurationsSettingList = () => {
               { label: t('settings.image.None'), value: 'none' },
             ],
           },
-          setValue: (value) => setImagePullingBehavior(value),
           defaultValue: defaultConfigurationsSettings.image_pulling_behavior,
           value: options.image_pulling_behavior,
-          onChange: (value) => setImagePullingBehavior(value),
+          setValue: (value) => setImagePullingBehavior(value),
         },
         {
           type: 'custom',
@@ -214,7 +213,9 @@ const ConfigurationsSettingList = () => {
           ),
           value: options.cuda_gpu,
           defaultValue: defaultConfigurationsSettings.cuda_gpu,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
         {
           type: 'checkbox',
@@ -222,7 +223,9 @@ const ConfigurationsSettingList = () => {
           description: t('settings.DescRocmGPUSupport'),
           value: options.rocm_gpu,
           defaultValue: defaultConfigurationsSettings.rocm_gpu,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
       ],
     },
@@ -249,7 +252,9 @@ const ConfigurationsSettingList = () => {
           ),
           value: options.cuda_fgpu,
           defaultValue: defaultConfigurationsSettings.cuda_fgpu,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
         {
           type: 'checkbox',
@@ -263,7 +268,9 @@ const ConfigurationsSettingList = () => {
           ),
           value: options.tpu,
           defaultValue: defaultConfigurationsSettings.tpu,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
         {
           type: 'checkbox',
@@ -277,7 +284,9 @@ const ConfigurationsSettingList = () => {
           ),
           value: options.ipu,
           defaultValue: defaultConfigurationsSettings.ipu,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
         {
           type: 'checkbox',
@@ -291,7 +300,9 @@ const ConfigurationsSettingList = () => {
           ),
           value: options.atom,
           defaultValue: defaultConfigurationsSettings.atom,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
         {
           type: 'checkbox',
@@ -305,7 +316,9 @@ const ConfigurationsSettingList = () => {
           ),
           value: options.atom_plus,
           defaultValue: defaultConfigurationsSettings.atom_plus,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
         {
           type: 'checkbox',
@@ -319,7 +332,9 @@ const ConfigurationsSettingList = () => {
           ),
           value: options.atom_max,
           defaultValue: defaultConfigurationsSettings.atom_max,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
         {
           type: 'checkbox',
@@ -333,7 +348,9 @@ const ConfigurationsSettingList = () => {
           ),
           value: options.gaudi2,
           defaultValue: defaultConfigurationsSettings.gaudi2,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
         {
           type: 'checkbox',
@@ -347,7 +364,9 @@ const ConfigurationsSettingList = () => {
           ),
           value: options.warboy,
           defaultValue: defaultConfigurationsSettings.warboy,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
         {
           type: 'checkbox',
@@ -361,7 +380,9 @@ const ConfigurationsSettingList = () => {
           ),
           value: options.rngd,
           defaultValue: defaultConfigurationsSettings.rngd,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
         {
           type: 'checkbox',
@@ -375,7 +396,9 @@ const ConfigurationsSettingList = () => {
           ),
           value: options.hyperaccel_lpu,
           defaultValue: defaultConfigurationsSettings.hyperaccel_lpu,
-          disabled: true,
+          checkboxProps: {
+            disabled: true,
+          },
         },
       ],
     },
@@ -387,7 +410,6 @@ const ConfigurationsSettingList = () => {
         settingGroups={settingGroupList}
         showSearchBar
         showChangedOptionFilter
-        showResetButton
       />
       <OverlayNetworkSettingModal
         onRequestClose={toggleOverlayNetworkModal}

--- a/react/src/components/MaintenanceSettingList.tsx
+++ b/react/src/components/MaintenanceSettingList.tsx
@@ -99,6 +99,7 @@ const MaintenanceSettingList = () => {
                 : t('maintenance.RecalculateUsage')}
             </Button>
           ),
+          showResetButton: false,
         },
       ],
     },
@@ -121,6 +122,7 @@ const MaintenanceSettingList = () => {
                 : t('maintenance.RescanImages')}
             </Button>
           ),
+          showResetButton: false,
         },
       ],
     },

--- a/react/src/components/SettingItem.tsx
+++ b/react/src/components/SettingItem.tsx
@@ -1,8 +1,20 @@
-import { Badge, Checkbox, Select, SelectProps, Typography, theme } from 'antd';
+import { SettingOutlined } from '@ant-design/icons';
+import { useToggle } from 'ahooks';
+import {
+  Alert,
+  Badge,
+  Checkbox,
+  CheckboxProps,
+  Dropdown,
+  Select,
+  Typography,
+  theme,
+} from 'antd';
 import { createStyles } from 'antd-style';
-import { BAIFlex } from 'backend.ai-ui';
+import { BAIButton, BAIFlex, BAIModal, BAISelectProps } from 'backend.ai-ui';
+import { t } from 'i18next';
 import _ from 'lodash';
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ReactNode, useState } from 'react';
 
 export interface SettingItemProps {
   'data-testid'?: string;
@@ -13,9 +25,11 @@ export interface SettingItemProps {
   defaultValue?: any;
   value?: any;
   setValue?: (value: any) => void;
-  selectProps?: Omit<SelectProps, 'value' | 'onChange' | 'defaultValue'>;
-  onChange?: (value: any) => void;
-  disabled?: boolean;
+  showResetButton?: boolean;
+  checkboxProps?: Omit<CheckboxProps, 'value' | 'onChange' | 'defaultValue'>;
+  selectProps?: Omit<BAISelectProps, 'value' | 'onChange' | 'defaultValue'>;
+  onAfterChange?: (value: any) => void;
+  onReset?: () => void;
 }
 
 const useStyles = createStyles(({ css }) => ({
@@ -35,12 +49,30 @@ const SettingItem: React.FC<SettingItemProps> = ({
   children,
   defaultValue,
   value,
+  setValue,
+  onAfterChange,
+  onReset,
   selectProps,
-  onChange,
-  disabled,
+  checkboxProps,
+  showResetButton = true,
 }) => {
+  'use memo';
+
   const { token } = theme.useToken();
   const { styles } = useStyles();
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [isOpenResetChangesModal, { toggle: setIsOpenResetChangesModal }] =
+    useToggle(false);
+
+  const resetItem = () => {
+    if (onReset) {
+      onReset();
+    } else {
+      !selectProps?.disabled &&
+        !checkboxProps?.disabled &&
+        setValue?.(defaultValue);
+    }
+  };
 
   return (
     <BAIFlex
@@ -48,20 +80,52 @@ const SettingItem: React.FC<SettingItemProps> = ({
       direction="column"
       align="start"
       gap={'xxs'}
+      onMouseEnter={() => setIsDropdownOpen(true)}
+      onMouseLeave={() => setIsDropdownOpen(false)}
     >
       <BAIFlex direction="row" gap={'xxs'}>
-        <Typography.Text
-          strong
-          style={{
-            fontSize: token.fontSize,
-          }}
-        >
-          {title}
-        </Typography.Text>
-        {!disabled &&
-          value !== undefined &&
-          value !== null &&
-          defaultValue !== value && <Badge dot status="warning" />}
+        <BAIFlex gap="xxs" align="start">
+          <Typography.Text
+            strong
+            style={{
+              fontSize: token.fontSize,
+            }}
+          >
+            {title}
+          </Typography.Text>
+          {(!selectProps?.disabled || !checkboxProps?.disabled) &&
+            value !== undefined &&
+            value !== null &&
+            defaultValue !== value && <Badge dot status="warning" />}
+          {!selectProps?.disabled &&
+            !checkboxProps?.disabled &&
+            showResetButton && (
+              <Dropdown
+                menu={{
+                  items: [
+                    {
+                      key: 'reset',
+                      label: t('button.Reset'),
+                      onClick: () => setIsOpenResetChangesModal(),
+                      danger: true,
+                    },
+                  ],
+                }}
+                onOpenChange={(e) => e && setIsDropdownOpen(true)}
+              >
+                <BAIButton
+                  icon={<SettingOutlined />}
+                  type="text"
+                  style={{
+                    width: 20,
+                    height: 20,
+                    opacity: isDropdownOpen ? 1 : 0,
+                    transition: 'opacity 0.2s ease-in-out',
+                  }}
+                />
+              </Dropdown>
+            )}
+        </BAIFlex>
       </BAIFlex>
       {type === 'custom' && (
         <BAIFlex
@@ -76,24 +140,35 @@ const SettingItem: React.FC<SettingItemProps> = ({
       )}
       {type === 'checkbox' && (
         <Checkbox
-          checked={value}
-          onChange={onChange}
-          disabled={disabled}
           className={styles.baiSettingItemCheckbox}
+          checked={value}
+          onChange={(e) => {
+            setValue?.(e.target.checked);
+            onAfterChange?.(e);
+          }}
+          {...checkboxProps}
         >
-          <Typography.Text type={disabled ? 'secondary' : undefined}>
+          <Typography.Text
+            type={checkboxProps?.disabled ? 'secondary' : undefined}
+          >
             {description}
           </Typography.Text>
         </Checkbox>
       )}
       {type === 'select' && (
         <>
-          {description}
+          <Typography.Text
+            type={selectProps?.disabled ? 'secondary' : undefined}
+          >
+            {description}
+          </Typography.Text>
           <Select
             value={value}
             popupMatchSelectWidth={false}
-            onChange={onChange}
-            disabled={disabled}
+            onChange={(value) => {
+              setValue?.(value);
+              onAfterChange?.(value);
+            }}
             style={{
               marginTop: token.marginXS,
               ...selectProps?.style,
@@ -102,6 +177,24 @@ const SettingItem: React.FC<SettingItemProps> = ({
           ></Select>
         </>
       )}
+      <BAIModal
+        open={isOpenResetChangesModal}
+        title={t('dialog.ask.DoYouWantToResetChanges')}
+        okText={t('button.Reset')}
+        okButtonProps={{ danger: true }}
+        onOk={() => {
+          resetItem();
+          setIsOpenResetChangesModal();
+        }}
+        cancelText={t('button.Cancel')}
+        onCancel={() => setIsOpenResetChangesModal()}
+      >
+        <Alert
+          showIcon
+          message={t('dialog.warning.CannotBeUndone')}
+          type="warning"
+        />
+      </BAIModal>
     </BAIFlex>
   );
 };

--- a/react/src/components/SettingList.tsx
+++ b/react/src/components/SettingList.tsx
@@ -147,7 +147,12 @@ const SettingList: React.FC<SettingPageProps> = ({
   };
 
   const changedItemValidator = (item: SettingItemProps) => {
-    if (item.value === null || item.value === undefined || !!item.disabled) {
+    if (
+      item.value === null ||
+      item.value === undefined ||
+      item?.selectProps?.disabled ||
+      item?.checkboxProps?.disabled
+    ) {
       return false;
     }
     return item.value !== item.defaultValue;
@@ -188,6 +193,7 @@ const SettingList: React.FC<SettingPageProps> = ({
           {extraButton}
           {!!showResetButton && (
             <BAIButton
+              danger
               icon={<RedoOutlined />}
               onClick={() => setIsOpenResetChangesModal()}
             >
@@ -296,8 +302,13 @@ export default SettingList;
 
 const resetSettingItems = (settingGroups: SettingGroup[]) => {
   _.flatMap(settingGroups, (item) => item.settingItems).forEach((option) => {
-    !option.disabled &&
-      option?.setValue &&
-      option.setValue(option.defaultValue);
+    if (option.onReset) {
+      option.onReset();
+    } else {
+      !option?.selectProps?.disabled &&
+        !option?.checkboxProps?.disabled &&
+        option?.setValue &&
+        option.setValue(option.defaultValue);
+    }
   });
 };

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -3,6 +3,7 @@ import { jotaiStore } from '../components/DefaultProviders';
 import { BAITableColumnOverrideRecord } from 'backend.ai-ui';
 import { atom, useAtom } from 'jotai';
 import { atomFamily } from 'jotai/utils';
+import { SetStateAction } from 'react';
 import { CustomThemeConfig } from 'src/helper/customThemeConfig';
 
 interface UserSettings {
@@ -53,7 +54,7 @@ interface GeneralSettings {
 
 export const useBAISettingUserState = <K extends keyof UserSettings>(
   name: K,
-): [UserSettings[K], (newValue: UserSettings[K]) => void] => {
+): [UserSettings[K], (newValue: SetStateAction<UserSettings[K]>) => void] => {
   return useAtom<UserSettings[K]>(SettingAtomFamily('user.' + name));
 };
 
@@ -108,9 +109,14 @@ const SettingAtomFamily = atomFamily((param: string) => {
       get(settingAtom); // only for the reactivity
       return rawToSetting(localStorage.getItem(key));
     },
-    (get, set, newValue: any) => {
-      // const prev = get(SettingAtomFamily(param));
+    (get, set, newValueOrUpdater: any) => {
       const key = 'backendaiwebui.settings.' + param;
+      const currentValue = rawToSetting(localStorage.getItem(key));
+      const newValue =
+        typeof newValueOrUpdater === 'function'
+          ? newValueOrUpdater(currentValue)
+          : newValueOrUpdater;
+
       localStorage.setItem(key, settingToRaw(newValue));
       const [namespace, name] = param.split('.', 2);
 

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -104,9 +104,7 @@ const UserPreferencesPage = () => {
           defaultValue: false,
           value: desktopNotification,
           setValue: setDesktopNotification,
-          onChange: (e: any) => {
-            setDesktopNotification(e.target.checked);
-
+          onAfterChange: (e: any) => {
             // Request permission for desktop notifications
             if (!e.target.checked || Notification.permission === 'granted')
               return;
@@ -136,9 +134,6 @@ const UserPreferencesPage = () => {
           defaultValue: false,
           value: compactSidebar,
           setValue: setCompactSidebar,
-          onChange: (e: any) => {
-            setCompactSidebar(e.target.checked);
-          },
         },
         {
           'data-testid': 'items-language-select',
@@ -172,22 +167,12 @@ const UserPreferencesPage = () => {
           value: selectedLanguage || defaultLanguage,
           setValue: (value: any) => {
             setSelectedLanguage(value);
+            setLanguage(value);
             const event = new CustomEvent('language-changed', {
               detail: {
                 language: value,
               },
             });
-            setLanguage(value);
-            document.dispatchEvent(event);
-          },
-          onChange: (value: any) => {
-            setSelectedLanguage(value);
-            const event = new CustomEvent('language-changed', {
-              detail: {
-                language: value,
-              },
-            });
-            setLanguage(value);
             document.dispatchEvent(event);
           },
         },
@@ -200,9 +185,7 @@ const UserPreferencesPage = () => {
           ),
           defaultValue: false,
           value: preserveLogin,
-          onChange: (e: any) => {
-            setPreserveLogin(e.target.checked);
-          },
+          setValue: setPreserveLogin,
         },
         {
           'data-testid': 'items-automatic-update-check',
@@ -214,9 +197,6 @@ const UserPreferencesPage = () => {
           defaultValue: false,
           value: autoAutomaticUpdateCheck,
           setValue: setAutoAutomaticUpdateCheck,
-          onChange: (e: any) => {
-            setAutoAutomaticUpdateCheck(e.target.checked);
-          },
         },
         {
           'data-testid': 'items-auto-logout',
@@ -226,9 +206,6 @@ const UserPreferencesPage = () => {
           defaultValue: false,
           value: autoLogout,
           setValue: setAutoLogout,
-          onChange: (e: any) => {
-            setAutoLogout(e.target.checked);
-          },
         },
         {
           'data-testid': 'items-my-keypair-info',
@@ -243,6 +220,7 @@ const UserPreferencesPage = () => {
               {t('button.Config')}
             </Button>
           ),
+          showResetButton: false,
         },
         {
           'data-testid': 'items-ssh-keypair-management',
@@ -257,6 +235,7 @@ const UserPreferencesPage = () => {
               {t('button.Config')}
             </Button>
           ),
+          showResetButton: false,
         },
         {
           'data-testid': 'items-max-concurrent-uploads',
@@ -286,9 +265,6 @@ const UserPreferencesPage = () => {
           defaultValue: 2,
           value: maxConcurrentUpload || 2,
           setValue: setMaxConcurrentUpload,
-          onChange: (value: any) => {
-            setMaxConcurrentUpload(value);
-          },
         },
       ]),
     },
@@ -311,6 +287,7 @@ const UserPreferencesPage = () => {
               {t('button.Config')}
             </Button>
           ),
+          showResetButton: false,
         },
         {
           'data-testid': 'items-edit-user-config-script',
@@ -327,6 +304,7 @@ const UserPreferencesPage = () => {
               {t('button.Config')}
             </Button>
           ),
+          showResetButton: false,
         },
       ],
     },
@@ -343,9 +321,6 @@ const UserPreferencesPage = () => {
           defaultValue: false,
           value: experimentalAIAgents,
           setValue: setExperimentalAIAgents,
-          onChange: (e) => {
-            setExperimentalAIAgents(e.target.checked);
-          },
         },
       ],
     },


### PR DESCRIPTION
Resolves #4689 ([FR-1720](https://lablup.atlassian.net/browse/FR-1720))

## Summary
- Add `resetThemeConfig` function to reset individual theme color tokens back to their default values
- Support functional updates in `useBAISettingUserState` to prevent race conditions during bulk resets
- Fix theme color reset functionality to properly restore default theme.json values

## Test plan
- [ ] Verify individual theme color reset works correctly for each color picker
- [ ] Verify "Reset All" button properly resets all theme colors at once
- [ ] Confirm reset values match the default theme.json configuration

[FR-1720]: https://lablup.atlassian.net/browse/FR-1720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ