### PR TITLE
fix(FR-991): address review findings for BAIModal from PR #5382

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIModal.tsx
@@ -25,7 +25,7 @@ export interface BAIModalProps extends ModalProps {
    * Callback invoked before the modal is closed when `confirmBeforeClose` is true.
    * Return false (or a rejected Promise) to prevent closing; return void/true to allow it.
    */
-  onConfirmClose?: () => void | Promise<boolean>;
+  onConfirmClose?: () => void | boolean | Promise<boolean>;
   /** Makes the modal header sticky so it remains visible when body content is scrolled */
   stickyTitle?: boolean;
   /** Visual variant that changes the header title color */
@@ -69,6 +69,7 @@ const useStyles = createStyles(
           position: sticky;
           top: 0;
           z-index: 1;
+          background: var(--ant-color-bg-elevated, #fff);
         }
       `
         : ''}
@@ -84,6 +85,7 @@ const BAIModal: React.FC<BAIModalProps> = ({
   type = 'normal',
   ...modalProps
 }) => {
+  'use memo';
   const { token } = theme.useToken();
   const { styles } = useStyles({
     stickyTitle,
@@ -120,8 +122,12 @@ const BAIModal: React.FC<BAIModalProps> = ({
 
   const handleCancel: ModalProps['onCancel'] = async (e) => {
     if (confirmBeforeClose && onConfirmClose) {
-      const result = await Promise.resolve(onConfirmClose());
-      if (result === false) {
+      try {
+        const result = await Promise.resolve(onConfirmClose());
+        if (result === false) {
+          return;
+        }
+      } catch {
         return;
       }
     }


### PR DESCRIPTION
## Summary
- Fix `onConfirmClose` type signature to support synchronous `boolean` returns alongside `void | Promise<boolean>`
- Add try/catch in `handleCancel` to gracefully handle rejected promises from `onConfirmClose` (preventing unhandled rejections)
- Add `'use memo'` directive to BAIModal component for React Compiler optimization
- Add explicit background to sticky header CSS to prevent content bleed-through during scroll

## Test plan
- [ ] Verify modal close with `confirmBeforeClose` works when `onConfirmClose` returns `true`, `false`, `void`, `Promise<true>`, `Promise<false>`, and rejected Promise
- [ ] Verify sticky title modal scrolling doesn't show content through header
- [ ] Verify no regressions in existing modal usage