### PR TITLE
fix(FR-2069): prevent error page when saving empty theme.json

### DIFF
--- a/react/src/components/BrandingSettingItems/ThemeJsonConfigModal.tsx
+++ b/react/src/components/BrandingSettingItems/ThemeJsonConfigModal.tsx
@@ -106,8 +106,16 @@ const ThemeJsonConfigModal: React.FC<ThemeJsonConfigModalProps> = ({
                   message.error(t('theme.CannotApplyInvalidJsonConfig'));
                 } else {
                   // should export current value not the userCustomThemeConfig state
+                  let parsedValue;
+                  try {
+                    parsedValue = JSON.parse(editorValue);
+                  } catch (error) {
+                    logger.warn('Invalid JSON format in export', error);
+                    message.error(t('theme.CannotApplyInvalidJsonConfig'));
+                    return;
+                  }
                   const blob = new Blob(
-                    [JSON.stringify(JSON.parse(editorValue), null, 2)],
+                    [JSON.stringify(parsedValue, null, 2)],
                     { type: 'application/json' },
                   );
                   downloadBlob(blob, `theme.json`);
@@ -128,7 +136,15 @@ const ThemeJsonConfigModal: React.FC<ThemeJsonConfigModalProps> = ({
                   message.error(t('theme.CannotApplyInvalidJsonConfig'));
                   return;
                 }
-                setUserCustomThemeConfig(JSON.parse(editorValue));
+                let parsedValue;
+                try {
+                  parsedValue = JSON.parse(editorValue);
+                } catch (error) {
+                  logger.warn('Invalid JSON format in theme config', error);
+                  message.error(t('theme.CannotApplyInvalidJsonConfig'));
+                  return;
+                }
+                setUserCustomThemeConfig(parsedValue);
                 message.success(t('theme.JsonConfigAppliedSuccessfully'));
                 onRequestClose();
               }}


### PR DESCRIPTION
Resolves [FR-2069](https://lablup.atlassian.net/browse/FR-2069)

## Summary
Prevent React error page when saving empty or invalid JSON in the Theme JSON Configuration modal on the branding page.

## Changes
- Add try-catch error handling for `JSON.parse(editorValue)` in both OK and Export button handlers
- Display user-friendly error message instead of crashing with uncaught `SyntaxError`
- Affected file: `react/src/components/BrandingSettingItems/ThemeJsonConfigModal.tsx`

## Before
- Saving empty editor content caused uncaught `JSON.parse` error → React error page
- Export with invalid JSON crashed the page

## After
- Invalid JSON shows error message: "Cannot apply invalid JSON config"
- Monaco schema validation still works for structure errors
- No more error pages on empty/invalid JSON input

**Checklist:**
- [x] Bug fix - no documentation needed
- [x] No manager version requirements
- [x] Test: Open branding page → JSON Config modal → Clear all content → Click OK/Export → See error message instead of crash

[FR-2069]: https://lablup.atlassian.net/browse/FR-2069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ