### PR TITLE
feat(FR-2166): implement Previous/Next page navigation

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/config.ts
+++ b/packages/backend.ai-docs-toolkit/src/config.ts
@@ -117,6 +117,14 @@ const DEFAULT_FIGURE_LABELS: Record<string, string> = {
   th: 'รูปที่',
 };
 
+/** Localized labels for website navigation and metadata */
+export const WEBSITE_LABELS: Record<string, Record<string, string>> = {
+  en: { previous: 'Previous', next: 'Next', editThisPage: 'Edit this page', lastUpdated: 'Last updated on', searchPlaceholder: 'Search docs...', noResults: 'No results found' },
+  ko: { previous: '이전', next: '다음', editThisPage: '이 페이지 편집', lastUpdated: '마지막 업데이트', searchPlaceholder: '문서 검색...', noResults: '검색 결과가 없습니다' },
+  ja: { previous: '前へ', next: '次へ', editThisPage: 'このページを編集', lastUpdated: '最終更新日', searchPlaceholder: 'ドキュメント検索...', noResults: '結果が見つかりません' },
+  th: { previous: 'ก่อนหน้า', next: 'ถัดไป', editThisPage: 'แก้ไขหน้านี้', lastUpdated: 'อัปเดตล่าสุด', searchPlaceholder: 'ค้นหาเอกสาร...', noResults: 'ไม่พบผลลัพธ์' },
+};
+
 // ── Resolved config (all defaults applied) ────────────────────
 
 export interface ResolvedDocConfig {

--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -14,7 +14,7 @@ export type {
   ToolkitConfig,
   ResolvedDocConfig,
 } from './config.js';
-export { resolveConfig, loadToolkitConfig } from './config.js';
+export { resolveConfig, loadToolkitConfig, WEBSITE_LABELS } from './config.js';
 
 // ── Theme ───────────────────────────────────────────────────────
 export type { PdfTheme } from './theme.js';

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -578,6 +578,87 @@ details > :last-child {
 }
 
 /* ==========================================================================
+   Page Footer (website mode)
+   ========================================================================== */
+.page-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.page-metadata {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.page-metadata .edit-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.page-metadata .edit-link:hover {
+  text-decoration: underline;
+}
+
+.page-metadata .edit-link svg {
+  width: 1rem;
+  height: 1rem;
+  fill: currentColor;
+}
+
+.page-metadata .last-updated {
+  color: var(--ifm-color-emphasis-600);
+}
+
+/* Pagination Navigation */
+.pagination-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.pagination-nav__link {
+  display: block;
+  flex: 1;
+  padding: 1rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-pre-border-radius);
+  text-decoration: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.pagination-nav__link:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  text-decoration: none;
+}
+
+.pagination-nav__link--next {
+  text-align: right;
+}
+
+.pagination-nav__sublabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.25rem;
+}
+
+.pagination-nav__label {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+}
+
+/* ==========================================================================
    Responsive
    ========================================================================== */
 @media (max-width: 768px) {
@@ -594,6 +675,17 @@ details > :last-child {
   }
   .doc-main {
     padding: 1.5rem;
+  }
+  .pagination-nav {
+    flex-direction: column;
+  }
+  .pagination-nav__link--next {
+    text-align: left;
+  }
+  .page-metadata {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
   }
 }
 `;

--- a/packages/backend.ai-docs-toolkit/src/website-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-builder.ts
@@ -5,6 +5,7 @@
 
 import type { Chapter } from './markdown-processor.js';
 import type { ResolvedDocConfig } from './config.js';
+import { WEBSITE_LABELS } from './config.js';
 import { escapeHtml } from './markdown-extensions.js';
 
 export interface WebPageContext {
@@ -82,6 +83,38 @@ ${chapter.htmlContent}
 }
 
 /**
+ * Build Previous/Next navigation buttons (Docusaurus-style).
+ */
+function buildPaginationNav(
+  allChapters: Chapter[],
+  currentIndex: number,
+  lang: string,
+): string {
+  const labels = WEBSITE_LABELS[lang] ?? WEBSITE_LABELS.en;
+  const prev = currentIndex > 0 ? allChapters[currentIndex - 1] : null;
+  const next = currentIndex < allChapters.length - 1 ? allChapters[currentIndex + 1] : null;
+
+  const prevHtml = prev
+    ? `<a class="pagination-nav__link pagination-nav__link--prev" href="./${prev.slug}.html">
+        <div class="pagination-nav__sublabel">${labels.previous}</div>
+        <div class="pagination-nav__label">&laquo; ${escapeHtml(prev.title)}</div>
+      </a>`
+    : '<span></span>';
+
+  const nextHtml = next
+    ? `<a class="pagination-nav__link pagination-nav__link--next" href="./${next.slug}.html">
+        <div class="pagination-nav__sublabel">${labels.next}</div>
+        <div class="pagination-nav__label">${escapeHtml(next.title)} &raquo;</div>
+      </a>`
+    : '<span></span>';
+
+  return `<nav class="pagination-nav" aria-label="Docs pages">
+  ${prevHtml}
+  ${nextHtml}
+</nav>`;
+}
+
+/**
  * Build a complete HTML page for a single chapter in the static website.
  */
 export function buildWebPage(context: WebPageContext): string {
@@ -89,6 +122,7 @@ export function buildWebPage(context: WebPageContext): string {
 
   const sidebar = buildWebsiteSidebar(allChapters, currentIndex, metadata, config);
   const content = buildPageContent(chapter);
+  const pagination = buildPaginationNav(allChapters, currentIndex, metadata.lang);
   const langLabel = config.languageLabels[metadata.lang] || metadata.lang;
   const pageTitle = `${escapeHtml(chapter.title)} - ${escapeHtml(metadata.title)}`;
 
@@ -105,7 +139,10 @@ export function buildWebPage(context: WebPageContext): string {
   ${sidebar}
   <main class="doc-main">
     ${content}
-    <div class="page-footer"></div>
+    <div class="page-footer">
+      <div class="page-metadata"></div>
+      ${pagination}
+    </div>
   </main>
 </div>
 </body>


### PR DESCRIPTION
Resolves #5631 (FR-2166)

## Summary
- Add Docusaurus-style Previous/Next pagination navigation to website pages via `buildPaginationNav()` in `website-builder.ts`
- Add `WEBSITE_LABELS` with localized "Previous"/"Next" labels for en, ko, ja, th
- Add CSS styles for `.pagination-nav`, `.pagination-nav__link`, `.pagination-nav__sublabel`, and `.pagination-nav__label` with hover effects and responsive layout
- Add `.page-footer` and `.page-metadata` container styles for the page bottom area
- First and last pages correctly show only Next or Previous respectively

## Test plan
- [ ] Verify TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Verify first page shows only "Next" link, last page shows only "Previous" link
- [ ] Verify middle pages show both Previous and Next with correct chapter titles
- [ ] Verify pagination labels render correctly in all 4 languages
- [ ] Verify responsive layout at < 768px (stacks vertically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)