### PR TITLE
fix(FR-1923): missing version control of BAIAdminResourceGroupSelect

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
@@ -37,7 +37,8 @@ const BAIAdminResourceGroupSelect = ({
         )
         @refetchable(queryName: "BAIAdminResourceGroupSelectPaginationQuery") {
           allScalingGroupsV2(first: $first, after: $after, filter: $filter)
-            @connection(key: "BAIAdminResourceGroupSelect_allScalingGroupsV2") {
+            @connection(key: "BAIAdminResourceGroupSelect_allScalingGroupsV2")
+            @since(version: "25.18.0") {
             count
             edges {
               node {

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -836,6 +836,9 @@ class Client {
       // Instead of adding conditional logic in all related components, make it supported starting from version 25.17.0 or later.
       this._features['reservoir'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('25.18.0')) {
+      this._features['admin-resource-group-select'] = true;
+    }
     if (this.isManagerVersionCompatibleWith('25.18.2')) {
       this._features['allow-only-ro-permission-for-model-project-folder'] = true;
     }


### PR DESCRIPTION
Resolves #5062 ([FR-1923](https://lablup.atlassian.net/browse/FR-1923))

# Add version check for admin resource group select feature

This PR adds a version check for the admin resource group select feature, making it available only for manager version 25.18.0 or later. The changes include:

1. Adding the `@since(version: "25.18.0")` directive to the `allScalingGroupsV2` GraphQL query
2. Adding a new feature flag `admin-resource-group-select` in the client
3. Conditionally rendering the resource group select component in the agent settings modal
4. Adding version checks before sending scaling group data in mutations

**Checklist:**

- [ ] Documentation
- [x] Minium required manager version: 25.18.0
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1923]: https://lablup.atlassian.net/browse/FR-1923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ