### PR TITLE
fix(FR-2013): display GraphQL error messages from network responses in error boundary

### DIFF
--- a/react/src/components/BAIErrorBoundary.tsx
+++ b/react/src/components/BAIErrorBoundary.tsx
@@ -1,7 +1,8 @@
 import { isLoginSessionExpiredState } from './LoginSessionExtendButton';
 import { ReloadOutlined } from '@ant-design/icons';
-import { Alert, Button, Result, Typography } from 'antd';
+import { Alert, Button, Result, theme, Typography } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';
+import type { GraphQLFormattedError } from 'graphql';
 import { useAtomValue } from 'jotai';
 import React from 'react';
 import {
@@ -9,6 +10,53 @@ import {
   ErrorBoundaryPropsWithRender,
 } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
+
+/**
+ * Extended Error with GraphQL error information
+ */
+interface ErrorWithGraphQL extends Error {
+  source?: {
+    errors?: ReadonlyArray<GraphQLFormattedError>;
+    variables?: any;
+    operation?: {
+      name?: string;
+    };
+  };
+  errors?: ReadonlyArray<GraphQLFormattedError>;
+}
+
+/**
+ * Type guard to check if error has GraphQL source errors
+ */
+function hasGraphQLSourceErrors(error: unknown): error is ErrorWithGraphQL & {
+  source: { errors: ReadonlyArray<GraphQLFormattedError> };
+} {
+  if (!(error instanceof Error) || !('source' in error)) {
+    return false;
+  }
+
+  const err = error as ErrorWithGraphQL;
+  return (
+    typeof err.source === 'object' &&
+    err.source !== null &&
+    'errors' in err.source &&
+    Array.isArray(err.source.errors) &&
+    err.source.errors.length > 0
+  );
+}
+
+/**
+ * Type guard to check if error has errors array
+ */
+function hasErrorsArray(error: unknown): error is ErrorWithGraphQL & {
+  errors: ReadonlyArray<GraphQLFormattedError>;
+} {
+  return (
+    error instanceof Error &&
+    'errors' in error &&
+    Array.isArray((error as ErrorWithGraphQL).errors)
+  );
+}
 
 interface BAIErrorBoundaryProps extends Omit<
   ErrorBoundaryPropsWithRender,
@@ -22,6 +70,7 @@ const BAIErrorBoundary: React.FC<BAIErrorBoundaryProps> = ({
   ...props
 }) => {
   const { t } = useTranslation();
+  const { token } = theme.useToken();
   const isExpiredLoginSession = useAtomValue(isLoginSessionExpiredState);
   return (
     <ErrorBoundary
@@ -65,36 +114,145 @@ const BAIErrorBoundary: React.FC<BAIErrorBoundaryProps> = ({
                       ? t('errorBoundary.ExpiredLoginSessionReLogin')
                       : t('errorBoundary.ReloadPage')}
                   </Button>
-                  {process.env.NODE_ENV === 'development' && (
-                    <BAIFlex
-                      direction="column"
-                      gap="sm"
-                      align="center"
-                      style={{ width: '100%' }}
-                    >
-                      <Alert
-                        type="info"
-                        showIcon
-                        description={
-                          <BAIFlex direction="column" align="start" gap={'md'}>
-                            <Button
-                              type="default"
-                              icon={<ReloadOutlined />}
-                              onClick={() => {
-                                resetErrorBoundary();
-                              }}
+                  {
+                    // TODO: Include this to App Config
+                    // @ts-ignore
+                    globalThis?.backendaiwebui?.debug === true && (
+                      <BAIFlex
+                        direction="column"
+                        gap="sm"
+                        align="center"
+                        style={{ width: '100%' }}
+                      >
+                        <Alert
+                          type="info"
+                          description={
+                            <BAIFlex
+                              direction="column"
+                              align="center"
+                              gap={'md'}
                             >
-                              {t('errorBoundary.ResetErrorBoundary')}
-                            </Button>
-                            <Typography.Text>
-                              {(error as Error).message}
-                            </Typography.Text>
-                          </BAIFlex>
-                        }
-                        title={t('errorBoundary.DisplayOnlyDevEnv')}
-                      />
-                    </BAIFlex>
-                  )}
+                              <Button
+                                type="default"
+                                icon={<ReloadOutlined />}
+                                onClick={() => {
+                                  resetErrorBoundary();
+                                }}
+                              >
+                                {t('errorBoundary.ResetErrorBoundary')}
+                              </Button>
+                              <BAIFlex direction="column" gap="sm">
+                                <Typography.Text strong>
+                                  {t('errorBoundary.ErrorMessage')}
+                                </Typography.Text>
+                                <Typography.Paragraph
+                                  style={{
+                                    whiteSpace: 'pre-wrap',
+                                    wordBreak: 'break-word',
+                                    maxHeight: '150px',
+                                    overflow: 'auto',
+                                    textAlign: 'left',
+                                  }}
+                                >
+                                  <pre style={{ margin: 0 }}>
+                                    {(() => {
+                                      // Try to extract GraphQL errors using type guards
+                                      // Case 1: Relay error with source.errors
+                                      if (hasGraphQLSourceErrors(error)) {
+                                        return error.source.errors
+                                          .map((e) => e.message)
+                                          .join('\n\n');
+                                      }
+
+                                      // Case 2: Error object with errors array
+                                      if (hasErrorsArray(error)) {
+                                        return error.errors
+                                          .map((e) => e.message)
+                                          .join('\n\n');
+                                      }
+
+                                      // Case 3: Standard Error message
+                                      if (
+                                        error instanceof Error &&
+                                        error.message
+                                      ) {
+                                        return error.message;
+                                      }
+
+                                      // Fallback: stringify the error
+                                      return JSON.stringify(error, null, 2);
+                                    })()}
+                                  </pre>
+                                </Typography.Paragraph>
+
+                                {/* Debug: Show only relevant error information */}
+                                <Typography.Text
+                                  strong
+                                  style={{ marginTop: token.marginXS }}
+                                >
+                                  {t('errorBoundary.DebugInfo')}
+                                </Typography.Text>
+                                <Typography.Paragraph
+                                  style={{
+                                    whiteSpace: 'pre-wrap',
+                                    wordBreak: 'break-word',
+                                    maxHeight: '150px',
+                                    overflow: 'auto',
+                                    textAlign: 'left',
+                                  }}
+                                >
+                                  <pre style={{ margin: 0 }}>
+                                    {JSON.stringify(
+                                      {
+                                        ...(error instanceof Error && {
+                                          name: error.name,
+                                          message: error.message,
+                                        }),
+                                        ...(hasGraphQLSourceErrors(error) && {
+                                          errors: error.source.errors,
+                                          variables: error.source.variables,
+                                          operationName:
+                                            error.source.operation?.name,
+                                        }),
+                                      },
+                                      null,
+                                      2,
+                                    )}
+                                  </pre>
+                                </Typography.Paragraph>
+
+                                {error instanceof Error && error.stack && (
+                                  <>
+                                    <Typography.Text
+                                      strong
+                                      style={{ marginTop: token.marginXS }}
+                                    >
+                                      {t('errorBoundary.StackTrace')}
+                                    </Typography.Text>
+                                    <Typography.Paragraph
+                                      style={{
+                                        whiteSpace: 'pre-wrap',
+                                        wordBreak: 'break-word',
+                                        maxHeight: '150px',
+                                        overflow: 'auto',
+                                        textAlign: 'left',
+                                        marginBottom: 0,
+                                      }}
+                                    >
+                                      <pre style={{ margin: 0 }}>
+                                        {(error as Error).stack}
+                                      </pre>
+                                    </Typography.Paragraph>
+                                  </>
+                                )}
+                              </BAIFlex>
+                            </BAIFlex>
+                          }
+                          title={t('errorBoundary.DisplayOnlyDevEnv')}
+                        />
+                      </BAIFlex>
+                    )
+                  }
                 </BAIFlex>
               }
             ></Result>

--- a/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
@@ -22,8 +22,10 @@ import {
   useRelayEnvironment,
 } from 'react-relay';
 
-interface TerminateSessionModalProps
-  extends Omit<ModalProps, 'onOk' | 'onCancel'> {
+interface TerminateSessionModalProps extends Omit<
+  ModalProps,
+  'onOk' | 'onCancel'
+> {
   sessionFrgmts?: TerminateSessionModalFragment$key;
   onRequestClose: (success: boolean) => void;
 }
@@ -93,7 +95,8 @@ const getWSProxyVersion = async (
   baiClient: BackendAIClient,
 ) => {
   // TODO: remove globalThis.appLauncher(backend-ai-app-launcher) dependency after migration to React
-  if (baiClient.debug === true) {
+  // @ts-ignore
+  if (globalThis?.backendaiwebui?.debug === true) {
     if (globalThis.appLauncher?.forceUseV1Proxy?.checked) return 'v1';
     else if (globalThis.appLauncher?.forceUseV2Proxy?.checked) return 'v2';
   }

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -64,7 +64,8 @@ export const useBackendAIAppLauncher = (
 
   const getWSProxyVersion = async (): Promise<'v1' | 'v2'> => {
     // TODO: remove globalThis.appLauncher(backend-ai-app-launcher) dependency after migration to React
-    if (baiClient.debug === true) {
+    // @ts-ignore
+    if (globalThis?.backendaiwebui?.debug === true) {
       if (debugOptions?.forceUseV1Proxy) return 'v1';
       else if (debugOptions?.forceUseV2Proxy) return 'v2';
     }

--- a/react/src/hooks/useCurrentProject.tsx
+++ b/react/src/hooks/useCurrentProject.tsx
@@ -29,6 +29,7 @@ interface ScalingGroupsResponse {
   scaling_groups: ScalingGroupItem[];
 }
 
+// TODO: check undefined and add error handling
 const currentProjectAtom = atomWithDefault(() => {
   return {
     // @ts-ignore

--- a/react/src/hooks/useMergedAllowedStorageHostPermission.ts
+++ b/react/src/hooks/useMergedAllowedStorageHostPermission.ts
@@ -14,7 +14,7 @@ export const useMergedAllowedStorageHostPermission = (
     useLazyLoadQuery<useMergedAllowedStorageHostPermission_KeypairQuery>(
       graphql`
         query useMergedAllowedStorageHostPermission_KeypairQuery(
-          $domainName: String!
+          $domainName: String
           $accessKey: String
         ) {
           keypair(domain_name: $domainName, access_key: $accessKey)

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -156,7 +156,7 @@ const ComputeSessionListPage = () => {
   const queryRef = useLazyLoadQuery<ComputeSessionListPageQuery>(
     graphql`
         query ComputeSessionListPageQuery(
-          $projectId: UUID!
+          $projectId: UUID
           $first: Int = 20
           $offset: Int = 0
           $filter: String

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -202,7 +202,7 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
     useLazyLoadQuery<VFolderNodeListPageQuery>(
       graphql`
         query VFolderNodeListPageQuery(
-          $projectId: UUID!
+          $projectId: UUID
           $offset: Int
           $first: Int
           $filter: String

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "Falsche API-Serveradresse."
   },
   "errorBoundary": {
+    "DebugInfo": "Debug-Info:",
     "DisplayOnlyDevEnv": "Dieser Fehlerblock wird nur in der WebUI-Entwicklungsumgebung angezeigt.",
+    "ErrorMessage": "Fehlermeldung:",
     "ExpiredLoginSessionReLogin": "Anmeldung",
     "ExpiredLoginSessionTitle": "Ihre Anmeldesitzung ist abgelaufen.",
     "ReloadPage": "Laden Sie die Seite neu",
     "ResetErrorBoundary": "ErrorBoundary zurücksetzen",
+    "StackTrace": "Stack-Trace:",
     "Title": "Es ist ein Fehler aufgetreten."
   },
   "explorer": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -706,11 +706,14 @@
     "WrongAPIServerAddress": "Λάθος διεύθυνση διακομιστή API."
   },
   "errorBoundary": {
+    "DebugInfo": "Πληροφορίες αποσφαλμάτωσης:",
     "DisplayOnlyDevEnv": "Αυτό το μπλοκ σφάλματος εμφανίζεται μόνο στο περιβάλλον ανάπτυξης WebUI.",
+    "ErrorMessage": "Μήνυμα σφάλματος:",
     "ExpiredLoginSessionReLogin": "Σύνδεση",
     "ExpiredLoginSessionTitle": "Η περίοδος σύνδεσής σας έχει λήξει.",
     "ReloadPage": "Επαναφόρτωση της σελίδας",
     "ResetErrorBoundary": "Επαναφορά ErrorBoundary",
+    "StackTrace": "Ιχνη στοίβας:",
     "Title": "Εμφανίστηκε σφάλμα."
   },
   "explorer": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -714,11 +714,14 @@
     "WrongAPIServerAddress": "Wrong API server address."
   },
   "errorBoundary": {
+    "DebugInfo": "Debug Info:",
     "DisplayOnlyDevEnv": "This error block is displayed only in WebUI development environment.",
+    "ErrorMessage": "Error Message:",
     "ExpiredLoginSessionReLogin": "Login",
     "ExpiredLoginSessionTitle": "Your login session has expired.",
     "ReloadPage": "Reload the page",
     "ResetErrorBoundary": "Reset ErrorBoundary",
+    "StackTrace": "Stack Trace:",
     "Title": "An error has occurred."
   },
   "explorer": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "Dirección del servidor API incorrecta."
   },
   "errorBoundary": {
+    "DebugInfo": "Información de depuración:",
     "DisplayOnlyDevEnv": "Este bloque de error sólo se muestra en el entorno de desarrollo WebUI.",
+    "ErrorMessage": "Mensaje de error:",
     "ExpiredLoginSessionReLogin": "Inicio de sesión",
     "ExpiredLoginSessionTitle": "Su sesión ha expirado.",
     "ReloadPage": "Recargar la página",
     "ResetErrorBoundary": "Restablecer ErrorBoundary",
+    "StackTrace": "Traza de pila:",
     "Title": "Se ha producido un error."
   },
   "explorer": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "Väärä API-palvelimen osoite."
   },
   "errorBoundary": {
+    "DebugInfo": "Vianmääritystiedot:",
     "DisplayOnlyDevEnv": "Tämä virhelohko näytetään vain WebUI-kehitysympäristössä.",
+    "ErrorMessage": "Virheilmoitus:",
     "ExpiredLoginSessionReLogin": "Kirjaudu sisään",
     "ExpiredLoginSessionTitle": "Kirjautumisistuntosi on päättynyt.",
     "ReloadPage": "Lataa sivu uudelleen",
     "ResetErrorBoundary": "Nollaa ErrorBoundary",
+    "StackTrace": "Pinon jäljitys:",
     "Title": "On tapahtunut virhe."
   },
   "explorer": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "Mauvaise adresse du serveur API."
   },
   "errorBoundary": {
+    "DebugInfo": "Informations de débogage :",
     "DisplayOnlyDevEnv": "Ce bloc d'erreur n'est affiché que dans l'environnement de développement WebUI.",
+    "ErrorMessage": "Message d'erreur :",
     "ExpiredLoginSessionReLogin": "Connexion",
     "ExpiredLoginSessionTitle": "Votre session de connexion a expiré.",
     "ReloadPage": "Recharger la page",
     "ResetErrorBoundary": "Réinitialisation de la limite d'erreur",
+    "StackTrace": "Trace de la pile :",
     "Title": "Une erreur s'est produite."
   },
   "explorer": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -708,11 +708,14 @@
     "WrongAPIServerAddress": "Alamat server API salah."
   },
   "errorBoundary": {
+    "DebugInfo": "Info debug:",
     "DisplayOnlyDevEnv": "Blok kesalahan ini hanya ditampilkan di lingkungan pengembangan WebUI.",
+    "ErrorMessage": "Pesan Kesalahan:",
     "ExpiredLoginSessionReLogin": "Masuk",
     "ExpiredLoginSessionTitle": "Sesi login Anda telah kedaluwarsa.",
     "ReloadPage": "Muat ulang halaman",
     "ResetErrorBoundary": "Setel Ulang Batas Kesalahan",
+    "StackTrace": "Jejak tumpukan:",
     "Title": "Telah terjadi kesalahan."
   },
   "explorer": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -708,11 +708,14 @@
     "WrongAPIServerAddress": "Indirizzo del server API errato."
   },
   "errorBoundary": {
+    "DebugInfo": "Informazioni di debug:",
     "DisplayOnlyDevEnv": "Questo blocco di errore viene visualizzato solo nell'ambiente di sviluppo WebUI.",
+    "ErrorMessage": "Messaggio di errore:",
     "ExpiredLoginSessionReLogin": "Accesso",
     "ExpiredLoginSessionTitle": "La sessione di accesso è scaduta.",
     "ReloadPage": "Ricarica la pagina",
     "ResetErrorBoundary": "Azzeramento di ErrorBoundary",
+    "StackTrace": "Traccia dello stack:",
     "Title": "Si è verificato un errore."
   },
   "explorer": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -708,11 +708,14 @@
     "WrongAPIServerAddress": "APIサーバーのアドレスが間違っています。"
   },
   "errorBoundary": {
+    "DebugInfo": "デバッグ情報:",
     "DisplayOnlyDevEnv": "このエラーブロックはWebUI開発環境でのみ表示されます。",
+    "ErrorMessage": "エラーメッセージ：",
     "ExpiredLoginSessionReLogin": "ログイン",
     "ExpiredLoginSessionTitle": "ログインセッションの有効期限が切れました。",
     "ReloadPage": "ページの更新",
     "ResetErrorBoundary": "ErrorBoundaryの初期化",
+    "StackTrace": "スタックトレース:",
     "Title": "エラーが発生しました。"
   },
   "explorer": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -711,11 +711,14 @@
     "WrongAPIServerAddress": "잘못된 API 서버 주소"
   },
   "errorBoundary": {
+    "DebugInfo": "디버그 정보:",
     "DisplayOnlyDevEnv": "이 에러 블록은 WebUI 개발 환경에서만 표시됩니다.",
+    "ErrorMessage": "오류 메시지:",
     "ExpiredLoginSessionReLogin": "로그인",
     "ExpiredLoginSessionTitle": "로그인 세션이 만료되었습니다.",
     "ReloadPage": "페이지 새로고침",
     "ResetErrorBoundary": "ErrorBoundary 초기화",
+    "StackTrace": "스택 트레이스:",
     "Title": "에러가 발생했습니다."
   },
   "explorer": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -707,11 +707,14 @@
     "WrongAPIServerAddress": "API серверийн хаяг буруу байна."
   },
   "errorBoundary": {
+    "DebugInfo": "Алдааг оношлох мэдээлэл:",
     "DisplayOnlyDevEnv": "Энэ алдааны блок нь зөвхөн WebUI хөгжүүлэлтийн орчинд харагдана.",
+    "ErrorMessage": "Алдааны мэдэгдэл:",
     "ExpiredLoginSessionReLogin": "Нэвтрэх",
     "ExpiredLoginSessionTitle": "Таны нэвтрэх хугацаа дууссан.",
     "ReloadPage": "Хуудсыг дахин ачаална уу",
     "ResetErrorBoundary": "Алдааны хил хязгаарыг дахин тохируулах",
+    "StackTrace": "Стэк мөр:",
     "Title": "Алдаа гарсан байна."
   },
   "explorer": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -708,11 +708,14 @@
     "WrongAPIServerAddress": "Alamat pelayan API salah."
   },
   "errorBoundary": {
+    "DebugInfo": "Maklumat Debug:",
     "DisplayOnlyDevEnv": "Blok ralat ini hanya dipaparkan dalam persekitaran pembangunan WebUI.",
+    "ErrorMessage": "Mesej Ralat:",
     "ExpiredLoginSessionReLogin": "Log masuk",
     "ExpiredLoginSessionTitle": "Sesi log masuk anda telah tamat tempoh.",
     "ReloadPage": "Muat semula halaman",
     "ResetErrorBoundary": "Tetapkan Semula ErrorBoundary",
+    "StackTrace": "Jejak ralat:",
     "Title": "Ralat telah berlaku."
   },
   "explorer": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "Nieprawidłowy adres serwera API."
   },
   "errorBoundary": {
+    "DebugInfo": "Informacje debugowania:",
     "DisplayOnlyDevEnv": "Ten blok błędu jest wyświetlany tylko w środowisku programistycznym WebUI.",
+    "ErrorMessage": "Komunikat o błędzie:",
     "ExpiredLoginSessionReLogin": "Logowanie",
     "ExpiredLoginSessionTitle": "Sesja logowania wygasła.",
     "ReloadPage": "Przeładuj stronę",
     "ResetErrorBoundary": "Reset ErrorBoundary",
+    "StackTrace": "Stos wywołań:",
     "Title": "Wystąpił błąd."
   },
   "explorer": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "Endereço do servidor API incorreto."
   },
   "errorBoundary": {
+    "DebugInfo": "Informações de depuração:",
     "DisplayOnlyDevEnv": "Este bloco de erro é apresentado apenas no ambiente de desenvolvimento da WebUI.",
+    "ErrorMessage": "Mensagem de erro:",
     "ExpiredLoginSessionReLogin": "Iniciar sessão",
     "ExpiredLoginSessionTitle": "A sua sessão de início de sessão expirou.",
     "ReloadPage": "Recarregar a página",
     "ResetErrorBoundary": "Repor ErrorBoundary",
+    "StackTrace": "Pilha de chamadas:",
     "Title": "Ocorreu um erro."
   },
   "explorer": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "Endereço do servidor API incorreto."
   },
   "errorBoundary": {
+    "DebugInfo": "Informações de depuração:",
     "DisplayOnlyDevEnv": "Este bloco de erro é apresentado apenas no ambiente de desenvolvimento da WebUI.",
+    "ErrorMessage": "Mensagem de erro:",
     "ExpiredLoginSessionReLogin": "Iniciar sessão",
     "ExpiredLoginSessionTitle": "A sua sessão de início de sessão expirou.",
     "ReloadPage": "Recarregar a página",
     "ResetErrorBoundary": "Repor ErrorBoundary",
+    "StackTrace": "Rastreamento da pilha:",
     "Title": "Ocorreu um erro."
   },
   "explorer": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "Неверный адрес сервера API."
   },
   "errorBoundary": {
+    "DebugInfo": "Отладочная информация:",
     "DisplayOnlyDevEnv": "Данный блок ошибок отображается только в среде разработки WebUI.",
+    "ErrorMessage": "Сообщение об ошибке:",
     "ExpiredLoginSessionReLogin": "Вход в систему",
     "ExpiredLoginSessionTitle": "Срок действия вашей сессии входа в систему истек.",
     "ReloadPage": "Перезагрузить страницу",
     "ResetErrorBoundary": "Сброс границы ошибки",
+    "StackTrace": "Стек вызовов:",
     "Title": "Произошла ошибка."
   },
   "explorer": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -698,11 +698,14 @@
     "WrongAPIServerAddress": "ที่อยู่เซิร์ฟเวอร์ API ไม่ถูกต้อง"
   },
   "errorBoundary": {
+    "DebugInfo": "ข้อมูลดีบัก:",
     "DisplayOnlyDevEnv": "บล็อกข้อผิดพลาดนี้จะแสดงเฉพาะในสภาพแวดล้อมการพัฒนา WebUI เท่านั้น",
+    "ErrorMessage": "ข้อความแสดงข้อผิดพลาด:",
     "ExpiredLoginSessionReLogin": "เข้าสู่ระบบ",
     "ExpiredLoginSessionTitle": "เซสชั่นการเข้าสู่ระบบของคุณหมดอายุแล้ว",
     "ReloadPage": "โหลดหน้าใหม่",
     "ResetErrorBoundary": "รีเซ็ต ErrorBoundary",
+    "StackTrace": "รายละเอียด Stack Trace:",
     "Title": "เกิดข้อผิดพลาด"
   },
   "explorer": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "Yanlış API sunucu adresi."
   },
   "errorBoundary": {
+    "DebugInfo": "Hata Ayıklama Bilgileri:",
     "DisplayOnlyDevEnv": "Bu hata bloğu yalnızca WebUI geliştirme ortamında görüntülenir.",
+    "ErrorMessage": "Hata mesajı:",
     "ExpiredLoginSessionReLogin": "Giriş",
     "ExpiredLoginSessionTitle": "Giriş oturumunuzun süresi doldu.",
     "ReloadPage": "Sayfayı yeniden yükle",
     "ResetErrorBoundary": "ErrorBoundary'yi Sıfırla",
+    "StackTrace": "Yığın İzleme:",
     "Title": "Bir hata oluştu."
   },
   "explorer": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "Địa chỉ máy chủ API sai."
   },
   "errorBoundary": {
+    "DebugInfo": "Thông tin gỡ lỗi:",
     "DisplayOnlyDevEnv": "Khối lỗi này chỉ được hiển thị trong môi trường phát triển WebUI.",
+    "ErrorMessage": "Thông báo lỗi:",
     "ExpiredLoginSessionReLogin": "Đăng nhập",
     "ExpiredLoginSessionTitle": "Phiên đăng nhập của bạn đã hết hạn.",
     "ReloadPage": "Tải lại trang",
     "ResetErrorBoundary": "Đặt lại ranh giới lỗi",
+    "StackTrace": "Dấu vết ngăn xếp:",
     "Title": "Một lỗi đã xảy ra."
   },
   "explorer": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "错误的 API 服务器地址。"
   },
   "errorBoundary": {
+    "DebugInfo": "调试信息：",
     "DisplayOnlyDevEnv": "此错误块仅在 WebUI 开发环境中显示。",
+    "ErrorMessage": "错误信息：",
     "ExpiredLoginSessionReLogin": "登录",
     "ExpiredLoginSessionTitle": "您的登录会话已过期。",
     "ReloadPage": "重新载入页面",
     "ResetErrorBoundary": "重置错误边界",
+    "StackTrace": "堆栈跟踪：",
     "Title": "发生错误。"
   },
   "explorer": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -709,11 +709,14 @@
     "WrongAPIServerAddress": "错误的 API 服务器地址。"
   },
   "errorBoundary": {
+    "DebugInfo": "除錯資訊：",
     "DisplayOnlyDevEnv": "此错误块仅在 WebUI 开发环境中显示。",
+    "ErrorMessage": "錯誤訊息：",
     "ExpiredLoginSessionReLogin": "登录",
     "ExpiredLoginSessionTitle": "您的登录会话已过期。",
     "ReloadPage": "重新载入页面",
     "ResetErrorBoundary": "重置错误边界",
+    "StackTrace": "堆疊追蹤：",
     "Title": "发生错误。"
   },
   "explorer": {

--- a/src/components/backend-ai-app-launcher.ts
+++ b/src/components/backend-ai-app-launcher.ts
@@ -788,6 +788,7 @@ export default class BackendAiAppLauncher extends BackendAIPage {
         status: 'rejected',
       };
       this.notification.show(false, undefined, `session-app-${sessionUuid}`);
+      return;
     }
   }
 

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -507,6 +507,8 @@ class Client {
         description: errorDesc,
         error_code: errorCode,
         traceback: traceback,
+        // Include response body for GraphQL errors
+        response: body,
       };
     }
 
@@ -1429,22 +1431,6 @@ class Client {
       null,
     );
     return this._wrapWithPromise(rqst, false, null, timeout);
-  }
-
-  // legacy aliases (DO NOT USE for new codes)
-  createKernel(
-    kernelType,
-    sessionId: string = '',
-    resources = {},
-    timeout = 0,
-  ): Promise<any> {
-    return this.createIfNotExists(
-      kernelType,
-      sessionId,
-      resources,
-      timeout,
-      'x86_64',
-    );
   }
 
   // legacy aliases (DO NOT USE for new codes)

--- a/src/lib/backend.ai-client-node.ts
+++ b/src/lib/backend.ai-client-node.ts
@@ -1199,16 +1199,6 @@ class Client {
     return this._wrapWithPromise(rqst, false, null, timeout);
   }
 
-  // legacy aliases (DO NOT USE for new codes)
-  createKernel(kernelType, sessionId = undefined, resources = {}, timeout = 0) {
-    return this.createIfNotExists(
-      kernelType,
-      sessionId,
-      resources,
-      timeout,
-      'x86_64',
-    );
-  }
 
   // legacy aliases (DO NOT USE for new codes)
   destroyKernel(sessionId, ownerKey = null) {

--- a/src/types/backend-ai-console.d.ts
+++ b/src/types/backend-ai-console.d.ts
@@ -123,11 +123,7 @@ export default class BackendAIWebUI extends BackendAIWebUI_base {
   protected render(): import('lit-element').TemplateResult;
   stateChanged(state: any): void;
 }
-declare global {
-  interface HTMLElementTagNameMap {
-    'backend-ai-webui': BackendAIWebUI;
-  }
-}
+
 export {};
 
 export interface SessionResources {


### PR DESCRIPTION
resolves FR-2013

# Improved GraphQL Error Handling and Error Boundary UI, Resolved Build Errors.

This PR enhances error handling for GraphQL requests and improves the error boundary UI to provide more useful debugging information. And resolved errors that occur with `pnpm run build:d`

## Changes:

1. **RelayEnvironment.ts**:
    - Added proper handling for GraphQL errors with HTTP 400/500 status codes
    - Improved error formatting with detailed GraphQL error messages
    - Return partial data when available instead of throwing errors immediately
2. **BAIErrorBoundary.tsx**:
    - Enhanced error display with structured sections for error message, debug info, and stack trace
    - Added better formatting for GraphQL errors with pre-formatted text
    - Improved layout and readability of error information
3. **backend.ai-client-esm.ts**:
    - Include response body in error objects for GraphQL errors
    - Added default values for session resources in createKernel
4. **backend-ai-app-launcher.ts**:
    - Fixed a missing return statement in error handling
5. **backend-ai-login.ts**:
    - Removed unnecessary parameter in _parseConfig call

![image.png](https://app.graphite.com/user-attachments/assets/a70b978e-8a8f-4dc8-9f5e-11caf7481abe.png)

How to test: [https://lablup.atlassian.net/browse/FR-2013?focusedCommentId=23622](https://lablup.atlassian.net/browse/FR-2013?focusedCommentId=23622)



**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after