### PR TITLE
fix(FR-991): fix visual and click bugs in signup modal after React migration

### DIFF
--- a/react/src/components/SignupModal.tsx
+++ b/react/src/components/SignupModal.tsx
@@ -89,9 +89,13 @@ const SignupModal: React.FC<SignupModalProps> = ({
         }
         onCancel={onRequestClose}
         destroyOnHidden
+        getContainer={false}
         width={400}
+        styles={{
+          body: { fontSize: 14 },
+        }}
         footer={
-          <BAIFlex justify="end">
+          <BAIFlex justify="end" gap="sm">
             <BAIButton onClick={onRequestClose}>{t('button.Cancel')}</BAIButton>
             <BAIButton type="primary" action={handleSubmit}>
               {t('signUp.SignUp')}
@@ -231,15 +235,18 @@ const SignupModal: React.FC<SignupModalProps> = ({
       <TermsOfServiceModal
         open={showTOS}
         onRequestClose={() => setShowTOS(false)}
+        getContainer={false}
       />
       <PrivacyPolicyModal
         open={showPrivacyPolicy}
         onRequestClose={() => setShowPrivacyPolicy(false)}
+        getContainer={false}
       />
       <Modal
         open={showEmailSentDialog}
         title={t('signUp.ThankYou')}
         closable={false}
+        getContainer={false}
         footer={
           <BAIButton
             type="primary"


### PR DESCRIPTION
Resolves #5360 (FR-991)

## Summary

Fix three issues introduced during PR #5356 (Lit-to-React migration of SignupModal):

- **Click not working**: Added `getContainer={false}` to all modals (`BAIModal`, `TermsOfServiceModal`, `PrivacyPolicyModal`, email confirmation `Modal`) to prevent portal rendering outside Shadow DOM, which caused click events and styles to not work properly
- **Footer button spacing**: Added `gap="sm"` to footer `BAIFlex` so Cancel and Signup buttons have proper spacing
- **Font size inconsistency**: Set explicit `fontSize: 14` on modal body style to prevent CSS inheritance issues from Lit parent components

## Test plan

- [ ] Open login page and click Signup button
- [ ] Verify font size is consistent (14px) across all form fields
- [ ] Verify Cancel and Signup buttons have appropriate spacing in footer
- [ ] Verify all input fields are clickable and focusable
- [ ] Verify Terms of Service link opens the TOS modal correctly
- [ ] Verify Privacy Policy link opens the Privacy Policy modal correctly
- [ ] Verify form submission (Signup button click) works correctly