### PR TITLE
feat(FR-1822): add logic to validate CIDR range correctly feat/add-logic-to-validate-CIDR

### DIFF
--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -26,6 +26,7 @@ import {
   theme,
   Checkbox,
   Skeleton,
+  Tag,
 } from 'antd';
 import {
   BAIDomainSelector,
@@ -642,6 +643,15 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
             <Select
               mode="tags"
               tokenSeparators={[',', ' ']}
+              tagRender={(props) => {
+                const isValid =
+                  _.isString(props.label) && isValidIPOrCidr(props.label);
+                return (
+                  <Tag color={!isValid ? 'red' : undefined} {...props}>
+                    {props.label}
+                  </Tag>
+                );
+              }}
               open={false}
               suffixIcon={null}
               placeholder={t('credential.AllowedClientIPPlaceholder')}


### PR DESCRIPTION
resolves #4887 (FR-1822)

This PR enhances the IP address and CIDR range validation functions with more robust implementations:

- Adds strict validation for IPv4 addresses that rejects leading zeros, whitespace, and ensures proper octet ranges
- Implements comprehensive IPv6 validation that handles compression correctly and rejects invalid formats
- Adds CIDR range validation that verifies network addresses have zero host bits
- Includes extensive test coverage for all validation functions

The new validation functions include:

- `isValidIPv4` - Strict IPv4 address validation
- `isValidIPv6` - Strict IPv6 address validation with proper handling of :: compression
- `isValidIP` - Validates both IPv4 and IPv6 addresses
- `isCidrRange` - Validates CIDR notation with proper network address checking
- `isValidIPOrCidr` - Combined validation for both IP addresses and CIDR ranges

![CleanShot 2025-12-24 at 14.00.15@2x.png](https://app.graphite.com/user-attachments/assets/b95ee9b3-95f4-4175-b550-bf166fa26352.png)



**note**

- please run `pnpm test src/helper/index.test.tsx`

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after