### PR TITLE
misc(FR-1940): Modify the upload dropdown button to open only when clicked

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -95,6 +95,7 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
         </Tooltip>
         <Dropdown
           disabled={!enableWrite}
+          trigger={['click']}
           popupRender={() => {
             return (
               <BAIFlex


### PR DESCRIPTION
resolves #5089 (FR-1940)

Added `trigger={['click']}` to the Dropdown component in ExplorerActionControls to ensure the dropdown menu only opens on click events rather than hover.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after