### PR TITLE
test(FR-2022): add e2e tests for create file in file browser

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-03-03
+> **Last Updated:** 2026-03-04
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 78 / 280 features covered (28%)**
+**Overall (in-scope routes): 71 / 273 features covered (26%)**
 
 | Page | Route | Features | Covered | Status |
 |------|-------|:--------:|:-------:|:------:|
@@ -24,7 +24,7 @@
 | Serving | `/serving` | 7 | 0 | ❌ 0% |
 | Endpoint Detail | `/serving/:serviceId` | 14 | 0 | ❌ 0% |
 | Service Launcher | `/service/start` | 5 | 0 | ❌ 0% |
-| VFolder / Data | `/data` | 34 | 21 | 🔶 62% |
+| VFolder / Data | `/data` | 38 | 25 | 🔶 66% |
 | Model Store | `/model-store` | 6 | 0 | ❌ 0% |
 | Storage Host | `/storage-settings/:hostname` | 3 | 0 | ❌ 0% |
 | My Environment | `/my-environment` | 2 | 0 | ❌ 0% |
@@ -42,7 +42,7 @@
 | Branding | `/branding` | 14 | 0 | ❌ 0% |
 | App Launcher | (modal) | 18 | 10 | 🔶 56% |
 | Chat | `/chat/:id?` | 6 | 0 | ❌ 0% |
-| **Total** | | **280** | **78** | **28%** |
+| **Total** | | **273** | **71** | **26%** |
 
 ---
 
@@ -247,7 +247,7 @@
 
 ### 9. Data / VFolder (`/data`)
 
-**Test files:** [`e2e/vfolder/vfolder-crud.spec.ts`](vfolder/vfolder-crud.spec.ts), [`e2e/vfolder/vfolder-explorer-modal.spec.ts`](vfolder/vfolder-explorer-modal.spec.ts), [`e2e/vfolder/vfolder-consecutive-deletion.spec.ts`](vfolder/vfolder-consecutive-deletion.spec.ts), [`e2e/vfolder/file-upload.spec.ts`](vfolder/file-upload.spec.ts), [`e2e/vfolder/file-upload-dnd.spec.ts`](vfolder/file-upload-dnd.spec.ts), [`e2e/vfolder/file-upload-duplicate.spec.ts`](vfolder/file-upload-duplicate.spec.ts), [`e2e/vfolder/file-upload-permissions.spec.ts`](vfolder/file-upload-permissions.spec.ts), [`e2e/vfolder/file-upload-subdirectory.spec.ts`](vfolder/file-upload-subdirectory.spec.ts)
+**Test files:** [`e2e/vfolder/vfolder-crud.spec.ts`](vfolder/vfolder-crud.spec.ts), [`e2e/vfolder/vfolder-explorer-modal.spec.ts`](vfolder/vfolder-explorer-modal.spec.ts), [`e2e/vfolder/vfolder-consecutive-deletion.spec.ts`](vfolder/vfolder-consecutive-deletion.spec.ts), [`e2e/vfolder/file-upload.spec.ts`](vfolder/file-upload.spec.ts), [`e2e/vfolder/file-upload-dnd.spec.ts`](vfolder/file-upload-dnd.spec.ts), [`e2e/vfolder/file-upload-duplicate.spec.ts`](vfolder/file-upload-duplicate.spec.ts), [`e2e/vfolder/file-upload-permissions.spec.ts`](vfolder/file-upload-permissions.spec.ts), [`e2e/vfolder/file-upload-subdirectory.spec.ts`](vfolder/file-upload-subdirectory.spec.ts), [`e2e/vfolder/file-create.spec.ts`](vfolder/file-create.spec.ts)
 
 **Tabs:** Active | Deleted
 **Filter (Active tab):** all | general | pipeline | automount | model
@@ -280,6 +280,12 @@
 | Explorer modal (open/close) | ✅ | `User can open and close VFolder explorer modal` |
 | Explorer modal (file browser) | ✅ | `User can access File Browser from VFolder explorer` |
 | Explorer modal (details view) | ✅ | `User can view VFolder details in the explorer` |
+| File creation (Create File button) | ✅ | `User can see Create File button in file explorer` |
+| File creation (new file) | ✅ | `User can create a new file in the file explorer` |
+| File creation (yaml config) | ✅ | `User can create a yaml configuration file` |
+| File creation (empty name validation) | ✅ | `User cannot create a file with empty name` |
+| File creation (invalid chars validation) | ✅ | `User cannot create a file with invalid characters in name` |
+| File creation (read-only disabled) | 🚧 | Skipped: `User cannot create files in read-only VFolder` |
 | Active/Deleted tab switching | ❌ | - |
 | Usage mode filtering (general/pipeline/automount/model) | ❌ | - |
 | Property filtering (name, status, location) | ❌ | - |
@@ -294,7 +300,7 @@
 | File/folder rename | ❌ | - |
 | File/folder delete within explorer | ❌ | - |
 
-**Coverage: 🔶 21/34 features**
+**Coverage: 🔶 25/38 features (includes 1 skipped)**
 
 ---
 

--- a/e2e/utils/classes/vfolder/FolderExplorerModal.ts
+++ b/e2e/utils/classes/vfolder/FolderExplorerModal.ts
@@ -58,10 +58,18 @@ export class FolderExplorerModal {
 
   async getCreateFolderButton(): Promise<Locator> {
     const createButton = this.modal.getByRole('button', {
-      name: 'folder-add Create',
+      name: 'folder-add Create Folder',
     });
     await expect(createButton).toBeVisible();
     return createButton;
+  }
+
+  async getCreateFileButton(): Promise<Locator> {
+    const createFileButton = this.modal.getByRole('button', {
+      name: 'file-add Create File',
+    });
+    await expect(createFileButton).toBeVisible();
+    return createFileButton;
   }
 
   async getFileBrowserButton(): Promise<Locator> {

--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -122,6 +122,15 @@ export async function login(
   });
 
   await page.goto(webuiEndpoint);
+  // Remove webpack-dev-server overlay iframe that can intercept pointer events
+  await page
+    .evaluate(() => {
+      const overlay = document.getElementById(
+        'webpack-dev-server-client-overlay',
+      );
+      if (overlay) overlay.remove();
+    })
+    .catch(() => {});
   await page.getByLabel('Email or Username').fill(username);
   await page.getByLabel('Password').fill(password);
   // Expand the endpoint section if it's not already visible

--- a/e2e/vfolder/file-create.spec.ts
+++ b/e2e/vfolder/file-create.spec.ts
@@ -1,0 +1,222 @@
+import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import {
+  loginAsUser,
+  navigateTo,
+  createVFolderAndVerify,
+  moveToTrashAndVerify,
+  deleteForeverAndVerifyFromTrash,
+} from '../utils/test-util';
+import { test, expect, Page } from '@playwright/test';
+
+const openFolderExplorer = async (
+  page: Page,
+  folderName: string,
+): Promise<FolderExplorerModal> => {
+  await navigateTo(page, 'data');
+  await page.waitForLoadState('networkidle');
+  const folderLink = page.getByRole('link', { name: folderName }).first();
+  await folderLink.waitFor({ state: 'visible' });
+  await folderLink.click();
+  const modal = new FolderExplorerModal(page);
+  await modal.waitForOpen();
+  return modal;
+};
+
+test.describe(
+  'File Creation in VFolder Explorer',
+  { tag: ['@critical', '@vfolder', '@functional'] },
+  () => {
+    const testFolderName = 'e2e-test-file-create-' + new Date().getTime();
+
+    test.beforeAll(async ({ browser, request }) => {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      await loginAsUser(page, request);
+      await createVFolderAndVerify(page, testFolderName);
+      await context.close();
+    });
+
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+    });
+
+    test.afterAll(async ({ browser, request }) => {
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      await loginAsUser(page, request);
+      try {
+        await moveToTrashAndVerify(page, testFolderName);
+        await deleteForeverAndVerifyFromTrash(page, testFolderName);
+      } catch {
+        console.log(`Could not delete ${testFolderName}, it may not exist`);
+      }
+      await context.close();
+    });
+
+    test('User can see Create File button in file explorer', async ({
+      page,
+    }) => {
+      const modal = await openFolderExplorer(page, testFolderName);
+      await modal.verifyFileExplorerLoaded();
+
+      // Verify Create File button is visible and enabled
+      const createFileButton = await modal.getCreateFileButton();
+      await expect(createFileButton).toBeEnabled();
+
+      await modal.close();
+    });
+
+    test('User can create a new file in the file explorer', async ({
+      page,
+    }) => {
+      const modal = await openFolderExplorer(page, testFolderName);
+      await modal.verifyFileExplorerLoaded();
+
+      // Click Create File button
+      const createFileButton = await modal.getCreateFileButton();
+      await createFileButton.click();
+
+      // Verify Create File modal appears
+      const createFileModal = page.getByRole('dialog').filter({
+        hasText: 'Create a new file',
+      });
+      await expect(createFileModal).toBeVisible();
+
+      // Enter file name
+      const fileName = 'test-file-' + new Date().getTime() + '.txt';
+      await createFileModal.getByRole('textbox').fill(fileName);
+
+      // Click Create button
+      await createFileModal.getByRole('button', { name: 'Create' }).click();
+
+      // Verify file appears in the file list
+      await modal.verifyFileVisible(fileName);
+
+      await modal.close();
+    });
+
+    test('User can create a yaml configuration file', async ({ page }) => {
+      const modal = await openFolderExplorer(page, testFolderName);
+      await modal.verifyFileExplorerLoaded();
+
+      const createFileButton = await modal.getCreateFileButton();
+      await createFileButton.click();
+
+      const createFileModal = page.getByRole('dialog').filter({
+        hasText: 'Create a new file',
+      });
+      await expect(createFileModal).toBeVisible();
+
+      const fileName = 'model-definition-' + new Date().getTime() + '.yaml';
+      await createFileModal.getByRole('textbox').fill(fileName);
+
+      await createFileModal.getByRole('button', { name: 'Create' }).click();
+
+      await modal.verifyFileVisible(fileName);
+      await modal.close();
+    });
+
+    test('User cannot create a file with empty name', async ({ page }) => {
+      const modal = await openFolderExplorer(page, testFolderName);
+      await modal.verifyFileExplorerLoaded();
+
+      const createFileButton = await modal.getCreateFileButton();
+      await createFileButton.click();
+
+      const createFileModal = page.getByRole('dialog').filter({
+        hasText: 'Create a new file',
+      });
+      await expect(createFileModal).toBeVisible();
+
+      // Click Create without entering a name
+      await createFileModal.getByRole('button', { name: 'Create' }).click();
+
+      // Verify validation error message appears
+      await expect(
+        createFileModal.getByText('Please enter the file name.'),
+      ).toBeVisible();
+
+      // Modal should still be open
+      await expect(createFileModal).toBeVisible();
+
+      // Cancel the modal
+      await createFileModal.getByRole('button', { name: 'Cancel' }).click();
+      await modal.close();
+    });
+
+    test('User cannot create a file with invalid characters in name', async ({
+      page,
+    }) => {
+      const modal = await openFolderExplorer(page, testFolderName);
+      await modal.verifyFileExplorerLoaded();
+
+      const createFileButton = await modal.getCreateFileButton();
+      await createFileButton.click();
+
+      const createFileModal = page.getByRole('dialog').filter({
+        hasText: 'Create a new file',
+      });
+      await expect(createFileModal).toBeVisible();
+
+      // Test forward slash
+      await createFileModal.getByRole('textbox').fill('invalid/file.txt');
+      await createFileModal.getByRole('button', { name: 'Create' }).click();
+      await expect(
+        createFileModal.getByText('File name must not contain path separators'),
+      ).toBeVisible();
+      await expect(createFileModal).toBeVisible();
+
+      // Test backslash
+      await createFileModal.getByRole('textbox').clear();
+      await createFileModal.getByRole('textbox').fill('invalid\\file.txt');
+      await createFileModal.getByRole('button', { name: 'Create' }).click();
+      await expect(
+        createFileModal.getByText('File name must not contain path separators'),
+      ).toBeVisible();
+      await expect(createFileModal).toBeVisible();
+
+      await createFileModal.getByRole('button', { name: 'Cancel' }).click();
+      await modal.close();
+    });
+  },
+);
+
+test.describe(
+  'File Creation - Read Only VFolder',
+  { tag: ['@critical', '@vfolder', '@functional'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsUser(page, request);
+      await navigateTo(page, 'data');
+    });
+
+    // TODO: Permission API returns inaccurate response, so write buttons are not properly disabled for read-only folders.
+    // Re-enable this test when the permission API is fixed.
+    test.skip('User cannot create files in read-only VFolder', async ({
+      page,
+    }) => {
+      const roFolderName = 'e2e-test-file-create-ro-' + new Date().getTime();
+
+      // Create a read-only vfolder
+      await createVFolderAndVerify(page, roFolderName, 'general', 'user', 'ro');
+
+      // Open the folder explorer
+      const modal = await openFolderExplorer(page, roFolderName);
+      await modal.verifyFileExplorerLoaded();
+      await modal.verifyPermission('Read only');
+
+      // Verify Create File button is disabled
+      const createFileButton = page
+        .getByRole('dialog')
+        .first()
+        .getByRole('button', { name: /Create File/ });
+      await expect(createFileButton.first()).toBeDisabled();
+
+      await modal.close();
+
+      // Cleanup
+      await moveToTrashAndVerify(page, roFolderName);
+      await deleteForeverAndVerifyFromTrash(page, roFolderName);
+    });
+  },
+);


### PR DESCRIPTION
Resolves #5717(FR-2022)

## Summary

- Add E2E tests for the Create File feature in VFolder file browser
- Fix validation message assertions to match actual i18n values
- Skip read-only permission test due to inaccurate permission API response
- Add webpack-dev-server overlay removal in login helper to prevent pointer event interception

## Test Cases

- **User can see Create File button** in file explorer
- **User can create a new file** (.txt) in the file explorer
- **User can create a yaml configuration file** (.yaml)
- **User cannot create a file with empty name** — validates required field
- **User cannot create a file with invalid characters** — validates `/` and `\` in name
- **User cannot create files in read-only VFolder** — skipped (permission API issue)