### PR TITLE
fix(FR-1876): remove unnecessary filter for resource usage values in MyResourceWithinResourceGroup

### DIFF
--- a/react/src/components/MyResourceWithinResourceGroup.tsx
+++ b/react/src/components/MyResourceWithinResourceGroup.tsx
@@ -144,12 +144,8 @@ const MyResourceWithinResourceGroup: React.FC<
             ?.remaining?.[key as ResourceSlotName],
         );
 
-        // Filter out if both using and remaining have no values
-        if (
-          (usingCurrent === 0 || !isFinite(usingCurrent)) &&
-          (remainingCurrent === 0 || !isFinite(remainingCurrent))
-        )
-          return null;
+        // Skip displaying if both used and free are not finite numbers
+        if (!isFinite(usingCurrent) && !isFinite(remainingCurrent)) return null;
 
         return {
           key,


### PR DESCRIPTION
Resolves #4952 ([FR-1876](https://lablup.atlassian.net/browse/FR-1876))

# Improved Resource Slot Filtering Logic

This PR refines the filtering logic for resource slots in the `MyResourceWithinResourceGroup` component. Previously, slots were hidden when both `usingCurrent` and `remainingCurrent` values were zero or not finite. The updated logic now only hides resource slots when both values are not finite numbers, allowing slots with zero values to be displayed.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1876]: https://lablup.atlassian.net/browse/FR-1876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ