### PR TITLE
feat(FR-1820): Implement bulk user update feature

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -70,6 +70,8 @@ jobs:
         run: pnpm run lint
       - name: run relay-compiler
         run: pnpm run relay
+      - name: Clear Jest cache
+        run: pnpm exec jest --clearCache
       - name: Jest report
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
@@ -119,6 +121,10 @@ jobs:
         run: pnpm install
       - name: Run ESLint on backend.ai-ui
         run: pnpm run lint
+      - name: run relay-compiler
+        run: cd ../.. && pnpm run relay
+      - name: Clear Jest cache
+        run: pnpm exec jest --clearCache
       - name: Jest report for backend.ai-ui
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:

--- a/react/src/components/UpdateUsersModal.tsx
+++ b/react/src/components/UpdateUsersModal.tsx
@@ -1,0 +1,385 @@
+import ProjectSelect from './ProjectSelect';
+import UserResourcePolicySelect from './UserResourcePolicySelect';
+import { App, Form, InputNumber, theme } from 'antd';
+import { FormInstance } from 'antd/lib';
+import {
+  BAIAlert,
+  BAIDomainSelect,
+  BAIFlex,
+  BAIModal,
+  BAIModalProps,
+  BAISelect,
+  useBAILogger,
+  useErrorMessageResolver,
+  useMutationWithPromise,
+} from 'backend.ai-ui';
+import _ from 'lodash';
+import { Suspense, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment } from 'react-relay';
+import { PayloadError } from 'relay-runtime';
+import { UpdateUsersModalFragment$key } from 'src/__generated__/UpdateUsersModalFragment.graphql';
+import {
+  ModifyUserInput,
+  UpdateUsersModalMutation,
+} from 'src/__generated__/UpdateUsersModalMutation.graphql';
+import { SIGNED_32BIT_MAX_INT } from 'src/helper/const-vars';
+
+interface UpdateUsersFormValues {
+  domain_name?: string;
+  group_ids?: string[];
+  status?: 'active' | 'inactive' | 'before-verification' | 'deleted';
+  resource_policy?: string;
+  container_uid?: number;
+  container_main_gid?: number;
+  container_gids?: string[];
+}
+
+export interface UpdateUsersModalProps extends Omit<BAIModalProps, 'title'> {
+  userFrgmt: UpdateUsersModalFragment$key;
+}
+
+const UpdateUsersModal = ({
+  userFrgmt,
+  ...modalProps
+}: UpdateUsersModalProps) => {
+  'use memo';
+  const formRef = useRef<FormInstance<UpdateUsersFormValues>>(null);
+  const [isPending, setIsPending] = useState(false);
+  const { token } = theme.useToken();
+  const { t } = useTranslation();
+  const { message } = App.useApp();
+  const { getErrorMessage } = useErrorMessageResolver();
+  const { logger } = useBAILogger();
+
+  const users = useFragment<UpdateUsersModalFragment$key>(
+    graphql`
+      fragment UpdateUsersModalFragment on UserNode @relay(plural: true) {
+        id
+        email
+        username
+        full_name
+      }
+    `,
+    userFrgmt,
+  );
+
+  // TODO: when backend supports batch update, change to batch mutation
+  const mutateUpdateUsersWithPromise =
+    useMutationWithPromise<UpdateUsersModalMutation>(graphql`
+      mutation UpdateUsersModalMutation(
+        $email: String!
+        $props: ModifyUserInput!
+      ) {
+        modify_user(email: $email, props: $props) {
+          ok
+          msg
+        }
+      }
+    `);
+
+  return (
+    <BAIModal
+      title={t('credential.UpdateUsers')}
+      okText={t('button.Update')}
+      confirmLoading={isPending}
+      {...modalProps}
+      onOk={(e) => {
+        formRef.current
+          ?.validateFields()
+          .then((values) => {
+            setIsPending(true);
+            const userList = _.compact(users);
+
+            // Build props with type safety and remove empty values
+            const props = _.omitBy(
+              {
+                domain_name: values.domain_name,
+                group_ids: values.group_ids,
+                status: values.status,
+                resource_policy: values.resource_policy,
+                container_uid: values.container_uid,
+                container_main_gid: values.container_main_gid,
+                container_gids: !_.isEmpty(values.container_gids)
+                  ? _.map(values.container_gids, (gid) => _.toNumber(gid))
+                  : undefined,
+              } satisfies ModifyUserInput,
+              (value) => _.isNil(value) || value === '' || _.isEmpty(value),
+            );
+
+            const promises = userList.map((user) =>
+              mutateUpdateUsersWithPromise({
+                email: user.email || '',
+                props,
+              }).catch((error) => Promise.reject({ user, error })),
+            );
+            Promise.allSettled(promises)
+              .then((results) => {
+                const fulfilled = results.filter(
+                  (r) => r.status === 'fulfilled',
+                );
+                const rejected = results.filter((r) => r.status === 'rejected');
+
+                if (rejected.length > 0) {
+                  const failedUserNames = rejected
+                    .map((r) => {
+                      const reason = r.reason;
+                      return reason.user.email || t('credential.WrongEmail');
+                    })
+                    .join(', ');
+
+                  failedUserNames &&
+                    message.error(
+                      t('credential.FailedToUpdateUsers', {
+                        users: failedUserNames,
+                      }),
+                    );
+                  const error =
+                    rejected[0]?.reason?.error?.length > 0 &&
+                    rejected[0].reason.error[0];
+                  error &&
+                    message.error(getErrorMessage(error as PayloadError));
+                }
+
+                if (fulfilled.length > 0) {
+                  message.success(
+                    t('credential.UpdatedUsers', {
+                      count: fulfilled.length,
+                      total: userList.length,
+                    }),
+                  );
+                  modalProps.onOk?.(e);
+                }
+              })
+              .finally(() => {
+                setIsPending(false);
+              });
+          })
+          .catch((error) => {
+            logger.error('Validation failed:', error);
+          });
+      }}
+    >
+      <BAIFlex direction="column" align="stretch">
+        <BAIAlert
+          type="warning"
+          showIcon
+          title={t('credential.UpdateUsersWarningAlertTitle')}
+          description={
+            <ul
+              style={{
+                margin: 0,
+                padding: 0,
+                paddingTop: token.paddingXXS,
+                listStyle: 'circle',
+                listStylePosition: 'inside',
+                maxHeight: 165,
+                overflowY: 'auto',
+              }}
+            >
+              {_.map(users, (user) => (
+                <li key={user.id}>{user.email}</li>
+              ))}
+            </ul>
+          }
+          style={{ marginBottom: token.marginSM }}
+        />
+        {/* TODO: We need to create a Form.Item component that can distinguish between keeping the default value and clearing the value. */}
+        <Form ref={formRef} layout="vertical" preserve={false}>
+          <Suspense
+            fallback={
+              <Form.Item label={t('credential.Domain')}>
+                <BAISelect loading />
+              </Form.Item>
+            }
+          >
+            <Form.Item name="domain_name" label={t('credential.Domain')}>
+              <BAIDomainSelect
+                onChange={() => {
+                  formRef.current?.setFieldValue('group_ids', []);
+                }}
+                allowClear
+              />
+            </Form.Item>
+          </Suspense>
+          <Suspense
+            fallback={
+              <Form.Item label={t('credential.Projects')}>
+                <BAISelect loading />
+              </Form.Item>
+            }
+          >
+            <Form.Item noStyle dependencies={['domain_name']}>
+              {({ getFieldValue }) => (
+                <Form.Item
+                  name="group_ids"
+                  label={t('credential.Projects')}
+                  validateStatus={
+                    !getFieldValue('domain_name') ? 'warning' : undefined
+                  }
+                  help={
+                    !getFieldValue('domain_name')
+                      ? t('credential.validation.PleaseSelectDomain')
+                      : undefined
+                  }
+                >
+                  <ProjectSelect
+                    mode="multiple"
+                    domain={getFieldValue('domain_name')}
+                    disableDefaultFilter
+                    disabled={!getFieldValue('domain_name')}
+                  />
+                </Form.Item>
+              )}
+            </Form.Item>
+          </Suspense>
+          <Form.Item name="status" label={t('credential.UserStatus')}>
+            <BAISelect
+              options={[
+                {
+                  value: 'active',
+                  label: t('general.Active'),
+                },
+                {
+                  value: 'inactive',
+                  label: t('general.Inactive'),
+                },
+                {
+                  value: 'before-verification',
+                  label: t('credential.BeforeVerification'),
+                },
+                {
+                  value: 'deleted',
+                  label: t('credential.Deleted'),
+                },
+              ]}
+            />
+          </Form.Item>
+          <Suspense
+            fallback={
+              <Form.Item label={t('resourcePolicy.ResourcePolicy')}>
+                <BAISelect loading />
+              </Form.Item>
+            }
+          >
+            <Form.Item
+              name="resource_policy"
+              label={t('resourcePolicy.ResourcePolicy')}
+            >
+              <UserResourcePolicySelect allowClear />
+            </Form.Item>
+          </Suspense>
+          <Form.Item
+            name="container_uid"
+            label={t('credential.ContainerUID')}
+            tooltip={t('credential.ContainerUIDTooltip')}
+            rules={[
+              {
+                type: 'number',
+                min: 1,
+                message: t('credential.validation.PleaseEnterPositiveInteger'),
+              },
+            ]}
+          >
+            <InputNumber
+              style={{ width: '100%' }}
+              max={SIGNED_32BIT_MAX_INT}
+              min={1}
+            />
+          </Form.Item>
+          <Form.Item
+            name="container_main_gid"
+            label={t('credential.ContainerGID')}
+            tooltip={t('credential.ContainerGIDTooltip')}
+            rules={[
+              {
+                type: 'number',
+                min: 1,
+                message: t('credential.validation.PleaseEnterPositiveInteger'),
+              },
+            ]}
+          >
+            <InputNumber
+              style={{ width: '100%' }}
+              max={SIGNED_32BIT_MAX_INT}
+              min={1}
+            />
+          </Form.Item>
+          <Form.Item
+            name="container_gids"
+            label={t('credential.ContainerSupplementaryGIDs')}
+            tooltip={t('credential.ContainerSupplementaryGIDsTooltip')}
+            rules={[
+              () => ({
+                validator(_rule, values) {
+                  if (
+                    _.isEmpty(values) ||
+                    _.every(values, (v) => {
+                      const num = _.toNumber(v);
+                      return num > 0 && num <= SIGNED_32BIT_MAX_INT;
+                    })
+                  ) {
+                    return Promise.resolve();
+                  } else {
+                    return Promise.reject(
+                      new Error(
+                        t(
+                          'credential.validation.PleaseEnterPositiveAndUnder2_31',
+                        ),
+                      ),
+                    );
+                  }
+                },
+              }),
+              () => ({
+                validator(_rule, values) {
+                  if (
+                    _.isEmpty(values) ||
+                    _.every(values, (v) => {
+                      return _.isInteger(_.toNumber(v));
+                    })
+                  ) {
+                    return Promise.resolve();
+                  } else {
+                    return Promise.reject(
+                      new Error(
+                        t('credential.validation.PleaseEnterValidNumber'),
+                      ),
+                    );
+                  }
+                },
+              }),
+              () => ({
+                validator(_rule, values) {
+                  if (
+                    _.isEmpty(values) ||
+                    _.uniq(values).length === values.length
+                  ) {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(
+                    new Error(
+                      t('credential.validation.PleaseEnterUniqueNumbers'),
+                    ),
+                  );
+                },
+              }),
+            ]}
+          >
+            <BAISelect
+              mode="tags"
+              tokenSeparators={[',', ' ']}
+              open={false}
+              suffixIcon={null}
+              placeholder={t(
+                'credential.ContainerSupplementaryGIDsPlaceholder',
+              )}
+            />
+          </Form.Item>
+        </Form>
+      </BAIFlex>
+    </BAIModal>
+  );
+};
+
+export default UpdateUsersModal;

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -32,6 +32,7 @@ import {
   BAIDomainSelect,
   BAIModal,
   BAIModalProps,
+  BAISelect,
   BAIUnmountAfterClose,
   filterOutNullAndUndefined,
   useBAILogger,
@@ -587,7 +588,11 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
             label={t('credential.Domain')}
             rules={[{ required: true }]}
           >
-            <BAIDomainSelect />
+            <BAIDomainSelect
+              onChange={() => {
+                formRef.current?.setFieldValue('group_ids', []);
+              }}
+            />
           </Form.Item>
           <Suspense
             fallback={
@@ -657,26 +662,41 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
               placeholder={t('credential.AllowedClientIPPlaceholder')}
             />
           </Form.Item>
+
           <Form.Item
             name="container_uid"
             label={t('credential.ContainerUID')}
             tooltip={t('credential.ContainerUIDTooltip')}
+            rules={[
+              {
+                type: 'number',
+                min: 1,
+                message: t('credential.validation.PleaseEnterPositiveInteger'),
+              },
+            ]}
           >
             <InputNumber
               style={{ width: '100%' }}
               max={SIGNED_32BIT_MAX_INT}
-              min={0}
+              min={1}
             />
           </Form.Item>
           <Form.Item
             name="container_main_gid"
             label={t('credential.ContainerGID')}
             tooltip={t('credential.ContainerGIDTooltip')}
+            rules={[
+              {
+                type: 'number',
+                min: 1,
+                message: t('credential.validation.PleaseEnterPositiveInteger'),
+              },
+            ]}
           >
             <InputNumber
               style={{ width: '100%' }}
               max={SIGNED_32BIT_MAX_INT}
-              min={0}
+              min={1}
             />
           </Form.Item>
           <Form.Item
@@ -689,14 +709,17 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
                   if (
                     _.isEmpty(values) ||
                     _.every(values, (v) => {
-                      return _.toNumber(v) <= SIGNED_32BIT_MAX_INT;
+                      const num = _.toNumber(v);
+                      return num > 0 && num <= SIGNED_32BIT_MAX_INT;
                     })
                   ) {
                     return Promise.resolve();
                   } else {
                     return Promise.reject(
                       new Error(
-                        t('credential.validation.PleaseEnterUnder2_31'),
+                        t(
+                          'credential.validation.PleaseEnterPositiveAndUnder2_31',
+                        ),
                       ),
                     );
                   }
@@ -737,7 +760,7 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
               }),
             ]}
           >
-            <Select
+            <BAISelect
               mode="tags"
               tokenSeparators={[',', ' ']}
               open={false}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "Vor Überprüfung",
     "ConcurrentSessions": "Gleichzeitige Sitzungen",
     "ContainerGID": "Container-GID",
-    "ContainerGIDTooltip": "Primäre Gruppen-ID, die Prozessen im Container zugewiesen wird",
+    "ContainerGIDTooltip": "Standardmäßige numerische Gruppen‑ID (GID), die Prozessen im Container zugewiesen wird",
     "ContainerSupplementaryGIDs": "Ergänzende GIDs",
     "ContainerSupplementaryGIDsPlaceholder": "GIDs durch Komma oder Leerzeichen getrennt eingeben",
-    "ContainerSupplementaryGIDsTooltip": "Zusätzliche Gruppen-IDs für Container-Prozesse",
+    "ContainerSupplementaryGIDsTooltip": "Zusätzliche numerische Gruppen-IDs für Containerprozesse",
     "ContainerUID": "Container-UID",
-    "ContainerUIDTooltip": "Benutzer-ID, die Prozessen im Container zugewiesen wird",
+    "ContainerUIDTooltip": "Numerische Benutzer‑ID, die Prozessen im Container zugewiesen wird",
     "Create": "Erstellen",
     "CreatePolicy": "Richtlinie erstellen",
     "CreateResourcePolicy": "Ressourcenrichtlinie erstellen",
@@ -194,6 +194,7 @@
     "ExportCSV": "CSV-Datei exportieren",
     "ExportCSVFile": "CSV-Datei exportieren",
     "FailedToDeleteUsers": "Konnte Benutzer nicht dauerhaft löschen: {{users}}",
+    "FailedToUpdateUsers": "Aktualisierung der Benutzer fehlgeschlagen: {{users}}",
     "FileName": "Dateiname",
     "For900Seconds": "für 900 Sekunden",
     "FullName": "Vollständiger Name",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "Der Benutzerstatus hat sich geändert.",
     "TooltipForRequirePasswordChange": "Wenn Sie diese Option aktivieren, muss der Benutzer bei der nächsten Anmeldung sein Passwort ändern.",
     "TypePermanentlyDelete": "Bitte geben Sie \"{{text}}\" ein.",
+    "UpdateUsers": "Benutzer aktualisieren",
+    "UpdateUsersWarningAlertTitle": "Das Festlegen von UID oder GID(s) kann die Verwendung zuvor erstellter Ordner-Mounts einschränken.",
+    "UpdatedUsers": "Aktualisiert {{count}} von {{total}} Benutzern.",
     "UserAccountCreated": "Benutzerkonto wurde erfolgreich erstellt",
     "UserAccountCreatedError": "Ein Benutzerkonto mit derselben E-Mail-Adresse oder demselben Benutzernamen existiert bereits.",
     "UserDetail": "Benutzerdetails",
@@ -262,9 +266,11 @@
     "WrongEmail": "Ungültige E‑Mail‑Adresse",
     "YouAreAboutToDeleteCredential": "Sie sind dabei, die Anmeldeinformationen dieses Benutzers zu löschen:",
     "validation": {
-      "PleaseEnterUnder2_31": "Bitte geben Sie einen Wert unter 2³¹ ein",
+      "PleaseEnterPositiveAndUnder2_31": "Bitte geben Sie einen positiven Wert kleiner als 2^31 ein.",
+      "PleaseEnterPositiveInteger": "Bitte geben Sie einen positiven Wert ein.",
       "PleaseEnterUniqueNumbers": "Bitte geben Sie eindeutige Zahlen ein",
-      "PleaseEnterValidNumber": "Bitte geben Sie eine gültige Zahl ein"
+      "PleaseEnterValidNumber": "Bitte geben Sie eine gültige Zahl ein",
+      "PleaseSelectDomain": "Bitte wählen Sie zuerst eine Domain aus."
     }
   },
   "dashboard": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "Πριν από την επαλήθευση",
     "ConcurrentSessions": "Ταυτόχρονες συνεδρίες",
     "ContainerGID": "GID κοντέινερ",
-    "ContainerGIDTooltip": "Κύριο ID ομάδας που εκχωρείται σε διεργασίες εντός του κοντέινερ",
+    "ContainerGIDTooltip": "Προεπιλεγμένο αριθμητικό αναγνωριστικό ομάδας (GID) που εκχωρείται στις διεργασίες εντός του container",
     "ContainerSupplementaryGIDs": "Συμπληρωματικά GID",
     "ContainerSupplementaryGIDsPlaceholder": "Εισάγετε GID χωρισμένα με κόμματα ή κενά",
-    "ContainerSupplementaryGIDsTooltip": "Επιπλέον ID ομάδων για διεργασίες κοντέινερ",
+    "ContainerSupplementaryGIDsTooltip": "Επιπλέον αριθμητικά αναγνωριστικά ομάδας (GID) που εκχωρούνται στις διεργασίες του κοντέινερ",
     "ContainerUID": "UID κοντέινερ",
-    "ContainerUIDTooltip": "ID χρήστη που εκχωρείται σε διεργασίες εντός του κοντέινερ",
+    "ContainerUIDTooltip": "Αριθμητικό αναγνωριστικό χρήστη (UID) που εκχωρείται στις διεργασίες εντός του κοντέινερ",
     "Create": "Δημιουργώ",
     "CreatePolicy": "Δημιουργία πολιτικής",
     "CreateResourcePolicy": "Δημιουργία πολιτικής πόρων",
@@ -194,6 +194,7 @@
     "ExportCSV": "εξαγωγή CSV",
     "ExportCSVFile": "Εξαγωγή αρχείου CSV",
     "FailedToDeleteUsers": "Η μόνιμη διαγραφή του/των χρηστών απέτυχε: {{users}}",
+    "FailedToUpdateUsers": "Αποτυχία ενημέρωσης χρηστών: {{users}}",
     "FileName": "Ονομα αρχείου",
     "For900Seconds": "για 900 δευτερόλεπτα",
     "FullName": "Πλήρες όνομα",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "Η κατάσταση του χρήστη έχει αλλάξει.",
     "TooltipForRequirePasswordChange": "Εάν ενεργοποιηθεί αυτή η επιλογή, ο χρήστης θα πρέπει να αλλάξει τον κωδικό πρόσβασης κατά την επόμενη σύνδεση.",
     "TypePermanentlyDelete": "Παρακαλώ πληκτρολογήστε \"{{text}}\".",
+    "UpdateUsers": "Ενημέρωση χρηστών",
+    "UpdateUsersWarningAlertTitle": "Η ρύθμιση του UID ή των GID(s) μπορεί να περιορίσει τη χρήση ήδη δημιουργημένων προσαρτήσεων φακέλων.",
+    "UpdatedUsers": "Ενημερώθηκαν {{count}} από τους {{total}} χρήστες.",
     "UserAccountCreated": "Ο λογαριασμός χρήστη δημιουργήθηκε με επιτυχία",
     "UserAccountCreatedError": "Υπάρχει ήδη λογαριασμός με το ίδιο email ή όνομα χρήστη.",
     "UserDetail": "Λεπτομέρεια χρήστη",
@@ -262,9 +266,11 @@
     "WrongEmail": "Λανθασμένο email",
     "YouAreAboutToDeleteCredential": "Πρόκειται να διαγράψετε τα διαπιστευτήρια αυτού του χρήστη:",
     "validation": {
-      "PleaseEnterUnder2_31": "Παρακαλώ εισάγετε τιμή μικρότερη από 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Παρακαλώ εισαγάγετε μια θετική τιμή μικρότερη από 2^31",
+      "PleaseEnterPositiveInteger": "Εισαγάγετε μια θετική τιμή.",
       "PleaseEnterUniqueNumbers": "Παρακαλώ εισάγετε μοναδικούς αριθμούς",
-      "PleaseEnterValidNumber": "Παρακαλώ εισάγετε έγκυρο αριθμό"
+      "PleaseEnterValidNumber": "Παρακαλώ εισάγετε έγκυρο αριθμό",
+      "PleaseSelectDomain": "Παρακαλώ επιλέξτε πρώτα το domain."
     }
   },
   "dashboard": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -169,12 +169,12 @@
     "BeforeVerification": "Before Verification",
     "ConcurrentSessions": "Concurrent Sessions",
     "ContainerGID": "Container GID",
-    "ContainerGIDTooltip": "Default group ID assigned to processes inside the container",
+    "ContainerGIDTooltip": "Default numeric group ID assigned to processes inside the container",
     "ContainerSupplementaryGIDs": "Supplementary GID",
     "ContainerSupplementaryGIDsPlaceholder": "Enter GIDs separated by commas or spaces",
-    "ContainerSupplementaryGIDsTooltip": "Additional group IDs assigned to container processes",
+    "ContainerSupplementaryGIDsTooltip": "Additional numeric group IDs assigned to container processes",
     "ContainerUID": "Container UID",
-    "ContainerUIDTooltip": "User ID assigned to processes inside the container",
+    "ContainerUIDTooltip": "Numeric User ID assigned to processes inside the container",
     "Create": "Create",
     "CreatePolicy": "Create Policy",
     "CreateResourcePolicy": "Create Resource Policy",
@@ -197,6 +197,7 @@
     "ExportCSV": "export CSV",
     "ExportCSVFile": "Export CSV File",
     "FailedToDeleteUsers": "Failed to permanently delete the user(s): {{users}}",
+    "FailedToUpdateUsers": "Failed to update users: {{users}}",
     "FileName": "File name",
     "For900Seconds": "for 900 seconds",
     "FullName": "Full Name",
@@ -249,6 +250,9 @@
     "StatusUpdatedSuccessfully": "The user status has changed.",
     "TooltipForRequirePasswordChange": "When enabled, the user must change their password at next login.",
     "TypePermanentlyDelete": "Please type \"{{text}}\".",
+    "UpdateUsers": "Update Users",
+    "UpdateUsersWarningAlertTitle": "Setting UID or GID(s) may restrict the use of previously created folder mounts.",
+    "UpdatedUsers": "Updated {{count}} out of {{total}} users.",
     "UserAccountCreated": "User account is successfully created",
     "UserAccountCreatedError": "A user account with the same email or username already exists.",
     "UserDetail": "User Detail",
@@ -265,9 +269,11 @@
     "WrongEmail": "Wrong Email",
     "YouAreAboutToDeleteCredential": "You are about to delete this user's credential:",
     "validation": {
-      "PleaseEnterUnder2_31": "Please enter a value less than 2^31.",
+      "PleaseEnterPositiveAndUnder2_31": "Please enter a positive value less than 2^31",
+      "PleaseEnterPositiveInteger": "Please enter a positive value.",
       "PleaseEnterUniqueNumbers": "Enter a unique number.",
-      "PleaseEnterValidNumber": "Please enter a valid number."
+      "PleaseEnterValidNumber": "Please enter a valid number.",
+      "PleaseSelectDomain": "Please select domain first."
     }
   },
   "dashboard": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "Antes de la verificación",
     "ConcurrentSessions": "Sesiones simultáneas",
     "ContainerGID": "GID del contenedor",
-    "ContainerGIDTooltip": "ID de grupo principal asignado a procesos dentro del contenedor",
+    "ContainerGIDTooltip": "ID de grupo numérico predeterminado asignado a los procesos dentro del contenedor",
     "ContainerSupplementaryGIDs": "GIDs suplementarios",
     "ContainerSupplementaryGIDsPlaceholder": "Ingresar GIDs separados por comas o espacios",
-    "ContainerSupplementaryGIDsTooltip": "IDs de grupo adicionales para procesos del contenedor",
+    "ContainerSupplementaryGIDsTooltip": "IDs numéricos de grupo adicionales asignados a los procesos del contenedor",
     "ContainerUID": "UID del contenedor",
-    "ContainerUIDTooltip": "ID de usuario asignado a procesos dentro del contenedor",
+    "ContainerUIDTooltip": "ID de usuario numérico asignado a los procesos dentro del contenedor",
     "Create": "Cree",
     "CreatePolicy": "Crear política",
     "CreateResourcePolicy": "Crear política de recursos",
@@ -194,6 +194,7 @@
     "ExportCSV": "exportar CSV",
     "ExportCSVFile": "Exportar archivo CSV",
     "FailedToDeleteUsers": "No se pudieron eliminar permanentemente los usuarios: {{users}}",
+    "FailedToUpdateUsers": "Error al actualizar usuarios: {{users}}",
     "FileName": "Nombre del fichero",
     "For900Seconds": "durante 900 segundos",
     "FullName": "Nombre y apellidos",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "El estado del usuario ha cambiado.",
     "TooltipForRequirePasswordChange": "Si activa esta opción, los usuarios deberán cambiar su contraseña en el próximo inicio de sesión.",
     "TypePermanentlyDelete": "Por favor, escriba \"{{text}}\".",
+    "UpdateUsers": "Actualizar usuarios",
+    "UpdateUsersWarningAlertTitle": "Establecer UID o GID(s) puede restringir el uso de montajes de carpetas creados previamente.",
+    "UpdatedUsers": "Actualizados {{count}} de {{total}} usuarios.",
     "UserAccountCreated": "La cuenta de usuario se ha creado correctamente",
     "UserAccountCreatedError": "Ya existe una cuenta de usuario con el mismo correo electrónico o nombre de usuario.",
     "UserDetail": "Detalle del usuario",
@@ -262,9 +266,11 @@
     "WrongEmail": "Correo electrónico incorrecto",
     "YouAreAboutToDeleteCredential": "Estás a punto de eliminar la credencial de este usuario:",
     "validation": {
-      "PleaseEnterUnder2_31": "Por favor ingrese un valor menor a 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Introduzca un valor positivo menor que 2^31",
+      "PleaseEnterPositiveInteger": "Por favor, introduzca un valor positivo.",
       "PleaseEnterUniqueNumbers": "Por favor ingrese números únicos",
-      "PleaseEnterValidNumber": "Por favor ingrese un número válido"
+      "PleaseEnterValidNumber": "Por favor ingrese un número válido",
+      "PleaseSelectDomain": "Seleccione primero el dominio."
     }
   },
   "dashboard": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "Ennen varmuutta",
     "ConcurrentSessions": "Samanaikaiset istunnot",
     "ContainerGID": "Säiliön GID",
-    "ContainerGIDTooltip": "Ensisijainen ryhmätunnus, joka annetaan säiliön sisällä oleville prosesseille",
+    "ContainerGIDTooltip": "Kontin sisällä prosesseille asetettu oletusarvoinen numeerinen ryhmä-ID",
     "ContainerSupplementaryGIDs": "Täydentävät GID:t",
     "ContainerSupplementaryGIDsPlaceholder": "Syötä GID:t pilkuilla tai välilyönneillä erotettuna",
-    "ContainerSupplementaryGIDsTooltip": "Lisäryhmätunnukset säiliöprosesseille",
+    "ContainerSupplementaryGIDsTooltip": "Konttiprosesseille määritetyt lisäryhmätunnukset",
     "ContainerUID": "Säiliön UID",
-    "ContainerUIDTooltip": "Käyttäjätunnus, joka annetaan säiliön sisällä oleville prosesseille",
+    "ContainerUIDTooltip": "Säiliön sisäisille prosesseille määritetty numeerinen käyttäjätunnus.",
     "Create": "Luo",
     "CreatePolicy": "Luo politiikka",
     "CreateResourcePolicy": "Luo resurssikäytäntö",
@@ -194,6 +194,7 @@
     "ExportCSV": "viedä CSV",
     "ExportCSVFile": "Vie CSV-tiedosto",
     "FailedToDeleteUsers": "Käyttäjän(ien) pysyvä poistaminen epäonnistui: {{users}}",
+    "FailedToUpdateUsers": "Käyttäjien päivittäminen epäonnistui: {{users}}",
     "FileName": "Tiedoston nimi",
     "For900Seconds": "900 sekuntia",
     "FullName": "Koko nimi",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "Käyttäjän tila on muuttunut.",
     "TooltipForRequirePasswordChange": "Kun tämä asetus on päällä, käyttäjän on vaihdettava salasanansa seuraavalla kirjautumiskerralla.",
     "TypePermanentlyDelete": "Kirjoita \"{{text}}\".",
+    "UpdateUsers": "Päivitä käyttäjät",
+    "UpdateUsersWarningAlertTitle": "UID:n tai GID:ien asettaminen saattaa rajoittaa aiemmin liitettyjen kansioiden käyttöä.",
+    "UpdatedUsers": "Päivitetty {{count}}/{{total}} käyttäjää.",
     "UserAccountCreated": "Käyttäjätili on luotu onnistuneesti",
     "UserAccountCreatedError": "Käyttäjätili samalla sähköpostiosoitteella tai käyttäjätunnuksella on jo olemassa.",
     "UserDetail": "Käyttäjän tiedot",
@@ -262,9 +266,11 @@
     "WrongEmail": "Virheellinen sähköpostiosoite",
     "YouAreAboutToDeleteCredential": "Olet poistamassa tämän käyttäjän kirjautumistiedot:",
     "validation": {
-      "PleaseEnterUnder2_31": "Syötä arvo alle 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Syötä positiivinen arvo, joka on pienempi kuin 2^31",
+      "PleaseEnterPositiveInteger": "Syötä positiivinen arvo.",
       "PleaseEnterUniqueNumbers": "Syötä yksilöllisiä numeroita",
-      "PleaseEnterValidNumber": "Syötä kelvollinen numero"
+      "PleaseEnterValidNumber": "Syötä kelvollinen numero",
+      "PleaseSelectDomain": "Valitse ensin toimialue."
     }
   },
   "dashboard": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -165,12 +165,12 @@
     "BeforeVerification": "Avant vérification",
     "ConcurrentSessions": "Sessions simultanées",
     "ContainerGID": "GID du conteneur",
-    "ContainerGIDTooltip": "ID de groupe principal attribué aux processus dans le conteneur",
+    "ContainerGIDTooltip": "Identifiant numérique de groupe par défaut attribué aux processus dans le conteneur",
     "ContainerSupplementaryGIDs": "GIDs supplémentaires",
     "ContainerSupplementaryGIDsPlaceholder": "Entrer les GIDs séparés par des virgules ou des espaces",
-    "ContainerSupplementaryGIDsTooltip": "IDs de groupe additionnels pour les processus du conteneur",
+    "ContainerSupplementaryGIDsTooltip": "Identifiants numériques de groupe supplémentaires attribués aux processus du conteneur",
     "ContainerUID": "UID du conteneur",
-    "ContainerUIDTooltip": "ID utilisateur attribué aux processus dans le conteneur",
+    "ContainerUIDTooltip": "Identifiant utilisateur numérique attribué aux processus dans le conteneur",
     "Create": "Créer",
     "CreatePolicy": "Créer une stratégie",
     "CreateResourcePolicy": "Créer une stratégie de ressources",
@@ -193,6 +193,7 @@
     "ExportCSV": "exporter CSV",
     "ExportCSVFile": "Exporter le fichier CSV",
     "FailedToDeleteUsers": "Impossible de supprimer définitivement l'utilisateur(s) : {{users}}",
+    "FailedToUpdateUsers": "Échec de la mise à jour des utilisateurs : {{users}}",
     "FileName": "Nom de fichier",
     "For900Seconds": "pendant 900 secondes",
     "FullName": "Nom et prénom",
@@ -245,6 +246,9 @@
     "StatusUpdatedSuccessfully": "Le statut de l'utilisateur a changé.",
     "TooltipForRequirePasswordChange": "Si cette option est activée, l'utilisateur devra changer son mot de passe lors de sa prochaine connexion.",
     "TypePermanentlyDelete": "Veuillez saisir \"{{text}}\".",
+    "UpdateUsers": "Mettre à jour les utilisateurs",
+    "UpdateUsersWarningAlertTitle": "La définition de l'UID ou des GID peut restreindre l'utilisation des points de montage de dossiers créés précédemment.",
+    "UpdatedUsers": "{{count}} utilisateurs mis à jour sur {{total}}.",
     "UserAccountCreated": "Le compte utilisateur est créé avec succès",
     "UserAccountCreatedError": "Un compte utilisateur avec la même adresse e-mail ou le même nom d'utilisateur existe déjà.",
     "UserDetail": "Détails de l'utilisateur",
@@ -261,9 +265,11 @@
     "WrongEmail": "Adresse e-mail incorrecte",
     "YouAreAboutToDeleteCredential": "Vous êtes sur le point de supprimer les identifiants de cet utilisateur :",
     "validation": {
-      "PleaseEnterUnder2_31": "Veuillez entrer une valeur inférieure à 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Veuillez saisir une valeur positive inférieure à 2^31",
+      "PleaseEnterPositiveInteger": "Veuillez saisir une valeur positive.",
       "PleaseEnterUniqueNumbers": "Veuillez entrer des nombres uniques",
-      "PleaseEnterValidNumber": "Veuillez entrer un nombre valide"
+      "PleaseEnterValidNumber": "Veuillez entrer un nombre valide",
+      "PleaseSelectDomain": "Veuillez d'abord sélectionner un domaine."
     }
   },
   "dashboard": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -165,12 +165,12 @@
     "BeforeVerification": "Sebelum verifikasi",
     "ConcurrentSessions": "Sesi Serentak",
     "ContainerGID": "GID kontainer",
-    "ContainerGIDTooltip": "ID grup utama yang ditetapkan untuk proses di dalam kontainer",
+    "ContainerGIDTooltip": "ID grup numerik default yang ditetapkan untuk proses di dalam kontainer",
     "ContainerSupplementaryGIDs": "GID tambahan",
     "ContainerSupplementaryGIDsPlaceholder": "Masukkan GID dipisahkan dengan koma atau spasi",
-    "ContainerSupplementaryGIDsTooltip": "ID grup tambahan untuk proses kontainer",
+    "ContainerSupplementaryGIDsTooltip": "ID grup numerik tambahan yang ditetapkan pada proses kontainer",
     "ContainerUID": "UID kontainer",
-    "ContainerUIDTooltip": "ID pengguna yang ditetapkan untuk proses di dalam kontainer",
+    "ContainerUIDTooltip": "ID pengguna numerik yang ditetapkan untuk proses di dalam kontainer",
     "Create": "Buat",
     "CreatePolicy": "Buat Kebijakan",
     "CreateResourcePolicy": "Buat Kebijakan Sumber Daya",
@@ -193,6 +193,7 @@
     "ExportCSV": "ekspor CSV",
     "ExportCSVFile": "Ekspor File CSV",
     "FailedToDeleteUsers": "Gagal menghapus pengguna secara permanen: {{users}}",
+    "FailedToUpdateUsers": "Gagal memperbarui pengguna: {{users}}",
     "FileName": "Nama file",
     "For900Seconds": "selama 900 detik",
     "FullName": "Nama Lengkap",
@@ -245,6 +246,9 @@
     "StatusUpdatedSuccessfully": "Status pengguna telah berubah.",
     "TooltipForRequirePasswordChange": "Jika opsi ini diaktifkan, pengguna harus mengganti kata sandi saat masuk berikutnya.",
     "TypePermanentlyDelete": "Silakan ketik \"{{text}}\".",
+    "UpdateUsers": "Perbarui Pengguna",
+    "UpdateUsersWarningAlertTitle": "Menetapkan UID atau GID(s) dapat membatasi penggunaan mount folder yang telah dibuat sebelumnya.",
+    "UpdatedUsers": "Diperbarui {{count}} dari {{total}} pengguna.",
     "UserAccountCreated": "Akun pengguna berhasil dibuat",
     "UserAccountCreatedError": "Akun dengan email atau nama pengguna yang sama sudah ada.",
     "UserDetail": "Detail Pengguna",
@@ -261,9 +265,11 @@
     "WrongEmail": "Alamat email salah",
     "YouAreAboutToDeleteCredential": "Anda akan menghapus kredensial pengguna ini:",
     "validation": {
-      "PleaseEnterUnder2_31": "Silakan masukkan nilai kurang dari 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Silakan masukkan nilai positif kurang dari 2^31",
+      "PleaseEnterPositiveInteger": "Harap masukkan nilai positif.",
       "PleaseEnterUniqueNumbers": "Silakan masukkan angka yang unik",
-      "PleaseEnterValidNumber": "Silakan masukkan angka yang valid"
+      "PleaseEnterValidNumber": "Silakan masukkan angka yang valid",
+      "PleaseSelectDomain": "Silakan pilih domain terlebih dahulu."
     }
   },
   "dashboard": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -165,12 +165,12 @@
     "BeforeVerification": "Prima della verifica",
     "ConcurrentSessions": "Sessioni simultanee",
     "ContainerGID": "GID contenitore",
-    "ContainerGIDTooltip": "ID gruppo principale assegnato ai processi nel contenitore",
+    "ContainerGIDTooltip": "ID numerico di gruppo predefinito assegnato ai processi all'interno del container",
     "ContainerSupplementaryGIDs": "GID supplementari",
     "ContainerSupplementaryGIDsPlaceholder": "Inserire GID separati da virgole o spazi",
-    "ContainerSupplementaryGIDsTooltip": "ID gruppo aggiuntivi per i processi del contenitore",
+    "ContainerSupplementaryGIDsTooltip": "ID di gruppo numerici aggiuntivi assegnati ai processi del container",
     "ContainerUID": "UID contenitore",
-    "ContainerUIDTooltip": "ID utente assegnato ai processi nel contenitore",
+    "ContainerUIDTooltip": "ID utente numerico assegnato ai processi all'interno del container",
     "Create": "Creare",
     "CreatePolicy": "Crea criterio",
     "CreateResourcePolicy": "Crea politica delle risorse",
@@ -193,6 +193,7 @@
     "ExportCSV": "esporta CSV",
     "ExportCSVFile": "Esporta file CSV",
     "FailedToDeleteUsers": "Impossibile eliminare definitivamente l'utente/i: {{users}}",
+    "FailedToUpdateUsers": "Impossibile aggiornare gli utenti: {{users}}",
     "FileName": "Nome del file",
     "For900Seconds": "per 900 secondi",
     "FullName": "Nome e cognome",
@@ -245,6 +246,9 @@
     "StatusUpdatedSuccessfully": "Lo stato dell'utente è cambiato.",
     "TooltipForRequirePasswordChange": "Se abiliti questa opzione, l'utente dovrà cambiare la password al prossimo accesso.",
     "TypePermanentlyDelete": "Digita \"{{text}}\".",
+    "UpdateUsers": "Aggiorna utenti",
+    "UpdateUsersWarningAlertTitle": "Impostare UID o GID(s) potrebbe limitare l'uso dei mount di cartelle creati in precedenza.",
+    "UpdatedUsers": "Aggiornati {{count}} di {{total}} utenti.",
     "UserAccountCreated": "L'account utente è stato creato con successo",
     "UserAccountCreatedError": "Esiste già un account utente con lo stesso indirizzo email o nome utente.",
     "UserDetail": "Dettagli utente",
@@ -261,9 +265,11 @@
     "WrongEmail": "Email non valida",
     "YouAreAboutToDeleteCredential": "Stai per eliminare le credenziali di questo utente:",
     "validation": {
-      "PleaseEnterUnder2_31": "Inserisci un valore inferiore a 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Inserisci un valore positivo inferiore a 2^31",
+      "PleaseEnterPositiveInteger": "Inserisci un valore positivo.",
       "PleaseEnterUniqueNumbers": "Inserisci numeri univoci",
-      "PleaseEnterValidNumber": "Inserisci un numero valido"
+      "PleaseEnterValidNumber": "Inserisci un numero valido",
+      "PleaseSelectDomain": "Seleziona prima un dominio."
     }
   },
   "dashboard": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -165,12 +165,12 @@
     "BeforeVerification": "確認前",
     "ConcurrentSessions": "同時セッション",
     "ContainerGID": "コンテナGID",
-    "ContainerGIDTooltip": "コンテナ内のプロセスに割り当てられるプライマリグループID",
+    "ContainerGIDTooltip": "コンテナ内のプロセスに割り当てられるデフォルトの数値グループID",
     "ContainerSupplementaryGIDs": "補助GID",
     "ContainerSupplementaryGIDsPlaceholder": "カンマまたはスペースで区切ってGIDを入力",
-    "ContainerSupplementaryGIDsTooltip": "コンテナプロセスに割り当てられる追加のグループID",
+    "ContainerSupplementaryGIDsTooltip": "コンテナプロセスに割り当てる追加の数値グループID",
     "ContainerUID": "コンテナUID",
-    "ContainerUIDTooltip": "コンテナ内のプロセスに割り当てられるユーザーID",
+    "ContainerUIDTooltip": "コンテナ内のプロセスに割り当てられる数値ユーザーID",
     "Create": "作成する",
     "CreatePolicy": "ポリシーを作成する",
     "CreateResourcePolicy": "リソースポリシーの作成",
@@ -193,6 +193,7 @@
     "ExportCSV": "CSVをエクスポート",
     "ExportCSVFile": "CSVファイルのエクスポート",
     "FailedToDeleteUsers": "次のユーザーを完全に削除できませんでした: {{users}}",
+    "FailedToUpdateUsers": "ユーザーの更新に失敗しました: {{users}}",
     "FileName": "ファイル名",
     "For900Seconds": "900秒間",
     "FullName": "フルネーム",
@@ -245,6 +246,9 @@
     "StatusUpdatedSuccessfully": "ユーザーステータスが変更されました。",
     "TooltipForRequirePasswordChange": "このオプションをオンにすると、ユーザーは次回ログイン時にパスワードを変更する必要があります。",
     "TypePermanentlyDelete": "\"{{text}}\"と入力してください。",
+    "UpdateUsers": "ユーザーを更新",
+    "UpdateUsersWarningAlertTitle": "UID または GID を設定すると、既存のフォルダマウントの使用が制限される場合があります。",
+    "UpdatedUsers": "全{{total}}人中{{count}}人のユーザーを更新しました。",
     "UserAccountCreated": "ユーザーアカウントが正常に作成されました",
     "UserAccountCreatedError": "同じメールアドレスまたはユーザー名のアカウントは既に存在します。",
     "UserDetail": "ユーザーの詳細",
@@ -261,9 +265,11 @@
     "WrongEmail": "メールアドレスが正しくありません",
     "YouAreAboutToDeleteCredential": "このユーザーの資格情報を削除しようとしています:",
     "validation": {
-      "PleaseEnterUnder2_31": "2³¹未満の値を入力してください",
+      "PleaseEnterPositiveAndUnder2_31": "2^31未満の正の値を入力してください。",
+      "PleaseEnterPositiveInteger": "正の値を入力してください。",
       "PleaseEnterUniqueNumbers": "重複しない数値を入力してください",
-      "PleaseEnterValidNumber": "有効な数値を入力してください"
+      "PleaseEnterValidNumber": "有効な数値を入力してください",
+      "PleaseSelectDomain": "先にドメインを選択してください。"
     }
   },
   "dashboard": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -168,12 +168,12 @@
     "BeforeVerification": "검증 필요",
     "ConcurrentSessions": "동시 세션수",
     "ContainerGID": "컨테이너 GID",
-    "ContainerGIDTooltip": "컨테이너 내부 프로세스에 할당되는 기본 그룹 ID",
+    "ContainerGIDTooltip": "컨테이너 내부의 프로세스에 할당되는 기본 숫자 그룹 ID",
     "ContainerSupplementaryGIDs": "보조 GID",
     "ContainerSupplementaryGIDsPlaceholder": "쉼표 또는 공백으로 구분하여 GID 입력",
-    "ContainerSupplementaryGIDsTooltip": "컨테이너 프로세스에 할당되는 추가 그룹 ID",
+    "ContainerSupplementaryGIDsTooltip": "컨테이너 프로세스에 할당된 추가 숫자 그룹 ID",
     "ContainerUID": "컨테이너 UID",
-    "ContainerUIDTooltip": "컨테이너 내부 프로세스에 할당되는 사용자 ID",
+    "ContainerUIDTooltip": "컨테이너 내 프로세스에 할당되는 숫자 사용자 ID",
     "Create": "생성",
     "CreatePolicy": "정책 만들기",
     "CreateResourcePolicy": "자원 정책 만들기",
@@ -196,6 +196,7 @@
     "ExportCSV": "CSV로 내보내기",
     "ExportCSVFile": "CSV 파일 내보내기",
     "FailedToDeleteUsers": "유저를 영구적으로 삭제하는데 실패했습니다: {{users}}",
+    "FailedToUpdateUsers": "사용자 업데이트에 실패했습니다: {{users}}",
     "FileName": "파일 이름",
     "For900Seconds": "(900초당)",
     "FullName": "성명",
@@ -248,6 +249,9 @@
     "StatusUpdatedSuccessfully": "사용자 상태가 변경되었습니다.",
     "TooltipForRequirePasswordChange": "이 옵션을 켜면 사용자는 다음 로그인 시 비밀번호를 변경해야 합니다.",
     "TypePermanentlyDelete": "\"{{text}}\"를 입력해 주세요.",
+    "UpdateUsers": "사용자 업데이트",
+    "UpdateUsersWarningAlertTitle": "UID 또는 GID을 설정하면 기존에 생성된 폴더 마운트의 사용이 제한될 수 있습니다.",
+    "UpdatedUsers": "총 {{total}}명 중 {{count}}명의 사용자를 업데이트했습니다.",
     "UserAccountCreated": "사용자 계정이 생성되었습니다.",
     "UserAccountCreatedError": "동일한 이메일 또는 사용자 이름을 가진 사용자 계정이 이미 존재합니다.",
     "UserDetail": "사용자 정보",
@@ -264,9 +268,11 @@
     "WrongEmail": "잘못된 이메일",
     "YouAreAboutToDeleteCredential": "다음 사용자의 자격증명을 삭제하려고 합니다:",
     "validation": {
-      "PleaseEnterUnder2_31": "2³¹ 미만의 값을 입력하세요",
+      "PleaseEnterPositiveAndUnder2_31": "2^31보다 작은 양수를 입력하세요.",
+      "PleaseEnterPositiveInteger": "양수를 입력하세요.",
       "PleaseEnterUniqueNumbers": "중복되지 않는 숫자를 입력하세요",
-      "PleaseEnterValidNumber": "유효한 숫자를 입력하세요"
+      "PleaseEnterValidNumber": "유효한 숫자를 입력하세요",
+      "PleaseSelectDomain": "도메인을 먼저 선택해 주세요."
     }
   },
   "dashboard": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -165,12 +165,12 @@
     "BeforeVerification": "Баталгаажуулахаас өмнө",
     "ConcurrentSessions": "Зэрэгцээ Session-үүд",
     "ContainerGID": "Контейнерийн GID",
-    "ContainerGIDTooltip": "Контейнер доторх процессуудад оноогдсон үндсэн бүлгийн ID",
+    "ContainerGIDTooltip": "Контейнер доторх процессуудад оноогдох анхдагч тоон бүлгийн ID",
     "ContainerSupplementaryGIDs": "Нэмэлт GID-үүд",
     "ContainerSupplementaryGIDsPlaceholder": "GID-үүдийг таслал эсвэл зайгаар тусгаарлан оруулна уу",
-    "ContainerSupplementaryGIDsTooltip": "Контейнерийн процессуудад оноогдсон нэмэлт бүлгийн ID-үүд",
+    "ContainerSupplementaryGIDsTooltip": "Контейнерийн процессуудад хуваарилагдсан нэмэлт тоон группийн ID-үүд",
     "ContainerUID": "Контейнерийн UID",
-    "ContainerUIDTooltip": "Контейнер доторх процессуудад оноогдсон хэрэглэгчийн ID",
+    "ContainerUIDTooltip": "Контейнер доторх процессуудад олгогдсон тоон хэрэглэгчийн ID",
     "Create": "Үүсгэх",
     "CreatePolicy": "Бодлого үүсгэх",
     "CreateResourcePolicy": "Нөөцийн бодлогыг бий болгох",
@@ -193,6 +193,7 @@
     "ExportCSV": "CSV экспортлох",
     "ExportCSVFile": "CSV файлыг экспортлох",
     "FailedToDeleteUsers": "Хэрэглэгч(д)ийг бүрмөсөн устгаж чадсангүй: {{users}}",
+    "FailedToUpdateUsers": "Хэрэглэгчдийг шинэчлэхэд алдаа гарлаа: {{users}}",
     "FileName": "Файлын нэр",
     "For900Seconds": "900 секундын турш",
     "FullName": "Бүтэн нэр",
@@ -245,6 +246,9 @@
     "StatusUpdatedSuccessfully": "Хэрэглэгчийн статус өөрчлөгдсөн.",
     "TooltipForRequirePasswordChange": "Энэхүү сонголтыг идэвхжүүлбэл хэрэглэгч дараагийн нэвтрэхдээ нууц үгээ өөрчлөх шаардлагатай болно.",
     "TypePermanentlyDelete": "Та \"{{text}}\" гэж оруулна уу.",
+    "UpdateUsers": "Хэрэглэгчдийг шинэчлэх",
+    "UpdateUsersWarningAlertTitle": "UID эсвэл GID(үүд)-г тогтоох нь өмнө үүсгэсэн хавтасны маунтуудыг ашиглахад хязгаарлалт үүсгэж болно.",
+    "UpdatedUsers": "Нийт {{total}} хэрэглэгчээс {{count}} нь шинэчлэгдсэн.",
     "UserAccountCreated": "Хэрэглэгчийн бүртгэл амжилттай үүсгэгдсэн",
     "UserAccountCreatedError": "Ижил имэйл хаяг эсвэл хэрэглэгчийн нэртэй данс аль хэдийнэ бүртгэлтэй байна.",
     "UserDetail": "Хэрэглэгчийн дэлгэрэнгүй",
@@ -261,9 +265,11 @@
     "WrongEmail": "Имэйл буруу",
     "YouAreAboutToDeleteCredential": "Та энэ хэрэглэгчийн итгэмжлэлийг устгах гэж байна:",
     "validation": {
-      "PleaseEnterUnder2_31": "2³¹-ээс бага утга оруулна уу",
+      "PleaseEnterPositiveAndUnder2_31": "2^31-аас бага эерэг утга оруулна уу",
+      "PleaseEnterPositiveInteger": "Эерэг утга оруулна уу.",
       "PleaseEnterUniqueNumbers": "Давтагдаагүй тоо оруулна уу",
-      "PleaseEnterValidNumber": "Зөв тоо оруулна уу"
+      "PleaseEnterValidNumber": "Зөв тоо оруулна уу",
+      "PleaseSelectDomain": "Эхлээд доменээ сонгоно уу."
     }
   },
   "dashboard": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -165,12 +165,12 @@
     "BeforeVerification": "Sebelum pengesahan",
     "ConcurrentSessions": "Sesi Serentak",
     "ContainerGID": "GID kontena",
-    "ContainerGIDTooltip": "ID kumpulan utama yang ditetapkan kepada proses dalam kontena",
+    "ContainerGIDTooltip": "ID kumpulan berangka lalai yang diberikan kepada proses di dalam kontena",
     "ContainerSupplementaryGIDs": "GID tambahan",
     "ContainerSupplementaryGIDsPlaceholder": "Masukkan GID dipisahkan dengan koma atau ruang",
-    "ContainerSupplementaryGIDsTooltip": "ID kumpulan tambahan untuk proses kontena",
+    "ContainerSupplementaryGIDsTooltip": "ID kumpulan bernombor tambahan yang diberikan kepada proses kontena",
     "ContainerUID": "UID kontena",
-    "ContainerUIDTooltip": "ID pengguna yang ditetapkan kepada proses dalam kontena",
+    "ContainerUIDTooltip": "ID pengguna berangka yang ditetapkan kepada proses dalam kontena",
     "Create": "Buat",
     "CreatePolicy": "Buat Dasar",
     "CreateResourcePolicy": "Buat Dasar Sumber",
@@ -193,6 +193,7 @@
     "ExportCSV": "eksport CSV",
     "ExportCSVFile": "Eksport Fail CSV",
     "FailedToDeleteUsers": "Gagal memadamkan pengguna secara kekal: {{users}}",
+    "FailedToUpdateUsers": "Gagal mengemas kini pengguna: {{users}}",
     "FileName": "Nama fail",
     "For900Seconds": "selama 900 saat",
     "FullName": "Nama penuh",
@@ -245,6 +246,9 @@
     "StatusUpdatedSuccessfully": "Status pengguna telah berubah.",
     "TooltipForRequirePasswordChange": "Jika pilihan ini diaktifkan, pengguna perlu menukar kata laluan mereka semasa log masuk seterusnya.",
     "TypePermanentlyDelete": "Sila taip \"{{text}}\".",
+    "UpdateUsers": "Kemas kini Pengguna",
+    "UpdateUsersWarningAlertTitle": "Menetapkan UID atau GID(s) mungkin menghadkan penggunaan pemasangan folder yang telah dibuat sebelum ini.",
+    "UpdatedUsers": "Dikemas kini {{count}} daripada {{total}} pengguna.",
     "UserAccountCreated": "Akaun pengguna berjaya dibuat",
     "UserAccountCreatedError": "Akaun pengguna dengan alamat e-mel atau nama pengguna yang sama sudah wujud.",
     "UserDetail": "Maklumat Pengguna",
@@ -261,9 +265,11 @@
     "WrongEmail": "E-mel tidak sah",
     "YouAreAboutToDeleteCredential": "Anda akan memadamkan kelayakan pengguna ini:",
     "validation": {
-      "PleaseEnterUnder2_31": "Sila masukkan nilai kurang daripada 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Sila masukkan nilai positif kurang daripada 2^31",
+      "PleaseEnterPositiveInteger": "Sila masukkan nilai positif.",
       "PleaseEnterUniqueNumbers": "Sila masukkan nombor yang unik",
-      "PleaseEnterValidNumber": "Sila masukkan nombor yang sah"
+      "PleaseEnterValidNumber": "Sila masukkan nombor yang sah",
+      "PleaseSelectDomain": "Sila pilih domain terlebih dahulu."
     }
   },
   "dashboard": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "Przed weryfikacją",
     "ConcurrentSessions": "Sesje równoległe",
     "ContainerGID": "GID kontenera",
-    "ContainerGIDTooltip": "Główne ID grupy przypisane do procesów w kontenerze",
+    "ContainerGIDTooltip": "Domyślny numeryczny identyfikator grupy przypisywany procesom wewnątrz kontenera",
     "ContainerSupplementaryGIDs": "Dodatkowe GID",
     "ContainerSupplementaryGIDsPlaceholder": "Wprowadź GID oddzielone przecinkami lub spacjami",
-    "ContainerSupplementaryGIDsTooltip": "Dodatkowe ID grup dla procesów kontenera",
+    "ContainerSupplementaryGIDsTooltip": "Dodatkowe numeryczne identyfikatory grup przypisane procesom kontenera",
     "ContainerUID": "UID kontenera",
-    "ContainerUIDTooltip": "ID użytkownika przypisany do procesów w kontenerze",
+    "ContainerUIDTooltip": "Liczbowy identyfikator użytkownika przypisany procesom w kontenerze",
     "Create": "Stwórz",
     "CreatePolicy": "Utwórz politykę",
     "CreateResourcePolicy": "Utwórz politykę zasobów",
@@ -194,6 +194,7 @@
     "ExportCSV": "eksportuj CSV",
     "ExportCSVFile": "Eksportuj plik CSV",
     "FailedToDeleteUsers": "Nie udało się trwale usunąć użytkownika(ów): {{users}}",
+    "FailedToUpdateUsers": "Nie udało się zaktualizować użytkowników: {{users}}",
     "FileName": "Nazwa pliku",
     "For900Seconds": "przez 900 sekund",
     "FullName": "Pełne imię i nazwisko",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "Status użytkownika uległ zmianie.",
     "TooltipForRequirePasswordChange": "Jeśli ta opcja jest włączona, użytkownik będzie musiał zmienić hasło przy następnym logowaniu.",
     "TypePermanentlyDelete": "Wpisz \"{{text}}\".",
+    "UpdateUsers": "Aktualizuj użytkowników",
+    "UpdateUsersWarningAlertTitle": "Ustawienie UID lub GID(ów) może ograniczyć używanie wcześniej utworzonych punktów montowania folderów.",
+    "UpdatedUsers": "Zaktualizowano {{count}} z {{total}} użytkowników.",
     "UserAccountCreated": "Konto użytkownika zostało pomyślnie utworzone",
     "UserAccountCreatedError": "Konto użytkownika z tym samym adresem e-mail lub nazwą użytkownika już istnieje.",
     "UserDetail": "Szczegóły użytkownika",
@@ -262,9 +266,11 @@
     "WrongEmail": "Nieprawidłowy adres e-mail",
     "YouAreAboutToDeleteCredential": "Zamierzasz usunąć dane uwierzytelniające tego użytkownika:",
     "validation": {
-      "PleaseEnterUnder2_31": "Proszę wprowadzić wartość mniejszą niż 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Wprowadź dodatnią wartość mniejszą niż 2^31",
+      "PleaseEnterPositiveInteger": "Wprowadź wartość dodatnią.",
       "PleaseEnterUniqueNumbers": "Proszę wprowadzić unikalne liczby",
-      "PleaseEnterValidNumber": "Proszę wprowadzić prawidłową liczbę"
+      "PleaseEnterValidNumber": "Proszę wprowadzić prawidłową liczbę",
+      "PleaseSelectDomain": "Najpierw wybierz domenę."
     }
   },
   "dashboard": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "Antes da verificação",
     "ConcurrentSessions": "Sessões Simultâneas",
     "ContainerGID": "GID do contêiner",
-    "ContainerGIDTooltip": "ID do grupo principal atribuído aos processos dentro do contêiner",
+    "ContainerGIDTooltip": "ID numérico de grupo padrão atribuído aos processos dentro do contêiner",
     "ContainerSupplementaryGIDs": "GIDs suplementares",
     "ContainerSupplementaryGIDsPlaceholder": "Inserir GIDs separados por vírgulas ou espaços",
-    "ContainerSupplementaryGIDsTooltip": "IDs de grupo adicionais para processos do contêiner",
+    "ContainerSupplementaryGIDsTooltip": "IDs numéricos de grupo adicionais atribuídos aos processos do contêiner",
     "ContainerUID": "UID do contêiner",
-    "ContainerUIDTooltip": "ID do usuário atribuído aos processos dentro do contêiner",
+    "ContainerUIDTooltip": "ID numérico de usuário atribuído aos processos no contêiner",
     "Create": "Crio",
     "CreatePolicy": "Criar política",
     "CreateResourcePolicy": "Criar Política de Recursos",
@@ -194,6 +194,7 @@
     "ExportCSV": "exportar CSV",
     "ExportCSVFile": "Exportar arquivo CSV",
     "FailedToDeleteUsers": "Falha ao excluir permanentemente o(s) usuário(s): {{users}}",
+    "FailedToUpdateUsers": "Falha ao atualizar usuários: {{users}}",
     "FileName": "Nome do arquivo",
     "For900Seconds": "por 900 segundos",
     "FullName": "Nome completo",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "O estado do utilizador foi alterado.",
     "TooltipForRequirePasswordChange": "Ao ativar esta opção, o usuário deverá alterar a senha no próximo login.",
     "TypePermanentlyDelete": "Por favor, digite \"{{text}}\".",
+    "UpdateUsers": "Atualizar usuários",
+    "UpdateUsersWarningAlertTitle": "Definir UID ou GID(s) pode restringir o uso de montagens de pastas criadas anteriormente.",
+    "UpdatedUsers": "Atualizados {{count}} de {{total}} usuários.",
     "UserAccountCreated": "A conta do usuário foi criada com sucesso",
     "UserAccountCreatedError": "Já existe uma conta de usuário com o mesmo e-mail ou nome de usuário.",
     "UserDetail": "Detalhe do usuário",
@@ -262,9 +266,11 @@
     "WrongEmail": "E-mail inválido",
     "YouAreAboutToDeleteCredential": "Você está prestes a excluir a credencial deste usuário:",
     "validation": {
-      "PleaseEnterUnder2_31": "Por favor, insira um valor menor que 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Por favor, insira um valor positivo menor que 2^31.",
+      "PleaseEnterPositiveInteger": "Por favor, insira um valor positivo.",
       "PleaseEnterUniqueNumbers": "Por favor, insira números únicos",
-      "PleaseEnterValidNumber": "Por favor, insira um número válido"
+      "PleaseEnterValidNumber": "Por favor, insira um número válido",
+      "PleaseSelectDomain": "Por favor, selecione o domínio primeiro."
     }
   },
   "dashboard": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "Antes da verificação",
     "ConcurrentSessions": "Sessões Simultâneas",
     "ContainerGID": "GID do container",
-    "ContainerGIDTooltip": "ID do grupo principal atribuído aos processos dentro do container",
+    "ContainerGIDTooltip": "ID numérico de grupo padrão atribuído aos processos dentro do contêiner",
     "ContainerSupplementaryGIDs": "GIDs suplementares",
     "ContainerSupplementaryGIDsPlaceholder": "Inserir GIDs separados por vírgulas ou espaços",
-    "ContainerSupplementaryGIDsTooltip": "IDs de grupo adicionais para processos do container",
+    "ContainerSupplementaryGIDsTooltip": "IDs numéricos de grupo adicionais atribuídos aos processos do contêiner",
     "ContainerUID": "UID do container",
-    "ContainerUIDTooltip": "ID do utilizador atribuído aos processos dentro do container",
+    "ContainerUIDTooltip": "ID numérico do usuário atribuído aos processos dentro do contêiner",
     "Create": "Crio",
     "CreatePolicy": "Criar política",
     "CreateResourcePolicy": "Criar Política de Recursos",
@@ -194,6 +194,7 @@
     "ExportCSV": "exportar CSV",
     "ExportCSVFile": "Exportar arquivo CSV",
     "FailedToDeleteUsers": "Falha ao excluir permanentemente o(s) usuário(s): {{users}}",
+    "FailedToUpdateUsers": "Falha ao atualizar os usuários: {{users}}",
     "FileName": "Nome do arquivo",
     "For900Seconds": "por 900 segundos",
     "FullName": "Nome completo",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "O estado do utilizador foi alterado.",
     "TooltipForRequirePasswordChange": "Ao ativar esta opção, o usuário deverá alterar a senha no próximo login.",
     "TypePermanentlyDelete": "Por favor, digite \"{{text}}\".",
+    "UpdateUsers": "Atualizar utilizadores",
+    "UpdateUsersWarningAlertTitle": "Definir UID ou GID(s) pode restringir o uso de montagens de pastas criadas anteriormente.",
+    "UpdatedUsers": "Atualizados {{count}} de {{total}} utilizadores.",
     "UserAccountCreated": "A conta do usuário foi criada com sucesso",
     "UserAccountCreatedError": "Já existe uma conta de usuário com o mesmo e-mail ou nome de usuário.",
     "UserDetail": "Detalhe do usuário",
@@ -262,9 +266,11 @@
     "WrongEmail": "E-mail inválido",
     "YouAreAboutToDeleteCredential": "Você está prestes a excluir a credencial deste usuário:",
     "validation": {
-      "PleaseEnterUnder2_31": "Por favor, insira um valor inferior a 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Por favor, insira um valor positivo menor que 2^31",
+      "PleaseEnterPositiveInteger": "Por favor, insira um valor positivo.",
       "PleaseEnterUniqueNumbers": "Por favor, insira números únicos",
-      "PleaseEnterValidNumber": "Por favor, insira um número válido"
+      "PleaseEnterValidNumber": "Por favor, insira um número válido",
+      "PleaseSelectDomain": "Por favor, selecione primeiro o domínio."
     }
   },
   "dashboard": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "Перед проверкой",
     "ConcurrentSessions": "Параллельные сеансы",
     "ContainerGID": "GID контейнера",
-    "ContainerGIDTooltip": "Основной ID группы, назначенный процессам внутри контейнера",
+    "ContainerGIDTooltip": "Идентификатор группы (GID) по умолчанию, присваиваемый процессам внутри контейнера",
     "ContainerSupplementaryGIDs": "Дополнительные GID",
     "ContainerSupplementaryGIDsPlaceholder": "Введите GID через запятую или пробел",
-    "ContainerSupplementaryGIDsTooltip": "Дополнительные ID групп для процессов контейнера",
+    "ContainerSupplementaryGIDsTooltip": "Дополнительные числовые GID, назначаемые процессам контейнера",
     "ContainerUID": "UID контейнера",
-    "ContainerUIDTooltip": "ID пользователя, назначенный процессам внутри контейнера",
+    "ContainerUIDTooltip": "Числовой идентификатор пользователя (UID), назначаемый процессам внутри контейнера",
     "Create": "Создавать",
     "CreatePolicy": "Создать политику",
     "CreateResourcePolicy": "Создать политику ресурсов",
@@ -194,6 +194,7 @@
     "ExportCSV": "экспорт CSV",
     "ExportCSVFile": "Экспорт файла CSV",
     "FailedToDeleteUsers": "Не удалось безвозвратно удалить пользователя(ей): {{users}}",
+    "FailedToUpdateUsers": "Не удалось обновить пользователей: {{users}}",
     "FileName": "Имя файла",
     "For900Seconds": "на 900 секунд",
     "FullName": "ФИО",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "Статус пользователя изменился.",
     "TooltipForRequirePasswordChange": "При включении этой опции пользователь будет обязан сменить пароль при следующем входе.",
     "TypePermanentlyDelete": "Пожалуйста, введите \"{{text}}\".",
+    "UpdateUsers": "Обновить пользователей",
+    "UpdateUsersWarningAlertTitle": "Задание UID или GID(ов) может ограничить использование ранее созданных точек монтирования.",
+    "UpdatedUsers": "Обновлено {{count}} из {{total}} пользователей.",
     "UserAccountCreated": "Учетная запись пользователя успешно создана",
     "UserAccountCreatedError": "Учетная запись с таким же адресом электронной почты или именем пользователя уже существует.",
     "UserDetail": "Сведения о пользователе",
@@ -262,9 +266,11 @@
     "WrongEmail": "Неверный адрес электронной почты",
     "YouAreAboutToDeleteCredential": "Вы собираетесь удалить учетные данные этого пользователя:",
     "validation": {
-      "PleaseEnterUnder2_31": "Пожалуйста, введите значение меньше 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Введите положительное значение меньше 2^31",
+      "PleaseEnterPositiveInteger": "Введите положительное значение.",
       "PleaseEnterUniqueNumbers": "Пожалуйста, введите уникальные числа",
-      "PleaseEnterValidNumber": "Пожалуйста, введите допустимое число"
+      "PleaseEnterValidNumber": "Пожалуйста, введите допустимое число",
+      "PleaseSelectDomain": "Пожалуйста, сначала выберите домен."
     }
   },
   "dashboard": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "ก่อนการตรวจสอบ",
     "ConcurrentSessions": "เซสชันพร้อมกัน",
     "ContainerGID": "GID คอนเทนเนอร์",
-    "ContainerGIDTooltip": "รหัสกลุ่มหลักที่กำหนดให้กับกระบวนการภายในคอนเทนเนอร์",
+    "ContainerGIDTooltip": "รหัสกลุ่มแบบตัวเลขเริ่มต้นที่กำหนดให้กับกระบวนการภายในคอนเทนเนอร์",
     "ContainerSupplementaryGIDs": "GID เสริม",
     "ContainerSupplementaryGIDsPlaceholder": "ป้อน GID คั่นด้วยเครื่องหมายจุลภาคหรือช่องว่าง",
-    "ContainerSupplementaryGIDsTooltip": "รหัสกลุ่มเพิ่มเติมสำหรับกระบวนการคอนเทนเนอร์",
+    "ContainerSupplementaryGIDsTooltip": "รหัสกลุ่มตัวเลขเพิ่มเติมที่กำหนดให้กับกระบวนการในคอนเทนเนอร์",
     "ContainerUID": "UID คอนเทนเนอร์",
-    "ContainerUIDTooltip": "รหัสผู้ใช้ที่กำหนดให้กับกระบวนการภายในคอนเทนเนอร์",
+    "ContainerUIDTooltip": "รหัสผู้ใช้แบบตัวเลขที่กำหนดให้กับกระบวนการภายในคอนเทนเนอร์",
     "Create": "สร้าง",
     "CreatePolicy": "สร้างนโยบาย",
     "CreateResourcePolicy": "สร้างนโยบายทรัพยากร",
@@ -194,6 +194,7 @@
     "ExportCSV": "ส่งออก CSV",
     "ExportCSVFile": "ส่งออกไฟล์ CSV",
     "FailedToDeleteUsers": "ไม่สามารถลบผู้ใช้อย่างถาวรได้: {{users}}",
+    "FailedToUpdateUsers": "ไม่สามารถอัปเดตผู้ใช้ได้: {{users}}",
     "FileName": "ชื่อไฟล์",
     "For900Seconds": "สำหรับ 900 วินาที",
     "FullName": "ชื่อเต็ม",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "สถานะผู้ใช้มีการเปลี่ยนแปลง",
     "TooltipForRequirePasswordChange": "หากเปิดใช้งานตัวเลือกนี้ ผู้ใช้จะต้องเปลี่ยนรหัสผ่านเมื่อเข้าสู่ระบบครั้งถัดไป",
     "TypePermanentlyDelete": "กรุณาพิมพ์ \"{{text}}\".",
+    "UpdateUsers": "อัปเดตผู้ใช้",
+    "UpdateUsersWarningAlertTitle": "การตั้งค่า UID หรือ GID อาจทำให้ไม่สามารถใช้งานการเมานท์โฟลเดอร์ที่สร้างไว้ก่อนหน้านี้ได้",
+    "UpdatedUsers": "อัปเดตแล้ว {{count}} จากผู้ใช้ทั้งหมด {{total}} คน",
     "UserAccountCreated": "สร้างบัญชีผู้ใช้สำเร็จแล้ว",
     "UserAccountCreatedError": "มีบัญชีผู้ใช้ที่มีอีเมลหรือชื่อผู้ใช้เดียวกันอยู่แล้ว",
     "UserDetail": "รายละเอียดผู้ใช้",
@@ -262,9 +266,11 @@
     "WrongEmail": "อีเมลไม่ถูกต้อง",
     "YouAreAboutToDeleteCredential": "คุณกำลังจะลบข้อมูลรับรองของผู้ใช้รายนี้:",
     "validation": {
-      "PleaseEnterUnder2_31": "กรุณากรอกค่าที่น้อยกว่า 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "กรุณาใส่จำนวนบวกที่น้อยกว่า 2^31",
+      "PleaseEnterPositiveInteger": "กรุณาใส่ค่าที่เป็นจำนวนบวก",
       "PleaseEnterUniqueNumbers": "กรุณากรอกตัวเลขที่ไม่ซ้ำกัน",
-      "PleaseEnterValidNumber": "กรุณากรอกตัวเลขที่ถูกต้อง"
+      "PleaseEnterValidNumber": "กรุณากรอกตัวเลขที่ถูกต้อง",
+      "PleaseSelectDomain": "กรุณาเลือกโดเมนก่อน"
     }
   },
   "dashboard": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "Doğrulamadan önce",
     "ConcurrentSessions": "Birleşen oturumlar",
     "ContainerGID": "Konteyner GID",
-    "ContainerGIDTooltip": "Konteyner içindeki işlemlere atanan birincil grup kimliği",
+    "ContainerGIDTooltip": "Konteyner içindeki işlemlere atanan varsayılan sayısal grup kimliği",
     "ContainerSupplementaryGIDs": "Ek GID'ler",
     "ContainerSupplementaryGIDsPlaceholder": "GID'leri virgül veya boşlukla ayırarak girin",
-    "ContainerSupplementaryGIDsTooltip": "Konteyner işlemlerine atanan ek grup kimlikleri",
+    "ContainerSupplementaryGIDsTooltip": "Konteyner işlemlerine atanan ek sayısal grup kimlikleri",
     "ContainerUID": "Konteyner UID",
-    "ContainerUIDTooltip": "Konteyner içindeki işlemlere atanan kullanıcı kimliği",
+    "ContainerUIDTooltip": "Konteyner içindeki işlemlere atanan sayısal kullanıcı kimliği",
     "Create": "Oluşturmak",
     "CreatePolicy": "İlke Oluştur",
     "CreateResourcePolicy": "Kaynak Politikası Oluştur",
@@ -194,6 +194,7 @@
     "ExportCSV": "CSV'yi dışa aktar",
     "ExportCSVFile": "CSV Dosyasını Dışa Aktar",
     "FailedToDeleteUsers": "Kullanıcı(lar) kalıcı olarak silinemedi: {{users}}",
+    "FailedToUpdateUsers": "Kullanıcılar güncellenemedi: {{users}}",
     "FileName": "Dosya adı",
     "For900Seconds": "900 saniye",
     "FullName": "Ad Soyad",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "Kullanıcı durumu değişti.",
     "TooltipForRequirePasswordChange": "Bu seçeneği etkinleştirirseniz kullanıcı bir sonraki girişte şifresini değiştirmek zorunda kalacaktır.",
     "TypePermanentlyDelete": "Lütfen \"{{text}}\" yazın.",
+    "UpdateUsers": "Kullanıcıları Güncelle",
+    "UpdateUsersWarningAlertTitle": "UID veya GID(lerin) ayarlanması, daha önce oluşturulmuş klasör bağlamalarının kullanılmasını kısıtlayabilir.",
+    "UpdatedUsers": "Toplam {{total}} kullanıcıdan {{count}} güncellendi.",
     "UserAccountCreated": "Kullanıcı hesabı başarıyla oluşturuldu",
     "UserAccountCreatedError": "Aynı e-posta adresi veya kullanıcı adına sahip bir hesap zaten mevcut.",
     "UserDetail": "Kullanıcı Detayı",
@@ -262,9 +266,11 @@
     "WrongEmail": "Geçersiz e-posta",
     "YouAreAboutToDeleteCredential": "Bu kullanıcının kimlik bilgilerini silmek üzeresiniz:",
     "validation": {
-      "PleaseEnterUnder2_31": "Lütfen 2³¹'den küçük bir değer girin",
+      "PleaseEnterPositiveAndUnder2_31": "Lütfen 2^31'den küçük pozitif bir değer girin.",
+      "PleaseEnterPositiveInteger": "Lütfen pozitif bir değer girin.",
       "PleaseEnterUniqueNumbers": "Lütfen benzersiz sayılar girin",
-      "PleaseEnterValidNumber": "Lütfen geçerli bir sayı girin"
+      "PleaseEnterValidNumber": "Lütfen geçerli bir sayı girin",
+      "PleaseSelectDomain": "Lütfen önce bir domain seçin."
     }
   },
   "dashboard": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "Trước khi xác minh",
     "ConcurrentSessions": "Phiên đồng thời",
     "ContainerGID": "GID container",
-    "ContainerGIDTooltip": "ID nhóm chính được gán cho các tiến trình trong container",
+    "ContainerGIDTooltip": "ID nhóm số mặc định được gán cho các tiến trình trong container",
     "ContainerSupplementaryGIDs": "GID bổ sung",
     "ContainerSupplementaryGIDsPlaceholder": "Nhập GID phân cách bằng dấu phẩy hoặc khoảng trắng",
-    "ContainerSupplementaryGIDsTooltip": "ID nhóm bổ sung cho các tiến trình container",
+    "ContainerSupplementaryGIDsTooltip": "Các ID nhóm số bổ sung được gán cho các tiến trình của container",
     "ContainerUID": "UID container",
-    "ContainerUIDTooltip": "ID người dùng được gán cho các tiến trình trong container",
+    "ContainerUIDTooltip": "ID người dùng số được gán cho các tiến trình trong container",
     "Create": "Tạo nên",
     "CreatePolicy": "Tạo chính sách",
     "CreateResourcePolicy": "Tạo chính sách tài nguyên",
@@ -194,6 +194,7 @@
     "ExportCSV": "xuất CSV",
     "ExportCSVFile": "Xuất tệp CSV",
     "FailedToDeleteUsers": "Không thể xóa vĩnh viễn người dùng: {{users}}.",
+    "FailedToUpdateUsers": "Không thể cập nhật người dùng: {{users}}",
     "FileName": "Tên tệp",
     "For900Seconds": "trong 900 giây",
     "FullName": "Họ và tên",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "Trạng thái người dùng đã thay đổi.",
     "TooltipForRequirePasswordChange": "Khi bật tùy chọn này, người dùng sẽ phải thay đổi mật khẩu ở lần đăng nhập tiếp theo.",
     "TypePermanentlyDelete": "Vui lòng nhập \"{{text}}\".",
+    "UpdateUsers": "Cập nhật người dùng",
+    "UpdateUsersWarningAlertTitle": "Thiết lập UID hoặc GID có thể giới hạn việc sử dụng các mount thư mục đã tạo trước đó.",
+    "UpdatedUsers": "Đã cập nhật {{count}} trong tổng số {{total}} người dùng.",
     "UserAccountCreated": "Tài khoản người dùng được tạo thành công",
     "UserAccountCreatedError": "Một tài khoản người dùng với cùng địa chỉ email hoặc tên đăng nhập đã tồn tại.",
     "UserDetail": "Chi tiết Người dùng",
@@ -262,9 +266,11 @@
     "WrongEmail": "Email không hợp lệ",
     "YouAreAboutToDeleteCredential": "Bạn sắp xóa thông tin xác thực của người dùng này:",
     "validation": {
-      "PleaseEnterUnder2_31": "Vui lòng nhập giá trị nhỏ hơn 2³¹",
+      "PleaseEnterPositiveAndUnder2_31": "Vui lòng nhập một giá trị dương nhỏ hơn 2^31",
+      "PleaseEnterPositiveInteger": "Vui lòng nhập một giá trị dương.",
       "PleaseEnterUniqueNumbers": "Vui lòng nhập các số không trùng lặp",
-      "PleaseEnterValidNumber": "Vui lòng nhập số hợp lệ"
+      "PleaseEnterValidNumber": "Vui lòng nhập số hợp lệ",
+      "PleaseSelectDomain": "Vui lòng chọn miền trước."
     }
   },
   "dashboard": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "验证之前",
     "ConcurrentSessions": "并发会话",
     "ContainerGID": "容器GID",
-    "ContainerGIDTooltip": "分配给容器内进程的主组ID",
+    "ContainerGIDTooltip": "分配给容器内进程的默认数值组 ID",
     "ContainerSupplementaryGIDs": "附加GID",
     "ContainerSupplementaryGIDsPlaceholder": "用逗号或空格分隔输入GID",
-    "ContainerSupplementaryGIDsTooltip": "分配给容器进程的附加组ID",
+    "ContainerSupplementaryGIDsTooltip": "分配给容器进程的额外数字组 ID",
     "ContainerUID": "容器UID",
-    "ContainerUIDTooltip": "分配给容器内进程的用户ID",
+    "ContainerUIDTooltip": "分配给容器内进程的数值用户 ID",
     "Create": "创造",
     "CreatePolicy": "创建策略",
     "CreateResourcePolicy": "创建资源策略",
@@ -194,6 +194,7 @@
     "ExportCSV": "导出 CSV",
     "ExportCSVFile": "导出 CSV 文件",
     "FailedToDeleteUsers": "无法永久删除用户：{{users}}",
+    "FailedToUpdateUsers": "更新用户失败：{{users}}",
     "FileName": "文件名",
     "For900Seconds": "900 秒",
     "FullName": "全名",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "用户状态已更改。",
     "TooltipForRequirePasswordChange": "启用此选项后，用户下次登录时需更改密码。",
     "TypePermanentlyDelete": "请输入“{{text}}”。",
+    "UpdateUsers": "更新用户",
+    "UpdateUsersWarningAlertTitle": "设置 UID 或 GID 可能会限制对已创建文件夹挂载的访问。",
+    "UpdatedUsers": "已更新 {{count}} / {{total}} 名用户。",
     "UserAccountCreated": "用户帐户已成功创建",
     "UserAccountCreatedError": "具有相同邮箱或用户名的账号已存在。",
     "UserDetail": "用户详情",
@@ -262,9 +266,11 @@
     "WrongEmail": "无效的邮箱地址",
     "YouAreAboutToDeleteCredential": "您将要删除该用户的凭据：",
     "validation": {
-      "PleaseEnterUnder2_31": "请输入小于2³¹的值",
+      "PleaseEnterPositiveAndUnder2_31": "请输入小于 2^31 的正数",
+      "PleaseEnterPositiveInteger": "请输入正数。",
       "PleaseEnterUniqueNumbers": "请输入不重复的数字",
-      "PleaseEnterValidNumber": "请输入有效的数字"
+      "PleaseEnterValidNumber": "请输入有效的数字",
+      "PleaseSelectDomain": "请先选择域。"
     }
   },
   "dashboard": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -166,12 +166,12 @@
     "BeforeVerification": "驗證之前",
     "ConcurrentSessions": "並發會話",
     "ContainerGID": "容器GID",
-    "ContainerGIDTooltip": "分配給容器內程序的主要群組ID",
+    "ContainerGIDTooltip": "預設分配給容器內進程的數值群組 ID",
     "ContainerSupplementaryGIDs": "附加GID",
     "ContainerSupplementaryGIDsPlaceholder": "用逗號或空格分隔輸入GID",
-    "ContainerSupplementaryGIDsTooltip": "分配給容器程序的附加群組ID",
+    "ContainerSupplementaryGIDsTooltip": "分配給容器進程的額外數字群組 ID",
     "ContainerUID": "容器UID",
-    "ContainerUIDTooltip": "分配給容器內程序的使用者ID",
+    "ContainerUIDTooltip": "分配給容器內進程的數值使用者 ID",
     "Create": "創造",
     "CreatePolicy": "創建策略",
     "CreateResourcePolicy": "創建資源策略",
@@ -194,6 +194,7 @@
     "ExportCSV": "導出 CSV",
     "ExportCSVFile": "導出 CSV 文件",
     "FailedToDeleteUsers": "無法永久刪除使用者：{{users}}",
+    "FailedToUpdateUsers": "更新使用者失敗：{{users}}",
     "FileName": "文件名",
     "For900Seconds": "900 秒",
     "FullName": "全名",
@@ -246,6 +247,9 @@
     "StatusUpdatedSuccessfully": "用户状态已更改。",
     "TooltipForRequirePasswordChange": "啟用此選項後，使用者在下次登入時需更改密碼。",
     "TypePermanentlyDelete": "請輸入 \"{{text}}\".",
+    "UpdateUsers": "更新使用者",
+    "UpdateUsersWarningAlertTitle": "設定 UID 或 GID（或多個）可能會限制先前建立之資料夾掛載的使用。",
+    "UpdatedUsers": "已更新 {{count}} / {{total}} 位使用者。",
     "UserAccountCreated": "用戶帳戶已成功創建",
     "UserAccountCreatedError": "已存在相同電子郵件或使用者名稱的帳號。",
     "UserDetail": "用戶詳情",
@@ -262,9 +266,11 @@
     "WrongEmail": "電子郵件格式錯誤",
     "YouAreAboutToDeleteCredential": "您將要刪除該使用者的憑證：",
     "validation": {
-      "PleaseEnterUnder2_31": "請輸入小於2³¹的值",
+      "PleaseEnterPositiveAndUnder2_31": "請輸入小於 2^31 的正數",
+      "PleaseEnterPositiveInteger": "請輸入正數。",
       "PleaseEnterUniqueNumbers": "請輸入不重複的數字",
-      "PleaseEnterValidNumber": "請輸入有效的數字"
+      "PleaseEnterValidNumber": "請輸入有效的數字",
+      "PleaseSelectDomain": "請先選擇網域。"
     }
   },
   "dashboard": {


### PR DESCRIPTION
resolves #4885 (FR-1820)

This PR adds a new modal component `UpdateUsersModal` that allows administrators to update multiple user accounts simultaneously. The modal provides options to:

- Change domain assignment
- Update project memberships
- Modify user status
- Assign resource policies
- Set container UID, main GID, and supplementary GIDs

The update functionality is integrated into the UserManagement component with a new "Update" button that appears when users are selected. The modal includes validation for numeric inputs and displays appropriate success/error messages after the update operation.

Internationalization strings have been added to all language files to support the new feature.

![CleanShot 2026-01-13 at 16.00.51@2x.png](https://app.graphite.com/user-attachments/assets/8cf2f762-c561-4f6b-bd92-d73e28fba46d.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [x] Minium required manager version: main
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after