### PR TITLE
fix(FR-1784): Replace popconfirm with Modal for image deletion

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -511,6 +511,7 @@
     "ErrorOccurred": "Ein Fehler ist aufgetreten",
     "PleaseTypeToConfirm": "Bitte geben Sie {{confirmText}} ein, um zu bestätigen.",
     "ask": {
+      "DoYouWantToDelete": "Möchten Sie dies wirklich löschen?",
       "DoYouWantToDeleteSomething": "Sind Sie sicher, dass Sie \"{{ Name }}\" löschen wollen?",
       "DoYouWantToProceed": "Willst du fortfahren?",
       "DoYouWantToResetChanges": "Möchten Sie Ihre Änderungen zurücksetzen?"

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -508,6 +508,7 @@
   "dialog": {
     "ErrorOccurred": "Προέκυψε σφάλμα",
     "ask": {
+      "DoYouWantToDelete": "Είστε σίγουροι ότι θέλετε να διαγράψετε;",
       "DoYouWantToDeleteSomething": "Είστε σίγουροι ότι θέλετε να διαγράψετε το \"{{ name }}\";",
       "DoYouWantToProceed": "Θέλετε να συνεχίσετε?",
       "DoYouWantToResetChanges": "Θέλετε να επαναφέρετε τις αλλαγές σας;"

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -514,6 +514,7 @@
     "ErrorOccurred": "Error Occurred",
     "PleaseTypeToConfirm": "Please type {{ confirmText }} to confirm.",
     "ask": {
+      "DoYouWantToDelete": "Are you sure you want to delete?",
       "DoYouWantToDeleteSomething": "Are you sure you want to delete \"{{ name }}\"?",
       "DoYouWantToProceed": "Do you want to proceed?",
       "DoYouWantToResetChanges": "Do you want to reset your changes?"

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -511,6 +511,7 @@
     "ErrorOccurred": "Se ha producido un error",
     "PleaseTypeToConfirm": "Escriba {{confirmText}} para confirmar.",
     "ask": {
+      "DoYouWantToDelete": "¿Está seguro de que desea eliminar?",
       "DoYouWantToDeleteSomething": "¿Estás seguro de que quieres borrar \"{{ name }}\"?",
       "DoYouWantToProceed": "¿Quieres continuar?",
       "DoYouWantToResetChanges": "¿Quieres restablecer tus cambios?"

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -511,6 +511,7 @@
     "ErrorOccurred": "Tapahtunut virhe",
     "PleaseTypeToConfirm": "Kirjoita {{confirmText}} vahvistaaksesi.",
     "ask": {
+      "DoYouWantToDelete": "Haluatko varmasti poistaa tämän?",
       "DoYouWantToDeleteSomething": "Oletko varma, että haluat poistaa \"{{ name }}\"?\"?",
       "DoYouWantToProceed": "Haluatteko jatkaa?",
       "DoYouWantToResetChanges": "Haluatko nollata tekemäsi muutokset?"

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -511,6 +511,7 @@
     "ErrorOccurred": "Erreur est survenue",
     "PleaseTypeToConfirm": "Veuillez taper {{confirmText}} pour confirmer.",
     "ask": {
+      "DoYouWantToDelete": "Voulez-vous vraiment supprimer ?",
       "DoYouWantToDeleteSomething": "Êtes-vous sûr de vouloir supprimer \"{{ nom }}\" ?",
       "DoYouWantToProceed": "Voulez-vous poursuivre?",
       "DoYouWantToResetChanges": "Voulez-vous réinitialiser vos modifications ?"

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -510,6 +510,7 @@
     "ErrorOccurred": "Terjadi Galat",
     "PleaseTypeToConfirm": "Harap ketik {{confirmText}} untuk mengonfirmasi.",
     "ask": {
+      "DoYouWantToDelete": "Apakah Anda yakin ingin menghapus?",
       "DoYouWantToDeleteSomething": "Apakah Anda yakin ingin menghapus \"{{ nama }}\"?",
       "DoYouWantToProceed": "Apakah Anda ingin lanjut?",
       "DoYouWantToResetChanges": "Apakah Anda ingin mengatur ulang perubahan Anda?"

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -510,6 +510,7 @@
     "ErrorOccurred": "Errore",
     "PleaseTypeToConfirm": "Si prega di digitare {{confirmText}} per confermare.",
     "ask": {
+      "DoYouWantToDelete": "Sei sicuro di voler eliminare?",
       "DoYouWantToDeleteSomething": "Si è sicuri di voler eliminare \"{{ nome }}\"?",
       "DoYouWantToProceed": "Vuoi procedere?",
       "DoYouWantToResetChanges": "Vuoi ripristinare le modifiche?"

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -510,6 +510,7 @@
     "ErrorOccurred": "エラーが発生しました",
     "PleaseTypeToConfirm": "確認するには{{confirmText}}を入力してください。",
     "ask": {
+      "DoYouWantToDelete": "本当に削除しますか？",
       "DoYouWantToDeleteSomething": "本当に\"{{ name }}\"を削除しますか？",
       "DoYouWantToProceed": "続行しますか？",
       "DoYouWantToResetChanges": "変更をリセットしますか?"

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -513,6 +513,7 @@
     "ErrorOccurred": "문제가 발생했습니다",
     "PleaseTypeToConfirm": "{{confirmText}}를 입력하십시오.",
     "ask": {
+      "DoYouWantToDelete": "정말로 삭제하시겠습니까?",
       "DoYouWantToDeleteSomething": "\"{{ name }}\"을(를) 삭제하시겠습니까?",
       "DoYouWantToProceed": "계속 진행하시겠습니까?",
       "DoYouWantToResetChanges": "변경사항을 초기화하시겠습니까?"

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -509,6 +509,7 @@
     "ErrorOccurred": "Алдаа гарлаа",
     "PleaseTypeToConfirm": "Баталгаажуулахын тулд {{confirmText}} оруулна уу.",
     "ask": {
+      "DoYouWantToDelete": "Та үүнийг устгахдаа итгэлтэй байна уу?",
       "DoYouWantToDeleteSomething": "Та \"{{ name }}\"-г устгахдаа итгэлтэй байна уу?",
       "DoYouWantToProceed": "Та үргэлжлүүлэхийг хүсч байна уу?",
       "DoYouWantToResetChanges": "Та өөрчлөлтөө дахин тохируулахыг хүсэж байна уу?"

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -510,6 +510,7 @@
     "ErrorOccurred": "Ralat Berlaku",
     "PleaseTypeToConfirm": "Sila taipkan {{confirmText}} untuk mengesahkan.",
     "ask": {
+      "DoYouWantToDelete": "Adakah anda pasti mahu memadam?",
       "DoYouWantToDeleteSomething": "Adakah anda pasti mahu memadamkan \"{{ name }}\"?",
       "DoYouWantToProceed": "Adakah anda mahu meneruskan?",
       "DoYouWantToResetChanges": "Adakah anda mahu menetapkan semula perubahan anda?"

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -511,6 +511,7 @@
     "ErrorOccurred": "Wystąpił błąd",
     "PleaseTypeToConfirm": "Wpisz {{confirmText}}, aby potwierdzić.",
     "ask": {
+      "DoYouWantToDelete": "Czy na pewno chcesz to usunąć?",
       "DoYouWantToDeleteSomething": "Czy na pewno chcesz usunąć \"{{ name }}\"?",
       "DoYouWantToProceed": "Czy chcesz kontynuować?",
       "DoYouWantToResetChanges": "Czy chcesz zresetować zmiany?"

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -511,6 +511,7 @@
     "ErrorOccurred": "Ocorreu um erro",
     "PleaseTypeToConfirm": "Digite {{confirmText}} para confirmar.",
     "ask": {
+      "DoYouWantToDelete": "Tem certeza de que deseja excluir?",
       "DoYouWantToDeleteSomething": "Tem a certeza de que pretende eliminar \"{{ name }}\"?",
       "DoYouWantToProceed": "Você quer prosseguir?",
       "DoYouWantToResetChanges": "Deseja redefinir suas alterações?"

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -511,6 +511,7 @@
     "ErrorOccurred": "Ocorreu um erro",
     "PleaseTypeToConfirm": "Digite {{confirmText}} para confirmar.",
     "ask": {
+      "DoYouWantToDelete": "Tem certeza de que deseja excluir?",
       "DoYouWantToDeleteSomething": "Tem a certeza de que pretende eliminar \"{{ name }}\"?",
       "DoYouWantToProceed": "Você quer prosseguir?",
       "DoYouWantToResetChanges": "Deseja redefinir suas alterações?"

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -511,6 +511,7 @@
     "ErrorOccurred": "Возникла ошибка",
     "PleaseTypeToConfirm": "Пожалуйста, введите {{confirmText}}, чтобы подтвердить.",
     "ask": {
+      "DoYouWantToDelete": "Вы уверены, что хотите удалить?",
       "DoYouWantToDeleteSomething": "Вы уверены, что хотите удалить \"{{ имя }}\"?",
       "DoYouWantToProceed": "Вы хотите продолжить?",
       "DoYouWantToResetChanges": "Вы хотите сбросить изменения?"

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -505,6 +505,7 @@
     "ErrorOccurred": "เกิดข้อผิดพลาด",
     "PleaseTypeToConfirm": "กรุณาพิมพ์ {{confirmText}} เพื่อยืนยัน",
     "ask": {
+      "DoYouWantToDelete": "คุณแน่ใจว่าต้องการลบหรือไม่?",
       "DoYouWantToDeleteSomething": "คุณแน่ใจหรือไม่ที่จะลบ \"{{ name }}\"?",
       "DoYouWantToProceed": "คุณต้องการดำเนินการต่อหรือไม่?",
       "DoYouWantToResetChanges": "คุณต้องการรีเซ็ตการเปลี่ยนแปลงของคุณหรือไม่?"

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -511,6 +511,7 @@
     "ErrorOccurred": "Hata oluştu",
     "PleaseTypeToConfirm": "Onaylamak için lütfen {{confirmText}} yazın.",
     "ask": {
+      "DoYouWantToDelete": "Silmek istediğinizden emin misiniz?",
       "DoYouWantToDeleteSomething": "\"{{ name }}\" silmek istediğinizden emin misiniz?",
       "DoYouWantToProceed": "Devam etmek istiyor musunuz?",
       "DoYouWantToResetChanges": "Değişikliklerinizi sıfırlamak istiyor musunuz?"

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -511,6 +511,7 @@
     "ErrorOccurred": "Xảy ra lỗi",
     "PleaseTypeToConfirm": "Vui lòng nhập {{confirmText}} để xác nhận.",
     "ask": {
+      "DoYouWantToDelete": "Bạn có chắc chắn muốn xóa không?",
       "DoYouWantToDeleteSomething": "Bạn có chắc chắn muốn xóa \"{{ name }}\" không?",
       "DoYouWantToProceed": "Bạn có muốn tiếp tục?",
       "DoYouWantToResetChanges": "Bạn có muốn đặt lại các thay đổi của mình không?"

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -511,6 +511,7 @@
     "ErrorOccurred": "错误发生",
     "PleaseTypeToConfirm": "请键入{{confirmText}}以确认。",
     "ask": {
+      "DoYouWantToDelete": "您确定要删除吗？",
       "DoYouWantToDeleteSomething": "您确定要删除\"{{ 名称 }}}\"吗？",
       "DoYouWantToProceed": "您要继续吗？",
       "DoYouWantToResetChanges": "您想重置您的更改吗？"

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -512,6 +512,7 @@
     "ErrorOccurred": "錯誤發生",
     "PleaseTypeToConfirm": "請鍵入{{confirmText}}以確認。",
     "ask": {
+      "DoYouWantToDelete": "您確定要刪除嗎？",
       "DoYouWantToDeleteSomething": "您确定要删除\"{{ 名称 }}}\"吗？",
       "DoYouWantToProceed": "您要繼續嗎？",
       "DoYouWantToResetChanges": "您想重置您的變更嗎？"


### PR DESCRIPTION
resolves #4807 ([FR-1784](https://lablup.atlassian.net/browse/FR-1784))

This PR replaces the Popconfirm component with a BAIModal for deleting customized images in the CustomizedImageList component. The change improves the user experience by:

1. Using a proper modal dialog with an Alert component to warn users about the irreversible action
2. Improving the deletion flow by centralizing the deletion logic in the modal
3. Removing the `inFlightImageId` state in favor of tracking the image to delete with a dedicated state variable
4. Properly handling loading states during the deletion process

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1784]: https://lablup.atlassian.net/browse/FR-1784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ