### PR TITLE
refactor(FR-991): migrate plugin loading system from Lit to React

### DIFF
--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -12,6 +12,7 @@ import ForceTOTPChecker from '../ForceTOTPChecker';
 import NetworkStatusBanner from '../NetworkStatusBanner';
 import NoResourceGroupAlert from '../NoResourceGroupAlert';
 import PasswordChangeRequestAlert from '../PasswordChangeRequestAlert';
+import PluginLoader from '../PluginLoader';
 import ThemePreviewModeAlert from '../ThemePreviewModeAlert';
 import { DRAWER_WIDTH } from '../WEBUINotificationDrawer';
 import WebUIBreadcrumb from '../WebUIBreadcrumb';
@@ -96,10 +97,9 @@ function MainLayout() {
     setMainContentDivRefState(contentScrollFlexRef);
   }, [contentScrollFlexRef, setMainContentDivRefState]);
 
-  // Call `useSetupWebUIPluginEffect` to setup listener for 'backend-ai-config-loaded' event
-  useSetupWebUIPluginEffect({
-    webUIRef: webUIRef,
-  });
+  // Setup listener for 'backend-ai-plugin-config' event from Lit shell.
+  // This stores the plugin config string in Jotai state for PluginLoader to consume.
+  useSetupWebUIPluginEffect();
 
   useLayoutEffect(() => {
     const handleNavigate = (e: any) => {
@@ -268,6 +268,9 @@ function MainLayout() {
                     </PageAccessGuard>
                   </AutoAdminPrimaryColorProvider>
                 </BAIErrorBoundary>
+                <ErrorBoundaryWithNullFallback>
+                  <PluginLoader />
+                </ErrorBoundaryWithNullFallback>
               </Suspense>
               {/* @ts-ignore */}
               <backend-ai-webui id="webui-shell" ref={webUIRef} />

--- a/react/src/components/PluginLoader.tsx
+++ b/react/src/components/PluginLoader.tsx
@@ -1,0 +1,179 @@
+/**
+ * PluginLoader - React component that handles loading Backend.AI WebUI plugins.
+ *
+ * This component replaces the Lit-based plugin loading system that was previously
+ * in backend-ai-webui.ts. It:
+ * 1. Reads plugin configuration from Jotai state (set by Lit shell via event)
+ * 2. Dynamically imports each plugin module (ES modules)
+ * 3. Creates web component elements and appends them to a container
+ * 4. Extracts metadata (menuitem, icon, group, permission) from each plugin element
+ * 5. Updates Jotai plugin state atoms for navigation menu integration
+ * 6. Manages plugin active/inactive state based on the current route
+ */
+import {
+  type PluginPage,
+  type WebUIPluginType,
+  pluginApiEndpointState,
+  pluginLoadedState,
+  webUIPluginsState,
+} from '../hooks/useWebUIPluginState';
+import { usePluginConfigStringValue } from '../hooks/useWebUIPluginState';
+import { atom, useAtomValue, useSetAtom } from 'jotai';
+import { useCallback, useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+
+interface BackendAIPageElement extends HTMLElement {
+  active: boolean;
+  permission?: string;
+  menuitem?: string;
+  icon?: string;
+  group?: string;
+  requestUpdate?: () => void;
+}
+
+/**
+ * Internal atom to track whether the plugin loading process has started.
+ * Prevents re-loading plugins on re-renders.
+ */
+const pluginLoadingStartedState = atom<boolean>(false);
+
+function PluginLoader() {
+  'use memo';
+
+  const pluginConfigString = usePluginConfigStringValue();
+  const apiEndpoint = useAtomValue(pluginApiEndpointState);
+  const setWebUIPlugins = useSetAtom(webUIPluginsState);
+  const setPluginLoaded = useSetAtom(pluginLoadedState);
+  const loadingStarted = useAtomValue(pluginLoadingStartedState);
+  const setLoadingStarted = useSetAtom(pluginLoadingStartedState);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const pluginElementsRef = useRef<Map<string, BackendAIPageElement>>(
+    new Map(),
+  );
+  const location = useLocation();
+
+  const loadPlugins = useCallback(
+    async (configString: string) => {
+      const pluginNames = configString
+        .split(',')
+        .map((name) => name.trim())
+        .filter((name) => name.length > 0);
+
+      if (pluginNames.length === 0) {
+        setPluginLoaded(true);
+        document.dispatchEvent(
+          new CustomEvent('backend-ai-plugin-loaded', { detail: true }),
+        );
+        return;
+      }
+
+      const plugins: WebUIPluginType = {
+        page: [],
+        menuitem: [],
+        'menuitem-user': [],
+        'menuitem-admin': [],
+        'menuitem-superadmin': [],
+      };
+
+      const pluginLoaderQueue: Promise<void>[] = pluginNames.map(
+        async (page) => {
+          const pluginUrl =
+            (globalThis as Record<string, unknown>).isElectron && apiEndpoint
+              ? `${apiEndpoint}/dist/plugins/${page}.js`
+              : `../plugins/${page}.js`;
+
+          try {
+            await import(/* @vite-ignore */ pluginUrl);
+
+            const pageItem = document.createElement(
+              page,
+            ) as BackendAIPageElement;
+            pageItem.classList.add('page');
+            pageItem.setAttribute('name', page);
+
+            // Append to the container div so the web component connects to the DOM
+            if (containerRef.current) {
+              containerRef.current.appendChild(pageItem);
+            }
+
+            // Store reference for activation management
+            pluginElementsRef.current.set(page, pageItem);
+
+            plugins.menuitem.push(page);
+
+            switch (pageItem.permission) {
+              case 'superadmin':
+                plugins['menuitem-superadmin'].push(page);
+                break;
+              case 'admin':
+                plugins['menuitem-admin'].push(page);
+                break;
+              default:
+                plugins['menuitem-user'].push(page);
+            }
+
+            const pluginPageData: PluginPage = {
+              name: page,
+              url: page,
+              menuitem: pageItem.menuitem ?? '',
+              icon: pageItem.icon,
+              group: pageItem.group,
+            };
+            plugins.page.push(pluginPageData);
+          } catch {
+            // Failed to load plugin - skip it silently
+            // The plugin may not exist or may have a syntax error
+          }
+        },
+      );
+
+      await Promise.all(pluginLoaderQueue);
+
+      // Set backward compat global
+      (globalThis as Record<string, unknown>).backendaiPages = plugins.page;
+
+      // Update Jotai state
+      setWebUIPlugins(plugins);
+      setPluginLoaded(true);
+
+      // Dispatch backward compat event
+      document.dispatchEvent(
+        new CustomEvent('backend-ai-plugin-loaded', { detail: true }),
+      );
+    },
+    [apiEndpoint, setWebUIPlugins, setPluginLoaded],
+  );
+
+  // Load plugins when config string becomes available
+  useEffect(() => {
+    if (pluginConfigString && !loadingStarted) {
+      setLoadingStarted(true);
+      loadPlugins(pluginConfigString);
+    }
+  }, [pluginConfigString, loadingStarted, setLoadingStarted, loadPlugins]);
+
+  // Activate/deactivate plugin pages based on current route
+  useEffect(() => {
+    const currentPage = location.pathname.split('/')[1] || '';
+
+    pluginElementsRef.current.forEach((element, name) => {
+      if (name === currentPage) {
+        element.active = true;
+        element.requestUpdate?.();
+      } else {
+        element.active = false;
+        element.removeAttribute('active');
+      }
+    });
+  }, [location.pathname]);
+
+  return (
+    <div
+      ref={containerRef}
+      id="plugin-container"
+      style={{ display: 'contents' }}
+    />
+  );
+}
+
+export default PluginLoader;

--- a/react/src/hooks/useWebUIPluginState.tsx
+++ b/react/src/hooks/useWebUIPluginState.tsx
@@ -1,4 +1,4 @@
-import { atom, useAtom, useAtomValue } from 'jotai';
+import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { useEffect } from 'react';
 
 export type PluginPage = {
@@ -17,8 +17,30 @@ export type WebUIPluginType = {
   'menuitem-superadmin': string[];
 };
 
-const webUIPluginsState = atom<WebUIPluginType | undefined>(undefined);
-const pluginLoadedState = atom<boolean>(false);
+/**
+ * Jotai atom holding the parsed plugin configuration string from config.toml.
+ * Set when Lit dispatches 'backend-ai-plugin-config' with the raw
+ * comma-separated plugin page names.
+ */
+export const pluginConfigStringState = atom<string | undefined>(undefined);
+
+/**
+ * Jotai atom holding the API endpoint for Electron plugin URL resolution.
+ */
+export const pluginApiEndpointState = atom<string | undefined>(undefined);
+
+/**
+ * Jotai atom holding the fully resolved plugin metadata.
+ * Updated by PluginLoader after all plugin modules are imported and inspected.
+ */
+export const webUIPluginsState = atom<WebUIPluginType | undefined>(undefined);
+
+/**
+ * Jotai atom indicating whether plugin loading has completed.
+ * Set to true by PluginLoader after all plugins are loaded,
+ * or immediately if there are no plugins to load.
+ */
+export const pluginLoadedState = atom<boolean>(false);
 
 export const useWebUIPluginValue = () => {
   return useAtomValue(webUIPluginsState);
@@ -28,29 +50,64 @@ export const useWebUIPluginLoadedValue = () => {
   return useAtomValue(pluginLoadedState);
 };
 
-export const useSetupWebUIPluginEffect = ({
-  webUIRef,
-}: {
-  // TODO: fetch and load plugins in this hook instead of relying on webUIRef
-  webUIRef: React.RefObject<any>;
-}) => {
+export const usePluginConfigStringValue = () => {
+  return useAtomValue(pluginConfigStringState);
+};
+
+/**
+ * Hook that listens for 'backend-ai-plugin-config' events from the Lit shell
+ * and stores the plugin config string in Jotai state.
+ *
+ * The Lit shell dispatches this event in loadConfig() with:
+ * - pluginPages: the raw config.plugin.page string (e.g. "test-plugin1,test-plugin2")
+ * - apiEndpoint: the login panel API endpoint for Electron plugin URL resolution
+ *
+ * If no plugin config exists, the Lit shell dispatches the event with an empty
+ * pluginPages string so React can mark plugins as loaded immediately.
+ */
+export const useSetupWebUIPluginEffect = () => {
   'use memo';
-  const [, setWebUIPlugins] = useAtom(webUIPluginsState);
-  const [, setPluginLoaded] = useAtom(pluginLoadedState);
+  const setPluginConfigString = useSetAtom(pluginConfigStringState);
+  const setPluginApiEndpoint = useSetAtom(pluginApiEndpointState);
+  const setPluginLoaded = useSetAtom(pluginLoadedState);
+
   useEffect(() => {
-    const configHandler = () => {
-      setWebUIPlugins(webUIRef.current?.plugins);
+    const handlePluginConfig = (e: Event) => {
+      const detail = (
+        e as CustomEvent<{ pluginPages: string; apiEndpoint?: string }>
+      ).detail;
+      const pluginPages = detail?.pluginPages ?? '';
+      if (detail?.apiEndpoint) {
+        setPluginApiEndpoint(detail.apiEndpoint);
+      }
+      if (pluginPages) {
+        setPluginConfigString(pluginPages);
+      } else {
+        // No plugins to load, mark as loaded immediately
+        setPluginLoaded(true);
+      }
     };
-    const pluginHandler = () => {
+
+    // Also handle legacy 'backend-ai-plugin-loaded' for backward compat
+    const handleLegacyPluginLoaded = () => {
       setPluginLoaded(true);
-      // Also update plugins in case they changed after loading
-      setWebUIPlugins(webUIRef.current?.plugins);
     };
-    document.addEventListener('backend-ai-config-loaded', configHandler);
-    document.addEventListener('backend-ai-plugin-loaded', pluginHandler);
+
+    document.addEventListener('backend-ai-plugin-config', handlePluginConfig);
+    document.addEventListener(
+      'backend-ai-plugin-loaded',
+      handleLegacyPluginLoaded,
+    );
+
     return () => {
-      document.removeEventListener('backend-ai-config-loaded', configHandler);
-      document.removeEventListener('backend-ai-plugin-loaded', pluginHandler);
+      document.removeEventListener(
+        'backend-ai-plugin-config',
+        handlePluginConfig,
+      );
+      document.removeEventListener(
+        'backend-ai-plugin-loaded',
+        handleLegacyPluginLoaded,
+      );
     };
-  }, [webUIRef, setWebUIPlugins, setPluginLoaded]);
+  }, [setPluginConfigString, setPluginApiEndpoint, setPluginLoaded]);
 };

--- a/src/types/backend-ai-console.d.ts
+++ b/src/types/backend-ai-console.d.ts
@@ -100,7 +100,6 @@ export default class BackendAIWebUI extends BackendAIWebUI_base {
   showTOSAgreement(): void;
   showPPAgreement(): void;
   _updatePageFromPath(path: string): void;
-  _activatePluginPage(): void;
   _moveTo(url: any, params?: any, fromReact?: boolean): void;
   _moveToLogPage(): void;
   _readRecentProjectGroup(): any;


### PR DESCRIPTION
Resolves #5379(FR-991)

## Summary

Migrates the plugin loading pipeline from the Lit-based `backend-ai-webui.ts` to React. Plugins are now loaded, registered, and activated by a new React `PluginLoader` component, while the Lit shell only dispatches the raw plugin configuration for React to consume.

### Changes

- **New `PluginLoader` component** (`react/src/components/PluginLoader.tsx`):
  - Dynamically imports plugin ES modules using the same URL patterns as the old Lit loader
  - Creates web component elements and appends them to a container div
  - Extracts metadata (menuitem, icon, group, permission) from each plugin element
  - Updates Jotai plugin state atoms directly for navigation menu integration
  - Manages plugin active/inactive state based on the current React Router route
  - Handles Electron API endpoint for plugin URL resolution

- **Refactored `useWebUIPluginState` hook** (`react/src/hooks/useWebUIPluginState.tsx`):
  - Replaced dependency on `webUIRef.current?.plugins` with event-driven approach
  - Listens for new `backend-ai-plugin-config` event from Lit shell
  - Stores plugin config string and API endpoint in new Jotai atoms
  - Keeps backward compat listener for `backend-ai-plugin-loaded` event

- **Simplified `backend-ai-webui.ts`**:
  - Removed ~80 lines of plugin loading logic (dynamic import, DOM creation, metadata extraction)
  - Removed `_activatePluginPage()` method and all call sites
  - Now dispatches `backend-ai-plugin-config` event with raw config data for React
  - Removed unused `BackendAIPage` import

- **Updated MainLayout** to include `PluginLoader` with error boundary
- **Updated type declarations** to remove `_activatePluginPage()` signature

### Backward Compatibility

- `globalThis.backendaiPages` is still set after plugin loading
- `backend-ai-plugin-loaded` event is still dispatched
- Plugin URL patterns unchanged (`../plugins/{name}.js` or `{apiEndpoint}/dist/plugins/{name}.js`)
- Existing Lit web component plugins work without modification

## Test plan

- [ ] Verify plugins load correctly when `config.toml` has `[plugin] page = "test-plugin1,test-plugin2"`
- [ ] Verify no plugins scenario works (no `[plugin]` section in config)
- [ ] Verify plugin menu items appear in sidebar with correct permissions
- [ ] Verify plugin page activation/deactivation on route changes
- [ ] Verify Electron mode uses correct API endpoint for plugin URLs
- [ ] Verify `globalThis.backendaiPages` is set for backward compatibility
- [ ] Verify `backend-ai-plugin-loaded` event fires for external listeners
