### PR TITLE
fix(FR-1945): fix storybook check workflow incorrectly flagging react components

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -41,7 +41,6 @@ jobs:
               packages/backend.ai-ui/src/components/*.tsx) ;;
               *) continue ;;
             esac
-            # Skip story and test files
             case "$file" in
               *.stories.tsx|*.test.tsx) continue ;;
             esac


### PR DESCRIPTION
Resolves ([FR-1945](https://lablup.atlassian.net/browse/FR-1945))

## Summary

- Fix `dorny/paths-filter@v3` returning all changed files regardless of filter configuration
- Add explicit path filtering in bash script to only check files in `packages/backend.ai-ui/src/components/`
- Upgrade `actions/checkout` from v4 to v6
- Add test files to verify the workflow behavior

## Problem

The GitHub Actions `storybook-check` workflow was incorrectly flagging React components (`react/src/**/*.tsx`), hooks, pages, and helper files as missing Storybook stories, even though only `packages/backend.ai-ui/src/components/` files should require stories.

## Solution

Added explicit path filtering in the bash script:
```bash
case "$file" in
  packages/backend.ai-ui/src/components/*.tsx) ;;
  *) continue ;;
esac
```

## Test plan

- [x] Verify workflow only detects `packages/backend.ai-ui/src/components/TestComponent/TestComponentForWorkflow.tsx` as missing story
- [x] Verify `react/src/components/TestComponentForWorkflow.tsx` is NOT flagged
- [x] Verify `react/src/hooks/useTestHookForWorkflow.tsx` is NOT flagged
- [x] Verify `react/src/pages/TestPageForWorkflow.tsx` is NOT flagged
- [x] Remove test files after verification

<img width="701" height="184" alt="스크린샷 2026-01-23 오후 4 35 29" src="https://github.com/user-attachments/assets/8e3dab6d-9f9a-4faa-888a-6b52bac32474" />

🤖 Generated with [Claude Code](https://claude.ai/code)

[FR-1945]: https://lablup.atlassian.net/browse/FR-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ