### PR TITLE
feat(FR-1860): Create a BAIProjectSelect

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectSelect.tsx
@@ -1,0 +1,293 @@
+import { BAIProjectSelectPaginatedQuery } from '../../__generated__/BAIProjectSelectPaginatedQuery.graphql';
+import { BAIProjectSelectValueQuery } from '../../__generated__/BAIProjectSelectValueQuery.graphql';
+import { toLocalId } from '../../helper';
+import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
+import { useFetchKey } from '../../hooks';
+import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import { mergeFilterValues } from '../BAIPropertyFilter';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import TotalFooter from '../TotalFooter';
+import { useControllableValue } from 'ahooks';
+import { GetRef, Skeleton } from 'antd';
+import _ from 'lodash';
+import {
+  useDeferredValue,
+  useImperativeHandle,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export type ProjectNode = NonNullable<
+  NonNullable<
+    BAIProjectSelectPaginatedQuery['response']['group_nodes']
+  >['edges'][number]
+>['node'];
+
+export interface BAIProjectSelectRef {
+  refetch: () => void;
+}
+
+export interface BAIProjectSelectProps extends Omit<
+  BAISelectProps,
+  'options' | 'labelInValue' | 'ref'
+> {
+  filter?: string;
+  ref?: React.Ref<BAIProjectSelectRef>;
+}
+
+const BAIProjectSelect: React.FC<BAIProjectSelectProps> = ({
+  loading,
+  filter,
+  ref,
+  ...selectProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+  const [controllableValue, setControllableValue] = useControllableValue<
+    string | string[] | undefined
+  >(selectProps);
+  const [controllableOpen, setControllableOpen] = useControllableValue<boolean>(
+    selectProps,
+    {
+      valuePropName: 'open',
+      trigger: 'onOpenChange',
+      defaultValuePropName: 'defaultOpen',
+    },
+  );
+  const deferredOpen = useDeferredValue(controllableOpen);
+  const [searchStr, setSearchStr] = useState<string>();
+  const deferredSearchStr = useDebouncedDeferredValue(searchStr);
+  const [optimisticSearchStr, setOptimisticSearchStr] =
+    useOptimistic(searchStr);
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  // Defer query refetch to prevent flickering during user selection
+  const deferredControllableValue = useDeferredValue(controllableValue);
+
+  const { group_nodes: selectedGroupNodes } =
+    useLazyLoadQuery<BAIProjectSelectValueQuery>(
+      graphql`
+        query BAIProjectSelectValueQuery(
+          $selectedFilter: String
+          $first: Int!
+          $skipSelected: Boolean!
+        ) {
+          group_nodes(
+            filter: $selectedFilter
+            first: $first
+            permission: "read_attribute"
+          ) @skip(if: $skipSelected) {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      `,
+      {
+        selectedFilter: mergeFilterValues(
+          [
+            !_.isEmpty(deferredControllableValue)
+              ? mergeFilterValues(
+                  _.castArray(deferredControllableValue).map((value) => {
+                    // Convert Global ID to local UUID for filtering
+                    const filterValue = toLocalId(value);
+                    return `id == "${filterValue}"`;
+                  }),
+                  '|',
+                )
+              : null,
+            filter,
+          ],
+          '&',
+        ),
+        first: _.castArray(deferredControllableValue).length,
+        skipSelected: _.isEmpty(deferredControllableValue),
+      },
+      {
+        fetchPolicy: !_.isEmpty(deferredControllableValue)
+          ? 'store-or-network'
+          : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+    );
+
+  const { paginationData, result, loadNext, isLoadingNext } =
+    useLazyPaginatedQuery<BAIProjectSelectPaginatedQuery, ProjectNode>(
+      graphql`
+        query BAIProjectSelectPaginatedQuery(
+          $offset: Int!
+          $limit: Int!
+          $filter: String
+        ) {
+          group_nodes(
+            offset: $offset
+            first: $limit
+            filter: $filter
+            permission: "read_attribute"
+            order: "-created_at"
+          ) {
+            count
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      `,
+      { limit: 10 },
+      {
+        filter: mergeFilterValues([
+          filter,
+          deferredSearchStr ? `name ilike "%${deferredSearchStr}%"` : null,
+        ]),
+      },
+      {
+        fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+      {
+        getTotal: (result) => result.group_nodes?.count ?? undefined,
+        getItem: (result) =>
+          result.group_nodes?.edges?.map((edge) => edge?.node),
+        getId: (item) => item?.id,
+      },
+    );
+
+  // Expose refetch function through ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: () => {
+        startRefetchTransition(() => {
+          updateFetchKey();
+        });
+      },
+    }),
+    [updateFetchKey, startRefetchTransition],
+  );
+
+  const availableOptions = _.map(paginationData, (item) => ({
+    label: item?.name,
+    value: item?.id,
+  }));
+
+  const controllableValueWithLabel = selectedGroupNodes?.edges
+    ? // Sort by deferredControllableValue order to maintain selection order
+      _.castArray(deferredControllableValue)
+        .map((value) => {
+          const edge = selectedGroupNodes.edges.find(
+            (edge) => edge?.node?.id === value,
+          );
+          return edge
+            ? {
+                label: edge.node?.name,
+                value: edge.node?.id,
+              }
+            : null;
+        })
+        .filter(
+          (item): item is { label: string; value: string } => item !== null,
+        )
+    : !_.isEmpty(deferredControllableValue)
+      ? _.castArray(deferredControllableValue).map((value) => ({
+          label: value,
+          value: value,
+        }))
+      : undefined;
+
+  const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
+    controllableValueWithLabel,
+  );
+
+  return (
+    <BAISelect
+      ref={selectRef}
+      placeholder={t('comp:BAIProjectSelect.SelectProject')}
+      loading={
+        loading ||
+        controllableValue !== deferredControllableValue ||
+        searchStr !== deferredSearchStr ||
+        isPendingRefetch
+      }
+      {...selectProps}
+      searchAction={async (value) => {
+        setOptimisticSearchStr(value);
+        setSearchStr(value);
+        await selectProps.searchAction?.(value);
+      }}
+      showSearch={
+        selectProps.showSearch === false
+          ? false
+          : {
+              searchValue: optimisticSearchStr,
+              autoClearSearchValue: true,
+              ...(_.isObject(selectProps.showSearch)
+                ? _.omit(selectProps.showSearch, ['searchValue'])
+                : {}),
+              filterOption: false,
+            }
+      }
+      value={
+        controllableValue !== deferredControllableValue
+          ? optimisticValueWithLabel
+          : controllableValueWithLabel
+      }
+      labelInValue
+      onChange={(value, option) => {
+        // In multiple mode, when removing tags, value.label is a React element
+        // So we need to find the original label from availableOptions
+        const castedValue = _.isEmpty(value) ? [] : _.castArray(value);
+        const valueWithOriginalLabel = castedValue.map((v) => {
+          // If label is string, use it directly; if React element, find from options
+          const label = _.isString(v.label)
+            ? v.label
+            : (availableOptions.find((opt) => opt.value === v.value)?.label ??
+              v.value);
+          return {
+            label,
+            value: v.value,
+          };
+        });
+        setOptimisticValueWithLabel(valueWithOriginalLabel);
+        setControllableValue(
+          castedValue.map((v) => _.toString(v.value)),
+          option,
+        );
+      }}
+      options={availableOptions}
+      endReached={() => {
+        loadNext();
+      }}
+      open={controllableOpen}
+      onOpenChange={setControllableOpen}
+      notFoundContent={
+        _.isUndefined(paginationData) ? (
+          <Skeleton.Input active size="small" block />
+        ) : undefined
+      }
+      footer={
+        _.isNumber(result.group_nodes?.count) &&
+        result.group_nodes.count > 0 ? (
+          <TotalFooter
+            loading={isLoadingNext}
+            total={result.group_nodes.count}
+          />
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BAIProjectSelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -81,3 +81,9 @@ export type {
   UserNode,
   BAIUserSelectRef,
 } from './BAIUserSelect';
+export { default as BAIProjectSelect } from './BAIProjectSelect';
+export type {
+  BAIProjectSelectProps,
+  ProjectNode,
+  BAIProjectSelectRef,
+} from './BAIProjectSelect';

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Projektressourcenrichtlinie",
     "UpdateMultipleProjects": "Mehrere Projekte aktualisieren"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Projekt auswählen"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Zugelassene Hosts für Ordner",
     "AllowedResourceGroups": "Zugelassene Ressourcengruppen",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Πολιτική πόρων έργου",
     "UpdateMultipleProjects": "Ενημέρωση πολλαπλών έργων"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Επιλέξτε έργο"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Επιτρεπόμενοι hosts φακέλων",
     "AllowedResourceGroups": "Επιτρεπόμενες ομάδες πόρων",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Project Resource Policy",
     "UpdateMultipleProjects": "Update Multiple Projects"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Select Project"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Allowed Folder Hosts",
     "AllowedResourceGroups": "Allowed Resource Groups",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Política de recursos del proyecto",
     "UpdateMultipleProjects": "Actualizar varios proyectos"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Seleccionar proyecto"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Hosts permitidos para carpetas",
     "AllowedResourceGroups": "Grupos de recursos permitidos",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Projektin resurssipolitiikka",
     "UpdateMultipleProjects": "Päivitä useita projekteja"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Valitse projekti"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Sallitut kansioisäntäkoneet",
     "AllowedResourceGroups": "Sallitut resurssiryhmät",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Politique de ressources du projet",
     "UpdateMultipleProjects": "Mettre à jour plusieurs projets"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Sélectionner un projet"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Hôtes autorisés pour les dossiers",
     "AllowedResourceGroups": "Groupes de ressources autorisés",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Kebijakan Sumber Daya Proyek",
     "UpdateMultipleProjects": "Perbarui Beberapa Proyek"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Pilih Proyek"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Host Folder yang Diizinkan",
     "AllowedResourceGroups": "Grup Sumber Daya yang Diizinkan",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Politica delle risorse del progetto",
     "UpdateMultipleProjects": "Aggiorna più progetti"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Seleziona progetto"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Host autorizzati per le cartelle",
     "AllowedResourceGroups": "Gruppi di risorse consentiti",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "プロジェクトのリソースポリシー",
     "UpdateMultipleProjects": "プロジェクトを一括更新"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "プロジェクトを選択"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "許可済みフォルダホスト",
     "AllowedResourceGroups": "許可されたリソースグループ",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "프로젝트 리소스 정책",
     "UpdateMultipleProjects": "프로젝트 일괄 업데이트"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "프로젝트를 선택해주세요"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "허용된 호스트",
     "AllowedResourceGroups": "허용된 리소스 그룹",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Төслийн нөөцийн бодлого",
     "UpdateMultipleProjects": "Олон төслийг шинэчлэх"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Төсөл сонгох"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Зөвшөөрөгдсөн хавтас хостууд",
     "AllowedResourceGroups": "Зөвшөөрөгдсөн нөөцийн бүлгүүд",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Polisi Sumber Projek",
     "UpdateMultipleProjects": "Kemas kini Beberapa Projek"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Pilih Projek"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Hos Dibenarkan untuk Folder",
     "AllowedResourceGroups": "Kumpulan Sumber yang Dibenarkan",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Polityka zasobów projektu",
     "UpdateMultipleProjects": "Aktualizuj wiele projektów"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Wybierz projekt"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Dozwolone hosty dla folderów",
     "AllowedResourceGroups": "Dozwolone grupy zasobów",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -100,6 +100,9 @@
     "ProjectResourcePolicy": "Política de Recursos do Projeto",
     "UpdateMultipleProjects": "Atualizar vários projetos"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Selecionar projeto"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Hosts permitidos para pastas",
     "AllowedResourceGroups": "Grupos de Recursos Permitidos",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Política de Recursos do Projeto",
     "UpdateMultipleProjects": "Atualizar vários projetos"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Selecionar projeto"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Hosts permitidos para pastas",
     "AllowedResourceGroups": "Grupos de Recursos Permitidos",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Политика ресурсов проекта",
     "UpdateMultipleProjects": "Обновить несколько проектов"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Выберите проект"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Разрешённые хосты для папок",
     "AllowedResourceGroups": "Разрешённые группы ресурсов",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "นโยบายทรัพยากรโครงการ",
     "UpdateMultipleProjects": "อัปเดตหลายโครงการ"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "เลือกโปรเจกต์"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "โฮสต์ที่อนุญาตสำหรับโฟลเดอร์",
     "AllowedResourceGroups": "กลุ่มทรัพยากรที่ได้รับอนุญาต",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Proje Kaynak Politikası",
     "UpdateMultipleProjects": "Birden Çok Projeyi Güncelle"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Proje seç"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "İzin Verilen Klasör Sunucuları",
     "AllowedResourceGroups": "İzin Verilen Kaynak Grupları",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "Chính sách tài nguyên dự án",
     "UpdateMultipleProjects": "Cập nhật nhiều dự án"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "Chọn dự án"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "Máy chủ thư mục được cho phép",
     "AllowedResourceGroups": "Nhóm tài nguyên được phép",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "项目资源策略",
     "UpdateMultipleProjects": "批量更新项目"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "选择项目"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "允许的文件夹主机",
     "AllowedResourceGroups": "允许的资源组",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -101,6 +101,9 @@
     "ProjectResourcePolicy": "專案資源政策",
     "UpdateMultipleProjects": "更新多個專案"
   },
+  "comp:BAIProjectSelect": {
+    "SelectProject": "選擇專案"
+  },
   "comp:BAIProjectSettingModal": {
     "AllowedFolderHosts": "允許的資料夾主機",
     "AllowedResourceGroups": "允許的資源群組",

--- a/react/src/components/Chat/EndpointSelect.tsx
+++ b/react/src/components/Chat/EndpointSelect.tsx
@@ -53,6 +53,7 @@ const EndpointSelect: React.FC<EndpointSelectProps> = ({
     {
       valuePropName: 'open',
       trigger: 'onOpenChange',
+      defaultValuePropName: 'defaultOpen',
     },
   );
   const deferredOpen = useDeferredValue(controllableOpen);


### PR DESCRIPTION
resolves #4932 (FR-1860)

This PR adds a new `BAIProjectSelect` component that provides a searchable dropdown for selecting projects. The component:

- Supports single and multiple project selection
- Includes pagination with infinite scrolling
- Provides search functionality to filter projects by name
- Shows loading states appropriately
- Maintains selection order in multi-select mode
- Exposes a refetch method via ref for refreshing data
- Includes proper TypeScript typing and GraphQL integration

The component is exported from the fragments index to make it available throughout the application.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after