### PR TITLE
fix(FR-1806): remove circular reference in BAIDynamicUnitInputNumberWithSlider component

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIDynamicUnitInputNumberWithSlider.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDynamicUnitInputNumberWithSlider.tsx
@@ -4,7 +4,9 @@ import {
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
 import { useUpdatableState } from '../hooks';
-import { BAIDynamicUnitInputNumberProps } from './BAIDynamicUnitInputNumber';
+import BAIDynamicUnitInputNumber, {
+  BAIDynamicUnitInputNumberProps,
+} from './BAIDynamicUnitInputNumber';
 import BAIFlex from './BAIFlex';
 import { useControllableValue } from 'ahooks';
 import { Slider, theme } from 'antd';
@@ -20,7 +22,7 @@ export interface BAIDynamicUnitInputNumberWithSliderProps
   step?: number;
   inputMinWidth?: number;
 }
-const DynamicUnitInputNumberWithSlider: React.FC<
+const BAIDynamicUnitInputNumberWithSlider: React.FC<
   BAIDynamicUnitInputNumberWithSliderProps
 > = ({
   min = '0m',
@@ -78,7 +80,7 @@ const DynamicUnitInputNumberWithSlider: React.FC<
         direction="column"
         align="stretch"
       >
-        <DynamicUnitInputNumberWithSlider
+        <BAIDynamicUnitInputNumber
           {...otherProps}
           key={key}
           min={min}
@@ -234,4 +236,4 @@ const DynamicUnitInputNumberWithSlider: React.FC<
   );
 };
 
-export default DynamicUnitInputNumberWithSlider;
+export default BAIDynamicUnitInputNumberWithSlider;

--- a/packages/backend.ai-ui/src/hooks/index.ts
+++ b/packages/backend.ai-ui/src/hooks/index.ts
@@ -3,7 +3,7 @@ import {
   useBAIDeviceMetaData,
   useConnectedBAIClient,
 } from '../components';
-import { useSuspenseTanQuery } from '../helper/reactQueryAlias';
+import { useSuspenseTanQuery, useTanQuery } from '../helper/reactQueryAlias';
 import { useEventNotStable } from './useEventNotStable';
 import _ from 'lodash';
 import { useMemo, useState } from 'react';
@@ -69,7 +69,7 @@ export const useAllowedHostNames = () => {
     queryKey: ['useAllowedHOstNames'],
     queryFn: () => baiClient.vfolder.list_all_hosts(),
   });
-  return data.allowed;
+  return data?.allowed;
 };
 
 export type ResourceSlotDetail = {
@@ -93,7 +93,7 @@ export const useResourceSlotsDetails = (resourceGroupName?: string) => {
   'use memo';
   const [key, checkUpdate] = useUpdatableState('first');
   const baiRequestWithPromise = useBAISignedRequestWithPromise();
-  const { data: resourceSlotsInRG, isLoading } = useSuspenseTanQuery<{
+  const { data: resourceSlotsInRG, isLoading } = useTanQuery<{
     [key in ResourceSlotName]?: ResourceSlotDetail | undefined;
   }>({
     queryKey: ['useResourceSlots', resourceGroupName, key],


### PR DESCRIPTION
Resolves #4869 ([FR-1806](https://lablup.atlassian.net/browse/FR-1806))

## Summary

- Fix `BAIDynamicUnitInputNumberWithSlider` component self-referencing bug that was causing the session launcher page to fail
- Fix component naming consistency (renamed internal variable to match export name)
- Add optional chaining for null safety in `useAllowedHostNames` hook
- Change `useResourceSlotsDetails` from `useSuspenseTanQuery` to `useTanQuery` for better error handling

## Test plan

- [ ] Verify session launcher page loads correctly
- [ ] Verify resource slot details are fetched without errors
- [ ] Test the `BAIDynamicUnitInputNumberWithSlider` component functionality

[FR-1806]: https://lablup.atlassian.net/browse/FR-1806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ