### PR TITLE
feat(FR-1823): add required and error boundary to quota setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ e2e/                    # End-to-end tests
 
 ## GitHub Copilot Custom Instructions
 
-This repository includes custom instructions for GitHub Copilot to provide more accurate code reviews and suggestions. These instructions are automatically applied when using GitHub Copilot on github.com, VS Code, and Visual Studio.
+This repository includes custom instructions for GitHub Copilot to provide more accurate code reviews and suggestions. These instructions are automatically applied when using GitHub Copilot on github.com, VS Code, and Visual Studio. When writing new code or refactoring, please make sure to refer to these instructions.
 
 ### Instruction Files
 

--- a/react/src/components/QuotaSettingModal.tsx
+++ b/react/src/components/QuotaSettingModal.tsx
@@ -61,31 +61,36 @@ const QuotaSettingModal: React.FC<Props> = ({
     `);
 
   const _onOk = () => {
-    formRef.current?.validateFields().then((values) => {
-      commitSetQuotaScope({
-        variables: {
-          quota_scope_id: quotaScope?.quota_scope_id || '',
-          storage_host_name: quotaScope?.storage_host_name || '',
-          props: {
-            hard_limit_bytes: GBToBytes(values?.hard_limit_bytes),
+    formRef.current
+      ?.validateFields()
+      .then((values) => {
+        commitSetQuotaScope({
+          variables: {
+            quota_scope_id: quotaScope?.quota_scope_id || '',
+            storage_host_name: quotaScope?.storage_host_name || '',
+            props: {
+              hard_limit_bytes: GBToBytes(values?.hard_limit_bytes),
+            },
           },
-        },
-        onCompleted(response) {
-          if (response?.set_quota_scope?.quota_scope?.id) {
-            message.success(
-              t('storageHost.quotaSettings.QuotaScopeSuccessfullyUpdated'),
-            );
-          } else {
-            message.error(t('dialog.ErrorOccurred'));
-          }
-          onRequestClose();
-        },
-        onError(error) {
-          logger.error(error);
-          message.error(error?.message);
-        },
+          onCompleted(response) {
+            if (response?.set_quota_scope?.quota_scope?.id) {
+              message.success(
+                t('storageHost.quotaSettings.QuotaScopeSuccessfullyUpdated'),
+              );
+            } else {
+              message.error(t('dialog.ErrorOccurred'));
+            }
+            onRequestClose();
+          },
+          onError(error) {
+            logger.error(error);
+            message.error(error?.message);
+          },
+        });
+      })
+      .catch((error) => {
+        logger.error(error);
       });
-    });
   };
 
   return (
@@ -104,11 +109,13 @@ const QuotaSettingModal: React.FC<Props> = ({
         wrapperCol={{ span: 20 }}
         validateTrigger={['onChange', 'onBlur']}
         style={{ marginBottom: 40, marginTop: 20 }}
+        requiredMark={false}
       >
         <Form.Item
           name="hard_limit_bytes"
           label={t('storageHost.HardLimit')}
           initialValue={bytesToGB(quotaScope?.details?.hard_limit_bytes)}
+          required
           rules={[
             {
               pattern: /^\d+(\.\d+)?$/,

--- a/react/src/components/StorageHostSettingsPanel.tsx
+++ b/react/src/components/StorageHostSettingsPanel.tsx
@@ -108,8 +108,8 @@ const StorageHostSettingsPanel: React.FC<StorageHostSettingsPanelProps> = ({
         <BAIFlex justify="between">
           {currentSettingType === 'project' ? (
             <BAIFlex style={{ marginBottom: 10 }}>
-              <Form layout="inline">
-                <Form.Item label={t('resourceGroup.Domain')}>
+              <Form layout="inline" requiredMark={false}>
+                <Form.Item label={t('resourceGroup.Domain')} required>
                   <BAIDomainSelector
                     style={{ width: '20vw', marginRight: 10 }}
                     value={selectedDomainName}
@@ -121,7 +121,7 @@ const StorageHostSettingsPanel: React.FC<StorageHostSettingsPanelProps> = ({
                     }}
                   />
                 </Form.Item>
-                <Form.Item label={t('webui.menu.Project')}>
+                <Form.Item label={t('webui.menu.Project')} required>
                   <ProjectSelectForAdminPage
                     value={selectedProjectId}
                     disabled={!selectedDomainName}
@@ -137,7 +137,7 @@ const StorageHostSettingsPanel: React.FC<StorageHostSettingsPanelProps> = ({
             </BAIFlex>
           ) : (
             <Form layout="inline">
-              <Form.Item label={t('data.User')}>
+              <Form.Item label={t('data.User')} required>
                 <UserSelector
                   style={{ width: '30vw', marginBottom: 10 }}
                   value={selectedUserEmail}

--- a/react/src/pages/StorageHostSettingPage.tsx
+++ b/react/src/pages/StorageHostSettingPage.tsx
@@ -2,12 +2,13 @@ import { StorageHostSettingPageQuery } from '../__generated__/StorageHostSetting
 import StorageHostResourcePanel from '../components/StorageHostResourcePanel';
 import StorageHostSettingsPanel from '../components/StorageHostSettingsPanel';
 import { useWebUINavigate } from '../hooks';
-import { Breadcrumb, Card, Empty, Typography } from 'antd';
+import { Breadcrumb, Card, Empty, Skeleton, Typography } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useParams } from 'react-router-dom';
+import ErrorBoundaryWithNullFallback from 'src/components/ErrorBoundaryWithNullFallback';
 
 interface StorageHostSettingPageProps {
   // storageHostId: string;
@@ -59,11 +60,13 @@ const StorageHostSettingPage: React.FC<StorageHostSettingPageProps> = () => {
       </Typography.Title>
       <StorageHostResourcePanel storageVolumeFrgmt={storage_volume || null} />
       {isQuotaSupportedStorage ? (
-        <Suspense fallback={<div>loading...</div>}>
-          <StorageHostSettingsPanel
-            storageVolumeFrgmt={storage_volume || null}
-          />
-        </Suspense>
+        <ErrorBoundaryWithNullFallback>
+          <Suspense fallback={<Skeleton active />}>
+            <StorageHostSettingsPanel
+              storageVolumeFrgmt={storage_volume || null}
+            />
+          </Suspense>
+        </ErrorBoundaryWithNullFallback>
       ) : (
         <Card title={t('storageHost.QuotaSettings')}>
           <Empty


### PR DESCRIPTION
# Add required attribute to form fields in storage host settings

This PR adds the `required` attribute to form fields in the storage host settings UI to clearly indicate which fields are mandatory:

- Added `required` to the hard limit bytes field in `QuotaSettingModal`
- Added `required` to domain, project, and user selectors in `StorageHostSettingsPanel`
- Improved loading state by replacing the generic "loading..." text with a proper `Skeleton` component
- Added error boundary around the storage host settings panel for better error handling

**AFTER**

![image.png](https://app.graphite.com/user-attachments/assets/1447c49f-0b49-4c87-b3f9-dc92944c1006.png)



![image.png](https://app.graphite.com/user-attachments/assets/cb0294a7-c6d5-4b3c-8809-245f074971d6.png)

![image.png](https://app.graphite.com/user-attachments/assets/61f94123-e9d8-4ec3-81e4-3e6c465878ce.png)

![image.png](https://app.graphite.com/user-attachments/assets/63a86132-9cf0-479d-ae2b-dde266c24cc7.png)



**BEFORE**

![image.png](https://app.graphite.com/user-attachments/assets/26ace851-9d55-475c-9565-9403201d1fa6.png)



![image.png](https://app.graphite.com/user-attachments/assets/74b0f268-a147-40f3-a76b-3d05b1f3bcc7.png)

![image.png](https://app.graphite.com/user-attachments/assets/ffb9c5e0-3e7e-4087-a989-be6cc89aa203.png)

![image.png](https://app.graphite.com/user-attachments/assets/4afbc174-6414-4674-8215-0f5bfe501021.png)



**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after