### PR TITLE
fix(FR-1786): fix session launcher resource form initialization

### DIFF
--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -13,6 +13,7 @@ import PortSelectFormItem, {
 } from '../components/PortSelectFormItem';
 import ResourceNumber from '../components/ResourceNumber';
 import ResourceAllocationFormItems, {
+  RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
   ResourceAllocationFormValue,
 } from '../components/SessionFormItems/ResourceAllocationFormItems';
 import SessionLauncherValidationTour from '../components/SessionLauncherErrorTourProps';
@@ -280,7 +281,12 @@ const SessionLauncherPage = () => {
   }, []);
 
   const mergedInitialValues: SessionLauncherFormValue = useMemo(() => {
-    return _.merge({}, defaultFormValues, formValuesFromQueryParams);
+    return _.merge(
+      {},
+      defaultFormValues,
+      formValuesFromQueryParams,
+      RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
+    );
   }, [defaultFormValues, formValuesFromQueryParams]);
 
   // ScrollTo top when step is changed


### PR DESCRIPTION
### Resolves #4821 ([FR-1786](https://lablup.atlassian.net/browse/FR-1786))

Add RESOURCE_ALLOCATION_INITIAL_FORM_VALUES to SessionLauncherPage

This PR adds the `RESOURCE_ALLOCATION_INITIAL_FORM_VALUES` constant to the merged initial values in the `SessionLauncherPage` component. This ensures that resource allocation form values are properly initialized when the page loads.

## Changes

- Import `RESOURCE_ALLOCATION_INITIAL_FORM_VALUES` from ResourceAllocationFormItems
- Include this constant in the merged initial values calculation to ensure proper resource allocation defaults

This change helps maintain consistent resource allocation values during page initialization and prevents potential undefined values in the form.

[FR-1786]: https://lablup.atlassian.net/browse/FR-1786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ