### PR TITLE
fix(FR-1801): add ellipsis to DoubleTag component

### DIFF
--- a/react/src/components/DoubleTag.tsx
+++ b/react/src/components/DoubleTag.tsx
@@ -1,6 +1,6 @@
 import TextHighlighter from './TextHighlighter';
 import { Tag } from 'antd';
-import { BAIFlex } from 'backend.ai-ui';
+import { BAIFlex, BAIText } from 'backend.ai-ui';
 import _ from 'lodash';
 import React from 'react';
 
@@ -45,13 +45,21 @@ const DoubleTag: React.FC<{
             }}
             color={objValue.color}
           >
-            {!_.isUndefined(highlightKeyword) ? (
-              <TextHighlighter keyword={highlightKeyword}>
-                {objValue.label}
-              </TextHighlighter>
-            ) : (
-              objValue.label
-            )}
+            <BAIText
+              style={{
+                fontSize: 'inherit',
+                maxWidth: 150,
+              }}
+              ellipsis={{ tooltip: true }}
+            >
+              {!_.isUndefined(highlightKeyword) ? (
+                <TextHighlighter keyword={highlightKeyword}>
+                  {objValue.label}
+                </TextHighlighter>
+              ) : (
+                objValue.label
+              )}
+            </BAIText>
           </Tag>
         ) : null,
       )}


### PR DESCRIPTION
resolves #NNN (FR-1801)

This PR adds text truncation with ellipsis to the tag labels in the DoubleTag component. Long tag labels are now limited to a maximum width of 150px, with overflow text being truncated and replaced with an ellipsis. The full label text is still accessible via a tooltip when hovering over the truncated label.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after