### PR TITLE
ci: bump github/codeql-action from v2 to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

- Bump all `github/codeql-action` references (`init`, `autobuild`, `analyze`) from **v2** to **v3**
- CodeQL Action v2 has been deprecated since January 2025 and will stop receiving updates
- Supersedes #2479, which only updated `init` but left `autobuild` and `analyze` on v2

## Changes

| Action | Before | After |
|--------|--------|-------|
| `github/codeql-action/init` | `v2` | `v3` |
| `github/codeql-action/autobuild` | `v2` | `v3` |
| `github/codeql-action/analyze` | `v2` | `v3` |

## Notes

- No breaking changes: v3 is a drop-in replacement for v2 ([migration guide](https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/))
- v3 uses Node.js 20 instead of Node.js 16 (which is EOL)
- This also cleans up stale bump PRs: #2501, #2483, #2469, #2401 (all closed as no longer applicable)

🤖 Generated with [Claude Code](https://claude.ai/code)