### PR TITLE
fix(FR-2004): accurately find and identify cloned folders

### DIFF
--- a/react/src/components/ModelTryContentButton.tsx
+++ b/react/src/components/ModelTryContentButton.tsx
@@ -367,10 +367,10 @@ const ModelTryContentButton: React.FC<ModelTryContentButtonProps> = ({
       `,
       {
         modelStoreScopeId: `domain:${currentDomain}`,
-        modelStoreScopeFilter: `usage_mode == "model" & status != "DELETE_PENDING" & status != "DELETE_ONGOING" & status != "DELETE_ERROR" & status != "DELETE_COMPLETE"${folderName ? ` & name like "%${folderName}%"` : ''}`,
+        modelStoreScopeFilter: `usage_mode == "model" & status != "DELETE_PENDING" & status != "DELETE_ONGOING" & status != "DELETE_ERROR" & status != "DELETE_COMPLETE"${folderName ? ` & name like "${folderName}%"` : ''}`,
         permission: 'read_attribute',
         currentUserScopeId: `user:${currentUser.uuid}`,
-        currentUserScopeFilter: `ownership_type == "user" & usage_mode == "model" & status != "DELETE_PENDING" & status != "DELETE_ONGOING" & status != "DELETE_ERROR" & status != "DELETE_COMPLETE"${folderName ? ` & name like "%${folderName}%"` : ''}`,
+        currentUserScopeFilter: `ownership_type == "user" & usage_mode == "model" & status != "DELETE_PENDING" & status != "DELETE_ONGOING" & status != "DELETE_ERROR" & status != "DELETE_COMPLETE"${folderName ? ` & name like "${folderName}%"` : ''}`,
       },
       {
         fetchPolicy:

--- a/react/src/pages/ReservoirPage.tsx
+++ b/react/src/pages/ReservoirPage.tsx
@@ -413,13 +413,13 @@ const ReservoirPage: React.FC = () => {
           </BAIFlex>
           <BAIArtifactTable
             artifactFragment={filterOutEmpty(
-              artifacts.edges.map((e) => e?.node) ?? [],
+              artifacts?.edges.map((e) => e?.node) ?? [],
             )}
             onClickPull={(artifactId: string, revisionId: string) => {
-              artifacts.edges.forEach((artifact) => {
+              artifacts?.edges.forEach((artifact) => {
                 if (artifact.node.id === artifactId) {
                   setSelectedArtifact(artifact.node);
-                  artifact.node.revisions.edges.forEach((revision) => {
+                  artifact.node.revisions?.edges.forEach((revision) => {
                     if (revision.node.id === revisionId) {
                       setSelectedRevision([revision.node]);
                       return;
@@ -430,7 +430,7 @@ const ReservoirPage: React.FC = () => {
               });
             }}
             onClickDelete={(artifactId: string) => {
-              artifacts.edges.forEach((edge) => {
+              artifacts?.edges.forEach((edge) => {
                 if (edge.node.id === artifactId) {
                   setSelectedArtifacts([edge.node]);
                   return;
@@ -438,7 +438,7 @@ const ReservoirPage: React.FC = () => {
               });
             }}
             onClickRestore={(artifactId: string) => {
-              artifacts.edges.forEach((edge) => {
+              artifacts?.edges.forEach((edge) => {
                 if (edge.node.id === artifactId) {
                   setSelectedRestoreArtifacts([edge.node]);
                   return;
@@ -448,12 +448,12 @@ const ReservoirPage: React.FC = () => {
             rowSelection={{
               type: 'checkbox',
               onChange: (keys) => {
-                const artifactIdList = artifacts.edges.map((e) => e.node.id);
+                const artifactIdList = artifacts?.edges.map((e) => e.node.id);
                 setSelectedArtifactIdList((prev) => {
                   const _filtered = prev.filter(
                     (v) => !artifactIdList.includes(v.id),
                   );
-                  const _selected = artifacts.edges
+                  const _selected = artifacts?.edges
                     .filter((e) => keys.includes(e.node.id))
                     .map((arr) => ({
                       id: arr.node.id,
@@ -468,7 +468,7 @@ const ReservoirPage: React.FC = () => {
             pagination={{
               pageSize: tablePaginationOption.pageSize,
               current: tablePaginationOption.current,
-              total: artifacts.count,
+              total: artifacts?.count,
               onChange: (current, pageSize) => {
                 if (_.isNumber(current) && _.isNumber(pageSize)) {
                   setTablePaginationOption({ current, pageSize });


### PR DESCRIPTION
Resolves #5190 ([FR-2004](https://lablup.atlassian.net/browse/FR-2004))

# Fix Model Search and Artifact Handling

This PR makes two important fixes:

1. Updates the model search filter in `ModelTryContentButton.tsx` to correctly match folder names by changing the wildcard pattern from `name like "%folderName%"` to `name like "folderName%"`. This ensures we only match folder names that start with the specified prefix rather than containing it anywhere.
2. Adds null checks in `ReservoirPage.tsx` when accessing artifacts and their properties to prevent potential runtime errors when artifacts data is undefined or null.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-2004]: https://lablup.atlassian.net/browse/FR-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ