### PR TITLE
style(FR-1782): refactor chat page and components to use flex-based layout

### DIFF
--- a/react/src/components/Chat/AssistantChatMesssage.tsx
+++ b/react/src/components/Chat/AssistantChatMesssage.tsx
@@ -1,6 +1,7 @@
 import ChatMessage, { ChatMessageProps } from './ChatMessage';
 import CopyButton from './CopyButton';
 import Compact from 'antd/es/space/Compact';
+import _ from 'lodash';
 
 export const AssistantChatMessage: React.FC<ChatMessageProps> = ({
   message,
@@ -15,22 +16,24 @@ export const AssistantChatMessage: React.FC<ChatMessageProps> = ({
       isStreaming={isStreaming}
       enableExtraHover={false}
       extra={
-        <Compact>
-          <CopyButton
-            type="text"
-            size="small"
-            copyable={{
-              text: message.parts
-                ?.filter((part) => part.type === 'text')
-                .map((part) => part.text)
-                .join('')
-                .trim(),
-            }}
-            style={{
-              display: isStreaming ? 'none' : 'block',
-            }}
-          />
-        </Compact>
+        _.some(message.parts, (part) => part.type === 'text') && (
+          <Compact>
+            <CopyButton
+              type="text"
+              size="small"
+              copyable={{
+                text: message.parts
+                  ?.filter((part) => part.type === 'text')
+                  .map((part) => part.text)
+                  .join('')
+                  .trim(),
+              }}
+              style={{
+                display: isStreaming ? 'none' : 'block',
+              }}
+            />
+          </Compact>
+        )
       }
       avatar={'🤖'}
     />

--- a/react/src/components/Chat/VirtualChatMessageList.tsx
+++ b/react/src/components/Chat/VirtualChatMessageList.tsx
@@ -58,7 +58,7 @@ const VirtualChatMessageList: React.FC<VirtualizedListProps> = ({
       <Virtuoso
         atBottomStateChange={setAtBottom}
         atBottomThreshold={60}
-        computeItemKey={(_, item) => item.id}
+        computeItemKey={(index, item) => item.id || index}
         data={messages}
         followOutput={'auto'}
         initialTopMostItemIndex={messages?.length - 1}

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -21,17 +21,6 @@ import { useParams } from 'react-router-dom';
 import { StringParam, useQueryParams } from 'use-query-params';
 
 const useStyles = createStyles(({ css }) => ({
-  chatViewHorizontal: css`
-    overflow: auto;
-    height: calc(100vh - 224px);
-  `,
-  chatViewVertical: css`
-    overflow: hidden;
-  `,
-  chatCard: css`
-    flex: 1;
-    overflow: 'hidden';
-  `,
   fixEditableVerticalAlign: css`
     & {
       top: 0 !important;
@@ -157,6 +146,8 @@ const ChatHistoryDrawer = ({
 };
 
 const PureChatPage = ({ id }: { id: string }) => {
+  'use memo';
+
   const defaultEndpointId = useDefaultEndpointId();
   const provider = useChatProviderData(defaultEndpointId);
   const { styles } = useStyles();
@@ -197,11 +188,19 @@ const PureChatPage = ({ id }: { id: string }) => {
             {chat.label}
           </Typography.Text>
         }
-        styles={{
-          body: { overflow: 'hidden', paddingTop: 0 },
-        }}
         style={{
           overflow: 'hidden',
+          minHeight: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+        }}
+        styles={{
+          body: {
+            overflow: 'hidden',
+            height: '100%',
+            paddingTop: 0,
+          },
         }}
         extra={
           <>
@@ -229,45 +228,45 @@ const PureChatPage = ({ id }: { id: string }) => {
       >
         {id && (
           <BAIFlex
-            className={styles.chatViewVertical}
             direction="column"
             align="stretch"
             gap={'xs'}
+            style={{
+              overflow: 'hidden',
+              minHeight: 0,
+              height: '100%',
+            }}
           >
-            <BAIFlex
-              className={styles.chatViewHorizontal}
-              gap={'xs'}
-              direction="row"
-              align="stretch"
-            >
-              <Suspense fallback={<Card className={styles.chatCard} loading />}>
-                {_.map(chat.chats, (chatData) => (
-                  <ChatCard
-                    key={chatData.id}
-                    className={styles.chatCard}
-                    chat={chatData}
-                    onUpdateChat={(newChatProperties) => {
-                      updateChatData(chatData.id, newChatProperties);
-                    }}
-                    fetchOnClient
-                    onRemoveChat={() => {
-                      removeChatData(chatData.id);
-                    }}
-                    onAddChat={() => {
-                      addChatData(chatData);
-                    }}
-                    onSaveMessage={(message) => {
-                      saveChatMessage(chatData.id, message);
-                    }}
-                    onClearMessage={(chatData) => {
-                      clearChatMessage(chatData.id);
-                    }}
-                    closable={isClosable(chat.chats.length)}
-                    cloneable={isClonable(chat.chats.length)}
-                  />
-                ))}
-              </Suspense>
-            </BAIFlex>
+            <Suspense fallback={<Card loading />}>
+              {_.map(chat.chats, (chatData) => (
+                <ChatCard
+                  key={chatData.id}
+                  chat={chatData}
+                  onUpdateChat={(newChatProperties) => {
+                    updateChatData(chatData.id, newChatProperties);
+                  }}
+                  fetchOnClient
+                  onRemoveChat={() => {
+                    removeChatData(chatData.id);
+                  }}
+                  onAddChat={() => {
+                    addChatData(chatData);
+                  }}
+                  onSaveMessage={(message) => {
+                    saveChatMessage(chatData.id, message);
+                  }}
+                  onClearMessage={(chatData) => {
+                    clearChatMessage(chatData.id);
+                  }}
+                  closable={isClosable(chat.chats.length)}
+                  cloneable={isClonable(chat.chats.length)}
+                  style={{
+                    flex: 1,
+                    overflow: 'hidden',
+                  }}
+                />
+              ))}
+            </Suspense>
           </BAIFlex>
         )}
         <ChatHistoryDrawer


### PR DESCRIPTION
Resolves #4818 ([FR-1782](https://lablup.atlassian.net/browse/FR-1782))

## Summary
- Refactor chat page layout from vh-based calculation to flex-based layout
- Replace `useStyles` (antd-style) with inline styles in ChatCard component
- Fix chat card height issue where content was hidden when screen became narrow

## Changes
- **ChatPage.tsx**: Replace `height: calc(100vh - 224px)` with `flex: 1; minHeight: 0` for responsive layout
- **ChatCard.tsx**: Remove unnecessary `createStyles` usage, use inline styles with `theme.useToken()` for theme-aware values

## Test plan
- [ ] Verify chat page displays correctly at various screen sizes
- [ ] Verify chat card fills available height properly
- [ ] Verify theme tokens are applied correctly for alerts

[FR-1782]: https://lablup.atlassian.net/browse/FR-1782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ