### PR TITLE
fix(FR-2068): handle null/undefined for unlimited resource policy values

### DIFF
--- a/react/src/components/FormItemWithUnlimited.tsx
+++ b/react/src/components/FormItemWithUnlimited.tsx
@@ -29,8 +29,15 @@ const FormItemWithUnlimited: React.FC<FormItemWithUnlimitedProps> = ({
   // Detect changes in form value to update the isUnlimited state.
   useEffect(() => {
     const fieldValue = form.getFieldValue(name);
+    // When unlimitedValue is undefined or null, treat both null and undefined
+    // form values as "unlimited" because Ant Design may internally convert
+    // undefined to null when storing form field values.
+    const isFieldUnlimited =
+      unlimitedValue === undefined || unlimitedValue === null
+        ? fieldValue === undefined || fieldValue === null
+        : fieldValue === unlimitedValue;
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setIsUnlimited(fieldValue === unlimitedValue);
+    setIsUnlimited(isFieldUnlimited);
   }, [form, name, unlimitedValue]);
 
   // Disable children when isUnlimited is true.
@@ -73,7 +80,9 @@ const FormItemWithUnlimited: React.FC<FormItemWithUnlimitedProps> = ({
           const checked = e.target.checked;
           setIsUnlimited(checked);
           if (checked) {
-            form.setFieldValue(name, unlimitedValue);
+            // Use null instead of undefined because Ant Design may treat
+            // undefined as "reset to initial value" rather than storing it.
+            form.setFieldValue(name, unlimitedValue ?? null);
           } else {
             form.resetFields([name]);
           }

--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -173,10 +173,7 @@ const KeypairResourcePolicySettingModal: React.FC<
       ?.validateFields()
       .then((values) => {
         const total_resource_slots = _.mapValues(
-          _.pickBy(
-            values.total_resource_slots,
-            (value) => !_.isUndefined(value),
-          ),
+          _.pickBy(values.total_resource_slots, (value) => !_.isNil(value)),
           (value, key) => {
             if (_.includes(key, 'mem')) {
               return convertToBinaryUnit(value, '', 0)?.numberFixed;


### PR DESCRIPTION
Resolves #5325 ([FR-2068](https://lablup.atlassian.net/browse/FR-2068))

## Summary

Fixes bug where unlimited resource values in keypair resource policy modal display as 0 instead of showing "Unlimited" checkbox checked.

**Root Cause:**
- Ant Design Form internally converts `undefined` to `null` when storing form field values
- The strict equality check (`null === undefined`) failed to detect unlimited state
- `_.pickBy` only filtered `undefined` values but not `null`, causing `null` to leak through to the server

**Changes:**
- **FormItemWithUnlimited.tsx**: Handle both `null` and `undefined` as unlimited values when `unlimitedValue` is `undefined` or `null`
- **KeypairResourcePolicySettingModal.tsx**: Changed `_.pickBy` filter from `!_.isUndefined(value)` to `!_.isNil(value)` to filter both `null` and `undefined` from resource slots

## Test plan
- [ ] Set a keypair resource policy resource slot (e.g., CPU) to a specific value (e.g., 4)
- [ ] Check "Unlimited" checkbox for the resource
- [ ] Save the policy
- [ ] Re-open the policy settings modal
- [ ] Verify the "Unlimited" checkbox is checked (not showing 0)
- [ ] Test with other fields using `unlimitedValue={0}` to ensure no regression

[FR-2068]: https://lablup.atlassian.net/browse/FR-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ