### PR TITLE
fix(FR-1843): Resolve stale values in BAIProjectSettingModal component

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectSettingModal.tsx
@@ -16,9 +16,17 @@ import { BAIProjectSettingModalQuery } from '../../__generated__/BAIProjectSetti
 import { convertToBinaryUnit } from '../../helper';
 import { useErrorMessageResolver, useResourceSlotsDetails } from '../../hooks';
 import BAIModal, { BAIModalProps } from '../BAIModal';
-import { App, Checkbox, Form, Input, InputNumber, theme } from 'antd';
+import {
+  App,
+  Checkbox,
+  Form,
+  FormInstance,
+  Input,
+  InputNumber,
+  theme,
+} from 'antd';
 import _ from 'lodash';
-import { useDeferredValue } from 'react';
+import { useDeferredValue, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   graphql,
@@ -60,7 +68,7 @@ const BAIProjectSettingModal = ({
   const { t } = useTranslation();
   const deferredOpen = useDeferredValue(modalProps.open);
   const { resourceSlotsInRG, deviceMetaData } = useResourceSlotsDetails();
-  const [form] = Form.useForm<FormValues>();
+  const form = useRef<FormInstance<FormValues>>(null);
   const { message } = App.useApp();
   const { getErrorMessage } = useErrorMessageResolver();
 
@@ -165,8 +173,8 @@ const BAIProjectSettingModal = ({
     `);
 
   const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
-    form
-      .validateFields()
+    form.current
+      ?.validateFields()
       .then((values) => {
         const allPermissions =
           vfolder_host_permissions?.vfolder_host_permission_list;
@@ -382,14 +390,11 @@ const BAIProjectSettingModal = ({
       }}
     >
       <Form
-        form={form}
+        ref={form}
         preserve={false}
         layout="vertical"
         requiredMark="optional"
         initialValues={{
-          ...(projectFragment ?? {
-            is_active: true,
-          }),
           total_resource_slots: _.mapValues(
             JSON.parse(project?.total_resource_slots || '{}'),
             (value, key) => {
@@ -415,7 +420,7 @@ const BAIProjectSettingModal = ({
           description: project?.description,
           resource_policy: project?.resource_policy,
           scaling_groups: project?.scaling_groups,
-          is_active: project?.is_active,
+          is_active: projectFragment ? project?.is_active : true,
         }}
       >
         <Form.Item


### PR DESCRIPTION
resolves #4915 (FR-1843)

This PR changes the form handling in BAIProjectSettingModal from using a form instance created with `Form.useForm()` to using a form reference with `useRef<FormInstance>()`. This approach provides better control over the form instance lifecycle.

Key changes:

- Replaced `[form] = Form.useForm<FormValues>()` with `form = useRef<FormInstance<FormValues>>(null)`
- Updated form access from direct `form` to `form.current?`
- Modified the Form component to use `ref={form}` instead of `form={form}`
- Fixed the initialValues logic for `is_active` to properly handle the default value when creating a new project

**how to test**
* run `pnpm build` and `pnpm server:p -s`
* go to project page and click the edit button and create button

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after