### PR TITLE
style(FR-2009): update antd deprecated props in chat-related components and fix broken styles.

### DIFF
--- a/react/src/components/Chat/ChatMessageContainer.tsx
+++ b/react/src/components/Chat/ChatMessageContainer.tsx
@@ -37,7 +37,7 @@ export const ChatMessageContainer: React.FC<ChatMessageContainerProps> = memo(
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
       >
-        <Avatar icon={avatar} style={{ fontSize: token.fontSizeHeading3 }} />
+        <Avatar style={{ fontSize: token.fontSizeHeading3 }}>{avatar}</Avatar>
         <BAIFlex
           direction="column"
           align={placement.left ? 'start' : 'end'}

--- a/react/src/components/Chat/ChatTokenCounter.tsx
+++ b/react/src/components/Chat/ChatTokenCounter.tsx
@@ -59,7 +59,7 @@ const ChatTokenCounter: React.FC<ChatTokenCounterProps> = ({
           <Typography.Text>{tokenPerSecond.toFixed(1)}</Typography.Text>{' '}
           <Typography.Text type="secondary">TPS</Typography.Text>
         </span>{' '}
-        <Divider type="vertical" />
+        <Divider orientation="vertical" />
         <span>
           <Typography.Text>{totalTokenCount}</Typography.Text>{' '}
           <Typography.Text type="secondary"> tokens</Typography.Text>

--- a/react/src/components/SessionDetailDrawer.tsx
+++ b/react/src/components/SessionDetailDrawer.tsx
@@ -59,7 +59,7 @@ const SessionDetailDrawer: React.FC<SessionDetailDrawerProps> = ({
   return (
     <Drawer
       title={t('session.SessionInfo')}
-      width={800}
+      size={800}
       extra={
         <BAIFetchKeyButton
           loading={isPendingReload}

--- a/react/src/components/UserDropdownMenu.tsx
+++ b/react/src/components/UserDropdownMenu.tsx
@@ -220,15 +220,14 @@ const UserDropdownMenu: React.FC<{
             icon={
               <Avatar
                 size={17}
-                icon={
-                  <UserOutlined
-                    style={{ fontSize: 10, color: token.colorPrimary }}
-                  />
-                }
                 style={{
                   backgroundColor: token.colorBgBase,
                 }}
-              ></Avatar>
+              >
+                <UserOutlined
+                  style={{ fontSize: 10, color: token.colorPrimary }}
+                />
+              </Avatar>
             }
           >
             {screens.lg && _.truncate(userInfo.username, { length: 30 })}

--- a/react/src/components/WEBUINotificationDrawer.tsx
+++ b/react/src/components/WEBUINotificationDrawer.tsx
@@ -41,7 +41,7 @@ const WEBUINotificationDrawer: React.FC<Props> = ({ ...drawerProps }) => {
 
   return (
     <Drawer
-      width={DRAWER_WIDTH}
+      size={DRAWER_WIDTH}
       title={t('notification.Notifications')}
       mask={false}
       className="webui-notification-drawer"


### PR DESCRIPTION
Resolves #5202 ([FR-2009](https://lablup.atlassian.net/browse/FR-2009))

# Update Ant Design component usage to match latest API

This PR updates several components to align with the latest Ant Design API:

1. Changed `Avatar` component to use children instead of `icon` prop
2. Updated `Divider` to use `orientation="vertical"` instead of `type="vertical"`
3. Changed `Drawer` component to use `size` prop instead of `width`
4. Replaced `List` with `BAITable` in ChatHistoryDrawer for better consistency
5. Improved layout in ChatPage with proper `BAIFlex` wrapping
6. Added width styling to loading fallback card

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-2009]: https://lablup.atlassian.net/browse/FR-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ