### PR TITLE
chore(FR-2170): display links before model info in statusline with multi-line layout

### DIFF
--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -158,26 +158,27 @@ except Exception:
 
 IFS=$'\t' read -r JIRA_SUMMARY JIRA_STATUS TEAMS_URL <<< "$PARSED"
 
-# ── Build single-line output: Model | Teams | Jira ───────
-LINE="$MODEL_PART  "
+# ── Line 1: Links (Teams + Jira) ─────────────────────────
+LINE1=""
 
 if [[ -n "$TEAMS_URL" ]]; then
-  LINE+=$(link "$TEAMS_URL" "Teams")
+  LINE1+=$(link "$TEAMS_URL" "Teams")
+  LINE1+="  "
 fi
 
-[[ -n "$LINE" ]] && LINE+="  "
 JIRA_URL="https://lablup.atlassian.net/browse/${JIRA_KEY}"
-LINE+=$(link "$JIRA_URL" "$JIRA_KEY")
+LINE1+=$(link "$JIRA_URL" "$JIRA_KEY")
 
 if [[ -n "$JIRA_STATUS" ]]; then
-  LINE+=" (${JIRA_STATUS})"
+  LINE1+=" (${JIRA_STATUS})"
 fi
 
 if [[ -n "$JIRA_SUMMARY" ]]; then
   if (( ${#JIRA_SUMMARY} > 45 )); then
     JIRA_SUMMARY="${JIRA_SUMMARY:0:42}..."
   fi
-  LINE+=": ${JIRA_SUMMARY}"
+  LINE1+=": ${JIRA_SUMMARY}"
 fi
 
-printf '%b' "$LINE"
+# ── Line 2: Model + token info ────────────────────────────
+printf '%b\n%b' "$LINE1" "$MODEL_PART"


### PR DESCRIPTION
Resolves #5636 ([FR-2170](https://lablup.atlassian.net/browse/FR-2170))

## Summary
- Reorganize statusline output into two lines: links first, model/token info second
- Line 1: Teams thread link + Jira issue link (status, summary) — most actionable, always visible
- Line 2: Model name and token usage — secondary context, acceptable if truncated on narrow terminals

![CleanShot 2026-02-26 at 15.57.04@2x.png](https://app.graphite.com/user-attachments/assets/4a567861-01f2-4103-874b-741f21787d27.png)

## Test plan
- [ ] Verify Teams and Jira links appear on the first line
- [ ] Verify model/token info appears on the second line
- [ ] Verify on a narrow terminal that links remain visible while model info may be truncated

[FR-2170]: https://lablup.atlassian.net/browse/FR-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ