### PR TITLE
feat(FR-92): add wsproxy api token setting UI

### DIFF
--- a/react/src/components/ResourceGroupSettingModal.tsx
+++ b/react/src/components/ResourceGroupSettingModal.tsx
@@ -39,6 +39,7 @@ type FormInputType = {
   description: string;
   allowedSessionTypes: string[];
   wsProxyAddress: string;
+  wsProxyAPIToken: string;
   active: boolean;
   public: boolean;
   scheduler: string;
@@ -70,6 +71,7 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
         is_active
         is_public
         wsproxy_addr
+        wsproxy_api_token
         scheduler
         scheduler_opts
       }
@@ -139,6 +141,7 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
       ? _.toNumber(schedulerOpts?.config?.num_retries_to_skip)
       : null,
     wsProxyAddress: resourceGroup?.wsproxy_addr,
+    wsProxyAPIToken: resourceGroup?.wsproxy_api_token,
   });
 
   return (
@@ -182,6 +185,7 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
               is_public: values.public,
               is_active: values.active,
               wsproxy_addr: values.wsProxyAddress,
+              wsproxy_api_token: values.wsProxyAPIToken,
             };
 
             if (resourceGroup) {
@@ -342,6 +346,12 @@ const ResourceGroupSettingModal: React.FC<ResourceGroupCreateModalProps> = ({
             rules={[{ type: 'url', message: t('error.InvalidUrl') }]}
           >
             <Input placeholder="http://localhost:10200" />
+          </Form.Item>
+          <Form.Item
+            label={t('resourceGroup.WsproxyAPIToken')}
+            name="wsProxyAPIToken"
+          >
+            <Input.Password placeholder={t('resourceGroup.EnterAPIToken')} />
           </Form.Item>
           <Row>
             <Col span={12}>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1286,6 +1286,7 @@
     "Domain": "Bereich",
     "Driver": "Treiber",
     "DriverOptions": "Treiberoptionen",
+    "EnterAPIToken": "API-Token eingeben",
     "EnterValidResourceGroupName": "Geben Sie einen gültigen Ressourcengruppennamen ein",
     "Information": "Information",
     "ModifyResourceGroup": "Ressourcengruppe ändern",
@@ -1314,6 +1315,7 @@
     "SelectScheduler": "Wählen Sie Planer",
     "TimeoutSeconds": "Sekunden",
     "TypeResourceGroupNameToDelete": "Geben Sie den Namen der zu löschenden Ressourcengruppe ein",
+    "WsproxyAPIToken": "WSProxy-API-Token",
     "WsproxyAddress": "WSProxy-Server-Adresse"
   },
   "resourcePolicy": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1283,6 +1283,7 @@
     "Domain": "Τομέας",
     "Driver": "Οδηγός",
     "DriverOptions": "Επιλογές προγράμματος οδήγησης",
+    "EnterAPIToken": "Εισάγετε το API token",
     "EnterValidResourceGroupName": "Εισαγάγετε έγκυρο όνομα ομάδας πόρων",
     "Information": "Πληροφορίες",
     "ModifyResourceGroup": "Τροποποίηση ομάδας πόρων",
@@ -1311,6 +1312,7 @@
     "SelectScheduler": "Επιλέξτε Προγραμματιστής",
     "TimeoutSeconds": "δευτερόλεπτα",
     "TypeResourceGroupNameToDelete": "Πληκτρολογήστε όνομα ομάδας πόρων για διαγραφή",
+    "WsproxyAPIToken": "Διακριτικό API WSProxy",
     "WsproxyAddress": "Διεύθυνση διακομιστή WSProxy"
   },
   "resourcePolicy": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1292,6 +1292,7 @@
     "Domain": "Domain",
     "Driver": "Driver",
     "DriverOptions": "Driver Options",
+    "EnterAPIToken": "Enter API Token",
     "EnterValidResourceGroupName": "Enter valid Resource group name",
     "Information": "Information",
     "ModifyResourceGroup": "Modify Resource Group",
@@ -1320,6 +1321,7 @@
     "SelectScheduler": "Select Scheduler",
     "TimeoutSeconds": "Seconds",
     "TypeResourceGroupNameToDelete": "Type resource group name to delete",
+    "WsproxyAPIToken": "WSProxy API Token",
     "WsproxyAddress": "WSProxy Server Address"
   },
   "resourcePolicy": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1286,6 +1286,7 @@
     "Domain": "Dominio",
     "Driver": "Conductor",
     "DriverOptions": "Opciones del conductor",
+    "EnterAPIToken": "Introduzca el token de la API",
     "EnterValidResourceGroupName": "Introduzca un nombre de grupo de recursos válido",
     "Information": "Información",
     "ModifyResourceGroup": "Modificar grupo de recursos",
@@ -1314,6 +1315,7 @@
     "SelectScheduler": "Seleccione Programador",
     "TimeoutSeconds": "Segundos",
     "TypeResourceGroupNameToDelete": "Escriba el nombre del grupo de recursos que desea eliminar",
+    "WsproxyAPIToken": "Token API de WSProxy",
     "WsproxyAddress": "Dirección del servidor WSProxy"
   },
   "resourcePolicy": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1285,6 +1285,7 @@
     "Domain": "Verkkotunnus",
     "Driver": "Kuljettaja",
     "DriverOptions": "Kuljettajan vaihtoehdot",
+    "EnterAPIToken": "Syötä API-avain",
     "EnterValidResourceGroupName": "Syötä kelvollinen resurssiryhmän nimi",
     "Information": "Tiedot",
     "ModifyResourceGroup": "Resurssiryhmän muokkaaminen",
@@ -1313,6 +1314,7 @@
     "SelectScheduler": "Valitse Ajastin",
     "TimeoutSeconds": "Sekuntia",
     "TypeResourceGroupNameToDelete": "Kirjoita poistettavan resurssiryhmän nimi",
+    "WsproxyAPIToken": "WSProxy API -avain",
     "WsproxyAddress": "WSProxy-palvelimen osoite"
   },
   "resourcePolicy": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1286,6 +1286,7 @@
     "Domain": "Domaine",
     "Driver": "Conducteur",
     "DriverOptions": "Options de pilote",
+    "EnterAPIToken": "Saisissez le jeton API",
     "EnterValidResourceGroupName": "Entrez un nom de groupe de ressources valide",
     "Information": "Information",
     "ModifyResourceGroup": "Modifier le groupe de ressources",
@@ -1314,6 +1315,7 @@
     "SelectScheduler": "Sélectionnez le planificateur",
     "TimeoutSeconds": "Seconds",
     "TypeResourceGroupNameToDelete": "Tapez le nom du groupe de ressources à supprimer",
+    "WsproxyAPIToken": "Jeton d'API WSProxy",
     "WsproxyAddress": "Adresse du serveur WSProxy"
   },
   "resourcePolicy": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1284,6 +1284,7 @@
     "Domain": "Domain",
     "Driver": "Driver",
     "DriverOptions": "Opsi Driver",
+    "EnterAPIToken": "Masukkan token API",
     "EnterValidResourceGroupName": "Masukkan nama grup Sumber Daya yang valid",
     "Information": "Informasi",
     "ModifyResourceGroup": "Ubah Grup Sumber Daya",
@@ -1312,6 +1313,7 @@
     "SelectScheduler": "Pilih Penjadwal",
     "TimeoutSeconds": "Detik",
     "TypeResourceGroupNameToDelete": "Ketik nama grup sumber daya yang akan dihapus",
+    "WsproxyAPIToken": "Token API WSProxy",
     "WsproxyAddress": "Alamat Server WSProxy"
   },
   "resourcePolicy": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1284,6 +1284,7 @@
     "Domain": "Dominio",
     "Driver": "autista",
     "DriverOptions": "Opzioni conducente Driver",
+    "EnterAPIToken": "Inserisci token API",
     "EnterValidResourceGroupName": "Inserisci un nome del gruppo di risorse valido",
     "Information": "Informazioni",
     "ModifyResourceGroup": "Modifica gruppo di risorse",
@@ -1312,6 +1313,7 @@
     "SelectScheduler": "Seleziona l'agenda",
     "TimeoutSeconds": "Secondi",
     "TypeResourceGroupNameToDelete": "Digita il nome del gruppo di risorse da eliminare",
+    "WsproxyAPIToken": "Token API di WSProxy",
     "WsproxyAddress": "Indirizzo del server WSProxy"
   },
   "resourcePolicy": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1285,6 +1285,7 @@
     "Domain": "ドメイン",
     "Driver": "運転者",
     "DriverOptions": "ドライバーオプション",
+    "EnterAPIToken": "APIトークンを入力",
     "EnterValidResourceGroupName": "有効なリソースグループ名を入力してください",
     "Information": "情報",
     "ModifyResourceGroup": "リソースグループの変更",
@@ -1313,6 +1314,7 @@
     "SelectScheduler": "スケジューラを選択",
     "TimeoutSeconds": "秒",
     "TypeResourceGroupNameToDelete": "削除するリソースグループ名を入力します",
+    "WsproxyAPIToken": "WSProxy APIトークン",
     "WsproxyAddress": "WSProxy サーバアドレス"
   },
   "resourcePolicy": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1288,6 +1288,7 @@
     "Domain": "도메인",
     "Driver": "드라이버",
     "DriverOptions": "드라이버 옵션",
+    "EnterAPIToken": "API 토큰 입력",
     "EnterValidResourceGroupName": "올바른 자원 그룹 이름을 입력해 주세요.",
     "Information": "정보",
     "ModifyResourceGroup": "자원 그룹 수정",
@@ -1316,6 +1317,7 @@
     "SelectScheduler": "스케줄러 선택",
     "TimeoutSeconds": "초",
     "TypeResourceGroupNameToDelete": "삭제하려는 자원 그룹 이름을 다시 한번 입력하세요.",
+    "WsproxyAPIToken": "WSProxy API 토큰",
     "WsproxyAddress": "WSProxy 서버 주소"
   },
   "resourcePolicy": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1284,6 +1284,7 @@
     "Domain": "Домэйн",
     "Driver": "Жолооч",
     "DriverOptions": "Жолоочийн сонголтууд",
+    "EnterAPIToken": "API токен оруулна уу",
     "EnterValidResourceGroupName": "Зөв нөөцийн бүлгийн нэрийг оруулна уу",
     "Information": "Мэдээлэл",
     "ModifyResourceGroup": "Нөөцийн бүлгийг өөрчлөх",
@@ -1312,6 +1313,7 @@
     "SelectScheduler": "Цагийн хуваарийг сонгоно уу",
     "TimeoutSeconds": "Секунд",
     "TypeResourceGroupNameToDelete": "Устгахын тулд нөөцийн бүлгийн нэрийг бичнэ үү",
+    "WsproxyAPIToken": "WSProxy API токен",
     "WsproxyAddress": "WSProxy серверийн хаяг"
   },
   "resourcePolicy": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1285,6 +1285,7 @@
     "Domain": "Domain",
     "Driver": "Pemandu",
     "DriverOptions": "Pilihan Pemandu",
+    "EnterAPIToken": "Masukkan token API",
     "EnterValidResourceGroupName": "Masukkan nama kumpulan Sumber yang sah",
     "Information": "Maklumat",
     "ModifyResourceGroup": "Ubahsuai Kumpulan Sumber",
@@ -1313,6 +1314,7 @@
     "SelectScheduler": "Pilih Penjadual",
     "TimeoutSeconds": "Detik",
     "TypeResourceGroupNameToDelete": "Taipkan nama kumpulan sumber untuk dipadamkan",
+    "WsproxyAPIToken": "Token API WSProxy",
     "WsproxyAddress": "Alamat Pelayan WSProxy"
   },
   "resourcePolicy": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1285,6 +1285,7 @@
     "Domain": "Domena",
     "Driver": "Kierowca",
     "DriverOptions": "Opcje sterownika",
+    "EnterAPIToken": "Wprowadź token API",
     "EnterValidResourceGroupName": "Wpisz poprawną nazwę grupy zasobów",
     "Information": "Informacja",
     "ModifyResourceGroup": "Modyfikuj grupę zasobów",
@@ -1313,6 +1314,7 @@
     "SelectScheduler": "Wybierz harmonogram",
     "TimeoutSeconds": "sekundy",
     "TypeResourceGroupNameToDelete": "Wpisz nazwę grupy zasobów do usunięcia",
+    "WsproxyAPIToken": "Token API WSProxy",
     "WsproxyAddress": "Adres serwera WSProxy"
   },
   "resourcePolicy": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1286,6 +1286,7 @@
     "Domain": "Domínio",
     "Driver": "Motorista",
     "DriverOptions": "Opções do driver",
+    "EnterAPIToken": "Insira o token da API",
     "EnterValidResourceGroupName": "Insira um nome de grupo de recursos válido",
     "Information": "Informação",
     "ModifyResourceGroup": "Modificar Grupo de Recursos",
@@ -1314,6 +1315,7 @@
     "SelectScheduler": "Selecione o Agendador",
     "TimeoutSeconds": "Segundos",
     "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir",
+    "WsproxyAPIToken": "Token da API do WSProxy",
     "WsproxyAddress": "Endereço do servidor WSProxy"
   },
   "resourcePolicy": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1285,6 +1285,7 @@
     "Domain": "Domínio",
     "Driver": "Motorista",
     "DriverOptions": "Opções do driver",
+    "EnterAPIToken": "Insira o token da API",
     "EnterValidResourceGroupName": "Insira um nome de grupo de recursos válido",
     "Information": "Informação",
     "ModifyResourceGroup": "Modificar Grupo de Recursos",
@@ -1313,6 +1314,7 @@
     "SelectScheduler": "Selecione o Agendador",
     "TimeoutSeconds": "Segundos",
     "TypeResourceGroupNameToDelete": "Digite o nome do grupo de recursos para excluir",
+    "WsproxyAPIToken": "Token de API do WSProxy",
     "WsproxyAddress": "Endereço do servidor WSProxy"
   },
   "resourcePolicy": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1285,6 +1285,7 @@
     "Domain": "Домен",
     "Driver": "Драйвер",
     "DriverOptions": "Параметры драйвера",
+    "EnterAPIToken": "Введите API‑токен",
     "EnterValidResourceGroupName": "Введите действительное имя группы ресурсов",
     "Information": "Информация",
     "ModifyResourceGroup": "Изменить группу ресурсов",
@@ -1313,6 +1314,7 @@
     "SelectScheduler": "Выберите планировщик",
     "TimeoutSeconds": "Секунды",
     "TypeResourceGroupNameToDelete": "Введите имя группы ресурсов для удаления",
+    "WsproxyAPIToken": "API-токен WSProxy",
     "WsproxyAddress": "Адрес WSProxy-сервера"
   },
   "resourcePolicy": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1275,6 +1275,7 @@
     "Domain": "โดเมน",
     "Driver": "ไดรเวอร์",
     "DriverOptions": "ตัวเลือกไดรเวอร์",
+    "EnterAPIToken": "กรอกโทเค็น API",
     "EnterValidResourceGroupName": "ป้อนชื่อกลุ่มทรัพยากรที่ถูกต้อง",
     "Information": "ข้อมูล",
     "ModifyResourceGroup": "แก้ไขกลุ่มทรัพยากร",
@@ -1303,6 +1304,7 @@
     "SelectScheduler": "เลือกตัวจัดกำหนดการ",
     "TimeoutSeconds": "วินาที",
     "TypeResourceGroupNameToDelete": "พิมพ์ชื่อกลุ่มทรัพยากรเพื่อลบ",
+    "WsproxyAPIToken": "โทเค็น API ของ WSProxy",
     "WsproxyAddress": "ที่อยู่เซิร์ฟเวอร์ WSProxy"
   },
   "resourcePolicy": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1286,6 +1286,7 @@
     "Domain": "Etki Alanı",
     "Driver": "sürücü",
     "DriverOptions": "Sürücü Seçenekleri",
+    "EnterAPIToken": "API jetonunu girin",
     "EnterValidResourceGroupName": "Geçerli Kaynak grubu adını girin",
     "Information": "Bilgi",
     "ModifyResourceGroup": "Kaynak Grubunu Değiştir",
@@ -1314,6 +1315,7 @@
     "SelectScheduler": "Zamanlayıcı Seç",
     "TimeoutSeconds": "saniye",
     "TypeResourceGroupNameToDelete": "Silmek için kaynak grubu adını yazın",
+    "WsproxyAPIToken": "WSProxy API Jetonu",
     "WsproxyAddress": "WSProxy Sunucu Adresi"
   },
   "resourcePolicy": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1286,6 +1286,7 @@
     "Domain": "Lãnh địa",
     "Driver": "Người lái xe",
     "DriverOptions": "Tùy chọn trình điều khiển",
+    "EnterAPIToken": "Nhập token API",
     "EnterValidResourceGroupName": "Nhập tên nhóm tài nguyên hợp lệ",
     "Information": "Thông tin",
     "ModifyResourceGroup": "Sửa đổi nhóm tài nguyên",
@@ -1314,6 +1315,7 @@
     "SelectScheduler": "Chọn bộ lập lịch",
     "TimeoutSeconds": "Giây",
     "TypeResourceGroupNameToDelete": "Nhập tên nhóm tài nguyên để xóa",
+    "WsproxyAPIToken": "Token API WSProxy",
     "WsproxyAddress": "Địa chỉ máy chủ WSProxy"
   },
   "resourcePolicy": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1286,6 +1286,7 @@
     "Domain": "域名",
     "Driver": "司机",
     "DriverOptions": "驱动程序选项",
+    "EnterAPIToken": "输入API令牌",
     "EnterValidResourceGroupName": "输入有效的资源组名称",
     "Information": "信息",
     "ModifyResourceGroup": "修改资源组",
@@ -1314,6 +1315,7 @@
     "SelectScheduler": "选择调度程序",
     "TimeoutSeconds": "秒",
     "TypeResourceGroupNameToDelete": "输入要删除的资源组名称",
+    "WsproxyAPIToken": "WSProxy API令牌",
     "WsproxyAddress": "WSProxy 服务器地址"
   },
   "resourcePolicy": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1285,6 +1285,7 @@
     "Domain": "域名",
     "Driver": "司機",
     "DriverOptions": "驅動程序選項",
+    "EnterAPIToken": "輸入 API 令牌",
     "EnterValidResourceGroupName": "輸入有效的資源組名稱",
     "Information": "資訊",
     "ModifyResourceGroup": "修改資源組",
@@ -1313,6 +1314,7 @@
     "SelectScheduler": "選擇調度程序",
     "TimeoutSeconds": "秒",
     "TypeResourceGroupNameToDelete": "輸入要刪除的資源組名稱",
+    "WsproxyAPIToken": "WSProxy API 令牌",
     "WsproxyAddress": "WSProxy 服务器地址"
   },
   "resourcePolicy": {


### PR DESCRIPTION
Resolves #1942 ([FR-92](https://lablup.atlassian.net/browse/FR-92))

# Add WSProxy API Token to Resource Group Settings

This PR adds a new field for WSProxy API Token in the Resource Group Settings modal. The token is stored securely using a password input field and is included in the form submission when creating or updating resource groups.

The changes include:

- Adding `wsProxyAPIToken` to the form input type
- Including `wsproxy_api_token` in the GraphQL query
- Adding a new password input field for the API token in the form
- Adding translations for the new field in all supported languages



![image.png](https://app.graphite.com/user-attachments/assets/c8c85604-b603-46ad-9a05-53baf9a906e3.png)

![image.png](https://app.graphite.com/user-attachments/assets/3e296032-aa62-42fa-9657-c9c1966631d6.png)



**Checklist:**

- [x] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-92]: https://lablup.atlassian.net/browse/FR-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ