### PR TITLE
fix(FR-2100): fix endpoint history dropdown on login page

### DIFF
--- a/react/src/components/LoginFormPanel.tsx
+++ b/react/src/components/LoginFormPanel.tsx
@@ -285,6 +285,7 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
                       onClick: onEndpointMenuClick,
                     }}
                     trigger={['click']}
+                    overlayStyle={{ zIndex: 10001 }}
                   >
                     <Button
                       icon={<CloudOutlined />}


### PR DESCRIPTION
Resolves #5483(FR-2100)

## Summary

- The cloud button dropdown on the login page was not displaying because the `LoginView` wrapper div creates a stacking context at `z-index: 10000` (to appear above LoadingCurtain at z-index 9999), while the Ant Design `Dropdown` popup rendered in `document.body` had a default z-index of ~1050, placing it behind the login modal stacking context
- Added `overlayStyle={{ zIndex: 10001 }}` to the endpoint history `Dropdown` so its popup is rendered above the login wrapper stacking context

## Root Cause

`LoginView` wraps its content in a zero-size `position: fixed` div with `z-index: 10000`. This div creates a new CSS stacking context. The `Dropdown` popup (rendered in `document.body`) had a default z-index of ~1050, which is lower than the login wrapper's stacking context (10000), causing the popup to render behind the modal and be invisible.

## Test plan

- [ ] Open the login page and expand Advanced Settings
- [ ] Click the cloud (history) button - dropdown should appear with endpoint history or "No endpoint saved"
- [ ] Log in successfully - the endpoint should be saved to history
- [ ] Re-open the login page and click the cloud button - the saved endpoint should appear in the dropdown list
- [ ] Clicking an endpoint from the list should fill it into the endpoint input field
- [ ] The delete button should remove the endpoint from the list