### PR TITLE
docs(FR-857): add editable AI agent plan and progress tracker

### DIFF
--- a/.docs/editable-ai-agent-plan.md
+++ b/.docs/editable-ai-agent-plan.md
@@ -1,0 +1,52 @@
+# Editable AI Agent - Implementation Plan
+
+> Supersedes [PR #3356](https://github.com/lablup/backend.ai-webui/pull/3356) (FR-857)
+
+## Goal
+
+Users can create, edit, and delete custom AI agents stored in localStorage, alongside built-in agents from `ai-agents.json`. Custom agents can connect to external LLM APIs (not just Backend.AI endpoints) and specify a default model.
+
+## PR Stack
+
+| # | Title | Scope |
+|---|-------|-------|
+| 1 | Schema & Type Extensions | `AIAgent` interface, schema.json, `UserSettings` |
+| 2 | useAIAgent Hook CRUD | Merge logic, `upsertAgent`, `deleteAgent` |
+| 3 | AgentEditorModal | Create/edit form modal + i18n keys |
+| 4 | AIAgentPage Edit/Delete UI | Add/edit/delete buttons, custom agent badge |
+| 5 | Chat Integration | External endpoint URL, API key, default model |
+
+## Architecture
+
+### Data Flow
+
+```
+Built-in agents (ai-agents.json)  ──┐
+                                     ├── useAIAgent() ── merged agents[]
+User-created agents (localStorage) ──┘
+```
+
+### Agent Types
+
+| Type | Source | Editable | Deletable |
+|------|--------|----------|-----------|
+| Built-in | `ai-agents.json` | Yes (creates override) | No |
+| Custom | `localStorage` | Yes | Yes |
+| Overridden | Built-in + user edit | Yes | Reset to default |
+
+### External Endpoint Support
+
+When an agent has `endpoint_url`:
+- Skip Backend.AI endpoint GraphQL query (use `store-only` fetch policy)
+- Construct `baseURL` from `endpoint_url` instead of `endpoint.url`
+- Use `endpoint_token` as Bearer token
+- Hide EndpointSelect in ChatHeader
+- Pre-select `config.default_model` if available
+
+## Key Design Decisions
+
+1. **Merge strategy**: User agents with same ID override built-in agents (supports "edit built-in" flow)
+2. **Storage**: `useBAISetting('extra_ai_agents')` — localStorage via Jotai atoms
+3. **Agent IDs**: `crypto.randomUUID()` for new custom agents
+4. **No server dependency**: All agent management is client-side
+5. **Backward compatible**: Existing `ai-agents.json` format unchanged; new fields are optional

--- a/.docs/editable-ai-agent-progress.md
+++ b/.docs/editable-ai-agent-progress.md
@@ -1,0 +1,52 @@
+# Editable AI Agent - Progress Tracker
+
+> See [plan](./editable-ai-agent-plan.md) for full details
+
+## Status: In Progress
+
+### PR 1: Schema & Type Extensions
+- [ ] Extend `AIAgent` interface with `endpoint_url`, `endpoint_token`, `isCustom`
+- [ ] Add `default_model` to `AIAgentConfig`
+- [ ] Update `ai-agents.schema.json` with new optional fields
+- [ ] Add `extra_ai_agents` to `UserSettings` in `useBAISetting.tsx`
+
+### PR 2: useAIAgent Hook CRUD
+- [ ] Add `useBAISettingUserState('extra_ai_agents')` integration
+- [ ] Implement merge logic (user agents override built-in by ID)
+- [ ] Add `upsertAgent` function
+- [ ] Add `deleteAgent` function
+- [ ] Export `builtInAgents` for override detection
+
+### PR 3: AgentEditorModal
+- [ ] Create `AgentEditorModal.tsx` with BAIModal + Form pattern
+- [ ] Form sections: Basic Info, System Prompt, Endpoint, LLM Parameters
+- [ ] Connection type toggle (Backend.AI vs External)
+- [ ] Add i18n keys for all 21 languages
+
+### PR 4: AIAgentPage Edit/Delete UI
+- [ ] Add "Add Agent" button in page header
+- [ ] Add Dropdown menu on agent cards (Edit/Delete/Reset)
+- [ ] Visual badge for custom agents ("Custom" tag)
+- [ ] Visual badge for overridden agents ("Edited" tag)
+- [ ] Delete confirmation modal
+- [ ] Integrate AgentEditorModal
+
+### PR 5: Chat Integration
+- [ ] ChatCard: Use `agent.endpoint_url` for baseURL when available
+- [ ] ChatCard: Use `agent.endpoint_token` for API key
+- [ ] ChatCard: Pre-select `agent.config.default_model`
+- [ ] ChatHeader: Hide EndpointSelect when agent has external URL
+- [ ] ChatCard: Update `onChangeAgent` to propagate endpoint info
+
+## Files Modified
+
+| File | PRs |
+|------|-----|
+| `react/src/hooks/useAIAgent.ts` | 1, 2 |
+| `react/src/hooks/useBAISetting.tsx` | 1 |
+| `resources/ai-agents.schema.json` | 1 |
+| `react/src/components/AgentEditorModal.tsx` | 3 (new) |
+| `react/src/pages/AIAgentPage.tsx` | 4 |
+| `react/src/components/Chat/ChatCard.tsx` | 5 |
+| `react/src/components/Chat/ChatHeader.tsx` | 5 |
+| `resources/i18n/*.json` | 3 |


### PR DESCRIPTION
Resolves #3524 (FR-857)

> This is PR 1/6 in the editable AI agent stack. Supersedes #3356.

## Summary

- Add implementation plan document (`.docs/editable-ai-agent-plan.md`) describing the 5-PR architecture for editable AI agents
- Add progress tracker (`.docs/editable-ai-agent-progress.md`) with per-PR task checklists and file modification matrix

## Context

The original PR #3356 was stale and targeted the old `LLMChatCard`/`EndpointLLMChatCard` components which have since been replaced by `ChatCard`/`ChatHeader`. This stack reimplements the feature using current patterns.

## Stack Overview

1. **#5498** - Plan & progress docs (this PR)
2. **#5499** - Schema & type extensions
3. **#5500** - useAIAgent hook CRUD
4. **#5501** - AgentEditorModal component
5. **#5502** - AIAgentPage edit/delete UI
6. **#5503** - Chat integration for external endpoints

## Test plan

- [ ] Verify `.docs/` files are present and correctly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)