### PR TITLE
style(FR-1740): simplify Korean success message expressions

### DIFF
--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -672,7 +672,7 @@
     "NoExplorerSupportForUnmanagedFolder": "Unmanaged 폴더는 파일 탐색기를 지원하지 않습니다.",
     "NoPermissions": "이 폴더에 접근할 권한이 없습니다",
     "ProcessingUpload": "파일을 업로드하는 중입니다. 잠시만 기다려주세요.",
-    "SelectedItemsDeletedSuccessfully": "선택한 파일이 정상적으로 삭제되었습니다.",
+    "SelectedItemsDeletedSuccessfully": "선택한 파일이 삭제되었습니다.",
     "SelectedItemsDeletionFailed": "파일을 삭제하는 동안 문제가 발생했습니다. 다시 시도해 주세요.",
     "SuccessfullyUploadedToFolder": "파일 업로드가 완료되었습니다. ",
     "UploadFailed": "'{{folderName}}'에 업로드 실패",
@@ -2056,7 +2056,7 @@
       "PrimaryColor": "주요 색상",
       "PrimaryColorDesc": "주요 동작을 나타내는 버튼이나 설명 텍스트에 적용되는 기본 색상입니다. \n헤더의 로고 부분 배경색으로도 적용됩니다.",
       "SuccessColor": "완료 색상",
-      "SuccessColorDesc": "사용자가 수행한 동작이 정상적으로 완료되었음을 나타내는 버튼, 알림 또는 아이콘에 사용되는 색상입니다.",
+      "SuccessColorDesc": "사용자가 수행한 동작이 완료되었음을 나타내는 버튼, 알림 또는 아이콘에 사용되는 색상입니다.",
       "TextColor": "텍스트 색상",
       "TextColorDesc": "텍스트에 사용되는 색상입니다."
     }


### PR DESCRIPTION
Resolves #4731 ([FR-1740](https://lablup.atlassian.net/browse/FR-1740))

## Summary

Simplified Korean success message expressions by removing the word "정상적으로" (normally/properly) to make messages more concise and natural.

## Changes

Updated Korean translation file ():
1. "선택한 파일이 정상적으로 삭제되었습니다." → "선택한 파일이 삭제되었습니다."
2. "사용자가 수행한 동작이 정상적으로 완료되었음을 나타내는..." → "사용자가 수행한 동작이 완료되었음을 나타내는..."

## Context

The word "정상적으로" is redundant in success messages as success is already implied. Removing it makes the UI text more concise and natural in Korean.

**Checklist:**

- [x] Documentation - N/A (translation only)
- [x] Minimum required manager version - N/A
- [x] Specific setting for review - N/A
- [x] Minimum requirements to check during review - Check that Korean success messages display correctly
- [x] Test case(s) - Verify file deletion success message and success color description in admin settings

[FR-1740]: https://lablup.atlassian.net/browse/FR-1740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ