### PR TITLE
fix(FR-1846): Folder explorer modal not opening when accessing directly via URL parameters 

### DIFF
--- a/react/src/components/FolderExplorerModal.tsx
+++ b/react/src/components/FolderExplorerModal.tsx
@@ -102,7 +102,7 @@ const FolderExplorerModal: React.FC<FolderExplorerProps> = ({
     {
       // Only fetch when both deferredOpen and modalProps.open are true to prevent unnecessary requests during React transitions
       fetchPolicy:
-        deferredOpen && modalProps.open ? 'network-only' : 'store-only',
+        deferredOpen && modalProps.open ? 'store-and-network' : 'store-only',
     },
   );
 
@@ -248,11 +248,11 @@ const FolderExplorerModal: React.FC<FolderExplorerProps> = ({
     >
       <Suspense fallback={<Skeleton active />}>
         {/* Use <Skeleton/> instead of using `loading` prop because layout align issue. */}
-        {deferredOpen !== modalProps.open ? (
+        {deferredOpen !== modalProps.open || vfolder_node === undefined ? (
           <Skeleton active />
         ) : (
           <BAIFlex direction="column" gap={'lg'} align="stretch">
-            {!vfolder_node ? (
+            {vfolder_node === null ? (
               <Alert
                 title={t('explorer.FolderNotFoundOrNoAccess')}
                 type="error"


### PR DESCRIPTION
Resolves #4918 ([FR-1846](https://lablup.atlassian.net/browse/FR-1846))

## Summary

This PR fixes the folder explorer not opening when accessing directly via URL parameters (e.g., http://127.0.0.1:9083/data?folder=58d09ff5-12bf-4f0a-987e-8c8189fc2618).

## Problem

When users accessed the folder explorer via direct URL with folder parameter, the modal failed to open and show the folder contents. This occurred because:

1. The 'network-only' fetch policy prevented using cached data during initial render
2. The loading state logic didn't properly handle undefined state during React transitions
3. The null check wasn't precise enough to distinguish between loading states

## Changes

- **Fetch Policy**: Changed from 'network-only' to 'store-and-network'
  - Allows using cached data while fetching fresh data in the background
  - Improves initial render performance when accessing via direct URL
  
- **Loading State Logic**: Enhanced condition to check both deferredOpen !== modalProps.open OR vfolder_node === undefined
  - Properly shows loading skeleton during data fetch
  - Handles undefined state during React transitions
  
- **Null Check Refinement**: Changed from !vfolder_node to vfolder_node === null
  - Distinguishes between loading (undefined) and error (null) states
  - Shows error message only when folder is truly not found

## Testing

- [ ] Direct URL access with folder parameter opens folder explorer correctly
- [ ] Loading skeleton displays during initial data fetch
- [ ] Error message shows when folder is not found or access is denied
- [ ] Normal folder explorer navigation still works as expected

[FR-1846]: https://lablup.atlassian.net/browse/FR-1846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ