### PR TITLE
fix(FR-2148): refactor UserResourceGroupAlert to read query params internally and use @required directive

### DIFF
--- a/react/src/components/FairShareItems/FairShareList.tsx
+++ b/react/src/components/FairShareItems/FairShareList.tsx
@@ -223,7 +223,7 @@ const FairShareList: React.FC = () => {
 
   const {
     resourceGroups,
-    domains,
+    domainFairShares,
     projectFairShares,
     userFairShares,
     project,
@@ -268,13 +268,16 @@ const FairShareList: React.FC = () => {
             }
           }
         }
-        domains: rgDomainFairShares(
+        domainFairShares: rgDomainFairShares(
           scope: { resourceGroupName: $resourceGroupName }
           filter: $domainFilter
           orderBy: $domainOrder
           limit: $limit
           offset: $offset
-        ) @skip(if: $skipDomain) {
+        )
+          # FIXME: @required(action: THROW) can detect invalid URL params, but cannot distinguish other errors that cause null.
+          @skip(if: $skipDomain)
+          @required(action: THROW) {
           count
           edges {
             node {
@@ -291,7 +294,10 @@ const FairShareList: React.FC = () => {
           orderBy: $projectOrder
           limit: $limit
           offset: $offset
-        ) @skip(if: $skipProject) {
+        )
+          # FIXME: @required(action: THROW) can detect invalid URL params, but cannot distinguish other errors that cause null.
+          @skip(if: $skipProject)
+          @required(action: THROW) {
           count
           edges {
             node {
@@ -309,12 +315,14 @@ const FairShareList: React.FC = () => {
           orderBy: $userOrder
           limit: $limit
           offset: $offset
-        ) @skip(if: $skipUser) {
+        )
+          # FIXME: @required(action: THROW) can detect invalid URL params, but cannot distinguish other errors that cause null.
+          @skip(if: $skipUser)
+          @required(action: THROW) {
           count
           edges {
             node {
               ...UserFairShareTableFragment
-              ...UserResourceGroupAlertFragment
             }
           }
         }
@@ -526,11 +534,9 @@ const FairShareList: React.FC = () => {
               : undefined,
         }}
       />
-      {currentStep === 'user' && userFairShares?.edges?.[0]?.node && (
+      {currentStep === 'user' && (
         <Suspense fallback={null}>
-          <UserResourceGroupAlert
-            userFairShareFrgmt={userFairShares.edges[0].node}
-          />
+          <UserResourceGroupAlert />
         </Suspense>
       )}
       <Alert type="info" title={t('fairShare.step.Description')} showIcon />
@@ -696,7 +702,7 @@ const FairShareList: React.FC = () => {
           {currentStep === 'domain' && (
             <DomainFairShareTable
               domainFairShareNodeFragment={
-                domains?.edges?.map((edge) => edge?.node) || null
+                domainFairShares?.edges?.map((edge) => edge?.node) || null
               }
               loading={
                 GQLQueryVariables !== deferredGQLQueryVariables ||
@@ -727,7 +733,7 @@ const FairShareList: React.FC = () => {
               }}
               pagination={{
                 pageSize: tablePaginationOption.pageSize,
-                total: domains?.count || 0,
+                total: domainFairShares?.count || 0,
                 current: tablePaginationOption.current,
                 style: {
                   marginRight: token.marginXS,

--- a/react/src/components/FairShareItems/FairShareWeightSettingModal.tsx
+++ b/react/src/components/FairShareItems/FairShareWeightSettingModal.tsx
@@ -142,7 +142,6 @@ const FairShareWeightSettingModal: React.FC<
         spec {
           weight
         }
-        ...UserResourceGroupAlertFragment
       }
     `,
     userFairShareFrgmt,
@@ -541,7 +540,6 @@ const FairShareWeightSettingModal: React.FC<
         )}
         {!isBulkEdit && userFairShares?.[0] && (
           <UserResourceGroupAlert
-            userFairShareFrgmt={userFairShares[0]}
             isModalOpen={modalProps?.open ?? false}
             style={{ marginBottom: token.marginMD }}
           />

--- a/react/src/pages/SchedulerPage.tsx
+++ b/react/src/pages/SchedulerPage.tsx
@@ -64,21 +64,12 @@ const SchedulerPage: React.FC<SchedulerPageProps> = () => {
           <ErrorBoundary
             fallbackRender={({ error, resetErrorBoundary }) => {
               const gqlError = error as ErrorWithGraphQL;
+              // FIXME: @required(action: THROW) can detect invalid URL params, but cannot distinguish other errors that cause null. Needs a better approach later.
               // Check for invalid query parameters causing GraphQL errors
-              const isWrongParameterError = _.some(
-                gqlError?.source?.errors,
-                (err) =>
-                  _.some(
-                    [
-                      'Cannot return null for non-nullable field Query',
-                      'No such domain',
-                      'No such scaling group',
-                      'No such project',
-                      'No such user',
-                    ],
-                    (msg) => _.includes(err?.message, msg),
-                  ),
-              );
+              const isWrongParameterError =
+                _.includes(gqlError?.message, 'domainFairShares') ||
+                _.includes(gqlError?.message, 'projectFairShares') ||
+                _.includes(gqlError?.message, 'userFairShares');
 
               return (
                 <FairShareErrorFallback


### PR DESCRIPTION
Resolves #5591 ([FR-2148](https://lablup.atlassian.net/browse/FR-2148))

test server: 10.122.10.253

## Summary

- **`UserResourceGroupAlert`** **refactored to read query params internally**: Removed `resourceGroupName`, `domainName`, `projectId`, `projectName` props. The component now uses `useQueryStates` from `nuqs` to read `resourceGroup`, `domain`, `project` directly from the URL query string.
- **Project name fetched internally via GraphQL**: Added `name` field to the existing `group` query inside `UserResourceGroupAlert`, eliminating the need to pass `projectName` as a prop.
- **Replaced manual null checks with** **`@required(action: THROW)`** **directive**: In `FairShareList`, the manual `if (!domains || !projectFairShares || !userFairShares) throw new Error(...)` block was replaced with `@required(action: THROW)` on the respective GraphQL fields. When a non-skipped field returns null (e.g., due to an invalid URL parameter), Relay throws automatically and the existing `ErrorBoundary` in `SchedulerPage` catches it.
- **Updated error detection in** **`SchedulerPage`**: The `isWrongParameterError` check now matches on the field name strings (`domainFairShares`, `projectFairShares`, `userFairShares`) present in the `@required` throw message, replacing the previous manual error string list.
- **FIXME noted for** **`@required`** **limitation**: Added a comment that `@required(action: THROW)` cannot distinguish invalid URL params from other server errors that cause null. A better approach can be applied in the future.

## Checklist

- [ ] Documentation
- [ ] Minimum required manager version
- [ ] Specific setting for review (e.g., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-2148]: https://lablup.atlassian.net/browse/FR-2148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ