### PR TITLE
fix(FR-1790): fix chat clear functionality

### DIFF
--- a/react/src/hooks/useEventNotStable.tsx
+++ b/react/src/hooks/useEventNotStable.tsx
@@ -4,7 +4,7 @@ export function useEventNotStable<Args extends unknown[], Return>(
   handler: (...args: Args) => Return,
 ) {
   // eslint-disable-next-line
-  const handlerRef = useRef<typeof handler | undefined>(undefined);
+  const handlerRef = useRef<typeof handler>(handler);
 
   // In a real implementation, this would run before layout effects
   useLayoutEffect(() => {
@@ -16,6 +16,6 @@ export function useEventNotStable<Args extends unknown[], Return>(
   return useCallback((...args: Args) => {
     // In a real implementation, this would throw if called during render
     const fn = handlerRef.current;
-    return fn ? fn(...args) : undefined;
+    return fn(...args);
   }, []);
 }


### PR DESCRIPTION
Resolves #4826 ([FR-1790](https://lablup.atlassian.net/browse/FR-1790))
Resolves #4815 ([FR-1781](https://lablup.atlassian.net/browse/FR-1781))
Resolves #4826 ([FR-1790](https://lablup.atlassian.net/browse/FR-1790))

## Problem
When pressing the **Clear Chat** button, the chat history doesn't get cleared properly. This occurs because the useChat hook doesn't properly reinitialize when the transport parameters change.

## Solution
This PR fixes the chat clear functionality by:

1. **Improved useChat ID generation**: Changed from simple `chat-${endpoint?.endpoint_id}-${modelId}` to `chat-${baseURL}-${modelId}-${chat.provider.apiKey}` which includes more unique identifiers
2. **Wrapped fetch with useEventNotStable**: The fetch function is now wrapped with `useEventNotStable()` hook to ensure proper transport reinitialization
3. **Addressed upstream issue**: Added workaround for vercel/ai#8956 where useChat doesn't run new transport without ID change

## Changes
- Modified [ChatCard.tsx](react/src/components/Chat/ChatCard.tsx):
  - Added `useEventNotStable` hook import
  - Updated useChat `id` to include baseURL and apiKey for better uniqueness
  - Wrapped fetch function with `useEventNotStable()`
  - Added explanatory comment about the fix

## Testing
- Verify that clicking "Clear Chat" button properly clears the chat history
- Verify that changing chat parameters (endpoint, model, API key) triggers proper transport reinitialization
- Verify that normal chat functionality still works as expected

**Checklist:**

- [x] Code changes are focused and address the specific issue
- [x] No breaking changes to existing chat functionality
- [ ] Test case: Clear chat and verify messages are properly cleared

[FR-1790]: https://lablup.atlassian.net/browse/FR-1790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FR-1781]: https://lablup.atlassian.net/browse/FR-1781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ