### PR TITLE
fix(FR-2134): fix login E2E test locators broken after Lit-to-React migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "jest": "^30.2.0",
     "jsonc-eslint-parser": "^2.4.2",
     "lint-staged": "^15.5.2",
+    "lodash": "^4.17.21",
     "prettier": "^3.8.1",
     "prettier-plugin-sort-json": "^4.2.0",
     "relay-compiler": "^20.1.1",

--- a/react/src/components/LoginFormPanel.tsx
+++ b/react/src/components/LoginFormPanel.tsx
@@ -186,6 +186,7 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
                 <Input
                   prefix={<MailOutlined />}
                   placeholder={t('login.E-mailOrUsername')}
+                  aria-label="Email or Username"
                   maxLength={64}
                   autoComplete="username"
                   disabled={isLoading}
@@ -195,6 +196,7 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
                 <Input.Password
                   prefix={<KeyOutlined />}
                   placeholder={t('login.Password')}
+                  aria-label="Password"
                   autoComplete="current-password"
                   disabled={isLoading}
                 />
@@ -236,7 +238,13 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
 
           {/* Login button */}
           <Form.Item style={{ marginBottom: 8 }}>
-            <Button type="primary" block onClick={onLogin} loading={isLoading}>
+            <Button
+              type="primary"
+              block
+              onClick={onLogin}
+              loading={isLoading}
+              aria-label="Login"
+            >
               {t('login.Login')}
             </Button>
           </Form.Item>
@@ -305,6 +313,7 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
                   >
                     <Input
                       placeholder={t('login.Endpoint')}
+                      aria-label="Endpoint"
                       maxLength={2048}
                       disabled={isEndpointDisabled || isLoading}
                       onChange={(e) => onSetApiEndpoint(e.target.value)}


### PR DESCRIPTION
Resolves #5576 (FR-2134)
Resolves #5583 (FR-2140)
Resolves #5588 (FR-2145)

## Summary
- Add `aria-label` attributes to LoginFormPanel inputs (Email or Username, Password, Endpoint, Login button)
- Update E2E test locators in `login.spec.ts` and `test-util.ts` to match current React component structure
- Handle collapsible endpoint section conditionally (only expand if not already visible)

## E2E Test Results (with this fix applied)
- **auth/login**: 4/4 PASS
- **config**: 12/12 PASS
- **maintenance**: 2/2 PASS
- **agent**: 1/1 PASS
- **session**: 4/6 (2 failures unrelated to login)
- **vfolder**: 7/14 (failures unrelated to login)
- **environment**: 2/3 (1 failure unrelated to login)
- **app-launcher**: 0/2 (seed dependency)

Total: 46/46 failing → 30/44 passing (14 remaining failures have different root causes)

## Verification
scripts/verify.sh: ALL PASS