### PR TITLE
fix(FR-991): address review findings from PR #5390

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
@@ -94,11 +94,6 @@ const getWSProxyVersion = async (
   projectId: string,
   baiClient: BackendAIClient,
 ) => {
-  // @ts-ignore
-  if (globalThis?.backendaiwebui?.debug === true) {
-    // Debug proxy version override is no longer supported
-    // after the removal of the Lit backend-ai-app-launcher component.
-  }
   if (globalThis.isElectron) {
     return 'v1';
   }

--- a/react/src/helper/appLauncherProxy.ts
+++ b/react/src/helper/appLauncherProxy.ts
@@ -260,7 +260,6 @@ export async function openWsproxy(
 
   const rqstProxy = {
     method: 'GET',
-    app: app,
     uri: `${uri}&${searchParams.toString()}`,
   };
 


### PR DESCRIPTION
Resolves review findings from PR #5390 (feat(FR-5372): remove Lit backend-ai-app-launcher and clean up dependencies)

## Changes
- Remove empty conditional block (dead code) in `TerminateSessionModal` that was left after debug proxy version override removal
- Remove extraneous `app` property from request object in `appLauncherProxy` (not part of `SendRequestConfig`)