### PR TITLE
feat(FR-1897): add ConfigProvider settings to Storybook preview

### DIFF
--- a/packages/backend.ai-ui/.storybook/decorators.tsx
+++ b/packages/backend.ai-ui/.storybook/decorators.tsx
@@ -1,0 +1,112 @@
+import BAIText from '../src/components/BAIText';
+import { i18n } from '../src/locale';
+import { getAntdLocale } from './localeConfig';
+import { themeConfigs, type ThemeMode, type ThemeStyle } from './themeConfig';
+import type { Decorator } from '@storybook/react-vite';
+import { ConfigProvider, Skeleton, theme } from 'antd';
+import React, { Suspense, useEffect } from 'react';
+import { I18nextProvider, useTranslation } from 'react-i18next';
+
+interface StorybookProviderProps {
+  locale: string;
+  themeMode: ThemeMode;
+  themeStyle: ThemeStyle;
+  children: React.ReactNode;
+}
+
+const GlobalConfigProvider: React.FC<StorybookProviderProps> = ({
+  locale,
+  themeMode,
+  themeStyle,
+  children,
+}) => {
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const antdLocale = getAntdLocale(locale);
+  const currentThemeConfig = themeConfigs[themeStyle];
+
+  return (
+    <ConfigProvider
+      locale={antdLocale}
+      theme={{
+        ...(themeMode === 'dark'
+          ? currentThemeConfig.dark
+          : currentThemeConfig.light),
+        algorithm:
+          themeMode === 'dark' ? theme.darkAlgorithm : theme.defaultAlgorithm,
+      }}
+      modal={{
+        mask: {
+          blur: false,
+        },
+      }}
+      drawer={{
+        mask: {
+          blur: false,
+        },
+      }}
+      tag={{
+        variant: 'outlined',
+      }}
+      form={{
+        requiredMark: (label, { required }) => (
+          <>
+            {label}
+            {!required && (
+              <BAIText
+                type="secondary"
+                style={{
+                  marginLeft: token.marginXXS,
+                  wordBreak: 'keep-all',
+                }}
+              >
+                {`(${t('general.Optional')})`}
+              </BAIText>
+            )}
+          </>
+        ),
+      }}
+    >
+      <div style={{ padding: '16px' }}>{children}</div>
+    </ConfigProvider>
+  );
+};
+
+const StorybookProvider: React.FC<StorybookProviderProps> = ({
+  locale,
+  themeMode,
+  themeStyle,
+  children,
+}) => {
+  useEffect(() => {
+    i18n.changeLanguage(locale);
+  }, [locale]);
+
+  return (
+    <Suspense fallback={<Skeleton active />}>
+      <I18nextProvider i18n={i18n}>
+        <GlobalConfigProvider
+          locale={locale}
+          themeMode={themeMode}
+          themeStyle={themeStyle}
+        >
+          {children}
+        </GlobalConfigProvider>
+      </I18nextProvider>
+    </Suspense>
+  );
+};
+
+export const withGlobalProvider: Decorator = (Story, context) => {
+  const { locale, themeMode, themeStyle } = context.globals;
+
+  return (
+    <StorybookProvider
+      locale={locale}
+      themeMode={themeMode}
+      themeStyle={themeStyle}
+    >
+      <Story />
+    </StorybookProvider>
+  );
+};

--- a/packages/backend.ai-ui/.storybook/localeConfig.ts
+++ b/packages/backend.ai-ui/.storybook/localeConfig.ts
@@ -1,0 +1,73 @@
+import type { Locale } from 'antd/es/locale';
+import deDE from 'antd/locale/de_DE';
+import elGR from 'antd/locale/el_GR';
+import enUS from 'antd/locale/en_US';
+import esES from 'antd/locale/es_ES';
+import fiFI from 'antd/locale/fi_FI';
+import frFR from 'antd/locale/fr_FR';
+import idID from 'antd/locale/id_ID';
+import itIT from 'antd/locale/it_IT';
+import jaJP from 'antd/locale/ja_JP';
+import koKR from 'antd/locale/ko_KR';
+import mnMN from 'antd/locale/mn_MN';
+import msMY from 'antd/locale/ms_MY';
+import plPL from 'antd/locale/pl_PL';
+import ptBR from 'antd/locale/pt_BR';
+import ptPT from 'antd/locale/pt_PT';
+import ruRU from 'antd/locale/ru_RU';
+import thTH from 'antd/locale/th_TH';
+import trTR from 'antd/locale/tr_TR';
+import viVN from 'antd/locale/vi_VN';
+import zhCN from 'antd/locale/zh_CN';
+import zhTW from 'antd/locale/zh_TW';
+
+export const antdLocaleMap: Record<string, Locale> = {
+  en: enUS,
+  ko: koKR,
+  ja: jaJP,
+  'zh-CN': zhCN,
+  'zh-TW': zhTW,
+  de: deDE,
+  fr: frFR,
+  es: esES,
+  pt: ptPT,
+  'pt-BR': ptBR,
+  it: itIT,
+  ru: ruRU,
+  pl: plPL,
+  el: elGR,
+  fi: fiFI,
+  tr: trTR,
+  th: thTH,
+  vi: viVN,
+  id: idID,
+  ms: msMY,
+  mn: mnMN,
+};
+
+export const getAntdLocale = (locale: string): Locale =>
+  antdLocaleMap[locale] ?? enUS;
+
+export const localeItems = [
+  { value: 'en', title: 'English' },
+  { value: 'ko', title: '한국어' },
+  { value: 'ja', title: '日本語' },
+  { value: 'zh-CN', title: '简体中文' },
+  { value: 'zh-TW', title: '繁體中文' },
+  { value: 'de', title: 'Deutsch' },
+  { value: 'fr', title: 'Français' },
+  { value: 'es', title: 'Español' },
+  { value: 'pt', title: 'Português' },
+  { value: 'pt-BR', title: 'Português (Brasil)' },
+  { value: 'it', title: 'Italiano' },
+  { value: 'ru', title: 'Русский' },
+  { value: 'pl', title: 'Polski' },
+  { value: 'el', title: 'Ελληνικά' },
+  { value: 'fi', title: 'Suomi' },
+  { value: 'tr', title: 'Türkçe' },
+  { value: 'th', title: 'ไทย' },
+  { value: 'vi', title: 'Tiếng Việt' },
+  { value: 'id', title: 'Indonesia' },
+  { value: 'ms', title: 'Melayu' },
+  { value: 'mn', title: 'Монгол' },
+];

--- a/packages/backend.ai-ui/.storybook/preview.tsx
+++ b/packages/backend.ai-ui/.storybook/preview.tsx
@@ -1,95 +1,10 @@
-import { i18n } from '../src/locale';
+import { withGlobalProvider } from './decorators';
+import { localeItems } from './localeConfig';
 import type { Preview } from '@storybook/react-vite';
-import { ConfigProvider, Skeleton } from 'antd';
-import type { Locale } from 'antd/es/locale';
-import deDE from 'antd/locale/de_DE';
-import elGR from 'antd/locale/el_GR';
-import enUS from 'antd/locale/en_US';
-import esES from 'antd/locale/es_ES';
-import fiFI from 'antd/locale/fi_FI';
-import frFR from 'antd/locale/fr_FR';
-import idID from 'antd/locale/id_ID';
-import itIT from 'antd/locale/it_IT';
-import jaJP from 'antd/locale/ja_JP';
-import koKR from 'antd/locale/ko_KR';
-import mnMN from 'antd/locale/mn_MN';
-import msMY from 'antd/locale/ms_MY';
-import plPL from 'antd/locale/pl_PL';
-import ptBR from 'antd/locale/pt_BR';
-import ptPT from 'antd/locale/pt_PT';
-import ruRU from 'antd/locale/ru_RU';
-import thTH from 'antd/locale/th_TH';
-import trTR from 'antd/locale/tr_TR';
-import viVN from 'antd/locale/vi_VN';
-import zhCN from 'antd/locale/zh_CN';
-import zhTW from 'antd/locale/zh_TW';
-import React, { Suspense, useEffect } from 'react';
-import { I18nextProvider } from 'react-i18next';
-
-const antdLocaleMap: Record<string, Locale> = {
-  en: enUS,
-  ko: koKR,
-  ja: jaJP,
-  'zh-CN': zhCN,
-  'zh-TW': zhTW,
-  de: deDE,
-  fr: frFR,
-  es: esES,
-  pt: ptPT,
-  'pt-BR': ptBR,
-  it: itIT,
-  ru: ruRU,
-  pl: plPL,
-  el: elGR,
-  fi: fiFI,
-  tr: trTR,
-  th: thTH,
-  vi: viVN,
-  id: idID,
-  ms: msMY,
-  mn: mnMN,
-};
-
-const getAntdLocale = (locale: string): Locale => antdLocaleMap[locale] ?? enUS;
-
-interface LocaleProviderProps {
-  locale: string;
-  children: React.ReactNode;
-}
-
-const LocaleProvider: React.FC<LocaleProviderProps> = ({
-  locale,
-  children,
-}) => {
-  useEffect(() => {
-    i18n.changeLanguage(locale);
-  }, [locale]);
-
-  const antdLocale = getAntdLocale(locale);
-  return (
-    <Suspense fallback={<Skeleton active />}>
-      <I18nextProvider i18n={i18n}>
-        <ConfigProvider locale={antdLocale}>
-          <div style={{ padding: '16px' }}>{children}</div>
-        </ConfigProvider>
-      </I18nextProvider>
-    </Suspense>
-  );
-};
 
 const preview: Preview = {
   tags: ['autodocs'],
-  decorators: [
-    (Story, context) => {
-      const { locale } = context.globals;
-
-      return (
-        <LocaleProvider locale={locale}>
-          <Story />
-        </LocaleProvider>
-      );
-    },
-  ],
+  decorators: [withGlobalProvider],
   parameters: {
     docs: {
       extractComponentDescription: (_component: any, { notes }: any) => {
@@ -104,35 +19,41 @@ const preview: Preview = {
       description: 'Internationalization locale',
       toolbar: {
         icon: 'globe',
+        items: localeItems,
+        showName: true,
+        dynamicTitle: true,
+      },
+    },
+    themeMode: {
+      name: 'Theme',
+      description: 'Light or dark theme',
+      toolbar: {
         items: [
-          { value: 'en', title: 'English' },
-          { value: 'ko', title: '한국어' },
-          { value: 'ja', title: '日本語' },
-          { value: 'zh-CN', title: '简体中文' },
-          { value: 'zh-TW', title: '繁體中文' },
-          { value: 'de', title: 'Deutsch' },
-          { value: 'fr', title: 'Français' },
-          { value: 'es', title: 'Español' },
-          { value: 'pt', title: 'Português' },
-          { value: 'pt-BR', title: 'Português (Brasil)' },
-          { value: 'it', title: 'Italiano' },
-          { value: 'ru', title: 'Русский' },
-          { value: 'pl', title: 'Polski' },
-          { value: 'el', title: 'Ελληνικά' },
-          { value: 'fi', title: 'Suomi' },
-          { value: 'tr', title: 'Türkçe' },
-          { value: 'th', title: 'ไทย' },
-          { value: 'vi', title: 'Tiếng Việt' },
-          { value: 'id', title: 'Indonesia' },
-          { value: 'ms', title: 'Melayu' },
-          { value: 'mn', title: 'Монгол' },
+          { value: 'light', title: 'Light', icon: 'sun' },
+          { value: 'dark', title: 'Dark', icon: 'moon' },
         ],
         showName: true,
+        dynamicTitle: true,
+      },
+    },
+    themeStyle: {
+      name: 'Theme Style',
+      description: 'Theme style preset',
+      toolbar: {
+        icon: 'paintbrush',
+        items: [
+          { value: 'default', title: 'Default (Ant Design)' },
+          { value: 'webui', title: 'WebUI (Backend.AI)' },
+        ],
+        showName: true,
+        dynamicTitle: true,
       },
     },
   },
   initialGlobals: {
     locale: 'en',
+    themeMode: 'light',
+    themeStyle: 'default',
   },
 };
 

--- a/packages/backend.ai-ui/.storybook/themeConfig.ts
+++ b/packages/backend.ai-ui/.storybook/themeConfig.ts
@@ -1,0 +1,19 @@
+import webuiThemeJson from '../../../resources/theme.json';
+import type { ThemeConfig } from 'antd';
+
+export type ThemeMode = 'light' | 'dark';
+export type ThemeStyle = 'default' | 'webui';
+
+export const themeConfigs: Record<
+  ThemeStyle,
+  { light: ThemeConfig; dark: ThemeConfig }
+> = {
+  default: {
+    light: {},
+    dark: {},
+  },
+  webui: {
+    light: webuiThemeJson.light,
+    dark: webuiThemeJson.dark,
+  },
+};

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} ausgewählt",
+    "Optional": "Optional",
     "TotalItems": "Total {{total}} Elemente",
     "button": {
       "Cancel": "Stornieren",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} Επιλεγμένη",
+    "Optional": "Προαιρετικό",
     "TotalItems": "Σύνολο {{total}} στοιχεία",
     "button": {
       "Cancel": "Ματαίωση",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -255,6 +255,7 @@
   },
   "general": {
     "NSelected": "{{count}} selected",
+    "Optional": "Optional",
     "TotalItems": "Total {{total}} items",
     "button": {
       "Cancel": "Cancel",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} seleccionado",
+    "Optional": "Opcional",
     "TotalItems": "Total {{total}} elementos",
     "button": {
       "Cancel": "Cancelar",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} valittu",
+    "Optional": "Valinnainen",
     "TotalItems": "Yhteensä {{total}} kohteet",
     "button": {
       "Cancel": "Peruuttaa",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} sélectionné",
+    "Optional": "Facultatif",
     "TotalItems": "Éléments totaux {{total}}",
     "button": {
       "Cancel": "Annuler",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} dipilih",
+    "Optional": "Opsional",
     "TotalItems": "Total {{total}} item",
     "button": {
       "Cancel": "Membatalkan",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} selezionato",
+    "Optional": "Opzionale",
     "TotalItems": "Totali {{total}} elementi",
     "button": {
       "Cancel": "Cancellare",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}}選択",
+    "Optional": "任意",
     "TotalItems": "Total {{total}}アイテム",
     "button": {
       "Cancel": "キャンセル",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}}개 선택됨",
+    "Optional": "선택",
     "TotalItems": "총 {{total}} 항목",
     "button": {
       "Cancel": "취소",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} сонгогдсон",
+    "Optional": "Заавал биш",
     "TotalItems": "Нийт {{total}} зүйлүүд",
     "button": {
       "Cancel": "Цуаах",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} dipilih",
+    "Optional": "Pilihan",
     "TotalItems": "Jumlah {{total}} item",
     "button": {
       "Cancel": "Batalkan",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}}",
+    "Optional": "Opcjonalne",
     "TotalItems": "Total {{total}}",
     "button": {
       "Cancel": "Anulować",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -251,6 +251,7 @@
   },
   "general": {
     "NSelected": "{{count}} selecionado",
+    "Optional": "Opcional",
     "TotalItems": "Total {{total}} itens",
     "button": {
       "Cancel": "Cancelar",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} selecionado",
+    "Optional": "Opcional",
     "TotalItems": "Total {{total}} itens",
     "button": {
       "Cancel": "Cancelar",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} выбрал",
+    "Optional": "Необязательно",
     "TotalItems": "Total {{total}} элементы",
     "button": {
       "Cancel": "Отмена",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} เลือก",
+    "Optional": "ไม่บังคับ",
     "TotalItems": "รวม {{total}} รายการ",
     "button": {
       "Cancel": "ยกเลิก",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -247,6 +247,7 @@
   },
   "general": {
     "NSelected": "{{count}} seçildi",
+    "Optional": "İsteğe bağlı",
     "TotalItems": "Total {{total}} öğeleri",
     "button": {
       "Cancel": "İptal etmek",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}} Đã chọn",
+    "Optional": "Không bắt buộc",
     "TotalItems": "Tổng số {{total}} các mục",
     "button": {
       "Cancel": "Hủy bỏ",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}}选择",
+    "Optional": "可选",
     "TotalItems": "总计{{total}}项目",
     "button": {
       "Cancel": "取消",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -252,6 +252,7 @@
   },
   "general": {
     "NSelected": "{{count}}選擇",
+    "Optional": "選填",
     "TotalItems": "總計{{total}}項目",
     "button": {
       "Cancel": "取消",


### PR DESCRIPTION
Resolves #5013(FR-1897)

## Summary
- Add theme configuration with light/dark mode toggle to Storybook
- Add ConfigProvider settings matching the actual app (modal/drawer mask blur, tag variant, form optional labels)
- Add `general.Optional` translations for all 21 supported languages

## Changes
- **preview.tsx**: Added theme config (light/dark), modal/drawer blur disabled, outlined tag variant, custom form requiredMark
- **locale/*.json**: Added "Optional" translation key in all 21 languages

## Test plan
- [ ] Verify Storybook theme toggle works (light/dark mode)
- [ ] Verify form fields show "(Optional)" label for non-required fields
- [ ] Verify modal/drawer backdrop blur is disabled
- [ ] Verify translations appear correctly in different locales

<img width="359" height="63" alt="스크린샷 2026-01-21 오전 10 25 17" src="https://github.com/user-attachments/assets/46ba86f7-a087-4c23-9cba-0a8241bc024c" />


🤖 Generated with [Claude Code](https://claude.ai/claude-code)