### PR TITLE
refactor(FR-2105): unify i18n terminology to plural forms for menu labels

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2428,7 +2428,6 @@
       "Remaining": "Übrig",
       "Reservoir": "Reservoir",
       "ResourcePolicies": "Ressourcenrichtlinien",
-      "ResourcePolicy": "Ressourcenrichtlinie",
       "Resources": "Ressourcen",
       "Scheduler": "Scheduler",
       "Serving": "Bedienung von",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2423,7 +2423,6 @@
       "Remaining": "Παραμένων",
       "Reservoir": "Δεξαμενή",
       "ResourcePolicies": "Πολιτικές Πόρων",
-      "ResourcePolicy": "Πολιτική πόρων",
       "Resources": "Πόροι",
       "Scheduler": "Προγραμματιστής",
       "Serving": "Εξυπηρέτηση",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2436,7 +2436,6 @@
       "Remaining": "Remaining",
       "Reservoir": "Reservoir",
       "ResourcePolicies": "Resource Policies",
-      "ResourcePolicy": "Resource Policy",
       "Resources": "Resources",
       "Scheduler": "Scheduler",
       "Serving": "Serving",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2428,7 +2428,6 @@
       "Remaining": "Restante",
       "Reservoir": "Depósito",
       "ResourcePolicies": "Políticas de recursos",
-      "ResourcePolicy": "Política de recursos",
       "Resources": "Recursos",
       "Scheduler": "Planificador",
       "Serving": "Sirviendo a",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2428,7 +2428,6 @@
       "Remaining": "Jäljellä oleva",
       "Reservoir": "Säiliö",
       "ResourcePolicies": "Resurssipolitiikat",
-      "ResourcePolicy": "Resurssipolitiikka",
       "Resources": "Resurssit",
       "Scheduler": "Aikataulu",
       "Serving": "Palvelevat",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2428,7 +2428,6 @@
       "Remaining": "Restant",
       "Reservoir": "Réservoir",
       "ResourcePolicies": "Politiques des ressources",
-      "ResourcePolicy": "Politique de ressources",
       "Resources": "Ressources",
       "Scheduler": "Planificateur",
       "Serving": "Servir",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2429,7 +2429,6 @@
       "Remaining": "Tersisa",
       "Reservoir": "Waduk",
       "ResourcePolicies": "Kebijakan Sumber Daya",
-      "ResourcePolicy": "Kebijakan Sumber Daya",
       "Resources": "Sumber daya",
       "Scheduler": "Penjadwal",
       "Serving": "Penyajian",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2425,7 +2425,6 @@
       "Remaining": "Rimanente",
       "Reservoir": "Serbatoio",
       "ResourcePolicies": "Politiche delle risorse",
-      "ResourcePolicy": "Politica delle risorse",
       "Resources": "risorse",
       "Scheduler": "Scheduler",
       "Serving": "Servire",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2429,7 +2429,6 @@
       "Remaining": "残り",
       "Reservoir": "貯水池",
       "ResourcePolicies": "リソースポリシー",
-      "ResourcePolicy": "リソースポリシー",
       "Resources": "リソース管理",
       "Scheduler": "スケジューラ",
       "Serving": "モデルサービス",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2434,7 +2434,6 @@
       "Remaining": "가용량",
       "Reservoir": "리저버",
       "ResourcePolicies": "자원 정책",
-      "ResourcePolicy": "자원 정책",
       "Resources": "자원",
       "Scheduler": "스케줄러",
       "Serving": "모델 서빙",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2406,7 +2406,6 @@
       "Remaining": "Үлдсэн",
       "Reservoir": "Дүрэмирсанир",
       "ResourcePolicies": "Нөөцийн бодлогууд",
-      "ResourcePolicy": "Нөөцийн бодлого",
       "Resources": "Нөөц",
       "Scheduler": "Хуваарийн өгөх",
       "Serving": "Үйлчилж байна",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2426,7 +2426,6 @@
       "Remaining": "Tinggal",
       "Reservoir": "Takungan",
       "ResourcePolicies": "Dasar Sumber",
-      "ResourcePolicy": "Dasar Sumber",
       "Resources": "Sumber",
       "Scheduler": "Penjadual",
       "Serving": "Melayan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2427,7 +2427,6 @@
       "Remaining": "Pozostały",
       "Reservoir": "Zbiornik",
       "ResourcePolicies": "Polityki zasobów",
-      "ResourcePolicy": "Polityka zasobów",
       "Resources": "Zasoby",
       "Scheduler": "Harmonogram",
       "Serving": "Obsługa",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2428,7 +2428,6 @@
       "Remaining": "Restante",
       "Reservoir": "Reservatório",
       "ResourcePolicies": "Políticas de Recursos",
-      "ResourcePolicy": "Política de Recursos",
       "Resources": "Recursos",
       "Scheduler": "Agendador",
       "Serving": "Servir",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2429,7 +2429,6 @@
       "Remaining": "Restante",
       "Reservoir": "Reservatório",
       "ResourcePolicies": "Políticas de Recursos",
-      "ResourcePolicy": "Política de Recursos",
       "Resources": "Recursos",
       "Scheduler": "Agendador",
       "Serving": "Servir",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2427,7 +2427,6 @@
       "Remaining": "Оставшийся",
       "Reservoir": "Резервуар",
       "ResourcePolicies": "Ресурсные политики",
-      "ResourcePolicy": "Политика ресурсов",
       "Resources": "Ресурсы",
       "Scheduler": "Планировщик",
       "Serving": "Обслуживание",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2414,7 +2414,6 @@
       "Remaining": "ที่เหลืออยู่",
       "Reservoir": "อ่างเก็บน้ำ",
       "ResourcePolicies": "นโยบายทรัพยากร",
-      "ResourcePolicy": "นโยบายทรัพยากร",
       "Resources": "ทรัพยากร",
       "Scheduler": "ผู้กำหนดตารางเวลา",
       "Serving": "การให้บริการ",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2428,7 +2428,6 @@
       "Remaining": "Geriye kalan",
       "Reservoir": "Rezervuar",
       "ResourcePolicies": "Kaynak Politikaları",
-      "ResourcePolicy": "Kaynak Politikası",
       "Resources": "Kaynaklar",
       "Scheduler": "Zamanlayıcı",
       "Serving": "Servis",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2430,7 +2430,6 @@
       "Remaining": "Còn lại",
       "Reservoir": "Hồ chứa",
       "ResourcePolicies": "Chính sách tài nguyên",
-      "ResourcePolicy": "Chính sách tài nguyên",
       "Resources": "Tài nguyên",
       "Scheduler": "Người lập lịch",
       "Serving": "Phục vụ",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2430,7 +2430,6 @@
       "Remaining": "其余的",
       "Reservoir": "水库",
       "ResourcePolicies": "资源政策",
-      "ResourcePolicy": "资源政策",
       "Resources": "资源",
       "Scheduler": "调度程序",
       "Serving": "服务",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2429,7 +2429,6 @@
       "Remaining": "其餘的",
       "Reservoir": "水庫",
       "ResourcePolicies": "資源政策",
-      "ResourcePolicy": "資源政策",
       "Resources": "資源",
       "Scheduler": "調度程序",
       "Serving": "服务",


### PR DESCRIPTION
Resolves #5491(FR-2105)

## Summary

- Removed the deprecated `webui.menu.ResourcePolicy` key from all 21 language i18n files
- The plural form `webui.menu.ResourcePolicies` is already used exclusively in navigation code (`routes.tsx`, `useWebUIMenuItems.tsx`)
- The singular key `webui.menu.ResourcePolicy` was not referenced in any source file
- The `webui.menu.Project` key is retained as it is legitimately used in `WebUIHeader.tsx` and `StorageHostSettingsPanel.tsx` for single-project selector labels

## Audit Results

- `webui.menu.ResourcePolicy`: Not used in any `.tsx` or `.ts` source file — removed
- `webui.menu.Project`: Used in 2 files as a field label for project selectors — retained
- Documentation already uses "Resource Policies" (plural) for page/menu references

## Test plan
- [ ] Verify that the Resource Policies menu item still appears correctly in the navigation
- [ ] Verify that no translation errors appear in the browser console
- [ ] Verify that project selector labels still display "Project" correctly in WebUIHeader and StorageHostSettingsPanel