### PR TITLE
chore: update copyright year to 2026 and add license headers

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2025 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 const {
   app,

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
           </ul>
           <ul>
             <li>Powered by open-source software</li>
-            <li class="copyright">Copyright &copy; 2015-2025 Lablup Inc.</li>
+            <li class="copyright">Copyright &copy; 2015-2026 Lablup Inc.</li>
           </ul>
         </div>
         <div class="sk-folding-cube">

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:react-only": "pnpm run --prefix ./react build:only",
     "server:p": "serve build/rollup",
     "server:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && PORT=$BAI_WEBUI_DEV_REACT_PORT PROXY=http://localhost:$BAI_WEBUI_DEV_WEBDEV_PORT pnpm --prefix ./react run start",
-    "build:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && concurrently -c \"auto\" --names \"react-relay,react\" \"cd react && pnpm run relay:watch\" \"PORT=$BAI_WEBUI_DEV_REACT_PORT pnpm --prefix ./react run start\"",
+    "build:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && concurrently -c \"auto\" --names \"react-relay,react\" \"cd react && pnpm run relay:watch\" \"BAI_WEBUI_DEV_PROXY= PORT=$BAI_WEBUI_DEV_REACT_PORT pnpm --prefix ./react run start\"",
     "electron:d": "electron build/electron-app --dev",
     "electron:d:hmr": "LIVE_DEBUG=1 electron build/electron-app --dev",
     "relay": "relay-compiler",

--- a/react/craco.config.cjs
+++ b/react/craco.config.cjs
@@ -19,6 +19,24 @@ module.exports = {
     enable: false, // Disable ESLint webpack plugin for ESLint 9 compatibility. Use CLI lint instead.
   },
   devServer: (devServerConfig, { env, paths }) => {
+    // Serve static files from the root project directory so that
+    // /resources/*, /config.toml, /manifest/*, /dist/* are available
+    // without a separate webdev server.
+    const projectRoot = path.resolve(__dirname, '..');
+    const existingStatic = devServerConfig.static
+      ? Array.isArray(devServerConfig.static)
+        ? devServerConfig.static
+        : [devServerConfig.static]
+      : [];
+    devServerConfig.static = [
+      ...existingStatic,
+      {
+        directory: projectRoot,
+        publicPath: '/',
+        watch: true,
+      },
+    ];
+
     devServerConfig.watchFiles = {
       paths: [
         '../index.html',

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { routes } from './routes';
 import { NuqsAdapter } from 'nuqs/adapters/react-router/v6';
 import {

--- a/react/src/RelayEnvironment.ts
+++ b/react/src/RelayEnvironment.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { manipulateGraphQLQueryWithClientDirectives } from './helper/graphql-transformer';
 import { GraphQLFormattedError } from 'graphql';
 import { createClient } from 'graphql-sse';

--- a/react/src/components/AboutBackendAIModal.tsx
+++ b/react/src/components/AboutBackendAIModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import { useThemeMode } from '../hooks/useThemeMode';
@@ -86,7 +90,7 @@ const AboutBackendAIModal = ({
           open-source software
         </BAILink>
         <br />
-        Copyright &copy; 2015-2025 Lablup Inc.
+        Copyright &copy; 2015-2026 Lablup Inc.
         <br />
         <BAILink
           target="_blank"

--- a/react/src/components/AccessKeySelect.tsx
+++ b/react/src/components/AccessKeySelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { AccessKeySelectQuery } from '../__generated__/AccessKeySelectQuery.graphql';
 import { BAISelect, BAISelectProps } from 'backend.ai-ui';
 import _ from 'lodash';

--- a/react/src/components/ActionItemContent.tsx
+++ b/react/src/components/ActionItemContent.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import WebUILink from './WebUILink';
 import { Button, Divider, Typography, theme } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';

--- a/react/src/components/ActiveAgents.tsx
+++ b/react/src/components/ActiveAgents.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import AgentList from './AgentList';
 import { theme } from 'antd';
 import { BAIBoardItemTitle, BAIFetchKeyButton, BAIFlex } from 'backend.ai-ui';

--- a/react/src/components/AgentDetailDrawer.tsx
+++ b/react/src/components/AgentDetailDrawer.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import AgentDetailDrawerContent from './AgentDetailDrawerContent';
 import { Drawer, type DrawerProps, Skeleton } from 'antd';
 import { BAIFetchKeyButton, toLocalId, useBAILogger } from 'backend.ai-ui';

--- a/react/src/components/AgentDetailDrawerContent.tsx
+++ b/react/src/components/AgentDetailDrawerContent.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import AgentActionButtons from './AgentNodeItems/AgentActionButtons';
 import AgentComputePlugins from './AgentNodeItems/AgentComputePlugins';
 import AgentResources from './AgentNodeItems/AgentResources';

--- a/react/src/components/AgentDetailModal.tsx
+++ b/react/src/components/AgentDetailModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { AgentDetailModalFragment$key } from '../__generated__/AgentDetailModalFragment.graphql';
 import {
   convertToDecimalUnit,

--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   AgentListQuery,
   AgentListQuery$data,

--- a/react/src/components/AgentNodeItems/AgentActionButtons.tsx
+++ b/react/src/components/AgentNodeItems/AgentActionButtons.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import AgentSettingModal from '../AgentSettingModal';
 import { SettingOutlined } from '@ant-design/icons';
 import { Space, Tooltip } from 'antd';

--- a/react/src/components/AgentNodeItems/AgentComputePlugins.tsx
+++ b/react/src/components/AgentNodeItems/AgentComputePlugins.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { BAIDoubleTag, BAITag } from 'backend.ai-ui';
 import _ from 'lodash';
 import { graphql, useFragment } from 'react-relay';

--- a/react/src/components/AgentNodeItems/AgentResources.tsx
+++ b/react/src/components/AgentNodeItems/AgentResources.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import AgentDetailModal from '../AgentDetailModal';
 import SimpleProgressWithLabel from '../SimpleProgressWithLabel';
 import { InfoCircleOutlined } from '@ant-design/icons';

--- a/react/src/components/AgentNodeItems/AgentStatusTag.tsx
+++ b/react/src/components/AgentNodeItems/AgentStatusTag.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { BAIDoubleTag, BAIDoubleTagProps, BAIFlex } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/AgentSelect.tsx
+++ b/react/src/components/AgentSelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { AgentSelectQuery } from '../__generated__/AgentSelectQuery.graphql';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
 import { useControllableValue } from 'ahooks';

--- a/react/src/components/AgentSettingModal.tsx
+++ b/react/src/components/AgentSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   AgentSettingModalFragment$data,
   AgentSettingModalFragment$key,

--- a/react/src/components/AgentStats.tsx
+++ b/react/src/components/AgentStats.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useControllableValue } from 'ahooks';
 import { Segmented, Skeleton, theme, Typography } from 'antd';
 import {

--- a/react/src/components/AgentSummaryList.tsx
+++ b/react/src/components/AgentSummaryList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   AgentSummaryListQuery,
   AgentSummaryListQuery$data,

--- a/react/src/components/AliasedImageDoubleTags.tsx
+++ b/react/src/components/AliasedImageDoubleTags.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { AliasedImageDoubleTagsFragment$key } from '../__generated__/AliasedImageDoubleTagsFragment.graphql';
 import { preserveDotStartCase } from '../helper';
 import { useBackendAIImageMetaData } from '../hooks';

--- a/react/src/components/AllocationHistory.tsx
+++ b/react/src/components/AllocationHistory.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import AllocationHistoryStatistics from './AllocationHistoryStatistics';
 import { Alert, Form, Select, Skeleton } from 'antd';
 import { useUpdatableState, BAIFlex, BAIFetchKeyButton } from 'backend.ai-ui';

--- a/react/src/components/AllocationHistoryStatistics.tsx
+++ b/react/src/components/AllocationHistoryStatistics.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { convertToBinaryUnit, convertToDecimalUnit, SizeUnit } from '../helper';
 import {
   UserStatsData,

--- a/react/src/components/AnnouncementAlert.tsx
+++ b/react/src/components/AnnouncementAlert.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
 import { theme } from 'antd';

--- a/react/src/components/AutoRefreshSwitch.tsx
+++ b/react/src/components/AutoRefreshSwitch.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Switch, type SwitchProps, Typography } from 'antd';
 import { BAIFlex, useInterval } from 'backend.ai-ui';
 import React from 'react';

--- a/react/src/components/AutoScalingRuleEditorModal.tsx
+++ b/react/src/components/AutoScalingRuleEditorModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   AutoScalingMetricComparator,
   AutoScalingMetricSource,

--- a/react/src/components/BAIBoard.tsx
+++ b/react/src/components/BAIBoard.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import Board, { BoardProps } from '@cloudscape-design/board-components/board';
 import BoardItem from '@cloudscape-design/board-components/board-item';
 import { createStyles } from 'antd-style';

--- a/react/src/components/BAICodeEditor.tsx
+++ b/react/src/components/BAICodeEditor.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import useControllableState_deprecated from '../hooks/useControllableState';
 import { useThemeMode } from '../hooks/useThemeMode';
 import { loadLanguage, LanguageName } from '@uiw/codemirror-extensions-langs';

--- a/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
+++ b/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import SessionActionButtons, {
   PrimaryAppOption,
 } from './ComputeSessionNodeItems/SessionActionButtons';

--- a/react/src/components/BAIContentWithDrawerArea.tsx
+++ b/react/src/components/BAIContentWithDrawerArea.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { isOpenDrawerState } from './BAINotificationButton';
 import { Grid, Layout, theme } from 'antd';
 import { BasicProps } from 'antd/lib/layout/layout';

--- a/react/src/components/BAIErrorBoundary.tsx
+++ b/react/src/components/BAIErrorBoundary.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { isLoginSessionExpiredState } from './LoginSessionExtendButton';
 import { ReloadOutlined } from '@ant-design/icons';
 import { Alert, Button, Result, theme, Typography } from 'antd';

--- a/react/src/components/BAIGeneralNotificationItem.tsx
+++ b/react/src/components/BAIGeneralNotificationItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { NotificationState } from '../hooks/useBAINotification';
 import BAINotificationBackgroundProgress from './BAINotificationBackgroundProgress';
 import {

--- a/react/src/components/BAIHelpDrawer.tsx
+++ b/react/src/components/BAIHelpDrawer.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ExportOutlined } from '@ant-design/icons';
 import { Button, Drawer, type DrawerProps } from 'antd';
 import React from 'react';

--- a/react/src/components/BAIJSONViewerModal.tsx
+++ b/react/src/components/BAIJSONViewerModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useThemeMode } from '../hooks/useThemeMode';
 import BAICodeEditor from './BAICodeEditor';
 import { Alert } from 'antd';

--- a/react/src/components/BAIMenu.tsx
+++ b/react/src/components/BAIMenu.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ConfigProvider, Menu, type MenuProps, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import classNames from 'classnames';

--- a/react/src/components/BAINodeNotificationItem.tsx
+++ b/react/src/components/BAINodeNotificationItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { NotificationState } from '../hooks/useBAINotification';
 import BAIComputeSessionNodeNotificationItem from './BAIComputeSessionNodeNotificationItem';
 import BAIVirtualFolderNodeNotificationItem from './BAIVirtualFolderNodeNotificationItem';

--- a/react/src/components/BAINotificationBackgroundProgress.tsx
+++ b/react/src/components/BAINotificationBackgroundProgress.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Progress, theme } from 'antd';
 import _ from 'lodash';
 import { NotificationState } from 'src/hooks/useBAINotification';

--- a/react/src/components/BAINotificationButton.tsx
+++ b/react/src/components/BAINotificationButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   useBAINotificationEffect,
   useBAINotificationState,

--- a/react/src/components/BAIPanelItem.tsx
+++ b/react/src/components/BAIPanelItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import usePrimaryColors from '../hooks/usePrimaryColors';
 import { Progress, type ProgressProps, theme, Typography } from 'antd';
 import { createStyles } from 'antd-style';

--- a/react/src/components/BAIProgress.tsx
+++ b/react/src/components/BAIProgress.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import usePrimaryColors from '../hooks/usePrimaryColors';
 import { type ProgressProps, theme, Typography } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';

--- a/react/src/components/BAIRadioGroup.tsx
+++ b/react/src/components/BAIRadioGroup.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ConfigProvider, Radio, theme } from 'antd';
 import type { RadioGroupProps } from 'antd';
 import { createStyles } from 'antd-style';

--- a/react/src/components/BAISider.tsx
+++ b/react/src/components/BAISider.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ConfigProvider, Grid, type SiderProps, theme } from 'antd';
 import Sider from 'antd/es/layout/Sider';
 import { BAIFlex } from 'backend.ai-ui';

--- a/react/src/components/BAITabs.tsx
+++ b/react/src/components/BAITabs.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Tabs, type TabsProps } from 'antd';
 import { createStyles } from 'antd-style';
 import classNames from 'classnames';

--- a/react/src/components/BAIVirtualFolderNodeNotificationItem.tsx
+++ b/react/src/components/BAIVirtualFolderNodeNotificationItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import BAINotificationBackgroundProgress from './BAINotificationBackgroundProgress';
 import { useToggle } from 'ahooks';
 import { Card, List, theme, Typography } from 'antd';

--- a/react/src/components/BatchSessionScheduledTimeSetting.tsx
+++ b/react/src/components/BatchSessionScheduledTimeSetting.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import DatePickerISO, { DatePickerISOProps } from './DatePickerISO';
 import { useWebComponentInfo } from './DefaultProviders';
 import { useToggle } from 'ahooks';

--- a/react/src/components/BrandingSettingItems/LogoPreviewer.tsx
+++ b/react/src/components/BrandingSettingItems/LogoPreviewer.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { App, Image, Space, Tooltip, Typography, Upload } from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIButton, BAIFlex, BAIUncontrolledInput } from 'backend.ai-ui';

--- a/react/src/components/BrandingSettingItems/LogoSizeSettingItem.tsx
+++ b/react/src/components/BrandingSettingItems/LogoSizeSettingItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Col, Row, theme, Typography } from 'antd';
 import { BAIFlex, BAIUncontrolledInput } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/BrandingSettingItems/ThemeColorPicker.tsx
+++ b/react/src/components/BrandingSettingItems/ThemeColorPicker.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Col, ColorPicker, type ColorPickerProps, Row, theme } from 'antd';
 import { ComponentTokenMap } from 'antd/es/theme/interface';
 import { AliasToken } from 'antd/lib/theme/internal';

--- a/react/src/components/BrandingSettingItems/ThemeJsonConfigModal.tsx
+++ b/react/src/components/BrandingSettingItems/ThemeJsonConfigModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ExportOutlined, ImportOutlined } from '@ant-design/icons';
 import type { Monaco } from '@monaco-editor/react';
 import { Alert, App, Skeleton, theme, Upload } from 'antd';

--- a/react/src/components/BrandingSettingList.tsx
+++ b/react/src/components/BrandingSettingList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import LogoPreviewer, {
   getLogoThemeKey,
 } from './BrandingSettingItems/LogoPreviewer';

--- a/react/src/components/ChangePasswordView.tsx
+++ b/react/src/components/ChangePasswordView.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useAnonymousBackendaiClient } from '../hooks';
 import { App, Form, Input } from 'antd';
 import { BAIButton, BAIFlex, BAIModal } from 'backend.ai-ui';

--- a/react/src/components/Chat/AIAgentSelect.tsx
+++ b/react/src/components/Chat/AIAgentSelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { AIAgent, useAIAgent } from '../../hooks/useAIAgent';
 import { FluentEmojiIcon } from '../FluentEmojiIcon';
 import { useControllableValue } from 'ahooks';

--- a/react/src/components/Chat/AssistantChatMesssage.tsx
+++ b/react/src/components/Chat/AssistantChatMesssage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import ChatMessage, { ChatMessageProps } from './ChatMessage';
 import CopyButton from './CopyButton';
 import Compact from 'antd/es/space/Compact';

--- a/react/src/components/Chat/ChatCard.tsx
+++ b/react/src/components/Chat/ChatCard.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ChatCardQuery } from '../../__generated__/ChatCardQuery.graphql';
 import { useSuspenseTanQuery } from '../../hooks/reactQueryAlias';
 import { useAIAgent } from '../../hooks/useAIAgent';

--- a/react/src/components/Chat/ChatHeader.tsx
+++ b/react/src/components/Chat/ChatHeader.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ChatHeader_Endpoint$key } from '../../__generated__/ChatHeader_Endpoint.graphql';
 import { useWebUINavigate } from '../../hooks';
 import { AIAgent } from '../../hooks/useAIAgent';

--- a/react/src/components/Chat/ChatHistory.ts
+++ b/react/src/components/Chat/ChatHistory.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useWebUINavigate } from '../../hooks';
 import {
   DEFAULT_CHAT_PARAMETERS,

--- a/react/src/components/Chat/ChatInput.tsx
+++ b/react/src/components/Chat/ChatInput.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import ChatSender, {
   AttachmentChangeInfo,
   ChatAttachmentsProps,

--- a/react/src/components/Chat/ChatMessage.tsx
+++ b/react/src/components/Chat/ChatMessage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   ChatMessageContainer,
   ChatMessagePlacement,

--- a/react/src/components/Chat/ChatMessageContainer.tsx
+++ b/react/src/components/Chat/ChatMessageContainer.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Avatar, theme } from 'antd';
 import { BAIFlex, BAIFlexProps } from 'backend.ai-ui';
 import React, { memo } from 'react';

--- a/react/src/components/Chat/ChatMessageContent.tsx
+++ b/react/src/components/Chat/ChatMessageContent.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import CopyButton from './CopyButton';
 import { SyntaxHighlighter } from './SyntaxHighlighter';
 import { theme, Typography } from 'antd';

--- a/react/src/components/Chat/ChatMessages.tsx
+++ b/react/src/components/Chat/ChatMessages.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import PureChatTokenCounter from './ChatTokenCounter';
 import VirtualChatMessageList from './VirtualChatMessageList';
 import { UIMessage } from '@ai-sdk/react';

--- a/react/src/components/Chat/ChatModel.tsx
+++ b/react/src/components/Chat/ChatModel.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import type { AIAgent } from '../../hooks/useAIAgent';
 import { APICallError } from 'ai';
 import type { UIMessage } from 'ai';

--- a/react/src/components/Chat/ChatParametersSliders.tsx
+++ b/react/src/components/Chat/ChatParametersSliders.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import InputNumberWithSlider from '../InputNumberWithSlider';
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import { DEFAULT_CHAT_PARAMETERS, type ChatParameters } from './ChatModel';

--- a/react/src/components/Chat/ChatSender.tsx
+++ b/react/src/components/Chat/ChatSender.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { CloudUploadOutlined, LinkOutlined } from '@ant-design/icons';
 import {
   Attachments,
@@ -52,8 +56,7 @@ export type AttachmentChangeInfo = Parameters<
 >[0];
 
 interface ChatSenderProps
-  extends Omit<SenderProps, 'onChange'>,
-    ChatAttachmentsProps {
+  extends Omit<SenderProps, 'onChange'>, ChatAttachmentsProps {
   loading?: boolean;
   autoFocus?: boolean;
   items?: Attachment[];

--- a/react/src/components/Chat/ChatTokenCounter.tsx
+++ b/react/src/components/Chat/ChatTokenCounter.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useTokenCount } from '../../hooks/useTokenizer';
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import { UIMessage } from 'ai';

--- a/react/src/components/Chat/CopyButton.tsx
+++ b/react/src/components/Chat/CopyButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Button, type ButtonProps, Tooltip } from 'antd';
 import { CopyConfig } from 'antd/es/typography/Base';
 import { CheckIcon, CopyIcon } from 'lucide-react';

--- a/react/src/components/Chat/CustomModelForm.tsx
+++ b/react/src/components/Chat/CustomModelForm.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import EndpointTokenSelect from './EndpointTokenSelect';
 import { ReloadOutlined } from '@ant-design/icons';
 import useResizeObserver from '@react-hook/resize-observer';

--- a/react/src/components/Chat/EndpointSelect.tsx
+++ b/react/src/components/Chat/EndpointSelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   EndpointSelectQuery,
   EndpointSelectQuery$data,
@@ -19,8 +23,10 @@ export type Endpoint = NonNullable<
   NonNullableItem<EndpointSelectQuery$data['endpoint_list']>
 >;
 
-export interface EndpointSelectProps
-  extends Omit<SelectProps, 'options' | 'labelInValue'> {
+export interface EndpointSelectProps extends Omit<
+  SelectProps,
+  'options' | 'labelInValue'
+> {
   fetchKey?: string;
   lifecycleStageFilter?: LifecycleStage[];
 }

--- a/react/src/components/Chat/EndpointTokenSelect.tsx
+++ b/react/src/components/Chat/EndpointTokenSelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import type {
   EndpointTokenSelectQuery,
   EndpointTokenSelectQuery$data,

--- a/react/src/components/Chat/ModelSelect.tsx
+++ b/react/src/components/Chat/ModelSelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import type { ChatModel } from './ChatModel';
 import { Select, type SelectProps } from 'antd';
 import _ from 'lodash';

--- a/react/src/components/Chat/ScrollBottomHandlerButton.tsx
+++ b/react/src/components/Chat/ScrollBottomHandlerButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Button } from 'antd';
 import { useEventNotStable } from 'backend.ai-ui';
 import { ArrowDownIcon } from 'lucide-react';

--- a/react/src/components/Chat/SyntaxHighlighter.tsx
+++ b/react/src/components/Chat/SyntaxHighlighter.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useHighlight } from '../../hooks/useHighlight';
 import DOMPurify from 'dompurify';
 import { HTMLAttributes, memo } from 'react';

--- a/react/src/components/Chat/UserChatMesssage.tsx
+++ b/react/src/components/Chat/UserChatMesssage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import ChatMessage from './ChatMessage';
 import type { ChatMessagePlacement } from './ChatMessageContainer';
 import { UIMessage } from '@ai-sdk/react';

--- a/react/src/components/Chat/VirtualChatMessageList.tsx
+++ b/react/src/components/Chat/VirtualChatMessageList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { AssistantChatMessage } from './AssistantChatMesssage';
 import ScrollBottomHandlerButton from './ScrollBottomHandlerButton';
 import { UserChatMessage } from './UserChatMesssage';

--- a/react/src/components/CodeHighlighterModal.tsx
+++ b/react/src/components/CodeHighlighterModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import SourceCodeView from './SourceCodeView';
 import { BAIModal, BAIModalProps } from 'backend.ai-ui';
 

--- a/react/src/components/ComputeSessionNodeItems/AppLaunchConfirmationModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLaunchConfirmationModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Typography } from 'antd';
 import { BAIButton, BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/AppLauncherModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { AppLauncherModalFragment$key } from '../../__generated__/AppLauncherModalFragment.graphql';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import {

--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   ConnectedKernelListFragment$data,
   ConnectedKernelListFragment$key,

--- a/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerCommitModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ContainerCommitModalFragment$key } from '../../__generated__/ContainerCommitModalFragment.graphql';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import { useSetBAINotification } from '../../hooks/useBAINotification';

--- a/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerLogModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ContainerLogModalFragment$key } from '../../__generated__/ContainerLogModalFragment.graphql';
 import { downloadBlob } from '../../helper/csv-util';
 import { useSuspendedBackendaiClient } from '../../hooks';

--- a/react/src/components/ComputeSessionNodeItems/ContainerLogModalWithLazyQueryLoader.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ContainerLogModalWithLazyQueryLoader.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ContainerLogModalWithLazyQueryLoaderQuery } from '../../__generated__/ContainerLogModalWithLazyQueryLoaderQuery.graphql';
 import { useCurrentProjectValue } from '../../hooks/useCurrentProject';
 import ContainerLogModal from './ContainerLogModal';

--- a/react/src/components/ComputeSessionNodeItems/EditableSessionName.tsx
+++ b/react/src/components/ComputeSessionNodeItems/EditableSessionName.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { EditableSessionNameFragment$key } from '../../__generated__/EditableSessionNameFragment.graphql';
 import { EditableSessionNameRefetchQuery } from '../../__generated__/EditableSessionNameRefetchQuery.graphql';
 import { useBaiSignedRequestWithPromise } from '../../helper';

--- a/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SFTPConnectionInfoModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import SourceCodeView from '../SourceCodeView';
 import { Alert, Descriptions } from 'antd';
 import { createStyles } from 'antd-style';

--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   SessionActionButtonsFragment$data,
   SessionActionButtonsFragment$key,

--- a/react/src/components/ComputeSessionNodeItems/SessionIdleChecks.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionIdleChecks.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SessionIdleChecksNodeFragment$key } from '../../__generated__/SessionIdleChecksNodeFragment.graphql';
 import { SessionIdleChecksQuery } from '../../__generated__/SessionIdleChecksQuery.graphql';
 import {

--- a/react/src/components/ComputeSessionNodeItems/SessionReservation.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionReservation.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SessionReservationFragment$key } from '../../__generated__/SessionReservationFragment.graphql';
 import { formatDurationAsDays } from '../../helper';
 import { Typography } from 'antd';

--- a/react/src/components/ComputeSessionNodeItems/SessionResourceNumbers.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionResourceNumbers.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 const SessionResourceNumbers = () => {
   return <div>SessionResourceNumbers</div>;
 };

--- a/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SessionSlotCellFragment$key } from '../../__generated__/SessionSlotCellFragment.graphql';
 import { convertToBinaryUnit } from '../../helper';
 import { ResourceSlotName } from '../../hooks/backendai';

--- a/react/src/components/ComputeSessionNodeItems/SessionStatusDetailModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionStatusDetailModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SessionStatusDetailModalFragment$key } from '../../__generated__/SessionStatusDetailModalFragment.graphql';
 import { useSuspendedBackendaiClient } from '../../hooks';
 import { useCurrentUserRole } from '../../hooks/backendai';

--- a/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionStatusTag.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   SessionStatusTagFragment$data,
   SessionStatusTagFragment$key,

--- a/react/src/components/ComputeSessionNodeItems/TCPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TCPConnectionInfoModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Descriptions } from 'antd';
 import { BAIModal, BAIModalProps } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/ComputeSessionNodeItems/TensorboardPathModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TensorboardPathModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { App, Form, Input, Typography } from 'antd';
 import {
   BAIButton,

--- a/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/TerminateSessionModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   TerminateSessionModalFragment$data,
   TerminateSessionModalFragment$key,

--- a/react/src/components/ComputeSessionNodeItems/VNCConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/VNCConnectionInfoModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Alert, Descriptions, Typography } from 'antd';
 import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/ComputeSessionNodeItems/VSCodeDesktopConnectionModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/VSCodeDesktopConnectionModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import SourceCodeView from '../SourceCodeView';
 import { Descriptions, Skeleton, Typography } from 'antd';
 import {

--- a/react/src/components/ComputeSessionNodeItems/XRDPConnectionInfoModal.tsx
+++ b/react/src/components/ComputeSessionNodeItems/XRDPConnectionInfoModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Alert, Descriptions, Typography } from 'antd';
 import { BAIFlex, BAIModal, BAIModalProps } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/ConfigurableResourceCard.tsx
+++ b/react/src/components/ConfigurableResourceCard.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import MyResource from './MyResource';
 import MyResourceWithinResourceGroup from './MyResourceWithinResourceGroup';

--- a/react/src/components/ConfigurationsSettingList.tsx
+++ b/react/src/components/ConfigurationsSettingList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import OverlayNetworkSettingModal from './OverlayNetworkSettingModal';
 import SchedulerSettingModal from './SchedulerSettingModal';

--- a/react/src/components/ContainerRegistryEditorModal.tsx
+++ b/react/src/components/ContainerRegistryEditorModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ContainerRegistryEditorModalCreateMutation } from '../__generated__/ContainerRegistryEditorModalCreateMutation.graphql';
 import { ContainerRegistryEditorModalFragment$key } from '../__generated__/ContainerRegistryEditorModalFragment.graphql';
 import { ContainerRegistryEditorModalModifyRegistryMutation } from '../__generated__/ContainerRegistryEditorModalModifyRegistryMutation.graphql';
@@ -32,8 +36,10 @@ type RegistryFormInput = {
   extra?: string;
 };
 
-interface ContainerRegistryEditorModalProps
-  extends Omit<BAIModalProps, 'onOk'> {
+interface ContainerRegistryEditorModalProps extends Omit<
+  BAIModalProps,
+  'onOk'
+> {
   onOk: (type: 'create' | 'modify') => void;
   containerRegistryFrgmt?: ContainerRegistryEditorModalFragment$key | null;
 }

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ContainerRegistryListDeleteMutation } from '../__generated__/ContainerRegistryListDeleteMutation.graphql';
 import { ContainerRegistryListDomainMutation } from '../__generated__/ContainerRegistryListDomainMutation.graphql';
 import {

--- a/react/src/components/CopyableCodeText.tsx
+++ b/react/src/components/CopyableCodeText.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Typography } from 'antd';
 import React, { PropsWithChildren } from 'react';
 

--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { CustomizedImageListForgetMutation } from '../__generated__/CustomizedImageListForgetMutation.graphql';
 import {
   CustomizedImageListQuery,

--- a/react/src/components/DatePickerISO.tsx
+++ b/react/src/components/DatePickerISO.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useControllableValue } from 'ahooks';
 import { DatePicker } from 'antd';
 import { PickerProps } from 'antd/es/date-picker/generatePicker';
@@ -6,8 +10,10 @@ import dayjs, { Dayjs } from 'dayjs';
 import _ from 'lodash';
 import React from 'react';
 
-export interface DatePickerISOProps
-  extends Omit<PickerProps<Dayjs>, 'value' | 'onChange'> {
+export interface DatePickerISOProps extends Omit<
+  PickerProps<Dayjs>,
+  'value' | 'onChange'
+> {
   value?: string | undefined | null;
   onChange?: (value: string | undefined) => void;
   localFormat?: boolean;

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { RelayEnvironment } from '../RelayEnvironment';
 // @ts-ignore
 import rawFixAntCss from '../fix_antd.css?raw';

--- a/react/src/components/DeleteVFolderModal.tsx
+++ b/react/src/components/DeleteVFolderModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { DeleteVFolderModalFragment$key } from '../__generated__/DeleteVFolderModalFragment.graphql';
 import { VFolderNodesFragment$data } from '../__generated__/VFolderNodesFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';

--- a/react/src/components/DescriptionLabel.tsx
+++ b/react/src/components/DescriptionLabel.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Typography } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';
 import React, { ReactNode } from 'react';

--- a/react/src/components/DesktopAppDownloadModal.tsx
+++ b/react/src/components/DesktopAppDownloadModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useAppDownloadMap } from '../hooks';
 import { DownloadOutlined } from '@ant-design/icons';
 import { Select, Button, Descriptions, Tooltip } from 'antd';

--- a/react/src/components/EditableVFolderName.tsx
+++ b/react/src/components/EditableVFolderName.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { EditableVFolderNameFragment$key } from '../__generated__/EditableVFolderNameFragment.graphql';
 import { EditableVFolderNameRefetchQuery } from '../__generated__/EditableVFolderNameRefetchQuery.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';

--- a/react/src/components/EduAppLauncher.test.ts
+++ b/react/src/components/EduAppLauncher.test.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Tests for the _dispatchNotification helper in EduAppLauncher.
  *
  * The helper is the core notification bridge introduced in this refactor:

--- a/react/src/components/EduAppLauncher.tsx
+++ b/react/src/components/EduAppLauncher.tsx
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Backend.AI Education App Launcher - React Migration
  *
  * Handles token-based authentication, session management, and app launching

--- a/react/src/components/EmailVerificationView.tsx
+++ b/react/src/components/EmailVerificationView.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useAnonymousBackendaiClient } from '../hooks';
 import { App, Form, Input } from 'antd';
 import { BAIButton, BAIFlex, BAIModal } from 'backend.ai-ui';

--- a/react/src/components/EndpointList.tsx
+++ b/react/src/components/EndpointList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   EndpointListFragment$data,
   EndpointListFragment$key,
@@ -40,8 +44,10 @@ import { Link } from 'react-router-dom';
 
 type Endpoint = EndpointListFragment$data[number];
 
-interface EndpointListProps
-  extends Omit<BAITableProps<Endpoint>, 'dataSource' | 'columns'> {
+interface EndpointListProps extends Omit<
+  BAITableProps<Endpoint>,
+  'dataSource' | 'columns'
+> {
   endpointsFrgmt: EndpointListFragment$key;
   loading?: boolean;
   pagination: TablePaginationConfig;

--- a/react/src/components/EndpointOwnerInfo.tsx
+++ b/react/src/components/EndpointOwnerInfo.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { EndpointOwnerInfoFragment$key } from '../__generated__/EndpointOwnerInfoFragment.graphql';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Button, Tooltip, theme } from 'antd';

--- a/react/src/components/EndpointStatusTag.tsx
+++ b/react/src/components/EndpointStatusTag.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { EndpointStatusTagFragment$key } from '../__generated__/EndpointStatusTagFragment.graphql';
 import { Tag } from 'antd';
 import React from 'react';

--- a/react/src/components/EndpointTokenGenerationModal.tsx
+++ b/react/src/components/EndpointTokenGenerationModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { baiSignedRequestWithPromise } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
@@ -12,8 +16,10 @@ import dayjs from 'dayjs';
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
-interface EndpointTokenGenerationModalProps
-  extends Omit<BAIModalProps, 'onOk' | 'onClose' | 'onCancel'> {
+interface EndpointTokenGenerationModalProps extends Omit<
+  BAIModalProps,
+  'onOk' | 'onClose' | 'onCancel'
+> {
   endpoint_id: string;
   onRequestClose: (success?: boolean) => void;
 }

--- a/react/src/components/EnvVarFormList.test.tsx
+++ b/react/src/components/EnvVarFormList.test.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 // EnvVarFormList.test.tsx
 import '../../__test__/matchMedia.mock.js';
 import { sanitizeSensitiveEnv } from './EnvVarFormList';

--- a/react/src/components/EnvVarFormList.tsx
+++ b/react/src/components/EnvVarFormList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
 import {
   AutoComplete,

--- a/react/src/components/ErrorBoundaryWithNullFallback.tsx
+++ b/react/src/components/ErrorBoundaryWithNullFallback.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import React, { PropsWithChildren } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 

--- a/react/src/components/ErrorLogList.tsx
+++ b/react/src/components/ErrorLogList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
 import TableColumnsSettingModal from './TableColumnsSettingModal';

--- a/react/src/components/FairShareItems/DomainFairShareTable.tsx
+++ b/react/src/components/FairShareItems/DomainFairShareTable.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import { SettingOutlined } from '@ant-design/icons';
 import { Divider, theme, Typography } from 'antd';

--- a/react/src/components/FairShareItems/FairShareList.tsx
+++ b/react/src/components/FairShareItems/FairShareList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import DomainFairShareTable, {
   availableDomainFairShareSorterValues,

--- a/react/src/components/FairShareItems/FairShareWeightSettingModal.tsx
+++ b/react/src/components/FairShareItems/FairShareWeightSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import { Alert, App, Form, Input, InputNumber, theme } from 'antd';
 import { FormInstance } from 'antd/lib';

--- a/react/src/components/FairShareItems/ProjectFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ProjectFairShareTable.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import { SettingOutlined } from '@ant-design/icons';
 import { Divider, theme, Typography } from 'antd';

--- a/react/src/components/FairShareItems/ResourceGroupFairShareSettingModal.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupFairShareSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import { App, Col, Form, Input, InputNumber, Row, theme } from 'antd';
 import { FormInstance } from 'antd/lib';

--- a/react/src/components/FairShareItems/ResourceGroupFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupFairShareTable.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import ResourceGroupFairShareSettingModal from './ResourceGroupFairShareSettingModal';
 import { SettingOutlined } from '@ant-design/icons';

--- a/react/src/components/FairShareItems/UsageBucketChartContent.tsx
+++ b/react/src/components/FairShareItems/UsageBucketChartContent.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { presetPalettes } from '@ant-design/colors';
 import { Empty, Tabs, Typography, theme } from 'antd';
 import { createStyles } from 'antd-style';

--- a/react/src/components/FairShareItems/UsageBucketModal.tsx
+++ b/react/src/components/FairShareItems/UsageBucketModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import UsageBucketChartContent from './UsageBucketChartContent';
 import { DatePicker, Descriptions, Skeleton } from 'antd';
 import {

--- a/react/src/components/FairShareItems/UserFairShareTable.tsx
+++ b/react/src/components/FairShareItems/UserFairShareTable.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import { SettingOutlined } from '@ant-design/icons';
 import { Divider, theme, Typography } from 'antd';

--- a/react/src/components/FileBrowserButton.tsx
+++ b/react/src/components/FileBrowserButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useWebUINavigate } from '../hooks';
 import { PrimaryAppOption } from './ComputeSessionNodeItems/SessionActionButtons';
 import { EllipsisOutlined } from '@ant-design/icons';

--- a/react/src/components/FileUploadManager.tsx
+++ b/react/src/components/FileUploadManager.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import { theme, Typography } from 'antd';

--- a/react/src/components/FlexActivityIndicator.tsx
+++ b/react/src/components/FlexActivityIndicator.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { LoadingOutlined } from '@ant-design/icons';
 import { Spin, type SpinProps } from 'antd';
 import { BAIFlex, BAIFlexProps } from 'backend.ai-ui';

--- a/react/src/components/FluentEmojiIcon.tsx
+++ b/react/src/components/FluentEmojiIcon.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 // Always use this component instead of directly importing `FluentEmoji` from `@lobehub/fluent-emoji`.
 // eslint-disable-next-line no-restricted-imports
 import { getFluentEmojiCDN as originalGetFluentEmojiCDN } from '@lobehub/fluent-emoji';

--- a/react/src/components/FolderCreateModal.tsx
+++ b/react/src/components/FolderCreateModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBaiSignedRequestWithPromise } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserRole } from '../hooks/backendai';

--- a/react/src/components/FolderExplorerHeader.tsx
+++ b/react/src/components/FolderExplorerHeader.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { FolderExplorerHeaderFragment$key } from '../__generated__/FolderExplorerHeaderFragment.graphql';
 import EditableVFolderName from './EditableVFolderName';
 import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';

--- a/react/src/components/FolderExplorerModal.tsx
+++ b/react/src/components/FolderExplorerModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useFileUploadManager } from './FileUploadManager';
 import FolderExplorerHeader from './FolderExplorerHeader';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';

--- a/react/src/components/FolderExplorerOpener.tsx
+++ b/react/src/components/FolderExplorerOpener.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import React from 'react';
 import { useLocation } from 'react-router-dom';
 import { StringParam, useQueryParam } from 'use-query-params';

--- a/react/src/components/FolderInvitationResponseModal.tsx
+++ b/react/src/components/FolderInvitationResponseModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import {
   InvitationItem,

--- a/react/src/components/FolderInvitationResponseModalOpener.tsx
+++ b/react/src/components/FolderInvitationResponseModalOpener.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { BAIUnmountAfterClose } from 'backend.ai-ui';
 import React from 'react';
 import { useQueryParam, StringParam } from 'use-query-params';

--- a/react/src/components/FolderLink.tsx
+++ b/react/src/components/FolderLink.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { FolderLink_vfolderNode$key } from '../__generated__/FolderLink_vfolderNode.graphql';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import { FolderOutlined } from '@ant-design/icons';

--- a/react/src/components/ForceTOTPChecker.tsx
+++ b/react/src/components/ForceTOTPChecker.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ForceTOTPCheckerQuery } from '../__generated__/ForceTOTPCheckerQuery.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTOTPSupported } from '../hooks/backendai';

--- a/react/src/components/FormItemControl.tsx
+++ b/react/src/components/FormItemControl.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Form, type FormItemProps } from 'antd';
 import _ from 'lodash';
 import React from 'react';

--- a/react/src/components/FormItemWithUnlimited.tsx
+++ b/react/src/components/FormItemWithUnlimited.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Form, Checkbox, type FormItemProps } from 'antd';
 import { CheckboxChangeEvent } from 'antd/es/checkbox';
 import { BAIFlex } from 'backend.ai-ui';

--- a/react/src/components/GeneratedKeypairListModal.tsx
+++ b/react/src/components/GeneratedKeypairListModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { localeCompare } from '../helper';
 import { exportCSVWithFormattingRules } from '../helper/csv-util';
 import { Alert } from 'antd';
@@ -22,8 +26,10 @@ type KeypairType = NonNullable<
   NonNullable<GeneratedKeypairListModalFragment$data>[number]
 >;
 
-interface GeneratedKeypairListModalProps
-  extends Omit<BAIModalProps, 'onOk' | 'onCancel'> {
+interface GeneratedKeypairListModalProps extends Omit<
+  BAIModalProps,
+  'onOk' | 'onCancel'
+> {
   keypairFragment: GeneratedKeypairListModalFragment$key;
   onRequestClose: () => void;
 }

--- a/react/src/components/HiddenFormItem.tsx
+++ b/react/src/components/HiddenFormItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Form, type FormItemProps } from 'antd';
 import React, { useEffect } from 'react';
 

--- a/react/src/components/IdleCheckDescriptionModal.tsx
+++ b/react/src/components/IdleCheckDescriptionModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { type ModalProps, Typography, theme } from 'antd';
 import { BAIFlex, BAIModal } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   ImageEnvironmentSelectFormItemsQuery,
   ImageEnvironmentSelectFormItemsQuery$data,

--- a/react/src/components/ImageInstallModal.tsx
+++ b/react/src/components/ImageInstallModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { addNumberWithUnits } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useSetBAINotification } from '../hooks/useBAINotification';

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   ImageListQuery,
   ImageListQuery$data,

--- a/react/src/components/ImageMetaIcon.tsx
+++ b/react/src/components/ImageMetaIcon.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBackendAIImageMetaData } from '../hooks';
 import React from 'react';
 

--- a/react/src/components/ImageNodeSimpleTag.tsx
+++ b/react/src/components/ImageNodeSimpleTag.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ImageNodeSimpleTagFragment$key } from '../__generated__/ImageNodeSimpleTagFragment.graphql';
 import { preserveDotStartCase } from '../helper';
 import {

--- a/react/src/components/ImageTags.tsx
+++ b/react/src/components/ImageTags.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ImageTagsUNSAFELazySessionImageTagQuery } from '../__generated__/ImageTagsUNSAFELazySessionImageTagQuery.graphql';
 import { preserveDotStartCase } from '../helper';
 import { useBackendAIImageMetaData } from '../hooks';
@@ -9,8 +13,10 @@ import _ from 'lodash';
 import React from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
-interface ImageAliasNameAndBaseVersionTagsProps
-  extends Omit<DoubleTagObjectValue, 'label'> {
+interface ImageAliasNameAndBaseVersionTagsProps extends Omit<
+  DoubleTagObjectValue,
+  'label'
+> {
   image: string | null;
 }
 const ImageAliasNameAndBaseVersionTags: React.FC<

--- a/react/src/components/ImageWithFallback.tsx
+++ b/react/src/components/ImageWithFallback.tsx
@@ -1,7 +1,13 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import React, { useState } from 'react';
 
-interface ImageWithFallbackProps
-  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'onError'> {
+interface ImageWithFallbackProps extends Omit<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  'onError'
+> {
   src: string;
   fallbackIcon: React.ReactNode;
   alt: string;

--- a/react/src/components/ImportArtifactRevisionToFolderButton.tsx
+++ b/react/src/components/ImportArtifactRevisionToFolderButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ImportArtifactRevisionToFolderButtonFragment$key } from '../__generated__/ImportArtifactRevisionToFolderButtonFragment.graphql';
 import { theme } from 'antd';
 import { BAIButton, BAIButtonProps } from 'backend.ai-ui';
@@ -6,8 +10,7 @@ import { FolderInput } from 'lucide-react';
 import React from 'react';
 import { graphql, useFragment } from 'react-relay';
 
-export interface ImportArtifactRevisionToFolderButtonProps
-  extends BAIButtonProps {
+export interface ImportArtifactRevisionToFolderButtonProps extends BAIButtonProps {
   loading?: boolean;
   revisionsFrgmt: ImportArtifactRevisionToFolderButtonFragment$key;
 }

--- a/react/src/components/ImportArtifactRevisionToFolderModal.tsx
+++ b/react/src/components/ImportArtifactRevisionToFolderModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import FolderCreateModal from './FolderCreateModal';
 import { useToggle } from 'ahooks';
 import {
@@ -34,8 +38,10 @@ import {
   useSetCurrentProject,
 } from 'src/hooks/useCurrentProject';
 
-export interface ImportArtifactRevisionToFolderModalProps
-  extends Omit<BAIModalProps, 'onOk'> {
+export interface ImportArtifactRevisionToFolderModalProps extends Omit<
+  BAIModalProps,
+  'onOk'
+> {
   selectedArtifactRevisionFrgmt: ImportArtifactRevisionToFolderModalArtifactRevisionFragment$key;
   modelStoreProjectsFrgmt?: ImportArtifactRevisionToFolderModalModelStoreProjectsFragment$key;
   onOk?: (

--- a/react/src/components/ImportFromHuggingFaceModal.tsx
+++ b/react/src/components/ImportFromHuggingFaceModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ImportFromHuggingFaceModalQuery } from '../__generated__/ImportFromHuggingFaceModalQuery.graphql';
 import { baiSignedRequestWithPromise } from '../helper';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';

--- a/react/src/components/ImportNotebookForm.tsx
+++ b/react/src/components/ImportNotebookForm.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import CopyButton from './Chat/CopyButton';
 import { PrimaryAppOption } from './ComputeSessionNodeItems/SessionActionButtons';

--- a/react/src/components/ImportRepoForm.tsx
+++ b/react/src/components/ImportRepoForm.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import StorageSelect from './StorageSelect';
 import {

--- a/react/src/components/InferenceSessionErrorModal.tsx
+++ b/react/src/components/InferenceSessionErrorModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { InferenceSessionErrorModalFragment$key } from '../__generated__/InferenceSessionErrorModalFragment.graphql';
 import CopyableCodeText from './CopyableCodeText';
 import { Descriptions, type DescriptionsProps, Button } from 'antd';

--- a/react/src/components/Information.tsx
+++ b/react/src/components/Information.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { newLineToBrElement } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanQuery } from '../hooks/reactQueryAlias';

--- a/react/src/components/InputNumberWithSlider.tsx
+++ b/react/src/components/InputNumberWithSlider.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import useControllableState_deprecated from '../hooks/useControllableState';
 import {
   InputNumber,

--- a/react/src/components/InviteFolderSettingModal.tsx
+++ b/react/src/components/InviteFolderSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { localeCompare, useBaiSignedRequestWithPromise } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation, useTanQuery } from '../hooks/reactQueryAlias';

--- a/react/src/components/KeypairInfoModal.tsx
+++ b/react/src/components/KeypairInfoModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { KeypairInfoModalFragment$key } from '../__generated__/KeypairInfoModalFragment.graphql';
 import { KeypairInfoModalQuery } from '../__generated__/KeypairInfoModalQuery.graphql';
 import { Descriptions, type ModalProps, Tag, Typography, theme } from 'antd';

--- a/react/src/components/KeypairResourcePolicyInfoModal.tsx
+++ b/react/src/components/KeypairResourcePolicyInfoModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { KeypairResourcePolicyInfoModalFragment$key } from '../__generated__/KeypairResourcePolicyInfoModalFragment.graphql';
 import { Descriptions, theme, Typography } from 'antd';
 import { createStyles } from 'antd-style';

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { KeypairResourcePolicyInfoModalFragment$key } from '../__generated__/KeypairResourcePolicyInfoModalFragment.graphql';
 import { KeypairResourcePolicyListMutation } from '../__generated__/KeypairResourcePolicyListMutation.graphql';
 import {

--- a/react/src/components/KeypairResourcePolicySelect.tsx
+++ b/react/src/components/KeypairResourcePolicySelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { KeypairResourcePolicySelectQuery } from '../__generated__/KeypairResourcePolicySelectQuery.graphql';
 import { localeCompare } from '../helper';
 import useControllableState_deprecated from '../hooks/useControllableState';

--- a/react/src/components/KeypairResourcePolicySettingModal.tsx
+++ b/react/src/components/KeypairResourcePolicySettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   CreateKeyPairResourcePolicyInput,
   KeypairResourcePolicySettingModalCreateMutation,

--- a/react/src/components/KeypairSettingModal.tsx
+++ b/react/src/components/KeypairSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { KeypairSettingModalCreateMutation } from '../__generated__/KeypairSettingModalCreateMutation.graphql';
 import { KeypairSettingModalFragment$key } from '../__generated__/KeypairSettingModalFragment.graphql';
 import { KeypairSettingModalModifyMutation } from '../__generated__/KeypairSettingModalModifyMutation.graphql';

--- a/react/src/components/LoadingCurtain.test.tsx
+++ b/react/src/components/LoadingCurtain.test.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import LoadingCurtain from './LoadingCurtain';
 import '@testing-library/jest-dom';
 import { act, render } from '@testing-library/react';

--- a/react/src/components/LoadingCurtain.tsx
+++ b/react/src/components/LoadingCurtain.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { createStyles } from 'antd-style';
 import React, { useEffect, useState } from 'react';
 

--- a/react/src/components/LocationStateBreadCrumb.tsx
+++ b/react/src/components/LocationStateBreadCrumb.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useWebUINavigate } from '../hooks';
 import { Breadcrumb } from 'antd';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/LoginFormPanel.tsx
+++ b/react/src/components/LoginFormPanel.tsx
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * LoginFormPanel - The form UI for the login dialog.
  *
  * Renders SESSION/API login forms, endpoint configuration,

--- a/react/src/components/LoginSessionExtendButton.tsx
+++ b/react/src/components/LoginSessionExtendButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBaiSignedRequestWithPromise } from '../helper';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
 import { ClockCircleOutlined } from '@ant-design/icons';

--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * LoginView - React implementation of the Backend.AI login component.
  *
  * Supports SESSION and API connection modes, OTP/TOTP flows,

--- a/react/src/components/MainLayout/MainLayout.tsx
+++ b/react/src/components/MainLayout/MainLayout.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBAISettingUserState } from '../../hooks/useBAISetting';
 import { useCustomThemeConfig } from '../../hooks/useCustomThemeConfig';
 import useKeyboardShortcut from '../../hooks/useKeyboardShortcut';

--- a/react/src/components/MainLayout/WebUIHeader.tsx
+++ b/react/src/components/MainLayout/WebUIHeader.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   useCurrentDomainValue,
   useSuspendedBackendaiClient,

--- a/react/src/components/MainLayout/WebUISider.tsx
+++ b/react/src/components/MainLayout/WebUISider.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../../hooks';
 import { useCurrentUserRole } from '../../hooks/backendai';
 import { useCustomThemeConfig } from '../../hooks/useCustomThemeConfig';
@@ -29,11 +33,10 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { useWebUIMenuItems } from 'src/hooks/useWebUIMenuItems';
 
-interface WebUISiderProps
-  extends Pick<
-    BAISiderProps,
-    'collapsed' | 'collapsedWidth' | 'onBreakpoint' | 'onCollapse'
-  > {}
+interface WebUISiderProps extends Pick<
+  BAISiderProps,
+  'collapsed' | 'collapsedWidth' | 'onBreakpoint' | 'onCollapse'
+> {}
 
 const WebUISider: React.FC<WebUISiderProps> = (props) => {
   'use memo';

--- a/react/src/components/MaintenanceSettingList.tsx
+++ b/react/src/components/MaintenanceSettingList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import SettingList, { SettingGroup } from './SettingList';

--- a/react/src/components/ManageAppsModal.tsx
+++ b/react/src/components/ManageAppsModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ManageAppsModalMutation } from '../__generated__/ManageAppsModalMutation.graphql';
 import { ManageAppsModal_image$key } from '../__generated__/ManageAppsModal_image.graphql';
 import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';

--- a/react/src/components/ManageImageResourceLimitModal.tsx
+++ b/react/src/components/ManageImageResourceLimitModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   ManageImageResourceLimitModalMutation,
   ResourceLimitInput,

--- a/react/src/components/ModelCardChat.tsx
+++ b/react/src/components/ModelCardChat.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ModelCardChatQuery } from '../__generated__/ModelCardChatQuery.graphql';
 import { useChatProviderData } from '../pages/ChatPage';
 import ChatCard from './Chat/ChatCard';

--- a/react/src/components/ModelCardModal.tsx
+++ b/react/src/components/ModelCardModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ModelCardModalFragment$key } from '../__generated__/ModelCardModalFragment.graphql';
 import { useBackendAIImageMetaData } from '../hooks';
 import { useModelCardMetadata } from '../hooks/useModelCardMetadata';

--- a/react/src/components/ModelCloneModal.tsx
+++ b/react/src/components/ModelCloneModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ModelCloneModalVFolderFragment$key } from '../__generated__/ModelCloneModalVFolderFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';

--- a/react/src/components/ModelTryContentButton.tsx
+++ b/react/src/components/ModelTryContentButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ModelTryContentButtonVFolderFragment$key } from '../__generated__/ModelTryContentButtonVFolderFragment.graphql';
 import { ModelTryContentButtonVFolderNodeListQuery } from '../__generated__/ModelTryContentButtonVFolderNodeListQuery.graphql';
 import {

--- a/react/src/components/MountedVFolderLinks.tsx
+++ b/react/src/components/MountedVFolderLinks.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { MountedVFolderLinksFragment$key } from '../__generated__/MountedVFolderLinksFragment.graphql';
 import { MountedVFolderLinksLegacyLazyFolderLinkFragment$key } from '../__generated__/MountedVFolderLinksLegacyLazyFolderLinkFragment.graphql';
 import { MountedVFolderLinksQuery } from '../__generated__/MountedVFolderLinksQuery.graphql';

--- a/react/src/components/MyKeypairInfoModal.tsx
+++ b/react/src/components/MyKeypairInfoModal.tsx
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2025 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { MyKeypairInfoModalQuery } from '../__generated__/MyKeypairInfoModalQuery.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';

--- a/react/src/components/MyResource.tsx
+++ b/react/src/components/MyResource.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ResourceSlotName } from '../hooks/backendai';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { useResourceLimitAndRemaining } from '../hooks/useResourceLimitAndRemaining';

--- a/react/src/components/MyResourceWithinResourceGroup.test.tsx
+++ b/react/src/components/MyResourceWithinResourceGroup.test.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import '../../__test__/matchMedia.mock.js';
 import * as useResourceLimitAndRemainingModule from '../hooks/useResourceLimitAndRemaining';
 import MyResourceWithinResourceGroup from './MyResourceWithinResourceGroup';

--- a/react/src/components/MyResourceWithinResourceGroup.tsx
+++ b/react/src/components/MyResourceWithinResourceGroup.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ResourceSlotName } from '../hooks/backendai';
 import {
   useCurrentProjectValue,

--- a/react/src/components/NetworkStatusBanner.tsx
+++ b/react/src/components/NetworkStatusBanner.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useDebounce, useNetwork } from 'ahooks';
 import { Alert } from 'antd';
 import { createStyles } from 'antd-style';

--- a/react/src/components/NoResourceGroupAlert.tsx
+++ b/react/src/components/NoResourceGroupAlert.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useCurrentResourceGroupValue } from '../hooks/useCurrentProject';
 import { BAIAlert, BAIAlertProps } from 'backend.ai-ui';
 import _ from 'lodash';

--- a/react/src/components/NonLinearSlider.tsx
+++ b/react/src/components/NonLinearSlider.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import useControllableState_deprecated from '../hooks/useControllableState';
 import { Slider, type SliderSingleProps } from 'antd';
 import _, { isNumber } from 'lodash';
@@ -10,8 +14,10 @@ export type StepType =
     }
   | number
   | string;
-interface NonLinearSliderProps
-  extends Omit<SliderSingleProps, 'value' | 'defaultValue' | 'onChange'> {
+interface NonLinearSliderProps extends Omit<
+  SliderSingleProps,
+  'value' | 'defaultValue' | 'onChange'
+> {
   steps: StepType[];
   value?: number | string;
   defaultValue?: number | string;

--- a/react/src/components/OverlayNetworkSettingModal.tsx
+++ b/react/src/components/OverlayNetworkSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanQuery } from '../hooks/reactQueryAlias';
 import QuestionIconWithTooltip from './QuestionIconWithTooltip';

--- a/react/src/components/PaginationInfoText.tsx
+++ b/react/src/components/PaginationInfoText.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useTranslation } from 'react-i18next';
 
 export interface PaginationInfoTextProps {

--- a/react/src/components/PasswordChangeRequestAlert.tsx
+++ b/react/src/components/PasswordChangeRequestAlert.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { PasswordChangeRequestAlertQuery } from '../__generated__/PasswordChangeRequestAlertQuery.graphql';
 import { BAIAlert, BAIAlertProps } from 'backend.ai-ui';
 import React from 'react';

--- a/react/src/components/PendingSessionNodeList.tsx
+++ b/react/src/components/PendingSessionNodeList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import SessionNodes from './SessionNodes';
 import SharedResourceGroupSelectForCurrentProject from './SharedResourceGroupSelectForCurrentProject';
 import { Form } from 'antd';

--- a/react/src/components/PluginLoader.tsx
+++ b/react/src/components/PluginLoader.tsx
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * PluginLoader - React component that handles loading Backend.AI WebUI plugins.
  *
  * It:

--- a/react/src/components/PopConfirmWithInput.tsx
+++ b/react/src/components/PopConfirmWithInput.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ExclamationCircleFilled } from '@ant-design/icons';
 import {
   Form,

--- a/react/src/components/PortSelectFormItem.tsx
+++ b/react/src/components/PortSelectFormItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { Form, type FormItemProps, Select, Tag } from 'antd';
 import { TagProps } from 'antd/lib';

--- a/react/src/components/PrivacyPolicyModal.tsx
+++ b/react/src/components/PrivacyPolicyModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { Skeleton } from 'antd';

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ProjectResourcePolicyListMutation } from '../__generated__/ProjectResourcePolicyListMutation.graphql';
 import {
   ProjectResourcePolicyListQuery,

--- a/react/src/components/ProjectResourcePolicySettingModal.tsx
+++ b/react/src/components/ProjectResourcePolicySettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   CreateProjectResourcePolicyInput,
   ProjectResourcePolicySettingModalCreateMutation,

--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ProjectSelectorQuery } from '../__generated__/ProjectSelectorQuery.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';

--- a/react/src/components/ProjectSelectForAdminPage.tsx
+++ b/react/src/components/ProjectSelectForAdminPage.tsx
@@ -1,8 +1,14 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import ProjectSelect, { ProjectSelectProps } from './ProjectSelect';
 import React from 'react';
 
-interface ProjectSelectForAdminPageProps
-  extends Omit<ProjectSelectProps, 'disableDefaultFilter'> {}
+interface ProjectSelectForAdminPageProps extends Omit<
+  ProjectSelectProps,
+  'disableDefaultFilter'
+> {}
 
 const ProjectSelectForAdminPage: React.FC<ProjectSelectForAdminPageProps> = ({
   ...projectSelectProps

--- a/react/src/components/PurgeUsersModal.tsx
+++ b/react/src/components/PurgeUsersModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { PurgeUsersModalFragment$key } from '../__generated__/PurgeUsersModalFragment.graphql';
 import { PurgeUsersModalMutation } from '../__generated__/PurgeUsersModalMutation.graphql';
 import { App, Checkbox, Form, theme } from 'antd';
@@ -17,8 +21,10 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 import { PayloadError } from 'relay-runtime';
 
-export interface PurgeUsersModalProps
-  extends Omit<BAIModalProps, 'title' | 'okText' | 'okButtonProps'> {
+export interface PurgeUsersModalProps extends Omit<
+  BAIModalProps,
+  'title' | 'okText' | 'okButtonProps'
+> {
   usersFrgmt: PurgeUsersModalFragment$key;
 }
 

--- a/react/src/components/QuestionIconWithTooltip.tsx
+++ b/react/src/components/QuestionIconWithTooltip.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { theme, Tooltip, type TooltipProps } from 'antd';
 import React from 'react';

--- a/react/src/components/QuotaPerStorageVolumePanelCard.tsx
+++ b/react/src/components/QuotaPerStorageVolumePanelCard.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { QuotaPerStorageVolumePanelCardQuery } from '../__generated__/QuotaPerStorageVolumePanelCardQuery.graphql';
 import { QuotaPerStorageVolumePanelCardUserQuery } from '../__generated__/QuotaPerStorageVolumePanelCardUserQuery.graphql';
 import { addQuotaScopeTypePrefix, convertToDecimalUnit } from '../helper';

--- a/react/src/components/QuotaScopeCard.tsx
+++ b/react/src/components/QuotaScopeCard.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { QuotaScopeCardFragment$key } from '../__generated__/QuotaScopeCardFragment.graphql';
 import { QuotaScopeCardUnsetMutation } from '../__generated__/QuotaScopeCardUnsetMutation.graphql';
 import { bytesToGB } from '../helper/index';

--- a/react/src/components/QuotaSettingModal.tsx
+++ b/react/src/components/QuotaSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { QuotaSettingModalFragment$key } from '../__generated__/QuotaSettingModalFragment.graphql';
 import { QuotaSettingModalSetMutation } from '../__generated__/QuotaSettingModalSetMutation.graphql';
 import { GBToBytes, bytesToGB } from '../helper';

--- a/react/src/components/RecentlyCreatedSession.tsx
+++ b/react/src/components/RecentlyCreatedSession.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { RecentlyCreatedSessionFragment$key } from '../__generated__/RecentlyCreatedSessionFragment.graphql';
 import SessionDetailDrawer from './SessionDetailDrawer';
 import SessionNodes from './SessionNodes';

--- a/react/src/components/ReservoirAuditLogList.tsx
+++ b/react/src/components/ReservoirAuditLogList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Tag, Typography } from 'antd';
 import { BAIPropertyFilter, BAIFlex, BAITable, BAIText } from 'backend.ai-ui';
 import dayjs from 'dayjs';

--- a/react/src/components/ResetPasswordRequired.tsx
+++ b/react/src/components/ResetPasswordRequired.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { baiSignedRequestWithPromise } from '../helper';
 import { useAnonymousBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';

--- a/react/src/components/ResourceGroupInfoModal.tsx
+++ b/react/src/components/ResourceGroupInfoModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ResourceGroupInfoModalFragment$key } from '../__generated__/ResourceGroupInfoModalFragment.graphql';
 import { ScalingGroupOpts } from './ResourceGroupList';
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ResourceGroupListDeleteMutation } from '../__generated__/ResourceGroupListDeleteMutation.graphql';
 import {
   ResourceGroupListQuery,

--- a/react/src/components/ResourceGroupSettingModal.tsx
+++ b/react/src/components/ResourceGroupSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ResourceGroupSettingModalAssociateDomainMutation } from '../__generated__/ResourceGroupSettingModalAssociateDomainMutation.graphql';
 import { ResourceGroupSettingModalCreateMutation } from '../__generated__/ResourceGroupSettingModalCreateMutation.graphql';
 import { ResourceGroupSettingModalFragment$key } from '../__generated__/ResourceGroupSettingModalFragment.graphql';

--- a/react/src/components/ResourceNumber.tsx
+++ b/react/src/components/ResourceNumber.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { convertToBinaryUnit } from '../helper';
 import { ResourceSlotName } from '../hooks/backendai';
 import { useCurrentResourceGroupValue } from '../hooks/useCurrentProject';
@@ -98,8 +102,10 @@ const ResourceNumber: React.FC<ResourceNumberProps> = ({
   );
 };
 
-interface AccTypeIconProps
-  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'src'> {
+interface AccTypeIconProps extends Omit<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  'src'
+> {
   type: ResourceSlotName | string;
   showTooltip?: boolean;
   size?: number;

--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ResourcePresetListDeleteMutation } from '../__generated__/ResourcePresetListDeleteMutation.graphql';
 import {
   ResourcePresetListQuery,

--- a/react/src/components/ResourcePresetSelect.tsx
+++ b/react/src/components/ResourcePresetSelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   ResourcePresetSelectQuery,
   ResourcePresetSelectQuery$data,
@@ -32,8 +36,10 @@ interface PresetOptionType extends Y {
 export type ResourcePreset = NonNullable<
   NonNullable<ResourcePresetSelectQuery$data['resource_presets']>[number]
 >;
-export interface ResourcePresetSelectProps
-  extends Omit<SelectProps, 'onChange'> {
+export interface ResourcePresetSelectProps extends Omit<
+  SelectProps,
+  'onChange'
+> {
   onChange?: (value: string, options: PresetOptionType) => void;
   allocatablePresetNames?: string[];
   showMinimumRequired?: boolean;

--- a/react/src/components/ResourcePresetSettingModal.tsx
+++ b/react/src/components/ResourcePresetSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   CreateResourcePresetInput,
   ResourcePresetSettingModalCreateMutation,

--- a/react/src/components/RestoreVFolderModal.tsx
+++ b/react/src/components/RestoreVFolderModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { RestoreVFolderModalFragment$key } from '../__generated__/RestoreVFolderModalFragment.graphql';
 import { VFolderNodesFragment$data } from '../__generated__/VFolderNodesFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';

--- a/react/src/components/ReverseThemeProvider.tsx
+++ b/react/src/components/ReverseThemeProvider.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import { theme, ConfigProvider, type ConfigProviderProps } from 'antd';
 import _ from 'lodash';

--- a/react/src/components/SFTPServerButton.tsx
+++ b/react/src/components/SFTPServerButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useWebUINavigate } from '../hooks';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { App, Dropdown, Image, Space, Tooltip } from 'antd';

--- a/react/src/components/SSHKeypairGenerationModal.tsx
+++ b/react/src/components/SSHKeypairGenerationModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanQuery } from '../hooks/reactQueryAlias';
 import { LoadingOutlined } from '@ant-design/icons';

--- a/react/src/components/SSHKeypairManagementModal.tsx
+++ b/react/src/components/SSHKeypairManagementModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanQuery } from '../hooks/reactQueryAlias';
 import SSHKeypairGenerationModal from './SSHKeypairGenerationModal';

--- a/react/src/components/SSHKeypairManualFormModal.tsx
+++ b/react/src/components/SSHKeypairManualFormModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { Form, type FormInstance, Input, Typography } from 'antd';

--- a/react/src/components/ScanArtifactModelsFromHuggingFaceModal.tsx
+++ b/react/src/components/ScanArtifactModelsFromHuggingFaceModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { App, Form, type FormInstance, Input, theme } from 'antd';
 import {
   BAIFlex,
@@ -11,8 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useMutation } from 'react-relay';
 import { ScanArtifactModelsFromHuggingFaceModalMutation } from 'src/__generated__/ScanArtifactModelsFromHuggingFaceModalMutation.graphql';
 
-export interface ScanArtifactModelsFromHuggingFaceModalProps
-  extends BAIModalProps {
+export interface ScanArtifactModelsFromHuggingFaceModalProps extends BAIModalProps {
   onRequestClose?: (
     e: React.MouseEvent<HTMLElement>,
     artifactId: string,

--- a/react/src/components/SchedulerSettingModal.tsx
+++ b/react/src/components/SchedulerSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { SchedulerType } from './ConfigurationsSettingList';
 import QuestionIconWithTooltip from './QuestionIconWithTooltip';

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ServiceLauncherPageContentFragment$key } from '../__generated__/ServiceLauncherPageContentFragment.graphql';
 import { ServiceLauncherPageContentModifyMutation } from '../__generated__/ServiceLauncherPageContentModifyMutation.graphql';
 import { ServiceLauncherPageContent_UserInfoQuery } from '../__generated__/ServiceLauncherPageContent_UserInfoQuery.graphql';

--- a/react/src/components/ServiceValidationView.tsx
+++ b/react/src/components/ServiceValidationView.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   SSEEventHandlerTypes,
   baiSignedRequestWithPromise,

--- a/react/src/components/SessionCountDashboardItem.tsx
+++ b/react/src/components/SessionCountDashboardItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { theme } from 'antd';
 import {
   BAIBoardItemTitle,

--- a/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
+++ b/react/src/components/SessionDetailAndContainerLogOpenerLegacy.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import ContainerLogModalWithLazyQueryLoader from './ComputeSessionNodeItems/ContainerLogModalWithLazyQueryLoader';
 import SessionDetailDrawer from './SessionDetailDrawer';

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SessionDetailContentFragment$key } from '../__generated__/SessionDetailContentFragment.graphql';
 import { SessionDetailContentLegacyQuery } from '../__generated__/SessionDetailContentLegacyQuery.graphql';
 import { SessionDetailContentQuery } from '../__generated__/SessionDetailContentQuery.graphql';

--- a/react/src/components/SessionDetailDrawer.tsx
+++ b/react/src/components/SessionDetailDrawer.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SessionDetailDrawerFragment$key } from '../__generated__/SessionDetailDrawerFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import SessionDetailContent from './SessionDetailContent';

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.test.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import '../../../__test__/matchMedia.mock.js';
 import {
   MergedResourceLimits,

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ResourceAllocationFormItemsQuery } from '../../__generated__/ResourceAllocationFormItemsQuery.graphql';
 import {
   addNumberWithUnits,

--- a/react/src/components/SessionFormItems/SharedMemoryFormItems.tsx
+++ b/react/src/components/SessionFormItems/SharedMemoryFormItems.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { compareNumberWithUnits, convertToBinaryUnit } from '../../helper';
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import { MergedResourceAllocationFormValue } from './ResourceAllocationFormItems';

--- a/react/src/components/SessionLauncherErrorTourProps.tsx
+++ b/react/src/components/SessionLauncherErrorTourProps.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { Tour, type TourProps } from 'antd';
 import React from 'react';

--- a/react/src/components/SessionLauncherFormIncompatibleValueChecker.tsx
+++ b/react/src/components/SessionLauncherFormIncompatibleValueChecker.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SessionLauncherFormValue } from '../pages/SessionLauncherPage';
 import { App, Form, type FormInstance } from 'antd';
 import _ from 'lodash';

--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { preserveDotStartCase, getImageFullName } from '../helper';
 import {
   useBackendAIImageMetaData,

--- a/react/src/components/SessionListColums/SessionInfoCell.tsx
+++ b/react/src/components/SessionListColums/SessionInfoCell.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SessionInfoCellFragment$key } from '../../__generated__/SessionInfoCellFragment.graphql';
 import {
   // useBackendaiImageMetaData,

--- a/react/src/components/SessionMetricGraph.tsx
+++ b/react/src/components/SessionMetricGraph.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   SessionMetricGraphQuery,
   SessionMetricGraphQuery$data,

--- a/react/src/components/SessionNameFormItem.tsx
+++ b/react/src/components/SessionNameFormItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useValidateSessionName } from '../hooks/useValidateSessionName';
 import { Form, type FormItemProps, Input } from 'antd';
 import React from 'react';

--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   SessionNodesFragment$data,
   SessionNodesFragment$key,
@@ -45,11 +49,10 @@ const isEnableSorter = (key: string) => {
   return _.includes(availableSessionSorterKeys, key);
 };
 
-interface SessionNodesProps
-  extends Omit<
-    BAITableProps<SessionNodeInList>,
-    'dataSource' | 'columns' | 'onChangeOrder'
-  > {
+interface SessionNodesProps extends Omit<
+  BAITableProps<SessionNodeInList>,
+  'dataSource' | 'columns' | 'onChangeOrder'
+> {
   sessionsFrgmt: SessionNodesFragment$key;
   onClickSessionName?: (session: SessionNodeInList) => void;
   disableSorter?: boolean;

--- a/react/src/components/SessionOwnerSetterCard.tsx
+++ b/react/src/components/SessionOwnerSetterCard.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SessionOwnerSetterCardQuery } from '../__generated__/SessionOwnerSetterCardQuery.graphql';
 import { useCurrentUserRole } from '../hooks/backendai';
 import { useTanQuery } from '../hooks/reactQueryAlias';

--- a/react/src/components/SessionTemplateModal.tsx
+++ b/react/src/components/SessionTemplateModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBackendAIImageMetaData } from '../hooks';
 import { SessionHistory } from '../hooks/useBAISetting';
 import {
@@ -33,14 +37,15 @@ const useStyle = createStyles(({ css }) => ({
   `,
 }));
 
-interface SessionTemplateModalProps
-  extends Omit<BAIModalProps, 'onOk' | 'onCancel'> {
+interface SessionTemplateModalProps extends Omit<
+  BAIModalProps,
+  'onOk' | 'onCancel'
+> {
   onRequestClose: (formValue?: SessionLauncherFormValue) => void;
 }
 
 interface ParsedSessionHistory
-  extends SessionLauncherFormValue,
-    SessionHistory {
+  extends SessionLauncherFormValue, SessionHistory {
   pinned?: boolean;
 }
 

--- a/react/src/components/SessionUsageMonitor.tsx
+++ b/react/src/components/SessionUsageMonitor.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SessionUsageMonitorFragment$key } from '../__generated__/SessionUsageMonitorFragment.graphql';
 import { convertToBinaryUnit, convertToDecimalUnit } from '../helper';
 import { ResourceSlotName } from '../hooks/backendai';

--- a/react/src/components/SettingItem.tsx
+++ b/react/src/components/SettingItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SettingOutlined } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
 import {

--- a/react/src/components/SettingList.tsx
+++ b/react/src/components/SettingList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import SettingItem, { SettingItemProps } from './SettingItem';
 import { RedoOutlined, SearchOutlined } from '@ant-design/icons';
 import { useToggle } from 'ahooks';

--- a/react/src/components/SharedFolderPermissionInfoModal.tsx
+++ b/react/src/components/SharedFolderPermissionInfoModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SharedFolderPermissionInfoModalFragment$key } from '../__generated__/SharedFolderPermissionInfoModalFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';

--- a/react/src/components/SharedResourceGroupSelectForCurrentProject.tsx
+++ b/react/src/components/SharedResourceGroupSelectForCurrentProject.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import useControllableState_deprecated from '../hooks/useControllableState';
 import {
@@ -9,11 +13,10 @@ import { BAISelect, BAISelectProps } from 'backend.ai-ui';
 import _ from 'lodash';
 import React, { useState, useTransition } from 'react';
 
-interface ResourceGroupSelectForCurrentProjectProps
-  extends Omit<
-    BAISelectProps,
-    'defaultValue' | 'value' | 'allowClear' | 'onClear' | 'onChange'
-  > {
+interface ResourceGroupSelectForCurrentProjectProps extends Omit<
+  BAISelectProps,
+  'defaultValue' | 'value' | 'allowClear' | 'onClear' | 'onChange'
+> {
   onChangeInTransition?: BAISelectProps['onChange'];
 }
 

--- a/react/src/components/ShellScriptEditModal.tsx
+++ b/react/src/components/ShellScriptEditModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBaiSignedRequestWithPromise } from '../helper';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { ShellScriptType } from '../pages/UserSettingsPage';

--- a/react/src/components/SiderToggleButton.tsx
+++ b/react/src/components/SiderToggleButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { HEADER_Z_INDEX_IN_MAIN_LAYOUT } from './MainLayout/MainLayout';
 import { Button, ConfigProvider, theme, Tooltip, Typography } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';

--- a/react/src/components/SignoutModal.tsx
+++ b/react/src/components/SignoutModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { Form, Input, message, Alert, type FormInstance } from 'antd';

--- a/react/src/components/SignupModal.tsx
+++ b/react/src/components/SignupModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { baiSignedRequestWithPromise } from '../helper';
 import { useAnonymousBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';

--- a/react/src/components/SimpleProgressWithLabel.tsx
+++ b/react/src/components/SimpleProgressWithLabel.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { theme, Tooltip, Typography } from 'antd';
 import {
   BAIFlex,

--- a/react/src/components/SourceCodeView.tsx
+++ b/react/src/components/SourceCodeView.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import CopyButton from './Chat/CopyButton';
 import { SyntaxHighlighter } from './Chat/SyntaxHighlighter';
 import { theme } from 'antd';

--- a/react/src/components/SplashModal.tsx
+++ b/react/src/components/SplashModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useThemeMode } from '../hooks/useThemeMode';
 import { theme } from 'antd';
 import {
@@ -110,7 +114,7 @@ const SplashModal: React.FC<SplashModalProps> = ({
           </BAILink>
         </BAIText>
         <BAIText style={{ fontSize: token.fontSizeSM - 1 }}>
-          Copyright &copy; 2015-2025 Lablup Inc.
+          Copyright &copy; 2015-2026 Lablup Inc.
         </BAIText>
         <BAIFlex gap="sm">
           <BAILink

--- a/react/src/components/StartFromURLModal.tsx
+++ b/react/src/components/StartFromURLModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import BAITabs from './BAITabs';
 import ImportNotebookForm from './ImportNotebookForm';
 import ImportRepoForm from './ImportRepoForm';

--- a/react/src/components/StorageHostResourcePanel.tsx
+++ b/react/src/components/StorageHostResourcePanel.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { StorageHostResourcePanelFragment$key } from '../__generated__/StorageHostResourcePanelFragment.graphql';
 import { convertToDecimalUnit, usageIndicatorColor } from '../helper/index';
 import { Progress, Descriptions, Typography, Tag } from 'antd';

--- a/react/src/components/StorageHostSettingsPanel.tsx
+++ b/react/src/components/StorageHostSettingsPanel.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { StorageHostSettingsPanelQuery } from '../__generated__/StorageHostSettingsPanelQuery.graphql';
 import { StorageHostSettingsPanel_storageVolumeFrgmt$key } from '../__generated__/StorageHostSettingsPanel_storageVolumeFrgmt.graphql';
 import { QuotaScopeType, addQuotaScopeTypePrefix } from '../helper/index';

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { StorageProxyListQuery } from '../__generated__/StorageProxyListQuery.graphql';
 import {
   convertToDecimalUnit,

--- a/react/src/components/StorageSelect.tsx
+++ b/react/src/components/StorageSelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { usageIndicatorColor } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';

--- a/react/src/components/StorageStatusPanelCard.tsx
+++ b/react/src/components/StorageStatusPanelCard.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { StorageStatusPanelCardQuery } from '../__generated__/StorageStatusPanelCardQuery.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';

--- a/react/src/components/SummaryItem.tsx
+++ b/react/src/components/SummaryItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { RightOutlined } from '@ant-design/icons';
 import { theme } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';

--- a/react/src/components/SummaryPageItems/SummaryItemInvitation.tsx
+++ b/react/src/components/SummaryPageItems/SummaryItemInvitation.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   baiSignedRequestWithPromise,
   useBaiSignedRequestWithPromise,

--- a/react/src/components/SwitchToProjectButton.tsx
+++ b/react/src/components/SwitchToProjectButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 'use memo';
 
 import { SwitchToProjectButtonQuery } from '../__generated__/SwitchToProjectButtonQuery.graphql';

--- a/react/src/components/TOTPActivateModal.tsx
+++ b/react/src/components/TOTPActivateModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { TOTPActivateModalFragment$key } from '../__generated__/TOTPActivateModalFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useTanMutation, useTanQuery } from '../hooks/reactQueryAlias';

--- a/react/src/components/TOTPActivateModalWithToken.tsx
+++ b/react/src/components/TOTPActivateModalWithToken.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useAnonymousBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useWebComponentInfo } from './DefaultProviders';

--- a/react/src/components/TableColumnsSettingModal.tsx
+++ b/react/src/components/TableColumnsSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SearchOutlined } from '@ant-design/icons';
 import { Checkbox, Input, theme, Form } from 'antd';
 import type { ColumnsType } from 'antd/es/table';

--- a/react/src/components/TermsOfServiceModal.tsx
+++ b/react/src/components/TermsOfServiceModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
 import { useBAISettingUserState } from '../hooks/useBAISetting';
 import { Skeleton } from 'antd';

--- a/react/src/components/TextHighlighter.tsx
+++ b/react/src/components/TextHighlighter.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { theme } from 'antd';
 import _ from 'lodash';
 import React from 'react';

--- a/react/src/components/ThemeAdminProvider.tsx
+++ b/react/src/components/ThemeAdminProvider.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import usePrimaryColors from '../hooks/usePrimaryColors';
 import {

--- a/react/src/components/ThemePreviewModeAlert.tsx
+++ b/react/src/components/ThemePreviewModeAlert.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSessionStorageState } from 'ahooks';
 import { BAIAlert, BAIAlertProps } from 'backend.ai-ui';
 import { useTranslation } from 'react-i18next';

--- a/react/src/components/ThemeSecondaryProvider.tsx
+++ b/react/src/components/ThemeSecondaryProvider.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useCustomThemeConfig } from '../hooks/useCustomThemeConfig';
 import usePrimaryColors from '../hooks/usePrimaryColors';
 import {

--- a/react/src/components/TotalFooter.tsx
+++ b/react/src/components/TotalFooter.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { LoadingOutlined } from '@ant-design/icons';
 import { theme, Typography } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';

--- a/react/src/components/TotalResourceWithinResourceGroup.tsx
+++ b/react/src/components/TotalResourceWithinResourceGroup.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { TotalResourceWithinResourceGroupFragment$key } from '../__generated__/TotalResourceWithinResourceGroupFragment.graphql';
 import { useCurrentUserRole } from '../hooks/backendai';
 import SharedResourceGroupSelectForCurrentProject from './SharedResourceGroupSelectForCurrentProject';

--- a/react/src/components/UpdateUsersModal.tsx
+++ b/react/src/components/UpdateUsersModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import ProjectSelect from './ProjectSelect';
 import UserResourcePolicySelect from './UserResourcePolicySelect';
 import { App, Form, InputNumber, theme } from 'antd';

--- a/react/src/components/UsageProgress.tsx
+++ b/react/src/components/UsageProgress.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { UsageProgressFragment_usageFrgmt$key } from '../__generated__/UsageProgressFragment_usageFrgmt.graphql';
 import { bytesToGB, usageIndicatorColor } from '../helper';
 import { Progress, Typography, theme } from 'antd';

--- a/react/src/components/UserCredentialList.tsx
+++ b/react/src/components/UserCredentialList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { KeypairSettingModalFragment$key } from '../__generated__/KeypairSettingModalFragment.graphql';
 import { UserCredentialListDeleteMutation } from '../__generated__/UserCredentialListDeleteMutation.graphql';
 import { UserCredentialListModifyMutation } from '../__generated__/UserCredentialListModifyMutation.graphql';

--- a/react/src/components/UserDropdownMenu.tsx
+++ b/react/src/components/UserDropdownMenu.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { UserProfileSettingModalQuery } from '../__generated__/UserProfileSettingModalQuery.graphql';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import {

--- a/react/src/components/UserInfoModal.tsx
+++ b/react/src/components/UserInfoModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { UserInfoModalQuery } from '../__generated__/UserInfoModalQuery.graphql';
 import { useTOTPSupported } from '../hooks/backendai';
 import { Descriptions, type DescriptionsProps, Tag, Spin } from 'antd';

--- a/react/src/components/UserManagement.tsx
+++ b/react/src/components/UserManagement.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { UserManagementModifyMutation } from '../__generated__/UserManagementModifyMutation.graphql';
 import {
   UserManagementQuery,

--- a/react/src/components/UserProfileSettingModal.tsx
+++ b/react/src/components/UserProfileSettingModal.tsx
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2025 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { UserProfileSettingModalQuery } from '../__generated__/UserProfileSettingModalQuery.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';

--- a/react/src/components/UserProfileSettingModalQuery.tsx
+++ b/react/src/components/UserProfileSettingModalQuery.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { graphql } from 'react-relay';
 
 export const UserProfileQuery = graphql`

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { UserResourcePolicyListMutation } from '../__generated__/UserResourcePolicyListMutation.graphql';
 import {
   UserResourcePolicyListQuery,

--- a/react/src/components/UserResourcePolicySelect.tsx
+++ b/react/src/components/UserResourcePolicySelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { UserResourcePolicySelectQuery } from '../__generated__/UserResourcePolicySelectQuery.graphql';
 import { localeCompare } from '../helper';
 import { Select, type SelectProps } from 'antd';

--- a/react/src/components/UserResourcePolicySettingModal.tsx
+++ b/react/src/components/UserResourcePolicySettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   CreateUserResourcePolicyInput,
   UserResourcePolicySettingModalCreateMutation,

--- a/react/src/components/UserSelect.tsx
+++ b/react/src/components/UserSelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { UserSelectQuery } from '../__generated__/UserSelectQuery.graphql';
 import { Select, type SelectProps } from 'antd';
 import _ from 'lodash';

--- a/react/src/components/UserSessionsMetrics.tsx
+++ b/react/src/components/UserSessionsMetrics.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { UserSessionsMetricsQuery } from '../__generated__/UserSessionsMetricsQuery.graphql';
 import { newLineToBrElement } from '../helper';
 import { useCurrentUserInfo } from '../hooks/backendai';

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { UserSettingModalCreateMutation } from '../__generated__/UserSettingModalCreateMutation.graphql';
 import { UserSettingModalModifyMutation } from '../__generated__/UserSettingModalModifyMutation.graphql';
 import { UserSettingModalQuery } from '../__generated__/UserSettingModalQuery.graphql';

--- a/react/src/components/VFolderLazyView.tsx
+++ b/react/src/components/VFolderLazyView.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useWebUINavigate } from '../hooks';
 import VFolderNodeIdenticon from './VFolderNodeIdenticon';
 import { Typography } from 'antd';

--- a/react/src/components/VFolderNameTitle.tsx
+++ b/react/src/components/VFolderNameTitle.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { VFolderNameTitleNodeFragment$key } from '../__generated__/VFolderNameTitleNodeFragment.graphql';
 import { theme, Tooltip, Typography } from 'antd';
 import { graphql, useFragment } from 'react-relay';

--- a/react/src/components/VFolderNodeDescription.tsx
+++ b/react/src/components/VFolderNodeDescription.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { VFolderNodeDescriptionFragment$key } from '../__generated__/VFolderNodeDescriptionFragment.graphql';
 import { VFolderNodeDescriptionPermissionRefreshQuery } from '../__generated__/VFolderNodeDescriptionPermissionRefreshQuery.graphql';
 import { useVirtualFolderNodePathFragment$key } from '../__generated__/useVirtualFolderNodePathFragment.graphql';

--- a/react/src/components/VFolderNodeIdenticon.tsx
+++ b/react/src/components/VFolderNodeIdenticon.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { VFolderNodeIdenticonFragment$key } from '../__generated__/VFolderNodeIdenticonFragment.graphql';
 import { shapes } from '@dicebear/collection';
 import { createAvatar } from '@dicebear/core';

--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   VFolderNodesFragment$data,
   VFolderNodesFragment$key,
@@ -60,8 +64,10 @@ export const statusTagColor = {
 };
 
 export type VFolderNodeInList = NonNullable<VFolderNodesFragment$data[number]>;
-interface VFolderNodesProps
-  extends Omit<BAITableProps<VFolderNodeInList>, 'dataSource' | 'columns'> {
+interface VFolderNodesProps extends Omit<
+  BAITableProps<VFolderNodeInList>,
+  'dataSource' | 'columns'
+> {
   vfoldersFrgmt: VFolderNodesFragment$key;
   // Callback when a row is removed from current list
   onRemoveRow?: (updatedFolderId?: string) => void;

--- a/react/src/components/VFolderPermissionCell.tsx
+++ b/react/src/components/VFolderPermissionCell.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { VFolderPermissionCellFragment$key } from '../__generated__/VFolderPermissionCellFragment.graphql';
 import { Typography } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';

--- a/react/src/components/VFolderPermissionTag.tsx
+++ b/react/src/components/VFolderPermissionTag.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { VFolderPermissionTag_VFolder$key } from '../__generated__/VFolderPermissionTag_VFolder.graphql';
 import { BAIDoubleTag, DoubleTagObjectValue } from 'backend.ai-ui';
 import _ from 'lodash';

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBaiSignedRequestWithPromise } from '../helper';
 import { useSuspenseTanQuery } from '../hooks/reactQueryAlias';
 import useControllableState_deprecated from '../hooks/useControllableState';

--- a/react/src/components/VFolderTable.tsx
+++ b/react/src/components/VFolderTable.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { VFolderTableProjectQuery } from '../__generated__/VFolderTableProjectQuery.graphql';
 import { useBaiSignedRequestWithPromise } from '../helper';
 import { useSuspendedBackendaiClient } from '../hooks';

--- a/react/src/components/VFolderTableFormItem.tsx
+++ b/react/src/components/VFolderTableFormItem.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { VFolder } from './VFolderSelect';
 import VFolderTable, {
   AliasMap,

--- a/react/src/components/VFolderTextFileEditorModal.tsx
+++ b/react/src/components/VFolderTextFileEditorModal.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useTanQuery, useTanMutation } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
 import { useThemeMode } from '../hooks/useThemeMode';

--- a/react/src/components/ValidationStatusTag.tsx
+++ b/react/src/components/ValidationStatusTag.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   CheckCircleOutlined,
   ClockCircleOutlined,

--- a/react/src/components/VirtualFolderNodeItems/VirtualFolderPath.tsx
+++ b/react/src/components/VirtualFolderNodeItems/VirtualFolderPath.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useVirtualFolderNodePathFragment$key } from '../../__generated__/useVirtualFolderNodePathFragment.graphql';
 import { useVirtualFolderPath } from '../../hooks/useVirtualFolderNodePath';
 import { theme } from 'antd';

--- a/react/src/components/WEBUIHelpButton.tsx
+++ b/react/src/components/WEBUIHelpButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useCurrentLanguage } from './DefaultProviders';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Button, type ButtonProps } from 'antd';

--- a/react/src/components/WEBUINotificationDrawer.tsx
+++ b/react/src/components/WEBUINotificationDrawer.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useWebUINavigate } from '../hooks';
 import { useBAINotificationState } from '../hooks/useBAINotification';
 import BAIGeneralNotificationItem from './BAIGeneralNotificationItem';

--- a/react/src/components/WebUIBreadcrumb.tsx
+++ b/react/src/components/WebUIBreadcrumb.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import WebUILink from './WebUILink';
 import { Breadcrumb, theme } from 'antd';
 import { BAIFlex, BAIFlexProps } from 'backend.ai-ui';

--- a/react/src/components/WebUILink.tsx
+++ b/react/src/components/WebUILink.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import _ from 'lodash';
 import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';

--- a/react/src/components/WebUINavigate.tsx
+++ b/react/src/components/WebUINavigate.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '../hooks';
 import _ from 'lodash';
 import React, { useEffect } from 'react';

--- a/react/src/components/WebUIThemeToggleButton.tsx
+++ b/react/src/components/WebUIThemeToggleButton.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useThemeMode } from '../hooks/useThemeMode';
 import { MoonOutlined, SunOutlined } from '@ant-design/icons';
 import { Button, type ButtonProps } from 'antd';

--- a/react/src/global-stores.test.ts
+++ b/react/src/global-stores.test.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Tests for global-stores module.
  *
  * Tests cover:

--- a/react/src/global-stores.ts
+++ b/react/src/global-stores.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Global store initialization for Backend.AI WebUI.
  *
  * This module creates the four singleton stores (previously initialized

--- a/react/src/helper/TabCounter.ts
+++ b/react/src/helper/TabCounter.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 /* TabCounter.ts
  * TypeScript port for React usage.
  * Original author: Shubanker Chourasia (MIT license)

--- a/react/src/helper/appLauncherProxy.ts
+++ b/react/src/helper/appLauncherProxy.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Standalone proxy utility functions for app launching.
  *
  * These functions are extracted from useBackendAIAppLauncher hook to allow

--- a/react/src/helper/big-number.test.ts
+++ b/react/src/helper/big-number.test.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { BigNumber } from './big-number';
 import { expect } from '@jest/globals';
 import Big from 'big.js';

--- a/react/src/helper/big-number.ts
+++ b/react/src/helper/big-number.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { generateDisplayValues, InputSizeUnit, SizeUnit } from '.';
 import { Big, type BigSource } from 'big.js';
 

--- a/react/src/helper/bui-language.ts
+++ b/react/src/helper/bui-language.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import de_DE from 'backend.ai-ui/dist/locale/de_DE';
 import el_GR from 'backend.ai-ui/dist/locale/el_GR';
 import en_US from 'backend.ai-ui/dist/locale/en_US';

--- a/react/src/helper/const-vars.ts
+++ b/react/src/helper/const-vars.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 export const SIGNED_32BIT_MAX_INT = 2147483647;
 export const SIGNED_32BIT_MIN_INT = -2147483648;
 

--- a/react/src/helper/csv-util.test.ts
+++ b/react/src/helper/csv-util.test.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 // csv-util.test.ts
 import { JSONToCSVBody } from './csv-util';
 

--- a/react/src/helper/csv-util.ts
+++ b/react/src/helper/csv-util.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import _ from 'lodash';
 
 /**

--- a/react/src/helper/customThemeConfig.ts
+++ b/react/src/helper/customThemeConfig.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { type ThemeConfig } from 'antd';
 import _ from 'lodash';
 

--- a/react/src/helper/graphql-transformer.test.ts
+++ b/react/src/helper/graphql-transformer.test.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { manipulateGraphQLQueryWithClientDirectives } from './graphql-transformer';
 
 describe('graphql-transformer', () => {

--- a/react/src/helper/graphql-transformer.ts
+++ b/react/src/helper/graphql-transformer.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { parse, print, visit } from 'graphql';
 
 // Delete nodes in enter

--- a/react/src/helper/index.test.tsx
+++ b/react/src/helper/index.test.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   getImageFullName,
   isOutsideRange,

--- a/react/src/helper/index.tsx
+++ b/react/src/helper/index.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { CommittedImage } from '../components/CustomizedImageList';
 import { Image } from '../components/ImageEnvironmentSelectFormItems';
 import { EnvironmentImage } from '../components/ImageList';

--- a/react/src/helper/loginConfig.ts
+++ b/react/src/helper/loginConfig.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Login Configuration Utilities
  *
  * Extracted from backend-ai-login.ts to support the React LoginView component.

--- a/react/src/helper/loginSessionAuth.ts
+++ b/react/src/helper/loginSessionAuth.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Login Session Authentication Utilities
  *
  * Extracted from backend-ai-login.ts _connectViaGQL method.

--- a/react/src/helper/react-to-webcomponent.tsx
+++ b/react/src/helper/react-to-webcomponent.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 

--- a/react/src/helper/resultTypes.test.ts
+++ b/react/src/helper/resultTypes.test.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   getResultValue,
   isErrorResult,

--- a/react/src/helper/resultTypes.ts
+++ b/react/src/helper/resultTypes.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Utility types for handling GraphQL @catch(to: RESULT) directive
  */
 

--- a/react/src/helper/types.tsx
+++ b/react/src/helper/types.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useLazyLoadQuery } from 'react-relay';
 
 export type LazyLoadQueryOptions = ArgumentTypes<typeof useLazyLoadQuery>[2];

--- a/react/src/hooks/backendai.test.tsx
+++ b/react/src/hooks/backendai.test.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import deviceMetadata from '../../../resources/device_metadata.json';
 // import json
 import schema from '../../../resources/device_metadata.schema.json';

--- a/react/src/hooks/backendai.tsx
+++ b/react/src/hooks/backendai.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '.';
 import { maskString } from '../helper';
 import {

--- a/react/src/hooks/hooksUsingRelay.tsx
+++ b/react/src/hooks/hooksUsingRelay.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '.';
 import { hooksUsingRelay_KeyPairQuery } from '../__generated__/hooksUsingRelay_KeyPairQuery.graphql';
 import { hooksUsingRelay_KeyPairResourcePolicyQuery } from '../__generated__/hooksUsingRelay_KeyPairResourcePolicyQuery.graphql';

--- a/react/src/hooks/index.test.tsx
+++ b/react/src/hooks/index.test.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { imageParser } from '.';
 import _ from 'lodash';
 

--- a/react/src/hooks/index.tsx
+++ b/react/src/hooks/index.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { getOS, preserveDotStartCase } from '../helper';
 import { useSuspenseTanQuery } from './reactQueryAlias';
 import { MenuKeys } from './useWebUIMenuItems';

--- a/react/src/hooks/reactPaginationQueryOptions.tsx
+++ b/react/src/hooks/reactPaginationQueryOptions.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 // import { offset_to_cursor } from "../helper";
 import { LazyLoadQueryOptions } from '../helper/types';
 import type { SorterResult } from 'antd/lib/table/interface';
@@ -292,7 +296,8 @@ interface AntdBasicPaginationOption {
 }
 
 interface InitialPaginationOption
-  extends AntdBasicPaginationOption,
+  extends
+    AntdBasicPaginationOption,
     Omit<BAIPaginationOption, 'limit' | 'offset'> {}
 
 interface BAIPaginationOptionState {

--- a/react/src/hooks/reactQueryAlias.tsx
+++ b/react/src/hooks/reactQueryAlias.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   type QueryKey,
   useQuery,

--- a/react/src/hooks/useAIAgent.ts
+++ b/react/src/hooks/useAIAgent.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useTanQuery } from './reactQueryAlias';
 import { useUpdatableState } from 'backend.ai-ui';
 import { useCallback } from 'react';

--- a/react/src/hooks/useApiEndpoint.ts
+++ b/react/src/hooks/useApiEndpoint.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { loginConfigState } from './useWebUIConfig';
 import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';

--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useWebUINavigate } from '.';
 import BAIGeneralNotificationItem from '../components/BAIGeneralNotificationItem';
 import { SSEEventHandlerTypes, listenToBackgroundTask } from '../helper';
@@ -56,8 +60,10 @@ type BackgroundTaskConfig<T> = {
   promise?: Promise<T> | null;
 };
 
-export interface NotificationState<T = any>
-  extends Omit<ArgsProps, 'placement' | 'key' | 'icon'> {
+export interface NotificationState<T = any> extends Omit<
+  ArgsProps,
+  'placement' | 'key' | 'icon'
+> {
   key: React.Key;
   created?: string;
   toTextKey?: string;
@@ -272,7 +278,6 @@ export const useBAINotificationEffect = () => {
         );
       }
     });
-
   }, [_notifications, upsertNotification]);
 };
 

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { BAIBoardItem } from '../components/BAIBoard';
 import { jotaiStore } from '../components/DefaultProviders';
 import { backendaiOptions } from '../global-stores';

--- a/react/src/hooks/useBackendAIAppLauncher.tsx
+++ b/react/src/hooks/useBackendAIAppLauncher.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '.';
 import { useSetBAINotification } from './useBAINotification';
 import { BAILink, useBAILogger, useErrorMessageResolver } from 'backend.ai-ui';

--- a/react/src/hooks/useBackendAIImageMetaData.test.tsx
+++ b/react/src/hooks/useBackendAIImageMetaData.test.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBackendAIImageMetaData } from '.';
 import { getImageFullName } from '../helper';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/react/src/hooks/useControllableState.test.ts
+++ b/react/src/hooks/useControllableState.test.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import useControllableState_deprecated, {
   Options,
   Props,

--- a/react/src/hooks/useControllableState.ts
+++ b/react/src/hooks/useControllableState.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import _ from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SetStateAction } from 'react';

--- a/react/src/hooks/useCurrentProject.tsx
+++ b/react/src/hooks/useCurrentProject.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '.';
 import { backendaiUtils } from '../global-stores';
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai';

--- a/react/src/hooks/useCustomThemeConfig.ts
+++ b/react/src/hooks/useCustomThemeConfig.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { CustomThemeConfig, getCustomTheme } from '../helper/customThemeConfig';
 import { useBAISettingUserState } from './useBAISetting';
 import { useSessionStorageState } from 'ahooks';

--- a/react/src/hooks/useDefaultImagesWithFallback.ts
+++ b/react/src/hooks/useDefaultImagesWithFallback.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { backendaiClientPromise } from '.';
 import { atom, useAtom } from 'jotai';
 import { atomWithDefault } from 'jotai/utils';

--- a/react/src/hooks/useGlobalStores.test.ts
+++ b/react/src/hooks/useGlobalStores.test.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Tests for useGlobalStores hooks.
  *
  * These hooks are thin wrappers that return the singleton store instances

--- a/react/src/hooks/useGlobalStores.ts
+++ b/react/src/hooks/useGlobalStores.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * React hooks for accessing the global Backend.AI stores.
  *
  * These hooks provide typed access to the singleton store instances

--- a/react/src/hooks/useHiddenColumnKeysSetting.tsx
+++ b/react/src/hooks/useHiddenColumnKeysSetting.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBAISettingUserState } from './useBAISetting';
 
 type KnownSettingName =

--- a/react/src/hooks/useHighlight.ts
+++ b/react/src/hooks/useHighlight.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useThemeMode } from './useThemeMode';
 import { useBAILogger } from 'backend.ai-ui';
 import { useMemo } from 'react';

--- a/react/src/hooks/useKeyboardShortcut.ts
+++ b/react/src/hooks/useKeyboardShortcut.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useEventListener } from 'ahooks';
 
 /**

--- a/react/src/hooks/useLocalStorageGlobalState.tsx
+++ b/react/src/hooks/useLocalStorageGlobalState.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useLocalStorageState } from 'ahooks';
 import { useCallback, useEffect } from 'react';
 

--- a/react/src/hooks/useLoginOrchestration.test.ts
+++ b/react/src/hooks/useLoginOrchestration.test.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Tests for useLoginOrchestration hook.
  *
  * The hook orchestrates the initial login flow once config is loaded.

--- a/react/src/hooks/useLoginOrchestration.ts
+++ b/react/src/hooks/useLoginOrchestration.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * useLoginOrchestration - React hook that orchestrates the initial login flow.
  *
  * This replaces the login orchestration logic that was previously in the Lit

--- a/react/src/hooks/useLogout.test.ts
+++ b/react/src/hooks/useLogout.test.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Tests for useLogout hook and related utilities.
  *
  * These tests cover:

--- a/react/src/hooks/useLogout.ts
+++ b/react/src/hooks/useLogout.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { backendaiOptions, backendaiUtils } from '../global-stores';
 import React, { useEffect, useEffectEvent } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/react/src/hooks/useMemoWithPrevious.test.tsx
+++ b/react/src/hooks/useMemoWithPrevious.test.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useMemoWithPrevious } from './useMemoWithPrevious';
 import { renderHook, act } from '@testing-library/react';
 

--- a/react/src/hooks/useMemoWithPrevious.tsx
+++ b/react/src/hooks/useMemoWithPrevious.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { DependencyList, useEffect, useMemo, useRef, useState } from 'react';
 
 export const useMemoWithPrevious = <T,>(

--- a/react/src/hooks/useMergedAllowedStorageHostPermission.ts
+++ b/react/src/hooks/useMergedAllowedStorageHostPermission.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '.';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { graphql, useLazyLoadQuery } from 'react-relay';

--- a/react/src/hooks/useModelCardMetadata.tsx
+++ b/react/src/hooks/useModelCardMetadata.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ServiceLauncherFormValue } from '../components/ServiceLauncherPageContent';
 import { useTanQuery } from './reactQueryAlias';
 import { useUpdatableState } from 'backend.ai-ui';

--- a/react/src/hooks/usePaginatedQuery.ts
+++ b/react/src/hooks/usePaginatedQuery.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useEventNotStable } from 'backend.ai-ui';
 import _ from 'lodash';
 import { useState, useTransition, useMemo, useRef, useEffect } from 'react';

--- a/react/src/hooks/usePainKiller.tsx
+++ b/react/src/hooks/usePainKiller.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useTranslation } from 'react-i18next';
 
 const errorMessageTable: {

--- a/react/src/hooks/usePrimaryColors.ts
+++ b/react/src/hooks/usePrimaryColors.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { generate } from '@ant-design/colors';
 import { theme } from 'antd';
 import { useMemo } from 'react';

--- a/react/src/hooks/useRecentSessionHistory.tsx
+++ b/react/src/hooks/useRecentSessionHistory.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { SessionHistory, useBAISettingUserState } from './useBAISetting';
 import { useEventNotStable, generateRandomString } from 'backend.ai-ui';
 import _ from 'lodash';

--- a/react/src/hooks/useResourceLimitAndRemaining.test.ts
+++ b/react/src/hooks/useResourceLimitAndRemaining.test.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import '../../__test__/matchMedia.mock.js';
 import { isMatchingMaxPerContainer } from './useResourceLimitAndRemaining';
 

--- a/react/src/hooks/useResourceLimitAndRemaining.tsx
+++ b/react/src/hooks/useResourceLimitAndRemaining.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '.';
 import { useResourceLimitAndRemainingFragment$key } from '../__generated__/useResourceLimitAndRemainingFragment.graphql';
 import { Image } from '../components/ImageEnvironmentSelectFormItems';

--- a/react/src/hooks/useScrollBreackPoint.tsx
+++ b/react/src/hooks/useScrollBreackPoint.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import _ from 'lodash';
 import { useState, useEffect } from 'react';
 

--- a/react/src/hooks/useSessionNodeLiveStat.tsx
+++ b/react/src/hooks/useSessionNodeLiveStat.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSessionNodeLiveStatSessionFragment$key } from '../__generated__/useSessionNodeLiveStatSessionFragment.graphql';
 import { useBAILogger } from 'backend.ai-ui';
 import { Big } from 'big.js';

--- a/react/src/hooks/useStartSession.tsx
+++ b/react/src/hooks/useStartSession.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '.';
 import { useSetBAINotification } from './useBAINotification';
 import {

--- a/react/src/hooks/useSuspendedFilteredAppTemplate.ts
+++ b/react/src/hooks/useSuspendedFilteredAppTemplate.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '.';
 import { useSuspenseTanQuery } from './reactQueryAlias';
 import _ from 'lodash';

--- a/react/src/hooks/useThemeMode.tsx
+++ b/react/src/hooks/useThemeMode.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useLocalStorageGlobalState } from './useLocalStorageGlobalState';
 import {
   PropsWithChildren,

--- a/react/src/hooks/useTokenizer.ts
+++ b/react/src/hooks/useTokenizer.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { startTransition, useEffect, useState } from 'react';
 
 export const encodeAsync = async (str: string) => {

--- a/react/src/hooks/useUserCustomThemeConfig.ts
+++ b/react/src/hooks/useUserCustomThemeConfig.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBAISettingUserState } from './useBAISetting';
 import { useCustomThemeConfig } from './useCustomThemeConfig';
 import { App } from 'antd';

--- a/react/src/hooks/useUserUsageStats.ts
+++ b/react/src/hooks/useUserUsageStats.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { UserStatsData, useSuspendedBackendaiClient } from '.';
 import { useSuspenseTanQuery } from './reactQueryAlias';
 

--- a/react/src/hooks/useVFolderInvitations.tsx
+++ b/react/src/hooks/useVFolderInvitations.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { backendaiClientPromise, useSuspendedBackendaiClient } from '.';
 import { mutationOptions } from './backendai';
 import { useTanMutation } from './reactQueryAlias';

--- a/react/src/hooks/useValidateServiceName.tsx
+++ b/react/src/hooks/useValidateServiceName.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { type FormItemProps } from 'antd';
 import type { RuleObject } from 'antd/es/form';
 import _ from 'lodash';

--- a/react/src/hooks/useValidateSessionName.tsx
+++ b/react/src/hooks/useValidateSessionName.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import type { RuleObject } from 'antd/es/form';
 import { FormItemProps } from 'antd/lib';
 import _ from 'lodash';

--- a/react/src/hooks/useVariantConfigs.ts
+++ b/react/src/hooks/useVariantConfigs.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { EnvVarConfig } from '../components/EnvVarFormList';
 import { useTranslation } from 'react-i18next';
 

--- a/react/src/hooks/useVirtualFolderNodePath.ts
+++ b/react/src/hooks/useVirtualFolderNodePath.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useVirtualFolderNodePathFragment$key } from '../__generated__/useVirtualFolderNodePathFragment.graphql';
 import { toLocalId } from 'backend.ai-ui';
 import _ from 'lodash';

--- a/react/src/hooks/useWebUIConfig.test.ts
+++ b/react/src/hooks/useWebUIConfig.test.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Tests for useWebUIConfig module.
  *
  * Tests cover:

--- a/react/src/hooks/useWebUIConfig.ts
+++ b/react/src/hooks/useWebUIConfig.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * WebUI Config - React-based config.toml parsing and state management.
  *
  * This module replaces the Lit shell's _parseConfig() and loadConfig() methods.

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient } from '.';
 import { useCurrentUserRole } from './backendai';
 import { useBAISettingUserState } from './useBAISetting';

--- a/react/src/hooks/useWebUIPluginState.tsx
+++ b/react/src/hooks/useWebUIPluginState.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { atom, useAtomValue } from 'jotai';
 
 export type PluginPage = {

--- a/react/src/index.tsx
+++ b/react/src/index.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 // Initialize global stores before any component renders.
 // This import has side effects: it instantiates the four singleton stores
 // and assigns them to globalThis for backward compatibility with Lit code.

--- a/react/src/lib/TabCounter.test.ts
+++ b/react/src/lib/TabCounter.test.ts
@@ -1,4 +1,8 @@
 /**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
  * Tests for TabCounter (TabCount class).
  *
  * TabCount tracks open browser tabs by writing per-tab heartbeat data to

--- a/react/src/lib/TabCounter.ts
+++ b/react/src/lib/TabCounter.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 /* TabCounter.ts
  * Based on TabCounter.js by Shubanker Chourasia
  * License: MIT

--- a/react/src/pages/AIAgentPage.tsx
+++ b/react/src/pages/AIAgentPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { FluentEmojiIcon } from '../components/FluentEmojiIcon';
 import { useWebUINavigate } from '../hooks';
 import { AIAgent, useAIAgent } from '../hooks/useAIAgent';

--- a/react/src/pages/AdminDashboardPage.tsx
+++ b/react/src/pages/AdminDashboardPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { AdminDashboardPageQuery } from '../__generated__/AdminDashboardPageQuery.graphql';
 import BAIBoard, { BAIBoardItem } from '../components/BAIBoard';
 import RecentlyCreatedSession from '../components/RecentlyCreatedSession';

--- a/react/src/pages/AdminSessionPage.tsx
+++ b/react/src/pages/AdminSessionPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Skeleton } from 'antd';
 import { BAICard, filterOutEmpty } from 'backend.ai-ui';
 import { parseAsString, useQueryStates } from 'nuqs';

--- a/react/src/pages/AgentSummaryPage.tsx
+++ b/react/src/pages/AgentSummaryPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import AgentSummaryList from '../components/AgentSummaryList';
 import { Skeleton, theme } from 'antd';
 import { BAICard } from 'backend.ai-ui';

--- a/react/src/pages/BrandingPage.tsx
+++ b/react/src/pages/BrandingPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
 import { Suspense } from 'react';

--- a/react/src/pages/ChangePasswordPage.tsx
+++ b/react/src/pages/ChangePasswordPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   CSSTokenVariables,
   NotificationForAnonymous,

--- a/react/src/pages/ChatPage.tsx
+++ b/react/src/pages/ChatPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ChatPageQuery } from '../__generated__/ChatPageQuery.graphql';
 import ChatCard from '../components/Chat/ChatCard';
 import {

--- a/react/src/pages/ComputeSessionListPage.tsx
+++ b/react/src/pages/ComputeSessionListPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   ComputeSessionListPageQuery,
   ComputeSessionListPageQuery$data,

--- a/react/src/pages/ConfigurationsPage.tsx
+++ b/react/src/pages/ConfigurationsPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import ConfigurationsSettingList from '../components/ConfigurationsSettingList';
 import { Card, Skeleton } from 'antd';
 import { filterOutEmpty } from 'backend.ai-ui';

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { DashboardPageQuery } from '../__generated__/DashboardPageQuery.graphql';
 import BAIBoard, { BAIBoardItem } from '../components/BAIBoard';
 import MyResource from '../components/MyResource';

--- a/react/src/pages/EduAppLauncherPage.tsx
+++ b/react/src/pages/EduAppLauncherPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   CSSTokenVariables,
   NotificationForAnonymous,

--- a/react/src/pages/EmailVerificationPage.tsx
+++ b/react/src/pages/EmailVerificationPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   CSSTokenVariables,
   NotificationForAnonymous,

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { AutoScalingRuleEditorModalFragment$key } from '../__generated__/AutoScalingRuleEditorModalFragment.graphql';
 import { EndpointDetailPageAutoScalingRuleDeleteMutation } from '../__generated__/EndpointDetailPageAutoScalingRuleDeleteMutation.graphql';
 import {

--- a/react/src/pages/EnvironmentPage.tsx
+++ b/react/src/pages/EnvironmentPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import ContainerRegistryList from '../components/ContainerRegistryList';
 import ImageList from '../components/ImageList';
 import ResourcePresetList from '../components/ResourcePresetList';

--- a/react/src/pages/InteractiveLoginPage.tsx
+++ b/react/src/pages/InteractiveLoginPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   CSSTokenVariables,
   NotificationForAnonymous,

--- a/react/src/pages/MaintenancePage.tsx
+++ b/react/src/pages/MaintenancePage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import MaintenanceSettingList from '../components/MaintenanceSettingList';
 import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';

--- a/react/src/pages/ModelStoreListPage.tsx
+++ b/react/src/pages/ModelStoreListPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ModelCardModalFragment$key } from '../__generated__/ModelCardModalFragment.graphql';
 import { ModelStoreListPageQuery } from '../__generated__/ModelStoreListPageQuery.graphql';
 import ModelCardModal from '../components/ModelCardModal';

--- a/react/src/pages/MyEnvironmentPage.tsx
+++ b/react/src/pages/MyEnvironmentPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import CustomizedImageList from '../components/CustomizedImageList';
 import FlexActivityIndicator from '../components/FlexActivityIndicator';
 import { BAICard } from 'backend.ai-ui';

--- a/react/src/pages/Page401.tsx
+++ b/react/src/pages/Page401.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import {
   getPathFromMenuKey,

--- a/react/src/pages/Page404.tsx
+++ b/react/src/pages/Page404.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import {
   getPathFromMenuKey,

--- a/react/src/pages/ProjectPage.tsx
+++ b/react/src/pages/ProjectPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { PlusOutlined } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
 import {

--- a/react/src/pages/ReservoirArtifactDetailPage.tsx
+++ b/react/src/pages/ReservoirArtifactDetailPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import ImportArtifactRevisionToFolderButton from '../components/ImportArtifactRevisionToFolderButton';
 import { Button, Typography, Descriptions, theme, Tooltip } from 'antd';
 import {

--- a/react/src/pages/ReservoirPage.tsx
+++ b/react/src/pages/ReservoirPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
 import { useToggle } from 'ahooks';
 import {

--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import KeypairResourcePolicyList from '../components/KeypairResourcePolicyList';
 import ProjectResourcePolicyList from '../components/ProjectResourcePolicyList';
 import UserResourcePolicyList from '../components/UserResourcePolicyList';

--- a/react/src/pages/ResourcesPage.tsx
+++ b/react/src/pages/ResourcesPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import AgentList from '../components/AgentList';
 import ResourceGroupList from '../components/ResourceGroupList';
 import StorageProxyList from '../components/StorageProxyList';

--- a/react/src/pages/SchedulerPage.tsx
+++ b/react/src/pages/SchedulerPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { QuestionCircleOutlined } from '@ant-design/icons';
 import { Button, Result, Skeleton, theme, Tooltip } from 'antd';
 import { BAICard, BAIFlex } from 'backend.ai-ui';

--- a/react/src/pages/ServiceLauncherPage.tsx
+++ b/react/src/pages/ServiceLauncherPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ServiceLauncherPageQuery } from '../__generated__/ServiceLauncherPageQuery.graphql';
 import ServiceLauncherPageContent from '../components/ServiceLauncherPageContent';
 import { graphql, useLazyLoadQuery } from 'react-relay';

--- a/react/src/pages/ServingPage.tsx
+++ b/react/src/pages/ServingPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ServingPageQuery } from '../__generated__/ServingPageQuery.graphql';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import EndpointList from '../components/EndpointList';

--- a/react/src/pages/SessionLauncherPage.tsx
+++ b/react/src/pages/SessionLauncherPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import DatePickerISO from '../components/DatePickerISO';
 import EnvVarFormList, {
   sanitizeSensitiveEnv,

--- a/react/src/pages/StartPage.tsx
+++ b/react/src/pages/StartPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import ActionItemContent from '../components/ActionItemContent';
 import AnnouncementAlert from '../components/AnnouncementAlert';
 import BAIBoard, { BAIBoardItem } from '../components/BAIBoard';

--- a/react/src/pages/StatisticsPage.tsx
+++ b/react/src/pages/StatisticsPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import AllocationHistory from '../components/AllocationHistory';
 import UserSessionsMetrics from '../components/UserSessionsMetrics';
 import { useSuspendedBackendaiClient } from '../hooks';

--- a/react/src/pages/StorageHostSettingPage.tsx
+++ b/react/src/pages/StorageHostSettingPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { StorageHostSettingPageQuery } from '../__generated__/StorageHostSettingPageQuery.graphql';
 import StorageHostResourcePanel from '../components/StorageHostResourcePanel';
 import StorageHostSettingsPanel from '../components/StorageHostSettingsPanel';

--- a/react/src/pages/UserCredentialsPage.tsx
+++ b/react/src/pages/UserCredentialsPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import UserCredentialList from '../components/UserCredentialList';
 import UserManagement from '../components/UserManagement';
 import { Skeleton } from 'antd';

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import ErrorLogList from '../components/ErrorLogList';
 import MyKeypairInfoModal from '../components/MyKeypairInfoModal';
 import SSHKeypairManagementModal from '../components/SSHKeypairManagementModal';

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import {
   VFolderNodeListPageQuery,
   VFolderNodeListPageQuery$data,

--- a/react/src/react-app-env.d.ts
+++ b/react/src/react-app-env.d.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 /// <reference types="react-scripts" />
 
 // declare module 'babel-plugin-relay/macro' {

--- a/react/src/reportWebVitals.ts
+++ b/react/src/reportWebVitals.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { ReportHandler } from 'web-vitals';
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import BAIErrorBoundary, { ErrorView } from './components/BAIErrorBoundary';
 import {
   DefaultProvidersForReactRoot,

--- a/react/src/setupTests.ts
+++ b/react/src/setupTests.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 // jest-dom adds custom jest matchers for asserting on DOM nodes.
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)

--- a/react/src/usePromiseTracker.ts
+++ b/react/src/usePromiseTracker.ts
@@ -1,3 +1,7 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
 import { useCallback, useState } from 'react';
 
 interface PromiseStatus<TData, TError> {

--- a/resources/templates/under_construction.html
+++ b/resources/templates/under_construction.html
@@ -216,7 +216,7 @@
     <h1 class="title">We’ll be back soon!</h1>
     <p>Sorry for the inconvenience but we’re performing some maintenance at the moment.</p>
     <p>If you need to you can always contact us, otherwise we’ll be back online shortly!</p>
-    <div class="copyright">Copyright &copy; 2015-2025 Lablup Inc.</div>
+    <div class="copyright">Copyright &copy; 2015-2026 Lablup Inc.</div>
   </div>
   <div class="sk-folding-cube">
     <div class="sk-cube1 sk-cube"></div>

--- a/src/backend-ai-app.ts
+++ b/src/backend-ai-app.ts
@@ -1,6 +1,6 @@
 /**
  @license
- Copyright (c) 2015-2025 Lablup Inc. All rights reserved.
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 
 // Minimal entry point for Rollup.

--- a/src/lib/json_to_csv.ts
+++ b/src/lib/json_to_csv.ts
@@ -3,7 +3,7 @@
 Backend.AI API : JSON to CSV Converter
 ======================================
 
-(C) Copyright 2015-2025 Lablup Inc.
+(C) Copyright 2015-2026 Lablup Inc.
 Licensed under MIT
 */
 


### PR DESCRIPTION
## Summary
- Update copyright year from 2025 to 2026 across all source files
- Add missing license headers (`Copyright (c) 2015-2026 Lablup Inc. All rights reserved.`) to files that lacked them

## Test plan
- [ ] Verify build succeeds with updated headers
- [ ] Confirm no functional changes — license header only