### PR TITLE
feat(FR-2163): implement website build orchestrator and CLI command

### DIFF
--- a/.claude/notes/branch-summary.md
+++ b/.claude/notes/branch-summary.md
@@ -1,0 +1,47 @@
+# Local Branch Summary (2026-02-26)
+
+211개 → 23개로 정리 완료. 188개 삭제됨.
+
+## A. docs-toolkit 스택 (8개) — 현재 작업 중
+
+| 순서 | PR | 설명 |
+|---|---|---|
+| 1 | [#5643](https://github.com/lablup/backend.ai-webui/pull/5643) | 마크다운→HTML 페이지 변환 코어 (`website-builder.ts`) |
+| 2 | [#5644](https://github.com/lablup/backend.ai-webui/pull/5644) | 빌드 오케스트레이터 + CLI `build:web` 명령 |
+| 3 | [#5645](https://github.com/lablup/backend.ai-webui/pull/5645) | 이전/다음 페이지 네비게이션 |
+| 4 | [#5646](https://github.com/lablup/backend.ai-webui/pull/5646) | "Edit this page" 링크 + 마지막 수정일 |
+| 5 | [#5647](https://github.com/lablup/backend.ai-webui/pull/5647) | 다국어 검색 인덱스 생성 |
+| 6 | [#5648](https://github.com/lablup/backend.ai-webui/pull/5648) | 클라이언트 사이드 검색 UI |
+| 7 | [#5649](https://github.com/lablup/backend.ai-webui/pull/5649) | CSS 공유 스타일시트 + `:lang()` 셀렉터 |
+| 8 | [#5650](https://github.com/lablup/backend.ai-webui/pull/5650) | 개발 서버 + npm 스크립트 *(현재 브랜치, 미커밋 변경 있음)* |
+
+## B. 활성 피처 (4개) — 머지 진행 가능
+
+| PR | 설명 | 규모 |
+|---|---|---|
+| [#5547](https://github.com/lablup/backend.ai-webui/pull/5547) OPEN | 엔드포인트 실시간 메트릭 시각화 (Recharts 차트, `EndpointMetricsPanel`) | 6파일, +373줄 |
+| [#5548](https://github.com/lablup/backend.ai-webui/pull/5548) OPEN | `cuda.mem` 메모리 타입 GPU 리소스 지원 | 9파일, +298줄 |
+| [#5108](https://github.com/lablup/backend.ai-webui/pull/5108) OPEN | 이미지 매칭 유틸 `findMatchingImage()` 추출 + 테스트 265줄 | 4파일, +403줄 |
+| [#5262](https://github.com/lablup/backend.ai-webui/pull/5262) OPEN | `useCurrentProjectValue`에 undefined/null 지원, ~30개 컴포넌트 수정 | 32파일, +273줄 |
+
+## C. 리뷰 필요 (4개)
+
+| PR | 설명 | 상태 | 판단 |
+|---|---|---|---|
+| [#5249](https://github.com/lablup/backend.ai-webui/pull/5249) **CLOSED** | 리소스 정책 관리 UI 마이그레이션 (`IdleTimeoutChecker` 613줄, 22개 언어 i18n) | 29파일, +1747줄 | PR 닫힘 — 재작업 필요하면 새 브랜치로 |
+| [#5227](https://github.com/lablup/backend.ai-webui/pull/5227) OPEN | 서빙 엔드포인트 라이프사이클 E2E 테스트 7개 | 2파일, +471줄 | Draft, 2/4 이후 방치 |
+| [#4619](https://github.com/lablup/backend.ai-webui/pull/4619) OPEN | 세션 시작 시 앱 자동 실행 토글 | +72줄 | **미완성** — 실행 로직 없음, 11월 이후 방치 |
+| [#5002](https://github.com/lablup/backend.ai-webui/pull/5002) OPEN | 앱 런처 E2E 테스트 7개 스위트 (~4000줄) | 14파일, +3973줄 | 1/20 기준, 리베이스 필요 |
+
+## D. 릴리스 (6개)
+
+| 브랜치 | main 대비 뒤처짐 | 리모트 | 비고 |
+|---|---|---|---|
+| **26.2** | 147 | 있음 | 현재 릴리스 |
+| **25.16** | 434 | 있음 | 안정 릴리스 |
+| **25.16+custom** | 434 | 있음 | 커스텀 배포 |
+| **25.16+custom2** | 434 | **없음** | 로컬 전용 |
+| **25.15** | 484 | 있음 | 핫픽스용 |
+| **25.14** | 541 | 있음 | 로컬 카피 삭제 가능 |
+
+## E. main (1개)

--- a/packages/backend.ai-docs-toolkit/.claude/settings.local.json
+++ b/packages/backend.ai-docs-toolkit/.claude/settings.local.json
@@ -1,0 +1,20 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(gt checkout:*)",
+      "Bash(gt submit:*)",
+      "WebFetch(domain:api.github.com)",
+      "Bash(bash:*)",
+      "Bash(git:*)"
+    ]
+  },
+  "disabledMcpjsonServers": [
+    "playwright-test",
+    "graphite"
+  ],
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true
+  }
+}

--- a/packages/backend.ai-docs-toolkit/src/cli.ts
+++ b/packages/backend.ai-docs-toolkit/src/cli.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'url';
 import { loadToolkitConfig, resolveConfig } from './config.js';
 import type { ResolvedDocConfig, AgentConfig } from './config.js';
 
-const COMMANDS = ['pdf', 'preview', 'preview:html', 'init', 'agents', 'help'] as const;
+const COMMANDS = ['pdf', 'preview', 'preview:html', 'build:web', 'init', 'agents', 'help'] as const;
 type Command = (typeof COMMANDS)[number];
 
 function printUsage(): void {
@@ -31,6 +31,7 @@ Commands:
   pdf            Generate PDF documents
   preview        PDF preview server (live-reload)
   preview:html   HTML preview server (live-reload, no PDF)
+  build:web      Generate static multi-page website
   init           Initialize a new documentation project
   agents         Generate Claude AI agent files from templates
   help           Show this help message
@@ -51,6 +52,9 @@ Options:
     --lang <en|ko|...>         Language (default: en)
     --port <number>            Port number (default: 3457)
 
+  build:web:
+    --lang <all|en|ko|...>    Language(s) to generate (default: all)
+
   agents:
     --force                    Overwrite existing agent files
 
@@ -60,6 +64,8 @@ Examples:
   docs-toolkit preview
   docs-toolkit preview --mode document --lang ko
   docs-toolkit preview:html --lang en
+  docs-toolkit build:web --lang all
+  docs-toolkit build:web --lang en
   docs-toolkit init
   docs-toolkit agents
   docs-toolkit agents --force
@@ -348,6 +354,15 @@ async function main(): Promise<void> {
     case 'preview:html': {
       const { startHtmlPreviewServer } = await import('./preview-server-web.js');
       await startHtmlPreviewServer(config);
+      break;
+    }
+
+    case 'build:web': {
+      const { generateWebsite } = await import('./website-generator.js');
+      const langIdx = argv.indexOf('--lang');
+      await generateWebsite(config, {
+        lang: langIdx >= 0 ? argv[langIdx + 1] : 'all',
+      });
       break;
     }
 

--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -32,6 +32,7 @@ export type {
   AnchorEntry,
   AnchorRegistry,
   LinkDiagnostic,
+  WebProcessingOptions,
 } from './markdown-processor-web.js';
 export {
   processMarkdownFilesForWeb,
@@ -69,6 +70,10 @@ export { renderPdf } from './pdf-renderer.js';
 // ── PDF Generation ──────────────────────────────────────────────
 export { generatePdf } from './generate-pdf.js';
 export type { GeneratePdfOptions } from './generate-pdf.js';
+
+// ── Website Generation ──────────────────────────────────────────
+export { generateWebsite } from './website-generator.js';
+export type { GenerateWebsiteOptions } from './website-generator.js';
 
 // ── Preview Servers ─────────────────────────────────────────────
 export { startPreviewServer } from './preview-server.js';

--- a/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
@@ -384,12 +384,18 @@ function buildWebRenderer(
   };
 }
 
+export interface WebProcessingOptions {
+  /** Enable multi-page link resolution (default: false) */
+  multiPage?: boolean;
+}
+
 export async function processMarkdownFilesForWeb(
   lang: string,
   navigation: NavEntry[],
   srcDir: string,
   version: string,
   config?: ResolvedDocConfig,
+  options?: WebProcessingOptions,
 ): Promise<Chapter[]> {
   const diagnostics: LinkDiagnostic[] = [];
   let chapterIndex = 0;
@@ -442,6 +448,7 @@ export async function processMarkdownFilesForWeb(
   detectDuplicateAnchors(registry, diagnostics);
 
   // ── Pass 2: Rewrite cross-page links using the registry ──────
+  const multiPage = options?.multiPage ?? false;
   for (const { chapter, filePath } of rendered) {
     chapter.htmlContent = fixMalformedCrossReferences(
       chapter.htmlContent,
@@ -453,6 +460,7 @@ export async function processMarkdownFilesForWeb(
       registry,
       diagnostics,
       filePath,
+      multiPage,
     );
   }
 

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -1,0 +1,175 @@
+/**
+ * Website build orchestrator.
+ * Reads markdown files, processes them into multi-page HTML, copies assets,
+ * and writes output to the dist directory.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { parse as parseYaml } from 'yaml';
+import { processMarkdownFilesForWeb } from './markdown-processor-web.js';
+import { buildWebPage, buildIndexPage } from './website-builder.js';
+import type { WebsiteMetadata } from './website-builder.js';
+import { generateWebStyles } from './styles-web.js';
+import { getDocVersion } from './version.js';
+import type { ResolvedDocConfig } from './config.js';
+
+interface BookConfig {
+  title: string;
+  description: string;
+  languages: string[];
+  navigation: Record<string, Array<{ title: string; path: string }>>;
+}
+
+export interface GenerateWebsiteOptions {
+  lang: string;
+}
+
+/**
+ * Rewrite server-absolute image paths to page-relative paths.
+ * The web markdown processor produces paths like `/images/foo.png`.
+ * For static pages at `{lang}/slug.html`, images at `{lang}/images/foo.png`,
+ * we need `./images/foo.png`.
+ */
+function rewriteImagePathsForStaticSite(html: string): string {
+  return html.replace(
+    /(src|href)="\/([^"]+\.(?:png|jpe?g|gif|svg|webp))"/gi,
+    (_match, attr, imgPath) => {
+      return `${attr}="./${imgPath}"`;
+    },
+  );
+}
+
+/**
+ * Generate a static website from documentation sources.
+ */
+export async function generateWebsite(
+  config: ResolvedDocConfig,
+  options?: Partial<GenerateWebsiteOptions>,
+): Promise<void> {
+  const configPath = path.join(config.srcDir, 'book.config.yaml');
+  const bookConfig: BookConfig = parseYaml(
+    fs.readFileSync(configPath, 'utf-8'),
+  );
+
+  const { display: version } = getDocVersion(
+    config.versionSource,
+    config.version,
+  );
+  const title = bookConfig.title;
+  const availableLanguages = bookConfig.languages;
+  const websiteOutDir = config.website?.outDir ?? 'web';
+
+  const langArg = options?.lang ?? 'all';
+  const languages =
+    langArg === 'all' ? availableLanguages : [langArg];
+
+  // Validate requested languages
+  for (const lang of languages) {
+    if (!availableLanguages.includes(lang)) {
+      console.error(
+        `Language "${lang}" not found in config. Available: ${availableLanguages.join(', ')}`,
+      );
+      process.exit(1);
+    }
+  }
+
+  const productName = config.productName;
+  console.log(`${productName} Website Generator`);
+  console.log(`Title: ${title}`);
+  console.log(`Version: ${version}`);
+  console.log(`Languages: ${languages.join(', ')}`);
+  console.log('');
+
+  // Create shared assets directory and write CSS
+  const distBase = path.join(config.distDir, websiteOutDir);
+  const assetsDir = path.join(distBase, 'assets');
+  fs.mkdirSync(assetsDir, { recursive: true });
+
+  // Write a combined CSS for all languages (use 'en' as base, CJK handled per-page via lang attr)
+  const cssContent = generateWebStyles();
+  fs.writeFileSync(path.join(assetsDir, 'styles.css'), cssContent, 'utf-8');
+  console.log(`Written: assets/styles.css`);
+
+  for (const lang of languages) {
+    const startTime = Date.now();
+    console.log(`[${lang}] Building website...`);
+
+    const navigation = bookConfig.navigation[lang];
+    if (!navigation) {
+      console.warn(`[${lang}] No navigation found, skipping`);
+      continue;
+    }
+
+    // Create language output directory
+    const langDir = path.join(distBase, lang);
+    fs.mkdirSync(langDir, { recursive: true });
+
+    // Process markdown files (multi-page mode)
+    console.log(`[${lang}] Processing ${navigation.length} chapters...`);
+    const chapters = await processMarkdownFilesForWeb(
+      lang,
+      navigation,
+      config.srcDir,
+      version,
+      config,
+      { multiPage: true },
+    );
+
+    const metadata: WebsiteMetadata = { title, version, lang };
+
+    // Generate individual HTML pages
+    console.log(`[${lang}] Generating ${chapters.length} pages...`);
+    for (let i = 0; i < chapters.length; i++) {
+      let pageHtml = buildWebPage({
+        chapter: chapters[i],
+        allChapters: chapters,
+        currentIndex: i,
+        metadata,
+        config,
+      });
+
+      // Fix image paths for static site
+      pageHtml = rewriteImagePathsForStaticSite(pageHtml);
+
+      const outputPath = path.join(langDir, `${chapters[i].slug}.html`);
+      fs.writeFileSync(outputPath, pageHtml, 'utf-8');
+    }
+
+    // Generate index.html (redirect to first page, or placeholder if no chapters)
+    const indexHtml =
+      chapters.length === 0
+        ? `<!DOCTYPE html>
+<html lang="${lang}">
+<head><meta charset="utf-8" /><title>${title}</title></head>
+<body><h1>${title}</h1><p>No documentation content was generated for this language.</p></body>
+</html>`
+        : buildIndexPage(chapters, metadata);
+    fs.writeFileSync(path.join(langDir, 'index.html'), indexHtml, 'utf-8');
+
+    // Copy images
+    const srcImagesDir = path.join(config.srcDir, lang, 'images');
+    const destImagesDir = path.join(langDir, 'images');
+    if (fs.existsSync(srcImagesDir)) {
+      fs.mkdirSync(destImagesDir, { recursive: true });
+      const imageFiles = fs.readdirSync(srcImagesDir);
+      let imageCount = 0;
+      for (const file of imageFiles) {
+        const srcPath = path.join(srcImagesDir, file);
+        if (fs.statSync(srcPath).isFile()) {
+          fs.copyFileSync(srcPath, path.join(destImagesDir, file));
+          imageCount++;
+        }
+      }
+      console.log(`[${lang}] Copied ${imageCount} images`);
+    }
+
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.log(
+      `[${lang}] Done: ${chapters.length} pages generated (${elapsed}s)`,
+    );
+    console.log('');
+  }
+
+  console.log(`Website generated at: ${distBase}`);
+}


### PR DESCRIPTION
Resolves #5628 (FR-2163)

## Summary
- Create `website-generator.ts` build orchestrator: `generateWebsite()` processes markdown files in multi-page mode, generates individual HTML pages per chapter, writes shared CSS, and copies images per language
- Add `WebProcessingOptions` interface with `multiPage` flag to `markdown-processor-web.ts` for multi-page link resolution
- Add `build:web` CLI command with `--lang` option (supports `all` or specific language code)
- Image paths are rewritten from server-absolute (`/images/foo.png`) to page-relative (`./images/foo.png`) for static site compatibility

## Test plan
- [ ] Verify TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Run `docs-toolkit build:web --lang en` and verify output structure: `dist/web/assets/styles.css`, `dist/web/en/*.html`, `dist/web/en/images/`
- [ ] Verify generated HTML pages have correct sidebar navigation and page content
- [ ] Verify `index.html` redirects to the first chapter
- [ ] Verify images are copied correctly to the output directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)