### PR TITLE
feat(FR-1930): improve defaultImportEnvironment partial path matching with flexible image string parsing

### DIFF
--- a/config.toml.sample
+++ b/config.toml.sample
@@ -3,6 +3,13 @@ apiEndpoint = "[Default API Endpoint. If blank, user input field will be shown.]
 apiEndpointText = "[Placeholder text instead of API endpoint input field.]"
 defaultSessionEnvironment = "[Default session kernel. If blank, alphabetically first kernel will be default.]"
 defaultImportEnvironment = "[Default kernel to use import features. If blank, cr.backend.ai/multiarch/python:3.9-ubuntu20.04 will be used.]"
+# Supported formats:
+#   - Full path with architecture: "registry/namespace:tag@arch" (e.g., "cr.backend.ai/multiarch/python:3.9-ubuntu20.04@x86_64")
+#     → Selects the exact image matching all components
+#   - Without architecture: "registry/namespace:tag" (e.g., "cr.backend.ai/multiarch/python:3.9-ubuntu20.04")
+#     → Selects the first available architecture for the specified tag
+#   - Without tag (registry/namespace only): "registry/namespace" (e.g., "cr.backend.ai/multiarch/python")
+#     → Selects the latest version with the first available architecture
 connectionMode = "[Connection mode. Default is API. Currenly supports API and SESSION]"
 allowChangeSigninMode = false           # Allows user to change signin mode between `API` and `SESSION`
 signupSupport = false                   # Enable/disable signup feature support. Manager plugin is required.


### PR DESCRIPTION
Resolves #5069 ([FR-1930](https://lablup.atlassian.net/browse/FR-1930))

## Summary
Enhanced the image environment selection logic to support partial image path matching for `defaultImportEnvironment` configuration.

## Problem
When `defaultImportEnvironment` was set to a partial image path (e.g., `registry/namespace` without tag/architecture), the system failed to select the appropriate image. Only exact full path matching was supported.

## Solution
Implemented flexible partial path matching with the following behavior:

| Format | Example | Behavior |
|--------|---------|----------|
| Full path with architecture | `registry/namespace:tag@arch` | Exact match |
| Without architecture | `registry/namespace:tag` | Selects first available architecture |
| Without tag | `registry/namespace` | Selects latest version |

## Key Changes

### New Utilities (`react/src/helper/index.tsx`)
- **`parseImageString()`**: Parses Docker image strings correctly, handling registry ports (e.g., `myregistry.org:5000/namespace:tag`)
- **`removeArchitectureFromImageFullName()`**: Helper for partial matching without architecture

### Component Updates (`ImageEnvironmentSelectFormItems.tsx`)
- Added partial matching logic after exact matching fails
- Supports all three format patterns listed above

### Testing (`react/src/helper/index.test.tsx`)
- Added 23 comprehensive test cases covering:
  - Standard images with all components
  - Registry with port numbers
  - IP addresses and IPv6 registries
  - Nested namespaces
  - Edge cases and defensive null/undefined handling

### Documentation (`config.toml.sample`)
- Added documentation explaining supported formats for `defaultImportEnvironment`

## Files Modified
- `config.toml.sample` (+7 lines)
- `react/src/components/ImageEnvironmentSelectFormItems.tsx` (+51/-5 lines)
- `react/src/helper/index.test.tsx` (+229 lines)
- `react/src/helper/index.tsx` (+83 lines)

## Technical Notes
- Tag separator `:` is correctly distinguished from registry port `:` by checking only after the last `/`
- Defensive validation added for null/undefined inputs
- Images are sorted by version (latest first), so selecting `images[0]` gives the latest version

**Checklist:**

- [x] Test case(s) to demonstrate the difference of before/after (23 Jest tests added)
- [x] Documentation (Added to config.toml.sample)


[FR-1930]: https://lablup.atlassian.net/browse/FR-1930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ