### PR TITLE
chore(FR-2003): add unified submit-staged-changes command

### DIFF
--- a/.claude/commands/amend-staged-changes.md
+++ b/.claude/commands/amend-staged-changes.md
@@ -1,0 +1,258 @@
+---
+description: Amend staged changes to existing PR and update PR description.
+argument-hint: [--update-desc]
+model: claude-sonnet-4-5
+---
+
+# Amend Staged Changes
+
+Amend staged changes to an existing PR and optionally update the PR description.
+
+## Arguments
+
+The `$ARGUMENTS` specifies optional flags:
+- `--update-desc`: Force update PR description even if no new changes
+
+If no argument is provided, PR description will only be updated if there are staged changes.
+
+## Workflow Overview
+
+```
+0. Verify MCP authentication
+1. Verify existing PR context
+2. Amend changes to current commit
+3. Push updated commit
+4. Update PR description (if needed)
+5. Display summary
+```
+
+## Detailed Process
+
+### Step 0: Verify MCP Authentication
+
+Verify that MCP tools are authenticated before starting the workflow.
+
+```
+# Test Graphite MCP authentication
+mcp__graphite__run_gt_cmd with args: ["--version"]
+```
+
+**If authentication fails:**
+- Inform the user that Graphite MCP needs re-authentication
+- Provide guidance on how to re-authenticate:
+  ```
+  ⚠️ MCP Authentication Required
+
+  Graphite MCP needs re-authentication.
+  Please re-authenticate via MCP settings and run the command again.
+  ```
+- Exit the workflow without making any changes
+
+**If authentication succeeds:**
+- Proceed to Step 1
+
+### Step 1: Verify Existing PR Context
+
+```bash
+# Check current branch
+git branch --show-current
+
+# Check if branch has an associated PR
+gh pr view --json number,title,url,body
+
+# Check current stack state
+mcp__graphite__run_gt_cmd with args: ["log", "short"]
+
+# Check staged changes
+git diff --cached --stat
+```
+
+**If no PR exists for current branch:**
+```
+⚠️ No PR Found
+
+Current branch does not have an associated PR.
+Use /submit-staged-changes to create a new Jira issue and PR.
+```
+- Exit the workflow
+
+**If PR exists:**
+- Extract PR number, title, URL, and current body
+- Proceed to Step 2
+
+### Step 2: Analyze Changes
+
+```bash
+# View staged changes
+git diff --cached
+
+# View current commit message
+git log -1 --format="%B"
+```
+
+- Review staged changes to understand what's being amended
+- If no staged changes and `--update-desc` not provided:
+  ```
+  ℹ️ No Staged Changes
+
+  No staged changes to amend. Use --update-desc flag to update PR description only.
+  Or stage your changes first:
+    git add <files>
+  ```
+  - Exit the workflow
+
+### Step 3: User Confirmation
+
+**IMPORTANT**: Present confirmation before making changes:
+
+```
+AskUserQuestion({
+  questions: [{
+    question: "Ready to amend changes to existing PR?",
+    header: "Confirm Amendment",
+    multiSelect: false,
+    options: [
+      {
+        label: "Amend & Push (Recommended)",
+        description: "PR: #YYYY - [PR title]\n\nChanges to amend:\n  - file1.ts (modified)\n  - file2.ts (added)\n\nThis will amend the current commit and force-push."
+      },
+      {
+        label: "Amend & Update Description",
+        description: "Same as above, plus update PR description with new changes"
+      },
+      {
+        label: "Cancel",
+        description: "Don't make any changes"
+      }
+    ]
+  }]
+})
+```
+
+### Step 4: Amend Commit
+
+```
+# Amend staged changes to current commit
+mcp__graphite__run_gt_cmd with args: ["modify", "--all"]
+```
+
+This command:
+- Adds staged changes to the current commit
+- Keeps the existing commit message
+- Prepares for pushing
+
+### Step 5: Push Updated Commit
+
+```
+# Push amended commit (force push)
+mcp__graphite__run_gt_cmd with args: ["submit"]
+```
+
+### Step 6: Update PR Description (Optional)
+
+If user selected "Amend & Update Description" or used `--update-desc` flag:
+
+Extract Jira issue from branch name or PR title (e.g., `FR-XXXX`), then update.
+
+**IMPORTANT**: The `Resolves` link MUST be placed at the TOP of the PR description body, before the Summary section. This ensures proper issue tracking and linking.
+
+**GitHub Issue Number**: Get the GitHub Issue number (`#YYYY`) from the Jira issue's "GitHub Issue URL" custom field (`customfield_10169`).
+
+```bash
+gh pr edit [PR_NUMBER] --body "$(cat <<'EOF'
+Resolves #YYYY ([FR-XXXX](https://lablup.atlassian.net/browse/FR-XXXX))
+
+## Summary
+- [Original summary points]
+- [New changes added in this amendment]
+
+## Test plan
+- [ ] [testing steps]
+EOF
+)"
+```
+
+### Step 7: Display Summary
+
+Present a clear summary:
+
+```
+✅ Amendment Complete!
+
+Pull Request: #YYYY
+  https://github.com/lablup/backend.ai-webui/pull/YYYY
+
+Branch: prefix/FR-XXXX-description
+
+Files Amended:
+  - file1.ts (modified)
+  - file2.ts (added)
+
+Commit: abc1234 → def5678 (amended)
+```
+
+## Error Handling
+
+### No Existing PR
+If `gh pr view` fails:
+```
+⚠️ No PR Found
+
+Current branch 'branch-name' does not have an associated PR.
+
+Options:
+1. Use /submit-staged-changes to create a new Jira issue and PR
+2. Manually create a PR first with: gh pr create
+```
+
+### Graphite Sync Issues
+If `gt modify` fails due to sync issues:
+```
+mcp__graphite__run_gt_cmd with args: ["sync"]
+```
+Then retry the modify operation.
+
+### Push Conflicts
+If `gt submit` fails due to conflicts:
+```
+⚠️ Push Failed
+
+There may be conflicts with the remote branch.
+Please resolve conflicts manually:
+  git fetch origin
+  git rebase origin/main
+```
+
+## Important Notes
+
+### Do's
+- Always verify PR exists before amending
+- Confirm with user before force-pushing
+- Keep PR description updated with amendment summary
+- Use Graphite MCP tools for git operations
+
+### Don'ts
+- Never amend without user confirmation
+- Don't amend if no staged changes (unless --update-desc)
+- Don't use direct `git push --force` commands
+- Don't modify commits that are not the HEAD of the current branch
+
+## Usage Examples
+
+```bash
+# Amend staged changes to existing PR
+/amend-staged-changes
+
+# Update PR description only (no code changes)
+/amend-staged-changes --update-desc
+```
+
+## Comparison with /submit-staged-changes
+
+| Aspect | /submit-staged-changes | /amend-staged-changes |
+|--------|------------------------|----------------------|
+| Purpose | Create new Jira issue + PR | Update existing PR |
+| Jira | Creates new issue | No Jira changes |
+| Branch | Creates new branch | Uses current branch |
+| Commit | New commit | Amends existing commit |
+| Use when | Starting new work | Adding to existing work |

--- a/.claude/commands/submit-staged-changes.md
+++ b/.claude/commands/submit-staged-changes.md
@@ -1,0 +1,297 @@
+---
+description: Create Jira issue and submit PR for staged changes in one workflow.
+argument-hint: [feat, fix, refactor, style, chore, e2e, docs]
+model: claude-sonnet-4-5
+---
+
+# Submit Staged Changes
+
+Create a Jira issue and submit a PR for staged changes in a single, streamlined workflow.
+
+## Arguments
+
+The `$ARGUMENTS` specifies the commit prefix type:
+- `feat`: New features or improvements
+- `fix`: Bug fixes
+- `refactor`: Code refactoring
+- `style`: Design/UI changes
+- `chore`: Other maintenance tasks
+- `e2e`: Add E2E test cases
+- `docs`: Documentation changes
+
+If no argument is provided, the prefix will be inferred from the changes.
+
+## Workflow Overview
+
+```
+0. Verify MCP authentication
+1. Analyze staged changes
+2. Create Jira issue
+3. Create branch and commit
+4. Submit PR
+5. Update Jira issue (sprint, assignee)
+6. Display summary
+```
+
+## Detailed Process
+
+### Step 0: Verify MCP Authentication
+
+Verify that MCP tools are authenticated before starting the workflow.
+
+```
+# Test Atlassian MCP authentication
+mcp__Atlassian__atlassianUserInfo
+
+# Test Graphite MCP authentication
+mcp__graphite__run_gt_cmd with args: ["--version"]
+```
+
+**If authentication fails:**
+- Inform the user which MCP service needs re-authentication
+- Provide guidance on how to re-authenticate:
+  ```
+  ⚠️ MCP Authentication Required
+
+  The following MCP service(s) need re-authentication:
+  - [ ] Atlassian: Re-authenticate via MCP settings
+  - [ ] Graphite: Re-authenticate via MCP settings
+
+  Please re-authenticate and run the command again.
+  ```
+- Exit the workflow without making any changes
+
+**If authentication succeeds:**
+- Proceed to Step 1
+
+### Step 1: Pre-flight Checks
+
+```bash
+# Verify staged changes exist
+git diff --cached --stat
+
+# Check current stack state
+mcp__graphite__run_gt_cmd with args: ["log", "short"]
+
+# Sync with trunk
+mcp__graphite__run_gt_cmd with args: ["sync"]
+```
+
+If no staged changes exist, inform the user and exit.
+
+### Step 2: Analyze Changes
+
+- Review `git diff --cached` to understand changes
+- Determine appropriate:
+  - Commit prefix (from argument or inferred)
+  - Issue title (concise, no prefix)
+  - Issue description (WHY, not HOW)
+  - PR summary
+
+### Step 3: User Confirmation (Single Prompt)
+
+**IMPORTANT**: Present all information in ONE confirmation prompt:
+
+```
+AskUserQuestion({
+  questions: [{
+    question: "Ready to create Jira issue and submit PR?",
+    header: "Confirm Submission",
+    multiSelect: false,
+    options: [
+      {
+        label: "Create Issue & Submit PR (Recommended)",
+        description: "Jira Issue:\n  Type: Task\n  Title: [issue title]\n\nPR:\n  Branch: prefix/FR-XXXX-description\n  Commit: prefix(FR-XXXX): description\n\nFiles:\n  - file1.ts\n  - file2.ts"
+      },
+      {
+        label: "Edit Details",
+        description: "Modify title, description, or prefix before proceeding"
+      },
+      {
+        label: "Cancel",
+        description: "Don't create anything"
+      }
+    ]
+  }]
+})
+```
+
+### Step 4: Create Jira Issue
+
+Use Atlassian MCP tools (refer to `.claude/atlassian-config.md`):
+
+```
+mcp__Atlassian__createJiraIssue with:
+  - cloudId: a28786f5-5410-4c2d-ae2d-9833cf63eb3f
+  - projectKey: FR
+  - issueTypeName: Task (or Story/Bug based on content)
+  - summary: [issue title without prefix]
+  - description: [WHY this work is needed + Expected outcomes]
+  - additional_fields: {"customfield_10173": {"id": "10232"}}
+```
+
+### Step 5: Create Branch and Commit
+
+```
+mcp__graphite__run_gt_cmd with args: ["create", "--all", "--message", "prefix(FR-XXXX): description"]
+```
+
+**Branch Naming Convention**:
+- Pattern: `prefix/FR-XXXX-short-description`
+- Examples: `feat/FR-1234-add-user-api`, `fix/FR-1234-null-check`
+
+If branch name is auto-generated incorrectly, rename it:
+```
+mcp__graphite__run_gt_cmd with args: ["branch", "rename", "correct-branch-name"]
+```
+
+### Step 6: Submit PR
+
+```
+mcp__graphite__run_gt_cmd with args: ["submit"]
+```
+
+### Step 7: Update PR Description
+
+Use `gh pr edit` to set the PR description.
+
+**IMPORTANT**: The `Resolves` link MUST be placed at the TOP of the PR description body, before the Summary section. This ensures proper issue tracking and linking.
+
+**GitHub Issue Number**: After creating the Jira issue, a GitHub issue is automatically created via Jira automation. Get the GitHub Issue number (`#YYYY`) from the Jira issue's "GitHub Issue URL" custom field (`customfield_10169`).
+
+```bash
+gh pr edit [PR_NUMBER] --body "$(cat <<'EOF'
+Resolves #YYYY ([FR-XXXX](https://lablup.atlassian.net/browse/FR-XXXX))
+
+## Summary
+- [bullet points of changes]
+
+## Test plan
+- [ ] [testing steps]
+EOF
+)"
+```
+
+### Step 8: Update Jira Issue
+
+Get current user and active sprint, then update:
+
+```
+# Get current user
+mcp__Atlassian__atlassianUserInfo
+
+# Get active sprint
+mcp__Atlassian__searchJiraIssuesUsingJql with:
+  - jql: "project = FR AND sprint in openSprints() ORDER BY created DESC"
+  - fields: ["customfield_10020"]
+
+# Update issue
+mcp__Atlassian__editJiraIssue with:
+  - issueIdOrKey: FR-XXXX
+  - fields: {
+      "assignee": {"accountId": "[user_account_id]"},
+      "customfield_10020": [sprint_id]
+    }
+```
+
+### Step 9: Display Summary
+
+Present a clear summary:
+
+```
+✅ Submission Complete!
+
+Jira Issue: FR-XXXX
+  https://lablup.atlassian.net/browse/FR-XXXX
+
+Pull Request: #YYYY
+  https://github.com/lablup/backend.ai-webui/pull/YYYY
+
+Branch: prefix/FR-XXXX-description
+
+Files Changed:
+  - file1.ts
+  - file2.ts
+```
+
+## Jira Issue Guidelines
+
+### Title
+- Concise description of what the work accomplishes
+- NO prefixes (feat, fix, etc.) - these belong in commit messages only
+- Example: "Improve user CRUD E2E tests with Page Object Model"
+
+### Description Format
+```
+[One-line summary]
+
+## Why This Work is Needed
+
+[2-3 sentences explaining the problem or need]
+
+## Expected Outcomes
+
+- [Key outcome 1]
+- [Key outcome 2]
+- [Key outcome 3]
+```
+
+### Issue Type Selection
+- **Task**: Small, distinct pieces of work (default)
+- **Story**: User-facing features with clear user value
+- **Bug**: Fixing incorrect behavior
+
+## Configuration Reference
+
+See `.claude/atlassian-config.md` for:
+- Cloud ID: `a28786f5-5410-4c2d-ae2d-9833cf63eb3f`
+- Project Key: `FR`
+- GitHub Repository field: `customfield_10173` with value `{"id": "10232"}`
+- Sprint field: `customfield_10020` (numeric ID only, not array)
+
+## Error Handling
+
+### MCP Authentication Failure
+If Atlassian or Graphite MCP authentication fails:
+1. Inform the user about the authentication issue
+2. Ask them to re-authenticate
+3. Retry the failed operation
+
+### No Staged Changes
+If `git diff --cached` returns empty:
+```
+No staged changes found. Please stage your changes first:
+  git add <files>
+```
+
+### Branch Name Conflicts
+If branch creation fails due to naming conflict:
+1. Use `gt branch rename` to use a unique name
+2. Or checkout existing branch and modify
+
+## Important Notes
+
+### Do's
+- Always use MCP tools for Jira and Graphite operations
+- Confirm with user before creating anything
+- Keep Jira descriptions focused on WHY, not HOW
+- Update sprint and assignee after issue creation
+
+### Don'ts
+- Never create issues or PRs without user confirmation
+- Don't include implementation details in Jira descriptions
+- Don't use `lj` CLI or direct `gt` commands
+- Don't skip the sync step before creating branches
+
+## Usage Examples
+
+```bash
+# Submit staged changes as a feature
+/submit-staged-changes feat
+
+# Submit staged changes as a bug fix
+/submit-staged-changes fix
+
+# Submit staged changes (prefix auto-detected)
+/submit-staged-changes
+```


### PR DESCRIPTION
Resolves #5188 ([FR-2003](https://lablup.atlassian.net/browse/FR-2003))

## Summary
- Add new `/submit-staged-changes` command that combines Jira issue creation and PR submission into a single workflow
- Add new `/amend-staged-changes` command that simplifies amending changes to existing PRs
- Streamlines the development process by reducing manual coordination between separate commands
- Includes automatic sprint and assignee assignment after issue creation
- Update command documentation to improve clarity on PR description formatting:
  - Place `Resolves` link at the top of PR descriptions for proper issue tracking
  - Specify how to extract GitHub issue number from Jira custom field

## Test plan
- [x] Verify command files are properly formatted
- [ ] Test `/submit-staged-changes feat` with staged changes
- [ ] Test `/amend-staged-changes` with modifications to existing PR
- [ ] Verify Jira issue is created with correct format
- [ ] Verify PR is submitted with proper branch naming
- [ ] Verify PR description updates correctly when amending

[FR-2003]: https://lablup.atlassian.net/browse/FR-2003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ