### PR TITLE
fix(FR-2136): watch resources/i18n for changes in dev server

### DIFF
--- a/react/craco.config.cjs
+++ b/react/craco.config.cjs
@@ -65,7 +65,8 @@ module.exports = {
       };
     }
 
-    // Watch config.toml and index.html for changes and trigger a full page reload.
+    // Watch config.toml, index.html, and i18n translation files for changes
+    // and trigger a full page reload.
     // We cannot rely on devServerConfig.watchFiles for this because liveReload is
     // set to false (to prevent HMR fallback reloads on React source changes). In
     // webpack-dev-server v4, the watchFiles mechanism checks liveReload before
@@ -82,6 +83,11 @@ module.exports = {
       const filesToWatch = [
         path.resolve(__dirname, '../config.toml'),
         path.resolve(__dirname, '../index.html'),
+        // Watch the i18n directory so that changes to translation JSON files
+        // trigger a full page reload. i18next-http-backend fetches these files
+        // at runtime (they are not bundled by webpack), so a page reload is
+        // needed to re-fetch the updated translations.
+        path.resolve(__dirname, '../resources/i18n'),
       ];
 
       const watchers = filesToWatch.map((file) => {


### PR DESCRIPTION
Resolves #5578(FR-2136)

## Summary

- Extend the custom `fs.watch`-based watcher in `craco.config.cjs` to also watch `resources/i18n/` directory
- When any translation JSON file changes, a full page reload is triggered via the `static-changed` WebSocket message
- `i18next-http-backend` re-fetches the updated JSON on reload, making translation changes visible without manual refresh

## Background

The dev server uses a custom watcher (added in FR-2149) because `liveReload: false` prevents `devServer.watchFiles` from sending browser reload signals. The same mechanism is extended here to cover `resources/i18n/`.

The `resources/` directory remains excluded from webpack's `watchOptions.ignored` since i18n files are served as static files, not bundled by webpack. The directory-level `fs.watch` call fires when any file inside changes, covering all locale JSON files at the top level of `resources/i18n/`.

## Verification

```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```