### PR TITLE
feat(FR-1861): Create agent skills for infinity scroll select components

### DIFF
--- a/.claude/skills/relay-infinite-scroll-select/SKILL.md
+++ b/.claude/skills/relay-infinite-scroll-select/SKILL.md
@@ -1,0 +1,475 @@
+---
+name: relay-infinite-scroll-select
+description: >
+  Create Relay-based infinite scroll select components extending BAISelect.
+  Supports name-based values (usePaginationFragment) and id-based values
+  (useLazyLoadQuery + useLazyPaginatedQuery) with search, optimistic updates,
+  and multiple selection modes.
+---
+
+# Relay Infinite Scroll Select Component Creator
+
+## Activation Triggers
+
+- "Create a Relay infinite scroll select for [entity]"
+- "Build a select with GraphQL pagination"
+- "Add [Entity]Select component with infinite scroll"
+- "Create a select component that fetches from GraphQL"
+
+## Quick Start Decision Tree
+
+```
+START: What type of value does your select use?
+
+┌─────────────────────────────────────────────────────────────┐
+│ Q: Is the select value the same as the display label?      │
+│    (e.g., entity's name field is both value and label)     │
+└─────────────────────────────────────────────────────────────┘
+                         │
+          ┌──────────────┴──────────────┐
+          │                             │
+         YES                           NO
+          │                             │
+          ▼                             ▼
+   ┌─────────────┐             ┌─────────────┐
+   │  Pattern A  │             │  Pattern B  │
+   │  (Simple)   │             │  (Complex)  │
+   └─────────────┘             └─────────────┘
+          │                             │
+          ▼                             ▼
+Reference:                    Reference:
+BAIAdminResourceGroupSelect   BAIVFolderSelect
+```
+
+## Pattern Comparison
+
+| Criteria | Pattern A (Name-Based) | Pattern B (ID-Based) |
+|----------|----------------------|-------------------|
+| **Value Type** | String (name) | String (id/row_id) |
+| **Relay Hook** | usePaginationFragment | useLazyLoadQuery + useLazyPaginatedQuery |
+| **Queries** | 1 fragment | 2 queries |
+| **Multiple Mode** | Single only | Full support |
+| **Global ID** | Not needed | Conversion required |
+| **Optimistic UI** | Not needed | Required |
+| **State Management** | Simple | Complex |
+| **Ref Export** | No | Yes (refetch support) |
+| **Complexity** | 🟢 ~100 lines | 🟡 ~350 lines |
+| **Use Case** | Name is unique identifier | ID different from name |
+
+## Implementation Checklists
+
+### Pattern A Checklist (Name-Based Value)
+
+**Component Setup:**
+- [ ] Import `usePaginationFragment` from 'react-relay'
+- [ ] Import BAISelect, TotalFooter, Skeleton
+- [ ] Create props interface extending `Omit<BAISelectProps, 'options' | 'labelInValue'>`
+- [ ] Add `queryRef` prop for fragment key
+
+**GraphQL Fragment:**
+```typescript
+graphql\`
+  fragment YourComponent_fragment on Query
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 10 }
+    after: { type: "String" }
+    filter: { type: "YourFilterType" }
+  )
+  @refetchable(queryName: "YourComponentPaginationQuery") {
+    yourEntities(first: $first, after: $after, filter: $filter)
+      @connection(key: "YourComponent_yourEntities") {
+      count
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+\`
+```
+
+**Required Checklist:**
+- [ ] @argumentDefinitions (first, after, filter)
+- [ ] @refetchable with unique queryName
+- [ ] @connection with unique key
+- [ ] count field for total
+- [ ] Required fields (id, name)
+
+**BAISelect Integration:**
+- [ ] `ref={selectRef}` with useRef
+- [ ] `options` from mapped edges
+- [ ] `searchAction` with `refetch()` and `scrollTo(0)`
+- [ ] `endReached={() => hasNext && loadNext(10)}`
+- [ ] `notFoundContent` with Skeleton
+- [ ] `footer` with TotalFooter
+
+### Pattern B Checklist (ID-Based Value)
+
+**Component Setup:**
+- [ ] Import `useLazyLoadQuery`, `useDeferredValue`, `useTransition`
+- [ ] Import `useLazyPaginatedQuery`, `useFetchKey` custom hooks
+- [ ] Import `useControllableValue` from 'ahooks'
+- [ ] Import `toLocalId`, `mergeFilterValues` helpers
+- [ ] Add 'use memo' directive
+
+**State Management:**
+- [ ] `useControllableValue` for value and open
+- [ ] `useDeferredValue` for controllableValue, open, fetchKey
+- [ ] `useState` for searchStr and optimisticValueWithLabel
+- [ ] `useTransition` for refetch
+- [ ] `useFetchKey` for cache invalidation
+
+**GraphQL Queries:**
+
+Query 1 - Selected Values:
+```typescript
+graphql\`
+  query YourComponentValueQuery(
+    $selectedFilter: String
+    $skipSelected: Boolean!
+  ) {
+    yourEntities(filter: $selectedFilter)
+      @skip(if: $skipSelected) {
+      edges {
+        node {
+          id
+          row_id
+          name
+        }
+      }
+    }
+  }
+\`
+```
+
+Query 2 - Paginated Options:
+```typescript
+graphql\`
+  query YourComponentPaginatedQuery(
+    $offset: Int!
+    $limit: Int!
+    $filter: String
+  ) {
+    yourEntities(
+      offset: $offset
+      first: $limit
+      filter: $filter
+      order: "-created_at"
+    ) {
+      count
+      edges {
+        node {
+          id
+          row_id
+          name
+        }
+      }
+    }
+  }
+\`
+```
+
+**Query Checklist:**
+- [ ] ValueQuery with @skip directive
+- [ ] PaginatedQuery with offset/limit
+- [ ] selectedFilter uses toLocalId() for Global IDs
+- [ ] Both queries have id, row_id, name
+- [ ] count field in PaginatedQuery
+
+**Value-to-Label Mapping:**
+- [ ] Build `controllableValueWithLabel` from selected query
+- [ ] Maintain selection order with _.castArray
+- [ ] Filter out null edges
+- [ ] Fallback to value as label when no data
+
+**Optimistic Updates:**
+- [ ] `useState` for optimisticValueWithLabel
+- [ ] Switch between optimistic and real value based on deferred comparison
+- [ ] Preserve labels in onChange (handle React element labels)
+
+**BAISelect Integration:**
+- [ ] `labelInValue` prop
+- [ ] `value` with optimistic switching
+- [ ] `onChange` with label preservation
+- [ ] `searchAction` with setState
+- [ ] `endReached={() => loadNext()}`
+- [ ] `labelRender`/`optionRender` for custom display
+- [ ] `loading` with three conditions
+
+**Ref Export:**
+- [ ] `useImperativeHandle` for refetch
+- [ ] `startRefetchTransition` wrapper
+- [ ] Export ref interface type
+
+## Common Patterns
+
+### Multiple Mode Support
+
+```typescript
+// Always use _.castArray for uniform handling
+_.castArray(controllableValue).map((value) => {
+  // Process each value
+});
+```
+
+### Search with Transitions
+
+```typescript
+searchAction={async (value) => {
+  // Pattern A: Refetch
+  selectRef.current?.scrollTo(0);
+  refetch({ filter: value ? { name: { contains: value } } : null });
+
+  // Pattern B: State update
+  setSearchStr(value);
+}}
+```
+
+### Global ID Conversion
+
+```typescript
+import { toLocalId, toGlobalId } from '../../helper';
+
+// When filtering (valuePropName === 'id')
+const filterValue = valuePropName === 'id' ? toLocalId(value) : value;
+```
+
+### Filter Merging
+
+```typescript
+import { mergeFilterValues } from '../BAIPropertyFilter';
+
+const filter = mergeFilterValues([
+  baseFilter,
+  searchStr ? \`name ilike "%\${searchStr}%"\` : null,
+  externalFilter,
+], '&'); // Default operator
+```
+
+### Controllable Props
+
+```typescript
+const [value, setValue] = useControllableValue(props);
+const [open, setOpen] = useControllableValue(props, {
+  valuePropName: 'open',
+  trigger: 'onOpenChange',
+});
+```
+
+## Best Practices
+
+### Performance
+
+1. **Use 'use memo' directive (Pattern B)**
+   ```typescript
+   const YourSelect: React.FC<Props> = (props) => {
+     'use memo';
+     // Component logic
+   };
+   ```
+
+2. **Defer values to prevent Suspense flicker**
+   ```typescript
+   const deferredOpen = useDeferredValue(open);
+   const deferredValue = useDeferredValue(value);
+   const deferredFetchKey = useDeferredValue(fetchKey);
+   ```
+
+3. **Optimize fetchPolicy**
+   ```typescript
+   // Selected values
+   fetchPolicy: !_.isEmpty(value) ? 'store-or-network' : 'store-only'
+
+   // Paginated options
+   fetchPolicy: deferredOpen ? 'network-only' : 'store-only'
+   ```
+
+4. **Skip unnecessary queries**
+   ```graphql
+   @skip(if: $skipSelected)
+   ```
+
+### UX
+
+1. **Always scroll to top on search**
+   ```typescript
+   selectRef.current?.scrollTo(0);
+   ```
+
+2. **Maintain selection order**
+   ```typescript
+   _.castArray(deferredValue)
+     .map((v) => findEdge(v))
+     .filter(Boolean);
+   ```
+
+3. **Handle React element labels**
+   ```typescript
+   const label = _.isString(v.label)
+     ? v.label
+     : (options.find((opt) => opt.value === v.value)?.label ?? v.value);
+   ```
+
+4. **Loading state priorities**
+   ```typescript
+   loading={
+     loading ||
+     controllableValue !== deferredControllableValue ||
+     isPendingRefetch
+   }
+   ```
+
+## Common Pitfalls & Solutions
+
+| Pitfall | Impact | Solution |
+|---------|--------|----------|
+| Missing `_.castArray` | Single mode breaks | Always normalize values |
+| Not using `deferredValue` | Suspense flicker | Defer controllable values |
+| Missing `@skip` directive | Unnecessary queries | Add skip when empty |
+| Not preserving labels | Lost labels on tag removal | Check if label is string or element |
+| Hardcoded valuePropName | Inflexible component | Use prop: `'id' \| 'row_id'` |
+| Direct option mutation | Stale data | Rebuild from query results |
+| No scroll on search | Poor UX | Call `selectRef.current?.scrollTo(0)` |
+| Wrong fetchPolicy | Performance issues | Use appropriate policy per query |
+
+## TypeScript Patterns
+
+### Props Interface
+
+```typescript
+export interface YourComponentSelectProps
+  extends Omit<BAISelectProps, 'options' | 'labelInValue'> {
+  // Pattern A
+  queryRef?: YourFragment$key;
+
+  // Pattern B
+  valuePropName?: 'id' | 'row_id';
+  filter?: string;
+  ref?: React.Ref<YourComponentRef>;
+}
+```
+
+### Ref Interface (Pattern B)
+
+```typescript
+export interface YourComponentRef {
+  refetch: () => void;
+}
+```
+
+### Type Extraction (Pattern B)
+
+```typescript
+export type YourEntityNode = NonNullable<
+  NonNullable<
+    YourPaginatedQuery['response']['yourEntities']
+  >['edges'][number]
+>['node'];
+```
+
+## Real-World Examples
+
+### Example 1: Simple Entity Selection (Pattern A)
+
+```typescript
+// Scenario: Select resource group by name
+<BAIAdminResourceGroupSelect
+  queryRef={queryRef}
+  placeholder="Select resource group"
+  onChange={(name) => setSelectedGroup(name)}
+/>
+```
+
+### Example 2: Multiple Selection with ID (Pattern B)
+
+```typescript
+const vfolderSelectRef = useRef<BAIVFolderSelectRef>(null);
+
+<BAIVFolderSelect
+  ref={vfolderSelectRef}
+  valuePropName="id"
+  mode="multiple"
+  value={selectedFolderIds}
+  onChange={setSelectedFolderIds}
+  onClickVFolder={(id) => navigate(\`/folders/\${id}\`)}
+/>
+
+<Button onClick={() => vfolderSelectRef.current?.refetch()}>
+  Refresh
+</Button>
+```
+
+### Example 3: With External Filters (Pattern B)
+
+```typescript
+<BAIVFolderSelect
+  filter={mergeFilterValues([
+    'status != "DELETE_COMPLETE"',
+    ownershipFilter ? \`ownership_type == "\${ownershipFilter}"\` : null,
+  ])}
+  excludeDeleted
+  onChange={(ids) => handleSelection(ids)}
+/>
+```
+
+## Quick Reference
+
+### When to Use Which Pattern
+
+**Pattern A** when:
+- ✅ Entity name is unique
+- ✅ Single selection sufficient
+- ✅ Simple implementation preferred
+- ✅ No Global ID conversion needed
+
+**Pattern B** when:
+- ✅ ID different from display name
+- ✅ Multiple selection required
+- ✅ Need external refetch capability
+- ✅ Global ID conversion needed
+- ✅ Optimistic UI updates important
+
+### Reference Files
+
+- **Pattern A**: `references/patterns/BAIAdminResourceGroupSelect.md`
+- **Pattern B**: `references/patterns/BAIVFolderSelect.md`
+- **Base Component**: `references/base/BAISelect.md`
+- **Hooks**: `references/hooks/` (useFetchKey, useLazyPaginatedQuery, useEventNotStable)
+- **Helpers**: `references/helpers/` (relay-helpers, mergeFilterValues)
+
+### File Structure
+
+```
+YourEntitySelect.tsx
+├── Imports (React, Relay, hooks, helpers)
+├── Type definitions (Props, Ref, Node extraction)
+├── Component with 'use memo'
+│   ├── State management
+│   ├── GraphQL queries
+│   ├── Value-to-label mapping (Pattern B)
+│   ├── useImperativeHandle (Pattern B)
+│   ├── Options building
+│   └── BAISelect integration
+└── Export
+```
+
+## Internationalization
+
+Use `comp:` prefix for component translations:
+
+```typescript
+t('comp:YourComponentSelect.PlaceHolder')
+t('comp:YourComponentSelect.SelectEntity')
+t('comp:YourComponentSelect.NoEntityFound')
+```
+
+## Additional Resources
+
+For comprehensive examples and detailed implementation, refer to:
+- `references/README.md` - File overview and usage notes
+- Full pattern implementations in `references/patterns/`
+- Base component API in `references/base/`
+- Hook documentation in `references/hooks/`
+- Helper utilities in `references/helpers/`

--- a/.claude/skills/relay-infinite-scroll-select/references/base/BAISelect.md
+++ b/.claude/skills/relay-infinite-scroll-select/references/base/BAISelect.md
@@ -1,0 +1,549 @@
+# BAISelect - Base Component API
+
+## Overview
+
+`BAISelect` is an enhanced Ant Design Select component with additional features for infinite scrolling, async search, and custom footer content. All Relay-based select components should extend this base component.
+
+## Key Features
+
+- **Infinite Scroll**: `endReached` prop triggers when scrolling reaches bottom
+- **Async Search**: `searchAction` prop for asynchronous search with transition
+- **Custom Footer**: Display total count or custom content at bottom of dropdown
+- **Scroll Detection**: Track scroll position with `atBottomStateChange`
+- **Ghost Mode**: Transparent styling for overlay contexts
+- **Auto Select**: Automatically select first option
+
+## Props Interface
+
+```typescript
+export interface BAISelectProps<
+  ValueType = any,
+  OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType,
+> extends SelectProps<ValueType, OptionType> {
+  ref?: React.RefObject<GetRef<typeof Select<ValueType, OptionType>> | null>;
+  ghost?: boolean;
+  autoSelectOption?:
+    | boolean
+    | ((options: SelectProps<ValueType, OptionType>['options']) => ValueType);
+  tooltip?: string;
+  atBottomThreshold?: number;
+  atBottomStateChange?: (atBottom: boolean) => void;
+  bottomLoading?: boolean;
+  footer?: React.ReactNode;
+  endReached?: () => void;
+  searchAction?: (value: string) => Promise<void>;
+}
+```
+
+## Important Props
+
+### `endReached: () => void`
+
+Called when user scrolls to bottom of dropdown. Use this for infinite scroll pagination.
+
+**Example:**
+```typescript
+<BAISelect
+  endReached={() => {
+    if (hasNext) {
+      loadNext(10); // Load next 10 items
+    }
+  }}
+/>
+```
+
+### `searchAction: (value: string) => Promise<void>`
+
+Async search handler integrated with React transitions. Automatically shows loading state.
+
+**Example:**
+```typescript
+<BAISelect
+  searchAction={async (value) => {
+    selectRef.current?.scrollTo(0); // Reset scroll
+    refetch({
+      filter: value ? { name: { contains: value } } : null,
+    });
+  }}
+/>
+```
+
+**Important:**
+- Wrapped in `useTransition()` automatically
+- Loading state managed internally
+- Always scroll to top on search for better UX
+
+### `footer: React.ReactNode`
+
+Display content at bottom of dropdown, typically for showing total count.
+
+**Example:**
+```typescript
+<BAISelect
+  footer={
+    _.isNumber(totalCount) && totalCount > 0 ? (
+      <TotalFooter loading={isLoadingNext} total={totalCount} />
+    ) : undefined
+  }
+/>
+```
+
+**Layout:**
+- Divider automatically added above footer
+- Right-aligned by default
+- Padding handled automatically
+
+### `atBottomThreshold: number` (default: 30)
+
+Pixel threshold for detecting bottom scroll. Lower value = more precise, higher value = triggers earlier.
+
+### `atBottomStateChange: (atBottom: boolean) => void`
+
+Callback when scroll position reaches/leaves bottom threshold.
+
+### `ghost: boolean`
+
+Transparent styling for use in overlay/floating contexts.
+
+### `autoSelectOption: boolean | ((options) => value)`
+
+Automatically select first option when options load.
+
+**Example:**
+```typescript
+// Auto-select first option
+<BAISelect autoSelectOption={true} />
+
+// Custom selection logic
+<BAISelect
+  autoSelectOption={(options) => options.find(opt => opt.default)?.value}
+/>
+```
+
+### `tooltip: string`
+
+Tooltip text for the select component.
+
+## Implementation
+
+```typescript
+import BAIFlex from './BAIFlex';
+import { Divider, Select, SelectProps, theme, Tooltip, Typography } from 'antd';
+import { createStyles } from 'antd-style';
+import { BaseOptionType, DefaultOptionType } from 'antd/es/select';
+import { GetRef } from 'antd/lib';
+import classNames from 'classnames';
+import _ from 'lodash';
+import React, { useLayoutEffect, useRef, useTransition } from 'react';
+
+const useStyles = createStyles(({ css, token }) => ({
+  ghostSelect: css\`
+    &.ant-select {
+      background-color: transparent;
+      border-color: \${token.colorBgBase} !important;
+      color: \${token.colorBgBase};
+
+      &:hover {
+        background-color: rgb(255 255 255 / 10%);
+      }
+
+      &:active {
+        background-color: rgb(255 255 255 / 10%);
+      }
+
+      .ant-select-suffix {
+        color: \${token.colorBgBase};
+      }
+
+      &:hover .ant-select-suffix {
+        color: \${token.colorBgBase};
+      }
+
+      &:active .ant-select-suffix {
+        color: \${token.colorBgBase};
+      }
+    }
+  \`,
+  customStyle: css\`
+    /* Change the opacity of images and tags when dropdown is open */
+    &.ant-select-open .ant-select-content .ant-select-content-value img,
+    &.ant-select-open
+      .ant-select-content
+      .ant-select-content-value
+      span.ant-tag {
+      opacity: 0.5;
+    }
+
+    /* Change color of secondary/success/warning/danger text to placeholder when open */
+    &.ant-select-open
+      .ant-select-content
+      .ant-select-content-value
+      .ant-typography-secondary,
+    &.ant-select-open
+      .ant-select-content
+      .ant-select-content-value
+      .ant-typography-success,
+    &.ant-select-open
+      .ant-select-content
+      .ant-select-content-value
+      .ant-typography-warning,
+    &.ant-select-open
+      .ant-select-content
+      .ant-select-content-value
+      .ant-typography-danger {
+      color: \${token.colorTextPlaceholder};
+    }
+  \`,
+}));
+
+function BAISelect<
+  ValueType = any,
+  OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType,
+>({
+  ref,
+  autoSelectOption,
+  ghost,
+  tooltip = '',
+  atBottomThreshold = 30,
+  atBottomStateChange,
+  footer,
+  endReached,
+  searchAction,
+  ...selectProps
+}: BAISelectProps<ValueType, OptionType>): React.ReactElement {
+  const { value, options, onChange } = selectProps;
+  const { styles } = useStyles();
+  const lastScrollTop = useRef<number>(0);
+  const isAtBottom = useRef<boolean>(false);
+  const { token } = theme.useToken();
+  const [isPending, startTransition] = useTransition();
+
+  useLayoutEffect(() => {
+    if (autoSelectOption && _.isEmpty(value) && options?.[0]) {
+      if (_.isBoolean(autoSelectOption)) {
+        onChange?.(options?.[0].value || options?.[0], options?.[0]);
+      } else if (_.isFunction(autoSelectOption)) {
+        onChange?.(autoSelectOption(options), options?.[0]);
+      }
+    }
+  }, [value, options, onChange, autoSelectOption]);
+
+  // Function to check if scroll has reached bottom
+  const handlePopupScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    if (!atBottomStateChange && !endReached) return;
+
+    const target = e.target as HTMLElement;
+    const scrollTop = target.scrollTop;
+    lastScrollTop.current = scrollTop;
+
+    const isAtBottomNow =
+      target.scrollHeight - scrollTop - target.clientHeight <=
+      atBottomThreshold;
+
+    // Only notify when state changes
+    if (isAtBottomNow !== isAtBottom.current) {
+      isAtBottom.current = isAtBottomNow;
+      atBottomStateChange?.(isAtBottomNow);
+
+      if (isAtBottomNow) {
+        endReached?.(); // Call endReached when at bottom
+      }
+    }
+  };
+
+  return (
+    <Tooltip title={tooltip}>
+      <Select<ValueType, OptionType>
+        {...selectProps}
+        loading={isPending || selectProps.loading}
+        showSearch={
+          selectProps.showSearch && _.isObject(selectProps.showSearch)
+            ? {
+                ...selectProps.showSearch,
+                onSearch: async (value) => {
+                  _.get(selectProps.showSearch, 'onSearch')?.(value);
+                  startTransition(async () => {
+                    await searchAction?.(value);
+                  });
+                },
+              }
+            : false
+        }
+        ref={ref}
+        className={classNames(
+          selectProps.className,
+          styles.customStyle,
+          ghost && styles.ghostSelect,
+        )}
+        onPopupScroll={(e) => {
+          if (atBottomStateChange || endReached) handlePopupScroll(e);
+          selectProps.onPopupScroll?.(e);
+        }}
+        popupRender={
+          footer
+            ? (menu) => {
+                return (
+                  <BAIFlex direction="column" align="stretch">
+                    {menu}
+                    <Divider
+                      style={{
+                        margin: 0,
+                        marginBottom: token.paddingXS,
+                      }}
+                    />
+                    <BAIFlex
+                      direction="column"
+                      align="end"
+                      gap={'xs'}
+                      style={{
+                        paddingBottom: token.paddingXXS,
+                        paddingInline: token.paddingSM,
+                      }}
+                    >
+                      {_.isString(footer) ? (
+                        <Typography.Text type="secondary">
+                          {footer}
+                        </Typography.Text>
+                      ) : (
+                        footer
+                      )}
+                    </BAIFlex>
+                  </BAIFlex>
+                );
+              }
+            : undefined
+        }
+      />
+    </Tooltip>
+  );
+}
+
+export default BAISelect;
+```
+
+## Key Implementation Details
+
+### 1. Transition-Based Search
+
+```typescript
+const [isPending, startTransition] = useTransition();
+
+showSearch={
+  selectProps.showSearch && _.isObject(selectProps.showSearch)
+    ? {
+        ...selectProps.showSearch,
+        onSearch: async (value) => {
+          _.get(selectProps.showSearch, 'onSearch')?.(value);
+          startTransition(async () => {
+            await searchAction?.(value);
+          });
+        },
+      }
+    : false
+}
+
+loading={isPending || selectProps.loading}
+```
+
+- Wraps `searchAction` in `useTransition()`
+- Automatically shows loading state during search
+- Non-blocking UI updates
+
+### 2. Scroll Detection Logic
+
+```typescript
+const handlePopupScroll = (e: React.UIEvent<HTMLDivElement>) => {
+  if (!atBottomStateChange && !endReached) return;
+
+  const target = e.target as HTMLElement;
+  const scrollTop = target.scrollTop;
+
+  const isAtBottomNow =
+    target.scrollHeight - scrollTop - target.clientHeight <=
+    atBottomThreshold;
+
+  // Only notify when state changes
+  if (isAtBottomNow !== isAtBottom.current) {
+    isAtBottom.current = isAtBottomNow;
+    atBottomStateChange?.(isAtBottomNow);
+
+    if (isAtBottomNow) {
+      endReached?.(); // Trigger pagination
+    }
+  }
+};
+```
+
+- Check if scroll is within threshold of bottom
+- Only trigger once per crossing
+- Prevent duplicate calls
+
+### 3. Custom Footer Rendering
+
+```typescript
+popupRender={
+  footer
+    ? (menu) => {
+        return (
+          <BAIFlex direction="column" align="stretch">
+            {menu}
+            <Divider
+              style={{
+                margin: 0,
+                marginBottom: token.paddingXS,
+              }}
+            />
+            <BAIFlex
+              direction="column"
+              align="end"
+              gap={'xs'}
+              style={{
+                paddingBottom: token.paddingXXS,
+                paddingInline: token.paddingSM,
+              }}
+            >
+              {_.isString(footer) ? (
+                <Typography.Text type="secondary">
+                  {footer}
+                </Typography.Text>
+              ) : (
+                footer
+              )}
+            </BAIFlex>
+          </BAIFlex>
+        );
+      }
+    : undefined
+}
+```
+
+- Divider above footer
+- Right-aligned content
+- Support both string and ReactNode
+
+### 4. Auto-Select Logic
+
+```typescript
+useLayoutEffect(() => {
+  if (autoSelectOption && _.isEmpty(value) && options?.[0]) {
+    if (_.isBoolean(autoSelectOption)) {
+      onChange?.(options?.[0].value || options?.[0], options?.[0]);
+    } else if (_.isFunction(autoSelectOption)) {
+      onChange?.(autoSelectOption(options), options?.[0]);
+    }
+  }
+}, [value, options, onChange, autoSelectOption]);
+```
+
+- Runs on options load
+- Only when value is empty
+- Support boolean or function
+
+## Usage Patterns
+
+### Pattern A (usePaginationFragment)
+
+```typescript
+<BAISelect
+  ref={selectRef}
+  options={selectOptions}
+  searchAction={async (value) => {
+    selectRef.current?.scrollTo(0);
+    refetch({ filter: value ? { name: { contains: value } } : null });
+  }}
+  endReached={() => {
+    hasNext && loadNext(10);
+  }}
+  footer={
+    count > 0 ? (
+      <TotalFooter loading={isLoadingNext} total={count} />
+    ) : undefined
+  }
+/>
+```
+
+### Pattern B (useLazyLoadQuery + useLazyPaginatedQuery)
+
+```typescript
+<BAISelect
+  ref={selectRef}
+  options={availableOptions}
+  searchAction={async (value) => {
+    setSearchStr(value);
+  }}
+  endReached={() => {
+    loadNext();
+  }}
+  labelInValue
+  value={optimisticValueWithLabel}
+  onChange={(value, option) => {
+    // Handle change with label preservation
+  }}
+  footer={
+    count > 0 ? (
+      <TotalFooter loading={isLoadingNext} total={count} />
+    ) : undefined
+  }
+/>
+```
+
+## Best Practices
+
+1. **Always scroll to top on search**
+   ```typescript
+   searchAction={async (value) => {
+     selectRef.current?.scrollTo(0); // ← Important!
+     // ... handle search
+   }}
+   ```
+
+2. **Check hasNext before loadNext**
+   ```typescript
+   endReached={() => {
+     hasNext && loadNext(10); // ← Check hasNext
+   }}
+   ```
+
+3. **Use Skeleton for initial load**
+   ```typescript
+   notFoundContent={
+     _.isUndefined(data) ? (
+       <Skeleton.Input active size="small" block />
+     ) : undefined
+   }
+   ```
+
+4. **Conditional footer rendering**
+   ```typescript
+   footer={
+     _.isNumber(count) && count > 0 ? (
+       <TotalFooter loading={isLoadingNext} total={count} />
+     ) : undefined
+   }
+   ```
+
+## Common Issues
+
+### Issue 1: Search doesn't reset scroll
+
+**Problem:** User searches but sees empty results because scroll is still at bottom.
+
+**Solution:**
+```typescript
+searchAction={async (value) => {
+  selectRef.current?.scrollTo(0); // ← Add this
+  // ... rest of search logic
+}}
+```
+
+### Issue 2: Multiple endReached calls
+
+**Problem:** `endReached` called multiple times when scrolling at bottom.
+
+**Solution:** Already handled internally - only triggers on state change.
+
+### Issue 3: Loading state not showing during search
+
+**Problem:** Search feels unresponsive.
+
+**Solution:** Use `searchAction` prop instead of `showSearch.onSearch` - it's wrapped in transition automatically.

--- a/.claude/skills/relay-infinite-scroll-select/references/helpers/mergeFilterValues.md
+++ b/.claude/skills/relay-infinite-scroll-select/references/helpers/mergeFilterValues.md
@@ -1,0 +1,342 @@
+# mergeFilterValues - Filter Composition Utility
+
+## Overview
+
+`mergeFilterValues` composes multiple GraphQL filter strings into a single filter expression with a specified operator. It automatically filters out empty values and wraps each filter in parentheses.
+
+## Main Function: mergeFilterValues
+
+**Signature:**
+```typescript
+export function mergeFilterValues(
+  filterStrings: Array<string | undefined | null>,
+  operator: string = '&',
+): string | undefined
+```
+
+**Parameters:**
+- `filterStrings`: Array of filter strings (can include `undefined` or `null`)
+- `operator`: Logical operator to join filters (default: `'&'` for AND)
+  - `'&'` - AND operator (all conditions must be true)
+  - `'|'` - OR operator (any condition can be true)
+
+**Returns:** Combined filter string or `undefined` if no valid filters
+
+**Example:**
+```typescript
+import { mergeFilterValues } from '../BAIPropertyFilter';
+
+// AND operator (default)
+const filter = mergeFilterValues([
+  'status == "RUNNING"',
+  'name ilike "%test%"',
+  null, // ignored
+  undefined, // ignored
+]);
+// => '(status == "RUNNING")&(name ilike "%test%")'
+
+// OR operator
+const filter = mergeFilterValues([
+  'id == "123"',
+  'id == "456"',
+  'id == "789"',
+], '|');
+// => '(id == "123")|(id == "456")|(id == "789")'
+
+// All empty
+const filter = mergeFilterValues([null, undefined, '']);
+// => undefined
+```
+
+## Implementation
+
+```typescript
+import _ from 'lodash';
+import { filterOutEmpty } from '../../helper';
+
+export function mergeFilterValues(
+  filterStrings: Array<string | undefined | null>,
+  operator: string = '&',
+) {
+  const mergedFilter = _.join(
+    _.map(filterOutEmpty(filterStrings), (str) => \`(\${str})\`),
+    operator,
+  );
+  return mergedFilter ? mergedFilter : undefined;
+}
+```
+
+**Process:**
+1. Filter out empty values using `filterOutEmpty`
+2. Wrap each filter in parentheses `(filter)`
+3. Join with operator
+4. Return `undefined` if result is empty string
+
+## Helper Function: trimFilterValue
+
+**Signature:**
+```typescript
+function trimFilterValue(filterValue: string): string
+```
+
+**Purpose:** Remove `%` wildcards from filter values for display purposes.
+
+**Example:**
+```typescript
+trimFilterValue('%search%');  // => 'search'
+trimFilterValue('search%');   // => 'search'
+trimFilterValue('%search');   // => 'search'
+trimFilterValue('search');    // => 'search'
+```
+
+**Implementation:**
+```typescript
+function trimFilterValue(filterValue: string): string {
+  return filterValue.replace(/^%|%$/g, '');
+}
+```
+
+**Usage:** Primarily used in BAIPropertyFilter for displaying filter values in tags.
+
+## Common Patterns
+
+### Pattern 1: Combining Base Filter and Search
+
+```typescript
+const mergedFilter = mergeFilterValues([
+  baseFilter, // e.g., 'status != "DELETE_COMPLETE"'
+  searchStr ? \`name ilike "%\${searchStr}%"\` : null,
+]);
+
+// Example result: '(status != "DELETE_COMPLETE")&(name ilike "%test%")'
+```
+
+### Pattern 2: Multiple Optional Filters
+
+```typescript
+const filter = mergeFilterValues([
+  excludeDeleted ? 'status != "DELETE_COMPLETE"' : null,
+  projectId ? \`project_id == "\${projectId}"\` : null,
+  ownershipType ? \`ownership_type == "\${ownershipType}"\` : null,
+  externalFilter, // from parent component
+]);
+```
+
+### Pattern 3: OR Conditions for Selected Values
+
+```typescript
+const selectedFilter = mergeFilterValues(
+  _.castArray(selectedValues).map((value) => {
+    return \`id == "\${value}"\`;
+  }),
+  '|', // OR operator
+);
+
+// Result: '(id == "123")|(id == "456")|(id == "789")'
+```
+
+### Pattern 4: Nested Filter Composition
+
+```typescript
+const excludedStatusFilter = mergeFilterValues([
+  'status != "DELETE_PENDING"',
+  'status != "DELETE_ONGOING"',
+  'status != "DELETE_ERROR"',
+  'status != "DELETE_COMPLETE"',
+], '&');
+
+const finalFilter = mergeFilterValues([
+  excludedStatusFilter,
+  searchFilter,
+  externalFilter,
+]);
+```
+
+## Usage in Pattern B (BAIVFolderSelect)
+
+### Selected Values Query
+
+```typescript
+const { vfolder_nodes: selectedVFolderNodes } = useLazyLoadQuery(
+  graphql\`
+    query BAIVFolderSelectValueQuery(
+      $selectedFilter: String
+      $skipSelectedVFolder: Boolean!
+    ) {
+      vfolder_nodes(filter: $selectedFilter)
+        @skip(if: $skipSelectedVFolder) {
+        edges {
+          node {
+            id
+            name
+          }
+        }
+      }
+    }
+  \`,
+  {
+    selectedFilter: mergeFilterValues(
+      [
+        !_.isEmpty(selectedValues)
+          ? mergeFilterValues(
+              _.castArray(selectedValues).map((value) => {
+                const filterValue = valuePropName === 'id'
+                  ? toLocalId(value)
+                  : value;
+                return \`\${valuePropName} == "\${filterValue}"\`;
+              }),
+              '|', // OR for selected values
+            )
+          : null,
+        baseFilter,
+      ],
+      '&', // AND with base filter
+    ),
+    skipSelectedVFolder: _.isEmpty(selectedValues),
+  },
+);
+```
+
+### Paginated Options Query
+
+```typescript
+const { paginationData, result } = useLazyPaginatedQuery(
+  query,
+  { limit: 10 },
+  {
+    filter: mergeFilterValues([
+      baseFilter,
+      excludeDeleted ? excludeDeletedStatusFilter : null,
+      searchStr ? \`name ilike "%\${searchStr}%"\` : null,
+      externalFilter,
+    ]),
+    scopeId: projectId ? \`project:\${projectId}\` : undefined,
+  },
+  options,
+  extractors,
+);
+```
+
+## Best Practices
+
+1. **Always use mergeFilterValues instead of manual string concatenation**
+   ```typescript
+   // ✅ Good: Handles empty values automatically
+   mergeFilterValues([filter1, null, filter2]);
+
+   // ❌ Bad: Manual concatenation with conditionals
+   [filter1, filter2].filter(Boolean).join('&');
+   ```
+
+2. **Use appropriate operator for context**
+   ```typescript
+   // AND for combining different conditions
+   mergeFilterValues([statusFilter, searchFilter], '&');
+
+   // OR for multiple values of same field
+   mergeFilterValues(
+     ids.map((id) => \`id == "\${id}"\`),
+     '|',
+   );
+   ```
+
+3. **Wrap complex filters in mergeFilterValues**
+   ```typescript
+   const excludedStatuses = mergeFilterValues([
+     'status != "DELETE_PENDING"',
+     'status != "DELETE_ONGOING"',
+   ], '&');
+
+   const finalFilter = mergeFilterValues([
+     excludedStatuses,
+     otherFilters,
+   ]);
+   ```
+
+4. **Use with conditional filters**
+   ```typescript
+   // ✅ Good: Null values are filtered out
+   mergeFilterValues([
+     baseFilter,
+     condition ? conditionalFilter : null,
+     anotherCondition ? anotherFilter : null,
+   ]);
+
+   // ❌ Bad: Manual null checking
+   let filters = [baseFilter];
+   if (condition) filters.push(conditionalFilter);
+   if (anotherCondition) filters.push(anotherFilter);
+   const finalFilter = filters.join('&');
+   ```
+
+## Filter Syntax Reference
+
+Backend.AI GraphQL filter syntax:
+
+```typescript
+// Equality
+'field == "value"'
+
+// Inequality
+'field != "value"'
+
+// Comparison
+'field > 10'
+'field < 100'
+'field >= 10'
+'field <= 100'
+
+// Case-insensitive LIKE
+'field ilike "%pattern%"'
+'field ilike "prefix%"'
+'field ilike "%suffix"'
+
+// Logical operators
+'condition1 & condition2'  // AND
+'condition1 | condition2'  // OR
+
+// Grouping
+'(condition1 & condition2) | condition3'
+```
+
+## Common Patterns
+
+### Exclude Deleted Items
+
+```typescript
+const excludeDeletedStatusFilter =
+  'status != "DELETE_PENDING" & ' +
+  'status != "DELETE_ONGOING" & ' +
+  'status != "DELETE_ERROR" & ' +
+  'status != "DELETE_COMPLETE"';
+
+// Or use mergeFilterValues
+const excludeDeletedStatusFilter = mergeFilterValues([
+  'status != "DELETE_PENDING"',
+  'status != "DELETE_ONGOING"',
+  'status != "DELETE_ERROR"',
+  'status != "DELETE_COMPLETE"',
+], '&');
+```
+
+### Search with Wildcards
+
+```typescript
+const searchFilter = searchStr
+  ? \`name ilike "%\${searchStr}%"\`
+  : null;
+```
+
+### Multiple ID Matching
+
+```typescript
+const idFilter = mergeFilterValues(
+  _.castArray(ids).map((id) => \`id == "\${id}"\`),
+  '|',
+);
+```
+
+## Dependencies
+
+- `lodash` - For `_.join`, `_.map`
+- `filterOutEmpty` from `../../helper` - Removes empty values

--- a/.claude/skills/relay-infinite-scroll-select/references/helpers/relay-helpers.md
+++ b/.claude/skills/relay-infinite-scroll-select/references/helpers/relay-helpers.md
@@ -1,0 +1,298 @@
+# Relay Helper Functions
+
+## Overview
+
+Utility functions for working with Relay Global IDs and filtering arrays.
+
+## Functions
+
+### toGlobalId
+
+Convert a local ID to a Relay Global ID.
+
+**Signature:**
+```typescript
+export const toGlobalId = (type: KnownGlobalIdType, id: string): string
+```
+
+**Parameters:**
+- `type`: The GraphQL type name (e.g., 'VirtualFolderNode', 'UserNode')
+- `id`: The local ID (UUID or other identifier)
+
+**Returns:** Base64-encoded Global ID string
+
+**Example:**
+```typescript
+import { toGlobalId } from '../../helper';
+
+const globalId = toGlobalId('VirtualFolderNode', '123e4567-e89b-12d3-a456-426614174000');
+// => "VmlydHVhbEZvbGRlck5vZGU6MTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDAw"
+```
+
+**Implementation:**
+```typescript
+export type KnownGlobalIdType =
+  | 'VirtualFolderNode'
+  | 'ComputeSessionNode'
+  | 'KeyPairNode'
+  | 'ScalingGroupNode'
+  | 'UserNode';
+
+export const toGlobalId = (type: KnownGlobalIdType, id: string): string => {
+  return btoa(\`\${type}:\${id}\`);
+};
+```
+
+### toLocalId
+
+Extract the local ID from a Relay Global ID.
+
+**Signature:**
+```typescript
+export const toLocalId = (globalId: string): string
+```
+
+**Parameters:**
+- `globalId`: Base64-encoded Relay Global ID
+
+**Returns:** Local ID (UUID or other identifier)
+
+**Example:**
+```typescript
+import { toLocalId } from '../../helper';
+
+const localId = toLocalId("VmlydHVhbEZvbGRlck5vZGU6MTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDAw");
+// => "123e4567-e89b-12d3-a456-426614174000"
+```
+
+**Implementation:**
+```typescript
+export const toLocalId = (globalId: string): string => {
+  return atob(globalId).split(':')?.[1];
+};
+```
+
+**Usage in Pattern B:**
+```typescript
+// When valuePropName is 'id', filter needs local UUID
+const filterValue = valuePropName === 'id' ? toLocalId(value) : value;
+return \`\${valuePropName} == "\${filterValue}"\`;
+
+// In label rendering, show local ID for debugging
+labelRender={({ label, value }) => (
+  <>
+    {label}
+    <BAIText type="secondary">
+      &nbsp; ({toLocalId(_.toString(value))})
+    </BAIText>
+  </>
+)}
+```
+
+### filterOutEmpty
+
+Filter out empty values from an array.
+
+**Signature:**
+```typescript
+export const filterOutEmpty = <T>(
+  arr: Array<T | undefined | null | '' | false | any[] | object>,
+): Array<T>
+```
+
+**Parameters:**
+- `arr`: Array that may contain empty values
+
+**Returns:** New array with only non-empty values
+
+**What is considered "empty":**
+- `undefined`
+- `null`
+- Empty string (`''`)
+- `false`
+- `true`
+- Empty arrays (`[]`)
+- Empty objects (`{}`)
+
+**Example:**
+```typescript
+import { filterOutEmpty } from '../../helper';
+
+const arr = [
+  'valid',
+  null,
+  undefined,
+  '',
+  'another valid',
+  false,
+  [],
+  {},
+];
+
+const filtered = filterOutEmpty(arr);
+// => ['valid', 'another valid']
+```
+
+**Implementation:**
+```typescript
+export const filterOutEmpty = <T>(
+  arr: Array<T | undefined | null | '' | false | any[] | object>,
+): Array<T> => _.filter(arr, (item) => !_.isEmpty(item)) as Array<T>;
+```
+
+**Usage in mergeFilterValues:**
+```typescript
+export function mergeFilterValues(
+  filterStrings: Array<string | undefined | null>,
+  operator: string = '&',
+) {
+  const mergedFilter = _.join(
+    _.map(filterOutEmpty(filterStrings), (str) => \`(\${str})\`),
+    operator,
+  );
+  return mergedFilter ? mergedFilter : undefined;
+}
+```
+
+### filterOutNullAndUndefined
+
+Filter out `null` and `undefined` from array of objects.
+
+**Signature:**
+```typescript
+export function filterOutNullAndUndefined<T extends { [key: string]: any }>(
+  arr: ReadonlyArray<T | null | undefined> | null | undefined,
+): T[]
+```
+
+**Parameters:**
+- `arr`: Array that may contain null/undefined values, or itself be null/undefined
+
+**Returns:** New array with only non-null/non-undefined objects
+
+**Example:**
+```typescript
+import { filterOutNullAndUndefined } from '../../helper';
+
+const users = [
+  { id: '1', name: 'Alice' },
+  null,
+  { id: '2', name: 'Bob' },
+  undefined,
+  { id: '3', name: 'Charlie' },
+];
+
+const validUsers = filterOutNullAndUndefined(users);
+// => [{ id: '1', name: 'Alice' }, { id: '2', name: 'Bob' }, { id: '3', name: 'Charlie' }]
+
+// Handle null/undefined array
+const result = filterOutNullAndUndefined(null);
+// => []
+```
+
+**Implementation:**
+```typescript
+export function filterOutNullAndUndefined<T extends { [key: string]: any }>(
+  arr: ReadonlyArray<T | null | undefined> | null | undefined,
+): T[] {
+  if (arr === null || arr === undefined) {
+    return [];
+  }
+  return arr.filter((item) => item !== null && item !== undefined);
+}
+```
+
+**Usage in GraphQL result processing:**
+```typescript
+const validEdges = filterOutNullAndUndefined(data.items?.edges);
+const items = validEdges.map((edge) => edge.node);
+```
+
+## Common Patterns
+
+### Global ID Conversion in Filters
+
+```typescript
+import { toLocalId } from '../../helper';
+
+// Build filter for selected values
+const selectedFilter = mergeFilterValues(
+  _.castArray(selectedValues).map((value) => {
+    // Convert Global ID to local UUID for backend filter
+    const filterValue = valuePropName === 'id' ? toLocalId(value) : value;
+    return \`\${valuePropName} == "\${filterValue}"\`;
+  }),
+  '|', // OR operator
+);
+```
+
+### Filtering Empty Values in Filter Arrays
+
+```typescript
+import { filterOutEmpty } from '../../helper';
+
+const mergedFilter = mergeFilterValues([
+  baseFilter,
+  excludeDeleted ? deletedStatusFilter : null,
+  searchStr ? \`name ilike "%\${searchStr}%"\` : null,
+  externalFilter,
+]);
+// filterOutEmpty is called inside mergeFilterValues
+```
+
+### Processing GraphQL Edges
+
+```typescript
+import { filterOutNullAndUndefined } from '../../helper';
+
+const data = useLazyLoadQuery(query, variables);
+
+// Safe edge processing
+const validEdges = filterOutNullAndUndefined(data.items?.edges);
+const items = validEdges.map((edge) => edge.node);
+```
+
+## Best Practices
+
+1. **Always use toLocalId for backend filters when valuePropName is 'id'**
+   ```typescript
+   // ✅ Good: Convert to local ID
+   const filterValue = valuePropName === 'id' ? toLocalId(value) : value;
+
+   // ❌ Bad: Use Global ID directly
+   const filterValue = value; // Backend doesn't understand Global IDs
+   ```
+
+2. **Use filterOutEmpty in filter merging**
+   ```typescript
+   // ✅ Good: Automatically handled by mergeFilterValues
+   mergeFilterValues([filter1, null, filter2]);
+
+   // ❌ Bad: Manual filtering
+   [filter1, filter2].filter(f => f).join('&');
+   ```
+
+3. **Use filterOutNullAndUndefined for GraphQL results**
+   ```typescript
+   // ✅ Good: Handle nullable edges
+   const validEdges = filterOutNullAndUndefined(data.items?.edges);
+
+   // ❌ Bad: Assume no nulls
+   const edges = data.items.edges; // May contain nulls
+   ```
+
+## Type Definitions
+
+```typescript
+export type KnownGlobalIdType =
+  | 'VirtualFolderNode'
+  | 'ComputeSessionNode'
+  | 'KeyPairNode'
+  | 'ScalingGroupNode'
+  | 'UserNode';
+```
+
+## Related Functions
+
+- `mergeFilterValues` - Uses `filterOutEmpty` internally
+- `BAIPropertyFilter` - Uses these helpers for filter logic

--- a/.claude/skills/relay-infinite-scroll-select/references/hooks/useEventNotStable.md
+++ b/.claude/skills/relay-infinite-scroll-select/references/hooks/useEventNotStable.md
@@ -1,0 +1,238 @@
+# useEventNotStable Hook
+
+## Overview
+
+`useEventNotStable` is a custom implementation of React's (experimental) `useEffectEvent` hook. It creates a stable callback reference that always calls the latest version of the handler without needing dependencies.
+
+## Purpose
+
+Used in **useLazyPaginatedQuery** to create a stable `loadNext` function that doesn't change reference but always calls the latest handler logic.
+
+## API
+
+```typescript
+export function useEventNotStable<Args extends unknown[], Return>(
+  handler: (...args: Args) => Return,
+): (...args: Args) => Return
+```
+
+## Implementation
+
+```typescript
+import { useCallback, useLayoutEffect, useRef } from 'react';
+
+export function useEventNotStable<Args extends unknown[], Return>(
+  handler: (...args: Args) => Return,
+) {
+  const handlerRef = useRef<typeof handler>(handler);
+
+  // In a real implementation, this would run before layout effects
+  useLayoutEffect(() => {
+    handlerRef.current = handler;
+  });
+
+  return useCallback((...args: Args) => {
+    // In a real implementation, this would throw if called during render
+    const fn = handlerRef.current;
+    return fn(...args);
+  }, []);
+}
+```
+
+## How It Works
+
+1. **Store latest handler in ref**
+   ```typescript
+   const handlerRef = useRef<typeof handler>(handler);
+
+   useLayoutEffect(() => {
+     handlerRef.current = handler; // Update to latest
+   });
+   ```
+
+2. **Return stable callback**
+   ```typescript
+   return useCallback((...args: Args) => {
+     const fn = handlerRef.current; // Always get latest
+     return fn(...args);
+   }, []); // Empty deps = never changes
+   ```
+
+## Why useEventNotStable?
+
+### Problem: Unstable Callbacks
+
+```typescript
+// ❌ Bad: New function on every render
+const loadNext = () => {
+  if (isLoadingNext || !hasNext) return;
+  previousResult.current = data || [];
+  startLoadingNextTransition(() => {
+    setOffset(offset + limit);
+  });
+};
+
+// BAISelect gets new loadNext every render → potential issues
+<BAISelect endReached={loadNext} />
+```
+
+### Solution: Stable Reference
+
+```typescript
+// ✅ Good: Stable reference, latest logic
+const loadNext = useEventNotStable(() => {
+  if (isLoadingNext || !hasNext) return;
+  previousResult.current = data || [];
+  startLoadingNextTransition(() => {
+    setOffset(offset + limit);
+  });
+});
+
+// BAISelect always gets same loadNext reference
+<BAISelect endReached={loadNext} />
+```
+
+## Usage in useLazyPaginatedQuery
+
+```typescript
+const loadNext = useEventNotStable(() => {
+  if (isLoadingNext || !hasNext) return;
+  previousResult.current = data || [];
+  startLoadingNextTransition(() => {
+    const nextOffset = offset + limit;
+    setOffset(nextOffset);
+  });
+});
+
+return {
+  paginationData: data,
+  result,
+  loadNext, // ← Stable reference
+  hasNext,
+  isLoadingNext,
+};
+```
+
+**Benefits:**
+- `loadNext` reference never changes
+- Always accesses latest `offset`, `limit`, `hasNext`, `isLoadingNext`
+- No dependency array needed
+- Prevents unnecessary re-renders in child components
+
+## Comparison with useCallback
+
+| Feature | useEventNotStable | useCallback |
+|---------|------------------|-------------|
+| **Reference Stability** | Always stable | Depends on deps |
+| **Latest Values** | Always latest | Must be in deps |
+| **Dependency Array** | Not needed | Required |
+| **React Version** | Works now | Standard |
+| **Use Case** | Event handlers, callbacks | General memoization |
+
+## Example: Without vs With
+
+### Without useEventNotStable
+
+```typescript
+// ❌ Problem: loadNext changes on every state change
+const loadNext = useCallback(() => {
+  if (isLoadingNext || !hasNext) return;
+  previousResult.current = data || [];
+  startLoadingNextTransition(() => {
+    setOffset(offset + limit);
+  });
+}, [isLoadingNext, hasNext, data, offset, limit]); // Many deps!
+
+// Causes BAISelect to re-evaluate endReached frequently
+<BAISelect endReached={loadNext} />
+```
+
+### With useEventNotStable
+
+```typescript
+// ✅ Solution: Stable reference, latest values
+const loadNext = useEventNotStable(() => {
+  if (isLoadingNext || !hasNext) return;
+  previousResult.current = data || [];
+  startLoadingNextTransition(() => {
+    setOffset(offset + limit);
+  });
+}); // No deps needed
+
+// BAISelect only evaluates endReached when actually called
+<BAISelect endReached={loadNext} />
+```
+
+## Best Practices
+
+1. **Use for event handlers passed as props**
+   ```typescript
+   const handleClick = useEventNotStable(() => {
+     // Access latest state without deps
+     doSomething(latestState);
+   });
+
+   <Component onClick={handleClick} />
+   ```
+
+2. **Use in custom hooks for stable API**
+   ```typescript
+   export const useCustomHook = () => {
+     const stableCallback = useEventNotStable(() => {
+       // Latest logic
+     });
+
+     return { stableCallback };
+   };
+   ```
+
+3. **Do NOT use for dependencies in useEffect**
+   ```typescript
+   // ❌ Bad: Won't trigger effect when logic changes
+   useEffect(() => {
+     stableCallback();
+   }, [stableCallback]); // Never changes
+
+   // ✅ Good: Use direct values instead
+   useEffect(() => {
+     doSomething(value);
+   }, [value]);
+   ```
+
+## When to Use
+
+✅ **Good Use Cases:**
+- Event handlers passed to child components
+- Callbacks in custom hooks
+- Functions that need latest closure values
+- Pagination callbacks like `loadNext`
+
+❌ **Don't Use For:**
+- useEffect dependencies
+- useMemo dependencies
+- useCallback dependencies
+- Anything that should trigger re-computation
+
+## Related: React's useEffectEvent
+
+This hook is inspired by React's experimental `useEffectEvent`. When `useEffectEvent` becomes stable in React, consider migrating to the official API.
+
+**Future Migration:**
+```typescript
+// Current
+const loadNext = useEventNotStable(() => {
+  // logic
+});
+
+// Future (when stable)
+const loadNext = useEffectEvent(() => {
+  // logic
+});
+```
+
+## Note
+
+From the implementation comment:
+> "In a real implementation, this would throw if called during render"
+
+This is a simplified version. React's official `useEffectEvent` would throw an error if called during the render phase, enforcing that it's only used for event handlers.

--- a/.claude/skills/relay-infinite-scroll-select/references/hooks/useFetchKey.md
+++ b/.claude/skills/relay-infinite-scroll-select/references/hooks/useFetchKey.md
@@ -1,0 +1,179 @@
+# useFetchKey Hook
+
+## Overview
+
+`useFetchKey` provides a mechanism for cache invalidation and refetching data in Relay queries. It returns a fetchKey that changes each time you call the update function, triggering a fresh network request.
+
+## Purpose
+
+Used in Pattern B (ID-based) components to:
+- Invalidate Relay cache
+- Force refetch of GraphQL queries
+- Expose external refetch functionality via component ref
+
+## API
+
+```typescript
+export const useFetchKey = () => {
+  return [...useDateISOState(INITIAL_FETCH_KEY), INITIAL_FETCH_KEY] as const;
+};
+
+// Returns: [currentKey, updateKey, INITIAL_KEY]
+// Type: readonly [string, (newValue?: string) => void, 'first']
+```
+
+## Usage
+
+```typescript
+const [fetchKey, updateFetchKey] = useFetchKey();
+
+// Use in query options
+useLazyLoadQuery(query, variables, {
+  fetchPolicy: 'store-and-network',
+  fetchKey: fetchKey, // ← Changes trigger refetch
+});
+
+// Trigger refetch
+updateFetchKey(); // Generates new ISO timestamp
+```
+
+## Implementation
+
+```typescript
+export const INITIAL_FETCH_KEY = 'first';
+
+export const useDateISOState = (initialValue?: string) => {
+  'use memo';
+  const [value, setValue] = useState(initialValue || new Date().toISOString());
+
+  const update = useEventNotStable((newValue?: string) => {
+    setValue(newValue || new Date().toISOString());
+  });
+  return [value, update] as const;
+};
+
+export const useUpdatableState = (initialValue: string) => {
+  return useDateISOState(initialValue);
+};
+
+export const useFetchKey = () => {
+  return [...useDateISOState(INITIAL_FETCH_KEY), INITIAL_FETCH_KEY] as const;
+};
+```
+
+## Related: useDateISOState
+
+Helper hook that maintains a timestamp state:
+
+```typescript
+const [timestamp, updateTimestamp] = useDateISOState('first');
+
+// Update to current time
+updateTimestamp(); // Sets to new Date().toISOString()
+
+// Update to specific value
+updateTimestamp('custom-value');
+```
+
+## Pattern B Integration
+
+```typescript
+const BAIVFolderSelect: React.FC<Props> = ({ ref, ...props }) => {
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  // Use in queries
+  useLazyLoadQuery(query, variables, {
+    fetchPolicy: 'store-or-network',
+    fetchKey: deferredFetchKey, // ← Deferred to prevent Suspense flicker
+  });
+
+  // Expose refetch via ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: () => {
+        startRefetchTransition(() => {
+          updateFetchKey(); // ← Triggers refetch
+        });
+      },
+    }),
+    [updateFetchKey, startRefetchTransition],
+  );
+};
+```
+
+## Why useDeferredValue?
+
+```typescript
+const [fetchKey, updateFetchKey] = useFetchKey();
+const deferredFetchKey = useDeferredValue(fetchKey);
+
+// Use deferred value in queries
+useLazyLoadQuery(query, variables, {
+  fetchKey: deferredFetchKey, // ← Not direct fetchKey
+});
+```
+
+**Reason**: Direct usage causes parent Suspense boundaries to show fallback UI during refetch. Deferring prevents this flicker.
+
+## Example: External Refetch
+
+```typescript
+// Parent component
+const MyComponent = () => {
+  const selectRef = useRef<BAIVFolderSelectRef>(null);
+
+  return (
+    <>
+      <BAIVFolderSelect ref={selectRef} />
+      <Button onClick={() => selectRef.current?.refetch()}>
+        Refresh
+      </Button>
+    </>
+  );
+};
+
+// Child component (BAIVFolderSelect)
+const BAIVFolderSelect = forwardRef<BAIVFolderSelectRef, Props>(
+  (props, ref) => {
+    const [fetchKey, updateFetchKey] = useFetchKey();
+
+    useImperativeHandle(ref, () => ({
+      refetch: () => {
+        updateFetchKey(); // ← Parent can trigger this
+      },
+    }));
+
+    return <BAISelect /* ... */ />;
+  }
+);
+```
+
+## Best Practices
+
+1. **Always defer fetchKey**
+   ```typescript
+   const deferredFetchKey = useDeferredValue(fetchKey);
+   ```
+
+2. **Use with transitions for refetch**
+   ```typescript
+   startRefetchTransition(() => {
+     updateFetchKey();
+   });
+   ```
+
+3. **Combine with appropriate fetchPolicy**
+   ```typescript
+   useLazyLoadQuery(query, variables, {
+     fetchPolicy: condition ? 'network-only' : 'store-only',
+     fetchKey: deferredFetchKey,
+   });
+   ```
+
+## When Not to Use
+
+- **Pattern A (Name-based)**: Uses `refetch()` from `usePaginationFragment` instead
+- **Cursor-based pagination**: Built-in refetch is usually sufficient
+- **Read-only queries**: If no refetch needed, skip this hook

--- a/.claude/skills/relay-infinite-scroll-select/references/hooks/useLazyPaginatedQuery.md
+++ b/.claude/skills/relay-infinite-scroll-select/references/hooks/useLazyPaginatedQuery.md
@@ -1,0 +1,364 @@
+# useLazyPaginatedQuery Hook
+
+## Overview
+
+`useLazyPaginatedQuery` is a custom hook for **offset-based pagination** with Relay. It accumulates items across pages, handles loading states with transitions, and resets when filter variables change.
+
+## Purpose
+
+Essential for **Pattern B (ID-based)** components that need:
+- Offset-based pagination (not cursor-based)
+- Accumulated data across pages
+- Automatic deduplication
+- Filter change detection and reset
+
+## API
+
+```typescript
+function useLazyPaginatedQuery<T, ItemType>(
+  query: GraphQLTaggedNode,
+  initialPaginationVariables: Pick<T['variables'], 'limit'>,
+  otherVariables: Omit<Partial<T['variables']>, 'limit' | 'offset'>,
+  options: Parameters<typeof useLazyLoadQuery<T>>[2],
+  { getItem, getId, getTotal }: extraOptions<T['response'], ItemType>,
+): {
+  paginationData: ItemType[] | undefined;
+  result: T['response'];
+  loadNext: () => void;
+  hasNext: boolean;
+  isLoadingNext: boolean;
+}
+```
+
+## Parameters
+
+### 1. `query: GraphQLTaggedNode`
+
+GraphQL query with `$offset` and `$limit` variables:
+
+```graphql
+query MyPaginatedQuery(
+  $offset: Int!
+  $limit: Int!
+  $filter: String
+) {
+  items(offset: $offset, first: $limit, filter: $filter) {
+    count
+    edges {
+      node {
+        id
+        name
+      }
+    }
+  }
+}
+```
+
+### 2. `initialPaginationVariables: Pick<T['variables'], 'limit'>`
+
+Initial page size (never changes after first render):
+
+```typescript
+{ limit: 10 }
+```
+
+### 3. `otherVariables: Omit<Partial<T['variables']>, 'limit' | 'offset'>`
+
+All other query variables (filter, scopeId, etc.):
+
+```typescript
+{
+  filter: mergeFilterValues([baseFilter, searchFilter]),
+  scopeId: projectId ? `project:${projectId}` : undefined,
+  permission: 'read_attribute' as const,
+}
+```
+
+**Important**: When these change, pagination resets automatically.
+
+### 4. `options: Parameters<typeof useLazyLoadQuery<T>>[2]`
+
+Relay query options:
+
+```typescript
+{
+  fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+  fetchKey: deferredFetchKey,
+}
+```
+
+### 5. `extraOptions: { getItem, getId, getTotal }`
+
+Extractors for pagination logic:
+
+```typescript
+{
+  getTotal: (result) => result.vfolder_nodes?.count ?? undefined,
+  getItem: (result) => result.vfolder_nodes?.edges?.map((edge) => edge?.node),
+  getId: (item) => item?.id,
+}
+```
+
+## Return Value
+
+```typescript
+{
+  paginationData: ItemType[] | undefined;  // Accumulated items
+  result: T['response'];                    // Current page result
+  loadNext: () => void;                     // Load next page
+  hasNext: boolean;                         // More pages available?
+  isLoadingNext: boolean;                   // Loading next page?
+}
+```
+
+## Implementation
+
+```typescript
+export function useLazyPaginatedQuery<T, ItemType>(
+  query: GraphQLTaggedNode,
+  initialPaginationVariables: Pick<T['variables'], 'limit'>,
+  otherVariables: Omit<Partial<T['variables']>, 'limit' | 'offset'>,
+  options: Parameters<typeof useLazyLoadQuery<T>>[2],
+  { getItem, getId, getTotal }: extraOptions<T['response'], ItemType>,
+) {
+  const previousResult = useRef<T['response'][]>([]);
+  const [isLoadingNext, startLoadingNextTransition] = useTransition();
+
+  // limit doesn't change after the first render
+  const [limit] = useState(initialPaginationVariables.limit);
+  const [offset, setOffset] = useState(0);
+
+  const previousOtherVariablesRef = useRef(otherVariables);
+
+  const isNewOtherVariables = !_.isEqual(
+    previousOtherVariablesRef.current,
+    otherVariables,
+  );
+
+  // Fetch the initial data using useLazyLoadQuery
+  const result = useLazyLoadQuery<T>(
+    query,
+    {
+      limit: isNewOtherVariables ? initialPaginationVariables.limit : limit,
+      offset: isNewOtherVariables ? 0 : offset,
+      ...otherVariables,
+    },
+    options,
+  );
+
+  const data = useMemo(() => {
+    const items = getItem(result);
+    if (isNewOtherVariables) {
+      previousResult.current = [];
+    }
+    return items
+      ? _.uniqBy([...previousResult.current, ...items], getId)
+      : undefined;
+  }, [result]);
+
+  const hasNext = offset + limit < (getTotal(result) as number);
+
+  const loadNext = useEventNotStable(() => {
+    if (isLoadingNext || !hasNext) return;
+    previousResult.current = data || [];
+    startLoadingNextTransition(() => {
+      const nextOffset = offset + limit;
+      setOffset(nextOffset);
+    });
+  });
+
+  useEffect(() => {
+    // Reset the offset and limit when otherVariables change after success rendering
+    if (isNewOtherVariables) {
+      previousOtherVariablesRef.current = otherVariables;
+      setOffset(0);
+    }
+  }, [isNewOtherVariables]);
+
+  return {
+    paginationData: data,
+    result,
+    loadNext,
+    hasNext,
+    isLoadingNext,
+  };
+}
+```
+
+## Key Features
+
+### 1. Automatic Pagination Reset
+
+```typescript
+const isNewOtherVariables = !_.isEqual(
+  previousOtherVariablesRef.current,
+  otherVariables,
+);
+
+// Reset when variables change
+if (isNewOtherVariables) {
+  previousResult.current = [];
+  setOffset(0);
+}
+```
+
+**Example**: When search changes, pagination starts from page 1.
+
+### 2. Item Accumulation & Deduplication
+
+```typescript
+const data = useMemo(() => {
+  const items = getItem(result);
+  if (isNewOtherVariables) {
+    previousResult.current = [];
+  }
+  return items
+    ? _.uniqBy([...previousResult.current, ...items], getId)
+    : undefined;
+}, [result]);
+```
+
+- Accumulates items from all loaded pages
+- Uses `_.uniqBy(getId)` to prevent duplicates
+- Resets on variable change
+
+### 3. Transition-Based Loading
+
+```typescript
+const loadNext = useEventNotStable(() => {
+  if (isLoadingNext || !hasNext) return;
+  previousResult.current = data || [];
+  startLoadingNextTransition(() => {
+    const nextOffset = offset + limit;
+    setOffset(nextOffset);
+  });
+});
+```
+
+- Uses `useTransition()` for non-blocking updates
+- Prevents multiple simultaneous loads
+- Checks `hasNext` before loading
+
+### 4. hasNext Calculation
+
+```typescript
+const hasNext = offset + limit < (getTotal(result) as number);
+```
+
+- Compares current offset + limit with total count
+- Returns `false` when all items loaded
+
+## Usage Example
+
+```typescript
+const { paginationData, result, loadNext, isLoadingNext } =
+  useLazyPaginatedQuery<BAIVFolderSelectPaginatedQuery, VFolderNode>(
+    graphql\`
+      query BAIVFolderSelectPaginatedQuery(
+        $offset: Int!
+        $limit: Int!
+        $filter: String
+      ) {
+        vfolder_nodes(
+          offset: $offset
+          first: $limit
+          filter: $filter
+          order: "-created_at"
+        ) {
+          count
+          edges {
+            node {
+              id
+              name
+              row_id
+            }
+          }
+        }
+      }
+    \`,
+    { limit: 10 },
+    {
+      filter: mergeFilterValues([
+        baseFilter,
+        searchStr ? \`name ilike "%\${searchStr}%"\` : null,
+      ]),
+    },
+    {
+      fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+      fetchKey: deferredFetchKey,
+    },
+    {
+      getTotal: (result) => result.vfolder_nodes?.count ?? undefined,
+      getItem: (result) =>
+        result.vfolder_nodes?.edges?.map((edge) => edge?.node),
+      getId: (item) => item?.id,
+    },
+  );
+
+// Use in BAISelect
+<BAISelect
+  options={_.map(paginationData, (item) => ({
+    label: item?.name,
+    value: item?.id,
+  }))}
+  endReached={() => loadNext()}
+  footer={
+    _.isNumber(result.vfolder_nodes?.count) ? (
+      <TotalFooter
+        loading={isLoadingNext}
+        total={result.vfolder_nodes.count}
+      />
+    ) : undefined
+  }
+/>
+```
+
+## Comparison with usePaginationFragment
+
+| Feature | useLazyPaginatedQuery | usePaginationFragment |
+|---------|----------------------|---------------------|
+| **Pagination Type** | Offset-based | Cursor-based |
+| **Data Accumulation** | Manual with `_.uniqBy` | Automatic via `@connection` |
+| **Relay Hook** | `useLazyLoadQuery` | Built-in fragment hook |
+| **Reset on Filter** | Automatic | Manual refetch |
+| **Complexity** | Higher | Lower |
+| **Use Case** | Offset pagination APIs | Cursor pagination (standard) |
+
+## Best Practices
+
+1. **Use with deferredValue**
+   ```typescript
+   const deferredOpen = useDeferredValue(open);
+   useLazyPaginatedQuery(query, variables, otherVars, {
+     fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+   });
+   ```
+
+2. **Reset pagination on search**
+   - Automatically handled when `otherVariables` changes
+   - Search string changes → `otherVariables` changes → reset to page 1
+
+3. **Check hasNext before loadNext**
+   ```typescript
+   endReached={() => {
+     if (!isLoadingNext) {
+       loadNext(); // Already checks hasNext internally
+     }
+   }}
+   ```
+
+4. **Use result for count, paginationData for items**
+   ```typescript
+   // For total count
+   result.vfolder_nodes?.count
+
+   // For accumulated items
+   paginationData // Already deduplicated
+   ```
+
+## Dependencies
+
+- `useEventNotStable`: Stable callback reference
+- `useLazyLoadQuery`: Relay's lazy query hook
+- `lodash`: For `_.uniqBy` and `_.isEqual`
+- React: `useState`, `useMemo`, `useRef`, `useEffect`, `useTransition`

--- a/.claude/skills/relay-infinite-scroll-select/references/patterns/BAIAdminResourceGroupSelect.md
+++ b/.claude/skills/relay-infinite-scroll-select/references/patterns/BAIAdminResourceGroupSelect.md
@@ -1,0 +1,267 @@
+# BAIAdminResourceGroupSelect (Pattern A: Name-Based)
+
+## Overview
+
+This component demonstrates **Pattern A**: Using `usePaginationFragment` for infinite scroll when the entity's **name is both the value and the label**. This is the simpler pattern that requires only one GraphQL query.
+
+## Key Characteristics
+
+- **Value Type**: `name` field (string)
+- **Relay Hook**: `usePaginationFragment`
+- **Multiple Mode**: Single selection only
+- **Queries**: 1 fragment with `@refetchable`
+- **Search**: Refetch-based with filter
+- **Complexity**: 🟢 Simple
+
+## When to Use
+
+Use this pattern when:
+- The entity's display name (`name` field) is unique
+- You want to use the name as the select value
+- Single selection is sufficient
+- You don't need Global ID conversion
+
+## Implementation
+
+```typescript
+import { BAIAdminResourceGroupSelectPaginationQuery } from '../../__generated__/BAIAdminResourceGroupSelectPaginationQuery.graphql';
+import { BAIAdminResourceGroupSelect_scalingGroupsV2Fragment$key } from '../../__generated__/BAIAdminResourceGroupSelect_scalingGroupsV2Fragment.graphql';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import TotalFooter from '../TotalFooter';
+import { Skeleton } from 'antd';
+import { GetRef } from 'antd/lib';
+import _ from 'lodash';
+import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { usePaginationFragment } from 'react-relay';
+import { graphql } from 'relay-runtime';
+
+export interface BAIAdminResourceGroupSelectProps
+  extends Omit<BAISelectProps, 'options' | 'labelInValue'> {
+  queryRef: BAIAdminResourceGroupSelect_scalingGroupsV2Fragment$key;
+}
+
+const BAIAdminResourceGroupSelect = ({
+  queryRef,
+  loading,
+  ...selectPropsWithoutLoading
+}: BAIAdminResourceGroupSelectProps) => {
+  const { t } = useTranslation();
+  const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+
+  const { data, loadNext, isLoadingNext, refetch, hasNext } =
+    usePaginationFragment<
+      BAIAdminResourceGroupSelectPaginationQuery,
+      BAIAdminResourceGroupSelect_scalingGroupsV2Fragment$key
+    >(
+      graphql\`
+        fragment BAIAdminResourceGroupSelect_scalingGroupsV2Fragment on Query
+        @argumentDefinitions(
+          first: { type: "Int", defaultValue: 10 }
+          after: { type: "String" }
+          filter: { type: "ScalingGroupFilter" }
+        )
+        @refetchable(queryName: "BAIAdminResourceGroupSelectPaginationQuery") {
+          allScalingGroupsV2(first: $first, after: $after, filter: $filter)
+            @connection(key: "BAIAdminResourceGroupSelect_allScalingGroupsV2") {
+            count
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      \`,
+      queryRef,
+    );
+
+  const selectOptions = _.map(data.allScalingGroupsV2.edges, (item) => ({
+    label: item.node.name,
+    value: item.node.name, // since scaling group uses name as primary key, use name as value
+  }));
+
+  return (
+    <BAISelect
+      ref={selectRef}
+      placeholder={t('comp:BAIAdminResourceGroupSelect.PlaceHolder')}
+      showSearch={{
+        autoClearSearchValue: true,
+        filterOption: false,
+      }}
+      loading={loading}
+      options={selectOptions}
+      {...selectPropsWithoutLoading}
+      searchAction={async (value) => {
+        selectRef.current?.scrollTo(0);
+        refetch({
+          filter: value
+            ? {
+                name: {
+                  contains: value,
+                },
+              }
+            : null,
+        });
+        await selectPropsWithoutLoading.searchAction?.(value);
+      }}
+      endReached={() => {
+        hasNext && loadNext(10);
+      }}
+      notFoundContent={
+        _.isUndefined(data) ? (
+          <Skeleton.Input active size="small" block />
+        ) : undefined
+      }
+      footer={
+        _.isNumber(data.allScalingGroupsV2.count) &&
+        data.allScalingGroupsV2.count > 0 ? (
+          <TotalFooter
+            loading={isLoadingNext}
+            total={data.allScalingGroupsV2.count}
+          />
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BAIAdminResourceGroupSelect;
+```
+
+## Key Points
+
+### 1. Fragment Definition
+```typescript
+graphql\`
+  fragment BAIAdminResourceGroupSelect_scalingGroupsV2Fragment on Query
+  @argumentDefinitions(
+    first: { type: "Int", defaultValue: 10 }
+    after: { type: "String" }
+    filter: { type: "ScalingGroupFilter" }
+  )
+  @refetchable(queryName: "BAIAdminResourceGroupSelectPaginationQuery") {
+    allScalingGroupsV2(first: $first, after: $after, filter: $filter)
+      @connection(key: "BAIAdminResourceGroupSelect_allScalingGroupsV2") {
+      count
+      edges {
+        node {
+          id
+          name
+        }
+      }
+    }
+  }
+\`
+```
+
+- **@argumentDefinitions**: Define variables for pagination and filtering
+- **@refetchable**: Enables refetching with new variables
+- **@connection**: Relay's normalized cache key for pagination
+
+### 2. Options Creation
+```typescript
+const selectOptions = _.map(data.allScalingGroupsV2.edges, (item) => ({
+  label: item.node.name,  // Display name
+  value: item.node.name,  // Value is same as name
+}));
+```
+
+Simple mapping from edges to options. **No labelInValue needed** since value and label are the same.
+
+### 3. Search Implementation
+```typescript
+searchAction={async (value) => {
+  selectRef.current?.scrollTo(0);  // Reset scroll position
+  refetch({
+    filter: value
+      ? {
+          name: {
+            contains: value,
+          },
+        }
+      : null,
+  });
+  await selectPropsWithoutLoading.searchAction?.(value);
+}}
+```
+
+- Scroll to top on search for better UX
+- Use `refetch` to reload data with new filter
+- Filter structure matches GraphQL schema
+
+### 4. Infinite Scroll
+```typescript
+endReached={() => {
+  hasNext && loadNext(10);
+}}
+```
+
+- Check `hasNext` before loading more
+- Load 10 items at a time (configurable)
+
+### 5. Loading States
+```typescript
+notFoundContent={
+  _.isUndefined(data) ? (
+    <Skeleton.Input active size="small" block />
+  ) : undefined
+}
+```
+
+Show skeleton during initial load, `undefined` when no results.
+
+### 6. Footer with Total Count
+```typescript
+footer={
+  _.isNumber(data.allScalingGroupsV2.count) &&
+  data.allScalingGroupsV2.count > 0 ? (
+    <TotalFooter
+      loading={isLoadingNext}
+      total={data.allScalingGroupsV2.count}
+    />
+  ) : undefined
+}
+```
+
+Display total count in footer, with loading state during pagination.
+
+## Advantages
+
+✅ **Simple**: Only one query, minimal state management
+✅ **Direct value mapping**: No need for labelInValue
+✅ **Refetch-based search**: Easy to implement and understand
+✅ **Built-in pagination**: Relay handles connection pagination
+
+## Limitations
+
+❌ **Name must be unique**: Cannot handle duplicate names
+❌ **Single selection only**: No multiple mode in this example
+❌ **No external refetch**: Cannot expose refetch via ref
+
+## Usage Example
+
+```typescript
+import { graphql, useLazyLoadQuery } from 'react-relay';
+import BAIAdminResourceGroupSelect from './BAIAdminResourceGroupSelect';
+
+const MyComponent = () => {
+  const query = useLazyLoadQuery(
+    graphql\`
+      query MyComponentQuery {
+        ...BAIAdminResourceGroupSelect_scalingGroupsV2Fragment
+      }
+    \`,
+    {}
+  );
+
+  return (
+    <BAIAdminResourceGroupSelect
+      queryRef={query}
+      placeholder="Select a resource group"
+      onChange={(name) => console.log('Selected:', name)}
+    />
+  );
+};
+```

--- a/.claude/skills/relay-infinite-scroll-select/references/patterns/BAIVFolderSelect.md
+++ b/.claude/skills/relay-infinite-scroll-select/references/patterns/BAIVFolderSelect.md
@@ -1,0 +1,745 @@
+# BAIVFolderSelect (Pattern B: ID-Based)
+
+## Overview
+
+This component demonstrates **Pattern B**: Using `useLazyLoadQuery` + `useLazyPaginatedQuery` for infinite scroll when the entity's **ID is different from the display name**. This is the more complex pattern that requires two GraphQL queries but provides maximum flexibility.
+
+## Key Characteristics
+
+- **Value Type**: `id` (Global ID) or `row_id` (UUID)
+- **Relay Hooks**: `useLazyLoadQuery` + `useLazyPaginatedQuery`
+- **Multiple Mode**: Full support
+- **Queries**: 2 (ValueQuery for selected items + PaginatedQuery for options)
+- **Search**: State-based with filter string
+- **Complexity**: 🟡 Moderate
+
+## When to Use
+
+Use this pattern when:
+- The entity's ID is different from the display name
+- You need multiple selection support
+- You need to convert between Global ID and local ID
+- You want external refetch capability via ref
+- You need optimistic UI updates
+
+## Implementation
+
+```typescript
+import { BAIVFolderSelectPaginatedQuery } from '../../__generated__/BAIVFolderSelectPaginatedQuery.graphql';
+import { BAIVFolderSelectValueQuery } from '../../__generated__/BAIVFolderSelectValueQuery.graphql';
+import { toLocalId } from '../../helper';
+import { useFetchKey } from '../../hooks';
+import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import BAILink from '../BAILink';
+import { mergeFilterValues } from '../BAIPropertyFilter';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import BAIText from '../BAIText';
+import TotalFooter from '../TotalFooter';
+import { useControllableValue } from 'ahooks';
+import { GetRef, Skeleton } from 'antd';
+import _ from 'lodash';
+import {
+  useDeferredValue,
+  useImperativeHandle,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export type VFolderNode = NonNullable<
+  NonNullable<
+    BAIVFolderSelectPaginatedQuery['response']['vfolder_nodes']
+  >['edges'][number]
+>['node'];
+
+export interface BAIVFolderSelectRef {
+  refetch: () => void;
+}
+
+export interface BAIVFolderSelectProps
+  extends Omit<BAISelectProps, 'options' | 'labelInValue' | 'ref'> {
+  currentProjectId?: string;
+  onClickVFolder?: (value: string) => void;
+  filter?: string;
+  valuePropName?: 'id' | 'row_id';
+  excludeDeleted?: boolean;
+  ref?: React.Ref<BAIVFolderSelectRef>;
+}
+
+// Exclude deleted or deleting vfolders
+const excludeDeletedStatusFilter =
+  'status != "DELETE_PENDING" & status != "DELETE_ONGOING" & status != "DELETE_ERROR" & status != "DELETE_COMPLETE"';
+
+const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
+  loading,
+  currentProjectId,
+  onClickVFolder,
+  filter,
+  excludeDeleted,
+  valuePropName = 'id',
+  ref,
+  ...selectProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+  const [controllableValue, setControllableValue] = useControllableValue<
+    string | string[] | undefined
+  >(selectProps);
+  const [controllableOpen, setControllableOpen] = useControllableValue<boolean>(
+    selectProps,
+    {
+      valuePropName: 'open',
+      trigger: 'onOpenChange',
+    },
+  );
+  const deferredOpen = useDeferredValue(controllableOpen);
+  const [searchStr, setSearchStr] = useState<string>();
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const mergedFilter = mergeFilterValues([
+    excludeDeleted ? excludeDeletedStatusFilter : null,
+    filter,
+  ]);
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  // Defer query refetch to prevent flickering during user selection
+  const deferredControllableValue = useDeferredValue(controllableValue);
+
+  const { vfolder_nodes: selectedVFolderNodes } =
+    useLazyLoadQuery<BAIVFolderSelectValueQuery>(
+      graphql\`
+        query BAIVFolderSelectValueQuery(
+          $selectedFilter: String
+          $skipSelectedVFolder: Boolean!
+          $scopeId: ScopeField
+        ) {
+          vfolder_nodes(
+            scope_id: $scopeId
+            filter: $selectedFilter
+            permission: "read_attribute"
+          ) @skip(if: $skipSelectedVFolder) {
+            edges {
+              node {
+                name
+                id
+                row_id
+              }
+            }
+          }
+        }
+      \`,
+      {
+        selectedFilter: mergeFilterValues(
+          [
+            !_.isEmpty(deferredControllableValue)
+              ? mergeFilterValues(
+                  _.castArray(deferredControllableValue).map((value) => {
+                    // When valuePropName is 'id', convert Global ID to local UUID
+                    // When valuePropName is 'row_id', use the value directly
+                    const filterValue =
+                      valuePropName === 'id' ? toLocalId(value) : value;
+                    return \`\${valuePropName} == "\${filterValue}"\`;
+                  }),
+                  '|',
+                )
+              : null,
+            mergedFilter,
+          ],
+          '&',
+        ),
+        skipSelectedVFolder: _.isEmpty(deferredControllableValue),
+        scopeId: currentProjectId ? \`project:\${currentProjectId}\` : undefined,
+      },
+      {
+        fetchPolicy: !_.isEmpty(deferredControllableValue)
+          ? 'store-or-network'
+          : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+    );
+
+  const { paginationData, result, loadNext, isLoadingNext } =
+    useLazyPaginatedQuery<BAIVFolderSelectPaginatedQuery, VFolderNode>(
+      graphql\`
+        query BAIVFolderSelectPaginatedQuery(
+          $offset: Int!
+          $limit: Int!
+          $scopeId: ScopeField
+          $filter: String
+          $permission: VFolderPermissionValueField
+        ) {
+          vfolder_nodes(
+            scope_id: $scopeId
+            offset: $offset
+            first: $limit
+            filter: $filter
+            permission: $permission
+            order: "-created_at"
+          ) {
+            count
+            edges {
+              node {
+                id
+                name
+                row_id
+              }
+            }
+          }
+        }
+      \`,
+      { limit: 10 },
+      {
+        filter: mergeFilterValues([
+          mergedFilter,
+          searchStr ? \`name ilike "%\${searchStr}%"\` : null,
+        ]),
+        scopeId: currentProjectId ? \`project:\${currentProjectId}\` : undefined,
+        permission: 'read_attribute' as const,
+      },
+      {
+        fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+      {
+        getTotal: (result) => result.vfolder_nodes?.count ?? undefined,
+        getItem: (result) =>
+          result.vfolder_nodes?.edges?.map((edge) => edge?.node),
+        getId: (item) => item?.id,
+      },
+    );
+
+  // Expose refetch function through ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: () => {
+        startRefetchTransition(() => {
+          updateFetchKey();
+        });
+      },
+    }),
+    [updateFetchKey, startRefetchTransition],
+  );
+
+  const availableOptions = _.map(paginationData, (item) => ({
+    label: item?.name,
+    value: item?.[valuePropName],
+  }));
+
+  const controllableValueWithLabel = selectedVFolderNodes?.edges
+    ? // Sort by deferredControllableValue order to maintain selection order
+      _.castArray(deferredControllableValue)
+        .map((value) => {
+          const edge = selectedVFolderNodes.edges.find(
+            (edge) => edge?.node?.[valuePropName] === value,
+          );
+          return edge
+            ? {
+                label: edge.node?.name,
+                value: edge.node?.[valuePropName],
+              }
+            : null;
+        })
+        .filter(
+          (item): item is { label: string; value: string } => item !== null,
+        )
+    : !_.isEmpty(deferredControllableValue)
+      ? _.castArray(deferredControllableValue).map((value) => ({
+          label: value,
+          value: value,
+        }))
+      : undefined;
+
+  const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
+    controllableValueWithLabel,
+  );
+
+  return (
+    <BAISelect
+      ref={selectRef}
+      placeholder={t('comp:BAIVFolderSelect.SelectFolder')}
+      loading={
+        loading ||
+        controllableValue !== deferredControllableValue ||
+        isPendingRefetch
+      }
+      {...selectProps}
+      searchAction={async (value) => {
+        setSearchStr(value);
+        await selectProps.searchAction?.(value);
+      }}
+      showSearch={{
+        searchValue: searchStr,
+        autoClearSearchValue: true,
+        filterOption: false,
+        ...(_.isObject(selectProps.showSearch)
+          ? _.omit(selectProps.showSearch, ['searchValue'])
+          : {}),
+      }}
+      labelRender={({ label, value }) => {
+        return onClickVFolder ? (
+          <BAILink onClick={() => onClickVFolder(_.toString(value))}>
+            {label}
+          </BAILink>
+        ) : (
+          <>
+            {label}
+            <BAIText type="secondary">
+              &nbsp; (
+              <BAIText
+                ellipsis
+                type="secondary"
+                style={{
+                  width: 80,
+                }}
+                monospace
+              >
+                {valuePropName === 'id'
+                  ? toLocalId(_.toString(value))
+                  : _.toString(value)}
+              </BAIText>
+              )
+            </BAIText>
+          </>
+        );
+      }}
+      optionRender={({ label, value }) => (
+        <>
+          {label}
+          <BAIText type="secondary">
+            &nbsp; (
+            <BAIText
+              ellipsis
+              style={{
+                width: 80,
+              }}
+              type="secondary"
+              monospace
+            >
+              {valuePropName === 'id'
+                ? toLocalId(_.toString(value))
+                : _.toString(value)}
+            </BAIText>
+            )
+          </BAIText>
+        </>
+      )}
+      value={
+        controllableValue !== deferredControllableValue
+          ? optimisticValueWithLabel
+          : controllableValueWithLabel
+      }
+      labelInValue
+      onChange={(value, option) => {
+        // In multiple mode, when removing tags, value.label is a React element
+        // So we need to find the original label from availableOptions
+        const valueWithOriginalLabel = _.castArray(value).map((v) => {
+          // If label is string, use it directly; if React element, find from options
+          const label = _.isString(v.label)
+            ? v.label
+            : (availableOptions.find((opt) => opt.value === v.value)?.label ??
+              v.value);
+          return {
+            label,
+            value: v.value,
+          };
+        });
+        setOptimisticValueWithLabel(valueWithOriginalLabel);
+        setControllableValue(
+          _.castArray(value).map((v) => _.toString(v.value)),
+          option,
+        );
+      }}
+      options={availableOptions}
+      endReached={() => {
+        loadNext();
+      }}
+      open={controllableOpen}
+      onOpenChange={setControllableOpen}
+      notFoundContent={
+        _.isUndefined(paginationData) ? (
+          <Skeleton.Input active size="small" block />
+        ) : undefined
+      }
+      footer={
+        _.isNumber(result.vfolder_nodes?.count) &&
+        result.vfolder_nodes.count > 0 ? (
+          <TotalFooter
+            loading={isLoadingNext}
+            total={result.vfolder_nodes.count}
+          />
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BAIVFolderSelect;
+```
+
+## Key Points
+
+### 1. Dual Query Architecture
+
+**Query 1: Selected Values (useLazyLoadQuery)**
+```typescript
+const { vfolder_nodes: selectedVFolderNodes } =
+  useLazyLoadQuery<BAIVFolderSelectValueQuery>(
+    graphql\`
+      query BAIVFolderSelectValueQuery(
+        $selectedFilter: String
+        $skipSelectedVFolder: Boolean!
+        $scopeId: ScopeField
+      ) {
+        vfolder_nodes(
+          scope_id: $scopeId
+          filter: $selectedFilter
+          permission: "read_attribute"
+        ) @skip(if: $skipSelectedVFolder) {
+          edges {
+            node {
+              name
+              id
+              row_id
+            }
+          }
+        }
+      }
+    \`,
+    {
+      selectedFilter: /* ... */,
+      skipSelectedVFolder: _.isEmpty(deferredControllableValue),
+      scopeId: currentProjectId ? \`project:\${currentProjectId}\` : undefined,
+    },
+    {
+      fetchPolicy: !_.isEmpty(deferredControllableValue)
+        ? 'store-or-network'
+        : 'store-only',
+      fetchKey: deferredFetchKey,
+    },
+  );
+```
+
+- **@skip directive**: Skip query when no selection (optimization)
+- **fetchPolicy**: `store-or-network` when has selection, `store-only` when empty
+- **Purpose**: Get labels for currently selected IDs
+
+**Query 2: Paginated Options (useLazyPaginatedQuery)**
+```typescript
+const { paginationData, result, loadNext, isLoadingNext } =
+  useLazyPaginatedQuery<BAIVFolderSelectPaginatedQuery, VFolderNode>(
+    graphql\`
+      query BAIVFolderSelectPaginatedQuery(
+        $offset: Int!
+        $limit: Int!
+        $scopeId: ScopeField
+        $filter: String
+        $permission: VFolderPermissionValueField
+      ) {
+        vfolder_nodes(
+          scope_id: $scopeId
+          offset: $offset
+          first: $limit
+          filter: $filter
+          permission: $permission
+          order: "-created_at"
+        ) {
+          count
+          edges {
+            node {
+              id
+              name
+              row_id
+            }
+          }
+        }
+      }
+    \`,
+    { limit: 10 },
+    { /* other variables */ },
+    {
+      fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+      fetchKey: deferredFetchKey,
+    },
+    {
+      getTotal: (result) => result.vfolder_nodes?.count ?? undefined,
+      getItem: (result) =>
+        result.vfolder_nodes?.edges?.map((edge) => edge?.node),
+      getId: (item) => item?.id,
+    },
+  );
+```
+
+- **Offset-based pagination**: Not cursor-based
+- **fetchPolicy**: `network-only` when open, `store-only` when closed
+- **Purpose**: Get paginated list of available options
+
+### 2. State Management
+
+**Controllable Values**
+```typescript
+const [controllableValue, setControllableValue] = useControllableValue<
+  string | string[] | undefined
+>(selectProps);
+
+const [controllableOpen, setControllableOpen] = useControllableValue<boolean>(
+  selectProps,
+  {
+    valuePropName: 'open',
+    trigger: 'onOpenChange',
+  },
+);
+```
+
+- Use `useControllableValue` from ahooks for controlled/uncontrolled support
+- Handle both `value` and `open` props
+
+**Deferred Values**
+```typescript
+const deferredOpen = useDeferredValue(controllableOpen);
+const deferredControllableValue = useDeferredValue(controllableValue);
+const deferredFetchKey = useDeferredValue(fetchKey);
+```
+
+- Prevent parent Suspense from triggering
+- Smooth transitions during async operations
+- Critical for good UX
+
+**Fetch Key Pattern**
+```typescript
+const [fetchKey, updateFetchKey] = useFetchKey();
+
+// In ref handler
+useImperativeHandle(
+  ref,
+  () => ({
+    refetch: () => {
+      startRefetchTransition(() => {
+        updateFetchKey();
+      });
+    },
+  }),
+  [updateFetchKey, startRefetchTransition],
+);
+```
+
+- Allow external refetch via ref
+- Use transition for non-blocking update
+
+### 3. Value-to-Label Mapping
+
+```typescript
+const controllableValueWithLabel = selectedVFolderNodes?.edges
+  ? // Sort by deferredControllableValue order to maintain selection order
+    _.castArray(deferredControllableValue)
+      .map((value) => {
+        const edge = selectedVFolderNodes.edges.find(
+          (edge) => edge?.node?.[valuePropName] === value,
+        );
+        return edge
+          ? {
+              label: edge.node?.name,
+              value: edge.node?.[valuePropName],
+            }
+          : null;
+      })
+      .filter(
+        (item): item is { label: string; value: string } => item !== null,
+      )
+  : !_.isEmpty(deferredControllableValue)
+    ? _.castArray(deferredControllableValue).map((value) => ({
+        label: value,
+        value: value,
+      }))
+    : undefined;
+```
+
+- Map selected IDs to `{ label, value }` pairs
+- Maintain selection order
+- Fallback to value as label if no data yet
+
+### 4. Optimistic Updates
+
+```typescript
+const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
+  controllableValueWithLabel,
+);
+
+// In BAISelect value prop
+value={
+  controllableValue !== deferredControllableValue
+    ? optimisticValueWithLabel  // Use optimistic during transition
+    : controllableValueWithLabel // Use real data when stable
+}
+```
+
+- Show user's selection immediately
+- Switch to real data when query resolves
+- Prevents flicker during selection
+
+### 5. Multiple Mode Support
+
+```typescript
+onChange={(value, option) => {
+  // In multiple mode, when removing tags, value.label is a React element
+  // So we need to find the original label from availableOptions
+  const valueWithOriginalLabel = _.castArray(value).map((v) => {
+    // If label is string, use it directly; if React element, find from options
+    const label = _.isString(v.label)
+      ? v.label
+      : (availableOptions.find((opt) => opt.value === v.value)?.label ??
+        v.value);
+    return {
+      label,
+      value: v.value,
+    };
+  });
+  setOptimisticValueWithLabel(valueWithOriginalLabel);
+  setControllableValue(
+    _.castArray(value).map((v) => _.toString(v.value)),
+    option,
+  );
+}}
+```
+
+- **Critical**: Use `_.castArray()` to handle both single and array values
+- Handle React element labels when removing tags
+- Find original label from availableOptions
+
+### 6. Global ID Conversion
+
+```typescript
+const filterValue =
+  valuePropName === 'id' ? toLocalId(value) : value;
+return \`\${valuePropName} == "\${filterValue}"\`;
+```
+
+- When `valuePropName === 'id'`, convert Global ID to local UUID
+- Backend filter uses local IDs, not Global IDs
+- `toLocalId()` from helper.ts
+
+### 7. Filter Merging
+
+```typescript
+const mergedFilter = mergeFilterValues([
+  excludeDeleted ? excludeDeletedStatusFilter : null,
+  filter,
+]);
+
+// In search
+filter: mergeFilterValues([
+  mergedFilter,
+  searchStr ? \`name ilike "%\${searchStr}%"\` : null,
+]),
+```
+
+- Combine multiple filter conditions
+- Null filters are ignored
+- Default operator is `&` (AND)
+
+### 8. Loading States
+
+```typescript
+loading={
+  loading ||
+  controllableValue !== deferredControllableValue ||
+  isPendingRefetch
+}
+```
+
+Three loading conditions:
+1. External `loading` prop
+2. Value transition (controllable !== deferred)
+3. Manual refetch in progress
+
+## Advantages
+
+✅ **Flexible value type**: Support both Global ID and row_id
+✅ **Multiple selection**: Full support with proper label handling
+✅ **Optimistic updates**: Smooth UX during async operations
+✅ **External refetch**: Expose refetch via ref
+✅ **Global ID conversion**: Automatic handling
+✅ **Filter composition**: Easy to add external filters
+✅ **Deferred values**: No Suspense flicker
+
+## Limitations
+
+❌ **Complex**: Requires two queries and more state
+❌ **More code**: ~350 lines vs ~100 lines for Pattern A
+❌ **Higher token cost**: Uses more tokens for generation
+
+## Usage Examples
+
+### Basic Usage
+```typescript
+const MyComponent = () => {
+  const [selectedFolders, setSelectedFolders] = useState<string[]>([]);
+
+  return (
+    <BAIVFolderSelect
+      mode="multiple"
+      value={selectedFolders}
+      onChange={setSelectedFolders}
+      currentProjectId="project-123"
+      placeholder="Select folders"
+    />
+  );
+};
+```
+
+### With External Refetch
+```typescript
+const MyComponent = () => {
+  const vfolderSelectRef = useRef<BAIVFolderSelectRef>(null);
+
+  const handleRefresh = () => {
+    vfolderSelectRef.current?.refetch();
+  };
+
+  return (
+    <>
+      <BAIVFolderSelect
+        ref={vfolderSelectRef}
+        valuePropName="id"
+        currentProjectId="project-123"
+      />
+      <Button onClick={handleRefresh}>Refresh</Button>
+    </>
+  );
+};
+```
+
+### With External Filter
+```typescript
+const MyComponent = () => {
+  const [ownershipFilter, setOwnershipFilter] = useState('');
+
+  return (
+    <BAIVFolderSelect
+      filter={mergeFilterValues([
+        'status != "DELETE_COMPLETE"',
+        ownershipFilter ? \`ownership_type == "\${ownershipFilter}"\` : null,
+      ])}
+      excludeDeleted
+    />
+  );
+};
+```
+
+### With Click Handler
+```typescript
+const MyComponent = () => {
+  const navigate = useNavigate();
+
+  return (
+    <BAIVFolderSelect
+      onClickVFolder={(folderId) => {
+        navigate(\`/folders/\${folderId}\`);
+      }}
+    />
+  );
+};
+```


### PR DESCRIPTION
resolves #4933 (FR-1861)

# Relay Infinite Scroll Select Component Creator Skill

Added a new Claude skill that helps create Relay-based infinite scroll select components extending BAISelect. The skill supports two implementation patterns:

- **Pattern A (Name-Based)**: Simple implementation using `usePaginationFragment` when the entity's name is both the value and label
- **Pattern B (ID-Based)**: More complex implementation using `useLazyLoadQuery` + `useLazyPaginatedQuery` when the entity's ID is different from the display name

The skill includes:
- Detailed implementation guides for both patterns
- Code examples with BAIAdminResourceGroupSelect and BAIVFolderSelect
- Helper functions for Global ID conversion and filter composition
- Custom hooks for pagination and cache invalidation
- Best practices for performance optimization
- Common pitfalls and solutions

This skill will help developers quickly implement standardized select components with infinite scrolling, search, optimistic updates, and multiple selection modes.

**Checklist:**
- [x] Documentation