### PR TITLE
fix(FR-1836): modify notification not to close during container commit

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
@@ -61,6 +61,7 @@ const ContainerCommitModal: React.FC<ContainerCommitModalProps> = ({
                 const task_id = (data as { task_id: string }).task_id;
                 onRequestClose();
                 return {
+                  duration: 0,
                   backgroundTask: {
                     status: 'pending',
                     taskId: task_id,


### PR DESCRIPTION
resolves #4916 (FR-1836)

This PR adds the `duration: 0` property to the container commit response object, ensuring the proper structure is maintained for background task handling.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after