### PR TITLE
chore(FR-2045): remove graphql.config.ts from tsconfig.json includes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,11 +25,5 @@
     "lib": ["es6", "dom", "es2016", "es2017", "es2020"],
     "preserveWatchOutput": true
   },
-  "include": [
-    "src/components/*",
-    "src/plugins/*",
-    "src/reducers/*",
-    "src/*",
-    "graphql.config.ts"
-  ]
+  "include": ["src/components/*", "src/plugins/*", "src/reducers/*", "src/*"]
 }


### PR DESCRIPTION
Resolves #5292 ([FR-2045](https://lablup.atlassian.net/browse/FR-2045))

## Summary
- Removed `graphql.config.ts` from tsconfig.json includes array
- Simplified includes configuration to a single line format

## Test plan
- [ ] Verify TypeScript compilation still works: `pnpm run build`
- [ ] Ensure no type checking errors are introduced
- [ ] Confirm development server starts without issues: `pnpm run server:d`

[FR-2045]: https://lablup.atlassian.net/browse/FR-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ