### PR TITLE
fix(FR-1931): change suppotable reservoir version to 25.17.0

### DIFF
--- a/react/src/pages/ReservoirPage.tsx
+++ b/react/src/pages/ReservoirPage.tsx
@@ -171,7 +171,7 @@ const ReservoirPage: React.FC = () => {
             count
             edges {
               node {
-                id
+                id @since(version: "25.17.0")
                 ...BAIArtifactTableArtifactFragment
                 ...BAIImportArtifactModalArtifactFragment
                 ...BAIDeactivateArtifactsModalArtifactsFragment

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -821,9 +821,6 @@ class Client {
     if (this.isManagerVersionCompatibleWith('25.13.2')) {
       this._features['copy-on-terminal'] = true;
     }
-    if (this.isManagerVersionCompatibleWith('25.14.0')) {
-      this._features['reservoir'] = true;
-    }
     if (this.isManagerVersionCompatibleWith('25.15.0')) {
       this._features['agent-stats'] = true;
     }
@@ -835,6 +832,9 @@ class Client {
     }
     if (this.isManagerVersionCompatibleWith('25.17.0')) {
       this._features['background-file-delete'] = true;
+      // The 'reservoir' feature is introduced with 25.14.0, but ArtifactRegistry.id is introduced with 25.17.0.
+      // Instead of adding conditional logic in all related components, make it supported starting from version 25.17.0 or later.
+      this._features['reservoir'] = true;
     }
     if (this.isManagerVersionCompatibleWith('25.18.2')) {
       this._features['allow-only-ro-permission-for-model-project-folder'] = true;


### PR DESCRIPTION
Resolves #5071 ([FR-1931](https://lablup.atlassian.net/browse/FR-1931))

# Update Reservoir Feature Compatibility to Version 25.17.0

This PR updates the version compatibility for the 'reservoir' feature from 25.14.0 to 25.17.0. The change is necessary because the `ArtifactRegistry.id` field, which is used in the reservoir feature, is only available from version 25.17.0 onwards. This is reflected by adding the `@since(version: "25.17.0")` directive to the GraphQL query in ReservoirPage.

Rather than implementing conditional logic in all related components, we've simplified by making the entire reservoir feature available only from version 25.17.0.

**Checklist:**

- [ ] Documentation
- [x] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1931]: https://lablup.atlassian.net/browse/FR-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ