### PR TITLE
fix(FR-2152): move devServer.server.close patching to onListening callback

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "lib": ["es6", "dom", "es2016", "es2017", "es2020"],
     "preserveWatchOutput": true
   },
-  "include": ["src/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
Resolves [FR-2152](https://lablup.atlassian.net/browse/FR-2152)

## Summary
- Move `devServer.server.close` patching from `setupMiddlewares` to `onListening` callback in craco.config.cjs
- In webpack-dev-server v4, `setupMiddlewares()` runs before `createServer()`, so `devServer.server` is `undefined` at that point — causing a silent TypeError that prevented `server.listen()` from ever being called
- Dev server now correctly binds to port 9081 on startup

## Test plan
- [ ] Run `pnpm run build:d` and verify port 9081 is listening (`lsof -i :9081 | grep LISTEN`)
- [ ] Verify `curl http://localhost:9081/` returns HTTP 200
- [ ] Verify file watcher reload works (edit `config.toml` or `resources/i18n/*.json` and confirm page reloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-2152]: https://lablup.atlassian.net/browse/FR-2152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ