### PR TITLE
mics(FR-1833): Modified BAIAdminResourceGroupSelect to use scaling group name as value

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof BAIAdminResourceGroupSelect> = {
 const BAIAdminResourceGroupSelectWithQuery = (
   props: Omit<
     React.ComponentProps<typeof BAIAdminResourceGroupSelect>,
-    'resourceGroupFragment'
+    'queryRef'
   >,
 ) => {
   const queryRef = useLazyLoadQuery<BAIAdminResourceGroupSelectStoriesQuery>(
@@ -30,9 +30,7 @@ const BAIAdminResourceGroupSelectWithQuery = (
     {},
   );
 
-  return (
-    <BAIAdminResourceGroupSelect resourceGroupFragment={queryRef} {...props} />
-  );
+  return <BAIAdminResourceGroupSelect queryRef={queryRef} {...props} />;
 };
 
 export const Default: Story = {

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
@@ -53,7 +53,7 @@ const BAIAdminResourceGroupSelect = ({
 
   const selectOptions = _.map(data.allScalingGroupsV2.edges, (item) => ({
     label: item.node.name,
-    value: item.node.id,
+    value: item.node.name, // since scaling group uses name as primary key, use name as value
   }));
 
   return (


### PR DESCRIPTION
resolves #4900 (FR-1833)

Changed the value of resource group select options from `id` to `name` in the `BAIAdminResourceGroupSelect` component. This ensures that the resource group name is used as the value instead of its ID when selecting resource groups in the admin interface.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after