### PR TITLE
fix(FR-1841): update Alert's deprecated props - message -> title

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/DeleteSelectedItemsModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/DeleteSelectedItemsModal.tsx
@@ -93,10 +93,7 @@ const DeleteSelectedItemsModal: React.FC<DeleteSelectedItemsModalProps> = ({
       }
       content={
         <BAIFlex align="stretch" direction="column" gap="md">
-          <Alert
-            type="warning"
-            message={t('general.modal.DeleteForeverDesc')}
-          />
+          <Alert type="warning" title={t('general.modal.DeleteForeverDesc')} />
           {selectedFiles.length > 1 ? (
             <BAIFlex gap="sm" direction="column" align="stretch">
               <Typography.Text strong>

--- a/packages/backend.ai-ui/src/components/fragments/BAIDeleteArtifactRevisionsModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeleteArtifactRevisionsModal.tsx
@@ -179,7 +179,7 @@ const BAIDeleteArtifactRevisionsModal = ({
                 </Tooltip>
               }
               showIcon
-              message={t('comp:BAIDeleteArtifactModal.ExcludedVersions', {
+              title={t('comp:BAIDeleteArtifactModal.ExcludedVersions', {
                 count:
                   selectedArtifactRevision.length -
                   filteredSelectedRevisions.length,

--- a/packages/backend.ai-ui/src/components/fragments/BAIImportArtifactModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIImportArtifactModal.tsx
@@ -210,7 +210,7 @@ const BAIImportArtifactModal = ({
                 </Tooltip>
               }
               showIcon
-              message={t('comp:BAIImportArtifactModal.ExcludedVersions', {
+              title={t('comp:BAIImportArtifactModal.ExcludedVersions', {
                 count:
                   selectedArtifactRevision.length -
                   filteredSelectedRevisions.length,

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectBulkEditModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectBulkEditModal.tsx
@@ -82,7 +82,7 @@ const BAIProjectBulkEditModal = ({
           type="info"
           showIcon
           ghostInfoBg={false}
-          message={t(
+          title={t(
             'comp:BAIProjectBulkEditModal.FollowingFoldersWillBeUpdated',
           )}
           description={

--- a/packages/backend.ai-ui/src/components/fragments/BAIPullingArtifactRevisionAlert.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIPullingArtifactRevisionAlert.tsx
@@ -49,7 +49,7 @@ const BAIPullingArtifactRevisionAlert = ({
     <Alert
       type="info"
       showIcon
-      message={t('comp:BAIPullingArtifactRevisionAlert.VersionIsPullingNow', {
+      title={t('comp:BAIPullingArtifactRevisionAlert.VersionIsPullingNow', {
         version: pullingArtifactRevision.version,
       })}
       action={

--- a/react/src/components/AllocationHistory.tsx
+++ b/react/src/components/AllocationHistory.tsx
@@ -33,7 +33,7 @@ const AllocationHistory: React.FC = () => {
 
   return (
     <BAIFlex direction="column" align="stretch" gap={'md'}>
-      <Alert showIcon message={t('statistics.UsageHistoryNote')} type="info" />
+      <Alert showIcon title={t('statistics.UsageHistoryNote')} type="info" />
       <BAIFlex gap={'sm'} justify="between">
         <Form.Item
           label={t('statistics.SelectPeriod')}

--- a/react/src/components/BAIErrorBoundary.tsx
+++ b/react/src/components/BAIErrorBoundary.tsx
@@ -87,7 +87,7 @@ const BAIErrorBoundary: React.FC<BAIErrorBoundaryProps> = ({
                             <Typography.Text>{error.message}</Typography.Text>
                           </BAIFlex>
                         }
-                        message={t('errorBoundary.DisplayOnlyDevEnv')}
+                        title={t('errorBoundary.DisplayOnlyDevEnv')}
                       />
                     </BAIFlex>
                   )}

--- a/react/src/components/BAIJSONViewerModal.tsx
+++ b/react/src/components/BAIJSONViewerModal.tsx
@@ -44,7 +44,7 @@ const BAIJSONViewerModal: React.FC<BAIJSONViewerModalProps> = ({
         {hasError && (
           <Alert
             type="warning"
-            message={t('general.InvalidJSONFormat')}
+            title={t('general.InvalidJSONFormat')}
             showIcon
           />
         )}

--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -481,7 +481,7 @@ const PureChatCard: React.FC<ChatCardProps> = ({
       )}
       {!_.isEmpty(error?.message) ? (
         <Alert
-          message={error?.message}
+          title={error?.message}
           type="error"
           showIcon
           className={alertStyle}
@@ -490,7 +490,7 @@ const PureChatCard: React.FC<ChatCardProps> = ({
       ) : null}
       {!baseURL ? (
         <Alert
-          message={t('error.InvalidBaseURL')}
+          title={t('error.InvalidBaseURL')}
           type="error"
           showIcon
           className={alertStyle}

--- a/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
@@ -90,12 +90,12 @@ const SFTPConnectionInfoModal: React.FC<SFTPConnectionInfoModalProps> = ({
         <Alert
           showIcon
           type="info"
-          message={<Trans i18nKey="session.SFTPDescription" />}
+          title={<Trans i18nKey="session.SFTPDescription" />}
         />
         <Alert
           showIcon
           type="warning"
-          message={
+          title={
             <>
               <Trans i18nKey="session.SFTPExtraNotification" />
               &nbsp;{t('session.SFTPSessionManagementDesc')}

--- a/react/src/components/ConfigurationsSettingList.tsx
+++ b/react/src/components/ConfigurationsSettingList.tsx
@@ -191,11 +191,7 @@ const ConfigurationsSettingList = () => {
       'data-testid': 'settings-plugins',
       title: t('settings.Plugins'),
       description: (
-        <Alert
-          message={t('settings.NoteAboutFixedSetup')}
-          type="info"
-          showIcon
-        />
+        <Alert title={t('settings.NoteAboutFixedSetup')} type="info" showIcon />
       ),
       settingItems: [
         {
@@ -234,11 +230,7 @@ const ConfigurationsSettingList = () => {
       'data-testid': 'settings-enterprise',
       title: t('settings.EnterpriseFeatures'),
       description: (
-        <Alert
-          message={t('settings.NoteAboutFixedSetup')}
-          type="info"
-          showIcon
-        />
+        <Alert title={t('settings.NoteAboutFixedSetup')} type="info" showIcon />
       ),
       settingItems: [
         {

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -518,7 +518,7 @@ const CustomizedImageList: React.FC = () => {
         <Alert
           type="warning"
           showIcon
-          message={t('dialog.warning.CannotBeUndone')}
+          title={t('dialog.warning.CannotBeUndone')}
         />
         {imageToDelete !== null && (
           <ul

--- a/react/src/components/DeleteVFolderModal.tsx
+++ b/react/src/components/DeleteVFolderModal.tsx
@@ -104,7 +104,7 @@ const DeleteVFolderModal: React.FC<DeleteVFolderModalProps> = ({
             <BAIAlert
               showIcon
               ghostInfoBg={false}
-              message={t('data.folders.ExcludedFolders', {
+              title={t('data.folders.ExcludedFolders', {
                 count: foldersByPermission.undeletable?.length || 0,
               })}
               description={

--- a/react/src/components/ErrorLogList.tsx
+++ b/react/src/components/ErrorLogList.tsx
@@ -324,7 +324,7 @@ const ErrorLogList: React.FC<{
         cancelText={t('button.Cancel')}
         onCancel={() => setIsOpenClearLogsModal(false)}
       >
-        <Alert message={t('dialog.warning.CannotBeUndone')} type="warning" />
+        <Alert title={t('dialog.warning.CannotBeUndone')} type="warning" />
       </BAIModal>
       <BAIUnmountAfterClose>
         <TableColumnsSettingModal

--- a/react/src/components/FolderExplorerModal.tsx
+++ b/react/src/components/FolderExplorerModal.tsx
@@ -144,10 +144,7 @@ const FolderExplorerModal: React.FC<FolderExplorerProps> = ({
   const hasNoPermissions = false;
 
   const fileExplorerElement = vfolder_node?.unmanaged_path ? (
-    <Alert
-      message={t('explorer.NoExplorerSupportForUnmanagedFolder')}
-      showIcon
-    />
+    <Alert title={t('explorer.NoExplorerSupportForUnmanagedFolder')} showIcon />
   ) : !hasNoPermissions && vfolder_node ? (
     <BAIFileExplorer
       ref={fileExplorerRef}
@@ -257,19 +254,19 @@ const FolderExplorerModal: React.FC<FolderExplorerProps> = ({
           <BAIFlex direction="column" gap={'lg'} align="stretch">
             {!vfolder_node ? (
               <Alert
-                message={t('explorer.FolderNotFoundOrNoAccess')}
+                title={t('explorer.FolderNotFoundOrNoAccess')}
                 type="error"
                 showIcon
               />
             ) : hasNoPermissions ? (
               <Alert
-                message={t('explorer.NoPermissions')}
+                title={t('explorer.NoPermissions')}
                 type="error"
                 showIcon
               />
             ) : currentProject?.id !== vfolder_node?.group &&
               !!vfolder_node?.group ? (
-              <Alert message={t('data.NotInProject')} type="warning" showIcon />
+              <Alert title={t('data.NotInProject')} type="warning" showIcon />
             ) : null}
 
             {xl ? (
@@ -277,7 +274,7 @@ const FolderExplorerModal: React.FC<FolderExplorerProps> = ({
                 style={{
                   gap: token.size,
                 }}
-                layout={'horizontal'}
+                orientation={'horizontal'}
               >
                 <Splitter.Panel resizable={false}>
                   {fileExplorerElement}

--- a/react/src/components/GeneratedKeypairListModal.tsx
+++ b/react/src/components/GeneratedKeypairListModal.tsx
@@ -81,12 +81,12 @@ const GeneratedKeypairListModal: React.FC<GeneratedKeypairListModalProps> = ({
         <Alert
           showIcon
           type="success"
-          message={t('credential.GeneratedKeypairSuccess')}
+          title={t('credential.GeneratedKeypairSuccess')}
         />
         <Alert
           showIcon
           type="warning"
-          message={t('credential.GeneratedKeypairWarning')}
+          title={t('credential.GeneratedKeypairWarning')}
         />
         <BAIText>{t('credential.GeneratedKeypairInfo')}</BAIText>
         <BAITable<KeypairType>

--- a/react/src/components/ModelCardModal.tsx
+++ b/react/src/components/ModelCardModal.tsx
@@ -182,7 +182,7 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
                 gap={'sm'}
               >
                 <Alert
-                  message={model_card?.error_msg}
+                  title={model_card?.error_msg}
                   type="error"
                   showIcon
                   style={{ width: '100%' }}

--- a/react/src/components/ModelCloneModal.tsx
+++ b/react/src/components/ModelCloneModal.tsx
@@ -147,7 +147,7 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
       }}
     >
       <BAIFlex direction="column" align="stretch" gap="sm">
-        <Alert showIcon type="info" message={t('modelStore.CloneInfo')} />
+        <Alert showIcon type="info" title={t('modelStore.CloneInfo')} />
         <Form
           ref={formRef}
           layout="vertical"
@@ -161,7 +161,6 @@ const ModelCloneModal: React.FC<ModelCloneModalProps> = ({
           }}
           scrollToFirstError
         >
-          {/*  */}
           <Form.Item label={t('data.ExistingFolderName')} required>
             <Input value={vfolder?.name || ''} disabled />
           </Form.Item>

--- a/react/src/components/NetworkStatusBanner.tsx
+++ b/react/src/components/NetworkStatusBanner.tsx
@@ -59,7 +59,7 @@ const NetworkStatusBanner = () => {
     <>
       {shouldOpenOfflineAlert && (
         <Alert
-          message={t('webui.YouAreOffline')}
+          title={t('webui.YouAreOffline')}
           className={styles.borderError}
           type="error"
           banner
@@ -67,7 +67,7 @@ const NetworkStatusBanner = () => {
       )}
       {shouldOpenSoftAlert && (
         <Alert
-          message={t('webui.NetworkSoftTimeout')}
+          title={t('webui.NetworkSoftTimeout')}
           className={styles.borderWarning}
           banner
           closable

--- a/react/src/components/NoResourceGroupAlert.tsx
+++ b/react/src/components/NoResourceGroupAlert.tsx
@@ -12,7 +12,7 @@ const NoResourceGroupAlert: React.FC<NoResourceGroupAlertProps> = (props) => {
 
   return _.isEmpty(currentResourceGroup) ? (
     <BAIAlert
-      message={t('resourceGroup.NoScalingGroupAssignedToThisProject')}
+      title={t('resourceGroup.NoScalingGroupAssignedToThisProject')}
       showIcon
       {...props}
     />

--- a/react/src/components/PasswordChangeRequestAlert.tsx
+++ b/react/src/components/PasswordChangeRequestAlert.tsx
@@ -26,7 +26,7 @@ const PasswordChangeRequestAlert: React.FC<Props> = ({ ...alertProps }) => {
       <BAIAlert
         banner
         type="warning"
-        message={t('webui.menu.PleaseChangeYourPassword')}
+        title={t('webui.menu.PleaseChangeYourPassword')}
         description={t('webui.menu.PasswordChangePlace')}
         {...alertProps}
       />

--- a/react/src/components/ProjectResourcePolicySettingModal.tsx
+++ b/react/src/components/ProjectResourcePolicySettingModal.tsx
@@ -213,7 +213,7 @@ const ProjectResourcePolicySettingModal: React.FC<Props> = ({
       {...baiModalProps}
     >
       <Alert
-        message={t('storageHost.BeCarefulToSetProjectResourcePolicy')}
+        title={t('storageHost.BeCarefulToSetProjectResourcePolicy')}
         type="warning"
         showIcon
         style={{ marginBottom: token.marginMD }}

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -337,7 +337,7 @@ const ResourceGroupList: React.FC = () => {
           >
             <Alert
               type="warning"
-              message={t('dialog.warning.DeleteForeverDesc')}
+              title={t('dialog.warning.DeleteForeverDesc')}
               style={{ width: '100%' }}
             />
             <BAIFlex>

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -859,7 +859,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
               (vf) => vf?.name && !vf?.name.startsWith('.'),
             ).length > 0 && (
               <Alert
-                message={t('modelService.ExtraMountsWarning')}
+                title={t('modelService.ExtraMountsWarning')}
                 type="warning"
                 showIcon
                 style={{ marginBottom: token.marginMD }}

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -200,18 +200,18 @@ const SessionDetailContent: React.FC<{
   return session ? (
     <BAIFlex direction="column" gap={'lg'} align="stretch">
       {resolvedProjectIdOfSession !== currentProject.id && (
-        <Alert message={t('session.NotInProject')} type="warning" showIcon />
+        <Alert title={t('session.NotInProject')} type="warning" showIcon />
       )}
       {currentUser.uuid !== session?.user_id && (
         <Alert
-          message={t('session.AnotherUserSession')}
+          title={t('session.AnotherUserSession')}
           type="warning"
           showIcon
         />
       )}
       {imminentExpirationTime && imminentExpirationTime < 3600 && (
         <Alert
-          message={t('session.IdleCheckExpirationWarning')}
+          title={t('session.IdleCheckExpirationWarning')}
           type="warning"
           showIcon
         />
@@ -427,7 +427,7 @@ const SessionDetailContent: React.FC<{
   ) : (
     <Alert
       showIcon
-      message={t('session.SessionNotFound')}
+      title={t('session.SessionNotFound')}
       type="error"
       description={id}
     ></Alert>

--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -431,7 +431,7 @@ const SessionLauncherPreview: React.FC<{
             <Alert
               type="warning"
               showIcon
-              message={t('session.launcher.EnqueueComputeSessionWarning')}
+              title={t('session.launcher.EnqueueComputeSessionWarning')}
             />
           )}
 
@@ -586,7 +586,7 @@ const SessionLauncherPreview: React.FC<{
             <Alert
               type="warning"
               showIcon
-              message={t('session.launcher.NoFolderMounted')}
+              title={t('session.launcher.NoFolderMounted')}
             />
           )}
           {form.getFieldValue('autoMountedFolderNames')?.length > 0 ? (

--- a/react/src/components/SettingItem.tsx
+++ b/react/src/components/SettingItem.tsx
@@ -216,7 +216,7 @@ const SettingItem: React.FC<SettingItemProps> = ({
       >
         <Alert
           showIcon
-          message={t('dialog.warning.CannotBeUndone')}
+          title={t('dialog.warning.CannotBeUndone')}
           type="warning"
         />
       </BAIModal>

--- a/react/src/components/SettingList.tsx
+++ b/react/src/components/SettingList.tsx
@@ -290,7 +290,7 @@ const SettingList: React.FC<SettingPageProps> = ({
       >
         <Alert
           showIcon
-          message={t('dialog.warning.CannotBeUndone')}
+          title={t('dialog.warning.CannotBeUndone')}
           type="warning"
         />
       </BAIModal>

--- a/react/src/components/SharedFolderPermissionInfoModal.tsx
+++ b/react/src/components/SharedFolderPermissionInfoModal.tsx
@@ -78,7 +78,7 @@ const SharedFolderPermissionInfoModal: React.FC<
         <Alert
           showIcon
           type="info"
-          message={
+          title={
             vfolder?.ownership_type === 'user'
               ? t('data.folders.SharedFolderAlertDesc')
               : t('data.folders.ProjectFolderAlertDesc')

--- a/react/src/components/SignoutModal.tsx
+++ b/react/src/components/SignoutModal.tsx
@@ -77,7 +77,7 @@ const SignoutModal: React.FC<SignoutModalProps> = ({
           disabled={signoutMutation.isPending}
         >
           <Form.Item name="alert">
-            <Alert message={t('login.DescConfirmLeave')} type="warning" />
+            <Alert title={t('login.DescConfirmLeave')} type="warning" />
           </Form.Item>
           <Form.Item
             name="email"

--- a/react/src/components/ThemePreviewModeAlert.tsx
+++ b/react/src/components/ThemePreviewModeAlert.tsx
@@ -11,7 +11,7 @@ const ThemePreviewModeAlert: React.FC<ThemePreviewModeAlertProps> = () => {
   });
 
   return isThemePreviewMode ? (
-    <BAIAlert showIcon type="warning" message={t('theme.PreviewModeAlert')} />
+    <BAIAlert showIcon type="warning" title={t('theme.PreviewModeAlert')} />
   ) : null;
 };
 

--- a/react/src/components/UserResourcePolicySettingModal.tsx
+++ b/react/src/components/UserResourcePolicySettingModal.tsx
@@ -208,7 +208,7 @@ const UserResourcePolicySettingModal: React.FC<Props> = ({
       {...baiModalProps}
     >
       <Alert
-        message={t('storageHost.BeCarefulToSetUserResourcePolicy')}
+        title={t('storageHost.BeCarefulToSetUserResourcePolicy')}
         type="warning"
         showIcon
         style={{ marginBottom: token.marginMD }}

--- a/react/src/components/UserSessionsMetrics.tsx
+++ b/react/src/components/UserSessionsMetrics.tsx
@@ -253,7 +253,7 @@ const UserSessionsMetrics: React.FC<UserSessionsMetricsProps> = () => {
       {dayDiff > 30 && (
         <Alert
           showIcon
-          message={t('statistics.prometheus.DataMissingInLowUsageDesc')}
+          title={t('statistics.prometheus.DataMissingInLowUsageDesc')}
         />
       )}
       {_.isEmpty(sortedMetricMetadata) ? (

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -493,7 +493,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
           >
             <Alert
               type="warning"
-              message={t('dialog.warning.DeleteForeverDesc')}
+              title={t('dialog.warning.DeleteForeverDesc')}
               style={{ width: '100%' }}
             />
             <BAIFlex>

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -550,7 +550,7 @@ const ComputeSessionListPage = () => {
             <Alert
               type="error"
               showIcon
-              message={t('error.FailedToLoadTableData')}
+              title={t('error.FailedToLoadTableData')}
             />
           )}
         </BAIFlex>

--- a/react/src/pages/ModelStoreListPage.tsx
+++ b/react/src/pages/ModelStoreListPage.tsx
@@ -331,7 +331,7 @@ const ModelStoreListPage: React.FC = () => {
                   {item?.error_msg && (
                     <Alert
                       style={{ width: '100%' }}
-                      message={
+                      title={
                         <Typography.Paragraph
                           ellipsis={{ rows: 6 }}
                           style={{ marginBottom: 0 }}


### PR DESCRIPTION
Resolves #4906 ([FR-1841](https://lablup.atlassian.net/browse/FR-1841))


# Update Alert component usage to use `title` prop instead of `message`

This PR updates all instances of the Alert component to use the `title` prop instead of the deprecated `message` prop. This change ensures consistency with the latest Ant Design guidelines and improves component usage across the application.

The change affects multiple components including:

- DeleteSelectedItemsModal
- BAIDeleteArtifactRevisionsModal
- BAIImportArtifactModal
- BAIPullingArtifactRevisionAlert
- AllocationHistory
- BAIErrorBoundary
- ChatCard
- SFTPConnectionInfoModal
- ConfigurationsSettingList
- And many others

**Checklist:**

- [x] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1841]: https://lablup.atlassian.net/browse/FR-1841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ