### PR TITLE
fix(FR-2156): hide Advanced settings when apiEndpoint is set in config.toml

### DIFF
--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -115,10 +115,8 @@ const LoginView: React.FC = () => {
     if (newCfg.api_endpoint === '') {
       setShowEndpointInput(true);
       setIsEndpointDisabled(false);
-    } else if (newCfg.api_endpoint_text === '') {
-      setShowEndpointInput(true);
-      setIsEndpointDisabled(false);
     } else {
+      setShowEndpointInput(false);
       setIsEndpointDisabled(true);
     }
   }, [isConfigLoaded, atomLoginConfig]);


### PR DESCRIPTION
Resolves #5620(FR-2156)

## Summary
- Fix LoginView to hide the Advanced settings section when `api_endpoint` is configured in `config.toml`
- Previously, when `api_endpoint` was set but `api_endpoint_text` was empty, the endpoint input was shown **and enabled**, allowing users to edit a pre-configured endpoint
- Simplified the 3-branch conditional to a 2-branch check: if `api_endpoint` is non-empty, hide the section entirely

## Changes
- `react/src/components/LoginView.tsx`: Simplified endpoint visibility logic (removed redundant `api_endpoint_text` branch)

## Verification
```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```

## Test plan
- [ ] With empty `apiEndpoint` in config.toml: Advanced settings section is visible with enabled input
- [ ] With `apiEndpoint` set in config.toml: Advanced settings section is hidden
- [ ] Login flow works correctly in both configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)