### PR TITLE
feat(FR-1849): seperate branding page with theme JSON config

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -94,6 +94,8 @@ const ReservoirArtifactDetailPage = React.lazy(
 
 const SchedulerPage = React.lazy(() => import('./pages/SchedulerPage'));
 
+const BrandingPage = React.lazy(() => import('./pages/BrandingPage'));
+
 interface CustomHandle {
   title?: string;
   labelKey?: string;
@@ -458,6 +460,11 @@ const router = createBrowserRouter([
         path: '/maintenance',
         element: <MaintenancePage />,
         handle: { labelKey: 'webui.menu.Maintenance' },
+      },
+      {
+        path: '/branding',
+        element: <BrandingPage />,
+        handle: { labelKey: 'webui.menu.Branding' },
       },
       {
         path: '/project',

--- a/react/src/components/BrandingSettingItems/ThemeJsonConfigModal.tsx
+++ b/react/src/components/BrandingSettingItems/ThemeJsonConfigModal.tsx
@@ -1,0 +1,70 @@
+import BAICodeEditor from '../BAICodeEditor';
+import { ExportOutlined } from '@ant-design/icons';
+import { Alert, App, theme } from 'antd';
+import { useThemeMode } from 'antd-style';
+import { BAIButton, BAIModal, BAIModalProps } from 'backend.ai-ui';
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { downloadBlob } from 'src/helper/csv-util';
+import { useUserCustomThemeConfig } from 'src/helper/customThemeConfig';
+
+interface ThemeJsonConfigModalProps extends BAIModalProps {}
+
+const ThemeJsonConfigModal: React.FC<ThemeJsonConfigModalProps> = ({
+  ...modalProps
+}) => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { message } = App.useApp();
+  const { isDarkMode } = useThemeMode();
+  const { userCustomThemeConfig } = useUserCustomThemeConfig();
+
+  return (
+    <BAIModal
+      title={t('theme.ThemeJsonConfiguration')}
+      {...modalProps}
+      width={800}
+      footer={
+        <>
+          {/* TODO: https://lablup.atlassian.net/browse/FR-1866 */}
+          {/* <BAIButton icon={<ImportOutlined />}>
+            {t('theme.button.ImportFromJson')}
+          </BAIButton> */}
+          <BAIButton
+            type="primary"
+            icon={<ExportOutlined />}
+            action={async () => {
+              if (_.isEmpty(userCustomThemeConfig)) {
+                message.error(t('userSettings.theme.NoChangesMade'));
+                return;
+              }
+              const blob = new Blob(
+                [JSON.stringify(userCustomThemeConfig, null, 2)],
+                { type: 'application/json' },
+              );
+              downloadBlob(blob, `theme.json`);
+            }}
+          >
+            {t('theme.button.ExportToJson')}
+          </BAIButton>
+        </>
+      }
+    >
+      <Alert
+        description={t('theme.ThemeJsonConfigurationDesc')}
+        showIcon
+        style={{ marginBottom: token.marginMD }}
+      />
+      <BAICodeEditor
+        editable={false}
+        value={JSON.stringify(userCustomThemeConfig, null, 2)}
+        language={'json'}
+        theme={isDarkMode ? 'dark' : 'light'}
+      />
+    </BAIModal>
+  );
+};
+
+export default ThemeJsonConfigModal;

--- a/react/src/components/BrandingSettingList.tsx
+++ b/react/src/components/BrandingSettingList.tsx
@@ -5,14 +5,14 @@ import LogoSizeSettingItem from './BrandingSettingItems/LogoSizeSettingItem';
 import ThemeColorPicker, {
   ThemeConfigPath,
 } from './BrandingSettingItems/ThemeColorPicker';
+import ThemeJsonConfigModal from './BrandingSettingItems/ThemeJsonConfigModal';
 import SettingList, { SettingGroup } from './SettingList';
-import { ExportOutlined } from '@ant-design/icons';
-import { App } from 'antd';
+import { SettingOutlined } from '@ant-design/icons';
 import { BAIAlert, BAIButton, BAIFlex } from 'backend.ai-ui';
 import _ from 'lodash';
 import { Fullscreen } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { downloadBlob } from 'src/helper/csv-util';
 import { useUserCustomThemeConfig } from 'src/helper/customThemeConfig';
 
 interface BrandingSettingListProps {}
@@ -21,10 +21,10 @@ const BrandingSettingList: React.FC<BrandingSettingListProps> = () => {
   'use memo';
 
   const { t } = useTranslation();
-  const { message } = App.useApp();
 
-  const { userCustomThemeConfig, setUserCustomThemeConfig } =
-    useUserCustomThemeConfig();
+  const [openThemeConfigModal, setOpenThemeConfigModal] = useState(false);
+
+  const { setUserCustomThemeConfig } = useUserCustomThemeConfig();
 
   const resetColorThemeConfig = (tokenName: ThemeConfigPath) => {
     setUserCustomThemeConfig('light.' + tokenName, undefined);
@@ -191,25 +191,6 @@ const BrandingSettingList: React.FC<BrandingSettingListProps> = () => {
         primaryButton={
           <BAIButton
             type="primary"
-            icon={<ExportOutlined />}
-            action={async () => {
-              if (_.isEmpty(userCustomThemeConfig)) {
-                message.error(t('userSettings.theme.NoChangesMade'));
-                return;
-              }
-
-              const blob = new Blob(
-                [JSON.stringify(userCustomThemeConfig, null, 2)],
-                { type: 'application/json' },
-              );
-              downloadBlob(blob, `theme.json`);
-            }}
-          >
-            {t('theme.button.ExportToJson')}
-          </BAIButton>
-        }
-        extraButton={
-          <BAIButton
             icon={<Fullscreen />}
             action={async () => {
               const previewWindow = window.open(
@@ -228,6 +209,22 @@ const BrandingSettingList: React.FC<BrandingSettingListProps> = () => {
             {t('userSettings.theme.Preview')}
           </BAIButton>
         }
+        extraButton={
+          <BAIButton
+            icon={<SettingOutlined />}
+            action={async () => {
+              setOpenThemeConfigModal(true);
+            }}
+          >
+            {t('theme.button.JsonConfig')}
+          </BAIButton>
+        }
+      />
+      <ThemeJsonConfigModal
+        open={openThemeConfigModal}
+        onCancel={() => {
+          setOpenThemeConfigModal(false);
+        }}
       />
     </BAIFlex>
   );

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -17,6 +17,7 @@ import {
   ApiOutlined,
   TeamOutlined,
 } from '@ant-design/icons';
+import { useSessionStorageState } from 'ahooks';
 import { MenuProps, theme, Typography } from 'antd';
 import { MenuItemType } from 'antd/lib/menu/interface';
 import {
@@ -35,6 +36,7 @@ import {
   PackagePlus,
   LinkIcon,
   ExternalLinkIcon,
+  Palette,
 } from 'lucide-react';
 import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -76,6 +78,7 @@ export type MenuKeys =
   | 'agent'
   | 'settings'
   | 'maintenance'
+  | 'branding'
   | 'information';
 
 type MenuItem = {
@@ -112,6 +115,10 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   const [experimentalAIAgents] = useBAISettingUserState(
     'experimental_ai_agents',
   );
+
+  const [isThemePreviewMode] = useSessionStorageState('isThemePreviewMode', {
+    defaultValue: false,
+  });
 
   const generalMenu = filterOutEmpty<WebUIGeneralMenuItemType>([
     {
@@ -275,6 +282,11 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
       ),
       icon: <ToolOutlined style={{ color: token.colorInfo }} />,
       key: 'maintenance',
+    },
+    !isThemePreviewMode && {
+      label: <WebUILink to="/branding">{t('webui.menu.Branding')}</WebUILink>,
+      icon: <Palette style={{ color: token.colorInfo }} />,
+      key: 'branding',
     },
     {
       label: (

--- a/react/src/pages/BrandingPage.tsx
+++ b/react/src/pages/BrandingPage.tsx
@@ -1,0 +1,39 @@
+import { Skeleton } from 'antd';
+import { BAICard } from 'backend.ai-ui';
+import { Suspense } from 'react';
+import { useTranslation } from 'react-i18next';
+import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
+import BrandingSettingList from 'src/components/BrandingSettingList';
+import { StringParam, useQueryParam, withDefault } from 'use-query-params';
+
+const tabParam = withDefault(StringParam, 'branding');
+
+const BrandingPage: React.FC = () => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+
+  return (
+    <BAICard
+      activeTabKey={curTabKey}
+      onTabChange={(key) => setCurTabKey(key)}
+      tabList={[
+        {
+          key: 'branding',
+          tab: t('webui.menu.Branding'),
+        },
+      ]}
+    >
+      <Suspense fallback={<Skeleton active />}>
+        {curTabKey === 'branding' && (
+          <BAIErrorBoundary>
+            <BrandingSettingList />
+          </BAIErrorBoundary>
+        )}
+      </Suspense>
+    </BAICard>
+  );
+};
+
+export default BrandingPage;

--- a/react/src/pages/ConfigurationsPage.tsx
+++ b/react/src/pages/ConfigurationsPage.tsx
@@ -1,23 +1,18 @@
 import ConfigurationsSettingList from '../components/ConfigurationsSettingList';
-import { useSessionStorageState } from 'ahooks';
 import { Card, Skeleton } from 'antd';
 import { filterOutEmpty } from 'backend.ai-ui';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
-import BrandingSettingList from 'src/components/BrandingSettingList';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
-type TabKey = 'configurations' | 'branding';
+type TabKey = 'configurations';
 
 const tabParam = withDefault(StringParam, 'configurations');
 
 const ConfigurationsPage = () => {
   const { t } = useTranslation();
   const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
-  const [isThemePreviewMode] = useSessionStorageState('isThemePreviewMode', {
-    defaultValue: false,
-  });
 
   return (
     <Card
@@ -28,21 +23,12 @@ const ConfigurationsPage = () => {
           key: 'configurations',
           tab: t('webui.menu.Configurations'),
         },
-        !isThemePreviewMode && {
-          key: 'branding',
-          tab: t('webui.menu.Branding'),
-        },
       ])}
     >
       <Suspense fallback={<Skeleton active />}>
         {curTabKey === 'configurations' && (
           <BAIErrorBoundary>
             <ConfigurationsSettingList />
-          </BAIErrorBoundary>
-        )}
-        {curTabKey === 'branding' && (
-          <BAIErrorBoundary>
-            <BrandingSettingList />
           </BAIErrorBoundary>
         )}
       </Suspense>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1978,8 +1978,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Sie verwenden derzeit den Theme‑Vorschau‑Modus. Bitte setzen Sie Ihre Arbeit im Originalfenster fort.",
+    "ThemeJsonConfiguration": "Theme-JSON-Konfiguration",
+    "ThemeJsonConfigurationDesc": "Importieren Sie eine JSON-Datei, um das Theme zu ändern, oder exportieren Sie das aktuelle Theme als JSON. Um die Änderungen auf Ihrer Website anzuwenden, exportieren Sie die JSON-Datei und kopieren Sie sie in resources/theme.json auf dem WebUI-Webserver.",
     "button": {
-      "ExportToJson": "Als JSON exportieren"
+      "ExportToJson": "Als JSON exportieren",
+      "ImportFromJson": "JSON importieren",
+      "JsonConfig": "JSON-Konfiguration"
     }
   },
   "time": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1977,8 +1977,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Αυτήν τη στιγμή βρίσκεστε σε λειτουργία προεπισκόπησης θέματος. Παρακαλώ συνεχίστε την πραγματική εργασία σας στο αρχικό παράθυρο.",
+    "ThemeJsonConfiguration": "Ρυθμίσεις θέματος (JSON)",
+    "ThemeJsonConfigurationDesc": "Εισάγετε ένα αρχείο JSON για να αλλάξετε το θέμα ή εξάγετε το τρέχον θέμα σε JSON. Για να εφαρμόσετε τις αλλαγές στον ιστότοπό σας, εξάγετε το JSON και αντιγράψτε το στο resources/theme.json στον διακομιστή ιστού του WebUI.",
     "button": {
-      "ExportToJson": "Εξαγωγή JSON"
+      "ExportToJson": "Εξαγωγή JSON",
+      "ImportFromJson": "Εισαγωγή JSON",
+      "JsonConfig": "Διαμόρφωση JSON"
     }
   },
   "time": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1986,8 +1986,12 @@
   },
   "theme": {
     "PreviewModeAlert": "You are currently using the theme preview mode. Please proceed with your actual work in the original window.",
+    "ThemeJsonConfiguration": "Theme JSON Configuration",
+    "ThemeJsonConfigurationDesc": "Import a JSON file to change the theme or export the current theme as JSON. To apply the changes to your site, export the JSON file and copy it to resources/theme.json in the WebUI web server.",
     "button": {
-      "ExportToJson": "Export JSON"
+      "ExportToJson": "Export JSON",
+      "ImportFromJson": "Import JSON",
+      "JsonConfig": "JSON Config"
     }
   },
   "time": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1980,8 +1980,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Actualmente está usando el modo de vista previa del tema. Por favor, continúe con su trabajo en la ventana original.",
+    "ThemeJsonConfiguration": "Configuración JSON del tema",
+    "ThemeJsonConfigurationDesc": "Importar un archivo JSON para cambiar el tema o exportar el tema actual como JSON. Para aplicar los cambios en su sitio, exporte el archivo JSON y cópielo en resources/theme.json en el servidor web de WebUI.",
     "button": {
-      "ExportToJson": "Exportar JSON"
+      "ExportToJson": "Exportar JSON",
+      "ImportFromJson": "Importar JSON",
+      "JsonConfig": "Configuración JSON"
     }
   },
   "time": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1979,8 +1979,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Käytät tällä hetkellä teeman esikatselutilaa. Jatka varsinaista työskentelyä alkuperäisessä ikkunassa.",
+    "ThemeJsonConfiguration": "Teeman JSON-määritys",
+    "ThemeJsonConfigurationDesc": "Tuo JSON-tiedosto muuttaaksesi teemaa tai vie nykyinen teema JSON-muodossa. Ota muutokset käyttöön sivustollasi viemällä JSON-tiedosto ja kopioimalla se WebUI-web-palvelimen tiedostoon resources/theme.json.",
     "button": {
-      "ExportToJson": "Vie JSON"
+      "ExportToJson": "Vie JSON",
+      "ImportFromJson": "Tuo JSON",
+      "JsonConfig": "JSON-asetukset"
     }
   },
   "time": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1980,8 +1980,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Vous êtes actuellement en mode aperçu du thème. Veuillez poursuivre votre travail dans la fenêtre d'origine.",
+    "ThemeJsonConfiguration": "Configuration JSON du thème",
+    "ThemeJsonConfigurationDesc": "Importez un fichier JSON pour modifier le thème ou exportez le thème actuel au format JSON. Pour appliquer les modifications à votre site, exportez le fichier JSON et copiez-le dans resources/theme.json sur le serveur web de WebUI.",
     "button": {
-      "ExportToJson": "Exporter en JSON"
+      "ExportToJson": "Exporter en JSON",
+      "ImportFromJson": "Importer JSON",
+      "JsonConfig": "Configuration JSON"
     }
   },
   "time": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1979,8 +1979,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Anda sedang menggunakan mode pratinjau tema. Silakan lanjutkan pekerjaan Anda di jendela asli.",
+    "ThemeJsonConfiguration": "Konfigurasi JSON Tema",
+    "ThemeJsonConfigurationDesc": "Impor file JSON untuk mengubah tema atau ekspor tema saat ini sebagai JSON. Untuk menerapkan perubahan ke situs Anda, ekspor file JSON dan salin ke resources/theme.json di server web WebUI.",
     "button": {
-      "ExportToJson": "Ekspor JSON"
+      "ExportToJson": "Ekspor JSON",
+      "ImportFromJson": "Impor JSON",
+      "JsonConfig": "Konfigurasi JSON"
     }
   },
   "time": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1977,8 +1977,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Stai usando la modalità anteprima del tema. Ti preghiamo di proseguire il lavoro nella finestra originale.",
+    "ThemeJsonConfiguration": "Configurazione JSON del tema",
+    "ThemeJsonConfigurationDesc": "Importa un file JSON per modificare il tema o esporta il tema corrente come JSON. Per applicare le modifiche al tuo sito, esporta il file JSON e copialo in resources/theme.json nel server web di WebUI.",
     "button": {
-      "ExportToJson": "Esporta JSON"
+      "ExportToJson": "Esporta JSON",
+      "ImportFromJson": "Importa JSON",
+      "JsonConfig": "Configurazione JSON"
     }
   },
   "time": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1979,8 +1979,12 @@
   },
   "theme": {
     "PreviewModeAlert": "現在、テーマのプレビュー モードを使用しています。実際の作業は元のウィンドウで行ってください。",
+    "ThemeJsonConfiguration": "テーマのJSON設定",
+    "ThemeJsonConfigurationDesc": "テーマを変更するにはJSONファイルをインポートするか、現在のテーマをJSONとしてエクスポートしてください。変更をサイトに適用するには、エクスポートしたJSONファイルをWebUIのWebサーバー上のresources/theme.jsonにコピーしてください。",
     "button": {
-      "ExportToJson": "JSON をエクスポート"
+      "ExportToJson": "JSON をエクスポート",
+      "ImportFromJson": "JSON をインポート",
+      "JsonConfig": "JSON設定"
     }
   },
   "time": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1984,8 +1984,12 @@
   },
   "theme": {
     "PreviewModeAlert": "현재 테마 미리보기 모드를 사용하고 있습니다. 실제 작업은 기존 창에서 진행해 주세요.",
+    "ThemeJsonConfiguration": "테마 JSON 설정",
+    "ThemeJsonConfigurationDesc": "JSON 파일을 불러와 테마를 변경하거나 현재 테마의 JSON 파일을 추출할 수 있습니다. 변경된 테마를 사이트에 적용하려면 JSON 파일을 내보낸 후 WebUI 웹서버의 resources/theme.json으로 복사해주세요.",
     "button": {
-      "ExportToJson": "JSON 내보내기"
+      "ExportToJson": "JSON 내보내기",
+      "ImportFromJson": "JSON 가져오기",
+      "JsonConfig": "JSON 설정"
     }
   },
   "time": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1977,8 +1977,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Та одоогоор сэдвийн урьдчилсан үзэх горимд байна. Жинхэнэ ажлаа эх цонхонд үргэлжлүүлнэ үү.",
+    "ThemeJsonConfiguration": "Сэдэвийн JSON тохиргоо",
+    "ThemeJsonConfigurationDesc": "Сэдвийг өөрчлөхийн тулд JSON файл импортлах эсвэл одоогийн сэдвийг JSON хэлбэрээр экспортлох. Сайтад өөрчлөлтүүдийг хэрэгжүүлэхийн тулд JSON файлыг экспортлаж, WebUI вэб серверийн resources/theme.json руу хуулна.",
     "button": {
-      "ExportToJson": "JSON-аар экспортлах"
+      "ExportToJson": "JSON-аар экспортлах",
+      "ImportFromJson": "JSON импортлах",
+      "JsonConfig": "JSON тохиргоо"
     }
   },
   "time": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1978,8 +1978,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Anda sedang menggunakan mod pratonton tema. Sila teruskan kerja sebenar anda di tetingkap asal.",
+    "ThemeJsonConfiguration": "Konfigurasi Tema JSON",
+    "ThemeJsonConfigurationDesc": "Import fail JSON untuk menukar tema atau eksport tema semasa sebagai JSON. Untuk menerapkan perubahan pada laman anda, eksport fail JSON dan salin ke resources/theme.json pada pelayan web WebUI.",
     "button": {
-      "ExportToJson": "Eksport JSON"
+      "ExportToJson": "Eksport JSON",
+      "ImportFromJson": "Import JSON",
+      "JsonConfig": "Konfigurasi JSON"
     }
   },
   "time": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1979,8 +1979,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Obecnie korzystasz z trybu podglądu motywu. Kontynuuj swoją pracę w oryginalnym oknie.",
+    "ThemeJsonConfiguration": "Konfiguracja motywu (JSON)",
+    "ThemeJsonConfigurationDesc": "Zaimportuj plik JSON, aby zmienić motyw lub wyeksportuj bieżący motyw jako JSON. Aby zastosować zmiany na swojej stronie, wyeksportuj plik JSON i skopiuj go do resources/theme.json na serwerze WebUI.",
     "button": {
-      "ExportToJson": "Eksportuj JSON"
+      "ExportToJson": "Eksportuj JSON",
+      "ImportFromJson": "Importuj JSON",
+      "JsonConfig": "Konfiguracja JSON"
     }
   },
   "time": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1980,8 +1980,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Você está atualmente no modo de pré-visualização do tema. Por favor, continue seu trabalho na janela original.",
+    "ThemeJsonConfiguration": "Configuração JSON do Tema",
+    "ThemeJsonConfigurationDesc": "Importe um arquivo JSON para alterar o tema ou exporte o tema atual como JSON. Para aplicar as alterações no seu site, exporte o arquivo JSON e copie-o para resources/theme.json no servidor WebUI.",
     "button": {
-      "ExportToJson": "Exportar JSON"
+      "ExportToJson": "Exportar JSON",
+      "ImportFromJson": "Importar JSON",
+      "JsonConfig": "Configuração JSON"
     }
   },
   "time": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1979,8 +1979,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Você está usando o modo de visualização do tema. Por favor, prossiga com seu trabalho na janela original.",
+    "ThemeJsonConfiguration": "Configuração JSON do Tema",
+    "ThemeJsonConfigurationDesc": "Importe um arquivo JSON para alterar o tema ou exporte o tema atual como JSON. Para aplicar as alterações no seu site, exporte o arquivo JSON e copie-o para resources/theme.json no servidor web do WebUI.",
     "button": {
-      "ExportToJson": "Exportar JSON"
+      "ExportToJson": "Exportar JSON",
+      "ImportFromJson": "Importar JSON",
+      "JsonConfig": "Configuração JSON"
     }
   },
   "time": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1979,8 +1979,12 @@
   },
   "theme": {
     "PreviewModeAlert": "В данный момент вы используете режим предварительного просмотра темы. Пожалуйста, продолжите работу в исходном окне.",
+    "ThemeJsonConfiguration": "Конфигурация темы (JSON)",
+    "ThemeJsonConfigurationDesc": "Импортируйте JSON-файл, чтобы изменить тему, или экспортируйте текущую тему в формате JSON. Чтобы применить изменения на вашем сайте, экспортируйте JSON-файл и скопируйте его в resources/theme.json на веб‑сервере WebUI.",
     "button": {
-      "ExportToJson": "Экспорт в JSON"
+      "ExportToJson": "Экспорт в JSON",
+      "ImportFromJson": "Импорт JSON",
+      "JsonConfig": "JSON-конфигурация"
     }
   },
   "time": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1964,8 +1964,12 @@
   },
   "theme": {
     "PreviewModeAlert": "คุณกำลังอยู่ในโหมดแสดงตัวอย่างธีม โปรดดำเนินงานจริงในหน้าต่างต้นฉบับ",
+    "ThemeJsonConfiguration": "การกำหนดค่า JSON ของธีม",
+    "ThemeJsonConfigurationDesc": "นำเข้าไฟล์ JSON เพื่อเปลี่ยนธีมหรือส่งออกธีมปัจจุบันเป็น JSON หากต้องการนำการเปลี่ยนแปลงไปใช้กับไซต์ ให้ส่งออกไฟล์ JSON แล้วคัดลอกไปที่ resources/theme.json บนเว็บเซิร์ฟเวอร์ของ WebUI",
     "button": {
-      "ExportToJson": "ส่งออก JSON"
+      "ExportToJson": "ส่งออก JSON",
+      "ImportFromJson": "นำเข้า JSON",
+      "JsonConfig": "การตั้งค่า JSON"
     }
   },
   "time": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1980,8 +1980,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Şu anda tema önizleme modundasınız. Lütfen asıl çalışmanızı orijinal pencerede sürdürün.",
+    "ThemeJsonConfiguration": "Tema JSON Yapılandırması",
+    "ThemeJsonConfigurationDesc": "Temayı değiştirmek için bir JSON dosyası içe aktarın veya mevcut temayı JSON olarak dışa aktarın. Değişikliklerin sitenize uygulanması için JSON dosyasını dışa aktarın ve WebUI web sunucusundaki resources/theme.json dosyasına kopyalayın.",
     "button": {
-      "ExportToJson": "JSON'u Dışa Aktar"
+      "ExportToJson": "JSON'u Dışa Aktar",
+      "ImportFromJson": "JSON'u İçe Aktar",
+      "JsonConfig": "JSON Yapılandırması"
     }
   },
   "time": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1980,8 +1980,12 @@
   },
   "theme": {
     "PreviewModeAlert": "Bạn đang ở chế độ xem trước giao diện. Vui lòng quay lại cửa sổ gốc để thực hiện công việc.",
+    "ThemeJsonConfiguration": "Cấu hình JSON chủ đề",
+    "ThemeJsonConfigurationDesc": "Nhập một tệp JSON để thay đổi chủ đề hoặc xuất chủ đề hiện tại dưới dạng JSON. Để áp dụng thay đổi lên trang của bạn, xuất tệp JSON và sao chép vào resources/theme.json trên máy chủ WebUI.",
     "button": {
-      "ExportToJson": "Xuất JSON"
+      "ExportToJson": "Xuất JSON",
+      "ImportFromJson": "Nhập JSON",
+      "JsonConfig": "Cấu hình JSON"
     }
   },
   "time": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1980,8 +1980,12 @@
   },
   "theme": {
     "PreviewModeAlert": "您当前处于主题预览模式。请在原窗口继续进行实际工作。",
+    "ThemeJsonConfiguration": "主题 JSON 配置",
+    "ThemeJsonConfigurationDesc": "导入 JSON 文件以更改主题，或将当前主题导出为 JSON。要将更改应用到您的站点，请导出 JSON 文件并将其复制到 WebUI Web 服务器的 resources/theme.json。",
     "button": {
-      "ExportToJson": "导出 JSON"
+      "ExportToJson": "导出 JSON",
+      "ImportFromJson": "导入 JSON",
+      "JsonConfig": "JSON 配置"
     }
   },
   "time": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1978,8 +1978,12 @@
   },
   "theme": {
     "PreviewModeAlert": "您目前正在使用主題預覽模式。請在原視窗繼續進行您的實際工作。",
+    "ThemeJsonConfiguration": "主題 JSON 設定",
+    "ThemeJsonConfigurationDesc": "匯入 JSON 檔案以變更主題，或將目前主題匯出為 JSON。要將變更套用到您的網站，請匯出 JSON 檔案並將其複製到 WebUI 網頁伺服器的 resources/theme.json。",
     "button": {
-      "ExportToJson": "匯出 JSON"
+      "ExportToJson": "匯出 JSON",
+      "ImportFromJson": "匯入 JSON",
+      "JsonConfig": "JSON 設定"
     }
   },
   "time": {

--- a/src/backend-ai-app.ts
+++ b/src/backend-ai-app.ts
@@ -32,6 +32,7 @@ export const navigate =
         '/scheduler',
         '/settings',
         '/maintenance',
+        '/branding',
         '/information',
         '/github',
         '/import',
@@ -73,6 +74,7 @@ export const navigate =
         'environment',
         'settings',
         'maintenance',
+        'branding',
         'information',
       ].includes(page)
     ) {

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -175,6 +175,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
     'scheduler',
     'reservoir',
     'project',
+    'branding',
   ];
   @property({ type: Array }) adminOnlyPages = [
     'experiment',
@@ -191,6 +192,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
     'maintenance',
     'information',
     'project',
+    'branding',
   ];
   @property({ type: Array }) optionalPages;
   @property({ type: Number }) timeoutSec = 5;


### PR DESCRIPTION
Resolves #4924 ([FR-1849](https://lablup.atlassian.net/browse/FR-1849))

## Summary
- Add a dedicated Branding page (`/branding`) to separate branding settings from the Configurations page
- Add Theme JSON Configuration modal for importing/exporting theme configurations
- Add Branding menu item with Palette icon in the superadmin menu (hidden in theme preview mode)
- Add i18n translations for all 21 supported languages

## Changes
- **New Files:**
  - `react/src/pages/BrandingPage.tsx` - Dedicated branding settings page
  - `react/src/components/BrandingSettingItems/ThemeJsonConfigModal.tsx` - Modal for JSON import/export
- **Modified Files:**
  - `react/src/App.tsx` - Added `/branding` route
  - `react/src/hooks/useWebUIMenuItems.tsx` - Added branding menu item
  - `react/src/components/BrandingSettingList.tsx` - Updated to work as standalone component
  - `react/src/pages/ConfigurationsPage.tsx` - Removed branding tab
  - `src/backend-ai-app.ts` & `src/components/backend-ai-webui.ts` - Added branding route for Lit

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1849]: https://lablup.atlassian.net/browse/FR-1849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ