### PR TITLE
chore: remove Lit-Element references from documentation

### DIFF
--- a/.claude/commands/fill-out-i18n.md
+++ b/.claude/commands/fill-out-i18n.md
@@ -25,8 +25,8 @@ High-performance auto-translation of missing i18n keys using Claude AI for Backe
 This command uses **Claude AI for high-quality translation** combined with **fast JSON processing** to efficiently detect and translate missing i18n keys. It leverages `jq` for rapid JSON operations with minimal overhead.
 
 Backend.AI WebUI supports two i18n systems:
-- **Main project**: `/resources/i18n/` - Legacy Lit-Element components
-- **React components**: `/packages/backend.ai-ui/src/locale/` - Modern React components
+- **Main project**: `/resources/i18n/` - Main WebUI translations
+- **Component library**: `/packages/backend.ai-ui/src/locale/` - Shared UI component translations
 
 ### Supported Languages
 `de`, `el`, `es`, `fi`, `fr`, `id`, `it`, `ja`, `ko`, `mn`, `ms`, `pl`, `pt-BR`, `pt`, `ru`, `th`, `tr`, `vi`, `zh-CN`, `zh-TW`

--- a/.claude/skills/backend-ai-guide/common-questions.md
+++ b/.claude/skills/backend-ai-guide/common-questions.md
@@ -88,7 +88,7 @@ It's named after the warehouse keeper puzzle game (Sokoban), reflecting its role
 
 **Connection Flow**:
 ```
-WebUI Code (React/Lit) → API Calls → Manager API → Backend Operations
+WebUI Code (React) → API Calls → Manager API → Backend Operations
 ```
 
 ---
@@ -483,38 +483,13 @@ curl -X POST http://localhost:8090/admin/graphql \
 
 ## WebUI-Specific Questions
 
-### Q: What's the difference between React and Lit-Element code in this WebUI?
-
-**A**: This WebUI is a **hybrid architecture**:
-
-**Lit-Element (`/src`)**:
-- Legacy web components
-- Material Web Components
-- Older features and pages
-
-**React (`/react`)**:
-- Modern UI components
-- Ant Design + Relay (GraphQL)
-- New features and pages
-
-**Integration**: Both coexist, gradually migrating from Lit to React.
-
----
-
 ### Q: How does the WebUI handle state management?
 
-**A**: Different strategies for different frameworks:
+**A**: The WebUI uses a layered state management approach:
 
-**React Components**:
-- **Relay** for GraphQL-backed state
-- **Recoil** for global client state
-- **React hooks** for local state
-
-**Lit-Element Components**:
-- **Redux** for global state
-- Component properties for local state
-
-**Recommendation**: New features should use React + Relay + Recoil pattern.
+- **Relay** for GraphQL-backed server state
+- **Jotai** for global client state (atomic state management)
+- **React hooks** (`useState`, `useReducer`) for local component state
 
 ---
 

--- a/.claude/skills/backend-ai-guide/examples/webui-integration-example.md
+++ b/.claude/skills/backend-ai-guide/examples/webui-integration-example.md
@@ -9,7 +9,7 @@
 
 ### Backend.AI WebUI Integration Architecture
 
-The **Backend.AI WebUI** (this project) is a **client application** that communicates with the Backend.AI backend platform through well-defined APIs. It's a hybrid Single Page Application (SPA) using both Lit-Element and React frameworks.
+The **Backend.AI WebUI** (this project) is a **client application** that communicates with the Backend.AI backend platform through well-defined APIs. It's a Single Page Application (SPA) built with React.
 
 ---
 
@@ -19,7 +19,6 @@ The **Backend.AI WebUI** (this project) is a **client application** that communi
 ┌─────────────────────────────────────────────┐
 │  Backend.AI WebUI (this project)            │
 │  - React components (/react)                │
-│  - Lit-Element components (/src)            │
 │  - Ant Design + Relay (GraphQL)             │
 └──────────────────┬──────────────────────────┘
                    │
@@ -214,16 +213,15 @@ fetch('/session', {
 
 ### Framework Architecture
 ```
-Backend.AI WebUI (Hybrid)
+Backend.AI WebUI
 ├── React Components (/react)
 │   ├── Ant Design UI Library
 │   ├── Relay (GraphQL Client)
-│   ├── Recoil (Global State)
-│   └── Modern features (new development)
-└── Lit-Element Components (/src)
-    ├── Material Web Components
-    ├── Redux (Legacy State)
-    └── Legacy features (maintenance mode)
+│   ├── Jotai (Global State)
+│   └── All features and pages
+└── Shared Component Library (/packages/backend.ai-ui)
+    ├── BAI* components
+    └── Vite build
 ```
 
 ### React + Relay Pattern (Preferred)
@@ -426,18 +424,22 @@ const client = new BackendAIClient({
 
 ```
 backend.ai-webui/
-├── react/                    # React components (modern)
+├── react/                    # Main React application
 │   ├── src/
 │   │   ├── components/       # UI components
+│   │   ├── pages/            # Page-level components
 │   │   ├── hooks/            # Custom React hooks
 │   │   ├── __generated__/    # Relay generated files
 │   │   └── App.tsx           # Main React app
-│   └── relay.config.js       # Relay compiler config
+│   └── craco.config.cjs      # Webpack customization
 │
-├── src/                      # Lit-Element components (legacy)
-│   ├── components/           # Web components
-│   ├── lib/                  # Shared libraries
-│   └── backend-ai-client.ts  # API client implementation
+├── packages/
+│   ├── backend.ai-ui/        # Shared component library (Vite)
+│   └── backend.ai-webui-docs/# User manual documentation
+│
+├── src/                      # Utilities and websocket proxy
+│   ├── lib/                  # Backend.AI client library
+│   └── wsproxy/              # WebSocket proxy for desktop app
 │
 └── resources/
     ├── config.toml.sample    # Configuration template
@@ -490,11 +492,11 @@ curl -X POST http://localhost:8090/admin/graphql \
 ## Summary: WebUI-Backend Communication
 
 **Key Points**:
-✅ **Hybrid Architecture**: React (modern) + Lit-Element (legacy)
+✅ **React Architecture**: React 19 + Ant Design 6 + Relay 20
 ✅ **Dual API Support**: REST for operations, GraphQL for queries
 ✅ **Authentication**: JWT tokens or signed requests
 ✅ **Hosted by**: Backend.AI Webserver component
-✅ **State Management**: Relay (GraphQL) + Recoil (global) for React
+✅ **State Management**: Relay (GraphQL) + Jotai (global client state)
 ✅ **Real-time Updates**: WebSocket connections for live data
 ✅ **Service Access**: App Proxy routes to in-container services
 ✅ **File Operations**: Storage Proxy handles vfolder operations

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,6 @@ This file provides custom instructions for GitHub Copilot when reviewing code an
 ## Project Overview
 
 Backend.AI WebUI is a **React web application** using React 19 + Ant Design 6 + Relay 20 (GraphQL).
-The legacy Lit-Element web components have been removed.
 
 ### Key Technologies
 
@@ -58,7 +57,7 @@ The legacy Lit-Element web components have been removed.
 When reviewing code:
 
 - All UI code is in `/react` (React) and `/packages/backend.ai-ui/` (shared components)
-- `/src` contains only legacy utilities and the websocket proxy
+- `/src` contains utilities and the websocket proxy
 - Check that GraphQL queries use Relay conventions in React components
 - Verify proper i18n usage with `useTranslation()` hook from `react-i18next`
 

--- a/.github/instructions/i18n.instructions.md
+++ b/.github/instructions/i18n.instructions.md
@@ -23,9 +23,9 @@ These instructions ensure proper internationalization practices across the Backe
 <span>{t('message.loadingData')}</span>
 ```
 
-## Translation Functions by Framework
+## Translation Functions
 
-### React Components (`/react`)
+### React Components
 Use React i18n hooks and functions:
 
 ```typescript
@@ -41,23 +41,6 @@ const MyComponent = () => {
     </div>
   );
 };
-```
-
-### Lit-Element Components (`/src`)
-Use `lit-translate` functions:
-
-```typescript
-import { translate as _t, get as _text } from 'lit-translate';
-
-render() {
-  return html`
-    <h1>${_t('summary.title')}</h1>
-    <mwc-button label="${_text('button.submit')}"></mwc-button>
-  `;
-}
-
-// In TypeScript code
-const message = _text('error.connectionFailed');
 ```
 
 ## Translation Key Structures
@@ -246,8 +229,7 @@ t('general.NSelected', { count: selectedItems.length })
 ```
 
 ### Common Placeholder Formats
-- React/Modern: `{{variable}}`, `{variable}`
-- Legacy: `{0}`, `{1}`, `%s`, `%d`
+- `{{variable}}`, `{variable}`
 
 ## Code Review Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Architecture
 
 This is a **React web application** using React 19 + Ant Design 6 + Relay 20 (GraphQL).
-The legacy Lit-Element web components have been removed.
 
 ### Key Technologies
 
@@ -72,7 +71,7 @@ packages/               # Monorepo workspace packages
   backend.ai-ui/        # Shared React component library (Vite build)
   backend.ai-webui-docs/# User manual documentation
   eslint-config-bai/    # Shared ESLint configuration
-src/                    # Legacy utilities and websocket proxy
+src/                    # Utilities and websocket proxy
   lib/                  # Backend.AI client library (ESM/Node.js)
   wsproxy/              # WebSocket proxy for desktop app
 resources/              # Static assets, i18n files (22 languages), themes
@@ -142,7 +141,7 @@ Production build (`pnpm run build`) runs these steps sequentially:
 - **react** 19, **react-dom** 19 - UI framework
 - **antd** 6 - Ant Design component library
 - **react-relay** 20, **relay-runtime** 20 - GraphQL client
-- **jotai** - Atomic state management (replaces legacy Recoil usage)
+- **jotai** - Atomic state management
 - **i18next**, **react-i18next** - Internationalization
 - **@craco/craco** - CRA webpack customization
 - **electron** 35 - Desktop app framework

--- a/README.md
+++ b/README.md
@@ -599,16 +599,15 @@ to update / extract i18n resources.
 
 ### Adding i18n strings
 
-- Use `_t` as i18n resource handler on lit-element templates.
-- Use `_tr` as i18n resource handler if i18n resource has HTML code inside.
-- Use `_text` as i18n resource handler on lit-element Javascript code.
+Use `useTranslation()` hook from `react-i18next` in React components:
 
-#### Example
+```typescript
+import { useTranslation } from 'react-i18next';
 
-In lit-html template:
-
-```html
-<div>${_t('general.helloworld')}</div>
+const MyComponent = () => {
+  const { t } = useTranslation();
+  return <div>{t('general.helloworld')}</div>;
+};
 ```
 
 In i18n resource (en.json):
@@ -623,22 +622,6 @@ In i18n resource (en.json):
 
 #### Adding new language
 
-1.  Copy `en.json` to target language. (e.g. `ko.json`)
-2.  Add language identifier to `supportLanguageCodes` in `backend-ai-webui.ts`.
-    e.g.
-
-```javascript
-  @property({type: Array}) supportLanguageCodes = ["en", "ko"];
-```
-
-3.  Add language information to `supportLanguages` in `backend-ai-usersettings-general-list.ts`.
-
-Note: DO NOT DELETE 'default' language. It is used for browser language.
-
-```javascript
-  @property({type: Array}) supportLanguages = [
-    {name: _text("language.Browser"), code: "default"},
-    {name: _text("language.English"), code: "en"},
-    {name: _text("language.Korean"), code: "ko"}
-  ];
-```
+1. Copy `en.json` to target language file (e.g. `ko.json`) in `resources/i18n/`
+2. Translate all keys in the new language file
+3. Add language configuration in the settings component

--- a/react/README.md
+++ b/react/README.md
@@ -1,81 +1,64 @@
 # backend-ai-webui-react
-This is a react project to integrate WebUI by wrapping web components.
 
-## Steps to Create a React-based Web Component
-1. Create a file under `/react/src/components` or `/react/src/pages` (e.g. `NewComponent`).
-2. Define a web component using the `reactWebComponent` function in `/react/src/index.tsx`:
-    ```tsx
-    // You should import using React.lazy to reduce the initial JS bundle size.
-    const NewComponent = React.lazy(() => import("./components/NewComponent"));
+Main React application for Backend.AI WebUI, built with React 19 + Ant Design 6 + Relay 20 (GraphQL).
 
-    customElements.define(
-      "backend-ai-react-newcomponent",
-      reactToWebComponent((props) => {
-        return (
-          // In most cases, you will need to access the backend.ai client and apply the same UI theme.
-          // After wrapping `DefaultProvider`, you can use custom hooks such as `useSuspendedBackendaiClient`. 
-          <DefaultProviders {...props}>
-            <NewComponent />
-          </DefaultProviders>
-        );
-      })
-    );
-    ```
-3. You can now use your new React-based web component in a lit component.
-4. If you want to use an existing web component as a child of your React-based web component, you have two options:
-  - Option 1: After importing the existing web component in the web component that uses the React-based web component, you can use the existing web component directly in the React component file.
-  - Option 2. You can use `<slot>` like this:
-    ```jsx
-    // In lit web component
-    <backend-ai-react-newcomponent>
-      <existing-web-component slot="hello"></existing-web-component> 
-    </backend-ai-react-newcomponent>
+## Project Structure
 
-    // In react component
-    const NewComponent = ()=>{
+```
+react/
+  src/
+    components/       # React UI components
+    pages/            # Page-level components
+    hooks/            # Custom React hooks
+    helper/           # Utility functions
+    __generated__/    # Relay compiler output
+  craco.config.cjs    # Webpack customization via Craco
+```
 
-      return <div>
-        <h1> hello </h1>
-        <slot name="hello"/> 
-      </div>
-    }
-    ```
+## Development
 
-## Limitations & Recommendation
-- static assets
-  - put that file to `/resources`, and use the path directly.
-    ```jsx
-    // ✅ DO
-    <img
-      src="/manifest/backend.ai-brand-simple.svg"
-      className="App-logo"
-      alt="logo"
-    />
-    // ❌ DON'T 
-    import logo from "./logo.svg";
+```console
+$ pnpm run server:d   # Start React dev server (default port: 9081)
+$ pnpm run wsproxy    # Start websocket proxy (required for local dev)
+```
 
-    <img src={logo} className="App-logo" alt="logo" />
-    ```
-- css
-  - If you want to customize the overall theme, you can use the Ant Design theme configuration. Please put your settings in /`resources/theme.json`. You can use [the theme editor](https://ant.design/theme-editor).
-  - "Importing `.css` directly in a React file doesn't work, but you can use inline styles. Only injecting to the shadow DOM works properly.
-    ```js
-    // ✅ DO
-    // inline or other css js library which can inject 
-    <Button style={{width:100}}/>
+## Static Assets
 
-    // ❌ DON'T 
-    // Do not import .css and .module.css
-    import './App.css';
-    import './App.module.css';
-    ```
-  - To import the raw string from a CSS file, add the `?raw` prefix.
-    ```jsx
-    import customCss from "./ExampleComponent.css?raw";
+Put static files in `/resources` and reference them directly:
 
-    const Component = ()=>{
-      return <div>
-        <style>{customCss}</style>
-      </div>
-    }
-    ```
+```jsx
+// DO
+<img src="/manifest/backend.ai-brand-simple.svg" alt="logo" />
+
+// DON'T
+import logo from "./logo.svg";
+<img src={logo} alt="logo" />
+```
+
+## Styling
+
+- Use Ant Design theme configuration via `/resources/theme.json` for global theming. You can use [the theme editor](https://ant.design/theme-editor).
+- Use `antd-style` for styled components when Ant Design tokens alone aren't sufficient.
+- Use inline styles or CSS-in-JS for component-specific styling.
+
+```jsx
+// DO: inline styles or antd-style
+<Button style={{ width: 100 }} />
+
+// DON'T: import .css or .module.css
+import './App.css';
+```
+
+To import raw CSS strings:
+
+```jsx
+import customCss from "./ExampleComponent.css?raw";
+
+const Component = () => {
+  return (
+    <div>
+      <style>{customCss}</style>
+    </div>
+  );
+};
+```


### PR DESCRIPTION
## Summary

- Remove all Lit-Element, lit-translate, Material Web Components, and legacy framework references from documentation
- Update architecture descriptions to reflect React-only codebase
- Rewrite `react/README.md` for current React architecture
- Update state management references from Recoil/Redux to Jotai
- Clean up i18n instructions to remove Lit-specific translation patterns

## Files Changed

- **CLAUDE.md** - Remove legacy Lit mentions, update `src/` and jotai descriptions
- **AGENTS.md** - Same cleanup as CLAUDE.md
- **README.md** - Rewrite i18n section for React `useTranslation()` hook
- **.github/copilot-instructions.md** - Remove Lit legacy references
- **.github/instructions/i18n.instructions.md** - Remove Lit-Element translation section
- **.claude/skills/backend-ai-guide/** - Update architecture diagrams and Q&A for React-only
- **.claude/commands/fill-out-i18n.md** - Update i18n system descriptions
- **react/README.md** - Complete rewrite for React-only architecture

## Test plan

- [ ] Verify documentation renders correctly on GitHub
- [ ] Confirm no remaining Lit-Element references in updated files