### PR TITLE
fix(FR-1970): apply an optimistic update to the BAIVFolderSelect

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -180,9 +180,12 @@ function BAISelect<
         {...selectProps}
         loading={isPending || selectProps.loading}
         showSearch={
-          selectProps.showSearch && _.isObject(selectProps.showSearch)
-            ? {
-                ...selectProps.showSearch,
+          selectProps.showSearch === false
+            ? false
+            : {
+                ...(_.isObject(selectProps.showSearch)
+                  ? selectProps.showSearch
+                  : {}),
                 onSearch: async (value) => {
                   _.get(selectProps.showSearch, 'onSearch')?.(value);
                   startTransition(async () => {
@@ -190,7 +193,6 @@ function BAISelect<
                   });
                 },
               }
-            : false
         }
         ref={ref}
         className={classNames(

--- a/packages/backend.ai-ui/src/components/BAITag.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAITag.test.tsx
@@ -1,6 +1,6 @@
 import BAITag from './BAITag';
-import { describe, expect, it } from '@jest/globals';
 import { render, screen, act } from '@testing-library/react';
+
 describe('BAITag', () => {
   describe('Basic Rendering', () => {
     it('should render tag with children text', () => {
@@ -92,12 +92,12 @@ describe('BAITag', () => {
     });
 
     it('should handle bordered property', () => {
-      render(<BAITag bordered>Bordered Tag</BAITag>);
+      render(<BAITag variant="outlined">Bordered Tag</BAITag>);
       expect(screen.getByText('Bordered Tag')).toBeInTheDocument();
     });
 
     it('should handle bordered={false} property', () => {
-      render(<BAITag bordered={false}>No Border Tag</BAITag>);
+      render(<BAITag variant="filled">No Border Tag</BAITag>);
       expect(screen.getByText('No Border Tag')).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
resolves #5142 (FR-1970)

This PR addresses two issues:

1. Fixes the `showSearch` behavior in the `BAISelect` component:
   - Previously, when `showSearch` was a simple `true` value, it was not applied correctly because the component only handled the object form of `showSearch`
   - Now `showSearch` works properly for both the boolean (`true/false`) and object configurations

2. Improves search experience in `BAIVFolderSelect`:
   - Implements optimistic UI updates for search using React's `useOptimistic` hook
   - Updates the search value immediately in the UI before the actual search action completes
   - Maintains the actual search state separately from the optimistic display value

These changes provide a more responsive user experience when searching in folder selection dropdowns.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after