### PR TITLE
feat(FR-991): migrate login orchestration from Lit shell to React

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
     <noscript>
       <p>Could not render Backend.AI Web UI. Check that JavaScript is enabled.</p>
     </noscript>
-    <script src="./dist/components/backend-ai-webui.js" type="module"></script>
+    <!-- Backend.AI client classes are now initialized by React global-stores.ts -->
     <script nonce="{{nonce}}">
       document.getElementById('version-detail').innerText = globalThis.packageVersion;
       document.getElementById('build-detail').innerText = ' Build ' + globalThis.buildVersion;

--- a/react/src/global-stores.ts
+++ b/react/src/global-stores.ts
@@ -13,6 +13,16 @@
  * React code should prefer the typed re-exports (or the hooks in
  * hooks/useGlobalStores.ts) instead of touching globalThis directly.
  */
+// ---------------------------------------------------------------------------
+// Backend.AI client classes on globalThis.
+// Previously set by the Lit shell (backend-ai-webui.ts).
+// Must be available before any component calls createBackendAIClient().
+// ---------------------------------------------------------------------------
+// @ts-ignore - resolved via craco webpack alias to dist/lib/backend.ai-client-esm.js
+import * as ai from 'backend.ai-client-esm';
+
+(globalThis as any).BackendAIClient = ai.backend.Client;
+(globalThis as any).BackendAIClientConfig = ai.backend.ClientConfig;
 
 // ---------------------------------------------------------------------------
 // BackendAISettingsStore

--- a/react/src/helper/TabCounter.ts
+++ b/react/src/helper/TabCounter.ts
@@ -1,0 +1,128 @@
+/* TabCounter.ts
+ * TypeScript port for React usage.
+ * Original author: Shubanker Chourasia (MIT license)
+ * https://github.com/shubanker/Tabs-Counter
+ */
+
+interface TabData {
+  list: Record<
+    string,
+    {
+      TabOpenedTimeStamp?: number;
+      url?: string;
+      lastActive: number;
+    }
+  >;
+  lastCleaned: number;
+}
+
+class TabCount {
+  updateInterval = 1000;
+  tabId = Math.random().toString(36).substring(7);
+  tabsCounter = 0;
+  private onTabCountUpdate: Array<(count: number) => void> = [];
+  private updateActiveInterval: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    this.updateActive();
+    this.start();
+    window.addEventListener('beforeunload', () => {
+      const data = this.getData();
+      delete data.list[this.tabId];
+      this.updateData(data);
+    });
+  }
+
+  tabsCount = (skipCallback = true): number => {
+    const data = this.getData();
+    const listIds = Object.keys(data.list);
+    const now = Date.now();
+    let count = 0;
+    listIds.forEach((id) => {
+      if (data.list[id].lastActive + this.updateInterval * 1.2 > now) {
+        count++;
+      }
+    });
+    if (!skipCallback && this.tabsCounter !== count) {
+      this.onTabCountUpdate.forEach((event) => {
+        event(count);
+      });
+    }
+    this.tabsCounter = count;
+    return count;
+  };
+
+  private updateActive = (): void => {
+    let data = this.getData();
+    const now = Date.now();
+    if (data.list[this.tabId] === undefined) {
+      data.list[this.tabId] = {
+        TabOpenedTimeStamp: now,
+        lastActive: now,
+      };
+    }
+    data.list[this.tabId].url = window.location.href;
+    data.list[this.tabId].lastActive = now;
+    if (data.lastCleaned === undefined || +data.lastCleaned + 20000 < now) {
+      data = this.clearList(data);
+    }
+    this.updateData(data);
+    this.tabsCount(false);
+  };
+
+  private clearList = (data: TabData): TabData => {
+    const listIds = Object.keys(data.list);
+    const now = Date.now();
+    listIds.forEach((id) => {
+      if (
+        data.list[id].lastActive + Math.max(8000, this.updateInterval * 1.5) <
+        now
+      ) {
+        delete data.list[id];
+      }
+    });
+    data.lastCleaned = now;
+    return data;
+  };
+
+  onTabChange = (
+    callback: (count: number) => void,
+    executeNow = false,
+  ): void => {
+    if (typeof callback === 'function') {
+      this.onTabCountUpdate.push(callback);
+      if (executeNow) {
+        callback(this.tabsCount());
+      }
+    }
+  };
+
+  private updateData = (data: TabData): void => {
+    localStorage.setItem('tabCountData', JSON.stringify(data));
+  };
+
+  private getData = (): TabData => {
+    const savedData = localStorage.getItem('tabCountData');
+    return savedData == null
+      ? { list: {}, lastCleaned: 0 }
+      : JSON.parse(savedData);
+  };
+
+  pause = (): void => {
+    if (this.updateActiveInterval !== null) {
+      clearInterval(this.updateActiveInterval);
+      this.updateActiveInterval = null;
+    }
+  };
+
+  start = (interval?: number): void => {
+    if (interval !== undefined) {
+      this.updateInterval = interval;
+    }
+    this.updateActiveInterval = setInterval(() => {
+      this.updateActive();
+    }, this.updateInterval);
+  };
+}
+
+export default TabCount;

--- a/react/src/hooks/useWebUIConfig.ts
+++ b/react/src/hooks/useWebUIConfig.ts
@@ -267,22 +267,6 @@ export function useInitializeConfig(): {
       setPluginLoaded(true);
     }
 
-    // Set a flag on globalThis before dispatching so the Lit shell can
-    // detect if the event was already fired (prevents race condition
-    // when the Lit shell attaches its listener after React dispatches).
-    (globalThis as Record<string, unknown>).__backendai_config_loaded__ = {
-      autoLogout,
-    };
-
-    // Dispatch event for Lit shell login flow orchestration.
-    // The Lit shell reads autoLogout from the event detail to decide
-    // whether to auto-logout on first tab open.
-    document.dispatchEvent(
-      new CustomEvent('backend-ai-config-loaded', {
-        detail: { autoLogout },
-      }),
-    );
-
     setConfigLoaded(true);
   }, [
     setRawConfig,

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -53,7 +53,6 @@ const TOTPActivateModalWithToken = React.lazy(
 );
 
 const SignupModal = React.lazy(() => import('./components/SignupModal'));
-const LoginViewLazy = React.lazy(() => import('./components/LoginView'));
 
 customElements.define(
   'backend-ai-react-signup-modal',
@@ -82,15 +81,6 @@ customElements.define(
   reactToWebComponent((props) => (
     <DefaultProviders {...props}>
       <ResetPasswordRequired />
-    </DefaultProviders>
-  )),
-);
-
-customElements.define(
-  'backend-ai-react-login-view',
-  reactToWebComponent((props) => (
-    <DefaultProviders {...props}>
-      <LoginViewLazy />
     </DefaultProviders>
   )),
 );

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -6,6 +6,7 @@ import {
 import ErrorBoundaryWithNullFallback from './components/ErrorBoundaryWithNullFallback';
 import FlexActivityIndicator from './components/FlexActivityIndicator';
 import LocationStateBreadCrumb from './components/LocationStateBreadCrumb';
+import LoginView from './components/LoginView';
 import MainLayout from './components/MainLayout/MainLayout';
 import WebUINavigate from './components/WebUINavigate';
 import { useSuspendedBackendaiClient } from './hooks';
@@ -590,6 +591,9 @@ export const routes: RouteObject[] = [
     element: (
       <BAIErrorBoundary>
         <DefaultProvidersForReactRoot>
+          <Suspense>
+            <LoginView />
+          </Suspense>
           {/*FYI, MainLayout has ErrorBoundaryWithNullFallback for <Outlet/> */}
           <MainLayout />
           <ErrorBoundaryWithNullFallback>


### PR DESCRIPTION
## Summary
- Move auto-login flow, session reconnection, and auto-logout detection from the removed Lit shell (`backend-ai-webui.ts`) into React `LoginView`
- Initialize Backend.AI client classes (`BackendAIClient`, `BackendAIClientConfig`) in `global-stores.ts` via webpack alias, replacing the Lit shell's module-scope setup
- Render `LoginView` directly in React router tree with a high z-index wrapper so the login dialog appears above the `LoadingCurtain` background

## Changes
- **`react/src/components/LoginView.tsx`**: Add auto-login orchestration effect, language initialization, `beforeunload` handler for auto-logout, and wrap output in z-index 10000 container
- **`react/src/routes.tsx`**: Add `LoginView` to `/` route alongside `MainLayout`
- **`react/src/global-stores.ts`**: Import `backend.ai-client-esm` and set `globalThis.BackendAIClient` / `BackendAIClientConfig`
- **`react/craco.config.cjs`**: Add webpack alias for `backend.ai-client-esm`, remove `ModuleScopePlugin` in dev
- **`react/src/index.tsx`**: Remove `backend-ai-react-login-view` web component registration
- **`react/src/hooks/useWebUIConfig.ts`**: Remove Lit-only `backend-ai-config-loaded` event dispatch
- **`react/src/helper/TabCounter.ts`**: New TypeScript port of `TabCounter` for auto-logout tab detection
- **`index.html`**: Remove Lit shell script tag

## Test plan
- [x] Refresh with existing session → splash → auto-reconnect → curtain fades → app shows
- [x] Clear localStorage + refresh → login dialog appears over curtain background → login → curtain fades
- [x] Endpoint info (i) button opens help modal above login dialog
- [ ] Signup, TOTP, and password reset modals work from login dialog
- [x] Auto-logout: enable in config, close all tabs, wait >3s, reopen → shows login dialog
- [ ] Multi-tab: open multiple tabs, close one, reopen → auto-reconnect (no forced logout)