### PR TITLE
feat(FR-2072)/set `reuseIfExists` to false when creating a session

### DIFF
--- a/react/src/components/FileBrowserButton.tsx
+++ b/react/src/components/FileBrowserButton.tsx
@@ -92,6 +92,7 @@ const FileBrowserButton: React.FC<FileBrowserButtonProps> = ({
     cluster_mode: 'single-node',
     cluster_size: 1,
     mount_ids: [toLocalId(vfolder.id || '').replaceAll('-', '')],
+    reuseIfExists: true,
   });
 
   return (

--- a/react/src/components/ImageInstallModal.tsx
+++ b/react/src/components/ImageInstallModal.tsx
@@ -70,6 +70,7 @@ const ImageInstallModal: React.FC<ImageInstallModalInterface> = ({
         cluster_size: 1,
         startupCommand: 'echo "Image is installed"',
         enqueueOnly: true,
+        reuseIfExists: false,
         config: {
           resources: {
             ..._.mapValues(_.keyBy(image?.resource_limits, 'key'), 'min'),

--- a/react/src/components/SFTPServerButton.tsx
+++ b/react/src/components/SFTPServerButton.tsx
@@ -116,6 +116,7 @@ const SFTPServerButton: React.FC<SFTPServerButtonProps> = ({
     cluster_size: 1,
     mount_ids: [toLocalId(vfolder?.id || '').replaceAll('-', '')],
     resourceGroup: sftpScalingGroupByCurrentProject?.[0],
+    reuseIfExists: true,
   });
 
   return (

--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -241,59 +241,62 @@ const SessionLauncherPreview: React.FC<{
                         </Typography.Text>
                         <Divider type="vertical" />
                         {/* TODO: replace this with AliasedImageDoubleTags after image list query with ImageNode is implemented. */}
-                        {_.map(
-                          form.getFieldValue('environments')?.image?.tags,
-                          (tag: { key: string; value: string }) => {
-                            const isCustomized = _.includes(
-                              tag.key,
-                              'customized_',
-                            );
-                            const tagValue = isCustomized
-                              ? _.find(
-                                  form.getFieldValue('environments')?.image
-                                    ?.labels,
-                                  {
-                                    key: 'ai.backend.customized-image.name',
-                                  },
-                                )?.value
-                              : tag.value;
-                            const aliasedTag = tagAlias(tag.key + tagValue);
-                            return _.isEqual(
-                              aliasedTag,
-                              preserveDotStartCase(tag.key + tagValue),
-                            ) || isCustomized ? (
-                              <BAIDoubleTag
-                                key={tag.key}
-                                values={[
-                                  {
-                                    label: tagAlias(tag.key),
-                                    color: isCustomized ? 'cyan' : 'blue',
-                                  },
-                                  {
-                                    label: tagValue,
-                                    color: isCustomized ? 'cyan' : 'blue',
-                                  },
-                                ]}
-                              />
-                            ) : (
-                              <Tag
-                                key={tag.key}
-                                color={isCustomized ? 'cyan' : 'blue'}
-                              >
-                                {aliasedTag}
-                              </Tag>
-                            );
-                          },
-                        )}
-                        <Typography.Text
-                          style={{ color: token.colorPrimary }}
-                          copyable={{
-                            text:
-                              getImageFullName(
-                                form.getFieldValue('environments')?.image,
-                              ) || form.getFieldValue('environments')?.version,
-                          }}
-                        />
+                        <BAIFlex gap={'xxs'}>
+                          {_.map(
+                            form.getFieldValue('environments')?.image?.tags,
+                            (tag: { key: string; value: string }) => {
+                              const isCustomized = _.includes(
+                                tag.key,
+                                'customized_',
+                              );
+                              const tagValue = isCustomized
+                                ? _.find(
+                                    form.getFieldValue('environments')?.image
+                                      ?.labels,
+                                    {
+                                      key: 'ai.backend.customized-image.name',
+                                    },
+                                  )?.value
+                                : tag.value;
+                              const aliasedTag = tagAlias(tag.key + tagValue);
+                              return _.isEqual(
+                                aliasedTag,
+                                preserveDotStartCase(tag.key + tagValue),
+                              ) || isCustomized ? (
+                                <BAIDoubleTag
+                                  key={tag.key}
+                                  values={[
+                                    {
+                                      label: tagAlias(tag.key),
+                                      color: isCustomized ? 'cyan' : 'blue',
+                                    },
+                                    {
+                                      label: tagValue,
+                                      color: isCustomized ? 'cyan' : 'blue',
+                                    },
+                                  ]}
+                                />
+                              ) : (
+                                <Tag
+                                  key={tag.key}
+                                  color={isCustomized ? 'cyan' : 'blue'}
+                                >
+                                  {aliasedTag}
+                                </Tag>
+                              );
+                            },
+                          )}
+                          <Typography.Text
+                            style={{ color: token.colorPrimary }}
+                            copyable={{
+                              text:
+                                getImageFullName(
+                                  form.getFieldValue('environments')?.image,
+                                ) ||
+                                form.getFieldValue('environments')?.version,
+                            }}
+                          />
+                        </BAIFlex>
                       </>
                     )}
                   </BAIFlex>

--- a/react/src/hooks/useStartSession.tsx
+++ b/react/src/hooks/useStartSession.tsx
@@ -174,6 +174,7 @@ export const useStartSession = () => {
         cluster_mode: values.cluster_mode,
         cluster_size: values.cluster_size,
         maxWaitSeconds: 15,
+        reuseIfExists: values.reuseIfExists ?? false,
 
         // Owner settings (optional)
         // FYI, `config.scaling_group` also changes based on owner settings

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -1153,6 +1153,7 @@ class Client {
       cluster_mode: 'single-node',
       cluster_size: 1,
       maxWaitSeconds: 0,
+      reuseIfExists: false,
     },
     timeout?: number,
     architecture: string = 'x86_64',

--- a/src/types/backend-ai-console.d.ts
+++ b/src/types/backend-ai-console.d.ts
@@ -136,6 +136,7 @@ export interface SessionResources {
   startupCommand?: string;
   bootstrap_script?: string;
   owner_access_key?: string;
+  reuseIfExists?: boolean;
   config?: {
     resources?: {
       cpu: number;


### PR DESCRIPTION
Resolves #5335 ([FR-2072](https://lablup.atlassian.net/browse/FR-2072))

# Add `reuseIfExists` parameter to session creation

This PR adds a new `reuseIfExists` parameter to session creation interfaces, allowing clients to specify whether an existing session should be reused if one with matching specifications already exists. The parameter is set to `false` by default in all implementations.

**Checklist:**

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-2072]: https://lablup.atlassian.net/browse/FR-2072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ