### PR TITLE
feat(FR-1567): add i18n configuration for Storybook

### DIFF
--- a/packages/backend.ai-ui/.storybook/preview.tsx
+++ b/packages/backend.ai-ui/.storybook/preview.tsx
@@ -1,27 +1,138 @@
+import { i18n } from '../src/locale';
 import type { Preview } from '@storybook/react-vite';
-import { ConfigProvider, theme as antdTheme } from 'antd';
-import React from 'react';
+import { ConfigProvider, Skeleton } from 'antd';
+import type { Locale } from 'antd/es/locale';
+import deDE from 'antd/locale/de_DE';
+import elGR from 'antd/locale/el_GR';
+import enUS from 'antd/locale/en_US';
+import esES from 'antd/locale/es_ES';
+import fiFI from 'antd/locale/fi_FI';
+import frFR from 'antd/locale/fr_FR';
+import idID from 'antd/locale/id_ID';
+import itIT from 'antd/locale/it_IT';
+import jaJP from 'antd/locale/ja_JP';
+import koKR from 'antd/locale/ko_KR';
+import mnMN from 'antd/locale/mn_MN';
+import msMY from 'antd/locale/ms_MY';
+import plPL from 'antd/locale/pl_PL';
+import ptBR from 'antd/locale/pt_BR';
+import ptPT from 'antd/locale/pt_PT';
+import ruRU from 'antd/locale/ru_RU';
+import thTH from 'antd/locale/th_TH';
+import trTR from 'antd/locale/tr_TR';
+import viVN from 'antd/locale/vi_VN';
+import zhCN from 'antd/locale/zh_CN';
+import zhTW from 'antd/locale/zh_TW';
+import React, { Suspense, useEffect } from 'react';
+import { I18nextProvider } from 'react-i18next';
+
+const antdLocaleMap: Record<string, Locale> = {
+  en: enUS,
+  ko: koKR,
+  ja: jaJP,
+  'zh-CN': zhCN,
+  'zh-TW': zhTW,
+  de: deDE,
+  fr: frFR,
+  es: esES,
+  pt: ptPT,
+  'pt-BR': ptBR,
+  it: itIT,
+  ru: ruRU,
+  pl: plPL,
+  el: elGR,
+  fi: fiFI,
+  tr: trTR,
+  th: thTH,
+  vi: viVN,
+  id: idID,
+  ms: msMY,
+  mn: mnMN,
+};
+
+const getAntdLocale = (locale: string): Locale => antdLocaleMap[locale] ?? enUS;
+
+interface LocaleProviderProps {
+  locale: string;
+  children: React.ReactNode;
+}
+
+const LocaleProvider: React.FC<LocaleProviderProps> = ({
+  locale,
+  children,
+}) => {
+  useEffect(() => {
+    i18n.changeLanguage(locale);
+  }, [locale]);
+
+  const antdLocale = getAntdLocale(locale);
+  return (
+    <Suspense fallback={<Skeleton active />}>
+      <I18nextProvider i18n={i18n}>
+        <ConfigProvider locale={antdLocale}>
+          <div style={{ padding: '16px' }}>{children}</div>
+        </ConfigProvider>
+      </I18nextProvider>
+    </Suspense>
+  );
+};
 
 const preview: Preview = {
   tags: ['autodocs'],
   decorators: [
-    (Story) => (
-      <ConfigProvider>
-        <div style={{ padding: '16px' }}>
+    (Story, context) => {
+      const { locale } = context.globals;
+
+      return (
+        <LocaleProvider locale={locale}>
           <Story />
-        </div>
-      </ConfigProvider>
-    ),
+        </LocaleProvider>
+      );
+    },
   ],
   parameters: {
-    // Docs addon configuration
     docs: {
       extractComponentDescription: (_component: any, { notes }: any) => {
         return notes?.markdown || notes?.text || null;
       },
     },
-    // Layout configuration
     layout: 'padded',
+  },
+  globalTypes: {
+    locale: {
+      name: 'Locale',
+      description: 'Internationalization locale',
+      toolbar: {
+        icon: 'globe',
+        items: [
+          { value: 'en', title: 'English' },
+          { value: 'ko', title: '한국어' },
+          { value: 'ja', title: '日本語' },
+          { value: 'zh-CN', title: '简体中文' },
+          { value: 'zh-TW', title: '繁體中文' },
+          { value: 'de', title: 'Deutsch' },
+          { value: 'fr', title: 'Français' },
+          { value: 'es', title: 'Español' },
+          { value: 'pt', title: 'Português' },
+          { value: 'pt-BR', title: 'Português (Brasil)' },
+          { value: 'it', title: 'Italiano' },
+          { value: 'ru', title: 'Русский' },
+          { value: 'pl', title: 'Polski' },
+          { value: 'el', title: 'Ελληνικά' },
+          { value: 'fi', title: 'Suomi' },
+          { value: 'tr', title: 'Türkçe' },
+          { value: 'th', title: 'ไทย' },
+          { value: 'vi', title: 'Tiếng Việt' },
+          { value: 'id', title: 'Indonesia' },
+          { value: 'ms', title: 'Melayu' },
+          { value: 'mn', title: 'Монгол' },
+        ],
+        showName: true,
+      },
+    },
+  },
+  initialGlobals: {
+    locale: 'en',
   },
 };
 


### PR DESCRIPTION
Resolves #4416(FR-1567)

## Summary
- Add i18n configuration for Storybook with 21 supported languages
- Add locale selector toolbar in Storybook to switch languages dynamically
- Add i18next dependencies for Storybook development

## Changes
- **packages/backend.ai-ui/src/i18n.ts**: New i18n configuration that imports all locale files directly
- **packages/backend.ai-ui/.storybook/preview.tsx**: Add i18n decorator with locale selector toolbar
- **packages/backend.ai-ui/package.json**: Add i18next-browser-languagedetector and i18next-http-backend as devDependencies

## Supported Languages
English, Korean, Japanese, Chinese (Simplified/Traditional), German, French, Spanish, Portuguese, Italian, Russian, Polish, Greek, Finnish, Turkish, Thai, Vietnamese, Indonesian, Malay, Mongolian

## Test Plan
- [ ] Run Storybook and verify locale selector appears in toolbar
- [ ] Switch between languages and verify translations update in components using `useTranslation`

https://github.com/user-attachments/assets/2150c4d5-dccc-41f7-a954-8c562c8f269d