### PR TITLE
fix(FR-991): address review findings for navigation pages from PR #5391

### DIFF
--- a/react/src/pages/ChangePasswordPage.tsx
+++ b/react/src/pages/ChangePasswordPage.tsx
@@ -19,7 +19,7 @@ const ChangePasswordPage: React.FC = () => {
     <>
       <CSSTokenVariables />
       <NotificationForAnonymous />
-      {/* @ts-ignore */}
+      {/* @ts-expect-error - custom Lit element not in JSX.IntrinsicElements */}
       <backend-ai-webui id="webui-shell" />
       <Suspense fallback={null}>
         <ChangePasswordPageContent />
@@ -29,6 +29,7 @@ const ChangePasswordPage: React.FC = () => {
 };
 
 const ChangePasswordPageContent: React.FC = () => {
+  'use memo';
   const apiEndpoint = useApiEndpoint();
 
   return <ChangePasswordViewLazy apiEndpoint={apiEndpoint} active={true} />;

--- a/react/src/pages/EduAppLauncherPage.tsx
+++ b/react/src/pages/EduAppLauncherPage.tsx
@@ -19,7 +19,7 @@ const EduAppLauncherPage: React.FC = () => {
     <>
       <CSSTokenVariables />
       <NotificationForAnonymous />
-      {/* @ts-ignore */}
+      {/* @ts-expect-error - custom Lit element not in JSX.IntrinsicElements */}
       <backend-ai-webui id="webui-shell" />
       <Suspense fallback={null}>
         <EduAppLauncherPageContent />
@@ -29,6 +29,7 @@ const EduAppLauncherPage: React.FC = () => {
 };
 
 const EduAppLauncherPageContent: React.FC = () => {
+  'use memo';
   const apiEndpoint = useApiEndpoint();
 
   return <EduAppLauncherLazy apiEndpoint={apiEndpoint} active={true} />;

--- a/react/src/pages/EmailVerificationPage.tsx
+++ b/react/src/pages/EmailVerificationPage.tsx
@@ -19,7 +19,7 @@ const EmailVerificationPage: React.FC = () => {
     <>
       <CSSTokenVariables />
       <NotificationForAnonymous />
-      {/* @ts-ignore */}
+      {/* @ts-expect-error - custom Lit element not in JSX.IntrinsicElements */}
       <backend-ai-webui id="webui-shell" />
       <Suspense fallback={null}>
         <EmailVerificationPageContent />
@@ -29,6 +29,7 @@ const EmailVerificationPage: React.FC = () => {
 };
 
 const EmailVerificationPageContent: React.FC = () => {
+  'use memo';
   const apiEndpoint = useApiEndpoint();
 
   return <EmailVerificationViewLazy apiEndpoint={apiEndpoint} active={true} />;


### PR DESCRIPTION
Resolves review findings from PR #5391 (refactor(FR-5378): consolidate navigation from Lit/Redux to React Router)

## Changes
- Add `'use memo'` directive to `ChangePasswordPageContent`, `EmailVerificationPageContent`, `EduAppLauncherPageContent`
- Replace `@ts-ignore` with `@ts-expect-error` for custom Lit element JSX (safer - will fail if the underlying issue is resolved)