### PR TITLE
feat(FR-1952): add diagnostic types and CSP rules with tests

### DIFF
--- a/react/src/diagnostics/rules/__tests__/cspRules.test.ts
+++ b/react/src/diagnostics/rules/__tests__/cspRules.test.ts
@@ -1,0 +1,318 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  checkCspConnectSrc,
+  checkCspScriptSrc,
+  checkCspStyleSrc,
+  checkCspWsConnectSrc,
+  parseCspConnectSrc,
+  parseCspDirective,
+} from '../cspRules';
+import { describe, expect, it } from '@jest/globals';
+
+describe('parseCspConnectSrc', () => {
+  it('should return empty array for null/undefined input', () => {
+    expect(parseCspConnectSrc(null)).toEqual([]);
+    expect(parseCspConnectSrc(undefined)).toEqual([]);
+  });
+
+  it('should return empty array when no connect-src directive exists', () => {
+    expect(parseCspConnectSrc("default-src 'self'")).toEqual([]);
+  });
+
+  it('should parse connect-src with multiple sources', () => {
+    const csp =
+      "default-src 'self'; connect-src https://api.example.com wss://ws.example.com; script-src 'self'";
+    expect(parseCspConnectSrc(csp)).toEqual([
+      'https://api.example.com',
+      'wss://ws.example.com',
+    ]);
+  });
+
+  it('should parse connect-src at end of string (no trailing semicolon)', () => {
+    const csp = "default-src 'self'; connect-src https://api.example.com";
+    expect(parseCspConnectSrc(csp)).toEqual(['https://api.example.com']);
+  });
+});
+
+describe('checkCspConnectSrc', () => {
+  it('should return null when CSP content is empty', () => {
+    expect(checkCspConnectSrc(null, 'https://api.example.com')).toBeNull();
+    expect(checkCspConnectSrc('', 'https://api.example.com')).toBeNull();
+  });
+
+  it('should return null when endpoint is empty', () => {
+    expect(checkCspConnectSrc("connect-src 'self'", '')).toBeNull();
+  });
+
+  it('should return null when neither connect-src nor default-src exists', () => {
+    expect(
+      checkCspConnectSrc("script-src 'self'", 'https://api.example.com'),
+    ).toBeNull();
+  });
+
+  it('should return null when wildcard * is present', () => {
+    expect(
+      checkCspConnectSrc('connect-src *', 'https://api.example.com'),
+    ).toBeNull();
+  });
+
+  it('should return null when endpoint matches a CSP source', () => {
+    expect(
+      checkCspConnectSrc(
+        'connect-src https://api.example.com',
+        'https://api.example.com',
+      ),
+    ).toBeNull();
+  });
+
+  it('should return diagnostic when endpoint is not in CSP sources', () => {
+    const result = checkCspConnectSrc(
+      'connect-src https://other.example.com',
+      'https://api.example.com',
+    );
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe('csp-connect-src-api');
+    expect(result?.severity).toBe('critical');
+    expect(result?.interpolationValues?.endpoint).toBe(
+      'https://api.example.com',
+    );
+  });
+
+  it('should match wildcard domain sources', () => {
+    expect(
+      checkCspConnectSrc(
+        'connect-src *.example.com',
+        'https://api.example.com',
+      ),
+    ).toBeNull();
+  });
+
+  it('should not match apex domain for wildcard (*.example.com vs example.com)', () => {
+    const result = checkCspConnectSrc(
+      'connect-src *.example.com',
+      'https://example.com',
+    );
+    expect(result).not.toBeNull();
+  });
+
+  it('should not match unrelated domain for wildcard (*.example.com vs badexample.com)', () => {
+    const result = checkCspConnectSrc(
+      'connect-src *.example.com',
+      'https://badexample.com',
+    );
+    expect(result).not.toBeNull();
+  });
+
+  it("should match 'self' only when page origin matches endpoint", () => {
+    // Same origin — should pass
+    expect(
+      checkCspConnectSrc(
+        "connect-src 'self'",
+        'https://app.example.com/api',
+        'https://app.example.com',
+      ),
+    ).toBeNull();
+
+    // Different origin — should fail
+    const result = checkCspConnectSrc(
+      "connect-src 'self'",
+      'https://api.other.com',
+      'https://app.example.com',
+    );
+    expect(result).not.toBeNull();
+  });
+
+  it("should treat 'self' as non-matching when no pageOrigin provided", () => {
+    const result = checkCspConnectSrc(
+      "connect-src 'self'",
+      'https://api.example.com',
+    );
+    expect(result).not.toBeNull();
+  });
+
+  // default-src fallback tests
+  it('should fall back to default-src when connect-src is absent', () => {
+    // default-src allows the endpoint
+    expect(
+      checkCspConnectSrc(
+        'default-src https://api.example.com',
+        'https://api.example.com',
+      ),
+    ).toBeNull();
+
+    // default-src blocks the endpoint
+    const result = checkCspConnectSrc(
+      'default-src https://other.example.com',
+      'https://api.example.com',
+    );
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('checkCspWsConnectSrc', () => {
+  it('should return null when CSP content or proxy URL is empty', () => {
+    expect(checkCspWsConnectSrc(null, 'wss://ws.example.com')).toBeNull();
+    expect(checkCspWsConnectSrc("connect-src 'self'", '')).toBeNull();
+  });
+
+  it('should return null when proxy URL matches CSP source', () => {
+    expect(
+      checkCspWsConnectSrc(
+        'connect-src wss://ws.example.com',
+        'wss://ws.example.com',
+      ),
+    ).toBeNull();
+  });
+
+  it('should return diagnostic when proxy URL is not in CSP sources', () => {
+    const result = checkCspWsConnectSrc(
+      'connect-src https://api.example.com',
+      'wss://ws.other.com',
+    );
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe('csp-connect-src-ws');
+    expect(result?.severity).toBe('critical');
+  });
+
+  it('should return null for invalid proxy URL', () => {
+    expect(
+      checkCspWsConnectSrc('connect-src https://api.example.com', 'not-a-url'),
+    ).toBeNull();
+  });
+
+  it('should compare protocol when matching WS sources', () => {
+    // https source should NOT match wss proxy (different protocols)
+    const result = checkCspWsConnectSrc(
+      'connect-src https://ws.example.com',
+      'wss://ws.example.com',
+    );
+    expect(result).not.toBeNull();
+  });
+
+  it('should handle scheme-only sources like wss:', () => {
+    expect(
+      checkCspWsConnectSrc('connect-src wss:', 'wss://ws.example.com'),
+    ).toBeNull();
+  });
+
+  it('should fall back to default-src when connect-src is absent', () => {
+    expect(
+      checkCspWsConnectSrc(
+        'default-src wss://ws.example.com',
+        'wss://ws.example.com',
+      ),
+    ).toBeNull();
+
+    const result = checkCspWsConnectSrc(
+      'default-src https://other.example.com',
+      'wss://ws.example.com',
+    );
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('parseCspDirective', () => {
+  it('should parse any CSP directive by name', () => {
+    const csp =
+      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self'";
+    expect(parseCspDirective(csp, 'script-src')).toEqual([
+      "'self'",
+      "'unsafe-inline'",
+    ]);
+    expect(parseCspDirective(csp, 'style-src')).toEqual(["'self'"]);
+    expect(parseCspDirective(csp, 'img-src')).toEqual([]);
+  });
+
+  it('should return empty array for null/undefined', () => {
+    expect(parseCspDirective(null, 'script-src')).toEqual([]);
+    expect(parseCspDirective(undefined, 'script-src')).toEqual([]);
+  });
+});
+
+describe('checkCspScriptSrc', () => {
+  it('should return null when no CSP content', () => {
+    expect(checkCspScriptSrc(null)).toBeNull();
+  });
+
+  it('should return null when neither script-src nor default-src exists', () => {
+    expect(checkCspScriptSrc("style-src 'self'")).toBeNull();
+  });
+
+  it("should return null when 'self' is allowed", () => {
+    expect(checkCspScriptSrc("script-src 'self'")).toBeNull();
+  });
+
+  it('should return null when wildcard is present', () => {
+    expect(checkCspScriptSrc('script-src *')).toBeNull();
+  });
+
+  it("should return diagnostic when 'self' is missing", () => {
+    const result = checkCspScriptSrc('script-src https://cdn.example.com');
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe('csp-script-src-blocked');
+    expect(result?.severity).toBe('critical');
+  });
+
+  it('should accept nonce-based policies as allowing scripts', () => {
+    expect(checkCspScriptSrc("script-src 'nonce-abc123'")).toBeNull();
+  });
+
+  it('should accept hash-based policies as allowing scripts', () => {
+    expect(checkCspScriptSrc("script-src 'sha256-abc123'")).toBeNull();
+    expect(checkCspScriptSrc("script-src 'sha384-abc123'")).toBeNull();
+    expect(checkCspScriptSrc("script-src 'sha512-abc123'")).toBeNull();
+  });
+
+  it('should fall back to default-src when script-src is absent', () => {
+    expect(checkCspScriptSrc("default-src 'self'")).toBeNull();
+
+    const result = checkCspScriptSrc('default-src https://cdn.example.com');
+    expect(result).not.toBeNull();
+  });
+});
+
+describe('checkCspStyleSrc', () => {
+  it('should return null when no CSP content', () => {
+    expect(checkCspStyleSrc(null)).toBeNull();
+  });
+
+  it('should return null when neither style-src nor default-src exists', () => {
+    expect(checkCspStyleSrc("script-src 'self'")).toBeNull();
+  });
+
+  it("should return null when 'unsafe-inline' is allowed", () => {
+    expect(checkCspStyleSrc("style-src 'self' 'unsafe-inline'")).toBeNull();
+  });
+
+  it('should return null when wildcard is present', () => {
+    expect(checkCspStyleSrc('style-src *')).toBeNull();
+  });
+
+  it("should return diagnostic when 'unsafe-inline' is missing", () => {
+    const result = checkCspStyleSrc("style-src 'self'");
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe('csp-style-src-no-inline');
+    expect(result?.severity).toBe('warning');
+  });
+
+  it('should accept nonce-based policies as allowing inline styles', () => {
+    expect(checkCspStyleSrc("style-src 'nonce-abc123'")).toBeNull();
+  });
+
+  it('should accept hash-based policies as allowing inline styles', () => {
+    expect(checkCspStyleSrc("style-src 'sha256-abc123'")).toBeNull();
+  });
+
+  it('should fall back to default-src when style-src is absent', () => {
+    // default-src with unsafe-inline — should pass
+    expect(checkCspStyleSrc("default-src 'self' 'unsafe-inline'")).toBeNull();
+
+    // default-src without unsafe-inline or nonce — should warn
+    const result = checkCspStyleSrc("default-src 'self'");
+    expect(result).not.toBeNull();
+    expect(result?.severity).toBe('warning');
+  });
+});

--- a/react/src/diagnostics/rules/cspRules.ts
+++ b/react/src/diagnostics/rules/cspRules.ts
@@ -1,0 +1,262 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import type { DiagnosticResult } from '../../types/diagnostics';
+
+/**
+ * Extract sources for a given CSP directive (e.g. connect-src, script-src).
+ */
+export function parseCspDirective(
+  cspContent: string | null | undefined,
+  directive: string,
+): string[] {
+  if (!cspContent) return [];
+
+  const regex = new RegExp(`${directive}\\s+([^;]*)`, 'i');
+  const match = cspContent.match(regex);
+  if (!match) return [];
+
+  return match[1]
+    .trim()
+    .split(/\s+/)
+    .filter((v) => v.length > 0);
+}
+
+/**
+ * Extract the CSP connect-src directive value from the page's meta tag.
+ */
+export function parseCspConnectSrc(
+  cspContent: string | null | undefined,
+): string[] {
+  return parseCspDirective(cspContent, 'connect-src');
+}
+
+/**
+ * Resolve effective sources for a directive, falling back to default-src.
+ * Per CSP spec, if a specific directive is absent, default-src applies.
+ */
+function getEffectiveSources(
+  cspContent: string,
+  directive: string,
+): string[] | null {
+  const sources = parseCspDirective(cspContent, directive);
+  if (sources.length > 0) return sources;
+
+  const defaultSources = parseCspDirective(cspContent, 'default-src');
+  if (defaultSources.length > 0) return defaultSources;
+
+  // Neither directive nor default-src exists — no CSP restriction
+  return null;
+}
+
+/**
+ * Check if a URL matches a CSP source expression.
+ * Handles exact URL, wildcard domains (*.example.com), and scheme-only sources.
+ */
+function matchesCspSource(
+  source: string,
+  targetUrl: URL,
+  pageOrigin?: string,
+): boolean {
+  if (source === '*') return true;
+
+  // 'self' only matches the page's own origin
+  if (source === "'self'") {
+    if (!pageOrigin) return false;
+    try {
+      const originUrl = new URL(pageOrigin);
+      return (
+        targetUrl.protocol === originUrl.protocol &&
+        targetUrl.hostname === originUrl.hostname &&
+        (targetUrl.port || getDefaultPort(targetUrl.protocol)) ===
+          (originUrl.port || getDefaultPort(originUrl.protocol))
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  // Wildcard domain matching (e.g., *.example.com)
+  if (source.startsWith('*.')) {
+    const domain = source.slice(2);
+    const hostname = targetUrl.hostname;
+    // Require dot boundary: *.example.com matches sub.example.com but NOT
+    // example.com (apex) or badexample.com
+    if (hostname === domain) return false;
+    return hostname.endsWith(`.${domain}`);
+  }
+
+  try {
+    const sourceUrl = new URL(source);
+    return (
+      targetUrl.protocol === sourceUrl.protocol &&
+      targetUrl.hostname === sourceUrl.hostname &&
+      (sourceUrl.port === '' || targetUrl.port === sourceUrl.port)
+    );
+  } catch {
+    // Handle scheme-only sources like "ws:" or "wss:"
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:$/.test(source)) {
+      return source.toLowerCase() === targetUrl.protocol.toLowerCase();
+    }
+    return false;
+  }
+}
+
+function getDefaultPort(protocol: string): string {
+  if (protocol === 'https:' || protocol === 'wss:') return '443';
+  if (protocol === 'http:' || protocol === 'ws:') return '80';
+  return '';
+}
+
+/**
+ * Check if the API endpoint is allowed by CSP connect-src.
+ * Falls back to default-src if connect-src is absent (per CSP spec).
+ * @param pageOrigin - The page's origin for resolving 'self' (e.g. window.location.origin)
+ */
+export function checkCspConnectSrc(
+  cspContent: string | null | undefined,
+  apiEndpoint: string,
+  pageOrigin?: string,
+): DiagnosticResult | null {
+  if (!cspContent || !apiEndpoint) return null;
+
+  const sources = getEffectiveSources(cspContent, 'connect-src');
+  if (!sources) return null;
+
+  let endpointUrl: URL;
+  try {
+    endpointUrl = new URL(apiEndpoint);
+  } catch {
+    return null;
+  }
+
+  const isAllowed = sources.some((source) =>
+    matchesCspSource(source, endpointUrl, pageOrigin),
+  );
+
+  if (!isAllowed) {
+    return {
+      id: 'csp-connect-src-api',
+      severity: 'critical',
+      titleKey: 'diagnostics.CspApiEndpointBlocked',
+      descriptionKey: 'diagnostics.CspApiEndpointBlockedDesc',
+      remediationKey: 'diagnostics.CspApiEndpointBlockedFix',
+      interpolationValues: { endpoint: apiEndpoint },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Check if the WebSocket proxy URL is allowed by CSP connect-src.
+ * Falls back to default-src if connect-src is absent (per CSP spec).
+ * @param pageOrigin - The page's origin for resolving 'self'
+ */
+export function checkCspWsConnectSrc(
+  cspContent: string | null | undefined,
+  proxyUrl: string,
+  pageOrigin?: string,
+): DiagnosticResult | null {
+  if (!cspContent || !proxyUrl) return null;
+
+  const sources = getEffectiveSources(cspContent, 'connect-src');
+  if (!sources) return null;
+
+  let wsUrl: URL;
+  try {
+    wsUrl = new URL(proxyUrl);
+  } catch {
+    return null;
+  }
+
+  const isAllowed = sources.some((source) =>
+    matchesCspSource(source, wsUrl, pageOrigin),
+  );
+
+  if (!isAllowed) {
+    return {
+      id: 'csp-connect-src-ws',
+      severity: 'critical',
+      titleKey: 'diagnostics.CspWsProxyBlocked',
+      descriptionKey: 'diagnostics.CspWsProxyBlockedDesc',
+      remediationKey: 'diagnostics.CspWsProxyBlockedFix',
+      interpolationValues: { proxyUrl },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Check if CSP script-src might block application scripts.
+ * Accepts 'self', wildcard, or nonce/hash-based policies.
+ * Falls back to default-src if script-src is absent.
+ */
+export function checkCspScriptSrc(
+  cspContent: string | null | undefined,
+): DiagnosticResult | null {
+  if (!cspContent) return null;
+
+  const sources = getEffectiveSources(cspContent, 'script-src');
+  if (!sources) return null;
+
+  const allowsScripts = sources.some(
+    (s) =>
+      s === "'self'" ||
+      s === '*' ||
+      s.startsWith("'nonce-") ||
+      s.startsWith("'sha256-") ||
+      s.startsWith("'sha384-") ||
+      s.startsWith("'sha512-"),
+  );
+
+  if (!allowsScripts) {
+    return {
+      id: 'csp-script-src-blocked',
+      severity: 'critical',
+      titleKey: 'diagnostics.CspScriptSrcBlocked',
+      descriptionKey: 'diagnostics.CspScriptSrcBlockedDesc',
+      remediationKey: 'diagnostics.CspScriptSrcBlockedFix',
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Check if CSP style-src might block inline styles (required by antd).
+ * Accepts 'unsafe-inline', wildcard, or nonce/hash-based policies.
+ * Falls back to default-src if style-src is absent.
+ */
+export function checkCspStyleSrc(
+  cspContent: string | null | undefined,
+): DiagnosticResult | null {
+  if (!cspContent) return null;
+
+  const sources = getEffectiveSources(cspContent, 'style-src');
+  if (!sources) return null;
+
+  const allowsInline = sources.some(
+    (s) =>
+      s === "'unsafe-inline'" ||
+      s === '*' ||
+      s.startsWith("'nonce-") ||
+      s.startsWith("'sha256-") ||
+      s.startsWith("'sha384-") ||
+      s.startsWith("'sha512-"),
+  );
+
+  if (!allowsInline) {
+    return {
+      id: 'csp-style-src-no-inline',
+      severity: 'warning',
+      titleKey: 'diagnostics.CspStyleSrcNoInline',
+      descriptionKey: 'diagnostics.CspStyleSrcNoInlineDesc',
+      remediationKey: 'diagnostics.CspStyleSrcNoInlineFix',
+    };
+  }
+
+  return null;
+}

--- a/react/src/types/diagnostics.ts
+++ b/react/src/types/diagnostics.ts
@@ -1,0 +1,15 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+
+export type DiagnosticSeverity = 'critical' | 'warning' | 'info' | 'passed';
+
+export interface DiagnosticResult {
+  id: string;
+  severity: DiagnosticSeverity;
+  titleKey: string;
+  descriptionKey: string;
+  remediationKey?: string;
+  interpolationValues?: Record<string, string>;
+}


### PR DESCRIPTION
Resolves #5115(FR-1952)

## Summary

- Add `DiagnosticResult` type and `DiagnosticSeverity` type
- Implement CSP diagnostic rules: `checkCspConnectSrc`, `checkCspWsConnectSrc`, `checkCspScriptSrc`, `checkCspStyleSrc`
- Add `parseCspDirective` and `parseCspConnectSrc` utility functions
- Proper `default-src` fallback, wildcard domain matching, `'self'` origin comparison, nonce/hash policy support
- 41 unit tests for all CSP rules