### PR TITLE
fix(FR-1938): skip useEffectEvent while searching in AgentSelect

### DIFF
--- a/react/src/components/AgentSelect.tsx
+++ b/react/src/components/AgentSelect.tsx
@@ -140,7 +140,8 @@ const AgentSelect: React.FC<Props> = ({
     : undefined;
 
   const changeToAutoWhenInvalidValueEffectEvent = useEffectEvent(() => {
-    if (fallbackToAuto && value) {
+    // skip while searching
+    if (_.isEmpty(searchStr) && fallbackToAuto && value) {
       const valueArray = _.castArray(value);
       const validValues = agentOptions.map((option) => option.value);
       const newValue = valueArray.filter((v) =>


### PR DESCRIPTION
resolves #5086 (FR-1938)

This PR modifies the `changeToAutoWhenInvalidValueEffectEvent` function in the `AgentSelect` component to skip the auto-fallback logic while a user is searching. It adds a condition to check if the search string is empty before applying the fallback behavior.

**how to test**
1. Please test this in Dogbowl.
2. Go to the Session Launcher page.
3. Select an agent.
4. Type a keyword that is not in the options.
5. Verify that the value does not automatically change to "auto".

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after