### PR TITLE
feat(FR-2164): extract website CSS to shared stylesheet with :lang() selectors

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -87,7 +87,7 @@ export type { HtmlPreviewOptions } from './preview-server-web.js';
 
 // ── Styles ──────────────────────────────────────────────────────
 export { generatePdfStyles } from './styles.js';
-export { generateWebStyles } from './styles-web.js';
+export { generateWebStyles, generateWebsiteStyles } from './styles-web.js';
 
 // ── Version ─────────────────────────────────────────────────────
 export { getDocVersion } from './version.js';

--- a/packages/backend.ai-docs-toolkit/src/styles-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles-web.ts
@@ -766,3 +766,29 @@ details > :last-child {
 }
 `;
 }
+
+/**
+ * Generate CSS for multi-page static website.
+ * Unlike generateWebStyles(lang), this produces a single stylesheet
+ * suitable for all languages by using :lang() selectors for CJK-specific rules.
+ */
+export function generateWebsiteStyles(): string {
+  // Base styles without any language-specific conditional
+  const baseStyles = generateWebStyles();
+
+  // Generate :lang() selectors for CJK word-break from CJK_LANGS
+  const cjkSelectors = Array.from(CJK_LANGS)
+    .sort()
+    .map((code) => `:lang(${code}) body`)
+    .join(',\n');
+
+  return baseStyles + `
+
+/* ==========================================================================
+   CJK Language Rules (via :lang() selectors for shared stylesheet)
+   ========================================================================== */
+${cjkSelectors} {
+  word-break: keep-all;
+}
+`;
+}

--- a/packages/backend.ai-docs-toolkit/src/website-generator.ts
+++ b/packages/backend.ai-docs-toolkit/src/website-generator.ts
@@ -13,7 +13,7 @@ import { slugify } from './markdown-processor.js';
 import { buildWebPage, buildIndexPage } from './website-builder.js';
 import { buildSearchIndex } from './search-index-builder.js';
 import type { WebsiteMetadata } from './website-builder.js';
-import { generateWebStyles } from './styles-web.js';
+import { generateWebsiteStyles } from './styles-web.js';
 import { getDocVersion } from './version.js';
 import type { ResolvedDocConfig } from './config.js';
 
@@ -147,8 +147,8 @@ export async function generateWebsite(
   const assetsDir = path.join(distBase, 'assets');
   fs.mkdirSync(assetsDir, { recursive: true });
 
-  // Write a combined CSS for all languages (use 'en' as base, CJK handled per-page via lang attr)
-  const cssContent = generateWebStyles();
+  // Write a combined CSS for all languages (CJK handled via :lang() selectors)
+  const cssContent = generateWebsiteStyles();
   fs.writeFileSync(path.join(assetsDir, 'styles.css'), cssContent, 'utf-8');
   console.log(`Written: assets/styles.css`);
 


### PR DESCRIPTION
Resolves #5629 (FR-2164)

## Summary
- Add `generateWebsiteStyles()` function to `styles-web.ts` that produces a single CSS file suitable for all languages
- Use `:lang()` CSS selectors for CJK `word-break: keep-all` rules instead of conditional generation per language
- Update `website-generator.ts` to use `generateWebsiteStyles()` instead of `generateWebStyles()` for the shared stylesheet
- Export `generateWebsiteStyles` from the package index

## Test plan
- [ ] Verify TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Verify generated `styles.css` contains `:lang(ko)`, `:lang(ja)`, `:lang(zh)` selectors
- [ ] Verify CJK pages correctly apply `word-break: keep-all` via the shared stylesheet
- [ ] Verify non-CJK pages are unaffected by the `:lang()` rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)