### PR TITLE
e2e(FR-2024): add tags to visual regression E2E tests

### DIFF
--- a/e2e/screenshot.test.ts
+++ b/e2e/screenshot.test.ts
@@ -27,80 +27,84 @@ const routes = [
 ];
 
 test.describe.configure({ mode: 'parallel' });
-test.describe.skip('Screenshot all routes', () => {
-  let screenshotPath: string;
-  test.beforeEach(async ({ page, request }) => {
-    await loginAsAdmin(page, request);
-    screenshotPath = process.env.SCREENSHOT_PATH
-      ? path.resolve(process.env.SCREENSHOT_PATH)
-      : path.resolve(__dirname + '/screenshots');
-  });
-
-  routes.forEach((route) => {
-    test(`screenshot ${route}`, async ({ page }) => {
-      await page.goto(`${webuiEndpoint}${route}`, {
-        waitUntil: 'networkidle',
-      });
-      await page.screenshot({
-        path: path.resolve(
-          `${screenshotPath}/${route.replace(/\//g, '_')}.png`,
-        ),
-        fullPage: true,
-      });
+test.describe.skip(
+  'Screenshot all routes',
+  { tag: ['@regression', '@visual'] },
+  () => {
+    let screenshotPath: string;
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+      screenshotPath = process.env.SCREENSHOT_PATH
+        ? path.resolve(process.env.SCREENSHOT_PATH)
+        : path.resolve(__dirname + '/screenshots');
     });
 
-    test(`screenshot ${route} (dark mode)`, async ({ page }) => {
-      await page.goto(`${webuiEndpoint}${route}`, {
-        waitUntil: 'networkidle',
+    routes.forEach((route) => {
+      test(`screenshot ${route}`, async ({ page }) => {
+        await page.goto(`${webuiEndpoint}${route}`, {
+          waitUntil: 'networkidle',
+        });
+        await page.screenshot({
+          path: path.resolve(
+            `${screenshotPath}/${route.replace(/\//g, '_')}.png`,
+          ),
+          fullPage: true,
+        });
       });
-      await page.getByRole('button', { name: 'moon' }).click();
-      // Wait for the dark mode to be applied
-      await page.waitForTimeout(500);
-      await page.screenshot({
-        path: path.resolve(
-          `${screenshotPath}/${route.replace(/\//g, '_')}_dark.png`,
-        ),
-        fullPage: true,
-      });
-    });
 
-    test(`screenshot ${route} without sidebar`, async ({ page }) => {
-      await page.goto(`${webuiEndpoint}${route}`, {
-        waitUntil: 'networkidle',
+      test(`screenshot ${route} (dark mode)`, async ({ page }) => {
+        await page.goto(`${webuiEndpoint}${route}`, {
+          waitUntil: 'networkidle',
+        });
+        await page.getByRole('button', { name: 'moon' }).click();
+        // Wait for the dark mode to be applied
+        await page.waitForTimeout(500);
+        await page.screenshot({
+          path: path.resolve(
+            `${screenshotPath}/${route.replace(/\//g, '_')}_dark.png`,
+          ),
+          fullPage: true,
+        });
       });
-      await page.screenshot({
-        path: path.resolve(
-          `${screenshotPath}/${route.replace(/\//g, '_')}_no_sidebar.png`,
-        ),
-        clip: {
-          x: 240,
-          y: 0,
-          width: (page.viewportSize()?.width || 0) - 240,
-          height: page.viewportSize()?.height || 0,
-        },
-      });
-    });
 
-    test(`screenshot ${route} without sidebar (dark mode)`, async ({
-      page,
-    }) => {
-      await page.goto(`${webuiEndpoint}${route}`, {
-        waitUntil: 'networkidle',
+      test(`screenshot ${route} without sidebar`, async ({ page }) => {
+        await page.goto(`${webuiEndpoint}${route}`, {
+          waitUntil: 'networkidle',
+        });
+        await page.screenshot({
+          path: path.resolve(
+            `${screenshotPath}/${route.replace(/\//g, '_')}_no_sidebar.png`,
+          ),
+          clip: {
+            x: 240,
+            y: 0,
+            width: (page.viewportSize()?.width || 0) - 240,
+            height: page.viewportSize()?.height || 0,
+          },
+        });
       });
-      await page.getByRole('button', { name: 'moon' }).click();
-      // Wait for the dark mode to be applied
-      await page.waitForTimeout(500);
-      await page.screenshot({
-        path: path.resolve(
-          `${screenshotPath}/${route.replace(/\//g, '_')}_no_sidebar_dark.png`,
-        ),
-        clip: {
-          x: 240,
-          y: 0,
-          width: (page.viewportSize()?.width || 0) - 240,
-          height: page.viewportSize()?.height || 0,
-        },
+
+      test(`screenshot ${route} without sidebar (dark mode)`, async ({
+        page,
+      }) => {
+        await page.goto(`${webuiEndpoint}${route}`, {
+          waitUntil: 'networkidle',
+        });
+        await page.getByRole('button', { name: 'moon' }).click();
+        // Wait for the dark mode to be applied
+        await page.waitForTimeout(500);
+        await page.screenshot({
+          path: path.resolve(
+            `${screenshotPath}/${route.replace(/\//g, '_')}_no_sidebar_dark.png`,
+          ),
+          clip: {
+            x: 240,
+            y: 0,
+            width: (page.viewportSize()?.width || 0) - 240,
+            height: page.viewportSize()?.height || 0,
+          },
+        });
       });
     });
-  });
-});
+  },
+);

--- a/e2e/seed.spec.ts
+++ b/e2e/seed.spec.ts
@@ -1,7 +1,9 @@
+// This is a seed file for Playwright MCP test generator.
+// It is not an actual E2E test and should be skipped in test runs.
 import { loginAsUser } from './utils/test-util';
 import { test } from '@playwright/test';
 
-test.describe('Test group', () => {
+test.describe.skip('Test group', () => {
   test.beforeEach(async ({ page, request }) => {
     await loginAsUser(page, request);
     // setup code here.

--- a/e2e/session/session-lifecycle.spec.ts
+++ b/e2e/session/session-lifecycle.spec.ts
@@ -25,7 +25,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe(
   'Session Lifecycle Management',
-  { tag: ['@critical', '@session'] },
+  { tag: ['@critical', '@session', '@functional'] },
   () => {
     // Run tests sequentially to avoid resource exhaustion
     test.describe.configure({ mode: 'serial' });

--- a/e2e/visual_regression/aiagents/aiagents_page.test.ts
+++ b/e2e/visual_regression/aiagents/aiagents_page.test.ts
@@ -20,8 +20,14 @@ test.beforeEach(async ({ page, request }) => {
   await page.getByRole('link', { name: 'AI Agents' }).click();
   await page.waitForLoadState('networkidle');
 });
-test(`ai agents full page`, async ({ page }) => {
-  await expect(page).toHaveScreenshot('ai_agents_page.png', {
-    fullPage: true,
-  });
-});
+test.describe(
+  'AI Agents page Visual Regression Test',
+  { tag: ['@regression', '@visual'] },
+  () => {
+    test('ai agents full page', async ({ page }) => {
+      await expect(page).toHaveScreenshot('ai_agents_page.png', {
+        fullPage: true,
+      });
+    });
+  },
+);

--- a/e2e/visual_regression/configurations/configurations_page.test.ts
+++ b/e2e/visual_regression/configurations/configurations_page.test.ts
@@ -11,41 +11,47 @@ test.beforeEach(async ({ page, request }) => {
   await page.waitForLoadState('networkidle');
 });
 
-test.describe('Configuration page Visual Regression Test', () => {
-  test('Configuration page', async ({ page }) => {
-    await expect(page).toHaveScreenshot('configurations_page.png', {
-      fullPage: true,
+test.describe(
+  'Configuration page Visual Regression Test',
+  { tag: ['@regression', '@config', '@visual'] },
+  () => {
+    test('Configuration page', async ({ page }) => {
+      await expect(page).toHaveScreenshot('configurations_page.png', {
+        fullPage: true,
+      });
     });
-  });
 
-  test('Overlay Network settings modal', async ({ page }) => {
-    await page
-      .locator('div')
-      .filter({
-        hasText:
-          /^Overlay NetworkConfiguration to use when creating overlay networks\.Config$/,
-      })
-      .getByRole('button')
-      .click();
-    await page.waitForLoadState('networkidle');
-    const overlayNetworkSettingsModal = page.locator('div.ant-modal').first();
-    await expect(overlayNetworkSettingsModal).toHaveScreenshot(
-      'overlay_network_settings_modal.png',
-    );
-    await page.getByRole('button', { name: 'Close' }).click();
-  });
+    test('Overlay Network settings modal', async ({ page }) => {
+      await page
+        .locator('div')
+        .filter({
+          hasText:
+            /^Overlay NetworkConfiguration to use when creating overlay networks\.Config$/,
+        })
+        .getByRole('button')
+        .click();
+      await page.waitForLoadState('networkidle');
+      const overlayNetworkSettingsModal = page.locator('div.ant-modal').first();
+      await expect(overlayNetworkSettingsModal).toHaveScreenshot(
+        'overlay_network_settings_modal.png',
+      );
+      await page.getByRole('button', { name: 'Close' }).click();
+    });
 
-  test('Scheduler settings modal', async ({ page }) => {
-    await page
-      .locator('div')
-      .filter({ hasText: /^SchedulerConfiguration per job scheduler\.Config$/ })
-      .getByRole('button')
-      .click();
-    await page.waitForLoadState('networkidle');
-    const SchedulerSettingModal = page.locator('div.ant-modal').first();
-    await expect(SchedulerSettingModal).toHaveScreenshot(
-      'scheduler_settings_modal.png',
-    );
-    await page.getByRole('button', { name: 'Close' }).click();
-  });
-});
+    test('Scheduler settings modal', async ({ page }) => {
+      await page
+        .locator('div')
+        .filter({
+          hasText: /^SchedulerConfiguration per job scheduler\.Config$/,
+        })
+        .getByRole('button')
+        .click();
+      await page.waitForLoadState('networkidle');
+      const SchedulerSettingModal = page.locator('div.ant-modal').first();
+      await expect(SchedulerSettingModal).toHaveScreenshot(
+        'scheduler_settings_modal.png',
+      );
+      await page.getByRole('button', { name: 'Close' }).click();
+    });
+  },
+);

--- a/e2e/visual_regression/dashboard/dashboard_page.test.ts
+++ b/e2e/visual_regression/dashboard/dashboard_page.test.ts
@@ -16,9 +16,15 @@ test.beforeEach(async ({ page, request }) => {
   await page.getByText('My Sessions').waitFor();
 });
 
-test(`dashboard full page`, async ({ page }) => {
-  await expect(page).toHaveScreenshot('dashboard_page.png', {
-    fullPage: true,
-    mask: [page.locator('td.ant-table-cell')],
-  });
-});
+test.describe(
+  'Dashboard page Visual Regression Test',
+  { tag: ['@regression', '@visual'] },
+  () => {
+    test('dashboard full page', async ({ page }) => {
+      await expect(page).toHaveScreenshot('dashboard_page.png', {
+        fullPage: true,
+        mask: [page.locator('td.ant-table-cell')],
+      });
+    });
+  },
+);

--- a/e2e/visual_regression/environments/environments_page.test.ts
+++ b/e2e/visual_regression/environments/environments_page.test.ts
@@ -11,74 +11,78 @@ test.beforeEach(async ({ page, request }) => {
   await page.locator('.ant-input-affix-wrapper').first().waitFor();
 });
 
-test.describe('Environments page Visual Regression Test', () => {
-  test(`images table`, async ({ page }) => {
-    // full page
-    await expect(page).toHaveScreenshot('images_table.png', {
-      fullPage: true,
+test.describe(
+  'Environments page Visual Regression Test',
+  { tag: ['@regression', '@environment', '@visual'] },
+  () => {
+    test(`images table`, async ({ page }) => {
+      // full page
+      await expect(page).toHaveScreenshot('images_table.png', {
+        fullPage: true,
+      });
+
+      // image resource limit modal
+      await page
+        .getByRole('row', { name: 'cr.backend' })
+        .getByRole('button')
+        .nth(1)
+        .click();
+      await page.getByText('Modify Minimum Image').waitFor();
+      const imageResourceLimitModal = page.locator(
+        'div.ant-modal.css-dev-only-do-not-override-1wkvdan.bai-modal',
+      );
+      await expect(imageResourceLimitModal).toHaveScreenshot(
+        'image_resource_limit_modal.png',
+      );
+      await page.getByRole('button', { name: 'Close' }).click();
     });
 
-    // image resource limit modal
-    await page
-      .getByRole('row', { name: 'cr.backend' })
-      .getByRole('button')
-      .nth(1)
-      .click();
-    await page.getByText('Modify Minimum Image').waitFor();
-    const imageResourceLimitModal = page.locator(
-      'div.ant-modal.css-dev-only-do-not-override-1wkvdan.bai-modal',
-    );
-    await expect(imageResourceLimitModal).toHaveScreenshot(
-      'image_resource_limit_modal.png',
-    );
-    await page.getByRole('button', { name: 'Close' }).click();
-  });
+    // resource presets table
+    test(`resource presets table`, async ({ page }) => {
+      await page.getByRole('tab', { name: 'Resource Presets' }).click();
+      await page.getByText('Name', { exact: true }).waitFor();
+      // full page
+      await expect(page).toHaveScreenshot('resource_presets_table.png', {
+        fullPage: true,
+      });
 
-  // resource presets table
-  test(`resource presets table`, async ({ page }) => {
-    await page.getByRole('tab', { name: 'Resource Presets' }).click();
-    await page.getByText('Name', { exact: true }).waitFor();
-    // full page
-    await expect(page).toHaveScreenshot('resource_presets_table.png', {
-      fullPage: true,
+      // modify resource preset
+      await page
+        .getByRole('row', { name: 'cpu01' })
+        .getByRole('button')
+        .first()
+        .click();
+      await page.getByText('Modify Resource Preset').waitFor();
+      const modifyResourcePresetMdoal = page.locator(
+        'div.ant-modal.css-dev-only-do-not-override-1wkvdan.bai-modal',
+      );
+      await expect(modifyResourcePresetMdoal).toHaveScreenshot(
+        'modify_resource_preset_modal.png',
+      );
+      await page.getByRole('button', { name: 'Close' }).click();
     });
 
-    // modify resource preset
-    await page
-      .getByRole('row', { name: 'cpu01' })
-      .getByRole('button')
-      .first()
-      .click();
-    await page.getByText('Modify Resource Preset').waitFor();
-    const modifyResourcePresetMdoal = page.locator(
-      'div.ant-modal.css-dev-only-do-not-override-1wkvdan.bai-modal',
-    );
-    await expect(modifyResourcePresetMdoal).toHaveScreenshot(
-      'modify_resource_preset_modal.png',
-    );
-    await page.getByRole('button', { name: 'Close' }).click();
-  });
+    // Registries table
+    test('registries table', async ({ page }) => {
+      await page.getByRole('tab', { name: 'Registries' }).click();
+      await page.getByTitle('Registry Name').waitFor();
+      await expect(page).toHaveScreenshot('registries_table.png', {
+        fullPage: true,
+      });
 
-  // Registries table
-  test('registries table', async ({ page }) => {
-    await page.getByRole('tab', { name: 'Registries' }).click();
-    await page.getByTitle('Registry Name').waitFor();
-    await expect(page).toHaveScreenshot('registries_table.png', {
-      fullPage: true,
+      // modify registry
+      await page.getByRole('button', { name: 'setting' }).nth(1).click();
+      const modifyRegistryModal = page.locator('div.ant-modal').first();
+      await expect(modifyRegistryModal).toHaveScreenshot(
+        'modify_registry_modal.png',
+      );
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      // add registry modal
+      await page.getByRole('button', { name: 'plus Add Registry' }).click();
+      await page.getByLabel('Add Registry').getByText('Add Registry').waitFor();
+      const addRegistryModal = page.locator('div.ant-modal-content').first();
+      await expect(addRegistryModal).toHaveScreenshot('add_registry_modal.png');
     });
-
-    // modify registry
-    await page.getByRole('button', { name: 'setting' }).nth(1).click();
-    const modifyRegistryModal = page.locator('div.ant-modal').first();
-    await expect(modifyRegistryModal).toHaveScreenshot(
-      'modify_registry_modal.png',
-    );
-    await page.getByRole('button', { name: 'Cancel' }).click();
-
-    // add registry modal
-    await page.getByRole('button', { name: 'plus Add Registry' }).click();
-    await page.getByLabel('Add Registry').getByText('Add Registry').waitFor();
-    const addRegistryModal = page.locator('div.ant-modal-content').first();
-    await expect(addRegistryModal).toHaveScreenshot('add_registry_modal.png');
-  });
-});
+  },
+);

--- a/e2e/visual_regression/import/import_page.test.ts
+++ b/e2e/visual_regression/import/import_page.test.ts
@@ -11,15 +11,21 @@ test.beforeEach(async ({ page, request }) => {
   await page.waitForLoadState('networkidle');
 });
 
-test('Import & Run page Visual Regression Test', async ({ page }) => {
-  await expect(page).toHaveScreenshot('import_page.png', {
-    mask: [
-      page.locator('#cpu-usage-bar #front'),
-      page.locator('#cpu-usage-bar-2 #front'),
-      page.locator('#mem-usage-bar'),
-      page.locator('#mem-usage-bar-2'),
-      page.locator('#concurrency-usage-bar'),
-    ],
-    fullPage: true,
-  });
-});
+test.describe(
+  'Import & Run page Visual Regression Test',
+  { tag: ['@regression', '@visual'] },
+  () => {
+    test('Import & Run page screenshot', async ({ page }) => {
+      await expect(page).toHaveScreenshot('import_page.png', {
+        mask: [
+          page.locator('#cpu-usage-bar #front'),
+          page.locator('#cpu-usage-bar-2 #front'),
+          page.locator('#mem-usage-bar'),
+          page.locator('#mem-usage-bar-2'),
+          page.locator('#concurrency-usage-bar'),
+        ],
+        fullPage: true,
+      });
+    });
+  },
+);

--- a/e2e/visual_regression/information/information_page.test.ts
+++ b/e2e/visual_regression/information/information_page.test.ts
@@ -11,8 +11,14 @@ test.beforeEach(async ({ page, request }) => {
   await page.waitForLoadState('networkidle');
 });
 
-test('Information page Visual Regression Test', async ({ page }) => {
-  await expect(page).toHaveScreenshot('information_page.png', {
-    fullPage: true,
-  });
-});
+test.describe(
+  'Information page Visual Regression Test',
+  { tag: ['@regression', '@visual'] },
+  () => {
+    test('Information page screenshot', async ({ page }) => {
+      await expect(page).toHaveScreenshot('information_page.png', {
+        fullPage: true,
+      });
+    });
+  },
+);

--- a/e2e/visual_regression/login/login_page.test.ts
+++ b/e2e/visual_regression/login/login_page.test.ts
@@ -7,32 +7,36 @@ test.beforeEach(async ({ page }) => {
   await page.getByRole('textbox', { name: 'Endpoint' }).fill(webServerEndpoint);
 });
 
-test.describe('Login page Visual Regression Test', () => {
-  test(`Login With email or Username modal`, async ({ page }) => {
-    const loginEmailModal = page.locator('div.card').first();
-    await expect(loginEmailModal).toHaveScreenshot('basic_login_modal.png');
-  });
-
-  test('Login With IAM modal', async ({ page }) => {
-    await page.getByLabel('Click To Use IAM').click();
-    await page.waitForLoadState('networkidle');
-    const loginIAMModal = page.locator('div.card').first();
-    await expect(loginIAMModal).toHaveScreenshot('iam_login_modal.png');
-  });
-
-  test('Sign up modal', async ({ page }) => {
-    await page.getByLabel('Sign up').click();
-    await page.waitForLoadState('networkidle');
-    const signupModal = page.locator('div.card').nth(4);
-    await expect(signupModal).toHaveScreenshot('signup_modal.png', {
-      maxDiffPixelRatio: 0.001,
+test.describe(
+  'Login page Visual Regression Test',
+  { tag: ['@regression', '@auth', '@visual'] },
+  () => {
+    test(`Login With email or Username modal`, async ({ page }) => {
+      const loginEmailModal = page.locator('div.card').first();
+      await expect(loginEmailModal).toHaveScreenshot('basic_login_modal.png');
     });
-  });
 
-  test('Change password modal', async ({ page }) => {
-    await page.getByLabel('Change').click();
-    await page.waitForLoadState('networkidle');
-    const changeModal = page.locator('div.card').nth(1);
-    await expect(changeModal).toHaveScreenshot('change_password_modal.png');
-  });
-});
+    test('Login With IAM modal', async ({ page }) => {
+      await page.getByLabel('Click To Use IAM').click();
+      await page.waitForLoadState('networkidle');
+      const loginIAMModal = page.locator('div.card').first();
+      await expect(loginIAMModal).toHaveScreenshot('iam_login_modal.png');
+    });
+
+    test('Sign up modal', async ({ page }) => {
+      await page.getByLabel('Sign up').click();
+      await page.waitForLoadState('networkidle');
+      const signupModal = page.locator('div.card').nth(4);
+      await expect(signupModal).toHaveScreenshot('signup_modal.png', {
+        maxDiffPixelRatio: 0.001,
+      });
+    });
+
+    test('Change password modal', async ({ page }) => {
+      await page.getByLabel('Change').click();
+      await page.waitForLoadState('networkidle');
+      const changeModal = page.locator('div.card').nth(1);
+      await expect(changeModal).toHaveScreenshot('change_password_modal.png');
+    });
+  },
+);

--- a/e2e/visual_regression/maintenance/maintenance_page.test.ts
+++ b/e2e/visual_regression/maintenance/maintenance_page.test.ts
@@ -7,6 +7,12 @@ test.beforeEach(async ({ page, request }) => {
   await page.waitForLoadState('networkidle');
 });
 
-test('Maintenance page Visual Regression Test', async ({ page }) => {
-  await expect(page).toHaveScreenshot('maintenance_page.png');
-});
+test.describe(
+  'Maintenance page Visual Regression Test',
+  { tag: ['@regression', '@maintenance', '@visual'] },
+  () => {
+    test('Maintenance page screenshot', async ({ page }) => {
+      await expect(page).toHaveScreenshot('maintenance_page.png');
+    });
+  },
+);

--- a/e2e/visual_regression/myenvironments/myenvironments_page.test.ts
+++ b/e2e/visual_regression/myenvironments/myenvironments_page.test.ts
@@ -1,28 +1,32 @@
 import { loginAsVisualRegressionUser2 } from '../../utils/test-util';
 import { expect, test } from '@playwright/test';
 
-test.describe('Summary page Visual Regression Test', () => {
-  test.beforeEach(async ({ page, request }) => {
-    await page.setViewportSize({
-      width: 2000,
-      height: 1200,
+test.describe(
+  'My Environments page Visual Regression Test',
+  { tag: ['@regression', '@environment', '@visual'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await page.setViewportSize({
+        width: 2000,
+        height: 1200,
+      });
+      await loginAsVisualRegressionUser2(page, request);
+      await page.getByRole('link', { name: 'My Environments' }).click();
+      await page.waitForLoadState('networkidle');
     });
-    await loginAsVisualRegressionUser2(page, request);
-    await page.getByRole('link', { name: 'My Environments' }).click();
-    await page.waitForLoadState('networkidle');
-  });
 
-  test(`my environments full page`, async ({ page }) => {
-    await expect(page).toHaveScreenshot('myenvironments_page.png', {
-      fullPage: true,
+    test(`my environments full page`, async ({ page }) => {
+      await expect(page).toHaveScreenshot('myenvironments_page.png', {
+        fullPage: true,
+      });
     });
-  });
 
-  test('column setting modal', async ({ page }) => {
-    await page.getByRole('button', { name: 'setting' }).click();
-    const columnSettingModal = page.locator('div.ant-modal').first();
-    await expect(columnSettingModal).toHaveScreenshot(
-      'column_setting_modal.png',
-    );
-  });
-});
+    test('column setting modal', async ({ page }) => {
+      await page.getByRole('button', { name: 'setting' }).click();
+      const columnSettingModal = page.locator('div.ant-modal').first();
+      await expect(columnSettingModal).toHaveScreenshot(
+        'column_setting_modal.png',
+      );
+    });
+  },
+);

--- a/e2e/visual_regression/resourcepolicy/resourcepolicy_page.test.ts
+++ b/e2e/visual_regression/resourcepolicy/resourcepolicy_page.test.ts
@@ -13,67 +13,73 @@ test.beforeEach(async ({ page, request }) => {
   await page.getByText('Name', { exact: true }).waitFor();
 });
 
-test.describe('Resource Policy page Visual Regression Test', () => {
-  // Keypair table
-  test(`keypair table`, async ({ page }) => {
-    await page.getByRole('tab', { name: 'Keypair' }).click();
-    await expect(page).toHaveScreenshot('keypair_table.png', {
-      fullPage: true,
+test.describe(
+  'Resource Policy page Visual Regression Test',
+  { tag: ['@regression', '@config', '@visual'] },
+  () => {
+    // Keypair table
+    test(`keypair table`, async ({ page }) => {
+      await page.getByRole('tab', { name: 'Keypair' }).click();
+      await expect(page).toHaveScreenshot('keypair_table.png', {
+        fullPage: true,
+      });
+
+      // info modal
+      await page.getByRole('button', { name: 'info-circle' }).click();
+      const resourceInfoModal = page.locator(
+        'div.ant-modal.css-dev-only-do-not-override-1wkvdan.bai-modal',
+      );
+      await expect(resourceInfoModal).toHaveScreenshot(
+        'keypair_info_modal.png',
+      );
+      await page.getByRole('button', { name: 'Close' }).click();
+
+      // create modal
+      await page.getByRole('button', { name: 'plus Create' }).click();
+      await page.getByText('Create Resource Policy').waitFor();
+      const createKeypairModal = page.locator('div.ant-modal-content').nth(1);
+      await expect(createKeypairModal).toHaveScreenshot(
+        'create_resource_policy_modal.png',
+      );
+      await page.getByRole('button', { name: 'Cancel' }).click();
     });
 
-    // info modal
-    await page.getByRole('button', { name: 'info-circle' }).click();
-    const resourceInfoModal = page.locator(
-      'div.ant-modal.css-dev-only-do-not-override-1wkvdan.bai-modal',
-    );
-    await expect(resourceInfoModal).toHaveScreenshot('keypair_info_modal.png');
-    await page.getByRole('button', { name: 'Close' }).click();
+    // User table
+    test('user table', async ({ page }) => {
+      await page.getByRole('tab', { name: 'User' }).click();
+      await page.getByText('Max Session Count Per Model').waitFor();
+      await expect(page).toHaveScreenshot('user_table.png', {
+        fullPage: true,
+      });
 
-    // create modal
-    await page.getByRole('button', { name: 'plus Create' }).click();
-    await page.getByText('Create Resource Policy').waitFor();
-    const createKeypairModal = page.locator('div.ant-modal-content').nth(1);
-    await expect(createKeypairModal).toHaveScreenshot(
-      'create_resource_policy_modal.png',
-    );
-    await page.getByRole('button', { name: 'Cancel' }).click();
-  });
-
-  // User table
-  test('user table', async ({ page }) => {
-    await page.getByRole('tab', { name: 'User' }).click();
-    await page.getByText('Max Session Count Per Model').waitFor();
-    await expect(page).toHaveScreenshot('user_table.png', {
-      fullPage: true,
+      // create modal
+      await page.getByRole('button', { name: 'plus Create' }).click();
+      await page.getByText('Create Resource Policy').waitFor();
+      const createUserModal = page.locator(
+        'div.ant-modal.css-dev-only-do-not-override-1wkvdan.bai-modal',
+      );
+      await expect(createUserModal).toHaveScreenshot('user_create_modal.png');
+      await page.getByRole('button', { name: 'Cancel' }).click();
     });
 
-    // create modal
-    await page.getByRole('button', { name: 'plus Create' }).click();
-    await page.getByText('Create Resource Policy').waitFor();
-    const createUserModal = page.locator(
-      'div.ant-modal.css-dev-only-do-not-override-1wkvdan.bai-modal',
-    );
-    await expect(createUserModal).toHaveScreenshot('user_create_modal.png');
-    await page.getByRole('button', { name: 'Cancel' }).click();
-  });
+    // Project table
+    test('project table', async ({ page }) => {
+      await page.getByRole('tab', { name: 'Project' }).click();
+      await page.getByText('Max Quota Scope Size (GB)').waitFor();
+      await expect(page).toHaveScreenshot('project_table.png', {
+        fullPage: true,
+      });
 
-  // Project table
-  test('project table', async ({ page }) => {
-    await page.getByRole('tab', { name: 'Project' }).click();
-    await page.getByText('Max Quota Scope Size (GB)').waitFor();
-    await expect(page).toHaveScreenshot('project_table.png', {
-      fullPage: true,
+      // create modal
+      await page.getByRole('button', { name: 'plus Create' }).click();
+      await page.getByText('Create Resource Policy').waitFor();
+      const createProjectModal = page.locator(
+        'div.ant-modal.css-dev-only-do-not-override-1wkvdan.bai-modal',
+      );
+      await expect(createProjectModal).toHaveScreenshot(
+        'project_create_modal.png',
+      );
+      await page.getByRole('button', { name: 'Cancel' }).click();
     });
-
-    // create modal
-    await page.getByRole('button', { name: 'plus Create' }).click();
-    await page.getByText('Create Resource Policy').waitFor();
-    const createProjectModal = page.locator(
-      'div.ant-modal.css-dev-only-do-not-override-1wkvdan.bai-modal',
-    );
-    await expect(createProjectModal).toHaveScreenshot(
-      'project_create_modal.png',
-    );
-    await page.getByRole('button', { name: 'Cancel' }).click();
-  });
-});
+  },
+);

--- a/e2e/visual_regression/resources/resources_page.test.ts
+++ b/e2e/visual_regression/resources/resources_page.test.ts
@@ -11,58 +11,64 @@ test.beforeEach(async ({ page, request }) => {
   await page.waitForLoadState('networkidle');
 });
 
-test.describe('Resources page Visual Regression Test', () => {
-  // Agent table
-  test(`Agent table`, async ({ page }) => {
-    await page.getByRole('tab', { name: 'Agent' }).click();
-    await page.waitForLoadState('networkidle');
+test.describe(
+  'Resources page Visual Regression Test',
+  { tag: ['@regression', '@agent', '@visual'] },
+  () => {
+    // Agent table
+    test(`Agent table`, async ({ page }) => {
+      await page.getByRole('tab', { name: 'Agent' }).click();
+      await page.waitForLoadState('networkidle');
 
-    await page.getByRole('button', { name: 'setting' }).nth(1).click();
+      await page.getByRole('button', { name: 'setting' }).nth(1).click();
 
-    const checkboxes = page.locator('input.ant-checkbox-input');
-    const count = await checkboxes.count();
-    for (let i = 0; i < count; i++) {
-      await checkboxes.nth(i).check();
-    }
-    await page.getByRole('button', { name: 'OK' }).click();
+      const checkboxes = page.locator('input.ant-checkbox-input');
+      const count = await checkboxes.count();
+      for (let i = 0; i < count; i++) {
+        await checkboxes.nth(i).check();
+      }
+      await page.getByRole('button', { name: 'OK' }).click();
 
-    await expect(page).toHaveScreenshot('agent_table.png', {
-      fullPage: true,
-      mask: [
-        page.locator('span.ant-tag').nth(3),
-        page.locator('td.ant-table-cell').nth(2),
-        page.locator('td.ant-table-cell').nth(4),
-        page.locator('td.ant-table-cell').nth(5),
-        page.locator('td.ant-table-cell').nth(6),
-      ],
+      await expect(page).toHaveScreenshot('agent_table.png', {
+        fullPage: true,
+        mask: [
+          page.locator('span.ant-tag').nth(3),
+          page.locator('td.ant-table-cell').nth(2),
+          page.locator('td.ant-table-cell').nth(4),
+          page.locator('td.ant-table-cell').nth(5),
+          page.locator('td.ant-table-cell').nth(6),
+        ],
+      });
+
+      // setting modal
+      await page
+        .getByRole('table')
+        .getByRole('button', { name: 'setting' })
+        .click();
+      await page.waitForLoadState('networkidle');
+      const agentSettingModal = page.locator('div.ant-modal-content').first();
+      await expect(agentSettingModal).toHaveScreenshot(
+        'agent_setting_modal.png',
+      );
+      await page.getByRole('button', { name: 'Cancel' }).click();
     });
 
-    // setting modal
-    await page
-      .getByRole('table')
-      .getByRole('button', { name: 'setting' })
-      .click();
-    await page.waitForLoadState('networkidle');
-    const agentSettingModal = page.locator('div.ant-modal-content').first();
-    await expect(agentSettingModal).toHaveScreenshot('agent_setting_modal.png');
-    await page.getByRole('button', { name: 'Cancel' }).click();
-  });
+    // Storages table
+    test('Storages table', async ({ page }) => {
+      await page.getByRole('tab', { name: 'Storages' }).click();
+      await page.getByText('local:volume1').waitFor();
+      await expect(page).toHaveScreenshot('user_table.png', {
+        fullPage: true,
+        mask: [page.locator('td.ant-table-cell').nth(2)],
+      });
 
-  // Storages table
-  test('Storages table', async ({ page }) => {
-    await page.getByRole('tab', { name: 'Storages' }).click();
-    await page.getByText('local:volume1').waitFor();
-    await expect(page).toHaveScreenshot('user_table.png', {
-      fullPage: true,
-      mask: [page.locator('td.ant-table-cell').nth(2)],
+      // storage setting page
+      await page.getByRole('button', { name: 'setting' }).click();
+      await page.getByText('Quota Settings').waitFor();
+      await expect(page).toHaveScreenshot('storage_setting_page.png', {
+        fullPage: true,
+        mask: [page.locator('td.ant-descriptions-item-content').first()],
+      });
     });
-
-    // storage setting page
-    await page.getByRole('button', { name: 'setting' }).click();
-    await page.getByText('Quota Settings').waitFor();
-    await expect(page).toHaveScreenshot('storage_setting_page.png', {
-      fullPage: true,
-      mask: [page.locator('td.ant-descriptions-item-content').first()],
-    });
-  });
-});
+  },
+);

--- a/e2e/visual_regression/serving/serving_page.test.ts
+++ b/e2e/visual_regression/serving/serving_page.test.ts
@@ -1,109 +1,113 @@
 import { loginAsVisualRegressionUser2 } from '../../utils/test-util';
 import { expect, test } from '@playwright/test';
 
-test.describe('Serving page Visual Regression Test', () => {
-  test.describe('Serving page', () => {
-    test.beforeEach(async ({ page, request }) => {
-      await loginAsVisualRegressionUser2(page, request);
-      await page.getByRole('link', { name: 'Serving' }).click();
-      await page.getByText('Active', { exact: true }).waitFor();
-    });
+test.describe(
+  'Serving page Visual Regression Test',
+  { tag: ['@regression', '@serving', '@visual'] },
+  () => {
+    test.describe('Serving page', () => {
+      test.beforeEach(async ({ page, request }) => {
+        await loginAsVisualRegressionUser2(page, request);
+        await page.getByRole('link', { name: 'Serving' }).click();
+        await page.getByText('Active', { exact: true }).waitFor();
+      });
 
-    test('serving full page', async ({ page }) => {
-      await page.setViewportSize({
-        width: 1920,
-        height: 1200,
+      test('serving full page', async ({ page }) => {
+        await page.setViewportSize({
+          width: 1920,
+          height: 1200,
+        });
+        await expect(page).toHaveScreenshot('serving_page.png', {
+          fullPage: true,
+        });
       });
-      await expect(page).toHaveScreenshot('serving_page.png', {
-        fullPage: true,
-      });
-    });
 
-    test('Create a new service page', async ({ page }) => {
-      await page.setViewportSize({
-        width: 1300,
-        height: 2300,
+      test('Create a new service page', async ({ page }) => {
+        await page.setViewportSize({
+          width: 1300,
+          height: 2300,
+        });
+        await page.getByRole('button', { name: 'Start Service' }).click();
+        await page.waitForLoadState('networkidle');
+        await expect(page).toHaveScreenshot('create_service_page.png', {
+          fullPage: true,
+          mask: [
+            page.locator(
+              'div:nth-child(3) > .ant-row > div:nth-child(2) > .ant-form-item-control-input > .ant-form-item-control-input-content > .ant-select > .ant-select-selector',
+            ),
+            page.locator(
+              'div:nth-child(2) > div > div:nth-child(4) > .ant-row > .ant-col > .ant-form-item-control-input > .ant-form-item-control-input-content > .ant-select > .ant-select-selector',
+            ),
+          ],
+        });
       });
-      await page.getByRole('button', { name: 'Start Service' }).click();
-      await page.waitForLoadState('networkidle');
-      await expect(page).toHaveScreenshot('create_service_page.png', {
-        fullPage: true,
-        mask: [
-          page.locator(
-            'div:nth-child(3) > .ant-row > div:nth-child(2) > .ant-form-item-control-input > .ant-form-item-control-input-content > .ant-select > .ant-select-selector',
-          ),
-          page.locator(
-            'div:nth-child(2) > div > div:nth-child(4) > .ant-row > .ant-col > .ant-form-item-control-input > .ant-form-item-control-input-content > .ant-select > .ant-select-selector',
-          ),
-        ],
-      });
-    });
 
-    test('Update Service', async ({ page }) => {
-      await page.setViewportSize({
-        width: 1100,
-        height: 2300,
+      test('Update Service', async ({ page }) => {
+        await page.setViewportSize({
+          width: 1100,
+          height: 2300,
+        });
+        await page.getByRole('button', { name: 'setting' }).click();
+        await page.getByText('Service Name(optional)').waitFor();
+        await expect(page).toHaveScreenshot('update_service_page.png', {
+          fullPage: true,
+          mask: [
+            page.locator(
+              'div:nth-child(3) > .ant-row > div:nth-child(2) > .ant-form-item-control-input > .ant-form-item-control-input-content > .ant-select > .ant-select-selector',
+            ),
+            page.locator(
+              'div:nth-child(2) > div > div:nth-child(4) > .ant-row > .ant-col > .ant-form-item-control-input > .ant-form-item-control-input-content > .ant-select > .ant-select-selector',
+            ),
+          ],
+        });
       });
-      await page.getByRole('button', { name: 'setting' }).click();
-      await page.getByText('Service Name(optional)').waitFor();
-      await expect(page).toHaveScreenshot('update_service_page.png', {
-        fullPage: true,
-        mask: [
-          page.locator(
-            'div:nth-child(3) > .ant-row > div:nth-child(2) > .ant-form-item-control-input > .ant-form-item-control-input-content > .ant-select > .ant-select-selector',
-          ),
-          page.locator(
-            'div:nth-child(2) > div > div:nth-child(4) > .ant-row > .ant-col > .ant-form-item-control-input > .ant-form-item-control-input-content > .ant-select > .ant-select-selector',
-          ),
-        ],
-      });
-    });
 
-    test('Delete modal', async ({ page }) => {
-      await page.getByRole('button', { name: 'delete' }).click();
-      const deleteModal = page.locator('div.ant-modal-content').first();
-      await expect(deleteModal).toHaveScreenshot('delete_modal.png');
-    });
-  });
-
-  test.describe('Routing Info page', () => {
-    test.beforeEach(async ({ page, request }) => {
-      await loginAsVisualRegressionUser2(page, request);
-      await page.getByRole('link', { name: 'Serving' }).click();
-      await page.getByText('Active', { exact: true }).waitFor();
-      await page.getByRole('link', { name: 'service_test2' }).click();
-      await page.waitForLoadState('networkidle');
-    });
-
-    test('Routing Info page', async ({ page }) => {
-      await page.setViewportSize({
-        width: 1100,
-        height: 1800,
-      });
-      await expect(page).toHaveScreenshot('routing_info_page.png', {
-        fullPage: true,
-        mask: [
-          page.locator('td.ant-descriptions-item-content:has-text("ubuntu")'),
-        ],
+      test('Delete modal', async ({ page }) => {
+        await page.getByRole('button', { name: 'delete' }).click();
+        const deleteModal = page.locator('div.ant-modal-content').first();
+        await expect(deleteModal).toHaveScreenshot('delete_modal.png');
       });
     });
 
-    test('Add Auto Scaling Rule modal', async ({ page }) => {
-      await page.getByRole('button', { name: 'plus Add Rules' }).click();
-      await page.getByText('Add Auto Scaling Rule').waitFor();
-      const addRuleModal = page.locator('div.ant-modal-content').first();
-      await expect(addRuleModal).toHaveScreenshot(
-        'add_auto_scaling_rule_modal.png',
-      );
-    });
+    test.describe('Routing Info page', () => {
+      test.beforeEach(async ({ page, request }) => {
+        await loginAsVisualRegressionUser2(page, request);
+        await page.getByRole('link', { name: 'Serving' }).click();
+        await page.getByText('Active', { exact: true }).waitFor();
+        await page.getByRole('link', { name: 'service_test2' }).click();
+        await page.waitForLoadState('networkidle');
+      });
 
-    test('generate token modal', async ({ page }) => {
-      await page.getByRole('button', { name: 'plus Generate Token' }).click();
-      await page.getByText('Generate new Token').waitFor();
-      const tokenModal = page.locator('div.ant-modal').first();
-      await expect(tokenModal).toHaveScreenshot('generate_token_modal.png', {
-        mask: [page.locator('div.ant-picker')],
+      test('Routing Info page', async ({ page }) => {
+        await page.setViewportSize({
+          width: 1100,
+          height: 1800,
+        });
+        await expect(page).toHaveScreenshot('routing_info_page.png', {
+          fullPage: true,
+          mask: [
+            page.locator('td.ant-descriptions-item-content:has-text("ubuntu")'),
+          ],
+        });
+      });
+
+      test('Add Auto Scaling Rule modal', async ({ page }) => {
+        await page.getByRole('button', { name: 'plus Add Rules' }).click();
+        await page.getByText('Add Auto Scaling Rule').waitFor();
+        const addRuleModal = page.locator('div.ant-modal-content').first();
+        await expect(addRuleModal).toHaveScreenshot(
+          'add_auto_scaling_rule_modal.png',
+        );
+      });
+
+      test('generate token modal', async ({ page }) => {
+        await page.getByRole('button', { name: 'plus Generate Token' }).click();
+        await page.getByText('Generate new Token').waitFor();
+        const tokenModal = page.locator('div.ant-modal').first();
+        await expect(tokenModal).toHaveScreenshot('generate_token_modal.png', {
+          mask: [page.locator('div.ant-picker')],
+        });
       });
     });
-  });
-});
+  },
+);

--- a/e2e/visual_regression/session/session_page.test.ts
+++ b/e2e/visual_regression/session/session_page.test.ts
@@ -32,67 +32,71 @@ test.afterEach(async ({ page }) => {
     .uncheck();
 });
 
-test.describe('Visual Regression Test for NEO Session Page', () => {
-  test('Create a new session step by step', async ({ page }) => {
-    // step1.png
-    await page.getByRole('button', { name: 'Start Session' }).nth(1).click();
-    await page.getByText('Session Type').first().waitFor();
-    await expect(page).toHaveScreenshot('step1.png', {
-      fullPage: true,
-      maxDiffPixelRatio: 0.005,
+test.describe(
+  'Visual Regression Test for NEO Session Page',
+  { tag: ['@regression', '@session', '@visual'] },
+  () => {
+    test('Create a new session step by step', async ({ page }) => {
+      // step1.png
+      await page.getByRole('button', { name: 'Start Session' }).nth(1).click();
+      await page.getByText('Session Type').first().waitFor();
+      await expect(page).toHaveScreenshot('step1.png', {
+        fullPage: true,
+        maxDiffPixelRatio: 0.005,
+      });
+
+      // step2.png
+      await page.getByRole('button', { name: 'Next right' }).click();
+      await page.getByText('Environments', { exact: true }).waitFor();
+      await expect(page).toHaveScreenshot('step2.png', {
+        fullPage: true,
+        mask: [
+          page
+            .locator(
+              '.ant-form-item-control-input-content > .ant-select > .ant-select-selector',
+            )
+            .first(),
+          page
+            .locator(
+              'div:nth-child(3) > .ant-row > .ant-col > .ant-form-item-control-input > .ant-form-item-control-input-content > .ant-select > .ant-select-selector',
+            )
+            .first(),
+          page.locator('.ant-select').nth(4),
+          page.locator('.ant-card-body').nth(3),
+        ],
+        maxDiffPixelRatio: 0.005,
+      });
+
+      // step3.png
+      await page.getByRole('button', { name: 'Next right' }).click();
+      await expect(page).toHaveScreenshot('step3.png', {
+        fullPage: true,
+      });
+
+      // step4.png
+      await page.getByRole('button', { name: 'Next right' }).click();
+      await expect(page).toHaveScreenshot('step4.png', {
+        fullPage: true,
+      });
+
+      // step5.png
+      await page.getByRole('button', { name: 'Next right' }).click();
+      await expect(page).toHaveScreenshot('step5.png', {
+        mask: [page.locator('div.ant-card-body').nth(10)],
+        fullPage: true,
+      });
     });
 
-    // step2.png
-    await page.getByRole('button', { name: 'Next right' }).click();
-    await page.getByText('Environments', { exact: true }).waitFor();
-    await expect(page).toHaveScreenshot('step2.png', {
-      fullPage: true,
-      mask: [
-        page
-          .locator(
-            '.ant-form-item-control-input-content > .ant-select > .ant-select-selector',
-          )
-          .first(),
-        page
-          .locator(
-            'div:nth-child(3) > .ant-row > .ant-col > .ant-form-item-control-input > .ant-form-item-control-input-content > .ant-select > .ant-select-selector',
-          )
-          .first(),
-        page.locator('.ant-select').nth(4),
-        page.locator('.ant-card-body').nth(3),
-      ],
-      maxDiffPixelRatio: 0.005,
+    test('Before create a new session', async ({ page }) => {
+      await page.getByText('Create a Session').waitFor();
+      await expect(page).toHaveScreenshot('session_page.png', {
+        mask: [
+          page.locator('div.ant-card-body').nth(1),
+          page.locator('tbody.ant-table-tbody'),
+        ],
+        fullPage: true,
+        maxDiffPixelRatio: 0.005,
+      });
     });
-
-    // step3.png
-    await page.getByRole('button', { name: 'Next right' }).click();
-    await expect(page).toHaveScreenshot('step3.png', {
-      fullPage: true,
-    });
-
-    // step4.png
-    await page.getByRole('button', { name: 'Next right' }).click();
-    await expect(page).toHaveScreenshot('step4.png', {
-      fullPage: true,
-    });
-
-    // step5.png
-    await page.getByRole('button', { name: 'Next right' }).click();
-    await expect(page).toHaveScreenshot('step5.png', {
-      mask: [page.locator('div.ant-card-body').nth(10)],
-      fullPage: true,
-    });
-  });
-
-  test('Before create a new session', async ({ page }) => {
-    await page.getByText('Create a Session').waitFor();
-    await expect(page).toHaveScreenshot('session_page.png', {
-      mask: [
-        page.locator('div.ant-card-body').nth(1),
-        page.locator('tbody.ant-table-tbody'),
-      ],
-      fullPage: true,
-      maxDiffPixelRatio: 0.005,
-    });
-  });
-});
+  },
+);

--- a/e2e/visual_regression/start/start_page.test.ts
+++ b/e2e/visual_regression/start/start_page.test.ts
@@ -11,8 +11,14 @@ test.beforeEach(async ({ page, request }) => {
   await page.waitForLoadState('networkidle');
 });
 
-test('Start page Visual Regression Test', async ({ page }) => {
-  await expect(page).toHaveScreenshot('start_page.png', {
-    fullPage: true,
-  });
-});
+test.describe(
+  'Start page Visual Regression Test',
+  { tag: ['@regression', '@visual'] },
+  () => {
+    test('Start page screenshot', async ({ page }) => {
+      await expect(page).toHaveScreenshot('start_page.png', {
+        fullPage: true,
+      });
+    });
+  },
+);

--- a/e2e/visual_regression/summary/summary_page.test.ts
+++ b/e2e/visual_regression/summary/summary_page.test.ts
@@ -12,31 +12,35 @@ test.beforeEach(async ({ page, request }) => {
   await page.waitForLoadState('networkidle');
 });
 
-test.describe('Summary page Visual Regression Test', () => {
-  test(`Test in light mode`, async ({ page }) => {
-    await expect(page).toHaveScreenshot(`summary_light.png`, {
-      mask: [
-        page.locator('lablup-progress-bar'),
-        page.locator('span.percentage.start-bar'),
-        page.locator('span.percentage.end-bar'),
-      ],
-      fullPage: true,
-    });
-  });
-
-  test(`Test in dark mode`, async ({ page }) => {
-    await page.getByRole('button', { name: 'moon' }).click();
-    await page.waitForLoadState('networkidle');
-
-    await expect(page).toHaveScreenshot('summary_dark.png', {
-      mask: [
-        page.locator('lablup-progress-bar'),
-        page.locator('span.percentage.start-bar'),
-        page.locator('span.percentage.end-bar'),
-      ],
-      fullPage: true,
+test.describe(
+  'Summary page Visual Regression Test',
+  { tag: ['@regression', '@visual'] },
+  () => {
+    test(`Test in light mode`, async ({ page }) => {
+      await expect(page).toHaveScreenshot(`summary_light.png`, {
+        mask: [
+          page.locator('lablup-progress-bar'),
+          page.locator('span.percentage.start-bar'),
+          page.locator('span.percentage.end-bar'),
+        ],
+        fullPage: true,
+      });
     });
 
-    await page.getByRole('button', { name: 'sun' }).click();
-  });
-});
+    test(`Test in dark mode`, async ({ page }) => {
+      await page.getByRole('button', { name: 'moon' }).click();
+      await page.waitForLoadState('networkidle');
+
+      await expect(page).toHaveScreenshot('summary_dark.png', {
+        mask: [
+          page.locator('lablup-progress-bar'),
+          page.locator('span.percentage.start-bar'),
+          page.locator('span.percentage.end-bar'),
+        ],
+        fullPage: true,
+      });
+
+      await page.getByRole('button', { name: 'sun' }).click();
+    });
+  },
+);

--- a/e2e/visual_regression/users/users_page.test.ts
+++ b/e2e/visual_regression/users/users_page.test.ts
@@ -11,103 +11,107 @@ test.beforeEach(async ({ page, request }) => {
   await page.getByText('Active', { exact: true }).waitFor();
 });
 
-test.describe('User page Visual Regression Test', () => {
-  test(`users table`, async ({ page }) => {
-    // full page
-    await expect(page).toHaveScreenshot('users_table.png', {
-      fullPage: true,
-      maxDiffPixelRatio: 0.005,
+test.describe(
+  'User page Visual Regression Test',
+  { tag: ['@regression', '@user', '@visual'] },
+  () => {
+    test(`users table`, async ({ page }) => {
+      // full page
+      await expect(page).toHaveScreenshot('users_table.png', {
+        fullPage: true,
+        maxDiffPixelRatio: 0.005,
+      });
+
+      // user detail modal
+      await page
+        .getByRole('row', { name: 'user2@lablup.com user2 user' })
+        .getByRole('button')
+        .first()
+        .click();
+      await page.getByText('model-store').waitFor();
+      const userDetailModal = page.locator('div.ant-modal').first();
+      await expect(userDetailModal).toHaveScreenshot('user_detail_modal.png', {
+        mask: [page.getByRole('cell', { name: 'model-store' })],
+        maxDiffPixelRatio: 0.005,
+      });
+      await page.getByRole('button', { name: 'Close' }).click();
+
+      // modify user detail modal
+      await page
+        .getByRole('row', { name: 'user2@lablup.com user2 user' })
+        .getByRole('button')
+        .nth(1)
+        .click();
+      await page.waitForLoadState('networkidle');
+      const modifyUserDetailModal = page.locator('div.ant-modal').nth(1);
+      await expect(modifyUserDetailModal).toHaveScreenshot(
+        'modify_user_detail_modal.png',
+      );
+      await page.getByRole('button', { name: 'Close' }).click();
     });
 
-    // user detail modal
-    await page
-      .getByRole('row', { name: 'user2@lablup.com user2 user' })
-      .getByRole('button')
-      .first()
-      .click();
-    await page.getByText('model-store').waitFor();
-    const userDetailModal = page.locator('div.ant-modal').first();
-    await expect(userDetailModal).toHaveScreenshot('user_detail_modal.png', {
-      mask: [page.getByRole('cell', { name: 'model-store' })],
-      maxDiffPixelRatio: 0.005,
-    });
-    await page.getByRole('button', { name: 'Close' }).click();
+    test(`credentials table`, async ({ page }) => {
+      await page.getByRole('link', { name: 'Users' }).click();
 
-    // modify user detail modal
-    await page
-      .getByRole('row', { name: 'user2@lablup.com user2 user' })
-      .getByRole('button')
-      .nth(1)
-      .click();
-    await page.waitForLoadState('networkidle');
-    const modifyUserDetailModal = page.locator('div.ant-modal').nth(1);
-    await expect(modifyUserDetailModal).toHaveScreenshot(
-      'modify_user_detail_modal.png',
-    );
-    await page.getByRole('button', { name: 'Close' }).click();
-  });
-
-  test(`credentials table`, async ({ page }) => {
-    await page.getByRole('link', { name: 'Users' }).click();
-
-    // credential table
-    await page
-      .locator('div')
-      .filter({ hasText: /^Credentials$/ })
-      .first()
-      .click();
-    await page.getByLabel('User ID').getByText('User ID').waitFor();
-    await expect(page).toHaveScreenshot('credentials_table.png', {
-      fullPage: true,
-      mask: [
-        page.getByRole('cell', { name: 'Sessions' }),
-        page.locator('td.ant-table-cell').nth(3),
-        page.locator('td.ant-table-cell').nth(11),
-        page.locator('td.ant-table-cell').nth(19),
-        page.locator('td.ant-table-cell').nth(27),
-        page.locator('td.ant-table-cell').nth(35),
-      ],
-    });
-
-    // keypair detail modal
-    await page
-      .getByRole('row', { name: 'user2@lablup.com' })
-      .getByRole('button')
-      .first()
-      .click();
-    await page
-      .getByLabel('Keypair DetailMain Access Key')
-      .getByText('user2@lablup.com')
-      .waitFor();
-    const keypairDetailModal = page.locator('div.ant-modal').first();
-    await expect(keypairDetailModal).toHaveScreenshot(
-      'keypair_detail_modal.png',
-      {
+      // credential table
+      await page
+        .locator('div')
+        .filter({ hasText: /^Credentials$/ })
+        .first()
+        .click();
+      await page.getByLabel('User ID').getByText('User ID').waitFor();
+      await expect(page).toHaveScreenshot('credentials_table.png', {
+        fullPage: true,
         mask: [
-          page.getByRole('cell', { name: 'Sessions' }).nth(5),
-          page.getByRole('cell', { name: 'Number Of Queries :' }),
-          page.getByRole('cell', { name: 'Last Used' }),
+          page.getByRole('cell', { name: 'Sessions' }),
+          page.locator('td.ant-table-cell').nth(3),
+          page.locator('td.ant-table-cell').nth(11),
+          page.locator('td.ant-table-cell').nth(19),
+          page.locator('td.ant-table-cell').nth(27),
+          page.locator('td.ant-table-cell').nth(35),
         ],
-      },
-    );
-    await page.getByRole('button', { name: 'Close' }).click();
+      });
 
-    // resource policy modal
-    await page
-      .getByRole('row', { name: 'user2@lablup.com' })
-      .getByRole('button')
-      .nth(1)
-      .click();
-    await page.getByText('Modify keypair resource policy').waitFor();
-    const modifyKeypairResourcePolicyModal = page
-      .locator('div.ant-modal')
-      .nth(1);
-    await expect(modifyKeypairResourcePolicyModal).toHaveScreenshot(
-      'modify_keypair_resource_policy_modal.png',
-      {
-        mask: [page.getByRole('cell', { name: 'Sessions' })],
-      },
-    );
-    await page.getByRole('button', { name: 'Close' }).click();
-  });
-});
+      // keypair detail modal
+      await page
+        .getByRole('row', { name: 'user2@lablup.com' })
+        .getByRole('button')
+        .first()
+        .click();
+      await page
+        .getByLabel('Keypair DetailMain Access Key')
+        .getByText('user2@lablup.com')
+        .waitFor();
+      const keypairDetailModal = page.locator('div.ant-modal').first();
+      await expect(keypairDetailModal).toHaveScreenshot(
+        'keypair_detail_modal.png',
+        {
+          mask: [
+            page.getByRole('cell', { name: 'Sessions' }).nth(5),
+            page.getByRole('cell', { name: 'Number Of Queries :' }),
+            page.getByRole('cell', { name: 'Last Used' }),
+          ],
+        },
+      );
+      await page.getByRole('button', { name: 'Close' }).click();
+
+      // resource policy modal
+      await page
+        .getByRole('row', { name: 'user2@lablup.com' })
+        .getByRole('button')
+        .nth(1)
+        .click();
+      await page.getByText('Modify keypair resource policy').waitFor();
+      const modifyKeypairResourcePolicyModal = page
+        .locator('div.ant-modal')
+        .nth(1);
+      await expect(modifyKeypairResourcePolicyModal).toHaveScreenshot(
+        'modify_keypair_resource_policy_modal.png',
+        {
+          mask: [page.getByRole('cell', { name: 'Sessions' })],
+        },
+      );
+      await page.getByRole('button', { name: 'Close' }).click();
+    });
+  },
+);

--- a/e2e/visual_regression/vfolder/vfolder_page.test.ts
+++ b/e2e/visual_regression/vfolder/vfolder_page.test.ts
@@ -11,49 +11,55 @@ test.beforeEach(async ({ page, request }) => {
   await page.getByText('This storage backend').waitFor();
 });
 
-test.describe('Vfolder page Visual Regression Test', () => {
-  test('Full page', async ({ page }) => {
-    await expect(page).toHaveScreenshot('vfolder_page.png', {
-      fullPage: true,
-    });
-  });
-
-  test('Create Folder modal', async ({ page }) => {
-    await page.getByRole('button', { name: 'Create Folder' }).nth(1).click();
-    const folderCreationModal = page.locator('.ant-modal-content').first();
-    await expect(folderCreationModal).toHaveScreenshot(
-      'create_folder_modal.png',
-    );
-    await page.getByRole('button', { name: 'Close' }).click();
-  });
-
-  test.describe('existing folder action modal', () => {
-    test('Folder info modal', async ({ page }) => {
-      await page.getByRole('link', { name: 'model_folder' }).click();
-      await page
-        .getByRole('heading', {
-          name: 'model_folder',
-          exact: true,
-        })
-        .waitFor();
-
-      const folderInfoModal = page.locator('.ant-modal-content').first();
-      await expect(folderInfoModal).toHaveScreenshot('folder_info_modal.png');
-      await page.getByRole('button', { name: 'Close' }).click();
+test.describe(
+  'Vfolder page Visual Regression Test',
+  { tag: ['@regression', '@vfolder', '@visual'] },
+  () => {
+    test('Full page', async ({ page }) => {
+      await expect(page).toHaveScreenshot('vfolder_page.png', {
+        fullPage: true,
+      });
     });
 
-    test('Modify Permission modal', async ({ page }) => {
-      await page
-        .getByRole('row', { name: `VFolder Identicon model_folder` })
-        .getByRole('button')
-        .first()
-        .click();
-      await page.getByText('Modify Permissions').waitFor();
-      const modifyPermissionModal = page.locator('.ant-modal-content').first();
-      await expect(modifyPermissionModal).toHaveScreenshot(
-        'modify_permission_modal.png',
+    test('Create Folder modal', async ({ page }) => {
+      await page.getByRole('button', { name: 'Create Folder' }).nth(1).click();
+      const folderCreationModal = page.locator('.ant-modal-content').first();
+      await expect(folderCreationModal).toHaveScreenshot(
+        'create_folder_modal.png',
       );
       await page.getByRole('button', { name: 'Close' }).click();
     });
-  });
-});
+
+    test.describe('existing folder action modal', () => {
+      test('Folder info modal', async ({ page }) => {
+        await page.getByRole('link', { name: 'model_folder' }).click();
+        await page
+          .getByRole('heading', {
+            name: 'model_folder',
+            exact: true,
+          })
+          .waitFor();
+
+        const folderInfoModal = page.locator('.ant-modal-content').first();
+        await expect(folderInfoModal).toHaveScreenshot('folder_info_modal.png');
+        await page.getByRole('button', { name: 'Close' }).click();
+      });
+
+      test('Modify Permission modal', async ({ page }) => {
+        await page
+          .getByRole('row', { name: `VFolder Identicon model_folder` })
+          .getByRole('button')
+          .first()
+          .click();
+        await page.getByText('Modify Permissions').waitFor();
+        const modifyPermissionModal = page
+          .locator('.ant-modal-content')
+          .first();
+        await expect(modifyPermissionModal).toHaveScreenshot(
+          'modify_permission_modal.png',
+        );
+        await page.getByRole('button', { name: 'Close' }).click();
+      });
+    });
+  },
+);


### PR DESCRIPTION
## Summary

Add proper Playwright test tags to all visual regression test files for better test organization and filtering.

### Changes

- Added `@regression`, `@visual`, and feature-specific tags to 17 visual regression test files
- Wrapped standalone tests in `test.describe` blocks for proper tagging structure
- Fixed incorrect describe title in `myenvironments_page.test.ts`

### Test Tags Applied

| File | Tags |
|------|------|
| login_page.test.ts | `@regression`, `@auth`, `@visual` |
| environments_page.test.ts | `@regression`, `@environment`, `@visual` |
| session_page.test.ts | `@regression`, `@session`, `@visual` |
| summary_page.test.ts | `@regression`, `@visual` |
| vfolder_page.test.ts | `@regression`, `@vfolder`, `@visual` |
| users_page.test.ts | `@regression`, `@user`, `@visual` |
| serving_page.test.ts | `@regression`, `@serving`, `@visual` |
| resources_page.test.ts | `@regression`, `@agent`, `@visual` |
| resourcepolicy_page.test.ts | `@regression`, `@config`, `@visual` |
| myenvironments_page.test.ts | `@regression`, `@environment`, `@visual` |
| maintenance_page.test.ts | `@regression`, `@maintenance`, `@visual` |
| information_page.test.ts | `@regression`, `@visual` |
| import_page.test.ts | `@regression`, `@visual` |
| start_page.test.ts | `@regression`, `@visual` |
| dashboard_page.test.ts | `@regression`, `@visual` |
| configurations_page.test.ts | `@regression`, `@config`, `@visual` |
| aiagents_page.test.ts | `@regression`, `@visual` |

## Test plan

- [ ] Run visual regression tests: `pnpm exec playwright test --grep @visual`
- [ ] Exclude visual tests from functional runs: `pnpm exec playwright test --grep-invert @visual`
- [ ] Verify all tests execute correctly with new tag structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Jira Issue**: [FR-2024](https://lablup.atlassian.net/browse/FR-2024)

[FR-2024]: https://lablup.atlassian.net/browse/FR-2024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ