### PR TITLE
fix(FR-1778): fix terminal guide dialog logic to properly open terminal

### DIFF
--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -1525,12 +1525,10 @@ export default class BackendAiAppLauncher extends BackendAIPage {
   async runTerminal(sessionUuid: string) {
     const isVisible = localStorage.getItem('backendaiwebui.terminalguide');
     if (
-      (!globalThis.backendaiclient.supports('copy-on-terminal') &&
-        !isVisible) ||
-      isVisible === 'true'
+      !globalThis.backendaiclient.supports('copy-on-terminal') &&
+      (!isVisible || isVisible === 'true')
     ) {
       this._openTerminalGuideDialog();
-      return;
     }
     if (
       globalThis.backendaiwsproxy == undefined ||
@@ -1740,9 +1738,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
    * Open a guide for terminal
    */
   _openTerminalGuideDialog() {
-    if (!globalThis.backendaiclient.supports('copy-on-terminal')) {
-      this.terminalGuideDialog.show();
-    }
+    this.terminalGuideDialog.show();
   }
 
   /**


### PR DESCRIPTION
Resolves #4801 ([FR-1778](https://lablup.atlassian.net/browse/FR-1778))

## Summary
- Fixed terminal guide dialog logic in `runTerminal()` to not early return after showing the guide dialog
- Simplified `_openTerminalGuideDialog()` to always show the dialog when called
- This ensures the terminal actually opens when user clicks 'Launch Terminal App' button in the session detail panel

## Test plan
- [ ] Open session detail panel
- [ ] Click 'Launch Terminal App' button
- [ ] Verify terminal opens properly (with or without guide dialog depending on settings)

[FR-1778]: https://lablup.atlassian.net/browse/FR-1778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ