### PR TITLE
chore: update version index to v25.19.0-alpha.0

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend.ai-webui",
   "productName": "Backend.AI Desktop",
-  "version": "25.18.0-alpha.0",
+  "version": "25.19.0-alpha.0",
   "repository": "https://github.com/lablup/backend.ai-webui.git",
   "author": "Lablup Inc. <contact@lablup.com>",
   "license": "LGPL-3.0-or-later",

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
     }
     globalThis.enableSW = true;
 
-    globalThis.packageVersion = "25.18.0-alpha.0";
-    globalThis.buildNumber = "7104";
+    globalThis.packageVersion = "25.19.0-alpha.0";
+    globalThis.buildNumber = "7184";
     globalThis.litNonce = "{{nonce}}";
     globalThis.baiNonce = "{{nonce}}";
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": 9,
   "name": "Backend.AI Web UI",
   "short_name": "BackendAIWebUI",
-  "version": "25.18.0-alpha.0",
+  "version": "25.19.0-alpha.0",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#fff",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backend.ai-webui",
   "productName": "Backend.AI Desktop",
-  "version": "25.18.0-alpha.0",
+  "version": "25.19.0-alpha.0",
   "repository": "https://github.com/lablup/backend.ai-webui.git",
   "author": "Lablup Inc. <contact@lablup.com>",
   "license": "LGPL-3.0-or-later",

--- a/packages/backend.ai-ui/package.json
+++ b/packages/backend.ai-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend.ai-ui",
-  "version": "25.18.0-alpha.0",
+  "version": "25.19.0-alpha.0",
   "description": "React components for Backend.AI",
   "repository": {
     "type": "git",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-ai-webui-react",
-  "version": "25.18.0-alpha.0",
+  "version": "25.19.0-alpha.0",
   "private": true,
   "dependencies": {
     "@ai-sdk/openai": "^2.0.69",

--- a/version.json
+++ b/version.json
@@ -1,1 +1,1 @@
-{ "package": "25.18.0-alpha.0", "buildNumber": "7104", "buildDate": "251125.141101", "revision": "c3134428e" }
+{ "package": "25.19.0-alpha.0", "buildNumber": "7184", "buildDate": "251224.161227", "revision": "b341eeced" }


### PR DESCRIPTION
# Bump version to 25.19.0-alpha.0

Updates the version number from 25.18.0-alpha.0 to 25.19.0-alpha.0.