### PR TITLE
fix(FR-991): address review findings for PluginLoader from PR #5392

### DIFF
--- a/react/src/hooks/useWebUIPluginState.tsx
+++ b/react/src/hooks/useWebUIPluginState.tsx
@@ -66,7 +66,6 @@ export const usePluginConfigStringValue = () => {
  * pluginPages string so React can mark plugins as loaded immediately.
  */
 export const useSetupWebUIPluginEffect = () => {
-  'use memo';
   const setPluginConfigString = useSetAtom(pluginConfigStringState);
   const setPluginApiEndpoint = useSetAtom(pluginApiEndpointState);
   const setPluginLoaded = useSetAtom(pluginLoadedState);


### PR DESCRIPTION
Resolves review findings from PR #5392 (refactor(FR-5379): migrate plugin loading system from Lit to React)

## Changes
- Consolidate duplicate imports from `useWebUIPluginState`
- Add `useRef` guard to prevent race condition on double-mount in Strict Mode
- Add `.catch()` handler on `loadPlugins` promise in useEffect to prevent unhandled rejections
- Log plugin load errors with `useBAILogger` instead of empty catch block
- Remove misplaced `'use memo'` from `useSetupWebUIPluginEffect` hook (hooks don't benefit from it)