### PR TITLE
feat(FR-1328): Ensure UI supports MIG usage smoothly

### DIFF
--- a/react/src/components/AgentDetailModal.tsx
+++ b/react/src/components/AgentDetailModal.tsx
@@ -66,8 +66,8 @@ const AgentDetailModal: React.FC<AgentDetailModalProps> = ({
     >
       <BAIFlex direction="column" align="stretch" gap={'md'}>
         <Row gutter={[24, 24]}>
-          <Col xs={24} sm={12}>
-            {parsedLiveStat?.devices?.cpu_util ? (
+          {parsedLiveStat?.devices?.cpu_util ? (
+            <Col xs={24} sm={12}>
               <BAIFlex direction="column" gap="xxs" align="stretch">
                 <Typography.Title level={5} style={{ marginTop: 0 }}>
                   {mergedResourceSlots?.cpu?.human_readable_name}
@@ -91,8 +91,8 @@ const AgentDetailModal: React.FC<AgentDetailModalProps> = ({
                   </BAIFlex>
                 ))}
               </BAIFlex>
-            ) : null}
-          </Col>
+            </Col>
+          ) : null}
           <Col xs={24} sm={12}>
             {parsedAvailableSlots?.mem ? (
               <BAIFlex direction="column" gap="xxs" align="stretch">

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1524,6 +1524,7 @@
       "Container": "Container",
       "Core": "Ader",
       "CreatedAt": "Erstellt am",
+      "CurrentAcceleratorTypeAllowsMaxOne": "Vom Typ \"{{ accelerator }}\" kann höchstens 1 zugewiesen werden.",
       "CurrentResourceGroup": "Aktuelle Ressourcengruppe",
       "CustomAllocation": "Benutzerdefinierte Zuordnung",
       "CustomResourceApplied": "Benutzerdefinierte Ressource wird angewendet",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1523,6 +1523,7 @@
       "Container": "Δοχείο",
       "Core": "Πυρήνας",
       "CreatedAt": "Δημιουργήθηκε στο",
+      "CurrentAcceleratorTypeAllowsMaxOne": "Μπορεί να εκχωρηθεί μόνο 1 συσκευή τύπου \"{{ accelerator }}\".",
       "CurrentResourceGroup": "Τρέχουσα ομάδα πόρων",
       "CustomAllocation": "Προσαρμοσμένη κατανομή",
       "CustomResourceApplied": "Εφαρμόζεται προσαρμοσμένος πόρος",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1531,6 +1531,7 @@
       "Container": "Container",
       "Core": "Core",
       "CreatedAt": "CreatedAt",
+      "CurrentAcceleratorTypeAllowsMaxOne": "\"{{ accelerator }}\" type can only have a maximum of 1.",
       "CurrentResourceGroup": "Current Resource Group",
       "CustomAllocation": "Custom allocation",
       "CustomResourceApplied": "Custom resource applied",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1526,6 +1526,7 @@
       "Container": "Contenedor",
       "Core": "Núcleo",
       "CreatedAt": "Creado en",
+      "CurrentAcceleratorTypeAllowsMaxOne": "Solo se puede asignar como máximo 1 \"{{ accelerator }}\".",
       "CurrentResourceGroup": "Grupo de recursos actual",
       "CustomAllocation": "Asignación personalizada",
       "CustomResourceApplied": "Se aplica el recurso personalizado",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1525,6 +1525,7 @@
       "Container": "Kontti",
       "Core": "Ydin",
       "CreatedAt": "LuotuAt",
+      "CurrentAcceleratorTypeAllowsMaxOne": "\"{{ accelerator }}\"-tyyppiä voi olla enintään yksi.",
       "CurrentResourceGroup": "Nykyinen resurssiryhmä",
       "CustomAllocation": "Mukautettu jako",
       "CustomResourceApplied": "Mukautettua resurssia sovelletaan",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1526,6 +1526,7 @@
       "Container": "Container",
       "Core": "Cœur",
       "CreatedAt": "Créé à",
+      "CurrentAcceleratorTypeAllowsMaxOne": "Pour le type \"{{ accelerator }}\", vous ne pouvez attribuer qu'un seul exemplaire.",
       "CurrentResourceGroup": "Groupe de ressources actuel",
       "CustomAllocation": "Attribution personnalisée",
       "CustomResourceApplied": "Ressource personnalisée appliquée",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1524,6 +1524,7 @@
       "Container": "Kontainer",
       "Core": "Core",
       "CreatedAt": "DibuatPada",
+      "CurrentAcceleratorTypeAllowsMaxOne": "Tipe \"{{ accelerator }}\" hanya dapat dialokasikan paling banyak 1.",
       "CurrentResourceGroup": "Grup Sumber Daya Saat Ini",
       "CustomAllocation": "Alokasi khusus",
       "CustomResourceApplied": "Sumber daya khusus diterapkan",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1523,6 +1523,7 @@
       "Container": "Contenitore",
       "Core": "Nucleo",
       "CreatedAt": "CreatoAt",
+      "CurrentAcceleratorTypeAllowsMaxOne": "È possibile assegnare al massimo 1 acceleratore di tipo \"{{ accelerator }}\".",
       "CurrentResourceGroup": "Gruppo di risorse attuale",
       "CustomAllocation": "Allocazione personalizzata",
       "CustomResourceApplied": "Viene applicata la risorsa personalizzata",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1525,6 +1525,7 @@
       "Container": "コンテナ",
       "Core": "芯",
       "CreatedAt": "作成日",
+      "CurrentAcceleratorTypeAllowsMaxOne": "\"{{ accelerator }}\"タイプは最大1個までしか割り当てられません。",
       "CurrentResourceGroup": "現在のリソースグループ",
       "CustomAllocation": "カスタム割り当て",
       "CustomResourceApplied": "カスタムリソースが適用されます",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1529,6 +1529,7 @@
       "Container": "컨테이너",
       "Core": "코어",
       "CreatedAt": "생성 시간",
+      "CurrentAcceleratorTypeAllowsMaxOne": "\"{{ accelerator }}\" 타입은 최대 1개까지만 할당할 수 있습니다.",
       "CurrentResourceGroup": "현재 자원 그룹",
       "CustomAllocation": "사용자 설정 자원 할당",
       "CustomResourceApplied": "사용자 설정 자원이 할당됨",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1523,6 +1523,7 @@
       "Container": "Контейнер",
       "Core": "Цөм",
       "CreatedAt": "Үүсгэсэн",
+      "CurrentAcceleratorTypeAllowsMaxOne": "\"{{ accelerator }}\" төрлийг хамгийн ихдээ 1 ширхэгээр л хуваарилж болно.",
       "CurrentResourceGroup": "Одоогийн нөөцийн бүлэг",
       "CustomAllocation": "Захиалгат хуваарилалт",
       "CustomResourceApplied": "Захиалгат нөөцийг ашигладаг",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1525,6 +1525,7 @@
       "Container": "Bekas",
       "Core": "Teras",
       "CreatedAt": "Dicipta Pada",
+      "CurrentAcceleratorTypeAllowsMaxOne": "Jenis \"{{ accelerator }}\" hanya boleh diperuntukkan maksimum 1 sahaja.",
       "CurrentResourceGroup": "Kumpulan Sumber Semasa",
       "CustomAllocation": "Peruntukan khusus",
       "CustomResourceApplied": "Sumber khusus digunakan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1525,6 +1525,7 @@
       "Container": "Pojemnik",
       "Core": "Rdzeń",
       "CreatedAt": "Utworzono o godz",
+      "CurrentAcceleratorTypeAllowsMaxOne": "Można przypisać maksymalnie 1 urządzenie typu \"{{ accelerator }}\".",
       "CurrentResourceGroup": "Bieżąca grupa zasobów",
       "CustomAllocation": "Przydział niestandardowy",
       "CustomResourceApplied": "Zastosowano zasób niestandardowy",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1526,6 +1526,7 @@
       "Container": "Recipiente",
       "Core": "Testemunho",
       "CreatedAt": "Criado em",
+      "CurrentAcceleratorTypeAllowsMaxOne": "É possível alocar no máximo 1 unidade do tipo \"{{ accelerator }}\".",
       "CurrentResourceGroup": "Grupo de Recursos Atual",
       "CustomAllocation": "Alocação personalizada",
       "CustomResourceApplied": "Recurso personalizado é aplicado",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1525,6 +1525,7 @@
       "Container": "Recipiente",
       "Core": "Testemunho",
       "CreatedAt": "Criado em",
+      "CurrentAcceleratorTypeAllowsMaxOne": "Só é possível alocar no máximo 1 \"{{ accelerator }}\".",
       "CurrentResourceGroup": "Grupo de Recursos Atual",
       "CustomAllocation": "Alocação personalizada",
       "CustomResourceApplied": "Recurso personalizado é aplicado",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1525,6 +1525,7 @@
       "Container": "Контейнер",
       "Core": "Ядро",
       "CreatedAt": "Создано в",
+      "CurrentAcceleratorTypeAllowsMaxOne": "Для типа \"{{ accelerator }}\" можно выделить не более одного устройства.",
       "CurrentResourceGroup": "Текущая группа ресурсов",
       "CustomAllocation": "Произвольное распределение",
       "CustomResourceApplied": "Настраиваемый ресурс применен",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1514,6 +1514,7 @@
       "Container": "คอนเทนเนอร์",
       "Core": "คอร์",
       "CreatedAt": "สร้างเมื่อ",
+      "CurrentAcceleratorTypeAllowsMaxOne": "\"{{ accelerator }}\" ประเภทสามารถกำหนดได้สูงสุด 1 ตัวเท่านั้น.",
       "CurrentResourceGroup": "กลุ่มทรัพยากรปัจจุบัน",
       "CustomAllocation": "การจัดสรรแบบกำหนดเอง",
       "CustomResourceApplied": "ใช้ทรัพยากรแบบกำหนดเอง",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1526,6 +1526,7 @@
       "Container": "Konteyner",
       "Core": "çekirdek",
       "CreatedAt": "Oluşturulma Tarihi",
+      "CurrentAcceleratorTypeAllowsMaxOne": "\"{{ accelerator }}\" türünden en fazla 1 adet atanabilir.",
       "CurrentResourceGroup": "Mevcut Kaynak Grubu",
       "CustomAllocation": "Özel tahsis",
       "CustomResourceApplied": "Özel kaynak uygulandı",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1526,6 +1526,7 @@
       "Container": "Thùng đựng hàng",
       "Core": "Cốt lõi",
       "CreatedAt": "Đã tạoTại",
+      "CurrentAcceleratorTypeAllowsMaxOne": "Loại \"{{ accelerator }}\" chỉ được phép gán tối đa 1 thiết bị.",
       "CurrentResourceGroup": "Nhóm tài nguyên hiện tại",
       "CustomAllocation": "Phân bổ tùy chỉnh",
       "CustomResourceApplied": "Tài nguyên tùy chỉnh được áp dụng",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1526,6 +1526,7 @@
       "Container": "容器",
       "Core": "核",
       "CreatedAt": "创建时间",
+      "CurrentAcceleratorTypeAllowsMaxOne": "\"{{ accelerator }}\" 类型最多只能分配 1 个。",
       "CurrentResourceGroup": "当前资源组",
       "CustomAllocation": "自定义分配",
       "CustomResourceApplied": "应用自定义资源",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1524,6 +1524,7 @@
       "Container": "容器",
       "Core": "核",
       "CreatedAt": "創建時間",
+      "CurrentAcceleratorTypeAllowsMaxOne": "\"{{ accelerator }}\" 類型最多只能分配 1 個。",
       "CurrentResourceGroup": "當前資源組",
       "CustomAllocation": "自定義分配",
       "CustomResourceApplied": "應用自定義資源",


### PR DESCRIPTION
Resolves #4066 ([FR-1328](https://lablup.atlassian.net/browse/FR-1328))

# Limit Unique Resource Type Allocation to Maximum of 1

This PR adds a constraint for unique resource types (like TPU) to limit their allocation to a maximum of 1 unit. The implementation:

1. Uses the `useResourceSlots` hook to identify unique resource types
2. Adds validation logic to prevent allocating more than 1 unit of a unique resource type
3. Limits the slider and input controls to a maximum value of 1 for unique resource types
4. Adds appropriate error messages in all supported languages
5. Fixes the CPU utilization display in the Agent Detail Modal by moving the conditional rendering to the correct position

![image.png](https://app.graphite.com/user-attachments/assets/144ef553-599f-47d8-ba46-bd1300bedc99.png)



**Checklist:**

- [x] Documentation
- [ ] Minium required manager version
- [x] Specific setting for review (eg., KB link, endpoint or how to setup): 10.122.12.117
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1328]: https://lablup.atlassian.net/browse/FR-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ