### PR TITLE
feat(FR-2016): Align BAIGraphQLPropertyFilter with GraphQL schema

### DIFF
--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -18,7 +18,7 @@ export type {
 export { default as BAIGraphQLPropertyFilter } from './BAIGraphQLPropertyFilter';
 export type {
   StringFilter,
-  NumberFilter,
+  IntFilter,
   BooleanFilter,
   EnumFilter,
   BaseFilter,

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Zuletzt aktualisiert",
     "Refresh": "Aktualisieren"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "nach",
+      "Before": "vor",
+      "GreaterThan": "größer als",
+      "GreaterThanOrEqual": "größer oder gleich",
+      "IContains": "enthält",
+      "IEndsWith": "endet mit",
+      "IEquals": "gleich",
+      "INotContains": "enthält nicht",
+      "INotEndsWith": "endet nicht mit",
+      "INotEquals": "ungleich",
+      "INotStartsWith": "beginnt nicht mit",
+      "IStartsWith": "beginnt mit",
+      "In": "enthalten in",
+      "LessThan": "kleiner als",
+      "LessThanOrEqual": "kleiner oder gleich",
+      "NotIn": "nicht enthalten in"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} Versionen sind ausgeschlossen.",
     "FailedToPullVersions": "Versäumte, Versionen zu ziehen.",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Τελευταία ενημέρωση",
     "Refresh": "Ανανέωση"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "μετά",
+      "Before": "πριν",
+      "GreaterThan": "μεγαλύτερο από",
+      "GreaterThanOrEqual": "μεγαλύτερο ή ίσο",
+      "IContains": "περιέχει",
+      "IEndsWith": "τελειώνει με",
+      "IEquals": "ίσο με",
+      "INotContains": "δεν περιέχει",
+      "INotEndsWith": "δεν τελειώνει με",
+      "INotEquals": "όχι ίσο με",
+      "INotStartsWith": "δεν αρχίζει με",
+      "IStartsWith": "αρχίζει με",
+      "In": "σε",
+      "LessThan": "μικρότερο από",
+      "LessThanOrEqual": "μικρότερο ή ίσο",
+      "NotIn": "όχι σε"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} Οι εκδόσεις εξαιρούνται.",
     "FailedToPullVersions": "Απέτυχε να τραβήξει εκδόσεις.",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Last Updated",
     "Refresh": "Refresh"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "after",
+      "Before": "before",
+      "GreaterThan": "greater than",
+      "GreaterThanOrEqual": "greater or equal",
+      "IContains": "contains",
+      "IEndsWith": "ends with",
+      "IEquals": "equals",
+      "INotContains": "not contains",
+      "INotEndsWith": "not ends with",
+      "INotEquals": "not equals",
+      "INotStartsWith": "not starts with",
+      "IStartsWith": "starts with",
+      "In": "in",
+      "LessThan": "less than",
+      "LessThanOrEqual": "less or equal",
+      "NotIn": "not in"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} versions are excluded.",
     "FailedToPullVersions": "Failed to pull versions.",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Última actualización",
     "Refresh": "Actualizar"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "después",
+      "Before": "antes",
+      "GreaterThan": "mayor que",
+      "GreaterThanOrEqual": "mayor o igual",
+      "IContains": "contiene",
+      "IEndsWith": "termina con",
+      "IEquals": "igual a",
+      "INotContains": "no contiene",
+      "INotEndsWith": "no termina con",
+      "INotEquals": "no igual a",
+      "INotStartsWith": "no empieza con",
+      "IStartsWith": "empieza con",
+      "In": "en",
+      "LessThan": "menor que",
+      "LessThanOrEqual": "menor o igual",
+      "NotIn": "no en"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "Las versiones {{count}} están excluidas.",
     "FailedToPullVersions": "No se pudo tirar de versiones.",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Viimeksi päivitetty",
     "Refresh": "Päivitä"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "jälkeen",
+      "Before": "ennen",
+      "GreaterThan": "suurempi kuin",
+      "GreaterThanOrEqual": "suurempi tai yhtä suuri",
+      "IContains": "sisältää",
+      "IEndsWith": "päättyy",
+      "IEquals": "yhtä suuri",
+      "INotContains": "ei sisällä",
+      "INotEndsWith": "ei pääty",
+      "INotEquals": "ei yhtä suuri",
+      "INotStartsWith": "ei ala",
+      "IStartsWith": "alkaa",
+      "In": "sisällä",
+      "LessThan": "pienempi kuin",
+      "LessThanOrEqual": "pienempi tai yhtä suuri",
+      "NotIn": "ei sisällä"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} versiot jätetään pois.",
     "FailedToPullVersions": "Versioiden vetäminen epäonnistui.",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Dernière mise à jour",
     "Refresh": "Rafraîchir"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "après",
+      "Before": "avant",
+      "GreaterThan": "supérieur à",
+      "GreaterThanOrEqual": "supérieur ou égal",
+      "IContains": "contient",
+      "IEndsWith": "se termine par",
+      "IEquals": "égal à",
+      "INotContains": "ne contient pas",
+      "INotEndsWith": "ne se termine pas par",
+      "INotEquals": "différent de",
+      "INotStartsWith": "ne commence pas par",
+      "IStartsWith": "commence par",
+      "In": "dans",
+      "LessThan": "inférieur à",
+      "LessThanOrEqual": "inférieur ou égal",
+      "NotIn": "pas dans"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "Les versions {{count}} sont exclues.",
     "FailedToPullVersions": "N'a pas réussi à tirer des versions.",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Terakhir diperbarui",
     "Refresh": "Segarkan"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "setelah",
+      "Before": "sebelum",
+      "GreaterThan": "lebih besar dari",
+      "GreaterThanOrEqual": "lebih besar atau sama",
+      "IContains": "mengandung",
+      "IEndsWith": "diakhiri dengan",
+      "IEquals": "sama dengan",
+      "INotContains": "tidak berisi",
+      "INotEndsWith": "tidak diakhiri dengan",
+      "INotEquals": "tidak sama dengan",
+      "INotStartsWith": "tidak dimulai dengan",
+      "IStartsWith": "dimulai dengan",
+      "In": "dalam",
+      "LessThan": "kurang dari",
+      "LessThanOrEqual": "kurang dari atau sama",
+      "NotIn": "tidak dalam"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} versi dikecualikan.",
     "FailedToPullVersions": "Gagal menarik versi.",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Ultimo aggiornamento",
     "Refresh": "Aggiorna"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "dopo",
+      "Before": "prima",
+      "GreaterThan": "maggiore di",
+      "GreaterThanOrEqual": "maggiore o uguale",
+      "IContains": "Contiene",
+      "IEndsWith": "termina con",
+      "IEquals": "uguale a",
+      "INotContains": "non contiene",
+      "INotEndsWith": "non termina con",
+      "INotEquals": "diverso da",
+      "INotStartsWith": "non inizia con",
+      "IStartsWith": "inizia con",
+      "In": "in",
+      "LessThan": "minore di",
+      "LessThanOrEqual": "minore o uguale",
+      "NotIn": "non in"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "Le versioni {{count}} sono escluse.",
     "FailedToPullVersions": "Non è riuscito a tirare le versioni.",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -86,6 +86,26 @@
     "LastUpdated": "最終更新",
     "Refresh": "更新"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "後",
+      "Before": "前",
+      "GreaterThan": "より大きい",
+      "GreaterThanOrEqual": "以上",
+      "IContains": "含む",
+      "IEndsWith": "で終わる",
+      "IEquals": "等しい",
+      "INotContains": "含まない",
+      "INotEndsWith": "で終わらない",
+      "INotEquals": "等しくない",
+      "INotStartsWith": "で始まらない",
+      "IStartsWith": "で始まる",
+      "In": "含まれる",
+      "LessThan": "より小さい",
+      "LessThanOrEqual": "以下",
+      "NotIn": "含まれない"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}}バージョンは除外されます。",
     "FailedToPullVersions": "バージョンを引くことができませんでした。",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -86,6 +86,26 @@
     "LastUpdated": "마지막 업데이트",
     "Refresh": "새로고침"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "이후",
+      "Before": "이전",
+      "GreaterThan": "초과",
+      "GreaterThanOrEqual": "이상",
+      "IContains": "포함",
+      "IEndsWith": "끝남",
+      "IEquals": "같음",
+      "INotContains": "포함하지 않음",
+      "INotEndsWith": "끝나지 않음",
+      "INotEquals": "같지 않음",
+      "INotStartsWith": "시작하지 않음",
+      "IStartsWith": "시작",
+      "In": "포함됨",
+      "LessThan": "미만",
+      "LessThanOrEqual": "이하",
+      "NotIn": "포함되지 않음"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}}개 버전은 제외됐습니다.",
     "FailedToPullVersions": "버전을 가져오는데 실패했습니다.",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Сүүлд шинэчлэгдсэн",
     "Refresh": "Шинэчлэх"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "дараа",
+      "Before": "өмнө",
+      "GreaterThan": "их",
+      "GreaterThanOrEqual": "их эсвэл тэнцүү",
+      "IContains": "агуулсан",
+      "IEndsWith": "төгсдөг",
+      "IEquals": "тэнцүү",
+      "INotContains": "агуулаагүй",
+      "INotEndsWith": "төгсдөггүй",
+      "INotEquals": "тэнцүү биш",
+      "INotStartsWith": "эхэлдэггүй",
+      "IStartsWith": "эхэлдэг",
+      "In": "дотор",
+      "LessThan": "бага",
+      "LessThanOrEqual": "бага эсвэл тэнцүү",
+      "NotIn": "дотор биш"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} хувилбарыг хасч болно.",
     "FailedToPullVersions": "Хувилбаруудыг татаж чадсангүй.",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Dikemaskini terakhir",
     "Refresh": "Segarkan"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "selepas",
+      "Before": "sebelum",
+      "GreaterThan": "lebih besar daripada",
+      "GreaterThanOrEqual": "lebih besar atau sama",
+      "IContains": "mengandungi",
+      "IEndsWith": "berakhir dengan",
+      "IEquals": "sama dengan",
+      "INotContains": "tidak mengandungi",
+      "INotEndsWith": "tidak berakhir dengan",
+      "INotEquals": "tidak sama dengan",
+      "INotStartsWith": "tidak bermula dengan",
+      "IStartsWith": "bermula dengan",
+      "In": "dalam",
+      "LessThan": "kurang daripada",
+      "LessThanOrEqual": "kurang atau sama",
+      "NotIn": "tidak dalam"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} versi dikecualikan.",
     "FailedToPullVersions": "Gagal menarik versi.",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Ostatnia aktualizacja",
     "Refresh": "Odśwież"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "po",
+      "Before": "przed",
+      "GreaterThan": "większe niż",
+      "GreaterThanOrEqual": "większe lub równe",
+      "IContains": "zawiera",
+      "IEndsWith": "kończy się na",
+      "IEquals": "równe",
+      "INotContains": "nie zawiera",
+      "INotEndsWith": "nie kończy się na",
+      "INotEquals": "nierówne",
+      "INotStartsWith": "nie zaczyna się od",
+      "IStartsWith": "zaczyna się od",
+      "In": "w",
+      "LessThan": "mniejsze niż",
+      "LessThanOrEqual": "mniejsze lub równe",
+      "NotIn": "nie w"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} wersje są wykluczone.",
     "FailedToPullVersions": "Nie udało się wyciągnąć wersji.",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Última atualização",
     "Refresh": "Atualizar"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "depois",
+      "Before": "antes",
+      "GreaterThan": "maior que",
+      "GreaterThanOrEqual": "maior ou igual",
+      "IContains": "contém",
+      "IEndsWith": "termina com",
+      "IEquals": "igual a",
+      "INotContains": "não contém",
+      "INotEndsWith": "não termina com",
+      "INotEquals": "diferente de",
+      "INotStartsWith": "não começa com",
+      "IStartsWith": "começa com",
+      "In": "em",
+      "LessThan": "menor que",
+      "LessThanOrEqual": "menor ou igual",
+      "NotIn": "não em"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "Description": "Descrição",
     "Name": "Nome",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Última atualização",
     "Refresh": "Atualizar"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "depois",
+      "Before": "antes",
+      "GreaterThan": "maior que",
+      "GreaterThanOrEqual": "maior ou igual",
+      "IContains": "contém",
+      "IEndsWith": "termina com",
+      "IEquals": "igual a",
+      "INotContains": "não contém",
+      "INotEndsWith": "não termina com",
+      "INotEquals": "diferente de",
+      "INotStartsWith": "não começa com",
+      "IStartsWith": "começa com",
+      "In": "em",
+      "LessThan": "menor que",
+      "LessThanOrEqual": "menor ou igual",
+      "NotIn": "não em"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} versões são excluídas.",
     "FailedToPullVersions": "Falhou em puxar versões.",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Обновлено",
     "Refresh": "Обновить"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "после",
+      "Before": "до",
+      "GreaterThan": "больше",
+      "GreaterThanOrEqual": "больше или равно",
+      "IContains": "содержит",
+      "IEndsWith": "заканчивается на",
+      "IEquals": "равно",
+      "INotContains": "не содержит",
+      "INotEndsWith": "не заканчивается на",
+      "INotEquals": "не равно",
+      "INotStartsWith": "не начинается с",
+      "IStartsWith": "начинается с",
+      "In": "в",
+      "LessThan": "меньше",
+      "LessThanOrEqual": "меньше или равно",
+      "NotIn": "не в"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} версии исключены.",
     "FailedToPullVersions": "Не удалось вытащить версии.",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -86,6 +86,26 @@
     "LastUpdated": "อัปเดตล่าสุด",
     "Refresh": "รีเฟรช"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "หลัง",
+      "Before": "ก่อน",
+      "GreaterThan": "มากกว่า",
+      "GreaterThanOrEqual": "มากกว่าหรือเท่ากับ",
+      "IContains": "ประกอบด้วย",
+      "IEndsWith": "ลงท้ายด้วย",
+      "IEquals": "เท่ากับ",
+      "INotContains": "ไม่มี",
+      "INotEndsWith": "ไม่ลงท้ายด้วย",
+      "INotEquals": "ไม่เท่ากับ",
+      "INotStartsWith": "ไม่เริ่มต้นด้วย",
+      "IStartsWith": "เริ่มต้นด้วย",
+      "In": "ใน",
+      "LessThan": "น้อยกว่า",
+      "LessThanOrEqual": "น้อยกว่าหรือเท่ากับ",
+      "NotIn": "ไม่ใน"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} ไม่รวมรุ่น",
     "FailedToPullVersions": "ไม่สามารถดึงเวอร์ชันได้",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Son güncelleme",
     "Refresh": "Yenile"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "sonra",
+      "Before": "önce",
+      "GreaterThan": "daha büyük",
+      "GreaterThanOrEqual": "büyük veya eşit",
+      "IContains": "içerir",
+      "IEndsWith": "ile biter",
+      "IEquals": "eşit",
+      "INotContains": "içermez",
+      "INotEndsWith": "ile bitmez",
+      "INotEquals": "eşit değil",
+      "INotStartsWith": "ile başlamaz",
+      "IStartsWith": "ile başlar",
+      "In": "içinde",
+      "LessThan": "daha küçük",
+      "LessThanOrEqual": "küçük veya eşit",
+      "NotIn": "içinde değil"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} sürümleri hariç tutulur.",
     "FailedToPullVersions": "Sürümleri çekemedi.",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -86,6 +86,26 @@
     "LastUpdated": "Cập nhật lần cuối",
     "Refresh": "Làm mới"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "sau",
+      "Before": "trước",
+      "GreaterThan": "lớn hơn",
+      "GreaterThanOrEqual": "lớn hơn hoặc bằng",
+      "IContains": "chứa",
+      "IEndsWith": "kết thúc bằng",
+      "IEquals": "bằng",
+      "INotContains": "không chứa",
+      "INotEndsWith": "không kết thúc bằng",
+      "INotEquals": "không bằng",
+      "INotStartsWith": "không bắt đầu bằng",
+      "IStartsWith": "bắt đầu bằng",
+      "In": "trong",
+      "LessThan": "nhỏ hơn",
+      "LessThanOrEqual": "nhỏ hơn hoặc bằng",
+      "NotIn": "không trong"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}} Các phiên bản được loại trừ.",
     "FailedToPullVersions": "Không thể kéo phiên bản.",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -86,6 +86,26 @@
     "LastUpdated": "最后更新",
     "Refresh": "刷新"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "之后",
+      "Before": "之前",
+      "GreaterThan": "大于",
+      "GreaterThanOrEqual": "大于或等于",
+      "IContains": "包含",
+      "IEndsWith": "以...结尾",
+      "IEquals": "等于",
+      "INotContains": "不包含",
+      "INotEndsWith": "不以...结尾",
+      "INotEquals": "不等于",
+      "INotStartsWith": "不以...开头",
+      "IStartsWith": "以...开头",
+      "In": "在...中",
+      "LessThan": "小于",
+      "LessThanOrEqual": "小于或等于",
+      "NotIn": "不在...中"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}}版本被排除在外。",
     "FailedToPullVersions": "未能拉动版本。",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -86,6 +86,26 @@
     "LastUpdated": "最後更新",
     "Refresh": "重新整理"
   },
+  "comp:BAIGraphQLPropertyFilter": {
+    "operator": {
+      "After": "之後",
+      "Before": "之前",
+      "GreaterThan": "大於",
+      "GreaterThanOrEqual": "大於或等於",
+      "IContains": "包含",
+      "IEndsWith": "以...結尾",
+      "IEquals": "等於",
+      "INotContains": "不包含",
+      "INotEndsWith": "不以...結尾",
+      "INotEquals": "不等於",
+      "INotStartsWith": "不以...開頭",
+      "IStartsWith": "以...開頭",
+      "In": "在...中",
+      "LessThan": "小於",
+      "LessThanOrEqual": "小於或等於",
+      "NotIn": "不在...中"
+    }
+  },
   "comp:BAIImportArtifactModal": {
     "ExcludedVersions": "{{count}}版本被排除在外。",
     "FailedToPullVersions": "未能拉動版本。",


### PR DESCRIPTION
Resolves #5220 ([FR-2016](https://lablup.atlassian.net/browse/FR-2016))

## Summary
- Add missing negation operators for string filters (notContains, notStartsWith, notEndsWith)
- Add case-insensitive negation operators (iNotContains, iNotStartsWith, iNotEndsWith, iNotEquals)
- Rename `NumberFilter` to `IntFilter` with schema-aligned property names (greaterThanOrEqual, lessThanOrEqual)
- Add new filter types: `UUIDFilter` and `DateTimeFilter`
- Fix default operators from 'eq' to 'equals'
- Update FairShareList to use UUID filter type for projectId and userUuid fields

## Test plan
- [ ] Verify BAIGraphQLPropertyFilter shows all new operators in dropdown
- [ ] Test string filter operators work correctly (contains, notContains, etc.)
- [ ] Test number filter operators use correct schema names
- [ ] Verify FairShareList project and user filters work with UUID type

🤖 Generated with [Claude Code](https://claude.ai/code)

[FR-2016]: https://lablup.atlassian.net/browse/FR-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ