### PR TITLE
fix(FR-991): address review findings for EduAppLauncher from PR #5389

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -596,6 +596,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Ihre Sitzung kann nicht autorisiert werden. Melden Sie sich zuerst im Portal an.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Computersitzung vorbereitet",
     "CreatingComputeSession": "Compute-Sitzung erstellen ...",
     "EmptyProject": "EmptyProject",
@@ -605,6 +607,7 @@
     "PleaseReload": "Bitte nach einiger Zeit neu laden.",
     "QueryingExistingComputeSession": "Vorhandene Compute-Sitzung wird abgefragt...",
     "SessionStatusIs": "Sitzungsstatus ist",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "Sitzung ist noch in Vorbereitung. Nach einiger Zeit neu laden"
   },
   "environment": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -593,6 +593,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Δεν είναι δυνατή η εξουσιοδότηση της περιόδου σύνδεσης. Πρώτα συνδεθείτε στην πύλη.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Η συνεδρία υπολογισμού προετοιμάστηκε",
     "CreatingComputeSession": "Δημιουργία συνεδρίας υπολογιστών ...",
     "EmptyProject": "EmptyProject",
@@ -602,6 +604,7 @@
     "PleaseReload": "Φορτώστε ξανά μετά από λίγο.",
     "QueryingExistingComputeSession": "Ερώτηση υφιστάμενης περιόδου λειτουργίας υπολογισμού ...",
     "SessionStatusIs": "Η κατάσταση περιόδου σύνδεσης είναι",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "Η συνεδρία βρίσκεται ακόμη σε προετοιμασία. Επαναφόρτωση μετά από λίγο"
   },
   "environment": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -599,6 +599,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Unable to authorize your session. Login to the portal first.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Compute session prepared",
     "CreatingComputeSession": "Creating compute session ...",
     "EmptyProject": "EmptyProject",
@@ -608,6 +610,7 @@
     "PleaseReload": "Please reload after some time.",
     "QueryingExistingComputeSession": "Querying existing compute session ...",
     "SessionStatusIs": "Session status is",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "Session is still in preparing. Reload after a while"
   },
   "environment": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -596,6 +596,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "No se ha podido autorizar su sesión. Conéctese primero al portal.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Sesión de cálculo preparada",
     "CreatingComputeSession": "Crear sesión de cálculo ...",
     "EmptyProject": "Proyecto vacío",
@@ -605,6 +607,7 @@
     "PleaseReload": "Por favor, vuelva a cargar después de algún tiempo.",
     "QueryingExistingComputeSession": "Consulta de la sesión de cálculo existente ...",
     "SessionStatusIs": "El estado de la sesión es",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "La sesión sigue en preparación. Recargar después de un rato"
   },
   "environment": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -596,6 +596,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Istuntoa ei pystytä valtuuttamaan. Kirjaudu ensin portaaliin.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Laskenta-istunto valmis",
     "CreatingComputeSession": "Laskenta-istunnon luominen ...",
     "EmptyProject": "EmptyProject",
@@ -605,6 +607,7 @@
     "PleaseReload": "Lataa uudelleen jonkin ajan kuluttua.",
     "QueryingExistingComputeSession": "Olemassa olevan laskenta-istunnon kysely ...",
     "SessionStatusIs": "Istunnon tila on",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "Istunto on edelleen valmistelussa. Lataa uudelleen hetken kuluttua"
   },
   "environment": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -596,6 +596,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Impossible d'autoriser votre session. Connectez-vous d'abord au portail.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Séance de calcul préparée",
     "CreatingComputeSession": "Création d'une session de calcul...",
     "EmptyProject": "Projet vide",
@@ -605,6 +607,7 @@
     "PleaseReload": "Veuillez actualiser la page après un certain temps.",
     "QueryingExistingComputeSession": "Vérification de session de calcul existante...",
     "SessionStatusIs": "L'état de la session est",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "La séance est encore en préparation. Actualiser la page après un certain temps"
   },
   "environment": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -595,6 +595,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Tidak dapat mengotorisasi sesi Anda. Login ke portal terlebih dahulu.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Sesi komputasi tersiapkan",
     "CreatingComputeSession": "Membuat sesi komputasi...",
     "EmptyProject": "Proyek Kosong",
@@ -604,6 +606,7 @@
     "PleaseReload": "Harap muat ulang setelah beberapa saat.",
     "QueryingExistingComputeSession": "Mengkueri sesi komputasi yang ada ...",
     "SessionStatusIs": "Status sesi adalah",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "Sesi masih dalam persiapan. Harap muat ulang setelah beberapa saat"
   },
   "environment": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -595,6 +595,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Impossibile autorizzare la tua sessione. Accedi prima al portale.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Sessione di calcolo preparata",
     "CreatingComputeSession": "Creazione della sessione di calcolo in corso...",
     "EmptyProject": "Progetto vuoto",
@@ -604,6 +606,7 @@
     "PleaseReload": "Si prega di ricaricare dopo un po' di tempo.",
     "QueryingExistingComputeSession": "Interrogazione della sessione di calcolo esistente in corso...",
     "SessionStatusIs": "Lo stato della sessione è",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "La sessione è ancora in preparazione. Ricarica dopo un po'"
   },
   "environment": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -595,6 +595,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "セッションを承認できません。最初にポータルにログインします。",
+    "CannotCreateSessionWithDifferentImage": "実行中のセッションと異なるイメージでセッションを作成することはできません。",
+    "CannotInitializeClient": "クライアント接続の初期化に失敗しました。",
     "ComputeSessionPrepared": "計算セッションの準備",
     "CreatingComputeSession": "計算セッションの作成..。",
     "EmptyProject": "ユーザーが所属しているプロジェクトがありません。",
@@ -604,6 +606,7 @@
     "PleaseReload": "しばらくしてからリロードしてください。",
     "QueryingExistingComputeSession": "既存の計算セッションのクエリ..。",
     "SessionStatusIs": "セッションステータスは",
+    "SessionStatusIsWithReload": "セッションステータス: {{status}}。しばらくしてからリロードしてください。",
     "SessionStillPreparing": "セッションはまだ準備中です。しばらくしてからリロードしてください"
   },
   "environment": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -598,6 +598,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "인증 실패. 포털에 로그인 되어 있는지 확인하십시오.",
+    "CannotCreateSessionWithDifferentImage": "실행 중인 세션과 다른 이미지로 세션을 생성할 수 없습니다.",
+    "CannotInitializeClient": "클라이언트 연결 초기화에 실패했습니다.",
     "ComputeSessionPrepared": "연산 세션이 준비되었습니다",
     "CreatingComputeSession": "연산 세션 생성 중 ...",
     "EmptyProject": "사용자가 소속된 프로젝트가 없습니다.",
@@ -607,6 +609,7 @@
     "PleaseReload": "잠시 후에 다시 시도해 보십시오.",
     "QueryingExistingComputeSession": "기존 연산 세션 조회 중 ...",
     "SessionStatusIs": "세션 상태는 ",
+    "SessionStatusIsWithReload": "세션 상태: {{status}}. 잠시 후 새로고침해 주세요.",
     "SessionStillPreparing": "연산 세션이 아직 준비 중입니다. 잠시 후 다시 로드해 주세요."
   },
   "environment": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -591,6 +591,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Таны session-г зөвшөөрөх боломжгүй байна. Эхлээд портал руу нэвтрэх.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Тооцоолох хэсгийг бэлтгэсэн",
     "CreatingComputeSession": "Тооцоолох session үүсгэж байна ...",
     "EmptyProject": "Хоосон төсөл",
@@ -600,6 +602,7 @@
     "PleaseReload": "Хэсэг хугацааны дараа дахин ачааллана уу.",
     "QueryingExistingComputeSession": "Одоо байгаа тооцоолох session-ээс асууж байна ...",
     "SessionStatusIs": "Session-ий байдал",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "Session бэлтгэл ажил үргэлжилж байна. Хэсэг хугацааны дараа дахин ажиллуулна уу"
   },
   "environment": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -595,6 +595,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Tidak dapat mengesahkan sesi anda. Masuk ke portal terlebih dahulu.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Sesi perkiraan disediakan",
     "CreatingComputeSession": "Membuat sesi mengira ...",
     "EmptyProject": "EmptyProject",
@@ -604,6 +606,7 @@
     "PleaseReload": "Muat semula selepas beberapa waktu.",
     "QueryingExistingComputeSession": "Pertanyaan sesi pengkomputeran yang ada ...",
     "SessionStatusIs": "Status sesi adalah",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "Sesi masih dalam persiapan. Muat semula selepas beberapa ketika"
   },
   "environment": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -596,6 +596,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Nie można autoryzować Twojej sesji. Najpierw zaloguj się do portalu.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Przygotowano sesję obliczeniową",
     "CreatingComputeSession": "Tworzę sesję obliczeniową...",
     "EmptyProject": "EmptyProject",
@@ -605,6 +607,7 @@
     "PleaseReload": "Załaduj ponownie po pewnym czasie.",
     "QueryingExistingComputeSession": "Wysyłam zapytanie do istniejącej sesji obliczeniowej...",
     "SessionStatusIs": "Stan sesji to",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "Sesja jest wciąż w przygotowaniu. Załaduj ponownie po chwili"
   },
   "environment": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -596,6 +596,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Incapaz de autorizar sua sessão. Faça login no portal primeiro.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Sessão de computação preparada",
     "CreatingComputeSession": "Criando sessão de computação ...",
     "EmptyProject": "EmptyProject",
@@ -605,6 +607,7 @@
     "PleaseReload": "Por favor recarregue depois de algum tempo.",
     "QueryingExistingComputeSession": "Consultando sessão de computação existente ...",
     "SessionStatusIs": "O status da sessão é",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "A sessão ainda está em preparação. Recarregue depois de um tempo"
   },
   "environment": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -596,6 +596,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Incapaz de autorizar sua sessão. Faça login no portal primeiro.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Sessão de computação preparada",
     "CreatingComputeSession": "Criando sessão de computação ...",
     "EmptyProject": "EmptyProject",
@@ -605,6 +607,7 @@
     "PleaseReload": "Por favor recarregue depois de algum tempo.",
     "QueryingExistingComputeSession": "Consultando sessão de computação existente ...",
     "SessionStatusIs": "O status da sessão é",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "A sessão ainda está em preparação. Recarregue depois de um tempo"
   },
   "environment": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -596,6 +596,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Не удалось авторизовать сеанс. Сначала войдите на портал.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Вычислительная сессия подготовлена",
     "CreatingComputeSession": "Создание вычислительного сеанса ...",
     "EmptyProject": "EmptyProject",
@@ -605,6 +607,7 @@
     "PleaseReload": "Пожалуйста, перезагрузите через некоторое время.",
     "QueryingExistingComputeSession": "Запрос существующего сеанса вычислений ...",
     "SessionStatusIs": "Статус сеанса",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "Сессия все еще находится в стадии подготовки. Перезагрузите через некоторое время"
   },
   "environment": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -590,6 +590,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "ไม่สามารถอนุญาตเซสชันของคุณได้ กรุณาเข้าสู่ระบบที่พอร์ทัลก่อน",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "เตรียมเซสชันการคำนวณแล้ว",
     "CreatingComputeSession": "กำลังสร้างเซสชันการคำนวณ ...",
     "EmptyProject": "โครงการว่างเปล่า",
@@ -599,6 +601,7 @@
     "PleaseReload": "กรุณาโหลดใหม่หลังจากผ่านไปสักครู่",
     "QueryingExistingComputeSession": "กำลังสอบถามเซสชันการคำนวณที่มีอยู่ ...",
     "SessionStatusIs": "สถานะเซสชันคือ",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "เซสชันยังอยู่ในขั้นตอนการเตรียมการ โหลดใหม่หลังจากผ่านไปสักครู่"
   },
   "environment": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -596,6 +596,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Oturumunuz yetkilendirilemiyor. Önce portala giriş yapın.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Hesaplama oturumu hazırlandı",
     "CreatingComputeSession": "Hesaplama oturumu oluşturuluyor...",
     "EmptyProject": "BoşProje",
@@ -605,6 +607,7 @@
     "PleaseReload": "Lütfen bir süre sonra yeniden yükleyin.",
     "QueryingExistingComputeSession": "Mevcut bilgi işlem oturumu sorgulanıyor...",
     "SessionStatusIs": "Oturum durumu (şimdiki değeri)",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "Oturum hala hazırlanıyor. Bir süre sonra yeniden yükle"
   },
   "environment": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -596,6 +596,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "Không thể cho phép phiên của bạn. Đăng nhập vào cổng trước.",
+    "CannotCreateSessionWithDifferentImage": "Cannot create a session with an image different from any running session.",
+    "CannotInitializeClient": "Failed to initialize the client connection.",
     "ComputeSessionPrepared": "Phiên máy tính được chuẩn bị",
     "CreatingComputeSession": "Đang tạo phiên máy tính ...",
     "EmptyProject": "Dự án trống rỗng",
@@ -605,6 +607,7 @@
     "PleaseReload": "Vui lòng tải lại sau một thời gian.",
     "QueryingExistingComputeSession": "Đang truy vấn phiên tính toán hiện có ...",
     "SessionStatusIs": "Trạng thái phiên là",
+    "SessionStatusIsWithReload": "Session status is {{status}}. Please reload after some time.",
     "SessionStillPreparing": "Phiên vẫn đang trong quá trình chuẩn bị. Tải lại sau một thời gian"
   },
   "environment": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -596,6 +596,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "无法授权您的会话。首先登录门户。",
+    "CannotCreateSessionWithDifferentImage": "无法使用与正在运行的会话不同的镜像创建会话。",
+    "CannotInitializeClient": "客户端连接初始化失败。",
     "ComputeSessionPrepared": "计算会话已准备好",
     "CreatingComputeSession": "正在创建计算会话...",
     "EmptyProject": "空项目",
@@ -605,6 +607,7 @@
     "PleaseReload": "请过一段时间重新加载。",
     "QueryingExistingComputeSession": "正在查询现有计算会话...",
     "SessionStatusIs": "会话状态为",
+    "SessionStatusIsWithReload": "会话状态为 {{status}}。请稍后重新加载。",
     "SessionStillPreparing": "会议还在准备中。一段时间后重新加载"
   },
   "environment": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -597,6 +597,8 @@
   },
   "eduapi": {
     "CannotAuthorizeSessionByToken": "無法授權您的會話。首先登錄門戶。",
+    "CannotCreateSessionWithDifferentImage": "無法使用與正在執行的工作階段不同的映像檔建立工作階段。",
+    "CannotInitializeClient": "用戶端連線初始化失敗。",
     "ComputeSessionPrepared": "計算會話已準備好",
     "CreatingComputeSession": "正在創建計算會話...",
     "EmptyProject": "空项目",
@@ -606,6 +608,7 @@
     "PleaseReload": "請過一段時間重新加載。",
     "QueryingExistingComputeSession": "正在查詢現有計算會話...",
     "SessionStatusIs": "會話狀態為",
+    "SessionStatusIsWithReload": "工作階段狀態為 {{status}}。請稍後重新載入。",
     "SessionStillPreparing": "會議還在準備中。一段時間後重新加載"
   },
   "environment": {


### PR DESCRIPTION
Resolves review findings from PR #5389 (feat(FR-991): migrate backend-ai-edu-applauncher to React)

## Changes
- Add `Secure; SameSite=Lax` flags and `encodeURIComponent` to sToken cookie
- Fix `String()` coercion that made falsy check unreachable in `_openServiceApp`
- Replace hardcoded English error string with i18n key
- Replace string concatenation with parameterized i18n key `SessionStatusIsWithReload`
- Add user notification on `_initClient` failure
- Add error handling for `_prepareProjectInformation` call
- Add new i18n keys to all 21 language files