### PR TITLE
feat(FR-991): migrate signup modal from Lit-Element to React

### DIFF
--- a/react/src/components/SignupModal.tsx
+++ b/react/src/components/SignupModal.tsx
@@ -1,0 +1,261 @@
+import { baiSignedRequestWithPromise } from '../helper';
+import { useAnonymousBackendaiClient } from '../hooks';
+import { useTanMutation } from '../hooks/reactQueryAlias';
+import PrivacyPolicyModal from './PrivacyPolicyModal';
+import TermsOfServiceModal from './TermsOfServiceModal';
+import { Checkbox, Form, Input, Modal, theme, Typography } from 'antd';
+import { BAIButton, BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const passwordPattern = /^(?=.*\d)(?=.*[a-zA-Z])(?=.*[_\W]).{8,}$/;
+
+interface SignupFormValues {
+  email: string;
+  user_name: string;
+  token: string;
+  password: string;
+  passwordConfirm: string;
+  agreement: boolean;
+}
+
+interface SignupModalProps extends BAIModalProps {
+  onRequestClose: () => void;
+  endpoint: string;
+  allowSignupWithoutConfirmation: boolean;
+  preloadedToken?: string;
+}
+
+const SignupModal: React.FC<SignupModalProps> = ({
+  onRequestClose,
+  endpoint,
+  allowSignupWithoutConfirmation,
+  preloadedToken,
+  ...modalProps
+}) => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const [form] = Form.useForm<SignupFormValues>();
+  const [showTOS, setShowTOS] = useState(false);
+  const [showPrivacyPolicy, setShowPrivacyPolicy] = useState(false);
+  const [showEmailSentDialog, setShowEmailSentDialog] = useState(false);
+
+  const anonymousBaiClient = useAnonymousBackendaiClient({
+    api_endpoint: endpoint,
+  });
+
+  const signupMutation = useTanMutation({
+    mutationFn: (values: SignupFormValues) => {
+      const body: Record<string, string> = {
+        email: values.email,
+        user_name: values.user_name,
+        password: values.password,
+      };
+      if (!allowSignupWithoutConfirmation) {
+        body.token = values.token;
+      }
+      return baiSignedRequestWithPromise({
+        method: 'POST',
+        url: '/auth/signup',
+        body,
+        client: anonymousBaiClient,
+      });
+    },
+  });
+
+  const handleSubmit = async () => {
+    const values = await form.validateFields();
+    await signupMutation.mutateAsync(values, {
+      onSuccess: () => {
+        if (!allowSignupWithoutConfirmation) {
+          onRequestClose();
+          setShowEmailSentDialog(true);
+        } else {
+          onRequestClose();
+        }
+      },
+    });
+  };
+
+  return (
+    <>
+      <BAIModal
+        title={
+          allowSignupWithoutConfirmation
+            ? t('signUp.SignUp')
+            : t('signUp.SignUpBETA')
+        }
+        onCancel={onRequestClose}
+        destroyOnHidden
+        width={400}
+        footer={
+          <BAIFlex justify="end">
+            <BAIButton onClick={onRequestClose}>{t('button.Cancel')}</BAIButton>
+            <BAIButton type="primary" action={handleSubmit}>
+              {t('signUp.SignUp')}
+            </BAIButton>
+          </BAIFlex>
+        }
+        {...modalProps}
+      >
+        <Form
+          form={form}
+          layout="vertical"
+          initialValues={{
+            token: preloadedToken || '',
+          }}
+          disabled={signupMutation.isPending}
+          requiredMark="optional"
+        >
+          <Form.Item
+            name="email"
+            label={t('signUp.E-mail')}
+            rules={[
+              {
+                required: true,
+                message: t('signUp.EmailInputRequired'),
+              },
+              {
+                type: 'email',
+                message: t('signUp.InvalidEmail'),
+              },
+            ]}
+          >
+            <Input
+              type="email"
+              maxLength={64}
+              placeholder={t('maxLength.64chars')}
+              autoFocus
+            />
+          </Form.Item>
+          <Form.Item name="user_name" label={t('signUp.UserName')}>
+            <Input maxLength={64} placeholder={t('maxLength.64chars')} />
+          </Form.Item>
+          {!allowSignupWithoutConfirmation && (
+            <Form.Item
+              name="token"
+              label={t('signUp.InvitationToken')}
+              rules={[
+                {
+                  required: true,
+                  message: t('signUp.TokenInputRequired'),
+                },
+              ]}
+            >
+              <Input maxLength={50} />
+            </Form.Item>
+          )}
+          <Form.Item
+            name="password"
+            label={t('signUp.Password')}
+            rules={[
+              {
+                required: true,
+                message: t('signUp.PasswordInputRequired'),
+              },
+              {
+                pattern: passwordPattern,
+                message: t('signUp.PasswordInvalid'),
+              },
+            ]}
+            hasFeedback
+          >
+            <Input.Password maxLength={64} />
+          </Form.Item>
+          <Form.Item
+            name="passwordConfirm"
+            label={t('signUp.PasswordAgain')}
+            dependencies={['password']}
+            hasFeedback
+            rules={[
+              {
+                required: true,
+                message: t('signUp.PasswordInputRequired'),
+              },
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  if (!value || getFieldValue('password') === value) {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(
+                    new Error(t('signUp.PasswordNotMatched')),
+                  );
+                },
+              }),
+            ]}
+          >
+            <Input.Password maxLength={64} />
+          </Form.Item>
+          <Form.Item
+            name="agreement"
+            valuePropName="checked"
+            rules={[
+              {
+                validator: (_, value) =>
+                  value
+                    ? Promise.resolve()
+                    : Promise.reject(
+                        new Error(t('signUp.RequestAgreementTermsOfService')),
+                      ),
+              },
+            ]}
+          >
+            <Checkbox>
+              <Typography.Text style={{ fontSize: token.fontSizeSM }}>
+                {t('signUp.PolicyAgreement_1')}
+                <Typography.Link
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setShowTOS(true);
+                  }}
+                >
+                  {t('signUp.TermsOfService')}
+                </Typography.Link>
+                {t('signUp.PolicyAgreement_2')}
+                <Typography.Link
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setShowPrivacyPolicy(true);
+                  }}
+                >
+                  {t('signUp.PrivacyPolicy')}
+                </Typography.Link>
+                {t('signUp.PolicyAgreement_3')}
+              </Typography.Text>
+            </Checkbox>
+          </Form.Item>
+        </Form>
+      </BAIModal>
+      <TermsOfServiceModal
+        open={showTOS}
+        onRequestClose={() => setShowTOS(false)}
+      />
+      <PrivacyPolicyModal
+        open={showPrivacyPolicy}
+        onRequestClose={() => setShowPrivacyPolicy(false)}
+      />
+      <Modal
+        open={showEmailSentDialog}
+        title={t('signUp.ThankYou')}
+        closable={false}
+        footer={
+          <BAIButton
+            type="primary"
+            onClick={() => setShowEmailSentDialog(false)}
+          >
+            {t('button.Okay')}
+          </BAIButton>
+        }
+        width={400}
+      >
+        <Typography.Paragraph style={{ maxWidth: 350 }}>
+          {t('signUp.VerificationMessage')}
+        </Typography.Paragraph>
+      </Modal>
+    </>
+  );
+};
+
+export default SignupModal;

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -49,6 +49,19 @@ const TOTPActivateModalWithToken = React.lazy(
   () => import('./components/TOTPActivateModalWithToken'),
 );
 
+const SignupModal = React.lazy(() => import('./components/SignupModal'));
+
+customElements.define(
+  'backend-ai-react-signup-modal',
+  reactToWebComponent((props) => {
+    return (
+      <DefaultProviders {...props}>
+        <SignupModalInWebComponent {...props} />
+      </DefaultProviders>
+    );
+  }),
+);
+
 customElements.define(
   'backend-ai-react-totp-registration-modal-before-login',
   reactToWebComponent((props) => {
@@ -95,6 +108,34 @@ customElements.define(
     );
   }),
 );
+
+const SignupModalInWebComponent: React.FC<ReactWebComponentProps> = (props) => {
+  const {
+    parsedValue: {
+      open = false,
+      endpoint = '',
+      allowSignupWithoutConfirmation = false,
+      preloadedToken,
+    } = {},
+  } = useWebComponentInfo<{
+    open: boolean;
+    endpoint: string;
+    allowSignupWithoutConfirmation: boolean;
+    preloadedToken?: string;
+  }>();
+
+  return (
+    <SignupModal
+      open={open}
+      endpoint={endpoint}
+      allowSignupWithoutConfirmation={allowSignupWithoutConfirmation}
+      preloadedToken={preloadedToken}
+      onRequestClose={() => {
+        props.dispatchEvent('close', null);
+      }}
+    />
+  );
+};
 
 const SourceCodeViewerInWebComponent: React.FC<ReactWebComponentProps> = () => {
   const {

--- a/src/components/backend-ai-login.ts
+++ b/src/components/backend-ai-login.ts
@@ -14,7 +14,7 @@ import './backend-ai-dialog';
 import { BackendAiStyles } from './backend-ai-general-styles';
 import { BackendAIPage } from './backend-ai-page';
 import { default as PainKiller } from './backend-ai-painkiller';
-import './backend-ai-signup';
+// Signup modal is now rendered via React web component (backend-ai-react-signup-modal)
 import '@material/mwc-button';
 import '@material/mwc-icon';
 import { IconButton } from '@material/mwc-icon-button';
@@ -37,7 +37,6 @@ globalThis.BackendAIClientConfig = ai.backend.ClientConfig;
  * This type definition is a workaround for resolving both Type error and Importing error.
  */
 type BackendAIDialog = HTMLElementTagNameMap['backend-ai-dialog'];
-type BackendAISignup = HTMLElementTagNameMap['backend-ai-signup'];
 
 declare global {
   const ai: any;
@@ -98,6 +97,8 @@ export default class BackendAILogin extends BackendAIPage {
   @property({ type: Object }) notification;
   @property({ type: Object }) user_groups;
   @property({ type: Boolean }) signup_support = false;
+  @property({ type: Boolean }) showSignupModal = false;
+  @property({ type: String }) signupPreloadedToken?: string;
   @property({ type: Boolean }) allowAnonymousChangePassword = false;
   @property({ type: Boolean }) change_signin_support = false;
   @property({ type: Boolean }) allow_signout = false;
@@ -576,14 +577,7 @@ export default class BackendAILogin extends BackendAIPage {
       defaultValue: false,
       value: generalConfig?.signupSupport,
     } as ConfigValueObject) as boolean;
-    // Signup support flag
-    if (this.signup_support) {
-      (
-        this.shadowRoot?.querySelector(
-          '#signup-dialog',
-        ) as HTMLElementTagNameMap['backend-ai-signup']
-      ).active = true;
-    }
+    // Signup modal is now rendered via React web component - no init needed
 
     // Signup support flag
     this.allowAnonymousChangePassword = this._getConfigValueByExists(
@@ -1346,13 +1340,8 @@ export default class BackendAILogin extends BackendAIPage {
       this.notification.show();
       return;
     }
-    const signupDialog = this.shadowRoot?.querySelector(
-      '#signup-dialog',
-    ) as BackendAISignup;
-    signupDialog.endpoint = this.api_endpoint;
-    signupDialog.allowSignupWithoutConfirmation =
-      this.allowSignupWithoutConfirmation;
-    signupDialog.open(token);
+    this.signupPreloadedToken = token;
+    this.showSignupModal = true;
   }
 
   private _showChangePasswordEmailDialog() {
@@ -2539,7 +2528,15 @@ export default class BackendAILogin extends BackendAIPage {
           </div>
         </div>
       </backend-ai-dialog>
-      <backend-ai-signup id="signup-dialog"></backend-ai-signup>
+      <backend-ai-react-signup-modal
+        value="${JSON.stringify({
+          open: this.showSignupModal,
+          endpoint: this.api_endpoint,
+          allowSignupWithoutConfirmation: this.allowSignupWithoutConfirmation,
+          preloadedToken: this.signupPreloadedToken,
+        })}"
+        @close="${() => (this.showSignupModal = false)}"
+      ></backend-ai-react-signup-modal>
     `;
   }
 }


### PR DESCRIPTION
Resolves #3657(FR-991)

## Summary
- Migrated the signup modal from Lit-Element (`backend-ai-signup`) to a React component (`SignupModal.tsx`)
- Registered as web component (`backend-ai-react-signup-modal`) for integration with the Lit-based login page
- Updated `backend-ai-login.ts` to use the new React-based signup modal

## Changes
- **Created** `react/src/components/SignupModal.tsx` — New React signup modal with:
  - Ant Design Form with email, username, invitation token, password, and password confirmation fields
  - Password validation (min 8 chars, letter + digit + special char)
  - Terms of Service and Privacy Policy agreement checkbox with links to existing React modals
  - Post-signup email verification dialog when `allowSignupWithoutConfirmation` is false
  - `BAIButton` with `action` prop for automatic loading state management
  - `useAnonymousBackendaiClient` for unauthenticated API calls
- **Modified** `react/src/index.tsx` — Added web component registration for signup modal
- **Modified** `src/components/backend-ai-login.ts` — Replaced Lit signup component with React web component, using `value` attribute for data passing and `@close` event for communication

## Test plan
- [ ] Verify signup button on login page opens the React signup modal
- [ ] Verify all form validations work (email format, password strength, password match, required fields)
- [ ] Verify Terms of Service and Privacy Policy links open their respective modals
- [ ] Verify signup API call works with valid data
- [ ] Verify email verification dialog appears when `allowSignupWithoutConfirmation` is false
- [ ] Verify preloaded token from URL populates the token field
- [ ] Verify modal closes properly and resets form state

🤖 Generated with [Claude Code](https://claude.com/claude-code)