### PR TITLE
fix: add nanoid to react/package.json after root dependency cleanup

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -622,6 +622,9 @@ importers:
       markty-toml:
         specifier: 0.1.1
         version: 0.1.1
+      nanoid:
+        specifier: ^5.1.6
+        version: 5.1.6
       nuqs:
         specifier: ^2.8.6
         version: 2.8.6(react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-router@6.30.3(react@19.2.3))(react@19.2.3)
@@ -10710,6 +10713,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.6:
+    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   napi-build-utils@1.0.2:
@@ -27664,6 +27672,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.6: {}
 
   napi-build-utils@1.0.2: {}
 

--- a/react/package.json
+++ b/react/package.json
@@ -50,6 +50,7 @@
     "lucide-react": "^0.552.0",
     "markdown-to-jsx": "^7.7.17",
     "marked": "^16.4.2",
+    "nanoid": "^5.1.6",
     "markty-toml": "0.1.1",
     "nuqs": "^2.8.6",
     "p-queue": "^8.1.1",


### PR DESCRIPTION
## Summary
- Add `nanoid` to `react/package.json` dependencies — it was removed from root `package.json` in #5464 but is imported in `react/src/components/Chat/ChatHistory.ts` (`nanoid/non-secure`)

## Test plan
- [x] `pnpm run build` succeeds
- [x] Dev server compiles without `Can't resolve 'nanoid/non-secure'` error