### PR TITLE
fix(FR-2061): handle empty file save in vfolder text editor

### DIFF
--- a/react/src/components/VFolderTextFileEditorModal.tsx
+++ b/react/src/components/VFolderTextFileEditorModal.tsx
@@ -1,4 +1,5 @@
 import { useTanQuery, useTanMutation } from '../hooks/reactQueryAlias';
+import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useThemeMode } from '../hooks/useThemeMode';
 import type { Monaco, OnMount } from '@monaco-editor/react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -24,11 +25,10 @@ const MonacoEditor = React.lazy(() =>
   })),
 );
 
-interface VFolderTextFileEditorModalProps
-  extends Omit<
-    BAIModalProps,
-    'children' | 'title' | 'onCancel' | 'onOk' | 'confirmLoading'
-  > {
+interface VFolderTextFileEditorModalProps extends Omit<
+  BAIModalProps,
+  'children' | 'title' | 'onCancel' | 'onOk' | 'confirmLoading'
+> {
   targetVFolderId: string;
   currentPath: string;
   fileInfo: VFolderFile | null;
@@ -69,6 +69,7 @@ const VFolderTextFileEditorModal: React.FC<VFolderTextFileEditorModalProps> = ({
   const baiClient = useConnectedBAIClient();
   const { getErrorMessage } = useErrorMessageResolver();
   const { token } = theme.useToken();
+  const { upsertNotification } = useSetBAINotification();
 
   const queryClient = useQueryClient();
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
@@ -119,7 +120,52 @@ const VFolderTextFileEditorModal: React.FC<VFolderTextFileEditorModalProps> = ({
         type: detectedMimeTypeRef.current,
       }) as RcFile;
 
-      await uploadFiles([file], targetVFolderId, currentPath);
+      // Workaround: tus-js-client skips PATCH requests for 0-byte files,
+      // immediately calling onSuccess without uploading any data.
+      // (ref: https://github.com/tus/tus-js-client/blob/v4.3.1/lib/upload.js#L578-L582)
+      // To handle empty content saves, we manually create an upload session
+      // and send the PATCH request directly.
+      if (file.size === 0) {
+        const uploadPath = [currentPath, fileInfo.name]
+          .filter(Boolean)
+          .join('/');
+        const uploadUrl: string = await baiClient.vfolder.create_upload_session(
+          uploadPath,
+          file,
+          targetVFolderId,
+        );
+
+        const response = await fetch(uploadUrl, {
+          method: 'PATCH',
+          headers: {
+            'Upload-Offset': '0',
+            'Content-Type': 'application/offset+octet-stream',
+            'Tus-Resumable': '1.0.0',
+          },
+          body: blob,
+        });
+
+        if (!response.ok) {
+          throw new Error(
+            t('explorer.UploadFailed', { folderName: fileInfo.name }),
+          );
+        }
+
+        upsertNotification({
+          key: 'upload:' + targetVFolderId,
+          open: true,
+          backgroundTask: {
+            status: 'resolved',
+            percent: 100,
+            onChange: {
+              resolved: t('explorer.SuccessfullyUploadedToFolder'),
+            },
+          },
+          duration: 3,
+        });
+      } else {
+        await uploadFiles([file], targetVFolderId, currentPath);
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({


### PR DESCRIPTION
Resolves [FR-2061](https://lablup.atlassian.net/browse/FR-2061)

## Problem
When using the file editor in the vfolder explorer to delete all content and save, the UI shows a success message but the file content is not actually modified on the server.

## Root Cause
The tus-js-client library skips sending PATCH requests for 0-byte files. When a file is created with size 0, tus-js-client immediately calls `onSuccess` without uploading any data to the server ([reference](https://github.com/tus/tus-js-client/blob/v4.3.1/lib/upload.js#L578-L582)):

```javascript
if (_this6._size === 0) {
  // Nothing to upload and file was successfully created
  _this6._emitSuccess(res);
  _this6._source.close();
  return;
}
```

## Solution
For 0-byte files, we now:
1. Create a tus upload session via `create_upload_session`
2. Manually send a PATCH request with the empty content
3. Show upload success notification using `useSetBAINotification`

For non-zero files, the existing `uploadFiles` → FileUploadManager flow continues to work normally.

## Changes
- **VFolderTextFileEditorModal.tsx**: Add special handling for 0-byte file saves with direct tus PATCH request and manual notification

## Test Plan
- [ ] Create a new text file in vfolder
- [ ] Edit the file and add some content
- [ ] Delete all content (file size becomes 0 bytes)
- [ ] Save the file
- [ ] Verify the file is actually empty on the server
- [ ] Verify success notification appears
- [ ] Test with non-empty file saves to ensure normal flow still works

[FR-2061]: https://lablup.atlassian.net/browse/FR-2061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ