### PR TITLE
feat(FR-1797): migrate app launcher related code to React

### DIFF
--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -11,7 +11,7 @@ These instructions apply to React components in the `/react` directory.
 ### 'use memo' Directive (Recommended)
 
 - This project uses the new **React Compiler**.
-- We actively use React directives such as `use memo` and `use client` at the top of files or components.
+- We actively use React directives such as `use memo` and `use client` at the top components (NOT files).
 - `use memo` is **intentional and valid** in this codebase.
 - Even if tooling or TypeScript/ESLint shows something like:
   - `Unknown directive: 'use memo'.`

--- a/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.ts
+++ b/packages/backend.ai-ui/src/hooks/useErrorMessageResolver.ts
@@ -28,29 +28,32 @@ export type ESMClientErrorResponse = {
 const useErrorMessageResolver = () => {
   const { t } = useTranslation();
 
+  const isErrorLike = (
+    error: unknown,
+  ): error is Partial<ErrorResponse & Error> => {
+    return typeof error === 'object' && error !== null;
+  };
+
   /**
    * Resolves the error message for a given error object.
    * @param error - The error object to resolve.
    * @param defaultMessage - (optional) The default message to return if no specific message is found.
    * @returns - The resolved error message (string).
    */
-  const getErrorMessage = (
-    error: Partial<ErrorResponse & Error> | undefined | null,
-    defaultMessage?: string,
-  ): string => {
+  const getErrorMessage = (error: unknown, defaultMessage?: string): string => {
     let errorMsg = defaultMessage || t('error.UnknownError');
-    if (!error) return errorMsg;
+    if (!error || !isErrorLike(error)) return errorMsg;
 
     // Prioritize `msg` or `message`(deprecated) field if available.
-    if (error?.msg || error?.message) {
-      const integratedErrorMsg = error?.msg || error?.message || '';
+    if (error.msg || error.message) {
+      const integratedErrorMsg = error.msg || error.message || '';
       errorMsg = !_.includes(integratedErrorMsg, 'Traceback')
         ? integratedErrorMsg
         : errorMsg;
     } else if (error.title) {
       errorMsg = error.title;
     }
-    if (error?.error_code) {
+    if (error.error_code) {
       errorMsg = _.join([errorMsg, `(${error.error_code})`], ' ');
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,9 +661,6 @@ importers:
       '@ant-design/icons':
         specifier: ^6.1.0
         version: 6.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@ant-design/v5-patch-for-react-19':
-        specifier: ^1.0.3
-        version: 1.0.3(antd@6.1.4(date-fns@3.6.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@ant-design/x':
         specifier: ^2.1.3
         version: 2.1.3(antd@6.1.4(date-fns@3.6.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1168,14 +1165,6 @@ packages:
     peerDependencies:
       react: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@ant-design/v5-patch-for-react-19@1.0.3':
-    resolution: {integrity: sha512-iWfZuSUl5kuhqLUw7jJXUQFMMkM7XpW7apmKzQBQHU0cpifYW4A79xIBt9YVO5IBajKpPG5UKP87Ft7Yrw1p/w==}
-    engines: {node: '>=12.x'}
-    peerDependencies:
-      antd: '>=5.22.6'
-      react: '>=19.0.0'
-      react-dom: '>=19.0.0'
 
   '@ant-design/x@2.1.3':
     resolution: {integrity: sha512-A+3eL9RPYwTpphm3IclhXkk/OfwRzzIw41j1NCONEDRSd4F3Du3dHo1hbDKzI42/hwR1LL8P/6hiehJvxYqHkw==}
@@ -15986,12 +15975,6 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       throttle-debounce: 5.0.2
-
-  '@ant-design/v5-patch-for-react-19@1.0.3(antd@6.1.4(date-fns@3.6.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      antd: 6.1.4(date-fns@3.6.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
 
   '@ant-design/x@2.1.3(antd@6.1.4(date-fns@3.6.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:

--- a/react/package.json
+++ b/react/package.json
@@ -9,7 +9,6 @@
     "@ant-design/colors": "^7.2.1",
     "@ant-design/cssinjs": "^2.0.1",
     "@ant-design/icons": "^6.1.0",
-    "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@ant-design/x": "^2.1.3",
     "@cloudscape-design/board-components": "3.0.60",
     "@codemirror/lang-jinja": "^6.0.0",

--- a/react/src/components/ComputeSessionNodeItems/AppLaunchConfirmationModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLaunchConfirmationModal.tsx
@@ -1,0 +1,89 @@
+import { Typography } from 'antd';
+import { BAIButton, BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment } from 'react-relay';
+import { AppLaunchConfirmationModalFragment$key } from 'src/__generated__/AppLaunchConfirmationModalFragment.graphql';
+import { useBackendAIAppLauncher } from 'src/hooks/useBackendAIAppLauncher';
+
+interface AppLaunchConfirmationModalProps extends BAIModalProps {
+  sessionFrgmt: AppLaunchConfirmationModalFragment$key;
+  appName: string;
+  onRequestClose: () => void;
+}
+
+/**
+ * Confirmation modal for apps that require user acknowledgment before launching.
+ * Used for nniboard and mlflow-ui apps that need to run before tunneling.
+ *
+ * This matches the legacy behavior of `_openAppLaunchConfirmationDialog` in
+ * backend-ai-app-launcher.ts
+ */
+const AppLaunchConfirmationModal: React.FC<AppLaunchConfirmationModalProps> = ({
+  sessionFrgmt,
+  appName,
+  onRequestClose,
+  ...modalProps
+}) => {
+  'use memo';
+
+  const { t } = useTranslation();
+
+  const session = useFragment(
+    graphql`
+      fragment AppLaunchConfirmationModalFragment on ComputeSessionNode {
+        id
+        row_id
+        name
+        ...useBackendAIAppLauncherFragment
+      }
+    `,
+    sessionFrgmt,
+  );
+
+  const { launchAppWithNotification } = useBackendAIAppLauncher(session);
+
+  const handleConfirmAndRun = async () => {
+    onRequestClose();
+
+    await launchAppWithNotification({
+      app: appName,
+      onPrepared(workerInfo) {
+        // Open app in new window after preparation
+        if (workerInfo.appConnectUrl) {
+          setTimeout(() => {
+            window.open(workerInfo.appConnectUrl?.href, '_blank');
+          }, 1000);
+        }
+      },
+    });
+  };
+
+  return (
+    <BAIModal
+      title={t('session.appLauncher.AppMustBeRun')}
+      onCancel={onRequestClose}
+      footer={null}
+      {...modalProps}
+    >
+      <BAIFlex direction="column" gap="md" align="stretch">
+        <Typography.Paragraph>
+          {t('session.appLauncher.AppMustBeRunDialog')}
+        </Typography.Paragraph>
+        <Typography.Paragraph>
+          {t('dialog.ask.DoYouWantToProceed')}
+        </Typography.Paragraph>
+
+        <BAIButton
+          type="primary"
+          size="large"
+          action={handleConfirmAndRun}
+          block
+        >
+          {t('session.appLauncher.ConfirmAndRun')}
+        </BAIButton>
+      </BAIFlex>
+    </BAIModal>
+  );
+};
+
+export default AppLaunchConfirmationModal;

--- a/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
@@ -5,7 +5,15 @@ import {
   TemplateItem,
   useSuspendedFilteredAppTemplate,
 } from '../../hooks/useSuspendedFilteredAppTemplate';
+import AppLaunchConfirmationModal from './AppLaunchConfirmationModal';
+import SFTPConnectionInfoModal from './SFTPConnectionInfoModal';
+import TCPConnectionInfoModal from './TCPConnectionInfoModal';
+import TensorboardPathModal from './TensorboardPathModal';
+import VNCConnectionInfoModal from './VNCConnectionInfoModal';
+import VSCodeDesktopConnectionModal from './VSCodeDesktopConnectionModal';
+import XRDPConnectionInfoModal from './XRDPConnectionInfoModal';
 import {
+  App,
   Button,
   Checkbox,
   Col,
@@ -21,17 +29,21 @@ import {
 import {
   BAIButton,
   BAIFlex,
-  BAILink,
   BAIModal,
   BAISelect,
   BAIText,
+  BAIUnmountAfterClose,
+  useBAILogger,
+  useErrorMessageResolver,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { useNavigate } from 'react-router-dom';
-import { useSetBAINotification } from 'src/hooks/useBAINotification';
+import {
+  TCP_APPS,
+  useBackendAIAppLauncher,
+} from 'src/hooks/useBackendAIAppLauncher';
 
 interface AppLauncherModalProps extends ModalProps {
   onRequestClose: () => void;
@@ -43,7 +55,9 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
   sessionFrgmt,
   ...modalProps
 }) => {
+  'use memo';
   const { t } = useTranslation();
+  const { logger } = useBAILogger();
   const baiClient = useSuspendedBackendaiClient();
   const formRef = useRef<FormInstance>(null);
   const [openToPublic, setOpenToPublic] = useState<boolean>(false);
@@ -51,9 +65,9 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
   const [forceUseV1Proxy, setForceUseV1Proxy] = useState<boolean>(false);
   const [forceUseV2Proxy, setForceUseV2Proxy] = useState<boolean>(false);
   const [useSubDomain, setUseSubDomain] = useState<boolean>(false);
-
-  const { upsertNotification } = useSetBAINotification();
-  const navigate = useNavigate();
+  const [subDomainValue, setSubDomainValue] = useState<string>('');
+  const { message } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
 
   const session = useFragment(
     graphql`
@@ -63,6 +77,10 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
         name
         service_ports
         access_key
+        ...useBackendAIAppLauncherFragment
+        ...SFTPConnectionInfoModalFragment
+        ...TensorboardPathModalFragment
+        ...AppLaunchConfirmationModalFragment
       }
     `,
     sessionFrgmt,
@@ -75,127 +93,238 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
   const { preOpenAppTemplate, baseAppTemplate } =
     useSuspendedFilteredAppTemplate(servicePorts);
 
-  // TODO: This should be merged into `useBackendAIAppLauncher` hook
+  const { launchAppWithNotification } = useBackendAIAppLauncher(session, {
+    forceUseV1Proxy: forceUseV1Proxy,
+    forceUseV2Proxy: forceUseV2Proxy,
+    subdomain: subDomainValue ?? undefined,
+  });
+
   const handleAppLaunch = async (app: Partial<TemplateItem> | null) => {
     if (!app?.name) return;
 
-    await formRef.current?.validateFields().then((values) => {
-      if (openToPublic) {
-        // @ts-ignore
-        globalThis.appLauncher.openToPublic = true;
-        // @ts-ignore
-        globalThis.appLauncher.clientIps = values.clientIps?.join(',') || '';
-      }
-      if (tryPreferredPort) {
-        // @ts-ignore
-        globalThis.appLauncher.preferredPort = values.preferredPort ?? 10250;
-      }
-      if (useSubDomain) {
-        // @ts-ignore
-        globalThis.appLauncher.subDomain = values.subDomain;
-      }
-      if (forceUseV1Proxy) {
-        // @ts-ignore
-        globalThis.appLauncher.forceUseV1Proxy = true;
-      }
-      if (forceUseV2Proxy) {
-        // @ts-ignore
-        globalThis.appLauncher.forceUseV2Proxy = true;
-      }
-    });
+    try {
+      const values = await formRef.current?.validateFields().catch(() => {
+        return;
+      });
 
-    // set notification for lit-element component
-    upsertNotification({
-      key: `session-app-${session?.row_id}`,
-      message: (
-        <span>
-          {t('general.Session')}:&nbsp;
-          <BAILink
-            style={{
-              fontWeight: 'normal',
-            }}
-            onClick={() => {
-              const newSearchParams = new URLSearchParams(location.search);
-              newSearchParams.set('sessionDetail', session?.row_id || '');
-              navigate({
-                pathname: `/session`,
-                search: newSearchParams.toString(),
-              });
-            }}
-          >
-            {session?.name}
-          </BAILink>
-        </span>
-      ),
-      description: t('session.appLauncher.LaunchingApp', {
-        appName: app?.title || '',
-      }),
-    });
+      // Handle special apps that require confirmation before launching (nniboard, mlflow-ui)
+      // These apps need to run before tunneling, so show confirmation dialog first
+      if (['nniboard', 'mlflow-ui'].includes(app?.name ?? '')) {
+        setConfirmationModalState({
+          open: true,
+          appName: app?.name ?? '',
+        });
+        return;
+      }
 
-    const appController = {
-      'app-name': app?.name ?? '',
-      'session-uuid': session?.row_id ?? '',
-      'session-name': session?.name ?? '',
-      'url-postfix': app?.redirect ?? '',
-    };
+      // Tensorboard - show path input modal BEFORE starting proxy
+      // This matches legacy behavior where modal is shown first, then proxy starts after path submission
+      if (app.name === 'tensorboard') {
+        setOpenTensorboardModal(true);
+        return;
+      }
 
-    if (['nniboard', 'mlflow-ui'].includes(app?.name ?? '')) {
-      // @ts-ignore
-      // eslint-disable-next-line react-hooks/immutability
-      globalThis.appLauncher.appController['app-name'] = app?.name ?? '';
-      // @ts-ignore
-      // eslint-disable-next-line react-hooks/immutability
-      globalThis.appLauncher.appController['session-uuid'] =
-        session?.row_id ?? '';
-      // @ts-ignore
-      // eslint-disable-next-line react-hooks/immutability
-      globalThis.appLauncher.appController['url-postfix'] = app?.redirect ?? '';
-      // @ts-ignore
-      globalThis.appLauncher._openAppLaunchConfirmationDialog();
-      onRequestClose();
-      return;
+      // Use new launchApp API for regular apps
+      // Errors are handled by the notification system in launchApp
+      await launchAppWithNotification({
+        app: app?.name ?? '',
+        port: tryPreferredPort ? values?.preferredPort : undefined,
+        openToPublic: openToPublic,
+        allowedClientIps: openToPublic ? values?.clientIps : undefined,
+        onPrepared(workerInfo) {
+          // SFTP (SSH) connection
+          if (app.name === 'sshd') {
+            setSftpModalState({
+              open: true,
+              host: workerInfo.tcpHost || '127.0.0.1',
+              port: parseInt(workerInfo.tcpPort || '0', 10),
+            });
+            return;
+          }
+
+          // VNC connection
+          if (app.name === 'vnc') {
+            setVncModalState({
+              open: true,
+              host: workerInfo.tcpHost || '127.0.0.1',
+              port: parseInt(workerInfo.tcpPort || '0', 10),
+            });
+            return;
+          }
+
+          // XRDP connection
+          if (app.name === 'xrdp') {
+            setXrdpModalState({
+              open: true,
+              host: workerInfo.tcpHost || '127.0.0.1',
+              port: parseInt(workerInfo.tcpPort || '0', 10),
+            });
+            return;
+          }
+
+          // VS Code Desktop connection
+          if (app.name === 'vscode-desktop') {
+            setVscodeModalState({
+              open: true,
+              host: workerInfo.tcpHost || '127.0.0.1',
+              port: parseInt(workerInfo.tcpPort || '0', 10),
+            });
+            return;
+          }
+
+          // Tensorboard - This code path should not be reached
+          // because tensorboard should be handled before launchAppWithNotification
+          if (app.name === 'tensorboard') {
+            logger.warn('Tensorboard reached onPrepared callback unexpectedly');
+            setOpenTensorboardModal(true);
+            return;
+          }
+
+          // Generic TCP apps (non-standard protocols)
+          // Apps that use TCP protocol but aren't handled by specific modals above
+          const servicePort = servicePorts.find(
+            (port) => port.name === app.name,
+          );
+          const isTCP = servicePort?.protocol === 'tcp';
+
+          if (isTCP && !TCP_APPS.includes(app.name ?? '')) {
+            setTcpModalState({
+              open: true,
+              appName: app.name ?? '',
+              host: workerInfo.tcpHost || '127.0.0.1',
+              port: parseInt(workerInfo.tcpPort || '0', 10),
+            });
+            return;
+          }
+
+          // HTTP apps (most apps) - open in new window
+          if (workerInfo.appConnectUrl && !isTCP) {
+            setTimeout(() => {
+              window.open(workerInfo.appConnectUrl?.href, '_blank');
+            }, 1000);
+          }
+        },
+      });
+    } catch (error) {
+      message.error(getErrorMessage(error));
     }
-    // @ts-ignore
-    await globalThis.appLauncher._runApp(appController).then(() => {});
   };
 
+  const [sftpModalState, setSftpModalState] = useState({
+    open: false,
+    host: '127.0.0.1',
+    port: 0,
+  });
+  const [vncModalState, setVncModalState] = useState({
+    open: false,
+    host: '127.0.0.1',
+    port: 0,
+  });
+  const [xrdpModalState, setXrdpModalState] = useState({
+    open: false,
+    host: '127.0.0.1',
+    port: 0,
+  });
+  const [vscodeModalState, setVscodeModalState] = useState({
+    open: false,
+    host: '127.0.0.1',
+    port: 0,
+  });
+  const [openTensorboardModal, setOpenTensorboardModal] = useState(false);
+  const [tcpModalState, setTcpModalState] = useState({
+    open: false,
+    appName: '',
+    host: '127.0.0.1',
+    port: 0,
+  });
+  const [confirmationModalState, setConfirmationModalState] = useState({
+    open: false,
+    appName: '',
+  });
+
   return (
-    <BAIModal
-      data-testid="app-launcher-modal"
-      title={
-        <BAIText
-          ellipsis
-          title={session?.name ?? ''}
-          style={{
-            maxWidth: 375,
-          }}
-        >
-          {`${t('session.appLauncher.App')}: ${session?.name ?? ''}`}
-        </BAIText>
-      }
-      width={450}
-      onCancel={onRequestClose}
-      footer={null}
-      destroyOnHidden
-      {...modalProps}
-    >
-      <BAIFlex direction="column" gap={'md'} align="stretch">
-        {_.map(baseAppTemplate, (apps, category) => {
-          return (
-            <div key={category}>
-              <Typography.Title
-                level={5}
-                style={{ marginTop: 0 }}
-                data-testid={`category-${category.split('.')[1]}`}
-              >
-                {category.split('.')[1]}
+    <>
+      <BAIModal
+        data-testid="app-launcher-modal"
+        title={
+          <BAIText
+            ellipsis
+            title={session?.name ?? ''}
+            style={{
+              maxWidth: 375,
+            }}
+          >
+            {`${t('session.appLauncher.App')}: ${session?.name ?? ''}`}
+          </BAIText>
+        }
+        width={450}
+        onCancel={onRequestClose}
+        footer={null}
+        destroyOnHidden
+        {...modalProps}
+      >
+        <BAIFlex direction="column" gap={'md'} align="stretch">
+          {_.map(baseAppTemplate, (apps, category) => {
+            return (
+              <div key={category}>
+                <Typography.Title
+                  level={5}
+                  style={{ marginTop: 0 }}
+                  data-testid={`category-${category.split('.')[1]}`}
+                >
+                  {category.split('.')[1]}
+                </Typography.Title>
+                <Row gutter={[24, 24]}>
+                  {_.map(apps, (app) => {
+                    return (
+                      <Col
+                        key={app?.name}
+                        data-testid={`app-${app?.name}`}
+                        span={6}
+                        style={{ alignContent: 'center' }}
+                      >
+                        <BAIFlex
+                          direction="column"
+                          gap={'xs'}
+                          style={{ height: '100%' }}
+                        >
+                          <BAIButton
+                            icon={
+                              <Image
+                                src={app?.src}
+                                alt={app?.name}
+                                preview={false}
+                                style={{ height: 36, width: 36 }}
+                              />
+                            }
+                            action={async () => {
+                              await handleAppLaunch(app);
+                              setOpenToPublic(false);
+                              setTryPreferredPort(false);
+                            }}
+                            style={{ height: 72, width: 72 }}
+                          />
+                          <Typography.Text style={{ textAlign: 'center' }}>
+                            {app?.title}
+                          </Typography.Text>
+                        </BAIFlex>
+                      </Col>
+                    );
+                  })}
+                </Row>
+              </div>
+            );
+          })}
+          {preOpenAppTemplate.length > 0 ? (
+            <>
+              <Typography.Title level={5} style={{ marginTop: 0 }}>
+                {t('session.launcher.PreOpenPortTitle')}
               </Typography.Title>
-              <Row gutter={[24, 24]}>
-                {_.map(apps, (app) => {
+              <Row gutter={[12, 12]}>
+                {_.map(preOpenAppTemplate, (app) => {
                   return (
                     <Col
                       key={app?.name}
-                      data-testid={`app-${app?.name}`}
                       span={6}
                       style={{ alignContent: 'center' }}
                     >
@@ -204,7 +333,7 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
                         gap={'xs'}
                         style={{ height: '100%' }}
                       >
-                        <BAIButton
+                        <Button
                           icon={
                             <Image
                               src={app?.src}
@@ -213,170 +342,235 @@ const AppLauncherModal: React.FC<AppLauncherModalProps> = ({
                               style={{ height: 36, width: 36 }}
                             />
                           }
-                          action={async () => {
-                            await handleAppLaunch(app).then(() => {
-                              setOpenToPublic(false);
-                              setTryPreferredPort(false);
-                              onRequestClose();
-                            });
+                          onClick={() => {
+                            handleAppLaunch(app);
                           }}
                           style={{ height: 72, width: 72 }}
                         />
                         <Typography.Text style={{ textAlign: 'center' }}>
                           {app?.title}
+                          {app?.ports?.length > 0 &&
+                            ` (${app.ports.join(', ')})`}
                         </Typography.Text>
                       </BAIFlex>
                     </Col>
                   );
                 })}
               </Row>
-            </div>
-          );
-        })}
-        {preOpenAppTemplate.length > 0 ? (
-          <>
-            <Typography.Title level={5} style={{ marginTop: 0 }}>
-              {t('session.launcher.PreOpenPortTitle')}
-            </Typography.Title>
-            <Row gutter={[12, 12]}>
-              {_.map(preOpenAppTemplate, (app) => {
-                return (
-                  <Col
-                    key={app?.name}
-                    span={6}
-                    style={{ alignContent: 'center' }}
-                  >
-                    <BAIFlex
-                      direction="column"
-                      gap={'xs'}
-                      style={{ height: '100%' }}
-                    >
-                      <Button
-                        icon={
-                          <Image
-                            src={app?.src}
-                            alt={app?.name}
-                            preview={false}
-                            style={{ height: 36, width: 36 }}
-                          />
-                        }
-                        onClick={() => {
-                          handleAppLaunch(app);
-                        }}
-                        style={{ height: 72, width: 72 }}
-                      />
-                      <Typography.Text style={{ textAlign: 'center' }}>
-                        {app?.title}
-                      </Typography.Text>
-                    </BAIFlex>
-                  </Col>
-                );
-              })}
-            </Row>
-          </>
-        ) : null}
-        <Form ref={formRef} layout="vertical" requiredMark={false}>
-          {/* @ts-ignore */}
-          {!globalThis.isElectron && baiClient._config.openPortToPublic ? (
-            <Form.Item
-              name={'clientIps'}
-              tooltip={<Trans i18nKey="session.OpenToPublicDesc" />}
-              label={
-                <BAIFlex gap={'xs'}>
-                  <Checkbox
-                    value={openToPublic}
-                    onChange={(value) => setOpenToPublic(value.target.checked)}
-                  >
-                    {t('session.OpenToPublic')}
-                  </Checkbox>
-                </BAIFlex>
-              }
-            >
-              <BAISelect
-                mode="tags"
-                suffixIcon={null}
-                open={false}
-                tokenSeparators={[',', ' ']}
-                disabled={!openToPublic}
-                placeholder={t('session.AllowedMultipleClientsIps')}
-              />
-            </Form.Item>
+            </>
           ) : null}
-          {baiClient._config.allowPreferredPort ? (
-            <Form.Item
-              name={'preferredPort'}
-              label={
-                <BAIFlex gap={'xs'}>
-                  <Checkbox
-                    value={tryPreferredPort}
-                    onChange={(value) =>
-                      setTryPreferredPort(value.target.checked)
-                    }
-                  >
-                    {t('session.TryPreferredPort')}
-                  </Checkbox>
-                </BAIFlex>
-              }
-              rules={[
-                {
-                  type: 'number',
-                  min: 1025,
-                },
-                {
-                  type: 'number',
-                  max: 65534,
-                },
-              ]}
-            >
-              <InputNumber
-                placeholder="10250"
-                disabled={!tryPreferredPort}
-                style={{ width: '100%' }}
-              />
-            </Form.Item>
-          ) : null}
-          {/* TODO: add debug value into baiClient._config */}
-          {/* @ts-ignore */}
-          {globalThis?.backendaiwebui?.debug ? (
-            <>
+          <Form ref={formRef} layout="vertical" requiredMark={false}>
+            {/* @ts-ignore */}
+            {!globalThis.isElectron && baiClient._config.openPortToPublic ? (
               <Form.Item
-                name="subDomain"
+                name={'clientIps'}
+                tooltip={<Trans i18nKey="session.OpenToPublicDesc" />}
                 label={
                   <BAIFlex gap={'xs'}>
                     <Checkbox
-                      value={useSubDomain}
+                      value={openToPublic}
                       onChange={(value) =>
-                        setUseSubDomain(value.target.checked)
+                        setOpenToPublic(value.target.checked)
                       }
                     >
-                      {t('session.UseSubdomain')}
+                      {t('session.OpenToPublic')}
                     </Checkbox>
                   </BAIFlex>
                 }
               >
-                <Input disabled={!useSubDomain} />
+                <BAISelect
+                  mode="tags"
+                  suffixIcon={null}
+                  open={false}
+                  tokenSeparators={[',', ' ']}
+                  disabled={!openToPublic}
+                  placeholder={t('session.AllowedMultipleClientsIps')}
+                />
               </Form.Item>
-              <Form.Item name={'forceUseV1Proxy'}>
-                <Checkbox
-                  disabled={forceUseV2Proxy}
-                  onChange={(value) => setForceUseV1Proxy(value.target.checked)}
+            ) : null}
+            {baiClient._config.allowPreferredPort ? (
+              <Form.Item
+                name={'preferredPort'}
+                label={
+                  <BAIFlex gap={'xs'}>
+                    <Checkbox
+                      value={tryPreferredPort}
+                      onChange={(value) =>
+                        setTryPreferredPort(value.target.checked)
+                      }
+                    >
+                      {t('session.TryPreferredPort')}
+                    </Checkbox>
+                  </BAIFlex>
+                }
+                rules={[
+                  {
+                    type: 'number',
+                    min: 1025,
+                  },
+                  {
+                    type: 'number',
+                    max: 65534,
+                  },
+                ]}
+              >
+                <InputNumber
+                  placeholder="10250"
+                  disabled={!tryPreferredPort}
+                  style={{ width: '100%' }}
+                />
+              </Form.Item>
+            ) : null}
+            {/* TODO: add debug value into baiClient._config */}
+            {/* @ts-ignore */}
+            {globalThis?.backendaiwebui?.debug ? (
+              <>
+                <Form.Item
+                  name="subDomain"
+                  label={
+                    <BAIFlex gap={'xs'}>
+                      <Checkbox
+                        value={useSubDomain}
+                        onChange={(value) =>
+                          setUseSubDomain(value.target.checked)
+                        }
+                      >
+                        {t('session.UseSubdomain')}
+                      </Checkbox>
+                    </BAIFlex>
+                  }
                 >
-                  {t('session.ForceUseV1Proxy')}
-                </Checkbox>
-              </Form.Item>
-              <Form.Item name={'forceUseV2Proxy'}>
-                <Checkbox
-                  disabled={forceUseV1Proxy}
-                  onChange={(value) => setForceUseV2Proxy(value.target.checked)}
-                >
-                  {t('session.ForceUseV2Proxy')}
-                </Checkbox>
-              </Form.Item>
-            </>
-          ) : null}
-        </Form>
-      </BAIFlex>
-    </BAIModal>
+                  <Input
+                    disabled={!useSubDomain}
+                    value={subDomainValue}
+                    onChange={(e) => setSubDomainValue(e.target.value)}
+                  />
+                </Form.Item>
+                <Form.Item name={'forceUseV1Proxy'}>
+                  <Checkbox
+                    disabled={forceUseV2Proxy}
+                    onChange={(value) =>
+                      setForceUseV1Proxy(value.target.checked)
+                    }
+                  >
+                    {t('session.ForceUseV1Proxy')}
+                  </Checkbox>
+                </Form.Item>
+                <Form.Item name={'forceUseV2Proxy'}>
+                  <Checkbox
+                    disabled={forceUseV1Proxy}
+                    onChange={(value) =>
+                      setForceUseV2Proxy(value.target.checked)
+                    }
+                  >
+                    {t('session.ForceUseV2Proxy')}
+                  </Checkbox>
+                </Form.Item>
+              </>
+            ) : null}
+          </Form>
+        </BAIFlex>
+      </BAIModal>
+      {session ? (
+        <>
+          <BAIUnmountAfterClose>
+            <SFTPConnectionInfoModal
+              sessionFrgmt={session}
+              open={sftpModalState.open}
+              host={sftpModalState.host}
+              port={sftpModalState.port}
+              onCancel={() => {
+                setSftpModalState({ open: false, host: '127.0.0.1', port: 0 });
+              }}
+            />
+          </BAIUnmountAfterClose>
+          <BAIUnmountAfterClose>
+            <VNCConnectionInfoModal
+              open={vncModalState.open}
+              host={vncModalState.host}
+              port={vncModalState.port}
+              onCancel={() => {
+                setVncModalState({ open: false, host: '127.0.0.1', port: 0 });
+              }}
+            />
+          </BAIUnmountAfterClose>
+          <BAIUnmountAfterClose>
+            <XRDPConnectionInfoModal
+              open={xrdpModalState.open}
+              host={xrdpModalState.host}
+              port={xrdpModalState.port}
+              onCancel={() => {
+                setXrdpModalState({ open: false, host: '127.0.0.1', port: 0 });
+              }}
+            />
+          </BAIUnmountAfterClose>
+          {session.row_id && (
+            <BAIUnmountAfterClose>
+              <VSCodeDesktopConnectionModal
+                sessionId={session.row_id}
+                open={vscodeModalState.open}
+                host={vscodeModalState.host}
+                port={vscodeModalState.port}
+                onCancel={() => {
+                  setVscodeModalState({
+                    open: false,
+                    host: '127.0.0.1',
+                    port: 0,
+                  });
+                }}
+              />
+            </BAIUnmountAfterClose>
+          )}
+          <BAIUnmountAfterClose>
+            <TensorboardPathModal
+              sessionFrgmt={session}
+              open={openTensorboardModal}
+              onRequestClose={() => {
+                setOpenTensorboardModal(false);
+              }}
+              onCancel={() => {
+                setOpenTensorboardModal(false);
+              }}
+            />
+          </BAIUnmountAfterClose>
+          <BAIUnmountAfterClose>
+            <TCPConnectionInfoModal
+              open={tcpModalState.open}
+              appName={tcpModalState.appName}
+              host={tcpModalState.host}
+              port={tcpModalState.port}
+              onCancel={() => {
+                setTcpModalState({
+                  open: false,
+                  appName: '',
+                  host: '127.0.0.1',
+                  port: 0,
+                });
+              }}
+            />
+          </BAIUnmountAfterClose>
+          <BAIUnmountAfterClose>
+            <AppLaunchConfirmationModal
+              sessionFrgmt={session}
+              open={confirmationModalState.open}
+              appName={confirmationModalState.appName}
+              onRequestClose={() => {
+                setConfirmationModalState({
+                  open: false,
+                  appName: '',
+                });
+              }}
+              onCancel={() => {
+                setConfirmationModalState({
+                  open: false,
+                  appName: '',
+                });
+              }}
+            />
+          </BAIUnmountAfterClose>
+        </>
+      ) : null}
+    </>
   );
 };
 

--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -310,7 +310,7 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = ({
                 icon={<BAITerminalAppIcon />}
                 onClick={() => {
                   onAction?.('terminal');
-                  appLauncher.runTerminal();
+                  appLauncher.runTerminal({});
                 }}
                 title={
                   isButtonTitleMode

--- a/react/src/components/ComputeSessionNodeItems/TCPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TCPConnectionInfoModal.tsx
@@ -1,0 +1,43 @@
+import { Descriptions } from 'antd';
+import { BAIModal, BAIModalProps } from 'backend.ai-ui';
+import { useTranslation } from 'react-i18next';
+
+interface TCPConnectionInfoModalProps extends BAIModalProps {
+  appName: string;
+  host: string;
+  port: number;
+}
+
+const TCPConnectionInfoModal: React.FC<TCPConnectionInfoModalProps> = ({
+  appName,
+  host,
+  port,
+  ...modalProps
+}) => {
+  'use memo';
+
+  const { t } = useTranslation();
+
+  return (
+    <BAIModal
+      title={t('session.appLauncher.TCPConnection')}
+      footer={null}
+      {...modalProps}
+    >
+      <Descriptions
+        column={1}
+        bordered
+        size="small"
+        title={t('session.ConnectionInformation')}
+      >
+        <Descriptions.Item label={t('environment.AppName')}>
+          {appName}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('session.Host')}>{host}</Descriptions.Item>
+        <Descriptions.Item label={t('session.Port')}>{port}</Descriptions.Item>
+      </Descriptions>
+    </BAIModal>
+  );
+};
+
+export default TCPConnectionInfoModal;

--- a/react/src/components/ComputeSessionNodeItems/TensorboardPathModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TensorboardPathModal.tsx
@@ -1,0 +1,117 @@
+import { App, Form, Input, Typography } from 'antd';
+import {
+  BAIButton,
+  BAIFlex,
+  BAIModal,
+  BAIModalProps,
+  useBAILogger,
+  useErrorMessageResolver,
+} from 'backend.ai-ui';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment } from 'react-relay';
+import { TensorboardPathModalFragment$key } from 'src/__generated__/TensorboardPathModalFragment.graphql';
+import { useSuspendedBackendaiClient } from 'src/hooks';
+import { useBackendAIAppLauncher } from 'src/hooks/useBackendAIAppLauncher';
+
+interface TensorboardPathModalProps extends BAIModalProps {
+  sessionFrgmt: TensorboardPathModalFragment$key;
+  onRequestClose: () => void;
+}
+
+const TensorboardPathModal: React.FC<TensorboardPathModalProps> = ({
+  sessionFrgmt,
+  onRequestClose,
+  ...modalProps
+}) => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const { logger } = useBAILogger();
+  const baiClient = useSuspendedBackendaiClient();
+  const [form] = Form.useForm();
+  const { message } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
+
+  const session = useFragment(
+    graphql`
+      fragment TensorboardPathModalFragment on ComputeSessionNode {
+        id
+        row_id
+        name
+        ...useBackendAIAppLauncherFragment
+      }
+    `,
+    sessionFrgmt,
+  );
+
+  const { launchAppWithNotification, closeWsproxy } =
+    useBackendAIAppLauncher(session);
+
+  const handleSubmit = async () => {
+    try {
+      const values = await form.validateFields();
+      const path = values.tensorboardPath || '/home/work/logs';
+
+      // 1. Shutdown existing tensorboard service
+      await baiClient.shutdown_service(session?.row_id, 'tensorboard');
+
+      // 2. Close existing wsproxy connection for tensorboard
+      // This matches legacy behavior: shutdown_service -> _close_wsproxy -> _open_wsproxy
+      await closeWsproxy('tensorboard').catch(() => {
+        logger.log(
+          'failed to close existing wsproxy for tensorboard, continuing anyway',
+        );
+      });
+
+      // 3. Launch new tensorboard with --logdir argument
+      await launchAppWithNotification({
+        app: 'tensorboard',
+        args: { '--logdir': path },
+        onPrepared(workerInfo) {
+          // Open tensorboard in new window
+          if (workerInfo.appConnectUrl) {
+            window.open(workerInfo.appConnectUrl.href, '_blank');
+          }
+        },
+      });
+
+      onRequestClose();
+    } catch (error) {
+      logger.error('Failed to launch tensorboard:', error);
+      message.error(getErrorMessage(error as Error));
+    }
+  };
+
+  return (
+    <BAIModal
+      title={t('session.TensorboardPath')}
+      onCancel={onRequestClose}
+      footer={null}
+      {...modalProps}
+    >
+      <BAIFlex direction="column" gap="md" align="stretch">
+        <Typography.Paragraph>
+          {t('session.InputTensorboardPath')}
+        </Typography.Paragraph>
+
+        <Form
+          form={form}
+          layout="vertical"
+          initialValues={{
+            tensorboardPath: '/home/work/logs',
+          }}
+        >
+          <Form.Item name="tensorboardPath">
+            <Input placeholder={t('session.DefaultTensorboardPath')} />
+          </Form.Item>
+        </Form>
+
+        <BAIButton type="primary" size="large" action={handleSubmit}>
+          {t('session.UseThisPath')}
+        </BAIButton>
+      </BAIFlex>
+    </BAIModal>
+  );
+};
+
+export default TensorboardPathModal;

--- a/react/src/components/ComputeSessionNodeItems/VNCConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/VNCConnectionInfoModal.tsx
@@ -1,0 +1,46 @@
+import { Alert, Descriptions, Typography } from 'antd';
+import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
+import { useTranslation } from 'react-i18next';
+
+interface VNCConnectionInfoModalProps extends BAIModalProps {
+  host?: string;
+  port: number;
+}
+
+const VNCConnectionInfoModal: React.FC<VNCConnectionInfoModalProps> = ({
+  host = '127.0.0.1',
+  port,
+  ...modalProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const vncDisplayUrl = `vnc://${host}:${port}`;
+  // Note: Original code uses ssh:// in href but displays vnc://
+  const vncHref = `vnc://${host}:${port}`;
+
+  return (
+    <BAIModal title={t('session.VNCconnection')} footer={null} {...modalProps}>
+      <BAIFlex direction="column" align="stretch" gap="md">
+        <Alert
+          title={t('session.UseYourFavoriteVNCApp')}
+          type="info"
+          showIcon
+        />
+        <Descriptions
+          column={1}
+          bordered
+          size="small"
+          title={t('session.ConnectionInformation')}
+        >
+          <Descriptions.Item label="VNC URL">
+            <Typography.Link href={vncHref} target="_blank">
+              {vncDisplayUrl}
+            </Typography.Link>
+          </Descriptions.Item>
+        </Descriptions>
+      </BAIFlex>
+    </BAIModal>
+  );
+};
+
+export default VNCConnectionInfoModal;

--- a/react/src/components/ComputeSessionNodeItems/VSCodeDesktopConnectionModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/VSCodeDesktopConnectionModal.tsx
@@ -1,0 +1,102 @@
+import SourceCodeView from '../SourceCodeView';
+import { Descriptions, Skeleton, Typography } from 'antd';
+import {
+  BAIButton,
+  BAIFlex,
+  BAIModal,
+  BAIModalProps,
+  BAIText,
+} from 'backend.ai-ui';
+import { useTranslation } from 'react-i18next';
+import { useSuspendedBackendaiClient } from 'src/hooks';
+import { useTanQuery } from 'src/hooks/reactQueryAlias';
+
+interface VSCodeDesktopConnectionModalProps extends BAIModalProps {
+  sessionId: string;
+  host?: string;
+  port: number;
+}
+
+const VSCodeDesktopConnectionModal: React.FC<
+  VSCodeDesktopConnectionModalProps
+> = ({ sessionId, host = '127.0.0.1', port, ...modalProps }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const baiClient = useSuspendedBackendaiClient();
+
+  const {
+    data: password,
+    isLoading,
+    isError,
+  } = useTanQuery<string>({
+    queryKey: ['vscodePassword', sessionId],
+    queryFn: async () => {
+      const file = '/home/work/.password';
+      const blob = await baiClient.download_single(sessionId, file);
+      const rawText = await blob.text();
+      return rawText;
+    },
+    enabled: !!sessionId && !!modalProps.open,
+    retry: false,
+    throwOnError: false,
+  });
+
+  const vscodeUri = `vscode://vscode-remote/ssh-remote+work@${host}%3A${port}/home/work`;
+
+  const sshConfig = `Host bai-vscode
+ User work
+ Hostname ${host}
+ Port ${port}
+ StrictHostKeyChecking no
+ UserKnownHostsFile /dev/null`;
+
+  return (
+    <BAIModal
+      width={600}
+      title={t('session.VSCodeRemoteConnection')}
+      footer={null}
+      {...modalProps}
+    >
+      <BAIFlex direction="column" gap="md" align="stretch">
+        <Typography.Paragraph>
+          {t('session.VSCodeRemoteDescription')}
+        </Typography.Paragraph>
+
+        <Descriptions
+          column={1}
+          bordered
+          size="small"
+          title={t('session.ConnectionInformation')}
+          styles={{
+            label: {
+              maxWidth: 210,
+            },
+          }}
+        >
+          <Descriptions.Item label={t('session.VSCodeRemotePasswordTitle')}>
+            {isLoading ? (
+              <Skeleton.Input />
+            ) : isError ? (
+              <BAIText type="secondary">-</BAIText>
+            ) : (
+              <BAIText copyable monospace>
+                {password}
+              </BAIText>
+            )}
+          </Descriptions.Item>
+        </Descriptions>
+
+        <Typography.Text>
+          {t('session.VSCodeRemoteNoticeSSHConfig')}
+        </Typography.Text>
+        <SourceCodeView language="shell">{sshConfig}</SourceCodeView>
+
+        <BAIButton href={vscodeUri} target="_blank" type="primary" size="large">
+          {t('session.appLauncher.OpenVSCodeRemote')}
+        </BAIButton>
+      </BAIFlex>
+    </BAIModal>
+  );
+};
+
+export default VSCodeDesktopConnectionModal;

--- a/react/src/components/ComputeSessionNodeItems/XRDPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/XRDPConnectionInfoModal.tsx
@@ -1,0 +1,45 @@
+import { Alert, Descriptions, Typography } from 'antd';
+import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
+import { useTranslation } from 'react-i18next';
+
+interface XRDPConnectionInfoModalProps extends BAIModalProps {
+  host?: string;
+  port: number;
+}
+
+const XRDPConnectionInfoModal: React.FC<XRDPConnectionInfoModalProps> = ({
+  host = '127.0.0.1',
+  port,
+  ...modalProps
+}) => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const rdpUrl = `rdp://${host}:${port}`;
+
+  return (
+    <BAIModal title={t('session.XRDPconnection')} footer={null} {...modalProps}>
+      <BAIFlex direction="column" align="stretch" gap="md">
+        <Alert
+          title={t('session.UseYourFavoriteMSTSCApp')}
+          type="info"
+          showIcon
+        />
+        <Descriptions
+          column={1}
+          bordered
+          size="small"
+          title={t('session.ConnectionInformation')}
+        >
+          <Descriptions.Item label="RDP URL">
+            <Typography.Link href={rdpUrl} target="_blank">
+              {rdpUrl}
+            </Typography.Link>
+          </Descriptions.Item>
+        </Descriptions>
+      </BAIFlex>
+    </BAIModal>
+  );
+};
+
+export default XRDPConnectionInfoModal;

--- a/react/src/components/PurgeUsersModal.tsx
+++ b/react/src/components/PurgeUsersModal.tsx
@@ -1,5 +1,3 @@
-'use memo';
-
 import { PurgeUsersModalFragment$key } from '../__generated__/PurgeUsersModalFragment.graphql';
 import { PurgeUsersModalMutation } from '../__generated__/PurgeUsersModalMutation.graphql';
 import { App, Checkbox, Form, theme } from 'antd';
@@ -32,6 +30,8 @@ const PurgeUsersModal: React.FC<PurgeUsersModalProps> = ({
   usersFrgmt,
   ...baiModalProps
 }) => {
+  'use memo';
+
   const { t } = useTranslation();
   const { message } = App.useApp();
   const formRef = useRef<FormInstance<PurgeUsersFormValues>>(null);

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -543,12 +543,13 @@ type BackendAIConfig = {
   endpoint: string;
   _endpointHost: string;
   accessKey: string;
+  secretKey: string;
   _secretKey: string;
   _userId: string;
   _password: string;
   _proxyURL: string;
   _proxyToken: string;
-  _connectionMode: string;
+  connectionMode: string;
   _session_id: string;
   domainName: string;
   default_session_environment: string;

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -1,16 +1,28 @@
-import { useWebUINavigate } from '.';
+import { useSuspendedBackendaiClient, useWebUINavigate } from '.';
 import { useSetBAINotification } from './useBAINotification';
-import { BAILink } from 'backend.ai-ui';
+import { BAILink, useBAILogger, useErrorMessageResolver } from 'backend.ai-ui';
+import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 import { useBackendAIAppLauncherFragment$key } from 'src/__generated__/useBackendAIAppLauncherFragment.graphql';
 
+export const TCP_APPS = ['sshd', 'vscode-desktop', 'xrdp', 'vnc'];
 export const useBackendAIAppLauncher = (
   sessionFrgmt?: useBackendAIAppLauncherFragment$key | null,
+  debugOptions?: {
+    forceUseV1Proxy?: boolean;
+    forceUseV2Proxy?: boolean;
+    subdomain?: string;
+  },
 ) => {
+  'use memo';
+
   const { t } = useTranslation();
   const { upsertNotification } = useSetBAINotification();
+  const { getErrorMessage } = useErrorMessageResolver();
   const webuiNavigate = useWebUINavigate();
+  const baiClient = useSuspendedBackendaiClient();
+  const { logger } = useBAILogger();
 
   // TODO: migrate backend-ai-app-launcher features to this hook using fragment data.
   const session = useFragment(
@@ -19,56 +31,890 @@ export const useBackendAIAppLauncher = (
         name
         row_id @required(action: NONE)
         vfolder_mounts
+        scaling_group
+        project_id
+        service_ports
       }
     `,
     sessionFrgmt,
   );
 
-  // @ts-ignore
-  return {
-    // TODO: AppLauncherModal should modify the hook to use, as it is currently separated,
-    // to re-declare the notification for use by the backend-ai-app-launcher.
-    runTerminal: () => {
-      upsertNotification({
-        key: `session-app-${session?.row_id}`,
-        message: (
-          <span>
-            {t('general.Session')}:&nbsp;
-            <BAILink
-              style={{
-                fontWeight: 'normal',
-              }}
-              onClick={() => {
-                const newSearchParams = new URLSearchParams(location.search);
-                newSearchParams.set('sessionDetail', session?.row_id || '');
-                webuiNavigate({
-                  pathname: `/session`,
-                  search: newSearchParams.toString(),
-                });
-              }}
-            >
-              {session?.name}
-            </BAILink>
-          </span>
-        ),
-        description: t('session.appLauncher.LaunchingApp', {
-          appName: 'Console',
-        }),
+  const appNotificationKey = `session-app-${session?.row_id}`;
+
+  // Constants for proxy worker connection
+  const PERMIT_KEY_STORAGE_KEY = 'backendaiwebui.appproxy-permit-key';
+  const MAX_RETRY_ATTEMPTS = 5;
+  const RETRY_DELAY_MS = 1000;
+  const SERVER_ERROR_CODES = [500, 501, 502];
+
+  /**
+   * Maps progress stage to translated description
+   */
+  const getStageDescription = (stage: string, appName: string): string => {
+    const stageKeyMap: Record<string, string> = {
+      configuring: t('session.launcher.SettingUpProxyForApp', { appName }),
+      connecting: t('session.launcher.AddingKernelToSocketQueue', { appName }),
+      connected: t('session.appLauncher.Prepared', { appName }),
+    };
+
+    return (
+      stageKeyMap[stage] || t('session.appLauncher.LaunchingApp', { appName })
+    );
+  };
+
+  const getWSProxyVersion = async (): Promise<'v1' | 'v2'> => {
+    // TODO: remove globalThis.appLauncher(backend-ai-app-launcher) dependency after migration to React
+    if (baiClient.debug === true) {
+      if (debugOptions?.forceUseV1Proxy) return 'v1';
+      else if (debugOptions?.forceUseV2Proxy) return 'v2';
+    }
+    if (globalThis.isElectron) {
+      return 'v1';
+    }
+    return baiClient.scalingGroup
+      .getWsproxyVersion(session?.scaling_group, session?.project_id)
+      .then((result: { wsproxy_version: 'v1' | 'v2' }) => {
+        return result.wsproxy_version;
       });
+  };
+
+  /**
+   * Get proxy URL with proper trailing slash handling.
+   *
+   * IMPORTANT: Always returns URL with trailing slash to ensure proper
+   * path resolution when used with new URL(relativePath, baseURL).
+   * Without trailing slash, new URL() treats the last segment as a file
+   * and replaces it instead of appending to it.
+   *
+   * Example:
+   * - new URL('conf', 'http://host/v2/') → 'http://host/v2/conf' ✓
+   * - new URL('conf', 'http://host/v2')  → 'http://host/conf' ✗
+   */
+  const getProxyURL = async (wsproxyVersion: string) => {
+    let url = 'http://127.0.0.1:5050/';
+    if (
       // @ts-ignore
-      globalThis.appLauncher.runTerminal(session?.row_id ?? '');
+      globalThis.__local_proxy?.url !== undefined
+    ) {
+      // @ts-ignore
+      url = globalThis.__local_proxy.url;
+    } else if (baiClient._config.proxyURL !== undefined) {
+      url = baiClient._config.proxyURL;
+    }
+    // Normalize base URL (remove trailing slash if exists)
+    const baseUrl = url.endsWith('/') ? url.slice(0, -1) : url;
+    if (session) {
+      if (wsproxyVersion !== 'v1') {
+        return `${baseUrl}/${wsproxyVersion}/`;
+      }
+    }
+    return `${baseUrl}/`;
+  };
+
+  const _resolveV1ProxyUri = async ({
+    proxyURL,
+    app,
+  }: {
+    proxyURL: string;
+    app: string;
+  }) => {
+    const param: {
+      endpoint: string;
+      mode?: string;
+      auth_mode?: string;
+      session?: string;
+      access_key?: string;
+      secret_key?: string;
+      api_version?: string;
+    } = {
+      endpoint: baiClient._config.endpoint,
+    };
+    if (baiClient._config.connectionMode === 'SESSION') {
+      param['mode'] = 'SESSION';
+      if (baiClient._loginSessionId) {
+        param['auth_mode'] = 'header';
+        param['session'] = baiClient._loginSessionId;
+      } else {
+        param['auth_mode'] = 'cookie';
+        param['session'] = baiClient._config._session_id;
+      }
+    } else {
+      param['mode'] = 'API';
+      param['access_key'] = baiClient._config.accessKey;
+      param['secret_key'] = baiClient._config.secretKey;
+    }
+    param['api_version'] = baiClient.APIMajorVersion;
+    // @ts-ignore
+    if (globalThis.isElectron && window.__local_proxy?.url === undefined) {
+      throw new AppLaunchError(
+        'Proxy is not ready yet. Check proxy settings for detail.',
+        'configuring',
+      );
+    }
+    const rqst = {
+      method: 'PUT',
+      body: JSON.stringify(param),
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      uri: new URL('conf', proxyURL).href,
+    };
+    const response = await sendRequest(rqst);
+    if (response === undefined) {
+      throw new AppLaunchError(
+        'Proxy configurator is not responding.',
+        'configuring',
+      );
+    }
+    const token = response.token;
+    return new URL(
+      `proxy/${token}/${session?.row_id}/add?${new URLSearchParams({ app }).toString()}`,
+      proxyURL,
+    ).href;
+  };
+
+  /**
+   * Open V2 WsProxy (direct connection) with session and app and port number.
+   *
+   * @param {string} sessionUuid
+   * @param {string} app
+   * @param {number} port
+   * @param {object | null} envs
+   * @param {object | null} args
+   */
+  const _resolveV2ProxyUri = async ({
+    app,
+    port = null,
+    envs = null,
+    args = null,
+  }: {
+    app: string;
+    port: number | null;
+    envs?: Record<string, unknown> | null;
+    args?: Record<string, unknown> | null;
+  }) => {
+    try {
+      const loginSessionToken = baiClient._config._session_id;
+      const tokenResponse = await baiClient.computeSession.startService(
+        loginSessionToken,
+        session?.row_id,
+        app,
+        port,
+        envs,
+        args,
+      );
+
+      if (tokenResponse === undefined) {
+        throw new AppLaunchError(
+          'Proxy configurator is not responding.',
+          'configuring',
+        );
+      }
+      const token = tokenResponse.token;
+      return new URL(
+        `v2/proxy/${token}/${session?.row_id}/add?${new URLSearchParams({ app }).toString()}`,
+        tokenResponse.wsproxy_addr,
+      ).href;
+    } catch (err) {
+      // Wrap in AppLaunchError if not already
+      if (err instanceof AppLaunchError) {
+        throw err;
+      }
+      throw new AppLaunchError(
+        err instanceof Error
+          ? err.message
+          : 'Proxy configurator is not responding.',
+        'configuring',
+        err instanceof Error ? err : undefined,
+      );
+    }
+  };
+
+  /**
+   * Close wsproxy connection for a specific app.
+   * Used when re-launching apps like tensorboard that need to be restarted with different args.
+   */
+  const _close_wsproxy = async (app: string) => {
+    const token = baiClient._config.accessKey;
+    const proxyURL = await getProxyURL(await getWSProxyVersion());
+
+    const uri = new URL(
+      `proxy/${token}/${session?.row_id}/delete?${new URLSearchParams({ app }).toString()}`,
+      proxyURL,
+    );
+
+    const permitKey = localStorage.getItem(PERMIT_KEY_STORAGE_KEY);
+    if (permitKey) {
+      uri.searchParams.set('permit_key', permitKey);
+    }
+
+    const response = await fetch(uri.href, {
+      method: 'GET',
+      credentials: 'include',
+      mode: 'cors',
+    });
+    return response.ok;
+  };
+
+  const _open_wsproxy = async ({
+    // sessionUuid,
+    app,
+    port = null,
+    envs,
+    args,
+    allowedClientIps = [],
+    openToPublic = false,
+    proxyVersion,
+    proxyURL,
+  }: {
+    app: string;
+    port?: number | null;
+    envs?: Record<string, unknown>;
+    args?: Record<string, unknown>;
+    allowedClientIps?: Array<string>;
+    openToPublic?: boolean;
+    proxyVersion: string;
+    proxyURL: string;
+  }) => {
+    if (!session?.service_ports) {
+      return false;
+    }
+
+    const uri =
+      proxyVersion === 'v1'
+        ? await _resolveV1ProxyUri({
+            app,
+            proxyURL,
+          })
+        : await _resolveV2ProxyUri({ app, port: null, envs, args });
+
+    const servicePortInfo = JSON.parse(session?.service_ports || '{}').find(
+      ({ name }: { name?: string }) => name === app,
+    );
+
+    if (_.isEmpty(servicePortInfo)) {
+      throw new AppLaunchError(
+        `Service port not found for app: ${app}`,
+        'configuring',
+      );
+    }
+
+    if (!uri) {
+      throw new AppLaunchError('Failed to resolve proxy URI', 'configuring');
+    }
+
+    const searchParams = new URLSearchParams();
+
+    if (port !== null && port > 1024 && port < 65535) {
+      searchParams.set('port', port.toString());
+    }
+    if (openToPublic) {
+      searchParams.set('open_to_public', 'true');
+      if (allowedClientIps?.length > 0) {
+        searchParams.set(
+          'allowed_client_ips',
+          _.map(allowedClientIps, _.trim).join(','),
+        );
+      }
+    }
+    if (_.keys(envs).length > 0) {
+      searchParams.set('envs', JSON.stringify(envs));
+    }
+    if (_.keys(args).length > 0) {
+      searchParams.set('args', JSON.stringify(args));
+    }
+
+    if (debugOptions?.subdomain) {
+      searchParams.set('subdomain', debugOptions?.subdomain);
+    }
+    if (servicePortInfo.is_inference) {
+      searchParams.set('is_inference', 'true');
+    }
+    searchParams.set('protocol', servicePortInfo.protocol || 'tcp');
+
+    const rqst_proxy = {
+      method: 'GET',
+      app: app,
+      uri: `${uri}&${searchParams.toString()}`,
+    };
+
+    try {
+      return await sendRequest(rqst_proxy);
+    } catch (err) {
+      // Wrap error in AppLaunchError with proper stage
+      throw new AppLaunchError(
+        err instanceof Error && err.message
+          ? err.message
+          : 'Failed to connect to coordinator',
+        'requesting',
+        err instanceof Error ? err : undefined,
+      );
+    }
+  };
+
+  /**
+   * Pure data operation that launches an app by coordinating all proxy operations.
+   * @returns Promise that resolves with app connection details
+   */
+  const _launchApp = async ({
+    app,
+    port,
+    envs,
+    args,
+    openToPublic,
+    allowedClientIps,
+    onProgress,
+  }: {
+    app: string;
+    port?: number;
+    envs?: Record<string, unknown>;
+    args?: Record<string, unknown>;
+    openToPublic?: boolean;
+    allowedClientIps?: Array<string>;
+    onProgress?: (progress: { percent: number; stage: string }) => void;
+  }) => {
+    // vscode-desktop uses sshd service internally
+    // Legacy implementation: sendAppName = 'sshd' when app === 'vscode-desktop'
+    const serviceAppName = app === 'vscode-desktop' ? 'sshd' : app;
+
+    // Stage 1: Detecting proxy version (0-20%)
+    const proxyVersion = await getWSProxyVersion();
+
+    // Stage 2: Getting proxy URL (20-40%)
+    onProgress?.({ percent: 20, stage: 'configuring' });
+    const proxyURL = await getProxyURL(proxyVersion);
+
+    // Stage 3: Adding to socket queue (40-60%)
+    onProgress?.({ percent: 40, stage: 'connecting' });
+    const response = await _open_wsproxy({
+      app: serviceAppName, // Use actual service name for API call
+      port, // Pass as-is (undefined becomes null in _open_wsproxy)
+      envs,
+      args,
+      openToPublic,
+      allowedClientIps,
+      proxyVersion,
+      proxyURL,
+    });
+
+    if (!response || typeof response === 'boolean') {
+      throw new AppLaunchError('Failed to configure proxy', 'configuring');
+    }
+
+    // Stage 4: Connecting to proxy worker (60-100%)
+    onProgress?.({ percent: 60, stage: 'connecting' });
+    const { appConnectUrl, reused, redirectUrl } = await _connectToProxyWorker(
+      response.url,
+      '',
+      !TCP_APPS.includes(app) || globalThis.isElectron, // Enable direct TCP for non-TCP apps, or when running in Electron
+    );
+
+    // Initialize TCP connection info variables
+    let tcpHost: string | null = null;
+    let tcpPort: string | null = null;
+    let directTCPSupported = false;
+
+    // Extract TCP connection information for TCP apps
+    if (TCP_APPS.includes(app)) {
+      if (globalThis.isElectron) {
+        // Electron environment: Use local proxy port
+        tcpHost = '127.0.0.1';
+        tcpPort = response.port?.toString() || null;
+      } else {
+        // Browser environment: Parse redirectUrl for gateway information
+        if (!reused) {
+          // New connection: Fetch redirect with do-not-redirect parameter
+          const redirectCheckUrl = new URL(appConnectUrl.href);
+          redirectCheckUrl.searchParams.set('do-not-redirect', 'true');
+
+          try {
+            const result = await fetch(redirectCheckUrl.href);
+            const body = await result.json();
+            const { redirectURI } = body;
+
+            if (redirectURI) {
+              const redirectURL = new URL(redirectURI);
+
+              // Check if directTCP is supported
+              const directTCPParam = redirectURL.searchParams.get('directTCP');
+              directTCPSupported = directTCPParam === 'true';
+
+              // Extract gateway URI
+              const gatewayURI = redirectURL.searchParams.get('gateway');
+
+              if (directTCPSupported && gatewayURI) {
+                // Parse gateway URL (format: tcp://host:port)
+                const gatewayURL = new URL(gatewayURI.replace('tcp', 'http'));
+                tcpHost = gatewayURL.hostname;
+                tcpPort = gatewayURL.port;
+              }
+            }
+          } catch (error) {
+            logger.error('Failed to fetch TCP connection info:', error);
+          }
+        } else {
+          // Reused connection: Use appConnectUrl directly
+          tcpHost = appConnectUrl.hostname;
+          tcpPort = appConnectUrl.port;
+          directTCPSupported = true; // Assume supported for reused connections
+        }
+      }
+    }
+
+    // Handle generic TCP apps (non-standard protocols)
+    if (response.url?.includes('protocol=tcp') && redirectUrl) {
+      try {
+        const redirectResponse = await fetch(redirectUrl);
+        const redirectBody = await redirectResponse.json();
+        const finalUrl = redirectBody?.redirect;
+
+        if (finalUrl) {
+          const decodedUrl = decodeURIComponent(finalUrl);
+
+          // Extract gateway from URL (format: gateway=tcp://host:port)
+          const gatewayMatch = decodedUrl.match(
+            /gateway=tcp:\/\/([^:]+):(\d+)/,
+          );
+
+          if (gatewayMatch) {
+            const [, gatewayHost, gatewayPort] = gatewayMatch;
+
+            if (gatewayHost && gatewayPort) {
+              tcpHost = gatewayHost;
+              tcpPort = gatewayPort;
+              directTCPSupported = true;
+            }
+          }
+        }
+      } catch (error) {
+        logger.error('Failed to parse generic TCP app URL:', error);
+      }
+    }
+
+    // Validate TCP connection info before returning
+    if (TCP_APPS.includes(app) && (!tcpHost || !tcpPort)) {
+      logger.warn(
+        `TCP connection info not available for ${app}. Using defaults.`,
+        {
+          tcpHost,
+          tcpPort,
+          directTCPSupported,
+          isElectron: globalThis.isElectron,
+          reused,
+        },
+      );
+    }
+
+    onProgress?.({ percent: 100, stage: 'connected' });
+
+    return {
+      appConnectUrl,
+      reused,
+      redirectUrl,
+      tcpHost,
+      tcpPort,
+      directTCPSupported,
+    };
+  };
+
+  /**
+   * Launch an app with full notification integration.
+   * This is the main public API that combines data operations with UI feedback.
+   */
+  const launchAppWithNotification = ({
+    app,
+    port,
+    envs,
+    args,
+    openToPublic,
+    allowedClientIps,
+    onPrepared,
+  }: {
+    app: string;
+    port?: number;
+    envs?: Record<string, unknown>;
+    args?: Record<string, unknown>;
+    openToPublic?: boolean;
+    allowedClientIps?: Array<string>;
+    onPrepared?: (workInfo: Awaited<ReturnType<typeof _launchApp>>) => void;
+  }) => {
+    const notificationKey = `${appNotificationKey}-${app}`;
+    const appName = app === 'ttyd' ? 'Console' : app;
+
+    // Create promise that will drive the notification lifecycle
+    const launchPromise = _launchApp({
+      app,
+      port,
+      envs,
+      args,
+      openToPublic,
+      allowedClientIps,
+      onProgress: (progress) => {
+        // Update notification with progress during stages
+        upsertNotification({
+          key: notificationKey,
+          backgroundTask: {
+            status: 'pending',
+            percent: progress.percent,
+          },
+          description: getStageDescription(progress.stage, appName),
+          skipDesktopNotification: true,
+        });
+      },
+    });
+
+    // Initial notification with promise-based lifecycle
+    upsertNotification({
+      key: notificationKey,
+      message: (
+        <span>
+          {t('general.Session')}:&nbsp;
+          <BAILink
+            style={{ fontWeight: 'normal' }}
+            onClick={() => {
+              const newSearchParams = new URLSearchParams(location.search);
+              newSearchParams.set('sessionDetail', session?.row_id || '');
+              webuiNavigate({
+                pathname: `/session`,
+                search: newSearchParams.toString(),
+              });
+            }}
+          >
+            {session?.name}
+          </BAILink>
+        </span>
+      ),
+      description: t('session.appLauncher.LaunchingApp', { appName }),
+      duration: 0,
+      open: true,
+      backgroundTask: {
+        promise: launchPromise,
+        status: 'pending',
+        percent: 0,
+        onChange: {
+          resolved: (data) => {
+            onPrepared?.(data);
+
+            return {
+              description: t('session.appLauncher.Prepared'),
+              backgroundTask: {
+                percent: 100,
+                status: 'resolved',
+              },
+              duration: 3,
+            };
+          },
+          rejected: (error: any) => {
+            return {
+              description: getErrorMessage(error),
+              extraDescription: error?.stack || JSON.stringify(error, null, 2),
+              duration: 0, // Persistent error notification
+            };
+          },
+        },
+      },
+    });
+
+    return launchPromise;
+  };
+
+  const _sleep = async (ms: number) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  };
+
+  /**
+   * Retry a request with backoff for server errors (500, 501, 502).
+   *
+   * @param request - Request configuration object
+   * @param maxRetries - Maximum number of retry attempts
+   * @param delayMs - Delay between retries in milliseconds
+   * @returns Result of the request
+   */
+  const _retryRequestWithBackoff = async (
+    request: any,
+    maxRetries: number = MAX_RETRY_ATTEMPTS,
+    delayMs: number = RETRY_DELAY_MS,
+  ): Promise<any> => {
+    let lastResult;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      lastResult = await sendRequest(request);
+
+      // Check if we got a server error response
+      const isServerError =
+        typeof lastResult === 'object' &&
+        lastResult?.status &&
+        SERVER_ERROR_CODES.includes(lastResult.status);
+
+      if (!isServerError) {
+        return lastResult;
+      }
+
+      // Wait before retrying (but not after the last attempt)
+      if (attempt < maxRetries - 1) {
+        await _sleep(delayMs);
+      }
+    }
+
+    // If all retries failed, return last result
+    return lastResult;
+  };
+
+  /**
+   * Add permit key from localStorage to URL if available.
+   *
+   * @param url - Base URL to add permit key to
+   * @returns URL with permit key parameter added (if available)
+   */
+  const _addPermitKeyToUrl = (url: URL): URL => {
+    const permitKey = localStorage.getItem(PERMIT_KEY_STORAGE_KEY);
+    if (permitKey) {
+      url.searchParams.set('permit_key', permitKey);
+    }
+    return url;
+  };
+
+  /**
+   * Extract and save permit key from redirect URL to localStorage.
+   *
+   * @param redirectUrl - URL containing permit_key parameter
+   */
+  const _savePermitKey = (redirectUrl: URL): void => {
+    const permitKey = redirectUrl.searchParams.get('permit_key');
+    if (permitKey && permitKey.length > 0) {
+      localStorage.setItem(PERMIT_KEY_STORAGE_KEY, permitKey);
+    }
+  };
+
+  const _connectToProxyWorker = async (
+    url: string,
+    urlPostfix: string,
+    executeRedirectRequest: boolean = true,
+  ) => {
+    // Initialize base URL with permit key if available
+    let targetUrl = _addPermitKeyToUrl(new URL(url + urlPostfix));
+
+    // Request permit key from proxy
+    const permitKeyRequest = {
+      method: 'GET',
+      uri: targetUrl.href,
+      headers: { Accept: 'application/json' },
+    };
+
+    const response = await sendRequest(permitKeyRequest);
+
+    if (response.error_code) {
+      throw response;
+    }
+
+    // Handle successful response with redirect_url
+    if (response?.redirect_url) {
+      const redirectUrl = new URL(response.redirect_url);
+
+      // Save permit key for reuse
+      _savePermitKey(redirectUrl);
+
+      const isReused = response.reuse || false;
+
+      // Execute redirect request if needed (for new permits)
+      if (executeRedirectRequest && !isReused) {
+        const redirectRequest = {
+          method: 'GET',
+          uri: redirectUrl.href,
+          mode: 'no-cors',
+          redirect: 'follow',
+          credentials: 'include',
+        };
+
+        await _retryRequestWithBackoff(redirectRequest);
+      }
+
+      // Use redirect URL as final target
+      targetUrl = _addPermitKeyToUrl(redirectUrl);
+
+      return {
+        appConnectUrl: targetUrl,
+        reused: isReused,
+        redirectUrl: response.redirect_url,
+      };
+    }
+
+    // Fallback: No redirect_url, use original URL with retry
+    targetUrl = _addPermitKeyToUrl(new URL(url + urlPostfix));
+
+    const fallbackRequest = {
+      method: 'GET',
+      uri: targetUrl.href,
+      mode: 'no-cors',
+      redirect: 'follow',
+      credentials: 'include',
+    };
+
+    await _retryRequestWithBackoff(fallbackRequest);
+
+    return {
+      appConnectUrl: targetUrl,
+      reused: false,
+      redirectUrl: null,
+    };
+  };
+
+  return {
+    /**
+     * Convenience method to launch terminal (ttyd) app.
+     * Uses the new launchApp() wrapper with full notification integration.
+     */
+    runTerminal: ({
+      openToPublic = false,
+      allowedClientIps = [],
+    }: {
+      openToPublic?: boolean;
+      allowedClientIps?: Array<string>;
+    }) => {
+      return launchAppWithNotification({
+        app: 'ttyd',
+        openToPublic,
+        allowedClientIps,
+        onPrepared(workInfo) {
+          // Auto-open window after 1 second
+          setTimeout(() => {
+            globalThis.open(workInfo.appConnectUrl?.href || '', '_blank');
+          }, 1000);
+        },
+      });
     },
-    // TODO: implement below function
-    // showLauncher: (params: {
-    //   'session-uuid'?: string;
-    //   'access-key'?: string;
-    //   'app-services'?: string;
-    //   mode?: string;
-    //   'app-services-option'?: string;
-    //   'service-ports'?: string;
-    //   runtime?: string;
-    //   filename?: string;
-    //   arguments?: string;
-    // }) => {},
+    /**
+     * Convenience method to launch Jupyter Notebook app.
+     * Uses the new launchApp() wrapper with full notification integration.
+     */
+    runJupyter: ({
+      openToPublic = false,
+      allowedClientIps = [],
+    }: {
+      openToPublic?: boolean;
+      allowedClientIps?: Array<string>;
+    }) => {
+      return launchAppWithNotification({
+        app: 'jupyter',
+        openToPublic,
+        allowedClientIps,
+      });
+    },
+    /**
+     * Convenience method to launch JupyterLab app.
+     * Uses the new launchApp() wrapper with full notification integration.
+     */
+    runJupyterLab: ({
+      openToPublic = false,
+      allowedClientIps = [],
+    }: {
+      openToPublic?: boolean;
+      allowedClientIps?: Array<string>;
+    }) => {
+      return launchAppWithNotification({
+        app: 'jupyterlab',
+        openToPublic,
+        allowedClientIps,
+      });
+    },
+    /**
+     * Convenience method to launch VSCode app.
+     * Uses the new launchApp() wrapper with full notification integration.
+     */
+    runVSCode: ({
+      openToPublic = false,
+      allowedClientIps = [],
+    }: {
+      openToPublic?: boolean;
+      allowedClientIps?: Array<string>;
+    }) => {
+      return launchAppWithNotification({
+        app: 'vscode',
+        openToPublic,
+        allowedClientIps,
+      });
+    },
+    /**
+     * Main API to launch any app with notification integration.
+     */
+    launchAppWithNotification,
+    /**
+     * Close wsproxy connection for a specific app.
+     * Used when re-launching apps like tensorboard that need to be restarted with different args.
+     */
+    closeWsproxy: _close_wsproxy,
   };
 };
+
+// Custom error class for app launch errors
+class AppLaunchError extends Error {
+  stage: 'detecting' | 'configuring' | 'requesting' | 'connecting';
+  originalError?: Error;
+
+  constructor(
+    message: string,
+    stage: 'detecting' | 'configuring' | 'requesting' | 'connecting',
+    originalError?: Error,
+  ) {
+    super(message);
+    this.name = 'AppLaunchError';
+    this.stage = stage;
+    this.originalError = originalError;
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AppLaunchError);
+    }
+  }
+}
+
+/**
+ * Send a request and return the response body.
+ * For error status codes, returns an object with status information for retry logic.
+ *
+ * @param request - Request configuration object
+ * @returns Parsed response body or error object with status
+ */
+interface SendRequestConfig extends RequestInit {
+  uri: string;
+  method?: string;
+}
+async function sendRequest(request: SendRequestConfig) {
+  try {
+    if (request.method === 'GET') {
+      request.body = undefined;
+    }
+
+    const resp = await fetch(request.uri, request);
+    const contentType = resp.headers.get('Content-Type');
+
+    let body;
+    if (contentType === null) {
+      body = resp.ok;
+    } else if (
+      contentType.startsWith('application/json') ||
+      contentType.startsWith('application/problem+json')
+    ) {
+      body = await resp.json();
+    } else if (contentType.startsWith('text/')) {
+      body = await resp.text();
+    } else {
+      body = await resp.blob();
+    }
+
+    // For error status codes, return an object with status for retry logic
+    if (!resp.ok) {
+      return {
+        status: resp.status,
+        statusText: resp.statusText,
+        body: body,
+      };
+    }
+
+    return body;
+  } catch (e) {
+    // Network errors or other exceptions
+    throw new Error(
+      `Request failed: ${e instanceof Error ? e.message : 'Unknown error'}`,
+    );
+  }
+}

--- a/react/src/hooks/useSuspendedFilteredAppTemplate.ts
+++ b/react/src/hooks/useSuspendedFilteredAppTemplate.ts
@@ -49,6 +49,7 @@ export const useSuspendedFilteredAppTemplate = (
       title: app.name,
       // TODO: change image according to the connected app.
       src: '/resources/icons/default_app.svg',
+      ports: app.container_ports,
     };
   });
 

--- a/react/src/hooks/useUserCustomThemeConfig.ts
+++ b/react/src/hooks/useUserCustomThemeConfig.ts
@@ -1,5 +1,3 @@
-'use memo';
-
 import { useBAISettingUserState } from './useBAISetting';
 import { useCustomThemeConfig } from './useCustomThemeConfig';
 import { App } from 'antd';
@@ -8,6 +6,8 @@ import { useEffectEvent, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export const useUserCustomThemeConfig = () => {
+  'use memo';
+
   const { t } = useTranslation();
   const { message } = App.useApp();
   const themeConfig = useCustomThemeConfig();


### PR DESCRIPTION
Resolves #4842 ([FR-1797](https://lablup.atlassian.net/browse/FR-1797))

## Summary

Migrate all app launcher related code from Lit-Element (`backend-ai-app-launcher.ts`) to React. This is part of the NEO: Session - App launcher epic (FR-495).

### New Components
- **AppLaunchConfirmationModal**: Confirmation dialog for nniboard/mlflow-ui apps that require user acknowledgment before launching
- **TensorboardPathModal**: Modal for entering tensorboard log directory path
- **VNCConnectionInfoModal**: Connection info modal for VNC apps
- **XRDPConnectionInfoModal**: Connection info modal for XRDP apps
- **VSCodeDesktopConnectionModal**: Connection info modal for VS Code Desktop
- **TCPConnectionInfoModal**: Generic TCP connection info modal for custom TCP apps

### Modified Components
- **AppLauncherModal**: Enhanced to handle all app types including special apps (tensorboard, nniboard, mlflow-ui, sshd, vnc, xrdp, vscode-desktop)
- **useBackendAIAppLauncher**: Major refactoring to implement app launching logic with proper proxy handling (v1/v2), TCP extraction, and notification management
- **SFTPConnectionInfoModal**: Minor updates for consistency
- **useBAINotification**: Added key-based notification management for better control

### Key Features Migrated
- HTTP/HTTPS app launching with proper proxy version detection
- TCP app connection (SFTP, VNC, XRDP, VS Code Desktop)
- Tensorboard with custom log directory support and proxy restart logic
- nniboard/mlflow-ui confirmation flow
- Open to public feature with client IP restrictions
- Preferred port configuration
- Subdomain support (debug mode)
- Electron app support with wsproxy

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1797]: https://lablup.atlassian.net/browse/FR-1797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ