### PR TITLE
docs(FR-1974): add Storybook story for component

### DIFF
--- a/.claude/commands/create-bui-component-story.md
+++ b/.claude/commands/create-bui-component-story.md
@@ -45,13 +45,28 @@ export interface BAIAlertProps extends AlertProps {
 
 ## Step 2: Determine Story Category
 
-| Component Type | Title Pattern |
-|----------------|---------------|
-| General UI Component | `Components/[Name]` |
-| Input Component | `Components/Input/[Name]` |
-| Layout Component | `Layout/[Name]` |
-| Table Sub-component | `Components/BAITable/[Name]` |
-| Relay Fragment Component | `Fragments/[Name]` |
+Check existing story files' `title` values to determine the correct category. Use the same category as similar components.
+
+| Category | Components | Title Pattern |
+|----------|------------|---------------|
+| Alert | BAIAlert, BAIAlertIconWithTooltip | `Alert/[Name]` |
+| Board | BAIBoardItemTitle | `Board/[Name]` |
+| Button | BAIButton, BAIBackButton, BAIFetchKeyButton | `Button/[Name]` |
+| Card | BAICard | `Card/[Name]` |
+| Filter | BAIPropertyFilter, BAIGraphQLPropertyFilter | `Filter/[Name]` |
+| Flex | BAIFlex | `Flex/[Name]` |
+| Input | DynamicUnitInputNumber, DynamicUnitInputNumberWithSlider | `Input/[Name]` |
+| Link | BAILink | `Link/[Name]` |
+| Modal | BAIModal, BAIConfirmModalWithInput | `Modal/[Name]` |
+| Notification | BAINotificationItem | `Notification/[Name]` |
+| Row | BAIRowWrapWithDividers | `Row/[Name]` |
+| Select | BAISelect | `Select/[Name]` |
+| Statistic | BAIStatistic, BAINumberWithUnit, BAIResourceNumberWithIcon, BAIProgressWithLabel | `Statistic/[Name]` |
+| Tag | BAITag, BooleanTag, BAIDoubleTag | `Tag/[Name]` |
+| Text | BAIText, BAITextHighlighter | `Text/[Name]` |
+| Relay Fragment | (components using GraphQL fragments) | `Fragments/[Name]` |
+
+If no existing category fits, create a new one following the `[Category]/[Name]` pattern.
 
 ## Step 3: Generate Story File
 

--- a/packages/backend.ai-ui/src/components/BAIDoubleTag.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDoubleTag.stories.tsx
@@ -1,0 +1,285 @@
+import BAIDoubleTag from './BAIDoubleTag';
+import BAIFlex from './BAIFlex';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * BAIDoubleTag displays multiple tags side-by-side with a connected appearance.
+ *
+ * Key features:
+ * - Accepts both string arrays and object arrays with custom colors/styles
+ * - Built-in text highlighting support
+ * - Automatic ellipsis with tooltip for long labels
+ * - Tags are visually connected (no gaps between them)
+ *
+ * @see BAIDoubleTag.tsx for implementation details
+ */
+const meta: Meta<typeof BAIDoubleTag> = {
+  title: 'Tag/BAIDoubleTag',
+  component: BAIDoubleTag,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**BAIDoubleTag** displays multiple tags in a connected layout with advanced text handling.
+
+## Features
+- **Flexible input**: Accepts string arrays or object arrays with custom properties
+- **Text highlighting**: Built-in keyword highlighting with \`highlightKeyword\`
+- **Ellipsis support**: Automatically truncates long labels with tooltips
+- **Connected appearance**: Tags are visually connected without gaps
+- **Custom styling**: Supports custom colors and styles per tag
+
+## Usage
+\`\`\`tsx
+// String array
+<BAIDoubleTag values={['Python', '3.11']} />
+
+// Object array with colors
+<BAIDoubleTag
+  values={[
+    { label: 'Python', color: 'blue' },
+    { label: '3.11', color: 'green' }
+  ]}
+/>
+
+// With keyword highlighting
+<BAIDoubleTag
+  values={['Python', '3.11']}
+  highlightKeyword="py"
+/>
+\`\`\`
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| \`values\` | \`string[] \\| DoubleTagObjectValue[]\` | \`[]\` | Tag values as strings or objects with color/style |
+| \`highlightKeyword\` | \`string\` | - | Keyword to highlight in tag labels |
+
+### DoubleTagObjectValue
+| Property | Type | Description |
+|----------|------|-------------|
+| \`label\` | \`string\` | Tag label text |
+| \`color\` | \`string\` | Tag color (Ant Design color presets or custom) |
+| \`style\` | \`React.CSSProperties\` | Custom styles for the tag |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    values: {
+      control: { type: 'object' },
+      description:
+        'Array of tag values (strings or objects with label, color, and style properties)',
+      table: {
+        type: { summary: 'string[] | DoubleTagObjectValue[]' },
+        defaultValue: { summary: '[]' },
+      },
+    },
+    highlightKeyword: {
+      control: { type: 'text' },
+      description: 'Keyword to highlight within tag labels',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIDoubleTag>;
+
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Basic usage with a string array. Tags are automatically styled with blue color.',
+      },
+    },
+  },
+  args: {
+    values: ['Frontend', 'Backend', 'Database'],
+  },
+};
+
+export const ObjectValues: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates using object values with custom colors for each tag.',
+      },
+    },
+  },
+  args: {
+    values: [
+      { label: 'Python', color: 'blue' },
+      { label: '3.11', color: 'green' },
+    ],
+  },
+};
+
+export const WithHighlight: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Highlights matching keywords within tag labels using BAITextHighlighter.',
+      },
+    },
+  },
+  args: {
+    values: ['Frontend', 'Backend', 'Database'],
+    highlightKeyword: 'end',
+  },
+};
+
+export const CustomColors: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Showcases various Ant Design color presets available for tags.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md">
+      <BAIDoubleTag
+        values={[
+          { label: 'Success', color: 'success' },
+          { label: 'Processing', color: 'processing' },
+        ]}
+      />
+      <BAIDoubleTag
+        values={[
+          { label: 'Warning', color: 'warning' },
+          { label: 'Error', color: 'error' },
+        ]}
+      />
+      <BAIDoubleTag
+        values={[
+          { label: 'Magenta', color: 'magenta' },
+          { label: 'Purple', color: 'purple' },
+          { label: 'Cyan', color: 'cyan' },
+        ]}
+      />
+      <BAIDoubleTag
+        values={[
+          { label: 'Gold', color: 'gold' },
+          { label: 'Lime', color: 'lime' },
+          { label: 'Volcano', color: 'volcano' },
+        ]}
+      />
+    </BAIFlex>
+  ),
+};
+
+export const LongLabels: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Long tag labels are automatically truncated with ellipsis. Hover over the tags to see the full text in a tooltip.',
+      },
+    },
+  },
+  args: {
+    values: [
+      { label: 'Very Long Tag Label That Will Be Truncated', color: 'blue' },
+      { label: 'Another Long Label', color: 'orange' },
+    ],
+  },
+};
+
+export const CustomStyles: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Each tag can have custom styles (font weight, size, style, etc.) through the style property.',
+      },
+    },
+  },
+  args: {
+    values: [
+      {
+        label: 'Custom',
+        color: 'purple',
+        style: { fontWeight: 'bold', fontSize: 14 },
+      },
+      { label: 'Styled', color: 'cyan', style: { fontStyle: 'italic' } },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'When values array is empty, the component renders null.',
+      },
+    },
+  },
+  args: {
+    values: [],
+  },
+};
+
+export const RealWorldExample: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Realistic examples showing how BAIDoubleTag is used in Backend.AI WebUI, such as displaying image names with versions, or resource allocations.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" style={{ alignItems: 'flex-start' }}>
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>Container Image:</div>
+        <BAIDoubleTag
+          values={[
+            { label: 'lablup/python', color: 'blue' },
+            { label: '3.11-ubuntu22.04', color: 'green' },
+          ]}
+        />
+      </div>
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>GPU Allocation:</div>
+        <BAIDoubleTag
+          values={[
+            { label: 'NVIDIA', color: 'processing' },
+            { label: 'A100', color: 'success' },
+            { label: '2 cores', color: 'orange' },
+          ]}
+        />
+      </div>
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>Session Status:</div>
+        <BAIDoubleTag
+          values={[
+            { label: 'RUNNING', color: 'success' },
+            { label: 'kernel-python', color: 'blue' },
+          ]}
+        />
+      </div>
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>
+          Search Result (keyword: &quot;tensor&quot;):
+        </div>
+        <BAIDoubleTag
+          values={[
+            { label: 'tensorflow', color: 'orange' },
+            { label: '2.12', color: 'cyan' },
+          ]}
+          highlightKeyword="tensor"
+        />
+      </div>
+    </BAIFlex>
+  ),
+};

--- a/packages/backend.ai-ui/src/components/BAIIntervalView.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIIntervalView.stories.tsx
@@ -1,0 +1,371 @@
+import BAIFlex from './BAIFlex';
+import BAIIntervalView from './BAIIntervalView';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from 'antd';
+import { useRef, useState } from 'react';
+
+/**
+ * BAIIntervalView renders content that updates at specified intervals.
+ *
+ * Key features:
+ * - Auto-updates content at specified intervals
+ * - Supports custom render function or direct value display
+ * - Trigger immediate update with triggerKey
+ * - Pauses when tab is hidden (by default)
+ *
+ * @see BAIIntervalView.tsx for implementation details
+ */
+const meta: Meta<typeof BAIIntervalView> = {
+  title: 'Utility/BAIIntervalView',
+  component: BAIIntervalView,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**BAIIntervalView** is a utility component that automatically updates its content at specified intervals.
+
+## Features
+- **Interval updates**: Execute callback at regular intervals and display the result
+- **Custom rendering**: Use \`render\` prop for custom display logic
+- **Manual trigger**: Update immediately when \`triggerKey\` changes
+- **Visibility-aware**: Automatically pauses when tab is hidden to save resources
+
+## Usage
+\`\`\`tsx
+// Display current time updated every second
+<BAIIntervalView
+  callback={() => new Date().toLocaleTimeString()}
+  delay={1000}
+/>
+
+// Custom render function
+<BAIIntervalView
+  callback={() => Math.random()}
+  delay={2000}
+  render={(value) => <div>Random: {value.toFixed(3)}</div>}
+/>
+
+// Manual trigger with triggerKey
+<BAIIntervalView
+  callback={fetchData}
+  delay={5000}
+  triggerKey={refreshKey}
+/>
+\`\`\`
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| \`callback\` | \`() => T\` | (required) | Function that returns the value to display |
+| \`delay\` | \`number \\| null\` | (required) | Update interval in milliseconds, or null to pause |
+| \`render\` | \`(data: T) => ReactNode\` | - | Custom render function, if omitted shows value directly |
+| \`triggerKey\` | \`string\` | - | Changing this value triggers immediate update |
+
+## When to Use
+- Real-time clocks or timers
+- Periodic status polling
+- Live data displays that need regular updates
+- Any content that changes over time and needs automatic refresh
+        `,
+      },
+    },
+  },
+  argTypes: {
+    callback: {
+      control: false,
+      description: 'Function that returns the value to display',
+      table: {
+        type: { summary: '() => T' },
+      },
+    },
+    delay: {
+      control: { type: 'number', min: 100, max: 10000, step: 100 },
+      description: 'Update interval in milliseconds (null to pause)',
+      table: {
+        type: { summary: 'number | null' },
+      },
+    },
+    render: {
+      control: false,
+      description: 'Optional custom render function',
+      table: {
+        type: { summary: '(data: T) => ReactNode' },
+      },
+    },
+    triggerKey: {
+      control: { type: 'text' },
+      description: 'Changing this value triggers immediate update',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIIntervalView>;
+
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Basic usage showing current time updated every second.',
+      },
+    },
+  },
+  render: () => (
+    <div>
+      <div style={{ marginBottom: 8, fontWeight: 500 }}>Current Time:</div>
+      <div style={{ fontSize: 24, fontFamily: 'monospace' }}>
+        <BAIIntervalView
+          callback={() => new Date().toLocaleTimeString()}
+          delay={1000}
+        />
+      </div>
+    </div>
+  ),
+};
+
+export const CustomRender: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Using custom render function to format the output. Shows random number updated every 2 seconds.',
+      },
+    },
+  },
+  render: () => (
+    <BAIIntervalView
+      callback={() => Math.random()}
+      delay={2000}
+      render={(value) => (
+        <div
+          style={{
+            padding: 16,
+            background: '#f5f5f5',
+            borderRadius: 4,
+            fontFamily: 'monospace',
+          }}
+        >
+          <div>Random Value: {value.toFixed(6)}</div>
+          <div style={{ fontSize: 12, color: '#666', marginTop: 4 }}>
+            Updates every 2 seconds
+          </div>
+        </div>
+      )}
+    />
+  ),
+};
+
+export const ManualTrigger: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates triggerKey to force immediate update. Click the button to trigger refresh.',
+      },
+    },
+  },
+  render: () => {
+    const [triggerKey, setTriggerKey] = useState('initial');
+    const countRef = useRef(0);
+
+    return (
+      <BAIFlex direction="column" gap="md">
+        <Button onClick={() => setTriggerKey(Date.now().toString())}>
+          Trigger Update
+        </Button>
+
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>
+            Auto-update every 5s:
+          </div>
+          <BAIIntervalView
+            callback={() => {
+              countRef.current += 1;
+              return `Updated at ${new Date().toLocaleTimeString()} (count: ${countRef.current})`;
+            }}
+            delay={5000}
+            triggerKey={triggerKey}
+            render={(value) => (
+              <div
+                style={{
+                  padding: 12,
+                  background: '#f5f5f5',
+                  borderRadius: 4,
+                  fontFamily: 'monospace',
+                }}
+              >
+                {value}
+              </div>
+            )}
+          />
+        </div>
+      </BAIFlex>
+    );
+  },
+};
+
+export const PauseResume: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates pausing and resuming the interval by setting delay to null.',
+      },
+    },
+  },
+  render: () => {
+    const [delay, setDelay] = useState<number | null>(1000);
+
+    return (
+      <BAIFlex direction="column" gap="md">
+        <BAIFlex gap="sm">
+          <Button
+            onClick={() => setDelay(1000)}
+            type={delay === 1000 ? 'primary' : 'default'}
+          >
+            Start (1s)
+          </Button>
+          <Button
+            onClick={() => setDelay(null)}
+            type={delay === null ? 'primary' : 'default'}
+          >
+            Pause
+          </Button>
+        </BAIFlex>
+
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>
+            Status: {delay === null ? '⏸️ Paused' : '▶️ Running'}
+          </div>
+          <div style={{ fontSize: 20, fontFamily: 'monospace' }}>
+            <BAIIntervalView
+              callback={() => new Date().toLocaleTimeString()}
+              delay={delay}
+            />
+          </div>
+        </div>
+      </BAIFlex>
+    );
+  },
+};
+
+export const MultipleCounters: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Multiple interval views with different update frequencies.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md">
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>Fast (1s):</div>
+        <BAIIntervalView
+          callback={() => Date.now()}
+          delay={1000}
+          render={(ms) => <div style={{ fontFamily: 'monospace' }}>{ms}</div>}
+        />
+      </div>
+
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>Medium (2s):</div>
+        <BAIIntervalView
+          callback={() => new Date().toLocaleTimeString()}
+          delay={2000}
+          render={(time) => (
+            <div style={{ fontFamily: 'monospace' }}>{time}</div>
+          )}
+        />
+      </div>
+
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>Slow (5s):</div>
+        <BAIIntervalView
+          callback={() => new Date().toLocaleDateString()}
+          delay={5000}
+          render={(date) => (
+            <div style={{ fontFamily: 'monospace' }}>{date}</div>
+          )}
+        />
+      </div>
+    </BAIFlex>
+  ),
+};
+
+export const RealWorldExample: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Realistic example: Session uptime counter and status polling.',
+      },
+    },
+  },
+  render: () => {
+    const startTimeRef = useRef(Date.now());
+    const [isRunning, setIsRunning] = useState(true);
+
+    return (
+      <BAIFlex direction="column" gap="lg" style={{ width: 400 }}>
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>Session Uptime</div>
+          <div
+            style={{
+              padding: 16,
+              background: '#f5f5f5',
+              borderRadius: 4,
+              fontFamily: 'monospace',
+              fontSize: 24,
+            }}
+          >
+            <BAIIntervalView
+              callback={() => {
+                const elapsed = Date.now() - startTimeRef.current;
+                const seconds = Math.floor(elapsed / 1000);
+                const minutes = Math.floor(seconds / 60);
+                const hours = Math.floor(minutes / 60);
+                return `${hours.toString().padStart(2, '0')}:${(minutes % 60).toString().padStart(2, '0')}:${(seconds % 60).toString().padStart(2, '0')}`;
+              }}
+              delay={isRunning ? 1000 : null}
+            />
+          </div>
+        </div>
+
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>
+            Resource Usage (refreshes every 3s)
+          </div>
+          <BAIIntervalView
+            callback={() => ({
+              cpu: (Math.random() * 100).toFixed(1),
+              memory: (Math.random() * 100).toFixed(1),
+            })}
+            delay={isRunning ? 3000 : null}
+            render={(usage) => (
+              <div
+                style={{
+                  padding: 12,
+                  background: '#f5f5f5',
+                  borderRadius: 4,
+                }}
+              >
+                <div>CPU: {usage.cpu}%</div>
+                <div>Memory: {usage.memory}%</div>
+              </div>
+            )}
+          />
+        </div>
+
+        <Button onClick={() => setIsRunning(!isRunning)} type="primary" block>
+          {isRunning ? 'Pause Monitoring' : 'Resume Monitoring'}
+        </Button>
+      </BAIFlex>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/BAIProgressWithLabel.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIProgressWithLabel.stories.tsx
@@ -1,0 +1,412 @@
+import BAIFlex from './BAIFlex';
+import BAIProgressWithLabel from './BAIProgressWithLabel';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * BAIProgressWithLabel displays a progress bar with title and value labels.
+ *
+ * Key features:
+ * - Title label on the left, value label on the right
+ * - Three size variants (small, middle, large)
+ * - Custom colors and styling support
+ * - Handles edge cases (NaN, 0%, 100%)
+ *
+ * @see BAIProgressWithLabel.tsx for implementation details
+ */
+const meta: Meta<typeof BAIProgressWithLabel> = {
+  title: 'Statistic/BAIProgressWithLabel',
+  component: BAIProgressWithLabel,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**BAIProgressWithLabel** is a custom progress component with title and value labels.
+
+## Features
+- **Dual labels**: Title on the left, value on the right
+- **Size variants**: Small, middle, and large sizes
+- **Custom styling**: Supports custom colors and styles
+- **Edge case handling**: Gracefully handles NaN, undefined, and out-of-range percentages
+- **Flexible width**: Supports fixed width or flex-based width
+
+## Usage
+\`\`\`tsx
+// Basic usage
+<BAIProgressWithLabel
+  title="CPU"
+  valueLabel="75%"
+  percent={75}
+/>
+
+// With custom color
+<BAIProgressWithLabel
+  title="Memory"
+  valueLabel="8GB / 16GB"
+  percent={50}
+  strokeColor="#ff4d4f"
+/>
+
+// Large size
+<BAIProgressWithLabel
+  title="Storage"
+  valueLabel="500GB / 1TB"
+  percent={50}
+  size="large"
+/>
+\`\`\`
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| \`title\` | \`ReactNode\` | - | Left label (usually resource name) |
+| \`valueLabel\` | \`ReactNode\` | - | Right label (usually current/total values) |
+| \`percent\` | \`number\` | - | Progress percentage (0-100) |
+| \`width\` | \`React.CSSProperties['width']\` | \`'flex: 1'\` | Custom width for the container |
+| \`strokeColor\` | \`string\` | \`token.colorSuccess\` | Progress bar fill color |
+| \`labelStyle\` | \`React.CSSProperties\` | - | Custom styles for both labels |
+| \`progressStyle\` | \`React.CSSProperties\` | - | Custom styles for the container |
+| \`size\` | \`'small' \\| 'middle' \\| 'large'\` | \`'small'\` | Size variant |
+| \`showInfo\` | \`boolean\` | \`true\` | Whether to show value label |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    title: {
+      control: { type: 'text' },
+      description: 'Left label, usually the resource name',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+    valueLabel: {
+      control: { type: 'text' },
+      description: 'Right label, usually current/total values',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+    percent: {
+      control: { type: 'number', min: 0, max: 100, step: 1 },
+      description: 'Progress percentage (0-100)',
+      table: {
+        type: { summary: 'number' },
+      },
+    },
+    width: {
+      control: { type: 'text' },
+      description: 'Custom width (CSS value or number)',
+      table: {
+        type: { summary: "React.CSSProperties['width']" },
+        defaultValue: { summary: 'flex: 1' },
+      },
+    },
+    strokeColor: {
+      control: { type: 'text' },
+      description: 'Progress bar fill color',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'token.colorSuccess' },
+      },
+    },
+    labelStyle: {
+      control: { type: 'object' },
+      description: 'Custom styles for both title and value labels',
+      table: {
+        type: { summary: 'React.CSSProperties' },
+      },
+    },
+    progressStyle: {
+      control: { type: 'object' },
+      description: 'Custom styles for the progress container',
+      table: {
+        type: { summary: 'React.CSSProperties' },
+      },
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['small', 'middle', 'large'],
+      description: 'Size variant affecting font size',
+      table: {
+        type: { summary: "'small' | 'middle' | 'large'" },
+        defaultValue: { summary: 'small' },
+      },
+    },
+    showInfo: {
+      control: { type: 'boolean' },
+      description: 'Whether to show the value label',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'true' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIProgressWithLabel>;
+
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Basic usage with title, value label, and percentage.',
+      },
+    },
+  },
+  args: {
+    title: 'CPU Usage',
+    valueLabel: '75%',
+    percent: 75,
+    size: 'small',
+  },
+};
+
+export const SizeVariants: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Three size variants available: small, middle, and large. Size affects font size of labels.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" style={{ width: 300 }}>
+      <BAIProgressWithLabel
+        title="Small Size"
+        valueLabel="50%"
+        percent={50}
+        size="small"
+      />
+      <BAIProgressWithLabel
+        title="Middle Size"
+        valueLabel="50%"
+        percent={50}
+        size="middle"
+      />
+      <BAIProgressWithLabel
+        title="Large Size"
+        valueLabel="50%"
+        percent={50}
+        size="large"
+      />
+    </BAIFlex>
+  ),
+};
+
+export const CustomColors: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Custom stroke colors can be applied to indicate different states or resource types.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" style={{ width: 300 }}>
+      <BAIProgressWithLabel
+        title="Success"
+        valueLabel="25%"
+        percent={25}
+        strokeColor="#52c41a"
+      />
+      <BAIProgressWithLabel
+        title="Warning"
+        valueLabel="50%"
+        percent={50}
+        strokeColor="#faad14"
+      />
+      <BAIProgressWithLabel
+        title="Error"
+        valueLabel="75%"
+        percent={75}
+        strokeColor="#ff4d4f"
+      />
+      <BAIProgressWithLabel
+        title="Info"
+        valueLabel="100%"
+        percent={100}
+        strokeColor="#1890ff"
+      />
+    </BAIFlex>
+  ),
+};
+
+export const CustomStyles: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Custom styles can be applied to labels and the progress container.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" style={{ width: 300 }}>
+      <BAIProgressWithLabel
+        title="Bold Labels"
+        valueLabel="60%"
+        percent={60}
+        labelStyle={{ fontWeight: 'bold' }}
+      />
+      <BAIProgressWithLabel
+        title="Custom Container"
+        valueLabel="40%"
+        percent={40}
+        progressStyle={{ borderRadius: 8, padding: 8 }}
+      />
+      <BAIProgressWithLabel
+        title="Monospace Value"
+        valueLabel="80%"
+        percent={80}
+        labelStyle={{ fontFamily: 'monospace' }}
+      />
+    </BAIFlex>
+  ),
+};
+
+export const EdgeCases: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Handles edge cases gracefully: 0%, 100%, NaN, and undefined percentages.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" style={{ width: 300 }}>
+      <BAIProgressWithLabel title="Zero Percent" valueLabel="0%" percent={0} />
+      <BAIProgressWithLabel
+        title="Full Percent"
+        valueLabel="100%"
+        percent={100}
+      />
+      <BAIProgressWithLabel
+        title="NaN Percent"
+        valueLabel="N/A"
+        percent={NaN}
+      />
+      <BAIProgressWithLabel
+        title="Undefined Percent"
+        valueLabel="N/A"
+        percent={undefined}
+      />
+      <BAIProgressWithLabel title="Over 100%" valueLabel="150%" percent={150} />
+    </BAIFlex>
+  ),
+};
+
+export const HideInfo: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Value label can be hidden using showInfo prop.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" style={{ width: 300 }}>
+      <BAIProgressWithLabel
+        title="With Info"
+        valueLabel="75%"
+        percent={75}
+        showInfo={true}
+      />
+      <BAIProgressWithLabel
+        title="Without Info"
+        valueLabel="75%"
+        percent={75}
+        showInfo={false}
+      />
+    </BAIFlex>
+  ),
+};
+
+export const RealWorldExample: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Realistic examples showing resource usage displays in Backend.AI WebUI.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="lg" style={{ width: 400 }}>
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>
+          Compute Resource Usage
+        </div>
+        <BAIFlex direction="column" gap="sm">
+          <BAIProgressWithLabel
+            title="CPU"
+            valueLabel="12 / 16 Cores"
+            percent={75}
+            strokeColor="#1890ff"
+            size="middle"
+          />
+          <BAIProgressWithLabel
+            title="Memory"
+            valueLabel="24GB / 64GB"
+            percent={37.5}
+            strokeColor="#52c41a"
+            size="middle"
+          />
+          <BAIProgressWithLabel
+            title="GPU"
+            valueLabel="2 / 4 Cards"
+            percent={50}
+            strokeColor="#722ed1"
+            size="middle"
+          />
+        </BAIFlex>
+      </div>
+
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>Storage Quota</div>
+        <BAIFlex direction="column" gap="sm">
+          <BAIProgressWithLabel
+            title="Home Folder"
+            valueLabel="45GB / 100GB"
+            percent={45}
+            strokeColor="#faad14"
+            size="middle"
+          />
+          <BAIProgressWithLabel
+            title="Shared Folder"
+            valueLabel="180GB / 200GB"
+            percent={90}
+            strokeColor="#ff4d4f"
+            size="middle"
+          />
+        </BAIFlex>
+      </div>
+
+      <div>
+        <div style={{ marginBottom: 8, fontWeight: 500 }}>
+          Session Allocation
+        </div>
+        <BAIFlex direction="column" gap="sm">
+          <BAIProgressWithLabel
+            title="Running Sessions"
+            valueLabel="8 / 20"
+            percent={40}
+            size="small"
+          />
+          <BAIProgressWithLabel
+            title="Compute Credits"
+            valueLabel="$450 / $1000"
+            percent={45}
+            size="small"
+          />
+        </BAIFlex>
+      </div>
+    </BAIFlex>
+  ),
+};

--- a/packages/backend.ai-ui/src/components/BAIUncontrolledInput.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUncontrolledInput.stories.tsx
@@ -1,0 +1,353 @@
+import BAIFlex from './BAIFlex';
+import BAIUncontrolledInput from './BAIUncontrolledInput';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+
+/**
+ * BAIUncontrolledInput is an uncontrolled input with commit-on-blur behavior.
+ *
+ * Key features:
+ * - Uncontrolled mode (uses defaultValue instead of value)
+ * - Commits value on blur or Enter key press
+ * - Shows Enter icon hint when focused
+ * - Hides number input spinners
+ *
+ * @see BAIUncontrolledInput.tsx for implementation details
+ */
+const meta: Meta<typeof BAIUncontrolledInput> = {
+  title: 'Input/BAIUncontrolledInput',
+  component: BAIUncontrolledInput,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**BAIUncontrolledInput** extends [Ant Design Input](https://ant.design/components/input) as an uncontrolled component.
+
+## BAI-Specific Features
+- **Uncontrolled mode**: Uses \`defaultValue\` instead of \`value\` prop
+- **Commit on blur/Enter**: Triggers \`onCommit\` callback when input loses focus or Enter is pressed
+- **Enter icon hint**: Shows ⏎ icon when focused to indicate Enter key support
+- **No number spinners**: Hides spinner arrows for number input type
+
+## Usage
+\`\`\`tsx
+// Basic usage
+<BAIUncontrolledInput
+  defaultValue="Initial value"
+  onCommit={(value) => console.log('Committed:', value)}
+/>
+
+// Number input without spinners
+<BAIUncontrolledInput
+  type="number"
+  defaultValue="42"
+  onCommit={(value) => updateValue(Number(value))}
+/>
+\`\`\`
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| \`defaultValue\` | \`string\` | - | Initial value (uncontrolled) |
+| \`onCommit\` | \`(value: string) => void\` | - | Callback when value is committed (blur or Enter) |
+
+For all other props, refer to [Ant Design Input](https://ant.design/components/input).
+
+## When to Use
+- When you need to defer value updates until the user finishes editing
+- For form fields that should only update on blur/Enter (not on every keystroke)
+- When you want to avoid re-renders on every character typed
+        `,
+      },
+    },
+  },
+  argTypes: {
+    defaultValue: {
+      control: { type: 'text' },
+      description: 'Initial value for the uncontrolled input',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    onCommit: {
+      action: 'committed',
+      description: 'Callback when value is committed (on blur or Enter key)',
+      table: {
+        type: { summary: '(value: string) => void' },
+      },
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['text', 'number', 'password', 'email', 'url'],
+      description: 'Input type',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'text' },
+      },
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: 'Placeholder text',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether input is disabled',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIUncontrolledInput>;
+
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Basic uncontrolled input. Type text and press Enter or click outside to commit the value.',
+      },
+    },
+  },
+  args: {
+    defaultValue: 'Edit me and press Enter',
+    placeholder: 'Type something...',
+  },
+};
+
+export const NumberInput: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Number input without spinner arrows. Notice the spinner controls are hidden.',
+      },
+    },
+  },
+  args: {
+    type: 'number',
+    defaultValue: '42',
+    placeholder: 'Enter a number',
+  },
+};
+
+export const CommitBehavior: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates commit-on-blur behavior. Edit the input and see the committed value update when you blur or press Enter.',
+      },
+    },
+  },
+  render: () => {
+    const [committedValue, setCommittedValue] = useState('');
+
+    return (
+      <BAIFlex direction="column" gap="md" style={{ width: 300 }}>
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>
+            Edit and press Enter or blur:
+          </div>
+          <BAIUncontrolledInput
+            defaultValue="Edit this text"
+            onCommit={(value) => setCommittedValue(value)}
+            placeholder="Type and commit..."
+          />
+        </div>
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>
+            Committed Value:
+          </div>
+          <div
+            style={{
+              padding: 8,
+              background: '#f5f5f5',
+              borderRadius: 4,
+              fontFamily: 'monospace',
+            }}
+          >
+            {committedValue || '(not committed yet)'}
+          </div>
+        </div>
+      </BAIFlex>
+    );
+  },
+};
+
+export const EnterIconHint: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Focus on the input to see the Enter icon hint appear in the suffix.',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" style={{ width: 300 }}>
+      <div>
+        <div style={{ marginBottom: 8 }}>Focus to see Enter icon:</div>
+        <BAIUncontrolledInput
+          defaultValue="Focus me"
+          placeholder="Click to focus..."
+        />
+      </div>
+      <div style={{ fontSize: 12, color: '#666' }}>
+        💡 The ⏎ icon appears when focused to indicate you can press Enter to
+        commit.
+      </div>
+    </BAIFlex>
+  ),
+};
+
+export const WithValidation: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Example with validation on commit.',
+      },
+    },
+  },
+  render: () => {
+    const [error, setError] = useState('');
+
+    return (
+      <BAIFlex direction="column" gap="md" style={{ width: 300 }}>
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>
+            Enter a number between 1-100:
+          </div>
+          <BAIUncontrolledInput
+            type="number"
+            defaultValue="50"
+            status={error ? 'error' : undefined}
+            onCommit={(value) => {
+              const num = Number(value);
+              if (isNaN(num) || num < 1 || num > 100) {
+                setError('Must be between 1 and 100');
+              } else {
+                setError('');
+              }
+            }}
+          />
+          {error && (
+            <div style={{ color: '#ff4d4f', marginTop: 4 }}>{error}</div>
+          )}
+        </div>
+      </BAIFlex>
+    );
+  },
+};
+
+export const DifferentStates: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Input in different states (normal, disabled, error, warning).',
+      },
+    },
+  },
+  render: () => (
+    <BAIFlex direction="column" gap="md" style={{ width: 300 }}>
+      <div>
+        <div style={{ marginBottom: 8 }}>Normal:</div>
+        <BAIUncontrolledInput defaultValue="Normal input" />
+      </div>
+      <div>
+        <div style={{ marginBottom: 8 }}>Disabled:</div>
+        <BAIUncontrolledInput defaultValue="Disabled input" disabled />
+      </div>
+      <div>
+        <div style={{ marginBottom: 8 }}>Error:</div>
+        <BAIUncontrolledInput defaultValue="Error state" status="error" />
+      </div>
+      <div>
+        <div style={{ marginBottom: 8 }}>Warning:</div>
+        <BAIUncontrolledInput defaultValue="Warning state" status="warning" />
+      </div>
+    </BAIFlex>
+  ),
+};
+
+export const RealWorldExample: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Realistic examples showing typical use cases in Backend.AI WebUI.',
+      },
+    },
+  },
+  render: () => {
+    const [sessionName, setSessionName] = useState('my-jupyter-session');
+    const [cpuLimit, setCpuLimit] = useState('4');
+    const [memoryGB, setMemoryGB] = useState('16');
+
+    return (
+      <BAIFlex direction="column" gap="lg" style={{ width: 400 }}>
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>
+            Session Configuration
+          </div>
+          <BAIFlex direction="column" gap="sm">
+            <div>
+              <div style={{ marginBottom: 4, fontSize: 12 }}>Session Name:</div>
+              <BAIUncontrolledInput
+                defaultValue={sessionName}
+                onCommit={(value) => setSessionName(value)}
+                placeholder="Enter session name"
+              />
+            </div>
+            <div>
+              <div style={{ marginBottom: 4, fontSize: 12 }}>CPU Cores:</div>
+              <BAIUncontrolledInput
+                type="number"
+                defaultValue={cpuLimit}
+                onCommit={(value) => setCpuLimit(value)}
+                placeholder="Number of cores"
+              />
+            </div>
+            <div>
+              <div style={{ marginBottom: 4, fontSize: 12 }}>Memory (GB):</div>
+              <BAIUncontrolledInput
+                type="number"
+                defaultValue={memoryGB}
+                onCommit={(value) => setMemoryGB(value)}
+                placeholder="Memory in GB"
+              />
+            </div>
+          </BAIFlex>
+        </div>
+
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>
+            Current Configuration
+          </div>
+          <div
+            style={{
+              padding: 12,
+              background: '#f5f5f5',
+              borderRadius: 4,
+              fontFamily: 'monospace',
+              fontSize: 12,
+            }}
+          >
+            <div>Session: {sessionName}</div>
+            <div>CPU: {cpuLimit} cores</div>
+            <div>Memory: {memoryGB} GB</div>
+          </div>
+        </div>
+      </BAIFlex>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/BAIUnmountAfterClose.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIUnmountAfterClose.stories.tsx
@@ -1,0 +1,398 @@
+import BAIFlex from './BAIFlex';
+import BAIUnmountAfterClose from './BAIUnmountAfterClose';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button, Drawer, Form, Input, Modal } from 'antd';
+import { useState } from 'react';
+
+/**
+ * BAIUnmountAfterClose unmounts Modal/Drawer children after close animation completes.
+ *
+ * Key features:
+ * - Preserves exit animations before unmounting
+ * - Works with both Modal and Drawer components
+ * - Prevents stale form state in modals
+ * - Automatically intercepts afterClose and afterOpenChange callbacks
+ *
+ * @see BAIUnmountAfterClose.tsx for implementation details
+ */
+const meta: Meta<typeof BAIUnmountAfterClose> = {
+  title: 'Utility/BAIUnmountAfterClose',
+  component: BAIUnmountAfterClose,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**BAIUnmountAfterClose** is a utility component that unmounts Modal/Drawer children after their close animations complete.
+
+## Problem it Solves
+When you close and reopen a Modal/Drawer with forms, the previous form state persists because React doesn't unmount the component. This wrapper ensures the child is fully unmounted after closing, preventing stale state issues.
+
+## Features
+- **Preserves animations**: Waits for close animation to complete before unmounting
+- **Modal/Drawer support**: Works with both Ant Design Modal and Drawer
+- **Callback preservation**: Maintains original \`afterClose\` and \`afterOpenChange\` callbacks
+- **Automatic cleanup**: Unmounts child after animation, preventing memory leaks
+
+## Usage
+\`\`\`tsx
+// Wrap Modal with form to prevent stale state
+<BAIUnmountAfterClose>
+  <Modal open={open} onCancel={() => setOpen(false)}>
+    <Form>
+      <Form.Item name="email">
+        <Input />
+      </Form.Item>
+    </Form>
+  </Modal>
+</BAIUnmountAfterClose>
+
+// Works with Drawer too
+<BAIUnmountAfterClose>
+  <Drawer open={open} onClose={() => setOpen(false)}>
+    <Form>{/* form fields */}</Form>
+  </Drawer>
+</BAIUnmountAfterClose>
+\`\`\`
+
+## When to Use
+- Modals/Drawers with forms that should reset on close
+- Components with expensive initialization that should be cleaned up
+- Any scenario where you need fresh component state on each open
+
+## Props
+This component accepts a single child element (Modal or Drawer) and automatically manages its lifecycle.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| \`children\` | \`React.ReactElement<ModalProps \\| DrawerProps>\` | Single Modal or Drawer component |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    children: {
+      control: false,
+      description: 'Single Modal or Drawer component to wrap',
+      table: {
+        type: { summary: 'React.ReactElement<ModalProps | DrawerProps>' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIUnmountAfterClose>;
+
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Basic usage with a Modal. The modal content unmounts after the close animation completes.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <div>
+        <Button onClick={() => setOpen(true)}>Open Modal</Button>
+        <BAIUnmountAfterClose>
+          <Modal
+            title="Basic Modal"
+            open={open}
+            onOk={() => setOpen(false)}
+            onCancel={() => setOpen(false)}
+          >
+            <p>This content will unmount after the modal closes.</p>
+            <p>Mounted at: {new Date().toLocaleTimeString()}</p>
+          </Modal>
+        </BAIUnmountAfterClose>
+      </div>
+    );
+  },
+};
+
+export const FormStateReset: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates form state reset. Without BAIUnmountAfterClose, form values would persist when reopening. With it, the form is fresh on each open.',
+      },
+    },
+  },
+  render: () => {
+    const [withUnmount, setWithUnmount] = useState(false);
+    const [withoutUnmount, setWithoutUnmount] = useState(false);
+
+    return (
+      <BAIFlex direction="column" gap="md">
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>
+            ✅ With BAIUnmountAfterClose (form resets on close):
+          </div>
+          <Button onClick={() => setWithUnmount(true)}>
+            Open Modal with Unmount
+          </Button>
+          <BAIUnmountAfterClose>
+            <Modal
+              title="Form with Unmount"
+              open={withUnmount}
+              onOk={() => setWithUnmount(false)}
+              onCancel={() => setWithUnmount(false)}
+            >
+              <Form>
+                <Form.Item label="Name" name="name">
+                  <Input placeholder="Type something and close" />
+                </Form.Item>
+                <Form.Item label="Email" name="email">
+                  <Input placeholder="Type something and close" />
+                </Form.Item>
+              </Form>
+              <p style={{ fontSize: 12, color: '#666' }}>
+                💡 Close and reopen - form will be reset!
+              </p>
+            </Modal>
+          </BAIUnmountAfterClose>
+        </div>
+
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>
+            ❌ Without BAIUnmountAfterClose (form state persists):
+          </div>
+          <Button onClick={() => setWithoutUnmount(true)}>
+            Open Modal without Unmount
+          </Button>
+          <Modal
+            title="Form without Unmount"
+            open={withoutUnmount}
+            onOk={() => setWithoutUnmount(false)}
+            onCancel={() => setWithoutUnmount(false)}
+          >
+            <Form>
+              <Form.Item label="Name" name="name">
+                <Input placeholder="Type something and close" />
+              </Form.Item>
+              <Form.Item label="Email" name="email">
+                <Input placeholder="Type something and close" />
+              </Form.Item>
+            </Form>
+            <p style={{ fontSize: 12, color: '#666' }}>
+              ⚠️ Close and reopen - form values persist!
+            </p>
+          </Modal>
+        </div>
+      </BAIFlex>
+    );
+  },
+};
+
+export const WithDrawer: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Works with Drawer component as well. The drawer content unmounts after the close animation.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <div>
+        <Button onClick={() => setOpen(true)}>Open Drawer</Button>
+        <BAIUnmountAfterClose>
+          <Drawer
+            title="Drawer with Unmount"
+            open={open}
+            onClose={() => setOpen(false)}
+          >
+            <Form>
+              <Form.Item label="Username" name="username">
+                <Input placeholder="Type and close to see reset" />
+              </Form.Item>
+              <Form.Item label="Password" name="password">
+                <Input.Password placeholder="Type and close to see reset" />
+              </Form.Item>
+            </Form>
+            <p style={{ fontSize: 12, color: '#666', marginTop: 16 }}>
+              Mounted at: {new Date().toLocaleTimeString()}
+            </p>
+          </Drawer>
+        </BAIUnmountAfterClose>
+      </div>
+    );
+  },
+};
+
+export const CallbackPreservation: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'BAIUnmountAfterClose preserves original afterClose and afterOpenChange callbacks.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+    const [log, setLog] = useState<string[]>([]);
+
+    const addLog = (message: string) => {
+      setLog((prev) => [
+        ...prev,
+        `[${new Date().toLocaleTimeString()}] ${message}`,
+      ]);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md">
+        <Button onClick={() => setOpen(true)}>Open Modal</Button>
+
+        <BAIUnmountAfterClose>
+          <Modal
+            title="Callback Test"
+            open={open}
+            onCancel={() => {
+              addLog('onCancel called');
+              setOpen(false);
+            }}
+            afterClose={() => {
+              addLog('afterClose called (after animation)');
+            }}
+          >
+            <p>Close this modal to see callback execution order.</p>
+          </Modal>
+        </BAIUnmountAfterClose>
+
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>Callback Log:</div>
+          <div
+            style={{
+              padding: 12,
+              background: '#f5f5f5',
+              borderRadius: 4,
+              fontFamily: 'monospace',
+              fontSize: 11,
+              maxHeight: 150,
+              overflow: 'auto',
+            }}
+          >
+            {log.length === 0 ? (
+              <div style={{ color: '#999' }}>(no callbacks yet)</div>
+            ) : (
+              log.map((entry, i) => <div key={i}>{entry}</div>)
+            )}
+          </div>
+        </div>
+      </BAIFlex>
+    );
+  },
+};
+
+export const RealWorldExample: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Realistic example: Session creation modal that should reset on each open.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+    const [createdSessions, setCreatedSessions] = useState<string[]>([]);
+
+    const handleCreate = (values: { sessionName: string; image: string }) => {
+      setCreatedSessions((prev) => [
+        ...prev,
+        `${values.sessionName} (${values.image})`,
+      ]);
+      setOpen(false);
+    };
+
+    return (
+      <BAIFlex direction="column" gap="md">
+        <Button type="primary" onClick={() => setOpen(true)}>
+          Create New Session
+        </Button>
+
+        <BAIUnmountAfterClose>
+          <Modal
+            title="Create Compute Session"
+            open={open}
+            onCancel={() => setOpen(false)}
+            footer={null}
+          >
+            <Form
+              layout="vertical"
+              onFinish={handleCreate}
+              initialValues={{
+                sessionName: `session-${Date.now()}`,
+                image: 'python:3.11',
+              }}
+            >
+              <Form.Item
+                label="Session Name"
+                name="sessionName"
+                rules={[
+                  { required: true, message: 'Please enter session name' },
+                ]}
+              >
+                <Input placeholder="my-jupyter-session" />
+              </Form.Item>
+
+              <Form.Item
+                label="Container Image"
+                name="image"
+                rules={[{ required: true, message: 'Please select image' }]}
+              >
+                <Input placeholder="python:3.11" />
+              </Form.Item>
+
+              <Form.Item>
+                <Button type="primary" htmlType="submit" block>
+                  Create Session
+                </Button>
+              </Form.Item>
+            </Form>
+            <p style={{ fontSize: 11, color: '#666', marginTop: 8 }}>
+              💡 Form resets with default values each time you open the modal
+            </p>
+          </Modal>
+        </BAIUnmountAfterClose>
+
+        <div>
+          <div style={{ marginBottom: 8, fontWeight: 500 }}>
+            Created Sessions:
+          </div>
+          <div
+            style={{
+              padding: 12,
+              background: '#f5f5f5',
+              borderRadius: 4,
+              fontFamily: 'monospace',
+              fontSize: 12,
+            }}
+          >
+            {createdSessions.length === 0 ? (
+              <div style={{ color: '#999' }}>(no sessions yet)</div>
+            ) : (
+              createdSessions.map((session, i) => (
+                <div key={i}>
+                  {i + 1}. {session}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </BAIFlex>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/ResourceStatistics.stories.tsx
+++ b/packages/backend.ai-ui/src/components/ResourceStatistics.stories.tsx
@@ -1,0 +1,355 @@
+import ResourceStatistics from './ResourceStatistics';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * ResourceStatistics displays resource usage statistics (CPU, memory, accelerators).
+ *
+ * Key features:
+ * - Shows CPU and memory statistics
+ * - Supports accelerator resources (GPU, TPU, etc.)
+ * - Toggleable display modes (used/free)
+ * - Progress bar visualization
+ * - Theme-aware styling
+ *
+ * @see ResourceStatistics.tsx for implementation details
+ */
+const meta: Meta<typeof ResourceStatistics> = {
+  title: 'Statistic/ResourceStatistics',
+  component: ResourceStatistics,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**ResourceStatistics** displays resource usage statistics including CPU, memory, and accelerators.
+
+## Features
+- **CPU and Memory**: Shows CPU cores and memory usage/free
+- **Accelerators**: Displays GPU, TPU, or other accelerator statistics
+- **Display modes**: Toggle between 'used' and 'free' resources
+- **Progress visualization**: Optional progress bars with steps
+- **Precision control**: Configurable decimal precision
+- **Empty state**: Shows empty message when no resources are available
+
+## Usage
+\`\`\`tsx
+<ResourceStatistics
+  resourceData={{
+    cpu: {
+      used: { current: 4, total: 8 },
+      free: { current: 4, total: 8 },
+      metadata: { title: 'CPU', displayUnit: 'Core' },
+    },
+    memory: {
+      used: { current: 8, total: 16 },
+      free: { current: 8, total: 16 },
+      metadata: { title: 'Memory', displayUnit: 'GiB' },
+    },
+    accelerators: [
+      {
+        key: 'gpu-0',
+        used: { current: 1, total: 2 },
+        free: { current: 1, total: 2 },
+        metadata: { title: 'GPU', displayUnit: 'GPU' },
+      },
+    ],
+  }}
+  displayType="used"
+  progressMode="normal"
+  precision={2}
+/>
+\`\`\`
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| \`resourceData\` | \`ResourceData\` | (required) | Resource data including CPU, memory, and accelerators |
+| \`displayType\` | \`'used' \\| 'free'\` | (required) | Whether to display used or free resources |
+| \`progressMode\` | \`BAIStatisticProps['progressMode']\` | \`'hidden'\` | Progress bar display mode |
+| \`precision\` | \`number\` | \`2\` | Number of decimal places to show |
+| \`progressSteps\` | \`number\` | - | Number of steps in progress bar |
+
+## When to Use
+- Dashboard resource monitoring
+- Cluster resource overview
+- Session resource allocation displays
+- Resource quota visualizations
+        `,
+      },
+    },
+  },
+  argTypes: {
+    resourceData: {
+      control: false,
+      description: 'Resource data including CPU, memory, and accelerators',
+      table: {
+        type: { summary: 'ResourceData' },
+      },
+    },
+    displayType: {
+      control: { type: 'select' },
+      options: ['used', 'free'],
+      description: 'Whether to display used or free resources',
+      table: {
+        type: { summary: "'used' | 'free'" },
+      },
+    },
+    progressMode: {
+      control: { type: 'select' },
+      options: ['hidden', 'normal', 'ghost'],
+      description: 'Progress bar display mode',
+      table: {
+        type: { summary: "'hidden' | 'normal' | 'ghost'" },
+        defaultValue: { summary: 'hidden' },
+      },
+    },
+    precision: {
+      control: { type: 'number', min: 0, max: 4, step: 1 },
+      description: 'Number of decimal places to show',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '2' },
+      },
+    },
+    progressSteps: {
+      control: { type: 'number', min: 1, max: 20, step: 1 },
+      description: 'Number of steps in progress bar',
+      table: {
+        type: { summary: 'number' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ResourceStatistics>;
+
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Basic resource statistics showing used resources.',
+      },
+    },
+  },
+  args: {
+    resourceData: {
+      cpu: {
+        used: { current: 4, total: 8 },
+        free: { current: 4, total: 8 },
+        metadata: { title: 'CPU', displayUnit: 'Core' },
+      },
+      memory: {
+        used: { current: 8, total: 16 },
+        free: { current: 8, total: 16 },
+        metadata: { title: 'Memory', displayUnit: 'GiB' },
+      },
+      accelerators: [],
+    },
+    displayType: 'used',
+    progressMode: 'hidden',
+    precision: 2,
+  },
+};
+
+export const WithAccelerators: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Resource statistics including GPU and other accelerators.',
+      },
+    },
+  },
+  args: {
+    resourceData: {
+      cpu: {
+        used: { current: 12, total: 24 },
+        free: { current: 12, total: 24 },
+        metadata: { title: 'CPU', displayUnit: 'Core' },
+      },
+      memory: {
+        used: { current: 64, total: 128 },
+        free: { current: 64, total: 128 },
+        metadata: { title: 'Memory', displayUnit: 'GiB' },
+      },
+      accelerators: [
+        {
+          key: 'gpu-0',
+          used: { current: 2, total: 4 },
+          free: { current: 2, total: 4 },
+          metadata: { title: 'NVIDIA GPU', displayUnit: 'GPU' },
+        },
+        {
+          key: 'tpu-0',
+          used: { current: 1, total: 2 },
+          free: { current: 1, total: 2 },
+          metadata: { title: 'TPU', displayUnit: 'TPU' },
+        },
+      ],
+    },
+    displayType: 'used',
+    progressMode: 'normal',
+    precision: 2,
+  },
+};
+
+export const FreeResources: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Displaying free (available) resources instead of used resources. Free resources are shown in success color.',
+      },
+    },
+  },
+  args: {
+    resourceData: {
+      cpu: {
+        used: { current: 6, total: 16 },
+        free: { current: 10, total: 16 },
+        metadata: { title: 'CPU', displayUnit: 'Core' },
+      },
+      memory: {
+        used: { current: 32, total: 64 },
+        free: { current: 32, total: 64 },
+        metadata: { title: 'Memory', displayUnit: 'GiB' },
+      },
+      accelerators: [
+        {
+          key: 'gpu-0',
+          used: { current: 1, total: 8 },
+          free: { current: 7, total: 8 },
+          metadata: { title: 'GPU', displayUnit: 'GPU' },
+        },
+      ],
+    },
+    displayType: 'free',
+    progressMode: 'normal',
+    precision: 2,
+  },
+};
+
+export const GhostProgress: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Resource statistics with ghost progress bars showing a subtle background style.',
+      },
+    },
+  },
+  args: {
+    resourceData: {
+      cpu: {
+        used: { current: 5, total: 8 },
+        free: { current: 3, total: 8 },
+        metadata: { title: 'CPU', displayUnit: 'Core' },
+      },
+      memory: {
+        used: { current: 12, total: 16 },
+        free: { current: 4, total: 16 },
+        metadata: { title: 'Memory', displayUnit: 'GiB' },
+      },
+      accelerators: [],
+    },
+    displayType: 'used',
+    progressMode: 'ghost',
+    progressSteps: 8,
+    precision: 2,
+  },
+};
+
+export const EmptyState: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Empty state when no resources are available. Shows a simple empty message.',
+      },
+    },
+  },
+  args: {
+    resourceData: {
+      cpu: null,
+      memory: null,
+      accelerators: [],
+    },
+    displayType: 'used',
+    progressMode: 'hidden',
+    precision: 2,
+  },
+};
+
+export const HighUtilization: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Resource statistics showing high resource utilization (near capacity).',
+      },
+    },
+  },
+  args: {
+    resourceData: {
+      cpu: {
+        used: { current: 15, total: 16 },
+        free: { current: 1, total: 16 },
+        metadata: { title: 'CPU', displayUnit: 'Core' },
+      },
+      memory: {
+        used: { current: 60, total: 64 },
+        free: { current: 4, total: 64 },
+        metadata: { title: 'Memory', displayUnit: 'GiB' },
+      },
+      accelerators: [
+        {
+          key: 'gpu-0',
+          used: { current: 7, total: 8 },
+          free: { current: 1, total: 8 },
+          metadata: { title: 'GPU', displayUnit: 'GPU' },
+        },
+      ],
+    },
+    displayType: 'used',
+    progressMode: 'normal',
+    precision: 1,
+  },
+};
+
+export const FractionalResources: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Resource statistics with fractional values showing precise resource allocation.',
+      },
+    },
+  },
+  args: {
+    resourceData: {
+      cpu: {
+        used: { current: 2.5, total: 8 },
+        free: { current: 5.5, total: 8 },
+        metadata: { title: 'CPU', displayUnit: 'Core' },
+      },
+      memory: {
+        used: { current: 12.75, total: 32 },
+        free: { current: 19.25, total: 32 },
+        metadata: { title: 'Memory', displayUnit: 'GiB' },
+      },
+      accelerators: [
+        {
+          key: 'gpu-0',
+          used: { current: 0.5, total: 1 },
+          free: { current: 0.5, total: 1 },
+          metadata: { title: 'GPU', displayUnit: 'fGPU' },
+        },
+      ],
+    },
+    displayType: 'used',
+    progressMode: 'normal',
+    precision: 2,
+  },
+};

--- a/packages/backend.ai-ui/src/components/TotalFooter.stories.tsx
+++ b/packages/backend.ai-ui/src/components/TotalFooter.stories.tsx
@@ -1,0 +1,99 @@
+import TotalFooter from './TotalFooter';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+/**
+ * TotalFooter displays total item count with optional loading indicator.
+ *
+ * Key features:
+ * - Shows total count with i18n support
+ * - Loading indicator during data fetch
+ * - Theme-aware styling
+ *
+ * @see TotalFooter.tsx for implementation details
+ */
+const meta: Meta<typeof TotalFooter> = {
+  title: 'Statistic/TotalFooter',
+  component: TotalFooter,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**TotalFooter** displays the total item count with an optional loading indicator.
+
+## Features
+- **Total count display**: Shows total items with internationalized text
+- **Loading state**: Shows loading spinner when data is being fetched
+- **Theme-aware**: Uses theme tokens for consistent styling
+
+## Usage
+\`\`\`tsx
+<TotalFooter total={42} />
+<TotalFooter loading total={42} />
+\`\`\`
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| \`total\` | \`number\` | - | Total number of items to display |
+| \`loading\` | \`boolean\` | \`false\` | Show loading indicator |
+
+## When to Use
+- Table footers showing total row count
+- List footers displaying total item count
+- Pagination components showing total results
+        `,
+      },
+    },
+  },
+  argTypes: {
+    total: {
+      control: { type: 'number', min: 0, max: 10000, step: 1 },
+      description: 'Total number of items to display',
+      table: {
+        type: { summary: 'number' },
+      },
+    },
+    loading: {
+      control: { type: 'boolean' },
+      description: 'Show loading indicator',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TotalFooter>;
+
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Basic usage showing total item count.',
+      },
+    },
+  },
+  args: {
+    total: 42,
+  },
+};
+
+export const Loading: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Loading state with spinner. Useful when data is being fetched or updated.',
+      },
+    },
+  },
+  args: {
+    loading: true,
+    total: 42,
+  },
+};


### PR DESCRIPTION
Resolves #5148 ([FR-1974](https://lablup.atlassian.net/browse/FR-1974))

## Summary

This PR adds comprehensive Storybook stories for **7 simple utility components** in the backend.ai-ui package (Phase 1 of FR-1974). Each story file includes:

- Complete component documentation with features, props, and usage examples
- Interactive args-based default story for Controls panel
- Multiple demonstration stories showing different use cases
- Real-world usage examples

## Components Added

1. **BAIDoubleTag** - Dual-value tag display component
2. **BAIProgressWithLabel** - Progress bar with title and value label
3. **BAIUncontrolledInput** - Uncontrolled input with commit-on-blur behavior
4. **BAIUnmountAfterClose** - Modal/Drawer unmount utility wrapper
5. **BAIIntervalView** - Auto-updating interval content renderer
6. **TotalFooter** - Total item count footer display
7. **ResourceStatistics** - Resource usage statistics (CPU, memory, accelerators)

## Changes Made

- Created 7 new `.stories.tsx` files (2,295+ lines)
- Updated `create-bui-component-story.md` command with actual story category patterns
- Fixed browser freeze issues in BAIIntervalView stories (used `useRef` instead of `useState`)
- Fixed progressMode type errors in ResourceStatistics stories (`'normal' | 'ghost' | 'hidden'`)

## Story Categories

Stories are organized by component type:
- `Tag/` - BAIDoubleTag
- `Statistic/` - BAIProgressWithLabel, TotalFooter, ResourceStatistics
- `Input/` - BAIUncontrolledInput
- `Utility/` - BAIUnmountAfterClose, BAIIntervalView

## Verification

Run Storybook to verify:
```bash
cd packages/backend.ai-ui && pnpm run storybook
```

All stories include:
- `tags: ['autodocs']` for auto-documentation
- Interactive Controls panel via `args`
- Comprehensive usage examples
- Real-world scenarios

[FR-1974]: https://lablup.atlassian.net/browse/FR-1974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ