### PR TITLE
chore(FR-2108): add docs-toolkit package to VS Code workspace

### DIFF
--- a/backend.ai-webui.code-workspace
+++ b/backend.ai-webui.code-workspace
@@ -16,6 +16,10 @@
       "path": "packages/backend.ai-webui-docs",
       "name": "webui-docs",
     },
+    {
+      "path": "packages/backend.ai-docs-toolkit",
+      "name": "docs-toolkit",
+    },
   ],
   "settings": {
     "i18n-ally.enabledFrameworks": ["react", "custom"],


### PR DESCRIPTION
Resolves #5504 ([FR-2108](https://lablup.atlassian.net/browse/FR-2108))

## Summary
- Add `packages/backend.ai-docs-toolkit` to the VS Code workspace configuration

## Test plan
- [ ] Open the workspace in VS Code and verify docs-toolkit appears in the sidebar

[FR-2108]: https://lablup.atlassian.net/browse/FR-2108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ