### PR TITLE
fix(FR-2114): move @ts-ignore to correct import line in global-stores.ts

### DIFF
--- a/react/src/global-stores.ts
+++ b/react/src/global-stores.ts
@@ -21,8 +21,8 @@
 // Backend.AI client classes on globalThis.
 // Must be available before any component calls createBackendAIClient().
 // ---------------------------------------------------------------------------
-// @ts-ignore - resolved via craco webpack alias to dist/lib/backend.ai-client-esm.js
 import { generateUUID } from './helper/uuid';
+// @ts-ignore - resolved via craco webpack alias to dist/lib/backend.ai-client-esm.js
 import * as ai from 'backend.ai-client-esm';
 
 (globalThis as any).BackendAIClient = ai.backend.Client;


### PR DESCRIPTION
Resolves #5537 (FR-2114)

## Summary

- Move `@ts-ignore` comment from the `generateUUID` import (which doesn't need it) to the `backend.ai-client-esm` import (which does)
- Fixes TS2307 error: Cannot find module 'backend.ai-client-esm'