### PR TITLE
style(FR-1842): changing the tag colors for Ceph storage in dark mode.

### DIFF
--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -31,11 +31,11 @@ const backendType = {
     icon: <Server />,
   },
   ceph: {
-    color: 'lightblue',
+    color: 'geekblue',
     icon: <BAICephIcon />,
   },
   cephfs: {
-    color: 'lightblue',
+    color: 'geekblue',
     icon: <BAICephIcon />,
   },
   vfs: {


### PR DESCRIPTION
Resolves #4908 ([FR-1842](https://lablup.atlassian.net/browse/FR-1842))

# Change Ceph and CephFS backend type color from lightblue to geekblue

This PR changes the color used for Ceph and CephFS backend types in the StorageProxyList component from 'lightblue' to 'geekblue' for better visual consistency.



After: ![image.png](https://app.graphite.com/user-attachments/assets/84e7f609-ddac-4cc7-8ecf-67861fd31e2a.png)

Before: ![image.png](https://app.graphite.com/user-attachments/assets/6befcfeb-946e-40a7-a8ca-6b3e74e9f339.png)



**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1842]: https://lablup.atlassian.net/browse/FR-1842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ