### PR TITLE
chore(FR-2158): add model and token usage info to statusline

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       lint-staged:
         specifier: ^15.5.2
         version: 15.5.2
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.23
       prettier:
         specifier: ^3.8.1
         version: 3.8.1


### PR DESCRIPTION
Resolves #5622 ([FR-2158](https://lablup.atlassian.net/browse/FR-2158))

## Summary
- Read session JSON from stdin once and reuse for both workspace extraction and model/token parsing
- Always display model name and context window usage percentage in the statusline
- Fall back to model/token-only display on non-Jira branches (e.g. `main`) or when PR/Jira cache is missing

![CleanShot 2026-02-26 at 15.35.43@2x.png](https://app.graphite.com/user-attachments/assets/2f94a58a-30be-4889-aefd-06ad713fd1d0.png)

## Test plan
- [ ] Verify statusline shows model + token info on `main` branch
- [ ] Verify statusline shows model + token + Jira info on `FR-XXXX` branches with cached data

[FR-2158]: https://lablup.atlassian.net/browse/FR-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ