### PR TITLE
fix: prevent login modal from reopening after successful authentication

### DIFF
--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -363,6 +363,7 @@ const LoginView: React.FC = () => {
         } else {
           setIsConnected(true);
           await doGQLConnect(client);
+          return;
         }
       } catch (err: unknown) {
         setIsBlockPanelOpen(false);

--- a/react/src/hooks/useLoginOrchestration.test.ts
+++ b/react/src/hooks/useLoginOrchestration.test.ts
@@ -152,11 +152,14 @@ beforeEach(() => {
   mockNavigationType('navigate');
 
   // Reset TabCount mock: single tab, not reloaded
-  MockedTabCount.mockImplementation(() => ({
-    tabsCounter: 1,
-    tabsCount: jest.fn().mockReturnValue(1),
-    pause: jest.fn(),
-  }));
+  MockedTabCount.mockImplementation(
+    () =>
+      ({
+        tabsCounter: 1,
+        tabsCount: jest.fn().mockReturnValue(1),
+        pause: jest.fn(),
+      }) as unknown as TabCount,
+  );
 
   mockedLoadConfig.mockResolvedValue(undefined);
 });
@@ -249,11 +252,14 @@ describe('useLoginOrchestration - normal flow', () => {
 
   it('calls onLogin(false) when there are multiple tabs even with auto_logout on', async () => {
     // Multiple tabs: tabsCounter > 1
-    MockedTabCount.mockImplementation(() => ({
-      tabsCounter: 2,
-      tabsCount: jest.fn().mockReturnValue(2),
-      pause: jest.fn(),
-    }));
+    MockedTabCount.mockImplementation(
+      () =>
+        ({
+          tabsCounter: 2,
+          tabsCount: jest.fn().mockReturnValue(2),
+          pause: jest.fn(),
+        }) as unknown as TabCount,
+    );
     const { options } = await renderOrchestrationHook(true, true);
     expect(options.onLogin).toHaveBeenCalledWith(false);
     expect(options.onOpen).not.toHaveBeenCalled();
@@ -321,11 +327,14 @@ describe('useLoginOrchestration - Electron', () => {
 describe('useLoginOrchestration - auto-logout (single tab, fresh navigation)', () => {
   beforeEach(() => {
     // Single tab, fresh navigation (not a reload)
-    MockedTabCount.mockImplementation(() => ({
-      tabsCounter: 1,
-      tabsCount: jest.fn().mockReturnValue(1),
-      pause: jest.fn(),
-    }));
+    MockedTabCount.mockImplementation(
+      () =>
+        ({
+          tabsCounter: 1,
+          tabsCount: jest.fn().mockReturnValue(1),
+          pause: jest.fn(),
+        }) as unknown as TabCount,
+    );
     mockNavigationType('navigate');
   });
 


### PR DESCRIPTION
## Summary

- Fix login modal staying open after successful login by adding early return in `connectUsingSession()` after `doGQLConnect()` succeeds, preventing the unconditional `open()` call meant for error/retry paths
- Fix TypeScript compilation errors in `useLoginOrchestration.test.ts` by casting partial `TabCount` mock objects to satisfy the full class type

## Test plan

- [ ] Log in with valid credentials → login modal should close and dashboard should be visible
- [ ] Log in with invalid credentials → login modal should stay open with error notification
- [ ] Verify `pnpm run test` passes in `/react` directory (TypeScript errors resolved)