### PR TITLE
refactor(FR-2023): refactor BAIDomainSelect to use options prop pattern

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIDomainSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDomainSelect.tsx
@@ -37,16 +37,11 @@ const BAIDomainSelect: React.FC<Props> = ({
       onChange={(_value, option) => {
         setValue(_value, option);
       }}
-    >
-      {_.map(domains, (domain) => {
-        return (
-          <Select.Option key={domain?.name} domainName={domain?.name}>
-            {domain?.name}
-          </Select.Option>
-        );
-      })}
-      ;
-    </Select>
+      options={_.map(domains, (domain) => ({
+        label: domain?.name,
+        value: domain?.name,
+      }))}
+    />
   );
 };
 

--- a/react/src/components/StorageHostSettingsPanel.tsx
+++ b/react/src/components/StorageHostSettingsPanel.tsx
@@ -113,9 +113,9 @@ const StorageHostSettingsPanel: React.FC<StorageHostSettingsPanelProps> = ({
                   <BAIDomainSelect
                     style={{ width: '20vw', marginRight: 10 }}
                     value={selectedDomainName}
-                    onChange={(_value, domain: any) => {
+                    onChange={(selectedDomainName) => {
                       startTransition(() => {
-                        setSelectedDomainName(domain?.domainName);
+                        setSelectedDomainName(selectedDomainName);
                         setSelectedProjectId(undefined);
                       });
                     }}


### PR DESCRIPTION
Resolves [FR-2023](https://lablup.atlassian.net/browse/FR-2023)

## Summary
- Refactored BAIDomainSelect to use `options` array prop instead of `Select.Option` children
- Simplified `onChange` handler in StorageHostSettingsPanel to directly use the value

## Changes
- **BAIDomainSelect.tsx**: Replaced `Select.Option` children with `options` prop pattern
- **StorageHostSettingsPanel.tsx**: Updated `onChange` handler to receive domain name directly instead of extracting from option object

## Test plan
- [ ] Verify domain selection works correctly in StorageHostSettingsPanel
- [ ] Confirm the onChange callback receives the correct domain name value
- [ ] Test that the dropdown displays all domains properly

[FR-2023]: https://lablup.atlassian.net/browse/FR-2023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ