### PR TITLE
feat(FR-1870): Create BAIVFolderSelect using usePaginationFragment

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -47,6 +47,26 @@ const useStyles = createStyles(({ css, token }) => ({
       opacity: 0.5;
     }
 
+    /* Change the color of secondary/success/warning/danger text to placeholder color when the dropdown is open */
+    &.ant-select-open
+      .ant-select-content
+      .ant-select-content-value
+      .ant-typography-secondary,
+    &.ant-select-open
+      .ant-select-content
+      .ant-select-content-value
+      .ant-typography-success,
+    &.ant-select-open
+      .ant-select-content
+      .ant-select-content-value
+      .ant-typography-warning,
+    &.ant-select-open
+      .ant-select-content
+      .ant-select-content-value
+      .ant-typography-danger {
+      color: ${token.colorTextPlaceholder};
+    }
+
     /* TODO: re-enable this style after fixing flickering when theme changes */
     /* Add a gradient effect to the right side of the dropdown to indicate more content */
     /* & .ant-select-content::after {
@@ -151,12 +171,19 @@ function BAISelect<
       <Select<ValueType, OptionType>
         {...selectProps}
         loading={isPending || selectProps.loading}
-        onSearch={async (value) => {
-          selectProps.onSearch?.(value);
-          startTransition(async () => {
-            await searchAction?.(value);
-          });
-        }}
+        showSearch={
+          selectProps.showSearch && _.isObject(selectProps.showSearch)
+            ? {
+                ...selectProps.showSearch,
+                onSearch: async (value) => {
+                  _.get(selectProps.showSearch, 'onSearch')?.(value);
+                  startTransition(async () => {
+                    await searchAction?.(value);
+                  });
+                },
+              }
+            : false
+        }
         ref={ref}
         className={classNames(
           selectProps.className,

--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
@@ -1,0 +1,353 @@
+import { BAIVFolderSelectPaginatedQuery } from '../../__generated__/BAIVFolderSelectPaginatedQuery.graphql';
+import { BAIVFolderSelectValueQuery } from '../../__generated__/BAIVFolderSelectValueQuery.graphql';
+import { toLocalId } from '../../helper';
+import { useFetchKey } from '../../hooks';
+import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import BAILink from '../BAILink';
+import { mergeFilterValues } from '../BAIPropertyFilter';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import BAIText from '../BAIText';
+import TotalFooter from '../TotalFooter';
+import { useControllableValue } from 'ahooks';
+import { GetRef, Skeleton } from 'antd';
+import _ from 'lodash';
+import {
+  useDeferredValue,
+  useImperativeHandle,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export type VFolderNode = NonNullable<
+  NonNullable<
+    BAIVFolderSelectPaginatedQuery['response']['vfolder_nodes']
+  >['edges'][number]
+>['node'];
+
+export interface BAIVFolderSelectRef {
+  refetch: () => void;
+}
+
+export interface BAIVFolderSelectProps
+  extends Omit<BAISelectProps, 'options' | 'labelInValue' | 'ref'> {
+  currentProjectId?: string;
+  onClickVFolder?: (value: string) => void;
+  filter?: string;
+  valuePropName?: 'id' | 'row_id';
+  excludeDeleted?: boolean;
+  ref?: React.Ref<BAIVFolderSelectRef>;
+}
+
+// Exclude deleted or deleting vfolders
+const excludeDeletedStatusFilter =
+  'status != "DELETE_PENDING" & status != "DELETE_ONGOING" & status != "DELETE_ERROR" & status != "DELETE_COMPLETE"';
+
+const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
+  loading,
+  currentProjectId,
+  onClickVFolder,
+  filter,
+  excludeDeleted,
+  valuePropName = 'id',
+  ref,
+  ...selectProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+  const [controllableValue, setControllableValue] = useControllableValue<
+    string | string[] | undefined
+  >(selectProps);
+  const [controllableOpen, setControllableOpen] = useControllableValue<boolean>(
+    selectProps,
+    {
+      valuePropName: 'open',
+      trigger: 'onOpenChange',
+    },
+  );
+  const deferredOpen = useDeferredValue(controllableOpen);
+  const [searchStr, setSearchStr] = useState<string>();
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const mergedFilter = mergeFilterValues([
+    excludeDeleted ? excludeDeletedStatusFilter : null,
+    filter,
+  ]);
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  // Defer query refetch to prevent flickering during user selection
+  const deferredControllableValue = useDeferredValue(controllableValue);
+
+  const { vfolder_nodes: selectedVFolderNodes } =
+    useLazyLoadQuery<BAIVFolderSelectValueQuery>(
+      graphql`
+        query BAIVFolderSelectValueQuery(
+          $selectedFilter: String
+          $skipSelectedVFolder: Boolean!
+          $scopeId: ScopeField
+        ) {
+          vfolder_nodes(
+            scope_id: $scopeId
+            filter: $selectedFilter
+            permission: "read_attribute"
+          ) @skip(if: $skipSelectedVFolder) {
+            edges {
+              node {
+                name
+                id
+                row_id
+              }
+            }
+          }
+        }
+      `,
+      {
+        selectedFilter: mergeFilterValues(
+          [
+            !_.isEmpty(deferredControllableValue)
+              ? mergeFilterValues(
+                  _.castArray(deferredControllableValue).map((value) => {
+                    // When valuePropName is 'id', convert Global ID to local UUID
+                    // When valuePropName is 'row_id', use the value directly
+                    const filterValue =
+                      valuePropName === 'id' ? toLocalId(value) : value;
+                    return `${valuePropName} == "${filterValue}"`;
+                  }),
+                  '|',
+                )
+              : null,
+            mergedFilter,
+          ],
+          '&',
+        ),
+        skipSelectedVFolder: _.isEmpty(deferredControllableValue),
+        scopeId: currentProjectId ? `project:${currentProjectId}` : undefined,
+      },
+      {
+        fetchPolicy: !_.isEmpty(deferredControllableValue)
+          ? 'store-or-network'
+          : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+    );
+
+  const { paginationData, result, loadNext, isLoadingNext } =
+    useLazyPaginatedQuery<BAIVFolderSelectPaginatedQuery, VFolderNode>(
+      graphql`
+        query BAIVFolderSelectPaginatedQuery(
+          $offset: Int!
+          $limit: Int!
+          $scopeId: ScopeField
+          $filter: String
+          $permission: VFolderPermissionValueField
+        ) {
+          vfolder_nodes(
+            scope_id: $scopeId
+            offset: $offset
+            first: $limit
+            filter: $filter
+            permission: $permission
+            order: "-created_at"
+          ) {
+            count
+            edges {
+              node {
+                id
+                name
+                row_id
+              }
+            }
+          }
+        }
+      `,
+      { limit: 10 },
+      {
+        filter: mergeFilterValues([
+          mergedFilter,
+          searchStr ? `name ilike "%${searchStr}%"` : null,
+        ]),
+        scopeId: currentProjectId ? `project:${currentProjectId}` : undefined,
+        permission: 'read_attribute' as const,
+      },
+      {
+        fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+      {
+        getTotal: (result) => result.vfolder_nodes?.count ?? undefined,
+        getItem: (result) =>
+          result.vfolder_nodes?.edges?.map((edge) => edge?.node),
+        getId: (item) => item?.id,
+      },
+    );
+
+  // Expose refetch function through ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: () => {
+        startRefetchTransition(() => {
+          updateFetchKey();
+        });
+      },
+    }),
+    [updateFetchKey, startRefetchTransition],
+  );
+
+  const availableOptions = _.map(paginationData, (item) => ({
+    label: item?.name,
+    value: item?.[valuePropName],
+  }));
+
+  const controllableValueWithLabel = selectedVFolderNodes?.edges
+    ? // Sort by deferredControllableValue order to maintain selection order
+      _.castArray(deferredControllableValue)
+        .map((value) => {
+          const edge = selectedVFolderNodes.edges.find(
+            (edge) => edge?.node?.[valuePropName] === value,
+          );
+          return edge
+            ? {
+                label: edge.node?.name,
+                value: edge.node?.[valuePropName],
+              }
+            : null;
+        })
+        .filter(
+          (item): item is { label: string; value: string } => item !== null,
+        )
+    : !_.isEmpty(deferredControllableValue)
+      ? _.castArray(deferredControllableValue).map((value) => ({
+          label: value,
+          value: value,
+        }))
+      : undefined;
+
+  const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
+    controllableValueWithLabel,
+  );
+
+  return (
+    <BAISelect
+      ref={selectRef}
+      placeholder={t('comp:BAIVFolderSelect.SelectFolder')}
+      loading={
+        loading ||
+        controllableValue !== deferredControllableValue ||
+        isPendingRefetch
+      }
+      {...selectProps}
+      searchAction={async (value) => {
+        setSearchStr(value);
+        await selectProps.searchAction?.(value);
+      }}
+      showSearch={{
+        searchValue: searchStr,
+        autoClearSearchValue: true,
+        filterOption: false,
+        ...(_.isObject(selectProps.showSearch)
+          ? _.omit(selectProps.showSearch, ['searchValue'])
+          : {}),
+      }}
+      labelRender={({ label, value }) => {
+        return onClickVFolder ? (
+          <BAILink onClick={() => onClickVFolder(_.toString(value))}>
+            {label}
+          </BAILink>
+        ) : (
+          <>
+            {label}
+            <BAIText type="secondary">
+              &nbsp; (
+              <BAIText
+                ellipsis
+                type="secondary"
+                style={{
+                  width: 80,
+                }}
+                monospace
+              >
+                {valuePropName === 'id'
+                  ? toLocalId(_.toString(value))
+                  : _.toString(value)}
+              </BAIText>
+              )
+            </BAIText>
+          </>
+        );
+      }}
+      optionRender={({ label, value }) => (
+        <>
+          {label}
+          <BAIText type="secondary">
+            &nbsp; (
+            <BAIText
+              ellipsis
+              style={{
+                width: 80,
+              }}
+              type="secondary"
+              monospace
+            >
+              {valuePropName === 'id'
+                ? toLocalId(_.toString(value))
+                : _.toString(value)}
+            </BAIText>
+            )
+          </BAIText>
+        </>
+      )}
+      value={
+        controllableValue !== deferredControllableValue
+          ? optimisticValueWithLabel
+          : controllableValueWithLabel
+      }
+      labelInValue
+      onChange={(value, option) => {
+        // In multiple mode, when removing tags, value.label is a React element
+        // So we need to find the original label from availableOptions
+        const valueWithOriginalLabel = _.castArray(value).map((v) => {
+          // If label is string, use it directly; if React element, find from options
+          const label = _.isString(v.label)
+            ? v.label
+            : (availableOptions.find((opt) => opt.value === v.value)?.label ??
+              v.value);
+          return {
+            label,
+            value: v.value,
+          };
+        });
+        setOptimisticValueWithLabel(valueWithOriginalLabel);
+        setControllableValue(
+          _.castArray(value).map((v) => _.toString(v.value)),
+          option,
+        );
+      }}
+      options={availableOptions}
+      endReached={() => {
+        loadNext();
+      }}
+      open={controllableOpen}
+      onOpenChange={setControllableOpen}
+      notFoundContent={
+        _.isUndefined(paginationData) ? (
+          <Skeleton.Input active size="small" block />
+        ) : undefined
+      }
+      footer={
+        _.isNumber(result.vfolder_nodes?.count) &&
+        result.vfolder_nodes.count > 0 ? (
+          <TotalFooter
+            loading={isLoadingNext}
+            total={result.vfolder_nodes.count}
+          />
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BAIVFolderSelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -64,3 +64,9 @@ export { default as BAIResourceGroupSelect } from './BAIResourceGroupSelect';
 export type { BAIResourceGroupSelectProps } from './BAIResourceGroupSelect';
 export { default as BAIProjectBulkEditModal } from './BAIProjectBulkEditModal';
 export type { BAIProjectBulkEditModalProps } from './BAIProjectBulkEditModal';
+export { default as BAIVFolderSelect } from './BAIVFolderSelect';
+export type {
+  BAIVFolderSelectProps,
+  VFolderNode,
+  BAIVFolderSelectRef,
+} from './BAIVFolderSelect';

--- a/packages/backend.ai-ui/src/hooks/index.ts
+++ b/packages/backend.ai-ui/src/hooks/index.ts
@@ -62,6 +62,11 @@ export const useUpdatableState = (initialValue: string) => {
   return useDateISOState(initialValue);
 };
 
+export const INITIAL_FETCH_KEY = 'first';
+export const useFetchKey = () => {
+  return [...useDateISOState(INITIAL_FETCH_KEY), INITIAL_FETCH_KEY] as const;
+};
+
 export const useAllowedHostNames = () => {
   'use memo';
   const baiClient = useConnectedBAIClient();

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "test"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Ordner auswählen"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Dateierweiterung ändern",
     "ChangeFileExtensionDesc": "Das Ändern der Dateierweiterung kann dazu führen, dass die Datei unbrauchbar oder falsch geöffnet wird. \nMöchten Sie fortfahren?",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "δοκιμή"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Επιλογή φακέλου"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Αλλαγή επέκτασης αρχείου",
     "ChangeFileExtensionDesc": "Η αλλαγή της επέκτασης του αρχείου μπορεί να προκαλέσει λανθασμένα το αρχείο. \nΘέλετε να προχωρήσετε;",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -182,6 +182,9 @@
   "comp:BAITestButton": {
     "Test": "Test"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Select Folder"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Change File Extension",
     "ChangeFileExtensionDesc": "Changing the file extension may cause the file to become unusable or open incorrectly. Do you want to proceed?",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "prueba"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Seleccionar carpeta"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Cambiar la extensión del archivo",
     "ChangeFileExtensionDesc": "Cambiar la extensión del archivo puede hacer que el archivo se vuelva inutilizable o se abra incorrectamente. \n¿Quieres continuar?",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "testi"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Valitse kansio"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Vaihda tiedoston laajennus",
     "ChangeFileExtensionDesc": "Tiedoston laajennuksen muuttaminen voi aiheuttaa tiedoston käyttökelvottoman tai avoimen väärin. \nHaluatko edetä?",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "test"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Sélectionner un dossier"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Modifier l'extension du fichier",
     "ChangeFileExtensionDesc": "La modification de l'extension du fichier peut faire en sorte que le fichier devienne inutilisable ou s'ouvre incorrectement. \nVoulez-vous continuer?",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "tes"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Pilih Folder"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Ubah ekstensi file",
     "ChangeFileExtensionDesc": "Mengubah ekstensi file dapat menyebabkan file menjadi tidak dapat digunakan atau dibuka secara tidak benar. \nApakah Anda ingin melanjutkan?",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "test"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Seleziona cartella"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Modificare l'estensione del file",
     "ChangeFileExtensionDesc": "La modifica dell'estensione del file può far sì che il file diventi inutilizzabile o si aprirà in modo errato. \nVuoi procedere?",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "テスト"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "フォルダを選択"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "ファイル拡張子を変更します",
     "ChangeFileExtensionDesc": "ファイル拡張子を変更すると、ファイルが使用できなくなったり、誤って開いたりすることがあります。\n先に進みたいですか？",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "테스트"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "폴더를 선택해주세요"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "파일 확장자 변경",
     "ChangeFileExtensionDesc": "파일 확장자를 변경하면 파일이 사용 불가능해지거나 올바르게 열리지 않을 수 있습니다. 계속하시겠습니까?",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "турших"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Хавтас сонгох"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Файлын өргөтгөлийг өөрчлөх",
     "ChangeFileExtensionDesc": "Файлын өргөтгөлийг өөрчлөх нь файлыг ашиглах боломжгүй эсвэл буруу нээхэд хүргэж болзошгүй юм. \nТа үргэлжлүүлэхийг хүсч байна уу?",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "ujian"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Pilih Folder"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Tukar Sambungan Fail",
     "ChangeFileExtensionDesc": "Menukar sambungan fail boleh menyebabkan fail menjadi tidak dapat digunakan atau dibuka dengan tidak betul. \nAdakah anda mahu meneruskan?",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "test"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Wybierz folder"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Zmień rozszerzenie pliku",
     "ChangeFileExtensionDesc": "Zmiana rozszerzenia pliku może spowodować, że plik staje się bezużyteczny lub nieprawidłowo otwierać. \nChcesz kontynuować?",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -178,6 +178,9 @@
   "comp:BAITestButton": {
     "Test": "teste"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Selecionar pasta"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Alterar a extensão do arquivo",
     "ChangeFileExtensionDesc": "Alterar a extensão do arquivo pode fazer com que o arquivo se torne inutilizável ou aberto incorretamente. \nVocê quer prosseguir?",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "teste"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Selecionar pasta"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Alterar a extensão do arquivo",
     "ChangeFileExtensionDesc": "Alterar a extensão do arquivo pode fazer com que o arquivo se torne inutilizável ou aberto incorretamente. \nVocê quer prosseguir?",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "тест"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Выбрать папку"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Изменить расширение файла",
     "ChangeFileExtensionDesc": "Изменение расширения файла может привести к тому, что файл станет непригодным для использования или неверно открытым. \nВы хотите продолжить?",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "ทดสอบ"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "เลือกโฟลเดอร์"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "เปลี่ยนนามสกุลไฟล์",
     "ChangeFileExtensionDesc": "การเปลี่ยนนามสกุลไฟล์อาจทำให้ไฟล์ไม่สามารถใช้งานได้หรือเปิดไม่ถูกต้อง \nคุณต้องการดำเนินการต่อหรือไม่?",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "test"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Klasör Seç"
+  },
   "comp:FileExplorer": {
     "Controls": "Kontroller",
     "CreateANewFolder": "Yeni bir klasör oluşturun",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "kiểm tra"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "Chọn thư mục"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "Thay đổi phần mở rộng tệp",
     "ChangeFileExtensionDesc": "Thay đổi tiện ích mở rộng tệp có thể khiến tệp trở nên không thể sử dụng hoặc mở không chính xác. \nBạn có muốn tiếp tục không?",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "测试"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "选择文件夹"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "更改文件扩展名",
     "ChangeFileExtensionDesc": "更改文件扩展名可能会导致文件变得无法使用或不正确打开。\n你想继续吗？",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -179,6 +179,9 @@
   "comp:BAITestButton": {
     "Test": "測試"
   },
+  "comp:BAIVFolderSelect": {
+    "SelectFolder": "選擇資料夾"
+  },
   "comp:FileExplorer": {
     "ChangeFileExtension": "更改文件擴展名",
     "ChangeFileExtensionDesc": "更改文件擴展名可能會導致文件變得無法使用或不正確打開。你想繼續嗎？",

--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -10,7 +10,7 @@ import {
   convertUnitValue,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
-import { INITIAL_FETCH_KEY, useSuspendedBackendaiClient } from '../hooks';
+import { useSuspendedBackendaiClient } from '../hooks';
 import { ResourceSlotName } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
@@ -42,6 +42,7 @@ import {
   BAIText,
   ResourceTypeIcon,
   useResourceSlotsDetails,
+  INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';

--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -7,7 +7,6 @@ import {
   convertToBinaryUnit,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
-import { INITIAL_FETCH_KEY, useFetchKey } from '../hooks';
 import { ResourceSlotName } from '../hooks/backendai';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
 import { useResourceGroupsForCurrentProject } from '../hooks/useCurrentProject';
@@ -32,6 +31,8 @@ import {
   mergeFilterValues,
   ResourceTypeIcon,
   useResourceSlotsDetails,
+  useFetchKey,
+  INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import React, { useDeferredValue, useMemo } from 'react';

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -4,11 +4,7 @@ import {
   ContainerRegistryListQuery,
   ContainerRegistryListQuery$data,
 } from '../__generated__/ContainerRegistryListQuery.graphql';
-import {
-  INITIAL_FETCH_KEY,
-  useFetchKey,
-  useSuspendedBackendaiClient,
-} from '../hooks';
+import { useSuspendedBackendaiClient } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
@@ -44,6 +40,8 @@ import {
   BAIPropertyFilter,
   BAIModal,
   useBAILogger,
+  useFetchKey,
+  INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { useState, useDeferredValue, useMemo } from 'react';

--- a/react/src/components/FolderExplorerModal.tsx
+++ b/react/src/components/FolderExplorerModal.tsx
@@ -13,6 +13,7 @@ import {
   BAIModal,
   BAIModalProps,
   toGlobalId,
+  useFetchKey,
   useInterval,
 } from 'backend.ai-ui';
 import _ from 'lodash';
@@ -20,11 +21,7 @@ import { Suspense, useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { FolderExplorerModalQuery } from 'src/__generated__/FolderExplorerModalQuery.graphql';
-import {
-  useCurrentDomainValue,
-  useFetchKey,
-  useSuspendedBackendaiClient,
-} from 'src/hooks';
+import { useCurrentDomainValue, useSuspendedBackendaiClient } from 'src/hooks';
 import { useSetBAINotification } from 'src/hooks/useBAINotification';
 import { useCurrentProjectValue } from 'src/hooks/useCurrentProject';
 import { useMergedAllowedStorageHostPermission } from 'src/hooks/useMergedAllowedStorageHostPermission';

--- a/react/src/components/ModelTryContentButton.tsx
+++ b/react/src/components/ModelTryContentButton.tsx
@@ -4,11 +4,7 @@ import {
   baiSignedRequestWithPromise,
   useBaiSignedRequestWithPromise,
 } from '../helper';
-import {
-  INITIAL_FETCH_KEY,
-  useCurrentDomainValue,
-  useSuspendedBackendaiClient,
-} from '../hooks';
+import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import {
   useSetBAINotification,
@@ -27,6 +23,7 @@ import {
   generateRandomString,
   useSearchVFolderFiles,
   useUpdatableState,
+  INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import React, { useRef, useEffect } from 'react';

--- a/react/src/components/MyResource.tsx
+++ b/react/src/components/MyResource.tsx
@@ -11,11 +11,11 @@ import {
   processMemoryValue,
   BAIFetchKeyButton,
   useResourceSlotsDetails,
+  useFetchKey,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { ReactNode, useTransition } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { useFetchKey } from 'src/hooks';
 
 interface MyResourceProps extends BAIFlexProps {
   fetchKey?: string;

--- a/react/src/components/MyResourceWithinResourceGroup.tsx
+++ b/react/src/components/MyResourceWithinResourceGroup.tsx
@@ -17,6 +17,7 @@ import {
   BAIFetchKeyButton,
   BAIFlexProps,
   useResourceSlotsDetails,
+  useFetchKey,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { ReactNode, useDeferredValue, useMemo, useTransition } from 'react';

--- a/react/src/components/PendingSessionNodeList.tsx
+++ b/react/src/components/PendingSessionNodeList.tsx
@@ -5,6 +5,8 @@ import {
   BAIFlex,
   filterOutNullAndUndefined,
   BAIFetchKeyButton,
+  useFetchKey,
+  INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { useDeferredValue, useMemo } from 'react';
@@ -15,7 +17,7 @@ import {
   PendingSessionNodeListQuery,
   PendingSessionNodeListQuery$variables,
 } from 'src/__generated__/PendingSessionNodeListQuery.graphql';
-import { INITIAL_FETCH_KEY, useFetchKey, useWebUINavigate } from 'src/hooks';
+import { useWebUINavigate } from 'src/hooks';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from 'src/hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 import { useCurrentResourceGroupValue } from 'src/hooks/useCurrentProject';

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -1,7 +1,7 @@
 import { SessionDetailContentFragment$key } from '../__generated__/SessionDetailContentFragment.graphql';
 import { SessionDetailContentLegacyQuery } from '../__generated__/SessionDetailContentLegacyQuery.graphql';
 import { SessionDetailContentQuery } from '../__generated__/SessionDetailContentQuery.graphql';
-import { INITIAL_FETCH_KEY, useSuspendedBackendaiClient } from '../hooks';
+import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { ResourceNumbersOfSession } from '../pages/SessionLauncherPage';
@@ -44,6 +44,7 @@ import {
   BAIFlex,
   BAISessionAgentIds,
   BAISessionClusterMode,
+  INITIAL_FETCH_KEY,
   BAIButton,
 } from 'backend.ai-ui';
 // import { graphql } from 'react-relay';

--- a/react/src/components/SessionDetailDrawer.tsx
+++ b/react/src/components/SessionDetailDrawer.tsx
@@ -1,9 +1,9 @@
 import { SessionDetailDrawerFragment$key } from '../__generated__/SessionDetailDrawerFragment.graphql';
-import { useFetchKey, useSuspendedBackendaiClient } from '../hooks';
+import { useSuspendedBackendaiClient } from '../hooks';
 import SessionDetailContent from './SessionDetailContent';
 import { Drawer, Skeleton } from 'antd';
 import { DrawerProps } from 'antd/lib';
-import { BAIFetchKeyButton } from 'backend.ai-ui';
+import { BAIFetchKeyButton, useFetchKey } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import React, { Suspense, useMemo, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -4,7 +4,6 @@ import {
   convertUnitValue,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
-import { INITIAL_FETCH_KEY, useFetchKey } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
 import BAIProgressWithLabel from './BAIProgressWithLabel';
 import DoubleTag from './DoubleTag';
@@ -18,6 +17,8 @@ import {
   BAIPureStorageIcon,
   BAITable,
   BAIFetchKeyButton,
+  INITIAL_FETCH_KEY,
+  useFetchKey,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { Server } from 'lucide-react';

--- a/react/src/components/UserCredentialList.tsx
+++ b/react/src/components/UserCredentialList.tsx
@@ -6,7 +6,6 @@ import {
   UserCredentialListQuery$data,
   UserCredentialListQuery$variables,
 } from '../__generated__/UserCredentialListQuery.graphql';
-import { INITIAL_FETCH_KEY } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
 import BAIRadioGroup from './BAIRadioGroup';
 import KeypairInfoModal from './KeypairInfoModal';
@@ -27,6 +26,7 @@ import {
   useBAILogger,
   useUpdatableState,
   BAIText,
+  INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';

--- a/react/src/components/UserManagement.tsx
+++ b/react/src/components/UserManagement.tsx
@@ -1,10 +1,6 @@
 import { UserManagementModifyMutation } from '../__generated__/UserManagementModifyMutation.graphql';
 import { UserManagementQuery } from '../__generated__/UserManagementQuery.graphql';
-import {
-  INITIAL_FETCH_KEY,
-  useFetchKey,
-  useSuspendedBackendaiClient,
-} from '../hooks';
+import { useSuspendedBackendaiClient } from '../hooks';
 import BAIRadioGroup from './BAIRadioGroup';
 import UserInfoModal from './UserInfoModal';
 import UserSettingModal from './UserSettingModal';
@@ -22,6 +18,8 @@ import {
   BAIFetchKeyButton,
   isValidUUID,
   BAIUserNodes,
+  useFetchKey,
+  INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { BanIcon, EditIcon, PlusIcon, UndoIcon } from 'lucide-react';

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -1,7 +1,6 @@
 import { getOS, preserveDotStartCase } from '../helper';
 import { useSuspenseTanQuery } from './reactQueryAlias';
 import { MenuKeys } from './useWebUIMenuItems';
-import { useDateISOState } from 'backend.ai-ui';
 import _ from 'lodash';
 import { useEffect, useMemo, useState } from 'react';
 import { NavigateOptions, To, useNavigate } from 'react-router-dom';
@@ -46,11 +45,6 @@ export const useBackendAIConnectedState = () => {
   }, []);
 
   return time;
-};
-
-export const INITIAL_FETCH_KEY = 'first';
-export const useFetchKey = () => {
-  return [...useDateISOState(INITIAL_FETCH_KEY), INITIAL_FETCH_KEY] as const;
 };
 
 export const useCurrentDomainValue = () => {

--- a/react/src/pages/AdminDashboardPage.tsx
+++ b/react/src/pages/AdminDashboardPage.tsx
@@ -5,18 +5,19 @@ import SessionCountDashboardItem from '../components/SessionCountDashboardItem';
 import TotalResourceWithinResourceGroup, {
   useIsAvailableTotalResourceWithinResourceGroup,
 } from '../components/TotalResourceWithinResourceGroup';
-import {
-  INITIAL_FETCH_KEY,
-  useFetchKey,
-  useSuspendedBackendaiClient,
-} from '../hooks';
+import { useSuspendedBackendaiClient } from '../hooks';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   useCurrentProjectValue,
   useCurrentResourceGroupValue,
 } from '../hooks/useCurrentProject';
 import { Skeleton, theme } from 'antd';
-import { filterOutEmpty, useInterval } from 'backend.ai-ui';
+import {
+  filterOutEmpty,
+  INITIAL_FETCH_KEY,
+  useFetchKey,
+  useInterval,
+} from 'backend.ai-ui';
 import _ from 'lodash';
 import { Suspense, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -13,7 +13,7 @@ import SessionNodes, {
 } from '../components/SessionNodes';
 import { handleRowSelectionChange } from '../helper';
 import { ExtractResultValue } from '../helper/resultTypes';
-import { INITIAL_FETCH_KEY, useFetchKey, useWebUINavigate } from '../hooks';
+import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import {
@@ -37,7 +37,9 @@ import {
   BAISessionsIcon,
   filterOutEmpty,
   filterOutNullAndUndefined,
+  INITIAL_FETCH_KEY,
   mergeFilterValues,
+  useFetchKey,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { PowerOffIcon } from 'lucide-react';

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -7,18 +7,19 @@ import SessionCountDashboardItem from '../components/SessionCountDashboardItem';
 import TotalResourceWithinResourceGroup, {
   useIsAvailableTotalResourceWithinResourceGroup,
 } from '../components/TotalResourceWithinResourceGroup';
-import {
-  INITIAL_FETCH_KEY,
-  useFetchKey,
-  useSuspendedBackendaiClient,
-} from '../hooks';
+import { useSuspendedBackendaiClient } from '../hooks';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import {
   useCurrentProjectValue,
   useCurrentResourceGroupValue,
 } from '../hooks/useCurrentProject';
 import { Skeleton, theme } from 'antd';
-import { filterOutEmpty, useInterval } from 'backend.ai-ui';
+import {
+  filterOutEmpty,
+  INITIAL_FETCH_KEY,
+  useFetchKey,
+  useInterval,
+} from 'backend.ai-ui';
 import _ from 'lodash';
 import { Suspense, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/react/src/pages/ProjectPage.tsx
+++ b/react/src/pages/ProjectPage.tsx
@@ -12,6 +12,7 @@ import {
   BAIPropertyFilter,
   BAIText,
   filterOutEmpty,
+  INITIAL_FETCH_KEY,
   isValidUUID,
   useUpdatableState,
 } from 'backend.ai-ui';
@@ -25,7 +26,6 @@ import {
   ProjectPageQuery$data,
   ProjectPageQuery$variables,
 } from 'src/__generated__/ProjectPageQuery.graphql';
-import { INITIAL_FETCH_KEY } from 'src/hooks';
 import { useBAIPaginationOptionStateOnSearchParam } from 'src/hooks/reactPaginationQueryOptions';
 
 type ProjectNode = NonNullable<

--- a/react/src/pages/ReservoirArtifactDetailPage.tsx
+++ b/react/src/pages/ReservoirArtifactDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   BAIText,
   convertToDecimalUnit,
   filterOutNullAndUndefined,
+  INITIAL_FETCH_KEY,
   useUpdatableState,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
@@ -31,7 +32,6 @@ import {
   ReservoirArtifactDetailPageQuery$data,
   ReservoirArtifactDetailPageQuery$variables,
 } from 'src/__generated__/ReservoirArtifactDetailPageQuery.graphql';
-import { INITIAL_FETCH_KEY } from 'src/hooks';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from 'src/hooks/reactPaginationQueryOptions';
 import { useSetBAINotification } from 'src/hooks/useBAINotification';
 import { JsonParam, useQueryParams, withDefault } from 'use-query-params';

--- a/react/src/pages/ReservoirPage.tsx
+++ b/react/src/pages/ReservoirPage.tsx
@@ -1,4 +1,3 @@
-import { INITIAL_FETCH_KEY } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
 import { useToggle } from 'ahooks';
 import {
@@ -26,6 +25,7 @@ import {
   BAIImportArtifactModalArtifactFragmentKey,
   BAIImportArtifactModalArtifactRevisionFragmentKey,
   BAIImportFromHuggingFaceModal,
+  INITIAL_FETCH_KEY,
   toLocalId,
   useUpdatableState,
 } from 'backend.ai-ui';


### PR DESCRIPTION
resolves #4939 (FR-1870)

This PR adds a new `BAIVFolderSelect` component that allows users to select virtual folders with the following features:

- Supports both single and multiple selection modes
- Provides search functionality with server-side filtering
- Excludes deleted or deleting vfolders from selection options
- Supports pagination with "load more" functionality
- Displays total count of available vfolders
- Optional click handler for selected vfolders
- Can be scoped to a specific project

The component is exported from the fragments index file for use throughout the application.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after