### PR TITLE
fix: resolve session loss on page refresh due to endpoint state race condition

### DIFF
--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -284,8 +284,8 @@ const LoginView: React.FC = () => {
   );
 
   const connectUsingSession = useCallback(
-    async (showError = true) => {
-      const ep = apiEndpoint.trim();
+    async (showError = true, endpointOverride?: string) => {
+      const ep = (endpointOverride ?? apiEndpoint).trim();
       if (ep === '') {
         setIsBlockPanelOpen(false);
         open();
@@ -459,8 +459,8 @@ const LoginView: React.FC = () => {
   );
 
   const connectUsingAPI = useCallback(
-    async (_showError = true) => {
-      const ep = apiEndpoint.trim();
+    async (_showError = true, endpointOverride?: string) => {
+      const ep = (endpointOverride ?? apiEndpoint).trim();
       const apiKey = form.getFieldValue('api_key') || '';
       const secretKey = form.getFieldValue('secret_key') || '';
 
@@ -600,9 +600,9 @@ const LoginView: React.FC = () => {
         if ((globalThis as Record<string, unknown>).isElectron) {
           await loadConfigFromWebServer(ep);
         }
-        await connectUsingSession(showError);
+        await connectUsingSession(showError, ep);
       } else if (connectionMode === 'API') {
-        await connectUsingAPI(showError);
+        await connectUsingAPI(showError, ep);
       } else {
         open();
       }


### PR DESCRIPTION
## Summary

- Fix login session being lost on page refresh caused by a race condition between `resolveEndpoint()` async setState and `connectUsingSession()` reading the stale (empty) `apiEndpoint` state from its closure
- Add `endpointOverride` parameter to `connectUsingSession` and `connectUsingAPI` so the `login` function can pass the synchronously resolved endpoint directly, bypassing the async state update timing issue

## Test plan

- [ ] Log in to the WebUI, then refresh the page — session should be preserved
- [ ] Verify login works normally with both SESSION and API connection modes
- [ ] Verify Electron app login persistence on refresh
- [ ] Verify that manually entering an endpoint and logging in still works correctly