### PR TITLE
fix(FR-1803): handle missing keypair information during login to clear session ID

### DIFF
--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -1765,6 +1765,11 @@ export default class BackendAILogin extends BackendAIPage {
       .then(async (response) => {
         this.is_connected = true;
         globalThis.backendaiclient = this.client;
+        if (!response['keypair']) {
+          // if no keypair info, logout and throw error
+          await this.client?.logout();
+          throw new Error('Keypair information is missing.');
+        }
         const resource_policy = response['keypair'].resource_policy;
         globalThis.backendaiclient.resource_policy = resource_policy;
         this.user = response['keypair'].user;


### PR DESCRIPTION
resolves #4860 (FR-1803)

This PR adds a check for missing keypair information during the login process. If the keypair data is missing from the response, the client will now automatically log out and throw an appropriate error message, preventing potential issues that could occur when trying to access undefined keypair properties.


**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after