### PR TITLE
fix(FR-991): remove residual dialog-body selector from e2e test from PR #5394

### DIFF
--- a/e2e/utils/classes/session/SessionDetailPage.ts
+++ b/e2e/utils/classes/session/SessionDetailPage.ts
@@ -203,7 +203,7 @@ export class SessionDetailPage extends BasePage {
     await logLines.first().waitFor({ state: 'visible', timeout: 5000 });
 
     // Get all text content from the modal body
-    const modalBody = logsModal.locator('.ant-modal-body, .dialog-body');
+    const modalBody = logsModal.locator('.ant-modal-body');
     const logsText = await modalBody.textContent();
 
     // Close the logs modal by clicking the close button


### PR DESCRIPTION
Resolves review findings from PR #5394 (chore(FR-5376): remove backend-ai-dialog and unused MWC/Vaadin dependencies)

## Changes
- Remove dead `.dialog-body` CSS fallback selector from e2e `SessionDetailPage` since `backend-ai-dialog` was fully removed