### PR TITLE
feat(FR-1942): unify resourceGroups query and add fair share configuration

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -3666,15 +3666,47 @@ type FairShareCalculationSnapshot
 }
 
 """
+Added in 26.1.0. Fair share calculation configuration for a resource group. Defines parameters for computing fair share factors across domains, projects, and users.
+"""
+type FairShareScalingGroupSpec
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  Half-life for exponential decay in days. Determines how quickly historical usage loses significance. Default is 7 days.
+  """
+  halfLifeDays: Int!
+
+  """
+  Total lookback period in days for usage aggregation. Only usage within this window is considered. Default is 28 days.
+  """
+  lookbackDays: Int!
+
+  """
+  Granularity of decay buckets in days. Usage is aggregated into buckets of this size. Default is 1 day.
+  """
+  decayUnitDays: Int!
+
+  """
+  Default weight for entities without explicit weight in this resource group. Default is 1.0.
+  """
+  defaultWeight: Decimal!
+
+  """
+  Weights for each resource type when calculating normalized usage. If a resource type is not specified, default weight (1.0) is used.
+  """
+  resourceWeights: ResourceSlot!
+}
+
+"""
 Added in 26.1.0. Configuration parameters that control how fair share factors are calculated. These parameters determine the decay rate, lookback period, and resource weighting for usage aggregation.
 """
 type FairShareSpec
   @join__type(graph: STRAWBERRY)
 {
   """
-  Base weight multiplier for this entity. Higher weight values result in higher scheduling priority. Default is 1.0. A weight of 2.0 means this entity is twice as important as one with weight 1.0.
+  Base weight multiplier for this entity. Higher weight values result in higher scheduling priority. Null means using resource group's default_weight.
   """
-  weight: Decimal!
+  weight: Decimal
 
   """
   Half-life for exponential decay in days. Determines how quickly historical usage loses significance. For example, with half_life_days=7, usage from 7 days ago contributes half as much as today's usage.
@@ -5885,6 +5917,26 @@ type Mutation
 
   """Added in 25.19.0. Update the traffic status of a route."""
   updateRouteTrafficStatus(input: UpdateRouteTrafficStatusInput!): UpdateRouteTrafficStatusPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.1.0. Upsert domain fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does.
+  """
+  upsertDomainFairShareWeight(input: UpsertDomainFairShareWeightInput!): UpsertDomainFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.1.0. Upsert project fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does.
+  """
+  upsertProjectFairShareWeight(input: UpsertProjectFairShareWeightInput!): UpsertProjectFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.1.0. Upsert user fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does.
+  """
+  upsertUserFairShareWeight(input: UpsertUserFairShareWeightInput!): UpsertUserFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.1.0. Update fair share configuration for a resource group (superadmin only). Only provided fields are updated; others retain their existing values.
+  """
+  updateResourceGroupFairShareSpec(input: UpdateResourceGroupFairShareSpecInput!): UpdateResourceGroupFairShareSpecPayload! @join__field(graph: STRAWBERRY)
 }
 
 """Added in 24.12.0."""
@@ -6107,6 +6159,7 @@ enum NotificationRuleType
   SESSION_STARTED @join__enumValue(graph: STRAWBERRY)
   SESSION_TERMINATED @join__enumValue(graph: STRAWBERRY)
   ARTIFACT_DOWNLOAD_COMPLETED @join__enumValue(graph: STRAWBERRY)
+  ENDPOINT_LIFECYCLE_CHANGED @join__enumValue(graph: STRAWBERRY)
 }
 
 """Added in 25.14.0"""
@@ -7115,11 +7168,8 @@ type Query
   """Added in 25.14.0"""
   reservoirRegistries(before: String = null, after: String = null, first: Int = null, last: Int = null, offset: Int = null, limit: Int = null): ReservoirRegistryConnection! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.18.0. List resource groups for a specific project"""
-  resourceGroups(project: ID!, filter: ResourceGroupFilter = null, orderBy: [ResourceGroupOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourceGroupConnection! @join__field(graph: STRAWBERRY)
-
-  """Added in 25.18.0. List all resource groups"""
-  allResourceGroups(filter: ResourceGroupFilter = null, orderBy: [ResourceGroupOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourceGroupConnection! @join__field(graph: STRAWBERRY)
+  """Added in 26.1.0. List resource groups"""
+  resourceGroups(filter: ResourceGroupFilter = null, orderBy: [ResourceGroupOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourceGroupConnection! @join__field(graph: STRAWBERRY)
 
   """Added in 25.14.0"""
   defaultArtifactRegistry(artifactType: ArtifactType!): ArtifactRegistry @join__field(graph: STRAWBERRY)
@@ -7376,7 +7426,7 @@ input ResourceConfigInput
   resourceOpts: ResourceOptsInput = null
 }
 
-"""Added in 25.18.0. Resource group with structured configuration"""
+"""Added in 26.1.0. Resource group with structured configuration"""
 type ResourceGroup implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
   @join__type(graph: STRAWBERRY)
@@ -7389,9 +7439,14 @@ type ResourceGroup implements Node
   Used as primary key and referenced by agents, sessions, and resource presets.
   """
   name: String!
+
+  """
+  Added in 26.1.0. Fair share calculation configuration for this resource group. Defines decay parameters and resource weights for fair share factor computation.
+  """
+  fairShareSpec: FairShareScalingGroupSpec!
 }
 
-"""Added in 25.18.0. Resource group connection"""
+"""Added in 26.1.0. Resource group connection"""
 type ResourceGroupConnection
   @join__type(graph: STRAWBERRY)
 {
@@ -7414,16 +7469,11 @@ type ResourceGroupEdge
   node: ResourceGroup!
 }
 
-"""Added in 25.18.0. Filter for resource groups"""
+"""Added in 26.1.0. Filter for resource groups"""
 input ResourceGroupFilter
   @join__type(graph: STRAWBERRY)
 {
   name: StringFilter = null
-  description: StringFilter = null
-  isActive: Boolean = null
-  isPublic: Boolean = null
-  scheduler: String = null
-  useHostNetwork: Boolean = null
   AND: [ResourceGroupFilter!] = null
   OR: [ResourceGroupFilter!] = null
   NOT: [ResourceGroupFilter!] = null
@@ -7436,7 +7486,7 @@ input ResourceGroupInput
   name: String!
 }
 
-"""Added in 25.18.0. Order by specification for resource groups"""
+"""Added in 26.1.0. Order by specification for resource groups"""
 input ResourceGroupOrderBy
   @join__type(graph: STRAWBERRY)
 {
@@ -7444,13 +7494,11 @@ input ResourceGroupOrderBy
   direction: OrderDirection! = ASC
 }
 
+"""Added in 26.1.0. Fields available for ordering resource groups"""
 enum ResourceGroupOrderField
   @join__type(graph: STRAWBERRY)
 {
   NAME @join__enumValue(graph: STRAWBERRY)
-  CREATED_AT @join__enumValue(graph: STRAWBERRY)
-  IS_ACTIVE @join__enumValue(graph: STRAWBERRY)
-  IS_PUBLIC @join__enumValue(graph: STRAWBERRY)
 }
 
 type ResourceLimit
@@ -7554,9 +7602,9 @@ type ResourceSlotEntry
   resourceType: String!
 
   """
-  Quantity of the resource as a decimal string to preserve precision. For 'cpu': number of cores (e.g., '2.0', '0.5'). For 'mem': bytes (e.g., '4294967296' for 4GB). For accelerators: device count or share fraction.
+  Quantity of the resource. For 'cpu': number of cores (e.g., 2.0, 0.5). For 'mem': bytes (e.g., 4294967296 for 4GB). For accelerators: device count or share fraction.
   """
-  quantity: String!
+  quantity: Decimal!
 }
 
 """
@@ -7580,6 +7628,23 @@ input ResourceSlotInput
 {
   """List of resource allocations."""
   entries: [ResourceSlotEntryInput!]!
+}
+
+"""
+Added in 26.1.0. Input for a single resource weight entry. Specifies how much a resource type contributes to fair share calculations.
+"""
+input ResourceWeightEntryInput
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  Resource type identifier (e.g., 'cpu', 'mem', 'cuda.shares'). Must match the resource types used in the cluster.
+  """
+  resourceType: String!
+
+  """
+  Weight multiplier for this resource type in fair share calculations. Higher weight means this resource contributes more to the normalized usage. Set to null to remove this resource type (revert to default weight 1.0). Example: 0.001 for memory (bytes) to normalize against CPU cores.
+  """
+  weight: Decimal = null
 }
 
 """
@@ -8655,6 +8720,47 @@ type UpdateReservoirRegistryPayload
   reservoir: ReservoirRegistry!
 }
 
+"""
+Added in 26.1.0. Input for updating resource group fair share configuration. All fields are optional - only provided fields will be updated, others retain existing values.
+"""
+input UpdateResourceGroupFairShareSpecInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Name of the resource group to update."""
+  resourceGroup: String!
+
+  """
+  Half-life for exponential decay in days. Leave null to keep existing value.
+  """
+  halfLifeDays: Int = null
+
+  """Total lookback period in days. Leave null to keep existing value."""
+  lookbackDays: Int = null
+
+  """
+  Granularity of decay buckets in days. Leave null to keep existing value.
+  """
+  decayUnitDays: Int = null
+
+  """Default weight for entities. Leave null to keep existing value."""
+  defaultWeight: Decimal = null
+
+  """
+  Resource weights for fair share calculation. Each entry specifies a resource type and its weight multiplier. Only provided resource types are updated (partial update). Set weight to null to remove that resource type (revert to default). Leave the entire list null to keep all existing values.
+  """
+  resourceWeights: [ResourceWeightEntryInput!] = null
+}
+
+"""
+Added in 26.1.0. Payload for resource group fair share spec update mutation.
+"""
+type UpdateResourceGroupFairShareSpecPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """The updated resource group with new fair share configuration."""
+  resourceGroup: ResourceGroup!
+}
+
 """Added in 25.19.0. Input for updating route traffic status."""
 input UpdateRouteTrafficStatusInput
   @join__type(graph: STRAWBERRY)
@@ -8717,6 +8823,63 @@ type UpsertDomainConfigPayload
 }
 
 """
+Added in 26.1.0. Input for upserting domain fair share weight. The weight parameter affects scheduling priority - higher weight = higher priority. Set weight to null to use resource group's default_weight.
+"""
+input UpsertDomainFairShareWeightInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Name of the scaling group (resource group) for this fair share."""
+  resourceGroup: String!
+
+  """Name of the domain to update weight for."""
+  domainName: String!
+
+  """
+  Priority weight multiplier. Higher weight = higher priority allocation ratio. Set to null to use resource group's default_weight.
+  """
+  weight: Decimal = null
+}
+
+"""Added in 26.1.0. Payload for domain fair share weight upsert mutation."""
+type UpsertDomainFairShareWeightPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """The updated or created domain fair share record."""
+  domainFairShare: DomainFairShare!
+}
+
+"""
+Added in 26.1.0. Input for upserting project fair share weight. The weight parameter affects scheduling priority - higher weight = higher priority. Set weight to null to use resource group's default_weight.
+"""
+input UpsertProjectFairShareWeightInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Name of the scaling group (resource group) for this fair share."""
+  resourceGroup: String!
+
+  """UUID of the project to update weight for."""
+  projectId: UUID!
+
+  """Name of the domain the project belongs to."""
+  domainName: String!
+
+  """
+  Priority weight multiplier. Higher weight = higher priority allocation ratio. Set to null to use resource group's default_weight.
+  """
+  weight: Decimal = null
+}
+
+"""
+Added in 26.1.0. Payload for project fair share weight upsert mutation.
+"""
+type UpsertProjectFairShareWeightPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """The updated or created project fair share record."""
+  projectFairShare: ProjectFairShare!
+}
+
+"""
 Added in 25.16.0.
 Input for creating or updating user-level app configuration.
 The provided extra_config object will completely replace the existing configuration;
@@ -8740,6 +8903,38 @@ type UpsertUserConfigPayload
   @join__type(graph: STRAWBERRY)
 {
   appConfig: AppConfig!
+}
+
+"""
+Added in 26.1.0. Input for upserting user fair share weight. The weight parameter affects scheduling priority - higher weight = higher priority. Set weight to null to use resource group's default_weight.
+"""
+input UpsertUserFairShareWeightInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Name of the scaling group (resource group) for this fair share."""
+  resourceGroup: String!
+
+  """UUID of the project the user belongs to."""
+  projectId: UUID!
+
+  """UUID of the user to update weight for."""
+  userUuid: UUID!
+
+  """Name of the domain the user belongs to."""
+  domainName: String!
+
+  """
+  Priority weight multiplier. Higher weight = higher priority allocation ratio. Set to null to use resource group's default_weight.
+  """
+  weight: Decimal = null
+}
+
+"""Added in 26.1.0. Payload for user fair share weight upsert mutation."""
+type UpsertUserFairShareWeightPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """The updated or created user fair share record."""
+  userFairShare: UserFairShare!
 }
 
 """

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.stories.tsx
@@ -24,7 +24,7 @@ const BAIAdminResourceGroupSelectWithQuery = (
   const queryRef = useLazyLoadQuery<BAIAdminResourceGroupSelectStoriesQuery>(
     graphql`
       query BAIAdminResourceGroupSelectStoriesQuery {
-        ...BAIAdminResourceGroupSelect_allResourceGroupsFragment
+        ...BAIAdminResourceGroupSelect_resourceGroupsFragment
       }
     `,
     {},

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.tsx
@@ -1,5 +1,5 @@
 import { BAIAdminResourceGroupSelectPaginationQuery } from '../../__generated__/BAIAdminResourceGroupSelectPaginationQuery.graphql';
-import { BAIAdminResourceGroupSelect_allResourceGroupsFragment$key } from '../../__generated__/BAIAdminResourceGroupSelect_allResourceGroupsFragment.graphql';
+import { BAIAdminResourceGroupSelect_resourceGroupsFragment$key } from '../../__generated__/BAIAdminResourceGroupSelect_resourceGroupsFragment.graphql';
 import BAISelect, { BAISelectProps } from '../BAISelect';
 import TotalFooter from '../TotalFooter';
 import { Skeleton } from 'antd';
@@ -12,7 +12,7 @@ import { graphql } from 'relay-runtime';
 
 export interface BAIAdminResourceGroupSelectProps
   extends Omit<BAISelectProps, 'options' | 'labelInValue'> {
-  queryRef: BAIAdminResourceGroupSelect_allResourceGroupsFragment$key;
+  queryRef: BAIAdminResourceGroupSelect_resourceGroupsFragment$key;
 }
 
 const BAIAdminResourceGroupSelect = ({
@@ -26,19 +26,19 @@ const BAIAdminResourceGroupSelect = ({
   const { data, loadNext, isLoadingNext, refetch, hasNext } =
     usePaginationFragment<
       BAIAdminResourceGroupSelectPaginationQuery,
-      BAIAdminResourceGroupSelect_allResourceGroupsFragment$key
+      BAIAdminResourceGroupSelect_resourceGroupsFragment$key
     >(
       graphql`
-        fragment BAIAdminResourceGroupSelect_allResourceGroupsFragment on Query
+        fragment BAIAdminResourceGroupSelect_resourceGroupsFragment on Query
         @argumentDefinitions(
           first: { type: "Int", defaultValue: 10 }
           after: { type: "String" }
           filter: { type: "ResourceGroupFilter" }
         )
         @refetchable(queryName: "BAIAdminResourceGroupSelectPaginationQuery") {
-          allResourceGroups(first: $first, after: $after, filter: $filter)
-            @connection(key: "BAIAdminResourceGroupSelect_allResourceGroups")
-            @since(version: "25.18.0") {
+          resourceGroups(first: $first, after: $after, filter: $filter)
+            @connection(key: "BAIAdminResourceGroupSelect_resourceGroups")
+            @since(version: "26.1.0") {
             count
             edges {
               node {
@@ -52,7 +52,7 @@ const BAIAdminResourceGroupSelect = ({
       queryRef,
     );
 
-  const selectOptions = _.map(data.allResourceGroups.edges, (item) => ({
+  const selectOptions = _.map(data.resourceGroups.edges, (item) => ({
     label: item.node.name,
     value: item.node.name, // since scaling group uses name as primary key, use name as value
   }));
@@ -90,11 +90,11 @@ const BAIAdminResourceGroupSelect = ({
         ) : undefined
       }
       footer={
-        _.isNumber(data.allResourceGroups.count) &&
-        data.allResourceGroups.count > 0 ? (
+        _.isNumber(data.resourceGroups.count) &&
+        data.resourceGroups.count > 0 ? (
           <TotalFooter
             loading={isLoadingNext}
-            total={data.allResourceGroups.count}
+            total={data.resourceGroups.count}
           />
         ) : undefined
       }

--- a/react/src/components/AgentSettingModal.tsx
+++ b/react/src/components/AgentSettingModal.tsx
@@ -42,7 +42,7 @@ const AgentSettingModal: React.FC<AgentSettingModalProps> = ({
   const queryRef = useLazyLoadQuery<AgentSettingModalQuery>(
     graphql`
       query AgentSettingModalQuery {
-        ...BAIAdminResourceGroupSelect_allResourceGroupsFragment
+        ...BAIAdminResourceGroupSelect_resourceGroupsFragment
       }
     `,
     {},

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -836,11 +836,11 @@ class Client {
       // Instead of adding conditional logic in all related components, make it supported starting from version 25.17.0 or later.
       this._features['reservoir'] = true;
     }
-    if (this.isManagerVersionCompatibleWith('25.18.0')) {
-      this._features['admin-resource-group-select'] = true;
-    }
     if (this.isManagerVersionCompatibleWith('25.18.2')) {
       this._features['allow-only-ro-permission-for-model-project-folder'] = true;
+    }
+    if (this.isManagerVersionCompatibleWith('26.1.0')) {
+      this._features['admin-resource-group-select'] = true;
     }
   }
 


### PR DESCRIPTION
Resolves #5092 ([FR-1942](https://lablup.atlassian.net/browse/FR-1942))

## Summary

This PR unifies the resource group queries and adds fair share configuration support to the GraphQL schema.

### Changes

**GraphQL Schema Updates:**
- Consolidated `resourceGroups` and `allResourceGroups` queries into a single `resourceGroups` query (version 26.1.0)
- Removed the project-specific `resourceGroups(project: ID!)` query in favor of filter-based approach
- Added `FairShareScalingGroupSpec` type for resource group fair share configuration
- Added `FairShareSpec.weight` as nullable field (uses resource group's default_weight when null)
- Added mutations for fair share weight management:
  - `upsertDomainFairShareWeight`
  - `upsertProjectFairShareWeight`
  - `upsertUserFairShareWeight`
  - `updateResourceGroupFairShareSpec`
- Added `ENDPOINT_LIFECYCLE_CHANGED` notification rule type

**Component Updates:**
- Updated `BAIAdminResourceGroupSelect` to use the new unified `resourceGroups` query
- Renamed fragment from `allResourceGroupsFragment` to `resourceGroupsFragment`
- Updated GraphQL connection key accordingly
- Updated `AgentSettingModal` to use the new fragment name

## Impact

- **Breaking Change**: The old `allResourceGroups` query is removed and replaced with `resourceGroups`
- Components using the old fragment name need to be updated (completed in this PR)
- The new query supports filtering without requiring a project ID parameter

**Checklist:**

- [x] Documentation - GraphQL schema documentation updated
- [ ] Minimum required manager version - 26.1.0 for new fair share features
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-1942]: https://lablup.atlassian.net/browse/FR-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ