### PR TITLE
refactor: remove unused loading background image from initial load

### DIFF
--- a/react/src/components/LoadingCurtain.test.tsx
+++ b/react/src/components/LoadingCurtain.test.tsx
@@ -51,19 +51,6 @@ describe('LoadingCurtain', () => {
     expect(curtain?.className).toContain('visuallyHidden');
   });
 
-  it('removes background image from body when backend-ai-connected fires', () => {
-    document.body.style.backgroundImage =
-      'url(/resources/images/loading-background-large.jpg)';
-
-    render(<LoadingCurtain />);
-
-    act(() => {
-      document.dispatchEvent(new CustomEvent('backend-ai-connected'));
-    });
-
-    expect(document.body.style.backgroundImage).toBe('none');
-  });
-
   it('does not apply visually hidden styles before backend-ai-connected event', () => {
     render(<LoadingCurtain />);
 

--- a/react/src/components/LoadingCurtain.tsx
+++ b/react/src/components/LoadingCurtain.tsx
@@ -49,8 +49,6 @@ const LoadingCurtain: React.FC = () => {
 
   useEffect(() => {
     const handleConnected = () => {
-      // Remove background image from body (previously done in Lit shell refreshPage())
-      document.body.style.backgroundImage = 'none';
       // Start fade-out transition
       setIsVisuallyHidden(true);
     };

--- a/resources/webui.css
+++ b/resources/webui.css
@@ -6,34 +6,12 @@ body {
   --lumo-primary-text-color: var(--token-colorPrimary, #27824F);
   --lumo-primary-color-50pct: var(--token-colorPrimary, #27824F);
   background-color: var(--token-colorBgBase, rgba(247, 247, 246, 1));
-  /* background-image: url("images/loading-background-large.jpg");
-  background-repeat: no-repeat;
-  background-attachment: fixed;
-  background-position: top left; */
 }
 
 body.dark-theme {
   background-color: #191919;
-  --theme-image-filter: brightness(0.15);
 }
 
-body::before {
-  content: "";
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  background-image: url("images/loading-background-large.jpg");
-  z-index: -1;
-  background-repeat: no-repeat;
-  background-attachment: fixed;
-  background-position: top left;
-}
-
-body.dark-theme::before {
-  filter: var(--theme-image-filter)
-}
 
 .splash {
   position: absolute;


### PR DESCRIPTION
## Summary

- Remove `body::before` pseudo-element that displayed `loading-background-large.jpg` during page load, which caused a brief visual flash before being hidden behind the app
- Remove the related `--theme-image-filter` dark-theme variable and commented-out body background-image CSS
- Remove the now-unnecessary `document.body.style.backgroundImage = 'none'` reset in `LoadingCurtain` component and its associated test case

The image file itself is preserved as it is still used by `resources/templates/under_construction.html`.

## Test plan

- [ ] Verify initial page load no longer flashes a background image
- [ ] Verify dark mode initial load works correctly without the image
- [ ] Verify the loading curtain fade-out transition still works properly
- [ ] Verify the under_construction page still displays the background image