### PR TITLE
fix(FR-1883): simplify BAITag token configuration and update Storybook preview

### DIFF
--- a/packages/backend.ai-ui/.storybook/preview.tsx
+++ b/packages/backend.ai-ui/.storybook/preview.tsx
@@ -1,6 +1,6 @@
 import { i18n } from '../src/locale';
 import type { Preview } from '@storybook/react-vite';
-import { ConfigProvider, Skeleton } from 'antd';
+import { ConfigProvider, Skeleton, theme, Typography } from 'antd';
 import type { Locale } from 'antd/es/locale';
 import deDE from 'antd/locale/de_DE';
 import elGR from 'antd/locale/el_GR';
@@ -24,7 +24,8 @@ import viVN from 'antd/locale/vi_VN';
 import zhCN from 'antd/locale/zh_CN';
 import zhTW from 'antd/locale/zh_TW';
 import React, { Suspense, useEffect } from 'react';
-import { I18nextProvider } from 'react-i18next';
+import { I18nextProvider, useTranslation } from 'react-i18next';
+import BAIText from '../src/components/BAIText';
 
 const antdLocaleMap: Record<string, Locale> = {
   en: enUS,
@@ -66,10 +67,46 @@ const LocaleProvider: React.FC<LocaleProviderProps> = ({
   }, [locale]);
 
   const antdLocale = getAntdLocale(locale);
+  const { token } = theme.useToken();
+  const { t } = useTranslation();
+
   return (
     <Suspense fallback={<Skeleton active />}>
       <I18nextProvider i18n={i18n}>
-        <ConfigProvider locale={antdLocale}>
+        <ConfigProvider
+          locale={antdLocale}
+          modal={{
+            mask: {
+              blur: false,
+            },
+          }}
+          drawer={{
+            mask: {
+              blur: false,
+            },
+          }}
+          form={{
+            requiredMark: (label, { required }) => (
+              <>
+                {label}
+                {!required && (
+                  <BAIText
+                    type="secondary"
+                    style={{
+                      marginLeft: token.marginXXS,
+                      wordBreak: 'keep-all',
+                    }}
+                  >
+                    {`(${t('general.Optional')})`}
+                  </BAIText>
+                )}
+              </>
+            ),
+          }}
+          tag={{
+            variant: 'outlined',
+          }}
+        >
           <div style={{ padding: '16px' }}>{children}</div>
         </ConfigProvider>
       </I18nextProvider>

--- a/packages/backend.ai-ui/src/components/BAITag.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAITag.stories.tsx
@@ -15,12 +15,14 @@ const meta: Meta<typeof BAITag> = {
 **BAITag** extends [Ant Design Tag](https://ant.design/components/tag) with Backend.AI-specific styling.
 
 ## BAI-Specific Styling
-| Style | Value | Description |
-|-------|-------|-------------|
-| \`borderRadiusSM\` | \`11px\` | Rounded borders for softer appearance |
-| \`defaultBg\` | \`transparent\` | Transparent backgrounds for all color variants |
-| \`colorText\` | \`#999999\` | Muted text color for better readability |
-| \`padding\` | \`token.paddingSM\` | Consistent horizontal padding using design tokens |
+| Token | Level | Value | Description |
+|-------|-------|-------|-------------|
+| \`borderRadiusSM\` | Global | \`11px\` | Rounded borders for softer appearance |
+| \`defaultBg\` | Component | \`transparent\` | Transparent background for default tag |
+| \`defaultColor\` | Component | \`#999999\` | Muted text color for better readability |
+| \`padding\` | Inline Style | \`token.paddingSM\` | Consistent horizontal padding using design tokens |
+
+> **Note:** Status color variants (success, processing, error, warning) use Ant Design's default preset colors.
 
 This component has no additional props beyond Ant Design Tag. The styling differences are applied automatically via ConfigProvider theme customization.
 

--- a/packages/backend.ai-ui/src/components/BAITag.tsx
+++ b/packages/backend.ai-ui/src/components/BAITag.tsx
@@ -9,15 +9,13 @@ const BAITag: React.FC<BAITagProps> = ({ ...tagProps }) => {
   return (
     <ConfigProvider
       theme={{
+        token: {
+          borderRadiusSM: 11,
+        },
         components: {
           Tag: {
-            borderRadiusSM: 11,
-            colorText: '#999999',
             defaultBg: 'transparent',
-            colorInfoBg: 'transparent',
-            colorWarningBg: 'transparent',
-            colorErrorBg: 'transparent',
-            colorSuccessBg: 'transparent',
+            defaultColor: '#999999',
           },
         },
       }}


### PR DESCRIPTION
Resolves #4986 ([FR-1883](https://lablup.atlassian.net/browse/FR-1883))

## Summary

- Updated BAITag component token values ([Ant Design Tag](https://ant.design/components/tag))
- Added global tag configuration in Storybook preview

## Changes

- **BAITag.tsx**: Modified token values (borderRadiusSM, colorText, defaultBg, background colors for each variant)
- **preview.tsx**: Set global tag variant to `outlined`

## Testing

Verify BAITag component renders correctly in Storybook

[FR-1883]: https://lablup.atlassian.net/browse/FR-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="507" height="295" alt="스크린샷 2026-01-14 오후 4 54 34" src="https://github.com/user-attachments/assets/8814b076-2764-4659-9173-181a707a1ef9" />

