### PR TITLE
fix(FR-1772): add throttle to reduce lag in chat rendering

### DIFF
--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -240,6 +240,7 @@ const PureChatCard: React.FC<ChatCardProps> = ({
   const [input, setInput] = useState('');
 
   const { error, messages, stop, status, sendMessage, setMessages } = useChat({
+    experimental_throttle: 100,
     messages: chat.messages,
     onFinish: () => {
       setStartTime(null);


### PR DESCRIPTION
resolves #4790 (FR-1772)

Adds experimental throttling to the chat component with a 100ms delay between message chunks. This helps control the rate at which messages are processed and displayed, providing a smoother user experience.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after