### PR TITLE
refactor(FR-991): consolidate navigation from Lit/Redux to React Router

### DIFF
--- a/react/src/hooks/useApiEndpoint.ts
+++ b/react/src/hooks/useApiEndpoint.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Hook to resolve the Backend.AI API endpoint.
+ * Checks sources in order:
+ * 1. localStorage (set by LoginView after config parsing)
+ * 2. The webui-shell login panel (Lit component)
+ * 3. Current window origin as fallback
+ */
+export const useApiEndpoint = (): string => {
+  const [endpoint, setEndpoint] = useState(() => {
+    // First, try localStorage (most reliable source after config is loaded)
+    const stored = localStorage.getItem('backendaiwebui.api_endpoint');
+    if (stored) {
+      return stored.replace(/^"+|"+$/g, '');
+    }
+    return '';
+  });
+
+  useEffect(() => {
+    if (endpoint) return;
+
+    // Listen for config loaded event to get the endpoint from the shell
+    const handleConfigLoaded = () => {
+      const webUIShell = document.querySelector('#webui-shell') as any;
+      const loginPanel =
+        webUIShell?.loginPanel ||
+        webUIShell?.shadowRoot?.querySelector('#login-panel');
+      const ep = loginPanel?.api_endpoint || '';
+      if (ep) {
+        setEndpoint(ep);
+      }
+    };
+
+    // Check if config is already loaded
+    handleConfigLoaded();
+
+    document.addEventListener('backend-ai-config-loaded', handleConfigLoaded);
+    return () => {
+      document.removeEventListener(
+        'backend-ai-config-loaded',
+        handleConfigLoaded,
+      );
+    };
+  }, [endpoint]);
+
+  return endpoint;
+};

--- a/react/src/pages/ChangePasswordPage.tsx
+++ b/react/src/pages/ChangePasswordPage.tsx
@@ -1,0 +1,37 @@
+import {
+  CSSTokenVariables,
+  NotificationForAnonymous,
+} from '../components/MainLayout/MainLayout';
+import { useApiEndpoint } from '../hooks/useApiEndpoint';
+import React, { Suspense } from 'react';
+
+const ChangePasswordViewLazy = React.lazy(
+  () => import('../components/ChangePasswordView'),
+);
+
+/**
+ * Standalone page for changing forgotten password.
+ * Renders outside MainLayout (no sidebar).
+ * Gets apiEndpoint from localStorage or config.
+ */
+const ChangePasswordPage: React.FC = () => {
+  return (
+    <>
+      <CSSTokenVariables />
+      <NotificationForAnonymous />
+      {/* @ts-ignore */}
+      <backend-ai-webui id="webui-shell" />
+      <Suspense fallback={null}>
+        <ChangePasswordPageContent />
+      </Suspense>
+    </>
+  );
+};
+
+const ChangePasswordPageContent: React.FC = () => {
+  const apiEndpoint = useApiEndpoint();
+
+  return <ChangePasswordViewLazy apiEndpoint={apiEndpoint} active={true} />;
+};
+
+export default ChangePasswordPage;

--- a/react/src/pages/EduAppLauncherPage.tsx
+++ b/react/src/pages/EduAppLauncherPage.tsx
@@ -1,0 +1,37 @@
+import {
+  CSSTokenVariables,
+  NotificationForAnonymous,
+} from '../components/MainLayout/MainLayout';
+import { useApiEndpoint } from '../hooks/useApiEndpoint';
+import React, { Suspense } from 'react';
+
+const EduAppLauncherLazy = React.lazy(
+  () => import('../components/EduAppLauncher'),
+);
+
+/**
+ * Standalone page for education app launcher.
+ * Renders outside MainLayout (no sidebar).
+ * Gets apiEndpoint from localStorage or config.
+ */
+const EduAppLauncherPage: React.FC = () => {
+  return (
+    <>
+      <CSSTokenVariables />
+      <NotificationForAnonymous />
+      {/* @ts-ignore */}
+      <backend-ai-webui id="webui-shell" />
+      <Suspense fallback={null}>
+        <EduAppLauncherPageContent />
+      </Suspense>
+    </>
+  );
+};
+
+const EduAppLauncherPageContent: React.FC = () => {
+  const apiEndpoint = useApiEndpoint();
+
+  return <EduAppLauncherLazy apiEndpoint={apiEndpoint} active={true} />;
+};
+
+export default EduAppLauncherPage;

--- a/react/src/pages/EmailVerificationPage.tsx
+++ b/react/src/pages/EmailVerificationPage.tsx
@@ -1,0 +1,37 @@
+import {
+  CSSTokenVariables,
+  NotificationForAnonymous,
+} from '../components/MainLayout/MainLayout';
+import { useApiEndpoint } from '../hooks/useApiEndpoint';
+import React, { Suspense } from 'react';
+
+const EmailVerificationViewLazy = React.lazy(
+  () => import('../components/EmailVerificationView'),
+);
+
+/**
+ * Standalone page for email verification.
+ * Renders outside MainLayout (no sidebar).
+ * Gets apiEndpoint from localStorage or config.
+ */
+const EmailVerificationPage: React.FC = () => {
+  return (
+    <>
+      <CSSTokenVariables />
+      <NotificationForAnonymous />
+      {/* @ts-ignore */}
+      <backend-ai-webui id="webui-shell" />
+      <Suspense fallback={null}>
+        <EmailVerificationPageContent />
+      </Suspense>
+    </>
+  );
+};
+
+const EmailVerificationPageContent: React.FC = () => {
+  const apiEndpoint = useApiEndpoint();
+
+  return <EmailVerificationViewLazy apiEndpoint={apiEndpoint} active={true} />;
+};
+
+export default EmailVerificationPage;

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -89,6 +89,15 @@ const ReservoirArtifactDetailPage = React.lazy(
 const SchedulerPage = React.lazy(() => import('./pages/SchedulerPage'));
 const BrandingPage = React.lazy(() => import('./pages/BrandingPage'));
 const AdminSessionPage = React.lazy(() => import('./pages/AdminSessionPage'));
+const EmailVerificationPage = React.lazy(
+  () => import('./pages/EmailVerificationPage'),
+);
+const ChangePasswordPage = React.lazy(
+  () => import('./pages/ChangePasswordPage'),
+);
+const EduAppLauncherPage = React.lazy(
+  () => import('./pages/EduAppLauncherPage'),
+);
 
 /**
  * MainLayout children routes - these are the actual page routes
@@ -527,6 +536,50 @@ export const routes: RouteObject[] = [
       <BAIErrorBoundary>
         <DefaultProvidersForReactRoot>
           <InteractiveLoginPage />
+        </DefaultProvidersForReactRoot>
+      </BAIErrorBoundary>
+    ),
+  },
+  {
+    path: '/verify-email',
+    errorElement: <ErrorView />,
+    element: (
+      <BAIErrorBoundary>
+        <DefaultProvidersForReactRoot>
+          <EmailVerificationPage />
+        </DefaultProvidersForReactRoot>
+      </BAIErrorBoundary>
+    ),
+  },
+  {
+    path: '/change-password',
+    errorElement: <ErrorView />,
+    element: (
+      <BAIErrorBoundary>
+        <DefaultProvidersForReactRoot>
+          <ChangePasswordPage />
+        </DefaultProvidersForReactRoot>
+      </BAIErrorBoundary>
+    ),
+  },
+  {
+    path: '/edu-applauncher',
+    errorElement: <ErrorView />,
+    element: (
+      <BAIErrorBoundary>
+        <DefaultProvidersForReactRoot>
+          <EduAppLauncherPage />
+        </DefaultProvidersForReactRoot>
+      </BAIErrorBoundary>
+    ),
+  },
+  {
+    path: '/applauncher',
+    errorElement: <ErrorView />,
+    element: (
+      <BAIErrorBoundary>
+        <DefaultProvidersForReactRoot>
+          <EduAppLauncherPage />
         </DefaultProvidersForReactRoot>
       </BAIErrorBoundary>
     ),

--- a/src/backend-ai-app.ts
+++ b/src/backend-ai-app.ts
@@ -2,139 +2,15 @@
  @license
  Copyright (c) 2015-2025 Lablup Inc. All rights reserved.
  */
+
+// Redux action type constants - kept for backward compatibility with reducers
 export const UPDATE_PAGE = 'UPDATE_PAGE';
 export const UPDATE_OFFLINE = 'UPDATE_OFFLINE';
 export const UPDATE_DRAWER_STATE = 'UPDATE_DRAWER_STATE';
 
-export const navigate =
-  (path: any, params: Record<string, unknown> = {}) =>
-  (dispatch: any) => {
-    // Extract the page name from path.
-    if (
-      [
-        '/start',
-        '/summary',
-        '/job',
-        '/session',
-        '/serving',
-        '/agent-summary',
-        '/experiment',
-        '/data',
-        '/my-environment',
-        '/statistics',
-        '/usersettings',
-        '/agent',
-        '/storage-settings',
-        '/resource',
-        '/admin-session',
-        '/user',
-        '/credential',
-        '/environment',
-        '/scheduler',
-        '/settings',
-        '/maintenance',
-        '/branding',
-        '/information',
-        '/github',
-        '/import',
-        '/chat',
-        '/ai-agent',
-        '/model-store',
-        '/project',
-      ].includes(path) !== true
-    ) {
-      // Fallback for Electron Shell/Windows OS
-      const fragments = path.split(/[/]+/);
-      if (fragments.length > 1 && fragments[0] === '') {
-        path = fragments[1];
-        params['requestURL'] = fragments.slice(2).join('/');
-      }
-    }
-    params['queryString'] = window.location.search;
-    if (path === 'index.html' || path === '') {
-      path = '/';
-    }
-    let page;
-    if (['/', 'build', '/build', 'app', '/app'].includes(path)) {
-      page = 'start';
-    } else if (path[0] === '/') {
-      page = path.slice(1);
-    } else {
-      page = path;
-    }
-
-    // const page = path === '/' ? 'summary' : path.slice(1);
-    // Any other info you might want to extract from the path (like page type),
-    // you can do here
-    if (
-      [
-        'admin-session',
-        'agent',
-        'resource',
-        'user',
-        'credential',
-        'environment',
-        'settings',
-        'maintenance',
-        'branding',
-        'information',
-      ].includes(page)
-    ) {
-      // page = 'summary';
-      // globalThis.history.pushState({}, '', '/summary');
-    }
-    dispatch(loadPage(page, params));
-
-    // Close the drawer - in case the *path* change came from a link in the drawer.
-    dispatch(updateDrawerState(false));
-  };
-
-const loadPage =
-  (page, params: Record<string, unknown> = {}) =>
-  (dispatch) => {
-    switch (page) {
-      case 'serving':
-        import('./components/backend-ai-serving-view.js');
-        break;
-      case 'agent':
-        break;
-      case 'verify-email':
-        break;
-      case 'change-password':
-        break;
-      case 'applauncher':
-      case 'edu-applauncher':
-        // Handled by backend-ai-react-edu-applauncher (React component)
-        break;
-      case 'error':
-      default:
-        if (typeof globalThis.backendaiPages !== 'undefined') {
-          for (const item of globalThis.backendaiPages) {
-            if ('url' in item) {
-              const path =
-                process.env.NODE_ENV === 'development'
-                  ? './plugins/'
-                  : '../plugins/';
-              import(path + item.url + '.js');
-            }
-          }
-          break;
-        } else {
-          document.addEventListener('backend-ai-plugin-loaded', () => {
-            return;
-          });
-        }
-        import('./components/backend-ai-error-view.js').then((module) => {
-          return;
-        });
-        break;
-    }
-    dispatch(updatePage(page, params));
-  };
-
-const updatePage = (page, params) => {
-  return { type: UPDATE_PAGE, page, params };
-};
+// Navigation is now handled by React Router.
+// The navigate() Redux action is no longer needed.
+// Use React Router's useNavigate() hook or dispatch 'react-navigate' event instead.
 
 export const updateDrawerState = (opened) => {
   return { type: UPDATE_DRAWER_STATE, opened };

--- a/src/components/backend-ai-error-view.ts
+++ b/src/components/backend-ai-error-view.ts
@@ -2,13 +2,11 @@
  @license
  Copyright (c) 2015-2025 Lablup Inc. All rights reserved.
  */
-import { navigate } from '../backend-ai-app';
 import {
   IronFlex,
   IronFlexAlignment,
   IronPositioning,
 } from '../plastics/layout/iron-flex-layout-classes';
-import { store } from '../store';
 import { BackendAiStyles } from './backend-ai-general-styles';
 import { BackendAIPage } from './backend-ai-page';
 import '@material/mwc-button';
@@ -71,11 +69,11 @@ export default class BackendAIErrorView extends BackendAIPage {
    */
   _moveTo(url = '') {
     const page = url !== '' ? url : 'start';
-    globalThis.history.pushState({}, '', '/start');
-    store.dispatch(navigate(decodeURIComponent('/' + page), {}));
+    const targetPath = '/' + page;
+    globalThis.history.pushState({}, '', targetPath);
     document.dispatchEvent(
       new CustomEvent('react-navigate', {
-        detail: url,
+        detail: targetPath,
       }),
     );
   }

--- a/src/components/backend-ai-serving-view.ts
+++ b/src/components/backend-ai-serving-view.ts
@@ -2,12 +2,10 @@
  @license
 Copyright (c) 2015-2025 Lablup Inc. All rights reserved.
 */
-import { navigate } from '../backend-ai-app';
 import {
   IronFlex,
   IronFlexAlignment,
 } from '../plastics/layout/iron-flex-layout-classes';
-import { store } from '../store';
 import { BackendAiStyles } from './backend-ai-general-styles';
 import { BackendAIPage } from './backend-ai-page';
 import '@material/mwc-circular-progress';
@@ -53,12 +51,13 @@ export default class BackendAIServingView extends BackendAIPage {
         @moveTo="${(e: CustomEvent) => {
           const path = e.detail.path;
           const params = e.detail.params;
-          globalThis.history.pushState(
-            {},
-            '',
-            path + '?folder=' + params.folder,
+          const fullPath = path + '?folder=' + params.folder;
+          globalThis.history.pushState({}, '', fullPath);
+          document.dispatchEvent(
+            new CustomEvent('react-navigate', {
+              detail: fullPath,
+            }),
           );
-          store.dispatch(navigate(decodeURIComponent(path), params));
         }}"
       ></backend-ai-react-serving-list>
     `;

--- a/src/types/backend-ai-console.d.ts
+++ b/src/types/backend-ai-console.d.ts
@@ -13,14 +13,7 @@ import 'weightless/popover';
 import 'weightless/popover-card';
 import 'weightless/progress-spinner';
 
-declare const BackendAIWebUI_base: (new (...args: any[]) => {
-  _storeUnsubscribe: import('redux').Unsubscribe;
-  connectedCallback(): void;
-  disconnectedCallback(): void;
-  stateChanged(_state: unknown): void;
-  readonly isConnected: boolean;
-}) &
-  typeof LitElement;
+declare const BackendAIWebUI_base: typeof LitElement;
 /**
  Backend.AI Web UI
 
@@ -106,7 +99,9 @@ export default class BackendAIWebUI extends BackendAIWebUI_base {
   _toggleDropdown(): void;
   showTOSAgreement(): void;
   showPPAgreement(): void;
-  _moveTo(url: any): void;
+  _updatePageFromPath(path: string): void;
+  _activatePluginPage(): void;
+  _moveTo(url: any, params?: any, fromReact?: boolean): void;
   _moveToLogPage(): void;
   _readRecentProjectGroup(): any;
   _writeRecentProjectGroup(value: string): void;
@@ -115,7 +110,6 @@ export default class BackendAIWebUI extends BackendAIWebUI_base {
   addTooltips(): Promise<void>;
   _createPopover(anchor: string, title: string): void;
   protected render(): import('lit-element').TemplateResult;
-  stateChanged(state: any): void;
 }
 
 export {};


### PR DESCRIPTION
Resolves #5378(FR-991)

## Summary

- Remove Redux-based navigation layer (`installRouter`, `navigate` actions, `store.dispatch`, `connect` mixin) from `backend-ai-webui.ts`
- Make React Router the sole source of truth for routing
- Simplify `backend-ai-app.ts` to only export action type constants (navigation logic removed)
- Add `_updatePageFromPath()` and `_activatePluginPage()` methods to derive page state from URL path
- Replace `store.dispatch(navigate(...))` with direct `history.pushState` + `react-navigate` events in `backend-ai-error-view.ts` and `backend-ai-serving-view.ts`
- Add React Router routes for `/verify-email`, `/change-password`, `/edu-applauncher`, `/applauncher` as standalone pages outside MainLayout
- Add `useApiEndpoint` hook for resolving API endpoint in standalone pages
- Keep bridge events (`move-to-from-react`, `react-navigate`, `locationPath:changed`) working for plugin page activation during transition

## Architecture Changes

**Before:** Lit/Redux `installRouter()` captures URL changes -> dispatches Redux `navigate` action -> `loadPage` does dynamic imports -> `stateChanged` updates `_page` -> bridge events sync React Router

**After:** React Router handles all URL routing -> dispatches `locationPath:changed` event -> Lit shell's `_updatePageFromPath()` derives `_page` from URL -> `_activatePluginPage()` manages plugin lifecycle

## Files Changed

### Modified
- `src/components/backend-ai-webui.ts` - Remove `installRouter`, `connect(store)`, simplify `_moveTo`, add `_updatePageFromPath` and `_activatePluginPage`
- `src/backend-ai-app.ts` - Remove `navigate`/`loadPage` Redux actions, keep constants
- `src/components/backend-ai-error-view.ts` - Replace Redux navigation with `react-navigate` event
- `src/components/backend-ai-serving-view.ts` - Replace Redux navigation with `react-navigate` event
- `src/types/backend-ai-console.d.ts` - Remove Redux mixin types, add new method declarations
- `react/src/routes.tsx` - Add routes for verify-email, change-password, edu-applauncher

### Added
- `react/src/pages/EmailVerificationPage.tsx` - Standalone email verification page
- `react/src/pages/ChangePasswordPage.tsx` - Standalone password change page
- `react/src/pages/EduAppLauncherPage.tsx` - Standalone edu app launcher page
- `react/src/hooks/useApiEndpoint.ts` - Hook for resolving API endpoint

## Test plan

- [ ] Verify page navigation works correctly (click sidebar menu items)
- [ ] Verify browser back/forward navigation works
- [ ] Verify deep linking works for all pages
- [ ] Verify `/verify-email` route renders correctly
- [ ] Verify `/change-password` route renders correctly
- [ ] Verify `/edu-applauncher` route renders correctly
- [ ] Verify `/error` (404) page works
- [ ] Verify plugin pages still activate/deactivate correctly (if applicable)
- [ ] Verify logout redirects correctly
- [ ] Verify Electron app navigation works (if applicable)
