### PR TITLE
fix(FR-1845): Set the `showResetButton` option for configuration items where the reset button is not functioning correctly

### DIFF
--- a/react/src/components/ConfigurationsSettingList.tsx
+++ b/react/src/components/ConfigurationsSettingList.tsx
@@ -174,6 +174,7 @@ const ConfigurationsSettingList = () => {
               {t('settings.Config')}
             </Button>
           ),
+          showResetButton: false,
         },
         {
           type: 'custom',
@@ -184,6 +185,7 @@ const ConfigurationsSettingList = () => {
               {t('settings.Config')}
             </Button>
           ),
+          showResetButton: false,
         },
       ],
     },


### PR DESCRIPTION
Resolves #4910 ([FR-1845](https://lablup.atlassian.net/browse/FR-1845))

# Disable reset buttons for configuration settings

This PR disables the reset buttons for configuration settings by adding `showResetButton: false` to the configuration button components in the `ConfigurationsSettingList`.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1845]: https://lablup.atlassian.net/browse/FR-1845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ