### PR TITLE
fix(FR-2094): replace nanoid/non-secure with uuid in ChatHistory

### DIFF
--- a/react/src/components/Chat/ChatHistory.ts
+++ b/react/src/components/Chat/ChatHistory.ts
@@ -11,16 +11,12 @@ import {
 } from './ChatModel';
 import { useBAILogger } from 'backend.ai-ui';
 import _ from 'lodash';
-import { customAlphabet } from 'nanoid/non-secure';
 import { useEffect, useCallback, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
 // Utils for chat history cache
 const createIdGenerator = () => {
-  const generator = customAlphabet(
-    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
-    8,
-  );
-  return (prefix: string) => `${prefix}/${generator()}`;
+  return (prefix: string) => `${prefix}/${uuidv4().slice(0, 8)}`;
 };
 
 const generateChatDataId = createIdGenerator();


### PR DESCRIPTION
Resolves #5465 ([FR-2094](https://lablup.atlassian.net/browse/FR-2094))

## Summary
- Replace uninstalled `nanoid/non-secure` import with `uuid` (already a project dependency)
- Fixes build error: `Module not found: Error: Cannot resolve nanoid/non-secure`
- Uses `uuidv4().slice(0, 8)` to generate equivalent 8-char random IDs for chat messages

[FR-2094]: https://lablup.atlassian.net/browse/FR-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ