### PR TITLE
feat(FR-991): migrate backend-ai-splash to React SplashModal

### DIFF
--- a/react/src/components/SplashModal.tsx
+++ b/react/src/components/SplashModal.tsx
@@ -1,0 +1,130 @@
+import { useThemeMode } from '../hooks/useThemeMode';
+import { theme } from 'antd';
+import { BAIFlex, BAIModal, BAIModalProps, BAIText } from 'backend.ai-ui';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface SplashModalProps extends BAIModalProps {
+  onRequestClose: () => void;
+}
+
+const SplashModal: React.FC<SplashModalProps> = ({
+  onRequestClose,
+  ...modalProps
+}) => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { isDarkMode } = useThemeMode();
+
+  const edition = globalThis.packageEdition || 'Open Source';
+  const version = globalThis.packageVersion || '';
+  const validUntil = globalThis.packageValidUntil || '';
+  const managerVersion = globalThis.backendaiclient?.managerVersion || '';
+  const buildVersion = globalThis.buildVersion || '';
+  const isElectron = globalThis.isElectron || false;
+
+  let licenseText = '';
+  if (edition !== 'Open Source') {
+    if (
+      validUntil === '2099-12-31' ||
+      validUntil === '""' ||
+      validUntil === ''
+    ) {
+      licenseText = t('license.Perpetual');
+    } else {
+      licenseText = t('license.Subscription');
+    }
+  } else {
+    licenseText = t('license.OpenSource');
+  }
+
+  const logoSrc = isDarkMode
+    ? 'manifest/backend.ai-text-bgdark.svg'
+    : 'manifest/backend.ai-text.svg';
+
+  return (
+    <BAIModal
+      {...modalProps}
+      title={
+        <div
+          style={{
+            height: 50,
+            width: 280,
+            backgroundImage: `url(${logoSrc})`,
+            backgroundSize: 'contain',
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'left top',
+          }}
+        />
+      }
+      footer={null}
+      width={350}
+      onCancel={() => onRequestClose()}
+      maskClosable={false}
+    >
+      <BAIFlex direction="column" gap="xs" style={{ paddingLeft: 20 }}>
+        <BAIText style={{ fontSize: 13 }}>
+          Backend.AI Web UI <span>{version}</span>
+        </BAIText>
+        <BAIText style={{ fontSize: 13 }}>{edition} Edition</BAIText>
+        {licenseText === t('license.Subscription') && validUntil ? (
+          <BAIText style={{ fontSize: 13 }}>
+            Subscription is active until {validUntil}
+          </BAIText>
+        ) : licenseText === t('license.Perpetual') ? (
+          <BAIText style={{ fontSize: 13 }}>Perpetual License</BAIText>
+        ) : null}
+        <div style={{ marginTop: 15 }}>
+          <BAIText style={{ fontSize: 13 }}>
+            Backend.AI Cluster {managerVersion}
+          </BAIText>
+        </div>
+        <BAIText style={{ fontSize: 13 }}>
+          {isElectron ? 'App' : 'WebServer'} Build {buildVersion}
+        </BAIText>
+      </BAIFlex>
+      <BAIFlex
+        direction="column"
+        gap="xs"
+        style={{ paddingLeft: 20, marginTop: token.marginSM }}
+      >
+        <BAIText style={{ fontSize: 13 }}>
+          Powered by{' '}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/lablup/backend.ai/blob/main/LICENSE"
+            style={{ color: token.colorLink }}
+          >
+            open-source software
+          </a>
+        </BAIText>
+        <BAIText style={{ fontSize: 12 }}>
+          Copyright &copy; 2015-2025 Lablup Inc.
+        </BAIText>
+        <BAIFlex gap="sm">
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href={`https://github.com/lablup/backend.ai-webui/releases/tag/v${version}`}
+            style={{ color: token.colorLink, fontSize: 12 }}
+          >
+            Release Note
+          </a>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/lablup/backend.ai-webui/blob/main/LICENSE"
+            style={{ color: token.colorLink, fontSize: 12 }}
+          >
+            License
+          </a>
+        </BAIFlex>
+      </BAIFlex>
+    </BAIModal>
+  );
+};
+
+export default SplashModal;

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -50,6 +50,7 @@ const TOTPActivateModalWithToken = React.lazy(
 );
 
 const SignupModal = React.lazy(() => import('./components/SignupModal'));
+const SplashModal = React.lazy(() => import('./components/SplashModal'));
 
 customElements.define(
   'backend-ai-react-signup-modal',
@@ -165,6 +166,32 @@ customElements.define(
     );
   }),
 );
+
+customElements.define(
+  'backend-ai-react-splash-modal',
+  reactToWebComponent((props) => {
+    return (
+      <DefaultProviders {...props}>
+        <SplashModalInWebComponent {...props} />
+      </DefaultProviders>
+    );
+  }),
+);
+
+const SplashModalInWebComponent: React.FC<ReactWebComponentProps> = (props) => {
+  const { parsedValue: { open = false } = {} } = useWebComponentInfo<{
+    open: boolean;
+  }>();
+
+  return (
+    <SplashModal
+      open={open}
+      onRequestClose={() => {
+        props.dispatchEvent('close', null);
+      }}
+    />
+  );
+};
 
 const root = ReactDOM.createRoot(
   document.getElementById('react-root') as HTMLElement,

--- a/src/components/backend-ai-webui.ts
+++ b/src/components/backend-ai-webui.ts
@@ -20,7 +20,6 @@ import BackendAIMetadataStore from './backend-ai-metadata-store';
 import { BackendAIPage } from './backend-ai-page';
 import './backend-ai-project-switcher';
 import BackendAISettingsStore from './backend-ai-settings-store';
-import './backend-ai-splash';
 import BackendAITasker from './backend-ai-tasker';
 import { BackendAIWebUIStyles } from './backend-ai-webui-styles';
 import './lablup-notification';
@@ -201,6 +200,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   @property({ type: Object }) keyPairInfo = Object();
   @property({ type: Boolean }) isOpenUserProfileDialog = false;
   @property({ type: Boolean }) isOpenSignoutDialog = false;
+  @property({ type: Boolean }) isOpenSplashDialog = false;
   @query('#app-page') appPage!: HTMLDivElement;
   @property({ type: Object }) _refreshPage = this.refreshPage.bind(this);
   // TODO need investigation about class method undefined issue
@@ -208,7 +208,6 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   @query('#login-panel') loginPanel: any;
   @query('#main-toolbar') mainToolbar: any;
   @query('#terms-of-service') TOSdialog!: LablupTermsOfService;
-  @query('backend-ai-splash') splash: any;
   @query('#dropdown-button') _dropdownMenuIcon!: IconButton;
 
   constructor() {
@@ -853,7 +852,7 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
   }
 
   _showSplash() {
-    this.splash.show();
+    this.isOpenSplashDialog = true;
   }
 
   protected render() {
@@ -890,7 +889,12 @@ export default class BackendAIWebUI extends connect(store)(LitElement) {
       </div>
 
       <backend-ai-login active id="login-panel"></backend-ai-login>
-      <backend-ai-splash id="about-backendai-panel"></backend-ai-splash>
+      <backend-ai-react-splash-modal
+        value="${JSON.stringify({ open: this.isOpenSplashDialog })}"
+        @close="${() => {
+          this.isOpenSplashDialog = false;
+        }}"
+      ></backend-ai-react-splash-modal>
       <lablup-notification id="notification"></lablup-notification>
       <backend-ai-indicator-pool id="indicator"></backend-ai-indicator-pool>
       <lablup-terms-of-service

--- a/src/types/backend-ai-console.d.ts
+++ b/src/types/backend-ai-console.d.ts
@@ -3,7 +3,6 @@ import './backend-ai-dialog';
 import './backend-ai-indicator-pool';
 import './backend-ai-login';
 import './backend-ai-settings-store';
-import './backend-ai-splash';
 import './lablup-notification';
 import './lablup-terms-of-service';
 import '@material/mwc-icon';
@@ -57,7 +56,6 @@ export default class BackendAIWebUI extends BackendAIWebUI_base {
   current_group: string;
   plugins: any;
   notification: any;
-  splash: any;
   loginPanel: any;
   _page: string;
   _sidepanel: string;


### PR DESCRIPTION
Resolves #5366(FR-991)

## Summary
- Create `react/src/components/SplashModal.tsx` as a React replacement for `src/components/backend-ai-splash.ts`
- Register `backend-ai-react-splash-modal` web component in `react/src/index.tsx` for Lit-Element host integration
- Update `src/components/backend-ai-webui.ts` to use the new React web component via `isOpenSplashDialog` state property
- Remove `src/components/backend-ai-splash.ts` (Lit-Element implementation) and its type declarations

## Test plan
- [ ] Open the application and click the "About" menu item to confirm the splash modal opens
- [ ] Verify the Backend.AI logo displays correctly in both light and dark modes
- [ ] Verify version info (WebUI version, edition, license type, manager version, build version) is shown correctly
- [ ] Verify the "Release Note" and "License" links are correct
- [ ] Verify clicking outside or the close button dismisses the modal
- [ ] Verify the modal does not show on page load (maskClosable=false still requires the X button or close event)
