### PR TITLE
fix(FR-2149): watch config.toml for changes in dev server

### DIFF
--- a/react/craco.config.cjs
+++ b/react/craco.config.cjs
@@ -41,25 +41,6 @@ module.exports = {
       },
     ];
 
-    // Only watch config.toml and index.html for full reloads when they change.
-    // Exclude resources/, dist/, and manifest/ because changes to those files
-    // (e.g. relay-generated files, CSS assets) should not cause full reloads.
-    // The __generated__/ directory is excluded to prevent relay compiler watch
-    // mode from triggering unnecessary full page reloads during development.
-    devServerConfig.watchFiles = {
-      paths: ['../index.html', '../config.toml'],
-      options: {
-        // Ignore relay-generated files and static assets to prevent full reloads
-        ignored: [
-          '**/src/__generated__/**',
-          '**/node_modules/**',
-          '**/dist/**',
-          '**/resources/**',
-          '**/manifest/**',
-        ],
-      },
-    };
-
     // Enable HMR explicitly and disable liveReload to prevent full page reloads
     // when HMR updates can handle the change.
     devServerConfig.hot = true;
@@ -85,12 +66,12 @@ module.exports = {
     }
 
     // Watch config.toml and index.html for changes and trigger a full page reload.
-    // We cannot rely on watchFiles + liveReload for this because liveReload is set
-    // to false (to prevent HMR fallback reloads on React source changes). In
-    // webpack-dev-server v4, the watchFiles mechanism uses liveReload to send the
-    // browser reload signal, so with liveReload:false, file changes are detected by
-    // chokidar but the reload signal is never sent. We work around this by setting up
-    // a separate chokidar watcher in setupMiddlewares that explicitly sends the
+    // We cannot rely on devServerConfig.watchFiles for this because liveReload is
+    // set to false (to prevent HMR fallback reloads on React source changes). In
+    // webpack-dev-server v4, the watchFiles mechanism checks liveReload before
+    // sending the browser reload signal, so with liveReload:false, file changes
+    // are detected but the reload signal is never sent. We work around this by
+    // setting up fs.watch watchers in setupMiddlewares that explicitly send the
     // 'static-changed' WebSocket message to trigger a full page reload.
     const existingSetupMiddlewares = devServerConfig.setupMiddlewares;
     devServerConfig.setupMiddlewares = (middlewares, devServer) => {
@@ -98,18 +79,32 @@ module.exports = {
         middlewares = existingSetupMiddlewares(middlewares, devServer);
       }
 
-      const chokidar = require('chokidar');
       const filesToWatch = [
         path.resolve(__dirname, '../config.toml'),
         path.resolve(__dirname, '../index.html'),
       ];
-      const watcher = chokidar.watch(filesToWatch, { ignoreInitial: true });
-      watcher.on('change', () => {
-        devServer.sendMessage(
-          devServer.webSocketServer.clients,
-          'static-changed',
-        );
+
+      const watchers = filesToWatch.map((file) => {
+        // Use a debounce timer to avoid rapid successive reloads from
+        // editors that write files in multiple steps (e.g. write + rename).
+        let debounceTimer;
+        return fs.watch(file, () => {
+          clearTimeout(debounceTimer);
+          debounceTimer = setTimeout(() => {
+            devServer.sendMessage(
+              devServer.webSocketServer.clients,
+              'static-changed',
+            );
+          }, 100);
+        });
       });
+
+      // Close watchers when the dev server shuts down to prevent resource leaks.
+      const originalClose = devServer.server.close.bind(devServer.server);
+      devServer.server.close = (callback) => {
+        watchers.forEach((w) => w.close());
+        originalClose(callback);
+      };
 
       return middlewares;
     };


### PR DESCRIPTION
Resolves #5592(FR-2149)

## Summary

- `config.toml` and `index.html` changes now trigger a full browser reload in the craco dev server
- Fix uses a dedicated chokidar watcher in `setupMiddlewares` that sends the `static-changed` WebSocket message directly, bypassing the `liveReload: false` flag
- HMR for React component changes continues to work correctly without unwanted full-page reloads

## Root Cause

`watchFiles.paths` in webpack-dev-server v4 relies on `liveReload` to send the browser reload signal. Since `liveReload: false` is set (to prevent HMR fallback reloads on React source changes), chokidar detects file changes but never sends the reload signal to the browser.

## Solution

Added a `setupMiddlewares` wrapper that creates a separate chokidar watcher for `config.toml` and `index.html`. On any change, it calls `devServer.sendMessage(devServer.webSocketServer.clients, 'static-changed')` directly — this triggers a full page reload without going through the `liveReload` flag.

## Verification

```
=== ALL PASS ===
```