### PR TITLE
fix: increase the number of agent nodes fetched to 100 for TotalResourceWithinResourceGroup

### DIFF
--- a/react/src/components/TotalResourceWithinResourceGroup.tsx
+++ b/react/src/components/TotalResourceWithinResourceGroup.tsx
@@ -86,7 +86,7 @@ const TotalResourceWithinResourceGroup: React.FC<
           }
           total_count
         }
-        agent_nodes(filter: $agentNodeFilter)
+        agent_nodes(filter: $agentNodeFilter, first: 100)
           @since(version: "24.12.0")
           @include(if: $isSuperAdmin) {
           edges {


### PR DESCRIPTION
> [!NOTE]
> This is a temporary measure for environments with many agents. It is scheduled to be replaced once a separate API for this is developed.

This PR adds a `first: 100` parameter to the `agent_nodes` GraphQL query in the TotalResourceWithinResourceGroup component to limit the number of results returned. 