### PR TITLE
fix(FR-1776): Prevent auto mount folders from being created as a project type

### DIFF
--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -362,6 +362,18 @@ const FolderCreateModal: React.FC<FolderCreateModalProps> = ({
                           ),
                         );
                       }
+                      if (
+                        value === 'project' &&
+                        currentUsageMode === 'automount'
+                      ) {
+                        return Promise.reject(
+                          new Error(
+                            t(
+                              'data.folders.AutoMountFoldersCanNotBeCreatedAsProjectType',
+                            ),
+                          ),
+                        );
+                      }
                       return Promise.resolve();
                     },
                   }),

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "Zum Hochladen von Datei(en) ist eine Schreibberechtigung erforderlich."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Auto-Mount-Ordner können nicht als Projekttyp erstellt werden.",
       "CannotDeleteFolder": "Der in einer oder mehreren Sitzungen bereitgestellte Ordner kann nicht gelöscht werden. Bitte beenden Sie zuerst die Sitzung.",
       "CannotDeletePipelineFolder": "Sie können Pipeline -Ordner nicht löschen.",
       "CannotRestorePipelineFolder": "Sie können Pipeline -Ordner nicht wiederherstellen.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -353,6 +353,7 @@
       "WritePermissionRequiredInUploadFiles": "Απαιτείται άδεια εγγραφής κατά τη μεταφόρτωση αρχείων."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Οι φάκελοι αυτόματης προσάρτησης δεν μπορούν να δημιουργηθούν ως τύπος έργου.",
       "CannotDeleteFolder": "Δεν είναι δυνατή η διαγραφή του φακέλου που είναι τοποθετημένος σε μία ή περισσότερες περιόδους σύνδεσης. Κλείστε πρώτα τη συνεδρία.",
       "CannotDeletePipelineFolder": "Δεν μπορείτε να διαγράψετε τους φακέλους αγωγών.",
       "CannotRestorePipelineFolder": "Δεν μπορείτε να επαναφέρετε τους φακέλους αγωγών.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -358,6 +358,7 @@
       "WritePermissionRequiredInUploadFiles": "Write permission is required in uploading file(s)."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Auto-mount folders cannot be created as project type.",
       "CannotDeleteFolder": "Cannot delete folder mounted in one or more sessions. Please terminate the session first.",
       "CannotDeletePipelineFolder": "You can't delete pipeline folders.",
       "CannotRestorePipelineFolder": "You can't restore pipeline folders.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "Se requiere permiso de escritura para cargar archivos."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "No se pueden crear carpetas de montaje automático como tipo de proyecto.",
       "CannotDeleteFolder": "No se puede eliminar la carpeta montada en una o más sesiones. Por favor, termine la sesión primero.",
       "CannotDeletePipelineFolder": "No puede eliminar las carpetas de tuberías.",
       "CannotRestorePipelineFolder": "No puedes restaurar las carpetas de tuberías.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "Tiedoston (tiedostojen) lataaminen edellyttää kirjoitusoikeutta."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Automaattisesti liitettäviä kansioita ei voi luoda projektityypiksi.",
       "CannotDeleteFolder": "Yhdessä tai useammassa istunnossa asennettua kansiota ei voi poistaa. Lopeta istunto ensin.",
       "CannotDeletePipelineFolder": "Et voi poistaa putkilinjan kansioita.",
       "CannotRestorePipelineFolder": "Putkilinjan kansiot eivät voi palauttaa.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "Une autorisation d'écriture est requise pour le téléchargement de fichiers."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Les dossiers montés automatiquement ne peuvent pas être créés en tant que type « projet ».",
       "CannotDeleteFolder": "Impossible de supprimer le dossier monté dans une ou plusieurs sessions. Veuillez d'abord terminer la session.",
       "CannotDeletePipelineFolder": "Vous ne pouvez pas supprimer les dossiers du pipeline.",
       "CannotRestorePipelineFolder": "Vous ne pouvez pas restaurer les dossiers du pipeline.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -354,6 +354,7 @@
       "WritePermissionRequiredInUploadFiles": "Izin menulis diperlukan dalam mengunggah file."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Folder auto-mount tidak dapat dibuat sebagai jenis proyek.",
       "CannotDeleteFolder": "Tidak dapat menghapus folder yang dipasang di satu atau beberapa sesi. Mohon hentikan sesi terlebih dahulu.",
       "CannotDeletePipelineFolder": "Anda tidak dapat menghapus folder pipa.",
       "CannotRestorePipelineFolder": "Anda tidak dapat mengembalikan folder pipa.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -354,6 +354,7 @@
       "WritePermissionRequiredInUploadFiles": "Per caricare i file è richiesta l'autorizzazione di scrittura."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Le cartelle auto-montate non possono essere create come tipo progetto.",
       "CannotDeleteFolder": "Impossibile eliminare la cartella montata in una o più sessioni. Si prega di terminare prima la sessione.",
       "CannotDeletePipelineFolder": "Non puoi eliminare le cartelle della pipeline.",
       "CannotRestorePipelineFolder": "Non puoi ripristinare le cartelle della pipeline.",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -354,6 +354,7 @@
       "WritePermissionRequiredInUploadFiles": "ファイルのアップロードには書き込み権限が必要です。"
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "自動マウントフォルダはプロジェクトとして作成できません。",
       "CannotDeleteFolder": "1つ以上のセッションでマウントされたフォルダを削除できません。最初にセッションを終了してください。",
       "CannotDeletePipelineFolder": "パイプラインフォルダーを削除することはできません。",
       "CannotRestorePipelineFolder": "パイプラインフォルダーを復元することはできません。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -357,6 +357,7 @@
       "WritePermissionRequiredInUploadFiles": "파일을 업로드하기 위해서는 쓰기(write) 권한이 필요합니다."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "자동 마운트 폴더는 프로젝트 타입으로 생성할 수 없습니다.",
       "CannotDeleteFolder": "폴더가 하나 이상의 세션에 마운트 되어있어 삭제할 수 없습니다. 세션 종료 후 삭제가 가능합니다.",
       "CannotDeletePipelineFolder": "파이프라인 폴더는 삭제할 수 없습니다.",
       "CannotRestorePipelineFolder": "파이프라인 폴더는 복원할 수 없습니다.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -354,6 +354,7 @@
       "WritePermissionRequiredInUploadFiles": "Файл (ууд) -ийг байршуулахад бичих зөвшөөрөл шаардлагатай."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Автоматаар холбогдох хавтаснуудыг төслийн төрөл болгон үүсгэж болохгүй.",
       "CannotDeleteFolder": "Нэг буюу хэд хэдэн хэсэгт суулгасан фолдерыг устгах боломжгүй. Эхлээд хуралдааныг зогсооно уу.",
       "CannotDeletePipelineFolder": "Та дамжуулах хоолойн хавтасыг устгах боломжгүй.",
       "CannotRestorePipelineFolder": "Та дамжуулах хоолойн хавтасыг сэргээх боломжгүй.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -354,6 +354,7 @@
       "WritePermissionRequiredInUploadFiles": "Kebenaran menulis diperlukan untuk memuat naik fail."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Folder auto-mount tidak boleh dicipta sebagai jenis projek.",
       "CannotDeleteFolder": "Tidak dapat menghapus folder yang dipasang dalam satu atau lebih sesi. Tamatkan sesi terlebih dahulu.",
       "CannotDeletePipelineFolder": "Anda tidak boleh memadam folder saluran paip.",
       "CannotRestorePipelineFolder": "Anda tidak boleh memulihkan folder saluran paip.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "Do przesyłania plików wymagane jest uprawnienie do zapisu."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Folderów z automatycznym montowaniem nie można utworzyć jako typu projektu.",
       "CannotDeleteFolder": "Nie można usunąć folderu zamontowanego w co najmniej jednej sesji. Najpierw zakończ sesję.",
       "CannotDeletePipelineFolder": "Nie możesz usunąć folderów rurociągów.",
       "CannotRestorePipelineFolder": "Nie możesz przywrócić folderów rurociągów.",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "A permissão de gravação é necessária ao enviar arquivo (s)."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Pastas de montagem automática não podem ser criadas como tipo de projeto.",
       "CannotDeleteFolder": "Não é possível excluir a pasta montada em uma ou mais sessões. Por favor, termine a sessão primeiro.",
       "CannotDeletePipelineFolder": "Você não pode excluir pastas de pipeline.",
       "CannotRestorePipelineFolder": "Você não pode restaurar pastas de pipeline.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "A permissão de gravação é necessária ao enviar arquivo (s)."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Pastas montadas automaticamente não podem ser criadas como tipo de projeto.",
       "CannotDeleteFolder": "Não é possível excluir a pasta montada em uma ou mais sessões. Por favor, termine a sessão primeiro.",
       "CannotDeletePipelineFolder": "Você não pode excluir pastas de pipeline.",
       "CannotRestorePipelineFolder": "Você não pode restaurar pastas de pipeline.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "Для загрузки файла (ов) требуется разрешение на запись."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Папки с автоматическим монтированием нельзя создавать как тип проекта.",
       "CannotDeleteFolder": "Невозможно удалить папку, установленную в одном или нескольких сеансах. Пожалуйста, сначала завершите сеанс.",
       "CannotDeletePipelineFolder": "Вы не можете удалить папки трубопровода.",
       "CannotRestorePipelineFolder": "Вы не можете восстановить папки трубопровода.",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "ต้องมีสิทธิ์เขียนในการอัปโหลดไฟล์"
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "โฟลเดอร์ที่เมานต์อัตโนมัติไม่สามารถสร้างเป็นประเภทโปรเจกต์ได้",
       "CannotDeleteFolder": "ไม่สามารถลบโฟลเดอร์ที่ถูกเมาท์ในหนึ่งหรือหลายเซสชัน กรุณายุติเซสชันก่อน",
       "CannotDeletePipelineFolder": "คุณไม่สามารถลบโฟลเดอร์ไปป์ไลน์ได้",
       "CannotRestorePipelineFolder": "คุณไม่สามารถกู้คืนโฟลเดอร์ไปป์ไลน์ได้",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "Dosya(lar)ı yüklerken yazma izni gereklidir."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Otomatik bağlanan klasörler proje türü olarak oluşturulamaz.",
       "CannotDeleteFolder": "Bir veya daha fazla oturuma bağlı klasör silinemez. Lütfen önce oturumu sonlandırın.",
       "CannotDeletePipelineFolder": "Boru hattı klasörlerini silemezsiniz.",
       "CannotRestorePipelineFolder": "Boru hattı klasörlerini geri yükleyemezsiniz.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "Quyền ghi là bắt buộc khi tải lên (các) tệp."
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "Không thể tạo thư mục tự động gắn dưới dạng loại dự án.",
       "CannotDeleteFolder": "Không thể xóa thư mục được gắn trong một hoặc nhiều phiên. Vui lòng kết thúc phiên trước.",
       "CannotDeletePipelineFolder": "Bạn không thể xóa các thư mục đường ống.",
       "CannotRestorePipelineFolder": "Bạn không thể khôi phục các thư mục đường ống.",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "上传文件需要写权限。"
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "无法将自动挂载的文件夹创建为项目类型。",
       "CannotDeleteFolder": "无法删除安装在一个或多个会话中的文件夹。请先终止会话。",
       "CannotDeletePipelineFolder": "您无法删除管道文件夹。",
       "CannotRestorePipelineFolder": "您无法还原管道文件夹。",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -355,6 +355,7 @@
       "WritePermissionRequiredInUploadFiles": "上傳文件需要寫權限。"
     },
     "folders": {
+      "AutoMountFoldersCanNotBeCreatedAsProjectType": "自動掛載資料夾無法建立為專案類型。",
       "CannotDeleteFolder": "無法刪除安裝在一個或多個會話中的文件夾。請先終止會話。",
       "CannotDeletePipelineFolder": "您無法刪除管道文件夾。",
       "CannotRestorePipelineFolder": "您無法還原管道文件夾。",


### PR DESCRIPTION
resolves #4797 (FR-1776)

This PR adds validation to prevent users from creating auto-mount folders as project type. When a user attempts to create a folder with the 'project' type while in 'automount' usage mode, an error message is displayed.

Added a new validation check in the `FolderCreateModal` component and included translations for the error message "Auto-mount folders cannot be created as project type" in all supported languages.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after