### PR TITLE
style(FR-667): apply word-break keep-all for CJK languages

### DIFF
--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -174,6 +174,8 @@ export const useCurrentLanguage = () => {
     // For changing locale globally, use dayjs.locale instead of dayjs().locale
     dayjs.locale(lang);
     // eslint-disable-next-line react-hooks/exhaustive-deps
+    document.documentElement.lang = lang;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -185,6 +187,7 @@ export const useCurrentLanguage = () => {
       i18n?.changeLanguage(lang);
       // For changing locale globally, use dayjs.locale instead of dayjs().locale
       dayjs.locale(lang);
+      document.documentElement.lang = lang;
     };
     window.addEventListener('langChanged', handler);
     return () => window.removeEventListener('langChanged', handler);

--- a/react/src/index.css
+++ b/react/src/index.css
@@ -4,3 +4,9 @@
   height: 1em !important;
   vertical-align: -0.125em !important;
 }
+
+:lang(ko) *,
+:lang(ja) *,
+:lang(zh) * {
+  word-break: keep-all;
+}


### PR DESCRIPTION
Resolves [FR-667](https://lablup.atlassian.net/browse/FR-667)

## Changes
- Set `document.documentElement.lang` on language initialization and change events
- Add CSS rule `:lang(ko|ja|zh) * { word-break: keep-all; }` to apply proper word breaking for CJK languages

## Implementation
1. **DefaultProviders.tsx**: Set `lang` attribute on `<html>` element
   - On mount: Initialize with current language
   - On change: Update when 'langChanged' event fires
2. **index.css**: Apply `word-break: keep-all` using CSS `:lang()` selector
   - Targets Korean (ko), Japanese (ja), and Chinese (zh) languages
   - Prevents awkward mid-word line breaks in CJK text

## Testing
- [x] Verify `<html lang="ko">` is set when using Korean
- [x] Verify text breaks at word boundaries (spaces) in Korean
- [x] Verify same behavior for Japanese and Chinese
- [x] Verify English and other languages are not affected

[FR-667]: https://lablup.atlassian.net/browse/FR-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ