### PR TITLE
feat(FR-2107): add version gate for model try content button

### DIFF
--- a/react/src/components/ModelCardModal.tsx
+++ b/react/src/components/ModelCardModal.tsx
@@ -3,7 +3,10 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { ModelCardModalFragment$key } from '../__generated__/ModelCardModalFragment.graphql';
-import { useBackendAIImageMetaData } from '../hooks';
+import {
+  useBackendAIImageMetaData,
+  useSuspendedBackendaiClient,
+} from '../hooks';
 import { useModelCardMetadata } from '../hooks/useModelCardMetadata';
 import ErrorBoundaryWithNullFallback from './ErrorBoundaryWithNullFallback';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
@@ -54,6 +57,7 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
+  const baiClient = useSuspendedBackendaiClient();
 
   const [visibleCloneModal, setVisibleCloneModal] = useState(false);
 
@@ -137,20 +141,22 @@ const ModelCardModal: React.FC<ModelCardModalProps> = ({
             : '90%'
       }
       footer={[
-        // This button is used to clone-and-create/create the model service with the content of the model card.
-        <ErrorBoundaryWithNullFallback key="model-try-content-button">
-          <Suspense
-            fallback={
-              <Tooltip title={t('modelStore.CheckingSettings')}>
-                <Button loading disabled />
-              </Tooltip>
-            }
-          >
-            <ModelTryContentButton
-              vfolderNode={model_card?.vfolder_node || null}
-            />
-          </Suspense>
-        </ErrorBoundaryWithNullFallback>,
+        baiClient.supports('model-try-content-button') && (
+          // This button is used to clone-and-create/create the model service with the content of the model card.
+          <ErrorBoundaryWithNullFallback key="model-try-content-button">
+            <Suspense
+              fallback={
+                <Tooltip title={t('modelStore.CheckingSettings')}>
+                  <Button loading disabled />
+                </Tooltip>
+              }
+            >
+              <ModelTryContentButton
+                vfolderNode={model_card?.vfolder_node || null}
+              />
+            </Suspense>
+          </ErrorBoundaryWithNullFallback>
+        ),
         <Button
           key="clone"
           type="primary"

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -878,6 +878,9 @@ class Client {
       this._features['allow-only-ro-permission-for-model-project-folder'] = true;
     }
     if (this.isManagerVersionCompatibleWith('26.1.0')) {
+      this._features['model-try-content-button'] = true;
+    }
+    if (this.isManagerVersionCompatibleWith('26.1.0')) {
       this._features['admin-resource-group-select'] = true;
     }
     if (this.isManagerVersionCompatibleWith('26.2.0')) {


### PR DESCRIPTION
Resolves #5496 ([FR-2107](https://lablup.atlassian.net/browse/FR-2107))

## Summary
- Add `model-try-content-button` feature flag for manager version >= 26.0.0
- Conditionally render the "Try Content" button in ModelCardModal based on version support

## Test plan
- [ ] Verify the "Try Content" button appears on manager >= 26.0.0
- [ ] Verify the "Try Content" button is hidden on manager < 26.0.0
- [ ] Verify no regression in Model Card modal functionality

[FR-2107]: https://lablup.atlassian.net/browse/FR-2107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ