### PR TITLE
fix(FR-1802): set nuqs shallow option to false for proper navigation sync

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -544,7 +544,14 @@ const router = createBrowserRouter([
 
 const App: FC = () => {
   return (
-    <NuqsAdapter>
+    <NuqsAdapter
+      defaultOptions={{
+        // nuqs uses 'shallow: true' by default. In this case, since react-router's navigate is not used,
+        // setting searchParam via navigate elsewhere may not function correctly.
+        // https://github.com/47ng/nuqs/blob/5d9557ddd2e34a42cf3a0e769cd74c9c607eda84/packages/e2e/react-router/v6/src/layout.tsx#L23-L41
+        shallow: false,
+      }}
+    >
       <RouterProvider router={router} />
     </NuqsAdapter>
   );


### PR DESCRIPTION
resolves [FR-1802]([https://lablup.atlassian.net/browse/FR-1802](https://lablup.atlassian.net/browse/FR-1802))

## Summary

- Set nuqs `shallow` option to `false` to fix synchronization issue with react-router navigate
- When `shallow: true` (default), nuqs does not use react-router's `navigate`, causing `location.search` retrieved via `useLocation` to be empty

## Reference

- https://github.com/47ng/nuqs/blob/5d9557ddd2e34a42cf3a0e769cd74c9c607eda84/packages/e2e/react-router/v6/src/layout.tsx#L23-L41

## Test plan

- [ ] Verify URL parameters are properly synchronized on pages with pagination
- [ ] Verify `location.search` is maintained after navigating to another page and returning

[FR-1802]: https://lablup.atlassian.net/browse/FR-1802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ