### PR TITLE
refactor: update documentation to reflect actual build system and state management

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,17 +4,18 @@ This file provides custom instructions for GitHub Copilot when reviewing code an
 
 ## Project Overview
 
-Backend.AI WebUI is a **hybrid web application** with two main UI frameworks:
-
-- **Lit-Element Web Components** (`/src`) - Legacy UI components using TypeScript
-- **React Components** (`/react`) - Modern UI components using React + Ant Design + Relay (GraphQL)
+Backend.AI WebUI is a **React web application** using React 19 + Ant Design 6 + Relay 20 (GraphQL).
+The legacy Lit-Element web components have been removed.
 
 ### Key Technologies
 
-- **Build System**: Rollup for bundling, pnpm for package management
-- **Styling**: Ant Design (React), Material Web Components (Lit)
-- **State Management**: Redux (legacy), Relay (GraphQL for React)
-- **GraphQL**: Relay compiler for React components
+- **React Build**: Webpack via @craco/craco (Create React App with customizations)
+- **Component Library Build**: Vite (`packages/backend.ai-ui/`)
+- **Service Worker**: Rollup + rollup-plugin-workbox (generates `sw.js` only)
+- **Package Manager**: pnpm with workspace monorepo
+- **Styling**: Ant Design + antd-style
+- **State Management**: Jotai (global UI state), Relay (server/GraphQL state)
+- **GraphQL**: Relay compiler for React components and backend.ai-ui package
 - **Testing**: Jest for unit tests, Playwright for E2E tests
 
 ## Code Review Guidelines
@@ -56,16 +57,16 @@ Backend.AI WebUI is a **hybrid web application** with two main UI frameworks:
 
 When reviewing code:
 
-- Recognize whether code is in `/src` (Lit-Element) or `/react` (React)
-- Understand the hybrid nature requires different patterns for each framework
+- All UI code is in `/react` (React) and `/packages/backend.ai-ui/` (shared components)
+- `/src` contains only legacy utilities and the websocket proxy
 - Check that GraphQL queries use Relay conventions in React components
-- Verify proper i18n usage with `_t`, `_tr`, `_text` functions
+- Verify proper i18n usage with `useTranslation()` hook from `react-i18next`
 
 ### Build and Development
 
-- Development requires both `pnpm run server:d` and `pnpm run build:d`
-- Build process: multi-stage with resource copying and TypeScript compilation
-- Pre-commit hooks run linting and formatting automatically
+- Development requires both `pnpm run server:d` (React dev server) and `pnpm run wsproxy` (WebSocket proxy)
+- Build process: multi-stage with resource copying, service worker generation (Rollup), and React build (Craco/Webpack)
+- Pre-commit hooks run linting and formatting automatically via Husky + lint-staged
 
 ## Git Workflow
 

--- a/.github/instructions/react.instructions.md
+++ b/.github/instructions/react.instructions.md
@@ -301,7 +301,7 @@ Always consider React composability when writing or reviewing components:
 2. **Composition Over Props Drilling**
 
    - Use component composition instead of passing props through multiple levels
-   - Consider using Recoil for global state management
+   - Consider using Jotai for global state management
    - Leverage children props and render props patterns
 
 3. **Reusability**
@@ -323,14 +323,11 @@ Always consider React composability when writing or reviewing components:
   <Child theme={theme} user={user} config={config} />
 </Parent>
 
-// ✅ Good: Composition with Recoil
-const themeState = atom({
-  key: 'theme',
-  default: 'light',
-});
+// ✅ Good: Composition with Jotai
+const themeAtom = atom('light');
 
 const Child = () => {
-  const theme = useRecoilValue(themeState);
+  const [theme] = useAtom(themeAtom);
   // ...
 };
 
@@ -1147,21 +1144,18 @@ const BAITable = <T extends { id: string }>({
 
 ### Global State
 
-- Use **Recoil** for global state management
+- Use **Jotai** for global state management
 - Use Relay for GraphQL-backed state
 - Use React Context for simple UI state that doesn't need persistence
 
 ```typescript
-// ✅ Good: Recoil for global state
-import { atom, useRecoilState } from "recoil";
+// ✅ Good: Jotai for global state
+import { atom, useAtom } from "jotai";
 
-const userSettingsState = atom({
-  key: "userSettings",
-  default: {},
-});
+const userSettingsAtom = atom({});
 
 const Component = () => {
-  const [settings, setSettings] = useRecoilState(userSettingsState);
+  const [settings, setSettings] = useAtom(userSettingsAtom);
   // ...
 };
 ```
@@ -1300,7 +1294,7 @@ When reviewing React code, check for:
 
 - [ ] Pre-defined error boundaries (`ErrorBoundaryWithNullFallback`, `BAIErrorBoundary`) are used
 - [ ] Error states and loading states are handled
-- [ ] Recoil is used for global state when appropriate
+- [ ] Jotai is used for global state when appropriate
 
 ### Internationalization & Accessibility
 


### PR DESCRIPTION
## Summary

- Correct build system documentation: React uses **CRA + Craco (Webpack)**, not Vite. Vite is only used for the `backend.ai-ui` component library package.
- Replace all **Recoil** references with **Jotai** (the actual state management library in use), including code examples.
- Clarify **Rollup's role** as service worker generation only, with link to #5454 for planned migration.
- Update project structure, build pipeline, library versions, and architecture description to match actual codebase.

### Files Changed

| File | Changes |
|------|---------|
| `AGENTS.md` (symlinked as `CLAUDE.md`) | Build system, state management, project structure, build pipeline, key libraries, i18n, Relay setup |
| `.github/copilot-instructions.md` | Architecture description, key technologies, development workflow |
| `.github/instructions/react.instructions.md` | Recoil → Jotai (composition examples, global state section, code review checklist) |