### PR TITLE
feat(FR-1913): add custom filebrowser and sftp session button

### DIFF
--- a/react/src/components/ImportNotebookForm.tsx
+++ b/react/src/components/ImportNotebookForm.tsx
@@ -144,6 +144,7 @@ const ImportNotebookForm: React.FC<ImportNotebookFormProps> = ({
           {t('import.GetAndRunNotebook')}
         </BAIButton>
         <Dropdown
+          trigger={['click']}
           menu={{
             items: [
               {


### PR DESCRIPTION
Resolves #5046 ([FR-1913](https://lablup.atlassian.net/browse/FR-1913))

# Add custom session launcher option to FileBrowser and SFTP buttons

This PR adds a dropdown menu with a "Start with Custom" option to both the FileBrowser and SFTP server buttons. When clicked, this option redirects users to the session launcher page with pre-filled configuration values, allowing them to customize the session settings before starting.

Key changes:

- Added dropdown menus with ellipsis icons next to the main buttons
- Created helper functions to generate launcher configuration values
- Implemented navigation to the session launcher with pre-filled form values
- Replaced usage of `row_id` with `toLocalId(vfolder.id)` for consistency
- Used `Space.Compact` to group the main button and dropdown together

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1913]: https://lablup.atlassian.net/browse/FR-1913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ