### PR TITLE
feat: improve login panel UI with segmented mode switch and side help panel

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,9 +432,6 @@ importers:
       underscore:
         specifier: ^1.13.7
         version: 1.13.7
-      web-animations-js:
-        specifier: ^2.3.2
-        version: 2.3.2
       webpack:
         specifier: ^5.104.1
         version: 5.104.1(esbuild@0.27.2)(webpack-cli@6.0.1)
@@ -15148,9 +15145,6 @@ packages:
 
   wbuf@1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}
-
-  web-animations-js@2.3.2:
-    resolution: {integrity: sha512-TOMFWtQdxzjWp8qx4DAraTWTsdhxVSiWa6NkPFSaPtZ1diKUxTn4yTix73A1euG1WbSOMMPcY51cnjTIHrGtDA==}
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
@@ -34531,8 +34525,6 @@ snapshots:
   wbuf@1.7.3:
     dependencies:
       minimalistic-assert: 1.0.1
-
-  web-animations-js@2.3.2: {}
 
   web-namespaces@2.0.1: {}
 

--- a/react/src/components/LoadingCurtain.tsx
+++ b/react/src/components/LoadingCurtain.tsx
@@ -17,20 +17,7 @@ const useStyle = createStyles(({ css }) => ({
     z-index: 9999;
   `,
   loadingBackgroundBefore: css`
-    &::before {
-      content: '';
-      position: fixed;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      background-image: url('/resources/images/loading-background-large.jpg');
-      z-index: -1;
-      background-repeat: no-repeat;
-      background-attachment: fixed;
-      background-position: top left;
-      filter: var(--theme-image-filter);
-    }
+    background-color: var(--token-colorBgLayout, #f5f5f5);
   `,
   loadingDragArea: css`
     position: absolute;

--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -32,9 +32,8 @@ import {
   loginPluginState,
 } from '../hooks/useWebUIConfig';
 import LoginFormPanel from './LoginFormPanel';
-import { Button, Form, Modal, type MenuProps } from 'antd';
+import { Button, Form, type MenuProps } from 'antd';
 import { BAIModal, BAIFlex } from 'backend.ai-ui';
-import DOMPurify from 'dompurify';
 import { useAtomValue } from 'jotai';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -78,9 +77,6 @@ const LoginView: React.FC = () => {
   const [isBlockPanelOpen, setIsBlockPanelOpen] = useState(false);
   const [blockMessage, setBlockMessage] = useState('');
   const [blockType, setBlockType] = useState('');
-  const [helpDescription, setHelpDescription] = useState('');
-  const [helpDescriptionTitle, setHelpDescriptionTitle] = useState('');
-  const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
   const [endpoints, setEndpoints] = useState<string[]>([]);
@@ -662,13 +658,14 @@ const LoginView: React.FC = () => {
     connectionMode,
   });
 
-  const changeSigninMode = useCallback(() => {
-    if (!loginConfig.change_signin_support) return;
-    const newMode: ConnectionMode =
-      connectionMode === 'SESSION' ? 'API' : 'SESSION';
-    setConnectionMode(newMode);
-    localStorage.setItem('backendaiwebui.connection_mode', newMode);
-  }, [connectionMode, loginConfig.change_signin_support]);
+  const handleConnectionModeChange = useCallback(
+    (mode: ConnectionMode) => {
+      if (!loginConfig.change_signin_support) return;
+      setConnectionMode(mode);
+      localStorage.setItem('backendaiwebui.connection_mode', mode);
+    },
+    [loginConfig.change_signin_support],
+  );
 
   const showSignupDialog = useCallback(
     (preloadToken?: string) => {
@@ -740,12 +737,6 @@ const LoginView: React.FC = () => {
     [handleLogin],
   );
 
-  const showEndpointDescription = useCallback(() => {
-    setHelpDescriptionTitle(t('login.EndpointInfo'));
-    setHelpDescription(t('login.DescEndpoint'));
-    setIsHelpOpen(true);
-  }, [t]);
-
   const handleSAMLLogin = useCallback(() => {
     const ep = apiEndpoint.trim();
     const { client } = createBackendAIClient('', '', ep, 'SESSION');
@@ -792,9 +783,8 @@ const LoginView: React.FC = () => {
         onEndpointMenuClick={handleEndpointMenuClick}
         onKeyDown={handleKeyDown}
         onLogin={handleLogin}
-        onChangeSigninMode={changeSigninMode}
+        onConnectionModeChange={handleConnectionModeChange}
         onShowSignupDialog={showSignupDialog}
-        onShowEndpointDescription={showEndpointDescription}
         onSAMLLogin={handleSAMLLogin}
         onOpenIDLogin={handleOpenIDLogin}
         onSetApiEndpoint={setApiEndpoint}
@@ -828,27 +818,6 @@ const LoginView: React.FC = () => {
           {blockMessage}
         </div>
       </BAIModal>
-
-      {/* Help Description - zIndex above login modal */}
-      <Modal
-        open={isHelpOpen}
-        title={helpDescriptionTitle}
-        onCancel={() => setIsHelpOpen(false)}
-        footer={null}
-        width={350}
-        zIndex={1050}
-        getContainer={false}
-      >
-        <div
-          style={{
-            fontSize: 14,
-            margin: 10,
-          }}
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(helpDescription),
-          }}
-        />
-      </Modal>
     </div>
   );
 };

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1015,6 +1015,8 @@
   "login": {
     "APIEndpointEmpty": "API-Endpunkt ist leer. Bitte geben Sie den API-Endpunkt für die Anmeldung an.",
     "APIKey": "API-Schlüssel",
+    "APIMode": "API",
+    "AdvancedSettings": "Erweitert",
     "CancelLogin": "Anmeldung abbrechen",
     "ChangePassword": "Kennwort ändern",
     "ClickToUseIAM": "Klicken Sie hier, um IAM zu verwenden",
@@ -1046,6 +1048,7 @@
     "PleaseWait": "Bitte warten Sie, um sich anzumelden.",
     "SecretKey": "Geheimer Schlüssel",
     "SendChangePasswordEmail": "E-Mail zum Ändern des Passworts senden",
+    "SessionMode": "Sitzung",
     "SignUp": "Anmelden",
     "SignoutFinished": "Abmeldung abgeschlossen.",
     "TooManyAttempt": "Es gab zu viele Anmeldeversuche. Anmeldeversuche sind seit einiger Zeit blockiert.",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1010,6 +1010,8 @@
   "login": {
     "APIEndpointEmpty": "Το API Endpoint είναι κενό. Προσδιορίστε το τελικό σημείο API για σύνδεση.",
     "APIKey": "Κλειδί API",
+    "APIMode": "API",
+    "AdvancedSettings": "Σύνθετες ρυθμίσεις",
     "CancelLogin": "Ακύρωση σύνδεσης",
     "ChangePassword": "Αλλαξε κωδικό",
     "ClickToUseIAM": "Κάντε κλικ για να χρησιμοποιήσετε το IAM",
@@ -1041,6 +1043,7 @@
     "PleaseWait": "Περιμένετε να συνδεθείτε.",
     "SecretKey": "Μυστικό κλειδί",
     "SendChangePasswordEmail": "Αποστολή email αλλαγής κωδικού πρόσβασης",
+    "SessionMode": "Συνεδρία",
     "SignUp": "Εγγραφείτε",
     "SignoutFinished": "Η έξοδος ολοκληρώθηκε.",
     "TooManyAttempt": "Υπήρξαν πάρα πολλές προσπάθειες σύνδεσης. Οι προσπάθειες σύνδεσης έχουν αποκλειστεί για λίγο.",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1019,6 +1019,8 @@
   "login": {
     "APIEndpointEmpty": "API Endpoint is empty. Please specify API endpoint to login.",
     "APIKey": "API Key",
+    "APIMode": "API",
+    "AdvancedSettings": "Advanced",
     "CancelLogin": "Cancel Login",
     "ChangePassword": "Change",
     "ClickToUseIAM": "Click To Use IAM",
@@ -1050,6 +1052,7 @@
     "PleaseWait": "Please wait to login.",
     "SecretKey": "Secret Key",
     "SendChangePasswordEmail": "Send change password email",
+    "SessionMode": "Session",
     "SignUp": "Sign up",
     "SignoutFinished": "Signout finished.",
     "TooManyAttempt": "There were too many login attempts. Login attempts have been blocked for a while.",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1013,6 +1013,8 @@
   "login": {
     "APIEndpointEmpty": "El punto final de la API está vacío. Especifique el punto final de la API para iniciar sesión.",
     "APIKey": "Clave API",
+    "APIMode": "API",
+    "AdvancedSettings": "Avanzado",
     "CancelLogin": "Cancelar conexión",
     "ChangePassword": "Cambiar contraseña",
     "ClickToUseIAM": "Haga clic para utilizar IAM",
@@ -1044,6 +1046,7 @@
     "PleaseWait": "Espere para iniciar sesión.",
     "SecretKey": "Clave secreta",
     "SendChangePasswordEmail": "Enviar correo electrónico de cambio de contraseña",
+    "SessionMode": "Sesión",
     "SignUp": "Inscríbete",
     "SignoutFinished": "Firma terminada.",
     "TooManyAttempt": "Ha habido demasiados intentos de inicio de sesión. Los intentos de inicio de sesión se han bloqueado durante un tiempo.",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1013,6 +1013,8 @@
   "login": {
     "APIEndpointEmpty": "API-päätepiste on tyhjä. Määritä API-päätepiste kirjautumista varten.",
     "APIKey": "API-avain",
+    "APIMode": "API",
+    "AdvancedSettings": "Lisäasetukset",
     "CancelLogin": "Peruuta kirjautuminen",
     "ChangePassword": "Vaihda salasana",
     "ClickToUseIAM": "Klikkaa käyttääksesi IAM:ää",
@@ -1044,6 +1046,7 @@
     "PleaseWait": "Odota kirjautumista.",
     "SecretKey": "Salainen avain",
     "SendChangePasswordEmail": "Lähetä sähköpostiviesti salasanan vaihtamisesta",
+    "SessionMode": "Istunto",
     "SignUp": "Rekisteröidy",
     "SignoutFinished": "Kirjautuminen päättyi.",
     "TooManyAttempt": "Kirjautumisyrityksiä oli liikaa. Kirjautumisyritykset on estetty jonkin aikaa.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1013,6 +1013,8 @@
   "login": {
     "APIEndpointEmpty": "Le point de terminaison de l'API est vide. Veuillez spécifier le point de terminaison de l'API pour vous connecter.",
     "APIKey": "clé API",
+    "APIMode": "API",
+    "AdvancedSettings": "Avancé",
     "CancelLogin": "Annuler Connexion",
     "ChangePassword": "Changer le mot de passe",
     "ClickToUseIAM": "Cliquez pour utiliser IAM",
@@ -1044,6 +1046,7 @@
     "PleaseWait": "Veuillez patienter pour vous connecter.",
     "SecretKey": "Clef secrète",
     "SendChangePasswordEmail": "Envoyer un e-mail de changement de mot de passe",
+    "SessionMode": "Session",
     "SignUp": "S'inscrire",
     "SignoutFinished": "Déconnexion terminée.",
     "TooManyAttempt": "Il y a eu trop de tentatives de connexion. Les tentatives de connexion sont bloquées depuis un certain temps.",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1014,6 +1014,8 @@
   "login": {
     "APIEndpointEmpty": "Titik Akhir API kosong. Harap tentukan titik akhir API untuk login.",
     "APIKey": "Kunci API",
+    "APIMode": "API",
+    "AdvancedSettings": "Lanjutan",
     "CancelLogin": "Batal Login",
     "ChangePassword": "Ganti kata sandi",
     "ClickToUseIAM": "Klik untuk Menggunakan IAM",
@@ -1045,6 +1047,7 @@
     "PleaseWait": "Harap tunggu untuk login.",
     "SecretKey": "Kunci rahasia",
     "SendChangePasswordEmail": "Kirim email ubah kata sandi",
+    "SessionMode": "Sesi",
     "SignUp": "Daftar",
     "SignoutFinished": "Keluar selesai.",
     "TooManyAttempt": "Ada terlalu banyak upaya login. Upaya login telah diblokir untuk sementara waktu.",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1012,6 +1012,8 @@
   "login": {
     "APIEndpointEmpty": "L'endpoint API è vuoto. Specifica l'endpoint API per accedere.",
     "APIKey": "Chiave API",
+    "APIMode": "API",
+    "AdvancedSettings": "Avanzato",
     "CancelLogin": "Annulla il login",
     "ChangePassword": "Cambia la password",
     "ClickToUseIAM": "Fai clic per utilizzare IAM",
@@ -1043,6 +1045,7 @@
     "PleaseWait": "Attendi per accedere.",
     "SecretKey": "Chiave segreta",
     "SendChangePasswordEmail": "Invia email di modifica password",
+    "SessionMode": "Sessione",
     "SignUp": "Iscriviti",
     "SignoutFinished": "Disconnessione completata.",
     "TooManyAttempt": "Ci sono stati troppi tentativi di accesso. I tentativi di accesso sono stati bloccati per un po'.",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1014,6 +1014,8 @@
   "login": {
     "APIEndpointEmpty": "APIエンドポイントが空です。ログインするAPIエンドポイントを指定してください。",
     "APIKey": "APIキー",
+    "APIMode": "API",
+    "AdvancedSettings": "詳細設定",
     "CancelLogin": "ログインをキャンセルする",
     "ChangePassword": "パスワードを変更する",
     "ClickToUseIAM": "クリックしてIAMを使用する",
@@ -1045,6 +1047,7 @@
     "PleaseWait": "ログインするまでお待ちください。",
     "SecretKey": "シークレットキー",
     "SendChangePasswordEmail": "パスワード変更メールを送信する",
+    "SessionMode": "セッション",
     "SignUp": "サインアップ",
     "SignoutFinished": "サインアウトが終了しました。",
     "TooManyAttempt": "ログインの試行回数が多すぎました。ログインの試行はしばらくの間ブロックされています。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1017,6 +1017,8 @@
   "login": {
     "APIEndpointEmpty": "API Endpoint 가 지정되지 않았습니다. 로그인을 위해 앤드포인트를 지정하세요.",
     "APIKey": "접근키",
+    "APIMode": "API",
+    "AdvancedSettings": "고급 설정",
     "CancelLogin": "로그인 취소",
     "ChangePassword": "비밀번호 재설정",
     "ClickToUseIAM": "IAM 사용",
@@ -1048,6 +1050,7 @@
     "PleaseWait": "로그인하고 있습니다. 잠시만 기다려주세요.",
     "SecretKey": "비밀키",
     "SendChangePasswordEmail": "비밀번호 재설정 이메일 보내기",
+    "SessionMode": "세션",
     "SignUp": "가입하기",
     "SignoutFinished": "탈퇴가 완료되었습니다.",
     "TooManyAttempt": "너무 많은 로그인 시도가 있었습니다. 잠시동안 로그인 시도가 차단되었습니다.",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -993,6 +993,8 @@
   "login": {
     "APIEndpointEmpty": "API Төгсгөлийн цэг хоосон байна. Нэвтрэхийн тулд API төгсгөлийн цэгийг зааж өгнө үү.",
     "APIKey": "API түлхүүр",
+    "APIMode": "API",
+    "AdvancedSettings": "Нарийвчилсан",
     "CancelLogin": "Нэвтрэхийг цуцлах",
     "ChangePassword": "Нууц үгээ солих",
     "ClickToUseIAM": "IAM ашиглахын тулд товшино уу",
@@ -1024,6 +1026,7 @@
     "PleaseWait": "Нэвтрэхийг хүлээнэ үү.",
     "SecretKey": "Нууц түлхүүр",
     "SendChangePasswordEmail": "Өөрчлөлтийн нууц үгийг имэйлээр илгээх",
+    "SessionMode": "Сессион",
     "SignUp": "Бүртгүүлэх",
     "SignoutFinished": "Бүртгэл дууслаа.",
     "TooManyAttempt": "Хэт олон нэвтрэх оролдлого хийсэн. Нэвтрэх оролдлогыг хэсэг хугацаанд хаасан байна.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1012,6 +1012,8 @@
   "login": {
     "APIEndpointEmpty": "Titik Akhir API kosong. Sila nyatakan titik akhir API untuk log masuk.",
     "APIKey": "Kunci API",
+    "APIMode": "API",
+    "AdvancedSettings": "Lanjutan",
     "CancelLogin": "Batal Log Masuk",
     "ChangePassword": "Tukar kata laluan",
     "ClickToUseIAM": "Klik Untuk Menggunakan IAM",
@@ -1043,6 +1045,7 @@
     "PleaseWait": "Sila tunggu untuk log masuk.",
     "SecretKey": "Kunci Rahsia",
     "SendChangePasswordEmail": "Hantar e-mel kata laluan perubahan",
+    "SessionMode": "Sesi",
     "SignUp": "Mendaftar",
     "SignoutFinished": "Log keluar selesai.",
     "TooManyAttempt": "Terlalu banyak percubaan log masuk. Percubaan masuk telah disekat sebentar.",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1012,6 +1012,8 @@
   "login": {
     "APIEndpointEmpty": "Punkt końcowy interfejsu API jest pusty. Określ punkt końcowy interfejsu API, aby się zalogować.",
     "APIKey": "Klucz API",
+    "APIMode": "API",
+    "AdvancedSettings": "Zaawansowane",
     "CancelLogin": "Anuluj logowanie",
     "ChangePassword": "Zmień hasło",
     "ClickToUseIAM": "Kliknij, aby użyć uprawnień",
@@ -1043,6 +1045,7 @@
     "PleaseWait": "Proszę czekać na zalogowanie.",
     "SecretKey": "Sekretny klucz",
     "SendChangePasswordEmail": "Wyślij e-mail ze zmianą hasła",
+    "SessionMode": "Sesja",
     "SignUp": "Zapisz się",
     "SignoutFinished": "Wylogowanie zakończone.",
     "TooManyAttempt": "Zbyt wiele prób logowania. Próby logowania zostały na jakiś czas zablokowane.",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1013,6 +1013,8 @@
   "login": {
     "APIEndpointEmpty": "O endpoint da API está vazio. Especifique o endpoint da API para fazer o login.",
     "APIKey": "Chave API",
+    "APIMode": "API",
+    "AdvancedSettings": "Avançado",
     "CancelLogin": "Cancelar Login",
     "ChangePassword": "Alterar a senha",
     "ClickToUseIAM": "Clique para usar IAM",
@@ -1044,6 +1046,7 @@
     "PleaseWait": "Por favor, espere para fazer o login.",
     "SecretKey": "Chave secreta",
     "SendChangePasswordEmail": "Enviar email de alteração de senha",
+    "SessionMode": "Sessão",
     "SignUp": "Inscrever-se",
     "SignoutFinished": "Desconexão concluída.",
     "TooManyAttempt": "Houve muitas tentativas de login. As tentativas de login foram bloqueadas por um tempo.",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1015,6 +1015,8 @@
   "login": {
     "APIEndpointEmpty": "O endpoint da API está vazio. Especifique o endpoint da API para fazer o login.",
     "APIKey": "Chave API",
+    "APIMode": "API",
+    "AdvancedSettings": "Avançado",
     "CancelLogin": "Cancelar Login",
     "ChangePassword": "Alterar a senha",
     "ClickToUseIAM": "Clique para usar IAM",
@@ -1046,6 +1048,7 @@
     "PleaseWait": "Por favor, espere para fazer o login.",
     "SecretKey": "Chave secreta",
     "SendChangePasswordEmail": "Enviar e-mail para alterar a senha",
+    "SessionMode": "Sessão",
     "SignUp": "Inscrever-se",
     "SignoutFinished": "Desconexão concluída.",
     "TooManyAttempt": "Houve muitas tentativas de login. As tentativas de login foram bloqueadas por um tempo.",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1012,6 +1012,8 @@
   "login": {
     "APIEndpointEmpty": "Конечная точка API пуста. Укажите конечную точку API для входа.",
     "APIKey": "Ключ API",
+    "APIMode": "API",
+    "AdvancedSettings": "Дополнительно",
     "CancelLogin": "Отменить Вход",
     "ChangePassword": "Измени пароль",
     "ClickToUseIAM": "Нажмите, чтобы использовать IAM",
@@ -1043,6 +1045,7 @@
     "PleaseWait": "Подождите, пока вы войдете.",
     "SecretKey": "Секретный ключ",
     "SendChangePasswordEmail": "Отправить электронное письмо для смены пароля",
+    "SessionMode": "Сессия",
     "SignUp": "Зарегистрироваться",
     "SignoutFinished": "Выход завершен.",
     "TooManyAttempt": "Слишком много попыток входа в систему. Попытки входа в систему на время заблокированы.",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1004,6 +1004,8 @@
   "login": {
     "APIEndpointEmpty": "จุดสิ้นสุด API ว่างเปล่า กรุณาระบุจุดสิ้นสุด API เพื่อเข้าสู่ระบบ",
     "APIKey": "คีย์ API",
+    "APIMode": "API",
+    "AdvancedSettings": "ขั้นสูง",
     "CancelLogin": "ยกเลิกการเข้าสู่ระบบ",
     "ChangePassword": "เปลี่ยน",
     "ClickToUseIAM": "คลิกเพื่อใช้ IAM",
@@ -1035,6 +1037,7 @@
     "PleaseWait": "กรุณารอเพื่อเข้าสู่ระบบ",
     "SecretKey": "คีย์ลับ",
     "SendChangePasswordEmail": "ส่งอีเมลเปลี่ยนรหัสผ่าน",
+    "SessionMode": "เซสชัน",
     "SignUp": "ลงทะเบียน",
     "SignoutFinished": "ออกจากระบบเสร็จสิ้น",
     "TooManyAttempt": "มีความพยายามเข้าสู่ระบบมากเกินไป การพยายามเข้าสู่ระบบถูกบล็อกชั่วคราว",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1013,6 +1013,8 @@
   "login": {
     "APIEndpointEmpty": "API Uç Noktası boş. Lütfen oturum açmak için API uç noktasını belirtin.",
     "APIKey": "API Anahtarı",
+    "APIMode": "API",
+    "AdvancedSettings": "Gelişmiş",
     "CancelLogin": "Girişi İptal Et",
     "ChangePassword": "Şifre değiştir",
     "ClickToUseIAM": "IAM'yi Kullanmak İçin Tıklayın",
@@ -1044,6 +1046,7 @@
     "PleaseWait": "Giriş yapmak için lütfen bekleyiniz.",
     "SecretKey": "Gizli anahtar",
     "SendChangePasswordEmail": "Şifre değiştirme e-postası gönder",
+    "SessionMode": "Oturum",
     "SignUp": "kaydol",
     "SignoutFinished": "Oturum kapatma işlemi tamamlandı.",
     "TooManyAttempt": "Çok fazla giriş denemesi oldu. Giriş denemeleri bir süreliğine engellendi.",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1015,6 +1015,8 @@
   "login": {
     "APIEndpointEmpty": "Điểm cuối API trống. Vui lòng chỉ định điểm cuối API để đăng nhập.",
     "APIKey": "Mã API",
+    "APIMode": "API",
+    "AdvancedSettings": "Nâng cao",
     "CancelLogin": "Hủy đăng nhập",
     "ChangePassword": "Đổi mật khẩu",
     "ClickToUseIAM": "Nhấp để sử dụng IAM",
@@ -1046,6 +1048,7 @@
     "PleaseWait": "Vui lòng đợi để đăng nhập.",
     "SecretKey": "Chìa khoá bí mật",
     "SendChangePasswordEmail": "Gửi email thay đổi mật khẩu",
+    "SessionMode": "Phiên",
     "SignUp": "Đăng ký",
     "SignoutFinished": "Đã kết thúc đăng ký.",
     "TooManyAttempt": "Đã có quá nhiều lần đăng nhập. Nỗ lực đăng nhập đã bị chặn trong một thời gian.",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1015,6 +1015,8 @@
   "login": {
     "APIEndpointEmpty": "API 端点为空。请指定要登录的 API 端点。",
     "APIKey": "API 密钥",
+    "APIMode": "API",
+    "AdvancedSettings": "高级设置",
     "CancelLogin": "取消登录",
     "ChangePassword": "更改密码",
     "ClickToUseIAM": "单击以使用 IAM",
@@ -1046,6 +1048,7 @@
     "PleaseWait": "请等待登录。",
     "SecretKey": "密钥",
     "SendChangePasswordEmail": "发送修改密码邮件",
+    "SessionMode": "会话",
     "SignUp": "注册",
     "SignoutFinished": "注销完毕。",
     "TooManyAttempt": "登录尝试次数过多。登录尝试已被阻止一段时间。",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1014,6 +1014,8 @@
   "login": {
     "APIEndpointEmpty": "API 端點為空。請指定要登錄的 API 端點。",
     "APIKey": "API 密鑰",
+    "APIMode": "API",
+    "AdvancedSettings": "進階設定",
     "CancelLogin": "取消登錄",
     "ChangePassword": "更改密碼",
     "ClickToUseIAM": "單擊以使用 IAM",
@@ -1045,6 +1047,7 @@
     "PleaseWait": "請等待登錄。",
     "SecretKey": "密鑰",
     "SendChangePasswordEmail": "發送修改密碼郵件",
+    "SessionMode": "工作階段",
     "SignUp": "註冊",
     "SignoutFinished": "註銷完畢。",
     "TooManyAttempt": "登錄嘗試次數過多。登錄嘗試已被阻止一段時間。",


### PR DESCRIPTION
## Summary

- Replace login panel mode switching (title + button) with Ant Design `Segmented` control (Session / API)
- Center the Backend.AI logo above the modal border line in the header area
- Unify modal padding using design tokens instead of per-section hardcoded values
- Move endpoint field into a collapsible "Advanced" section with chevron toggle
- Convert bottom signup/password links from stacked description+button to inline text links
- Show endpoint info and password reset help as a side panel to the right of the login modal instead of a separate overlay modal
- Remove loading Spin overlay (login button already has `loading` prop)
- Replace old WebUI screenshot background image in LoadingCurtain with solid theme color
- Remove unused `web-animations-js` dependency from lockfile
- Add i18n keys (`login.SessionMode`, `login.APIMode`, `login.AdvancedSettings`) to all 21 language files

## Test plan

- [ ] Verify login panel renders correctly in SESSION mode with email/password fields
- [ ] Verify switching to API mode via Segmented control shows API Key/Secret Key fields
- [ ] Verify Segmented control is hidden when `change_signin_support` is disabled
- [ ] Verify "Advanced" section expands/collapses and auto-expands when endpoint is empty
- [ ] Verify clicking the endpoint info icon shows the help side panel to the right of the modal
- [ ] Verify clicking "비밀번호 재설정" shows the change password help in the side panel
- [ ] Verify bottom links (signup, password reset) render on one line and are clickable
- [ ] Verify loading curtain shows solid background instead of old screenshot image
- [ ] Verify SSO buttons (SAML/OpenID) still render when configured
- [ ] Verify OTP field appears when 2FA is required