### PR TITLE
fix(FR-2049): use --merge-git-branch-lockfiles in jest.yml CI workflow

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -65,7 +65,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile
       - name: Run ESLint on React
         run: pnpm run lint
       - name: run relay-compiler
@@ -118,7 +118,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --merge-git-branch-lockfiles --no-frozen-lockfile
       - name: Run ESLint on backend.ai-ui
         run: pnpm run lint
       - name: run relay-compiler


### PR DESCRIPTION
Resolves #5301 ([FR-2049](https://lablup.atlassian.net/browse/FR-2049))

## Changes

Added `--merge-git-branch-lockfiles` flag to `pnpm install` commands in jest.yml CI workflow to support pnpm's git branch lockfile feature.

## Background

The project uses pnpm git branch lockfile feature (`gitBranchLockfile: true`) to avoid lockfile merge conflicts. Each feature branch creates its own lockfile (`pnpm-lock.<branch-name>.yaml`), but CI workflows were still using plain `pnpm install` which only checks the main `pnpm-lock.yaml`, causing `ERR_PNPM_OUTDATED_LOCKFILE` failures when dependencies change in PRs.

## Impact

- CI workflows now properly merge and use branch-specific lockfiles
- Eliminates `ERR_PNPM_OUTDATED_LOCKFILE` errors in PR checks
- Full support for pnpm git branch lockfile workflow in CI

**Checklist:**

- [x] Documentation - Not required (internal CI change)
- [x] Minimum required manager version - No change
- [x] Specific setting for review - None
- [x] Minimum requirements to check during review - Verify CI passes with branch lockfiles
- [x] Test case(s) - CI workflow will test automatically

[FR-2049]: https://lablup.atlassian.net/browse/FR-2049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ