### PR TITLE
fix(FR-2087): fix subscription re-subscription loop in session status refresher

### DIFF
--- a/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
+++ b/react/src/components/BAIComputeSessionNodeNotificationItem.tsx
@@ -154,6 +154,7 @@ const UNSAFE_useAutoRefreshInterval = (
 const SessionStatusRefresherUsingSubscription: React.FC<{
   sessionRowId: string;
 }> = ({ sessionRowId }) => {
+  'use memo';
   useSubscription({
     subscription: graphql`
       subscription BAIComputeSessionNodeNotificationItemSubscription(


### PR DESCRIPTION
Resolves [FR-2087](https://lablup.atlassian.net/browse/FR-2087)

## Summary
- Added `'use memo'` directive to `SessionStatusRefresherUsingSubscription` component
- Prevents subscription re-creation loop caused by unstable config object reference
- Follows Relay's recommended pattern for components using `useSubscription`

## Technical Details

The `useSubscription` hook in Relay uses reference comparison for its config object. When the config is recreated on every render (as an inline object), it triggers:
1. Dispose of old subscription
2. Create new subscription
3. Receive data → update store → component re-renders
4. Repeat from step 1 → infinite loop

Adding `'use memo'` directive optimizes the component and stabilizes its references, preventing this loop.

## Test plan
- [ ] Verify session status updates work correctly
- [ ] Check browser network tab - should see single subscription connection, not repeated re-subscriptions
- [ ] Confirm no console errors related to subscriptions

[FR-2087]: https://lablup.atlassian.net/browse/FR-2087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ