### PR TITLE
e2e(FR-2031): add comprehensive file upload E2E tests for VFolder

### DIFF
--- a/e2e/utils/classes/vfolder/FolderExplorerModal.ts
+++ b/e2e/utils/classes/vfolder/FolderExplorerModal.ts
@@ -99,4 +99,12 @@ export class FolderExplorerModal {
     await expect(closeButton).toBeVisible();
     return closeButton;
   }
+
+  async verifyFileVisible(fileName: string): Promise<void> {
+    await expect(
+      this.modal.getByRole('cell', { name: fileName, exact: true }),
+    ).toBeVisible({
+      timeout: 10000,
+    });
+  }
 }

--- a/e2e/vfolder/file-upload-dnd.spec.ts
+++ b/e2e/vfolder/file-upload-dnd.spec.ts
@@ -1,0 +1,161 @@
+// spec: e2e/vfolder/file-upload.plan.md
+import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import {
+  loginAsUser,
+  navigateTo,
+  createVFolderAndVerify,
+  moveToTrashAndVerify,
+  deleteForeverAndVerifyFromTrash,
+} from '../utils/test-util';
+import { test, expect, Page } from '@playwright/test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const openFolderExplorer = async (
+  page: Page,
+  folderName: string,
+): Promise<FolderExplorerModal> => {
+  await navigateTo(page, 'data');
+  await page
+    .getByRole('link', { name: folderName })
+    .first()
+    .click({ force: true });
+  const modal = new FolderExplorerModal(page);
+  await modal.waitForOpen();
+  return modal;
+};
+
+test.describe.serial(
+  'Drag-and-Drop File Upload',
+  { tag: ['@critical', '@vfolder', '@functional'] },
+  () => {
+    const testFolderName = 'e2e-test-dnd-upload-' + Date.now();
+    let tmpDir: string;
+    let testFilePath: string;
+    let uploadDir: string; // Directory to upload (contains the test file)
+
+    test.beforeAll(async () => {
+      // Create temporary directory and test file
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-dnd-upload-'));
+
+      // Create a subdirectory to simulate folder upload
+      uploadDir = path.join(tmpDir, 'upload-folder');
+      fs.mkdirSync(uploadDir);
+
+      testFilePath = path.join(uploadDir, 'test-dnd-file.txt');
+      fs.writeFileSync(
+        testFilePath,
+        'This is a test file for drag and drop upload testing',
+      );
+    });
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'data');
+    });
+
+    test.afterAll(async ({ browser, request }) => {
+      // Cleanup: delete VFolder
+      const context = await browser.newContext();
+      const page = await context.newPage();
+
+      await loginAsUser(page, request);
+
+      try {
+        await moveToTrashAndVerify(page, testFolderName);
+        await deleteForeverAndVerifyFromTrash(page, testFolderName);
+      } catch (error) {
+        console.log(`Could not delete ${testFolderName}, it may not exist`);
+      }
+
+      await context.close();
+
+      // Cleanup: delete temporary test files
+      try {
+        if (tmpDir && fs.existsSync(tmpDir)) {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+      } catch (error) {
+        console.log(`Could not delete temporary directory ${tmpDir}`);
+      }
+    });
+
+    test('User can upload a file via drag and drop', async ({ page }) => {
+      // 1. Create a VFolder with Read & Write permissions
+      await createVFolderAndVerify(
+        page,
+        testFolderName,
+        'general',
+        'user',
+        'rw',
+      );
+
+      // 2. Open the VFolder in FolderExplorerModal
+      const modal = await openFolderExplorer(page, testFolderName);
+
+      // 3. Verify file explorer loaded
+      await modal.verifyFileExplorerLoaded();
+
+      // 4. Simulate drag-and-drop of a file onto the file explorer area
+      const fileName = path.basename(testFilePath);
+
+      // Get the modal body (drop container)
+      const modalBody = page.locator('.ant-modal-body').first();
+
+      // Trigger dragenter to show the overlay by dispatching a real dragenter event
+      await modalBody.evaluate((element) => {
+        const dragEvent = new DragEvent('dragenter', {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: new DataTransfer(),
+        });
+        element.dispatchEvent(dragEvent);
+      });
+
+      // 5. Verify the drag-and-drop overlay appears with text "Drag and drop"
+      const dragOverlay = page.locator('.ant-upload-drag');
+      await expect(dragOverlay).toBeVisible({ timeout: 5000 });
+
+      // Verify the overlay text
+      await expect(
+        page.getByText('Drag and drop files to this area to upload.'),
+      ).toBeVisible();
+
+      // 6. Upload files by setting them on the hidden input in the Dragger component
+      // Even though the input has directory/webkitdirectory attributes, Playwright can
+      // set individual file paths with their relative paths to simulate directory structure
+      const fileInput = dragOverlay.locator('input[type="file"]');
+
+      // Set the file with its relative path (simulating it being inside a folder)
+      // This works because Ant Design's Upload component processes the files based on
+      // their webkitRelativePath property
+      await fileInput.evaluate((input: HTMLInputElement) => {
+        // Remove the directory attributes temporarily to allow file selection
+        input.removeAttribute('directory');
+        input.removeAttribute('webkitdirectory');
+      });
+
+      await fileInput.setInputFiles(testFilePath);
+
+      // Dismiss the drag overlay by dispatching a dragleave event to the document
+      // This simulates the user completing the drag-and-drop operation
+      await page.evaluate(() => {
+        const dragLeaveEvent = new DragEvent('dragleave', {
+          bubbles: true,
+          cancelable: true,
+        });
+        document.dispatchEvent(dragLeaveEvent);
+      });
+
+      // Wait for drag overlay to disappear after upload
+      await expect(dragOverlay).not.toBeVisible({ timeout: 10000 });
+
+      // 7. Verify the uploaded file appears in the file table
+      await modal.verifyFileVisible(fileName);
+
+      // 8. Close modal
+      await modal.close();
+    });
+  },
+);

--- a/e2e/vfolder/file-upload-duplicate.spec.ts
+++ b/e2e/vfolder/file-upload-duplicate.spec.ts
@@ -1,0 +1,188 @@
+// spec: Duplicate File Upload Test Plan
+import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import {
+  loginAsUser,
+  navigateTo,
+  createVFolderAndVerify,
+  moveToTrashAndVerify,
+  deleteForeverAndVerifyFromTrash,
+} from '../utils/test-util';
+import { test, expect, Page } from '@playwright/test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const openFolderExplorer = async (
+  page: Page,
+  folderName: string,
+): Promise<FolderExplorerModal> => {
+  await navigateTo(page, 'data');
+  await page
+    .getByRole('link', { name: folderName })
+    .first()
+    .click({ force: true });
+  const modal = new FolderExplorerModal(page);
+  await modal.waitForOpen();
+  return modal;
+};
+
+test.describe.serial(
+  'Duplicate File Upload',
+  { tag: ['@critical', '@vfolder', '@functional'] },
+  () => {
+    const testFolderName = 'e2e-test-dup-upload-' + Date.now();
+    let tmpDir: string;
+    let testFilePath: string;
+
+    test.beforeAll(async () => {
+      // Create temporary directory and test file
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-dup-upload-'));
+
+      testFilePath = path.join(tmpDir, 'test-duplicate-file.txt');
+      fs.writeFileSync(
+        testFilePath,
+        'This is test file for e2e duplicate upload testing',
+      );
+    });
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'data');
+    });
+
+    test.afterAll(async ({ browser, request }) => {
+      // Cleanup: delete VFolder
+      const context = await browser.newContext();
+      const page = await context.newPage();
+
+      await loginAsUser(page, request);
+
+      try {
+        await moveToTrashAndVerify(page, testFolderName);
+        await deleteForeverAndVerifyFromTrash(page, testFolderName);
+      } catch {
+        /* ignore cleanup errors */
+      }
+
+      await context.close();
+
+      // Cleanup: delete temporary test files
+      try {
+        if (tmpDir && fs.existsSync(tmpDir)) {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+      } catch {
+        /* ignore cleanup errors */
+      }
+    });
+
+    test('User sees duplicate confirmation when uploading existing file', async ({
+      page,
+    }) => {
+      // 1. Create a VFolder with Read & Write permissions
+      await createVFolderAndVerify(
+        page,
+        testFolderName,
+        'general',
+        'user',
+        'rw',
+      );
+
+      // 2. Open the VFolder in FolderExplorerModal
+      let modal = await openFolderExplorer(page, testFolderName);
+
+      // 3. Verify file explorer loaded
+      await modal.verifyFileExplorerLoaded();
+
+      // 4. Upload a test file via Upload button (first upload - establish baseline)
+      const uploadButton = await modal.getUploadButton();
+      await uploadButton.click();
+
+      const [fileChooser] = await Promise.all([
+        page.waitForEvent('filechooser'),
+        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+      ]);
+
+      await fileChooser.setFiles([testFilePath]);
+
+      // 5. Verify the file appears in the file table
+      const fileName = path.basename(testFilePath);
+      await modal.verifyFileVisible(fileName);
+
+      // 6. Close the modal
+      await modal.close();
+
+      // 7. Re-open the VFolder in FolderExplorerModal
+      modal = await openFolderExplorer(page, testFolderName);
+
+      // 8. Click "Upload" button again
+      const uploadButton2 = await modal.getUploadButton();
+      await uploadButton2.click();
+
+      // 9. Upload the SAME file again
+      const [fileChooser2] = await Promise.all([
+        page.waitForEvent('filechooser'),
+        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+      ]);
+
+      await fileChooser2.setFiles([testFilePath]);
+
+      // 10. Verify a confirmation modal appears with title "Overwrite Confirmation"
+      const confirmModal = page.getByRole('dialog').last();
+      await expect(confirmModal).toBeVisible();
+      await expect(
+        confirmModal.getByText(
+          'The file or folder with the same name already exists. Do you want to overwrite?',
+        ),
+      ).toBeVisible();
+
+      // 11. Click "OK" to confirm overwrite
+      await page.getByRole('button', { name: 'OK' }).click();
+
+      // 12. Verify the file still exists in the file table (overwritten)
+      await modal.verifyFileVisible(fileName);
+
+      // Close modal
+      await modal.close();
+    });
+
+    test('User can cancel duplicate file upload', async ({ page }) => {
+      // 1. Open the same VFolder in FolderExplorerModal
+      const modal = await openFolderExplorer(page, testFolderName);
+
+      // 2. Verify the file from previous test exists in the table
+      const fileName = path.basename(testFilePath);
+      await modal.verifyFileVisible(fileName);
+
+      // 3. Click "Upload" button
+      const uploadButton = await modal.getUploadButton();
+      await uploadButton.click();
+
+      // 4. Upload the same file again
+      const [fileChooser] = await Promise.all([
+        page.waitForEvent('filechooser'),
+        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+      ]);
+
+      await fileChooser.setFiles([testFilePath]);
+
+      // 5. Verify the duplicate confirmation modal appears ("Overwrite Confirmation")
+      const confirmModal = page.getByRole('dialog').last();
+      await expect(confirmModal).toBeVisible();
+      await expect(
+        confirmModal.getByText(
+          'The file or folder with the same name already exists. Do you want to overwrite?',
+        ),
+      ).toBeVisible();
+
+      // 6. Click "Cancel" to reject overwrite
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      // 7. Verify the original file still exists in the file table
+      await modal.verifyFileVisible(fileName);
+
+      // Close modal
+      await modal.close();
+    });
+  },
+);

--- a/e2e/vfolder/file-upload-permissions.spec.ts
+++ b/e2e/vfolder/file-upload-permissions.spec.ts
@@ -1,0 +1,121 @@
+// spec: Upload Permission Controls Test Plan
+import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import {
+  loginAsUser,
+  navigateTo,
+  createVFolderAndVerify,
+  moveToTrashAndVerify,
+  deleteForeverAndVerifyFromTrash,
+  isLocalEnvironment,
+  webServerEndpoint,
+} from '../utils/test-util';
+import { test, expect, Page } from '@playwright/test';
+
+// Check if backend server endpoint is also local
+const isBackendLocal =
+  webServerEndpoint.includes('127.0.0.1') ||
+  webServerEndpoint.includes('localhost');
+
+const openFolderExplorer = async (
+  page: Page,
+  folderName: string,
+): Promise<FolderExplorerModal> => {
+  await navigateTo(page, 'data');
+  await page
+    .getByRole('link', { name: folderName })
+    .first()
+    .click({ force: true });
+  const modal = new FolderExplorerModal(page);
+  await modal.waitForOpen();
+  return modal;
+};
+
+test.describe.serial(
+  'Upload Permission Controls',
+  { tag: ['@critical', '@vfolder', '@functional'] },
+  () => {
+    // Skip tests on external deployments where VFolder permission control may not work
+    test.skip(
+      !isLocalEnvironment || !isBackendLocal,
+      'Requires local environment with local backend server',
+    );
+
+    const roFolderName = 'e2e-test-perm-ro-' + Date.now();
+    const rwFolderName = 'e2e-test-perm-rw-' + Date.now();
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'data');
+    });
+
+    test.afterAll(async ({ browser, request }) => {
+      // Cleanup: delete both VFolders
+      const context = await browser.newContext();
+      const page = await context.newPage();
+
+      await loginAsUser(page, request);
+
+      // Clean up read-only folder
+      try {
+        await moveToTrashAndVerify(page, roFolderName);
+        await deleteForeverAndVerifyFromTrash(page, roFolderName);
+      } catch (error) {
+        console.log(`Could not delete ${roFolderName}, it may not exist`);
+      }
+
+      // Clean up read-write folder
+      try {
+        await moveToTrashAndVerify(page, rwFolderName);
+        await deleteForeverAndVerifyFromTrash(page, rwFolderName);
+      } catch (error) {
+        console.log(`Could not delete ${rwFolderName}, it may not exist`);
+      }
+
+      await context.close();
+    });
+
+    test('User cannot upload files to read-only VFolder', async ({ page }) => {
+      // 1. Create a VFolder with Read Only permissions
+      await createVFolderAndVerify(page, roFolderName, 'general', 'user', 'ro');
+
+      // 2. Open the VFolder in FolderExplorerModal
+      const modal = await openFolderExplorer(page, roFolderName);
+
+      // 3. Verify file explorer loaded (Name column header visible)
+      await modal.verifyFileExplorerLoaded();
+
+      // 4. Verify the Upload button is disabled (the button should be present but disabled)
+      const uploadButton = await modal.getUploadButton();
+      await expect(uploadButton).toBeDisabled();
+
+      // 5. Verify the Create folder button is disabled
+      const createButton = await modal.getCreateFolderButton();
+      await expect(createButton).toBeDisabled();
+
+      // 6. Close modal
+      await modal.close();
+    });
+
+    test('User can upload files to read-write VFolder', async ({ page }) => {
+      // 1. Create a VFolder with Read & Write permissions
+      await createVFolderAndVerify(page, rwFolderName, 'general', 'user', 'rw');
+
+      // 2. Open the VFolder in FolderExplorerModal
+      const modal = await openFolderExplorer(page, rwFolderName);
+
+      // 3. Verify file explorer loaded
+      await modal.verifyFileExplorerLoaded();
+
+      // 4. Verify the Upload button is enabled
+      const uploadButton = await modal.getUploadButton();
+      await expect(uploadButton).toBeEnabled();
+
+      // 5. Verify the Create folder button is enabled
+      const createButton = await modal.getCreateFolderButton();
+      await expect(createButton).toBeEnabled();
+
+      // 6. Close modal
+      await modal.close();
+    });
+  },
+);

--- a/e2e/vfolder/file-upload-subdirectory.spec.ts
+++ b/e2e/vfolder/file-upload-subdirectory.spec.ts
@@ -1,0 +1,154 @@
+// spec: Suite 5: Upload to Subdirectory
+import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import {
+  loginAsUser,
+  navigateTo,
+  createVFolderAndVerify,
+  moveToTrashAndVerify,
+  deleteForeverAndVerifyFromTrash,
+} from '../utils/test-util';
+import { test, expect, Page } from '@playwright/test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const openFolderExplorer = async (
+  page: Page,
+  folderName: string,
+): Promise<FolderExplorerModal> => {
+  await navigateTo(page, 'data');
+  await page
+    .getByRole('link', { name: folderName })
+    .first()
+    .click({ force: true });
+  const modal = new FolderExplorerModal(page);
+  await modal.waitForOpen();
+  return modal;
+};
+
+test.describe.serial(
+  'Upload to Subdirectory',
+  { tag: ['@critical', '@vfolder', '@functional'] },
+  () => {
+    const testFolderName = 'e2e-test-subdir-upload-' + Date.now();
+    const subfolderName = 'test-subfolder';
+    let tmpDir: string;
+    let testFilePath: string;
+
+    test.beforeAll(async () => {
+      // Create temporary directory and test file
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-subdir-'));
+
+      testFilePath = path.join(tmpDir, 'test-file-in-subfolder.txt');
+      fs.writeFileSync(
+        testFilePath,
+        'This is a test file uploaded to a subdirectory',
+      );
+    });
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'data');
+    });
+
+    test.afterAll(async ({ browser, request }) => {
+      // Cleanup: delete VFolder
+      const context = await browser.newContext();
+      const page = await context.newPage();
+
+      await loginAsUser(page, request);
+
+      try {
+        await moveToTrashAndVerify(page, testFolderName);
+        await deleteForeverAndVerifyFromTrash(page, testFolderName);
+      } catch (error) {
+        console.log(`Could not delete ${testFolderName}, it may not exist`);
+      }
+
+      await context.close();
+
+      // Cleanup: delete temporary test files
+      try {
+        if (tmpDir && fs.existsSync(tmpDir)) {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+      } catch (error) {
+        console.log(`Could not delete temporary directory ${tmpDir}`);
+      }
+    });
+
+    test('User can upload a file to a subdirectory', async ({ page }) => {
+      // 1. Create a VFolder with Read & Write permissions
+      await createVFolderAndVerify(
+        page,
+        testFolderName,
+        'general',
+        'user',
+        'rw',
+      );
+
+      // 2. Open the VFolder in FolderExplorerModal
+      const modal = await openFolderExplorer(page, testFolderName);
+
+      // 3. Verify file explorer loaded
+      await modal.verifyFileExplorerLoaded();
+
+      // 4. Create a new folder using the "Create" button
+      const createButton = await modal.getCreateFolderButton();
+      await createButton.click();
+
+      // Wait for create folder dialog to appear (nested dialog)
+      const createFolderDialog = page.getByRole('dialog').last();
+      await expect(createFolderDialog).toBeVisible();
+
+      // Enter folder name in the input field
+      const folderNameInput = createFolderDialog.getByRole('textbox');
+      await folderNameInput.fill(subfolderName);
+
+      // Click Create button to create the folder
+      await createFolderDialog.getByRole('button', { name: 'Create' }).click();
+
+      // Verify the subfolder appears in the file table (this implicitly waits for folder creation)
+      await modal.verifyFileVisible(subfolderName);
+
+      // 5. Navigate into the newly created folder (click folder name)
+      await page.getByRole('cell', { name: subfolderName }).first().click();
+
+      // 6. Verify breadcrumb shows the subdirectory path (waits for navigation)
+      await expect(
+        page.locator('.ant-breadcrumb').getByText(subfolderName),
+      ).toBeVisible();
+
+      // 7. Upload a file via Upload button
+      const uploadButton = await modal.getUploadButton();
+      await uploadButton.click();
+
+      const [fileChooser] = await Promise.all([
+        page.waitForEvent('filechooser'),
+        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+      ]);
+
+      await fileChooser.setFiles([testFilePath]);
+
+      // 8. Verify the file appears in the subdirectory's file table
+      const fileName = path.basename(testFilePath);
+      await modal.verifyFileVisible(fileName);
+
+      // 9. Navigate back to root (click home in breadcrumb)
+      // The breadcrumb has a home icon at the beginning
+      const breadcrumb = page.locator('.ant-breadcrumb');
+      await breadcrumb.locator('a').first().click();
+
+      // 10. Verify navigation back to root by checking subfolder is visible again
+      await modal.verifyFileVisible(subfolderName);
+
+      // The uploaded file should NOT be visible at the root level
+      await expect(
+        page.getByRole('cell', { name: fileName, exact: true }),
+      ).toHaveCount(0);
+
+      // Close modal
+      await modal.close();
+    });
+  },
+);

--- a/e2e/vfolder/file-upload.spec.ts
+++ b/e2e/vfolder/file-upload.spec.ts
@@ -1,0 +1,162 @@
+// spec: Button-Based File Upload Test Plan
+import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import {
+  loginAsUser,
+  navigateTo,
+  createVFolderAndVerify,
+  moveToTrashAndVerify,
+  deleteForeverAndVerifyFromTrash,
+} from '../utils/test-util';
+import { test, Page } from '@playwright/test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const openFolderExplorer = async (
+  page: Page,
+  folderName: string,
+): Promise<FolderExplorerModal> => {
+  await navigateTo(page, 'data');
+  await page
+    .getByRole('link', { name: folderName })
+    .first()
+    .click({ force: true });
+  const modal = new FolderExplorerModal(page);
+  await modal.waitForOpen();
+  return modal;
+};
+
+test.describe.serial(
+  'Button-Based File Upload',
+  { tag: ['@critical', '@vfolder', '@functional'] },
+  () => {
+    const testFolderName = 'e2e-test-upload-' + Date.now();
+    let tmpDir: string;
+    let testFile1Path: string;
+    let testFile2Path: string;
+    let testFile3Path: string;
+
+    test.beforeAll(async () => {
+      // Create temporary directory and test files
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-upload-'));
+
+      testFile1Path = path.join(tmpDir, 'test-upload-file-1.txt');
+      fs.writeFileSync(
+        testFile1Path,
+        'This is test file 1 for e2e upload testing',
+      );
+
+      testFile2Path = path.join(tmpDir, 'test-upload-file-2.txt');
+      fs.writeFileSync(
+        testFile2Path,
+        'This is test file 2 for e2e upload testing',
+      );
+
+      testFile3Path = path.join(tmpDir, 'test-upload-file-3.txt');
+      fs.writeFileSync(
+        testFile3Path,
+        'This is test file 3 for e2e upload testing',
+      );
+    });
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'data');
+    });
+
+    test.afterAll(async ({ browser, request }) => {
+      // Cleanup: delete VFolder
+      const context = await browser.newContext();
+      const page = await context.newPage();
+
+      await loginAsUser(page, request);
+
+      try {
+        await moveToTrashAndVerify(page, testFolderName);
+        await deleteForeverAndVerifyFromTrash(page, testFolderName);
+      } catch (error) {
+        console.log(`Could not delete ${testFolderName}, it may not exist`);
+      }
+
+      await context.close();
+
+      // Cleanup: delete temporary test files
+      try {
+        if (tmpDir && fs.existsSync(tmpDir)) {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+      } catch (error) {
+        console.log(`Could not delete temporary directory ${tmpDir}`);
+      }
+    });
+
+    test('User can upload a single file via Upload button', async ({
+      page,
+    }) => {
+      // 1. Create a VFolder with Read & Write permissions
+      await createVFolderAndVerify(
+        page,
+        testFolderName,
+        'general',
+        'user',
+        'rw',
+      );
+
+      // 2. Open the VFolder in FolderExplorerModal
+      const modal = await openFolderExplorer(page, testFolderName);
+
+      // 3. Verify file explorer loaded
+      await modal.verifyFileExplorerLoaded();
+
+      // 4. Click the "Upload" button
+      const uploadButton = await modal.getUploadButton();
+      await uploadButton.click();
+
+      // 5. In the dropdown, click "Upload Files" button and handle file chooser
+      const [fileChooser] = await Promise.all([
+        page.waitForEvent('filechooser'),
+        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+      ]);
+
+      // 6. Upload a single test file
+      await fileChooser.setFiles([testFile1Path]);
+
+      // 7. Verify the uploaded file appears in the file table
+      const fileName = path.basename(testFile1Path);
+      await modal.verifyFileVisible(fileName);
+
+      // 8. Close modal
+      await modal.close();
+    });
+
+    test('User can upload multiple files via Upload button', async ({
+      page,
+    }) => {
+      // 1. Open the VFolder in FolderExplorerModal
+      const modal = await openFolderExplorer(page, testFolderName);
+
+      // 2. Verify file explorer loaded
+      await modal.verifyFileExplorerLoaded();
+
+      // 3. Click the "Upload" button
+      const uploadButton = await modal.getUploadButton();
+      await uploadButton.click();
+
+      // 4. In the dropdown, click "Upload Files" and handle file chooser
+      const [fileChooser] = await Promise.all([
+        page.waitForEvent('filechooser'),
+        page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+      ]);
+
+      // 5. Upload multiple test files
+      await fileChooser.setFiles([testFile2Path, testFile3Path]);
+
+      // 6. Verify all uploaded files appear in the file table
+      await modal.verifyFileVisible(path.basename(testFile2Path));
+      await modal.verifyFileVisible(path.basename(testFile3Path));
+
+      // 7. Close modal
+      await modal.close();
+    });
+  },
+);

--- a/e2e/vfolder/vfolder-consecutive-deletion.spec.ts
+++ b/e2e/vfolder/vfolder-consecutive-deletion.spec.ts
@@ -12,6 +12,7 @@ test.describe.serial(
   'VFolder Consecutive Deletion - User Operations',
   { tag: ['@regression', '@vfolder', '@functional'] },
   () => {
+    test.setTimeout(90_000);
     const folder1Name = 'e2e-test-consecutive-1-' + new Date().getTime();
     const folder2Name = 'e2e-test-consecutive-2-' + new Date().getTime();
     const folder3Name = 'e2e-test-consecutive-3-' + new Date().getTime();
@@ -23,6 +24,7 @@ test.describe.serial(
     test('User can create and permanently delete multiple VFolders consecutively', async ({
       page,
     }) => {
+      test.setTimeout(90_000);
       // Create NotificationHandler instance for managing notifications throughout the test
       const notification = new NotificationHandler(page);
 

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.tsx
@@ -40,8 +40,10 @@ export type FilterProperty = {
   };
 };
 
-export interface BAIPropertyFilterProps
-  extends Omit<ComponentProps<typeof BAIFlex>, 'value' | 'onChange'> {
+export interface BAIPropertyFilterProps extends Omit<
+  ComponentProps<typeof BAIFlex>,
+  'value' | 'onChange'
+> {
   value?: string;
   onChange?: (value: string) => void;
   defaultValue?: string;
@@ -342,6 +344,7 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
           showSearch={{
             optionFilterProp: 'label',
           }}
+          aria-label="Filter property selector"
         />
         <Tooltip
           title={isValid || !isFocused ? '' : selectedProperty.rule?.message}
@@ -383,6 +386,7 @@ const BAIPropertyFilter: React.FC<BAIPropertyFilterProps> = ({
               onSearch={onSearch}
               allowClear
               status={!isValid && isFocused ? 'error' : undefined}
+              aria-label="Filter value search"
             />
           </AutoComplete>
         </Tooltip>


### PR DESCRIPTION
Resolves #5264 ([FR-2031](https://lablup.atlassian.net/browse/FR-2031))

## Summary

Adds comprehensive E2E test coverage for VFolder file upload functionality:

- **Button-based upload**: Single and multiple file uploads via Upload button
- **Drag-and-drop upload**: File upload via drag-and-drop with overlay
- **Duplicate detection**: Confirmation modal when uploading existing files
- **Permission checks**: Upload UI only available with Read & Write permissions
- **Subdirectory upload**: Folder upload preserving directory structure
- **Test utilities**: Refactored `selectPropertyFilter` helper for reusable VFolder filtering
- **BAIPropertyFilter**: Added `aria-label` attributes for better test accessibility

## Test plan

- [ ] All new E2E tests pass on CI
- [ ] Existing vfolder tests remain passing
- [ ] `selectPropertyFilter` utility works correctly across test suites

[FR-2031]: https://lablup.atlassian.net/browse/FR-2031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ