### PR TITLE
feat(FR-1800): restrict model project folder permission to read-only

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -425,6 +425,7 @@
       "Location": "Ort",
       "MaxFolderQuota": "Maximale Ordner-Quote",
       "MaxSize": "Maximale Größe",
+      "ModelProjectFolderRestrictedToReadOnly": "Die Berechtigung 'Lesen & Schreiben' wird für Model-Store-Ordner nicht unterstützt.",
       "ModifyPermissions": "Berechtigungen ändern",
       "MountPermission": "Erlaubnis montieren",
       "MountedSessions": "Gemountete Sitzungen",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -423,6 +423,7 @@
       "Location": "Τοποθεσία",
       "MaxFolderQuota": "Μέγιστη ποσόστωση φακέλων",
       "MaxSize": "Μέγιστο μέγεθος",
+      "ModelProjectFolderRestrictedToReadOnly": "Δεν υποστηρίζεται η άδεια 'Read & Write' για τον φάκελο του model store.",
       "ModifyPermissions": "Τροποποίηση δικαιωμάτων",
       "MountPermission": "Τοποθετημένος άδεια",
       "MountedSessions": "Προσαρτημένες συνεδρίες",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -428,6 +428,7 @@
       "Location": "Location",
       "MaxFolderQuota": "Max Folder Quota",
       "MaxSize": "Max Size",
+      "ModelProjectFolderRestrictedToReadOnly": "'Read & Write' permission is not supported for model store folder",
       "ModifyPermissions": "Modify permissions",
       "MountPermission": "Mount Permission",
       "MountedSessions": "Mounted Sessions",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -425,6 +425,7 @@
       "Location": "Ubicación",
       "MaxFolderQuota": "Cuota máxima de carpetas",
       "MaxSize": "Tamaño máximo",
+      "ModelProjectFolderRestrictedToReadOnly": "El permiso 'Lectura y escritura' no es compatible con la carpeta del almacén de modelos",
       "ModifyPermissions": "Modificar permisos",
       "MountPermission": "Montar permiso",
       "MountedSessions": "Sesiones montadas",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -425,6 +425,7 @@
       "Location": "Sijainti",
       "MaxFolderQuota": "Kansioiden enimmäiskiintiö",
       "MaxSize": "Enimmäiskoko",
+      "ModelProjectFolderRestrictedToReadOnly": "Luku- ja kirjoitusoikeutta ei tueta mallivaraston kansiolle.",
       "ModifyPermissions": "Muokkaa käyttöoikeuksia",
       "MountPermission": "Kiinnityslupa",
       "MountedSessions": "Liitetyt istunnot",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -425,6 +425,7 @@
       "Location": "Emplacement",
       "MaxFolderQuota": "Quota maximum de dossiers",
       "MaxSize": "Taille maximale",
+      "ModelProjectFolderRestrictedToReadOnly": "La permission 'Lecture et écriture' n'est pas prise en charge pour le dossier du référentiel de modèles.",
       "ModifyPermissions": "Modifier les autorisations",
       "MountPermission": "Autorisation de montage",
       "MountedSessions": "Sessions montées",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -424,6 +424,7 @@
       "Location": "Lokasi",
       "MaxFolderQuota": "Kuota Folder Maksimal",
       "MaxSize": "Ukuran maksimal",
+      "ModelProjectFolderRestrictedToReadOnly": "Izin 'Baca & Tulis' tidak didukung untuk folder penyimpanan model.",
       "ModifyPermissions": "Memodifikasi izin",
       "MountPermission": "MUNGGAL Izin",
       "MountedSessions": "Sesi Terpasang",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -424,6 +424,7 @@
       "Location": "Posizione",
       "MaxFolderQuota": "Quota massima della cartella",
       "MaxSize": "Dimensione massima",
+      "ModelProjectFolderRestrictedToReadOnly": "Il permesso 'Read & Write' non è supportato per la cartella del model store",
       "ModifyPermissions": "Modificare le autorizzazioni",
       "MountPermission": "Autorizzazione del montaggio",
       "MountedSessions": "Sessioni montate",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -424,6 +424,7 @@
       "Location": "ロケーション",
       "MaxFolderQuota": "最大割り当て可能容量",
       "MaxSize": "最大サイズ",
+      "ModelProjectFolderRestrictedToReadOnly": "モデルストアフォルダーでは「読み取り/書き込み」権限はサポートされていません",
       "ModifyPermissions": "権限修正",
       "MountPermission": "マウント許可",
       "MountedSessions": "マウント済みセッション",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -427,6 +427,7 @@
       "Location": "위치",
       "MaxFolderQuota": "최대 할당 가능 용량",
       "MaxSize": "최대 크기",
+      "ModelProjectFolderRestrictedToReadOnly": "모델 스토어 폴더에 대해 '읽기 및 쓰기' 권한이 허용되지 않습니다. ",
       "ModifyPermissions": "권한 수정",
       "MountPermission": "마운트 권한",
       "MountedSessions": "마운트 된 세션",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -424,6 +424,7 @@
       "Location": "Байршил",
       "MaxFolderQuota": "Фолдерын хамгийн их квот",
       "MaxSize": "Хамгийн их хэмжээ",
+      "ModelProjectFolderRestrictedToReadOnly": "Моделийн агуулах хавтас дээр 'Унших ба бичих' эрхийг дэмждэггүй.",
       "ModifyPermissions": "Зөвшөөрлийг өөрчлөх",
       "MountPermission": "ЗОРИУЛСАН",
       "MountedSessions": "Маунтлагдсан сессүүд",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -424,6 +424,7 @@
       "Location": "Lokasi",
       "MaxFolderQuota": "Kuota Folder Maks",
       "MaxSize": "Saiz maks",
+      "ModelProjectFolderRestrictedToReadOnly": "Kebenaran \"Baca & Tulis\" tidak disokong untuk folder stor model",
       "ModifyPermissions": "Ubah suai kebenaran",
       "MountPermission": "Izin gunung",
       "MountedSessions": "Sesi Terpasang",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -425,6 +425,7 @@
       "Location": "Lokalizacja",
       "MaxFolderQuota": "Maksymalny limit folderu",
       "MaxSize": "Max rozmiar",
+      "ModelProjectFolderRestrictedToReadOnly": "Uprawnienie 'Odczyt i zapis' nie jest obsługiwane dla folderu magazynu modeli",
       "ModifyPermissions": "Modyfikowanie uprawnień",
       "MountPermission": "Zamontować pozwolenie",
       "MountedSessions": "Zamontowane sesje",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -425,6 +425,7 @@
       "Location": "Localização",
       "MaxFolderQuota": "Quota máxima de pastas",
       "MaxSize": "Tamanho máximo",
+      "ModelProjectFolderRestrictedToReadOnly": "Permissão 'Leitura e gravação' não é suportada para a pasta do repositório de modelos",
       "ModifyPermissions": "Modificar permissões",
       "MountPermission": "Permissão de montagem",
       "MountedSessions": "Sessões Montadas",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -425,6 +425,7 @@
       "Location": "Localização",
       "MaxFolderQuota": "Quota máxima de pastas",
       "MaxSize": "Tamanho máximo",
+      "ModelProjectFolderRestrictedToReadOnly": "A permissão 'Leitura e escrita' não é suportada para a pasta do repositório de modelos",
       "ModifyPermissions": "Modificar permissões",
       "MountPermission": "Permissão de montagem",
       "MountedSessions": "Sessões montadas",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -425,6 +425,7 @@
       "Location": "Место расположения",
       "MaxFolderQuota": "Максимальная квота на папки",
       "MaxSize": "Максимальный размер",
+      "ModelProjectFolderRestrictedToReadOnly": "Разрешение 'Read & Write' не поддерживается для папки хранилища моделей",
       "ModifyPermissions": "Изменение прав доступа",
       "MountPermission": "Разрешение на крепление",
       "MountedSessions": "Смонтированные сессии",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -425,6 +425,7 @@
       "Location": "ตำแหน่ง",
       "MaxFolderQuota": "โควตาโฟลเดอร์สูงสุด",
       "MaxSize": "ขนาดสูงสุด",
+      "ModelProjectFolderRestrictedToReadOnly": "สิทธิ์ 'อ่านและเขียน' ไม่รองรับสำหรับโฟลเดอร์ Model Store",
       "ModifyPermissions": "แก้ไขสิทธิ์",
       "MountPermission": "การอนุญาตเมานต์",
       "MountedSessions": "เซสชันที่เมานต์",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -425,6 +425,7 @@
       "Location": "yer",
       "MaxFolderQuota": "Maksimum Klasör Kotası",
       "MaxSize": "Maksimum Boyut",
+      "ModelProjectFolderRestrictedToReadOnly": "'Okuma ve Yazma' izni model depolama klasörü için desteklenmiyor",
       "ModifyPermissions": "İzinleri değiştirme",
       "MountPermission": "Montaj İzni",
       "MountedSessions": "Bağlanmış Oturumlar",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -425,6 +425,7 @@
       "Location": "Vị trí",
       "MaxFolderQuota": "Hạn ngạch thư mục tối đa",
       "MaxSize": "Kích thước tối đa",
+      "ModelProjectFolderRestrictedToReadOnly": "Quyền 'Đọc & Ghi' không được hỗ trợ cho thư mục kho mô hình",
       "ModifyPermissions": "Sửa đổi quyền",
       "MountPermission": "Gắn kết quyền",
       "MountedSessions": "Các phiên đã gắn",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -425,6 +425,7 @@
       "Location": "地点",
       "MaxFolderQuota": "最大文件夹配额",
       "MaxSize": "最大尺寸",
+      "ModelProjectFolderRestrictedToReadOnly": "模型存储文件夹不支持“读写”权限",
       "ModifyPermissions": "修改权限",
       "MountPermission": "安装许可",
       "MountedSessions": "已挂载的会话",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -425,6 +425,7 @@
       "Location": "地點",
       "MaxFolderQuota": "最大文件夹配额",
       "MaxSize": "最大尺寸",
+      "ModelProjectFolderRestrictedToReadOnly": "模型儲存資料夾不支援「讀取與寫入」權限",
       "ModifyPermissions": "修改权限",
       "MountPermission": "安裝許可",
       "MountedSessions": "已掛載的工作階段",

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -834,6 +834,9 @@ class Client {
     if (this.isManagerVersionCompatibleWith('25.17.0')) {
       this._features['background-file-delete'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('25.18.2')) {
+      this._features['allow-only-ro-permission-for-model-project-folder'] = true;
+    }
   }
 
   /**


### PR DESCRIPTION
resolves #4851 ([FR-1800](https://lablup.atlassian.net/browse/FR-1800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ))

### Restrict Model Project Folders to Read-Only Permission

This PR adds a feature to restrict model project folders to read-only permission. When creating a folder with usage mode set to "model" and type set to "project", the "Read & Write" permission option is disabled and shows a tooltip explaining that this permission is not supported for model store folders.

The implementation:

- Adds validation to prevent selecting "Read & Write" permission for model project folders
- Disables the "Read & Write" radio button with a warning icon and tooltip
- Adds a new feature flag `allow-only-ro-permission-for-model-project-folder` for manager version 25.18.2+
- Adds translations for the new error message in all supported languages

**Checklist:**

- [x] Documentation
- [x] Minium required manager version: 25.18.2
- [x] Specific setting for review: Create a folder with usage mode "model" and type "project"
- [x] Minimum requirements to check during review: Verify that "Read & Write" permission is disabled for model project folders

[FR-1800]: https://lablup.atlassian.net/browse/FR-1800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ