### PR TITLE
fix(FR-991): resolve dev server and login dialog issues after React-first migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "server:p": "serve build/rollup",
     "server:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && PORT=$BAI_WEBUI_DEV_REACT_PORT PROXY=http://localhost:$BAI_WEBUI_DEV_WEBDEV_PORT pnpm --prefix ./react run start",
     "server:d-ie11": "web-dev-server --node-resolve --open --watch --port 3081 --hostname $BAI_WEBUI_DEV_HOST --esbuild-target auto --app-index demo/index.html --file-extensions .ts",
-    "build:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && concurrently -c \"auto\" --names \"webcomponent,react-relay,webdev\" \"./node_modules/typescript/bin/tsc --watch\" \"cd react && pnpm run relay:watch\" \"web-dev-server --node-resolve --port $BAI_WEBUI_DEV_WEBDEV_PORT --hostname localhost --esbuild-target auto --app-index index.html --file-extensions .ts\"",
+    "build:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && concurrently -c \"auto\" --names \"webcomponent,react-relay,webdev,react\" \"./node_modules/typescript/bin/tsc --watch\" \"cd react && pnpm run relay:watch\" \"web-dev-server --node-resolve --port $BAI_WEBUI_DEV_WEBDEV_PORT --hostname localhost --esbuild-target auto --app-index index.html --file-extensions .ts\" \"PORT=$BAI_WEBUI_DEV_REACT_PORT pnpm --prefix ./react run start\"",
     "electron:d": "electron build/electron-app --dev",
     "electron:d:hmr": "LIVE_DEBUG=1 electron build/electron-app --dev",
     "relay": "relay-compiler",

--- a/react/src/components/LoginFormPanel.tsx
+++ b/react/src/components/LoginFormPanel.tsx
@@ -116,6 +116,7 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
         keyboard={false}
         footer={null}
         width={400}
+        getContainer={false}
         styles={{
           body: { padding: 0 },
         }}
@@ -132,7 +133,7 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
 
         {/* Mode header */}
         <BAIFlex
-          justify="space-between"
+          justify="between"
           align="center"
           style={{
             margin: '0 25px',
@@ -446,6 +447,7 @@ const ResetPasswordRequiredInline: React.FC<{
       maskClosable={false}
       footer={null}
       width={450}
+      getContainer={false}
       destroyOnHidden
     >
       <BAIFlex
@@ -602,6 +604,7 @@ const TOTPActivateInline: React.FC<{
       confirmLoading={activateMutation.isPending}
       open={open}
       onCancel={onCancel}
+      getContainer={false}
       destroyOnHidden
       onOk={handleOk}
       loading={!isSuccess}

--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -581,7 +581,7 @@ const LoginView: React.FC<LoginViewProps> = () => {
       if (descriptor) {
         Object.defineProperty(el, key, descriptor);
       } else {
-        (el as Record<string, unknown>)[key] =
+        (el as unknown as Record<string, unknown>)[key] =
           handle[key as keyof LoginViewHandle];
       }
     });
@@ -638,11 +638,7 @@ const LoginView: React.FC<LoginViewProps> = () => {
       : endpoints.map((ep) => ({
           key: ep,
           label: (
-            <BAIFlex
-              justify="space-between"
-              align="center"
-              style={{ minWidth: 300 }}
-            >
+            <BAIFlex justify="between" align="center" style={{ minWidth: 300 }}>
               <span>{ep}</span>
               <Button
                 type="text"
@@ -747,6 +743,7 @@ const LoginView: React.FC<LoginViewProps> = () => {
         }
         closable={false}
         maskClosable={false}
+        getContainer={false}
         destroyOnHidden
       >
         <div style={{ textAlign: 'center', paddingTop: 15 }}>
@@ -761,6 +758,7 @@ const LoginView: React.FC<LoginViewProps> = () => {
         onCancel={() => setIsHelpOpen(false)}
         footer={null}
         width={350}
+        getContainer={false}
       >
         <div
           style={{

--- a/react/src/react-app-env.d.ts
+++ b/react/src/react-app-env.d.ts
@@ -16,6 +16,16 @@ declare namespace globalThis {
   var isElectron: boolean;
   // eslint-disable-next-line no-var
   var electronInitialHref: string;
+  // eslint-disable-next-line no-var
+  var packageEdition: string;
+  // eslint-disable-next-line no-var
+  var packageVersion: string;
+  // eslint-disable-next-line no-var
+  var packageValidUntil: string;
+  // eslint-disable-next-line no-var
+  var buildVersion: string;
+  // eslint-disable-next-line no-var
+  var backendaiclient: any;
 }
 
 type DeepPartial<T> = {


### PR DESCRIPTION
## Summary

- Add React dev server to `build:d` script so the React-first architecture loads correctly in development
- Restore `globalThis.BackendAIClient` and `globalThis.BackendAIClientConfig` globals that were previously set by the now-removed `backend-ai-login.ts`
- Add `_waitForLoginPanel()` polling method to handle the timing gap between Lit shell's `firstUpdated` and React's `useEffect` handle assignment
- Fix `BAIFlex` justify prop from `'space-between'` to `'between'`
- Fix TypeScript cast error with intermediate `unknown` cast
- Add missing `globalThis` type declarations for `packageEdition`, `packageVersion`, `packageValidUntil`, `buildVersion`, `backendaiclient`
- Add `getContainer={false}` on all login modals so they render inside the shadow DOM where their CSS-in-JS styles are injected, fixing the invisible login dialog issue

## Test plan

- [ ] Run `pnpm run build:d` and verify the splash screen loads and transitions to the login dialog
- [ ] Verify the login form fields (email, password, endpoint) render correctly
- [ ] Test login flow with valid credentials
- [ ] Test block panel displays when config fails to load
- [ ] Verify TOTP and reset password dialogs render correctly when triggered