### PR TITLE
feat(FR-1937): add theme selection toolbar to BUI Storybook

### DIFF
--- a/packages/backend.ai-ui/.storybook/decorators.tsx
+++ b/packages/backend.ai-ui/.storybook/decorators.tsx
@@ -24,6 +24,7 @@ const GlobalConfigProvider: React.FC<StorybookProviderProps> = ({
   const { token } = theme.useToken();
   const antdLocale = getAntdLocale(locale);
   const currentThemeConfig = themeConfigs[themeStyle];
+  const isWebUIStyle = themeStyle === 'webui';
 
   return (
     <ConfigProvider
@@ -35,37 +36,35 @@ const GlobalConfigProvider: React.FC<StorybookProviderProps> = ({
         algorithm:
           themeMode === 'dark' ? theme.darkAlgorithm : theme.defaultAlgorithm,
       }}
-      modal={{
-        mask: {
-          blur: false,
+      {...(isWebUIStyle && {
+        modal: {
+          mask: { blur: false },
         },
-      }}
-      drawer={{
-        mask: {
-          blur: false,
+        drawer: {
+          mask: { blur: false },
         },
-      }}
-      tag={{
-        variant: 'outlined',
-      }}
-      form={{
-        requiredMark: (label, { required }) => (
-          <>
-            {label}
-            {!required && (
-              <BAIText
-                type="secondary"
-                style={{
-                  marginLeft: token.marginXXS,
-                  wordBreak: 'keep-all',
-                }}
-              >
-                {`(${t('general.Optional')})`}
-              </BAIText>
-            )}
-          </>
-        ),
-      }}
+        tag: {
+          variant: 'outlined',
+        },
+        form: {
+          requiredMark: (label, { required }) => (
+            <>
+              {label}
+              {!required && (
+                <BAIText
+                  type="secondary"
+                  style={{
+                    marginLeft: token.marginXXS,
+                    wordBreak: 'keep-all',
+                  }}
+                >
+                  {`(${t('general.Optional')})`}
+                </BAIText>
+              )}
+            </>
+          ),
+        },
+      })}
     >
       <div style={{ padding: '16px' }}>{children}</div>
     </ConfigProvider>

--- a/packages/backend.ai-ui/.storybook/theme.json
+++ b/packages/backend.ai-ui/.storybook/theme.json
@@ -1,0 +1,58 @@
+{
+  "light": {
+    "token": {
+      "fontFamily": "'Ubuntu', Roboto, sans-serif",
+      "colorPrimary": "#FF7A00",
+      "colorLink": "#FF7A00",
+      "colorText": "#141414",
+      "colorInfo": "#028DF2",
+      "colorError": "#FF4D4F",
+      "colorSuccess": "#00BD9B",
+      "screenXLMax": 1919,
+      "screenXXLMin": 1920,
+      "screenXXL": 1920
+    },
+    "components": {
+      "Tag": {
+        "borderRadiusSM": 1
+      },
+      "Layout": {
+        "lightSiderBg": "#FFF",
+        "siderBg": "#141414",
+        "headerBg": "#FF9729"
+      },
+      "Divider": {
+        "colorSplit": "#D9D9D9"
+      },
+      "Table": {
+        "headerBg": "#E3E3E3",
+        "headerSplitColor": "rgba(0,0,0,0.25)"
+      }
+    }
+  },
+  "dark": {
+    "token": {
+      "fontFamily": "'Ubuntu', Roboto, sans-serif",
+      "colorPrimary": "#DC6B03",
+      "colorLink": "#DC6B03",
+      "colorText": "#FFF",
+      "colorInfo": "#009BDD",
+      "colorError": "#DC4446",
+      "colorSuccess": "#03A487",
+      "colorFillSecondary": "#262626",
+      "screenXLMax": 1919,
+      "screenXXLMin": 1920,
+      "screenXXL": 1920
+    },
+    "components": {
+      "Tag": {
+        "borderRadiusSM": 1
+      },
+      "Layout": {
+        "lightSiderBg": "#FFF",
+        "siderBg": "#141414",
+        "headerBg": "#E88A28"
+      }
+    }
+  }
+}

--- a/packages/backend.ai-ui/.storybook/themeConfig.ts
+++ b/packages/backend.ai-ui/.storybook/themeConfig.ts
@@ -1,4 +1,4 @@
-import webuiThemeJson from '../../../resources/theme.json';
+import webuiThemeJson from './theme.json';
 import type { ThemeConfig } from 'antd';
 
 export type ThemeMode = 'light' | 'dark';


### PR DESCRIPTION
Resolves #5085 ([FR-1937](https://lablup.atlassian.net/browse/FR-1937))

## Summary

- Add theme.json in BUI package for WebUI theme configuration
- Update themeConfig.ts to import from local theme.json instead of root resources
- Apply ConfigProvider settings conditionally based on selected theme style

## Changes

| Theme Style | Theme Tokens | ConfigProvider Settings |
|-------------|--------------|-------------------------|
| Default | Ant Design defaults | Not applied |
| WebUI | Backend.AI custom | modal/drawer blur, tag variant, form requiredMark |

## Test plan

- [ ] Run Storybook and verify theme selection toolbar works
- [ ] Switch between "Default" and "WebUI" theme styles
- [ ] Verify modal/drawer blur, tag variant settings only apply in WebUI mode
- [ ] Verify light/dark mode works correctly with both theme styles


[FR-1937]: https://lablup.atlassian.net/browse/FR-1937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ