### PR TITLE
feat(FR-1966): add BAIBulkEditFormItem component for bulk editing forms

### DIFF
--- a/packages/backend.ai-ui/setupTests.ts
+++ b/packages/backend.ai-ui/setupTests.ts
@@ -11,3 +11,53 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   unobserve: jest.fn(),
   disconnect: jest.fn(),
 }));
+
+// Mock MessageChannel for Ant Design Form (used by @rc-component/form)
+// This provides a minimal mock that allows form internals to work
+if (typeof global.MessageChannel === 'undefined') {
+  class MockMessagePort {
+    onmessage: ((event: { data: unknown }) => void) | null = null;
+    postMessage(data: unknown) {
+      // Use queueMicrotask for more accurate async simulation
+      queueMicrotask(() => {
+        if (this.onmessage) {
+          this.onmessage({ data });
+        }
+      });
+    }
+    start() {}
+    close() {}
+    addEventListener() {}
+    removeEventListener() {}
+    dispatchEvent() {
+      return true;
+    }
+  }
+
+  class MockMessageChannel {
+    port1: MockMessagePort;
+    port2: MockMessagePort;
+    constructor() {
+      this.port1 = new MockMessagePort();
+      this.port2 = new MockMessagePort();
+      // Connect ports for bidirectional communication
+      const self = this;
+      this.port1.postMessage = (data: unknown) => {
+        queueMicrotask(() => {
+          if (self.port2.onmessage) {
+            self.port2.onmessage({ data });
+          }
+        });
+      };
+      this.port2.postMessage = (data: unknown) => {
+        queueMicrotask(() => {
+          if (self.port1.onmessage) {
+            self.port1.onmessage({ data });
+          }
+        });
+      };
+    }
+  }
+
+  global.MessageChannel = MockMessageChannel as unknown as typeof MessageChannel;
+}

--- a/packages/backend.ai-ui/src/components/BAIBulkEditFormItem.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIBulkEditFormItem.stories.tsx
@@ -1,0 +1,411 @@
+import BAIBulkEditFormItem from './BAIBulkEditFormItem';
+import BAIFlex from './BAIFlex';
+import BAISelect from './BAISelect';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Form, Input, InputNumber, Select, Button } from 'antd';
+import React, { useState } from 'react';
+
+/**
+ * BAIBulkEditFormItem is a custom Form.Item component for bulk editing scenarios.
+ *
+ * Key features:
+ * - **Keep as is**: Maintains current values without changes (default)
+ * - **Edit**: Allows modification of the field value
+ * - **Clear**: Unsets the value for all items (only for optional fields)
+ * - **Undo changes**: Reverts to "Keep as is" state
+ *
+ * @see BAIBulkEditFormItem.tsx for implementation details
+ */
+const meta: Meta<typeof BAIBulkEditFormItem> = {
+  title: 'Components/BAIBulkEditFormItem',
+  component: BAIBulkEditFormItem,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**BAIBulkEditFormItem** is a specialized Form.Item wrapper for bulk editing operations.
+
+## Features
+- Keep as is mode (default): Shows placeholder, value = undefined (excluded from submission)
+- Edit mode: Allows user to modify the field value
+- Clear mode: Sets field to null (only available for optional fields)
+- Undo changes: Reverts to "Keep as is" state
+
+## Usage
+\`\`\`tsx
+<Form>
+  <BAIBulkEditFormItem name="domain_name" label="Domain" showClear>
+    <BAISelect options={domainOptions} />
+  </BAIBulkEditFormItem>
+  <BAIBulkEditFormItem name="status" label="Status">
+    <BAISelect options={statusOptions} />
+  </BAIBulkEditFormItem>
+</Form>
+\`\`\`
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| showClear | \`boolean\` | \`false\` | Whether field can be cleared (shows Clear link) |
+| keepValueLabel | \`string\` | \`'Keep as is'\` (i18n) | Label displayed in keep mode placeholder |
+| clearValueLabel | \`string\` | \`'Clear'\` (i18n) | Label displayed in clear mode placeholder |
+| children | \`ReactElement\` | - | Input component to render |
+| ...formItemProps | \`FormItemProps\` | - | All Ant Design Form.Item props |
+
+## Form Values
+| Mode | Form Value | Behavior on Submit |
+|------|------------|-------------------|
+| Keep as is | \`undefined\` | Excluded from submission |
+| Edit | User input | Included in submission |
+| Clear | \`null\` | Explicitly clears the field |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    showClear: {
+      control: { type: 'boolean' },
+      description: 'Whether this field can be cleared (shows Clear link)',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    keepValueLabel: {
+      control: { type: 'text' },
+      description:
+        'Label displayed in the keep mode placeholder. Defaults to i18n "Keep as is".',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '"Keep as is"' },
+      },
+    },
+    clearValueLabel: {
+      control: { type: 'text' },
+      description:
+        'Label displayed in the clear mode placeholder. Defaults to i18n "Clear".',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '"Clear"' },
+      },
+    },
+    label: {
+      control: { type: 'text' },
+      description: 'Label text for the form item',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+    name: {
+      control: false,
+      description: 'Field name in form data',
+      table: {
+        type: { summary: 'NamePath' },
+      },
+    },
+    children: {
+      control: false,
+      description: 'Input component to render (typically Select, Input, etc.)',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Form
+        style={{
+          maxWidth: 600,
+          padding: 24,
+          border: '1px solid #d9d9d9',
+          borderRadius: 8,
+        }}
+      >
+        <Story />
+      </Form>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIBulkEditFormItem>;
+
+/**
+ * Basic usage with a required field.
+ * No Clear link is shown since the field is not optional.
+ */
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Basic usage with a required text input field. The field starts in "Keep as is" mode. Click the placeholder to switch to edit mode.',
+      },
+    },
+  },
+  args: {
+    name: 'nickname',
+    label: 'Nickname',
+    children: <Input placeholder="Enter nickname" />,
+  },
+};
+
+/**
+ * Optional field that can be cleared.
+ * Shows the Clear link in "Keep as is" mode.
+ */
+export const OptionalField: Story = {
+  name: 'OptionalField',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Optional field that can be cleared. The Clear link appears in "Keep as is" mode to allow unsetting the value.',
+      },
+    },
+  },
+  args: {
+    name: 'domain_name',
+    label: 'Domain',
+    showClear: true,
+    children: (
+      <BAISelect
+        placeholder="Select domain"
+        options={[
+          { value: 'default', label: 'Default' },
+          { value: 'custom', label: 'Custom' },
+          { value: 'test', label: 'Test' },
+        ]}
+      />
+    ),
+  },
+};
+
+/**
+ * Select input with options.
+ */
+export const WithSelect: Story = {
+  name: 'WithSelect',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Using BAIBulkEditFormItem with a Select component for choosing from predefined options.',
+      },
+    },
+  },
+  args: {
+    name: 'status',
+    label: 'User Status',
+    children: (
+      <Select
+        placeholder="Select status"
+        options={[
+          { value: 'active', label: 'Active' },
+          { value: 'inactive', label: 'Inactive' },
+          { value: 'deleted', label: 'Deleted' },
+        ]}
+      />
+    ),
+  },
+};
+
+/**
+ * Number input field.
+ */
+export const WithInputNumber: Story = {
+  name: 'WithInputNumber',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Using BAIBulkEditFormItem with InputNumber for numeric values.',
+      },
+    },
+  },
+  args: {
+    name: 'container_uid',
+    label: 'Container UID',
+    showClear: true,
+    children: <InputNumber placeholder="Enter UID" style={{ width: '100%' }} />,
+  },
+};
+
+/**
+ * Custom clearValueLabel example.
+ * Shows how to customize the label displayed when field is cleared.
+ */
+export const WithCustomClearLabel: Story = {
+  name: 'WithCustomClearLabel',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Example with custom clearValueLabel. When clearing this field, "No domain selected" will be displayed instead of default "Clear".',
+      },
+    },
+  },
+  args: {
+    name: 'domain',
+    label: 'Domain',
+    showClear: true,
+    clearValueLabel: 'No domain selected',
+    children: (
+      <BAISelect
+        placeholder="Select domain"
+        options={[
+          { value: 'default', label: 'Default' },
+          { value: 'custom', label: 'Custom' },
+        ]}
+      />
+    ),
+  },
+};
+
+/**
+ * Custom keepValueLabel example.
+ * Shows how to customize the label displayed in keep mode.
+ */
+export const WithCustomKeepLabel: Story = {
+  name: 'WithCustomKeepLabel',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Example with custom keepValueLabel. The keep mode placeholder will display "No changes to this field" instead of default "Keep as is".',
+      },
+    },
+  },
+  args: {
+    name: 'status',
+    label: 'Status',
+    keepValueLabel: 'No changes to this field',
+    children: (
+      <BAISelect
+        placeholder="Select status"
+        options={[
+          { value: 'active', label: 'Active' },
+          { value: 'inactive', label: 'Inactive' },
+        ]}
+      />
+    ),
+  },
+};
+
+/**
+ * Multiple fields in a form demonstrating different configurations.
+ */
+export const MultipleFields: Story = {
+  name: 'MultipleFields',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Example showing multiple BAIBulkEditFormItem fields in a single form with different configurations.',
+      },
+    },
+  },
+  render: () => (
+    <>
+      <BAIBulkEditFormItem name="domain" label="Domain" showClear>
+        <BAISelect
+          placeholder="Select domain"
+          options={[
+            { value: 'default', label: 'Default' },
+            { value: 'custom', label: 'Custom' },
+          ]}
+        />
+      </BAIBulkEditFormItem>
+      <BAIBulkEditFormItem name="status" label="Status">
+        <Select
+          placeholder="Select status"
+          options={[
+            { value: 'active', label: 'Active' },
+            { value: 'inactive', label: 'Inactive' },
+          ]}
+        />
+      </BAIBulkEditFormItem>
+      <BAIBulkEditFormItem name="notes" label="Notes" showClear>
+        <Input.TextArea rows={3} placeholder="Add notes" />
+      </BAIBulkEditFormItem>
+    </>
+  ),
+};
+
+/**
+ * Interactive example showing form values.
+ */
+export const WithFormValues: Story = {
+  name: 'WithFormValues',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Interactive example that shows the current form values. Try switching between Keep as is, Edit, and Clear modes to see how values change.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      const [form] = Form.useForm();
+      const [values, setValues] = useState<Record<string, unknown>>({});
+
+      return (
+        <Form
+          form={form}
+          style={{
+            maxWidth: 600,
+            padding: 24,
+            border: '1px solid #d9d9d9',
+            borderRadius: 8,
+          }}
+          onValuesChange={(_, allValues) => setValues(allValues)}
+        >
+          <Story />
+          <BAIFlex direction="column" gap="sm" style={{ marginTop: 16 }}>
+            <Button
+              type="primary"
+              onClick={() => {
+                const formValues = form.getFieldsValue();
+                setValues(formValues);
+              }}
+            >
+              Get Form Values
+            </Button>
+            <pre
+              style={{
+                background: '#f5f5f5',
+                padding: 12,
+                borderRadius: 4,
+                fontSize: 12,
+              }}
+            >
+              {JSON.stringify(values, null, 2)}
+            </pre>
+          </BAIFlex>
+        </Form>
+      );
+    },
+  ],
+  render: () => (
+    <>
+      <BAIBulkEditFormItem name="domain" label="Domain" showClear>
+        <BAISelect
+          placeholder="Select domain"
+          options={[
+            { value: 'default', label: 'Default' },
+            { value: 'custom', label: 'Custom' },
+          ]}
+        />
+      </BAIBulkEditFormItem>
+      <BAIBulkEditFormItem name="status" label="Status">
+        <Select
+          placeholder="Select status"
+          options={[
+            { value: 'active', label: 'Active' },
+            { value: 'inactive', label: 'Inactive' },
+          ]}
+        />
+      </BAIBulkEditFormItem>
+    </>
+  ),
+};

--- a/packages/backend.ai-ui/src/components/BAIBulkEditFormItem.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIBulkEditFormItem.test.tsx
@@ -1,0 +1,555 @@
+import BAIBulkEditFormItem from './BAIBulkEditFormItem';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Form, FormInstance, Select } from 'antd';
+import React, { useEffect } from 'react';
+
+// Mock react-i18next
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'comp:BAIBulkEditFormItem.KeepAsIs': 'Keep as is',
+        'comp:BAIBulkEditFormItem.Clear': 'Clear',
+        'comp:BAIBulkEditFormItem.UndoChanges': 'Undo changes',
+      };
+      return translations[key] || key;
+    },
+  }),
+}));
+
+// Helper component wrapper with Form context
+const FormWrapper: React.FC<{
+  children: React.ReactNode;
+  onValuesChange?: (changedValues: unknown, allValues: unknown) => void;
+  formRef?: React.MutableRefObject<FormInstance | null>;
+}> = ({ children, onValuesChange, formRef }) => {
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    if (formRef) {
+      formRef.current = form;
+    }
+  }, [form, formRef]);
+
+  return (
+    <Form form={form} onValuesChange={onValuesChange}>
+      {children}
+    </Form>
+  );
+};
+
+// Helper to select an option from antd Select dropdown
+const selectOption = async (
+  user: ReturnType<typeof userEvent.setup>,
+  selectElement: HTMLElement,
+  optionText: string,
+) => {
+  await user.click(selectElement);
+  // Wait for dropdown to open and find option
+  await waitFor(() => {
+    const dropdown = document.querySelector('.ant-select-dropdown');
+    expect(dropdown).toBeInTheDocument();
+  });
+  const dropdown = document.querySelector('.ant-select-dropdown');
+  const option = within(dropdown as HTMLElement).getByText(optionText);
+  await user.click(option);
+};
+
+describe('BAIBulkEditFormItem', () => {
+  // Skip pointer events check for antd Select dropdown interactions
+  const setupUser = () => userEvent.setup({ pointerEventsCheck: 0 });
+
+  describe('Basic Rendering', () => {
+    it('should render with "Keep as is" placeholder by default', () => {
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="testField" label="Test Field">
+            <Select options={[{ value: 'test', label: 'Test' }]} />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // "Keep as is" is now displayed as input value
+      expect(screen.getByDisplayValue('Keep as is')).toBeInTheDocument();
+      // Use getAllByText since label may appear in multiple form items (outer and inner)
+      const labels = screen.getAllByText('Test Field');
+      expect(labels.length).toBeGreaterThan(0);
+    });
+
+    it('should render with label from form item props', () => {
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="domain" label="Domain Name">
+            <Select options={[{ value: 'test', label: 'Test' }]} />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Use getAllByText since label may appear in multiple form items (outer and inner)
+      // and verify at least one label is visible
+      const labels = screen.getAllByText('Domain Name');
+      expect(labels.length).toBeGreaterThan(0);
+      expect(labels[0]).toBeInTheDocument();
+    });
+
+    it('should not show Clear link for non-optional fields', () => {
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="testField" label="Required Field">
+            <Select options={[{ value: 'test', label: 'Test' }]} />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      expect(screen.queryByText('Clear')).not.toBeInTheDocument();
+    });
+
+    it('should show Clear link for optional fields', () => {
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem
+            name="testField"
+            label="Optional Field"
+            showClear
+          >
+            <Select options={[{ value: 'test', label: 'Test' }]} />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      expect(screen.getByText('Clear')).toBeInTheDocument();
+    });
+  });
+
+  describe('Mode Transitions', () => {
+    it('should switch to edit mode when clicking Keep as is placeholder', async () => {
+      const user = setupUser();
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="testField" label="Test">
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'test', label: 'Test' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Initially in keep mode - "Keep as is" shown as input value
+      const keepAsIsInput = screen.getByDisplayValue('Keep as is');
+      expect(keepAsIsInput).toBeInTheDocument();
+
+      // Click to switch to edit mode
+      await user.click(keepAsIsInput);
+
+      // Should now show the Select component (keep as is input should be gone)
+      expect(screen.queryByDisplayValue('Keep as is')).not.toBeInTheDocument();
+      // Select is now visible
+      expect(screen.getByText('Select value')).toBeInTheDocument();
+    });
+
+    it('should show Undo changes link in edit mode after entering a value', async () => {
+      const user = setupUser();
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="testField" label="Test">
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'test', label: 'Test Option' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Click to switch to edit mode
+      await user.click(screen.getByDisplayValue('Keep as is'));
+
+      // Select a value
+      const selectEl = screen.getByText('Select value');
+      await selectOption(user, selectEl, 'Test Option');
+
+      // Should show Undo changes link after value is set
+      await waitFor(() => {
+        expect(screen.getByText('Undo changes')).toBeInTheDocument();
+      });
+    });
+
+    it('should return to keep mode when clicking Undo changes', async () => {
+      const user = setupUser();
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="testField" label="Test">
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'test', label: 'Test Option' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Switch to edit mode and select a value
+      await user.click(screen.getByDisplayValue('Keep as is'));
+      const selectEl = screen.getByText('Select value');
+      await selectOption(user, selectEl, 'Test Option');
+
+      // Wait for Undo changes to appear
+      await waitFor(() => {
+        expect(screen.getByText('Undo changes')).toBeInTheDocument();
+      });
+
+      // Click Undo changes
+      await user.click(screen.getByText('Undo changes'));
+
+      // Should be back to keep mode
+      expect(screen.getByDisplayValue('Keep as is')).toBeInTheDocument();
+      expect(screen.queryByText('Undo changes')).not.toBeInTheDocument();
+    });
+
+    it('should switch to clear mode when clicking Clear link', async () => {
+      const user = setupUser();
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="testField" label="Test" showClear>
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'test', label: 'Test' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Click Clear
+      await user.click(screen.getByText('Clear'));
+
+      // Clear mode shows "Clear" label as input value
+      expect(screen.getByDisplayValue('Clear')).toBeInTheDocument();
+      // Clear link should be replaced with Undo changes
+      expect(
+        screen.queryByRole('link', { name: 'Clear' }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('Undo changes')).toBeInTheDocument();
+    });
+
+    it('should return from clear mode to keep mode when clicking Undo changes', async () => {
+      const user = setupUser();
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="testField" label="Test" showClear>
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'test', label: 'Test' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Switch to clear mode
+      await user.click(screen.getByText('Clear'));
+      expect(screen.getByDisplayValue('Clear')).toBeInTheDocument();
+
+      // Click Undo changes
+      await user.click(screen.getByText('Undo changes'));
+
+      // Should be back to keep mode
+      expect(screen.getByDisplayValue('Keep as is')).toBeInTheDocument();
+      expect(screen.getByText('Clear')).toBeInTheDocument();
+    });
+
+    it('should switch from clear mode to edit mode when clicking placeholder', async () => {
+      const user = setupUser();
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="testField" label="Test" showClear>
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'test', label: 'Test' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Switch to clear mode
+      await user.click(screen.getByText('Clear'));
+      expect(screen.getByDisplayValue('Clear')).toBeInTheDocument();
+
+      // Click placeholder to switch to edit mode
+      await user.click(screen.getByDisplayValue('Clear'));
+
+      // Should now be in edit mode
+      expect(screen.getByText('Select value')).toBeInTheDocument();
+      expect(screen.queryByDisplayValue('Clear')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Form Value Handling', () => {
+    it('should set form value to undefined in keep mode', async () => {
+      const formRef = { current: null as FormInstance | null };
+      const user = setupUser();
+      render(
+        <FormWrapper formRef={formRef}>
+          <BAIBulkEditFormItem name="testField" label="Test">
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'test', label: 'Test Option' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Switch to edit mode and select a value
+      await user.click(screen.getByDisplayValue('Keep as is'));
+      const selectEl = screen.getByText('Select value');
+      await selectOption(user, selectEl, 'Test Option');
+
+      // Verify value is set
+      await waitFor(() => {
+        expect(formRef.current?.getFieldValue('testField')).toBe('test');
+      });
+
+      // Click Undo to go back to keep mode
+      await user.click(screen.getByText('Undo changes'));
+
+      // After undo, the value should be undefined (excluded from submission)
+      await waitFor(() => {
+        expect(formRef.current?.getFieldValue('testField')).toBeUndefined();
+      });
+    });
+
+    it('should set form value to null in clear mode', async () => {
+      const formRef = { current: null as FormInstance | null };
+      const user = setupUser();
+      render(
+        <FormWrapper formRef={formRef}>
+          <BAIBulkEditFormItem name="testField" label="Test" showClear>
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'test', label: 'Test' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Click Clear
+      await user.click(screen.getByText('Clear'));
+
+      // Should have set the value to null (explicit clear)
+      await waitFor(() => {
+        expect(formRef.current?.getFieldValue('testField')).toBeNull();
+      });
+    });
+
+    it('should allow user selection in edit mode', async () => {
+      const onValuesChange = jest.fn();
+      const user = setupUser();
+      render(
+        <FormWrapper onValuesChange={onValuesChange}>
+          <BAIBulkEditFormItem name="testField" label="Test">
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'selected', label: 'Selected Option' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Switch to edit mode
+      await user.click(screen.getByDisplayValue('Keep as is'));
+
+      // Select a value
+      const selectEl = screen.getByText('Select value');
+      await selectOption(user, selectEl, 'Selected Option');
+
+      // Should have recorded the value change
+      await waitFor(() => {
+        expect(onValuesChange).toHaveBeenCalled();
+        const calls = onValuesChange.mock.calls;
+        const hasSelected = calls.some(
+          (call) => call[0]?.testField === 'selected',
+        );
+        expect(hasSelected).toBe(true);
+      });
+    });
+  });
+
+  describe('With Select Component', () => {
+    it('should work with Select component in edit mode', async () => {
+      const user = setupUser();
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="status" label="Status">
+            <Select
+              placeholder="Select status"
+              options={[
+                { value: 'active', label: 'Active' },
+                { value: 'inactive', label: 'Inactive' },
+              ]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Switch to edit mode
+      await user.click(screen.getByDisplayValue('Keep as is'));
+
+      // Should show the Select
+      expect(screen.getByText('Select status')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle multiple fields independently', async () => {
+      const user = setupUser();
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="field1" label="Field 1">
+            <Select
+              placeholder="Field 1 select"
+              options={[{ value: 'test1', label: 'Test 1' }]}
+            />
+          </BAIBulkEditFormItem>
+          <BAIBulkEditFormItem name="field2" label="Field 2" showClear>
+            <Select
+              placeholder="Field 2 select"
+              options={[{ value: 'test2', label: 'Test 2' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Both should start in keep mode
+      const keepAsIsElements = screen.getAllByDisplayValue('Keep as is');
+      expect(keepAsIsElements).toHaveLength(2);
+
+      // Switch first field to edit mode
+      await user.click(keepAsIsElements[0]);
+
+      // First field should be in edit mode
+      expect(screen.getByText('Field 1 select')).toBeInTheDocument();
+
+      // Second field should still be in keep mode
+      expect(screen.getByDisplayValue('Keep as is')).toBeInTheDocument();
+      expect(screen.getByText('Clear')).toBeInTheDocument();
+    });
+
+    it('should pass through additional Form.Item props', () => {
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem
+            name="testField"
+            label="Test"
+            tooltip="This is a tooltip"
+          >
+            <Select options={[{ value: 'test', label: 'Test' }]} />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Required marker should be present (BAIBulkEditFormItem always sets required=true internally)
+      expect(
+        document.querySelector('.ant-form-item-required'),
+      ).toBeInTheDocument();
+    });
+
+    it('should use custom clearValueLabel when provided', async () => {
+      const user = setupUser();
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem
+            name="testField"
+            label="Test"
+            showClear
+            clearValueLabel="No value selected"
+          >
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'test', label: 'Test' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Switch to clear mode
+      await user.click(screen.getByText('Clear'));
+
+      // Should show custom clearValueLabel as input value
+      expect(screen.getByDisplayValue('No value selected')).toBeInTheDocument();
+      expect(screen.queryByDisplayValue('Clear')).not.toBeInTheDocument();
+    });
+
+    it('should use custom keepValueLabel when provided', () => {
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem
+            name="testField"
+            label="Test"
+            keepValueLabel="No changes to this field"
+          >
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'test', label: 'Test' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Should show custom keepValueLabel as input value instead of default "Keep as is"
+      expect(
+        screen.getByDisplayValue('No changes to this field'),
+      ).toBeInTheDocument();
+      expect(screen.queryByDisplayValue('Keep as is')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have clickable placeholder for keyboard navigation', async () => {
+      const user = setupUser();
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="testField" label="Test">
+            <Select
+              placeholder="Select value"
+              options={[{ value: 'test', label: 'Test' }]}
+            />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      const placeholder = screen.getByDisplayValue('Keep as is');
+
+      // Should be clickable
+      await user.click(placeholder);
+      expect(screen.getByText('Select value')).toBeInTheDocument();
+    });
+
+    it('should have accessible link for Clear action', () => {
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="testField" label="Test" showClear>
+            <Select options={[{ value: 'test', label: 'Test' }]} />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      const clearLink = screen.getByText('Clear');
+      expect(clearLink.tagName.toLowerCase()).toBe('a');
+    });
+
+    it('should have accessible link for Undo changes action', async () => {
+      const user = setupUser();
+      render(
+        <FormWrapper>
+          <BAIBulkEditFormItem name="testField" label="Test" showClear>
+            <Select options={[{ value: 'test', label: 'Test' }]} />
+          </BAIBulkEditFormItem>
+        </FormWrapper>,
+      );
+
+      // Switch to clear mode (which sets value to null, triggering Undo changes link)
+      await user.click(screen.getByText('Clear'));
+
+      const undoLink = screen.getByText('Undo changes');
+      expect(undoLink.tagName.toLowerCase()).toBe('a');
+    });
+  });
+});

--- a/packages/backend.ai-ui/src/components/BAIBulkEditFormItem.tsx
+++ b/packages/backend.ai-ui/src/components/BAIBulkEditFormItem.tsx
@@ -1,0 +1,270 @@
+import BAIFlex from './BAIFlex';
+import { DownOutlined } from '@ant-design/icons';
+import { useControllableValue } from 'ahooks';
+import { Form, FormItemProps, Input, theme, Typography } from 'antd';
+import type { RuleObject, RuleRender } from 'antd/es/form';
+import _ from 'lodash';
+import React, {
+  cloneElement,
+  ReactElement,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Represents the different edit modes for bulk editing.
+ * - 'keep': Maintains the current values without changes (value = undefined, excluded from submission)
+ * - 'edit': Allows modification of the field value
+ * - 'clear': Shows clear placeholder with clearValue (only available if optional)
+ */
+type BulkEditMode = 'keep' | 'edit' | 'clear';
+
+/**
+ * Rule type without the 'required' property.
+ * Uses distributive conditional types to properly omit 'required' from union type.
+ * - RuleObject: Object-based validation rules (removes 'required' property)
+ * - RuleRender: Function-based validation rules (kept as-is since it has no 'required')
+ */
+type RuleWithoutRequired = Omit<RuleObject, 'required'> | RuleRender;
+
+export interface BAIBulkEditFormItemProps
+  extends Omit<FormItemProps, 'required' | 'rules'> {
+  /**
+   * Whether this field is optional (allows clearing).
+   * When true, shows the "Clear" link in keep mode.
+   */
+  showClear?: boolean;
+  /**
+   * The label to display in the placeholder when in keep mode.
+   * If not provided, defaults to i18n 'comp:BAIBulkEditFormItem.KeepAsIs'.
+   */
+  keepValueLabel?: string;
+  /**
+   * The label to display in the placeholder when in clear mode.
+   * If not provided, defaults to i18n 'comp:BAIBulkEditFormItem.Clear'.
+   */
+  clearValueLabel?: string;
+  /**
+   * Children element to render (typically an input component like Select, Input, etc.)
+   */
+  children?: ReactElement;
+
+  /**
+   * Validation rules for the form item.
+   * Note: 'required' property is excluded as bulk edit handles required state internally.
+   */
+  rules?: RuleWithoutRequired[];
+}
+
+/**
+ * BAIBulkEditFormItem is a custom Form.Item component designed for bulk editing scenarios.
+ *
+ * ## Features
+ * - **Keep as is**: Maintains current values without changes (default state, value = undefined)
+ * - **Edit**: Allows user to modify the field value
+ * - **Clear**: Shows placeholder with clearValueLabel (only available when showClear is true)
+ * - **Undo changes**: Reverts to "Keep as is" state (appears when not in keep mode)
+ *
+ * ## Usage
+ * ```tsx
+ * <BAIBulkEditFormItem
+ *   name="domain_name"
+ *   label="Domain"
+ *   showClear
+ *   clearValueLabel="No domain"
+ * >
+ *   <BAISelect options={[...]} />
+ * </BAIBulkEditFormItem>
+ * ```
+ */
+const BAIBulkEditFormItem: React.FC<BAIBulkEditFormItemProps> = ({
+  name,
+  showClear = false,
+  keepValueLabel,
+  clearValueLabel,
+  children,
+  ...formItemProps
+}) => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const form = Form.useFormInstance();
+  const [mode, setMode] = useState<BulkEditMode>('keep');
+
+  const controlRef = useRef<ControlWrapperRef>(null);
+  const { token } = theme.useToken();
+
+  const focusControl = () => {
+    setTimeout(() => {
+      controlRef.current?.focus();
+      controlRef.current?.open();
+    }, 0);
+  };
+
+  const handlePlaceholderClick = (e: React.MouseEvent | React.FocusEvent) => {
+    e.preventDefault();
+    setMode('edit');
+    focusControl();
+  };
+
+  const handleControlBlur = () => {
+    const currentValue = form.getFieldValue(name);
+    if (currentValue === undefined) {
+      setMode('keep');
+    }
+    if (currentValue === null && showClear) {
+      setMode('clear');
+    }
+  };
+
+  const handleClear = () => {
+    setMode('clear');
+    form.setFieldValue(name, null);
+  };
+
+  const handleUndo = () => {
+    setMode('keep');
+    form.setFieldValue(name, undefined);
+  };
+
+  const resolvedKeepValueLabel =
+    keepValueLabel ?? t('comp:BAIBulkEditFormItem.KeepAsIs');
+  const resolvedClearValueLabel =
+    clearValueLabel ?? t('comp:BAIBulkEditFormItem.Clear');
+
+  return (
+    <Form.Item
+      {...formItemProps}
+      style={{ marginBottom: 0, ...formItemProps.style }}
+      required // Always handle required display in UI level for bulk edit
+      extra={
+        <BAIFlex justify="between" gap={'xs'}>
+          {formItemProps.extra ?? <div />}
+          <BAIFlex>
+            {mode === 'keep' && showClear && (
+              <Typography.Link onClick={handleClear}>
+                {t('comp:BAIBulkEditFormItem.Clear')}
+              </Typography.Link>
+            )}
+            {/* Use Form.Item to watch field value changes */}
+            <Form.Item noStyle dependencies={[name]}>
+              {({ getFieldValue }) =>
+                mode !== 'keep' &&
+                getFieldValue(name) !== undefined && (
+                  <Typography.Link onClick={handleUndo}>
+                    {t('comp:BAIBulkEditFormItem.UndoChanges')}
+                  </Typography.Link>
+                )
+              }
+            </Form.Item>
+          </BAIFlex>
+        </BAIFlex>
+      }
+    >
+      {mode === 'keep' ? (
+        // Keep as is mode: Show "Keep as is" placeholder
+        <Input
+          value={resolvedKeepValueLabel}
+          onMouseDown={handlePlaceholderClick}
+          onFocus={handlePlaceholderClick}
+          variant="filled"
+          suffix={
+            <DownOutlined
+              style={{
+                color: token.colorTextQuaternary,
+                fontSize: token.fontSizeSM,
+              }}
+            />
+          }
+        />
+      ) : mode === 'clear' ? (
+        // Clear mode: Show clear value label as placeholder
+        <Input
+          value={resolvedClearValueLabel}
+          onMouseDown={handlePlaceholderClick}
+          onFocus={handlePlaceholderClick}
+          variant="filled"
+          suffix={
+            <DownOutlined
+              style={{
+                color: token.colorTextQuaternary,
+                fontSize: token.fontSizeSM,
+              }}
+            />
+          }
+        />
+      ) : null}
+      <Form.Item
+        name={name}
+        {...formItemProps}
+        noStyle
+        hidden={mode !== 'edit'}
+      >
+        {children && (
+          <ControlWrapper ref={controlRef} onBlur={handleControlBlur}>
+            {children}
+          </ControlWrapper>
+        )}
+      </Form.Item>
+    </Form.Item>
+  );
+};
+
+BAIBulkEditFormItem.displayName = 'BAIBulkEditFormItem';
+
+export default BAIBulkEditFormItem;
+
+/**
+ * ControlWrapper wraps children with ref forwarding for focus control.
+ * This component injects a ref into children to enable programmatic focus.
+ */
+
+interface ControlWrapperRef {
+  open: () => void;
+  focus: () => void;
+}
+
+interface ControlWrapperProps {
+  children: ReactElement;
+  open?: boolean;
+  onBlur?: () => void;
+  onOpenChange?: (isOpen: boolean) => void;
+}
+const ControlWrapper = React.forwardRef<ControlWrapperRef, ControlWrapperProps>(
+  ({ children, ...props }, ref) => {
+    const innerRef = useRef<any>(null);
+    const [open, setOpen] = useControllableValue(props, {
+      valuePropName: 'open',
+      trigger: 'onOpenChange',
+    });
+
+    useImperativeHandle(ref, () => {
+      return {
+        ...(innerRef.current || {}),
+        open: () => {
+          setOpen(true);
+        },
+      };
+    });
+
+    // eslint-disable-next-line react-hooks/refs
+    const clonedChild = cloneElement(children, {
+      ...props,
+      // @ts-ignore
+      ref: innerRef,
+      open,
+      onOpenChange: (isOpen: boolean) => {
+        setOpen(isOpen);
+        const { onOpenChange } = children.props as any;
+        if (onOpenChange) {
+          onOpenChange(isOpen);
+        }
+      },
+    });
+
+    return clonedChild;
+  },
+);
+ControlWrapper.displayName = 'ControlWrapper';

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -1,5 +1,7 @@
 export { default as BAIBoardItemTitle } from './BAIBoardItemTitle';
 export type { BAIBoardItemTitleProps } from './BAIBoardItemTitle';
+export { default as BAIBulkEditFormItem } from './BAIBulkEditFormItem';
+export type { BAIBulkEditFormItemProps } from './BAIBulkEditFormItem';
 export { default as BAIFlex } from './BAIFlex';
 export type { BAIFlexProps } from './BAIFlex';
 export { default as BAICard } from './BAICard';

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -57,6 +57,11 @@
     "Updated": "Aktualisiert",
     "Version": "Version"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Löschen",
+    "KeepAsIs": "Unverändert lassen",
+    "UndoChanges": "Änderungen rückgängig machen"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Sind Sie sicher, dass Sie {{name}} deaktivieren möchten?",
     "AreYouSureYouWantToDeactivateSome": "Sind Sie sicher, dass Sie {{count}} Artefakte deaktivieren möchten?",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -57,6 +57,11 @@
     "Updated": "Ενημερωμένος",
     "Version": "Εκδοχή"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Καθαρισμός",
+    "KeepAsIs": "Διατήρηση ως έχει",
+    "UndoChanges": "Αναίρεση αλλαγών"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Είστε βέβαιοι ότι θέλετε να απενεργοποιήσετε {{name}};",
     "AreYouSureYouWantToDeactivateSome": "Είστε βέβαιοι ότι θέλετε να απενεργοποιήσετε {{count}} τεχνουργήματα;",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -57,6 +57,11 @@
     "Updated": "Updated",
     "Version": "Version"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Clear",
+    "KeepAsIs": "Keep as is",
+    "UndoChanges": "Undo changes"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Are you sure you want to deactivate {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Are you sure you want to deactivate {{count}} artifacts?",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -57,6 +57,11 @@
     "Updated": "Actualizado",
     "Version": "Versión"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Limpiar",
+    "KeepAsIs": "Mantener como está",
+    "UndoChanges": "Deshacer cambios"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "¿Estás seguro de que quieres desactivar {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "¿Estás seguro de que quieres desactivar {{count}} artefactos?",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -57,6 +57,11 @@
     "Updated": "Päivitetty",
     "Version": "Versio"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Tyhjennä",
+    "KeepAsIs": "Pidä ennallaan",
+    "UndoChanges": "Kumoa muutokset"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Oletko varma, että haluat deaktivoida {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Oletko varma, että haluat deaktivoida {{count}} esineitä?",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -57,6 +57,11 @@
     "Updated": "Mis à jour",
     "Version": "Version"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Effacer",
+    "KeepAsIs": "Conserver tel quel",
+    "UndoChanges": "Annuler les modifications"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Êtes-vous sûr de vouloir désactiver {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Êtes-vous sûr de vouloir désactiver les artefacts {{count}}?",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -57,6 +57,11 @@
     "Updated": "Diperbarui",
     "Version": "Versi"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Hapus",
+    "KeepAsIs": "Pertahankan",
+    "UndoChanges": "Batalkan perubahan"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Anda yakin ingin menonaktifkan {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Anda yakin ingin menonaktifkan artefak {{count}}?",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -57,6 +57,11 @@
     "Updated": "Aggiornato",
     "Version": "Versione"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Cancella",
+    "KeepAsIs": "Mantieni invariato",
+    "UndoChanges": "Annulla modifiche"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Sei sicuro di voler disattivare {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Sei sicuro di voler disattivare {{count}} artefatti?",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -57,6 +57,11 @@
     "Updated": "更新",
     "Version": "バージョン"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "クリア",
+    "KeepAsIs": "そのまま維持",
+    "UndoChanges": "変更を元に戻す"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "{{name}}を無効にしたいですか？",
     "AreYouSureYouWantToDeactivateSome": "{{count}}アーティファクトを無効にしたいですか？",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -57,6 +57,11 @@
     "Updated": "업데이트",
     "Version": "버전"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "지우기",
+    "KeepAsIs": "그대로 유지",
+    "UndoChanges": "변경 취소"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "{{name}}를 비활성화 하시겠습니까?",
     "AreYouSureYouWantToDeactivateSome": "{{count}}개의 아티팩트를 비활성화 하시겠습니까?",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -57,6 +57,11 @@
     "Updated": "Шинэчилсэн цаг нь",
     "Version": "Таамаглал"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Цэвэрлэх",
+    "KeepAsIs": "Хэвээр үлдээх",
+    "UndoChanges": "Өөрчлөлтийг буцаах"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Та {{name}} идэвхгүй болгохыг хүсч байна уу?}}?",
     "AreYouSureYouWantToDeactivateSome": "Та {{count}} олдворуудыг идэвхгүй болгохыг хүсч байна уу?",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -57,6 +57,11 @@
     "Updated": "Dikemas kini",
     "Version": "Versi"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Kosongkan",
+    "KeepAsIs": "Kekalkan seperti semula",
+    "UndoChanges": "Batal perubahan"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Adakah anda pasti mahu menyahaktifkan {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Adakah anda pasti mahu menyahaktifkan {{count}} artifak?",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -57,6 +57,11 @@
     "Updated": "Zaktualizowane",
     "Version": "Wersja"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Wyczyść",
+    "KeepAsIs": "Pozostaw bez zmian",
+    "UndoChanges": "Cofnij zmiany"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Czy na pewno chcesz dezaktywować {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Czy na pewno chcesz dezaktywować {{count}} artefakty?",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -57,6 +57,11 @@
     "Updated": "Atualizado",
     "Version": "Versão"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Limpar",
+    "KeepAsIs": "Manter como está",
+    "UndoChanges": "Desfazer alterações"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Tem certeza de que deseja desativar {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Tem certeza de que deseja desativar os artefatos {{count}}?",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -57,6 +57,11 @@
     "Updated": "Atualizado",
     "Version": "Versão"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Limpar",
+    "KeepAsIs": "Manter como está",
+    "UndoChanges": "Desfazer alterações"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Tem certeza de que deseja desativar {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Tem certeza de que deseja desativar os artefatos {{count}}?",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -57,6 +57,11 @@
     "Updated": "Обновлено",
     "Version": "Версия"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Очистить",
+    "KeepAsIs": "Оставить как есть",
+    "UndoChanges": "Отменить изменения"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Вы уверены, что хотите деактивировать {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Вы уверены, что хотите деактивировать {{count}} артефакты?",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -57,6 +57,11 @@
     "Updated": "อัปเดต",
     "Version": "รุ่น"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "ล้าง",
+    "KeepAsIs": "เก็บไว้ตามเดิม",
+    "UndoChanges": "ยกเลิกการเปลี่ยนแปลง"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "แน่ใจหรือว่าคุณต้องการปิดการใช้งาน {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "คุณแน่ใจหรือไม่ว่าต้องการปิดการใช้งาน {{count}} สิ่งประดิษฐ์?",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -57,6 +57,11 @@
     "Updated": "Güncellenmiş",
     "Version": "Versiyon"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Temizle",
+    "KeepAsIs": "Olduğu gibi bırak",
+    "UndoChanges": "Değişiklikleri geri al"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "{{name}} 'ı devre dışı bırakmak istediğinizden emin misiniz?",
     "AreYouSureYouWantToDeactivateSome": "{{count}} artefaktları devre dışı bırakmak istediğinizden emin misiniz?",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -57,6 +57,11 @@
     "Updated": "Cập nhật",
     "Version": "Phiên bản"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "Xóa",
+    "KeepAsIs": "Giữ nguyên",
+    "UndoChanges": "Hoàn tác thay đổi"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Bạn có chắc bạn muốn hủy kích hoạt {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Bạn có chắc là bạn muốn hủy kích hoạt {{count}} Artifacts?",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -57,6 +57,11 @@
     "Updated": "更新",
     "Version": "版本"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "清除",
+    "KeepAsIs": "保持原样",
+    "UndoChanges": "撤销更改"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "您确定要停用{{name}}吗？",
     "AreYouSureYouWantToDeactivateSome": "您确定要停用{{count}}文物吗？",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -57,6 +57,11 @@
     "Updated": "更新",
     "Version": "版本"
   },
+  "comp:BAIBulkEditFormItem": {
+    "Clear": "清除",
+    "KeepAsIs": "保持原樣",
+    "UndoChanges": "撤銷更改"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "您確定要停用{{name}}嗎？",
     "AreYouSureYouWantToDeactivateSome": "您確定要停用{{count}}文物嗎？",


### PR DESCRIPTION
Resolves #5132 ([FR-1966](https://lablup.atlassian.net/browse/FR-1966))

## Summary

- Add `BAIBulkEditFormItem` component for bulk editing form scenarios
- Supports three edit modes: **Keep as is**, **Edit**, and **Clear**
- Includes comprehensive unit tests and Storybook stories
- Add i18n translations for all 21 supported languages

## Features

- **Keep as is**: Maintains current values without changes (default state, value = undefined)
- **Edit**: Allows user to modify the field value
- **Clear**: Shows placeholder with clearValueLabel (only available when `showClear` is true)
- **Undo changes**: Reverts to "Keep as is" state (appears when not in keep mode)

## Test plan

- [ ] Run unit tests: `pnpm test` in `packages/backend.ai-ui`
- [ ] Check Storybook stories at `Components/BAIBulkEditFormItem`
- [ ] Verify all three modes work correctly (Keep as is → Edit → Clear)
- [ ] Verify Undo changes functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

[FR-1966]: https://lablup.atlassian.net/browse/FR-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ