### PR TITLE
refactor(FR-2014): migrate StorageSelect to new antd 6 showSearch API

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -46,6 +46,7 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
   customStyle: css`
     /* Change the opacity of images and tags in the select option when the dropdown is open */
+    &.ant-select-open .ant-select-content .ant-select-content-value .ant-badge,
     &.ant-select-open .ant-select-content .ant-select-content-value img,
     &.ant-select-open
       .ant-select-content

--- a/react/src/components/StorageSelect.tsx
+++ b/react/src/components/StorageSelect.tsx
@@ -40,8 +40,7 @@ const StorageSelect: React.FC<Props> = ({
   value,
   onChange,
   defaultValue,
-  searchValue,
-  onSearch,
+  showSearch,
   ...partialSelectProps
 }) => {
   const { t } = useTranslation();
@@ -63,7 +62,12 @@ const StorageSelect: React.FC<Props> = ({
       defaultValue,
     });
   const [controllableSearchValue, setControllableSearchValue] =
-    useControllableState_deprecated({ value: searchValue, onChange: onSearch });
+    useControllableState_deprecated({
+      value:
+        typeof showSearch === 'boolean' ? undefined : showSearch?.searchValue,
+      onChange:
+        typeof showSearch === 'boolean' ? undefined : showSearch?.onSearch,
+    });
   useEffect(() => {
     if (!autoSelectType || !vhostInfo) return; // Return early if vhostInfo is null
     let nextHost = vhostInfo?.default ?? vhostInfo?.allowed[0] ?? '';
@@ -95,11 +99,16 @@ const StorageSelect: React.FC<Props> = ({
           ...(vhostInfo?.volume_info?.[host] || {}),
         });
       }}
-      showSearch={{
-        searchValue: controllableSearchValue,
-        onSearch: setControllableSearchValue,
-        filterOption: true,
-      }}
+      showSearch={
+        showSearch === false
+          ? false
+          : {
+              ...(typeof showSearch === 'object' ? showSearch : {}),
+              searchValue: controllableSearchValue,
+              onSearch: setControllableSearchValue,
+              filterOption: true,
+            }
+      }
       optionLabelProp={showUsageStatus ? 'label' : 'value'}
       options={_.map(vhostInfo?.allowed, (host) => ({
         label: showUsageStatus ? (


### PR DESCRIPTION
Resolves #5211 ([FR-2014](https://lablup.atlassian.net/browse/FR-2014))

## Summary
- Remove deprecated `searchValue` and `onSearch` props from StorageSelect
- Consolidate search functionality into `showSearch` prop object for Ant Design 6 compatibility
- Add badge opacity handling in BAISelect for dropdown open state

## Test plan
- [ ] Verify StorageSelect search functionality works correctly
- [ ] Check that badge opacity is properly applied when dropdown is open
- [ ] Test with existing components that use StorageSelect

🤖 Generated with [Claude Code](https://claude.ai/code)

[FR-2014]: https://lablup.atlassian.net/browse/FR-2014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ