### PR TITLE
fix(FR-2103): fix TypeScript type errors and lint warnings in test files

### DIFF
--- a/react/src/helper/customThemeConfig.test.ts
+++ b/react/src/helper/customThemeConfig.test.ts
@@ -9,12 +9,11 @@ describe('customThemeConfig', () => {
   let fetchMock: jest.Mock;
   let originalFetch: typeof global.fetch;
   let dispatchEventSpy: jest.SpyInstance;
-  let originalNodeEnv: string | undefined;
+  const originalNodeEnv: string | undefined = process.env.NODE_ENV;
 
   beforeEach(() => {
     // Save original values
     originalFetch = global.fetch;
-    originalNodeEnv = process.env.NODE_ENV;
 
     // Setup fetch mock
     fetchMock = jest.fn();
@@ -27,7 +26,11 @@ describe('customThemeConfig', () => {
   afterEach(() => {
     // Restore original values
     global.fetch = originalFetch;
-    process.env.NODE_ENV = originalNodeEnv;
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value: originalNodeEnv,
+      writable: true,
+      configurable: true,
+    });
     jest.clearAllMocks();
   });
 
@@ -99,7 +102,11 @@ describe('customThemeConfig', () => {
     });
 
     it('should apply REACT_APP_THEME_COLOR in development environment', async () => {
-      process.env.NODE_ENV = 'development';
+      Object.defineProperty(process.env, 'NODE_ENV', {
+        value: 'development',
+        writable: true,
+        configurable: true,
+      });
       process.env.REACT_APP_THEME_COLOR = '#ff0000';
 
       const mockTheme: CustomThemeConfig = {
@@ -132,7 +139,11 @@ describe('customThemeConfig', () => {
     });
 
     it('should not apply REACT_APP_THEME_COLOR in production environment', async () => {
-      process.env.NODE_ENV = 'production';
+      Object.defineProperty(process.env, 'NODE_ENV', {
+        value: 'production',
+        writable: true,
+        configurable: true,
+      });
       process.env.REACT_APP_THEME_COLOR = '#ff0000';
 
       const mockTheme: CustomThemeConfig = {
@@ -371,7 +382,11 @@ describe('customThemeConfig', () => {
     });
 
     it('should only apply REACT_APP_THEME_COLOR when both development mode and env var are set', async () => {
-      process.env.NODE_ENV = 'development';
+      Object.defineProperty(process.env, 'NODE_ENV', {
+        value: 'development',
+        writable: true,
+        configurable: true,
+      });
       delete process.env.REACT_APP_THEME_COLOR;
 
       const mockTheme: CustomThemeConfig = {
@@ -404,7 +419,11 @@ describe('customThemeConfig', () => {
     });
 
     it('should preserve existing Layout component settings when applying REACT_APP_THEME_COLOR', async () => {
-      process.env.NODE_ENV = 'development';
+      Object.defineProperty(process.env, 'NODE_ENV', {
+        value: 'development',
+        writable: true,
+        configurable: true,
+      });
       process.env.REACT_APP_THEME_COLOR = '#ff0000';
 
       const mockTheme: CustomThemeConfig = {

--- a/react/src/hooks/useKeyboardShortcut.test.ts
+++ b/react/src/hooks/useKeyboardShortcut.test.ts
@@ -1,5 +1,5 @@
-import { renderHook } from '@testing-library/react';
 import useKeyboardShortcut from './useKeyboardShortcut';
+import { renderHook } from '@testing-library/react';
 
 // Mock ahooks useEventListener
 jest.mock('ahooks', () => ({
@@ -50,7 +50,7 @@ describe('useKeyboardShortcut', () => {
     it('should pass the keyboard event to handler', () => {
       renderHook(() => useKeyboardShortcut(mockHandler));
 
-      const event = triggerKeydown({ key: 'Enter' });
+      triggerKeydown({ key: 'Enter' });
 
       expect(mockHandler).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/react/src/hooks/useTokenizer.test.ts
+++ b/react/src/hooks/useTokenizer.test.ts
@@ -1,5 +1,6 @@
 import { useTokenCount, encodeAsync } from './useTokenizer';
 import { renderHook, waitFor } from '@testing-library/react';
+import { encode } from 'gpt-tokenizer';
 
 // Mock gpt-tokenizer
 jest.mock('gpt-tokenizer', () => ({
@@ -59,8 +60,7 @@ describe('useTokenizer', () => {
     });
 
     it('should fallback to string length on encoding error', async () => {
-      const { encode } = require('gpt-tokenizer');
-      encode.mockImplementationOnce(() => {
+      (encode as jest.Mock).mockImplementationOnce(() => {
         throw new Error('Encoding failed');
       });
 

--- a/react/src/hooks/useVariantConfigs.test.ts
+++ b/react/src/hooks/useVariantConfigs.test.ts
@@ -1,5 +1,5 @@
-import { renderHook } from '@testing-library/react';
 import { useRuntimeEnvVarConfigs } from './useVariantConfigs';
+import { renderHook } from '@testing-library/react';
 import { useTranslation } from 'react-i18next';
 
 // Mock react-i18next
@@ -144,7 +144,7 @@ describe('useRuntimeEnvVarConfigs', () => {
   it('should have consistent structure across all runtimes', () => {
     const { result } = renderHook(() => useRuntimeEnvVarConfigs());
 
-    Object.entries(result.current).forEach(([runtime, config]) => {
+    Object.entries(result.current).forEach(([_runtime, config]) => {
       expect(config).toHaveProperty('optionalEnvVars');
       expect(Array.isArray(config.optionalEnvVars)).toBe(true);
 


### PR DESCRIPTION
## Summary
- Fix TS2312/TS2540 type errors and ESLint warnings in test files
- Replace `(rule: any)` casts with proper type guards in `useValidateSessionName.test.tsx`
- Use `Object.defineProperty` for read-only `process.env.NODE_ENV` in `customThemeConfig.test.ts`
- Replace `require()` with ESM import in `useTokenizer.test.ts`
- Fix unused variable warnings in `useKeyboardShortcut.test.ts` and `useVariantConfigs.test.ts`