### PR TITLE
feat(FR-2165): add serve:web dev server and package scripts

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/cli.ts
+++ b/packages/backend.ai-docs-toolkit/src/cli.ts
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'url';
 import { loadToolkitConfig, resolveConfig } from './config.js';
 import type { ResolvedDocConfig, AgentConfig } from './config.js';
 
-const COMMANDS = ['pdf', 'preview', 'preview:html', 'build:web', 'init', 'agents', 'help'] as const;
+const COMMANDS = ['pdf', 'preview', 'preview:html', 'build:web', 'serve:web', 'init', 'agents', 'help'] as const;
 type Command = (typeof COMMANDS)[number];
 
 function printUsage(): void {
@@ -32,6 +32,7 @@ Commands:
   preview        PDF preview server (live-reload)
   preview:html   HTML preview server (live-reload, no PDF)
   build:web      Generate static multi-page website
+  serve:web      Website dev server (live-reload)
   init           Initialize a new documentation project
   agents         Generate Claude AI agent files from templates
   help           Show this help message
@@ -55,6 +56,10 @@ Options:
   build:web:
     --lang <all|en|ko|...>    Language(s) to generate (default: all)
 
+  serve:web:
+    --lang <en|ko|...>        Language (default: en)
+    --port <number>            Port number (default: 3458)
+
   agents:
     --force                    Overwrite existing agent files
 
@@ -66,6 +71,8 @@ Examples:
   docs-toolkit preview:html --lang en
   docs-toolkit build:web --lang all
   docs-toolkit build:web --lang en
+  docs-toolkit serve:web --lang en
+  docs-toolkit serve:web --lang ko --port 3459
   docs-toolkit init
   docs-toolkit agents
   docs-toolkit agents --force
@@ -363,6 +370,12 @@ async function main(): Promise<void> {
       await generateWebsite(config, {
         lang: langIdx >= 0 ? argv[langIdx + 1] : 'all',
       });
+      break;
+    }
+
+    case 'serve:web': {
+      const { startWebsitePreviewServer } = await import('./preview-server-website.js');
+      await startWebsitePreviewServer(config);
       break;
     }
 

--- a/packages/backend.ai-docs-toolkit/src/index.ts
+++ b/packages/backend.ai-docs-toolkit/src/index.ts
@@ -84,6 +84,8 @@ export { startPreviewServer } from './preview-server.js';
 export type { PreviewServerOptions } from './preview-server.js';
 export { startHtmlPreviewServer } from './preview-server-web.js';
 export type { HtmlPreviewOptions } from './preview-server-web.js';
+export { startWebsitePreviewServer } from './preview-server-website.js';
+export type { WebsitePreviewOptions } from './preview-server-website.js';
 
 // ── Styles ──────────────────────────────────────────────────────
 export { generatePdfStyles } from './styles.js';

--- a/packages/backend.ai-docs-toolkit/src/preview-server-website.ts
+++ b/packages/backend.ai-docs-toolkit/src/preview-server-website.ts
@@ -1,0 +1,220 @@
+/**
+ * Website Preview Server - serves the multi-page static website with live-reload.
+ * Rebuilds pages on file changes and serves the generated files from disk.
+ */
+
+import fs from 'fs';
+import http from 'http';
+import path from 'path';
+import { parse as parseYaml } from 'yaml';
+import { generateWebsite } from './website-generator.js';
+import type { ResolvedDocConfig } from './config.js';
+
+interface BookConfig {
+  title: string;
+  description: string;
+  languages: string[];
+  navigation: Record<string, Array<{ title: string; path: string }>>;
+}
+
+export interface WebsitePreviewOptions {
+  lang: string;
+  port: number;
+}
+
+function parseArgs(argv: string[]): WebsitePreviewOptions {
+  let lang = 'en';
+  let port = 3458;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--lang' && argv[i + 1]) { lang = argv[i + 1]; i++; }
+    if (argv[i] === '--port' && argv[i + 1]) { port = parseInt(argv[i + 1], 10); i++; }
+  }
+  return { lang, port };
+}
+
+/** MIME types for static files */
+const MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+};
+
+/**
+ * Start a development server for the multi-page website with live-reload.
+ * Performs an initial build, watches for changes, rebuilds, and serves files.
+ */
+export async function startWebsitePreviewServer(
+  config: ResolvedDocConfig,
+  options?: Partial<WebsitePreviewOptions>,
+): Promise<void> {
+  const args = { ...parseArgs(process.argv.slice(2)), ...options };
+
+  const configPath = path.join(config.srcDir, 'book.config.yaml');
+  const bookConfig: BookConfig = parseYaml(fs.readFileSync(configPath, 'utf-8'));
+
+  const navigation = bookConfig.navigation[args.lang];
+  if (!navigation) {
+    console.error(`No navigation found for language: ${args.lang}`);
+    console.error(`Available: ${Object.keys(bookConfig.navigation).join(', ')}`);
+    process.exit(1);
+  }
+
+  const websiteOutDir = config.website?.outDir ?? 'web';
+  const distBase = path.join(config.distDir, websiteOutDir);
+
+  let currentEtag = Date.now().toString(36);
+
+  // Initial build
+  console.log(`  Building website (${args.lang})...`);
+  await generateWebsite(config, { lang: args.lang });
+
+  // Serialized rebuild: prevents concurrent builds and unhandled promise rejections
+  const debounceMs = 500;
+  let rebuildTimer: ReturnType<typeof setTimeout> | null = null;
+  let currentBuild: Promise<void> | null = null;
+  let pendingRebuild = false;
+
+  function runSerializedBuild(changedFile: string) {
+    if (currentBuild) {
+      pendingRebuild = true;
+      return;
+    }
+
+    pendingRebuild = false;
+    currentBuild = (async () => {
+      console.log(`  File changed: ${path.relative(config.projectRoot, changedFile)}`);
+      try {
+        await generateWebsite(config, { lang: args.lang });
+        currentEtag = Date.now().toString(36);
+        console.log('  Rebuild complete.');
+      } catch (err) {
+        console.error('  Rebuild failed:', err);
+      } finally {
+        currentBuild = null;
+        if (pendingRebuild) {
+          runSerializedBuild(changedFile);
+        }
+      }
+    })();
+  }
+
+  function scheduleRebuild(changedFile: string) {
+    if (rebuildTimer) clearTimeout(rebuildTimer);
+    rebuildTimer = setTimeout(() => {
+      rebuildTimer = null;
+      runSerializedBuild(changedFile);
+    }, debounceMs);
+  }
+
+  // Watch source files
+  const srcLangDir = path.join(config.srcDir, args.lang);
+  if (fs.existsSync(srcLangDir)) {
+    fs.watch(srcLangDir, { recursive: true }, (_event, filename) => {
+      const name = filename?.toString();
+      if (name && (name.endsWith('.md') || name.endsWith('.yaml'))) {
+        scheduleRebuild(path.join(srcLangDir, name));
+      }
+    });
+  }
+
+  // Watch config
+  fs.watch(configPath, () => { scheduleRebuild(configPath); });
+
+  // Inject live-reload script into HTML responses
+  const RELOAD_SCRIPT = `<script>
+(function(){
+  var etag='';
+  setInterval(function(){
+    fetch('/__reload').then(function(r){return r.json()}).then(function(d){
+      if(etag&&d.etag!==etag)location.reload();
+      etag=d.etag;
+    }).catch(function(){});
+  },1000);
+})();
+</script>`;
+
+  // HTTP server
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url || '/', `http://localhost:${args.port}`);
+
+    // Live-reload polling endpoint
+    if (url.pathname === '/__reload') {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' });
+      res.end(JSON.stringify({ etag: currentEtag }));
+      return;
+    }
+
+    // Resolve file path from URL
+    let filePath: string;
+    if (url.pathname === '/' || url.pathname === `/${args.lang}/` || url.pathname === `/${args.lang}`) {
+      // Serve language index for root and language root paths
+      filePath = path.join(distBase, args.lang, 'index.html');
+    } else {
+      // Normalize: remove leading slash
+      const safePath = path.normalize(url.pathname).replace(/^\/+/, '');
+      filePath = path.resolve(distBase, safePath);
+    }
+
+    // Security: ensure file is within distBase
+    if (!filePath.startsWith(distBase + path.sep) && filePath !== distBase) {
+      res.writeHead(403, { 'Content-Type': 'text/plain' });
+      res.end('Forbidden');
+      return;
+    }
+
+    // Check if file exists
+    if (!fs.existsSync(filePath) || !fs.statSync(filePath).isFile()) {
+      // Try with .html extension
+      if (!filePath.endsWith('.html') && fs.existsSync(filePath + '.html')) {
+        filePath = filePath + '.html';
+      } else {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not found');
+        return;
+      }
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    const mimeType = MIME_TYPES[ext] ?? 'application/octet-stream';
+
+    // For HTML files, inject live-reload script
+    if (ext === '.html') {
+      let html = fs.readFileSync(filePath, 'utf-8');
+      html = html.replace('</body>', `${RELOAD_SCRIPT}\n</body>`);
+      res.writeHead(200, { 'Content-Type': mimeType, 'Cache-Control': 'no-cache' });
+      res.end(html);
+      return;
+    }
+
+    // Serve static files with error handling to prevent process crash
+    res.writeHead(200, { 'Content-Type': mimeType, 'Cache-Control': 'max-age=5' });
+    const stream = fs.createReadStream(filePath);
+    stream.on('error', (err) => {
+      console.error(`  Stream error for ${filePath}:`, err.message);
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+      }
+      res.end('Internal server error');
+    });
+    stream.pipe(res);
+  });
+
+  server.listen(args.port, () => {
+    const productName = config.productName;
+    console.log('');
+    console.log(`  ${productName} - Website Preview`);
+    console.log(`  Language:  ${args.lang}`);
+    console.log(`  URL:       http://localhost:${args.port}`);
+    console.log('');
+    console.log(`  Editing src/${args.lang}/**/*.md will auto-reload the page.`);
+    console.log('  Press Ctrl+C to stop.');
+    console.log('');
+  });
+}

--- a/packages/backend.ai-webui-docs/package.json
+++ b/packages/backend.ai-webui-docs/package.json
@@ -22,6 +22,13 @@
     "preview:html:ja": "pnpm run build:toolkit && docs-toolkit preview:html --lang ja",
     "preview:html:th": "pnpm run build:toolkit && docs-toolkit preview:html --lang th",
     "preview:html:catalog": "pnpm run build:toolkit && docs-toolkit preview:html --mode catalog",
+    "build:web": "pnpm run build:toolkit && docs-toolkit build:web --lang all",
+    "build:web:en": "pnpm run build:toolkit && docs-toolkit build:web --lang en",
+    "build:web:ko": "pnpm run build:toolkit && docs-toolkit build:web --lang ko",
+    "serve:web": "pnpm run build:toolkit && docs-toolkit serve:web --lang en",
+    "serve:web:ko": "pnpm run build:toolkit && docs-toolkit serve:web --lang ko",
+    "serve:web:ja": "pnpm run build:toolkit && docs-toolkit serve:web --lang ja",
+    "serve:web:th": "pnpm run build:toolkit && docs-toolkit serve:web --lang th",
     "agents": "docs-toolkit agents",
     "agents:force": "docs-toolkit agents --force"
   },


### PR DESCRIPTION
Resolves #5630 (FR-2165)

## Summary
- Create `preview-server-website.ts` with `startWebsitePreviewServer()` for multi-page website development
- Dev server performs initial `build:web`, watches `src/{lang}/**/*.md` and `book.config.yaml` for changes, rebuilds on change, and injects live-reload script into HTML responses
- Add `serve:web` CLI command with `--lang` and `--port` options (default port: 3458)
- Add package scripts to `webui-docs/package.json`: `build:web`, `build:web:en`, `build:web:ko`, `serve:web`, `serve:web:ko`, `serve:web:ja`, `serve:web:th`
- Export `startWebsitePreviewServer` and `WebsitePreviewOptions` from the package index

## Test plan
- [ ] Verify TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Run `docs-toolkit serve:web --lang en` and verify pages are served at `http://localhost:3458`
- [ ] Edit a markdown file and verify live-reload triggers a page refresh
- [ ] Verify `pnpm run serve:web` works from the webui-docs package
- [ ] Verify `pnpm run build:web` generates static files in `dist/web/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)