### PR TITLE
fix(FR-1987): close upload dropdown after selecting upload option in file explorer

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/ExplorerActionControls.tsx
@@ -59,6 +59,8 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
   const { token } = theme.useToken();
   const { styles } = useStyles();
   const { uploadFiles } = useUploadVFolderFiles();
+  const [openUploadDropdown, { toggle: toggleUploadDropdown }] =
+    useToggle(false);
   const [openCreateModal, { toggle: toggleCreateModal }] = useToggle(false);
   const [openDeleteModal, { toggle: toggleDeleteModal }] = useToggle(false);
   const lastFileListRef = useRef<Array<RcFile>>([]);
@@ -96,6 +98,8 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
         <Dropdown
           disabled={!enableWrite}
           trigger={['click']}
+          open={openUploadDropdown}
+          onOpenChange={toggleUploadDropdown}
           popupRender={() => {
             return (
               <BAIFlex
@@ -120,7 +124,11 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
                   multiple
                   showUploadList={false}
                 >
-                  <Button type="text" icon={<FileAddOutlined />}>
+                  <Button
+                    type="text"
+                    icon={<FileAddOutlined />}
+                    onClick={() => toggleUploadDropdown()}
+                  >
                     {t('comp:FileExplorer.UploadFiles')}
                   </Button>
                 </Upload>
@@ -135,7 +143,11 @@ const ExplorerActionControls: React.FC<ExplorerActionControlsProps> = ({
                   }}
                   showUploadList={false}
                 >
-                  <Button type="text" icon={<FolderAddOutlined />}>
+                  <Button
+                    type="text"
+                    icon={<FolderAddOutlined />}
+                    onClick={() => toggleUploadDropdown()}
+                  >
                     {t('comp:FileExplorer.UploadFolder')}
                   </Button>
                 </Upload>


### PR DESCRIPTION
Resolves #5168 ([FR-1987](https://lablup.atlassian.net/browse/FR-1987))

## Summary
- Fix the upload dropdown in File Explorer not closing after selecting an upload option
- Add controlled state (`openUploadDropdown`) to manage dropdown visibility
- Add `onClick` handlers to "Upload Files" and "Upload Folder" buttons to close the dropdown when clicked

## Changes
- Added `useToggle` hook for `openUploadDropdown` state
- Added `open` and `onOpenChange` props to the Dropdown component
- Added `onClick` handlers to both Upload buttons to toggle the dropdown closed

## Test plan
- [ ] Open File Explorer
- [ ] Click the upload dropdown button
- [ ] Select "Upload Files" - verify dropdown closes and file picker opens
- [ ] Click the upload dropdown button again
- [ ] Select "Upload Folder" - verify dropdown closes and folder picker opens

🤖 Generated with [Claude Code](https://claude.ai/code)

[FR-1987]: https://lablup.atlassian.net/browse/FR-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ