### PR TITLE
fix(FR-1911): reset agent list pagination when filters change

### DIFF
--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -218,6 +218,7 @@ const AgentList: React.FC<AgentListProps> = ({
             value={queryParams.status}
             onChange={(e) => {
               setQueryParams({ status: e.target.value });
+              setTablePaginationOption({ current: 1 });
             }}
           />
 
@@ -252,6 +253,7 @@ const AgentList: React.FC<AgentListProps> = ({
             value={queryParams.filter || undefined}
             onChange={(value) => {
               setQueryParams({ filter: value || null });
+              setTablePaginationOption({ current: 1 });
             }}
           />
         </BAIFlex>


### PR DESCRIPTION
Resolves #5041 ([FR-1911](https://lablup.atlassian.net/browse/FR-1911))

## Summary

- Reset pagination to page 1 when status filter changes in Agent List
- Reset pagination to page 1 when search filter changes in Agent List

## Why This Change

When users change the status filter or apply search filters in the Agent List, the pagination state remained on the current page instead of resetting to page 1. This caused confusing UX where users might see empty results or miss relevant agents that appear on earlier pages.

## Test Plan

- [ ] Change the status filter (All/Schedulable/Preparing/Occupied/Paused) and verify pagination resets to page 1
- [ ] Apply a search filter and verify pagination resets to page 1
- [ ] Clear filters and verify expected behavior

[FR-1911]: https://lablup.atlassian.net/browse/FR-1911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ