### PR TITLE
feat(FR-1984): UX enhancements for BAIDynamicUnitInputNumber

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIDynamicUnitInputNumber.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDynamicUnitInputNumber.tsx
@@ -23,6 +23,8 @@ export interface BAIDynamicUnitInputNumberProps
   units?: string[];
   roundStep?: number;
   onChange?: (value: string) => void;
+  addonPrefix?: React.ReactNode;
+  addonSuffix?: React.ReactNode;
   ref?: RefObject<HTMLInputElement | null>;
 }
 
@@ -33,6 +35,8 @@ const BAIDynamicUnitInputNumber: React.FC<BAIDynamicUnitInputNumberProps> = ({
   min = '0m',
   max = '300p',
   roundStep,
+  addonPrefix,
+  addonSuffix,
   ...inputNumberProps
 }) => {
   const [value, setValue] = useControllableValue<string | null | undefined>(
@@ -84,7 +88,14 @@ const BAIDynamicUnitInputNumber: React.FC<BAIDynamicUnitInputNumberProps> = ({
   }, [ref, numValue, _unitFromValue, setValue]);
 
   return (
-    <Space.Compact size={inputNumberProps?.size} block>
+    <Space.Compact
+      size={inputNumberProps?.size}
+      block
+      style={{
+        display: 'flex',
+      }}
+    >
+      {addonPrefix && <Space.Addon>{addonPrefix}</Space.Addon>}
       <InputNumber
         {...inputNumberProps}
         ref={(node) => {
@@ -94,6 +105,9 @@ const BAIDynamicUnitInputNumber: React.FC<BAIDynamicUnitInputNumberProps> = ({
           );
         }}
         stringMode
+        style={{
+          ...inputNumberProps?.style,
+        }}
         onBlur={() => {
           if (_.isNumber(roundStep) && roundStep > 0) {
             const nextRoundedNumValue =
@@ -223,10 +237,11 @@ const BAIDynamicUnitInputNumber: React.FC<BAIDynamicUnitInputNumberProps> = ({
         suffixIcon={units.length > 1 ? undefined : null}
         open={units.length > 1 ? undefined : false}
         style={{
-          width: 75,
+          flex: 1,
           cursor: units.length > 1 ? undefined : 'default',
         }}
       />
+      {addonSuffix && <Space.Addon>{addonSuffix}</Space.Addon>}
     </Space.Compact>
   );
 };

--- a/packages/backend.ai-ui/src/components/BAIDynamicUnitInputNumberWithSlider.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDynamicUnitInputNumberWithSlider.tsx
@@ -21,6 +21,8 @@ export interface BAIDynamicUnitInputNumberWithSliderProps
   warn?: string;
   step?: number;
   inputMinWidth?: number;
+  addonPrefix?: React.ReactNode;
+  addonSuffix?: React.ReactNode;
 }
 const BAIDynamicUnitInputNumberWithSlider: React.FC<
   BAIDynamicUnitInputNumberWithSliderProps
@@ -32,6 +34,8 @@ const BAIDynamicUnitInputNumberWithSlider: React.FC<
   extraMarks,
   hideSlider,
   step = 0.05,
+  addonPrefix,
+  addonSuffix,
   ...otherProps
 }) => {
   const [value, setValue] = useControllableValue<string | undefined | null>(
@@ -92,10 +96,12 @@ const BAIDynamicUnitInputNumberWithSlider: React.FC<
             setValue(nextValue);
           }}
           style={{
-            minWidth: 130,
+            width: '100%',
           }}
           roundStep={step}
           changeOnBlur={!isMinOversMaxValue}
+          addonPrefix={addonPrefix}
+          addonSuffix={addonSuffix}
         />
       </BAIFlex>
       <BAIFlex

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -831,7 +831,6 @@ const ResourceAllocationFormItems: React.FC<
                             <BAIDynamicUnitInputNumberWithSlider
                               max={resourceLimits.mem?.max}
                               min={resourceLimits.mem?.min}
-                              prefix={'MEM'}
                               extraMarks={{
                                 ...(remaining.mem
                                   ? {

--- a/react/src/components/SessionFormItems/SharedMemoryFormItems.tsx
+++ b/react/src/components/SessionFormItems/SharedMemoryFormItems.tsx
@@ -186,11 +186,8 @@ const SharedMemoryFormItems: React.FC<SharedMemoryFormItemsProps> = ({
                   <BAIDynamicUnitInputNumber
                     min={min}
                     size="small"
-                    prefix={'SHM'}
+                    addonPrefix={'SHM'}
                     max={getFieldValue(['resource', 'mem']) || '0g'}
-                    style={{
-                      width: 150,
-                    }}
                     onChange={onChangeResourceShmem}
                   />
                 </Form.Item>


### PR DESCRIPTION
resolves #5164 (FR-1984)

Added `addonPrefix` and `addonSuffix` props to `BAIDynamicUnitInputNumber` and `BAIDynamicUnitInputNumberWithSlider` components to allow adding custom elements before and after the input field. This provides more flexibility in UI customization.

Also improved the styling of these components:
- Made the input field width more responsive by using flex layout
- Removed hardcoded width values
- Fixed display issues in compact mode

Updated usage in SessionFormItems to use the new props instead of the deprecated `prefix` prop.

![CleanShot 2026-01-29 at 14.14.06@2x.png](https://app.graphite.com/user-attachments/assets/b38df1c1-a2b7-49c6-97d3-53aef8220625.png)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after