### PR TITLE
test(FR-1962): add E2E tests for user settings page

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-03-06
+> **Last Updated:** 2026-03-09
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 75 / 273 features covered (27%)**
+**Overall (in-scope routes): 92 / 284 features covered (32%)**
 
 | Page | Route | Features | Covered | Status |
 |------|-------|:--------:|:-------:|:------:|
@@ -34,7 +34,7 @@
 | Resource Policy | `/resource-policy` | 13 | 0 | ❌ 0% |
 | User Credentials | `/credential` | 16 | 6 | 🔶 38% |
 | Maintenance | `/maintenance` | 3 | 2 | 🔶 67% |
-| User Settings | `/usersettings` | 10 | 0 | ❌ 0% |
+| User Settings | `/usersettings` | 14 | 13 | 🔶 93% |
 | Project | `/project` | 6 | 0 | ❌ 0% |
 | Statistics | `/statistics` | 2 | 0 | ❌ 0% |
 | Scheduler | `/scheduler` | 6 | 0 | ❌ 0% |
@@ -42,7 +42,7 @@
 | Branding | `/branding` | 14 | 0 | ❌ 0% |
 | App Launcher | (modal) | 18 | 10 | 🔶 56% |
 | Chat | `/chat/:id?` | 6 | 0 | ❌ 0% |
-| **Total** | | **273** | **75** | **27%** |
+| **Total** | | **284** | **92** | **32%** |
 
 ---
 
@@ -570,7 +570,7 @@
 
 ### 19. User Settings (`/usersettings`)
 
-**Test files:** None
+**Test files:** [`e2e/user/user-settings.spec.ts`](user/user-settings.spec.ts)
 
 **Tabs:** General | Logs
 
@@ -579,15 +579,19 @@
 
 | Feature | Status | Test |
 |---------|--------|------|
-| Language selection | ❌ | - |
-| Desktop notifications toggle | ❌ | - |
-| Compact sidebar toggle | ❌ | - |
-| Auto-logout configuration | ❌ | - |
-| SSH keypair info → MyKeypairInfoModal | ❌ | - |
-| SSH keypair management → SSHKeypairManagementModal | ❌ | - |
-| Bootstrap script → ShellScriptEditModal | ❌ | - |
-| User config script → ShellScriptEditModal | ❌ | - |
-| Experimental features toggle | ❌ | - |
+| Language selection | ✅ | `User can change language selection` |
+| Desktop notifications toggle | ✅ | `User can toggle Desktop Notification checkbox` |
+| Compact sidebar toggle | ✅ | `User can toggle Use Compact Sidebar checkbox` |
+| Automatic update check toggle | ✅ | `User can toggle Automatic Update Check checkbox` |
+| Auto-logout configuration | ✅ | `User can toggle Auto Logout checkbox` |
+| Max concurrent uploads | ✅ | `User can change max concurrent uploads` |
+| Tab navigation (General ↔ Logs) | ✅ | `User can switch to Logs tab`, `User can switch back to General tab from Logs` |
+| SSH keypair info → MyKeypairInfoModal | ✅ | `User can open and close My Keypair Info modal` |
+| SSH keypair management → SSHKeypairManagementModal | ✅ | `User can open and close SSH Keypair Management modal` |
+| Bootstrap script → ShellScriptEditModal | ✅ | `User can open and close Bootstrap Script editor modal` |
+| User config script → ShellScriptEditModal | ✅ | `User can open and close User Config Script editor modal`, `User can switch between rc files in User Config Script modal` |
+| Experimental features toggle | ✅ | `User can toggle Experimental AI Agents checkbox` |
+| Search settings by keyword | ✅ | `User can search settings by keyword` |
 
 #### Logs Tab
 
@@ -595,7 +599,7 @@
 |---------|--------|------|
 | Error log viewing | ❌ | - |
 
-**Coverage: ❌ 0/10 features**
+**Coverage: ✅ 13/14 features**
 
 ---
 
@@ -927,7 +931,7 @@ To efficiently build new E2E tests, these POMs should be created:
 | `/maintenance` | 🔶 | ✅ | - |
 | `/project` | ❌ | ❌ | **P2** |
 | `/statistics` | ❌ | ❌ | P3 |
-| `/usersettings` | ❌ | ❌ | **P2** |
+| `/usersettings` | ✅ | ❌ | P2 |
 | `/scheduler` | ❌ | ❌ | P3 |
 | `/reservoir` | ❌ | ❌ | P3 |
 | `/branding` | ❌ | ❌ | P3 |

--- a/e2e/user/user-settings.spec.ts
+++ b/e2e/user/user-settings.spec.ts
@@ -1,0 +1,500 @@
+// spec: User Settings page E2E tests
+// Tests the /usersettings page: General tab preferences including
+// desktop notifications, compact sidebar, language selection, auto-logout,
+// automatic update check, keypair info, SSH keypair management,
+// shell script editing, experimental features, and tab navigation.
+import { loginAsUser, navigateTo } from '../utils/test-util';
+import { checkActiveTab } from '../utils/test-util-antd';
+import test, { expect } from '@playwright/test';
+
+test.describe.serial(
+  'User Settings - General Preferences',
+  { tag: ['@critical', '@user', '@functional'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      // 1. Login as user
+      await loginAsUser(page, request);
+
+      // 2. Navigate to user settings page
+      await navigateTo(page, 'usersettings');
+
+      // 3. Wait for page to load
+      await expect(page.getByRole('tab', { name: 'General' })).toBeVisible();
+    });
+
+    test('User can see the General tab active by default', async ({ page }) => {
+      // 1. Verify General tab is active (use .first() since SettingList has its own tabs)
+      await checkActiveTab(page.locator('.ant-tabs').first(), 'General');
+
+      // 2. Verify Preferences group is visible
+      await expect(page.getByTestId('group-preferences')).toBeVisible();
+    });
+
+    test('User can toggle Desktop Notification checkbox', async ({
+      page,
+      context,
+    }) => {
+      // 0. Grant notification permission so the toggle isn't reverted
+      await context.grantPermissions(['notifications']);
+
+      // 1. Find the Desktop Notification setting item
+      const settingItem = page.getByTestId('items-desktop-notification');
+      await expect(settingItem).toBeVisible();
+
+      // 2. Find the checkbox within the setting item
+      const checkbox = settingItem.locator('input[type="checkbox"]');
+
+      // 3. Get initial state
+      const initialChecked = await checkbox.isChecked();
+
+      // 4. Toggle the checkbox
+      await checkbox.click({ force: true });
+
+      // 5. Verify state changed
+      await expect(checkbox).toBeChecked({ checked: !initialChecked });
+
+      // 6. Toggle back to restore original state
+      await checkbox.click({ force: true });
+      await expect(checkbox).toBeChecked({ checked: initialChecked });
+    });
+
+    test('User can toggle Use Compact Sidebar checkbox', async ({ page }) => {
+      // 1. Find the Compact Sidebar setting item
+      const settingItem = page.getByTestId('items-use-compact-sidebar');
+      await expect(settingItem).toBeVisible();
+
+      // 2. Find the checkbox
+      const checkbox = settingItem.locator('input[type="checkbox"]');
+
+      // 3. Get initial state
+      const initialChecked = await checkbox.isChecked();
+
+      // 4. Toggle
+      await checkbox.click({ force: true });
+      await expect(checkbox).toBeChecked({ checked: !initialChecked });
+
+      // 5. Toggle back to restore
+      await checkbox.click({ force: true });
+      await expect(checkbox).toBeChecked({ checked: initialChecked });
+    });
+
+    test('User can change language selection', async ({ page }) => {
+      // 1. Find the language setting item
+      const settingItem = page.getByTestId('items-language-select');
+      await expect(settingItem).toBeVisible();
+
+      // 2. Find the Ant Design select within the setting item
+      const selectTrigger = settingItem.locator('.ant-select');
+      await expect(selectTrigger).toBeVisible();
+
+      // 3. Open the dropdown
+      await selectTrigger.click();
+
+      // 4. Verify dropdown is visible with language options
+      const dropdown = page.locator('.ant-select-dropdown').last();
+      await expect(dropdown).toBeVisible();
+
+      // 5. Select Korean — language change triggers UI re-render
+      await dropdown
+        .locator('.ant-select-item-option')
+        .filter({ hasText: '한국어' })
+        .click();
+
+      // 6. Wait for UI to update after language change, then verify
+      //    Use .ant-select (not .ant-select-selection-item) because showSearch
+      //    changes DOM structure and i18n re-render recreates elements
+      await expect(
+        page.getByTestId('items-language-select').locator('.ant-select'),
+      ).toContainText('한국어', { timeout: 15000 });
+
+      // 7. Restore English — re-locate elements since DOM may have changed
+      await page
+        .getByTestId('items-language-select')
+        .locator('.ant-select')
+        .click();
+      const restoredDropdown = page.locator('.ant-select-dropdown').last();
+      await expect(restoredDropdown).toBeVisible();
+
+      await restoredDropdown
+        .locator('.ant-select-item-option')
+        .filter({ hasText: 'English' })
+        .click();
+
+      // 8. Verify English is restored
+      await expect(
+        page.getByTestId('items-language-select').locator('.ant-select'),
+      ).toContainText('English', { timeout: 15000 });
+    });
+
+    test('User can toggle Automatic Update Check checkbox', async ({
+      page,
+    }) => {
+      // 1. Find the automatic update check setting item
+      const settingItem = page.getByTestId('items-automatic-update-check');
+      await expect(settingItem).toBeVisible();
+
+      // 2. Find the checkbox
+      const checkbox = settingItem.locator('input[type="checkbox"]');
+
+      // 3. Get initial state
+      const initialChecked = await checkbox.isChecked();
+
+      // 4. Toggle
+      await checkbox.click({ force: true });
+      await expect(checkbox).toBeChecked({ checked: !initialChecked });
+
+      // 5. Toggle back to restore
+      await checkbox.click({ force: true });
+      await expect(checkbox).toBeChecked({ checked: initialChecked });
+    });
+
+    test('User can toggle Auto Logout checkbox', async ({ page }) => {
+      // 1. Find the auto logout setting item
+      const settingItem = page.getByTestId('items-auto-logout');
+      await expect(settingItem).toBeVisible();
+
+      // 2. Find the checkbox
+      const checkbox = settingItem.locator('input[type="checkbox"]');
+
+      // 3. Get initial state
+      const initialChecked = await checkbox.isChecked();
+
+      // 4. Toggle
+      await checkbox.click({ force: true });
+      await expect(checkbox).toBeChecked({ checked: !initialChecked });
+
+      // 5. Toggle back to restore
+      await checkbox.click({ force: true });
+      await expect(checkbox).toBeChecked({ checked: initialChecked });
+    });
+
+    test('User can change max concurrent uploads', async ({ page }) => {
+      // 1. Find the max concurrent uploads setting item
+      const settingItem = page.getByTestId('items-max-concurrent-uploads');
+      await expect(settingItem).toBeVisible();
+
+      // 2. Find the select
+      const selectTrigger = settingItem.locator('.ant-select');
+      await expect(selectTrigger).toBeVisible();
+
+      // 3. Open the dropdown
+      await selectTrigger.click();
+
+      // 4. Verify dropdown with numeric options
+      const dropdown = page.locator('.ant-select-dropdown').last();
+      await expect(dropdown).toBeVisible();
+      await expect(
+        dropdown.locator('.ant-select-item-option').first(),
+      ).toBeVisible();
+
+      // 5. Select "3"
+      await dropdown
+        .locator('.ant-select-item-option')
+        .filter({ hasText: '3' })
+        .click();
+
+      // 6. Verify selection — use parent .ant-select since .ant-select-selection-item
+      //    may not render immediately in Ant Design 6
+      await expect(selectTrigger).toContainText('3');
+
+      // 7. Restore default (2)
+      await selectTrigger.click();
+      const restoredDropdown = page.locator('.ant-select-dropdown').last();
+      await restoredDropdown
+        .locator('.ant-select-item-option')
+        .filter({ hasText: '2' })
+        .first()
+        .click();
+    });
+  },
+);
+
+test.describe.serial(
+  'User Settings - Keypair & SSH Management',
+  { tag: ['@regression', '@user', '@functional'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'usersettings');
+      await expect(page.getByRole('tab', { name: 'General' })).toBeVisible();
+    });
+
+    test('User can open and close My Keypair Info modal', async ({ page }) => {
+      // 1. Find the My Keypair Info setting item
+      const settingItem = page.getByTestId('items-my-keypair-info');
+      await expect(settingItem).toBeVisible();
+
+      // 2. Click the Config button
+      await settingItem.getByRole('button', { name: 'Config' }).click();
+
+      // 3. Verify modal opens
+      const modal = page.locator('.ant-modal').last();
+      await expect(modal).toBeVisible();
+
+      // 4. Close the modal without making changes (use X button to avoid ambiguity)
+      await modal.locator('.ant-modal-close').click();
+      await expect(modal).toBeHidden();
+    });
+
+    test('User can open and close SSH Keypair Management modal', async ({
+      page,
+    }) => {
+      // 1. Find the SSH Keypair Management setting item
+      const settingItem = page.getByTestId('items-ssh-keypair-management');
+      await expect(settingItem).toBeVisible();
+
+      // 2. Click the Config button
+      await settingItem.getByRole('button', { name: 'Config' }).click();
+
+      // 3. Verify modal opens
+      const modal = page.locator('.ant-modal').last();
+      await expect(modal).toBeVisible();
+
+      // 4. Close the modal without making changes (use X button to avoid ambiguity)
+      await modal.locator('.ant-modal-close').click();
+      await expect(modal).toBeHidden();
+    });
+  },
+);
+
+test.describe.serial(
+  'User Settings - Shell Environments',
+  { tag: ['@regression', '@user', '@functional'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'usersettings');
+      await expect(page.getByRole('tab', { name: 'General' })).toBeVisible();
+    });
+
+    test('User can see Shell Environments group', async ({ page }) => {
+      // 1. Verify the Shell Environments group is visible
+      const group = page.getByTestId('group-shell-environments');
+      await expect(group).toBeVisible();
+
+      // 2. Verify both script items are visible
+      await expect(
+        page.getByTestId('items-edit-bootstrap-script'),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId('items-edit-user-config-script'),
+      ).toBeVisible();
+    });
+
+    test('User can open and close Bootstrap Script editor modal', async ({
+      page,
+    }) => {
+      // 1. Find the Bootstrap Script setting item
+      const settingItem = page.getByTestId('items-edit-bootstrap-script');
+
+      // 2. Click the Config button
+      await settingItem.getByRole('button', { name: 'Config' }).click();
+
+      // 3. Verify modal opens with correct title
+      const modal = page.locator('.ant-modal').last();
+      await expect(modal).toBeVisible();
+      await expect(modal.locator('.ant-modal-title')).toContainText(
+        'Bootstrap Script',
+      );
+
+      // 4. Verify code editor is present
+      await expect(modal.locator('.cm-editor')).toBeVisible();
+
+      // 5. Close the modal without saving (Cancel button)
+      await modal.getByRole('button', { name: 'Cancel' }).click();
+      await expect(modal).toBeHidden();
+    });
+
+    test('User can open and close User Config Script editor modal', async ({
+      page,
+    }) => {
+      // 1. Find the User Config Script setting item
+      const settingItem = page.getByTestId('items-edit-user-config-script');
+
+      // 2. Click the Config button
+      await settingItem.getByRole('button', { name: 'Config' }).click();
+
+      // 3. Verify modal opens with correct title
+      const modal = page.locator('.ant-modal').last();
+      await expect(modal).toBeVisible();
+      await expect(modal.locator('.ant-modal-title')).toContainText(
+        'User Config Script',
+      );
+
+      // 4. Verify code editor is present
+      await expect(modal.locator('.cm-editor')).toBeVisible();
+
+      // 5. Verify rc file selector is present with .bashrc as default
+      await expect(modal.locator('.ant-select')).toBeVisible();
+      await expect(modal.locator('.ant-select')).toContainText('.bashrc');
+
+      // 6. Close the modal without saving
+      await modal.getByRole('button', { name: 'Cancel' }).click();
+      await expect(modal).toBeHidden();
+    });
+
+    test('User can switch between rc files in User Config Script modal', async ({
+      page,
+    }) => {
+      // 1. Open User Config Script modal
+      const settingItem = page.getByTestId('items-edit-user-config-script');
+      await settingItem.getByRole('button', { name: 'Config' }).click();
+
+      const modal = page.locator('.ant-modal').last();
+      await expect(modal).toBeVisible();
+
+      // 2. Open the rc file selector
+      await modal.locator('.ant-select').click();
+
+      // 3. Verify dropdown options
+      const dropdown = page.locator('.ant-select-dropdown').last();
+      await expect(dropdown).toBeVisible();
+      await expect(
+        dropdown
+          .locator('.ant-select-item-option')
+          .filter({ hasText: '.zshrc' }),
+      ).toBeVisible();
+      await expect(
+        dropdown
+          .locator('.ant-select-item-option')
+          .filter({ hasText: '.vimrc' }),
+      ).toBeVisible();
+
+      // 4. Select .zshrc
+      await dropdown
+        .locator('.ant-select-item-option')
+        .filter({ hasText: '.zshrc' })
+        .click();
+
+      // 5. Verify selection changed
+      await expect(modal.locator('.ant-select')).toContainText('.zshrc');
+
+      // 6. Close without saving
+      await modal.getByRole('button', { name: 'Cancel' }).click();
+      await expect(modal).toBeHidden();
+    });
+  },
+);
+
+test.describe.serial(
+  'User Settings - Experimental Features',
+  { tag: ['@regression', '@user', '@functional'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'usersettings');
+      await expect(page.getByRole('tab', { name: 'General' })).toBeVisible();
+    });
+
+    test('User can see Experimental Features group', async ({ page }) => {
+      // 1. Verify the Experimental Features group is visible
+      const group = page.getByTestId('group-experimental-features');
+      await expect(group).toBeVisible();
+
+      // 2. Verify AI Agents item is visible
+      await expect(
+        page.getByTestId('items-experimental-ai-agents'),
+      ).toBeVisible();
+    });
+
+    test('User can toggle Experimental AI Agents checkbox', async ({
+      page,
+    }) => {
+      // 1. Find the AI Agents setting item
+      const settingItem = page.getByTestId('items-experimental-ai-agents');
+      await expect(settingItem).toBeVisible();
+
+      // 2. Find the checkbox
+      const checkbox = settingItem.locator('input[type="checkbox"]');
+
+      // 3. Get initial state
+      const initialChecked = await checkbox.isChecked();
+
+      // 4. Toggle
+      await checkbox.click({ force: true });
+      await expect(checkbox).toBeChecked({ checked: !initialChecked });
+
+      // 5. Toggle back to restore
+      await checkbox.click({ force: true });
+      await expect(checkbox).toBeChecked({ checked: initialChecked });
+    });
+  },
+);
+
+test.describe(
+  'User Settings - Tab Navigation',
+  { tag: ['@regression', '@user', '@functional'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'usersettings');
+      await expect(page.getByRole('tab', { name: 'General' })).toBeVisible();
+    });
+
+    test('User can switch to Logs tab', async ({ page }) => {
+      // 1. Click Logs tab
+      await page.getByRole('tab', { name: 'Logs' }).click();
+
+      // 2. Verify Logs tab is active
+      await checkActiveTab(page.locator('.ant-tabs').first(), 'Logs');
+
+      // 3. Verify Preferences group is no longer visible
+      await expect(page.getByTestId('group-preferences')).not.toBeVisible();
+    });
+
+    test('User can switch back to General tab from Logs', async ({ page }) => {
+      // 1. Switch to Logs
+      await page.getByRole('tab', { name: 'Logs' }).click();
+      await checkActiveTab(page.locator('.ant-tabs').first(), 'Logs');
+
+      // 2. Switch back to General
+      await page.getByRole('tab', { name: 'General' }).click();
+
+      // 3. Verify General tab is active and content visible
+      await checkActiveTab(page.locator('.ant-tabs').first(), 'General');
+      await expect(page.getByTestId('group-preferences')).toBeVisible();
+    });
+  },
+);
+
+test.describe(
+  'User Settings - Search and Filter',
+  { tag: ['@regression', '@user', '@functional'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'usersettings');
+      await expect(page.getByRole('tab', { name: 'General' })).toBeVisible();
+    });
+
+    test('User can search settings by keyword', async ({ page }) => {
+      // 1. Find the search bar (plain Input with SearchOutlined prefix)
+      const searchInput = page
+        .locator('.ant-input-affix-wrapper')
+        .locator('input')
+        .first();
+      await expect(searchInput).toBeVisible();
+
+      // 2. Type a search term that matches a specific setting
+      await searchInput.fill('Notification');
+
+      // 3. Verify filtered results — Desktop Notification should be visible
+      await expect(
+        page.getByTestId('items-desktop-notification'),
+      ).toBeVisible();
+
+      // 4. Verify unrelated settings are hidden
+      await expect(
+        page.getByTestId('items-max-concurrent-uploads'),
+      ).not.toBeVisible();
+
+      // 5. Clear the search to restore all settings
+      await searchInput.clear();
+
+      // 6. Verify all settings are visible again
+      await expect(
+        page.getByTestId('items-max-concurrent-uploads'),
+      ).toBeVisible();
+    });
+  },
+);


### PR DESCRIPTION
Resolves #5125(FR-1962) (test coverage)

## Summary

- Add Playwright E2E tests for `/usersettings` page (previously 0% coverage)
- 18 test cases across 6 describe blocks:
  - **General Preferences** (serial): tab visibility, desktop notification toggle, compact sidebar toggle, language selection, automatic update check toggle, auto-logout toggle, max concurrent uploads
  - **Keypair & SSH Management** (serial): My Keypair Info modal, SSH Keypair Management modal
  - **Shell Environments** (serial): group visibility, bootstrap script editor modal, user config script editor modal, rc file switching
  - **Experimental Features** (serial): group visibility, AI agents toggle
  - **Tab Navigation**: switch to Logs tab, switch back to General tab
  - **Search and Filter**: search settings by keyword
- All tests restore original state to avoid side effects
- Update E2E coverage report: User Settings 0% → 93% (13/14 features)

## Run

```bash
npx playwright test e2e/user/user-settings.spec.ts
npx playwright test e2e/user/user-settings.spec.ts --headed  # with browser
```

## New Files

- `e2e/user/user-settings.spec.ts` — 18 test cases

## Modified Files

- `e2e/E2E_COVERAGE_REPORT.md` — Updated coverage for User Settings page