### PR TITLE
feat(FR-1955): add diagnostic hooks for CSP, storage, endpoint, and config checks

### DIFF
--- a/react/src/hooks/useCspDiagnostics.ts
+++ b/react/src/hooks/useCspDiagnostics.ts
@@ -1,0 +1,103 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useSuspendedBackendaiClient } from '.';
+import {
+  checkCspConnectSrc,
+  checkCspScriptSrc,
+  checkCspStyleSrc,
+  checkCspWsConnectSrc,
+} from '../diagnostics/rules/cspRules';
+import type { DiagnosticResult } from '../types/diagnostics';
+import { useProxyUrl } from './useWebUIConfig';
+import { useMemo } from 'react';
+
+/**
+ * Hook that checks CSP directives: connect-src, script-src, style-src.
+ * Synchronous — no suspense needed.
+ */
+export function useCspDiagnostics(): DiagnosticResult[] {
+  'use memo';
+
+  const baiClient = useSuspendedBackendaiClient();
+  const proxyUrl = useProxyUrl();
+
+  return useMemo(() => {
+    const cspMeta = document.querySelector(
+      'meta[http-equiv="Content-Security-Policy"]',
+    );
+    const cspContent = cspMeta?.getAttribute('content') ?? null;
+    const apiEndpoint: string = baiClient?._config?.endpoint ?? '';
+
+    const results: DiagnosticResult[] = [];
+
+    if (!cspContent) {
+      results.push({
+        id: 'csp-not-set',
+        severity: 'passed',
+        titleKey: 'diagnostics.CspNotSet',
+        descriptionKey: 'diagnostics.CspNotSetDesc',
+      });
+      return results;
+    }
+
+    const pageOrigin = globalThis.location?.origin;
+
+    // Check connect-src for API endpoint
+    const apiCheck = checkCspConnectSrc(cspContent, apiEndpoint, pageOrigin);
+    if (apiCheck) {
+      results.push(apiCheck);
+    } else if (apiEndpoint) {
+      results.push({
+        id: 'csp-connect-src-api-passed',
+        severity: 'passed',
+        titleKey: 'diagnostics.CspApiEndpointAllowed',
+        descriptionKey: 'diagnostics.CspApiEndpointAllowedDesc',
+        interpolationValues: { endpoint: apiEndpoint },
+      });
+    }
+
+    // Check connect-src for WebSocket proxy
+    const wsCheck = checkCspWsConnectSrc(cspContent, proxyUrl, pageOrigin);
+    if (wsCheck) {
+      results.push(wsCheck);
+    } else if (proxyUrl) {
+      results.push({
+        id: 'csp-connect-src-ws-passed',
+        severity: 'passed',
+        titleKey: 'diagnostics.CspWsProxyAllowed',
+        descriptionKey: 'diagnostics.CspWsProxyAllowedDesc',
+        interpolationValues: { proxyUrl },
+      });
+    }
+
+    // Check script-src allows loading app scripts
+    const scriptCheck = checkCspScriptSrc(cspContent);
+    if (scriptCheck) {
+      results.push(scriptCheck);
+    } else {
+      results.push({
+        id: 'csp-script-src-passed',
+        severity: 'passed',
+        titleKey: 'diagnostics.CspScriptSrcPassed',
+        descriptionKey: 'diagnostics.CspScriptSrcPassedDesc',
+      });
+    }
+
+    // Check style-src allows inline styles (required by antd)
+    const styleCheck = checkCspStyleSrc(cspContent);
+    if (styleCheck) {
+      results.push(styleCheck);
+    } else {
+      results.push({
+        id: 'csp-style-src-passed',
+        severity: 'passed',
+        titleKey: 'diagnostics.CspStyleSrcPassed',
+        descriptionKey: 'diagnostics.CspStyleSrcPassedDesc',
+      });
+    }
+
+    return results;
+  }, [baiClient?._config?.endpoint, proxyUrl]);
+}

--- a/react/src/hooks/useEndpointDiagnostics.ts
+++ b/react/src/hooks/useEndpointDiagnostics.ts
@@ -1,0 +1,137 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useSuspendedBackendaiClient } from '.';
+import {
+  checkEndpointReachability,
+  checkProxyReachability,
+  checkSslMismatch,
+} from '../diagnostics/rules/endpointRules';
+import type { DiagnosticResult } from '../types/diagnostics';
+import { useTanQuery } from './reactQueryAlias';
+import { useProxyUrl } from './useWebUIConfig';
+import { useMemo } from 'react';
+
+/**
+ * Hook that checks endpoint/proxy reachability and SSL mismatch.
+ * Uses TanStack Query to perform health check fetches.
+ */
+export function useEndpointDiagnostics(): {
+  results: DiagnosticResult[];
+  isLoading: boolean;
+} {
+  'use memo';
+
+  const baiClient = useSuspendedBackendaiClient();
+  const proxyUrl = useProxyUrl();
+  const apiEndpoint: string = baiClient?._config?.endpoint ?? '';
+
+  const { data: healthCheck, isLoading: isEndpointLoading } = useTanQuery<{
+    isReachable: boolean;
+    error?: string;
+  }>({
+    queryKey: ['diagnostics', 'endpoint-health', apiEndpoint],
+    queryFn: async () => {
+      if (!apiEndpoint) return { isReachable: true };
+      try {
+        const response = await fetch(apiEndpoint, {
+          method: 'GET',
+          signal: AbortSignal.timeout(10000),
+        });
+        return { isReachable: response.ok || response.status < 500 };
+      } catch (e) {
+        return {
+          isReachable: false,
+          error: e instanceof Error ? e.message : 'Unknown error',
+        };
+      }
+    },
+    enabled: !!apiEndpoint,
+    staleTime: 60_000,
+    retry: 1,
+  });
+
+  const { data: proxyHealthCheck, isLoading: isProxyLoading } = useTanQuery<{
+    isReachable: boolean;
+    error?: string;
+  }>({
+    queryKey: ['diagnostics', 'proxy-health', proxyUrl],
+    queryFn: async () => {
+      if (!proxyUrl) return { isReachable: true };
+      try {
+        const response = await fetch(proxyUrl, {
+          method: 'GET',
+          signal: AbortSignal.timeout(10000),
+        });
+        return { isReachable: response.ok || response.status < 500 };
+      } catch (e) {
+        return {
+          isReachable: false,
+          error: e instanceof Error ? e.message : 'Unknown error',
+        };
+      }
+    },
+    enabled: !!proxyUrl,
+    staleTime: 60_000,
+    retry: 1,
+  });
+
+  const results = useMemo(() => {
+    const diagnostics: DiagnosticResult[] = [];
+
+    const sslCheck = checkSslMismatch(apiEndpoint, proxyUrl);
+    if (sslCheck) {
+      diagnostics.push(sslCheck);
+    } else if (apiEndpoint && proxyUrl) {
+      diagnostics.push({
+        id: 'ssl-match-passed',
+        severity: 'passed',
+        titleKey: 'diagnostics.SslMatchPassed',
+        descriptionKey: 'diagnostics.SslMatchPassedDesc',
+      });
+    }
+
+    if (healthCheck) {
+      const reachCheck = checkEndpointReachability(
+        apiEndpoint,
+        healthCheck.isReachable,
+        healthCheck.error,
+      );
+      if (reachCheck) {
+        diagnostics.push(reachCheck);
+      } else if (apiEndpoint) {
+        diagnostics.push({
+          id: 'endpoint-reachable-passed',
+          severity: 'passed',
+          titleKey: 'diagnostics.EndpointReachable',
+          descriptionKey: 'diagnostics.EndpointReachableDesc',
+          interpolationValues: { endpoint: apiEndpoint },
+        });
+      }
+    }
+
+    if (proxyHealthCheck) {
+      const proxyCheck = checkProxyReachability(
+        proxyUrl,
+        proxyHealthCheck.isReachable,
+        proxyHealthCheck.error,
+      );
+      if (proxyCheck) {
+        diagnostics.push(proxyCheck);
+      } else if (proxyUrl) {
+        diagnostics.push({
+          id: 'proxy-reachable-passed',
+          severity: 'passed',
+          titleKey: 'diagnostics.ProxyReachable',
+          descriptionKey: 'diagnostics.ProxyReachableDesc',
+          interpolationValues: { proxyUrl },
+        });
+      }
+    }
+
+    return diagnostics;
+  }, [apiEndpoint, proxyUrl, healthCheck, proxyHealthCheck]);
+
+  return { results, isLoading: isEndpointLoading || isProxyLoading };
+}

--- a/react/src/hooks/useStorageProxyDiagnostics.ts
+++ b/react/src/hooks/useStorageProxyDiagnostics.ts
@@ -1,0 +1,98 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import type { useStorageProxyDiagnosticsQuery } from '../__generated__/useStorageProxyDiagnosticsQuery.graphql';
+import { checkStorageVolumeHealth } from '../diagnostics/rules/storageProxyRules';
+import type { StorageVolumeInfo } from '../diagnostics/rules/storageProxyRules';
+import type { DiagnosticResult } from '../types/diagnostics';
+import { useMemo } from 'react';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+/**
+ * Hook that checks storage volume health.
+ * Suspends while loading storage volume data via GraphQL.
+ */
+export function useStorageProxyDiagnostics(): DiagnosticResult[] {
+  'use memo';
+
+  const { storage_volume_list: storageVolumeList } =
+    useLazyLoadQuery<useStorageProxyDiagnosticsQuery>(
+      graphql`
+        query useStorageProxyDiagnosticsQuery {
+          storage_volume_list(limit: 100, offset: 0) {
+            items {
+              id
+              backend
+              usage
+            }
+          }
+        }
+      `,
+      {},
+      { fetchPolicy: 'store-and-network' },
+    );
+
+  return useMemo(() => {
+    const results: DiagnosticResult[] = [];
+    const items = storageVolumeList?.items ?? [];
+
+    if (items.length === 0) {
+      results.push({
+        id: 'storage-no-volumes',
+        severity: 'passed',
+        titleKey: 'diagnostics.StorageNoVolumes',
+        descriptionKey: 'diagnostics.StorageNoVolumesDesc',
+      });
+      return results;
+    }
+
+    let healthIssueCount = 0;
+
+    for (const item of items) {
+      if (!item) continue;
+
+      let usageInfo: { used_bytes: number; capacity_bytes: number } | undefined;
+      if (item.usage) {
+        try {
+          const parsed = JSON.parse(item.usage as string);
+          if (
+            typeof parsed?.used_bytes === 'number' &&
+            typeof parsed?.capacity_bytes === 'number'
+          ) {
+            usageInfo = {
+              used_bytes: parsed.used_bytes,
+              capacity_bytes: parsed.capacity_bytes,
+            };
+          }
+        } catch {
+          // Invalid usage JSON, skip
+        }
+      }
+
+      const volumeInfo: StorageVolumeInfo = {
+        id: item.id as string,
+        backend: item.backend ?? 'unknown',
+        usage: usageInfo,
+      };
+
+      const healthCheck = checkStorageVolumeHealth(volumeInfo);
+      if (healthCheck) {
+        results.push(healthCheck);
+        healthIssueCount++;
+      }
+    }
+
+    if (healthIssueCount === 0) {
+      results.push({
+        id: 'storage-health-passed',
+        severity: 'passed',
+        titleKey: 'diagnostics.StorageHealthPassed',
+        descriptionKey: 'diagnostics.StorageHealthPassedDesc',
+        interpolationValues: { count: String(items.length) },
+      });
+    }
+
+    return results;
+  }, [storageVolumeList?.items]);
+}

--- a/react/src/hooks/useWebServerConfigDiagnostics.ts
+++ b/react/src/hooks/useWebServerConfigDiagnostics.ts
@@ -1,0 +1,87 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useSuspendedBackendaiClient } from '.';
+import { checkBlocklistValidity } from '../diagnostics/rules/configRules';
+import { checkSslMismatch } from '../diagnostics/rules/endpointRules';
+import type { DiagnosticResult } from '../types/diagnostics';
+import { useProxyUrl, useRawConfig } from './useWebUIConfig';
+import { VALID_MENU_KEYS } from './useWebUIMenuItems';
+import { useMemo } from 'react';
+
+/**
+ * Hook that checks webserver configuration consistency.
+ * Compares raw TOML config values against the running client config.
+ * Synchronous — no suspense needed.
+ */
+export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
+  'use memo';
+
+  const baiClient = useSuspendedBackendaiClient();
+  const rawConfig = useRawConfig();
+  const proxyUrl = useProxyUrl();
+
+  return useMemo(() => {
+    const results: DiagnosticResult[] = [];
+    const apiEndpoint: string = baiClient?._config?.endpoint ?? '';
+    const blockList: string[] = baiClient?._config?.blockList ?? [];
+
+    // Check SSL mismatch between API endpoint and proxy URL from config
+    const sslCheck = checkSslMismatch(apiEndpoint, proxyUrl);
+    if (sslCheck) {
+      results.push({
+        ...sslCheck,
+        id: 'config-ssl-mismatch',
+        titleKey: 'diagnostics.ConfigSslMismatch',
+        descriptionKey: 'diagnostics.ConfigSslMismatchDesc',
+      });
+    } else if (apiEndpoint && proxyUrl) {
+      results.push({
+        id: 'config-ssl-match-passed',
+        severity: 'passed',
+        titleKey: 'diagnostics.ConfigSslMatchPassed',
+        descriptionKey: 'diagnostics.ConfigSslMatchPassedDesc',
+      });
+    }
+
+    // Check if proxy URL is configured
+    if (rawConfig && !rawConfig.wsproxy?.proxyURL) {
+      results.push({
+        id: 'config-missing-proxy-url',
+        severity: 'info',
+        titleKey: 'diagnostics.MissingProxyUrl',
+        descriptionKey: 'diagnostics.MissingProxyUrlDesc',
+      });
+    } else if (rawConfig?.wsproxy?.proxyURL) {
+      results.push({
+        id: 'config-proxy-url-passed',
+        severity: 'passed',
+        titleKey: 'diagnostics.ProxyUrlConfigured',
+        descriptionKey: 'diagnostics.ProxyUrlConfiguredDesc',
+        interpolationValues: { proxyUrl },
+      });
+    }
+
+    // Check if blocklist contains invalid menu keys
+    const blocklistCheck = checkBlocklistValidity(blockList, VALID_MENU_KEYS);
+    if (blocklistCheck) {
+      results.push(blocklistCheck);
+    } else if (blockList.length > 0) {
+      results.push({
+        id: 'config-blocklist-valid',
+        severity: 'passed',
+        titleKey: 'diagnostics.BlocklistValid',
+        descriptionKey: 'diagnostics.BlocklistValidDesc',
+        interpolationValues: { count: String(blockList.length) },
+      });
+    }
+
+    return results;
+  }, [
+    baiClient?._config?.endpoint,
+    baiClient?._config?.blockList,
+    proxyUrl,
+    rawConfig,
+  ]);
+}

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -64,36 +64,43 @@ export type MenuGroupName =
   | 'metrics'
   | 'mlops';
 
-export type MenuKeys =
+/**
+ * Single source of truth for all valid menu keys.
+ * MenuKeys type is derived from this array.
+ */
+export const VALID_MENU_KEYS = [
   // generalMenu keys
-  | 'start'
-  | 'dashboard'
-  | 'summary' // 'alias to dashboard' for backward compatibility
-  | 'session'
-  | 'job' // 'alias to session' for backward compatibility
-  | 'serving'
-  | 'model-store'
-  | 'ai-agent'
-  | 'chat'
-  | 'data'
-  | 'my-environment'
-  | 'agent-summary'
-  | 'statistics'
-  | 'pipeline'
+  'start',
+  'dashboard',
+  'summary', // alias to dashboard for backward compatibility
+  'session',
+  'job', // alias to session for backward compatibility
+  'serving',
+  'model-store',
+  'ai-agent',
+  'chat',
+  'data',
+  'my-environment',
+  'agent-summary',
+  'statistics',
+  'pipeline',
   // adminMenu keys
-  | 'admin-session'
-  | 'credential'
-  | 'environment'
-  | 'scheduler'
-  | 'resource-policy'
-  | 'reservoir'
+  'admin-session',
+  'credential',
+  'environment',
+  'scheduler',
+  'resource-policy',
+  'reservoir',
   // superAdminMenu keys
-  | 'admin-dashboard'
-  | 'agent'
-  | 'settings'
-  | 'maintenance'
-  | 'branding'
-  | 'information';
+  'admin-dashboard',
+  'agent',
+  'settings',
+  'maintenance',
+  'branding',
+  'information',
+] as const;
+
+export type MenuKeys = (typeof VALID_MENU_KEYS)[number];
 
 // Convert menu key to URL path
 // Most keys map directly to /${key}, with exceptions for backward compatibility


### PR DESCRIPTION
Resolves #5118(FR-1955)

## Summary

- Add `useCspDiagnostics` hook — checks CSP meta tag against API endpoint and WebSocket proxy
- Add `useStorageProxyDiagnostics` hook — queries `storage_volume_list` via GraphQL and checks volume health
- Add `useEndpointDiagnostics` hook — checks endpoint reachability and SSL mismatch
- Add `useWebServerConfigDiagnostics` hook — validates webserver.conf settings against runtime config
- Refactor `VALID_MENU_KEYS` to single-source-of-truth pattern (`as const` array → derived type)