### PR TITLE
fix: remove unused imports and variables in test files

### DIFF
--- a/packages/backend.ai-ui/src/components/BAICard.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAICard.test.tsx
@@ -1,7 +1,6 @@
 import BAICard from './BAICard';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 
 describe('BAICard', () => {
   describe('Basic Rendering', () => {

--- a/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
+++ b/packages/backend.ai-ui/src/components/BAIPropertyFilter.test.tsx
@@ -1,9 +1,8 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import BAIPropertyFilter, {
   mergeFilterValues,
   parseFilterValue,
 } from './BAIPropertyFilter';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 describe('parseFilterValue', () => {
   it('should correctly parse filter with binary operators', () => {
@@ -72,7 +71,13 @@ describe('mergeFilterValues', () => {
   });
 
   it('should filter out empty, null, and undefined values', () => {
-    const filters = ['name ilike "%test%"', null, undefined, '', 'status == "active"'];
+    const filters = [
+      'name ilike "%test%"',
+      null,
+      undefined,
+      '',
+      'status == "active"',
+    ];
     const result = mergeFilterValues(filters);
     expect(result).toBe('(name ilike "%test%")&(status == "active")');
   });
@@ -123,7 +128,9 @@ describe('BAIPropertyFilter Component', () => {
   it('should render property selector and search input', () => {
     render(<BAIPropertyFilter filterProperties={mockFilterProperties} />);
 
-    expect(screen.getByLabelText('Filter property selector')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Filter property selector'),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText('Filter value search')).toBeInTheDocument();
   });
 
@@ -141,7 +148,7 @@ describe('BAIPropertyFilter Component', () => {
     // Component should render without crashing
     const searchInput = screen.getByLabelText('Filter value search');
     expect(searchInput).toBeInTheDocument();
-    
+
     // The component receives and processes the value internally
     // We can verify it accepted the value by checking it doesn't call onChange on mount
     expect(mockOnChange).not.toHaveBeenCalled();
@@ -264,19 +271,19 @@ describe('BAIPropertyFilter Component', () => {
     ];
 
     const mockOnChange = jest.fn();
-    const { container } = render(
-      <BAIPropertyFilter 
+    render(
+      <BAIPropertyFilter
         filterProperties={filterPropertiesWithValidation}
         onChange={mockOnChange}
       />,
     );
 
     const searchInput = screen.getByLabelText('Filter value search');
-    
+
     // Focus input and enter invalid email
     fireEvent.focus(searchInput);
     fireEvent.change(searchInput, { target: { value: 'invalid' } });
-    
+
     // Try to submit invalid value
     fireEvent.keyDown(searchInput, { key: 'Enter', code: 'Enter' });
 
@@ -355,7 +362,7 @@ describe('BAIPropertyFilter Component', () => {
     // Component should render without crashing
     const searchInput = screen.getByLabelText('Filter value search');
     expect(searchInput).toBeInTheDocument();
-    
+
     // The component accepts defaultValue and processes it internally
     // Verify it doesn't call onChange on mount
     expect(mockOnChange).not.toHaveBeenCalled();
@@ -402,7 +409,7 @@ describe('BAIPropertyFilter Component', () => {
     );
 
     const searchInput = screen.getByLabelText('Filter value search');
-    
+
     // Try to enter value not in options
     fireEvent.change(searchInput, { target: { value: 'invalid' } });
     fireEvent.keyDown(searchInput, { key: 'Enter', code: 'Enter' });

--- a/packages/backend.ai-ui/src/helper/useDebouncedDeferredValue.test.ts
+++ b/packages/backend.ai-ui/src/helper/useDebouncedDeferredValue.test.ts
@@ -1,6 +1,6 @@
+import useDebouncedDeferredValue from './useDebouncedDeferredValue';
 import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react';
-import useDebouncedDeferredValue from './useDebouncedDeferredValue';
 
 describe('useDebouncedDeferredValue', () => {
   beforeEach(() => {
@@ -14,9 +14,7 @@ describe('useDebouncedDeferredValue', () => {
 
   describe('Basic Functionality', () => {
     it('should return initial value immediately', () => {
-      const { result } = renderHook(() =>
-        useDebouncedDeferredValue('initial'),
-      );
+      const { result } = renderHook(() => useDebouncedDeferredValue('initial'));
       expect(result.current).toBe('initial');
     });
 
@@ -94,8 +92,7 @@ describe('useDebouncedDeferredValue', () => {
     it('should respect custom wait time option', async () => {
       const customWait = 500;
       const { result, rerender } = renderHook(
-        ({ value }) =>
-          useDebouncedDeferredValue(value, { wait: customWait }),
+        ({ value }) => useDebouncedDeferredValue(value, { wait: customWait }),
         { initialProps: { value: 'initial' } },
       );
 
@@ -316,15 +313,13 @@ describe('useDebouncedDeferredValue', () => {
 
   describe('Performance Considerations', () => {
     it('should not cause memory leaks with unmounting', () => {
-      const { unmount } = renderHook(() =>
-        useDebouncedDeferredValue('test'),
-      );
+      const { unmount } = renderHook(() => useDebouncedDeferredValue('test'));
 
       expect(() => unmount()).not.toThrow();
     });
 
     it('should handle unmount during debounce', async () => {
-      const { result, rerender, unmount } = renderHook(
+      const { rerender, unmount } = renderHook(
         ({ value }) => useDebouncedDeferredValue(value),
         { initialProps: { value: 'initial' } },
       );


### PR DESCRIPTION
Resolves #5485

## Summary
- Remove unused `import React from 'react'` in `BAICard.test.tsx` and `BAIPropertyFilter.test.tsx` (React 19 doesn't require explicit React import for JSX)
- Remove unused `container` destructuring in `BAIPropertyFilter.test.tsx`
- Remove unused `result` variable in `useDebouncedDeferredValue.test.ts`

These fixes resolve ESLint `@typescript-eslint/no-unused-vars` warnings that were causing the `backend-ai-ui-coverage` CI job to fail with `--max-warnings=0`.

## Test plan
- [x] `pnpm run lint` passes in `packages/backend.ai-ui/` with 0 warnings
- [ ] CI `backend-ai-ui-coverage` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)