### PR TITLE
fix(FR-2135): auto-rebuild backend.ai-client-esm.ts on change

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:react-only": "pnpm run --prefix ./react build:only",
     "server:p": "serve build/web",
     "server:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && HOST=$BAI_WEBUI_DEV_HOST PORT=$BAI_WEBUI_DEV_REACT_PORT PROXY=http://localhost:$BAI_WEBUI_DEV_WEBDEV_PORT pnpm --prefix ./react run start",
-    "build:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && concurrently --kill-others -c \"auto\" --names \"react-relay,react\" \"cd react && pnpm run relay:watch\" \"HOST=$BAI_WEBUI_DEV_HOST BAI_WEBUI_DEV_PROXY= PORT=$BAI_WEBUI_DEV_REACT_PORT pnpm --prefix ./react run start\"",
+    "build:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && concurrently --kill-others -c \"auto\" --names \"tsc,react-relay,react\" \"tsc --watch --preserveWatchOutput\" \"cd react && pnpm run relay:watch\" \"HOST=$BAI_WEBUI_DEV_HOST BAI_WEBUI_DEV_PROXY= PORT=$BAI_WEBUI_DEV_REACT_PORT pnpm --prefix ./react run start\"",
     "electron:d": "electron build/electron-app --dev",
     "electron:d:hmr": "LIVE_DEBUG=1 electron build/electron-app --dev",
     "relay": "relay-compiler",

--- a/react/craco.config.cjs
+++ b/react/craco.config.cjs
@@ -294,10 +294,10 @@ module.exports = {
           ignored: [
             // Ignore node_modules (standard exclusion for performance)
             '**/node_modules/**',
-            // Ignore static assets that are served directly by webpack-dev-server
-            // and are not part of the webpack module graph. These don't need
-            // webpack to watch them; the dev server serves them as static files.
-            path.resolve(__dirname, '../dist/**'),
+            // Note: dist/ is intentionally NOT ignored because
+            // backend.ai-client-esm.js (resolved via webpack alias) is part of
+            // the module graph and needs to trigger HMR when recompiled by
+            // `tsc --watch` (run concurrently in the build:d script).
             path.resolve(__dirname, '../resources/**'),
             path.resolve(__dirname, '../manifest/**'),
           ],


### PR DESCRIPTION
Resolves #5577(FR-2135)

## Summary

- Add `tsc --watch --preserveWatchOutput` as a third concurrent process in `build:d` so that changes to `src/lib/backend.ai-client-esm.ts` are automatically recompiled to `dist/lib/backend.ai-client-esm.js`
- Remove `dist/**` from `watchOptions.ignored` in `craco.config.cjs` so webpack detects changes to the compiled JS (which is in the module graph via the webpack alias) and triggers HMR

## Root Cause

Three compounding issues prevented auto-rebuild:

1. The webpack alias points to `dist/lib/backend.ai-client-esm.js` (pre-compiled JS), not the TypeScript source
2. No `tsc --watch` was running for the root `tsconfig.json` during development
3. `dist/**` was excluded from webpack's file watcher, so even a regenerated JS file would not trigger HMR

## Test plan

- [ ] Run `pnpm run build:d` — verify three concurrent processes start: `tsc`, `react-relay`, and `react`
- [ ] Modify `src/lib/backend.ai-client-esm.ts` — verify `tsc --watch` recompiles automatically
- [ ] Confirm the dev server picks up the change and triggers HMR or reload
- [ ] Verify Relay watch and React HMR still work correctly for React source changes

## Verification

```
=== Relay === PASS
=== Lint === PASS
=== Format === PASS
=== TypeScript === PASS
=== ALL PASS ===
```