### PR TITLE
feat(FR-1922): missing vallidation of importing from github and gitlab

### DIFF
--- a/react/src/components/ImportRepoForm.tsx
+++ b/react/src/components/ImportRepoForm.tsx
@@ -76,6 +76,13 @@ const createRepoBootstrapScript = (
   return scriptLines.filter(Boolean).join('\n');
 };
 
+// Only allow: https://github.com/owner/repo or https://github.com/owner/repo/ or https://github.com/owner/repo/tree/branch
+const GITHUB_URL_REGEX =
+  /^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)(\/?)$|^https:\/\/github\.com\/([\w.-]+)\/([\w.-]+)\/tree\/([\w./-]+)$/;
+
+const GITLAB_URL_REGEX =
+  /^https:\/\/gitlab\.com\/([\w.-]+)\/([\w.-]+)(\/?)$|^https:\/\/gitlab\.com\/([\w.-]+)\/([\w.-]+)\/-\/tree\/([\w./-]+)$/;
+
 const ImportRepoForm: React.FC<ImportFromURLFormProps> = ({
   urlType,
   initialUrl,
@@ -297,10 +304,7 @@ const ImportRepoForm: React.FC<ImportFromURLFormProps> = ({
           { required: true },
           { type: 'string', max: 2048 },
           {
-            pattern:
-              urlType === 'github'
-                ? /^(https?):\/\/github\.com\/([\w./-]{1,})$/
-                : /^(https?):\/\/gitlab\.com\/([\w./-]{1,})$/,
+            pattern: urlType === 'github' ? GITHUB_URL_REGEX : GITLAB_URL_REGEX,
             message: t('import.WrongURLType'),
           },
         ]}


### PR DESCRIPTION
Resolves #5060 ([FR-1922](https://lablup.atlassian.net/browse/FR-1922))

# Improved URL validation for GitHub and GitLab repository imports

This PR enhances the validation of GitHub and GitLab repository URLs during import by:

1. Implementing more precise regex patterns that validate specific URL formats:
    - For GitHub: Allows `https://github.com/owner/repo`, `https://github.com/owner/repo/`, or `https://github.com/owner/repo/tree/branch`
    - For GitLab: Allows `https://gitlab.com/owner/repo`, `https://gitlab.com/owner/repo/`, or `https://gitlab.com/owner/repo/-/tree/branch`
2. Extracting the regex patterns into named constants (`GITHUB_URL_REGEX` and `GITLAB_URL_REGEX`) for better code organization and reusability

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1922]: https://lablup.atlassian.net/browse/FR-1922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ