### PR TITLE
chore(FR-1947): migrate Graphite CLI to MCP and enforce Atlassian MCP usage

### DIFF
--- a/.claude/atlassian-config.md
+++ b/.claude/atlassian-config.md
@@ -1,0 +1,90 @@
+# Atlassian Configuration Reference
+
+Reference document for Atlassian MCP configuration values. Use this document instead of making repeated API calls to look up field IDs and settings.
+
+## Instance
+
+- **Site**: `lablup.atlassian.net`
+- **Cloud ID**: `a28786f5-5410-4c2d-ae2d-9833cf63eb3f`
+
+## Project
+
+- **Default Project Key**: `FR`
+- **URL Pattern**: `https://lablup.atlassian.net/browse/FR-{issue_number}`
+
+## Custom Fields
+
+| Field ID | Name | Purpose | Value Format |
+|----------|------|---------|--------------|
+| `customfield_10020` | Sprint | Sprint assignment | Numeric ID only (e.g., `1570`) |
+| `customfield_10173` | GitHub Repository | Link PR repository | `{"id":"10232"}` |
+
+### Field Format Critical Notes
+
+#### Sprint Field (`customfield_10020`)
+- **Correct format**: Numeric ID directly - `1570`
+- **Wrong format**: Array format - `[1570]` ❌ (causes Bad Request error)
+
+#### Assignee Field
+- **Correct format**: `{"accountId": "user_account_id"}`
+
+#### GitHub Repository (`customfield_10173`)
+- **Default Value**: `{"id":"10232"}` (backend.ai-webui)
+
+## Default Values for Issue Creation
+
+```json
+{
+  "project": "FR",
+  "customfield_10173": {"id": "10232"}
+}
+```
+
+## Common JQL Queries
+
+| Purpose | JQL |
+|---------|-----|
+| Active sprint issues | `project = FR AND sprint in openSprints() ORDER BY created DESC` |
+| Specific issue type | `project = FR AND issuetype = Story` |
+
+## Atlassian MCP Tools Reference
+
+| Tool | Purpose |
+|------|---------|
+| `mcp__Atlassian__createJiraIssue` | Create issue |
+| `mcp__Atlassian__editJiraIssue` | Update issue |
+| `mcp__Atlassian__getJiraIssue` | Get issue details |
+| `mcp__Atlassian__searchJiraIssuesUsingJql` | Search issues with JQL |
+| `mcp__Atlassian__atlassianUserInfo` | Get current user info |
+| `mcp__Atlassian__getVisibleJiraProjects` | List accessible projects |
+| `mcp__Atlassian__getJiraIssueTypeMetaWithFields` | Get issue type field metadata |
+
+## How to Find Sprint ID
+
+To find the active sprint ID:
+
+1. Search for issues in active sprint:
+   ```
+   mcp__Atlassian__searchJiraIssuesUsingJql
+   JQL: "project = FR AND sprint in openSprints() ORDER BY created DESC"
+   ```
+
+2. Get sprint field from found issue:
+   ```
+   mcp__Atlassian__getJiraIssue
+   fields: ["customfield_10020"]
+   ```
+
+## Tool Usage Rules
+
+**Use Atlassian MCP for ALL Jira operations:**
+
+| Operation | MCP Tool |
+|-----------|----------|
+| Search/Query | `mcp__Atlassian__searchJiraIssuesUsingJql` |
+| Get Details | `mcp__Atlassian__getJiraIssue` |
+| Create | `mcp__Atlassian__createJiraIssue` |
+| Update | `mcp__Atlassian__editJiraIssue` |
+| Get User Info | `mcp__Atlassian__atlassianUserInfo` |
+
+**Authentication**: If MCP authentication fails, re-authenticate and retry.

--- a/.claude/commands/create-jira-issue.md
+++ b/.claude/commands/create-jira-issue.md
@@ -20,8 +20,8 @@ This command accept $ARGUMENTS to specify the type of changes to analyze:
 ### Change Detection
 Based on the argument provided:
 - **stage**: Use `git diff --cached` to get staged changes
-- **pr**: Use `gt parent` to find the parent branch of current branch, then use `git diff <parent-branch>...HEAD` to get changes in current branch only
-- **branch**: Use `git diff main...HEAD` to get all branch changes  
+- **pr**: Use Graphite MCP tool `mcp__graphite__run_gt_cmd` with args `["parent"]` to find the parent branch of current branch, then use `git diff <parent-branch>...HEAD` to get changes in current branch only
+- **branch**: Use `git diff main...HEAD` to get all branch changes
 - **commit**: Use `git diff HEAD~1..HEAD` to get latest commit changes
 
 ### Jira Issue Creation
@@ -105,11 +105,14 @@ Current Claude Code commands use inconsistent text-based prompts ("Proceed? [y/n
 - Only proceed with creation after user selects the confirmation option
 
 ### Issue Creation
-- Use the "Atlassian MCP" command to create a Jira issue of proper type.
-- Default values:
+- **CRITICAL**: Use Atlassian MCP tools **ONLY** for all Jira operations. Do **NOT** use `lj` CLI or any other CLI tools for Jira issue creation/modification.
+- If Atlassian MCP authentication fails, re-authenticate and retry before proceeding.
+- **Refer to `.claude/atlassian-config.md` for field IDs and configuration values**
+- Use `mcp__Atlassian__createJiraIssue` for creating issues
+- Use `mcp__Atlassian__editJiraIssue` for updating issues
+- Default values (see `.claude/atlassian-config.md` for details):
   - Jira Project: **FR**
-  - GitHub Repository (`customfield_10173`): The PR to resolve this issue should be created in this repository.
-    - Default: `{"id":"10232"}` (backend.ai-webui)
+  - GitHub Repository (`customfield_10173`): `{"id":"10232"}` (backend.ai-webui)
 - After creating the issue, open it in your browser to review using `open` cli command.
 
 ## Usage Examples

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,12 @@
     "playwright-test": {
       "command": "npx",
       "args": ["playwright", "run-test-mcp-server"]
+    },
+    "graphite": {
+      "type": "stdio",
+      "command": "gt",
+      "args": ["mcp"],
+      "env": {}
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,20 @@ e2e/                    # End-to-end tests
   - Format: `prefix(JIRA-ISSUE-NUMBER): title`
   - GitHub PR content starts with `Resolves #1234(FR-1234)` where #1234 is the cloned issue number and FR-1234 is the Jira issue number
 
-- Use the gh command for detailed GitHub information.
-- Use the Lablup Jira CLI command `lj` to find GitHub issues cloned from Jira issue numbers or to find dedicated Teams threads.
-- Use Atlassian MCP command for detailed Jira issue information.
-- Branch creation, commits, and pushes are done through graphite commands. Follow graphite's Stacked PR strategy. Write work by appropriately stacking individual PRs.
+- **CRITICAL - MCP Tool Requirements (No CLI alternatives)**:
+  - **Jira**: Use Atlassian MCP (`mcp__Atlassian__*`) for ALL operations
+    - `mcp__Atlassian__searchJiraIssuesUsingJql` - Search/query issues
+    - `mcp__Atlassian__getJiraIssue` - Get issue details
+    - `mcp__Atlassian__createJiraIssue` - Create issues
+    - `mcp__Atlassian__editJiraIssue` - Update issues
+  - **GitHub**: Use GitHub MCP (`mcp__github__*`) or `gh` CLI
+    - `mcp__github__search_issues` - Search issues
+    - `mcp__github__issue_read` - Get issue details
+  - **Git/PR**: Use Graphite MCP (`mcp__graphite__run_gt_cmd`) for branch/commit/push
+    - Do NOT use `git commit`, `git push`, `git checkout -b` directly
+    - Allowed: `git status`, `git diff`, `git add`, `git log`, `git stash`
+- If MCP authentication fails, re-authenticate and retry before proceeding.
+- Follow Graphite's Stacked PR strategy. Write work by appropriately stacking individual PRs.
 
 ### Configuration
 


### PR DESCRIPTION
Resolves #5110 ([FR-1947](https://lablup.atlassian.net/browse/FR-1947))

## Summary

This PR updates the Claude Code configuration to standardize MCP tool usage:

- **Migrate from Graphite CLI to Graphite MCP**: Use `mcp__graphite__run_gt_cmd` for all git branch/commit/push operations instead of direct git commands
- **Enforce Atlassian MCP for ALL Jira operations**: Clarify that `mcp__Atlassian__*` tools must be used exclusively for Jira (no CLI alternatives)
- **Add `.claude/atlassian-config.md`**: New reference document with field IDs, tool names, and configuration values
- **Update workflow guides**: Enhanced `create-pr-stack-for-stage.md` with Graphite best practices and stack management commands

### Key Changes

**CLAUDE.md:**
- Added explicit MCP tool requirements section with specific tool names
- Clarified Jira operations use Atlassian MCP exclusively
- Clarified GitHub operations can use GitHub MCP or `gh` CLI
- Specified which git commands are allowed vs must go through Graphite MCP

**atlassian-config.md (New):**
- Field IDs and format notes (Sprint, Assignee, GitHub Repository)
- Common JQL queries reference
- MCP tools reference table
- How to find active sprint ID

**create-pr-stack-for-stage.md:**
- Added Graphite best practices section
- Stack management commands (navigate, modify, sync, reorder)
- Handling conflicts and mid-stack changes

**.mcp.json:**
- Added Graphite MCP server configuration

## Test plan

- [x] Verify Claude Code uses Graphite MCP for branch/commit/push operations
- [x] Verify Claude Code uses Atlassian MCP for all Jira operations
- [x] Verify allowed git commands work directly (status, diff, add, log, stash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-1947]: https://lablup.atlassian.net/browse/FR-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ