### PR TITLE
feat(FR-1828): show accelerator allocation information in agent detail panel

### DIFF
--- a/react/src/components/AgentDetailDrawerContent.tsx
+++ b/react/src/components/AgentDetailDrawerContent.tsx
@@ -45,6 +45,7 @@ const AgentDetailDrawerContent: React.FC<AgentDetailDrawerContentProps> = ({
         schedulable
         first_contact
         region
+        scaling_group
         ...AgentStatusTagFragment
         ...AgentComputePluginsFragment
         ...AgentResourcesFragment
@@ -80,16 +81,15 @@ const AgentDetailDrawerContent: React.FC<AgentDetailDrawerContentProps> = ({
         column={md ? 2 : 1}
         labelStyle={{ wordBreak: 'keep-all' }}
       >
-        <Descriptions.Item label={t('agent.Status')}>
-          <AgentStatusTag agentNodeFrgmt={agent} />
-        </Descriptions.Item>
-        <Descriptions.Item label={t('agent.StatusChanged')}>
-          {dayjs(agent?.status_changed).format('lll ')}
+        <Descriptions.Item label={t('agent.ResourceGroup')} span={md ? 2 : 1}>
+          {agent?.scaling_group}
         </Descriptions.Item>
         <Descriptions.Item label={t('agent.Region')}>
-          {regionData.length > 1
-            ? _.join([regionData?.[0], regionData?.[1]], ' / ')
-            : regionData?.[0]}
+          <Typography.Text style={{ minWidth: 200 }}>
+            {regionData.length > 1
+              ? _.join([regionData?.[0], regionData?.[1]], ' / ')
+              : regionData?.[0]}
+          </Typography.Text>
         </Descriptions.Item>
         <Descriptions.Item label={t('agent.Schedulable')}>
           {agent?.schedulable ? (
@@ -97,6 +97,9 @@ const AgentDetailDrawerContent: React.FC<AgentDetailDrawerContentProps> = ({
           ) : (
             <CloseOutlined style={{ color: token.colorTextDisabled }} />
           )}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('agent.Status')} span={md ? 2 : 1}>
+          <AgentStatusTag agentNodeFrgmt={agent} />
         </Descriptions.Item>
         <Descriptions.Item label={t('agent.ComputePlugins')} span={md ? 2 : 1}>
           <BAIFlex gap="sm" wrap="wrap">

--- a/react/src/components/AgentNodeItems/AgentResources.tsx
+++ b/react/src/components/AgentNodeItems/AgentResources.tsx
@@ -1,5 +1,5 @@
 import SimpleProgressWithLabel from '../SimpleProgressWithLabel';
-import { Col, Descriptions, Grid, Row } from 'antd';
+import { Col, Descriptions, Row } from 'antd';
 import {
   BAIFlex,
   BAIText,
@@ -24,7 +24,6 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
   'use memo';
 
   const { t } = useTranslation();
-  const { md } = Grid.useBreakpoint();
   const { mergedResourceSlots } = useResourceSlotsDetails();
 
   const agent = useFragment(
@@ -33,6 +32,7 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
         occupied_slots
         available_slots
         live_stat
+        gpu_alloc_map
       }
     `,
     agentNodeFrgmt,
@@ -47,15 +47,8 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
   const parsedLiveStat = JSON.parse(agent?.live_stat || '{}');
 
   return (
-    <Descriptions
-      bordered
-      column={md ? 2 : 1}
-      labelStyle={{ wordBreak: 'keep-all' }}
-    >
-      <Descriptions.Item
-        label={t('agent.ResourceAllocation')}
-        span={md ? 2 : 1}
-      >
+    <Descriptions bordered column={1} labelStyle={{ wordBreak: 'keep-all' }}>
+      <Descriptions.Item label={t('agent.ResourceAllocation')}>
         <Row gutter={[16, 16]}>
           {_.map(
             parsedAvailableSlots,
@@ -75,11 +68,7 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
                         size="default"
                         title={
                           <BAIFlex gap="xxs">
-                            <ResourceTypeIcon
-                              key={key}
-                              type={key}
-                              showTooltip={false}
-                            />
+                            <ResourceTypeIcon key={key} type={key} />
                             {mergedResourceSlots?.['cpu']?.human_readable_name}
                           </BAIFlex>
                         }
@@ -113,11 +102,7 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
                         size="default"
                         title={
                           <BAIFlex gap="xxs">
-                            <ResourceTypeIcon
-                              key={key}
-                              type={key}
-                              showTooltip={false}
-                            />
+                            <ResourceTypeIcon key={key} type={key} />
                             {mergedResourceSlots?.['mem']?.human_readable_name}
                           </BAIFlex>
                         }
@@ -145,11 +130,7 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
                       size="default"
                       title={
                         <BAIFlex gap="xxs">
-                          <ResourceTypeIcon
-                            key={key}
-                            type={key}
-                            showTooltip={false}
-                          />
+                          <ResourceTypeIcon key={key} type={key} />
                           {mergedResourceSlots?.[key]?.human_readable_name}
                         </BAIFlex>
                       }
@@ -167,7 +148,30 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
           )}
         </Row>
       </Descriptions.Item>
-      <Descriptions.Item label={t('agent.Utilization')} span={md ? 2 : 1}>
+      {!_.isEmpty(agent?.gpu_alloc_map) && (
+        <Descriptions.Item label={t('agent.AcceleratorAllocations')}>
+          <Row gutter={[16, 8]}>
+            {_.map(
+              agent?.gpu_alloc_map as Record<string, number> | null,
+              (count, deviceId) => (
+                <Col xs={24} sm={12} key={deviceId}>
+                  <BAIFlex justify="between" gap="xxs">
+                    <BAIText
+                      ellipsis={{ tooltip: true }}
+                      style={{ maxWidth: 140 }}
+                      copyable
+                    >
+                      {deviceId}
+                    </BAIText>
+                    <BAIText>{count}</BAIText>
+                  </BAIFlex>
+                </Col>
+              ),
+            )}
+          </Row>
+        </Descriptions.Item>
+      )}
+      <Descriptions.Item label={t('agent.Utilization')}>
         <Row gutter={[16, 16]}>
           <Col xs={24} sm={12} key={'cpu_util'}>
             <SimpleProgressWithLabel

--- a/react/src/components/AgentNodeItems/AgentStatusTag.tsx
+++ b/react/src/components/AgentNodeItems/AgentStatusTag.tsx
@@ -1,8 +1,10 @@
-import { BAIDoubleTag, BAIDoubleTagProps } from 'backend.ai-ui';
+import { BAIDoubleTag, BAIDoubleTagProps, BAIFlex } from 'backend.ai-ui';
+import dayjs from 'dayjs';
+import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 import { AgentStatusTagFragment$key } from 'src/__generated__/AgentStatusTagFragment.graphql';
 
-interface AgentStatusTagProps extends BAIDoubleTagProps {
+interface AgentStatusTagProps extends Omit<BAIDoubleTagProps, 'values'> {
   agentNodeFrgmt?: AgentStatusTagFragment$key | null;
 }
 
@@ -11,10 +13,14 @@ const AgentStatusTag: React.FC<AgentStatusTagProps> = ({
   ...doubleTagProps
 }) => {
   'use memo';
+
+  const { t } = useTranslation();
+
   const agent = useFragment(
     graphql`
       fragment AgentStatusTagFragment on AgentNode {
         status
+        status_changed
         version
       }
     `,
@@ -37,15 +43,28 @@ const AgentStatusTag: React.FC<AgentStatusTagProps> = ({
   };
 
   return (
-    <BAIDoubleTag
-      values={[
-        { label: agent?.status || '', color: getStatusColor(agent?.status) },
-        {
-          label: agent?.version || '',
-        },
-      ]}
-      {...doubleTagProps}
-    />
+    <BAIFlex gap="xs" wrap="wrap">
+      <BAIDoubleTag
+        values={[
+          { label: agent?.status || '', color: getStatusColor(agent?.status) },
+          {
+            label: agent?.version || '',
+          },
+        ]}
+        {...doubleTagProps}
+      />
+      <BAIDoubleTag
+        values={[
+          {
+            label: t('agent.StatusChanged'),
+          },
+          {
+            label: dayjs(agent?.status_changed).format('lll'),
+          },
+        ]}
+        {...doubleTagProps}
+      />
+    </BAIFlex>
   );
 };
 

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Zeigt einen Überblick auf einen Blick über alle im System ausgeführten Agenten."
   },
   "agent": {
+    "AcceleratorAllocations": "Beschleunigerzuweisungen",
     "Agent": "Agent",
     "AgentInfo": "Agentinformationen",
     "AgentSetting": "Agent-Einstellungen",
@@ -34,7 +35,7 @@
     "Starts": "Startet",
     "StartsAt": "Gestartet am",
     "Status": "Status",
-    "StatusChanged": "Status geändert",
+    "StatusChanged": "Geändert",
     "Terminated": "Beendet",
     "Utilization": "Inanspruchnahme"
   },

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Δείχνει μια επισκόπηση όλων των παραγόντων που εκτελούνται σήμερα στο σύστημα."
   },
   "agent": {
+    "AcceleratorAllocations": "Κατανομές επιταχυντών",
     "Agent": "Πράκτορας",
     "AgentInfo": "Πληροφορίες πράκτορα",
     "AgentSetting": "Ρυθμίσεις πράκτορα",
@@ -34,7 +35,7 @@
     "Starts": "Ξεκινά",
     "StartsAt": "Ξεκίνησε στις",
     "Status": "Κατάσταση",
-    "StatusChanged": "Κατάσταση ενημερώθηκε",
+    "StatusChanged": "Τροποποιήθηκε",
     "Terminated": "Τερματίστηκε",
     "Utilization": "Χρήση"
   },

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Shows an at-a-glance overview of all agents currently running in the system."
   },
   "agent": {
+    "AcceleratorAllocations": "Accelerator Allocations",
     "Agent": "Agent",
     "AgentInfo": "Agent Info",
     "AgentSetting": "Agent Settings",
@@ -34,7 +35,7 @@
     "Starts": "Starts",
     "StartsAt": "Started At",
     "Status": "Status",
-    "StatusChanged": "Status Changed",
+    "StatusChanged": "Changed",
     "Terminated": "Terminated",
     "Utilization": "Utilization"
   },

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Muestra una descripción general de un vistazo de todos los agentes que actualmente se ejecutan en el sistema."
   },
   "agent": {
+    "AcceleratorAllocations": "Asignaciones de aceleradores",
     "Agent": "Agente",
     "AgentInfo": "Información del agente",
     "AgentSetting": "Configuración del agente",
@@ -34,7 +35,7 @@
     "Starts": "Inicia",
     "StartsAt": "Iniciado en",
     "Status": "Estado",
-    "StatusChanged": "Estado actualizado",
+    "StatusChanged": "Modificado",
     "Terminated": "Terminado",
     "Utilization": "Utilización"
   },

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Näyttää yleiskatsauksen kaikista järjestelmässä tällä hetkellä toimivista edustajista."
   },
   "agent": {
+    "AcceleratorAllocations": "Kiihdyttimien varaukset",
     "Agent": "Agentti",
     "AgentInfo": "Agentin tiedot",
     "AgentSetting": "Agentin asetukset",
@@ -34,7 +35,7 @@
     "Starts": "Alkaa",
     "StartsAt": "Aloitusaika",
     "Status": "Tila",
-    "StatusChanged": "Tila muuttui",
+    "StatusChanged": "Muutettu",
     "Terminated": "Lopetettu",
     "Utilization": "Käyttö"
   },

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Affiche un aperçu de tous les agents qui s'exécute actuellement dans le système."
   },
   "agent": {
+    "AcceleratorAllocations": "Allocations d'accélérateurs",
     "Agent": "Agent",
     "AgentInfo": "Informations sur l'agent",
     "AgentSetting": "Paramètres de l'agent",
@@ -34,7 +35,7 @@
     "Starts": "Départs",
     "StartsAt": "Démarré le",
     "Status": "Statut",
-    "StatusChanged": "Statut modifié",
+    "StatusChanged": "Modifié",
     "Terminated": "Terminé",
     "Utilization": "Utilisation"
   },

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Menunjukkan ikhtisar sekilas dari semua agen yang saat ini berjalan dalam sistem."
   },
   "agent": {
+    "AcceleratorAllocations": "Alokasi Akselerator",
     "Agent": "Agen",
     "AgentInfo": "Info Agen",
     "AgentSetting": "Pengaturan Agen",
@@ -34,7 +35,7 @@
     "Starts": "Mulai",
     "StartsAt": "Dimulai pada",
     "Status": "Status",
-    "StatusChanged": "Status diubah",
+    "StatusChanged": "Diubah",
     "Terminated": "Dihentikan",
     "Utilization": "Pemanfaatan"
   },

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Mostra una panoramica a colpo d'occhio di tutti gli agenti attualmente in esecuzione nel sistema."
   },
   "agent": {
+    "AcceleratorAllocations": "Allocazioni degli acceleratori",
     "Agent": "Agente",
     "AgentInfo": "Informazioni agente",
     "AgentSetting": "Impostazioni dell'agente",
@@ -34,7 +35,7 @@
     "Starts": "Inizia",
     "StartsAt": "Avviato il",
     "Status": "Stato",
-    "StatusChanged": "Stato modificato",
+    "StatusChanged": "Modificato",
     "Terminated": "Terminato",
     "Utilization": "Utilizzo"
   },

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "現在システムで実行されているすべてのエージェントの概要を示しています。"
   },
   "agent": {
+    "AcceleratorAllocations": "アクセラレータの割り当て",
     "Agent": "代理店",
     "AgentInfo": "エージェント情報",
     "AgentSetting": "エージェント設定",
@@ -34,7 +35,7 @@
     "Starts": "開始",
     "StartsAt": "開始時刻",
     "Status": "状態",
-    "StatusChanged": "ステータスが変更されました",
+    "StatusChanged": "変更済み",
     "Terminated": "終了しました",
     "Utilization": "使用量"
   },

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "현재 시스템에서 실행 중인 모든 에이전트 개요를 표시합니다."
   },
   "agent": {
+    "AcceleratorAllocations": "가속기 할당",
     "Agent": "에이전트",
     "AgentInfo": "에이전트 정보",
     "AgentSetting": "에이전트 설정",
@@ -34,7 +35,7 @@
     "Starts": "시작",
     "StartsAt": "생성일",
     "Status": "상태",
-    "StatusChanged": "상태 변경일",
+    "StatusChanged": "변경일",
     "Terminated": "종료됨",
     "Utilization": "사용량"
   },

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Системд ажиллаж байгаа бүх агентуудын тоймыг нэг дор харуулна."
   },
   "agent": {
+    "AcceleratorAllocations": "Хурдасгагчийн хуваарилалт",
     "Agent": "Агент",
     "AgentInfo": "Агентын мэдээлэл",
     "AgentSetting": "Агент тохиргоо",
@@ -34,7 +35,7 @@
     "Starts": "Эхлэв",
     "StartsAt": "Эхэлсэн огноо",
     "Status": "Статус",
-    "StatusChanged": "Төлөв өөрчлөгдсөн",
+    "StatusChanged": "Өөрчлөгдсөн",
     "Terminated": "Цуцлагдсан",
     "Utilization": "Ашиглалт"
   },

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Menunjukkan gambaran keseluruhan sepintas lalu semua ejen yang sedang berjalan dalam sistem."
   },
   "agent": {
+    "AcceleratorAllocations": "Peruntukan Akselerator",
     "Agent": "Ejen",
     "AgentInfo": "Maklumat Ejen",
     "AgentSetting": "Tetapan Agen",
@@ -34,7 +35,7 @@
     "Starts": "Bermula",
     "StartsAt": "Mula pada",
     "Status": "Status",
-    "StatusChanged": "Status berubah",
+    "StatusChanged": "Diubah",
     "Terminated": "Ditamatkan",
     "Utilization": "Penggunaan"
   },

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Pokazuje przegląd w skrócie wszystkich agentów obecnie działających w systemie."
   },
   "agent": {
+    "AcceleratorAllocations": "Przydziały akceleratorów",
     "Agent": "Agent",
     "AgentInfo": "Informacje o agencie",
     "AgentSetting": "Ustawienia agenta",
@@ -34,7 +35,7 @@
     "Starts": "Rozpoczyna się",
     "StartsAt": "Rozpoczęto",
     "Status": "Status",
-    "StatusChanged": "Zmieniono status",
+    "StatusChanged": "Zmieniono",
     "Terminated": "Zakończony",
     "Utilization": "Wykorzystanie"
   },

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Mostra uma visão geral de todos os agentes atualmente em execução no sistema."
   },
   "agent": {
+    "AcceleratorAllocations": "Alocações de aceleradores",
     "Agent": "Agente",
     "AgentInfo": "Informações do Agente",
     "AgentSetting": "Definições do agente",
@@ -34,7 +35,7 @@
     "Starts": "Começa",
     "StartsAt": "Iniciado em",
     "Status": "Status",
-    "StatusChanged": "Status alterado",
+    "StatusChanged": "Alterado",
     "Terminated": "Rescindido",
     "Utilization": "Utilização"
   },

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Mostra uma visão geral de todos os agentes atualmente em execução no sistema."
   },
   "agent": {
+    "AcceleratorAllocations": "Alocações de aceleradores",
     "Agent": "Agente",
     "AgentInfo": "Informações do Agente",
     "AgentSetting": "Definições do agente",
@@ -34,7 +35,7 @@
     "Starts": "Começa",
     "StartsAt": "Iniciado em",
     "Status": "Status",
-    "StatusChanged": "Status alterado",
+    "StatusChanged": "Alterado",
     "Terminated": "Rescindido",
     "Utilization": "Utilização"
   },

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Показывает обзор всех агентов, работающих в настоящее время в системе."
   },
   "agent": {
+    "AcceleratorAllocations": "Выделенные ускорители",
     "Agent": "Агент",
     "AgentInfo": "Информация об агенте",
     "AgentSetting": "Настройки агента",
@@ -34,7 +35,7 @@
     "Starts": "Начинается",
     "StartsAt": "Запущено",
     "Status": "Статус",
-    "StatusChanged": "Статус изменён",
+    "StatusChanged": "Изменено",
     "Terminated": "Прекращено",
     "Utilization": "Утилизация"
   },

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "แสดงภาพรวม at-a-glance ของตัวแทนทั้งหมดที่ทำงานอยู่ในระบบ"
   },
   "agent": {
+    "AcceleratorAllocations": "การจัดสรรตัวเร่งความเร็ว",
     "Agent": "ตัวแทน",
     "AgentInfo": "ข้อมูลเอเจนต์",
     "AgentSetting": "การตั้งค่าตัวแทน",
@@ -34,7 +35,7 @@
     "Starts": "เริ่มต้น",
     "StartsAt": "เริ่มเมื่อ",
     "Status": "สถานะ",
-    "StatusChanged": "สถานะเปลี่ยนแปลงแล้ว",
+    "StatusChanged": "เปลี่ยนแปลงแล้ว",
     "Terminated": "ยุติแล้ว",
     "Utilization": "การใช้งาน"
   },

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Şu anda sistemde çalışan tüm ajanlara bir bakışta genel bir bakış gösterir."
   },
   "agent": {
+    "AcceleratorAllocations": "Hızlandırıcı Tahsisleri",
     "Agent": "Ajan",
     "AgentInfo": "Ajan Bilgileri",
     "AgentSetting": "Temsilci Ayarları",
@@ -34,7 +35,7 @@
     "Starts": "başlar",
     "StartsAt": "Başlama Zamanı",
     "Status": "Durum",
-    "StatusChanged": "Durum değişti",
+    "StatusChanged": "Değiştirildi",
     "Terminated": "Sonlandırılmış",
     "Utilization": "Kullanım"
   },

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "Hiển thị tổng quan at-a-glance của tất cả các tác nhân hiện đang chạy trong hệ thống."
   },
   "agent": {
+    "AcceleratorAllocations": "Phân bổ thiết bị tăng tốc",
     "Agent": "Đại lý",
     "AgentInfo": "Thông tin agent",
     "AgentSetting": "Cài đặt đại lý",
@@ -34,7 +35,7 @@
     "Starts": "Bắt đầu",
     "StartsAt": "Bắt đầu lúc",
     "Status": "Trạng thái",
-    "StatusChanged": "Trạng thái đã thay đổi",
+    "StatusChanged": "Đã thay đổi",
     "Terminated": "Đã chấm dứt",
     "Utilization": "Sử dụng"
   },

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "显示了当前在系统中运行的所有代理的一目了然概述。"
   },
   "agent": {
+    "AcceleratorAllocations": "加速器分配",
     "Agent": "代理",
     "AgentInfo": "代理信息",
     "AgentSetting": "代理设置",
@@ -34,7 +35,7 @@
     "Starts": "开始",
     "StartsAt": "启动时间",
     "Status": "地位",
-    "StatusChanged": "状态已更改",
+    "StatusChanged": "已更改",
     "Terminated": "已终止",
     "Utilization": "利用率"
   },

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -5,6 +5,7 @@
     "ActiveAgentsTooltip": "顯示了當前在系統中運行的所有代理的一目了然的概述。"
   },
   "agent": {
+    "AcceleratorAllocations": "加速器分配",
     "Agent": "代理",
     "AgentInfo": "代理資訊",
     "AgentSetting": "代理设置",
@@ -34,7 +35,7 @@
     "Starts": "開始",
     "StartsAt": "開始時間",
     "Status": "地位",
-    "StatusChanged": "狀態已變更",
+    "StatusChanged": "已變更",
     "Terminated": "已終止",
     "Utilization": "利用率"
   },


### PR DESCRIPTION
resolves #4895 ([FR-1828](https://lablup.atlassian.net/browse/FR-1828))

test server: 10.122.12.245

### Enhanced Agent Detail Drawer with GPU Allocation Map

This PR enhances the Agent Detail Drawer with the following improvements:

1. Added GPU allocation map display in the Agent Resources section
2. Implemented a "rescan_gpu_alloc_maps" mutation when refreshing agent details
3. Reorganized the agent detail layout for better information hierarchy:
   - Added scaling group information
   - Improved status display with a more compact "Changed" label
   - Restructured resource allocation display

The PR also updates translations across all languages to support the new "Accelerator Allocations" section and shortened "Changed" label (previously "Status Changed").

![image.png](https://app.graphite.com/user-attachments/assets/2970e03d-e0f5-4f47-8d32-38d2d1504a3c.png)

**Checklist:** (if applicable)

- [x] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1828]: https://lablup.atlassian.net/browse/FR-1828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ