### PR TITLE
chore(FR-1640): apply pnpm git branch lockfile

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,11 @@ patchedDependencies:
   "@lobehub/fluent-emoji@2.0.0": react/patches/lobehub__fluent-emoji@2.0.0.patch
   "@rc-component/form": react/patches/@rc-component__form.patch
 
+gitBranchLockfile: true
+
+mergeGitBranchLockfilesBranchPattern:
+  - main
+
 minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude:


### PR DESCRIPTION
Resolves #4505 ([FR-1640](https://lablup.atlassian.net/browse/FR-1640))

## Summary

Enable pnpm Git Branch Lockfile feature to eliminate pnpm-lock.yaml merge conflicts.

## Changes

- **pnpm-workspace.yaml**: Add `gitBranchLockfile` and `mergeGitBranchLockfilesBranchPattern` settings
- **package.json**: Bump pnpm engine constraint from `^10.16.0` to `>=10.21.0` (required for the feature to work)
- **.github/workflows/jest.yml**: 
  - Add `ref: ${{ github.head_ref }}` to checkout actual branch (not detached HEAD) so pnpm can detect branch lockfiles
  - Update cache keys to include branch lockfiles (`pnpm-lock.*.yaml`)
- **.github/workflows/publish-backend.ai-ui.yml**: Update cache key to include branch lockfiles
- **.github/workflows/cleanup-branch-lockfiles.yml**: New workflow to auto-merge and clean up branch lockfiles on main

## How it works

### On feature branches
- `pnpm install` creates `pnpm-lock.<branch-name>.yaml` instead of modifying `pnpm-lock.yaml`
- No lockfile conflicts when multiple developers change dependencies simultaneously

### On main (after merge)
- `cleanup-branch-lockfiles.yml` workflow triggers when branch lockfiles are merged
- `pnpm install` automatically merges branch lockfiles into `pnpm-lock.yaml` and deletes branch lockfiles
- Commits and pushes the cleanup

## Related

- pnpm docs: https://pnpm.io/git_branch_lockfiles

[FR-1640]: https://lablup.atlassian.net/browse/FR-1640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ