### PR TITLE
fix(wsproxy): increase socket timeout and enable keepalive

### DIFF
--- a/src/wsproxy/lib/backend.ai-ws-appproxy.js
+++ b/src/wsproxy/lib/backend.ai-ws-appproxy.js
@@ -123,7 +123,8 @@ module.exports = proxy = class Proxy extends ai.backend.Client {
       logger.info(
         `App-Proxy server connection established: ${this.ip}:${this.port}.`,
       );
-      tcpConn.setTimeout(60000);
+      tcpConn.setTimeout(3600000);
+      tcpConn.setKeepAlive(true, 30000);
       tcpConn.on('timeout', () => {
         logger.debug(`Socket timeout`);
         tcpConn.destroy();

--- a/src/wsproxy/lib/console-appproxy.js
+++ b/src/wsproxy/lib/console-appproxy.js
@@ -108,7 +108,8 @@ module.exports = proxy = class Proxy {
       logger.info(
         `App-proxy server connection established: ${this.ip}:${this.port}.`,
       );
-      tcpConn.setTimeout(30000);
+      tcpConn.setTimeout(3600000);
+      tcpConn.setKeepAlive(true, 30000);
       tcpConn.on('timeout', () => {
         logger.debug(`Socket timeout`);
         tcpConn.destroy();


### PR DESCRIPTION
## Summary
- Increase TCP socket timeout from 60s/30s to 1 hour for app proxy connections
- Enable TCP keepalive with 30-second interval to maintain connection health
- Prevents premature connection drops during long-running sessions