### PR TITLE
fix(FR-1837): The messages suddenly disappear after changing the user information

### DIFF
--- a/react/src/components/UserDropdownMenu.tsx
+++ b/react/src/components/UserDropdownMenu.tsx
@@ -45,6 +45,7 @@ const UserDropdownMenu: React.FC<{
   buttonRender?: (defaultButton: React.ReactNode) => React.ReactNode;
   style?: CSSProperties;
 }> = ({ buttonRender = (btn) => btn, style }) => {
+  'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const [userInfo] = useCurrentUserInfo();
@@ -195,8 +196,10 @@ const UserDropdownMenu: React.FC<{
       <Dropdown
         menu={{ items }}
         trigger={['click']}
-        overlayStyle={{
-          maxWidth: 300,
+        styles={{
+          root: {
+            maxWidth: 300,
+          },
         }}
         placement="bottomRight"
       >
@@ -214,7 +217,6 @@ const UserDropdownMenu: React.FC<{
               fontSize: token.fontSizeLG,
               ...style,
             }}
-            // icon={<UserOutlined />}
             icon={
               <Avatar
                 size={17}
@@ -224,7 +226,6 @@ const UserDropdownMenu: React.FC<{
                   />
                 }
                 style={{
-                  // border: 1,
                   backgroundColor: token.colorBgBase,
                 }}
               ></Avatar>

--- a/react/src/components/UserProfileSettingModal.tsx
+++ b/react/src/components/UserProfileSettingModal.tsx
@@ -11,16 +11,7 @@ import TOTPActivateModal from './TOTPActivateModal';
 import { UserProfileQuery } from './UserProfileSettingModalQuery';
 import { ExclamationCircleFilled, LoadingOutlined } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import {
-  Modal,
-  ModalProps,
-  Input,
-  Form,
-  message,
-  Switch,
-  Spin,
-  FormInstance,
-} from 'antd';
+import { ModalProps, Input, Form, Switch, Spin, FormInstance, App } from 'antd';
 import { BAIModal, useErrorMessageResolver } from 'backend.ai-ui';
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -52,8 +43,7 @@ const UserProfileSettingModal: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
   const formRef = useRef<FormInstance<UserProfileFormValues>>(null);
-  const [messageApi, contextHolder] = message.useMessage();
-  const [modal, modalContextHolder] = Modal.useModal();
+  const { message, modal } = App.useApp();
   const [isOpenTOTPActivateModal, { toggle: toggleTOTPActivateModal }] =
     useToggle(false);
   const baiClient = useSuspendedBackendaiClient();
@@ -74,13 +64,11 @@ const UserProfileSettingModal: React.FC<Props> = ({
       ?.validateFields()
       .then((values) => {
         userMutations.updateFullName(values.full_name, {
-          onSuccess: (newFullName) => {
-            if (newFullName !== userInfo.full_name) {
-              messageApi.open({
-                type: 'success',
-                content: t('webui.menu.FullNameUpdated'),
-              });
-            }
+          onSuccess: () => {
+            message.open({
+              type: 'success',
+              content: t('webui.menu.FullNameUpdated'),
+            });
 
             if (
               values.newPassword &&
@@ -95,14 +83,14 @@ const UserProfileSettingModal: React.FC<Props> = ({
                 },
                 {
                   onSuccess: () => {
-                    messageApi.open({
+                    message.open({
                       type: 'success',
                       content: t('webui.menu.PasswordUpdated'),
                     });
                     onRequestClose(true);
                   },
                   onError: (e) => {
-                    messageApi.open({
+                    message.open({
                       type: 'error',
                       content: e.message,
                     });
@@ -114,7 +102,7 @@ const UserProfileSettingModal: React.FC<Props> = ({
             }
           },
           onError: (e) => {
-            messageApi.open({
+            message.open({
               type: 'error',
               content: e.message,
             });
@@ -144,7 +132,7 @@ const UserProfileSettingModal: React.FC<Props> = ({
             ref={formRef}
             layout="vertical"
             initialValues={{
-              full_name: userInfo.full_name,
+              full_name: user?.full_name ?? userInfo.full_name,
               totp_activated: user?.totp_activated || false,
             }}
             preserve={false}
@@ -293,8 +281,6 @@ const UserProfileSettingModal: React.FC<Props> = ({
           />
         )}
       </BAIModal>
-      {contextHolder}
-      {modalContextHolder}
     </>
   );
 };

--- a/react/src/components/UserProfileSettingModalQuery.tsx
+++ b/react/src/components/UserProfileSettingModalQuery.tsx
@@ -8,6 +8,7 @@ export const UserProfileQuery = graphql`
     user(email: $email) {
       id
       totp_activated @skipOnClient(if: $isNotSupportTotp)
+      full_name
 
       # This is edge case for TOTP activation modal
       # eslint-disable-next-line relay/must-colocate-fragment-spreads


### PR DESCRIPTION
Resolves #4912 ([FR-1837](https://lablup.atlassian.net/browse/FR-1837))

# Update UserDropdownMenu and UserProfileSettingModal components

This PR updates the UserDropdownMenu and UserProfileSettingModal components with several improvements:

1. In UserDropdownMenu:
    - Replaced deprecated `overlayStyle` with the new `styles.root` property in Dropdown component
    - Added 'use memo' directive
    - Removed commented-out code
2. In UserProfileSettingModal:
    - Replaced individual Ant Design imports with more concise imports
    - Migrated from standalone message and modal APIs to App.useApp() for better context management
    - Added support for displaying user's full name from the GraphQL query result
3. In UserProfileSettingModalQuery:
    - Added `full_name` field to fix this error: The updated full_name persists in local React state but doesn't synchronize back to the Form's initial values when the modal reopens, requiring a page refresh to display the correct value.
    - By adding support for displaying user's full name from the GraphQL query result, the setting modal always shows up to date data.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1837]: https://lablup.atlassian.net/browse/FR-1837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ