### PR TITLE
fix(FR-1678): Enhance BAITable to handle an invalid page number

### DIFF
--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -105,6 +105,8 @@
     "Unlimited": "Unbegrenzt"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Zur ersten Seite",
+    "InvalidPageNumber": "Ungültige Seitenzahl",
     "SearchTableColumn": "Suchtabellenspalten",
     "SelectColumnToDisplay": "Wählen Sie Spalten aus, um angezeigt zu werden",
     "SettingTable": "Tabelleneinstellungen"

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -105,6 +105,8 @@
     "Unlimited": "Απεριόριστος"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Μετάβαση στην πρώτη σελίδα",
+    "InvalidPageNumber": "Μη έγκυρος αριθμός σελίδας",
     "SearchTableColumn": "Στήλες πίνακα αναζήτησης",
     "SelectColumnToDisplay": "Επιλέξτε στήλες για εμφάνιση",
     "SettingTable": "Ρυθμίσεις πίνακα"

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -108,6 +108,8 @@
     "Unlimited": "Unlimited"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Go to first page",
+    "InvalidPageNumber": "Invalid page number",
     "SearchTableColumn": "Search table columns",
     "SelectColumnToDisplay": "Select columns to display",
     "SettingTable": "Table Settings"

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -105,6 +105,8 @@
     "Unlimited": "Ilimitado"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Ir a la primera página",
+    "InvalidPageNumber": "Número de página no válido",
     "SearchTableColumn": "Columnas de la tabla de búsqueda",
     "SelectColumnToDisplay": "Seleccionar columnas para mostrar",
     "SettingTable": "Configuración de tabla"

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -105,6 +105,8 @@
     "Unlimited": "Rajoittamaton"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Siirry ensimmäiselle sivulle",
+    "InvalidPageNumber": "Virheellinen sivunumero",
     "SearchTableColumn": "Hakutaulukon sarakkeet",
     "SelectColumnToDisplay": "Valitse näytettävä sarakkeet",
     "SettingTable": "Taulukon asetukset"

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -105,6 +105,8 @@
     "Unlimited": "Illimité"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Aller à la première page",
+    "InvalidPageNumber": "Numéro de page invalide",
     "SearchTableColumn": "Colonnes de table de recherche",
     "SelectColumnToDisplay": "Sélectionnez des colonnes à afficher",
     "SettingTable": "Paramètres de la table"

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -105,6 +105,8 @@
     "Unlimited": "Tak terbatas"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Ke halaman pertama",
+    "InvalidPageNumber": "Nomor halaman tidak valid",
     "SearchTableColumn": "Kolom Tabel Cari",
     "SelectColumnToDisplay": "Pilih kolom untuk ditampilkan",
     "SettingTable": "Pengaturan Tabel"

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -105,6 +105,8 @@
     "Unlimited": "Illimitato"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Vai alla prima pagina",
+    "InvalidPageNumber": "Numero di pagina non valido",
     "SearchTableColumn": "Colonne della tabella di ricerca",
     "SelectColumnToDisplay": "Seleziona le colonne da visualizzare",
     "SettingTable": "Impostazioni della tabella"

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -105,6 +105,8 @@
     "Unlimited": "無制限"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "最初のページへ",
+    "InvalidPageNumber": "無効なページ番号です",
     "SearchTableColumn": "テーブル列を検索します",
     "SelectColumnToDisplay": "表示する列を選択します",
     "SettingTable": "テーブル設定"

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -105,6 +105,8 @@
     "Unlimited": "제한없음"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "첫 페이지로 이동하기",
+    "InvalidPageNumber": "유효하지 않은 페이지 번호입니다",
     "SearchTableColumn": "표시할 열 검색",
     "SelectColumnToDisplay": "표시할 열 선택",
     "SettingTable": "표 설정"

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -105,6 +105,8 @@
     "Unlimited": "Хязгааргүй"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Эх хуудас руу шилжих",
+    "InvalidPageNumber": "Хуудасны дугаар буруу байна",
     "SearchTableColumn": "Хүснэгтийн баганыг хайх",
     "SelectColumnToDisplay": "Дэлгэцийн баганыг сонгоно уу",
     "SettingTable": "Хүснэгтийн тохиргоо"

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -105,6 +105,8 @@
     "Unlimited": "Tidak terhad"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Pergi ke halaman pertama",
+    "InvalidPageNumber": "Nombor halaman tidak sah",
     "SearchTableColumn": "Lajur jadual carian",
     "SelectColumnToDisplay": "Pilih lajur untuk dipaparkan",
     "SettingTable": "Tetapan Jadual"

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -105,6 +105,8 @@
     "Unlimited": "Nieograniczony"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Przejdź do pierwszej strony",
+    "InvalidPageNumber": "Nieprawidłowy numer strony",
     "SearchTableColumn": "Wyszukaj kolumny tabeli",
     "SelectColumnToDisplay": "Wybierz kolumny do wyświetlenia",
     "SettingTable": "Ustawienia tabeli"

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -104,6 +104,8 @@
     "Unlimited": "Ilimitado"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Ir para a primeira página",
+    "InvalidPageNumber": "Número de página inválido",
     "SearchTableColumn": "Pesquisar colunas da tabela",
     "SelectColumnToDisplay": "Selecione colunas para exibir",
     "SettingTable": "Configurações da tabela"

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -105,6 +105,8 @@
     "Unlimited": "Ilimitado"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Ir para a primeira página",
+    "InvalidPageNumber": "Número de página inválido",
     "SearchTableColumn": "Pesquisar colunas da tabela",
     "SelectColumnToDisplay": "Selecione colunas para exibir",
     "SettingTable": "Configurações da tabela"

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -105,6 +105,8 @@
     "Unlimited": "Неограниченный"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Перейти на первую страницу",
+    "InvalidPageNumber": "Неверный номер страницы",
     "SearchTableColumn": "Поиск таблицы столбцов",
     "SelectColumnToDisplay": "Выберите столбцы, чтобы отобразить",
     "SettingTable": "Настройки таблицы"

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -105,6 +105,8 @@
     "Unlimited": "ไม่ จำกัด"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "ไปยังหน้าแรก",
+    "InvalidPageNumber": "หมายเลขหน้าไม่ถูกต้อ",
     "SearchTableColumn": "คอลัมน์ตารางค้นหา",
     "SelectColumnToDisplay": "เลือกคอลัมน์ที่จะแสดง",
     "SettingTable": "การตั้งค่าตาราง"

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -105,6 +105,8 @@
     "Unlimited": "Sınırsız"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "İlk sayfaya git",
+    "InvalidPageNumber": "Geçersiz sayfa numarası",
     "SearchTableColumn": "Arama Tablosu sütunları",
     "SelectColumnToDisplay": "Görüntülemek için sütunları seçin",
     "SettingTable": "Masa Ayarları"

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -105,6 +105,8 @@
     "Unlimited": "Không giới hạn"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "Đến trang đầu",
+    "InvalidPageNumber": "Số trang không hợp lệ",
     "SearchTableColumn": "Các cột bảng tìm kiếm",
     "SelectColumnToDisplay": "Chọn các cột để hiển thị",
     "SettingTable": "Cài đặt bảng"

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -105,6 +105,8 @@
     "Unlimited": "无限"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "转到第一页",
+    "InvalidPageNumber": "无效的页码",
     "SearchTableColumn": "搜索表列",
     "SelectColumnToDisplay": "选择要显示的列",
     "SettingTable": "表设置"

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -105,6 +105,8 @@
     "Unlimited": "無限"
   },
   "comp:BAITable": {
+    "GoToFirstPage": "跳到第一頁",
+    "InvalidPageNumber": "無效的頁碼",
     "SearchTableColumn": "搜索表列",
     "SelectColumnToDisplay": "選擇要顯示的列",
     "SettingTable": "表設置"


### PR DESCRIPTION
resolves #4634 (FR-1678)

This PR enhances the BAITable component by adding validation for page numbers and providing a user-friendly experience when an invalid page number is detected.

## Features Added:
- Added page number validation logic to check if the current page is within valid range
- Implemented a friendly error message when an invalid page number is detected
- Added a "Go to first page" button to help users recover from invalid pagination states
- Added translations for new UI text in all supported languages

## Implementation Details:
- Created `isValidPageNumber()` function to validate current page against total pages
- Used BAIConfigProvider with custom renderEmpty to show the error message
- Added internationalization support for the new UI text elements

![CleanShot 2025-12-16 at 11.17.16@2x.png](https://app.graphite.com/user-attachments/assets/f917b3b5-1e68-42bb-b761-12e49c32bf9e.png)

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after