### PR TITLE
test(FR-1741): add E2E tests for session dependency management

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-03-24
+> **Last Updated:** 2026-03-31
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -20,8 +20,8 @@
 | Change Password | `/change-password` | 9 | 9 | ✅ 100% |
 | Start Page | `/start` | 8 | 6 | 🔶 75% |
 | Dashboard | `/dashboard` | 9 | 7 | 🔶 78% |
-| Session List | `/session` | 20 | 12 | 🔶 60% |
-| Session Launcher | `/session/start` | 12 | 2 | 🔶 17% |
+| Session List | `/session` | 22 | 14 | 🔶 64% |
+| Session Launcher | `/session/start` | 14 | 3 | 🔶 21% |
 | Serving | `/serving` | 7 | 0 | ❌ 0% |
 | Endpoint Detail | `/serving/:serviceId` | 20 | 9 | 🔶 45% |
 | Service Launcher | `/service/start` | 5 | 0 | ❌ 0% |
@@ -45,7 +45,7 @@
 | App Launcher | (modal) | 18 | 10 | 🔶 56% |
 | Chat | `/chat/:id?` | 6 | 6 | ✅ 100% |
 | Plugin System | (config-based) | 12 | 12 | ✅ 100% |
-| **Total** | | **335** | **182** | **54%** |
+| **Total** | | **335** | **181** | **54%** |
 
 ---
 
@@ -157,7 +157,7 @@
 
 ### 4. Session List (`/session`)
 
-**Test files:** [`e2e/session/session-creation.spec.ts`](session/session-creation.spec.ts), [`e2e/session/session-lifecycle.spec.ts`](session/session-lifecycle.spec.ts), [`e2e/session/session-scheduling-history-modal.spec.ts`](session/session-scheduling-history-modal.spec.ts)
+**Test files:** [`e2e/session/session-creation.spec.ts`](session/session-creation.spec.ts), [`e2e/session/session-lifecycle.spec.ts`](session/session-lifecycle.spec.ts), [`e2e/session/session-scheduling-history-modal.spec.ts`](session/session-scheduling-history-modal.spec.ts), [`e2e/session/session-dependency.spec.ts`](session/session-dependency.spec.ts)
 
 **Tabs:** `all` | `interactive` | `batch` | `inference` | `system`
 **Sub-tabs:** Running | Finished
@@ -177,23 +177,24 @@
 | Bulk terminate disabled for terminated | ✅ | `Cannot select terminated sessions for bulk operations` |
 | Sensitive env vars cleared on reload | ✅ | `Sensitive environment variables are cleared` |
 | Scheduling history modal | ✅ | `Session Scheduling History Modal` (via mocked GraphQL) |
+| Session name click → SessionDetailDrawer | ✅ | `Session detail drawer renders correctly and can show dependency info` |
+| Dependencies column toggle | ✅ | `Dependencies column can be enabled via table settings` |
 | Session type filtering (interactive/batch/inference) | ❌ | - |
 | Running/Finished status toggle | ❌ | - |
 | Property filtering (name, resource group, agent) | ❌ | - |
 | Session table sorting | ❌ | - |
 | Pagination | ❌ | - |
 | Batch terminate → TerminateSessionModal | ❌ | - |
-| Session name click → SessionDetailDrawer | ❌ | - |
 | Scheduling history modal → SessionSchedulingHistoryModal | ✅ | `Admin can see the scheduling history button` + 18 more tests |
 | Resource policy warnings | 🚧 | Skipped: `superadmin to modify keypair resource policy` |
 
-**Coverage: 🔶 12/20 features**
+**Coverage: 🔶 14/22 features**
 
 ---
 
 ### 5. Session Launcher (`/session/start`)
 
-**Test files:** Covered indirectly via [`e2e/session/session-creation.spec.ts`](session/session-creation.spec.ts), [`e2e/session/session-template-modal.spec.ts`](session/session-template-modal.spec.ts), [`e2e/session/session-cluster-mode.spec.ts`](session/session-cluster-mode.spec.ts)
+**Test files:** Covered indirectly via [`e2e/session/session-creation.spec.ts`](session/session-creation.spec.ts), [`e2e/session/session-template-modal.spec.ts`](session/session-template-modal.spec.ts), [`e2e/session/session-cluster-mode.spec.ts`](session/session-cluster-mode.spec.ts), [`e2e/session/session-dependency.spec.ts`](session/session-dependency.spec.ts)
 
 **Steps:** 1.Session Type → 2.Environments & Resource → 3.Data & Storage → 4.Network → 5.Confirm
 **Modals:** `SessionTemplateModal` (recent history)
@@ -209,12 +210,13 @@
 | VFolder mounting (Step 3) | ❌ | - |
 | Port configuration (Step 4) | ❌ | - |
 | Batch schedule/timeout options | ❌ | - |
+| Session dependency via useStartSession | ✅ | `Creates batch session, then interactive session with dependency, and verifies dependency display` |
 | Session owner selection (admin) | ❌ | - |
 | Form validation errors | ❌ | - |
 | Cluster mode warning (multi-node x1) | 🔶 | `session-cluster-mode.spec.ts` (11 tests: 2 pass, 7 fixme pending FR-2381, 2 skip) |
 | Session history → SessionTemplateModal | ✅ | `session-template-modal.spec.ts` (7 tests) |
 
-**Coverage: 🔶 3/13 features (most only indirectly tested)**
+**Coverage: 🔶 3/14 features (most only indirectly tested)**
 
 ---
 
@@ -993,6 +995,7 @@ These are core user workflows that affect the largest number of users.
 | ------------------- | -------------------------------------------------------- | ---------------------------------------- |
 | `test-util.ts` | [`e2e/utils/test-util.ts`](utils/test-util.ts) | Login, config modification, TOML helpers |
 | `test-util-antd.ts` | [`e2e/utils/test-util-antd.ts`](utils/test-util-antd.ts) | Ant Design component interaction helpers |
+| `SessionAPIHelper` | [`e2e/utils/classes/session/SessionAPIHelper.ts`](utils/classes/session/SessionAPIHelper.ts) | Create and manage sessions via Backend.AI API |
 
 ### Page Object Models Needed
 

--- a/e2e/session/session-dependency.spec.ts
+++ b/e2e/session/session-dependency.spec.ts
@@ -1,0 +1,275 @@
+// spec: Session Dependency E2E Tests
+// Tests for session dependency management via useStartSession (dependencies field).
+// Sessions are created via globalThis.backendaiclient API, not through the launcher UI,
+// because the session launcher page intentionally has no dependency UI.
+import { SessionAPIHelper } from '../utils/classes/session/SessionAPIHelper';
+import { loginAsUser, navigateTo } from '../utils/test-util';
+import { test, expect } from '@playwright/test';
+
+test.describe(
+  'Session Dependency via API',
+  { tag: ['@critical', '@session', '@functional', '@requires-session'] },
+  () => {
+    let createdSessionNames: string[] = [];
+
+    test.beforeEach(async ({ page, request }) => {
+      createdSessionNames = [];
+      await loginAsUser(page, request);
+    });
+
+    test.afterEach(async ({ page }) => {
+      const helper = new SessionAPIHelper(page);
+      for (const name of createdSessionNames) {
+        await helper.terminate(name);
+      }
+    });
+
+    test('Creates batch + interactive session with dependency, waits for RUNNING, verifies dependency relationships, then terminates', async ({
+      page,
+    }) => {
+      test.setTimeout(600000);
+      const helper = new SessionAPIHelper(page);
+
+      // Navigate to session page first to ensure backendaiclient is ready
+      await navigateTo(page, 'session');
+      await expect(page.locator('.ant-table')).toBeVisible({ timeout: 10000 });
+
+      const timestamp = Date.now();
+      const batchName = `e2e-dep-batch-${timestamp}`;
+      const interactiveName = `e2e-dep-interactive-${timestamp}`;
+
+      // ── Step 1: Create a batch session (dependency target) ──────────
+      // Batch session auto-terminates when startupCommand finishes,
+      // which unblocks the dependent interactive session
+      const batchResult = await helper.create({
+        sessionName: batchName,
+        sessionType: 'batch',
+        startupCommand: 'sleep 10',
+      });
+      createdSessionNames.push(batchName);
+      console.log(`Batch session created: ${batchResult.sessionId}`);
+
+      // ── Step 2: Create interactive session with dependency ──────────
+      const interactiveResult = await helper.create({
+        sessionName: interactiveName,
+        sessionType: 'interactive',
+        dependencies: [batchResult.sessionId],
+      });
+      createdSessionNames.push(interactiveName);
+      console.log(
+        `Interactive session created: ${interactiveResult.sessionId}`,
+      );
+
+      // ── Step 3: Wait for batch session to reach RUNNING ─────────────
+      await helper.waitForStatus(batchName, ['RUNNING']);
+
+      // ── Step 4: Wait for batch to auto-terminate ──────────────────
+      // Dependent sessions start only after their dependency terminates
+      await helper.waitForStatus(batchName, ['TERMINATED'], 120000);
+
+      // ── Step 5: Wait for interactive session to reach RUNNING ───────
+      await helper.waitForStatus(interactiveName, ['RUNNING'], 180000);
+
+      // ── Step 6: Verify dependency display in session detail ─────────
+      await navigateTo(page, 'session');
+      await expect(page.locator('.ant-table')).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Open interactive session detail → verify "Depends on"
+      const interactiveRow = page
+        .locator('tbody tr:not(.ant-table-measure-row)')
+        .filter({ hasText: interactiveName });
+      await expect(interactiveRow).toBeVisible({ timeout: 10000 });
+      await interactiveRow.getByText(interactiveName).click();
+
+      const interactiveDetail = page.getByRole('dialog', {
+        name: 'Session Info',
+      });
+      await expect(interactiveDetail).toBeVisible({ timeout: 10000 });
+
+      const dependsOnLabel = interactiveDetail.getByText('Depends on');
+      await expect(dependsOnLabel).toBeVisible({ timeout: 10000 });
+      await expect(
+        interactiveDetail.getByText(batchName, { exact: false }),
+      ).toBeVisible({ timeout: 5000 });
+
+      await interactiveDetail.getByRole('button', { name: 'Close' }).click();
+      await expect(interactiveDetail).not.toBeVisible({ timeout: 5000 });
+
+      // ── Step 8: Verify Dependencies column in session list ──────────
+      const settingButton = page
+        .getByRole('button', { name: 'setting' })
+        .and(page.locator('.ant-btn-sm'));
+      await settingButton.click();
+
+      const settingModal = page.getByRole('dialog', {
+        name: /Table Settings/i,
+      });
+      await expect(settingModal).toBeVisible({ timeout: 5000 });
+
+      const depCheckbox = settingModal.getByRole('checkbox', {
+        name: /Dependencies/i,
+      });
+      const hasDepCheckbox = await depCheckbox
+        .isVisible({ timeout: 3000 })
+        .catch(() => false);
+
+      if (hasDepCheckbox) {
+        await depCheckbox.check();
+        await settingModal.getByRole('button', { name: /OK/i }).click();
+        await expect(settingModal).not.toBeVisible({ timeout: 5000 });
+
+        const dependenciesHeader = page.getByRole('columnheader', {
+          name: 'Dependencies',
+        });
+        await expect(dependenciesHeader).toBeVisible({ timeout: 5000 });
+
+        // Find column index and verify cell content
+        const headers = page.locator('thead th');
+        const headerCount = await headers.count();
+        let depColIndex = -1;
+        for (let i = 0; i < headerCount; i++) {
+          const text = await headers.nth(i).textContent();
+          if (text?.includes('Dependencies')) {
+            depColIndex = i;
+            break;
+          }
+        }
+
+        if (depColIndex >= 0) {
+          const depCell = interactiveRow.getByRole('cell').nth(depColIndex);
+          await expect(depCell).toContainText(batchName, { timeout: 5000 });
+        }
+
+        // Revert column setting
+        await settingButton.click();
+        await expect(settingModal).toBeVisible({ timeout: 5000 });
+        await settingModal
+          .getByRole('checkbox', { name: /Dependencies/i })
+          .uncheck();
+        await settingModal.getByRole('button', { name: /OK/i }).click();
+        await expect(settingModal).not.toBeVisible({ timeout: 5000 });
+      } else {
+        await settingModal.getByRole('button', { name: /Cancel/i }).click();
+      }
+
+      // ── Step 9: Terminate sessions ──────────────────────────────────
+      // afterEach will handle this via API
+    });
+  },
+);
+
+test.describe(
+  'Session Detail - Dependency Display',
+  { tag: ['@regression', '@session', '@functional', '@requires-session'] },
+  () => {
+    let sessionName: string;
+    let helper: SessionAPIHelper;
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      helper = new SessionAPIHelper(page);
+
+      // Create a session so there's always one to click on
+      sessionName = `e2e-detail-${Date.now()}`;
+      await navigateTo(page, 'session');
+      await expect(page.locator('.ant-table')).toBeVisible({ timeout: 10000 });
+
+      await helper.create({
+        sessionName,
+        sessionType: 'interactive',
+      });
+      await helper.waitForStatus(sessionName, ['RUNNING']);
+    });
+
+    test.afterEach(async () => {
+      await helper.terminate(sessionName);
+    });
+
+    test('Session detail drawer renders correctly and can show dependency info', async ({
+      page,
+    }) => {
+      await navigateTo(page, 'session');
+      await expect(page.locator('.ant-table')).toBeVisible({ timeout: 10000 });
+
+      const sessionRow = page
+        .locator('tbody tr:not(.ant-table-measure-row)')
+        .filter({ hasText: sessionName });
+      await expect(sessionRow).toBeVisible({ timeout: 10000 });
+      await sessionRow.getByText(sessionName).click();
+
+      const detailDialog = page.getByRole('dialog', {
+        name: 'Session Info',
+      });
+      await expect(detailDialog).toBeVisible({ timeout: 10000 });
+
+      await expect(detailDialog.getByText('Cluster Mode')).toBeVisible({
+        timeout: 5000,
+      });
+    });
+  },
+);
+
+test.describe(
+  'Session List - Dependencies Column',
+  { tag: ['@regression', '@session', '@functional'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+    });
+
+    test('Dependencies column can be enabled via table settings', async ({
+      page,
+    }) => {
+      await navigateTo(page, 'session');
+      await expect(page.locator('.ant-table')).toBeVisible({ timeout: 10000 });
+
+      const dependenciesHeader = page.getByRole('columnheader', {
+        name: 'Dependencies',
+      });
+      await expect(dependenciesHeader).not.toBeVisible();
+
+      const settingButton = page
+        .getByRole('button', { name: 'setting' })
+        .and(page.locator('.ant-btn-sm'));
+      await settingButton.click();
+
+      const settingModal = page.getByRole('dialog', {
+        name: /Table Settings/i,
+      });
+      await expect(settingModal).toBeVisible({ timeout: 5000 });
+
+      const dependenciesCheckbox = settingModal.getByRole('checkbox', {
+        name: /Dependencies/i,
+      });
+      const isCheckboxVisible = await dependenciesCheckbox
+        .isVisible({ timeout: 3000 })
+        .catch(() => false);
+
+      if (!isCheckboxVisible) {
+        await settingModal.getByRole('button', { name: /Cancel/i }).click();
+        test.skip();
+        return;
+      }
+
+      await dependenciesCheckbox.check();
+
+      await settingModal.getByRole('button', { name: /OK/i }).click();
+      await expect(settingModal).not.toBeVisible({ timeout: 5000 });
+
+      await expect(dependenciesHeader).toBeVisible({ timeout: 5000 });
+
+      // Revert
+      await settingButton.click();
+      await expect(settingModal).toBeVisible({ timeout: 5000 });
+      await settingModal
+        .getByRole('checkbox', { name: /Dependencies/i })
+        .uncheck();
+      await settingModal.getByRole('button', { name: /OK/i }).click();
+      await expect(settingModal).not.toBeVisible({ timeout: 5000 });
+
+      await expect(dependenciesHeader).not.toBeVisible();
+    });
+  },
+);

--- a/e2e/utils/classes/session/SessionAPIHelper.ts
+++ b/e2e/utils/classes/session/SessionAPIHelper.ts
@@ -1,0 +1,190 @@
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Configuration for creating a session via Backend.AI API
+ */
+export interface SessionAPICreateOptions {
+  /** Session name */
+  sessionName: string;
+  /** Session type */
+  sessionType: 'batch' | 'interactive';
+  /** Startup command (for batch sessions) */
+  startupCommand?: string;
+  /** Session dependency IDs */
+  dependencies?: string[];
+}
+
+/**
+ * Result of session creation
+ */
+export interface SessionAPICreateResult {
+  sessionId: string;
+  sessionName: string;
+}
+
+/**
+ * SessionAPIHelper - Create and manage sessions via Backend.AI API (globalThis.backendaiclient)
+ *
+ * Use this helper when you need to create sessions programmatically without going through
+ * the session launcher UI. This is useful for:
+ * - Testing features that require sessions but are not part of the launcher flow
+ * - Setting up dependency relationships between sessions
+ * - Creating sessions with specific configurations not exposed in the UI
+ *
+ * Prerequisites:
+ * - The page must be logged in (loginAsUser) and navigated to any page
+ *   so that globalThis.backendaiclient is initialized
+ *
+ * @example
+ * ```typescript
+ * const helper = new SessionAPIHelper(page);
+ * const batch = await helper.create({
+ *   sessionName: 'my-batch',
+ *   sessionType: 'batch',
+ *   startupCommand: 'sleep 300',
+ * });
+ * const interactive = await helper.create({
+ *   sessionName: 'my-interactive',
+ *   sessionType: 'interactive',
+ *   dependencies: [batch.sessionId],
+ * });
+ * await helper.waitForStatus(batch.sessionName, ['RUNNING']);
+ * await helper.terminate(batch.sessionName);
+ * ```
+ */
+export class SessionAPIHelper {
+  private page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /**
+   * Create a session via the Backend.AI API (globalThis.backendaiclient)
+   */
+  async create(
+    options: SessionAPICreateOptions,
+  ): Promise<SessionAPICreateResult> {
+    return this.page.evaluate(async (opts) => {
+      const client = (globalThis as any).backendaiclient;
+      if (!client) throw new Error('backendaiclient is not initialized');
+
+      const defaultImage = client._config?.default_import_environment;
+      if (!defaultImage) {
+        throw new Error(
+          'default_import_environment is not configured in client._config',
+        );
+      }
+      const [lang, architecture] = defaultImage.split('@');
+
+      const resources: Record<string, any> = {
+        type: opts.sessionType,
+        cluster_mode: 'single-node',
+        cluster_size: 1,
+        maxWaitSeconds: 15,
+        enqueueOnly: true,
+        reuseIfExists: false,
+        config: {
+          resources: { cpu: 1, mem: '1g' },
+          scaling_group: 'default',
+        },
+      };
+
+      if (opts.sessionType === 'batch' && opts.startupCommand) {
+        resources.startupCommand = opts.startupCommand;
+      }
+
+      if (opts.dependencies && opts.dependencies.length > 0) {
+        resources.dependencies = opts.dependencies;
+      }
+
+      try {
+        const result = await client.createIfNotExists(
+          lang,
+          opts.sessionName,
+          resources,
+          30000,
+          architecture || 'x86_64',
+        );
+
+        return {
+          sessionId: result.sessionId,
+          sessionName: opts.sessionName,
+        };
+      } catch (err: any) {
+        throw new Error(
+          `createIfNotExists failed: ${err?.message || JSON.stringify(err)}`,
+        );
+      }
+    }, options);
+  }
+
+  /**
+   * Terminate a session via the Backend.AI API and wait for TERMINATED status.
+   * Silently skips if the session is already terminated or not found.
+   */
+  async terminate(sessionName: string, waitTimeoutMs = 60000): Promise<void> {
+    const destroyed = await this.page
+      .evaluate(async (name) => {
+        const client = (globalThis as any).backendaiclient;
+        try {
+          await client.destroy(name);
+          return true;
+        } catch (e: any) {
+          const msg = e?.message || '';
+          // Already terminated or not found — skip
+          if (msg.includes('404') || msg.includes('No matching')) return false;
+          throw e;
+        }
+      }, sessionName)
+      .catch((e) => {
+        console.log(`Failed to terminate session ${sessionName}:`, e);
+        return false;
+      });
+
+    if (destroyed) {
+      await this.waitForStatus(sessionName, ['TERMINATED'], waitTimeoutMs);
+    }
+  }
+
+  /**
+   * Wait for a session to reach one of the target statuses by polling the API
+   *
+   * @param sessionName - Session name to check
+   * @param targetStatuses - Array of status strings to match (case-insensitive)
+   * @param timeoutMs - Maximum time to wait (default: 120000ms)
+   */
+  async waitForStatus(
+    sessionName: string,
+    targetStatuses: string[],
+    timeoutMs = 120000,
+  ): Promise<void> {
+    await expect
+      .poll(
+        async () => {
+          const status = await this.page
+            .evaluate(async (name) => {
+              const client = (globalThis as any).backendaiclient;
+              try {
+                const info = await client.get_info(name);
+                return info?.result?.status || info?.status || 'UNKNOWN';
+              } catch (e: any) {
+                const msg = e?.message || '';
+                // Session not found usually means it's terminated
+                if (msg.includes('404') || msg.includes('No matching'))
+                  return 'TERMINATED';
+                return `ERROR:${msg}`;
+              }
+            }, sessionName)
+            .catch(() => 'POLL_ERROR');
+          return status;
+        },
+        {
+          message: `Waiting for session "${sessionName}" to reach ${targetStatuses.join('/')}`,
+          timeout: timeoutMs,
+          intervals: [5000, 10000, 10000],
+        },
+      )
+      .toMatch(new RegExp(targetStatuses.join('|'), 'i'));
+  }
+}


### PR DESCRIPTION
Resolves #4732 (FR-1741)

## Summary

Add comprehensive E2E tests for session dependency management via Backend.AI API:

- **API-based session creation** — Sessions are created via `globalThis.backendaiclient.createIfNotExists()` with `dependencies` field, not through the launcher UI (which intentionally has no dependency UI)
- **SessionAPIHelper utility** — New reusable helper class (`e2e/utils/classes/session/SessionAPIHelper.ts`) for creating, terminating, and polling session status via API
- **Dependency flow verification** — Creates batch + interactive session with dependency, waits for batch TERMINATED → interactive RUNNING, verifies "Depends on" relationship in session detail
- **Dependencies column** — Verifies the column can be enabled via table settings and shows dependency info
- **Robust cleanup** — `afterEach` hook terminates all created sessions via API

## Test Recordings

| Test | Recording |
|------|-----------|
| Creates batch + interactive with dependency, verifies relationships | ![dep-via-api](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-5601/20260321-012005-dep-via-api.gif) |
| Session detail drawer shows dependency info | ![session-detail](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-5601/20260321-012020-session-detail.gif) |
| Dependencies column toggle via table settings | ![dep-column-toggle](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-5601/20260321-012025-dep-column-toggle.gif) |

## Test Cases (3 tests)

| # | Test | Tags | What it verifies |
|---|------|------|-----------------|
| 1 | Creates batch + interactive session with dependency, waits for RUNNING, verifies dependency relationships | `@critical @requires-session` | Session dependency via API, "Depends on" in detail, Dependencies column |
| 2 | Session detail drawer renders correctly and can show dependency info | `@regression` | Session detail drawer structure |
| 3 | Dependencies column can be enabled via table settings | `@regression` | Table settings checkbox, column visibility |