### PR TITLE
fix(FR-1805): Specify the output path for the wsproxy build

### DIFF
--- a/src/wsproxy/webpack.config.js
+++ b/src/wsproxy/webpack.config.js
@@ -8,6 +8,8 @@ module.exports = {
     app: ['./manager.js'],
   },
   output: {
+    clean: true,
+    path: path.resolve(__dirname, 'dist'),
     libraryTarget: 'commonjs2',
     filename: 'wsproxy.js',
   },


### PR DESCRIPTION
# Clean webpack output directory for wsproxy

This PR updates the webpack configuration for the wsproxy component to clean the output directory before each build by adding the `clean: true` option. It also explicitly sets the output path to `dist` in the component directory.

**how to test**
* run `make clean` first.
* run `make compile_wsproxy`
* Please check whether the `wsproxy.js` file is located in `src/lib/wsproxy/dist/`

**Checklist:**
- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after