### PR TITLE
docs(FR-2051): add PDF generation tool for user manual documentation

### DIFF
--- a/packages/backend.ai-webui-docs/README.md
+++ b/packages/backend.ai-webui-docs/README.md
@@ -1,0 +1,212 @@
+# Backend.AI WebUI Docs
+
+PDF generation tool for the Backend.AI WebUI User Guide. Converts multilingual Markdown documentation into production-ready PDF with cover page, table of contents, headers/footers, and themeable styling.
+
+## Prerequisites
+
+- Node.js 18+
+- pnpm (workspace is managed from the monorepo root)
+- Playwright Chromium (installed automatically on first run)
+
+```bash
+# Install dependencies from the monorepo root
+pnpm install
+```
+
+## Quick Start
+
+```bash
+cd packages/backend.ai-webui-docs
+
+# Generate PDF for all languages
+pnpm run pdf
+
+# Generate PDF for a specific language
+pnpm run pdf:en
+pnpm run pdf:ko
+pnpm run pdf:ja
+pnpm run pdf:th
+```
+
+Output files are written to `dist/`:
+
+```
+# Release build (26.2.0)
+dist/Backend.AI_WebUI_User_Guide_v26.2.0_en.pdf
+
+# Pre-release build (26.2.0-alpha.0, commit abc1234)
+dist/Backend.AI_WebUI_User_Guide_v26.2.0-alpha.0+abc1234_en.pdf
+```
+
+## Preview Server
+
+The preview server generates real PDFs through the same Playwright pipeline as production, with live-reload on file changes.
+
+```bash
+# Sample content preview (~1s generation)
+pnpm run preview
+
+# Style catalog with theme reference (~1s)
+pnpm run preview:catalog
+
+# Full document preview (~15-30s)
+pnpm run preview:doc        # English
+pnpm run preview:doc:ko     # Korean
+pnpm run preview:doc:ja     # Japanese
+pnpm run preview:doc:th     # Thai
+```
+
+Open `http://localhost:3456` to view the PDF in the browser. The page auto-refreshes when the PDF is rebuilt.
+
+### Preview Modes
+
+| Mode | Command | Content | Speed |
+|------|---------|---------|-------|
+| `sample` | `pnpm run preview` | Sample chapters exercising all styling elements | ~1s |
+| `catalog` | `pnpm run preview:catalog` | Theme variable reference + sample chapters | ~1s |
+| `document` | `pnpm run preview:doc` | Real Markdown content from `src/{lang}/` | ~15-30s |
+
+In `document` mode, editing any `.md` file under `src/{lang}/` triggers an automatic PDF rebuild.
+
+### CLI Options
+
+```bash
+tsx scripts/preview-server.ts --mode <mode> --lang <lang> --theme <name> --port <port>
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--mode` | `sample` | `sample`, `catalog`, or `document` |
+| `--lang` | `en` | Language code (`en`, `ko`, `ja`, `th`) |
+| `--theme` | `default` | Theme name |
+| `--port` | `3456` | HTTP server port |
+
+## Style Catalog (HTML)
+
+A standalone HTML page showing all PDF styling elements. Useful for quick visual checks without Playwright rendering.
+
+```bash
+pnpm run catalog
+# Output: dist/preview/style-catalog.html
+```
+
+## Theme System
+
+Themes control all visual aspects of the PDF: colors, typography, cover page, code blocks, tables, blockquotes, and header/footer templates.
+
+The theme interface is defined in `scripts/theme.ts`:
+
+```typescript
+interface PdfTheme {
+  name: string;
+
+  // Colors
+  brandColor: string;        // Accent color (default: #ff9d00)
+  textPrimary: string;       // Main text (default: #1a1a1a)
+  textSecondary: string;     // Secondary text (default: #666)
+  linkColor: string;         // Link color (default: #0066cc)
+  borderColor: string;       // General borders (default: #e0e0e0)
+
+  // Typography
+  baseFontSize: string;      // Body text (default: 11pt)
+  headingH1Size: string;     // H1 (default: 22pt)
+  headingH2Size: string;     // H2 (default: 16pt)
+  // ... and more (code, table, blockquote, cover, TOC)
+
+  // Header/Footer (Playwright displayHeaderFooter templates)
+  headerHtml: string;
+  footerHtml: string;
+}
+```
+
+Currently only the `default` theme is built-in. Custom theme loading from disk (e.g., `themes/customer-blue.json`) is planned for future implementation. To customize styling, edit the `defaultTheme` values in `scripts/theme.ts` directly.
+
+## Versioning
+
+The document version is derived from the monorepo root `package.json` version field.
+
+| Package Version | Cover Page | Filename |
+|----------------|------------|----------|
+| `26.2.0` (release) | `v26.2.0` | `..._v26.2.0_en.pdf` |
+| `26.2.0-alpha.0` (pre-release) | `v26.2.0-alpha.0 (abc1234)` | `..._v26.2.0-alpha.0+abc1234_en.pdf` |
+
+For pre-release versions, the git short hash is appended so that PDFs generated from different commits are distinguishable even when the package version has not been bumped. The version logic is defined in `scripts/version.ts`.
+
+## Project Structure
+
+```
+packages/backend.ai-webui-docs/
+├── src/
+│   ├── book.config.yaml          # Book metadata, languages, navigation
+│   ├── en/                       # English Markdown source
+│   ├── ko/                       # Korean
+│   ├── ja/                       # Japanese
+│   └── th/                       # Thai
+├── scripts/
+│   ├── generate-pdf.ts           # Main entry point (pnpm run pdf)
+│   ├── markdown-processor.ts     # Markdown → HTML conversion
+│   ├── html-builder.ts           # Assembles cover + TOC + chapters
+│   ├── pdf-renderer.ts           # Playwright PDF rendering (3-pass)
+│   ├── styles.ts                 # CSS generation from theme
+│   ├── theme.ts                  # Theme interface and defaults
+│   ├── version.ts                # Version resolution (semver + git hash)
+│   ├── preview-server.ts         # Dev server with live-reload
+│   ├── sample-content.ts         # Sample chapters for preview
+│   └── style-catalog.ts          # Standalone HTML catalog
+├── dist/                         # Generated output (gitignored)
+├── TERMINOLOGY.md                # Standardized terms across languages
+├── DOCUMENTATION-STYLE-GUIDE.md  # Writing conventions
+├── TRANSLATION-GUIDE.md          # Translation rules per language
+└── SCREENSHOT-GUIDELINES.md      # Image conventions
+```
+
+## PDF Generation Pipeline
+
+The PDF is generated through a multi-stage pipeline:
+
+1. **Markdown Processing** (`markdown-processor.ts`) — Parses `.md` files, extracts headings, resolves image paths, generates chapter-scoped heading IDs.
+
+2. **HTML Assembly** (`html-builder.ts`) — Builds a single HTML document containing:
+   - Cover page with logo, title, version, date
+   - Table of Contents with placeholder page numbers
+   - All chapter content with section breaks
+
+3. **PDF Rendering** (`pdf-renderer.ts`) — 3-pass Playwright rendering:
+   - **Pass 1**: Render to PDF, extract page numbers from named destinations
+   - **Pass 2**: Inject real page numbers into TOC, render again
+   - **Pass 3**: Final render with header/footer enabled
+   - **Post-processing**: Mask header/footer on cover page using pdf-lib
+
+## Writing Documentation
+
+### Adding a New Page
+
+1. Create a Markdown file under `src/{lang}/` (e.g., `src/en/new_feature/new_feature.md`)
+2. Add a navigation entry in `src/book.config.yaml` for **all 4 languages**
+3. Create the corresponding files in `src/ko/`, `src/ja/`, `src/th/`
+
+### Markdown Conventions
+
+- One `# H1` per file as the page title
+- `## H2` for major sections, `### H3` for subsections
+- Images: `![](images/filename.png)` — place image files in `src/{lang}/images/`
+- Cross-references: `[Link Text](#heading-id)`
+- Inline code for UI elements: `` `Settings` ``, `` `config.toml` ``
+
+Refer to the following guides for detailed conventions:
+
+- [TERMINOLOGY.md](TERMINOLOGY.md) — Standardized terms across languages
+- [DOCUMENTATION-STYLE-GUIDE.md](DOCUMENTATION-STYLE-GUIDE.md) — Formatting rules
+- [TRANSLATION-GUIDE.md](TRANSLATION-GUIDE.md) — Translation guidelines
+- [SCREENSHOT-GUIDELINES.md](SCREENSHOT-GUIDELINES.md) — Image conventions
+
+## Supported Languages
+
+| Code | Language |
+|------|----------|
+| `en` | English |
+| `ko` | Korean (한국어) |
+| `ja` | Japanese (日本語) |
+| `th` | Thai (ภาษาไทย) |
+
+All languages must have identical page structure and navigation entries in `book.config.yaml`.

--- a/packages/backend.ai-webui-docs/package.json
+++ b/packages/backend.ai-webui-docs/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "backend.ai-webui-docs",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "pdf": "tsx scripts/generate-pdf.ts --lang all",
+    "pdf:en": "tsx scripts/generate-pdf.ts --lang en",
+    "pdf:ko": "tsx scripts/generate-pdf.ts --lang ko",
+    "pdf:ja": "tsx scripts/generate-pdf.ts --lang ja",
+    "pdf:th": "tsx scripts/generate-pdf.ts --lang th",
+    "pdf:all": "tsx scripts/generate-pdf.ts --lang all",
+    "catalog": "tsx scripts/style-catalog.ts",
+    "preview": "tsx scripts/preview-server.ts --mode sample",
+    "preview:catalog": "tsx scripts/preview-server.ts --mode catalog",
+    "preview:doc": "tsx scripts/preview-server.ts --mode document --lang en",
+    "preview:doc:ko": "tsx scripts/preview-server.ts --mode document --lang ko",
+    "preview:doc:ja": "tsx scripts/preview-server.ts --mode document --lang ja",
+    "preview:doc:th": "tsx scripts/preview-server.ts --mode document --lang th"
+  },
+  "devDependencies": {
+    "marked": "^12.0.2",
+    "pdf-lib": "^1.17.1",
+    "playwright": "^1.58.0",
+    "tsx": "^4.19.0",
+    "typescript": "~5.5.4",
+    "yaml": "^2.7.0"
+  }
+}

--- a/packages/backend.ai-webui-docs/scripts/generate-pdf.ts
+++ b/packages/backend.ai-webui-docs/scripts/generate-pdf.ts
@@ -1,0 +1,130 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { parse as parseYaml } from 'yaml';
+import { processMarkdownFiles } from './markdown-processor.js';
+import { buildFullDocument } from './html-builder.js';
+import { renderPdf } from './pdf-renderer.js';
+import { loadTheme } from './theme.js';
+import { getDocVersion } from './version.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DOCS_ROOT = path.resolve(__dirname, '..');
+const SRC_DIR = path.join(DOCS_ROOT, 'src');
+const CONFIG_PATH = path.join(SRC_DIR, 'book.config.yaml');
+
+interface BookConfig {
+  title: string;
+  description: string;
+  languages: string[];
+  navigation: Record<string, Array<{ title: string; path: string }>>;
+}
+
+function parseArgs(argv: string[]): { lang: string; theme: string } {
+  let lang = 'all';
+  let theme = 'default';
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--lang' && argv[i + 1]) {
+      lang = argv[i + 1];
+      i++;
+    }
+    if (argv[i] === '--theme' && argv[i + 1]) {
+      theme = argv[i + 1];
+      i++;
+    }
+  }
+  return { lang, theme };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const config: BookConfig = parseYaml(
+    fs.readFileSync(CONFIG_PATH, 'utf-8'),
+  );
+
+  const theme = loadTheme(args.theme);
+  const { display: version, filename: versionForFilename } = getDocVersion();
+  const title = config.title;
+  const availableLanguages = config.languages;
+
+  const languages =
+    args.lang === 'all' ? availableLanguages : [args.lang];
+
+  // Validate requested language
+  for (const lang of languages) {
+    if (!availableLanguages.includes(lang)) {
+      console.error(
+        `Language "${lang}" not found in config. Available: ${availableLanguages.join(', ')}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  console.log(`Backend.AI WebUI Docs PDF Generator`);
+  console.log(`Title: ${title}`);
+  console.log(`Version: ${version}`);
+  console.log(`Theme: ${theme.name}`);
+  console.log(`Languages: ${languages.join(', ')}`);
+  console.log('');
+
+  for (const lang of languages) {
+    const startTime = Date.now();
+    console.log(`[${lang}] Generating PDF...`);
+
+    const navigation = config.navigation[lang];
+    if (!navigation) {
+      console.warn(`[${lang}] No navigation found, skipping`);
+      continue;
+    }
+
+    // Process markdown files
+    console.log(`[${lang}] Processing ${navigation.length} chapters...`);
+    const chapters = await processMarkdownFiles(
+      lang,
+      navigation,
+      SRC_DIR,
+      version,
+    );
+
+    // Build single unified HTML document
+    console.log(`[${lang}] Building HTML...`);
+    const html = buildFullDocument(
+      chapters,
+      { title, version, lang },
+      DOCS_ROOT,
+      theme,
+    );
+
+    // Render PDF
+    const outputPath = path.join(
+      DOCS_ROOT,
+      'dist',
+      `Backend.AI_WebUI_User_Guide_${versionForFilename}_${lang}.pdf`,
+    );
+
+    console.log(`[${lang}] Rendering PDF...`);
+    await renderPdf({
+      html,
+      outputPath,
+      title,
+      version,
+      lang,
+      theme,
+    });
+
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    const fileSize = (fs.statSync(outputPath).size / 1024 / 1024).toFixed(1);
+    console.log(
+      `[${lang}] Done: ${outputPath} (${fileSize} MB, ${elapsed}s)`,
+    );
+    console.log('');
+  }
+
+  console.log('PDF generation complete!');
+}
+
+main().catch((err) => {
+  console.error('PDF generation failed:', err);
+  process.exit(1);
+});

--- a/packages/backend.ai-webui-docs/scripts/html-builder.ts
+++ b/packages/backend.ai-webui-docs/scripts/html-builder.ts
@@ -1,0 +1,150 @@
+import fs from 'fs';
+import path from 'path';
+import type { Chapter } from './markdown-processor.js';
+import type { PdfTheme } from './theme.js';
+import { defaultTheme } from './theme.js';
+import { generatePdfStyles } from './styles.js';
+
+export interface DocMetadata {
+  title: string;
+  version: string;
+  lang: string;
+}
+
+const LANGUAGE_LABELS: Record<string, string> = {
+  en: 'English',
+  ko: '한국어',
+  ja: '日本語',
+  th: 'ภาษาไทย',
+};
+
+const LOCALIZED_STRINGS: Record<string, { userGuide: string; tableOfContents: string }> = {
+  en: { userGuide: 'User Guide', tableOfContents: 'Table of Contents' },
+  ko: { userGuide: '사용자 가이드', tableOfContents: '목차' },
+  ja: { userGuide: 'ユーザーガイド', tableOfContents: '目次' },
+  th: { userGuide: 'คู่มือผู้ใช้', tableOfContents: 'สารบัญ' },
+};
+
+function getFormattedDate(lang: string): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.toLocaleString(
+    lang === 'th'
+      ? 'th-TH'
+      : lang === 'ja'
+        ? 'ja-JP'
+        : lang === 'ko'
+          ? 'ko-KR'
+          : 'en-US',
+    { month: 'long' },
+  );
+  return `${month} ${year}`;
+}
+
+function buildCoverHtml(metadata: DocMetadata, logoSvg: string): string {
+  const langLabel = LANGUAGE_LABELS[metadata.lang] || metadata.lang;
+  const strings = LOCALIZED_STRINGS[metadata.lang] || LOCALIZED_STRINGS.en;
+  const date = getFormattedDate(metadata.lang);
+
+  return `
+<section class="cover-page" id="cover-page">
+  <div class="cover-logo">
+    ${logoSvg}
+  </div>
+  <h1 class="cover-title">${metadata.title}</h1>
+  <p class="cover-subtitle">${strings.userGuide}</p>
+  <hr class="cover-divider" />
+  <div class="cover-meta">
+    <p class="version">${metadata.version}</p>
+    <p class="company">Lablup Inc.</p>
+    <p class="date">${date}</p>
+    <p class="lang">${langLabel}</p>
+  </div>
+</section>
+`;
+}
+
+function buildTocHtml(chapters: Chapter[], lang: string): string {
+  const strings = LOCALIZED_STRINGS[lang] || LOCALIZED_STRINGS.en;
+  const tocItems = chapters
+    .map((chapter, index) => {
+      const num = index + 1;
+      const anchorId = chapter.headings[0]?.id || `chapter-${chapter.slug}`;
+      const chapterLink = `<a href="#${anchorId}"><span class="toc-text">${num}. ${chapter.title}</span><span class="toc-pagenum" data-toc-target="${anchorId}"></span></a>`;
+
+      // Get H2-level subsections
+      const subsections = chapter.headings.filter((h) => h.level === 2);
+      let subsectionHtml = '';
+      if (subsections.length > 0) {
+        const subItems = subsections
+          .map(
+            (h) =>
+              `<li><a href="#${h.id}"><span class="toc-text">${h.text}</span><span class="toc-pagenum" data-toc-target="${h.id}"></span></a></li>`,
+          )
+          .join('\n');
+        subsectionHtml = `\n<ol class="toc-sections">\n${subItems}\n</ol>`;
+      }
+
+      return `<li class="toc-chapter">${chapterLink}${subsectionHtml}</li>`;
+    })
+    .join('\n');
+
+  return `
+<section class="toc-section" id="toc-section">
+  <h1 class="toc-heading">${strings.tableOfContents}</h1>
+  <ol class="toc-list">
+    ${tocItems}
+  </ol>
+</section>
+`;
+}
+
+function buildContentHtml(chapters: Chapter[]): string {
+  return chapters
+    .map(
+      (chapter) =>
+        `<section class="chapter" id="chapter-${chapter.slug}">\n` +
+        `<a id="${chapter.slug}"></a>\n` +
+        `${chapter.htmlContent}\n</section>`,
+    )
+    .join('\n');
+}
+
+/**
+ * Build a single unified HTML document containing cover, TOC, and all content.
+ * This ensures internal links work and page numbering is consistent.
+ */
+export function buildFullDocument(
+  chapters: Chapter[],
+  metadata: DocMetadata,
+  docsRoot: string,
+  theme: PdfTheme = defaultTheme,
+): string {
+  const logoPath = path.resolve(
+    docsRoot,
+    '../../manifest/backend.ai-brand-simple.svg',
+  );
+  const logoSvg = fs.existsSync(logoPath)
+    ? fs.readFileSync(logoPath, 'utf-8')
+    : '<div style="font-size:48px;color:#ff9d00;font-weight:bold;">Backend.AI</div>';
+
+  const coverHtml = buildCoverHtml(metadata, logoSvg);
+  const tocHtml = buildTocHtml(chapters, metadata.lang);
+  const contentHtml = buildContentHtml(chapters);
+  const styles = generatePdfStyles(theme);
+
+  return `<!DOCTYPE html>
+<html lang="${metadata.lang}">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${metadata.title} (${metadata.lang})</title>
+  <style>${styles}</style>
+</head>
+<body>
+${coverHtml}
+${tocHtml}
+${contentHtml}
+</body>
+</html>`;
+}

--- a/packages/backend.ai-webui-docs/scripts/markdown-processor.ts
+++ b/packages/backend.ai-webui-docs/scripts/markdown-processor.ts
@@ -1,0 +1,334 @@
+import fs from 'fs';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { Marked } from 'marked';
+
+export interface Heading {
+  level: number;
+  text: string;
+  id: string;
+}
+
+export interface Chapter {
+  title: string;
+  slug: string;
+  htmlContent: string;
+  headings: Heading[];
+}
+
+interface NavEntry {
+  title: string;
+  path: string;
+}
+
+/**
+ * Fallback mapping for non-ASCII paths in book.config.yaml
+ * that don't match actual filesystem directory names.
+ */
+const PATH_FALLBACKS: Record<string, string> = {
+  // Korean
+  '일반.md': 'user_settings/user_settings.md',
+  '어드민_menu/어드민_menu.md': 'admin_menu/admin_menu.md',
+  // Japanese
+  'ユーザー_settings/ユーザー_settings.md': 'user_settings/user_settings.md',
+  '管理者_menu/管理者_menu.md': 'admin_menu/admin_menu.md',
+  // Thai
+  'ผู้ใช้_settings/ผู้ใช้_settings.md': 'user_settings/user_settings.md',
+  'ผู้ดูแลระบบ_menu/ผู้ดูแลระบบ_menu.md': 'admin_menu/admin_menu.md',
+};
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/<[^>]+>/g, '') // remove angle bracket tags like <anchor>
+    .replace(/[^\p{L}\p{N}\s-]/gu, '') // keep Unicode letters/numbers for CJK support
+    .replace(/\s+/g, '-') // spaces to dashes
+    .replace(/-+/g, '-') // collapse dashes
+    .replace(/^-|-$/g, ''); // trim dashes
+}
+
+function resolveMarkdownPath(
+  lang: string,
+  configPath: string,
+  srcDir: string,
+): string {
+  const primaryPath = path.join(srcDir, lang, configPath);
+  if (fs.existsSync(primaryPath)) return primaryPath;
+
+  const fallback = PATH_FALLBACKS[configPath];
+  if (fallback) {
+    const fallbackPath = path.join(srcDir, lang, fallback);
+    if (fs.existsSync(fallbackPath)) return fallbackPath;
+  }
+
+  throw new Error(
+    `Markdown file not found: ${configPath} (lang: ${lang}). ` +
+      `Tried: ${primaryPath}` +
+      (fallback ? ` and ${path.join(srcDir, lang, fallback)}` : ''),
+  );
+}
+
+function rewriteImagePaths(
+  markdown: string,
+  lang: string,
+  srcDir: string,
+  mdFilePath: string,
+): string {
+  const mdDir = path.dirname(mdFilePath);
+  return markdown.replace(
+    /!\[([^\]]*)\]\(images\/([^)]+)\)/g,
+    (_, alt, filename) => {
+      // Images are always in src/{lang}/images/
+      const absPath = path.join(srcDir, lang, 'images', filename);
+      if (fs.existsSync(absPath)) {
+        return `![${alt}](${pathToFileURL(absPath).toString()})`;
+      }
+      // Try relative to the md file's directory
+      const relPath = path.join(mdDir, 'images', filename);
+      if (fs.existsSync(relPath)) {
+        return `![${alt}](${pathToFileURL(relPath).toString()})`;
+      }
+      // Keep original if not found
+      return `![${alt}](images/${filename})`;
+    },
+  );
+}
+
+/**
+ * Strip RST grid table borders (+------+------+) and clean up
+ * so that marked can parse the pipe rows as markdown tables.
+ */
+function normalizeRstTables(markdown: string): string {
+  const lines = markdown.split('\n');
+  const result: string[] = [];
+  let inRstTable = false;
+  let headerInserted = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Detect RST table border: +----+----+ or +=====+=====+
+    if (/^\+[-=+]+\+$/.test(line.trim())) {
+      if (!inRstTable) {
+        inRstTable = true;
+        headerInserted = false;
+      }
+      // Check if this is a header separator (uses = instead of -)
+      if (/^\+[=+]+\+$/.test(line.trim()) && !headerInserted) {
+        // Insert a markdown header separator after the first pipe row
+        const prevLine = result[result.length - 1];
+        if (prevLine && prevLine.trim().startsWith('|')) {
+          const cols = prevLine.split('|').filter((c) => c.length > 0);
+          result.push('|' + cols.map((c) => '---').join('|') + '|');
+          headerInserted = true;
+        }
+      }
+      // Skip the border line itself
+      continue;
+    }
+
+    if (inRstTable && line.trim() === '') {
+      inRstTable = false;
+      headerInserted = false;
+    }
+
+    // For RST table pipe rows, ensure they end with |
+    if (inRstTable && line.trim().startsWith('|')) {
+      let cleaned = line.trim();
+      if (!cleaned.endsWith('|')) {
+        cleaned += '|';
+      }
+      result.push(cleaned);
+
+      // If this is the first row and we haven't inserted a header separator yet
+      if (!headerInserted) {
+        // Header separator will be inserted when we encounter the border line
+      }
+    } else {
+      result.push(line);
+    }
+  }
+
+  return result.join('\n');
+}
+
+/**
+ * Replace Sphinx template variables used in disclaimer.md
+ */
+function substituteTemplateVars(
+  markdown: string,
+  version: string,
+): string {
+  const now = new Date();
+  const year = String(now.getFullYear());
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+
+  return (
+    markdown
+      // |year|, |version|, |version_date|, |date| — with optional spaces
+      .replace(/\|\s*year\s*\|/g, year)
+      .replace(/\|\s*version\s*\|/g, version)
+      .replace(/\|\s*version_date\s*\|/g, `${year}.${month}.${day}`)
+      .replace(/\|\s*date\s*\|/g, `${year}/${month}/${day}`)
+      // Remove RST-style escape sequences (\ followed by space)
+      .replace(/\\\s/g, ' ')
+  );
+}
+
+/**
+ * Convert 3-space indented note blocks into markdown blockquotes.
+ * Must distinguish from list continuations and code blocks.
+ */
+function convertIndentedNotes(markdown: string): string {
+  const lines = markdown.split('\n');
+  const result: string[] = [];
+  let inList = false;
+  let inCodeBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Track fenced code blocks
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      result.push(line);
+      continue;
+    }
+    if (inCodeBlock) {
+      result.push(line);
+      continue;
+    }
+
+    // Track list context
+    if (/^[\s]*[-*+]\s/.test(line) || /^[\s]*\d+\.\s/.test(line)) {
+      inList = true;
+    } else if (line.trim() === '') {
+      // Blank line may end list context (check next line)
+      const nextLine = lines[i + 1];
+      if (
+        nextLine &&
+        !/^[\s]*[-*+]\s/.test(nextLine) &&
+        !/^[\s]*\d+\.\s/.test(nextLine) &&
+        !/^\s{3,}/.test(nextLine)
+      ) {
+        inList = false;
+      }
+    }
+
+    // Check for 3-space indented text that's NOT in a list context
+    if (/^ {3}\S/.test(line) && !inList) {
+      result.push('> ' + line.trim());
+    } else if (/^ {3}\s/.test(line) && !inList && result.length > 0 && result[result.length - 1].startsWith('> ')) {
+      // Continuation of a note block
+      result.push('> ' + line.trim());
+    } else {
+      result.push(line);
+    }
+  }
+
+  return result.join('\n');
+}
+
+/**
+ * Process cross-reference links: [text <anchor>](#text <anchor>) → #chapterSlug-slugified-id
+ * The heading IDs are prefixed with chapterSlug, so cross-references must match.
+ */
+function processCrossReferences(
+  html: string,
+  chapterSlug: string,
+): string {
+  // Match href="#text <anchor>" patterns
+  return html.replace(
+    /href="#([^"]*)<([^>]+)>[^"]*"/g,
+    (_, _text, anchor) => `href="#${chapterSlug}-${slugify(anchor)}"`,
+  );
+}
+
+/**
+ * Remove duplicate H1 headings if a chapter has multiple H1s.
+ * Keep only the first one.
+ */
+function deduplicateH1(markdown: string): string {
+  let foundFirst = false;
+  const lines = markdown.split('\n');
+  const result: string[] = [];
+
+  for (const line of lines) {
+    if (/^# /.test(line)) {
+      if (!foundFirst) {
+        foundFirst = true;
+        result.push(line);
+      }
+      // Skip subsequent H1s
+    } else {
+      result.push(line);
+    }
+  }
+
+  return result.join('\n');
+}
+
+export async function processMarkdownFiles(
+  lang: string,
+  navigation: NavEntry[],
+  srcDir: string,
+  version: string,
+): Promise<Chapter[]> {
+  const chapters: Chapter[] = [];
+
+  for (const nav of navigation) {
+    let mdPath: string;
+    try {
+      mdPath = resolveMarkdownPath(lang, nav.path, srcDir);
+    } catch {
+      console.warn(`Skipping missing file: ${nav.path} (${lang})`);
+      continue;
+    }
+
+    let markdown = fs.readFileSync(mdPath, 'utf-8');
+    const chapterSlug = slugify(nav.title);
+
+    // Pre-processing pipeline
+    markdown = deduplicateH1(markdown);
+    markdown = substituteTemplateVars(markdown, version);
+    markdown = rewriteImagePaths(markdown, lang, srcDir, mdPath);
+    markdown = normalizeRstTables(markdown);
+    markdown = convertIndentedNotes(markdown);
+
+    // Track headings for TOC
+    const headings: Heading[] = [];
+
+    // Configure marked with custom renderer
+    // marked@12 uses positional args: heading(text, level, raw), image(href, title, text)
+    const marked = new Marked();
+    const renderer = {
+      heading(text: string, level: number, _raw: string): string {
+        // text may contain HTML tags from inline parsing, strip for slug/toc
+        const plainText = text.replace(/<[^>]+>/g, '');
+        const id = `${chapterSlug}-${slugify(plainText)}`;
+        headings.push({ level, text: plainText, id });
+        return `<h${level} id="${id}">${text}</h${level}>\n`;
+      },
+      image(href: string, title: string | null, text: string): string {
+        const titleAttr = title ? ` title="${title}"` : '';
+        return `<img src="${href}" alt="${text || ''}" class="doc-image"${titleAttr} />\n`;
+      },
+    };
+
+    marked.use({ renderer });
+
+    let htmlContent = await marked.parse(markdown);
+
+    // Post-processing: fix cross-reference links
+    htmlContent = processCrossReferences(htmlContent, chapterSlug);
+
+    chapters.push({
+      title: nav.title,
+      slug: chapterSlug,
+      htmlContent,
+      headings,
+    });
+  }
+
+  return chapters;
+}

--- a/packages/backend.ai-webui-docs/scripts/pdf-renderer.ts
+++ b/packages/backend.ai-webui-docs/scripts/pdf-renderer.ts
@@ -1,0 +1,232 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+import { chromium } from 'playwright';
+import { PDFDocument, PDFName, PDFArray, PDFDict, PDFRef, rgb } from 'pdf-lib';
+import type { PdfTheme } from './theme.js';
+import { defaultTheme, resolveHeaderFooter } from './theme.js';
+
+interface RenderOptions {
+  html: string;
+  outputPath: string;
+  title: string;
+  version: string;
+  lang: string;
+  theme?: PdfTheme;
+}
+
+const PDF_OPTIONS = {
+  format: 'A4' as const,
+  printBackground: true,
+  margin: { top: '25mm', bottom: '20mm', left: '20mm', right: '20mm' },
+};
+
+const PRINT_WIDTH_PX = Math.round(170 * 96 / 25.4); // 643
+
+/**
+ * Extract page numbers from the PDF's named destinations.
+ * Chromium stores /Dests directly in the catalog as a dictionary
+ * mapping /anchorId → [pageRef, /XYZ, left, top, zoom].
+ */
+function extractPageMapFromPdf(
+  pdfDoc: PDFDocument,
+  targetIds: Set<string>,
+): Record<string, number> {
+  const context = pdfDoc.context;
+  const pages = pdfDoc.getPages();
+
+  // Build page ref → page number lookup
+  const pageRefToNum = new Map<string, number>();
+  pages.forEach((pg, idx) => {
+    pageRefToNum.set(pg.ref.toString(), idx + 1);
+  });
+
+  const pageMap: Record<string, number> = {};
+
+  // Get catalog
+  const catalogRef = context.trailerInfo.Root;
+  const catalog = context.lookup(catalogRef) as PDFDict | undefined;
+  if (!catalog) return pageMap;
+
+  // Chromium puts destinations directly in catalog as /Dests dict
+  const destsRef = catalog.get(PDFName.of('Dests'));
+  if (!destsRef) return pageMap;
+
+  const destsDict = context.lookup(destsRef) as PDFDict | undefined;
+  if (!destsDict || !destsDict.entries) return pageMap;
+
+  for (const [key, val] of destsDict.entries()) {
+    // Key is PDFName like /quickstart-quickstart
+    // Remove the leading '/' and decode any URL-encoded chars (#xx → %xx → decode)
+    let anchorId = key.toString().replace(/^\//, '');
+    // Chromium double-encodes non-ASCII in PDF name objects:
+    // Unicode → URL-encode → #xx encoding. So #25EB = %EB, then %EB%AA%A9 = 목
+    anchorId = anchorId.replace(/#([0-9A-Fa-f]{2})/g, '%$1');
+    try { anchorId = decodeURIComponent(anchorId); } catch { /* keep as-is */ }
+    try { anchorId = decodeURIComponent(anchorId); } catch { /* keep as-is */ }
+    if (!targetIds.has(anchorId)) continue;
+
+    // Val is a destination array: [pageRef, /XYZ, left, top, zoom]
+    const dest = context.lookup(val);
+    if (dest instanceof PDFArray && dest.size() > 0) {
+      const pageRef = dest.get(0);
+      if (pageRef instanceof PDFRef) {
+        const pageNum = pageRefToNum.get(pageRef.toString());
+        if (pageNum !== undefined) {
+          pageMap[anchorId] = pageNum;
+        }
+      }
+    }
+  }
+
+  return pageMap;
+}
+
+/**
+ * Get the target IDs referenced by the TOC.
+ */
+async function getTocTargetIds(
+  page: import('playwright').Page,
+): Promise<string[]> {
+  return page.evaluate(() => {
+    const ids: string[] = [];
+    document.querySelectorAll('[data-toc-target]').forEach((span) => {
+      const id = (span as HTMLElement).getAttribute('data-toc-target');
+      if (id) ids.push(id);
+    });
+    return ids;
+  });
+}
+
+/**
+ * Inject page numbers into TOC spans.
+ */
+async function injectTocPageNumbers(
+  page: import('playwright').Page,
+  pageMap: Record<string, number>,
+): Promise<void> {
+  await page.evaluate((map: Record<string, number>) => {
+    document.querySelectorAll('[data-toc-target]').forEach((span) => {
+      const targetId = (span as HTMLElement).getAttribute('data-toc-target');
+      if (targetId && map[targetId] !== undefined) {
+        span.textContent = String(map[targetId]);
+      }
+    });
+  }, pageMap);
+}
+
+export async function renderPdf(options: RenderOptions): Promise<void> {
+  const theme = options.theme ?? defaultTheme;
+  const { headerHtml, footerHtml } = resolveHeaderFooter(theme, options.title);
+
+  fs.mkdirSync(path.dirname(options.outputPath), { recursive: true });
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bai-docs-'));
+  const tmpHtmlPath = path.join(tmpDir, 'document.html');
+  fs.writeFileSync(tmpHtmlPath, options.html, 'utf-8');
+
+  const browser = await chromium.launch();
+  let pdfBuffer: Buffer;
+  try {
+    const page = await browser.newPage({
+      viewport: { width: PRINT_WIDTH_PX, height: 800 },
+    });
+
+    console.log('  Loading document...');
+    await page.goto(pathToFileURL(tmpHtmlPath).toString(), {
+      waitUntil: 'networkidle',
+      timeout: 120_000,
+    });
+
+    await page
+      .waitForFunction(
+        () => {
+          const images = Array.from(document.querySelectorAll('img'));
+          if (images.length === 0) return true;
+          return images.every(
+            (img) => img.complete && (img.naturalWidth > 0 || img.src === ''),
+          );
+        },
+        { timeout: 120_000 },
+      )
+      .catch(() => {
+        console.warn('  Warning: Some images may not have loaded completely');
+      });
+
+    const targetIds = await getTocTargetIds(page);
+    const targetIdSet = new Set(targetIds);
+
+    // Pass 1: Render PDF → read named destinations → inject page numbers
+    console.log('  Calculating page positions (pass 1)...');
+    const prelim1 = await page.pdf({
+      ...PDF_OPTIONS,
+      displayHeaderFooter: true,
+      headerTemplate: '<span></span>',
+      footerTemplate: '<span></span>',
+    });
+    const doc1 = await PDFDocument.load(prelim1);
+    const map1 = extractPageMapFromPdf(doc1, targetIdSet);
+    console.log(`    Found ${Object.keys(map1).length}/${targetIds.length} destinations`);
+    await injectTocPageNumbers(page, map1);
+
+    // Pass 2: Re-render with filled TOC numbers → re-extract (layout may shift)
+    console.log('  Calculating page positions (pass 2)...');
+    const prelim2 = await page.pdf({
+      ...PDF_OPTIONS,
+      displayHeaderFooter: true,
+      headerTemplate: '<span></span>',
+      footerTemplate: '<span></span>',
+    });
+    const doc2 = await PDFDocument.load(prelim2);
+    const map2 = extractPageMapFromPdf(doc2, targetIdSet);
+    console.log(`    Found ${Object.keys(map2).length}/${targetIds.length} destinations`);
+    await injectTocPageNumbers(page, map2);
+
+    // Show samples
+    const entries = Object.entries(map2);
+    if (entries.length > 0) {
+      console.log(`  Samples:`);
+      entries.slice(0, 5).forEach(([id, pg]) => console.log(`    ${id} → page ${pg}`));
+    }
+
+    // Final PDF render with visible header/footer
+    console.log('  Rendering final PDF...');
+    pdfBuffer = await page.pdf({
+      ...PDF_OPTIONS,
+      displayHeaderFooter: true,
+      headerTemplate: headerHtml,
+      footerTemplate: footerHtml,
+    });
+  } finally {
+    await browser.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  // Post-process: metadata + cover page masking
+  console.log('  Post-processing...');
+  const pdfDoc = await PDFDocument.load(pdfBuffer);
+
+  pdfDoc.setTitle(`${options.title} ${options.version} (${options.lang})`);
+  pdfDoc.setAuthor('Lablup Inc.');
+  pdfDoc.setSubject('Backend.AI WebUI User Guide');
+  pdfDoc.setCreator('Backend.AI Docs PDF Generator');
+  pdfDoc.setProducer('Playwright + pdf-lib');
+  pdfDoc.setCreationDate(new Date());
+
+  // Hide header/footer on cover page with white rectangles
+  const coverPage = pdfDoc.getPage(0);
+  const { width, height } = coverPage.getSize();
+
+  coverPage.drawRectangle({
+    x: 0, y: 0, width, height: 60,
+    color: rgb(1, 1, 1),
+  });
+  coverPage.drawRectangle({
+    x: 0, y: height - 75, width, height: 75,
+    color: rgb(1, 1, 1),
+  });
+
+  const finalBytes = await pdfDoc.save();
+  fs.writeFileSync(options.outputPath, finalBytes);
+}

--- a/packages/backend.ai-webui-docs/scripts/preview-server.ts
+++ b/packages/backend.ai-webui-docs/scripts/preview-server.ts
@@ -1,0 +1,356 @@
+import fs from 'fs';
+import http from 'http';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { parse as parseYaml } from 'yaml';
+import { processMarkdownFiles } from './markdown-processor.js';
+import { buildFullDocument } from './html-builder.js';
+import { renderPdf } from './pdf-renderer.js';
+import { loadTheme } from './theme.js';
+import { buildSampleChapters, buildCatalogChapters } from './sample-content.js';
+import { getDocVersion } from './version.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DOCS_ROOT = path.resolve(__dirname, '..');
+const SRC_DIR = path.join(DOCS_ROOT, 'src');
+const CONFIG_PATH = path.join(SRC_DIR, 'book.config.yaml');
+const DIST_DIR = path.join(DOCS_ROOT, 'dist');
+
+interface BookConfig {
+  title: string;
+  description: string;
+  languages: string[];
+  navigation: Record<string, Array<{ title: string; path: string }>>;
+}
+
+type PreviewMode = 'catalog' | 'document' | 'sample';
+
+const MODE_LABELS: Record<PreviewMode, string> = {
+  catalog: 'Style Catalog (theme reference + sample elements)',
+  sample: 'Sample content (fast)',
+  document: 'Full document (real markdown)',
+};
+
+function parseArgs(argv: string[]): { lang: string; theme: string; port: number; mode: PreviewMode } {
+  let lang = 'en';
+  let theme = 'default';
+  let port = 3456;
+  let mode: PreviewMode = 'sample';
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--lang' && argv[i + 1]) { lang = argv[i + 1]; i++; }
+    if (argv[i] === '--theme' && argv[i + 1]) { theme = argv[i + 1]; i++; }
+    if (argv[i] === '--port' && argv[i + 1]) { port = parseInt(argv[i + 1], 10); i++; }
+    if (argv[i] === '--mode' && argv[i + 1]) { mode = argv[i + 1] as PreviewMode; i++; }
+  }
+  return { lang, theme, port, mode };
+}
+
+/**
+ * Build the PDF viewer page that embeds the actual PDF.
+ * On reload signal, the PDF <object> src is cache-busted to show updated PDF.
+ */
+function buildPdfViewerPage(title: string, mode: PreviewMode): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>PDF Preview - ${title}</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #525659;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+    .toolbar {
+      height: 40px;
+      background: #323639;
+      display: flex;
+      align-items: center;
+      padding: 0 16px;
+      gap: 16px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.4);
+      flex-shrink: 0;
+    }
+    .toolbar .title { color: #ccc; font-size: 13px; font-weight: 500; }
+    .toolbar .badge {
+      background: #ff9d00; color: #000; font-size: 10px; font-weight: 700;
+      padding: 2px 8px; border-radius: 3px; text-transform: uppercase; letter-spacing: 0.5px;
+    }
+    .toolbar .spacer { flex: 1; }
+    .toolbar .info { color: #888; font-size: 11px; }
+    .toolbar .status { color: #4caf50; font-size: 11px; }
+    .toolbar .status.building { color: #ff9d00; }
+    .pdf-container {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      overflow: hidden;
+    }
+    .pdf-container object,
+    .pdf-container iframe {
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="toolbar">
+    <span class="badge">PDF Preview</span>
+    <span class="title">${title}</span>
+    <span class="spacer"></span>
+    <span class="info">${MODE_LABELS[mode]}</span>
+    <span class="status" id="status">Ready</span>
+  </div>
+  <div class="pdf-container">
+    <object id="pdf-viewer" data="/preview.pdf" type="application/pdf">
+      <iframe id="pdf-fallback" src="/preview.pdf"></iframe>
+    </object>
+  </div>
+  <script>
+  (function() {
+    let lastEtag = '';
+    const statusEl = document.getElementById('status');
+    async function poll() {
+      try {
+        const res = await fetch('/__reload');
+        const data = await res.json();
+        if (data.building) {
+          statusEl.textContent = 'Rebuilding PDF...';
+          statusEl.className = 'status building';
+        } else if (lastEtag && lastEtag !== data.etag) {
+          statusEl.textContent = 'Ready';
+          statusEl.className = 'status';
+          const viewer = document.getElementById('pdf-viewer');
+          const fallback = document.getElementById('pdf-fallback');
+          const newSrc = '/preview.pdf?t=' + Date.now();
+          if (viewer) viewer.data = newSrc;
+          if (fallback) fallback.src = newSrc;
+        } else {
+          statusEl.textContent = 'Ready';
+          statusEl.className = 'status';
+        }
+        lastEtag = data.etag;
+      } catch {}
+      setTimeout(poll, 500);
+    }
+    poll();
+  })();
+  </script>
+</body>
+</html>`;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const config: BookConfig = parseYaml(fs.readFileSync(CONFIG_PATH, 'utf-8'));
+  const { display: version } = getDocVersion();
+  const theme = loadTheme(args.theme);
+  const title = config.title;
+
+  let currentEtag = Date.now().toString(36);
+  let isBuilding = false;
+
+  fs.mkdirSync(DIST_DIR, { recursive: true });
+  const previewPdfPath = path.join(DIST_DIR, `preview_${args.mode}_${args.lang}.pdf`);
+
+  /**
+   * Generate preview PDF using the actual Playwright pipeline.
+   * All modes produce a real PDF — identical rendering to production.
+   */
+  async function generatePreviewPdf(): Promise<void> {
+    isBuilding = true;
+    const start = Date.now();
+
+    let html: string;
+    if (args.mode === 'catalog') {
+      // Catalog mode: theme reference + sample elements
+      const chapters = buildCatalogChapters(theme);
+      html = buildFullDocument(chapters, { title, version, lang: args.lang }, DOCS_ROOT, theme);
+    } else if (args.mode === 'sample') {
+      // Sample mode: sample elements only (no theme reference chapter)
+      const chapters = buildSampleChapters();
+      html = buildFullDocument(chapters, { title, version, lang: args.lang }, DOCS_ROOT, theme);
+    } else {
+      // Document mode: real markdown content
+      const navigation = config.navigation[args.lang];
+      if (!navigation) {
+        console.error(`  No navigation found for language: ${args.lang}`);
+        isBuilding = false;
+        return;
+      }
+      const chapters = await processMarkdownFiles(args.lang, navigation, SRC_DIR, version);
+      html = buildFullDocument(chapters, { title, version, lang: args.lang }, DOCS_ROOT, theme);
+    }
+
+    console.log('  Rendering PDF via Playwright...');
+    await renderPdf({
+      html,
+      outputPath: previewPdfPath,
+      title,
+      version,
+      lang: args.lang,
+      theme,
+    });
+
+    const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+    const fileSize = (fs.statSync(previewPdfPath).size / 1024).toFixed(0);
+    console.log(`  PDF generated in ${elapsed}s (${fileSize} KB)`);
+
+    currentEtag = Date.now().toString(36);
+    isBuilding = false;
+  }
+
+  // Initial build
+  console.log(`  Generating initial preview PDF...`);
+  console.log(`  Mode: ${MODE_LABELS[args.mode]}`);
+  await generatePreviewPdf();
+
+  // Serialized rebuild: prevents concurrent Playwright runs
+  const debounceMs = 500;
+  let rebuildTimer: ReturnType<typeof setTimeout> | null = null;
+  let currentBuild: Promise<void> | null = null;
+  let pendingRebuild = false;
+
+  function runSerializedBuild() {
+    if (currentBuild) {
+      pendingRebuild = true;
+      return;
+    }
+
+    pendingRebuild = false;
+    currentBuild = (async () => {
+      console.log(`  Rebuilding...`);
+      try {
+        await generatePreviewPdf();
+      } catch (err) {
+        console.error('  Rebuild failed:', err);
+        isBuilding = false;
+      } finally {
+        currentBuild = null;
+        if (pendingRebuild) {
+          runSerializedBuild();
+        }
+      }
+    })();
+  }
+
+  function scheduleRebuild(changedFile: string) {
+    if (rebuildTimer) clearTimeout(rebuildTimer);
+    rebuildTimer = setTimeout(() => {
+      rebuildTimer = null;
+      console.log(`  File changed: ${path.relative(DOCS_ROOT, changedFile)}`);
+      pendingRebuild = true;
+      runSerializedBuild();
+    }, debounceMs);
+  }
+
+  // For document mode, watch markdown files
+  if (args.mode === 'document') {
+    const srcLangDir = path.join(SRC_DIR, args.lang);
+    if (fs.existsSync(srcLangDir)) {
+      fs.watch(srcLangDir, { recursive: true }, (_event, filename) => {
+        if (filename && (filename.endsWith('.md') || filename.endsWith('.yaml'))) {
+          scheduleRebuild(path.join(srcLangDir, filename));
+        }
+      });
+      console.log(`  Watching: src/${args.lang}/**/*.md`);
+    }
+  }
+
+  // Always watch config
+  fs.watch(CONFIG_PATH, () => { scheduleRebuild(CONFIG_PATH); });
+
+  // Watch theme directory for changes
+  const themesDir = path.join(DOCS_ROOT, 'themes');
+  if (fs.existsSync(themesDir)) {
+    fs.watch(themesDir, { recursive: true }, (_event, filename) => {
+      if (filename) scheduleRebuild(path.join(themesDir, filename));
+    });
+  }
+
+  // HTTP server
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url || '/', `http://localhost:${args.port}`);
+
+    // Live-reload polling endpoint
+    if (url.pathname === '/__reload') {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' });
+      res.end(JSON.stringify({ etag: currentEtag, building: isBuilding }));
+      return;
+    }
+
+    // All modes: / serves viewer, /preview.pdf serves actual PDF
+    if (url.pathname === '/' || url.pathname === '/index.html') {
+      const viewerHtml = buildPdfViewerPage(title, args.mode);
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'no-cache' });
+      res.end(viewerHtml);
+      return;
+    }
+
+    if (url.pathname === '/preview.pdf') {
+      if (fs.existsSync(previewPdfPath)) {
+        const stat = fs.statSync(previewPdfPath);
+        res.writeHead(200, {
+          'Content-Type': 'application/pdf',
+          'Content-Length': stat.size,
+          'Cache-Control': 'no-cache',
+        });
+        fs.createReadStream(previewPdfPath).pipe(res);
+      } else {
+        res.writeHead(503, { 'Content-Type': 'text/plain' });
+        res.end('PDF is being generated...');
+      }
+      return;
+    }
+
+    // Serve static files (images) from src/{lang}/
+    const safePath = path.normalize(url.pathname).replace(/^\/+/, '');
+    const filePath = path.join(SRC_DIR, args.lang, safePath);
+    if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+      const ext = path.extname(filePath).toLowerCase();
+      const mimeTypes: Record<string, string> = {
+        '.png': 'image/png',
+        '.jpg': 'image/jpeg',
+        '.jpeg': 'image/jpeg',
+        '.gif': 'image/gif',
+        '.svg': 'image/svg+xml',
+        '.webp': 'image/webp',
+      };
+      res.writeHead(200, { 'Content-Type': mimeTypes[ext] || 'application/octet-stream' });
+      fs.createReadStream(filePath).pipe(res);
+      return;
+    }
+
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  });
+
+  server.listen(args.port, () => {
+    console.log('');
+    console.log(`  Backend.AI Docs Preview Server`);
+    console.log(`  Mode:      ${args.mode} — ${MODE_LABELS[args.mode]}`);
+    console.log(`  Theme:     ${theme.name}`);
+    console.log(`  Language:  ${args.lang}`);
+    console.log(`  URL:       http://localhost:${args.port}`);
+    console.log(`  PDF:       http://localhost:${args.port}/preview.pdf`);
+    console.log('');
+    if (args.mode === 'document') {
+      console.log(`  Editing src/${args.lang}/**/*.md will regenerate the PDF.`);
+    } else {
+      console.log(`  All modes generate real PDF via Playwright (identical to production).`);
+    }
+    console.log(`  Editing scripts/*.ts requires server restart.`);
+    console.log('');
+    console.log(`  Press Ctrl+C to stop.`);
+  });
+}
+
+main().catch((err) => {
+  console.error('Preview server failed:', err);
+  process.exit(1);
+});

--- a/packages/backend.ai-webui-docs/scripts/sample-content.ts
+++ b/packages/backend.ai-webui-docs/scripts/sample-content.ts
@@ -1,0 +1,285 @@
+import type { Chapter } from './markdown-processor.js';
+import type { PdfTheme } from './theme.js';
+import { resolveHeaderFooter } from './theme.js';
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/**
+ * Build a "Theme Reference" chapter that shows all theme variable values
+ * and header/footer template source code. This renders using the same
+ * PDF styles as production, so you see exactly how it looks in print.
+ */
+export function buildThemeInfoChapter(theme: PdfTheme): Chapter {
+  const { headerHtml, footerHtml } = resolveHeaderFooter(theme, 'Backend.AI WebUI');
+
+  const colorVars = [
+    ['brandColor', theme.brandColor],
+    ['textPrimary', theme.textPrimary],
+    ['textSecondary', theme.textSecondary],
+    ['textTertiary', theme.textTertiary],
+    ['linkColor', theme.linkColor],
+    ['borderColor', theme.borderColor],
+    ['codeBackground', theme.codeBackground],
+    ['codeBorder', theme.codeBorder],
+    ['tableHeaderBg', theme.tableHeaderBg],
+    ['tableBorder', theme.tableBorder],
+    ['blockquoteBg', theme.blockquoteBg],
+    ['blockquoteBorderColor', theme.blockquoteBorderColor],
+  ] as const;
+
+  const sizeVars = [
+    ['baseFontSize', theme.baseFontSize],
+    ['headingH1Size', theme.headingH1Size],
+    ['headingH2Size', theme.headingH2Size],
+    ['headingH3Size', theme.headingH3Size],
+    ['headingH4Size', theme.headingH4Size],
+    ['codeFontSize', theme.codeFontSize],
+    ['tableFontSize', theme.tableFontSize],
+    ['blockquoteFontSize', theme.blockquoteFontSize],
+    ['tocHeadingSize', theme.tocHeadingSize],
+    ['coverTitleSize', theme.coverTitleSize],
+    ['coverSubtitleSize', theme.coverSubtitleSize],
+    ['coverLogoWidth', theme.coverLogoWidth],
+  ] as const;
+
+  const colorRows = colorVars
+    .map(
+      ([name, value]) =>
+        `<tr><td><code>${name}</code></td><td><span style="display:inline-block;width:14px;height:14px;background:${value};border:1px solid #ccc;border-radius:2px;vertical-align:middle;margin-right:6px;"></span> <code>${value}</code></td></tr>`,
+    )
+    .join('\n');
+
+  const sizeRows = sizeVars
+    .map(([name, value]) => `<tr><td><code>${name}</code></td><td><code>${value}</code></td></tr>`)
+    .join('\n');
+
+  return {
+    title: 'Theme Reference',
+    slug: 'theme-reference',
+    headings: [
+      { level: 1, text: 'Theme Reference', id: 'theme-reference' },
+      { level: 2, text: 'Color Variables', id: 'theme-colors' },
+      { level: 2, text: 'Size Variables', id: 'theme-sizes' },
+      { level: 2, text: 'Header / Footer Templates', id: 'theme-header-footer' },
+    ],
+    htmlContent: `
+<h1 id="theme-reference">Theme Reference: ${theme.name}</h1>
+<p>This section shows all theme variables and their current values. The PDF you are viewing is rendered using these exact settings.</p>
+
+<h2 id="theme-colors">Color Variables</h2>
+<table>
+  <thead><tr><th>Variable</th><th>Value</th></tr></thead>
+  <tbody>${colorRows}</tbody>
+</table>
+
+<h2 id="theme-sizes">Size Variables</h2>
+<table>
+  <thead><tr><th>Variable</th><th>Value</th></tr></thead>
+  <tbody>${sizeRows}</tbody>
+</table>
+
+<h2 id="theme-header-footer">Header / Footer Templates</h2>
+<p>These templates are rendered by Playwright's <code>displayHeaderFooter</code>. Only inline styles work. Available CSS classes: <code>.date</code>, <code>.title</code>, <code>.url</code>, <code>.pageNumber</code>, <code>.totalPages</code>.</p>
+<h3>Header Template</h3>
+<pre><code>${escapeHtml(headerHtml.trim())}</code></pre>
+<h3>Footer Template</h3>
+<pre><code>${escapeHtml(footerHtml.trim())}</code></pre>
+`,
+  };
+}
+
+/**
+ * Build sample chapters that exercise every PDF styling element.
+ * Used by the preview server to generate a quick sample PDF
+ * that is pixel-identical to production output.
+ */
+export function buildSampleChapters(): Chapter[] {
+  return [
+    {
+      title: 'Introduction & Overview',
+      slug: 'introduction',
+      headings: [
+        { level: 1, text: 'Introduction & Overview', id: 'introduction-introduction' },
+        { level: 2, text: 'System Requirements', id: 'introduction-system-requirements' },
+        { level: 2, text: 'Getting Started', id: 'introduction-getting-started' },
+      ],
+      htmlContent: `
+<h1 id="introduction-introduction">Introduction &amp; Overview</h1>
+<p>Backend.AI WebUI is a web-based graphical interface for the Backend.AI computing platform. It provides users with an intuitive way to manage compute sessions, storage folders, and other resources without needing to use command-line tools.</p>
+
+<h2 id="introduction-system-requirements">System Requirements</h2>
+<p>Before installing Backend.AI WebUI, ensure your system meets the following requirements:</p>
+<table>
+  <thead>
+    <tr>
+      <th>Component</th>
+      <th>Requirement</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Browser</td>
+      <td>Chrome 90+, Firefox 88+, Safari 14+</td>
+      <td>Latest versions recommended</td>
+    </tr>
+    <tr>
+      <td>Network</td>
+      <td>Stable internet connection</td>
+      <td>Required for API communication</td>
+    </tr>
+    <tr>
+      <td>Resolution</td>
+      <td>1280×800 minimum</td>
+      <td>1920×1080 recommended</td>
+    </tr>
+    <tr>
+      <td><code>config.toml</code></td>
+      <td>Properly configured</td>
+      <td>See configuration section</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2 id="introduction-getting-started">Getting Started</h2>
+<p>Follow these steps to get started with Backend.AI WebUI:</p>
+<ol>
+  <li>Navigate to the Backend.AI WebUI URL provided by your administrator.</li>
+  <li>Enter your <strong>credentials</strong> on the login page:
+    <ul>
+      <li><strong>User ID</strong>: Your registered email address</li>
+      <li><strong>Password</strong>: Your account password</li>
+    </ul>
+  </li>
+  <li>Click <strong>Login</strong> to access the dashboard.</li>
+  <li>Explore the sidebar navigation to access different features.</li>
+</ol>
+<blockquote>
+  <p>Your administrator must configure the <code>apiEndpoint</code> in <code>config.toml</code> before you can connect to the Backend.AI server.</p>
+</blockquote>
+`,
+    },
+    {
+      title: 'Session Management',
+      slug: 'session-management',
+      headings: [
+        { level: 1, text: 'Session Management', id: 'session-management-session-management' },
+        { level: 2, text: 'Creating Sessions', id: 'session-management-creating-sessions' },
+        { level: 2, text: 'Monitoring & Logs', id: 'session-management-monitoring-logs' },
+        { level: 3, text: 'Resource Usage', id: 'session-management-resource-usage' },
+      ],
+      htmlContent: `
+<h1 id="session-management-session-management">Session Management</h1>
+<p>Sessions are the core computing unit in Backend.AI. Each session runs inside an isolated container with configurable resources including CPU, memory, and GPU (including <strong>fractional GPU</strong> or fGPU).</p>
+
+<h2 id="session-management-creating-sessions">Creating Sessions</h2>
+<p>To create a new compute session:</p>
+<ol>
+  <li>Navigate to the <strong>Sessions</strong> page from the sidebar.</li>
+  <li>Click the <strong>+ New Session</strong> button in the top-right corner.</li>
+  <li>Configure the following fields:
+    <ul>
+      <li><strong>Session Name</strong>: Enter a descriptive name for identification.</li>
+      <li><strong>Resource Group</strong>: Select the target resource group.</li>
+      <li><strong>Image</strong>: Choose the container image (e.g., <code>cr.backend.ai/stable/python</code>).</li>
+      <li><strong>Resource Allocation</strong>: Set CPU, memory, and GPU requirements.</li>
+    </ul>
+  </li>
+  <li>Click <strong>Launch</strong> to start the session.</li>
+</ol>
+
+<h3 id="session-management-resource-usage">Resource Usage</h3>
+<p>Monitor your session resources in real-time through the session detail panel.</p>
+<blockquote>
+  <p><strong>Warning:</strong> Sessions that exceed their allocated memory will be terminated automatically. Always request sufficient resources before starting computationally intensive workloads.</p>
+</blockquote>
+
+<h4>Configuration Example</h4>
+<pre><code>[general]
+apiEndpoint = "https://api.backend.ai"
+apiEndpointText = "Backend.AI Cloud"
+defaultSessionEnvironment = "cr.backend.ai/stable/python"
+siteDescription = "Backend.AI WebUI"
+
+[resources]
+maxCPU = 8
+maxMemory = "16g"
+maxGPU = 1.0</code></pre>
+
+<h2 id="session-management-monitoring-logs">Monitoring &amp; Logs</h2>
+<p>You can view logs for any running or completed session:</p>
+<ul>
+  <li>Click the session name to open the detail panel</li>
+  <li>Select the <strong>Logs</strong> tab to view container output</li>
+  <li>Use the <strong>Download</strong> button to save logs locally</li>
+  <li>Filter logs by severity level:
+    <ul>
+      <li><em>Info</em> — General informational messages</li>
+      <li><em>Warning</em> — Non-critical issues</li>
+      <li><em>Error</em> — Critical failures requiring attention</li>
+    </ul>
+  </li>
+</ul>
+<p>For more information about sessions, see the <a href="#introduction-getting-started">Getting Started</a> section.</p>
+<hr />
+<p>This concludes the session management overview. For advanced topics, refer to the <a href="#session-management-creating-sessions">Creating Sessions</a> subsection above.</p>
+`,
+    },
+    {
+      title: 'Storage & Data',
+      slug: 'storage-data',
+      headings: [
+        { level: 1, text: 'Storage & Data', id: 'storage-data-storage-data' },
+        { level: 2, text: 'Virtual Folders', id: 'storage-data-virtual-folders' },
+      ],
+      htmlContent: `
+<h1 id="storage-data-storage-data">Storage &amp; Data</h1>
+<p>Backend.AI provides persistent storage through <strong>virtual folders</strong> (vfolders). These folders persist across sessions and can be shared with other users or mounted into compute sessions.</p>
+
+<h2 id="storage-data-virtual-folders">Virtual Folders</h2>
+<p>Virtual folders (vfolders) are the primary mechanism for storing and managing data in Backend.AI:</p>
+<table>
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Max Size</td>
+      <td>Maximum storage per folder</td>
+      <td>Unlimited (admin configurable)</td>
+    </tr>
+    <tr>
+      <td>Sharing</td>
+      <td>Share folders with other users</td>
+      <td>Disabled by default</td>
+    </tr>
+    <tr>
+      <td>Auto-mount</td>
+      <td>Automatically mount in new sessions</td>
+      <td>Configurable per folder</td>
+    </tr>
+  </tbody>
+</table>
+<blockquote>
+  <p>Deleting a storage folder is <strong>irreversible</strong>. All data in the folder will be permanently lost. Always back up important data before deletion.</p>
+</blockquote>
+<p>To create a new virtual folder, navigate to the <strong>Data &amp; Storage</strong> page and click <strong>+ New Folder</strong>.</p>
+`,
+    },
+  ];
+}
+
+/**
+ * Build catalog chapters: theme reference + all sample elements.
+ * When rendered through renderPdf, produces a PDF that shows
+ * all styling elements exactly as they appear in production.
+ */
+export function buildCatalogChapters(theme: PdfTheme): Chapter[] {
+  return [buildThemeInfoChapter(theme), ...buildSampleChapters()];
+}

--- a/packages/backend.ai-webui-docs/scripts/style-catalog.ts
+++ b/packages/backend.ai-webui-docs/scripts/style-catalog.ts
@@ -1,0 +1,433 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { loadTheme, resolveHeaderFooter } from './theme.js';
+import type { PdfTheme } from './theme.js';
+import { generatePdfStyles } from './styles.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DOCS_ROOT = path.resolve(__dirname, '..');
+const DIST_DIR = path.join(DOCS_ROOT, 'dist', 'preview');
+
+function parseArgs(argv: string[]): { theme: string } {
+  let theme = 'default';
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--theme' && argv[i + 1]) {
+      theme = argv[i + 1];
+      i++;
+    }
+  }
+  return { theme };
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+export function generateStyleCatalog(theme: PdfTheme): string {
+  const styles = generatePdfStyles(theme);
+  const { headerHtml, footerHtml } = resolveHeaderFooter(theme, 'Backend.AI WebUI');
+
+  // Load logo if available
+  const logoPath = path.resolve(DOCS_ROOT, '../../manifest/backend.ai-brand-simple.svg');
+  const logoSvg = fs.existsSync(logoPath)
+    ? fs.readFileSync(logoPath, 'utf-8')
+    : '<div style="font-size:48px;color:#ff9d00;font-weight:bold;">Backend.AI</div>';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>PDF Style Catalog - ${theme.name}</title>
+  <style>${styles}</style>
+  <style>
+    /* Catalog-specific overrides */
+    body {
+      background: #e8e8e8;
+      padding: 20px 20px 60px;
+    }
+    .catalog-card {
+      background: white;
+      max-width: 210mm;
+      margin: 0 auto 24px;
+      padding: 32px 40px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.12);
+      border-radius: 4px;
+    }
+    .catalog-label {
+      font-size: 11px;
+      color: #999;
+      text-transform: uppercase;
+      letter-spacing: 1.5px;
+      margin: 0 0 16px 0;
+      padding-bottom: 8px;
+      border-bottom: 1px solid #eee;
+      font-weight: 600;
+    }
+    .catalog-nav {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      background: #1a1a1a;
+      color: white;
+      padding: 12px 24px;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      gap: 24px;
+      font-size: 13px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+    }
+    .catalog-nav a {
+      color: #ccc;
+      text-decoration: none;
+      font-size: 12px;
+    }
+    .catalog-nav a:hover { color: white; }
+    .catalog-nav .brand {
+      font-weight: 700;
+      font-size: 14px;
+      color: ${theme.brandColor};
+      margin-right: auto;
+    }
+    body { padding-top: 60px; }
+
+    /* Theme info panel */
+    .theme-info {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 12px;
+    }
+    .theme-var {
+      font-family: monospace;
+      font-size: 11px;
+      padding: 8px;
+      background: #f9f9f9;
+      border-radius: 3px;
+      border: 1px solid #eee;
+    }
+    .theme-var .label { color: #999; display: block; margin-bottom: 2px; }
+    .theme-var .value { font-weight: 600; }
+    .color-swatch {
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      border-radius: 2px;
+      border: 1px solid #ddd;
+      vertical-align: middle;
+      margin-right: 4px;
+    }
+
+    /* Header/Footer preview */
+    .hf-preview {
+      background: #f5f5f5;
+      border: 1px dashed #ccc;
+      padding: 4px;
+      margin: 8px 0;
+      position: relative;
+    }
+    .hf-preview::before {
+      content: attr(data-label);
+      position: absolute;
+      top: -18px;
+      left: 0;
+      font-size: 10px;
+      color: #999;
+      text-transform: uppercase;
+    }
+    .hf-source {
+      background: #f6f8fa;
+      border: 1px solid #e1e4e8;
+      border-radius: 3px;
+      padding: 8px 12px;
+      font-family: monospace;
+      font-size: 10px;
+      white-space: pre-wrap;
+      word-break: break-all;
+      color: #333;
+      margin-top: 8px;
+    }
+
+    /* Cover page preview - don't stretch full height */
+    .cover-page { min-height: auto; padding: 40px; }
+    .chapter { page-break-before: auto; }
+  </style>
+</head>
+<body>
+
+<nav class="catalog-nav">
+  <span class="brand">PDF Style Catalog</span>
+  <a href="#theme">Theme</a>
+  <a href="#header-footer">Header/Footer</a>
+  <a href="#cover">Cover</a>
+  <a href="#toc">TOC</a>
+  <a href="#headings">Headings</a>
+  <a href="#text">Text</a>
+  <a href="#lists">Lists</a>
+  <a href="#code">Code</a>
+  <a href="#tables">Tables</a>
+  <a href="#blockquotes">Blockquotes</a>
+  <a href="#images">Images</a>
+</nav>
+
+<!-- Theme Variables -->
+<div class="catalog-card" id="theme">
+  <div class="catalog-label">Theme: ${theme.name}</div>
+  <div class="theme-info">
+    <div class="theme-var">
+      <span class="label">brandColor</span>
+      <span class="value"><span class="color-swatch" style="background:${theme.brandColor}"></span>${theme.brandColor}</span>
+    </div>
+    <div class="theme-var">
+      <span class="label">textPrimary</span>
+      <span class="value"><span class="color-swatch" style="background:${theme.textPrimary}"></span>${theme.textPrimary}</span>
+    </div>
+    <div class="theme-var">
+      <span class="label">textSecondary</span>
+      <span class="value"><span class="color-swatch" style="background:${theme.textSecondary}"></span>${theme.textSecondary}</span>
+    </div>
+    <div class="theme-var">
+      <span class="label">linkColor</span>
+      <span class="value"><span class="color-swatch" style="background:${theme.linkColor}"></span>${theme.linkColor}</span>
+    </div>
+    <div class="theme-var">
+      <span class="label">baseFontSize</span>
+      <span class="value">${theme.baseFontSize}</span>
+    </div>
+    <div class="theme-var">
+      <span class="label">codeFontSize</span>
+      <span class="value">${theme.codeFontSize}</span>
+    </div>
+    <div class="theme-var">
+      <span class="label">tableFontSize</span>
+      <span class="value">${theme.tableFontSize}</span>
+    </div>
+    <div class="theme-var">
+      <span class="label">blockquoteBorderColor</span>
+      <span class="value"><span class="color-swatch" style="background:${theme.blockquoteBorderColor}"></span>${theme.blockquoteBorderColor}</span>
+    </div>
+  </div>
+</div>
+
+<!-- Header / Footer -->
+<div class="catalog-card" id="header-footer">
+  <div class="catalog-label">Header / Footer (Playwright templates)</div>
+  <p style="font-size:10pt; color:#666; margin-top:0;">
+    These templates are rendered by Playwright's <code>displayHeaderFooter</code>.
+    Only inline styles work. Available classes: <code>.date</code>, <code>.title</code>,
+    <code>.url</code>, <code>.pageNumber</code>, <code>.totalPages</code>.
+  </p>
+
+  <div class="hf-preview" data-label="Header preview" style="margin-top:24px;">
+    ${headerHtml}
+  </div>
+  <details>
+    <summary style="font-size:11px; color:#666; cursor:pointer;">View header HTML source</summary>
+    <div class="hf-source">${escapeHtml(headerHtml.trim())}</div>
+  </details>
+
+  <div class="hf-preview" data-label="Footer preview" style="margin-top:24px;">
+    ${footerHtml}
+  </div>
+  <details>
+    <summary style="font-size:11px; color:#666; cursor:pointer;">View footer HTML source</summary>
+    <div class="hf-source">${escapeHtml(footerHtml.trim())}</div>
+  </details>
+</div>
+
+<!-- Cover Page -->
+<div class="catalog-card" id="cover">
+  <div class="catalog-label">Cover Page</div>
+  <section class="cover-page">
+    <div class="cover-logo">
+      ${logoSvg}
+    </div>
+    <h1 class="cover-title">Backend.AI WebUI</h1>
+    <p class="cover-subtitle">User Guide</p>
+    <hr class="cover-divider" />
+    <div class="cover-meta">
+      <p class="version">v26.2.0</p>
+      <p class="company">Lablup Inc.</p>
+      <p class="date">February 2026</p>
+      <p class="lang">English</p>
+    </div>
+  </section>
+</div>
+
+<!-- Table of Contents -->
+<div class="catalog-card" id="toc">
+  <div class="catalog-label">Table of Contents</div>
+  <h1 class="toc-heading">Table of Contents</h1>
+  <ol class="toc-list">
+    <li class="toc-chapter">
+      <a href="#"><span class="toc-text">1. Introduction &amp; Overview</span><span class="toc-pagenum">3</span></a>
+      <ol class="toc-sections">
+        <li><a href="#"><span class="toc-text">System Requirements</span><span class="toc-pagenum">4</span></a></li>
+        <li><a href="#"><span class="toc-text">Getting Started</span><span class="toc-pagenum">5</span></a></li>
+      </ol>
+    </li>
+    <li class="toc-chapter">
+      <a href="#"><span class="toc-text">2. Session Management</span><span class="toc-pagenum">8</span></a>
+      <ol class="toc-sections">
+        <li><a href="#"><span class="toc-text">Creating Sessions</span><span class="toc-pagenum">9</span></a></li>
+        <li><a href="#"><span class="toc-text">Monitoring &amp; Logs</span><span class="toc-pagenum">12</span></a></li>
+      </ol>
+    </li>
+    <li class="toc-chapter">
+      <a href="#"><span class="toc-text">3. Storage &amp; Data</span><span class="toc-pagenum">15</span></a>
+    </li>
+  </ol>
+</div>
+
+<!-- Headings -->
+<div class="catalog-card" id="headings">
+  <div class="catalog-label">Headings</div>
+  <h1>Heading 1 &mdash; Chapter Title (${theme.headingH1Size})</h1>
+  <p>Introductory paragraph after H1. This demonstrates the standard paragraph spacing.</p>
+
+  <h2>Heading 2 &mdash; Major Section (${theme.headingH2Size})</h2>
+  <p>Content under H2. This is a typical section within a chapter.</p>
+
+  <h3>Heading 3 &mdash; Subsection (${theme.headingH3Size})</h3>
+  <p>Content under H3. More detailed topic within a section.</p>
+
+  <h4>Heading 4 &mdash; Sub-subsection (${theme.headingH4Size})</h4>
+  <p>Content under H4. The most granular heading level used.</p>
+</div>
+
+<!-- Text Styles -->
+<div class="catalog-card" id="text">
+  <div class="catalog-label">Text &amp; Inline Styles</div>
+  <p>This is a regular paragraph with <strong>bold text</strong>, <em>italic text</em>,
+     and <code>inline code</code> formatting. The base font size is ${theme.baseFontSize}.</p>
+  <p>Here is a <a href="#">link to another section</a> and an
+     <a href="#internal">internal cross-reference link</a>.</p>
+  <hr />
+  <p>The horizontal rule above separates content sections.</p>
+</div>
+
+<!-- Lists -->
+<div class="catalog-card" id="lists">
+  <div class="catalog-label">Lists</div>
+  <h3>Unordered List</h3>
+  <ul>
+    <li>First item in the list</li>
+    <li>Second item with a nested list:
+      <ul>
+        <li>Nested item A</li>
+        <li>Nested item B</li>
+      </ul>
+    </li>
+    <li>Third item</li>
+  </ul>
+
+  <h3>Ordered List (Procedure Steps)</h3>
+  <ol>
+    <li>Navigate to the <strong>Sessions</strong> page from the sidebar.</li>
+    <li>Click the <strong>+ New Session</strong> button.</li>
+    <li>Configure the following fields:
+      <ul>
+        <li><strong>Session Name</strong>: Enter a descriptive name.</li>
+        <li><strong>Resource Group</strong>: Select the target resource group.</li>
+        <li><strong>Image</strong>: Choose the container image.</li>
+      </ul>
+    </li>
+    <li>Click <strong>Launch</strong> to start the session.</li>
+  </ol>
+</div>
+
+<!-- Code -->
+<div class="catalog-card" id="code">
+  <div class="catalog-label">Code</div>
+  <h3>Inline Code</h3>
+  <p>Use the <code>config.toml</code> file to configure the <code>apiEndpoint</code> setting.</p>
+
+  <h3>Code Block</h3>
+  <pre><code>[general]
+apiEndpoint = "https://api.backend.ai"
+apiEndpointText = "Backend.AI Cloud"
+defaultSessionEnvironment = "cr.backend.ai/stable/python"
+siteDescription = "Backend.AI WebUI"</code></pre>
+</div>
+
+<!-- Tables -->
+<div class="catalog-card" id="tables">
+  <div class="catalog-label">Tables</div>
+  <table>
+    <thead>
+      <tr>
+        <th>Feature</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>apiEndpoint</code></td>
+        <td>The API server endpoint URL</td>
+        <td><code>https://api.backend.ai</code></td>
+      </tr>
+      <tr>
+        <td><code>defaultSessionEnvironment</code></td>
+        <td>Default container image for new sessions</td>
+        <td><code>cr.backend.ai/stable/python</code></td>
+      </tr>
+      <tr>
+        <td><code>siteDescription</code></td>
+        <td>Display name shown in the browser tab</td>
+        <td><code>Backend.AI WebUI</code></td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<!-- Blockquotes (Notes) -->
+<div class="catalog-card" id="blockquotes">
+  <div class="catalog-label">Blockquotes (Notes / Warnings)</div>
+  <blockquote>
+    <p>This is an informational note. The admin must configure the resource group
+       before users can create sessions.</p>
+  </blockquote>
+  <blockquote>
+    <p><strong>Warning:</strong> Deleting a storage folder is irreversible. All data
+       in the folder will be permanently lost.</p>
+  </blockquote>
+</div>
+
+<!-- Images -->
+<div class="catalog-card" id="images">
+  <div class="catalog-label">Images</div>
+  <p>Images use the <code>.doc-image</code> class with a subtle border and centered layout:</p>
+  <div style="background:#f0f0f0; padding:20px; text-align:center; border:0.5px solid ${theme.borderColor}; border-radius:3px;">
+    <span style="color:#999; font-size:10pt;">[Screenshot placeholder - 600x300]</span>
+  </div>
+</div>
+
+</body>
+</html>`;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const theme = loadTheme(args.theme);
+
+  console.log(`Backend.AI WebUI Docs Style Catalog`);
+  console.log(`Theme: ${theme.name}`);
+
+  const html = generateStyleCatalog(theme);
+
+  fs.mkdirSync(DIST_DIR, { recursive: true });
+  const outputPath = path.join(DIST_DIR, `style-catalog.html`);
+  fs.writeFileSync(outputPath, html, 'utf-8');
+
+  const fileSize = (fs.statSync(outputPath).size / 1024).toFixed(1);
+  console.log(`Generated: ${outputPath} (${fileSize} KB)`);
+}
+
+main().catch((err) => {
+  console.error('Style catalog generation failed:', err);
+  process.exit(1);
+});

--- a/packages/backend.ai-webui-docs/scripts/styles.ts
+++ b/packages/backend.ai-webui-docs/scripts/styles.ts
@@ -1,0 +1,389 @@
+import type { PdfTheme } from './theme.js';
+import { defaultTheme } from './theme.js';
+
+export function generatePdfStyles(theme: PdfTheme): string {
+  return `
+/* ==========================================================================
+   Base
+   ========================================================================== */
+@page {
+  size: A4;
+  margin: 25mm 20mm 20mm 20mm;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
+    "Noto Sans KR", "Noto Sans JP", "Noto Sans Thai",
+    Helvetica, Arial, sans-serif;
+  font-size: ${theme.baseFontSize};
+  line-height: 1.6;
+  color: ${theme.textPrimary};
+  margin: 0;
+  padding: 0;
+}
+
+/* ==========================================================================
+   Cover Page
+   ========================================================================== */
+.cover-page {
+  page-break-after: always;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  text-align: center;
+  padding: 60px 40px;
+}
+
+.cover-logo {
+  margin-bottom: 80px;
+}
+
+.cover-logo svg {
+  width: ${theme.coverLogoWidth};
+  height: auto;
+}
+
+.cover-title {
+  font-size: ${theme.coverTitleSize};
+  font-weight: 700;
+  color: ${theme.textPrimary};
+  margin: 0 0 16px 0;
+  letter-spacing: -0.5px;
+  border: none;
+  padding: 0;
+}
+
+.cover-subtitle {
+  font-size: ${theme.coverSubtitleSize};
+  color: ${theme.textSecondary};
+  margin: 0 0 60px 0;
+  font-weight: 400;
+}
+
+.cover-meta {
+  color: ${theme.textTertiary};
+  font-size: ${theme.baseFontSize};
+  line-height: 2;
+}
+
+.cover-meta .version {
+  font-size: 16pt;
+  color: #444;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.cover-meta .company {
+  font-size: 12pt;
+  color: ${theme.textSecondary};
+}
+
+.cover-meta .date,
+.cover-meta .lang {
+  font-size: ${theme.baseFontSize};
+  color: #999;
+}
+
+.cover-divider {
+  width: 80px;
+  height: 3px;
+  background: ${theme.brandColor};
+  margin: 40px auto;
+  border: none;
+}
+
+/* ==========================================================================
+   Table of Contents
+   ========================================================================== */
+.toc-section {
+  page-break-after: always;
+}
+
+.toc-heading {
+  font-size: ${theme.tocHeadingSize};
+  margin-bottom: 30px;
+  border-bottom: 2px solid ${theme.brandColor};
+  padding-bottom: 10px;
+}
+
+.toc-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.toc-chapter {
+  margin-bottom: 4px;
+}
+
+.toc-chapter > a {
+  font-size: ${theme.baseFontSize};
+  font-weight: 600;
+  color: ${theme.textPrimary};
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  padding: 4px 0;
+  border-bottom: 0.5px solid #eee;
+}
+
+.toc-chapter > a .toc-text {
+  flex-shrink: 0;
+  margin-right: 4px;
+}
+
+.toc-chapter > a .toc-pagenum {
+  flex-shrink: 0;
+  margin-left: auto;
+  text-align: right;
+  min-width: 30px;
+  color: ${theme.textSecondary};
+  font-weight: 400;
+}
+
+.toc-sections {
+  list-style: none;
+  padding-left: 24px;
+  margin: 2px 0 4px 0;
+}
+
+.toc-sections li {
+  margin-bottom: 1px;
+}
+
+.toc-sections li a {
+  font-size: 10pt;
+  font-weight: 400;
+  color: #555;
+  text-decoration: none;
+  display: flex;
+  align-items: baseline;
+  padding: 1px 0;
+}
+
+.toc-sections li a .toc-text {
+  flex-shrink: 0;
+  margin-right: 4px;
+}
+
+.toc-sections li a .toc-pagenum {
+  flex-shrink: 0;
+  margin-left: auto;
+  text-align: right;
+  min-width: 30px;
+  color: ${theme.textTertiary};
+}
+
+/* ==========================================================================
+   Chapter Content
+   ========================================================================== */
+.chapter {
+  page-break-before: always;
+}
+
+h1 {
+  font-size: ${theme.headingH1Size};
+  font-weight: 700;
+  color: ${theme.textPrimary};
+  margin-top: 0;
+  margin-bottom: 20px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid ${theme.brandColor};
+}
+
+h2 {
+  font-size: ${theme.headingH2Size};
+  font-weight: 600;
+  color: #2a2a2a;
+  margin-top: 32px;
+  margin-bottom: 14px;
+  page-break-after: avoid;
+}
+
+h3 {
+  font-size: ${theme.headingH3Size};
+  font-weight: 600;
+  color: #3a3a3a;
+  margin-top: 24px;
+  margin-bottom: 10px;
+  page-break-after: avoid;
+}
+
+h4 {
+  font-size: ${theme.headingH4Size};
+  font-weight: 600;
+  color: #444;
+  margin-top: 18px;
+  margin-bottom: 8px;
+  page-break-after: avoid;
+}
+
+p {
+  margin: 8px 0;
+  orphans: 3;
+  widows: 3;
+}
+
+/* ==========================================================================
+   Images
+   ========================================================================== */
+.doc-image {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 12px auto;
+  border: 0.5px solid ${theme.borderColor};
+  border-radius: 3px;
+  page-break-inside: avoid;
+}
+
+/* ==========================================================================
+   Tables
+   ========================================================================== */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 12px 0;
+  font-size: ${theme.tableFontSize};
+  page-break-inside: auto;
+}
+
+thead {
+  display: table-header-group;
+}
+
+tr {
+  page-break-inside: avoid;
+}
+
+th {
+  background-color: ${theme.tableHeaderBg};
+  font-weight: 600;
+  text-align: left;
+  padding: 8px 10px;
+  border: 0.5px solid ${theme.tableBorder};
+}
+
+td {
+  padding: 6px 10px;
+  border: 0.5px solid ${theme.tableBorder};
+  vertical-align: top;
+}
+
+/* ==========================================================================
+   Code
+   ========================================================================== */
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: ${theme.codeFontSize};
+  background-color: ${theme.codeBackground};
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 0.5px solid ${theme.codeBorder};
+}
+
+pre {
+  background-color: ${theme.codeBackground};
+  padding: 12px;
+  border-radius: 4px;
+  border: 0.5px solid ${theme.codeBorder};
+  overflow-x: auto;
+  font-size: ${theme.codeFontSize};
+  line-height: 1.5;
+  page-break-inside: avoid;
+}
+
+pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+
+/* ==========================================================================
+   Lists
+   ========================================================================== */
+ul, ol {
+  margin: 8px 0;
+  padding-left: 24px;
+}
+
+li {
+  margin-bottom: 4px;
+}
+
+li > ul,
+li > ol {
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+/* ==========================================================================
+   Blockquotes (Notes)
+   ========================================================================== */
+blockquote {
+  margin: 14px 0;
+  padding: 10px 16px;
+  border-left: 3px solid ${theme.blockquoteBorderColor};
+  background-color: ${theme.blockquoteBg};
+  font-size: ${theme.blockquoteFontSize};
+  color: #555;
+  page-break-inside: avoid;
+}
+
+blockquote p {
+  margin: 4px 0;
+}
+
+/* ==========================================================================
+   Links
+   ========================================================================== */
+a {
+  color: ${theme.linkColor};
+  text-decoration: none;
+}
+
+a[href^="#"] {
+  color: ${theme.linkColor};
+}
+
+/* ==========================================================================
+   Horizontal Rules
+   ========================================================================== */
+hr {
+  border: none;
+  border-top: 1px solid ${theme.borderColor};
+  margin: 24px 0;
+}
+
+/* ==========================================================================
+   Strong / Emphasis
+   ========================================================================== */
+strong {
+  font-weight: 600;
+}
+
+em {
+  font-style: italic;
+}
+
+/* ==========================================================================
+   Print
+   ========================================================================== */
+@media print {
+  body {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}
+`;
+}
+
+/** Pre-built styles using the default theme (backward compatibility). */
+export const pdfStyles = generatePdfStyles(defaultTheme);

--- a/packages/backend.ai-webui-docs/scripts/theme.ts
+++ b/packages/backend.ai-webui-docs/scripts/theme.ts
@@ -1,0 +1,147 @@
+export interface PdfTheme {
+  name: string;
+
+  // Colors
+  brandColor: string;
+  textPrimary: string;
+  textSecondary: string;
+  textTertiary: string;
+  linkColor: string;
+  borderColor: string;
+
+  // Cover Page
+  coverTitleSize: string;
+  coverSubtitleSize: string;
+  coverLogoWidth: string;
+
+  // Typography
+  baseFontSize: string;
+  headingH1Size: string;
+  headingH2Size: string;
+  headingH3Size: string;
+  headingH4Size: string;
+
+  // Code
+  codeFontSize: string;
+  codeBackground: string;
+  codeBorder: string;
+
+  // Table
+  tableFontSize: string;
+  tableHeaderBg: string;
+  tableBorder: string;
+
+  // Blockquote (Notes)
+  blockquoteBg: string;
+  blockquoteBorderColor: string;
+  blockquoteFontSize: string;
+
+  // TOC
+  tocHeadingSize: string;
+
+  // Header / Footer (Playwright displayHeaderFooter templates)
+  headerHtml: string;
+  footerHtml: string;
+}
+
+/**
+ * Build default header HTML template.
+ * Playwright header/footer templates support these CSS classes:
+ *   .date, .title, .url, .pageNumber, .totalPages
+ * Only inline styles are allowed (no external stylesheets).
+ */
+function defaultHeaderHtml(title: string, theme: { headerFooterColor: string; headerFooterFontSize: string }): string {
+  return `
+    <div style="width: 100%; font-size: ${theme.headerFooterFontSize}; color: ${theme.headerFooterColor}; padding: 0 15mm; margin-top: 5mm;">
+      <span style="float: left;">${title}</span>
+    </div>
+  `;
+}
+
+function defaultFooterHtml(theme: { headerFooterColor: string; headerFooterFontSize: string }): string {
+  return `
+    <div style="width: 100%; font-size: ${theme.headerFooterFontSize}; color: ${theme.headerFooterColor}; text-align: center; padding: 0 15mm; margin-bottom: 3mm;">
+      <span class="pageNumber"></span>
+    </div>
+  `;
+}
+
+// Internal defaults used to build headerHtml/footerHtml
+const HEADER_FOOTER_DEFAULTS = {
+  headerFooterFontSize: '8px',
+  headerFooterColor: '#aaa',
+};
+
+export const defaultTheme: PdfTheme = {
+  name: 'default',
+
+  brandColor: '#ff9d00',
+  textPrimary: '#1a1a1a',
+  textSecondary: '#666',
+  textTertiary: '#888',
+  linkColor: '#0066cc',
+  borderColor: '#e0e0e0',
+
+  coverTitleSize: '32pt',
+  coverSubtitleSize: '14pt',
+  coverLogoWidth: '200px',
+
+  baseFontSize: '11pt',
+  headingH1Size: '22pt',
+  headingH2Size: '16pt',
+  headingH3Size: '13pt',
+  headingH4Size: '11pt',
+
+  codeFontSize: '9pt',
+  codeBackground: '#f6f8fa',
+  codeBorder: '#e1e4e8',
+
+  tableFontSize: '10pt',
+  tableHeaderBg: '#f5f5f5',
+  tableBorder: '#d0d0d0',
+
+  blockquoteBg: '#fffbf0',
+  blockquoteBorderColor: '#ff9d00',
+  blockquoteFontSize: '10pt',
+
+  tocHeadingSize: '24pt',
+
+  // Placeholder - will be resolved with actual title at render time
+  headerHtml: defaultHeaderHtml('{{TITLE}}', HEADER_FOOTER_DEFAULTS),
+  footerHtml: defaultFooterHtml(HEADER_FOOTER_DEFAULTS),
+};
+
+/**
+ * Resolve header/footer template placeholders.
+ * Call this after knowing the document title.
+ */
+export function resolveHeaderFooter(
+  theme: PdfTheme,
+  title: string,
+): { headerHtml: string; footerHtml: string } {
+  return {
+    headerHtml: theme.headerHtml.replace(/\{\{TITLE\}\}/g, title),
+    footerHtml: theme.footerHtml,
+  };
+}
+
+/**
+ * Load a theme by name. Returns the default theme if name is not found.
+ */
+export function loadTheme(themeName?: string): PdfTheme {
+  if (!themeName || themeName === 'default') {
+    return defaultTheme;
+  }
+
+  // Built-in themes
+  const builtinThemes: Record<string, PdfTheme> = {
+    default: defaultTheme,
+  };
+
+  const theme = builtinThemes[themeName];
+  if (!theme) {
+    console.warn(`Theme "${themeName}" not found. Using default theme.`);
+    return defaultTheme;
+  }
+  return theme;
+}

--- a/packages/backend.ai-webui-docs/scripts/version.ts
+++ b/packages/backend.ai-webui-docs/scripts/version.ts
@@ -1,0 +1,45 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_PKG_PATH = path.resolve(__dirname, '..', '..', '..', 'package.json');
+
+function getGitShortHash(): string | null {
+  try {
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the document version from the monorepo root package.json.
+ *
+ * - Release version (`26.2.0`) → `v26.2.0`
+ * - Pre-release version (`26.2.0-alpha.0`) → `v26.2.0-alpha.0 (abc1234)`
+ *
+ * The git short hash is appended for pre-release builds so that
+ * PDFs generated from different commits are distinguishable even
+ * when the package version has not been bumped.
+ */
+export function getDocVersion(): { display: string; filename: string } {
+  const pkgJson = JSON.parse(fs.readFileSync(ROOT_PKG_PATH, 'utf-8'));
+  const raw: string = pkgJson.version || '0.0.0';
+  const isPreRelease = raw.includes('-');
+
+  if (!isPreRelease) {
+    const v = `v${raw}`;
+    return { display: v, filename: v };
+  }
+
+  const hash = getGitShortHash();
+  const base = `v${raw}`;
+
+  return {
+    display: hash ? `${base} (${hash})` : base,
+    filename: hash ? `v${raw}+${hash}` : base,
+  };
+}

--- a/packages/backend.ai-webui-docs/tsconfig.json
+++ b/packages/backend.ai-webui-docs/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "./dist",
+    "rootDir": "./scripts",
+    "declaration": false,
+    "skipLibCheck": true
+  },
+  "include": ["scripts/**/*.ts"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - react
   - packages/backend.ai-ui
   - packages/eslint-config-bai
+  - packages/backend.ai-webui-docs
 
 ignoredBuiltDependencies:
   - "@vaadin/vaadin-usage-statistics"


### PR DESCRIPTION
Resolves #5306 ([FR-2051](https://lablup.atlassian.net/browse/FR-2051))

## Summary
- Add a complete PDF generation pipeline for producing customer-facing user manual PDFs from Markdown documentation source
- Professional cover page with logo, title, version, and metadata
- Table of Contents with clickable internal links and accurate page numbers (via PDF named destinations extraction)
- Two-pass page number calculation to handle TOC reflow
- Unicode-aware heading ID generation for CJK language support (en, ja, ko, th)
- Searchable/selectable text with proper image embedding
- **README documentation** with comprehensive usage guide
- **Theme system** for customizable styling (colors, typography, cover, header/footer)
- **Preview server** with live-reload for fast iteration (3 modes: sample/catalog/document)
- **Sample content** for quick styling tests without processing real markdown
- **Style catalog** for visual reference of all PDF elements
- **Version logic improvements**: keep pre-release suffix, append git hash for pre-release builds

## Architecture
- `generate-pdf.ts` — CLI entry point, reads `book.config.yaml` navigation
- `markdown-processor.ts` — Markdown→HTML conversion with `marked`, image path resolution, Unicode-aware slugification
- `html-builder.ts` — Assembles cover page, TOC, and content into single HTML document
- `styles.ts` — Print-optimized CSS generation from theme (A4, pagination, typography)
- `theme.ts` — Theme interface and defaults for customization
- `version.ts` — Version resolution (semver + git hash for pre-release)
- `pdf-renderer.ts` — Playwright-based rendering with pdf-lib post-processing (metadata, cover masking, named destination extraction)
- `preview-server.ts` — Dev server with live-reload and real PDF generation
- `sample-content.ts` — Sample chapters exercising all styling elements
- `style-catalog.ts` — Standalone HTML catalog showing theme variables and samples

## Usage
```bash
# Generate PDFs
pnpm --filter backend.ai-webui-docs run pdf       # All 4 languages
pnpm --filter backend.ai-webui-docs run pdf:en    # English only

# Preview with live-reload
pnpm --filter backend.ai-webui-docs run preview              # Sample content (~1s)
pnpm --filter backend.ai-webui-docs run preview:catalog     # Theme + samples (~1s)
pnpm --filter backend.ai-webui-docs run preview:doc         # Full document (~15-30s)

# Style catalog (HTML)
pnpm --filter backend.ai-webui-docs run catalog
```

## Test plan
- [x] Generate English PDF: 116/116 TOC destinations matched
- [x] Generate Japanese PDF: 110/110 TOC destinations matched
- [x] Generate Korean PDF: 110/110 TOC destinations matched
- [x] Generate Thai PDF: 110/110 TOC destinations matched
- [x] Preview server generates identical PDF to production
- [x] Version logic: release (`v26.2.0`) and pre-release (`v26.2.0-alpha.0 (abc1234)`)
- [ ] Verify cover page displays correctly (no page number)
- [ ] Verify TOC clickable links navigate to correct pages
- [ ] Verify page numbers match TOC entries
- [ ] Verify images render at appropriate sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-2051]: https://lablup.atlassian.net/browse/FR-2051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ