### PR TITLE
feat(FR-1882): add BAIButton, BAIModal, BAISelect Storybook story

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIButton.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIButton.stories.tsx
@@ -1,0 +1,163 @@
+import BAIButton from './BAIButton';
+import BAIFlex from './BAIFlex';
+import BAIText from './BAIText';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { action } from 'storybook/internal/actions';
+
+const meta: Meta<typeof BAIButton> = {
+  title: 'Components/BAIButton',
+  component: BAIButton,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**BAIButton** extends [Ant Design Button](https://ant.design/components/button).
+
+## BAI-Specific Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| \`action\` | \`() => Promise<void>\` | \`undefined\` | Async operation with automatic loading state via React Transition |
+
+## Key Features
+- **Automatic Loading State**: When \`action\` is provided, the button automatically shows loading state during async execution
+- **React Transition Integration**: Uses \`useTransition\` for responsive UI updates
+- **Double-Click Prevention**: Automatically prevents multiple clicks during execution
+- **Composable**: Can combine \`action\` with \`onClick\` for sync + async logic
+
+For all other props, refer to [Ant Design Button](https://ant.design/components/button).
+        `,
+      },
+    },
+  },
+  argTypes: {
+    // BAI-specific props - document fully
+    action: {
+      control: false,
+      description:
+        'Async operation with automatic loading state management via React Transition',
+      table: {
+        type: { summary: '() => Promise<void>' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIButton>;
+
+// Default story: Use args for interactive Controls
+export const Default: Story = {
+  name: 'Basic',
+  args: {
+    children: 'Click me',
+    type: 'primary',
+    action: async () => {
+      // Simulate API call
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      action('action completed')();
+    },
+  },
+};
+
+// Comparison story: Demonstrate BAI-specific action prop
+export const WithAction: Story = {
+  render: () => {
+    const [count, setCount] = useState(0);
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIText>Count: {count}</BAIText>
+        <BAIFlex gap="md">
+          <BAIButton
+            type="primary"
+            action={async () => {
+              // Simulate async operation (e.g., API call)
+              await new Promise((resolve) => setTimeout(resolve, 1500));
+              setCount((prev) => prev + 1);
+            }}
+          >
+            Async Action (auto-loading)
+          </BAIButton>
+
+          <BAIButton
+            type="default"
+            onClick={() => {
+              setCount((prev) => prev + 1);
+            }}
+          >
+            Sync onClick (no loading)
+          </BAIButton>
+        </BAIFlex>
+      </BAIFlex>
+    );
+  },
+};
+
+// Demonstrate double-click prevention
+export const PreventDoubleClick: Story = {
+  render: () => {
+    const [clickCount, setClickCount] = useState(0);
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIText>
+          API calls made: {clickCount} (try clicking multiple times quickly)
+        </BAIText>
+        <BAIButton
+          type="primary"
+          action={async () => {
+            setClickCount((prev) => prev + 1);
+            await new Promise((resolve) => setTimeout(resolve, 3000));
+          }}
+        >
+          Submit (3s delay)
+        </BAIButton>
+      </BAIFlex>
+    );
+  },
+};
+
+// Demonstrate combining action with onClick
+export const CombinedHandlers: Story = {
+  render: () => {
+    const [logs, setLogs] = useState<string[]>([]);
+
+    const addLog = (message: string) => {
+      setLogs((prev) => [
+        ...prev,
+        `${new Date().toLocaleTimeString()}: ${message}`,
+      ]);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIButton
+          type="primary"
+          action={async () => {
+            addLog('Async action started');
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            addLog('Async action completed');
+          }}
+          onClick={() => {
+            addLog('Sync onClick executed');
+          }}
+        >
+          Both action & onClick
+        </BAIButton>
+
+        <BAIFlex
+          direction="column"
+          style={{ maxHeight: 200, overflow: 'auto', fontSize: '12px' }}
+        >
+          {logs.map((log, i) => (
+            <BAIText key={i}>{log}</BAIText>
+          ))}
+        </BAIFlex>
+      </BAIFlex>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/BAIModal.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIModal.stories.tsx
@@ -1,0 +1,157 @@
+import BAIButton from './BAIButton';
+import BAIFlex from './BAIFlex';
+import BAIModal from './BAIModal';
+import BAIText from './BAIText';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+const meta: Meta<typeof BAIModal> = {
+  title: 'Components/BAIModal',
+  component: BAIModal,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAIModal** extends [Ant Design Modal](https://ant.design/components/modal).
+
+## BAI-Specific Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| \`draggable\` | \`boolean\` | \`false\` | Enable dragging modal by header |
+
+## Additional Features
+- **Fixed z-index**: Uses \`DEFAULT_BAI_MODAL_Z_INDEX = 1001\`
+- **Centered by default**: \`centered\` defaults to \`true\`
+- **Consistent styling**: Standard header, body, footer styles with dividers
+
+For all other props, refer to [Ant Design Modal](https://ant.design/components/modal).
+        `,
+      },
+    },
+  },
+  argTypes: {
+    // BAI-specific props - document fully
+    draggable: {
+      control: { type: 'boolean' },
+      description:
+        'Enable dragging modal by header. Hover over the drag icon to activate.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIModal>;
+
+const ModalContent = () => (
+  <BAIFlex direction="column" gap="md">
+    <BAIText>
+      This is sample content for the BAI Modal component. It demonstrates how
+      content is displayed within the modal body.
+    </BAIText>
+    <BAIText>
+      The modal provides consistent styling with proper header dividers, body
+      padding, and footer layout following Backend.AI design guidelines.
+    </BAIText>
+  </BAIFlex>
+);
+
+// Default story with interactive controls
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Basic modal with standard props. Click the button to open the modal.',
+      },
+    },
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <BAIButton type="primary" onClick={() => setOpen(true)}>
+          Open Modal
+        </BAIButton>
+        <BAIModal
+          {...args}
+          open={open}
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        >
+          <ModalContent />
+        </BAIModal>
+      </>
+    );
+  },
+  args: {
+    title: 'Modal Title',
+    draggable: false,
+  },
+};
+
+// Draggable modal comparison
+export const DraggableModal: Story = {
+  name: 'Draggable Feature',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the draggable feature. Hover over the drag handle icon (☰) in the modal header to activate dragging. The modal can be moved around the viewport while staying within bounds.',
+      },
+    },
+  },
+  render: () => {
+    const [openNormal, setOpenNormal] = useState(false);
+    const [openDraggable, setOpenDraggable] = useState(false);
+
+    return (
+      <BAIFlex gap="md">
+        <BAIButton type="primary" onClick={() => setOpenNormal(true)}>
+          Open Normal Modal
+        </BAIButton>
+        <BAIButton type="primary" onClick={() => setOpenDraggable(true)}>
+          Open Draggable Modal
+        </BAIButton>
+
+        <BAIModal
+          title="Normal Modal (Not Draggable)"
+          open={openNormal}
+          onOk={() => setOpenNormal(false)}
+          onCancel={() => setOpenNormal(false)}
+          draggable={false}
+        >
+          <BAIText>
+            This modal cannot be dragged. It stays in the center of the
+            viewport.
+          </BAIText>
+        </BAIModal>
+
+        <BAIModal
+          title="Draggable Modal"
+          open={openDraggable}
+          onOk={() => setOpenDraggable(false)}
+          onCancel={() => setOpenDraggable(false)}
+          draggable={true}
+        >
+          <BAIFlex direction="column" gap="sm">
+            <BAIText>
+              Hover over the drag handle icon (☰) to the left of the title,
+              then drag this modal around!
+            </BAIText>
+            <BAIText>
+              The modal will stay within the viewport bounds and cannot be
+              dragged outside the visible area.
+            </BAIText>
+          </BAIFlex>
+        </BAIModal>
+      </BAIFlex>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/BAISelect.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.stories.tsx
@@ -1,0 +1,318 @@
+import BAIFlex from './BAIFlex';
+import BAISelect from './BAISelect';
+import BAIText from './BAIText';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+const meta: Meta<typeof BAISelect> = {
+  title: 'Components/BAISelect',
+  component: BAISelect,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAISelect** extends [Ant Design Select](https://ant.design/components/select).
+
+## BAI-Specific Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| \`ghost\` | \`boolean\` | \`false\` | Transparent background style |
+| \`autoSelectOption\` | \`boolean \\| (options) => value\` | - | Auto-select first option when empty |
+| \`tooltip\` | \`string\` | \`''\` | Tooltip text for the select |
+| \`footer\` | \`ReactNode \\| string\` | - | Custom footer in dropdown |
+| \`endReached\` | \`() => void\` | - | Callback when scroll reaches end |
+| \`searchAction\` | \`(value: string) => Promise<void>\` | - | Async search with transition |
+| \`atBottomThreshold\` | \`number\` | \`30\` | Threshold for bottom detection (px) |
+| \`atBottomStateChange\` | \`(atBottom: boolean) => void\` | - | Callback for bottom state changes |
+
+For all other props, refer to [Ant Design Select](https://ant.design/components/select).
+        `,
+      },
+    },
+  },
+  argTypes: {
+    // BAI-specific props - document fully
+    ghost: {
+      control: { type: 'boolean' },
+      description: 'Transparent background style',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    autoSelectOption: {
+      control: { type: 'boolean' },
+      description: 'Auto-select first option when value is empty',
+      table: {
+        type: { summary: 'boolean | (options) => value' },
+        defaultValue: { summary: '-' },
+      },
+    },
+    tooltip: {
+      control: { type: 'text' },
+      description: 'Tooltip text displayed on hover',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: "''" },
+      },
+    },
+    footer: {
+      control: false,
+      description: 'Custom footer content in dropdown',
+      table: {
+        type: { summary: 'ReactNode | string' },
+        defaultValue: { summary: '-' },
+      },
+    },
+    endReached: {
+      control: false,
+      description: 'Callback when scroll reaches end (for infinite scroll)',
+      table: {
+        type: { summary: '() => void' },
+        defaultValue: { summary: '-' },
+      },
+    },
+    searchAction: {
+      control: false,
+      description: 'Async search action with React transition',
+      table: {
+        type: { summary: '(value: string) => Promise<void>' },
+        defaultValue: { summary: '-' },
+      },
+    },
+    atBottomThreshold: {
+      control: { type: 'number' },
+      description: 'Threshold for bottom detection in pixels',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '30' },
+      },
+    },
+    atBottomStateChange: {
+      control: false,
+      description: 'Callback for bottom state changes',
+      table: {
+        type: { summary: '(atBottom: boolean) => void' },
+        defaultValue: { summary: '-' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAISelect>;
+
+const sampleOptions = [
+  { label: 'Option 1', value: 'option1' },
+  { label: 'Option 2', value: 'option2' },
+  { label: 'Option 3', value: 'option3' },
+  { label: 'Option 4', value: 'option4' },
+];
+
+// Default story with interactive controls
+export const Default: Story = {
+  name: 'Basic',
+  args: {
+    options: sampleOptions,
+    placeholder: 'Select an option',
+    style: { width: 200 },
+    ghost: false,
+    autoSelectOption: false,
+  },
+};
+
+// Ghost style comparison
+export const GhostStyle: Story = {
+  render: () => (
+    <BAIFlex
+      direction="column"
+      gap="md"
+      style={{ padding: 24, background: '#1890ff' }}
+    >
+      <BAIFlex direction="column" gap="xs">
+        <BAIText style={{ color: 'white' }}>Ghost Style (Transparent)</BAIText>
+        <BAISelect
+          options={sampleOptions}
+          placeholder="Select option"
+          ghost={true}
+          style={{ width: 200 }}
+        />
+      </BAIFlex>
+      <BAIFlex direction="column" gap="xs">
+        <BAIText style={{ color: 'white' }}>Normal Style</BAIText>
+        <BAISelect
+          options={sampleOptions}
+          placeholder="Select option"
+          ghost={false}
+          style={{ width: 200 }}
+        />
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};
+
+// Auto-select option
+export const AutoSelectOption: Story = {
+  render: () => {
+    const [value1, setValue1] = useState<string>();
+    const [value2, setValue2] = useState<string>();
+
+    return (
+      <BAIFlex direction="column" gap="md">
+        <BAIFlex direction="column" gap="xs">
+          <BAIText>Auto-select enabled (first option selected)</BAIText>
+          <BAISelect
+            options={sampleOptions}
+            placeholder="Auto-selects first option"
+            autoSelectOption={true}
+            value={value1}
+            onChange={setValue1}
+            style={{ width: 250 }}
+          />
+          <BAIText type="secondary">Selected: {value1 || 'None'}</BAIText>
+        </BAIFlex>
+        <BAIFlex direction="column" gap="xs">
+          <BAIText>Auto-select disabled</BAIText>
+          <BAISelect
+            options={sampleOptions}
+            placeholder="Select manually"
+            autoSelectOption={false}
+            value={value2}
+            onChange={setValue2}
+            style={{ width: 250 }}
+          />
+          <BAIText type="secondary">Selected: {value2 || 'None'}</BAIText>
+        </BAIFlex>
+      </BAIFlex>
+    );
+  },
+};
+
+// Tooltip feature
+export const WithTooltip: Story = {
+  render: () => (
+    <BAIFlex direction="column" gap="md">
+      <BAIFlex direction="column" gap="xs">
+        <BAIText>Hover over the select to see tooltip</BAIText>
+        <BAISelect
+          options={sampleOptions}
+          placeholder="Select an option"
+          tooltip="This is a helpful tooltip message"
+          style={{ width: 250 }}
+        />
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};
+
+// Footer in dropdown
+export const WithFooter: Story = {
+  render: () => (
+    <BAIFlex direction="column" gap="md">
+      <BAIFlex direction="column" gap="xs">
+        <BAIText>Select with custom footer (string)</BAIText>
+        <BAISelect
+          options={sampleOptions}
+          placeholder="Open dropdown to see footer"
+          footer="Total: 4 options"
+          style={{ width: 250 }}
+        />
+      </BAIFlex>
+      <BAIFlex direction="column" gap="xs">
+        <BAIText>Select with custom footer (ReactNode)</BAIText>
+        <BAISelect
+          options={sampleOptions}
+          placeholder="Open dropdown"
+          footer={
+            <BAIText type="secondary" style={{ fontSize: '12px' }}>
+              Custom footer content
+            </BAIText>
+          }
+          style={{ width: 250 }}
+        />
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};
+
+// Infinite scroll with endReached
+export const InfiniteScroll: Story = {
+  render: () => {
+    const [options, setOptions] = useState(
+      Array.from({ length: 20 }, (_, i) => ({
+        label: `Option ${i + 1}`,
+        value: `option${i + 1}`,
+      })),
+    );
+    const [loading, setLoading] = useState(false);
+
+    const handleEndReached = () => {
+      if (loading) return;
+
+      setLoading(true);
+      // Simulate loading more options
+      setTimeout(() => {
+        const currentLength = options.length;
+        const newOptions = Array.from({ length: 10 }, (_, i) => ({
+          label: `Option ${currentLength + i + 1}`,
+          value: `option${currentLength + i + 1}`,
+        }));
+        setOptions([...options, ...newOptions]);
+        setLoading(false);
+      }, 1000);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="xs">
+        <BAIText>Scroll to bottom to load more options</BAIText>
+        <BAISelect
+          options={options}
+          placeholder="Scroll down to load more"
+          endReached={handleEndReached}
+          loading={loading}
+          footer={
+            loading ? 'Loading more...' : `${options.length} options loaded`
+          }
+          style={{ width: 250 }}
+        />
+      </BAIFlex>
+    );
+  },
+};
+
+// Async search with searchAction
+export const AsyncSearch: Story = {
+  render: () => {
+    const [options, setOptions] = useState(sampleOptions);
+
+    const handleSearch = async (value: string) => {
+      // Simulate async search
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      if (!value) {
+        setOptions(sampleOptions);
+      } else {
+        const filtered = sampleOptions.filter((opt) =>
+          opt.label.toLowerCase().includes(value.toLowerCase()),
+        );
+        setOptions(filtered);
+      }
+    };
+
+    return (
+      <BAIFlex direction="column" gap="xs">
+        <BAIText>Type to search with async action</BAIText>
+        <BAISelect
+          options={options}
+          placeholder="Type to search..."
+          searchAction={handleSearch}
+          showSearch
+          filterOption={false}
+          style={{ width: 250 }}
+        />
+      </BAIFlex>
+    );
+  },
+};


### PR DESCRIPTION
Resolves #4984 ([FR-1882](https://lablup.atlassian.net/browse/FR-1882))

## Summary
Add Storybook story files for core Backend.AI UI components, demonstrating BAI-specific features that extend Ant Design components.

## Components Covered
- **BAIButton**: `action` prop with automatic loading state and React Transition integration
- **BAIModal**: `draggable` prop for draggable modals
- **BAISelect**: Multiple BAI-specific features including `ghost`, `autoSelectOption`, `tooltip`, `footer`, `endReached`, `searchAction`

## Changes
- Created `BAIButton.stories.tsx` with stories for async action handling, double-click prevention, and combined handlers
- Created `BAIModal.stories.tsx` with stories for draggable feature comparison
- Created `BAISelect.stories.tsx` with comprehensive stories for all BAI-specific props
- All stories use BAI components (BAIText, BAIFlex) instead of native HTML elements for consistency
- Stories follow CSF 3 format with proper `args` for Default stories and `render` for comparison stories

## Documentation
Each story file includes:
- Complete BAI-specific props documentation in argTypes
- Component description with prop tables
- References to Ant Design documentation for inherited props
- Interactive Controls for Default stories
- Visual comparison stories for BAI-specific features

**Checklist:**
- [x] Documentation (inline in story files)
- [x] Stories demonstrate only BAI-specific features
- [x] All stories use BAI components (BAIText, BAIFlex)
- [x] No console.log usage (uses Storybook actions)

[FR-1882]: https://lablup.atlassian.net/browse/FR-1882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ