### PR TITLE
fix(FR-1948): fix broken Storybook components on ui.backend.ai

### DIFF
--- a/packages/backend.ai-ui/.storybook/decorators.tsx
+++ b/packages/backend.ai-ui/.storybook/decorators.tsx
@@ -1,5 +1,41 @@
 import BAIText from '../src/components/BAIText';
 import { i18n } from '../src/locale';
+import dayjs from 'dayjs';
+import 'dayjs/locale/de';
+import 'dayjs/locale/el';
+import 'dayjs/locale/es';
+import 'dayjs/locale/fi';
+import 'dayjs/locale/fr';
+import 'dayjs/locale/id';
+import 'dayjs/locale/it';
+import 'dayjs/locale/ja';
+import 'dayjs/locale/ko';
+import 'dayjs/locale/mn';
+import 'dayjs/locale/ms';
+import 'dayjs/locale/pl';
+import 'dayjs/locale/pt';
+import 'dayjs/locale/pt-br';
+import 'dayjs/locale/ru';
+import 'dayjs/locale/th';
+import 'dayjs/locale/tr';
+import 'dayjs/locale/vi';
+import 'dayjs/locale/zh-cn';
+import 'dayjs/locale/zh-tw';
+import duration from 'dayjs/plugin/duration';
+import localeData from 'dayjs/plugin/localeData';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+import weekday from 'dayjs/plugin/weekday';
+
+dayjs.extend(weekday);
+dayjs.extend(localeData);
+dayjs.extend(localizedFormat);
+dayjs.extend(relativeTime);
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(duration);
 import { getAntdLocale } from './localeConfig';
 import { themeConfigs, type ThemeStyle } from './themeConfig';
 import type { Decorator } from '@storybook/react-vite';
@@ -90,6 +126,7 @@ const StorybookProvider: React.FC<StorybookProviderProps> = ({
 }) => {
   useEffect(() => {
     i18n.changeLanguage(locale);
+    dayjs.locale(locale);
   }, [locale]);
 
   return (

--- a/packages/backend.ai-ui/src/components/BAILink.tsx
+++ b/packages/backend.ai-ui/src/components/BAILink.tsx
@@ -1,4 +1,4 @@
-import { Typography } from 'antd';
+import { theme, Typography } from 'antd';
 import { createStyles } from 'antd-style';
 import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
@@ -34,8 +34,14 @@ const BAILink: React.FC<BAILinkProps> = ({
   ...linkProps
 }) => {
   const { styles } = useStyles();
+  const { token } = theme.useToken();
   return type !== 'disabled' && to ? (
-    <Link className={type ? styles?.[type] : undefined} to={to} {...linkProps}>
+    <Link
+      className={type ? styles?.[type] : undefined}
+      to={to}
+      {...linkProps}
+      style={{ fontFamily: token.fontFamily, ...linkProps.style }}
+    >
       {children}
     </Link>
   ) : (

--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.stories.tsx
@@ -38,7 +38,7 @@ export const Default: Story = {
   render: () => (
     <RelayResolver
       mockResolvers={{
-        ScalingGroupV2Connection: () => ({
+        ResourceGroupConnection: () => ({
           count: 3,
           edges: [
             { node: { id: 'rg-1', name: 'default' } },
@@ -59,7 +59,7 @@ export const Empty: Story = {
   render: () => (
     <RelayResolver
       mockResolvers={{
-        ScalingGroupV2Connection: () => ({
+        ResourceGroupConnection: () => ({
           count: 0,
           edges: [],
         }),
@@ -76,7 +76,7 @@ export const WithCustomPlaceholder: Story = {
   render: () => (
     <RelayResolver
       mockResolvers={{
-        ScalingGroupV2Connection: () => ({
+        ResourceGroupConnection: () => ({
           count: 5,
           edges: [
             { node: { id: 'rg-1', name: 'development' } },
@@ -99,7 +99,7 @@ export const Disabled: Story = {
   render: () => (
     <RelayResolver
       mockResolvers={{
-        ScalingGroupV2Connection: () => ({
+        ResourceGroupConnection: () => ({
           count: 3,
           edges: [
             { node: { id: 'rg-1', name: 'default' } },


### PR DESCRIPTION
Resolves #5111 ([FR-1948](https://lablup.atlassian.net/browse/FR-1948))

## Summary

Fixed three broken Storybook components on ui.backend.ai:

### 1. BAIFetchKeyButton - dayjs relativeTime error
- **Issue**: `me(...).fromNow is not a function` error
- **Root cause**: dayjs relativeTime plugin not loaded in Storybook
- **Fix**: Added all dayjs plugins (relativeTime, duration, utc, timezone, weekday, localeData, localizedFormat) and 21 locale imports to `.storybook/decorators.tsx` to match `BAIConfigProvider` configuration

### 2. BAIAdminResourceGroupSelect - items displayed as one
- **Issue**: All dropdown items displayed as a single item instead of separate options
- **Root cause**: Incorrect mock resolver type `ScalingGroupV2Connection` instead of `ResourceGroupConnection`
- **Fix**: Updated mock resolvers to use `ResourceGroupConnection` type across all story variants (Default, Empty, WithCustomPlaceholder, Disabled)

### 3. BAILink - Font not applied with WebUI theme
- **Issue**: react-router-dom `Link` component doesn't inherit Ant Design theme styles
- **Root cause**: react-router-dom Link doesn't automatically apply Ant Design theme tokens
- **Fix**: Added `theme.useToken()` to access fontFamily token and applied it via inline style to ensure consistent font rendering in Storybook WebUI theme

## Changes

- `packages/backend.ai-ui/.storybook/decorators.tsx`: Added dayjs plugins and locale support
- `packages/backend.ai-ui/src/components/BAILink.tsx`: Applied Ant Design theme fontFamily to Link component
- `packages/backend.ai-ui/src/components/fragments/BAIAdminResourceGroupSelect.stories.tsx`: Fixed mock resolver type

**Checklist:**

- [x] All three Storybook components now render correctly on ui.backend.ai
- [x] dayjs `fromNow()` function works in BAIFetchKeyButton
- [x] BAIAdminResourceGroupSelect displays items as separate options
- [x] BAILink applies correct font with WebUI theme

[FR-1948]: https://lablup.atlassian.net/browse/FR-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ