### PR TITLE
refactor(FR-2001): remove server-side duplicate name validation from session and service name hooks

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/EditableSessionName.tsx
+++ b/react/src/components/ComputeSessionNodeItems/EditableSessionName.tsx
@@ -181,11 +181,7 @@ const EditableSessionName: React.FC<EditableSessionNameProps> = ({
             flex: 1,
           }}
         >
-          <Form.Item
-            name="sessionName"
-            rules={validationRules}
-            validateDebounce={200}
-          >
+          <Form.Item name="sessionName" rules={validationRules}>
             <Input
               size="large"
               value={optimisticName || ''}

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -888,7 +888,6 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                         <Form.Item
                           label={t('modelService.ServiceName')}
                           name="serviceName"
-                          validateDebounce={500}
                           rules={endpoint ? [] : validationRules}
                         >
                           <Input disabled={!!endpoint} />

--- a/react/src/components/SessionNameFormItem.tsx
+++ b/react/src/components/SessionNameFormItem.tsx
@@ -18,7 +18,6 @@ const SessionNameFormItem: React.FC<SessionNameFormItemProps> = ({
     <Form.Item
       label={t('session.launcher.SessionName')}
       name="sessionName"
-      validateDebounce={200}
       // Original rule : /^(?=.{4,64}$)\w[\w.-]*\w$/
       // https://github.com/lablup/backend.ai/blob/main/src/ai/backend/manager/api/session.py#L355-L356
       rules={validationRules}

--- a/react/src/hooks/useValidateServiceName.tsx
+++ b/react/src/hooks/useValidateServiceName.tsx
@@ -1,96 +1,45 @@
-import { useValidateServiceNameQuery } from '../__generated__/useValidateServiceNameQuery.graphql';
-import { useCurrentProjectValue } from './useCurrentProject';
 import { type FormItemProps } from 'antd';
 import type { RuleObject } from 'antd/es/form';
 import _ from 'lodash';
-import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useRelayEnvironment, fetchQuery } from 'react-relay';
 
 export const useValidateServiceName = (): Exclude<
   FormItemProps['rules'],
   undefined
 > => {
+  'use memo';
   const { t } = useTranslation();
-  const relayEvn = useRelayEnvironment();
-  const currentProject = useCurrentProjectValue();
-  return useMemo(
-    () => [
-      {
-        min: 4,
-        message: t('modelService.ServiceNameMinLength'),
-      },
-      {
-        max: 24,
-        message: t('modelService.ServiceNameMaxLength'),
-        type: 'string',
-      },
-      {
-        validator(_f: RuleObject, value: string) {
-          if (_.isEmpty(value)) {
-            return Promise.resolve();
-          }
-          if (!/^\w/.test(value)) {
-            return Promise.reject(t('modelService.ServiceNameShouldStartWith'));
-          }
-
-          if (!/\w$/.test(value)) {
-            return Promise.reject(t('modelService.ServiceNameShouldEndWith'));
-          }
-
-          if (!/^[\w-]*$/.test(value)) {
-            return Promise.reject(
-              t('modelService.ServiceNameInvalidCharacter'),
-            );
-          }
+  return [
+    {
+      min: 4,
+      message: t('modelService.ServiceNameMinLength'),
+    },
+    {
+      max: 24,
+      message: t('modelService.ServiceNameMaxLength'),
+      type: 'string',
+    },
+    {
+      validator(_f: RuleObject, value: string) {
+        if (_.isEmpty(value)) {
           return Promise.resolve();
-        },
+        }
+        if (!/^\w/.test(value)) {
+          return Promise.reject(t('modelService.ServiceNameShouldStartWith'));
+        }
+
+        if (!/\w$/.test(value)) {
+          return Promise.reject(t('modelService.ServiceNameShouldEndWith'));
+        }
+
+        if (!/^[\w-]*$/.test(value)) {
+          return Promise.reject(t('modelService.ServiceNameInvalidCharacter'));
+        }
+        return Promise.resolve();
       },
-      {
-        validator: async (_f: RuleObject, value: string) => {
-          if (!value) return Promise.resolve();
-          return fetchQuery<useValidateServiceNameQuery>(
-            relayEvn,
-            graphql`
-              query useValidateServiceNameQuery(
-                $projectID: UUID!
-                $filter: String
-                $offset: Int!
-                $limit: Int!
-              ) {
-                endpoint_list(
-                  project: $projectID
-                  filter: $filter
-                  offset: $offset
-                  limit: $limit
-                ) {
-                  total_count
-                }
-              }
-            `,
-            {
-              projectID: currentProject.id,
-              filter: `lifecycle_stage != "destroyed" & name == "${value}"`,
-              offset: 0,
-              limit: 1,
-            },
-          )
-            .toPromise()
-            .catch(() => {
-              // ignore network error
-              return Promise.resolve();
-            })
-            .then((data) => {
-              if ((data?.endpoint_list?.total_count ?? 0) > 0) {
-                return Promise.reject(t('modelService.ServiceAlreadyExists'));
-              }
-            });
-        },
-      },
-      {
-        required: true,
-      },
-    ],
-    [relayEvn, currentProject.id, t],
-  );
+    },
+    {
+      required: true,
+    },
+  ];
 };

--- a/react/src/hooks/useValidateSessionName.tsx
+++ b/react/src/hooks/useValidateSessionName.tsx
@@ -1,91 +1,47 @@
-import { useValidateSessionNameQuery } from '../__generated__/useValidateSessionNameQuery.graphql';
-import { useCurrentProjectValue } from './useCurrentProject';
 import type { RuleObject } from 'antd/es/form';
 import { FormItemProps } from 'antd/lib';
 import _ from 'lodash';
-import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useRelayEnvironment, fetchQuery } from 'react-relay';
 
 export const useValidateSessionName = (
   currentName?: string | null,
 ): Exclude<FormItemProps['rules'], undefined> => {
+  'use memo';
   const { t } = useTranslation();
-  const relayEvn = useRelayEnvironment();
-  const currentProject = useCurrentProjectValue();
-  return useMemo(
-    () => [
-      {
-        min: 4,
-        message: t('session.validation.SessionNameTooShort'),
-      },
-      {
-        max: 64,
-        message: t('session.validation.SessionNameTooLong64'),
-      },
-      {
-        validator(_f: RuleObject, value: string) {
-          if (_.isEmpty(value)) {
-            return Promise.resolve();
-          }
-          if (!/^\w/.test(value)) {
-            return Promise.reject(
-              t('session.validation.SessionNameShouldStartWith'),
-            );
-          }
-
-          if (!/\w$/.test(value)) {
-            return Promise.reject(
-              t('session.validation.SessionNameShouldEndWith'),
-            );
-          }
-
-          if (!/^[\w.-]*$/.test(value)) {
-            return Promise.reject(
-              t('session.validation.SessionNameInvalidCharacter'),
-            );
-          }
+  return [
+    {
+      min: 4,
+      message: t('session.validation.SessionNameTooShort'),
+    },
+    {
+      max: 64,
+      message: t('session.validation.SessionNameTooLong64'),
+    },
+    {
+      validator(_f: RuleObject, value: string) {
+        if (_.isEmpty(value)) {
           return Promise.resolve();
-        },
+        }
+        if (!/^\w/.test(value)) {
+          return Promise.reject(
+            t('session.validation.SessionNameShouldStartWith'),
+          );
+        }
+
+        if (!/\w$/.test(value)) {
+          return Promise.reject(
+            t('session.validation.SessionNameShouldEndWith'),
+          );
+        }
+
+        if (!/^[\w.-]*$/.test(value)) {
+          return Promise.reject(
+            t('session.validation.SessionNameInvalidCharacter'),
+          );
+        }
+        return Promise.resolve();
       },
-      {
-        validator: async (_f: RuleObject, value: string) => {
-          if (value === currentName || !value) {
-            return Promise.resolve();
-          }
-          return fetchQuery<useValidateSessionNameQuery>(
-            relayEvn,
-            graphql`
-              query useValidateSessionNameQuery(
-                $projectId: UUID!
-                $filter: String
-              ) {
-                compute_session_nodes(project_id: $projectId, filter: $filter) {
-                  count
-                }
-              }
-            `,
-            {
-              projectId: currentProject.id,
-              filter: `status != "TERMINATED" & status != "CANCELLED" & name == "${value}"`,
-            },
-          )
-            .toPromise()
-            .catch(() => {
-              // ignore network error
-              return;
-            })
-            .then((data) => {
-              if ((data?.compute_session_nodes?.count ?? 0) > 0) {
-                return Promise.reject(
-                  t('session.launcher.SessionAlreadyExists'),
-                );
-              }
-            });
-        },
-      },
-      currentName ? { required: true } : {},
-    ],
-    [currentName, relayEvn, currentProject.id, t],
-  );
+    },
+    currentName ? { required: true } : {},
+  ];
 };


### PR DESCRIPTION
Resolves #5184 ([FR-2001](https://lablup.atlassian.net/browse/FR-2001))

Simplify client-side validation by removing GraphQL queries that check for duplicate session and service names, as the server already handles duplicate detection during creation requests.

## Why This Work is Needed

The current implementation performs duplicate name checks via GraphQL queries in useValidateSessionName and useValidateServiceName hooks. This creates validation logic inconsistencies between client and server, and the debounce delays are unnecessary since the server provides authoritative duplicate detection during creation.

## Changes

- Remove server-side validation queries from both hooks
- Remove validateDebounce from form items using these hooks  
- Simplify hooks using React Compiler 'use memo' directive
- Keep only client-side format validation (length, characters, patterns)

[FR-2001]: https://lablup.atlassian.net/browse/FR-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ