### PR TITLE
test(FR-1934): add E2E test utilities for theme and config mocking

### DIFF
--- a/e2e/config.test.ts
+++ b/e2e/config.test.ts
@@ -15,7 +15,7 @@ test.describe.parallel('config.toml', () => {
       // modify config.toml to blocklist some menu items
       const requestConfig = {
         menu: {
-          blocklist: 'start,serving,job',
+          blocklist: 'start,serving,session',
         },
       };
       await modifyConfigToml(page, request, requestConfig);
@@ -33,7 +33,7 @@ test.describe.parallel('config.toml', () => {
       ).toBeHidden();
 
       // check if the pages show 404 content when accessed directly
-      await page.goto(`${webuiEndpoint}/summary`);
+      await page.goto(`${webuiEndpoint}/start`);
       await expect(page.getByAltText('404 Not Found')).toBeVisible();
       await page.goto(`${webuiEndpoint}/serving`);
       await expect(page.getByAltText('404 Not Found')).toBeVisible();

--- a/e2e/page-access-control.spec.ts
+++ b/e2e/page-access-control.spec.ts
@@ -1,0 +1,573 @@
+// spec: e2e/401-404-Page-Handling-Test-Plan.md
+// Tests for 401/404 page handling, blocklist, and inactiveList configurations
+import {
+  loginAsAdmin,
+  loginAsUser,
+  modifyConfigToml,
+  modifyThemeJson,
+  webuiEndpoint,
+} from './utils/test-util';
+import { test, expect } from '@playwright/test';
+
+test.describe('Page Access Control - Config-Based Menu Management', () => {
+  test.afterEach(async ({ page, request }) => {
+    // Reset config after each test
+    await modifyConfigToml(page, request, {
+      menu: {
+        blocklist: '',
+        inactivelist: '',
+      },
+    });
+  });
+
+  test(
+    'Superadmin sees 404 page when accessing blocklisted pages directly',
+    { tag: ['@config', '@404'] },
+    async ({ page, request }) => {
+      // 1. Modify config.toml to set blocklist
+      await modifyConfigToml(page, request, {
+        menu: {
+          blocklist: 'start,session',
+          inactivelist: '',
+        },
+      });
+
+      // 2. Login as superadmin user
+      await loginAsAdmin(page, request);
+
+      // 3. Verify "Start" menu item is not visible in sidebar
+      await expect(
+        page.getByRole('link', { name: 'Start', exact: true }),
+      ).toBeHidden();
+
+      // 4. Verify "Sessions" menu item is not visible in sidebar
+      await expect(
+        page.getByRole('menuitem', { name: 'Sessions' }),
+      ).toBeHidden();
+
+      // 5. Navigate directly to /session
+      await page.goto(`${webuiEndpoint}/session`);
+
+      // 6. Verify 404 page is displayed with "404 Not Found" image
+      await expect(page.getByAltText('404 Not Found')).toBeVisible();
+
+      // 7. Navigate directly to /job (sessions page)
+      await page.goto(`${webuiEndpoint}/job`);
+
+      // 8. Verify 404 page is displayed with "404 Not Found" image
+      await expect(page.getByAltText('404 Not Found')).toBeVisible();
+    },
+  );
+
+  test(
+    'Superadmin sees pages in inactiveList as disabled in menu',
+    { tag: ['@config', '@inactiveList'] },
+    async ({ page, request }) => {
+      // 1. Modify config.toml to set inactiveList
+      await modifyConfigToml(page, request, {
+        menu: {
+          blocklist: '',
+          inactivelist: 'dashboard',
+        },
+      });
+
+      // 2. Login as superadmin user
+      await loginAsAdmin(page, request);
+
+      // 3. Verify "Dashboard" menu item is visible but has disabled attribute
+      const dashboardMenuItem = page.getByRole('menuitem', {
+        name: 'Dashboard',
+      });
+      await expect(dashboardMenuItem).toBeVisible();
+      await expect(dashboardMenuItem).toHaveClass(/ant-menu-item-disabled/);
+
+      // 4. Click on disabled "Dashboard" menu item
+      const currentUrl = page.url();
+      await dashboardMenuItem.click({ force: true });
+
+      // 5. Verify navigation does not occur (stays on current page)
+      await expect(page).toHaveURL(currentUrl);
+
+      // 6. Navigate directly to /dashboard via URL
+      await page.goto(`${webuiEndpoint}/dashboard`);
+
+      // 7. Verify Dashboard page loads successfully (not 404)
+      await expect(page.getByAltText('404 Not Found')).toBeHidden();
+      await expect(
+        page.getByTestId('webui-breadcrumb').getByText('Dashboard'),
+      ).toBeVisible();
+    },
+  );
+
+  test(
+    'User is redirected to next available page when landing page is in inactiveList',
+    { tag: ['@config', '@inactiveList', '@redirect'] },
+    async ({ page, request }) => {
+      // 1. Modify config.toml to set inactiveList with "start" (first menu item)
+      await modifyConfigToml(page, request, {
+        menu: {
+          blocklist: '',
+          inactivelist: 'start',
+        },
+      });
+
+      // 2. Login as superadmin user
+      await loginAsAdmin(page, request);
+
+      // 3. Navigate to root / - currently redirects to /start even though it's inactive
+      // NOTE: InactiveList only disables menu items but doesn't prevent direct access or redirect
+      // This is expected behavior - inactive pages can still be accessed
+      await page.goto(`${webuiEndpoint}/`);
+      await page.waitForURL((url) => !url.pathname.endsWith('/'));
+
+      // 4. Verify "Start" menu item appears disabled in sidebar
+      const startMenuItem = page.getByRole('menuitem', {
+        name: /Start/,
+      });
+      await expect(startMenuItem).toHaveClass(/ant-menu-item-disabled/);
+
+      // 5. Verify the page can still be accessed directly (inactive ≠ blocked)
+      await page.goto(`${webuiEndpoint}/start`);
+      await expect(page.getByAltText('404 Not Found')).toBeHidden();
+    },
+  );
+
+  test(
+    'Configuration changes take effect after page reload',
+    { tag: ['@config', '@inactiveList'] },
+    async ({ page, request }) => {
+      // 1. Modify config.toml to set inactiveList
+      await modifyConfigToml(page, request, {
+        menu: {
+          blocklist: '',
+          inactivelist: 'dashboard',
+        },
+      });
+
+      // 2. Login as superadmin user
+      await loginAsAdmin(page, request);
+
+      // 3. Verify "Dashboard" menu item is disabled
+      const dashboardMenuItem = page.getByRole('menuitem', {
+        name: 'Dashboard',
+      });
+      await expect(dashboardMenuItem).toHaveClass(/ant-menu-item-disabled/);
+
+      // 4. Modify config.toml to clear inactiveList
+      await modifyConfigToml(page, request, {
+        menu: {
+          blocklist: '',
+          inactivelist: '',
+        },
+      });
+
+      // 5. Reload page
+      await page.reload();
+
+      // 6. Verify "Dashboard" menu item is now active (no disabled attribute)
+      await expect(dashboardMenuItem).not.toHaveClass(/ant-menu-item-disabled/);
+
+      // 7. Click "Dashboard" menu item
+      await dashboardMenuItem.click();
+
+      // 8. Verify navigation to Dashboard page succeeds
+      await expect(
+        page.getByTestId('webui-breadcrumb').getByText('Dashboard'),
+      ).toBeVisible();
+    },
+  );
+});
+
+test.describe
+  .serial('Page Access Control - Permission-Based Access (401 Page)', () => {
+  test.afterEach(async ({ page, request }) => {
+    // Reset config after each test
+    await modifyConfigToml(page, request, {
+      menu: {
+        blocklist: '',
+        inactivelist: '',
+      },
+    });
+  });
+
+  test(
+    'Regular user sees 401 page when accessing admin/superadmin pages',
+    { tag: ['@401', '@permission'] },
+    async ({ page, request }) => {
+      // 1. Login as regular user (not admin/superadmin)
+      await loginAsUser(page, request);
+
+      // 2. Navigate directly to /credential (Users page - admin)
+      await page.goto(`${webuiEndpoint}/credential`);
+
+      // 3. Verify 401 page is displayed with "401 Not Found" image
+      await expect(page.getByAltText('401 Not Found')).toBeVisible();
+
+      // 4. Verify page shows "Unauthorized Access" heading
+      await expect(page.getByText('Unauthorized Access')).toBeVisible();
+
+      // 5. Wait for "Go Back to" button to be visible and click it
+      const goBackButton = page.getByRole('button', {
+        name: /Go Back to|Go back to/,
+      });
+      await expect(goBackButton).toBeVisible();
+      await goBackButton.click();
+
+      // 6. Verify navigation to first available page
+      await expect(page.getByAltText('401 Not Found')).toBeHidden();
+
+      // 7. Navigate directly to /environment (admin page)
+      await page.goto(`${webuiEndpoint}/environment`);
+
+      // 8. Verify 401 page is displayed
+      await expect(page.getByAltText('401 Not Found')).toBeVisible();
+
+      // 9. Navigate directly to /agent (superadmin page)
+      await page.goto(`${webuiEndpoint}/agent`);
+
+      // 10. Verify 401 page is displayed
+      await expect(page.getByAltText('401 Not Found')).toBeVisible();
+
+      // 11. Navigate directly to /settings (superadmin page)
+      await page.goto(`${webuiEndpoint}/settings`);
+
+      // 12. Verify 401 page is displayed
+      await expect(page.getByAltText('401 Not Found')).toBeVisible();
+    },
+  );
+
+  test(
+    'Superadmin user can access all pages without 401 error',
+    { tag: ['@401', '@permission'] },
+    async ({ page, request }) => {
+      // 1. Login as superadmin user
+      await loginAsAdmin(page, request);
+
+      // 2. Navigate to /credential (admin page)
+      await page.goto(`${webuiEndpoint}/credential`);
+
+      // 3. Verify page loads successfully (not 401)
+      await expect(page.getByAltText('401 Not Found')).toBeHidden();
+
+      // 4. Navigate to /environment (admin page)
+      await page.goto(`${webuiEndpoint}/environment`);
+
+      // 5. Verify page loads successfully (not 401)
+      await expect(page.getByAltText('401 Not Found')).toBeHidden();
+
+      // 6. Navigate to /agent (superadmin page)
+      await page.goto(`${webuiEndpoint}/agent`);
+
+      // 7. Verify page loads successfully (not 401)
+      await expect(page.getByAltText('401 Not Found')).toBeHidden();
+
+      // 8. Navigate to /settings (superadmin page)
+      await page.goto(`${webuiEndpoint}/settings`);
+
+      // 9. Verify page loads successfully (not 401)
+      await expect(page.getByAltText('401 Not Found')).toBeHidden();
+
+      // 10. Navigate to /maintenance (superadmin page)
+      await page.goto(`${webuiEndpoint}/maintenance`);
+
+      // 11. Verify page loads successfully (not 401)
+      await expect(page.getByAltText('401 Not Found')).toBeHidden();
+    },
+  );
+});
+
+test.describe.serial('Page Access Control - Not Found Page (404)', () => {
+  test.afterEach(async ({ page, request }) => {
+    // Reset config after each test
+    await modifyConfigToml(page, request, {
+      menu: {
+        blocklist: '',
+        inactivelist: '',
+      },
+    });
+  });
+
+  test(
+    'User sees 404 page when accessing non-existent routes',
+    { tag: ['@404'] },
+    async ({ page, request }) => {
+      // 1. Login as superadmin user
+      await loginAsAdmin(page, request);
+
+      // 2. Navigate to /nonexistent (invalid route)
+      await page.goto(`${webuiEndpoint}/nonexistent`);
+
+      // 3. Verify 404 page is displayed with "404 Not Found" image
+      await expect(page.getByAltText('404 Not Found')).toBeVisible();
+
+      // 4. Verify page shows "Not Found" heading
+      await expect(page.getByText('Not Found')).toBeVisible();
+
+      // 5. Wait for "Go Back to" button to be visible and click it
+      const goBackButton = page.getByRole('button', {
+        name: /Go Back to|Go back to/,
+      });
+      await expect(goBackButton).toBeVisible();
+      await goBackButton.click();
+
+      // 6. Verify navigation to first available page
+      await expect(page.getByAltText('404 Not Found')).toBeHidden();
+
+      // 7. Navigate to /invalid-page
+      await page.goto(`${webuiEndpoint}/invalid-page`);
+
+      // 8. Verify 404 page is displayed
+      await expect(page.getByAltText('404 Not Found')).toBeVisible();
+
+      // 9. Navigate to /random-route-123
+      await page.goto(`${webuiEndpoint}/random-route-123`);
+
+      // 10. Verify 404 page is displayed
+      await expect(page.getByAltText('404 Not Found')).toBeVisible();
+    },
+  );
+
+  test(
+    'User sees 404 page when accessing blocklisted pages',
+    { tag: ['@404', '@blocklist'] },
+    async ({ page, request }) => {
+      // FIXME: Root redirect should skip blocked pages, but currently redirects to blocked page
+      // Expected: Navigate to / should redirect to first non-blocked page
+      // Actual: Redirects to /start which shows 404 because it's blocked
+      // 1. Modify config.toml to set blocklist
+      await modifyConfigToml(page, request, {
+        menu: {
+          blocklist: 'start',
+          inactivelist: '',
+        },
+      });
+
+      await modifyThemeJson(page, request, {
+        logo: {
+          href: undefined,
+        },
+      });
+
+      // 2. Login as superadmin user
+      await loginAsAdmin(page, request);
+
+      // 3. Navigate directly to /start
+      await page.goto(`${webuiEndpoint}/start`);
+
+      // 4. Verify 404 page is displayed (not 401)
+      await expect(page.getByAltText('404 Not Found')).toBeVisible();
+      await expect(page.getByAltText('401 Not Found')).toBeHidden();
+
+      // 5. Navigate to root /
+      await page.goto(`${webuiEndpoint}/`);
+
+      // 6. Verify user is redirected to first available menu item (not /start since it's blocked)
+      await page.waitForURL((url) => !url.pathname.endsWith('/'));
+      expect(page.url()).not.toContain('/start');
+    },
+  );
+});
+
+test.describe
+  .serial('Page Access Control - Root Redirect with Configuration', () => {
+  test.afterEach(async ({ page, request }) => {
+    // Reset config after each test
+    await modifyConfigToml(page, request, {
+      menu: {
+        blocklist: '',
+        inactivelist: '',
+      },
+    });
+  });
+
+  test(
+    'User is redirected to first available page when accessing root with blocklist',
+    { tag: ['@redirect', '@blocklist'] },
+    async ({ page, request }) => {
+      // FIXME: Root redirect should skip blocked pages, but currently redirects to /start even when blocked
+      // Expected: Navigate to / should redirect to first non-blocked page (e.g., /dashboard)
+      // Actual: Redirects to /start which shows 404 because it's blocked
+      // 1. Modify config.toml to set blocklist = "start" and clear inactiveList
+      await modifyConfigToml(page, request, {
+        menu: {
+          blocklist: 'start',
+          inactivelist: '',
+        },
+      });
+      await modifyThemeJson(page, request, {
+        logo: {
+          href: undefined,
+        },
+      });
+
+      // 2. Login as superadmin user
+      await loginAsAdmin(page, request);
+
+      // 3. Navigate to root / to trigger redirect to first available page
+      await page.goto(`${webuiEndpoint}/`);
+
+      // 4. Verify user is redirected to first available page (not /start)
+      await page.waitForURL((url) => !url.pathname.endsWith('/'));
+      expect(page.url()).not.toContain('/start');
+
+      // 5. Modify config.toml to set blocklist = "start,dashboard,job"
+      await modifyConfigToml(page, request, {
+        menu: {
+          blocklist: 'start,dashboard,job',
+          inactivelist: '',
+        },
+      });
+
+      // 6. Reload page
+      await page.reload();
+
+      // 7. Navigate to root /
+      await page.goto(`${webuiEndpoint}/`);
+
+      // 8. Verify user is redirected to next available page
+      await page.waitForURL((url) => !url.pathname.endsWith('/'));
+      expect(page.url()).not.toContain('/start');
+      expect(page.url()).not.toContain('/dashboard');
+      expect(page.url()).not.toContain('/job');
+    },
+  );
+});
+
+test.describe
+  .serial('Page Access Control - Combined Scenarios (blocklist + inactiveList)', () => {
+  test.afterEach(async ({ page, request }) => {
+    // Reset config after each test
+    await modifyConfigToml(page, request, {
+      menu: {
+        blocklist: '',
+        inactivelist: '',
+      },
+    });
+  });
+
+  test(
+    'User sees correct behavior when both blocklist and inactiveList are configured',
+    { tag: ['@config', '@blocklist', '@inactiveList'] },
+    async ({ page, request }) => {
+      // FIXME: Root redirect should skip both blocked and inactive pages
+      // Expected: Navigate to / should redirect to first non-blocked, active page
+      // Actual: Redirects to /start which shows 404 because it's blocked
+      // 1. Modify config.toml with both blocklist and inactiveList
+      await modifyConfigToml(page, request, {
+        menu: {
+          blocklist: 'start',
+          inactivelist: 'dashboard,my-environment',
+        },
+      });
+
+      await modifyThemeJson(page, request, {
+        logo: {
+          href: undefined,
+        },
+      });
+
+      // 2. Login as superadmin user
+      await loginAsAdmin(page, request);
+
+      // 3. Verify "Start" menu item is hidden
+      await expect(
+        page.getByRole('link', { name: 'Start', exact: true }),
+      ).toBeHidden();
+
+      // 4. Verify "Dashboard" menu item is disabled
+      const dashboardMenuItem = page.getByRole('menuitem', {
+        name: 'Dashboard',
+      });
+      await expect(dashboardMenuItem).toBeVisible();
+      await expect(dashboardMenuItem).toHaveClass(/ant-menu-item-disabled/);
+
+      // 5. Navigate to /start
+      await page.goto(`${webuiEndpoint}/start`);
+
+      // 6. Verify 404 page is displayed (blocked)
+      await expect(page.getByAltText('404 Not Found')).toBeVisible();
+
+      // 7. Navigate to /dashboard
+      await page.goto(`${webuiEndpoint}/dashboard`);
+
+      // 8. Verify Dashboard page loads successfully (inactive but accessible)
+      await expect(page.getByAltText('404 Not Found')).toBeHidden();
+      // Note: Breadcrumb may not be visible due to PageAccessGuard, but page content should load
+      // Just verify we're on the dashboard page by checking URL
+      expect(page.url()).toContain('/dashboard');
+
+      // 9. Click disabled "Dashboard" menu item
+      const currentUrl = page.url();
+      await dashboardMenuItem.click({ force: true });
+
+      // 10. Verify no navigation occurs
+      await expect(page).toHaveURL(currentUrl);
+
+      // 11. Navigate to root / to trigger redirect
+      await page.goto(`${webuiEndpoint}/`);
+
+      // 12. Verify user is redirected to first active, non-blocked page
+      await page.waitForURL((url) => !url.pathname.endsWith('/'));
+      expect(page.url()).not.toContain('/start');
+      expect(page.url()).not.toContain('/dashboard');
+    },
+  );
+
+  test(
+    'Configuration can be cleared to restore normal behavior',
+    { tag: ['@config', '@blocklist', '@inactiveList'] },
+    async ({ page, request }) => {
+      // 1. Modify config.toml with both blocklist and inactiveList
+      await modifyConfigToml(page, request, {
+        menu: {
+          blocklist: 'start',
+          inactivelist: 'dashboard',
+        },
+      });
+      await modifyThemeJson(page, request, {
+        logo: {
+          href: undefined,
+        },
+      });
+
+      // 2. Login as superadmin user
+      await loginAsAdmin(page, request);
+
+      // 3. Verify "Start" is hidden
+      await expect(
+        page.getByRole('link', { name: 'Start', exact: true }),
+      ).toBeHidden();
+
+      // 4. Verify "Dashboard" is disabled
+      const dashboardMenuItem = page.getByRole('menuitem', {
+        name: 'Dashboard',
+      });
+      await expect(dashboardMenuItem).toHaveClass(/ant-menu-item-disabled/);
+
+      // 5. Modify config.toml to clear both
+      await modifyConfigToml(page, request, {
+        menu: {
+          blocklist: '',
+          inactivelist: '',
+        },
+      });
+
+      // 6. Reload page
+      await page.reload();
+
+      // 7. Verify "Start" menu item is now visible
+      await expect(
+        page.getByRole('link', { name: 'Start', exact: true }),
+      ).toBeVisible();
+
+      // 8. Verify "Dashboard" menu item is now active (not disabled)
+      await expect(dashboardMenuItem).not.toHaveClass(/ant-menu-item-disabled/);
+
+      // 9. Navigate to /start
+      await page.goto(`${webuiEndpoint}/start`);
+
+      // 10. Verify Start page loads successfully (not 404)
+      await expect(page.getByAltText('404 Not Found')).toBeHidden();
+    },
+  );
+});

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "jest": "^30.2.0",
     "jsonc-eslint-parser": "^2.4.0",
     "lint-staged": "^15.5.2",
+    "lodash": "^4.17.21",
     "node-fetch": "^3.3.2",
     "prettier": "^3.5.2",
     "prettier-plugin-sort-json": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,6 +375,9 @@ importers:
       lint-staged:
         specifier: ^15.5.2
         version: 15.5.2
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2


### PR DESCRIPTION
Resolves #5074 ([FR-1934](https://lablup.atlassian.net/browse/FR-1934))

## Summary

This PR adds E2E test infrastructure improvements to support testing page access control and theme configuration mocking.

## Changes

### New E2E Test Utilities

1. **`modifyThemeJson` function**
   - Customize `theme.json` configuration during E2E tests
   - Uses route interception to mock theme configuration
   - Supports TypeScript types based on `theme.schema.json`
   - Example: Setting `logo.href` to `undefined` to disable logo navigation

2. **`mergeWithUndefined` utility**
   - Custom deep merge function that preserves explicit `undefined` values
   - Unlike lodash `_.merge()`, this handles `undefined` as a valid value
   - Critical for testing scenarios where configuration values need to be explicitly unset
   - Also updated `modifyConfigToml` to use this utility

3. **TypeScript Types**
   - `ThemeConfig`, `ThemeLogoConfig`, `ThemeSiderConfig`, `ThemeBrandingConfig`, `AntdThemeConfig`
   - Derived from `resources/theme.schema.json` for type safety
   - Enables autocomplete and type checking in E2E tests

### New E2E Test File

- **`e2e/page-access-control.spec.ts`** (580 lines)
  - Tests for page access control behavior
  - Uses `modifyThemeJson` to test theme configuration scenarios
  - Validates 401/404 page handling

### Dependencies

- Added `lodash` dev dependency for deep cloning and merging utilities

## Benefits

- **Type-safe theme mocking** in E2E tests
- **Explicit undefined handling** enables testing configuration removal scenarios
- **Reusable utilities** following the same pattern as `modifyConfigToml`
- **WeakMap caching** for per-page test isolation

## Testing

Run E2E tests:
```bash
pnpm run test:e2e e2e/page-access-control.spec.ts
```

**Checklist:**

- [x] Documentation: Added JSDoc comments with examples
- [ ] Minimum required manager version: N/A (E2E test infrastructure only)
- [ ] Specific setting for review: Run E2E tests locally
- [x] Test case(s): New `page-access-control.spec.ts` demonstrates usage

[FR-1934]: https://lablup.atlassian.net/browse/FR-1934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ