### PR TITLE
feat(FR-1792): add download vfolder button to Data page

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/FileItemControls.tsx
@@ -1,3 +1,4 @@
+import { initiateDownload } from '../../../helper';
 import { BAITrashBinIcon } from '../../../icons';
 import { BAIButtonProps } from '../../BAIButton';
 import BAIFlex from '../../BAIFlex';
@@ -88,7 +89,15 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
       <Button
         type="text"
         size="small"
-        icon={<DownloadIcon color={token.colorInfo} />}
+        icon={
+          <DownloadIcon
+            color={
+              !enableDownload || downloadFileMutation.isPending
+                ? token.colorTextDisabled
+                : token.colorInfo
+            }
+          />
+        }
         disabled={!enableDownload || downloadFileMutation.isPending}
         loading={downloadFileMutation.isPending}
         onClick={(e) => {
@@ -100,7 +109,13 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
       <Button
         type="text"
         size="small"
-        icon={<BAITrashBinIcon style={{ color: token.colorError }} />}
+        icon={
+          <BAITrashBinIcon
+            style={{
+              color: !enableDelete ? token.colorTextDisabled : token.colorError,
+            }}
+          />
+        }
         disabled={!enableDelete}
         onClick={(e) => {
           e.stopPropagation();
@@ -113,38 +128,3 @@ const FileItemControls: React.FC<FileItemControlsProps> = ({
 };
 
 export default FileItemControls;
-
-/**
- *
- * @param downloadURL
- * @param fileName
- */
-const initiateDownload = async (
-  downloadURL: string,
-  fileName: string,
-): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    try {
-      // @ts-ignore - iOS Safari
-      if (globalThis.iOSSafari) {
-        const newWindow = window.open(downloadURL, '_blank');
-        newWindow && resolve();
-      } else {
-        const downloadLink = document.createElement('a');
-        downloadLink.style.display = 'none';
-        downloadLink.href = downloadURL;
-        downloadLink.download = fileName;
-        downloadLink.addEventListener('click', (e) => {
-          e.stopPropagation();
-        });
-        document.body.appendChild(downloadLink);
-        downloadLink.click();
-        document.body.removeChild(downloadLink);
-
-        resolve();
-      }
-    } catch (error) {
-      reject(error);
-    }
-  });
-};

--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderDownloadButton.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderDownloadButton.tsx
@@ -1,0 +1,65 @@
+import { initiateDownload } from '../../helper';
+import BAIButton, { BAIButtonProps } from '../BAIButton';
+import { useConnectedBAIClient } from '../provider';
+import { useMutation } from '@tanstack/react-query';
+import { theme } from 'antd';
+import { DownloadIcon } from 'lucide-react';
+
+export interface BAIVFolderDownloadButtonProps extends BAIButtonProps {
+  vfolderId: string;
+  vfolderName: string;
+}
+
+const BAIVFolderDownloadButton = ({
+  vfolderId,
+  vfolderName,
+  ...buttonProps
+}: BAIVFolderDownloadButtonProps) => {
+  const { token } = theme.useToken();
+  const baiClient = useConnectedBAIClient();
+
+  const { mutateAsync } = useMutation({
+    mutationFn: async () => {
+      try {
+        const tokenResponse = await baiClient.vfolder.request_download_token(
+          './',
+          vfolderId,
+          true,
+        );
+        const downloadParams = new URLSearchParams({
+          token: tokenResponse.token,
+          archive: 'true',
+        });
+        const downloadURL = `${tokenResponse.url}?${downloadParams.toString()}`;
+        await initiateDownload(downloadURL, `${vfolderName}.zip`);
+      } catch (error) {
+        throw error;
+      }
+    },
+  });
+
+  return (
+    <BAIButton
+      icon={
+        <DownloadIcon
+          color={
+            buttonProps.disabled ? token.colorTextDisabled : token.colorInfo
+          }
+        />
+      }
+      style={{
+        color: buttonProps.disabled ? token.colorTextDisabled : token.colorInfo,
+        background: buttonProps.disabled
+          ? token.colorBgContainerDisabled
+          : token.colorInfoBg,
+      }}
+      {...buttonProps}
+      action={async () => {
+        await mutateAsync();
+        await buttonProps.action?.();
+      }}
+    />
+  );
+};
+
+export default BAIVFolderDownloadButton;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -45,3 +45,5 @@ export type {
   BAIActivateArtifactsModalArtifactsFragmentKey,
 } from './BAIActivateArtifactsModal';
 export { default as BAIVFolderDeleteButton } from './BAIVFolderDeleteButton';
+export { default as BAIVFolderDownloadButton } from './BAIVFolderDownloadButton';
+export type { BAIVFolderDeleteButtonProps } from './BAIVFolderDeleteButton';

--- a/packages/backend.ai-ui/src/helper/index.ts
+++ b/packages/backend.ai-ui/src/helper/index.ts
@@ -420,3 +420,38 @@ export const generateRandomString = (n = 3) => {
 
   return randStr;
 };
+
+/**
+ *
+ * @param downloadURL
+ * @param fileName
+ */
+export const initiateDownload = async (
+  downloadURL: string,
+  fileName: string,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    try {
+      // @ts-ignore - iOS Safari
+      if (globalThis.iOSSafari) {
+        const newWindow = window.open(downloadURL, '_blank');
+        newWindow && resolve();
+      } else {
+        const downloadLink = document.createElement('a');
+        downloadLink.style.display = 'none';
+        downloadLink.href = downloadURL;
+        downloadLink.download = fileName;
+        downloadLink.addEventListener('click', (e) => {
+          e.stopPropagation();
+        });
+        document.body.appendChild(downloadLink);
+        downloadLink.click();
+        document.body.removeChild(downloadLink);
+
+        resolve();
+      }
+    } catch (error) {
+      reject(error);
+    }
+  });
+};


### PR DESCRIPTION
resolves #4830 (FR-1792)

- add download vfolder button to data page
- Enhance the UI for the download and delete buttons
> **Notice**
> Since the backend sends the downloaded file with the name vfolderId.zip, it is not possible to set the file name to the vfolder name.

![CleanShot 2025-12-15 at 15.46.01@2x.png](https://app.graphite.com/user-attachments/assets/7ff95d63-2ead-433d-896d-98e9d4634724.png)

![CleanShot 2025-12-15 at 15.46.11@2x.png](https://app.graphite.com/user-attachments/assets/ff51c7c2-e0f9-4478-9ea0-820a357b9a4d.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after