### PR TITLE
fix(FR-1831): fix checkbox label not toggling on click in AppLauncherModal

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
@@ -286,8 +286,9 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
                   <Checkbox
                     value={openToPublic}
                     onChange={(value) => setOpenToPublic(value.target.checked)}
-                  />
-                  {t('session.OpenToPublic')}
+                  >
+                    {t('session.OpenToPublic')}
+                  </Checkbox>
                 </BAIFlex>
               }
             >
@@ -311,8 +312,9 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
                     onChange={(value) =>
                       setTryPreferredPort(value.target.checked)
                     }
-                  />
-                  {t('session.TryPreferredPort')}
+                  >
+                    {t('session.TryPreferredPort')}
+                  </Checkbox>
                 </BAIFlex>
               }
               rules={[
@@ -346,8 +348,9 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
                       onChange={(value) =>
                         setUseSubDomain(value.target.checked)
                       }
-                    />
-                    {t('session.UseSubdomain')}
+                    >
+                      {t('session.UseSubdomain')}
+                    </Checkbox>
                   </BAIFlex>
                 }
               >


### PR DESCRIPTION
Resolves #1916 ([FR-1831](https://lablup.atlassian.net/browse/FR-1831))

## Summary
- Fixed checkbox labels in AppLauncherModal not toggling when clicked
- Moved label text from outside to inside Checkbox components as children
- Affected checkboxes: "Open to Public", "Try Preferred Port", "Use Subdomain"

## Test plan
- [ ] Open App Launcher modal from a running session
- [ ] Click on checkbox labels (not just the checkbox itself)
- [ ] Verify checkboxes toggle correctly when label is clicked

[FR-1831]: https://lablup.atlassian.net/browse/FR-1831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ