### PR TITLE
feat(FR-1946): extract image matching logic into reusable utility function

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -7,11 +7,10 @@ import {
   ImageEnvironmentSelectFormItemsQuery$data,
 } from '../__generated__/ImageEnvironmentSelectFormItemsQuery.graphql';
 import {
+  findMatchingImage,
   getImageFullName,
   localeCompare,
-  parseImageString,
   preserveDotStartCase,
-  removeArchitectureFromImageFullName,
 } from '../helper';
 import {
   useBackendAIImageMetaData,
@@ -197,59 +196,26 @@ const ImageEnvironmentSelectFormItems: React.FC<
     let matchedImageByVersion: Image | undefined;
     const version = form.getFieldValue('environments')?.version;
 
-    // 1. Try exact full name matching (registry/namespace:tag@arch)
-    version &&
-      _.find(imageGroups, (group) => {
-        matchedEnvironmentByVersion = _.find(
-          group.environmentGroups,
-          (environment) => {
-            matchedImageByVersion = _.find(
-              environment.images,
-              (image) => getImageFullName(image) === version,
-            );
-            return !!matchedImageByVersion; // break iteration
-          },
-        );
-        return !!matchedEnvironmentByVersion; // break iteration
-      });
+    // Use findMatchingImage utility for 3-tier matching strategy
+    if (version) {
+      const allImages = imageGroups
+        .flatMap((group) =>
+          group.environmentGroups.flatMap((env) => env.images),
+        )
+        .filter((image): image is NonNullable<typeof image> => image != null);
+      matchedImageByVersion = findMatchingImage(version, allImages) as
+        | Image
+        | undefined;
 
-    // 2. If no exact match, try partial matching
-    if (!matchedEnvironmentByVersion && version) {
-      const { registryAndNamespace, hasTag, hasArch } =
-        parseImageString(version);
-
-      if (!hasArch && hasTag) {
-        // version is "registry/namespace:tag" format without architecture
+      // Find the corresponding environment group for the matched image
+      if (matchedImageByVersion) {
         _.find(imageGroups, (group) => {
           matchedEnvironmentByVersion = _.find(
             group.environmentGroups,
-            (environment) => {
-              matchedImageByVersion = _.find(environment.images, (image) => {
-                const fullName = getImageFullName(image);
-                // Match by removing architecture from fullName
-                return (
-                  removeArchitectureFromImageFullName(fullName) === version
-                );
-              });
-              return !!matchedImageByVersion;
-            },
-          );
-          return !!matchedEnvironmentByVersion;
-        });
-      } else if (!hasTag) {
-        // version is "registry/namespace" format (no tag, no architecture)
-        // Select the latest version (first image in sorted array)
-        _.find(imageGroups, (group) => {
-          matchedEnvironmentByVersion = _.find(
-            group.environmentGroups,
-            (environment) => {
-              if (environment.environmentName === registryAndNamespace) {
-                // images are already sorted by version (latest first)
-                matchedImageByVersion = environment.images[0];
-                return true;
-              }
-              return false;
-            },
+            (environment) =>
+              environment.images.some(
+                (image) => image === matchedImageByVersion,
+              ),
           );
           return !!matchedEnvironmentByVersion;
         });

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -24,6 +24,7 @@ import {
   toFixedWithTypeValidation,
   addNumberWithUnits,
   subNumberWithUnits,
+  findMatchingImage,
 } from './index';
 
 describe('isOutsideRange', () => {
@@ -1051,5 +1052,269 @@ describe('subNumberWithUnits', () => {
   it('should handle negative results', () => {
     const result = subNumberWithUnits('2g', '5g', 'g');
     expect(result).toBe('-3g');
+  });
+});
+
+describe('findMatchingImage', () => {
+  // Sample images for testing
+  const mockImages = [
+    {
+      registry: 'cr.backend.ai',
+      namespace: 'lablup/python',
+      tag: '3.9-ubuntu',
+      architecture: 'x86_64',
+    },
+    {
+      registry: 'cr.backend.ai',
+      namespace: 'lablup/python',
+      tag: '3.9-ubuntu',
+      architecture: 'aarch64',
+    },
+    {
+      registry: 'cr.backend.ai',
+      namespace: 'lablup/python',
+      tag: '3.8-ubuntu',
+      architecture: 'x86_64',
+    },
+    {
+      registry: 'cr.backend.ai',
+      namespace: 'lablup/tensorflow',
+      tag: '2.9-cuda',
+      architecture: 'x86_64',
+    },
+  ];
+
+  // Images with deprecated 'name' field instead of 'namespace'
+  const mockImagesWithNameField = [
+    {
+      registry: 'cr.backend.ai',
+      name: 'lablup/python',
+      tag: '3.9-ubuntu',
+      architecture: 'x86_64',
+    },
+  ];
+
+  describe('Tier 1: Exact match', () => {
+    it('should find exact match with full image string', () => {
+      const result = findMatchingImage(
+        'cr.backend.ai/lablup/python:3.9-ubuntu@x86_64',
+        mockImages,
+      );
+      expect(result).toBe(mockImages[0]);
+    });
+
+    it('should find exact match for different architecture', () => {
+      const result = findMatchingImage(
+        'cr.backend.ai/lablup/python:3.9-ubuntu@aarch64',
+        mockImages,
+      );
+      expect(result).toBe(mockImages[1]);
+    });
+
+    it('should find exact match for different image', () => {
+      const result = findMatchingImage(
+        'cr.backend.ai/lablup/tensorflow:2.9-cuda@x86_64',
+        mockImages,
+      );
+      expect(result).toBe(mockImages[3]);
+    });
+  });
+
+  describe('Tier 2: Partial match without architecture', () => {
+    it('should find match by registry/namespace:tag', () => {
+      const result = findMatchingImage(
+        'cr.backend.ai/lablup/python:3.9-ubuntu',
+        mockImages,
+      );
+      expect(result).toBe(mockImages[0]); // First matching arch (x86_64)
+    });
+
+    it('should find match for different tag', () => {
+      const result = findMatchingImage(
+        'cr.backend.ai/lablup/python:3.8-ubuntu',
+        mockImages,
+      );
+      expect(result).toBe(mockImages[2]);
+    });
+  });
+
+  describe('Tier 3: Partial match without tag', () => {
+    it('should find match by registry/namespace only', () => {
+      const result = findMatchingImage(
+        'cr.backend.ai/lablup/python',
+        mockImages,
+      );
+      expect(result).toBe(mockImages[0]); // First in list
+    });
+
+    it('should find match for different environment', () => {
+      const result = findMatchingImage(
+        'cr.backend.ai/lablup/tensorflow',
+        mockImages,
+      );
+      expect(result).toBe(mockImages[3]);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should return undefined for empty string', () => {
+      expect(findMatchingImage('', mockImages)).toBeUndefined();
+    });
+
+    it('should return undefined for null', () => {
+      expect(findMatchingImage(null, mockImages)).toBeUndefined();
+    });
+
+    it('should return undefined for undefined', () => {
+      expect(findMatchingImage(undefined, mockImages)).toBeUndefined();
+    });
+
+    it('should return undefined for empty image list', () => {
+      expect(
+        findMatchingImage('cr.backend.ai/lablup/python:3.9-ubuntu@x86_64', []),
+      ).toBeUndefined();
+    });
+
+    it('should return undefined when no match found', () => {
+      expect(
+        findMatchingImage('nonexistent/image:tag@arch', mockImages),
+      ).toBeUndefined();
+    });
+
+    it('should return undefined when partial match not found', () => {
+      expect(
+        findMatchingImage('cr.backend.ai/nonexistent', mockImages),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('Registry with port', () => {
+    const imagesWithPort = [
+      {
+        registry: '192.168.0.1:7080',
+        namespace: 'lablup/python',
+        tag: '3.9',
+        architecture: 'x86_64',
+      },
+      {
+        registry: '192.168.0.1:7080',
+        namespace: 'lablup/python',
+        tag: '3.9',
+        architecture: 'aarch64',
+      },
+    ];
+
+    it('should correctly match exact image with registry port', () => {
+      const result = findMatchingImage(
+        '192.168.0.1:7080/lablup/python:3.9@x86_64',
+        imagesWithPort,
+      );
+      expect(result).toBe(imagesWithPort[0]);
+    });
+
+    it('should correctly match partial image without arch with registry port', () => {
+      const result = findMatchingImage(
+        '192.168.0.1:7080/lablup/python:3.9',
+        imagesWithPort,
+      );
+      expect(result).toBe(imagesWithPort[0]);
+    });
+
+    it('should correctly match image by registry/namespace only with port', () => {
+      const result = findMatchingImage(
+        '192.168.0.1:7080/lablup/python',
+        imagesWithPort,
+      );
+      expect(result).toBe(imagesWithPort[0]);
+    });
+  });
+
+  describe('Backward compatibility with deprecated name field', () => {
+    it('should work with images using name field instead of namespace', () => {
+      const result = findMatchingImage(
+        'cr.backend.ai/lablup/python:3.9-ubuntu@x86_64',
+        mockImagesWithNameField,
+      );
+      expect(result).toBe(mockImagesWithNameField[0]);
+    });
+
+    it('should match by environment name using name field', () => {
+      const result = findMatchingImage(
+        'cr.backend.ai/lablup/python',
+        mockImagesWithNameField,
+      );
+      expect(result).toBe(mockImagesWithNameField[0]);
+    });
+  });
+
+  describe('Custom getEnvironmentName option', () => {
+    it('should use custom getEnvironmentName function', () => {
+      const customImages = [
+        {
+          registry: 'custom-registry',
+          namespace: 'custom-namespace',
+          tag: '1.0',
+          architecture: 'x86_64',
+          customEnvName: 'my-custom-env',
+        },
+      ];
+
+      const result = findMatchingImage('my-custom-env', customImages, {
+        getEnvironmentName: (image) =>
+          (image as (typeof customImages)[0]).customEnvName,
+      });
+      expect(result).toBe(customImages[0]);
+    });
+  });
+
+  describe('Priority of matching tiers', () => {
+    it('should prefer exact match over partial match', () => {
+      // Create images where both exact and partial could match
+      const images = [
+        {
+          registry: 'cr.backend.ai',
+          namespace: 'lablup/python',
+          tag: '3.9-ubuntu',
+          architecture: 'aarch64',
+        },
+        {
+          registry: 'cr.backend.ai',
+          namespace: 'lablup/python',
+          tag: '3.9-ubuntu',
+          architecture: 'x86_64',
+        },
+      ];
+
+      // Exact match should return the specific architecture
+      const result = findMatchingImage(
+        'cr.backend.ai/lablup/python:3.9-ubuntu@x86_64',
+        images,
+      );
+      expect(result?.architecture).toBe('x86_64');
+    });
+
+    it('should prefer tier 2 over tier 3 when applicable', () => {
+      const images = [
+        {
+          registry: 'cr.backend.ai',
+          namespace: 'lablup/python',
+          tag: '3.8-ubuntu',
+          architecture: 'x86_64',
+        },
+        {
+          registry: 'cr.backend.ai',
+          namespace: 'lablup/python',
+          tag: '3.9-ubuntu',
+          architecture: 'x86_64',
+        },
+      ];
+
+      // Tier 2 match should find specific tag
+      const result = findMatchingImage(
+        'cr.backend.ai/lablup/python:3.9-ubuntu',
+        images,
+      );
+      expect(result?.tag).toBe('3.9-ubuntu');
+    });
   });
 });

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -482,6 +482,96 @@ export const removeArchitectureFromImageFullName = (
   return fullName?.replace(/@[^@]+$/, '');
 };
 
+/**
+ * Find the best matching image from a list of images based on the given image string.
+ * Uses a 3-tier matching strategy:
+ * 1. Exact match: registry/namespace:tag@arch
+ * 2. Partial match without architecture: registry/namespace:tag (matches first available architecture)
+ * 3. Partial match without tag: registry/namespace (selects first image in list, assumes sorted by version)
+ *
+ * @param imageString - The image identifier to search for (various formats supported)
+ * @param images - Array of images to search within
+ * @param options - Optional configuration
+ * @returns The best matching image, or undefined if no match found
+ *
+ * @example
+ * // Exact match
+ * findMatchingImage('cr.backend.ai/lablup/python:3.9-ubuntu@x86_64', images);
+ *
+ * // Match without architecture (first available arch)
+ * findMatchingImage('cr.backend.ai/lablup/python:3.9-ubuntu', images);
+ *
+ * // Match without tag (latest version)
+ * findMatchingImage('cr.backend.ai/lablup/python', images);
+ */
+export function findMatchingImage<
+  T extends {
+    registry?: string | null;
+    namespace?: string | null;
+    name?: string | null;
+    tag?: string | null;
+    architecture?: string | null;
+  },
+>(
+  imageString: string | undefined | null,
+  images: readonly T[],
+  options?: {
+    /**
+     * Custom function to get the environment name (registry/namespace) from an image.
+     * Defaults to `${image.registry}/${image.namespace ?? image.name}`
+     */
+    getEnvironmentName?: (image: T) => string;
+  },
+): T | undefined {
+  // Early return for invalid input
+  if (!imageString || !images || images.length === 0) {
+    return undefined;
+  }
+
+  const getEnvName =
+    options?.getEnvironmentName ??
+    ((image: T) => `${image.registry}/${image.namespace ?? image.name}`);
+
+  // Tier 1: Exact match (registry/namespace:tag@arch)
+  const exactMatch = images.find(
+    (image) => getImageFullName(image) === imageString,
+  );
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  // Parse the input string to determine matching strategy
+  const { registryAndNamespace, hasTag, hasArch } =
+    parseImageString(imageString);
+
+  // Tier 2: Match without architecture (registry/namespace:tag)
+  if (!hasArch && hasTag) {
+    const partialMatch = images.find((image) => {
+      const fullName = getImageFullName(image);
+      return (
+        fullName &&
+        removeArchitectureFromImageFullName(fullName) === imageString
+      );
+    });
+    if (partialMatch) {
+      return partialMatch;
+    }
+  }
+
+  // Tier 3: Match by environment name only (registry/namespace)
+  // Returns the first matching image (caller should ensure list is sorted by version if needed)
+  if (!hasTag) {
+    const envMatch = images.find(
+      (image) => getEnvName(image) === registryAndNamespace,
+    );
+    if (envMatch) {
+      return envMatch;
+    }
+  }
+
+  return undefined;
+}
+
 export const localeCompare = (a?: string | null, b?: string | null) => {
   if (a === null || a === undefined) return -1;
   if (b === null || b === undefined) return 1;

--- a/react/src/hooks/useDefaultImagesWithFallback.ts
+++ b/react/src/hooks/useDefaultImagesWithFallback.ts
@@ -7,7 +7,7 @@ import {
   useDefaultImagesWithFallbackQuery,
   useDefaultImagesWithFallbackQuery$data,
 } from '../__generated__/useDefaultImagesWithFallbackQuery.graphql';
-import { getImageFullName } from '../helper';
+import { findMatchingImage, getImageFullName } from '../helper';
 import { atom, useAtom } from 'jotai';
 import { atomWithDefault } from 'jotai/utils';
 import * as _ from 'lodash-es';
@@ -40,23 +40,20 @@ const IMAGES_QUERY = graphql`
   }
 `;
 
+// Start as `undefined` so the hook's effect always runs the image fetch and
+// resolves the configured image (if any) against the installed image list via
+// `findMatchingImage`. This lets shorthand config values
+// (e.g. "registry/namespace" without a tag/arch) be matched to a concrete
+// installed image instead of being used verbatim. Resolution falls back to the
+// raw config value when no installed image matches, so a configured value is
+// never lost.
 const defaultFileBrowserImageAtom = atomWithDefault<
   string | null | undefined | Promise<string | null | undefined>
->(async () => {
-  const baiClient = await backendaiClientPromise;
-  return _.isEmpty(baiClient._config?.defaultFileBrowserImage)
-    ? undefined
-    : baiClient._config?.defaultFileBrowserImage;
-});
+>(async () => undefined);
 
 const systemSSHImageAtom = atomWithDefault<
   string | null | undefined | Promise<string | null | undefined>
->(async () => {
-  const baiClient = await backendaiClientPromise;
-  return _.isEmpty(baiClient._config?.systemSSHImage)
-    ? undefined
-    : baiClient._config?.systemSSHImage;
-});
+>(async () => undefined);
 const systemSSHImageInfoAtom =
   atom<NonNullable<useDefaultImagesWithFallbackQuery$data['images']>[number]>();
 
@@ -92,9 +89,24 @@ export const useDefaultFileBrowserImageWithFallback = () => {
           ),
         )
         .then(async (filebrowserImages) => {
-          const firstImage = _.first(filebrowserImages);
+          const baiClient = await backendaiClientPromise;
+          const configValue = baiClient._config?.defaultFileBrowserImage;
+          const validImages =
+            filebrowserImages?.filter(
+              (image): image is NonNullable<typeof image> => image != null,
+            ) ?? [];
+
+          // Use findMatchingImage if config value exists, otherwise take first filtered image
+          const matchedImage = configValue
+            ? findMatchingImage(configValue, validImages)
+            : _.first(validImages);
+
+          // Fall back to the raw config value when it cannot be resolved to an
+          // installed image, so an explicitly configured image is never lost.
           setDefaultFileBrowserImage(
-            firstImage ? getImageFullName(firstImage) : null,
+            matchedImage
+              ? getImageFullName(matchedImage)
+              : configValue || null,
           );
         })
         .catch(() => {
@@ -144,9 +156,24 @@ export const useDefaultSystemSSHImageWithFallback = () => {
           ),
         )
         .then(async (sshImages) => {
-          const firstImage = _.first(sshImages);
-          setSystemSSHImage(firstImage ? getImageFullName(firstImage) : null);
-          setSystemSSHImageInfo(firstImage || undefined);
+          const baiClient = await backendaiClientPromise;
+          const configValue = baiClient._config?.systemSSHImage;
+          const validImages =
+            sshImages?.filter(
+              (image): image is NonNullable<typeof image> => image != null,
+            ) ?? [];
+
+          // Use findMatchingImage if config value exists, otherwise take first filtered image
+          const matchedImage = configValue
+            ? findMatchingImage(configValue, validImages)
+            : _.first(validImages);
+
+          // Fall back to the raw config value when it cannot be resolved to an
+          // installed image, so an explicitly configured image is never lost.
+          setSystemSSHImage(
+            matchedImage ? getImageFullName(matchedImage) : configValue || null,
+          );
+          setSystemSSHImageInfo(matchedImage || undefined);
         })
         .catch(() => {
           // in case of error, set null to disable SFTP button


### PR DESCRIPTION
Resolves #5107 (FR-1946)

## Summary

Extracts the image-matching logic that was inlined in `ImageEnvironmentSelectFormItems` into a reusable `findMatchingImage` helper, and uses it to give the `defaultFileBrowserImage` / `systemSSHImage` config values flexible partial matching.

## What changed

- **`react/src/helper/index.tsx`** — new `findMatchingImage(imageString, images, options?)` utility implementing a 3-tier matching strategy:
  1. Exact match: `registry/namespace:tag@arch`
  2. Without architecture: `registry/namespace:tag` (first matching arch)
  3. Without tag: `registry/namespace` (first image; caller sorts by version)
- **`react/src/components/ImageEnvironmentSelectFormItems.tsx`** — replaced the inline 3-tier matching with `findMatchingImage` (net −34 lines), removing the duplicated logic.
- **`react/src/hooks/useDefaultImagesWithFallback.ts`** — `defaultFileBrowserImage` / `systemSSHImage` config values are now resolved against the installed image list via `findMatchingImage`, so shorthand values (e.g. `registry/namespace` without a tag) map to a concrete installed image. Falls back to the raw config value when no installed image matches, so a configured value is never lost.
- **`react/src/helper/index.test.tsx`** — comprehensive unit tests for `findMatchingImage` (exact/partial/edge cases, registry-with-port, deprecated `name` field, custom `getEnvironmentName`, tier priority).

## Rebase + rewrite notes

This PR was 4 months stale and conflicting; it has been rebased onto the latest `main`.

During the rebase I found the original hook change was **dead code**: the config-resolution branch lived inside `if (image === undefined)`, but the atom returned `undefined` only when the config was *empty* — so `findMatchingImage` could never run for a configured value. Fixed by having the atoms start as `undefined` (so the fetch + resolution always runs) and resolving the config value inside the effect, with a raw-config fallback that preserves the previous behavior when no installed image matches (no regression). The `manual` launch path (used when `allow_manual_image_name_for_session` is set) still reads the raw config value directly, unchanged.

## Verification

- Relay / Lint / Format: **PASS**
- Unit tests: **135/135 pass** (21 new `findMatchingImage` tests)
- TypeScript: only pre-existing `@types/react` phantom errors — identical count on `main` (12 in `ImageEnvironmentSelectFormItems.tsx`, the unmodified file); **0 introduced by this change**, and 0 in the new utility/tests/hook.