### PR TITLE
fix(FR-2006): ensure notifications are opened when status updates

### DIFF
--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -134,6 +134,7 @@ export const useBAINotificationEffect = () => {
                 status: 'resolved',
               },
               duration: CLOSING_DURATION,
+              open: true,
             });
             const overrideData = generateOverrideByStatus(
               updatedNotification,
@@ -149,6 +150,7 @@ export const useBAINotificationEffect = () => {
                 status: 'rejected',
               },
               duration: CLOSING_DURATION,
+              open: true,
             });
             const overrideData = generateOverrideByStatus(
               updatedNotification,
@@ -214,6 +216,7 @@ export const useBAINotificationEffect = () => {
                 percent: 100,
               },
               duration: CLOSING_DURATION,
+              open: true,
               skipDesktopNotification: notification.skipDesktopNotification,
             });
           },
@@ -235,6 +238,7 @@ export const useBAINotificationEffect = () => {
                   ?.renderDataMessage?.(data?.message)
                   ?.toString() || data?.message,
               duration: CLOSING_DURATION,
+              open: true,
               skipDesktopNotification: notification.skipDesktopNotification,
             });
           },
@@ -250,6 +254,7 @@ export const useBAINotificationEffect = () => {
                   ?.renderDataMessage?.(data?.message)
                   ?.toString() || data?.message,
               duration: CLOSING_DURATION,
+              open: true,
               skipDesktopNotification: notification.skipDesktopNotification,
             });
           },
@@ -267,6 +272,7 @@ export const useBAINotificationEffect = () => {
                 percent: ratio * 100,
               },
               duration: CLOSING_DURATION,
+              open: true,
               skipDesktopNotification: notification.skipDesktopNotification,
             });
           },
@@ -367,6 +373,17 @@ export const useSetBAINotification = () => {
         if (!skipOverrideByStatus) {
           const overrideData = generateOverrideByStatus(newNotification);
           newNotification = _.merge({}, newNotification, overrideData);
+        }
+
+        // For pending background tasks, default to duration: 0 (stay open) unless explicitly set
+        if (
+          newNotification.backgroundTask?.status === 'pending' &&
+          !('duration' in params)
+        ) {
+          newNotification = {
+            ...newNotification,
+            duration: 0,
+          };
         }
 
         // This is to check if the notification should be updated using ant.d notification


### PR DESCRIPTION
Resolves [FR-2006](https://lablup.atlassian.net/browse/FR-2006)

## Summary
- Add `open: true` to notification update calls so that notifications are explicitly displayed when background task status changes

## Problem
When cloning a model folder, the progress notification shows 0% and does not update or close when the cloning is complete. The notification's `open` state was not being set when updating status.

## Changes
- Added `open: true` to notification updates for:
  - Resolved status
  - Rejected status  
  - Progress updates (onData, onError, onProgress callbacks)

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-2006]: https://lablup.atlassian.net/browse/FR-2006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ