### PR TITLE
fix(FR-991): address review findings for LoginView/LoginFormPanel from PR #5388

### DIFF
--- a/react/src/components/LoginFormPanel.tsx
+++ b/react/src/components/LoginFormPanel.tsx
@@ -23,6 +23,7 @@ import {
   WarningTwoTone,
 } from '@ant-design/icons';
 import {
+  App,
   Button,
   Dropdown,
   Form,
@@ -30,7 +31,6 @@ import {
   Modal,
   Spin,
   Typography,
-  message,
   theme,
   type FormInstance,
   type MenuProps,
@@ -387,6 +387,7 @@ const ResetPasswordRequiredInline: React.FC<{
   onCancel: () => void;
   onOk: () => void;
 }> = ({ open, username, currentPassword, apiEndpoint, onCancel, onOk }) => {
+  'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const [form] = Form.useForm<{ newPassword: string; confirm: string }>();
@@ -530,7 +531,9 @@ const TOTPActivateInline: React.FC<{
   onCancel: () => void;
   onOk: () => void;
 }> = ({ open, totpRegistrationToken, apiEndpoint, onCancel, onOk }) => {
+  'use memo';
   const { t } = useTranslation();
+  const { message } = App.useApp();
   const formRef = useRef<FormInstance<TOTPActivateFormData>>(null);
   const anonBaiClient = useAnonymousBackendaiClient({
     api_endpoint: apiEndpoint,


### PR DESCRIPTION
Resolves review findings from PR #5388 (feat(FR-991): migrate backend-ai-login to React LoginView)

## Changes
- Sanitize `dangerouslySetInnerHTML` with DOMPurify to prevent XSS
- Add `Secure; SameSite=Lax` flags to SSO cookie
- Replace hardcoded English strings with i18n translation keys
- Fix eslint-disable scope (block → line) for exhaustive-deps
- Add error notification in `connectUsingAPI` catch block
- Rename `saveLoginInfo` → `clearSavedLoginInfo` for semantic accuracy
- Add `'use memo'` directive to `ResetPasswordRequiredInline` and `TOTPActivateInline`
- Replace direct `message` import with `App.useApp()` in `TOTPActivateInline`