### PR TITLE
feat(FR-1956): add DiagnosticsPage and diagnostic UI components

### DIFF
--- a/react/src/components/CspDiagnosticsSection.tsx
+++ b/react/src/components/CspDiagnosticsSection.tsx
@@ -1,0 +1,16 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useCspDiagnostics } from '../hooks/useCspDiagnostics';
+import DiagnosticResultList from './DiagnosticResultList';
+
+const CspDiagnosticsSection: React.FC = () => {
+  'use memo';
+
+  const results = useCspDiagnostics();
+
+  return <DiagnosticResultList results={results} />;
+};
+
+export default CspDiagnosticsSection;

--- a/react/src/components/DiagnosticResultList.tsx
+++ b/react/src/components/DiagnosticResultList.tsx
@@ -1,0 +1,79 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import type { DiagnosticResult } from '../types/diagnostics';
+import { Alert, Skeleton, theme, Typography } from 'antd';
+import { BAIFlex } from 'backend.ai-ui';
+import { CheckCircle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+interface DiagnosticResultListProps {
+  results: DiagnosticResult[];
+  loading?: boolean;
+}
+
+const severityToAlertType = {
+  critical: 'error' as const,
+  warning: 'warning' as const,
+  info: 'info' as const,
+  passed: 'success' as const,
+};
+
+const DiagnosticResultList: React.FC<DiagnosticResultListProps> = ({
+  results,
+  loading = false,
+}) => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+
+  if (loading) {
+    return <Skeleton active paragraph={{ rows: 2 }} />;
+  }
+
+  // Separate issues from passed checks for visual grouping
+  const issues = results.filter((r) => r.severity !== 'passed');
+  const passed = results.filter((r) => r.severity === 'passed');
+
+  return (
+    <BAIFlex direction="column" align="stretch" gap="sm">
+      {issues.map((result) => (
+        <Alert
+          key={result.id}
+          type={severityToAlertType[result.severity]}
+          showIcon
+          title={t(result.titleKey, result.interpolationValues)}
+          description={
+            <BAIFlex align="start" direction="column" gap={token.paddingXXS}>
+              <span>
+                {t(result.descriptionKey, result.interpolationValues)}
+              </span>
+              {result.remediationKey && (
+                <span style={{ fontStyle: 'italic' }}>
+                  {t(result.remediationKey, result.interpolationValues)}
+                </span>
+              )}
+            </BAIFlex>
+          }
+        />
+      ))}
+      {passed.map((result) => (
+        <BAIFlex key={result.id} gap="xs" align="center">
+          <CheckCircle
+            size={token.fontSizeSM}
+            style={{ color: token.colorSuccess, flexShrink: 0 }}
+          />
+          <Typography.Text type="secondary">
+            {t(result.titleKey, result.interpolationValues)}
+            {' — '}
+            {t(result.descriptionKey, result.interpolationValues)}
+          </Typography.Text>
+        </BAIFlex>
+      ))}
+    </BAIFlex>
+  );
+};
+
+export default DiagnosticResultList;

--- a/react/src/components/EndpointDiagnosticsSection.tsx
+++ b/react/src/components/EndpointDiagnosticsSection.tsx
@@ -1,0 +1,16 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useEndpointDiagnostics } from '../hooks/useEndpointDiagnostics';
+import DiagnosticResultList from './DiagnosticResultList';
+
+const EndpointDiagnosticsSection: React.FC = () => {
+  'use memo';
+
+  const { results, isLoading } = useEndpointDiagnostics();
+
+  return <DiagnosticResultList results={results} loading={isLoading} />;
+};
+
+export default EndpointDiagnosticsSection;

--- a/react/src/components/StorageProxyDiagnosticsSection.tsx
+++ b/react/src/components/StorageProxyDiagnosticsSection.tsx
@@ -1,0 +1,16 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useStorageProxyDiagnostics } from '../hooks/useStorageProxyDiagnostics';
+import DiagnosticResultList from './DiagnosticResultList';
+
+const StorageProxyDiagnosticsSection: React.FC = () => {
+  'use memo';
+
+  const results = useStorageProxyDiagnostics();
+
+  return <DiagnosticResultList results={results} />;
+};
+
+export default StorageProxyDiagnosticsSection;

--- a/react/src/components/WebServerConfigDiagnosticsSection.tsx
+++ b/react/src/components/WebServerConfigDiagnosticsSection.tsx
@@ -1,0 +1,16 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useWebServerConfigDiagnostics } from '../hooks/useWebServerConfigDiagnostics';
+import DiagnosticResultList from './DiagnosticResultList';
+
+const WebServerConfigDiagnosticsSection: React.FC = () => {
+  'use memo';
+
+  const results = useWebServerConfigDiagnostics();
+
+  return <DiagnosticResultList results={results} />;
+};
+
+export default WebServerConfigDiagnosticsSection;

--- a/react/src/pages/DiagnosticsPage.tsx
+++ b/react/src/pages/DiagnosticsPage.tsx
@@ -1,0 +1,113 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import CspDiagnosticsSection from '../components/CspDiagnosticsSection';
+import EndpointDiagnosticsSection from '../components/EndpointDiagnosticsSection';
+import StorageProxyDiagnosticsSection from '../components/StorageProxyDiagnosticsSection';
+import WebServerConfigDiagnosticsSection from '../components/WebServerConfigDiagnosticsSection';
+import { ReloadOutlined } from '@ant-design/icons';
+import { Collapse, Skeleton } from 'antd';
+import { BAIButton, BAICard, BAIFlex } from 'backend.ai-ui';
+import { Suspense, useState, useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
+import ErrorBoundaryWithNullFallback from 'src/components/ErrorBoundaryWithNullFallback';
+import { StringParam, useQueryParam, withDefault } from 'use-query-params';
+
+type TabKey = 'diagnostics';
+
+const tabParam = withDefault(StringParam, 'diagnostics');
+
+const DiagnosticsPage = () => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [isPending, startTransition] = useTransition();
+
+  const handleRefresh = () => {
+    startTransition(() => {
+      setRefreshKey((prev) => prev + 1);
+    });
+  };
+
+  return (
+    <BAICard
+      activeTabKey={curTabKey}
+      onTabChange={(key) => setCurTabKey(key as TabKey)}
+      tabList={[
+        {
+          key: 'diagnostics',
+          tab: t('webui.menu.Diagnostics'),
+        },
+      ]}
+      tabBarExtraContent={
+        <BAIButton
+          icon={<ReloadOutlined spin={isPending} />}
+          onClick={handleRefresh}
+          loading={isPending}
+        >
+          {t('diagnostics.Refresh')}
+        </BAIButton>
+      }
+    >
+      {curTabKey === 'diagnostics' && (
+        <BAIFlex direction="column" align="stretch" gap="md">
+          <Collapse
+            key={refreshKey}
+            defaultActiveKey={['csp', 'storage', 'endpoint', 'config']}
+            items={[
+              {
+                key: 'csp',
+                label: t('diagnostics.ContentSecurityPolicy'),
+                children: (
+                  <ErrorBoundaryWithNullFallback>
+                    <Suspense fallback={<Skeleton active />}>
+                      <CspDiagnosticsSection />
+                    </Suspense>
+                  </ErrorBoundaryWithNullFallback>
+                ),
+              },
+              {
+                key: 'storage',
+                label: t('diagnostics.StorageProxy'),
+                children: (
+                  <ErrorBoundaryWithNullFallback>
+                    <Suspense fallback={<Skeleton active />}>
+                      <StorageProxyDiagnosticsSection />
+                    </Suspense>
+                  </ErrorBoundaryWithNullFallback>
+                ),
+              },
+              {
+                key: 'endpoint',
+                label: t('diagnostics.EndpointConnectivity'),
+                children: (
+                  <ErrorBoundaryWithNullFallback>
+                    <Suspense fallback={<Skeleton active />}>
+                      <EndpointDiagnosticsSection />
+                    </Suspense>
+                  </ErrorBoundaryWithNullFallback>
+                ),
+              },
+              {
+                key: 'config',
+                label: t('diagnostics.WebServerConfig'),
+                children: (
+                  <ErrorBoundaryWithNullFallback>
+                    <Suspense fallback={<Skeleton active />}>
+                      <WebServerConfigDiagnosticsSection />
+                    </Suspense>
+                  </ErrorBoundaryWithNullFallback>
+                ),
+              },
+            ]}
+          />
+        </BAIFlex>
+      )}
+    </BAICard>
+  );
+};
+
+export default DiagnosticsPage;


### PR DESCRIPTION
Resolves #5119(FR-1956)

## Summary

- Add `DiagnosticResultList` component — renders alerts (critical/warning/info) and passed checks with icons
- Add section components: `CspDiagnosticsSection`, `StorageProxyDiagnosticsSection`, `EndpointDiagnosticsSection`, `WebServerConfigDiagnosticsSection`
- Add `DiagnosticsPage` with collapsible sections, refresh button using `useTransition`, and independent `Suspense`/`ErrorBoundary` per section