### PR TITLE
chore: add create-e2e-test and fix-e2e-test Claude commands

### DIFF
--- a/.claude/commands/create-e2e-test.md
+++ b/.claude/commands/create-e2e-test.md
@@ -1,0 +1,218 @@
+---
+description: Create E2E tests for a feature or page using Playwright. Leverages existing POM classes, test utilities, and project conventions.
+argument-hint: <feature-description or page-path>
+---
+
+# Create E2E Test
+
+Create comprehensive Playwright E2E tests for: `$ARGUMENTS`
+
+## Process
+
+### 1. Understand the Target
+
+Analyze what needs to be tested:
+- If `$ARGUMENTS` is a page path (e.g., `/data`, `/session`), test that page's features
+- If `$ARGUMENTS` is a feature description (e.g., "file upload in vfolder"), test that specific feature
+- If `$ARGUMENTS` is a component name, find the component and test its user-facing behavior
+
+### 2. Research Phase
+
+Use the Explore agent to gather context:
+
+```
+Task({
+  subagent_type: "Explore",
+  prompt: "Research for E2E test creation..."
+})
+```
+
+Research these areas in parallel:
+
+**a) Existing E2E tests** — Find related tests to understand patterns:
+- `e2e/**/*.spec.ts` — existing test files for the same feature area
+- `e2e/utils/classes/` — available Page Object Model classes
+- `e2e/utils/test-util.ts` — available helper functions (login, navigation, CRUD)
+- `e2e/utils/test-util-antd.ts` — Ant Design helper functions
+
+**b) Source code** — Understand what the feature does:
+- React components implementing the feature
+- UI elements (buttons, modals, forms, tables) and their labels/roles
+- API calls and data flow
+- i18n keys (to understand button/label text)
+
+**c) Project conventions** — Read these files:
+- `.github/instructions/e2e.instructions.md` — E2E writing guidelines
+- `e2e/E2E-TEST-NAMING-GUIDELINES.md` — naming conventions
+- `playwright.config.ts` — Playwright configuration
+
+### 3. Plan the Test
+
+Use the `playwright-test-planner` agent to create a structured test plan:
+
+```
+Task({
+  subagent_type: "playwright-test-planner",
+  prompt: "Create test plan for [feature]..."
+})
+```
+
+The test plan must follow these conventions:
+
+#### File Organization
+- **Test file**: `e2e/{feature-domain}/{feature-action}.spec.ts`
+  - Use kebab-case for file names
+  - Group by feature domain: `auth/`, `vfolder/`, `session/`, `user/`, `config/`, etc.
+
+#### Naming Conventions
+- **describe blocks**: `[Feature] - [Context]` (e.g., `'File Creation in VFolder Explorer'`)
+- **test names**: User-centric action format:
+  - `User can [action] [when/with condition]`
+  - `User cannot [action] [when/with condition]`
+
+#### Tags
+Every `test.describe` must include tags:
+- Priority: `@smoke` (core paths), `@critical` (important), `@regression` (full)
+- Feature: `@auth`, `@vfolder`, `@session`, `@user`, `@config`, etc.
+- Type: `@functional`, `@visual`, `@integration`
+
+#### Test Structure
+```typescript
+test.describe('Feature Name', { tag: ['@critical', '@feature', '@functional'] }, () => {
+  test.beforeAll(async ({ browser, request }) => {
+    // Setup: create test data
+  });
+
+  test.beforeEach(async ({ page, request }) => {
+    await loginAsUser(page, request);  // or loginAsAdmin
+  });
+
+  test.afterAll(async ({ browser, request }) => {
+    // Cleanup: delete test data
+  });
+
+  test('User can do something', async ({ page }) => {
+    // 1. Navigate
+    // 2. Perform action
+    // 3. Assert result
+  });
+});
+```
+
+### 4. Create or Update Page Object Models
+
+If needed, create or update POM classes in `e2e/utils/classes/`:
+
+```typescript
+// e2e/utils/classes/{domain}/{ClassName}.ts
+import { expect, Locator, Page } from '@playwright/test';
+
+export class ClassName {
+  private readonly page: Page;
+  private readonly modal: Locator; // if modal-based
+
+  constructor(page: Page) {
+    this.page = page;
+    this.modal = page.getByRole('dialog').first();
+  }
+
+  // Methods for common interactions
+  async waitForOpen(): Promise<void> { ... }
+  async close(): Promise<void> { ... }
+  async getButton(name: string): Promise<Locator> { ... }
+  async verifyVisible(text: string): Promise<void> { ... }
+}
+```
+
+**POM Guidelines:**
+- Use semantic selectors (role-based, label-based)
+- Return `Locator` objects so tests can add their own assertions
+- Include `waitFor` methods for async content
+- Keep methods focused on single interactions
+
+### 5. Write the Tests
+
+Write the test file following these rules:
+
+**Imports:**
+```typescript
+import { SomePOM } from '../utils/classes/domain/SomePOM';
+import {
+  loginAsUser,
+  navigateTo,
+  createVFolderAndVerify,
+  // ... other needed utilities
+} from '../utils/test-util';
+import { test, expect, Page } from '@playwright/test';
+```
+
+**Key patterns to follow:**
+- Use `test.describe.serial()` when tests must run in order
+- Use `test.describe()` (parallel) when tests are independent
+- Always clean up created resources in `afterAll` or `afterEach`
+- Use unique names with timestamps: `'e2e-test-' + new Date().getTime()`
+- Trust Playwright auto-waiting — avoid `waitForTimeout`
+- Use `{ force: true }` on click only when elements may be covered
+
+**Available helper functions:**
+- `loginAsUser(page, request)` / `loginAsAdmin(page, request)`
+- `navigateTo(page, 'data')` — navigate to internal routes
+- `createVFolderAndVerify(page, name, mode?, type?, permission?)`
+- `moveToTrashAndVerify(page, name)` / `deleteForeverAndVerifyFromTrash(page, name)`
+- `modifyConfigToml(page, request, config)` — modify app config
+
+### 6. Validate
+
+Run these checks:
+
+```bash
+# List tests to verify they're recognized
+npx playwright test --list e2e/{path-to-test}.spec.ts
+
+# Format
+npx prettier --write e2e/{path-to-test}.spec.ts
+```
+
+### 7. Update Coverage Report
+
+Update `e2e/E2E_COVERAGE_REPORT.md`:
+- Add test file references to the relevant page section
+- Update feature coverage status (❌ → ✅)
+- Recalculate coverage percentages in the summary table
+- Update the "Last Updated" date
+
+### 8. Present Results
+
+Show a summary:
+
+```
+## E2E Test Created
+
+### Test File
+- `e2e/{domain}/{name}.spec.ts` — {N} test cases
+
+### Page Object Models
+- `e2e/utils/classes/{domain}/{Class}.ts` — {new/updated}
+
+### Test Cases
+1. User can [action 1]
+2. User can [action 2]
+3. User cannot [action 3]
+...
+
+### Tags
+@{priority} @{feature} @{type}
+
+### To Run
+npx playwright test e2e/{domain}/{name}.spec.ts
+npx playwright test e2e/{domain}/{name}.spec.ts --headed  # with browser
+```
+
+## Important Rules
+
+- **Selectors**: Prefer `getByRole()` > `getByLabel()` > `getByTestId()` > `getByText()` > CSS selectors
+- **No `waitForTimeout`**: Use explicit waits (`waitForSelector`, `waitFor`) or trust auto-waiting
+- **Unique data**: Always use timestamps in test data names to avoid collisions
+- **Cleanup**: Always clean up test data (delete vfolders, sessions, etc.)
+- **Independence**: Each test should work independently (don't rely on other tests' state)
+- **i18n**: Use English locale text for selectors since tests run with English UI

--- a/.claude/commands/fix-e2e-test.md
+++ b/.claude/commands/fix-e2e-test.md
@@ -1,0 +1,89 @@
+---
+description: Debug and fix failing E2E tests using Playwright MCP tools. Analyzes test failures, updates locators, and fixes test logic.
+argument-hint: <test-file-path or test-name>
+---
+
+# Fix E2E Test
+
+Debug and fix failing Playwright E2E test: `$ARGUMENTS`
+
+## Process
+
+### 1. Identify the Failing Test
+
+If `$ARGUMENTS` is a file path, use it directly. If it's a test name, find the file:
+
+```bash
+npx playwright test --list | grep -i "$ARGUMENTS"
+```
+
+### 2. Run the Test to See the Failure
+
+Use the `playwright-test-healer` agent to debug:
+
+```
+Task({
+  subagent_type: "playwright-test-healer",
+  prompt: "Debug and fix the failing test at [path]. Read the test file first, then run it to see the failure, then fix it."
+})
+```
+
+The healer agent has access to:
+- `mcp__playwright-test__test_run` — run tests
+- `mcp__playwright-test__test_debug` — debug single test with trace
+- `mcp__playwright-test__browser_snapshot` — capture page state
+- `mcp__playwright-test__browser_generate_locator` — generate correct locators
+- `mcp__playwright-test__browser_console_messages` — check for errors
+
+### 3. Common Failure Patterns
+
+**Locator changed** (most common after UI changes):
+- Button text changed (e.g., "Create" → "Create Folder")
+- Element role changed
+- DOM structure changed
+
+→ Fix: Use `browser_snapshot` to see current page state, then update locators
+
+**Timing issues**:
+- Element not yet visible when assertion runs
+- Network request not yet complete
+
+→ Fix: Add explicit `waitFor()` or increase timeout on specific assertions
+
+**Test data conflicts**:
+- Previous test didn't clean up properly
+- Parallel test using same resource name
+
+→ Fix: Ensure unique names with timestamps, add proper cleanup in afterAll
+
+**Modal/dialog interference**:
+- Notification covering the target element
+- Another dialog blocking interaction
+
+→ Fix: Use `{ force: true }` on click, or dismiss interfering elements first
+
+### 4. Update POM Classes if Needed
+
+If locators in Page Object Model classes need updating:
+- Read `e2e/utils/classes/` for the relevant POM
+- Update locator selectors to match current UI
+- Verify all tests using that POM still work
+
+### 5. Validate the Fix
+
+```bash
+# Run the specific test
+npx playwright test e2e/{path}.spec.ts
+
+# Run related tests to check for regressions
+npx playwright test e2e/{domain}/
+
+# List all tests to verify nothing broke
+npx playwright test --list e2e/{domain}/
+```
+
+### 6. Format
+
+```bash
+npx prettier --write e2e/{path}.spec.ts
+```

--- a/e2e/utils/classes/vfolder/FolderExplorerModal.ts
+++ b/e2e/utils/classes/vfolder/FolderExplorerModal.ts
@@ -58,10 +58,18 @@ export class FolderExplorerModal {
 
   async getCreateFolderButton(): Promise<Locator> {
     const createButton = this.modal.getByRole('button', {
-      name: 'folder-add Create',
+      name: 'folder-add Create Folder',
     });
     await expect(createButton).toBeVisible();
     return createButton;
+  }
+
+  async getCreateFileButton(): Promise<Locator> {
+    const createFileButton = this.modal.getByRole('button', {
+      name: 'file-add Create File',
+    });
+    await expect(createFileButton).toBeVisible();
+    return createFileButton;
   }
 
   async getFileBrowserButton(): Promise<Locator> {

--- a/e2e/vfolder/file-create.spec.ts
+++ b/e2e/vfolder/file-create.spec.ts
@@ -1,0 +1,214 @@
+import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import {
+  loginAsUser,
+  navigateTo,
+  createVFolderAndVerify,
+  moveToTrashAndVerify,
+  deleteForeverAndVerifyFromTrash,
+} from '../utils/test-util';
+import { test, expect, Page } from '@playwright/test';
+
+const openFolderExplorer = async (
+  page: Page,
+  folderName: string,
+): Promise<FolderExplorerModal> => {
+  await navigateTo(page, 'data');
+  await page
+    .getByRole('link', { name: folderName })
+    .first()
+    .click({ force: true });
+  const modal = new FolderExplorerModal(page);
+  await modal.waitForOpen();
+  return modal;
+};
+
+test.describe(
+  'File Creation in VFolder Explorer',
+  { tag: ['@critical', '@vfolder', '@functional'] },
+  () => {
+    const testFolderName = 'e2e-test-file-create-' + new Date().getTime();
+
+    test.beforeAll(async ({ browser, request }) => {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      await loginAsUser(page, request);
+      await createVFolderAndVerify(page, testFolderName);
+      await context.close();
+    });
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+    });
+
+    test.afterAll(async ({ browser, request }) => {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      await loginAsUser(page, request);
+      try {
+        await moveToTrashAndVerify(page, testFolderName);
+        await deleteForeverAndVerifyFromTrash(page, testFolderName);
+      } catch {
+        console.log(`Could not delete ${testFolderName}, it may not exist`);
+      }
+      await context.close();
+    });
+
+    test('User can see Create File button in file explorer', async ({
+      page,
+    }) => {
+      const modal = await openFolderExplorer(page, testFolderName);
+      await modal.verifyFileExplorerLoaded();
+
+      // Verify Create File button is visible and enabled
+      const createFileButton = await modal.getCreateFileButton();
+      await expect(createFileButton).toBeEnabled();
+
+      await modal.close();
+    });
+
+    test('User can create a new file in the file explorer', async ({
+      page,
+    }) => {
+      const modal = await openFolderExplorer(page, testFolderName);
+      await modal.verifyFileExplorerLoaded();
+
+      // Click Create File button
+      const createFileButton = await modal.getCreateFileButton();
+      await createFileButton.click();
+
+      // Verify Create File modal appears
+      const createFileModal = page.getByRole('dialog').filter({
+        hasText: 'Create a new file',
+      });
+      await expect(createFileModal).toBeVisible();
+
+      // Enter file name
+      const fileName = 'test-file-' + new Date().getTime() + '.txt';
+      await createFileModal.getByRole('textbox').fill(fileName);
+
+      // Click Create button
+      await createFileModal.getByRole('button', { name: 'Create' }).click();
+
+      // Verify file appears in the file list
+      await modal.verifyFileVisible(fileName);
+
+      await modal.close();
+    });
+
+    test('User can create a yaml configuration file', async ({ page }) => {
+      const modal = await openFolderExplorer(page, testFolderName);
+      await modal.verifyFileExplorerLoaded();
+
+      const createFileButton = await modal.getCreateFileButton();
+      await createFileButton.click();
+
+      const createFileModal = page.getByRole('dialog').filter({
+        hasText: 'Create a new file',
+      });
+      await expect(createFileModal).toBeVisible();
+
+      const fileName = 'model-definition-' + new Date().getTime() + '.yaml';
+      await createFileModal.getByRole('textbox').fill(fileName);
+
+      await createFileModal.getByRole('button', { name: 'Create' }).click();
+
+      await modal.verifyFileVisible(fileName);
+      await modal.close();
+    });
+
+    test('User cannot create a file with empty name', async ({ page }) => {
+      const modal = await openFolderExplorer(page, testFolderName);
+      await modal.verifyFileExplorerLoaded();
+
+      const createFileButton = await modal.getCreateFileButton();
+      await createFileButton.click();
+
+      const createFileModal = page.getByRole('dialog').filter({
+        hasText: 'Create a new file',
+      });
+      await expect(createFileModal).toBeVisible();
+
+      // Click Create without entering a name
+      await createFileModal.getByRole('button', { name: 'Create' }).click();
+
+      // Verify validation error message appears
+      await expect(
+        createFileModal.getByText('Please enter a file name'),
+      ).toBeVisible();
+
+      // Modal should still be open
+      await expect(createFileModal).toBeVisible();
+
+      // Cancel the modal
+      await createFileModal.getByRole('button', { name: 'Cancel' }).click();
+      await modal.close();
+    });
+
+    test('User cannot create a file with invalid characters in name', async ({
+      page,
+    }) => {
+      const modal = await openFolderExplorer(page, testFolderName);
+      await modal.verifyFileExplorerLoaded();
+
+      const createFileButton = await modal.getCreateFileButton();
+      await createFileButton.click();
+
+      const createFileModal = page.getByRole('dialog').filter({
+        hasText: 'Create a new file',
+      });
+      await expect(createFileModal).toBeVisible();
+
+      // Enter file name with path separator
+      await createFileModal.getByRole('textbox').fill('invalid/file.txt');
+
+      // Click Create
+      await createFileModal.getByRole('button', { name: 'Create' }).click();
+
+      // Verify validation error for invalid characters
+      await expect(
+        createFileModal.getByText('File name cannot contain'),
+      ).toBeVisible();
+
+      // Modal should still be open
+      await expect(createFileModal).toBeVisible();
+
+      await createFileModal.getByRole('button', { name: 'Cancel' }).click();
+      await modal.close();
+    });
+  },
+);
+
+test.describe(
+  'File Creation - Read Only VFolder',
+  { tag: ['@critical', '@vfolder', '@functional'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'data');
+    });
+
+    test('User cannot create files in read-only VFolder', async ({ page }) => {
+      const roFolderName = 'e2e-test-file-create-ro-' + new Date().getTime();
+
+      // Create a read-only vfolder
+      await createVFolderAndVerify(page, roFolderName, 'general', 'user', 'ro');
+
+      // Open the folder explorer
+      const modal = await openFolderExplorer(page, roFolderName);
+      await modal.verifyFileExplorerLoaded();
+      await modal.verifyPermission('Read only');
+
+      // Verify Create File button is disabled
+      const createFileButton = modal['modal'].getByRole('button', {
+        name: 'file-add',
+      });
+      await expect(createFileButton.first()).toBeDisabled();
+
+      await modal.close();
+
+      // Cleanup
+      await moveToTrashAndVerify(page, roFolderName);
+      await deleteForeverAndVerifyFromTrash(page, roFolderName);
+    });
+  },
+);


### PR DESCRIPTION
## Summary
Add two new Claude Code slash commands for E2E test workflow and include E2E tests for the Create File feature as a practical example.

### New Commands

#### `/create-e2e-test <feature-description>`
Creates comprehensive Playwright E2E tests following project conventions:
- Researches existing POM classes, test utilities, and related tests
- Plans test cases using the `playwright-test-planner` agent
- Creates/updates Page Object Model classes as needed
- Writes tests following naming conventions, tagging strategy, and cleanup patterns
- Updates E2E coverage report

#### `/fix-e2e-test <test-file-path>`
Debugs and fixes failing E2E tests:
- Uses the `playwright-test-healer` agent for diagnosis
- Common failure patterns: locator changes, timing issues, test data conflicts
- Updates POM classes and validates fixes

### E2E Tests: Create File in File Browser (6 test cases)
1. User can see Create File button in file explorer
2. User can create a new file in the file explorer
3. User can create a yaml configuration file
4. User cannot create a file with empty name
5. User cannot create a file with invalid characters in name
6. User cannot create files in read-only VFolder

## Changed Files
- `.claude/commands/create-e2e-test.md` (new)
- `.claude/commands/fix-e2e-test.md` (new)
- `e2e/vfolder/file-create.spec.ts` (new) — 6 E2E test cases
- `e2e/utils/classes/vfolder/FolderExplorerModal.ts` — add `getCreateFileButton()`, fix `getCreateFolderButton()` locator

## How to Run
```bash
npx playwright test e2e/vfolder/file-create.spec.ts
npx playwright test e2e/vfolder/file-create.spec.ts --headed  # with browser
```