### PR TITLE
fix(FR-2143): fix file-upload E2E test locators for icon+text cell rendering

### DIFF
--- a/e2e/utils/classes/vfolder/FolderExplorerModal.ts
+++ b/e2e/utils/classes/vfolder/FolderExplorerModal.ts
@@ -10,7 +10,7 @@ export class FolderExplorerModal {
   }
 
   async waitForOpen(): Promise<void> {
-    await expect(this.modal).toBeVisible();
+    await expect(this.modal).toBeVisible({ timeout: 10000 });
   }
 
   async clickCloseButton(): Promise<void> {
@@ -20,7 +20,7 @@ export class FolderExplorerModal {
 
   async close(): Promise<void> {
     await this.clickCloseButton();
-    await expect(this.modal).not.toBeVisible({ timeout: 2000 });
+    await expect(this.modal).not.toBeVisible({ timeout: 5000 });
   }
 
   async verifyFolderName(folderName: string): Promise<void> {
@@ -38,7 +38,7 @@ export class FolderExplorerModal {
   async verifyFileExplorerLoaded(): Promise<void> {
     await expect(
       this.modal.getByRole('columnheader', { name: 'Name' }),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 10000 });
   }
 
   async verifyFileExplorerNotLoaded(): Promise<void> {
@@ -52,7 +52,7 @@ export class FolderExplorerModal {
     const uploadButton = this.modal.getByRole('button', {
       name: 'upload Upload',
     });
-    await expect(uploadButton).toBeVisible();
+    await expect(uploadButton).toBeVisible({ timeout: 10000 });
     return uploadButton;
   }
 
@@ -102,7 +102,7 @@ export class FolderExplorerModal {
 
   async verifyFileVisible(fileName: string): Promise<void> {
     await expect(
-      this.modal.getByRole('cell', { name: fileName, exact: true }),
+      this.modal.getByRole('cell').filter({ hasText: fileName }),
     ).toBeVisible({
       timeout: 10000,
     });

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -476,8 +476,8 @@ export async function deleteForeverAndVerifyFromTrash(
   const deletionNotification = page.getByRole('alert').filter({
     hasText: /deleted forever/i,
   });
-  await expect(deletionNotification).toBeVisible({ timeout: 10000 });
-  await expect(deletionNotification).toBeHidden({ timeout: 10000 });
+  await expect(deletionNotification).toBeVisible({ timeout: 15000 });
+  await expect(deletionNotification).toBeHidden({ timeout: 15000 });
 
   // Verify deletion - clear filters again and search
   await clearAllFilters(page);

--- a/e2e/vfolder/file-upload-dnd.spec.ts
+++ b/e2e/vfolder/file-upload-dnd.spec.ts
@@ -17,12 +17,13 @@ const openFolderExplorer = async (
   folderName: string,
 ): Promise<FolderExplorerModal> => {
   await navigateTo(page, 'data');
-  await page
-    .getByRole('link', { name: folderName })
-    .first()
-    .click({ force: true });
+  await page.waitForLoadState('networkidle');
+  const folderLink = page.getByRole('link', { name: folderName }).first();
+  await expect(folderLink).toBeVisible({ timeout: 15000 });
+  await folderLink.click();
   const modal = new FolderExplorerModal(page);
   await modal.waitForOpen();
+  await modal.verifyFileExplorerLoaded();
   return modal;
 };
 

--- a/e2e/vfolder/file-upload-duplicate.spec.ts
+++ b/e2e/vfolder/file-upload-duplicate.spec.ts
@@ -17,12 +17,13 @@ const openFolderExplorer = async (
   folderName: string,
 ): Promise<FolderExplorerModal> => {
   await navigateTo(page, 'data');
-  await page
-    .getByRole('link', { name: folderName })
-    .first()
-    .click({ force: true });
+  await page.waitForLoadState('networkidle');
+  const folderLink = page.getByRole('link', { name: folderName }).first();
+  await expect(folderLink).toBeVisible({ timeout: 15000 });
+  await folderLink.click();
   const modal = new FolderExplorerModal(page);
   await modal.waitForOpen();
+  await modal.verifyFileExplorerLoaded();
   return modal;
 };
 

--- a/e2e/vfolder/file-upload-permissions.spec.ts
+++ b/e2e/vfolder/file-upload-permissions.spec.ts
@@ -21,12 +21,13 @@ const openFolderExplorer = async (
   folderName: string,
 ): Promise<FolderExplorerModal> => {
   await navigateTo(page, 'data');
-  await page
-    .getByRole('link', { name: folderName })
-    .first()
-    .click({ force: true });
+  await page.waitForLoadState('networkidle');
+  const folderLink = page.getByRole('link', { name: folderName }).first();
+  await expect(folderLink).toBeVisible({ timeout: 15000 });
+  await folderLink.click();
   const modal = new FolderExplorerModal(page);
   await modal.waitForOpen();
+  await modal.verifyFileExplorerLoaded();
   return modal;
 };
 

--- a/e2e/vfolder/file-upload-subdirectory.spec.ts
+++ b/e2e/vfolder/file-upload-subdirectory.spec.ts
@@ -17,12 +17,13 @@ const openFolderExplorer = async (
   folderName: string,
 ): Promise<FolderExplorerModal> => {
   await navigateTo(page, 'data');
-  await page
-    .getByRole('link', { name: folderName })
-    .first()
-    .click({ force: true });
+  await page.waitForLoadState('networkidle');
+  const folderLink = page.getByRole('link', { name: folderName }).first();
+  await expect(folderLink).toBeVisible({ timeout: 15000 });
+  await folderLink.click();
   const modal = new FolderExplorerModal(page);
   await modal.waitForOpen();
+  await modal.verifyFileExplorerLoaded();
   return modal;
 };
 

--- a/e2e/vfolder/file-upload.spec.ts
+++ b/e2e/vfolder/file-upload.spec.ts
@@ -7,7 +7,7 @@ import {
   moveToTrashAndVerify,
   deleteForeverAndVerifyFromTrash,
 } from '../utils/test-util';
-import { test, Page } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -17,12 +17,13 @@ const openFolderExplorer = async (
   folderName: string,
 ): Promise<FolderExplorerModal> => {
   await navigateTo(page, 'data');
-  await page
-    .getByRole('link', { name: folderName })
-    .first()
-    .click({ force: true });
+  await page.waitForLoadState('networkidle');
+  const folderLink = page.getByRole('link', { name: folderName }).first();
+  await expect(folderLink).toBeVisible({ timeout: 15000 });
+  await folderLink.click();
   const modal = new FolderExplorerModal(page);
   await modal.waitForOpen();
+  await modal.verifyFileExplorerLoaded();
   return modal;
 };
 

--- a/e2e/vfolder/vfolder-explorer-modal.spec.ts
+++ b/e2e/vfolder/vfolder-explorer-modal.spec.ts
@@ -16,12 +16,13 @@ const openFolderExplorer = async (
   folderName: string,
 ): Promise<FolderExplorerModal> => {
   await navigateTo(page, 'data');
-  await page
-    .getByRole('link', { name: folderName })
-    .first()
-    .click({ force: true });
+  await page.waitForLoadState('networkidle');
+  const folderLink = page.getByRole('link', { name: folderName }).first();
+  await expect(folderLink).toBeVisible({ timeout: 15000 });
+  await folderLink.click();
   const modal = new FolderExplorerModal(page);
   await modal.waitForOpen();
+  await modal.verifyFileExplorerLoaded();
   return modal;
 };
 
@@ -37,6 +38,7 @@ test.describe.serial(
     test('User can create folders and upload files in VFolder with write permissions', async ({
       page,
     }) => {
+      test.setTimeout(60000);
       const rwFolderName = 'e2e-test-folder-rw-' + new Date().getTime();
 
       // 1. Create a VFolder with Read & Write permissions
@@ -73,6 +75,7 @@ test.describe.serial(
     test('User can view files but cannot upload to read-only VFolder', async ({
       page,
     }) => {
+      test.setTimeout(60000);
       const roFolderName = 'e2e-test-folder-ro-' + new Date().getTime();
 
       // 1. Create a VFolder with Read Only permissions
@@ -184,7 +187,7 @@ test.describe(
 
       // 5. Wait for modal to actually be hidden
       await expect(page.getByRole('dialog').first()).not.toBeVisible({
-        timeout: 2000,
+        timeout: 5000,
       });
 
       // 6. Verify URL no longer has folder parameter


### PR DESCRIPTION
Resolves #5586 (FR-2143)

## Summary
- Fix `verifyFileVisible()` in `FolderExplorerModal.ts` to handle Ant Design table cells that contain both an icon (FileOutlined) and text — changed from exact cell name match to `filter({ hasText })`
- Fix flaky timing issues across all vfolder E2E tests:
  - Replace `click({ force: true })` with proper `waitForLoadState('networkidle')` + `expect().toBeVisible()` before clicking folder links
  - Add `verifyFileExplorerLoaded()` after modal opens to ensure content is ready
  - Increase timeouts on `waitForOpen()` (5s→10s), `verifyFileExplorerLoaded()` (5s→10s), `getUploadButton()` (5s→10s), `close()` (2s→5s), deletion notification (10s→15s)
  - Add missing `expect` import in `file-upload.spec.ts`

## Changed Files
| File | Change |
|------|--------|
| `e2e/utils/classes/vfolder/FolderExplorerModal.ts` | Fix `verifyFileVisible` locator, increase timeouts |
| `e2e/utils/test-util.ts` | Increase deletion notification timeout |
| `e2e/vfolder/file-upload.spec.ts` | Add `expect` import, fix `openFolderExplorer` |
| `e2e/vfolder/file-upload-dnd.spec.ts` | Fix `openFolderExplorer` timing |
| `e2e/vfolder/file-upload-duplicate.spec.ts` | Fix `openFolderExplorer` timing |
| `e2e/vfolder/file-upload-subdirectory.spec.ts` | Fix `openFolderExplorer` timing |
| `e2e/vfolder/file-upload-permissions.spec.ts` | Fix `openFolderExplorer` timing |
| `e2e/vfolder/vfolder-explorer-modal.spec.ts` | Fix `openFolderExplorer` timing, fix close timeout |