### PR TITLE
style(FR-2026): add border styling to keyboard shortcut text

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIText.tsx
+++ b/packages/backend.ai-ui/src/components/BAIText.tsx
@@ -10,6 +10,7 @@ export interface BAITextProps extends Omit<AntdTextProps, 'ellipsis'> {
   monospace?: boolean;
   // Enable CSS-based ellipsis with Safari compatibility (multi-line via -webkit-line-clamp)
   ellipsis?: boolean | EllipsisConfig;
+  keyboardWithLightBorder?: boolean;
 }
 
 // Derive Tooltip props from the ellipsis config.
@@ -44,6 +45,7 @@ const BAIText: React.FC<BAITextProps> = ({
   mark,
   code,
   keyboard,
+  keyboardWithLightBorder,
   ...restProps
 }) => {
   const { token } = theme.useToken();
@@ -82,7 +84,16 @@ const BAIText: React.FC<BAITextProps> = ({
   if (!ellipsis) {
     return (
       <Typography.Text
-        style={{ ...(monospace && { fontFamily: 'monospace' }), ...style }}
+        style={{
+          ...(monospace && { fontFamily: 'monospace' }),
+          ...(keyboardWithLightBorder && {
+            color: 'inherit',
+            margin: 0,
+            border: '1px solid rgba(255, 255, 255, 0.6)',
+            borderRadius: token.borderRadiusSM,
+          }),
+          ...style,
+        }}
         copyable={copyable}
         strong={strong}
         italic={italic}
@@ -90,7 +101,7 @@ const BAIText: React.FC<BAITextProps> = ({
         delete={deleteProp}
         mark={mark}
         code={code}
-        keyboard={keyboard}
+        keyboard={keyboardWithLightBorder || keyboard}
         {...restProps}
       >
         {children}

--- a/packages/backend.ai-ui/src/tests/RelayResolver.tsx
+++ b/packages/backend.ai-ui/src/tests/RelayResolver.tsx
@@ -28,7 +28,6 @@ const RelayResolver = ({
     queueResolver();
 
     return env;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mockResolvers]);
 
   return (

--- a/react/src/components/BAINotificationButton.tsx
+++ b/react/src/components/BAINotificationButton.tsx
@@ -10,6 +10,7 @@ import ReverseThemeProvider from './ReverseThemeProvider';
 import WEBUINotificationDrawer from './WEBUINotificationDrawer';
 import { BellOutlined } from '@ant-design/icons';
 import { Badge, Button, Tooltip, Typography, type ButtonProps } from 'antd';
+import { BAIText } from 'backend.ai-ui';
 import { t } from 'i18next';
 import { atom, useAtom } from 'jotai';
 import _ from 'lodash';
@@ -71,15 +72,8 @@ const BAINotificationButton: React.FC<ButtonProps> = ({ ...props }) => {
         <Tooltip
           title={
             <>
-              {t('notification.Notifications')}
-              <Typography.Text
-                keyboard
-                style={{
-                  color: 'inherit',
-                }}
-              >
-                ]
-              </Typography.Text>
+              {t('notification.Notifications')}{' '}
+              <BAIText keyboardWithLightBorder>{']'}</BAIText>
             </>
           }
           placement="left"

--- a/react/src/components/SiderToggleButton.tsx
+++ b/react/src/components/SiderToggleButton.tsx
@@ -3,8 +3,8 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { HEADER_Z_INDEX_IN_MAIN_LAYOUT } from './MainLayout/MainLayout';
-import { Button, ConfigProvider, theme, Tooltip, Typography } from 'antd';
-import { BAIFlex } from 'backend.ai-ui';
+import { Button, ConfigProvider, theme, Tooltip } from 'antd';
+import { BAIFlex, BAIText } from 'backend.ai-ui';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -23,7 +23,6 @@ const SiderToggleButton: React.FC<SiderToggleButtonProps> = ({
   hidden,
 }) => {
   const { t } = useTranslation();
-
   const { token } = theme.useToken();
   return (
     <BAIFlex
@@ -49,15 +48,8 @@ const SiderToggleButton: React.FC<SiderToggleButtonProps> = ({
         <Tooltip
           title={
             <>
-              {collapsed ? t('button.Expand') : t('button.Collapse')}
-              <Typography.Text
-                code
-                style={{
-                  color: 'inherit',
-                }}
-              >
-                {'['}
-              </Typography.Text>
+              {collapsed ? t('button.Expand') : t('button.Collapse')}{' '}
+              <BAIText keyboardWithLightBorder>{'['}</BAIText>
             </>
           }
           placement="right"


### PR DESCRIPTION
Resolves #5245 ([FR-2026](https://lablup.atlassian.net/browse/FR-2026))

## Summary

- Add `keyboardWithLightBorder` prop to `BAIText` component for keyboard shortcut styling on dark backgrounds (e.g., Tooltip)
- Replace shared `useKeyboardShortcutTextStyles` hook with the new `BAIText` prop in `SiderToggleButton` and `BAINotificationButton`
- Remove `useKeyboardShortcutTextStyles` and `createStyles` dependency from `useKeyboardShortcut.ts`
- Fix unrelated lint warning (unused eslint-disable directive in `RelayResolver.tsx`)

## Before/After

**Before:** Keyboard shortcut text styled via shared `createStyles` hook (`useKeyboardShortcutTextStyles`) exported from `useKeyboardShortcut.ts`
**After:** Keyboard shortcut text styled via `<BAIText keyboardWithLightBorder>` prop — more React-idiomatic, no style hook needed

## Files Changed

- `packages/backend.ai-ui/src/components/BAIText.tsx` - Added `keyboardWithLightBorder` prop
- `react/src/components/SiderToggleButton.tsx` - Use `BAIText keyboardWithLightBorder` instead of style hook
- `react/src/components/BAINotificationButton.tsx` - Use `BAIText keyboardWithLightBorder` instead of style hook
- `react/src/hooks/useKeyboardShortcut.ts` - Removed `useKeyboardShortcutTextStyles` export
- `packages/backend.ai-ui/src/tests/RelayResolver.tsx` - Removed unused eslint-disable directive

<img width="89" height="71" alt="스크린샷 2026-02-05 오후 3 53 11" src="https://github.com/user-attachments/assets/f0fa2de2-c9ac-424d-b859-128d39453e2d" />

<img width="89" height="71" alt="스크린샷 2026-02-05 오후 3 52 51" src="https://github.com/user-attachments/assets/6eecae51-3e6b-4cda-afd3-b87440826cc8" />


[FR-2026]: https://lablup.atlassian.net/browse/FR-2026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ