### PR TITLE
feat(FR-1943): migrate from use-query-params to nuqs

### DIFF
--- a/.claude/skills/react-url-state/SKILL.md
+++ b/.claude/skills/react-url-state/SKILL.md
@@ -28,7 +28,6 @@ Patterns from FR-1683 (#4646) migration to nuqs, FR-1431 (#4252), FR-1412
 - **Without `useDeferredValue` on `queryVariables`**, `useLazyLoadQuery` suspends on every keystroke/sort/page change — Suspense fallback flashes. This is the whole FR-1683 motivation.
 - **`useBAIPaginationOptionStateOnSearchParam` uses its own `useQueryStates`** — it doesn't share context with your page-level `useQueryStates`. Both write cleanly to URL but are independent.
 - **Batched setters in the same tick merge**, not overwrite. `setQueryParams({ a: 1 }); setQueryParams({ b: 2 })` → `{ a: 1, b: 2 }`, not `{ b: 2 }`.
-- **`useBAIPaginationOptionStateOnSearchParamLegacy` still exists** — don't introduce new usages; legacy only.
 
 ## 1. Import and hook shape
 
@@ -224,8 +223,9 @@ const [params, setParams] = useQueryStates({
 }, { history: 'replace' });
 ```
 
-`useBAIPaginationOptionStateOnSearchParamLegacy` still exists for backward
-compat — prefer the non-legacy variant (nuqs-based) for anything new.
+`useBAIPaginationOptionStateOnSearchParam` is the single URL-backed pagination
+hook (the former `...Legacy` variant was removed when its call sites were
+consolidated).
 
 ## 8. Typing URL-sized enums with `parseAsStringLiteral`
 
@@ -267,4 +267,3 @@ URL state is for: what someone else pasting the URL should see.
 - [ ] Query variables and fetchKey wrapped in `useDeferredValue` when feeding `useLazyLoadQuery`.
 - [ ] Pagination binds through `useBAIPaginationOptionStateOnSearchParam`, not hand-rolled.
 - [ ] Tab-scoped per-tab state cached via `useRef`, with a `setQueryParams(null)` reset before applying stored values.
-- [ ] `useBAIPaginationOptionStateOnSearchParamLegacy` not introduced in new code.

--- a/.specs/draft-auto-scaling-rule-management/dev-plan.md
+++ b/.specs/draft-auto-scaling-rule-management/dev-plan.md
@@ -52,7 +52,7 @@ The work splits into 5 dependency-ordered sub-tasks plus one optional polish tas
 - **Description**:
   - Replace the placeholder `AutoScalingRulePresetTab` body with a real query orchestrator that runs `prometheusQueryPresets(filter, orderBy, limit, offset)` via `useLazyLoadQuery`.
   - Render results in a `BAITable` with columns: `name`, `metricName`, `queryTemplate` (truncated with tooltip showing full PromQL), `timeWindow`, `createdAt`, `updatedAt`. Use existing date formatting helpers.
-  - Add `BAIPropertyFilter` for the `name` field (the only filter the schema currently exposes — `QueryDefinitionFilter`). Wire filter + offset/limit pagination through `useBAIPaginationOptionStateOnSearchParamLegacy` and `useQueryStates` (mirror `ServingTabContent`).
+  - Add `BAIPropertyFilter` for the `name` field (the only filter the schema currently exposes — `QueryDefinitionFilter`). Wire filter + offset/limit pagination through `useBAIPaginationOptionStateOnSearchParam` and `useQueryStates` (mirror `ServingTabContent`).
   - Add a `BAIFetchKeyButton` reload control + transition-driven loading state.
   - Add a disabled "Add Preset" toolbar button (real handler comes in Sub-task 3) so the toolbar layout is finalized once.
   - Use a Relay fragment for each row (`PrometheusQueryPresetRowFragment`) with the fields needed for both display and the (later) Edit modal.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,9 +950,6 @@ importers:
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
-      use-query-params:
-        specifier: ^2.2.2
-        version: 2.2.2(react-dom@19.2.7(react@19.2.7))(react-router-dom@6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       uuid:
         specifier: 'catalog:'
         version: 13.0.2
@@ -10748,9 +10745,6 @@ packages:
     resolution: {integrity: sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==}
     engines: {node: '>=20.0.0'}
 
-  serialize-query-params@2.0.4:
-    resolution: {integrity: sha512-y9WzzDj3BsGgKLCh0ugiinufS//YqOfao/yVJjkXA4VLuyNCfHOLU/cbulGPxs3aeCqhvROw7qPL04JSZnCo0w==}
-
   serve-handler@6.1.7:
     resolution: {integrity: sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==}
 
@@ -11690,19 +11684,6 @@ packages:
     resolution: {integrity: sha512-DXgG0kkgJN45TcyoXL49vJnn55LehnrmoHc7MbKi+QDBvr8dsesqws8UlyIWGHMR+JXgxc1nvY+jDGMlycsUcw==}
     peerDependencies:
       react: '>= 16.x'
-
-  use-query-params@2.2.2:
-    resolution: {integrity: sha512-OwGab8u8/x2xZp9uSyBsx0kXlkR9IR436zbygsYVGikPYY3OJosvve6IJVGwIJPcfyb/YHwvPrUNu65/JR++Kw==}
-    peerDependencies:
-      '@reach/router': ^1.2.1
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-      react-router-dom: '>=5'
-    peerDependenciesMeta:
-      '@reach/router':
-        optional: true
-      react-router-dom:
-        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -23762,8 +23743,6 @@ snapshots:
 
   serialize-javascript@7.0.7: {}
 
-  serialize-query-params@2.0.4: {}
-
   serve-handler@6.1.7:
     dependencies:
       bytes: 3.0.0
@@ -24894,14 +24873,6 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  use-query-params@2.2.2(react-dom@19.2.7(react@19.2.7))(react-router-dom@6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      serialize-query-params: 2.0.4
-    optionalDependencies:
-      react-router-dom: 6.30.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -25855,7 +25826,6 @@ time:
   typescript@5.5.4: '2024-07-22T23:02:51.857Z'
   typescript@5.9.3: '2025-09-30T21:19:38.784Z'
   typescript@6.0.3: '2026-04-16T23:38:27.905Z'
-  use-query-params@2.2.2: '2025-11-22T00:59:50.369Z'
   utf-8-validate@6.0.6: '2025-12-18T16:38:00.865Z'
   uuid@13.0.2: '2026-05-04T13:37:27.339Z'
   vite-plugin-checker@0.9.3: '2025-05-06T09:44:27.688Z'

--- a/react/package.json
+++ b/react/package.json
@@ -78,7 +78,6 @@
     "ts-md5": "^2.0.1",
     "tus-js-client": "catalog:",
     "typescript": "~6.0.3",
-    "use-query-params": "^2.2.2",
     "uuid": "catalog:",
     "web-vitals": "^3.5.2",
     "yaml": "^2.9.0",

--- a/react/src/components/AdminUserCredentialList.tsx
+++ b/react/src/components/AdminUserCredentialList.tsx
@@ -10,7 +10,7 @@ import {
   AdminUserCredentialListQuery$variables,
 } from '../__generated__/AdminUserCredentialListQuery.graphql';
 import { KeypairSettingModalFragment$key } from '../__generated__/KeypairSettingModalFragment.graphql';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import BAIRadioGroup from './BAIRadioGroup';
 import KeypairInfoModal from './KeypairInfoModal';
 import KeypairSettingModal from './KeypairSettingModal';
@@ -37,15 +37,10 @@ import {
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
 import { BanIcon, PlusIcon, SquarePenIcon, UndoIcon } from 'lucide-react';
+import { parseAsString, useQueryState, useQueryStates } from 'nuqs';
 import { useDeferredValue, useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
-import {
-  StringParam,
-  useQueryParam,
-  useQueryParams,
-  withDefault,
-} from 'use-query-params';
 
 type Keypair = NonNullable<
   NonNullable<
@@ -59,14 +54,17 @@ const AdminUserCredentialList: React.FC = () => {
   const { message } = App.useApp();
   const { logger } = useBAILogger();
 
-  const [action, setAction] = useQueryParam('action', StringParam);
+  const [action, setAction] = useQueryState('action', parseAsString);
 
   const [fetchKey, updateFetchKey] = useUpdatableState('first');
-  const [queryParams, setQueryParams] = useQueryParams({
-    activeType: withDefault(StringParam, 'active'),
-    order: withDefault(StringParam, undefined),
-    filter: withDefault(StringParam, undefined),
-  });
+  const [queryParams, setQueryParams] = useQueryStates(
+    {
+      activeType: parseAsString.withDefault('active'),
+      order: parseAsString,
+      filter: parseAsString,
+    },
+    { history: 'replace' },
+  );
 
   const [keypairSettingModalFrgmt, setKeypairSettingModalFrgmt] =
     useState<KeypairSettingModalFragment$key | null>(null);
@@ -83,7 +81,7 @@ const AdminUserCredentialList: React.FC = () => {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParamLegacy({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 20,
   });
@@ -174,7 +172,7 @@ const AdminUserCredentialList: React.FC = () => {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setOpenUserKeypairSettingModal(true);
 
-      setAction(undefined);
+      setAction(null);
     }
   }, [action, setAction]);
 
@@ -185,7 +183,7 @@ const AdminUserCredentialList: React.FC = () => {
           <BAIRadioGroup
             value={queryParams.activeType}
             onChange={(value) => {
-              setQueryParams({ activeType: value.target.value }, 'replaceIn');
+              setQueryParams({ activeType: value.target.value });
               setTablePaginationOption({
                 current: 1,
                 pageSize: tablePaginationOption.pageSize,
@@ -238,9 +236,9 @@ const AdminUserCredentialList: React.FC = () => {
                 type: 'string',
               },
             ]}
-            value={queryParams.filter}
+            value={queryParams.filter ?? undefined}
             onChange={(value) => {
-              setQueryParams({ filter: value }, 'replaceIn');
+              setQueryParams({ filter: value ?? null });
             }}
           />
         </BAIFlex>
@@ -532,7 +530,7 @@ const AdminUserCredentialList: React.FC = () => {
           },
         }}
         onChangeOrder={(nextOrder) => {
-          setQueryParams({ order: nextOrder }, 'replaceIn');
+          setQueryParams({ order: nextOrder ?? null });
         }}
       />
       <KeypairInfoModal

--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -12,7 +12,7 @@ import {
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
 import { ResourceSlotName } from '../hooks/backendai';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useResourceGroupsForCurrentProject } from '../hooks/useCurrentProject';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
@@ -40,10 +40,10 @@ import {
   INITIAL_FETCH_KEY,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { parseAsString, useQueryStates } from 'nuqs';
 import React, { useDeferredValue, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { StringParam, useQueryParams, withDefault } from 'use-query-params';
 
 type AgentSummary = NonNullable<
   AgentSummaryListQuery$data['agent_summary_list']
@@ -68,16 +68,19 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParamLegacy({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 20,
   });
 
-  const [queryParams, setQuery] = useQueryParams({
-    order: withDefault(StringParam, undefined),
-    filter: withDefault(StringParam, undefined),
-    status: withDefault(StringParam, 'ALIVE'),
-  });
+  const [queryParams, setQuery] = useQueryStates(
+    {
+      order: parseAsString,
+      filter: parseAsString,
+      status: parseAsString.withDefault('ALIVE'),
+    },
+    { history: 'replace' },
+  );
 
   const [fetchKey, updateFetchKey] = useFetchKey();
   const { sftpResourceGroups } = useResourceGroupsForCurrentProject();
@@ -386,7 +389,7 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
             value={queryParams.status}
             onChange={(e) => {
               const value = e.target.value;
-              setQuery({ status: value }, 'replaceIn');
+              setQuery({ status: value });
             }}
           />
 
@@ -413,9 +416,9 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
                 ],
               },
             ]}
-            value={queryParams.filter}
+            value={queryParams.filter ?? undefined}
             onChange={(value) => {
-              setQuery({ filter: value }, 'replaceIn');
+              setQuery({ filter: value ?? null });
               setTablePaginationOption({ current: 1 });
             }}
           />
@@ -453,7 +456,7 @@ const AgentSummaryList: React.FC<AgentSummaryListProps> = ({
           },
         }}
         onChangeOrder={(order) => {
-          setQuery({ order }, 'replaceIn');
+          setQuery({ order: order ?? null });
         }}
         tableSettings={{
           columnOverrides: columnOverrides,

--- a/react/src/components/AllocationHistory.tsx
+++ b/react/src/components/AllocationHistory.tsx
@@ -5,15 +5,18 @@
 import AllocationHistoryStatistics from './AllocationHistoryStatistics';
 import { Alert, Form, Select, Skeleton } from 'antd';
 import { useUpdatableState, BAIFlex, BAIFetchKeyButton } from 'backend.ai-ui';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
 import { Suspense, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { createEnumParam, useQueryParam, withDefault } from 'use-query-params';
 
 export type Period = '1D' | '1W';
-const periodParam = withDefault(createEnumParam<Period>(['1D', '1W']), '1D');
+
+const periodParam = parseAsStringLiteral(['1D', '1W'] as const).withDefault(
+  '1D',
+);
 
 const AllocationHistory: React.FC = () => {
-  const [selectedPeriod, setSelectedPeriod] = useQueryParam(
+  const [selectedPeriod, setSelectedPeriod] = useQueryState(
     'period',
     periodParam,
   );

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -9,7 +9,7 @@ import {
   ContainerRegistryListQuery$data,
 } from '../__generated__/ContainerRegistryListQuery.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
 import { usePainKiller } from '../hooks/usePainKiller';
@@ -39,10 +39,10 @@ import {
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { PlusIcon, SquarePenIcon } from 'lucide-react';
+import { parseAsString, useQueryStates } from 'nuqs';
 import { useState, useDeferredValue, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
-import { StringParam, useQueryParams, withDefault } from 'use-query-params';
 
 export type ContainerRegistry = NonNullable<
   NonNullable<
@@ -64,16 +64,19 @@ const ContainerRegistryList: React.FC<{
   const [visibleColumnSettingModal, { toggle: toggleColumnSettingModal }] =
     useToggle();
 
-  const [queryParams, setQueryParams] = useQueryParams({
-    filter: withDefault(StringParam, undefined),
-    order: withDefault(StringParam, undefined),
-  });
+  const [queryParams, setQueryParams] = useQueryStates(
+    {
+      filter: parseAsString,
+      order: parseAsString,
+    },
+    { history: 'replace' },
+  );
 
   const {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParamLegacy({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 20,
   });
@@ -432,9 +435,9 @@ const ContainerRegistryList: React.FC<{
               type: 'string',
             },
           ]}
-          value={queryParams.filter}
+          value={queryParams.filter ?? undefined}
           onChange={(value) => {
-            setQueryParams({ filter: value }, 'replaceIn');
+            setQueryParams({ filter: value ?? null });
           }}
         />
         <BAIFlex gap="xs">
@@ -485,7 +488,7 @@ const ContainerRegistryList: React.FC<{
           ),
         }}
         onChangeOrder={(order) => {
-          setQueryParams({ order }, 'replaceIn');
+          setQueryParams({ order: order ?? null });
         }}
         loading={
           deferredQueryVariables !== queryVariables ||

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -64,8 +64,6 @@ import React, {
 import { useTranslation, initReactI18next } from 'react-i18next';
 import { RelayEnvironmentProvider } from 'react-relay/hooks';
 import { useLocation } from 'react-router-dom';
-import { QueryParamProvider } from 'use-query-params';
-import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
 export const jotaiStore = createStore();
 dayjs.extend(weekday);
@@ -346,42 +344,40 @@ export const DefaultProvidersForReactRoot: React.FC<{
                * useBAIi18n.ts.
                */}
               <BAIMetaDataWrapper>
-                <QueryParamProvider adapter={ReactRouter6Adapter}>
-                  <App {...commonAppProps}>
-                    {/* Single app-wide notification renderer. Lives outside
+                <App {...commonAppProps}>
+                  {/* Single app-wide notification renderer. Lives outside
                         the Suspense below so toasts work on every route and
                         in both anonymous and authenticated states. Renders
                         null, so its position relative to the emotion caches
                         below is irrelevant. */}
-                    <NotificationHost />
-                    {/*
-                     * Two separate emotion caches are needed for CSP nonce
-                     * coverage:
-                     *
-                     * 1. StyleProvider (antd-style's custom EmotionContext):
-                     *    covers createStyles() and the antd-style css() helper.
-                     *    The nonce is passed directly as a prop.
-                     *
-                     * 2. CacheProvider (@emotion/react's CacheContext):
-                     *    covers createGlobalStyle(), which uses @emotion/react's
-                     *    Global component internally. Global reads the nonce from
-                     *    cache.sheet.nonce — it does NOT read antd-style's custom
-                     *    EmotionContext. Without this wrapper, style tags emitted
-                     *    by createGlobalStyle (e.g. ScrollbarGlobalStyle) carry no
-                     *    nonce and are blocked by `style-src 'nonce-...'` CSP.
-                     */}
-                    <CacheProvider value={emotionGlobalCache}>
-                      <StyleProvider nonce={globalThis.baiNonce}>
-                        <Suspense>
-                          {/* <BrowserRouter> */}
-                          {/* <RoutingEventHandler /> */}
-                          {children}
-                          {/* </BrowserRouter> */}
-                        </Suspense>
-                      </StyleProvider>
-                    </CacheProvider>
-                  </App>
-                </QueryParamProvider>
+                  <NotificationHost />
+                  {/*
+                   * Two separate emotion caches are needed for CSP nonce
+                   * coverage:
+                   *
+                   * 1. StyleProvider (antd-style's custom EmotionContext):
+                   *    covers createStyles() and the antd-style css() helper.
+                   *    The nonce is passed directly as a prop.
+                   *
+                   * 2. CacheProvider (@emotion/react's CacheContext):
+                   *    covers createGlobalStyle(), which uses @emotion/react's
+                   *    Global component internally. Global reads the nonce from
+                   *    cache.sheet.nonce — it does NOT read antd-style's custom
+                   *    EmotionContext. Without this wrapper, style tags emitted
+                   *    by createGlobalStyle (e.g. ScrollbarGlobalStyle) carry no
+                   *    nonce and are blocked by `style-src 'nonce-...'` CSP.
+                   */}
+                  <CacheProvider value={emotionGlobalCache}>
+                    <StyleProvider nonce={globalThis.baiNonce}>
+                      <Suspense>
+                        {/* <BrowserRouter> */}
+                        {/* <RoutingEventHandler /> */}
+                        {children}
+                        {/* </BrowserRouter> */}
+                      </Suspense>
+                    </StyleProvider>
+                  </CacheProvider>
+                </App>
               </BAIMetaDataWrapper>
             </BAIConfigProvider>
           </QueryClientProvider>

--- a/react/src/components/FolderExplorerOpener.tsx
+++ b/react/src/components/FolderExplorerOpener.tsx
@@ -2,15 +2,20 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { parseAsString, useQueryState } from 'nuqs';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { StringParam, useQueryParam } from 'use-query-params';
 
 const FolderExplorerModal = React.lazy(() => import('./FolderExplorerModalV2'));
 
+// The modal's own folder/path updates replace history; `useFolderExplorerOpener`
+// below opts into push explicitly (nuqs defaults to replace) so Back closes a
+// folder opened from a link.
+const explorerParam = parseAsString.withOptions({ history: 'replace' });
+
 const FolderExplorerOpener = () => {
-  const [folderId, setFolderId] = useQueryParam('folder', StringParam);
-  const [, setCurrentPath] = useQueryParam('path', StringParam);
+  const [folderId, setFolderId] = useQueryState('folder', explorerParam);
+  const [, setCurrentPath] = useQueryState('path', explorerParam);
   const normalizedFolderId = folderId?.replaceAll('-', '');
 
   return (
@@ -18,8 +23,8 @@ const FolderExplorerOpener = () => {
       vfolderID={normalizedFolderId || ''}
       open={!!normalizedFolderId}
       onRequestClose={() => {
-        setFolderId(null, 'replaceIn');
-        setCurrentPath(null, 'replaceIn');
+        setFolderId(null);
+        setCurrentPath(null);
       }}
       destroyOnHidden
     />
@@ -29,7 +34,10 @@ const FolderExplorerOpener = () => {
 export default FolderExplorerOpener;
 
 export const useFolderExplorerOpener = () => {
-  const [, setFolderId] = useQueryParam('folder', StringParam);
+  const [, setFolderId] = useQueryState(
+    'folder',
+    parseAsString.withOptions({ history: 'push' }),
+  );
 
   const location = useLocation();
   // a function to generate new path with folder id based on current path

--- a/react/src/components/FolderInvitationResponseModalOpener.tsx
+++ b/react/src/components/FolderInvitationResponseModalOpener.tsx
@@ -3,17 +3,17 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { BAIUnmountAfterClose } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import React from 'react';
-import { useQueryParam, StringParam } from 'use-query-params';
 
 const FolderInvitationResponseModal = React.lazy(
   () => import('./FolderInvitationResponseModal'),
 );
 
 const FolderInvitationResponseModalOpener = () => {
-  const [isInvitationOpen, setIsInvitationOpen] = useQueryParam(
+  const [isInvitationOpen, setIsInvitationOpen] = useQueryState(
     'invitation',
-    StringParam,
+    parseAsString.withOptions({ history: 'replace' }),
   );
 
   return (
@@ -21,7 +21,7 @@ const FolderInvitationResponseModalOpener = () => {
       <FolderInvitationResponseModal
         open={isInvitationOpen === 'true'}
         onCancel={() => {
-          setIsInvitationOpen(null, 'replaceIn');
+          setIsInvitationOpen(null);
         }}
       />
     </BAIUnmountAfterClose>

--- a/react/src/components/PendingSessionNodeList.tsx
+++ b/react/src/components/PendingSessionNodeList.tsx
@@ -7,7 +7,7 @@ import {
   PendingSessionNodeListQuery$variables,
 } from '../__generated__/PendingSessionNodeListQuery.graphql';
 import { useWebUINavigate } from '../hooks';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentResourceGroupValue } from '../hooks/useCurrentProject';
 import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
@@ -46,7 +46,7 @@ const PendingSessionNodeList: React.FC = () => {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParamLegacy({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 10,
   });

--- a/react/src/components/RecentlyCreatedSession.tsx
+++ b/react/src/components/RecentlyCreatedSession.tsx
@@ -14,10 +14,10 @@ import {
   BAIFetchKeyButton,
   BAIBoardItemTitle,
 } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import { useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useRefetchableFragment } from 'react-relay';
-import { useQueryParam, StringParam } from 'use-query-params';
 
 interface RecentlyCreatedSessionProps {
   queryRef: RecentlyCreatedSessionFragment$key;
@@ -30,9 +30,11 @@ const RecentlyCreatedSession: React.FC<RecentlyCreatedSessionProps> = ({
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [sessionDetailId, setSessionDetailId] = useQueryParam(
+  const [sessionDetailId, setSessionDetailId] = useQueryState(
     'sessionDetail',
-    StringParam,
+    // Push so Back closes the drawer (nuqs defaults to replace; the legacy
+    // param pushed history on open/close).
+    parseAsString.withOptions({ history: 'push' }),
   );
   const [isPendingRefetch, startRefetchTransition] = useTransition();
 
@@ -128,7 +130,7 @@ const RecentlyCreatedSession: React.FC<RecentlyCreatedSessionProps> = ({
           open={!!sessionDetailId}
           sessionId={sessionDetailId || undefined}
           onClose={() => {
-            setSessionDetailId(undefined, 'pushIn');
+            setSessionDetailId(null);
           }}
         />
       </BAIUnmountAfterClose>

--- a/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
+++ b/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
@@ -6,11 +6,14 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import ContainerLogModalWithLazyQueryLoader from './ComputeSessionNodeItems/ContainerLogModalWithLazyQueryLoader';
 import SessionDetailDrawer from './SessionDetailDrawer';
 import { BAIUnmountAfterClose } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import { useState, useEffect, useTransition } from 'react';
-import { useQueryParam, StringParam } from 'use-query-params';
 
 const SessionDetailAndContainerLogOpenerLegacy = () => {
-  const [sessionId, setSessionId] = useQueryParam('sessionDetail', StringParam);
+  const [sessionId, setSessionId] = useQueryState(
+    'sessionDetail',
+    parseAsString.withOptions({ history: 'replace' }),
+  );
   const [containerLogModalSessionId, setContainerLogModalSessionId] =
     useState<string>();
   const [isPendingLogModalOpen, startLogModalOpenTransition] = useTransition();
@@ -38,7 +41,7 @@ const SessionDetailAndContainerLogOpenerLegacy = () => {
             open={!!sessionId}
             sessionId={sessionId || undefined}
             onClose={() => {
-              setSessionId(null, 'replaceIn');
+              setSessionId(null);
             }}
           />
         </BAIUnmountAfterClose>

--- a/react/src/components/SessionDetailDrawer.tsx
+++ b/react/src/components/SessionDetailDrawer.tsx
@@ -15,8 +15,6 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 import { useLocation } from 'react-router-dom';
 
-// import { StringParam, useQueryParam } from 'use-query-params';
-
 interface SessionDetailDrawerProps extends DrawerProps {
   sessionId?: string;
 }

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -8,7 +8,7 @@ import {
   convertUnitValue,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import AutoUpdateFetchKeyButton from './AutoUpdateFetchKeyButton';
 import StorageHostDetailDrawer from './StorageHostDetailDrawer';
 import { type TableColumnsType, Tag, theme, Typography } from 'antd';
@@ -87,7 +87,7 @@ const StorageProxyList = () => {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParamLegacy({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 10,
   });

--- a/react/src/components/UserSessionsMetrics.tsx
+++ b/react/src/components/UserSessionsMetrics.tsx
@@ -15,10 +15,10 @@ import { Alert, DatePicker, Empty, Skeleton, theme } from 'antd';
 import { useUpdatableState, BAIFlex, filterOutEmpty } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import * as _ from 'lodash-es';
+import { parseAsString, useQueryState } from 'nuqs';
 import { Suspense, useEffect, useMemo, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 interface UserSessionsMetricsProps {}
 
@@ -29,13 +29,13 @@ const UserSessionsMetrics: React.FC<UserSessionsMetricsProps> = () => {
 
   const [usageFetchKey, updateUsageFetchKey] = useUpdatableState('first');
   const [isPendingUsageTransition, startUsageTransition] = useTransition();
-  const [startDate, setStartDate] = useQueryParam(
+  const [startDate, setStartDate] = useQueryState(
     'startDate',
-    withDefault(StringParam, dayjs().format('YYYY-MM-DD 00:00:00')),
+    parseAsString.withDefault(dayjs().format('YYYY-MM-DD 00:00:00')),
   );
-  const [endDate, setEndDate] = useQueryParam(
+  const [endDate, setEndDate] = useQueryState(
     'endDate',
-    withDefault(StringParam, dayjs().format('YYYY-MM-DD 23:59:59')),
+    parseAsString.withDefault(dayjs().format('YYYY-MM-DD 23:59:59')),
   );
   const userInfo = useCurrentUserInfo();
   const dayDiff = dayjs(endDate).diff(dayjs(startDate), 'day');

--- a/react/src/hooks/reactPaginationQueryOptions.tsx
+++ b/react/src/hooks/reactPaginationQueryOptions.tsx
@@ -6,21 +6,19 @@
 import { LazyLoadQueryOptions } from '../helper/types';
 import type { SorterResult } from 'antd/lib/table/interface';
 import * as _ from 'lodash-es';
-import { parseAsInteger, useQueryStates } from 'nuqs';
+import {
+  parseAsArrayOf,
+  parseAsInteger,
+  parseAsJson,
+  parseAsString,
+  useQueryStates,
+} from 'nuqs';
 import { useMemo, useState } from 'react';
 import {
   fetchQuery,
   GraphQLTaggedNode,
   useRelayEnvironment,
 } from 'react-relay';
-import {
-  ArrayParam,
-  NumberParam,
-  ObjectParam,
-  StringParam,
-  useQueryParams,
-  withDefault,
-} from 'use-query-params';
 
 export type SorterInterface = Pick<SorterResult<any>, 'field' | 'order'>;
 
@@ -48,9 +46,7 @@ export const orderToAntdSorterResult = (order: string[]) => {
     return {
       field,
       order: (orderKey === 'ASC' ? 'ascend' : 'descend') as
-        | 'ascend'
-        | 'descend'
-        | null,
+        'ascend' | 'descend' | null,
     };
   });
 };
@@ -94,12 +90,17 @@ export const useRelayPaginationQueryOptions = <
 }) => {
   const [isPending, setIsPending] = useState(false);
 
-  const [params, setParams] = useQueryParams({
-    page: NumberParam,
-    pageSize: NumberParam,
-    order: ArrayParam,
-    filter: ObjectParam,
-  });
+  const [params, setParams] = useQueryStates(
+    {
+      page: parseAsInteger,
+      pageSize: parseAsInteger,
+      order: parseAsArrayOf(parseAsString),
+      filter: parseAsJson<F>((value) => value as F),
+    },
+    {
+      history: 'replace',
+    },
+  );
 
   const page = params.page || defaultVariables.page;
   const pageSize = params.pageSize || defaultVariables.pageSize;
@@ -145,8 +146,10 @@ export const useRelayPaginationQueryOptions = <
         setParams({
           page: newPage,
           pageSize: newPageSize,
-          order: newOrder as [], // TODO: not use as []
-          filter: newFilter as {}, // TODO: not use as {}
+          order: newOrder as string[], // TODO: not use as []
+          // nuqs skips `undefined` in partial updates; `null` removes the key,
+          // matching the legacy clearing behavior when refreshing to defaults.
+          filter: newFilter ?? null,
         });
         setRefreshedQueryOptions((prev) => ({
           ...prev,
@@ -207,12 +210,17 @@ export const useBAIPaginationQueryOptions = ({
     filter?: string;
   }) => any;
 }) => {
-  const [params, setParams] = useQueryParams({
-    page: NumberParam,
-    pageSize: NumberParam,
-    filter: StringParam,
-    order: StringParam,
-  });
+  const [params, setParams] = useQueryStates(
+    {
+      page: parseAsInteger,
+      pageSize: parseAsInteger,
+      filter: parseAsString,
+      order: parseAsString,
+    },
+    {
+      history: 'replace',
+    },
+  );
   const page = params.page || defaultVariables.page;
   const pageSize = params.pageSize || defaultVariables.pageSize;
   const order = params.order || defaultVariables.order;
@@ -248,8 +256,10 @@ export const useBAIPaginationQueryOptions = ({
         setParams({
           page: newPage,
           pageSize: newPageSize,
-          order: newOrder,
-          filter: newFilter,
+          // `null` removes the key (nuqs skips `undefined`), so refreshing
+          // back to defaults clears stale order/filter from the URL.
+          order: newOrder ?? null,
+          filter: newFilter ?? null,
         });
         setRefreshedQueryOptions((prev) => ({
           ...prev,
@@ -341,54 +351,6 @@ export const useBAIPaginationOptionState = (
       },
     };
   }, [pageSize, current]);
-};
-
-export const useBAIPaginationOptionStateOnSearchParamLegacy = (
-  initialOptions: InitialPaginationOption,
-): BAIPaginationOptionState => {
-  const [{ pageSize, current }, setOptions] = useQueryParams({
-    current: withDefault(NumberParam, initialOptions.current),
-    pageSize: withDefault(NumberParam, initialOptions.pageSize),
-  });
-
-  const memoizedOptions = useMemo<{
-    baiPaginationOption: BAIPaginationOption;
-    tablePaginationOption: AntdBasicPaginationOption;
-  }>(() => {
-    return {
-      baiPaginationOption: {
-        limit: pageSize,
-        first: pageSize,
-        offset: current > 1 ? (current - 1) * pageSize : 0,
-      },
-      tablePaginationOption: {
-        pageSize: pageSize,
-        current: current,
-      },
-    };
-  }, [pageSize, current]);
-
-  return {
-    ...memoizedOptions,
-    setTablePaginationOption: (
-      pagination: Partial<AntdBasicPaginationOption>,
-    ) => {
-      if (
-        !_.isEqual(pagination, {
-          pageSize,
-          current,
-        })
-      ) {
-        setOptions(
-          (current) => ({
-            ...current,
-            ...pagination,
-          }),
-          'replaceIn',
-        );
-      }
-    },
-  };
 };
 
 export const useBAIPaginationOptionStateOnSearchParam = (

--- a/react/src/pages/AdminVFolderNodeListPage.tsx
+++ b/react/src/pages/AdminVFolderNodeListPage.tsx
@@ -16,7 +16,7 @@ import RestoreVFolderModal from '../components/RestoreVFolderModal';
 import VFolderNodes, { VFolderNodeInList } from '../components/VFolderNodes';
 import { handleRowSelectionChange } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { isDeletedCategory } from './VFolderNodeListPage';
 import { useToggle } from 'ahooks';
@@ -36,10 +36,10 @@ import {
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { PlusIcon } from 'lucide-react';
+import { parseAsString, useQueryStates } from 'nuqs';
 import React, { useDeferredValue, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import { StringParam, useQueryParams, withDefault } from 'use-query-params';
 
 type VFolderNodesType = NonNullableNodeOnEdges<
   AdminVFolderNodeListPageQuery$data['vfolder_nodes']
@@ -86,17 +86,20 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParamLegacy({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 10,
   });
 
-  const [queryParams, setQuery] = useQueryParams({
-    order: withDefault(StringParam, '-created_at'),
-    filter: withDefault(StringParam, undefined),
-    statusCategory: withDefault(StringParam, 'active'),
-    mode: withDefault(StringParam, 'all'),
-  });
+  const [queryParams, setQuery] = useQueryStates(
+    {
+      order: parseAsString.withDefault('-created_at'),
+      filter: parseAsString,
+      statusCategory: parseAsString.withDefault('active'),
+      mode: parseAsString.withDefault('all'),
+    },
+    { history: 'replace' },
+  );
 
   const queryMapRef = useRef({
     [queryParams.statusCategory]: { queryParams, tablePaginationOption },
@@ -231,13 +234,14 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
             const storedQuery = queryMapRef.current[key] || {
               mode: 'all',
             };
-            setQuery(
-              {
-                ...storedQuery.queryParams,
-                statusCategory: key as 'active' | 'deleted',
-              },
-              'replace',
-            );
+            // Reset the whole group first: nuqs partial updates merge, so
+            // without this the previous tab's filter/order/mode leak into a
+            // tab that has no cached state (legacy 'replace' cleared them).
+            setQuery(null);
+            setQuery({
+              ...storedQuery.queryParams,
+              statusCategory: key as 'active' | 'deleted',
+            });
             setTablePaginationOption(
               storedQuery.tablePaginationOption || { current: 1 },
             );
@@ -294,7 +298,7 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
                 optionType="button"
                 value={queryParams.mode}
                 onChange={(e) => {
-                  setQuery({ mode: e.target.value }, 'replaceIn');
+                  setQuery({ mode: e.target.value });
                   setTablePaginationOption({ current: 1 });
                   setSelectedFolderList([]);
                 }}
@@ -380,9 +384,9 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
                     ],
                   },
                 ]}
-                value={queryParams.filter || undefined}
+                value={queryParams.filter ?? undefined}
                 onChange={(value) => {
-                  setQuery({ filter: value }, 'replaceIn');
+                  setQuery({ filter: value ?? null });
                   setTablePaginationOption({ current: 1 });
                   setSelectedFolderList([]);
                 }}
@@ -494,7 +498,7 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
               },
             }}
             onChangeOrder={(order) => {
-              setQuery({ order }, 'replaceIn');
+              setQuery({ order: order ?? null });
             }}
             onRemoveRow={(removedId) => {
               setSelectedFolderList((prevSelected) =>

--- a/react/src/pages/AgentSummaryPage.tsx
+++ b/react/src/pages/AgentSummaryPage.tsx
@@ -5,21 +5,21 @@
 import AgentSummaryList from '../components/AgentSummaryList';
 import { Skeleton, theme } from 'antd';
 import { BAICard } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'agent-summary';
 
 interface ResourcesPageProps {}
 
-const tabParam = withDefault(StringParam, 'agent-summary');
+const tabParam = parseAsString
+  .withDefault('agent-summary')
+  .withOptions({ history: 'replace' });
 
 const ResourcesPage: React.FC<ResourcesPageProps> = () => {
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam, {
-    updateType: 'replace',
-  });
+  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
 
   const { token } = theme.useToken();
 

--- a/react/src/pages/BrandingPage.tsx
+++ b/react/src/pages/BrandingPage.tsx
@@ -6,17 +6,17 @@ import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import BrandingSettingList from '../components/BrandingSettingList';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
-const tabParam = withDefault(StringParam, 'branding');
+const tabParam = parseAsString.withDefault('branding');
 
 const BrandingPage: React.FC = () => {
   'use memo';
 
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
 
   return (
     <BAICard

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -36,10 +36,10 @@ import dayjs from 'dayjs';
 import { t } from 'i18next';
 import * as _ from 'lodash-es';
 import { HistoryIcon, PlusIcon, TrashIcon } from 'lucide-react';
+import { parseAsString, useQueryStates } from 'nuqs';
 import { Suspense, useState } from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useParams } from 'react-router-dom';
-import { StringParam, useQueryParams } from 'use-query-params';
 
 const useStyles = createStyles(({ css }) => ({
   fixEditableVerticalAlign: css`
@@ -83,11 +83,11 @@ function useDefaultEndpointId() {
 export function useChatProviderData(
   defaultEndpointId?: string,
 ): ChatProviderData {
-  const [{ endpointId, modelId, agentId, apiKey }] = useQueryParams({
-    endpointId: StringParam,
-    agentId: StringParam,
-    modelId: StringParam,
-    apiKey: StringParam,
+  const [{ endpointId, modelId, agentId, apiKey }] = useQueryStates({
+    endpointId: parseAsString,
+    agentId: parseAsString,
+    modelId: parseAsString,
+    apiKey: parseAsString,
   });
 
   return {

--- a/react/src/pages/ConfigurationsPage.tsx
+++ b/react/src/pages/ConfigurationsPage.tsx
@@ -6,17 +6,17 @@ import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import ConfigurationsSettingList from '../components/ConfigurationsSettingList';
 import { Card, Skeleton } from 'antd';
 import { filterOutEmpty } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'configurations';
 
-const tabParam = withDefault(StringParam, 'configurations');
+const tabParam = parseAsString.withDefault('configurations');
 
 const ConfigurationsPage = () => {
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
 
   return (
     <Card

--- a/react/src/pages/DiagnosticsPage.tsx
+++ b/react/src/pages/DiagnosticsPage.tsx
@@ -24,20 +24,20 @@ import {
   message,
 } from 'antd';
 import { BAIButton, BAICard, BAIFlex, useFetchKey } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import { Suspense, useCallback, useRef, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'diagnostics';
 type SectionKey = 'csp' | 'storage' | 'endpoint' | 'config';
 
-const tabParam = withDefault(StringParam, 'diagnostics');
+const tabParam = parseAsString.withDefault('diagnostics');
 
 const DiagnosticsPage = () => {
   'use memo';
 
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
   const [fetchKey, updateFetchKey] = useFetchKey();
   const [isPending, startTransition] = useTransition();
   const [showOnlyFailed, setShowOnlyFailed] = useState(false);

--- a/react/src/pages/EnvironmentPage.tsx
+++ b/react/src/pages/EnvironmentPage.tsx
@@ -9,15 +9,15 @@ import ResourcePresetList from '../components/ResourcePresetList';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
-const tabParam = withDefault(StringParam, 'image');
+const tabParam = parseAsString.withDefault('image');
 
 const EnvironmentPage = () => {
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
   const baiClient = useSuspendedBackendaiClient();
 
   return (

--- a/react/src/pages/InteractiveLoginPage.tsx
+++ b/react/src/pages/InteractiveLoginPage.tsx
@@ -7,10 +7,10 @@ import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { Button, Card, Descriptions } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import { Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import { StringParam, useQueryParam } from 'use-query-params';
 
 const InteractiveLoginPage = () => {
   return (
@@ -28,8 +28,8 @@ const Children = () => {
   useSuspendedBackendaiClient();
   const [userInfo] = useCurrentUserInfo();
   const { pathname, search } = useLocation();
-  const [callback] = useQueryParam('callback', StringParam);
-  const [name] = useQueryParam('name', StringParam);
+  const [callback] = useQueryState('callback', parseAsString);
+  const [name] = useQueryState('name', parseAsString);
   const { t } = useTranslation();
 
   // This route has no MainLayout, so the interactive-login card is its "main

--- a/react/src/pages/MaintenancePage.tsx
+++ b/react/src/pages/MaintenancePage.tsx
@@ -6,17 +6,17 @@ import BAIErrorBoundary from '../components/BAIErrorBoundary';
 import MaintenanceSettingList from '../components/MaintenanceSettingList';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'maintenance';
 
-const tabParam = withDefault(StringParam, 'maintenance');
+const tabParam = parseAsString.withDefault('maintenance');
 
 const MaintenancePage = () => {
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
 
   return (
     <BAICard

--- a/react/src/pages/MyEnvironmentPage.tsx
+++ b/react/src/pages/MyEnvironmentPage.tsx
@@ -5,15 +5,15 @@
 import CustomizedImageList from '../components/CustomizedImageList';
 import FlexActivityIndicator from '../components/FlexActivityIndicator';
 import { BAICard } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
-const tabParam = withDefault(StringParam, 'image');
+const tabParam = parseAsString.withDefault('image');
 
 const MyEnvironmentPage = () => {
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
 
   return (
     <BAICard

--- a/react/src/pages/ReservoirArtifactDetailPage.tsx
+++ b/react/src/pages/ReservoirArtifactDetailPage.tsx
@@ -4,6 +4,7 @@
  */
 import { ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key } from '../__generated__/ImportArtifactRevisionToFolderModalArtifactRevisionFragment.graphql';
 import {
+  ArtifactRevisionFilter,
   ArtifactStatus,
   ReservoirArtifactDetailPageQuery,
   ReservoirArtifactDetailPageQuery$data,
@@ -12,7 +13,7 @@ import {
 import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import ImportArtifactRevisionToFolderButton from '../components/ImportArtifactRevisionToFolderButton';
 import ImportArtifactRevisionToFolderModal from '../components/ImportArtifactRevisionToFolderModal';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { Button, Typography, Descriptions, theme, Tooltip } from 'antd';
 import {
@@ -41,11 +42,11 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import * as _ from 'lodash-es';
 import { Download } from 'lucide-react';
+import { parseAsJson, useQueryStates } from 'nuqs';
 import { useDeferredValue, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useParams } from 'react-router-dom';
-import { JsonParam, useQueryParams, withDefault } from 'use-query-params';
 
 dayjs.extend(relativeTime);
 
@@ -77,15 +78,20 @@ const ReservoirArtifactDetailPage = () => {
     useState<ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key>(
       [],
     );
-  const [queryParams, setQuery] = useQueryParams({
-    filter: withDefault(JsonParam, {}),
-  });
+  const [queryParams, setQuery] = useQueryStates(
+    {
+      filter: parseAsJson<ArtifactRevisionFilter>(
+        (value) => value as ArtifactRevisionFilter,
+      ).withDefault({}),
+    },
+    { history: 'replace' },
+  );
   const jsonStringFilter = JSON.stringify(queryParams.filter);
   const {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParamLegacy({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 10,
   });
@@ -414,7 +420,7 @@ const ReservoirArtifactDetailPage = () => {
             <BAIGraphQLPropertyFilter
               combinationMode="AND"
               onChange={(value) => {
-                setQuery({ filter: value ?? {} }, 'replaceIn');
+                setQuery({ filter: value ?? {} });
               }}
               filterProperties={[
                 {

--- a/react/src/pages/ReservoirPage.tsx
+++ b/react/src/pages/ReservoirPage.tsx
@@ -7,12 +7,13 @@ import {
   ReservoirPageQuery$data,
   ReservoirPageQuery$variables,
   ArtifactType,
+  ArtifactFilter,
 } from '../__generated__/ReservoirPageQuery.graphql';
 import AutoUpdateFetchKeyButton from '../components/AutoUpdateFetchKeyButton';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import ScanArtifactModelsFromHuggingFaceModal from '../components/ScanArtifactModelsFromHuggingFaceModal';
 import { useWebUINavigate } from '../hooks';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useToggle } from 'ahooks';
@@ -39,15 +40,10 @@ import {
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import { BanIcon, Brain, UndoIcon } from 'lucide-react';
+import { parseAsJson, parseAsString, useQueryStates } from 'nuqs';
 import React, { useMemo, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import {
-  withDefault,
-  JsonParam,
-  StringParam,
-  useQueryParams,
-} from 'use-query-params';
 
 const getStatusFilter = (status: string) => {
   return { availability: [status] };
@@ -96,15 +92,20 @@ const ReservoirPage: React.FC = () => {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParamLegacy({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 10,
   });
 
-  const [queryParams, setQuery] = useQueryParams({
-    filter: withDefault(JsonParam, {}),
-    mode: withDefault(StringParam, 'ALIVE'),
-  });
+  const [queryParams, setQuery] = useQueryStates(
+    {
+      filter: parseAsJson<ArtifactFilter>(
+        (value) => value as ArtifactFilter,
+      ).withDefault({}),
+      mode: parseAsString.withDefault('ALIVE'),
+    },
+    { history: 'replace' },
+  );
   const jsonStringFilter = JSON.stringify(queryParams.filter);
 
   const queryVariables: ReservoirPageQuery$variables = useMemo(
@@ -226,7 +227,7 @@ const ReservoirPage: React.FC = () => {
   //   return { type: { eq: type } };
   // };
   // const handleStatisticCardClick = (type: 'IMAGE' | 'PACKAGE' | 'MODEL') => {
-  //   setQuery({ filter: typeFilterGenerator(type) }, 'replaceIn');
+  //   setQuery({ filter: typeFilterGenerator(type) });
   // };
 
   return (
@@ -293,7 +294,7 @@ const ReservoirPage: React.FC = () => {
                 ]}
                 value={queryParams.mode}
                 onChange={(e) => {
-                  setQuery({ mode: e.target.value }, 'replaceIn');
+                  setQuery({ mode: e.target.value });
                   setTablePaginationOption({ current: 1 });
                   setSelectedArtifactIdList([]);
                   setSelectedArtifacts([]);
@@ -303,7 +304,7 @@ const ReservoirPage: React.FC = () => {
               <BAIGraphQLPropertyFilter
                 combinationMode="AND"
                 onChange={(value) => {
-                  setQuery({ filter: value ?? {} }, 'replaceIn');
+                  setQuery({ filter: value ?? {} });
                 }}
                 value={queryParams.filter}
                 filterProperties={[
@@ -511,7 +512,7 @@ const ReservoirPage: React.FC = () => {
               loading={false}
               filterValue={queryParams.auditFilter}
               onFilterChange={(value) => {
-                setQuery({ auditFilter: value }, 'replaceIn');
+                setQuery({ auditFilter: value });
               }}
               pagination={{
                 pageSize: tablePaginationOption.pageSize,
@@ -530,7 +531,7 @@ const ReservoirPage: React.FC = () => {
               }}
               order={queryParams.auditOrder}
               onChangeOrder={(order) => {
-                setQuery({ auditOrder: order }, 'replaceIn');
+                setQuery({ auditOrder: order });
               }}
             />
           </Suspense>

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -13,18 +13,18 @@ import UserResourcePolicyV2, {
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { Skeleton } from 'antd';
 import { filterOutEmpty, BAICard } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import React, { Suspense, useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryLoader } from 'react-relay';
-import { withDefault, StringParam, useQueryParam } from 'use-query-params';
 
-const tabParam = withDefault(StringParam, 'keypair');
+const tabParam = parseAsString.withDefault('keypair');
 
 interface ResourcePolicyPageProps {}
 const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
   'use memo';
   const { t } = useTranslation();
-  const [curTabKey] = useQueryParam('tab', tabParam);
+  const [curTabKey] = useQueryState('tab', tabParam);
   const webUINavigate = useWebUINavigate();
   const baiClient = useSuspendedBackendaiClient();
   const supportsSubFilter = baiClient.supports('sub-filter');

--- a/react/src/pages/ResourcesPage.tsx
+++ b/react/src/pages/ResourcesPage.tsx
@@ -8,21 +8,21 @@ import ResourceGroupList from '../components/ResourceGroupList';
 import StorageProxyList from '../components/StorageProxyList';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'agents' | 'storages' | 'resourceGroup';
 
 interface ResourcesPageProps {}
 
-const tabParam = withDefault(StringParam, 'agents');
+const tabParam = parseAsString
+  .withDefault('agents')
+  .withOptions({ history: 'replace' });
 
 const ResourcesPage: React.FC<ResourcesPageProps> = () => {
   const { t } = useTranslation();
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam, {
-    updateType: 'replace',
-  });
+  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
 
   return (
     <BAICard

--- a/react/src/pages/SchedulerPage.tsx
+++ b/react/src/pages/SchedulerPage.tsx
@@ -9,20 +9,19 @@ import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Button, Result, Skeleton, theme, Tooltip } from 'antd';
 import { BAICard, BAIFlex } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
-import { parseAsString, useQueryStates } from 'nuqs';
+import { parseAsString, useQueryState, useQueryStates } from 'nuqs';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
-const tabParam = withDefault(StringParam, 'fair-share');
+const tabParam = parseAsString.withDefault('fair-share');
 
 interface SchedulerPageProps {}
 
 const SchedulerPage: React.FC<SchedulerPageProps> = () => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [curTabKey] = useQueryParam('tab', tabParam);
+  const [curTabKey] = useQueryState('tab', tabParam);
   const webUINavigate = useWebUINavigate();
 
   return (

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -91,6 +91,12 @@ import {
 import dayjs from 'dayjs';
 import { useAtomValue } from 'jotai';
 import * as _ from 'lodash-es';
+import {
+  parseAsInteger,
+  parseAsJson,
+  parseAsString,
+  useQueryStates,
+} from 'nuqs';
 import React, {
   Suspense,
   useEffect,
@@ -102,13 +108,6 @@ import React, {
 import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import {
-  JsonParam,
-  NumberParam,
-  StringParam,
-  useQueryParams,
-  withDefault,
-} from 'use-query-params';
 
 type SessionLauncherFormData = Omit<
   Required<OptionalFieldsOnly<SessionLauncherFormValue>>,
@@ -221,9 +220,13 @@ const SessionLauncherPage = () => {
 
   const { startSession, defaultFormValues, upsertSessionNotification } =
     useStartSession();
-  const StepParam = withDefault(NumberParam, 0);
-  const FormValuesParam = withDefault(JsonParam, defaultFormValues);
-  const AppOptionParam = withDefault(JsonParam, {});
+  const StepParam = parseAsInteger.withDefault(0);
+  const FormValuesParam = parseAsJson<DeepPartial<SessionLauncherFormValue>>(
+    (value) => value as DeepPartial<SessionLauncherFormValue>,
+  ).withDefault(defaultFormValues);
+  const AppOptionParam = parseAsJson<AppOption>(
+    (value) => value as AppOption,
+  ).withDefault({});
   const [
     {
       step: currentStep,
@@ -233,12 +236,15 @@ const SessionLauncherPage = () => {
       // appOption: appOptionFromQueryParams,
     },
     setQuery,
-  ] = useQueryParams({
-    step: StepParam,
-    formValues: FormValuesParam,
-    redirectTo: StringParam,
-    appOption: AppOptionParam,
-  });
+  ] = useQueryStates(
+    {
+      step: StepParam,
+      formValues: FormValuesParam,
+      redirectTo: parseAsString,
+      appOption: AppOptionParam,
+    },
+    { history: 'replace' },
+  );
 
   const { search } = useLocation();
   const webuiNavigate = useWebUINavigate();
@@ -252,23 +258,20 @@ const SessionLauncherPage = () => {
       // To sync the latest form values to URL,
       // 'trailing' is set to true, and get the form values here."
       const currentValue = form.getFieldsValue();
-      setQuery(
-        {
-          formValues: _.assign(
-            _.omit(form.getFieldsValue(), [
-              'environments.image',
-              'environments.customizedTag',
-              'autoMountedFolderNames',
-              'owner',
-              'envvars',
-            ]),
-            {
-              envvars: sanitizeSensitiveEnv(currentValue.envvars),
-            },
-          ),
-        },
-        'replaceIn',
-      );
+      setQuery({
+        formValues: _.assign(
+          _.omit(form.getFieldsValue(), [
+            'environments.image',
+            'environments.customizedTag',
+            'autoMountedFolderNames',
+            'owner',
+            'envvars',
+          ]),
+          {
+            envvars: sanitizeSensitiveEnv(currentValue.envvars),
+          },
+        ),
+      });
     },
     {
       leading: false,
@@ -282,7 +285,7 @@ const SessionLauncherPage = () => {
       {
         step: nextStep,
       },
-      'pushIn',
+      { history: 'push' },
     );
   };
   const { token } = theme.useToken();
@@ -325,7 +328,7 @@ const SessionLauncherPage = () => {
       defaultFormValues,
       RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
       formValuesFromQueryParams,
-    );
+    ) as SessionLauncherFormValue;
   }, [defaultFormValues, formValuesFromQueryParams]);
 
   // ScrollTo top when step is changed
@@ -1231,7 +1234,12 @@ const SessionLauncherPage = () => {
                       title={t('button.Reset')}
                       description={t('session.launcher.ResetFormConfirm')}
                       onConfirm={() => {
-                        setQuery({}, 'replace');
+                        setQuery({
+                          step: null,
+                          formValues: null,
+                          redirectTo: null,
+                          appOption: null,
+                        });
                         setIsQueryReset(true);
                       }}
                       icon={

--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -26,15 +26,10 @@ import {
   BAIAlert,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { parseAsJson, parseAsString, useQueryStates } from 'nuqs';
 import { useEffect, useState, useMemo, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-import {
-  useQueryParams,
-  withDefault,
-  StringParam,
-  JsonParam,
-} from 'use-query-params';
 
 interface StartPageBoardItem extends BAIBoardItem {
   requiredMenuKey: MenuKeys;
@@ -65,10 +60,15 @@ const StartPage: React.FC = () => {
   const [vFolderInvitations] = useVFolderInvitations();
 
   // Parse query parameters
-  const [queryParams, setQueryParams] = useQueryParams({
-    type: withDefault(StringParam, undefined),
-    data: withDefault(JsonParam, undefined),
-  });
+  const [queryParams, setQueryParams] = useQueryStates(
+    {
+      type: parseAsString,
+      data: parseAsJson<{ url?: string; branch?: string }>(
+        (value) => value as { url?: string; branch?: string },
+      ),
+    },
+    { history: 'replace' },
+  );
 
   // Handle legacy GitHub URL format (for backward compatibility)
   const legacyGithubPath = useMemo(() => {
@@ -98,8 +98,8 @@ const StartPage: React.FC = () => {
       setIsOpenStartURLModal(true);
 
       setQueryParams({
-        type: undefined,
-        data: undefined,
+        type: null,
+        data: null,
       });
     } else if (legacyGithubPath) {
       // Handle legacy format: /github?owner/repo/path/notebook.ipynb (via redirect)
@@ -111,14 +111,12 @@ const StartPage: React.FC = () => {
       });
       setIsOpenStartURLModal(true);
 
-      // clear legacy query parameter
-      setQueryParams(
-        {
-          type: undefined,
-          data: undefined,
-        },
-        // clear legacy query parameter
-        'replace',
+      // Clear the entire query string: the legacy `?owner/repo/...` entry is
+      // an unmanaged bare key, so clearing type/data alone would leave it in
+      // the URL and reopen the modal on reload (legacy 'replace' cleared all).
+      webuiNavigate(
+        { pathname: location.pathname, search: '' },
+        { replace: true },
       );
     }
   });

--- a/react/src/pages/StatisticsPage.tsx
+++ b/react/src/pages/StatisticsPage.tsx
@@ -8,22 +8,23 @@ import UserSessionsMetrics from '../components/UserSessionsMetrics';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { Skeleton, theme } from 'antd';
 import { filterOutEmpty, BAICard } from 'backend.ai-ui';
+import { parseAsString, useQueryState } from 'nuqs';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 interface ResourcesPageProps {}
 
-const tabParam = withDefault(StringParam, 'allocation-history');
+const tabParam = parseAsString.withDefault('allocation-history');
 
 const ResourcesPage: React.FC<ResourcesPageProps> = () => {
   const { t } = useTranslation();
   const baiClient = useSuspendedBackendaiClient();
   const { token } = theme.useToken();
 
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam, {
-    updateType: 'replace',
-  });
+  const [curTabKey, setCurTabKey] = useQueryState(
+    'tab',
+    tabParam.withOptions({ history: 'replace' }),
+  );
 
   return (
     <BAICard

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -29,15 +29,15 @@ import { useSessionStorageState, useToggle } from 'ahooks';
 import { App, Button, Skeleton, Typography } from 'antd';
 import { BAICard, filterOutEmpty } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { parseAsString, useQueryState } from 'nuqs';
 import { Suspense, useEffect, useEffectEvent, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useQueryLoader } from 'react-relay';
-import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'general' | 'logs' | 'login-sessions' | 'login-history';
 export type ShellScriptType = 'bootstrap' | 'userconfig' | undefined;
 
-const tabParam = withDefault(StringParam, 'general');
+const tabParam = parseAsString.withDefault('general');
 
 const UserPreferencesPage = () => {
   'use memo';
@@ -45,7 +45,7 @@ const UserPreferencesPage = () => {
   const { t } = useTranslation();
   const { message } = App.useApp();
   const baiClient = useSuspendedBackendaiClient();
-  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+  const [curTabKey, setCurTabKey] = useQueryState('tab', tabParam);
 
   const [loginSessionQueryRef, loadLoginSessionQuery] =
     useQueryLoader<LoginSessionQueryType>(LoginSessionQuery);

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -16,7 +16,7 @@ import RestoreVFolderModal from '../components/RestoreVFolderModal';
 import VFolderNodes, { VFolderNodeInList } from '../components/VFolderNodes';
 import { handleRowSelectionChange } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
-import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useVFolderInvitations } from '../hooks/useVFolderInvitations';
@@ -37,15 +37,10 @@ import {
   useUpdatableState,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
+import { parseAsString, useQueryState, useQueryStates } from 'nuqs';
 import React, { useDeferredValue, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
-import {
-  StringParam,
-  useQueryParam,
-  useQueryParams,
-  withDefault,
-} from 'use-query-params';
 
 export const isDeletedCategory = (status?: string | null) => {
   return _.includes(
@@ -99,7 +94,10 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   const currentProject = useCurrentProjectValue();
   const baiClient = useSuspendedBackendaiClient();
   const [invitations] = useVFolderInvitations();
-  const [, setInvitationOpen] = useQueryParam('invitation', StringParam);
+  const [, setInvitationOpen] = useQueryState(
+    'invitation',
+    parseAsString.withOptions({ history: 'replace' }),
+  );
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.VFolderNodeListPage',
@@ -123,17 +121,20 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionStateOnSearchParamLegacy({
+  } = useBAIPaginationOptionStateOnSearchParam({
     current: 1,
     pageSize: 10,
   });
 
-  const [queryParams, setQuery] = useQueryParams({
-    order: withDefault(StringParam, '-created_at'),
-    filter: withDefault(StringParam, undefined),
-    statusCategory: withDefault(StringParam, 'active'),
-    mode: withDefault(StringParam, 'all'),
-  });
+  const [queryParams, setQuery] = useQueryStates(
+    {
+      order: parseAsString.withDefault('-created_at'),
+      filter: parseAsString,
+      statusCategory: parseAsString.withDefault('active'),
+      mode: parseAsString.withDefault('all'),
+    },
+    { history: 'replace' },
+  );
 
   const queryMapRef = useRef({
     [queryParams.statusCategory]: { queryParams, tablePaginationOption },
@@ -286,13 +287,14 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
             const storedQuery = queryMapRef.current[key] || {
               mode: 'all',
             };
-            setQuery(
-              {
-                ...storedQuery.queryParams,
-                statusCategory: key as 'active' | 'deleted',
-              },
-              'replace',
-            );
+            // Reset the whole group first: nuqs partial updates merge, so
+            // without this the previous tab's filter/order/mode leak into a
+            // tab that has no cached state (legacy 'replace' cleared them).
+            setQuery(null);
+            setQuery({
+              ...storedQuery.queryParams,
+              statusCategory: key as 'active' | 'deleted',
+            });
             setTablePaginationOption(
               storedQuery.tablePaginationOption || { current: 1 },
             );
@@ -303,7 +305,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
               <BAILink
                 type="hover"
                 onClick={() => {
-                  setInvitationOpen('true', 'replaceIn');
+                  setInvitationOpen('true');
                 }}
               >
                 {`${t('data.invitation.PendingInvitations')} (${invitations.length})`}
@@ -361,7 +363,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                 optionType="button"
                 value={queryParams.mode}
                 onChange={(e) => {
-                  setQuery({ mode: e.target.value }, 'replaceIn');
+                  setQuery({ mode: e.target.value });
                   setTablePaginationOption({ current: 1 });
                   setSelectedFolderList([]);
                 }}
@@ -457,9 +459,9 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                     type: 'string',
                   },
                 ]}
-                value={queryParams.filter || undefined}
+                value={queryParams.filter ?? undefined}
                 onChange={(value) => {
-                  setQuery({ filter: value }, 'replaceIn');
+                  setQuery({ filter: value ?? null });
                   setTablePaginationOption({ current: 1 });
                   setSelectedFolderList([]);
                 }}
@@ -563,7 +565,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
               },
             }}
             onChangeOrder={(order) => {
-              setQuery({ order }, 'replaceIn');
+              setQuery({ order: order ?? null });
             }}
             onRemoveRow={(removedId) => {
               setSelectedFolderList((prevSelected) =>


### PR DESCRIPTION
Resolves ([FR-1943](https://lablup.atlassian.net/browse/FR-1943))

## Summary

Migrate all remaining URL query parameter management from the legacy `use-query-params` library to `nuqs`, completing the app-wide unification of URL state on a single library. After this PR, `use-query-params` is fully removed from source, `package.json`, and the lockfile.

## Changes

### Core migration
- **Removed dependency**: `use-query-params` (and its transitive `serialize-query-params`)
- **Provider cleanup**: removed the now-dead `QueryParamProvider`/`ReactRouter6Adapter` wrapper from `DefaultProviders.tsx` — the `NuqsAdapter` in `App.tsx` (already on main) covers the whole router tree
- **Shared hooks**: migrated the remaining `useQueryParams` usages inside `reactPaginationQueryOptions.tsx` (`useRelayPaginationQueryOptions`, `useBAIPaginationQueryOptions`, `useBAIPaginationOptionStateOnSearchParamLegacy`) to `useQueryStates` with `history: 'replace'`

### Migrated files (32 source files)
Pages: AdminVFolderNodeListPage, AgentSummaryPage, BrandingPage, ChatPage, ConfigurationsPage, DiagnosticsPage, EnvironmentPage, InteractiveLoginPage, MaintenancePage, MyEnvironmentPage, ReservoirArtifactDetailPage, ReservoirPage, ResourcePolicyPage, ResourcesPage, SchedulerPage, SessionLauncherPage, StartPage, StatisticsPage, UserSettingsPage, VFolderNodeListPage
Components: AdminUserCredentialList, AgentSummaryList, AllocationHistory, ContainerRegistryList, DefaultProviders, FolderExplorerOpener, FolderInvitationResponseModalOpener, RecentlyCreatedSession, SessionDetailAndContainerLogOpenerLegacy, SessionDetailDrawer, UserSessionsMetrics + hooks/reactPaginationQueryOptions

### Migration patterns
- `useQueryParams({...})` → `useQueryStates({...}, { history: 'replace' })`
- `useQueryParam('key', Param)` → `useQueryState('key', parser)`
- `StringParam`/`NumberParam`/`BooleanParam` → `parseAsString`/`parseAsInteger`/`parseAsBoolean`
- `ArrayParam` → `parseAsArrayOf(parseAsString)`; `JsonParam`/`ObjectParam` → `parseAsJson<T>((v) => v as T)`
- `createEnumParam` → `parseAsStringLiteral([...] as const)`
- `withDefault(Param, v)` → `parser.withDefault(v)`; setter mode strings (`'replaceIn'`/`'pushIn'`) → hook-level `history` option (per-call `{ history: 'push' }` kept for the SessionLauncher wizard step)
- Clearing values: `undefined` → `null`; nullable filter values passed as `queryParams.filter ?? undefined`
- Existing `history` semantics preserved per call site (tab pages that used push before stay on push; `updateType: 'replace'` sites map to `history: 'replace'`)

### Consistency cleanups (post-review)
- Parser objects hoisted to module scope where they were module constants before the migration (AllocationHistory, AgentSummaryPage, MyEnvironmentPage, FolderExplorerOpener)
- `ResourcesPage` uses `tabParam.withOptions({ history: 'replace' })` instead of spreading the parser object

## Verification
- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay / Lint / Format / TypeScript)
- `use-query-params` references: 0 in `react/src`, `package.json`, `pnpm-lock.yaml`
- Live regression against a test cluster (admin login): page renders across all migrated routes, URL round-trips verified (`?order=` via sortable columns, `?period=1W` write+restore on Statistics, `?tab=` deep links on My Environments/Statistics/Credentials), zero nuqs-related console errors, reload-with-session intact


[FR-1943]: https://lablup.atlassian.net/browse/FR-1943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ