### PR TITLE
docs(FR-1976): add Storybook stories for fragment tag/display components

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactDescriptions.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactDescriptions.stories.tsx
@@ -1,0 +1,227 @@
+import { BAIArtifactDescriptionsStoriesQuery } from '../../__generated__/BAIArtifactDescriptionsStoriesQuery.graphql';
+import RelayResolver from '../../tests/RelayResolver';
+import BAIFlex from '../BAIFlex';
+import BAIArtifactDescriptions from './BAIArtifactDescriptions';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+import { MemoryRouter } from 'react-router-dom';
+
+/**
+ * BAIArtifactDescriptions displays detailed information about an artifact.
+ *
+ * Key features:
+ * - Shows artifact name, type, source, and description
+ * - Artifact type displayed with BAIArtifactTypeTag
+ * - Source as clickable link
+ * - Displays "N/A" for empty descriptions
+ *
+ * @see BAIArtifactDescriptions.tsx for implementation details
+ */
+const meta: Meta<typeof BAIArtifactDescriptions> = {
+  title: 'Fragments/BAIArtifactDescriptions',
+  component: BAIArtifactDescriptions,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**BAIArtifactDescriptions** displays detailed information about an artifact in a descriptions layout.
+
+## Features
+- Displays artifact name, type, source, and description
+- Artifact type shown with colored icon tag
+- Source displayed as clickable external link
+- Shows "N/A" for empty descriptions
+- 2-column bordered layout
+
+## Usage
+\`\`\`tsx
+<BAIArtifactDescriptions artifactFrgmt={artifact} />
+\`\`\`
+
+## Props
+| Name | Type | Description |
+|------|------|-------------|
+| \`artifactFrgmt\` | \`BAIArtifactDescriptionsFragment$key\` | Relay fragment reference for artifact |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    artifactFrgmt: {
+      control: false,
+      description: 'Relay fragment reference for artifact',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIArtifactDescriptions>;
+
+const QueryResolver = () => {
+  const { artifact } = useLazyLoadQuery<BAIArtifactDescriptionsStoriesQuery>(
+    graphql`
+      query BAIArtifactDescriptionsStoriesQuery {
+        artifact(id: "test-id") {
+          ...BAIArtifactDescriptionsFragment
+        }
+      }
+    `,
+    {},
+  );
+  return artifact && <BAIArtifactDescriptions artifactFrgmt={artifact} />;
+};
+
+/**
+ * Default story showing artifact with complete information.
+ */
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Displays an artifact with complete information including name, type, source, and description.',
+      },
+    },
+  },
+  render: () => (
+    <RelayResolver
+      mockResolvers={{
+        Artifact: () => ({
+          name: 'ResNet-50 Image Classification Model',
+          type: 'MODEL',
+          description:
+            'Deep residual learning model for image classification with 50 layers. Pre-trained on ImageNet dataset.',
+          source: {
+            name: 'Hugging Face',
+            url: 'https://huggingface.co/models',
+          },
+        }),
+      }}
+    >
+      <QueryResolver />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing artifact without description.
+ */
+export const WithoutDescription: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays "N/A" when artifact has no description.',
+      },
+    },
+  },
+  render: () => (
+    <RelayResolver
+      mockResolvers={{
+        Artifact: () => ({
+          name: 'TensorFlow Runtime Package',
+          type: 'PACKAGE',
+          description: null,
+          source: {
+            name: 'GitHub',
+            url: 'https://github.com/tensorflow/tensorflow',
+          },
+        }),
+      }}
+    >
+      <QueryResolver />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing artifact with long description.
+ */
+export const LongDescription: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays an artifact with a lengthy description text.',
+      },
+    },
+  },
+  render: () => (
+    <RelayResolver
+      mockResolvers={{
+        Artifact: () => ({
+          name: 'CUDA Container Image',
+          type: 'IMAGE',
+          description:
+            'NVIDIA CUDA is a parallel computing platform and programming model developed by NVIDIA for general computing on graphical processing units (GPUs). With CUDA, developers can dramatically speed up computing applications by harnessing the power of GPUs. This container image includes the complete CUDA toolkit, cuDNN libraries, and NCCL for multi-GPU communication. It is optimized for deep learning frameworks and high-performance computing applications.',
+          source: {
+            name: 'NVIDIA NGC',
+            url: 'https://catalog.ngc.nvidia.com/',
+          },
+        }),
+      }}
+    >
+      <QueryResolver />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing multiple artifacts with different types.
+ */
+export const DifferentTypes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Displays artifacts of different types (MODEL, PACKAGE, IMAGE) to show the variety of artifact information displays.',
+      },
+    },
+  },
+  render: () => {
+    const artifacts = [
+      {
+        name: 'BERT Base Model',
+        type: 'MODEL',
+        description:
+          'Pre-trained BERT model for natural language understanding.',
+        source: { name: 'Hugging Face', url: 'https://huggingface.co/' },
+      },
+      {
+        name: 'PyTorch Package',
+        type: 'PACKAGE',
+        description: 'Machine learning framework for Python.',
+        source: { name: 'PyPI', url: 'https://pypi.org/project/torch/' },
+      },
+      {
+        name: 'Ubuntu 22.04 Base Image',
+        type: 'IMAGE',
+        description: 'Official Ubuntu 22.04 LTS container image.',
+        source: { name: 'Docker Hub', url: 'https://hub.docker.com/' },
+      },
+    ];
+
+    return (
+      <BAIFlex direction="column" gap="lg">
+        {artifacts.map((artifactData, index) => (
+          <RelayResolver
+            key={index}
+            mockResolvers={{
+              Artifact: () => artifactData,
+            }}
+          >
+            <QueryResolver />
+          </RelayResolver>
+        ))}
+      </BAIFlex>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactStatusTag.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactStatusTag.stories.tsx
@@ -1,0 +1,302 @@
+import { BAIArtifactStatusTagStoriesQuery } from '../../__generated__/BAIArtifactStatusTagStoriesQuery.graphql';
+import RelayResolver from '../../tests/RelayResolver';
+import BAIFlex from '../BAIFlex';
+import BAIArtifactStatusTag from './BAIArtifactStatusTag';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+/**
+ * BAIArtifactStatusTag displays the status of an artifact revision using a tag component.
+ *
+ * Key features:
+ * - Displays artifact revision status (AVAILABLE, FAILED, NEEDS_APPROVAL, etc.)
+ * - Uses BAITag for consistent styling
+ * - Consumes Relay fragment for data
+ *
+ * @see BAIArtifactStatusTag.tsx for implementation details
+ */
+const meta: Meta<typeof BAIArtifactStatusTag> = {
+  title: 'Fragments/BAIArtifactStatusTag',
+  component: BAIArtifactStatusTag,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAIArtifactStatusTag** displays the status of an artifact revision.
+
+## Features
+- Displays artifact revision status as a tag
+- Supports all artifact status types (AVAILABLE, FAILED, NEEDS_APPROVAL, PULLED, PULLING, REJECTED, SCANNED, VERIFYING)
+- Uses Relay fragment for data fetching
+
+## Usage
+\`\`\`tsx
+<BAIArtifactStatusTag artifactRevisionFrgmt={artifactRevision} />
+\`\`\`
+
+## Props
+| Name | Type | Description |
+|------|------|-------------|
+| \`artifactRevisionFrgmt\` | \`BAIArtifactStatusTagFragment$key\` | Relay fragment reference for artifact revision |
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIArtifactStatusTag>;
+
+const QueryResolver = () => {
+  const { artifactRevision } =
+    useLazyLoadQuery<BAIArtifactStatusTagStoriesQuery>(
+      graphql`
+        query BAIArtifactStatusTagStoriesQuery {
+          artifactRevision(id: "test-id") {
+            ...BAIArtifactStatusTagFragment
+          }
+        }
+      `,
+      {},
+    );
+  return (
+    artifactRevision && (
+      <BAIArtifactStatusTag artifactRevisionFrgmt={artifactRevision} />
+    )
+  );
+};
+
+/**
+ * Default story showing AVAILABLE status.
+ */
+export const Default: Story = {
+  name: 'Available',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays an artifact revision with AVAILABLE status.',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <RelayResolver
+        mockResolvers={{
+          ArtifactRevision: () => ({ status: 'AVAILABLE' }),
+        }}
+      >
+        <QueryResolver />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Story showing PULLING status.
+ */
+export const Pulling: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays an artifact revision with PULLING status.',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <RelayResolver
+        mockResolvers={{
+          ArtifactRevision: () => ({ status: 'PULLING' }),
+        }}
+      >
+        <QueryResolver />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Story showing PULLED status.
+ */
+export const Pulled: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays an artifact revision with PULLED status.',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <RelayResolver
+        mockResolvers={{
+          ArtifactRevision: () => ({ status: 'PULLED' }),
+        }}
+      >
+        <QueryResolver />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Story showing VERIFYING status.
+ */
+export const Verifying: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays an artifact revision with VERIFYING status.',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <RelayResolver
+        mockResolvers={{
+          ArtifactRevision: () => ({ status: 'VERIFYING' }),
+        }}
+      >
+        <QueryResolver />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Story showing SCANNED status.
+ */
+export const Scanned: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays an artifact revision with SCANNED status.',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <RelayResolver
+        mockResolvers={{
+          ArtifactRevision: () => ({ status: 'SCANNED' }),
+        }}
+      >
+        <QueryResolver />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Story showing NEEDS_APPROVAL status.
+ */
+export const NeedsApproval: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays an artifact revision with NEEDS_APPROVAL status.',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <RelayResolver
+        mockResolvers={{
+          ArtifactRevision: () => ({ status: 'NEEDS_APPROVAL' }),
+        }}
+      >
+        <QueryResolver />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Story showing REJECTED status.
+ */
+export const Rejected: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays an artifact revision with REJECTED status.',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <RelayResolver
+        mockResolvers={{
+          ArtifactRevision: () => ({ status: 'REJECTED' }),
+        }}
+      >
+        <QueryResolver />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Story showing FAILED status.
+ */
+export const Failed: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays an artifact revision with FAILED status.',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <RelayResolver
+        mockResolvers={{
+          ArtifactRevision: () => ({ status: 'FAILED' }),
+        }}
+      >
+        <QueryResolver />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Story showing all status variants together.
+ */
+export const AllStatuses: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays all available artifact status variants.',
+      },
+    },
+  },
+  render: () => {
+    const statuses = [
+      'AVAILABLE',
+      'PULLING',
+      'PULLED',
+      'VERIFYING',
+      'SCANNED',
+      'NEEDS_APPROVAL',
+      'REJECTED',
+      'FAILED',
+    ] as const;
+
+    return (
+      <BAIFlex direction="column" gap="md">
+        {statuses.map((status) => (
+          <RelayResolver
+            key={status}
+            mockResolvers={{
+              ArtifactRevision: () => ({ status }),
+            }}
+          >
+            <QueryResolver />
+          </RelayResolver>
+        ))}
+      </BAIFlex>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactTypeTag.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactTypeTag.stories.tsx
@@ -1,0 +1,172 @@
+import { BAIArtifactTypeTagStoriesQuery } from '../../__generated__/BAIArtifactTypeTagStoriesQuery.graphql';
+import RelayResolver from '../../tests/RelayResolver';
+import BAIFlex from '../BAIFlex';
+import BAIArtifactTypeTag from './BAIArtifactTypeTag';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+/**
+ * BAIArtifactTypeTag displays the type of an artifact with an icon.
+ *
+ * Key features:
+ * - Displays artifact type (MODEL, PACKAGE, IMAGE) with colored icons
+ * - Uses lucide-react icons (Brain, Package, Container)
+ * - Consumes Relay fragment for data
+ *
+ * @see BAIArtifactTypeTag.tsx for implementation details
+ */
+const meta: Meta<typeof BAIArtifactTypeTag> = {
+  title: 'Fragments/BAIArtifactTypeTag',
+  component: BAIArtifactTypeTag,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAIArtifactTypeTag** displays the type of an artifact with a visual icon.
+
+## Features
+- Displays artifact type as a tag with icon
+- Three types: MODEL (Brain icon), PACKAGE (Package icon), IMAGE (Container icon)
+- Color-coded icons: MODEL (blue), PACKAGE (green), IMAGE (orange)
+- Uses Relay fragment for data fetching
+
+## Usage
+\`\`\`tsx
+<BAIArtifactTypeTag artifactTypeFrgmt={artifact} />
+\`\`\`
+
+## Props
+| Name | Type | Description |
+|------|------|-------------|
+| \`artifactTypeFrgmt\` | \`BAIArtifactTypeTagFragment$key\` | Relay fragment reference for artifact |
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIArtifactTypeTag>;
+
+const QueryResolver = () => {
+  const { artifact } = useLazyLoadQuery<BAIArtifactTypeTagStoriesQuery>(
+    graphql`
+      query BAIArtifactTypeTagStoriesQuery {
+        artifact(id: "test-id") {
+          ...BAIArtifactTypeTagFragment
+        }
+      }
+    `,
+    {},
+  );
+  return artifact && <BAIArtifactTypeTag artifactTypeFrgmt={artifact} />;
+};
+
+/**
+ * Default story showing MODEL type.
+ */
+export const Default: Story = {
+  name: 'Model',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays an artifact with MODEL type (Brain icon, blue color).',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <RelayResolver
+        mockResolvers={{
+          Artifact: () => ({ type: 'MODEL' }),
+        }}
+      >
+        <QueryResolver />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Story showing PACKAGE type.
+ */
+export const Package: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Displays an artifact with PACKAGE type (Package icon, green color).',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <RelayResolver
+        mockResolvers={{
+          Artifact: () => ({ type: 'PACKAGE' }),
+        }}
+      >
+        <QueryResolver />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Story showing IMAGE type.
+ */
+export const Image: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Displays an artifact with IMAGE type (Container icon, orange color).',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <RelayResolver
+        mockResolvers={{
+          Artifact: () => ({ type: 'IMAGE' }),
+        }}
+      >
+        <QueryResolver />
+      </RelayResolver>
+    );
+  },
+};
+
+/**
+ * Story showing all type variants together.
+ */
+export const AllTypes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Displays all available artifact type variants with their respective icons and colors.',
+      },
+    },
+  },
+  render: () => {
+    const types = ['MODEL', 'PACKAGE', 'IMAGE'] as const;
+
+    return (
+      <BAIFlex direction="column" gap="md">
+        {types.map((type) => (
+          <RelayResolver
+            key={type}
+            mockResolvers={{
+              Artifact: () => ({ type }),
+            }}
+          >
+            <QueryResolver />
+          </RelayResolver>
+        ))}
+      </BAIFlex>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/fragments/BAIArtifactTypeTag.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIArtifactTypeTag.tsx
@@ -38,7 +38,7 @@ const BAIArtifactTypeTag = ({ artifactTypeFrgmt }: BAIArtifactTypeTagProps) => {
     artifactTypeFrgmt,
   );
   return (
-    <Tag>
+    <Tag style={{ display: 'inline-flex', alignItems: 'center' }}>
       {getTypeIcon(artifact.type)}&nbsp;{artifact.type}
     </Tag>
   );

--- a/packages/backend.ai-ui/src/components/fragments/BAIPullingArtifactRevisionAlert.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIPullingArtifactRevisionAlert.stories.tsx
@@ -1,0 +1,152 @@
+import { BAIPullingArtifactRevisionAlertStoriesQuery } from '../../__generated__/BAIPullingArtifactRevisionAlertStoriesQuery.graphql';
+import RelayResolver from '../../tests/RelayResolver';
+import BAIPullingArtifactRevisionAlert from './BAIPullingArtifactRevisionAlert';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { App } from 'antd';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+/**
+ * BAIPullingArtifactRevisionAlert displays an informational alert for artifact revisions currently being pulled.
+ *
+ * Key features:
+ * - Shows version being pulled with status information
+ * - Cancel button with confirmation modal
+ * - GraphQL mutation to cancel pulling
+ * - Success/error message handling
+ *
+ * @see BAIPullingArtifactRevisionAlert.tsx for implementation details
+ */
+const meta: Meta<typeof BAIPullingArtifactRevisionAlert> = {
+  title: 'Fragments/BAIPullingArtifactRevisionAlert',
+  component: BAIPullingArtifactRevisionAlert,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**BAIPullingArtifactRevisionAlert** displays an alert for artifact revisions being pulled.
+
+## Features
+- Info alert showing version being pulled
+- Cancel button to stop pulling process
+- Confirmation modal with warning message
+- GraphQL mutation to cancel import
+- Success/error message notifications
+- Optional callback after successful cancellation
+
+## Usage
+\`\`\`tsx
+<BAIPullingArtifactRevisionAlert
+  pullingArtifactRevisionFrgmt={artifactRevision}
+  onOk={() => console.log('Cancelled')}
+/>
+\`\`\`
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| \`pullingArtifactRevisionFrgmt\` | \`BAIPullingArtifactRevisionAlertFragment$key\` | - | Relay fragment reference for artifact revision |
+| \`onOk\` | \`() => void\` | - | Optional callback after successful cancellation |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    pullingArtifactRevisionFrgmt: {
+      control: false,
+      description: 'Relay fragment reference for artifact revision',
+    },
+    onOk: {
+      action: 'onOk',
+      description: 'Optional callback after successful cancellation',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <App>
+        <Story />
+      </App>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIPullingArtifactRevisionAlert>;
+
+const QueryResolver = (props?: { onOk?: () => void }) => {
+  const { artifactRevision } =
+    useLazyLoadQuery<BAIPullingArtifactRevisionAlertStoriesQuery>(
+      graphql`
+        query BAIPullingArtifactRevisionAlertStoriesQuery {
+          artifactRevision(id: "test-id") {
+            ...BAIPullingArtifactRevisionAlertFragment
+          }
+        }
+      `,
+      {},
+    );
+  return (
+    artifactRevision && (
+      <BAIPullingArtifactRevisionAlert
+        pullingArtifactRevisionFrgmt={artifactRevision}
+        {...props}
+      />
+    )
+  );
+};
+
+/**
+ * Default story showing a pulling artifact revision alert.
+ */
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Displays an alert for an artifact revision being pulled. Click the Cancel button to see the confirmation modal.',
+      },
+    },
+  },
+  render: () => (
+    <RelayResolver
+      mockResolvers={{
+        ArtifactRevision: () => ({
+          id: 'QXJ0aWZhY3RSZXZpc2lvbjox',
+          status: 'PULLING',
+          version: 'v1.2.3',
+        }),
+      }}
+    >
+      <QueryResolver />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing alert with onOk callback.
+ */
+export const WithCallback: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the onOk callback being triggered after successful cancellation. Check the Actions panel.',
+      },
+    },
+  },
+  render: (args) => (
+    <RelayResolver
+      mockResolvers={{
+        ArtifactRevision: () => ({
+          id: 'QXJ0aWZhY3RSZXZpc2lvbjoy',
+          status: 'PULLING',
+          version: 'v2.0.0-beta.1',
+        }),
+      }}
+    >
+      <QueryResolver onOk={args.onOk} />
+    </RelayResolver>
+  ),
+};

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionAgentIds.stories.tsx
@@ -1,0 +1,313 @@
+import { BAISessionAgentIdsStoriesQuery } from '../../__generated__/BAISessionAgentIdsStoriesQuery.graphql';
+import RelayResolver from '../../tests/RelayResolver';
+import BAIFlex from '../BAIFlex';
+import BAISessionAgentIds from './BAISessionAgentIds';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+/**
+ * BAISessionAgentIds displays agent IDs associated with a compute session.
+ *
+ * Key features:
+ * - Displays inline agent IDs with configurable limit
+ * - Shows remaining agents in a popover
+ * - Copy all agent IDs functionality
+ * - Customizable empty state text
+ *
+ * @see BAISessionAgentIds.tsx for implementation details
+ */
+const meta: Meta<typeof BAISessionAgentIds> = {
+  title: 'Fragments/BAISessionAgentIds',
+  component: BAISessionAgentIds,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAISessionAgentIds** displays a list of agent IDs for compute sessions.
+
+## Features
+- Inline display of agent IDs with configurable limit
+- Popover to show remaining agent IDs when exceeding limit
+- Copy all agent IDs to clipboard functionality
+- Removes duplicate agent IDs automatically
+- Customizable empty state text
+
+## Usage
+\`\`\`tsx
+// Default (shows up to 3 agent IDs inline)
+<BAISessionAgentIds sessionFrgmt={session} />
+
+// Custom inline limit
+<BAISessionAgentIds sessionFrgmt={session} maxInline={5} />
+
+// Custom empty text
+<BAISessionAgentIds sessionFrgmt={session} emptyText="No agents" />
+\`\`\`
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| \`sessionFrgmt\` | \`BAISessionAgentIdsFragment$key\` | - | Relay fragment reference for session |
+| \`maxInline\` | \`number\` | \`3\` | Maximum number of agent IDs to display inline |
+| \`emptyText\` | \`string\` | \`'-'\` | Text to display when no agents exist |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    maxInline: {
+      control: { type: 'number', min: 1, max: 10 },
+      description: 'Maximum number of agent IDs to display inline',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '3' },
+      },
+    },
+    emptyText: {
+      control: { type: 'text' },
+      description: 'Text to display when no agents exist',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: "'-'" },
+      },
+    },
+    sessionFrgmt: {
+      control: false,
+      description: 'Relay fragment reference for session',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAISessionAgentIds>;
+
+const QueryResolver = (props?: { maxInline?: number; emptyText?: string }) => {
+  const { compute_session_node } =
+    useLazyLoadQuery<BAISessionAgentIdsStoriesQuery>(
+      graphql`
+        query BAISessionAgentIdsStoriesQuery {
+          compute_session_node(id: "test-id") {
+            ...BAISessionAgentIdsFragment
+          }
+        }
+      `,
+      {},
+    );
+  return (
+    compute_session_node && (
+      <BAISessionAgentIds sessionFrgmt={compute_session_node} {...props} />
+    )
+  );
+};
+
+/**
+ * Default story showing multiple agent IDs.
+ */
+export const Default: Story = {
+  name: 'Basic',
+  args: {
+    maxInline: 3,
+    emptyText: '-',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Displays multiple agent IDs with the default limit of 3 inline agents. Click "+2" to see the popover with remaining agents.',
+      },
+    },
+  },
+  render: ({ maxInline, emptyText }) => (
+    <RelayResolver
+      mockResolvers={{
+        ComputeSessionNode: () => ({
+          agent_ids: [
+            'i-1234567890abcdef0',
+            'i-2345678901bcdef01',
+            'i-3456789012cdef012',
+            'i-4567890123def0123',
+            'i-567890124ef01234',
+          ],
+        }),
+      }}
+    >
+      <QueryResolver maxInline={maxInline} emptyText={emptyText} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing single agent ID.
+ */
+export const SingleAgent: Story = {
+  args: {
+    maxInline: 3,
+    emptyText: '-',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays a single agent ID without the popover.',
+      },
+    },
+  },
+  render: ({ maxInline, emptyText }) => (
+    <RelayResolver
+      mockResolvers={{
+        ComputeSessionNode: () => ({
+          agent_ids: ['i-1234567890abcdef0'],
+        }),
+      }}
+    >
+      <QueryResolver maxInline={maxInline} emptyText={emptyText} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing empty state.
+ */
+export const Empty: Story = {
+  args: {
+    maxInline: 3,
+    emptyText: '-',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays the empty state text when no agents exist.',
+      },
+    },
+  },
+  render: ({ maxInline, emptyText }) => (
+    <RelayResolver
+      mockResolvers={{
+        ComputeSessionNode: () => ({
+          agent_ids: [],
+        }),
+      }}
+    >
+      <QueryResolver maxInline={maxInline} emptyText={emptyText} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing custom empty text.
+ */
+export const CustomEmptyText: Story = {
+  args: {
+    maxInline: 3,
+    emptyText: 'No agents available',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays custom empty state text.',
+      },
+    },
+  },
+  render: ({ maxInline, emptyText }) => (
+    <RelayResolver
+      mockResolvers={{
+        ComputeSessionNode: () => ({
+          agent_ids: [],
+        }),
+      }}
+    >
+      <QueryResolver maxInline={maxInline} emptyText={emptyText} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing many agent IDs with custom inline limit.
+ */
+export const ManyAgents: Story = {
+  args: {
+    maxInline: 5,
+    emptyText: '-',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Displays many agent IDs with maxInline set to 5. Click "+5" to see the popover with 10 total agents.',
+      },
+    },
+  },
+  render: ({ maxInline, emptyText }) => (
+    <RelayResolver
+      mockResolvers={{
+        ComputeSessionNode: () => ({
+          agent_ids: Array.from({ length: 10 }, (_, i) => `i-agent-${i + 1}`),
+        }),
+      }}
+    >
+      <QueryResolver maxInline={maxInline} emptyText={emptyText} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing all variants together.
+ */
+export const AllVariants: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays all different configurations of agent ID display.',
+      },
+    },
+  },
+  render: () => {
+    const variants = [
+      {
+        label: 'Single agent',
+        agent_ids: ['i-1234567890abcdef0'],
+        maxInline: 3,
+      },
+      {
+        label: 'Multiple agents (default)',
+        agent_ids: [
+          'i-agent-1',
+          'i-agent-2',
+          'i-agent-3',
+          'i-agent-4',
+          'i-agent-5',
+        ],
+        maxInline: 3,
+      },
+      {
+        label: 'Many agents (maxInline: 5)',
+        agent_ids: Array.from({ length: 10 }, (_, i) => `i-agent-${i + 1}`),
+        maxInline: 5,
+      },
+      { label: 'Empty state', agent_ids: [], maxInline: 3 },
+    ];
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        {variants.map((variant, index) => (
+          <RelayResolver
+            key={index}
+            mockResolvers={{
+              ComputeSessionNode: () => ({
+                agent_ids: variant.agent_ids,
+              }),
+            }}
+          >
+            <BAIFlex direction="row" gap="md" align="start">
+              <div style={{ width: 240 }}>
+                <strong>{variant.label}:</strong>
+              </div>
+              <QueryResolver maxInline={variant.maxInline} />
+            </BAIFlex>
+          </RelayResolver>
+        ))}
+      </BAIFlex>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionClusterMode.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionClusterMode.stories.tsx
@@ -1,0 +1,301 @@
+import { BAISessionClusterModeStoriesQuery } from '../../__generated__/BAISessionClusterModeStoriesQuery.graphql';
+import RelayResolver from '../../tests/RelayResolver';
+import BAIFlex from '../BAIFlex';
+import BAISessionClusterMode, {
+  BAISessionClusterModeProps,
+} from './BAISessionClusterMode';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+/**
+ * BAISessionClusterMode displays the cluster mode and size of a compute session.
+ *
+ * Key features:
+ * - Displays single-node or multi-node cluster mode
+ * - Shows cluster size with optional visibility control
+ * - Two display modes: text or tag
+ * - Internationalized labels
+ *
+ * @see BAISessionClusterMode.tsx for implementation details
+ */
+const meta: Meta<typeof BAISessionClusterMode> = {
+  title: 'Fragments/BAISessionClusterMode',
+  component: BAISessionClusterMode,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+**BAISessionClusterMode** displays cluster mode information for compute sessions.
+
+## Features
+- Displays cluster mode (Single-node or Multi-node)
+- Shows cluster size (number of nodes)
+- Two display modes: text (default) or tag
+- Optional cluster size visibility control
+- Internationalized labels
+
+## Usage
+\`\`\`tsx
+// Text mode (default)
+<BAISessionClusterMode sessionFrgmt={session} />
+
+// Tag mode
+<BAISessionClusterMode sessionFrgmt={session} mode="tag" />
+
+// Hide cluster size
+<BAISessionClusterMode sessionFrgmt={session} showSize={false} />
+\`\`\`
+
+## Props
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| \`sessionFrgmt\` | \`BAISessionClusterModeFragment$key\` | - | Relay fragment reference for session |
+| \`showSize\` | \`boolean\` | \`true\` | Whether to show cluster size |
+| \`mode\` | \`'text' \\| 'tag'\` | \`'text'\` | Display mode |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    showSize: {
+      control: { type: 'boolean' },
+      description: 'Whether to show cluster size',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'true' },
+      },
+    },
+    mode: {
+      control: { type: 'radio' },
+      options: ['text', 'tag'],
+      description: 'Display mode',
+      table: {
+        type: { summary: 'text | tag' },
+        defaultValue: { summary: 'tag' },
+      },
+    },
+    sessionFrgmt: {
+      control: false,
+      description: 'Relay fragment reference for session',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAISessionClusterMode>;
+
+const QueryResolver = (
+  props?: Omit<BAISessionClusterModeProps, 'sessionFrgmt'>,
+) => {
+  const { compute_session_node } =
+    useLazyLoadQuery<BAISessionClusterModeStoriesQuery>(
+      graphql`
+        query BAISessionClusterModeStoriesQuery {
+          compute_session_node(id: "test-id") {
+            ...BAISessionClusterModeFragment
+          }
+        }
+      `,
+      {},
+    );
+  return (
+    compute_session_node && (
+      <BAISessionClusterMode sessionFrgmt={compute_session_node} {...props} />
+    )
+  );
+};
+
+/**
+ * Default story showing single-node cluster in text mode.
+ */
+export const Default: Story = {
+  name: 'Basic',
+  args: {
+    showSize: true,
+    mode: 'text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays a single-node cluster session in text mode.',
+      },
+    },
+  },
+  render: ({ showSize, mode }) => (
+    <RelayResolver
+      mockResolvers={{
+        ComputeSessionNode: () => ({
+          cluster_mode: 'SINGLE',
+          cluster_size: 1,
+        }),
+      }}
+    >
+      <QueryResolver showSize={showSize} mode={mode} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing multi-node cluster.
+ */
+export const MultiNode: Story = {
+  args: {
+    showSize: true,
+    mode: 'text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays a multi-node cluster session with 4 nodes.',
+      },
+    },
+  },
+  render: ({ showSize, mode }) => (
+    <RelayResolver
+      mockResolvers={{
+        ComputeSessionNode: () => ({
+          cluster_mode: 'MULTI',
+          cluster_size: 4,
+        }),
+      }}
+    >
+      <QueryResolver showSize={showSize} mode={mode} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing tag mode display.
+ */
+export const TagMode: Story = {
+  args: {
+    showSize: true,
+    mode: 'tag',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays cluster mode as a tag instead of plain text.',
+      },
+    },
+  },
+  render: ({ showSize, mode }) => (
+    <RelayResolver
+      mockResolvers={{
+        ComputeSessionNode: () => ({
+          cluster_mode: 'MULTI',
+          cluster_size: 8,
+        }),
+      }}
+    >
+      <QueryResolver showSize={showSize} mode={mode} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing cluster mode without size.
+ */
+export const WithoutSize: Story = {
+  args: {
+    showSize: false,
+    mode: 'text',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Displays cluster mode without showing the cluster size.',
+      },
+    },
+  },
+  render: ({ showSize, mode }) => (
+    <RelayResolver
+      mockResolvers={{
+        ComputeSessionNode: () => ({
+          cluster_mode: 'MULTI',
+          cluster_size: 4,
+        }),
+      }}
+    >
+      <QueryResolver showSize={showSize} mode={mode} />
+    </RelayResolver>
+  ),
+};
+
+/**
+ * Story showing all variants together.
+ */
+export const AllVariants: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Displays all combinations of cluster modes and display options.',
+      },
+    },
+  },
+  render: () => {
+    const variants = [
+      {
+        label: 'Single-node (text)',
+        cluster_mode: 'SINGLE',
+        cluster_size: 1,
+        mode: 'text' as const,
+        showSize: true,
+      },
+      {
+        label: 'Multi-node (text)',
+        cluster_mode: 'MULTI',
+        cluster_size: 4,
+        mode: 'text' as const,
+        showSize: true,
+      },
+      {
+        label: 'Single-node (tag)',
+        cluster_mode: 'SINGLE',
+        cluster_size: 1,
+        mode: 'tag' as const,
+        showSize: true,
+      },
+      {
+        label: 'Multi-node (tag)',
+        cluster_mode: 'MULTI',
+        cluster_size: 8,
+        mode: 'tag' as const,
+        showSize: true,
+      },
+      {
+        label: 'Multi-node (no size)',
+        cluster_mode: 'MULTI',
+        cluster_size: 4,
+        mode: 'text' as const,
+        showSize: false,
+      },
+    ];
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        {variants.map((variant, index) => (
+          <RelayResolver
+            key={index}
+            mockResolvers={{
+              ComputeSessionNode: () => ({
+                cluster_mode: variant.cluster_mode,
+                cluster_size: variant.cluster_size,
+              }),
+            }}
+          >
+            <BAIFlex direction="row" gap="md" align="center">
+              <div style={{ width: 180 }}>
+                <strong>{variant.label}:</strong>
+              </div>
+              <QueryResolver mode={variant.mode} showSize={variant.showSize} />
+            </BAIFlex>
+          </RelayResolver>
+        ))}
+      </BAIFlex>
+    );
+  },
+};


### PR DESCRIPTION
Resolves #5200 ([FR-1976](https://lablup.atlassian.net/browse/FR-1976))

## Summary

Added Storybook stories for 6 fragment-based Tag/Display components to improve component documentation and developer experience:

1. **BAIArtifactStatusTag** - Displays artifact status with colored tags
2. **BAIArtifactTypeTag** - Shows artifact type (MODEL/PACKAGE/IMAGE) with icons
3. **BAISessionClusterMode** - Indicates session cluster mode
4. **BAISessionAgentIds** - Displays session agent IDs
5. **BAIPullingArtifactRevisionAlert** - Shows alert for pulling artifact revisions
6. **BAIArtifactDescriptions** - Renders artifact descriptions

All stories follow the RelayResolver + QueryResolver pattern with proper mock data.

## Changes

- Added Storybook stories for 6 fragment components
- Fixed `BAIArtifactTypeTag` to use `inline-flex` to prevent full-width stretch
- Used interactive `args` controls for better Storybook experience
- Followed CSF 3 format with proper meta configuration

## Test Plan

1. Run Storybook: `cd packages/backend.ai-ui && pnpm run storybook`
2. Navigate to `Fragments/` category
3. Verify all 6 components render correctly with mock data
4. Test interactive controls (where applicable)

**Checklist:**

- [x] Documentation - Added comprehensive Storybook stories
- [ ] Minimum required manager version - N/A
- [ ] Specific setting for review - Run Storybook to view stories
- [ ] Minimum requirements to check during review - Visual verification of all stories
- [ ] Test case(s) - Interactive Storybook stories serve as visual tests


[FR-1976]: https://lablup.atlassian.net/browse/FR-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ