### PR TITLE
feat(FR-1962): migrate localStorage settings to GraphQL AppConfig

### DIFF
--- a/react/src/hooks/useAppConfig.tsx
+++ b/react/src/hooks/useAppConfig.tsx
@@ -23,6 +23,9 @@ export interface AppConfigExtra {
   desktop_notification?: boolean;
   preserve_login?: boolean;
   auto_logout?: boolean;
+  automatic_update_check?: boolean;
+  experimental_ai_agents?: boolean;
+  max_concurrent_uploads?: number;
   beta_feature?: boolean;
   resource_panel_type?:
     | 'MyResource'

--- a/react/src/hooks/useAppConfig.tsx
+++ b/react/src/hooks/useAppConfig.tsx
@@ -2,6 +2,34 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+// TODO(needs-backend): Migration plan for Domain Configuration API
+//
+// When the backend implements the new schema (spec: 2026.1.23), this file
+// should be updated as follows:
+//
+// 1. Queries:
+//    - mergedAppConfig { extraConfig }  →  userPreference { mergedValue }
+//    - userAppConfig { extraConfig }    →  userPreference { value }
+//
+// 2. Mutations:
+//    - upsertUserAppConfig (full replacement)  →  setUserPreference (partial update)
+//    - deleteUserAppConfig                     →  TBD (clarify with backend)
+//
+// 3. New hooks to add:
+//    - useDomainConfig(domain): reads DomainConfig with scoped fields
+//      (publicConfig, authenticatedConfig, adminConfig, userPreferenceDefaults)
+//    - useDomainPublicConfig(domain): reads public config without auth
+//      (for pre-login theme/branding)
+//    - useSetDomainConfig(): admin mutation for domain-level settings
+//
+// 4. Access control scopes (DomainConfig fields):
+//    - publicConfig:             anyone (including anonymous)
+//    - authenticatedConfig:      logged-in users
+//    - adminConfig:              admin only
+//    - userPreferenceDefaults:   logged-in users (read), admin (write)
+//
+// The consumer-facing `useAppSetting` hook interface should remain unchanged,
+// so page-level components (e.g., UserSettingsPage) won't need modifications.
 import type { useAppConfigDeleteUserMutation } from '../__generated__/useAppConfigDeleteUserMutation.graphql';
 import type { useAppConfigMergedQuery } from '../__generated__/useAppConfigMergedQuery.graphql';
 import type { useAppConfigUpsertUserMutation } from '../__generated__/useAppConfigUpsertUserMutation.graphql';
@@ -15,6 +43,10 @@ import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
  *
  * All keys are optional — absence means "use domain default" (or no value set).
  * Keep this flat (single-level keys) because the backend uses shallow merge.
+ *
+ * TODO(needs-backend): This interface corresponds to the `UserPreference.value`
+ * JSON blob in the new spec. The shape can remain the same; consider renaming
+ * to `UserPreferenceValue` for clarity.
  */
 export interface AppConfigExtra {
   // UI preferences
@@ -40,6 +72,10 @@ export interface AppConfigExtra {
  * where user settings take precedence for the same keys (shallow merge).
  *
  * This hook suspends while loading — wrap with a Suspense boundary.
+ *
+ * TODO(needs-backend): Replace `mergedAppConfig { extraConfig }` with
+ * `userPreference { mergedValue }` when the Domain Configuration API lands.
+ * The returned shape stays the same — only the GraphQL operation changes.
  */
 export const useAppConfig = (options?: {
   fetchPolicy?: 'store-and-network' | 'store-or-network' | 'network-only';
@@ -78,6 +114,11 @@ export const useAppConfig = (options?: {
  * set vs what comes from domain defaults.
  *
  * Returns `null` if no user config has been set yet.
+ *
+ * TODO(needs-backend): Replace `userAppConfig { extraConfig }` with
+ * `userPreference { value }`. Once the new API supports partial updates via
+ * `setUserPreference`, this hook will only be needed for displaying which
+ * values the user has explicitly overridden (vs domain defaults).
  */
 export const useUserAppConfig = (options?: {
   fetchPolicy?: 'store-and-network' | 'store-or-network' | 'network-only';
@@ -118,6 +159,11 @@ export const useUserAppConfig = (options?: {
  * completely replaces the existing user config. To do a partial update, first
  * read the current config with `useUserAppConfig()`, merge your changes, then
  * call the upsert function with the full merged object.
+ *
+ * TODO(needs-backend): Replace with `setUserPreference` mutation which supports
+ * native partial updates. This will eliminate the read-merge-write pattern —
+ * callers can simply send `{ value: { [key]: newValue } }` and the backend
+ * will merge it. The `useAppSetting` hook can then be greatly simplified.
  *
  * @example
  * ```tsx
@@ -175,6 +221,10 @@ export const useUpsertUserAppConfig = () => {
  * Returns a function to delete the user's app configuration.
  *
  * After deletion, `mergedAppConfig` will return only domain-level defaults.
+ *
+ * TODO(needs-backend): The new spec does not define a separate delete mutation
+ * for user preferences. Clarify with backend whether deletion will be handled
+ * via `setUserPreference(value: {})` or a dedicated mutation.
  */
 export const useDeleteUserAppConfig = () => {
   'use memo';

--- a/react/src/hooks/useAppSetting.tsx
+++ b/react/src/hooks/useAppSetting.tsx
@@ -1,0 +1,75 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  AppConfigExtra,
+  useAppConfig,
+  useUpsertUserAppConfig,
+  useUserAppConfig,
+} from './useAppConfig';
+import { useBAISettingUserState } from './useBAISetting';
+import { useCallback } from 'react';
+
+/**
+ * Keys in `AppConfigExtra` that have a matching key in `UserSettings` (localStorage).
+ * Only these keys can be used with `useAppSetting`.
+ */
+type MigratableSettingKey = Extract<
+  keyof AppConfigExtra,
+  | 'selected_language'
+  | 'compact_sidebar'
+  | 'desktop_notification'
+  | 'preserve_login'
+  | 'auto_logout'
+  | 'beta_feature'
+  | 'resource_panel_type'
+>;
+
+/**
+ * Bridge hook that reads from server-synced AppConfig with localStorage fallback.
+ *
+ * - Reads: server value takes priority; falls back to localStorage if server has no value
+ * - Writes: updates both server (via GraphQL mutation) and localStorage (for backward compat)
+ *
+ * This hook suspends while loading — the component must be wrapped in a Suspense boundary.
+ *
+ * @example
+ * ```tsx
+ * const [compactSidebar, setCompactSidebar] = useAppSetting('compact_sidebar');
+ * ```
+ */
+export const useAppSetting = <K extends MigratableSettingKey>(
+  key: K,
+): [AppConfigExtra[K], (newValue: AppConfigExtra[K]) => void] => {
+  'use memo';
+
+  // Server-synced config (merged domain + user)
+  const [mergedConfig] = useAppConfig();
+  // User-only config (needed for partial updates since backend does full replacement)
+  const [userConfig] = useUserAppConfig();
+  // localStorage fallback
+  const [localValue, setLocalValue] = useBAISettingUserState(key);
+  // Mutation
+  const [upsertConfig] = useUpsertUserAppConfig();
+
+  // Server value takes priority; fall back to localStorage
+  const serverValue = mergedConfig[key];
+  const value = serverValue !== undefined ? serverValue : localValue;
+
+  const setValue = useCallback(
+    (newValue: AppConfigExtra[K]) => {
+      // Write to localStorage for backward compatibility
+      setLocalValue(newValue as any);
+
+      // Write to server (full replacement — merge with existing user config)
+      upsertConfig({
+        ...(userConfig ?? {}),
+        [key]: newValue,
+      });
+    },
+    [key, setLocalValue, upsertConfig, userConfig],
+  );
+
+  return [value as AppConfigExtra[K], setValue];
+};

--- a/react/src/hooks/useAppSetting.tsx
+++ b/react/src/hooks/useAppSetting.tsx
@@ -9,7 +9,7 @@ import {
   useUserAppConfig,
 } from './useAppConfig';
 import { useBAISettingUserState } from './useBAISetting';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 /**
  * Keys in `AppConfigExtra` that have a matching key in `UserSettings` (localStorage).
@@ -22,6 +22,9 @@ type MigratableSettingKey = Extract<
   | 'desktop_notification'
   | 'preserve_login'
   | 'auto_logout'
+  | 'automatic_update_check'
+  | 'experimental_ai_agents'
+  | 'max_concurrent_uploads'
   | 'beta_feature'
   | 'resource_panel_type'
 >;
@@ -45,30 +48,61 @@ export const useAppSetting = <K extends MigratableSettingKey>(
   'use memo';
 
   // Server-synced config (merged domain + user)
-  const [mergedConfig] = useAppConfig();
+  const [mergedConfig, { refresh: refreshMerged }] = useAppConfig();
   // User-only config (needed for partial updates since backend does full replacement)
-  const [userConfig] = useUserAppConfig();
+  const [userConfig, { refresh: refreshUser }] = useUserAppConfig();
   // localStorage fallback
   const [localValue, setLocalValue] = useBAISettingUserState(key);
   // Mutation
   const [upsertConfig] = useUpsertUserAppConfig();
 
+  // Optimistic local state for immediate UI feedback
+  const [optimisticValue, setOptimisticValue] = useState<
+    AppConfigExtra[K] | null
+  >(null);
+
   // Server value takes priority; fall back to localStorage
   const serverValue = mergedConfig[key];
-  const value = serverValue !== undefined ? serverValue : localValue;
+  const baseValue = serverValue !== undefined ? serverValue : localValue;
+  // Optimistic value takes highest priority for immediate UI response
+  const value = optimisticValue !== null ? optimisticValue : baseValue;
 
   const setValue = useCallback(
     (newValue: AppConfigExtra[K]) => {
+      // Optimistically update UI immediately
+      setOptimisticValue(newValue);
+
       // Write to localStorage for backward compatibility
       setLocalValue(newValue as any);
 
       // Write to server (full replacement — merge with existing user config)
-      upsertConfig({
-        ...(userConfig ?? {}),
-        [key]: newValue,
-      });
+      upsertConfig(
+        {
+          ...(userConfig ?? {}),
+          [key]: newValue,
+        },
+        {
+          onCompleted: () => {
+            // Clear optimistic state and refresh queries so Relay cache is up-to-date
+            setOptimisticValue(null);
+            refreshMerged();
+            refreshUser();
+          },
+          onError: () => {
+            setOptimisticValue(null);
+          },
+        },
+      );
     },
-    [key, setLocalValue, upsertConfig, userConfig],
+    [
+      key,
+      setLocalValue,
+      setOptimisticValue,
+      upsertConfig,
+      userConfig,
+      refreshMerged,
+      refreshUser,
+    ],
   );
 
   return [value as AppConfigExtra[K], setValue];

--- a/react/src/hooks/useAppSetting.tsx
+++ b/react/src/hooks/useAppSetting.tsx
@@ -14,6 +14,11 @@ import { useCallback, useState } from 'react';
 /**
  * Keys in `AppConfigExtra` that have a matching key in `UserSettings` (localStorage).
  * Only these keys can be used with `useAppSetting`.
+ *
+ * TODO(needs-backend): Once all settings are server-managed via `UserPreference`,
+ * this type can be replaced with `keyof AppConfigExtra` directly, removing the
+ * need for an explicit allowlist. The localStorage migration bridge can also be
+ * removed at that point.
  */
 type MigratableSettingKey = Extract<
   keyof AppConfigExtra,
@@ -37,6 +42,13 @@ type MigratableSettingKey = Extract<
  *
  * This hook suspends while loading — the component must be wrapped in a Suspense boundary.
  *
+ * TODO(needs-backend): When the Domain Configuration API lands with partial update
+ * support (`setUserPreference`), this hook can be simplified significantly:
+ *   - Remove `useUserAppConfig()` dependency (no more read-merge-write)
+ *   - Remove localStorage dual-write once migration period ends
+ *   - setValue can directly call `setUserPreference({ value: { [key]: newValue } })`
+ *   - The public interface `[value, setValue]` remains unchanged for consumers
+ *
  * @example
  * ```tsx
  * const [compactSidebar, setCompactSidebar] = useAppSetting('compact_sidebar');
@@ -49,7 +61,8 @@ export const useAppSetting = <K extends MigratableSettingKey>(
 
   // Server-synced config (merged domain + user)
   const [mergedConfig, { refresh: refreshMerged }] = useAppConfig();
-  // User-only config (needed for partial updates since backend does full replacement)
+  // User-only config (needed for read-merge-write since backend does full replacement)
+  // TODO(needs-backend): Remove once `setUserPreference` supports partial updates
   const [userConfig, { refresh: refreshUser }] = useUserAppConfig();
   // localStorage fallback
   const [localValue, setLocalValue] = useBAISettingUserState(key);
@@ -64,6 +77,12 @@ export const useAppSetting = <K extends MigratableSettingKey>(
   // Server value takes priority; fall back to localStorage
   const serverValue = mergedConfig[key];
   const baseValue = serverValue !== undefined ? serverValue : localValue;
+
+  // Clear optimistic state once server value has caught up
+  if (optimisticValue !== null && serverValue === optimisticValue) {
+    setOptimisticValue(null);
+  }
+
   // Optimistic value takes highest priority for immediate UI response
   const value = optimisticValue !== null ? optimisticValue : baseValue;
 
@@ -72,10 +91,11 @@ export const useAppSetting = <K extends MigratableSettingKey>(
       // Optimistically update UI immediately
       setOptimisticValue(newValue);
 
-      // Write to localStorage for backward compatibility
+      // TODO(needs-backend): Remove localStorage dual-write once migration period ends
       setLocalValue(newValue as any);
 
-      // Write to server (full replacement — merge with existing user config)
+      // TODO(needs-backend): Replace with `setUserPreference({ value: { [key]: newValue } })`
+      // to use native partial updates instead of this read-merge-write pattern.
       upsertConfig(
         {
           ...(userConfig ?? {}),
@@ -83,8 +103,7 @@ export const useAppSetting = <K extends MigratableSettingKey>(
         },
         {
           onCompleted: () => {
-            // Clear optimistic state and refresh queries so Relay cache is up-to-date
-            setOptimisticValue(null);
+            // Refresh queries so Relay cache catches up with server
             refreshMerged();
             refreshUser();
           },

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -7,6 +7,7 @@ import MyKeypairInfoModal from '../components/MyKeypairInfoModal';
 import SSHKeypairManagementModal from '../components/SSHKeypairManagementModal';
 import SettingList, { SettingGroup } from '../components/SettingList';
 import ShellScriptEditModal from '../components/ShellScriptEditModal';
+import { useAppSetting } from '../hooks/useAppSetting';
 import {
   useBAISettingGeneralState,
   useBAISettingUserState,
@@ -34,25 +35,23 @@ const UserPreferencesPage = () => {
   const { message } = App.useApp();
   const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
 
-  const [desktopNotification, setDesktopNotification] = useBAISettingUserState(
+  const [desktopNotification, setDesktopNotification] = useAppSetting(
     'desktop_notification',
   );
-  const [compactSidebar, setCompactSidebar] =
-    useBAISettingUserState('compact_sidebar');
+  const [compactSidebar, setCompactSidebar] = useAppSetting('compact_sidebar');
   const [selectedLanguage, setSelectedLanguage] =
-    useBAISettingUserState('selected_language');
+    useAppSetting('selected_language');
   const [, setLanguage] = useBAISettingGeneralState('language');
   const [autoAutomaticUpdateCheck, setAutoAutomaticUpdateCheck] =
     useBAISettingUserState('automatic_update_check');
-  const [autoLogout, setAutoLogout] = useBAISettingUserState('auto_logout');
+  const [autoLogout, setAutoLogout] = useAppSetting('auto_logout');
   const [isOpenSSHKeypairInfoModal, { toggle: toggleSSHKeypairInfoModal }] =
     useToggle(false);
   const [
     isOpenSSHKeypairManagementModal,
     { toggle: toggleSSHKeypairManagementModal },
   ] = useToggle(false);
-  const [preserveLogin, setPreserveLogin] =
-    useBAISettingUserState('preserve_login');
+  const [preserveLogin, setPreserveLogin] = useAppSetting('preserve_login');
   const [experimentalAIAgents, setExperimentalAIAgents] =
     useBAISettingUserState('experimental_ai_agents');
   const [shellInfo, setShellInfo] = useState<ShellScriptType>('bootstrap');

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -8,10 +8,7 @@ import SSHKeypairManagementModal from '../components/SSHKeypairManagementModal';
 import SettingList, { SettingGroup } from '../components/SettingList';
 import ShellScriptEditModal from '../components/ShellScriptEditModal';
 import { useAppSetting } from '../hooks/useAppSetting';
-import {
-  useBAISettingGeneralState,
-  useBAISettingUserState,
-} from '../hooks/useBAISetting';
+import { useBAISettingGeneralState } from '../hooks/useBAISetting';
 import { SettingOutlined } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
 import { App, Button, Skeleton, Typography } from 'antd';
@@ -42,8 +39,9 @@ const UserPreferencesPage = () => {
   const [selectedLanguage, setSelectedLanguage] =
     useAppSetting('selected_language');
   const [, setLanguage] = useBAISettingGeneralState('language');
-  const [autoAutomaticUpdateCheck, setAutoAutomaticUpdateCheck] =
-    useBAISettingUserState('automatic_update_check');
+  const [autoAutomaticUpdateCheck, setAutoAutomaticUpdateCheck] = useAppSetting(
+    'automatic_update_check',
+  );
   const [autoLogout, setAutoLogout] = useAppSetting('auto_logout');
   const [isOpenSSHKeypairInfoModal, { toggle: toggleSSHKeypairInfoModal }] =
     useToggle(false);
@@ -52,12 +50,13 @@ const UserPreferencesPage = () => {
     { toggle: toggleSSHKeypairManagementModal },
   ] = useToggle(false);
   const [preserveLogin, setPreserveLogin] = useAppSetting('preserve_login');
-  const [experimentalAIAgents, setExperimentalAIAgents] =
-    useBAISettingUserState('experimental_ai_agents');
+  const [experimentalAIAgents, setExperimentalAIAgents] = useAppSetting(
+    'experimental_ai_agents',
+  );
   const [shellInfo, setShellInfo] = useState<ShellScriptType>('bootstrap');
   const [isOpenShellScriptEditModal, { toggle: toggleShellScriptEditModal }] =
     useToggle(false);
-  const [maxConcurrentUpload, setMaxConcurrentUpload] = useBAISettingUserState(
+  const [maxConcurrentUpload, setMaxConcurrentUpload] = useAppSetting(
     'max_concurrent_uploads',
   );
 


### PR DESCRIPTION
Resolves #5125(FR-1962)

## Summary

- Create `useAppSetting()` bridge hook that reads from server-synced AppConfig with localStorage fallback
- On write, updates both server (GraphQL mutation) and localStorage (backward compat)
- Optimistic updates with render-time state clearing to prevent badge flicker
- Migrate 8 settings in `UserSettingsPage` from `useBAISettingUserState` to `useAppSetting`:
  - `desktop_notification`
  - `compact_sidebar`
  - `selected_language`
  - `auto_logout`
  - `preserve_login`
  - `automatic_update_check`
  - `experimental_ai_agents`
  - `max_concurrent_uploads`

## How It Works

1. **Read**: Server value (`mergedAppConfig`) takes priority; falls back to localStorage if server has no value
2. **Write**: Updates localStorage immediately + fires `upsertUserAppConfig` mutation (full replacement with merged user config)
3. **Backward compat**: Settings not yet migrated in other components continue to work via localStorage

## New Files

- `react/src/hooks/useAppSetting.tsx` — Bridge hook with `MigratableSettingKey` type

## Modified Files

- `react/src/hooks/useAppConfig.tsx` — Add `automatic_update_check`, `experimental_ai_agents`, `max_concurrent_uploads` to `AppConfigExtra`
- `react/src/pages/UserSettingsPage.tsx` — Swap 8 settings from `useBAISettingUserState` to `useAppSetting`

## Verification

```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```