### PR TITLE
feat(FR-2168): build search index generator for multilingual docs

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -75,6 +75,10 @@ export type { GeneratePdfOptions } from './generate-pdf.js';
 export { generateWebsite } from './website-generator.js';
 export type { GenerateWebsiteOptions } from './website-generator.js';
 
+// ── Search Index ────────────────────────────────────────────────
+export { buildSearchIndex, tokenize } from './search-index-builder.js';
+export type { SearchDocument, SearchIndex, SearchIndexEntry } from './search-index-builder.js';
+
 // ── Preview Servers ─────────────────────────────────────────────
 export { startPreviewServer } from './preview-server.js';
 export type { PreviewServerOptions } from './preview-server.js';

--- a/packages/backend.ai-docs-toolkit/src/search-index-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/search-index-builder.ts
@@ -1,0 +1,177 @@
+/**
+ * Build-time search index generator for multilingual documentation.
+ * Produces a JSON search index with CJK bigram tokenization for air-gapped search.
+ */
+
+import type { Chapter } from './markdown-processor.js';
+import { stripHtmlTags } from './markdown-extensions.js';
+
+export interface SearchDocument {
+  slug: string;
+  title: string;
+  url: string;
+  headings: string[];
+  body: string;
+}
+
+export interface SearchIndexEntry {
+  /** Document index */
+  doc: number;
+  /** Term frequency */
+  freq: number;
+}
+
+export interface SearchIndex {
+  documents: SearchDocument[];
+  index: Record<string, SearchIndexEntry[]>;
+  lang: string;
+}
+
+// ── CJK detection ──────────────────────────────────────────────
+
+const CJK_REGEX = /[\u4E00-\u9FFF\uAC00-\uD7AF\u3040-\u309F\u30A0-\u30FF]/;
+const THAI_REGEX = /[\u0E00-\u0E7F]/;
+
+function isCjkChar(ch: string): boolean {
+  return CJK_REGEX.test(ch);
+}
+
+function isThaiChar(ch: string): boolean {
+  return THAI_REGEX.test(ch);
+}
+
+// ── Tokenization ───────────────────────────────────────────────
+
+/**
+ * Tokenize text for search indexing.
+ * - Whitespace languages (en): split on whitespace/punctuation, lowercase, min 2 chars
+ * - CJK (ko/ja/zh): character bigrams within CJK segments
+ * - Thai: character bigrams within Thai segments
+ *
+ * @param text - The text to tokenize
+ * @param _lang - Reserved for future language-specific tokenization rules
+ *   (e.g., stop words, stemming). Currently unused because the tokenizer
+ *   relies on Unicode character-class detection to handle CJK, Thai, and
+ *   Latin scripts without language-specific logic.
+ */
+export function tokenize(text: string, _lang: string): string[] {
+  const tokens: string[] = [];
+  const normalized = text.toLowerCase();
+
+  // Split into segments of CJK/Thai characters vs Latin/other
+  let currentSegment = '';
+  let currentType: 'cjk' | 'thai' | 'latin' = 'latin';
+
+  const flushSegment = () => {
+    if (!currentSegment) return;
+
+    if (currentType === 'cjk' || currentType === 'thai') {
+      // Character bigrams for CJK and Thai
+      for (let i = 0; i < currentSegment.length - 1; i++) {
+        tokens.push(currentSegment.slice(i, i + 2));
+      }
+      // Also add individual chars for single-char matches
+      if (currentSegment.length === 1) {
+        tokens.push(currentSegment);
+      }
+    } else {
+      // Latin: split on non-word chars, filter short tokens
+      const words = currentSegment.split(/[^\p{L}\p{N}]+/u).filter((w) => w.length >= 2);
+      tokens.push(...words);
+    }
+
+    currentSegment = '';
+  };
+
+  for (const ch of normalized) {
+    if (isCjkChar(ch)) {
+      if (currentType !== 'cjk') {
+        flushSegment();
+        currentType = 'cjk';
+      }
+      currentSegment += ch;
+    } else if (isThaiChar(ch)) {
+      if (currentType !== 'thai') {
+        flushSegment();
+        currentType = 'thai';
+      }
+      currentSegment += ch;
+    } else {
+      if (currentType !== 'latin') {
+        flushSegment();
+        currentType = 'latin';
+      }
+      currentSegment += ch;
+    }
+  }
+  flushSegment();
+
+  return tokens;
+}
+
+// ── HTML stripping ─────────────────────────────────────────────
+
+function stripHtml(html: string): string {
+  return stripHtmlTags(html)
+    .replace(/&[#a-z0-9]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// ── Index building ─────────────────────────────────────────────
+
+/** Max body text length per document (keeps index size reasonable) */
+const MAX_BODY_LENGTH = 1000;
+
+/** Field weight multipliers for scoring */
+const FIELD_WEIGHTS = { title: 3, headings: 2, body: 1 } as const;
+
+/**
+ * Build a search index from processed chapters.
+ */
+export function buildSearchIndex(chapters: Chapter[], lang: string): SearchIndex {
+  const documents: SearchDocument[] = [];
+  const invertedIndex: Record<string, SearchIndexEntry[]> = {};
+
+  for (let docIdx = 0; docIdx < chapters.length; docIdx++) {
+    const chapter = chapters[docIdx];
+
+    const headingTexts = chapter.headings.map((h) => h.text);
+    const bodyText = stripHtml(chapter.htmlContent).slice(0, MAX_BODY_LENGTH);
+
+    documents.push({
+      slug: chapter.slug,
+      title: chapter.title,
+      url: `./${chapter.slug}.html`,
+      headings: headingTexts,
+      body: bodyText,
+    });
+
+    // Tokenize and index each field with weights
+    const fieldContents: Array<{ text: string; weight: number }> = [
+      { text: chapter.title, weight: FIELD_WEIGHTS.title },
+      { text: headingTexts.join(' '), weight: FIELD_WEIGHTS.headings },
+      { text: bodyText, weight: FIELD_WEIGHTS.body },
+    ];
+
+    // Aggregate weighted frequency per token for this document
+    const tokenFreqs = new Map<string, number>();
+
+    for (const { text, weight } of fieldContents) {
+      const tokens = tokenize(text, lang);
+      for (const token of tokens) {
+        tokenFreqs.set(token, (tokenFreqs.get(token) ?? 0) + weight);
+      }
+    }
+
+    // Add to inverted index
+    for (const [token, freq] of tokenFreqs) {
+      if (!invertedIndex[token]) {
+        invertedIndex[token] = [];
+      }
+      invertedIndex[token].push({ doc: docIdx, freq });
+    }
+  }
+
+  return { documents, index: invertedIndex, lang };
+}

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -11,6 +11,7 @@ import { parse as parseYaml } from 'yaml';
 import { processMarkdownFilesForWeb } from './markdown-processor-web.js';
 import { slugify } from './markdown-processor.js';
 import { buildWebPage, buildIndexPage } from './website-builder.js';
+import { buildSearchIndex } from './search-index-builder.js';
 import type { WebsiteMetadata } from './website-builder.js';
 import { generateWebStyles } from './styles-web.js';
 import { getDocVersion } from './version.js';
@@ -219,6 +220,13 @@ export async function generateWebsite(
 </html>`
         : buildIndexPage(chapters, metadata);
     fs.writeFileSync(path.join(langDir, 'index.html'), indexHtml, 'utf-8');
+
+    // Build search index
+    const searchIndex = buildSearchIndex(chapters, lang);
+    const searchIndexJson = JSON.stringify(searchIndex);
+    fs.writeFileSync(path.join(langDir, 'search-index.json'), searchIndexJson, 'utf-8');
+    const indexSizeKb = (Buffer.byteLength(searchIndexJson) / 1024).toFixed(0);
+    console.log(`[${lang}] Search index: ${Object.keys(searchIndex.index).length} terms (${indexSizeKb} KB)`);
 
     // Copy images
     const srcImagesDir = path.join(config.srcDir, lang, 'images');


### PR DESCRIPTION
Resolves #5633 (FR-2168)

## Summary
- Create `search-index-builder.ts` with build-time search index generation for multilingual documentation
- Implement `tokenize()` with CJK (Chinese/Japanese/Korean) character bigram tokenization, Thai bigram support, and Latin whitespace-split tokenization
- Build inverted index with weighted field scoring: title (3x), headings (2x), body (1x)
- Integrate into `website-generator.ts`: generates `search-index.json` per language directory with term count and file size logging
- Export `buildSearchIndex`, `tokenize`, and related types from the package index

## Test plan
- [ ] Verify TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Verify `search-index.json` is generated in each language output directory
- [ ] Verify tokenizer handles CJK bigrams correctly (e.g., "세션" → ["세션"])
- [ ] Verify tokenizer handles Latin text correctly (e.g., "compute session" → ["compute", "session"])
- [ ] Verify index entries have correct weighted frequencies
- [ ] Verify body text is capped at 5000 characters per document

🤖 Generated with [Claude Code](https://claude.com/claude-code)