### PR TITLE
fix(FR-1916): change propagated required fields of `useRuntimeEnvVarConfigs` to optional.

### DIFF
--- a/react/src/hooks/useVariantConfigs.ts
+++ b/react/src/hooks/useVariantConfigs.ts
@@ -14,13 +14,11 @@ export const useRuntimeEnvVarConfigs = (): Record<
 
   return {
     vllm: {
-      requiredEnvVars: [
+      optionalEnvVars: [
         {
           variable: 'BACKEND_MODEL_NAME',
           placeholder: t('modelService.VllmModelName'),
         },
-      ],
-      optionalEnvVars: [
         {
           variable: 'VLLM_QUANTIZATION',
           placeholder: t('modelService.VllmQuantization'),
@@ -40,13 +38,11 @@ export const useRuntimeEnvVarConfigs = (): Record<
       ],
     },
     sglang: {
-      requiredEnvVars: [
+      optionalEnvVars: [
         {
           variable: 'BACKEND_MODEL_NAME',
           placeholder: t('modelService.SglangModelName'),
         },
-      ],
-      optionalEnvVars: [
         {
           variable: 'SGLANG_QUANTIZATION',
           placeholder: t('modelService.SglangQuantization'),
@@ -66,13 +62,12 @@ export const useRuntimeEnvVarConfigs = (): Record<
       ],
     },
     nim: {
-      requiredEnvVars: [
+      optionalEnvVars: [
         {
           variable: 'NGC_API_KEY',
           placeholder: t('modelService.NimApiKey'),
         },
       ],
-      optionalEnvVars: [],
     },
   };
 };


### PR DESCRIPTION
Resolves #5051 ([FR-1916](https://lablup.atlassian.net/browse/FR-1916))

## Make `BACKEND_MODEL_NAME` optional for vllm and sglang variants

This PR changes the environment variable configuration for vllm, sglang, and nim variants:

- Moves `BACKEND_MODEL_NAME` from required to optional environment variables for both vllm and sglang variants
- Simplifies the nim variant configuration by using only optionalEnvVars array

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1916]: https://lablup.atlassian.net/browse/FR-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ