### PR TITLE
fix: restore endpoint info and saved endpoints on login page refresh

### DIFF
--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -64,7 +64,10 @@ const LoginView: React.FC = () => {
   );
   const [connectionMode, setConnectionMode] =
     useState<ConnectionMode>('SESSION');
-  const [apiEndpoint, setApiEndpoint] = useState('');
+  const [apiEndpoint, setApiEndpoint] = useState(() => {
+    const stored = localStorage.getItem('backendaiwebui.api_endpoint');
+    return stored ? stored.replace(/^"+|"+$/g, '') : '';
+  });
   const [otpRequired, setOtpRequired] = useState(false);
   const [needsOtpRegistration, setNeedsOtpRegistration] = useState(false);
   const [totpRegistrationToken, setTotpRegistrationToken] = useState('');
@@ -79,7 +82,9 @@ const LoginView: React.FC = () => {
   const [blockType, setBlockType] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isConnected, setIsConnected] = useState(false);
-  const [endpoints, setEndpoints] = useState<string[]>([]);
+  const [endpoints, setEndpoints] = useState<string[]>(() => {
+    return (globalThis as any).backendaioptions?.get('endpoints', []) ?? [];
+  });
   const [showEndpointInput, setShowEndpointInput] = useState(true);
   const [isEndpointDisabled, setIsEndpointDisabled] = useState(false);
 
@@ -143,13 +148,15 @@ const LoginView: React.FC = () => {
     configRef.current = loginConfig;
   }, [loginConfig]);
 
-  // Initialize endpoints from options
+  // Sync apiEndpoint state changes to the form field.
+  // Ant Design's initialValues only applies on first render, so subsequent
+  // state updates (from config loading, localStorage restoration, etc.)
+  // must be explicitly synced to the form.
   useEffect(() => {
-    const storedEndpoints =
-      (globalThis as any).backendaioptions?.get('endpoints', []) ?? [];
-
-    setEndpoints(storedEndpoints);
-  }, []);
+    if (apiEndpoint) {
+      form.setFieldsValue({ api_endpoint: apiEndpoint });
+    }
+  }, [apiEndpoint, form]);
 
   // Language initialization: bridge selected_language -> general.language
   // (replaces Lit shell's connectedCallback language setup)

--- a/react/src/global-stores.ts
+++ b/react/src/global-stores.ts
@@ -78,6 +78,17 @@ class BackendAISettingsStore {
   }
 
   set(name: string, value: any, namespace = 'user', skipDispatch = false) {
+    // Persist directly to localStorage to guarantee durability,
+    // regardless of whether the jotai event listener is ready.
+    const storageKey = 'backendaiwebui.settings.' + namespace + '.' + name;
+    if (typeof value === 'boolean') {
+      localStorage.setItem(storageKey, value ? 'true' : 'false');
+    } else if (typeof value === 'object') {
+      localStorage.setItem(storageKey, JSON.stringify(value));
+    } else {
+      localStorage.setItem(storageKey, String(value));
+    }
+
     if (!skipDispatch) {
       const event = new CustomEvent('backendaiwebui.settings:set', {
         detail: { name, value, namespace },
@@ -88,6 +99,10 @@ class BackendAISettingsStore {
   }
 
   delete(name: string, namespace = 'user', skipDispatch = false) {
+    // Remove directly from localStorage to guarantee durability.
+    const storageKey = 'backendaiwebui.settings.' + namespace + '.' + name;
+    localStorage.removeItem(storageKey);
+
     if (!skipDispatch) {
       const event = new CustomEvent('backendaiwebui.settings:delete', {
         detail: { name, namespace },

--- a/react/src/hooks/useBAISetting.tsx
+++ b/react/src/hooks/useBAISetting.tsx
@@ -149,9 +149,13 @@ document?.addEventListener('backendaiwebui.settings:set', (e: any) => {
 document?.addEventListener('backendaiwebui.settings:delete', (e: any) => {
   const { detail } = e;
   if (detail.namespace && detail.name) {
-    localStorage.removeItem(
-      'backendaiwebui.settings.' + detail.namespace + '.' + detail.name,
-    );
-    // jotaiStore.set(SettingAtomFamily(detail.namespace + '.' + detail.name), null);
+    const key = detail.namespace + '.' + detail.name;
+    // localStorage removal is now handled directly in BackendAISettingsStore.delete().
+    // Trigger jotai reactivity so React components re-render.
+    const prev = jotaiStore.get(settingAtom);
+    jotaiStore.set(settingAtom, {
+      ...prev,
+      ['backendaiwebui.settings.' + key]: null,
+    });
   }
 });


### PR DESCRIPTION
## Summary
- Fix login page losing endpoint info and saved endpoint list on browser refresh
- Make `BackendAISettingsStore.set()/delete()` write directly to localStorage for guaranteed persistence, rather than relying solely on the event-driven jotai atom chain
- Initialize `apiEndpoint` and `endpoints` state from storage synchronously on mount, and sync state changes to the Ant Design form field

## Test plan
- [ ] Enter an endpoint URL and log in successfully
- [ ] Refresh the page — the endpoint should remain filled in the login form
- [ ] Log in to multiple different endpoints over time
- [ ] Click the cloud icon next to the endpoint input — all previously used endpoints should appear in the dropdown
- [ ] Delete an endpoint from the dropdown list and verify it persists after refresh
- [ ] Verify normal login flow still works (SESSION and API modes)