### PR TITLE
feat(FR-991): extend BAIModal with missing backend-ai-dialog features

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIModal.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIModal.stories.tsx
@@ -3,6 +3,7 @@ import BAIFlex from './BAIFlex';
 import BAIModal from './BAIModal';
 import BAIText from './BAIText';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { App } from 'antd';
 import { useState } from 'react';
 
 const meta: Meta<typeof BAIModal> = {
@@ -20,6 +21,10 @@ const meta: Meta<typeof BAIModal> = {
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | \`draggable\` | \`boolean\` | \`false\` | Enable dragging modal by header |
+| \`confirmBeforeClose\` | \`boolean\` | \`false\` | When true, calls \`onConfirmClose\` before closing |
+| \`onConfirmClose\` | \`() => void \\| Promise<boolean>\` | - | Callback before close; return false/reject to prevent |
+| \`stickyTitle\` | \`boolean\` | \`false\` | Makes the header sticky when body content is scrolled |
+| \`type\` | \`'normal' \\| 'warning' \\| 'error'\` | \`'normal'\` | Visual variant that changes the header title color |
 
 ## Additional Features
 - **Fixed z-index**: Uses \`DEFAULT_BAI_MODAL_Z_INDEX = 1001\`
@@ -42,6 +47,42 @@ For all other props, refer to [Ant Design Modal](https://ant.design/components/m
         defaultValue: { summary: 'false' },
       },
     },
+    confirmBeforeClose: {
+      control: { type: 'boolean' },
+      description:
+        'When true, calls onConfirmClose before closing. If onConfirmClose returns false or rejects, the close is prevented.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    onConfirmClose: {
+      control: false,
+      description:
+        'Callback invoked before close when confirmBeforeClose is true. Return false or reject to prevent closing.',
+      table: {
+        type: { summary: '() => void | Promise<boolean>' },
+      },
+    },
+    stickyTitle: {
+      control: { type: 'boolean' },
+      description:
+        'Makes the modal header sticky so it remains visible when body content is scrolled.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    type: {
+      control: { type: 'select' },
+      options: ['normal', 'warning', 'error'],
+      description:
+        'Visual variant that changes the header title color. Uses Ant Design theme tokens for colors.',
+      table: {
+        type: { summary: "'normal' | 'warning' | 'error'" },
+        defaultValue: { summary: 'normal' },
+      },
+    },
   },
 };
 
@@ -58,6 +99,18 @@ const ModalContent = () => (
       The modal provides consistent styling with proper header dividers, body
       padding, and footer layout following Backend.AI design guidelines.
     </BAIText>
+  </BAIFlex>
+);
+
+const LongModalContent = () => (
+  <BAIFlex direction="column" gap="md">
+    {Array.from({ length: 20 }, (_, i) => (
+      <BAIText key={i}>
+        Paragraph {i + 1}: This is a long content section to demonstrate
+        scrollable body behavior and the sticky title feature. When the body
+        overflows, the header should remain fixed at the top.
+      </BAIText>
+    ))}
   </BAIFlex>
 );
 
@@ -150,6 +203,232 @@ export const DraggableModal: Story = {
               dragged outside the visible area.
             </BAIText>
           </BAIFlex>
+        </BAIModal>
+      </BAIFlex>
+    );
+  },
+};
+
+// Confirm before close story
+export const ConfirmBeforeClose: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the `confirmBeforeClose` feature. When enabled, a confirmation dialog is shown before the modal closes. The close is only allowed if the user confirms.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+    const { modal } = App.useApp();
+
+    return (
+      <>
+        <BAIButton type="primary" onClick={() => setOpen(true)}>
+          Open Modal with Confirm
+        </BAIButton>
+        <BAIModal
+          title="Form Modal"
+          open={open}
+          confirmBeforeClose
+          onConfirmClose={() =>
+            new Promise<boolean>((resolve) => {
+              modal.confirm({
+                title: 'Discard changes?',
+                content:
+                  'You have unsaved changes. Are you sure you want to close?',
+                onOk: () => resolve(true),
+                onCancel: () => resolve(false),
+              });
+            })
+          }
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        >
+          <BAIFlex direction="column" gap="md">
+            <BAIText>
+              This modal uses <strong>confirmBeforeClose</strong>. Try clicking
+              the X or Cancel button — a confirmation dialog will appear before
+              the modal actually closes.
+            </BAIText>
+          </BAIFlex>
+        </BAIModal>
+      </>
+    );
+  },
+};
+
+// Sticky title story
+export const StickyTitle: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the `stickyTitle` feature. The modal header stays fixed at the top as you scroll through long content in the body.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <BAIButton type="primary" onClick={() => setOpen(true)}>
+          Open Modal with Sticky Title
+        </BAIButton>
+        <BAIModal
+          title="Sticky Header Modal"
+          open={open}
+          stickyTitle
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+          styles={{
+            body: {
+              maxHeight: '300px',
+              overflowY: 'auto',
+            },
+          }}
+        >
+          <LongModalContent />
+        </BAIModal>
+      </>
+    );
+  },
+};
+
+// Warning type story
+export const WarningType: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the `type="warning"` variant. The modal title is rendered in the warning color (orange/amber) to indicate a potentially dangerous or irreversible action.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <BAIButton onClick={() => setOpen(true)}>Open Warning Modal</BAIButton>
+        <BAIModal
+          title="Warning: Irreversible Action"
+          type="warning"
+          open={open}
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+          okText="Proceed"
+          okButtonProps={{ danger: true }}
+        >
+          <BAIFlex direction="column" gap="md">
+            <BAIText>
+              This action cannot be undone. The <strong>warning</strong> type
+              highlights the title in an amber color to draw the user&apos;s
+              attention to potentially risky operations.
+            </BAIText>
+          </BAIFlex>
+        </BAIModal>
+      </>
+    );
+  },
+};
+
+// Error type story
+export const ErrorType: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the `type="error"` variant. The modal title is rendered in the error color (red) to signal a destructive or critical action.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <BAIButton danger onClick={() => setOpen(true)}>
+          Open Error Modal
+        </BAIButton>
+        <BAIModal
+          title="Error: Destructive Action"
+          type="error"
+          open={open}
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+          okText="Delete"
+          okButtonProps={{ danger: true }}
+        >
+          <BAIFlex direction="column" gap="md">
+            <BAIText>
+              This will permanently delete the selected resource. The{' '}
+              <strong>error</strong> type highlights the title in red to
+              indicate a destructive operation.
+            </BAIText>
+          </BAIFlex>
+        </BAIModal>
+      </>
+    );
+  },
+};
+
+// All type variants in one story
+export const TypeVariants: Story = {
+  name: 'All Type Variants',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Shows all available `type` variants side by side for comparison.',
+      },
+    },
+  },
+  render: () => {
+    const [openNormal, setOpenNormal] = useState(false);
+    const [openWarning, setOpenWarning] = useState(false);
+    const [openError, setOpenError] = useState(false);
+
+    return (
+      <BAIFlex gap="md" wrap="wrap">
+        <BAIButton type="primary" onClick={() => setOpenNormal(true)}>
+          Normal
+        </BAIButton>
+        <BAIButton onClick={() => setOpenWarning(true)}>Warning</BAIButton>
+        <BAIButton danger onClick={() => setOpenError(true)}>
+          Error
+        </BAIButton>
+
+        <BAIModal
+          title="Normal Modal Title"
+          type="normal"
+          open={openNormal}
+          onOk={() => setOpenNormal(false)}
+          onCancel={() => setOpenNormal(false)}
+        >
+          <BAIText>Normal type — default title color.</BAIText>
+        </BAIModal>
+
+        <BAIModal
+          title="Warning Modal Title"
+          type="warning"
+          open={openWarning}
+          onOk={() => setOpenWarning(false)}
+          onCancel={() => setOpenWarning(false)}
+        >
+          <BAIText>Warning type — title in amber/orange color.</BAIText>
+        </BAIModal>
+
+        <BAIModal
+          title="Error Modal Title"
+          type="error"
+          open={openError}
+          onOk={() => setOpenError(false)}
+          onCancel={() => setOpenError(false)}
+        >
+          <BAIText>Error type — title in red color.</BAIText>
         </BAIModal>
       </BAIFlex>
     );

--- a/packages/backend.ai-ui/src/components/BAIModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIModal.tsx
@@ -12,31 +12,85 @@ import Draggable, {
 } from 'react-draggable';
 
 export const DEFAULT_BAI_MODAL_Z_INDEX = 1001;
+
 export interface BAIModalProps extends ModalProps {
-  draggable?: boolean; // modal can be draggle
+  /** Enable dragging modal by header */
+  draggable?: boolean;
+  /**
+   * When true, calls `onConfirmClose` before closing the modal.
+   * If `onConfirmClose` returns false or rejects, the close is prevented.
+   */
+  confirmBeforeClose?: boolean;
+  /**
+   * Callback invoked before the modal is closed when `confirmBeforeClose` is true.
+   * Return false (or a rejected Promise) to prevent closing; return void/true to allow it.
+   */
+  onConfirmClose?: () => void | Promise<boolean>;
+  /** Makes the modal header sticky so it remains visible when body content is scrolled */
+  stickyTitle?: boolean;
+  /** Visual variant that changes the header title color */
+  type?: 'normal' | 'warning' | 'error';
 }
 
-const useStyles = createStyles(({ css }) => ({
-  modal: css`
-    .ant-modal-wrap.ant-modal-centered {
-      overflow: hidden;
-    }
-    .ant-modal-close {
-      width: 26px;
-      height: 26px;
-      top: 22px;
-      right: 18px;
-      -webkit-app-region: no-drag;
-    }
-    .ant-modal-title {
-      margin-right: 36px;
-    }
-  `,
-}));
+const useStyles = createStyles(
+  (
+    { css },
+    {
+      stickyTitle,
+      type,
+      colorWarning,
+      colorError,
+    }: {
+      stickyTitle: boolean;
+      type: 'normal' | 'warning' | 'error';
+      colorWarning: string;
+      colorError: string;
+    },
+  ) => ({
+    modal: css`
+      .ant-modal-wrap.ant-modal-centered {
+        overflow: hidden;
+      }
+      .ant-modal-close {
+        width: 26px;
+        height: 26px;
+        top: 22px;
+        right: 18px;
+        -webkit-app-region: no-drag;
+      }
+      .ant-modal-title {
+        margin-right: 36px;
+        ${type === 'warning' ? `color: ${colorWarning};` : ''}
+        ${type === 'error' ? `color: ${colorError};` : ''}
+      }
+      ${stickyTitle
+        ? `
+        .ant-modal-header {
+          position: sticky;
+          top: 0;
+          z-index: 1;
+        }
+      `
+        : ''}
+    `,
+  }),
+);
 
-const BAIModal: React.FC<BAIModalProps> = ({ className, ...modalProps }) => {
+const BAIModal: React.FC<BAIModalProps> = ({
+  className,
+  confirmBeforeClose,
+  onConfirmClose,
+  stickyTitle = false,
+  type = 'normal',
+  ...modalProps
+}) => {
   const { token } = theme.useToken();
-  const { styles } = useStyles();
+  const { styles } = useStyles({
+    stickyTitle,
+    type,
+    colorWarning: token.colorWarning,
+    colorError: token.colorError,
+  });
   const [disabled, setDisabled] = useState(true);
   const [bounds, setBounds] = useState({
     left: 0,
@@ -45,6 +99,7 @@ const BAIModal: React.FC<BAIModalProps> = ({ className, ...modalProps }) => {
     right: 0,
   }); //draggable space
   const draggleRef = useRef<HTMLDivElement>(null);
+
   const handleDrag = (_e: DraggableEvent, uiData: DraggableData) => {
     const { clientWidth, clientHeight } = window.document.documentElement; //browserWidth, browserHeight
     const targetRect = draggleRef.current?.getBoundingClientRect(); //Modal size and viewport
@@ -62,12 +117,24 @@ const BAIModal: React.FC<BAIModalProps> = ({ className, ...modalProps }) => {
         (targetRect.height - 69), // 69 is height of modal header
     });
   };
+
+  const handleCancel: ModalProps['onCancel'] = async (e) => {
+    if (confirmBeforeClose && onConfirmClose) {
+      const result = await Promise.resolve(onConfirmClose());
+      if (result === false) {
+        return;
+      }
+    }
+    modalProps.onCancel?.(e);
+  };
+
   return (
     <Modal
       {...modalProps}
       centered={modalProps.centered ?? true}
       className={classNames(`bai-modal ${className ?? ''}`, styles.modal)}
       wrapClassName={modalProps.draggable ? 'draggable' : ''}
+      onCancel={handleCancel}
       styles={{
         ...modalProps.styles,
         header: {


### PR DESCRIPTION
Resolves #5365(FR-991)

## Summary

- Add `confirmBeforeClose` + `onConfirmClose` props to intercept the cancel/close event. When `confirmBeforeClose` is `true`, `onConfirmClose` is called before the modal closes; if it returns `false` (or a rejected `Promise<boolean>`), the close is prevented.
- Add `stickyTitle` prop that makes the modal header `position: sticky` so it stays visible when the body content is long and scrollable.
- Add `type` prop (`'normal' | 'warning' | 'error'`) that changes the modal title color using Ant Design theme tokens (`token.colorWarning` / `token.colorError`).
- Add Storybook stories for every new feature: `ConfirmBeforeClose`, `StickyTitle`, `WarningType`, `ErrorType`, `TypeVariants`.

## Test plan

- [ ] Open Storybook and verify each new story renders correctly
- [ ] Verify `ConfirmBeforeClose` story: clicking Cancel/X opens a confirmation dialog; clicking "OK" in the dialog closes the modal, clicking "Cancel" keeps it open
- [ ] Verify `StickyTitle` story: scrolling the body keeps the header visible
- [ ] Verify `WarningType` story: modal title color is amber/orange
- [ ] Verify `ErrorType` story: modal title color is red
- [ ] Verify `TypeVariants` story: all three type variants open correctly
- [ ] Verify existing behavior is unchanged (draggable, default styling, z-index)
