### PR TITLE
fix(FR-2042): dispatch plugin-loaded event without plugins and fix E2E test timeouts/regex

### DIFF
--- a/e2e/session/session-lifecycle.spec.ts
+++ b/e2e/session/session-lifecycle.spec.ts
@@ -144,7 +144,8 @@ test.describe(
       expect(finishedSessions).toContain(createdSessionName);
     });
 
-    test('View session container logs', async ({ page }) => {
+    test('View session container logs', async ({ page }, testInfo) => {
+      testInfo.setTimeout(120000);
       // Create session
       const sessionLauncher = new SessionLauncher(page);
       const sessionName = `logs-test-${Date.now()}`;
@@ -173,7 +174,8 @@ test.describe(
       await sessionDetailPage.terminateSession(createdSessionName);
     });
 
-    test('Monitor session resource usage', async ({ page }) => {
+    test('Monitor session resource usage', async ({ page }, testInfo) => {
+      testInfo.setTimeout(120000);
       // Create session with minimum preset (resources are set via preset, not directly)
       const sessionLauncher = new SessionLauncher(page);
       const sessionName = `resource-test-${Date.now()}`;

--- a/e2e/vfolder/vfolder-explorer-modal.spec.ts
+++ b/e2e/vfolder/vfolder-explorer-modal.spec.ts
@@ -188,7 +188,7 @@ test.describe(
       });
 
       // 6. Verify URL no longer has folder parameter
-      await expect(page).toHaveURL(/\/data($|\?(?!.*folder=))/);
+      await expect(page).toHaveURL(/\/data\/?($|\?(?!.*folder=))/);
     });
 
     test('User can access File Browser from VFolder explorer modal', async ({

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -564,7 +564,17 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
             }
           }
         });
+      } else {
+        // No page plugins to load, dispatch event immediately
+        document.dispatchEvent(
+          new CustomEvent('backend-ai-plugin-loaded', { detail: true }),
+        );
       }
+    } else {
+      // No plugin config, dispatch event immediately
+      document.dispatchEvent(
+        new CustomEvent('backend-ai-plugin-loaded', { detail: true }),
+      );
     }
     this.loginPanel.refreshWithConfig(config);
     const event = new CustomEvent('backend-ai-config-loaded');


### PR DESCRIPTION
Resolves #5255 ([FR-2042](https://lablup.atlassian.net/browse/FR-2042))

## Summary
- Dispatch `backend-ai-plugin-loaded` event when no plugins are configured, fixing 404 page not rendering on unknown routes
- Fix VFolder explorer modal URL regex to allow trailing slash (`/data/` vs `/data`)
- Add missing `testInfo.setTimeout(120000)` to session lifecycle tests that wait up to 120s for session status

## Test plan
- [x] VFolder explorer modal test passes locally after regex fix
- [x] VFolder consecutive deletion test passes when run alone (server-side flaky)
- [ ] 404 page test requires deployment to verify (frontend code change)
- [ ] Session lifecycle test depends on server availability
- [ ] App launcher test is a server-side proxy issue (no code change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-2042]: https://lablup.atlassian.net/browse/FR-2042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ