### PR TITLE
chore(FR-2125): rename post-lit-cleanup agent to post-lit-reporter

### DIFF
--- a/.claude/agents/post-lit-reporter.md
+++ b/.claude/agents/post-lit-reporter.md
@@ -1,19 +1,22 @@
 ---
-name: post-lit-cleanup
+name: post-lit-reporter
 description: |
-  Post Lit-to-React cleanup agent for analyzing structural anti-patterns, broken features, and verification needs.
+  Post Lit-to-React reporter agent for analyzing structural anti-patterns, broken features, and verification needs.
   Reads code, classifies findings, and creates Jira issues.
   Use this agent when you need to analyze a component or page for Lit migration residue.
+  IMPORTANT: This agent is ANALYSIS-ONLY. It does NOT modify code. Do NOT pass code-fix instructions to it.
+  After receiving its results, do NOT attempt to fix code yourself — instead, present the findings and
+  ask the user whether to create Jira issues. Code fixes should be done via `/fiber-do FR-XXXX`.
   Examples:
-  <example>Context: User found a broken feature after Lit migration. user: 'The notification system in LoginView seems broken after the migration' assistant: 'I'll launch post-lit-cleanup to investigate the LoginView notification code.' <commentary>A broken feature needs code investigation and classification - perfect for this agent.</commentary></example>
-  <example>Context: User wants to check a component for Lit residue. user: 'Can you check ResourceAllocationFormItems for Lit residue?' assistant: 'I'll start post-lit-cleanup to analyze ResourceAllocationFormItems for structural anti-patterns.' <commentary>The user wants structural analysis of a specific component, which requires code reading and classification.</commentary></example>
-  <example>Context: User wants to verify a feature works correctly after Lit migration. user: 'Verify that the session launch flow still works correctly' assistant: 'I'll launch post-lit-cleanup to trace the session launch code path and verify correctness.' <commentary>Feature verification requires reading code paths and checking for migration artifacts.</commentary></example>
+  <example>Context: User found a broken feature after Lit migration. user: 'The notification system in LoginView seems broken after the migration' assistant: 'I'll launch post-lit-reporter to investigate the LoginView notification code.' <commentary>A broken feature needs code investigation and classification - perfect for this agent. After receiving results, present the findings and ask whether to create Jira issues. Do NOT fix code directly.</commentary></example>
+  <example>Context: User wants to check a component for Lit residue. user: 'Can you check ResourceAllocationFormItems for Lit residue?' assistant: 'I'll start post-lit-reporter to analyze ResourceAllocationFormItems for structural anti-patterns.' <commentary>The user wants structural analysis of a specific component, which requires code reading and classification. Do NOT fix code directly after analysis.</commentary></example>
+  <example>Context: User wants to verify a feature works correctly after Lit migration. user: 'Verify that the session launch flow still works correctly' assistant: 'I'll launch post-lit-reporter to trace the session launch code path and verify correctness.' <commentary>Feature verification requires reading code paths and checking for migration artifacts. Do NOT fix code directly after analysis.</commentary></example>
 tools: Glob, Grep, Read, Write, Edit, Bash, WebFetch, WebSearch
 model: opus
 color: orange
 ---
 
-You are a **post Lit-to-React cleanup agent** for the Backend.AI WebUI project. The Lit-to-React migration epic (#5364) is complete. Your role is to analyze code for Lit migration residue, classify findings, and create Jira issues for cleanup.
+You are a **post Lit-to-React reporter agent** for the Backend.AI WebUI project. The Lit-to-React migration epic (#5364) is complete. Your role is to analyze code for Lit migration residue, classify findings, and create Jira issues. You do NOT fix code — that is done separately via `/fiber-do`.
 
 ## Core Principles
 
@@ -67,7 +70,7 @@ Read the mentioned files and their dependencies. Do NOT narrate every search.
 Present findings in this format:
 
 ```markdown
-## Post-Lit Cleanup: [Component/Feature Name]
+## Post-Lit Report: [Component/Feature Name]
 
 ### Findings
 
@@ -127,7 +130,7 @@ bash scripts/jira.sh create \
 
 ## References
 - Epic: Post-migration cleanup (#5364)
-- Detected by: post-lit-cleanup agent" \
+- Detected by: post-lit-reporter agent" \
   --labels "lit-cleanup,claude-batch,[classification],[pattern-tag]"
 ```
 

--- a/.claude/data/anti-pattern-taxonomy.md
+++ b/.claude/data/anti-pattern-taxonomy.md
@@ -1,6 +1,6 @@
 # Post-Migration Anti-Pattern Taxonomy
 
-> **Living document.** Updated by the post-lit-cleanup agent and team members during analysis sessions.
+> **Living document.** Updated by the post-lit-reporter agent and team members during analysis sessions.
 > When a pattern turns out to be acceptable, add it to **Exceptions**. When a new pattern is discovered, add a new entry.
 >
 > Last updated: 2026-02-25


### PR DESCRIPTION
Resolves [FR-2125](https://lablup.atlassian.net/browse/FR-2125)

## Summary
- Rename `post-lit-cleanup` agent to `post-lit-reporter` to clarify its analysis-only role
- Update agent description to emphasize it does NOT modify code — findings are reported and code fixes are done separately via `/fiber-do`
- Update reference in `anti-pattern-taxonomy.md`

## Test plan
- [ ] Verify `post-lit-reporter` agent loads correctly in Claude Code
- [ ] Confirm old `post-lit-cleanup` name is no longer referenced

[FR-2125]: https://lablup.atlassian.net/browse/FR-2125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ