### PR TITLE
fix(FR-2108): apply language change immediately without page refresh

### DIFF
--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -172,12 +172,12 @@ const UserPreferencesPage = () => {
           onChange: (value: any) => {
             setSelectedLanguage(value);
             setLanguage(value);
-            const event = new CustomEvent('language-changed', {
+            const event = new CustomEvent('langChanged', {
               detail: {
-                language: value,
+                lang: value,
               },
             });
-            document.dispatchEvent(event);
+            window.dispatchEvent(event);
           },
         },
         globalThis.isElectron && {


### PR DESCRIPTION
Resolves #5495(FR-2108)

## Summary

- Fix event name mismatch: dispatch now uses `langChanged` to match the listener in `DefaultProviders.tsx`
- Fix detail property name mismatch: dispatch now uses `{ lang: value }` instead of `{ language: value }` to match what the listener reads via `e?.detail?.lang`
- Align dispatch target from `document` to `window` to match the `window.addEventListener('langChanged', ...)` listener

## Root Cause

`UserSettingsPage.tsx` dispatched a `CustomEvent('language-changed', { detail: { language: value } })` on `document`, but `DefaultProviders.tsx` listened for `langChanged` on `window` and read `e?.detail?.lang`. Both the event name and the detail property name were mismatched, causing the language change handler to never fire.

## Test plan

- [ ] Change language in User Settings and verify UI text updates immediately without page refresh
- [ ] Verify date formats (dayjs) update to match selected locale
- [ ] Verify HTML `lang` attribute on `<html>` element updates correctly
- [ ] Verify language preference persists across page reloads
- [ ] Verify initial language loading on page load is unaffected