### PR TITLE
chore(FR-2085): configure backend.ai-docs-toolkit package for npm registry publishing

### DIFF
--- a/.github/workflows/publish-backend.ai-docs-toolkit.yml
+++ b/.github/workflows/publish-backend.ai-docs-toolkit.yml
@@ -1,0 +1,82 @@
+name: Publish Backend.ai-docs-toolkit to npm registry
+
+on:
+  push:
+    paths:
+      - packages/backend.ai-docs-toolkit/**
+    branches:
+      - main
+    tags:
+      - v*
+
+jobs:
+  publish:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: latest
+          run_install: false
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+      - name: Update npm
+        run: npm install -g npm@latest
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Update to canary version
+        if: github.ref_type == 'branch'
+        run: |
+          cd packages/backend.ai-docs-toolkit
+          ./scripts/update-canary-version.sh
+
+      - name: Publish to npm (canary)
+        if: github.ref_type == 'branch'
+        run: |
+          cd packages/backend.ai-docs-toolkit
+          npm publish --tag canary --access public --no-git-checks
+
+      - name: Determine npm tag and publish strategy
+        if: github.ref_type == 'tag'
+        id: determine-tag
+        run: |
+          cd packages/backend.ai-docs-toolkit
+          # Extract version from GITHUB_REF (refs/tags/v25.17.2 -> 25.17.2)
+          VERSION="${GITHUB_REF#refs/tags/v}"
+
+          # Run the script and capture stdout (key=value pairs)
+          SCRIPT_OUTPUT=$(./scripts/determine-publish-strategy.sh "$VERSION")
+
+          # Parse each line and write to GITHUB_OUTPUT
+          echo "$SCRIPT_OUTPUT" | while IFS='=' read -r key value; do
+            if [ -n "$key" ]; then
+              echo "${key}=${value}" >> $GITHUB_OUTPUT
+            fi
+          done
+
+      - name: Publish to npm
+        if: github.ref_type == 'tag' && steps.determine-tag.outputs.should_publish == 'true'
+        run: |
+          cd packages/backend.ai-docs-toolkit
+          npm publish --tag ${{ steps.determine-tag.outputs.npm_tag }} --access public --no-git-checks

--- a/packages/backend.ai-docs-toolkit/package.json
+++ b/packages/backend.ai-docs-toolkit/package.json
@@ -1,12 +1,35 @@
 {
   "name": "backend.ai-docs-toolkit",
   "version": "0.1.0",
+  "description": "A reusable documentation toolkit for generating PDFs and web previews from Markdown content",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lablup/backend.ai-webui/tree/main/packages/backend.ai-docs-toolkit"
+  },
+  "bugs": {
+    "url": "https://github.com/lablup/backend.ai-webui/issues"
+  },
+  "author": "Lablup Inc. <contact@lablup.com>",
+  "license": "LGPL-3.0-or-later",
+  "keywords": [
+    "backend.ai",
+    "documentation",
+    "pdf",
+    "markdown",
+    "toolkit"
+  ],
   "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "bin": {
     "docs-toolkit": "./dist/cli.js"
   },
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
   "files": [
     "dist",
@@ -14,7 +37,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "@pdf-lib/fontkit": "^1.1.1",

--- a/packages/backend.ai-docs-toolkit/scripts/determine-publish-strategy.sh
+++ b/packages/backend.ai-docs-toolkit/scripts/determine-publish-strategy.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PACKAGE_JSON="${PACKAGE_DIR}/package.json"
+
+# Get git tag from argument (expects version without 'v' prefix, e.g., 25.17.2)
+GIT_TAG="$1"
+
+if [ -z "$GIT_TAG" ]; then
+  echo "Error: No git tag provided" >&2
+  echo "Usage: $0 <version>" >&2
+  echo "Example: $0 25.17.2-rc.0" >&2
+  exit 1
+fi
+
+echo "Analyzing version: ${GIT_TAG}" >&2
+
+PACKAGE_NAME=$(node -p "require('${PACKAGE_JSON}').name")
+
+# Determine npm tag based on version suffix
+if [[ "$GIT_TAG" == *"-alpha"* ]]; then
+  echo "⏭️  Alpha version detected. Skipping npm publish." >&2
+  echo "should_publish=false"
+  echo "npm_tag="
+  exit 0
+elif [[ "$GIT_TAG" == *"-rc"* ]]; then
+  echo "✅ RC version detected. Publishing to rc tag without version check." >&2
+  echo "should_publish=true"
+  echo "npm_tag=rc"
+  exit 0
+elif [[ "$GIT_TAG" == *"-beta"* ]]; then
+  echo "✅ Beta version detected. Publishing to beta tag without version check." >&2
+  echo "should_publish=true"
+  echo "npm_tag=beta"
+  exit 0
+else
+  NPM_TAG="latest"
+fi
+
+echo "  Determined npm tag: ${NPM_TAG}" >&2
+
+# Get the latest published version for the latest tag
+LATEST_VERSION=$(npm view "${PACKAGE_NAME}@${NPM_TAG}" version 2>/dev/null || echo "0.0.0")
+
+echo "  Current version: ${GIT_TAG}" >&2
+echo "  Latest published ${NPM_TAG} version: ${LATEST_VERSION}" >&2
+
+# Function to extract base version (major.minor.patch) from semver string
+extract_base_version() {
+  local version="$1"
+  # Extract major.minor.patch, ignoring prerelease tags
+  echo "$version" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/'
+}
+
+# Function to compare two semver versions (major.minor.patch only)
+# Returns: 0 if v1 > v2, 1 if v1 == v2, 2 if v1 < v2
+compare_versions() {
+  local v1="$1"
+  local v2="$2"
+
+  # Split versions into components
+  IFS='.' read -r -a v1_parts <<< "$v1"
+  IFS='.' read -r -a v2_parts <<< "$v2"
+
+  # Compare major, minor, patch
+  for i in 0 1 2; do
+    local part1="${v1_parts[$i]:-0}"
+    local part2="${v2_parts[$i]:-0}"
+
+    if (( part1 > part2 )); then
+      return 0  # v1 > v2
+    elif (( part1 < part2 )); then
+      return 2  # v1 < v2
+    fi
+  done
+
+  return 1  # v1 == v2
+}
+
+# Extract base versions for comparison
+CURRENT_BASE=$(extract_base_version "$GIT_TAG")
+LATEST_BASE=$(extract_base_version "$LATEST_VERSION")
+
+echo "  Comparing base versions: ${CURRENT_BASE} vs ${LATEST_BASE}" >&2
+
+# Compare versions (temporarily disable exit on error for return codes)
+set +e
+compare_versions "$CURRENT_BASE" "$LATEST_BASE"
+COMPARISON=$?
+set -e
+
+# Output results to stdout (GitHub Actions will capture this)
+case "$COMPARISON" in
+  0)  # Current > Latest
+    echo "✅ Version ${GIT_TAG} is publishable (> ${LATEST_VERSION})" >&2
+    echo "should_publish=true"
+    echo "npm_tag=${NPM_TAG}"
+    exit 0
+    ;;
+  1)  # Current == Latest
+    echo "⏭️  Skipping publish: version ${GIT_TAG} is already published as ${LATEST_VERSION}" >&2
+    echo "should_publish=false"
+    echo "npm_tag="
+    exit 0
+    ;;
+  2)  # Current < Latest
+    echo "⏭️  Skipping publish: version ${GIT_TAG} is lower than latest ${LATEST_VERSION}" >&2
+    echo "should_publish=false"
+    echo "npm_tag="
+    exit 0
+    ;;
+  *)
+    echo "Error: Unexpected comparison result" >&2
+    exit 1
+    ;;
+esac

--- a/packages/backend.ai-docs-toolkit/scripts/update-canary-version.sh
+++ b/packages/backend.ai-docs-toolkit/scripts/update-canary-version.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$(cd "${PACKAGE_DIR}/../.." && pwd)"
+PACKAGE_JSON="${PACKAGE_DIR}/package.json"
+ROOT_PACKAGE_JSON="${ROOT_DIR}/package.json"
+
+# Get commit hash and build date
+COMMIT_HASH=$(git rev-parse --short=9 HEAD)
+BUILD_DATE=$(date +%Y%m%d)
+
+# Read the base version from root package.json
+BASE_VERSION_FULL=$(node -p "require('${ROOT_PACKAGE_JSON}').version")
+# Extract only the version part before the first '-' (e.g., 25.16.0-alpha.0 -> 25.16.0)
+BASE_VERSION="${BASE_VERSION_FULL%%-*}"
+
+# Create canary version (React style: version-canary-hash-date)
+CANARY_VERSION="${BASE_VERSION}-canary-${COMMIT_HASH}-${BUILD_DATE}"
+
+echo "Updating version to ${CANARY_VERSION}"
+echo "  Base version: ${BASE_VERSION}"
+echo "  Commit hash: ${COMMIT_HASH}"
+echo "  Build date: ${BUILD_DATE}"
+
+# Update package.json version
+node -e "
+  const fs = require('fs');
+  const pkg = JSON.parse(fs.readFileSync('${PACKAGE_JSON}', 'utf8'));
+  pkg.version = '${CANARY_VERSION}';
+  fs.writeFileSync('${PACKAGE_JSON}', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+echo "Updated package.json version to ${CANARY_VERSION}"


### PR DESCRIPTION
Resolves #5422 ([FR-2085](https://lablup.atlassian.net/browse/FR-2085))

## Summary
- Added npm registry publishing metadata to `backend.ai-docs-toolkit/package.json` (description, repository, license, keywords, exports)
- Created GitHub Actions workflow `.github/workflows/publish-backend.ai-docs-toolkit.yml` for automated publishing
- Added `scripts/update-canary-version.sh` for canary version generation on main branch pushes
- Added `scripts/determine-publish-strategy.sh` for version comparison and tag determination
- Added `prepublishOnly` script to ensure build runs before publishing

## Implementation Details

**Package Metadata Updates:**
- Added `description`, `repository`, `bugs`, `author`, `license`, `keywords`
- Added `main`, `module`, `types` entry points
- Enhanced `exports` field with `import` and `types` conditions
- Added `prepublishOnly` hook to run `pnpm build` before publish

**Publishing Strategy (same as backend.ai-ui):**
- **main branch push**: Publish with `canary` tag (format: `version-canary-hash-date`)
- **alpha tags**: Skip publishing
- **beta/rc tags**: Publish to respective npm tags
- **release tags**: Publish to `latest` tag (only if version > published version)

**Scripts:**
- `update-canary-version.sh`: Generates canary version from root package.json version + commit hash + date
- `determine-publish-strategy.sh`: Compares versions and determines whether to publish and which npm tag to use

## Test plan
- [x] Verified `pnpm pack --dry-run` includes correct files (dist/, templates/, README.md, package.json)
- [x] Verified scripts have executable permissions
- [x] Tested `determine-publish-strategy.sh` with different version formats (0.1.0, 0.2.0-alpha.0)
- [ ] After merge to main, verify canary publish workflow triggers
- [ ] On next release tag, verify version-based publish workflow triggers

[FR-2085]: https://lablup.atlassian.net/browse/FR-2085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ