### PR TITLE
docs(FR-1893): add Storybook stories for BAIAlertIconWithTooltip, BooleanTag, BAIResourceNumberWithIcon, BAIFetchKeyButton

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIAlertIconWithTooltip.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIAlertIconWithTooltip.stories.tsx
@@ -1,0 +1,112 @@
+import BAIAlertIconWithTooltip from './BAIAlertIconWithTooltip';
+import BAIFlex from './BAIFlex';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof BAIAlertIconWithTooltip> = {
+  title: 'Components/BAIAlertIconWithTooltip',
+  component: BAIAlertIconWithTooltip,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAIAlertIconWithTooltip** extends [Ant Design Tooltip](https://ant.design/components/tooltip) with a built-in alert icon.
+
+## BAI-Specific Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| \`iconProps\` | \`React.ComponentProps<typeof CircleAlertIcon>\` | \`undefined\` | Props for the CircleAlertIcon from lucide-react |
+| \`type\` | \`'warning' | 'error'\` | \`'error'\` | Determines icon color: warning uses colorWarning token, error uses colorError token |
+
+**Note:** The \`children\` prop is omitted as the component provides its own icon.
+
+For all other props, refer to [Ant Design Tooltip](https://ant.design/components/tooltip).
+        `,
+      },
+    },
+  },
+  argTypes: {
+    // BAI-specific props - document fully
+    iconProps: {
+      control: { type: 'object' },
+      description: 'Props for the CircleAlertIcon (lucide-react)',
+      table: {
+        type: { summary: 'React.ComponentProps<typeof CircleAlertIcon>' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    type: {
+      control: { type: 'radio' },
+      options: ['warning', 'error'],
+      description:
+        'Determines icon color: warning uses colorWarning token, error uses colorError token',
+      table: {
+        type: { summary: "'warning' | 'error'" },
+        defaultValue: { summary: "'error'" },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIAlertIconWithTooltip>;
+
+// Default story: Use args for interactive Controls
+export const Default: Story = {
+  name: 'Basic',
+  args: {
+    title: 'This is an error alert icon',
+    type: 'error',
+  },
+};
+
+// Comparison story: Demonstrate BAI-specific type prop
+export const IconTypes: Story = {
+  render: () => (
+    <BAIFlex direction="row" gap="xl" align="center">
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>Error (default)</div>
+        <BAIAlertIconWithTooltip
+          title="This is an error message"
+          type="error"
+        />
+      </div>
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>Warning</div>
+        <BAIAlertIconWithTooltip
+          title="This is a warning message"
+          type="warning"
+        />
+      </div>
+    </BAIFlex>
+  ),
+};
+
+// Comparison story: Demonstrate BAI-specific iconProps
+export const CustomIconSize: Story = {
+  render: () => (
+    <BAIFlex direction="row" gap="xl" align="center">
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>Default size</div>
+        <BAIAlertIconWithTooltip title="Default icon size" type="error" />
+      </div>
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>Small (16px)</div>
+        <BAIAlertIconWithTooltip
+          title="Small icon size"
+          type="error"
+          iconProps={{ size: 16 }}
+        />
+      </div>
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>Large (32px)</div>
+        <BAIAlertIconWithTooltip
+          title="Large icon size"
+          type="warning"
+          iconProps={{ size: 32 }}
+        />
+      </div>
+    </BAIFlex>
+  ),
+};

--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.stories.tsx
@@ -1,0 +1,358 @@
+import BAIFetchKeyButton from './BAIFetchKeyButton';
+import BAIFlex from './BAIFlex';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+const meta: Meta<typeof BAIFetchKeyButton> = {
+  title: 'Components/BAIFetchKeyButton',
+  component: BAIFetchKeyButton,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAIFetchKeyButton** extends [Ant Design Button](https://ant.design/components/button) with fetch key management.
+
+A refresh button that manages fetch keys for data refetching with auto-update capabilities.
+
+## BAI-Specific Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| \`value\` | \`string\` | - | Current fetch key value |
+| \`loading\` | \`boolean\` | \`false\` | Loading state of the data fetch |
+| \`lastLoadTime\` | \`Date\` | \`undefined\` | Timestamp of the last successful load |
+| \`showLastLoadTime\` | \`boolean\` | \`false\` | Shows "Last updated: X ago" in tooltip |
+| \`autoUpdateDelay\` | \`number \\| null\` | \`null\` | Auto-refresh interval in milliseconds |
+| \`onChange\` | \`(fetchKey: string) => void\` | - | Callback fired when fetch key updates |
+| \`hidden\` | \`boolean\` | \`false\` | Hides the button completely |
+| \`pauseWhenHidden\` | \`boolean\` | \`true\` | Pauses auto-update when button is hidden |
+
+For all other props, refer to [Ant Design Button](https://ant.design/components/button).
+        `,
+      },
+    },
+  },
+  argTypes: {
+    value: {
+      control: { type: 'text' },
+      description: 'Current fetch key value',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    loading: {
+      control: { type: 'boolean' },
+      description: 'Loading state of the data fetch',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    lastLoadTime: {
+      control: { type: 'date' },
+      description: 'Timestamp of the last successful load',
+      table: {
+        type: { summary: 'Date' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    showLastLoadTime: {
+      control: { type: 'boolean' },
+      description: 'When true, shows "Last updated: X ago" in tooltip',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    autoUpdateDelay: {
+      control: { type: 'number' },
+      description: 'Auto-refresh interval in milliseconds, null to disable',
+      table: {
+        type: { summary: 'number | null' },
+        defaultValue: { summary: 'null' },
+      },
+    },
+    onChange: {
+      action: 'onChange',
+      description: 'Callback fired when fetch key should be updated',
+      table: {
+        type: { summary: '(fetchKey: string) => void' },
+      },
+    },
+    hidden: {
+      control: { type: 'boolean' },
+      description: 'When true, hides the button completely',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    pauseWhenHidden: {
+      control: { type: 'boolean' },
+      description: 'When true, pauses auto-update when button is hidden',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'true' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIFetchKeyButton>;
+
+export const Default: Story = {
+  name: 'Basic Usage',
+  args: {
+    value: new Date().toISOString(),
+    loading: false,
+    onChange: (fetchKey) => console.log('Fetch key updated:', fetchKey),
+  },
+};
+
+export const WithLastLoadTime: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows the last update time in a tooltip that updates every 5 seconds.',
+      },
+    },
+  },
+  render: () => {
+    const [fetchKey, setFetchKey] = useState(new Date().toISOString());
+    const [loading, setLoading] = useState(false);
+
+    const handleChange = (newKey: string) => {
+      setLoading(true);
+      setFetchKey(newKey);
+      // Simulate API call
+      setTimeout(() => {
+        setLoading(false);
+      }, 1000);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 200 }}>Without last load time:</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            showLastLoadTime={false}
+          />
+        </BAIFlex>
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 200 }}>With last load time:</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            showLastLoadTime={true}
+          />
+        </BAIFlex>
+      </BAIFlex>
+    );
+  },
+};
+
+export const AutoUpdate: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Automatically refreshes data at specified intervals. The button shows a counter that increments with each auto-refresh.',
+      },
+    },
+  },
+  render: () => {
+    const [fetchKey, setFetchKey] = useState(new Date().toISOString());
+    const [loading, setLoading] = useState(false);
+    const [counter, setCounter] = useState(0);
+
+    const handleChange = (newKey: string) => {
+      setLoading(true);
+      setFetchKey(newKey);
+      setCounter((prev) => prev + 1);
+      // Simulate API call
+      setTimeout(() => {
+        setLoading(false);
+      }, 800);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 200 }}>Auto-update (5s):</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            autoUpdateDelay={5000}
+            showLastLoadTime={true}
+          />
+          <span>Refresh count: {counter}</span>
+        </BAIFlex>
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 200 }}>Manual only:</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            showLastLoadTime={true}
+          />
+        </BAIFlex>
+      </BAIFlex>
+    );
+  },
+};
+
+export const LoadingState: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the loading state with a minimum display time to avoid flickering.',
+      },
+    },
+  },
+  render: () => {
+    const [fetchKey, setFetchKey] = useState(new Date().toISOString());
+    const [loading, setLoading] = useState(false);
+
+    const handleChange = (newKey: string) => {
+      setLoading(true);
+      setFetchKey(newKey);
+      // Simulate fast API call (loading will still show for at least 700ms)
+      setTimeout(() => {
+        setLoading(false);
+      }, 100);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 200 }}>Click to see loading:</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            showLastLoadTime={true}
+          />
+        </BAIFlex>
+        <div style={{ fontSize: '12px', color: '#666' }}>
+          Loading state persists for at least 700ms to prevent flickering
+        </div>
+      </BAIFlex>
+    );
+  },
+};
+
+export const HiddenState: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows how the button can be conditionally hidden while pausing auto-updates.',
+      },
+    },
+  },
+  render: () => {
+    const [fetchKey, setFetchKey] = useState(new Date().toISOString());
+    const [loading, setLoading] = useState(false);
+    const [isHidden, setIsHidden] = useState(false);
+
+    const handleChange = (newKey: string) => {
+      setLoading(true);
+      setFetchKey(newKey);
+      setTimeout(() => {
+        setLoading(false);
+      }, 800);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIFlex gap="sm" align="center">
+          <label>
+            <input
+              type="checkbox"
+              checked={isHidden}
+              onChange={(e) => setIsHidden(e.target.checked)}
+            />
+            {' Hide button'}
+          </label>
+        </BAIFlex>
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 200 }}>Button visibility:</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            hidden={isHidden}
+            autoUpdateDelay={3000}
+            showLastLoadTime={true}
+          />
+        </BAIFlex>
+      </BAIFlex>
+    );
+  },
+};
+
+export const ButtonSizes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Available button sizes using the Ant Design size prop.',
+      },
+    },
+  },
+  render: () => {
+    const [fetchKey, setFetchKey] = useState(new Date().toISOString());
+    const [loading, setLoading] = useState(false);
+
+    const handleChange = (newKey: string) => {
+      setLoading(true);
+      setFetchKey(newKey);
+      setTimeout(() => {
+        setLoading(false);
+      }, 800);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 100 }}>Large:</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            size="large"
+            showLastLoadTime={true}
+          />
+        </BAIFlex>
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 100 }}>Middle:</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            size="middle"
+            showLastLoadTime={true}
+          />
+        </BAIFlex>
+        <BAIFlex gap="sm" align="center">
+          <span style={{ width: 100 }}>Small:</span>
+          <BAIFetchKeyButton
+            value={fetchKey}
+            loading={loading}
+            onChange={handleChange}
+            size="small"
+            showLastLoadTime={true}
+          />
+        </BAIFlex>
+      </BAIFlex>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
+++ b/packages/backend.ai-ui/src/components/BAIFetchKeyButton.tsx
@@ -20,6 +20,20 @@ interface BAIFetchKeyButtonProps
   hidden?: boolean;
   pauseWhenHidden?: boolean;
 }
+
+/**
+ * A refresh button that manages fetch keys for data refetching with auto-update capabilities.
+ * Extends Ant Design Button with fetch key management, auto-refresh, and last update time display.
+ *
+ * @param value - Current fetch key value
+ * @param loading - Loading state of the data fetch
+ * @param lastLoadTime - Timestamp of the last successful load
+ * @param showLastLoadTime - When true, shows "Last updated: X ago" in tooltip
+ * @param autoUpdateDelay - Auto-refresh interval in milliseconds, null to disable
+ * @param onChange - Callback fired when fetch key should be updated
+ * @param hidden - When true, hides the button completely
+ * @param pauseWhenHidden - When true, pauses auto-update when button is hidden
+ */
 const BAIFetchKeyButton: React.FC<BAIFetchKeyButtonProps> = ({
   loading,
   onChange,

--- a/packages/backend.ai-ui/src/components/BAIResourceNumberWithIcon.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIResourceNumberWithIcon.stories.tsx
@@ -1,0 +1,404 @@
+import BAIFlex from './BAIFlex';
+import BAIResourceNumberWithIcon from './BAIResourceNumberWithIcon';
+import { BAIMetaDataProvider, DeviceMetaData } from './provider';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+// Mock device metadata for Storybook
+const mockDeviceMetaData: DeviceMetaData = {
+  // Base resources
+  cpu: {
+    slot_name: 'cpu',
+    description: 'CPU',
+    human_readable_name: 'CPU',
+    display_unit: 'Core',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'cpu',
+  },
+  mem: {
+    slot_name: 'mem',
+    description: 'Memory',
+    human_readable_name: 'Memory',
+    display_unit: 'GiB',
+    number_format: { binary: true, round_length: 2 },
+    display_icon: 'mem',
+  },
+  // NVIDIA
+  'cuda.device': {
+    slot_name: 'cuda.device',
+    description: 'NVIDIA GPU',
+    human_readable_name: 'GPU',
+    display_unit: 'GPU',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'nvidia',
+  },
+  'cuda.shares': {
+    slot_name: 'cuda.shares',
+    description: 'NVIDIA GPU (fractional)',
+    human_readable_name: 'GPU',
+    display_unit: 'FGPU',
+    number_format: { binary: false, round_length: 2 },
+    display_icon: 'nvidia',
+  },
+  // AMD
+  'rocm.device': {
+    slot_name: 'rocm.device',
+    description: 'AMD GPU',
+    human_readable_name: 'GPU',
+    display_unit: 'GPU',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'rocm',
+  },
+  // Google TPU
+  'tpu.device': {
+    slot_name: 'tpu.device',
+    description: 'Google TPU',
+    human_readable_name: 'TPU',
+    display_unit: 'TPU',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'tpu',
+  },
+  // Graphcore IPU
+  'ipu.device': {
+    slot_name: 'ipu.device',
+    description: 'Graphcore IPU',
+    human_readable_name: 'IPU',
+    display_unit: 'IPU',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'ipu',
+  },
+  // Intel Gaudi
+  'gaudi2.device': {
+    slot_name: 'gaudi2.device',
+    description: 'Intel Gaudi2',
+    human_readable_name: 'Gaudi2',
+    display_unit: 'Gaudi2',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'gaudi',
+  },
+  // FuriosaAI Warboy
+  'warboy.device': {
+    slot_name: 'warboy.device',
+    description: 'FuriosaAI Warboy',
+    human_readable_name: 'Warboy',
+    display_unit: 'Warboy',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'furiosa',
+  },
+  'rngd.device': {
+    slot_name: 'rngd.device',
+    description: 'FuriosaAI RNGD',
+    human_readable_name: 'RNGD',
+    display_unit: 'RNGD',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'furiosa',
+  },
+  // Rebellions ATOM
+  'atom.device': {
+    slot_name: 'atom.device',
+    description: 'Rebellions ATOM',
+    human_readable_name: 'ATOM',
+    display_unit: 'ATOM',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'rebel',
+  },
+  'atom-plus.device': {
+    slot_name: 'atom-plus.device',
+    description: 'Rebellions ATOM+',
+    human_readable_name: 'ATOM+',
+    display_unit: 'ATOM+',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'rebel',
+  },
+  'atom-max.device': {
+    slot_name: 'atom-max.device',
+    description: 'Rebellions ATOM Max',
+    human_readable_name: 'ATOM Max',
+    display_unit: 'ATOM Max',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'rebel',
+  },
+  // Hyperaccel LPU
+  'hyperaccel-lpu.device': {
+    slot_name: 'hyperaccel-lpu.device',
+    description: 'Hyperaccel LPU',
+    human_readable_name: 'LPU',
+    display_unit: 'LPU',
+    number_format: { binary: false, round_length: 0 },
+    display_icon: 'hyperaccel',
+  },
+};
+
+const meta: Meta<typeof BAIResourceNumberWithIcon> = {
+  title: 'Components/BAIResourceNumberWithIcon',
+  component: BAIResourceNumberWithIcon,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAIResourceNumberWithIcon** displays a resource value with its corresponding icon and unit.
+
+- **Automatic formatting**: Handles binary units (GiB, MiB) and decimal formats
+- **Resource icons**: Shows appropriate icons for CPU, memory, and accelerators
+- **Range display**: Supports min~max value ranges and unlimited (∞) resources
+- **Device metadata**: Uses BAIMetaDataProvider for device-specific formatting
+
+## Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| \`type\` | \`string\` | - | Resource type (e.g., 'cpu', 'mem', 'cuda.device') |
+| \`value\` | \`string\` | - | Resource amount as string |
+| \`max\` | \`string\` | \`undefined\` | Optional maximum value, supports 'Infinity' |
+| \`hideTooltip\` | \`boolean\` | \`false\` | When true, hides the tooltip on the resource icon |
+| \`opts\` | \`ResourceOpts\` | \`undefined\` | Additional options like shmem for memory |
+| \`extra\` | \`React.ReactNode\` | \`undefined\` | Extra content to display after the number |
+        `,
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <BAIMetaDataProvider deviceMetaData={mockDeviceMetaData}>
+        <Story />
+      </BAIMetaDataProvider>
+    ),
+  ],
+  argTypes: {
+    type: {
+      control: { type: 'select' },
+      options: [
+        'cpu',
+        'mem',
+        'cuda.device',
+        'cuda.shares',
+        'rocm.device',
+        'tpu.device',
+        'ipu.device',
+        'gaudi2.device',
+        'warboy.device',
+        'rngd.device',
+        'atom.device',
+        'atom-plus.device',
+        'atom-max.device',
+        'hyperaccel-lpu.device',
+      ],
+      description: 'Resource type',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    value: {
+      control: { type: 'text' },
+      description: 'Resource amount as string',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    max: {
+      control: { type: 'text' },
+      description: 'Optional maximum value, supports "Infinity"',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    hideTooltip: {
+      control: { type: 'boolean' },
+      description: 'When true, hides the tooltip on the resource icon',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    opts: {
+      control: { type: 'object' },
+      description: 'Additional options like shmem for memory resources',
+      table: {
+        type: { summary: 'ResourceOpts' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    extra: {
+      control: false,
+      description: 'Extra content to display after the resource number',
+      table: {
+        type: { summary: 'React.ReactNode' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIResourceNumberWithIcon>;
+
+export const Default: Story = {
+  name: 'Basic Usage',
+  args: {
+    type: 'cpu',
+    value: '4',
+  },
+};
+
+export const ResourceTypes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows all supported resource types with their respective icons and units.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" align="start">
+      {/* Base Resources */}
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>CPU:</span>
+        <BAIResourceNumberWithIcon type="cpu" value="8" />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>Memory:</span>
+        <BAIResourceNumberWithIcon type="mem" value="16000000000" />
+      </BAIFlex>
+      {/* NVIDIA */}
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>NVIDIA GPU:</span>
+        <BAIResourceNumberWithIcon type="cuda.device" value="2" />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>NVIDIA FGPU:</span>
+        <BAIResourceNumberWithIcon type="cuda.shares" value="0.5" />
+      </BAIFlex>
+      {/* AMD */}
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>AMD GPU:</span>
+        <BAIResourceNumberWithIcon type="rocm.device" value="1" />
+      </BAIFlex>
+      {/* Google TPU */}
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>Google TPU:</span>
+        <BAIResourceNumberWithIcon type="tpu.device" value="4" />
+      </BAIFlex>
+      {/* Graphcore IPU */}
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>Graphcore IPU:</span>
+        <BAIResourceNumberWithIcon type="ipu.device" value="2" />
+      </BAIFlex>
+      {/* Intel Gaudi */}
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>Intel Gaudi2:</span>
+        <BAIResourceNumberWithIcon type="gaudi2.device" value="1" />
+      </BAIFlex>
+      {/* FuriosaAI */}
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>FuriosaAI Warboy:</span>
+        <BAIResourceNumberWithIcon type="warboy.device" value="2" />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>FuriosaAI RNGD:</span>
+        <BAIResourceNumberWithIcon type="rngd.device" value="1" />
+      </BAIFlex>
+      {/* Rebellions */}
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>Rebellions ATOM:</span>
+        <BAIResourceNumberWithIcon type="atom.device" value="2" />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>Rebellions ATOM+:</span>
+        <BAIResourceNumberWithIcon type="atom-plus.device" value="1" />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>Rebellions ATOM Max:</span>
+        <BAIResourceNumberWithIcon type="atom-max.device" value="1" />
+      </BAIFlex>
+      {/* Hyperaccel */}
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 160 }}>Hyperaccel LPU:</span>
+        <BAIResourceNumberWithIcon type="hyperaccel-lpu.device" value="4" />
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};
+
+export const WithMaxValue: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Demonstrates resource ranges with minimum and maximum values.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" align="start">
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 150 }}>CPU (4~8):</span>
+        <BAIResourceNumberWithIcon type="cpu" value="4" max="8" />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 150 }}>Memory (8~16 GiB):</span>
+        <BAIResourceNumberWithIcon
+          type="mem"
+          value="8000000000"
+          max="16000000000"
+        />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 150 }}>GPU (1~Unlimited):</span>
+        <BAIResourceNumberWithIcon
+          type="cuda.device"
+          value="1"
+          max="Infinity"
+        />
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};
+
+export const WithSharedMemory: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Shows memory resources with shared memory (SHM) information.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" align="start">
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 180 }}>Memory with SHM:</span>
+        <BAIResourceNumberWithIcon
+          type="mem"
+          value="16000000000"
+          opts={{ shmem: 1000000000 }}
+        />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 180 }}>Memory without SHM:</span>
+        <BAIResourceNumberWithIcon type="mem" value="16000000000" />
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};
+
+export const WithoutTooltip: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Compares resource display with and without icon tooltips.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" align="start">
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 150 }}>With tooltip:</span>
+        <BAIResourceNumberWithIcon type="cpu" value="8" hideTooltip={false} />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 150 }}>Without tooltip:</span>
+        <BAIResourceNumberWithIcon type="cpu" value="8" hideTooltip={true} />
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};

--- a/packages/backend.ai-ui/src/components/BAIResourceNumberWithIcon.tsx
+++ b/packages/backend.ai-ui/src/components/BAIResourceNumberWithIcon.tsx
@@ -28,6 +28,17 @@ export interface BAIResourceNumberWithIconProps {
   max?: string;
 }
 
+/**
+ * Displays a resource value with its corresponding icon and unit.
+ * Supports various resource types (CPU, memory, accelerators) with automatic formatting.
+ *
+ * @param type - Resource type (e.g., 'cpu', 'mem', 'cuda.device', 'rocm.device')
+ * @param value - Resource amount as string
+ * @param max - Optional maximum value, supports 'Infinity' for unlimited resources
+ * @param hideTooltip - When true, hides the tooltip on the resource icon
+ * @param opts - Additional options like shmem for memory resources
+ * @param extra - Extra content to display after the resource number
+ */
 const BAIResourceNumberWithIcon = ({
   type,
   extra,

--- a/packages/backend.ai-ui/src/components/BooleanTag.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BooleanTag.stories.tsx
@@ -1,0 +1,172 @@
+import BAIFlex from './BAIFlex';
+import BooleanTag from './BooleanTag';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof BooleanTag> = {
+  title: 'Components/BooleanTag',
+  component: BooleanTag,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BooleanTag** renders a colored tag representing a boolean value with customizable labels and fallback content.
+
+- **True values**: Displays a green tag
+- **False values**: Displays a semi-transparent default tag
+- **Non-boolean values**: Renders customizable fallback content
+
+## Props
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| \`value\` | \`boolean \\| null \\| undefined\` | - | The boolean value to display |
+| \`trueLabel\` | \`string\` | \`'True'\` | Label shown when value is true |
+| \`falseLabel\` | \`string\` | \`'False'\` | Label shown when value is false |
+| \`fallback\` | \`React.ReactNode\` | \`'-'\` | Content rendered when value is not a boolean |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    value: {
+      control: { type: 'radio' },
+      options: [true, false, null],
+      description: 'The boolean value to display',
+      table: {
+        type: { summary: 'boolean | null | undefined' },
+      },
+    },
+    trueLabel: {
+      control: { type: 'text' },
+      description: 'Label shown when value is true',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: "'True'" },
+      },
+    },
+    falseLabel: {
+      control: { type: 'text' },
+      description: 'Label shown when value is false',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: "'False'" },
+      },
+    },
+    fallback: {
+      control: { type: 'text' },
+      description: 'Content rendered when value is not a boolean',
+      table: {
+        type: { summary: 'React.ReactNode' },
+        defaultValue: { summary: "'-'" },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BooleanTag>;
+
+export const Default: Story = {
+  name: 'Basic Usage',
+  args: {
+    value: true,
+    trueLabel: 'True',
+    falseLabel: 'False',
+    fallback: '-',
+  },
+};
+
+export const ValueStates: Story = {
+  name: 'All Value States',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows how the component renders different value types: true, false, null, and undefined.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" align="start">
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 120 }}>True:</span>
+        <BooleanTag value={true} />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 120 }}>False:</span>
+        <BooleanTag value={false} />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 120 }}>Null:</span>
+        <BooleanTag value={null} />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 120 }}>Undefined:</span>
+        <BooleanTag value={undefined} />
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};
+
+export const CustomLabels: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates customizable labels for true/false states using trueLabel and falseLabel props.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" align="start">
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 150 }}>Default:</span>
+        <BooleanTag value={true} />
+        <BooleanTag value={false} />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 150 }}>Yes/No:</span>
+        <BooleanTag value={true} trueLabel="Yes" falseLabel="No" />
+        <BooleanTag value={false} trueLabel="Yes" falseLabel="No" />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 150 }}>Enabled/Disabled:</span>
+        <BooleanTag value={true} trueLabel="Enabled" falseLabel="Disabled" />
+        <BooleanTag value={false} trueLabel="Enabled" falseLabel="Disabled" />
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};
+
+export const CustomFallback: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows different fallback options for non-boolean values using the fallback prop.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" align="start">
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 150 }}>Default (-):</span>
+        <BooleanTag value={null} />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 150 }}>Custom text:</span>
+        <BooleanTag value={null} fallback="N/A" />
+      </BAIFlex>
+      <BAIFlex gap="sm" align="center">
+        <span style={{ width: 150 }}>Custom element:</span>
+        <BooleanTag
+          value={undefined}
+          fallback={
+            <span style={{ color: 'gray', fontStyle: 'italic' }}>Unknown</span>
+          }
+        />
+      </BAIFlex>
+    </BAIFlex>
+  ),
+};


### PR DESCRIPTION
Resolves #5009 ([FR-1893](https://lablup.atlassian.net/browse/FR-1893))

## Summary

This PR adds comprehensive Storybook stories for the second batch of secondary UI components in the backend.ai-ui package.

## Components Added

### BAIAlertIconWithTooltip
- Basic usage with different types (info, success, warning, error)
- Custom tooltip placements
- Shows integration with alerts and notifications

### BooleanTag
- True/false value rendering
- Custom text labels
- Size variations (small, default, large)

### BAIResourceNumberWithIcon
- All 14 supported resource types (CPU, Memory, NVIDIA GPU, AMD GPU, TPU, IPU, Intel Gaudi2, FuriosaAI, Rebellions ATOM, Hyperaccel LPU)
- Min~max value ranges
- Shared memory display
- Tooltip control

### BAIFetchKeyButton
- Basic refresh button usage
- Last update time display
- Auto-refresh functionality (5s interval)
- Loading state handling (minimum 700ms)
- Hidden state with pause-when-hidden
- Button size variations

## Testing

- [x] Stories render correctly in Storybook
- [x] Controls work as expected
- [x] All component variants are demonstrated
- [x] ESLint and Prettier checks pass


[FR-1893]: https://lablup.atlassian.net/browse/FR-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ