### PR TITLE
fix(FR-1904): fix Monaco Editor schema loading in production build

### DIFF
--- a/react/craco.config.js
+++ b/react/craco.config.js
@@ -208,14 +208,28 @@ module.exports = {
       });
       paths.appHtml = webuiIndexHtml;
 
-      // Remove ModuleScopePlugin for development environment
+      // Configure ModuleScopePlugin to allow backend.ai-ui package
       if (env === 'development') {
-        webpackConfig.resolve.plugins = webpackConfig.resolve.plugins.filter(
-          (plugin) =>
-            !(
+        const backendAiUiEntryFile = path.resolve(
+          __dirname,
+          '../packages/backend.ai-ui/src/index.ts',
+        );
+
+        webpackConfig.resolve.plugins = webpackConfig.resolve.plugins.map(
+          (plugin) => {
+            if (
               plugin instanceof ModuleScopePlugin ||
-              plugin.name === 'ModuleScopePlugin'
-            ),
+              plugin.constructor.name === 'ModuleScopePlugin'
+            ) {
+              // Preserve existing allowedFiles and add backend.ai-ui entry file
+              const existingAllowedFiles = Array.from(plugin.allowedFiles);
+              return new ModuleScopePlugin(paths.appSrc, [
+                ...existingAllowedFiles,
+                backendAiUiEntryFile, // Allow backend.ai-ui/src (via entry file)
+              ]);
+            }
+            return plugin;
+          },
         );
       }
 


### PR DESCRIPTION
Resolves #5032 ([FR-1904](https://lablup.atlassian.net/browse/FR-1904))

## Summary

- Fix production build failure caused by static JSON schema imports in Monaco Editor
- Convert static imports to dynamic fetch for `theme.schema.json` and `antdThemeConfig.schema.json`
- Schemas are now loaded at runtime via `fetch()` in `beforeMount` callback instead of being bundled

## Changes

The `ThemeJsonConfigModal` component was importing JSON schema files directly:
```typescript
// Before (causing build failure)
import antdThemeJsonSchema from '../../../../resources/antdThemeConfig.schema.json';
import themeJsonSchema from '../../../../resources/theme.schema.json';
```

This caused issues with the production build. The fix loads schemas dynamically:
```typescript
// After (runtime loading)
const [themeSchema, antdSchema] = await Promise.all([
  fetch('/resources/theme.schema.json').then((r) => r.json()),
  fetch('/resources/antdThemeConfig.schema.json').then((r) => r.json()),
]);
```

## Test plan

- [ ] Verify `pnpm run build` completes without errors
- [ ] Verify Monaco Editor in Theme JSON Config modal still shows proper JSON validation
- [ ] Verify schema autocompletion works correctly in the editor

[FR-1904]: https://lablup.atlassian.net/browse/FR-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ