### PR TITLE
fix(FR-1807): use fixed height for LazyLog container in ContainerLogModal

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
@@ -241,9 +241,8 @@ const ContainerLogModal: React.FC<ContainerLogModalProps> = ({
 
         <div
           style={{
-            height: 'calc(100% - 50px)',
+            height: '100%',
             alignSelf: 'stretch',
-
             border: `1px solid ${token.colorBorder}`,
             overflow: 'hidden',
           }}


### PR DESCRIPTION
Resolves #4871 ([FR-1807](https://lablup.atlassian.net/browse/FR-1807))

## Summary
- Fix height styling issue in ContainerLogModal that could cause rendering problems with the LazyLog component

## Details
This change addresses a potential timing issue where `calc()` CSS values may not be resolved when LazyLog reads the container height.

As reported in [melloware/react-logviewer#36](https://github.com/melloware/react-logviewer/issues/36), the LazyLog component can encounter infinite loop or "Maximum update depth exceeded" errors when its parent container doesn't have a properly defined height at the time of initialization. The `calc(100% - 50px)` expression may not be computed in time for LazyLog to correctly read the container dimensions, leading to unexpected behavior.

By using a fixed `100%` height instead of a calculated value, we ensure the container has a stable height that LazyLog can reliably read during its initialization phase.

## Test plan
- [ ] Verify container log modal displays correctly
- [ ] Check that log content scrolls properly
- [ ] Confirm no "Maximum update depth exceeded" errors occur

[FR-1807]: https://lablup.atlassian.net/browse/FR-1807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ