### PR TITLE
feat(FR-1785): move Admin Settings to top menu and apply admin primary colors

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -15,7 +15,7 @@ import { DRAWER_WIDTH } from '../WEBUINotificationDrawer';
 import WebUIBreadcrumb from '../WebUIBreadcrumb';
 import WebUIHeader from './WebUIHeader';
 import WebUISider from './WebUISider';
-import { App, Layout, LayoutProps, theme } from 'antd';
+import { App, ConfigProvider, Layout, LayoutProps, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIFlex } from 'backend.ai-ui';
 import { atom, useSetAtom } from 'jotai';
@@ -29,6 +29,8 @@ import {
   useState,
 } from 'react';
 import { useNavigate, Outlet, useMatches, useLocation } from 'react-router-dom';
+import usePrimaryColors from 'src/hooks/usePrimaryColors';
+import { useWebUIMenuItems } from 'src/hooks/useWebUIMenuItems';
 import { useSetupWebUIPluginEffect } from 'src/hooks/useWebUIPluginState';
 
 export const HEADER_Z_INDEX_IN_MAIN_LAYOUT = 6;
@@ -211,7 +213,9 @@ function MainLayout() {
                   align="stretch"
                   className={styles.alertWrapper}
                 >
-                  <ThemePreviewModeAlert />
+                  <ErrorBoundaryWithNullFallback>
+                    <ThemePreviewModeAlert />
+                  </ErrorBoundaryWithNullFallback>
                   <ErrorBoundaryWithNullFallback>
                     <NoResourceGroupAlert />
                   </ErrorBoundaryWithNullFallback>
@@ -251,7 +255,9 @@ function MainLayout() {
                   )}
                 </ErrorBoundaryWithNullFallback>
                 <BAIErrorBoundary>
-                  <Outlet />
+                  <AutoAdminPrimaryColorProvider>
+                    <Outlet />
+                  </AutoAdminPrimaryColorProvider>
                 </BAIErrorBoundary>
               </Suspense>
               {/* @ts-ignore */}
@@ -263,6 +269,32 @@ function MainLayout() {
     </LayoutWithPageTestId>
   );
 }
+
+const AutoAdminPrimaryColorProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  'use memo';
+
+  const primaryColors = usePrimaryColors();
+  const { isSelectedAdminCategoryMenu } = useWebUIMenuItems();
+  if (isSelectedAdminCategoryMenu) {
+    return (
+      <ConfigProvider
+        theme={{
+          token: {
+            colorPrimary: primaryColors.admin,
+          },
+        }}
+      >
+        {children}
+      </ConfigProvider>
+    );
+  }
+
+  return children;
+};
 
 const LayoutWithPageTestId: React.FC<LayoutProps> = (props) => {
   const location = useLocation();

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -46,6 +46,8 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
     config.theme?.algorithm === theme.darkAlgorithm ? 'dark' : 'light';
 
   const currentUserRole = useCurrentUserRole();
+  const hasAdminCategoryRole =
+    currentUserRole === 'superadmin' || currentUserRole === 'admin';
   const webuiNavigate = useWebUINavigate();
   const location = useLocation();
   const baiClient = useSuspendedBackendaiClient();
@@ -111,6 +113,7 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
             height: 40,
             width: 42,
             marginLeft: token.margin,
+            marginBottom: 4,
           }}
         />
       </Tooltip>
@@ -203,67 +206,44 @@ const WebUISider: React.FC<WebUISiderProps> = (props) => {
             ]}
             // @ts-ignore
             items={filterOutEmpty([
-              ...groupedGeneralMenu,
-              (currentUserRole === 'superadmin' ||
-                currentUserRole === 'admin') && {
+              hasAdminCategoryRole && {
                 // Go to first page of admin setting pages.
-                type: 'group',
                 label: (
-                  <BAIFlex
-                    style={{
-                      borderBottom: `1px solid ${token.colorBorder}`,
-                    }}
-                  >
-                    {!props.collapsed && (
-                      <Typography.Text type="secondary" ellipsis>
-                        {t('webui.menu.Administration')}
-                      </Typography.Text>
-                    )}
-                  </BAIFlex>
+                  <WebUILink to="/credential">
+                    {t('webui.menu.AdminSettings')}
+                  </WebUILink>
                 ),
-                children: [
-                  {
-                    label: (
-                      <WebUILink
-                        to="/credential"
-                        state={{ goBack: location.pathname }}
-                      >
-                        {t('webui.menu.AdminSettings')}
-                      </WebUILink>
-                    ),
-                    icon: <SettingsIcon style={{ color: token.colorInfo }} />,
-                    key: 'admin-settings',
-                  },
-                ],
+                icon: <SettingsIcon style={{ color: token.colorInfo }} />,
+                key: 'admin-settings',
               },
+              ...groupedGeneralMenu,
             ])}
           />
         )}
-        {(currentUserRole === 'superadmin' || currentUserRole === 'admin') &&
-          isSelectedAdminCategoryMenu && (
-            <ConfigProvider
-              theme={{
-                token: {
-                  colorPrimary: primaryColors.admin,
-                },
-              }}
-            >
-              {adminHeader}
-              <BAIMenu
-                collapsed={props.collapsed}
-                selectedKeys={[
-                  // TODO: After matching first path of 'storage-settings' and 'agent', remove this code
-                  location.pathname.split('/')[1] === 'storage-settings'
-                    ? 'agent'
-                    : location.pathname.split('/')[1],
-                ]}
-                items={[
-                  ...adminMenu,
-                  ...(currentUserRole === 'superadmin' ? superAdminMenu : []),
-                ]}
-              />
-            </ConfigProvider>
-          )}
+        {hasAdminCategoryRole && isSelectedAdminCategoryMenu && (
+          <ConfigProvider
+            theme={{
+              token: {
+                colorPrimary: primaryColors.admin,
+              },
+            }}
+          >
+            {adminHeader}
+            <BAIMenu
+              collapsed={props.collapsed}
+              selectedKeys={[
+                // TODO: After matching first path of 'storage-settings' and 'agent', remove this code
+                location.pathname.split('/')[1] === 'storage-settings'
+                  ? 'agent'
+                  : location.pathname.split('/')[1],
+              ]}
+              items={[
+                ...adminMenu,
+                ...(currentUserRole === 'superadmin' ? superAdminMenu : []),
+              ]}
+            />
+          </ConfigProvider>
+        )}
       </BAIFlex>
       {props.collapsed ? null : (
         <BAIFlex

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -93,11 +93,10 @@ export interface UseWebUIMenuItemsProps {
   hideGroupName?: boolean;
 }
 
-export const useWebUIMenuItems = ({
-  hideGroupName,
-}: UseWebUIMenuItemsProps) => {
+export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   'use memo';
 
+  const { hideGroupName = false } = props || {};
   const plugins = useWebUIPluginValue();
 
   const location = useLocation();


### PR DESCRIPTION
Resolves #4810 ([FR-1785](https://lablup.atlassian.net/browse/FR-1785))

## Summary

This PR improves the accessibility and visual distinction of Admin Settings pages by:
1. Moving the Admin Settings menu item to the top of the navigation menu for immediate access without scrolling
2. Applying admin primary color theming to all admin pages for clear visual distinction from general pages

## Changes

### MainLayout.tsx
- Added `AutoAdminPrimaryColorProvider` component that wraps the page content
- Automatically applies admin primary color theme when user is on admin pages
- Wrapped `ThemePreviewModeAlert` with error boundary for safety

### WebUISider.tsx
- Moved Admin Settings menu item from a nested group to the top-level menu
- Positioned it above general menu items for immediate visibility
- Removed the "Administration" group label for cleaner UI
- Applied admin primary color theming to the admin menu section
- Simplified role checking logic with `hasAdminCategoryRole` variable

### useWebUIMenuItems.tsx
- Made props parameter optional with default values
- Simplified the hook signature for better ergonomics

## Benefits

- **Improved Accessibility**: Admin settings are now accessible without scrolling
- **Visual Distinction**: Admin pages are clearly distinguishable from general pages using admin primary color
- **Better UX**: Administrators can quickly identify and navigate to admin-specific pages
- **Reduced Confusion**: Clear visual separation prevents configuration errors

## Screenshots

### Before
- Admin Settings buried in the navigation menu
- No visual distinction between admin and general pages

### After  
- Admin Settings at the top of the menu (immediately visible)
- Admin pages use distinct admin primary color theme

**Checklist:**

- [x] Code changes are focused and atomic
- [x] ESLint passes with no warnings
- [x] Changes follow project conventions
- [ ] Manual testing completed
- [ ] No documentation updates needed (UI change only)


[FR-1785]: https://lablup.atlassian.net/browse/FR-1785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ