### PR TITLE
chore(FR-2151): add wiki markup auto-conversion to jira.sh md_to_adf

### DIFF
--- a/scripts/jira.sh
+++ b/scripts/jira.sh
@@ -75,6 +75,21 @@ md_to_adf() {
 import json, re, sys
 
 text = sys.argv[1]
+
+# Auto-convert common Jira wiki markup to Markdown before processing.
+# These patterns are unambiguous and never appear in valid Markdown.
+def wiki_to_md(t):
+    # h1. through h6. headings → # through ######
+    t = re.sub(r"^h([1-6])\.\s+", lambda m: "#" * int(m.group(1)) + " ", t, flags=re.MULTILINE)
+    # {{inline code}} → `inline code`
+    t = re.sub(r"\{\{([^}]+)\}\}", r"`\1`", t)
+    # {code:lang} or {code} blocks → ```lang / ```
+    t = re.sub(r"\{code(?::(\w+))?\}", lambda m: "```" + (m.group(1) or ""), t)
+    # {noformat} → ```
+    t = re.sub(r"\{noformat\}", "```", t)
+    return t
+
+text = wiki_to_md(text)
 lines = text.split("\n")
 content = []
 in_code = False


### PR DESCRIPTION
Resolves #5604 ([FR-2151](https://lablup.atlassian.net/browse/FR-2151))

## Summary
- Add `wiki_to_md()` pre-processing step to `md_to_adf()` in `scripts/jira.sh`
- Auto-converts Jira wiki markup patterns (`h1.`-`h6.`, `{{code}}`, `{code}`, `{noformat}`) to Markdown before ADF conversion
- All patterns are unambiguous and never appear in valid Markdown, so no false positives

## Test plan
- [ ] Verify wiki markup input (`h2. Title`, `{{code}}`) produces correct ADF headings and inline code
- [ ] Verify existing Markdown input passes through unchanged
- [ ] Verify `jira.sh update --desc` with wiki markup renders correctly in Jira

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-2151]: https://lablup.atlassian.net/browse/FR-2151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ