### PR TITLE
style(FR-1825): fix BAIPropertyFilter tooltip text color to white

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
@@ -345,7 +345,7 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
         <Tooltip
           title={isValid || !isFocused ? '' : selectedProperty.rule?.message}
           open={!isValid && isFocused}
-          color={token.colorError}
+          color="red"
         >
           <AutoComplete
             ref={autoCompleteRef}


### PR DESCRIPTION
# Change tooltip color from token.colorError to red in BAIPropertyFilter

This PR changes the tooltip color in the BAIPropertyFilter component from using the dynamic token.colorError to a static "red" color value. This ensures consistent error indication regardless of the current theme token configuration.

**After**

Light mode:

![image.png](https://app.graphite.com/user-attachments/assets/979241e5-876c-4573-81d2-cb56187558f7.png)



Dark mode:

![image.png](https://app.graphite.com/user-attachments/assets/721404b5-2df9-4476-a1f9-fbe8524c0513.png)



**Before**

Light mode:

![image.png](https://app.graphite.com/user-attachments/assets/e219135a-8a5d-477c-93e5-ec164a59ad11.png)



Dark mode:

![image.png](https://app.graphite.com/user-attachments/assets/6852ef6e-3ebb-4789-91cd-b6bce5d04df0.png)



**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after