### PR TITLE
chore(FR-2154): remove deprecated server:d command and update references

### DIFF
--- a/.claude/skills/backend-ai-guide/examples/webui-integration-example.md
+++ b/.claude/skills/backend-ai-guide/examples/webui-integration-example.md
@@ -453,7 +453,7 @@ backend.ai-webui/
 ### Running WebUI Locally
 ```bash
 # Terminal 1: Build and serve WebUI
-pnpm run server:d   # Watch mode, auto-reload
+pnpm run build:d    # Watch mode, auto-reload
 
 # Terminal 2: WebSocket proxy (for desktop app)
 pnpm run wsproxy

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,7 +63,7 @@ When reviewing code:
 
 ### Build and Development
 
-- Development requires both `pnpm run server:d` (React dev server) and `pnpm run wsproxy` (WebSocket proxy)
+- Development requires both `pnpm run build:d` (TypeScript watch + Relay watch + React dev server) and `pnpm run wsproxy` (WebSocket proxy)
 - Build process: multi-stage with resource copying and React build (Craco/Webpack with Workbox service worker generation)
 - Pre-commit hooks run linting and formatting automatically via Husky + lint-staged
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Development
 
-- `pnpm run server:d` - Start React dev server via Craco (port configured by `scripts/dev-config.js`)
-- `pnpm run build:d` - Concurrent Relay watch + React dev server
+- `pnpm run build:d` - Start development environment (TypeScript watch + Relay watch + React dev server)
 - `pnpm run wsproxy` - Start websocket proxy (required for local development)
 
 ### Build and Production
@@ -95,11 +94,10 @@ Production build (`pnpm run build`) runs these steps sequentially:
 
 ### Development Workflow
 
-1. **Dual Server Setup**: Run both `pnpm run server:d` (React dev server) and `pnpm run wsproxy` (WebSocket proxy) for full development
-2. **Alternative**: `pnpm run build:d` runs Relay watch + React dev server concurrently
-3. **Port Configuration**: Managed by `scripts/dev-config.js` (default React port: 9081)
-4. **Testing**: Jest unit tests + Playwright E2E tests
-5. **Linting**: ESLint 9 (flat config) + Prettier with pre-commit hooks via Husky
+1. **Dev Server**: Run `pnpm run build:d` (TypeScript watch + Relay watch + React dev server) and `pnpm run wsproxy` (WebSocket proxy) for full development
+2. **Port Configuration**: Managed by `scripts/dev-config.js` (default React port: 9081)
+3. **Testing**: Jest unit tests + Playwright E2E tests
+4. **Linting**: ESLint 9 (flat config) + Prettier with pre-commit hooks via Husky
 
 # Additional Workflow Description
 

--- a/DEV_ENVIRONMENT.md
+++ b/DEV_ENVIRONMENT.md
@@ -19,7 +19,7 @@ Simple configuration system for running multiple Backend.AI WebUI development se
 node scripts/dev-config.js show
 
 # Start development server (uses current configuration)
-pnpm run server:d
+pnpm run build:d
 ```
 
 ### 2. Environment Configuration
@@ -137,21 +137,21 @@ node scripts/dev-config.js show
 ```bash
 # Terminal 1: Default instance
 cd webui-ai
-pnpm run server:d
+pnpm run build:d
 # → React: 9081, WebDev: 3081
 
 # Terminal 2: Feature instance with offset
 cd webui-ai-feature  
 echo "BAI_WEBUI_DEV_PORT_OFFSET=10" > .env.development.local
 echo "THEME_HEADER_COLOR=#32CD32" >> .env.development.local
-pnpm run server:d
+pnpm run build:d
 # → React: 9091, WebDev: 3091, Green header
 
 # Terminal 3: Debug instance with different offset
 cd webui-ai-debug
 echo "BAI_WEBUI_DEV_PORT_OFFSET=20" > .env.development.local  
 echo "THEME_HEADER_COLOR=#DC143C" >> .env.development.local
-pnpm run server:d
+pnpm run build:d
 # → React: 9101, WebDev: 3101, Red header
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ BYELLOW := \033[1;93m
 NC := \033[0m
 
 test_web:
-	@pnpm run server:d
+	@pnpm run build:d
 test_electron: dep
 	@pnpm run electron:d
-test_electron_hmr: dep # For development with HMR, you have to run build:d and server:d first
+test_electron_hmr: dep # For development with HMR, you have to run build:d first
 	@pnpm run electron:d:hmr
 proxy:
 	@node ./src/wsproxy/local_proxy.js

--- a/README.md
+++ b/README.md
@@ -193,45 +193,16 @@ $ make compile_wsproxy
 
 ### Developing / testing with dev server
 
-Two options are available depending on your needs.
-
-#### Option A: Full dev mode (recommended)
-
-`pnpm run build:d` already starts both Relay watch and React dev server concurrently. Do **not** run `server:d` at the same time — that would start a duplicate server.
-
 On a terminal:
 
 ```console
-$ pnpm run build:d   # Starts Relay watch + React dev server together
+$ pnpm run build:d   # Starts TypeScript watch + Relay watch + React dev server
 ```
 
 On another terminal:
 
 ```console
 $ pnpm run wsproxy   # Start websocket proxy (required for API calls)
-```
-
-#### Option B: React dev server only (manual Relay compile)
-
-Use this option if you want to control Relay compilation separately.
-
-On a terminal:
-
-```console
-$ pnpm run server:d  # React dev server only (no Relay watch)
-```
-
-On another terminal:
-
-```console
-$ pnpm run wsproxy   # Start websocket proxy
-```
-
-When GraphQL queries change, compile Relay manually:
-
-```console
-$ pnpm run relay       # One-time compile (from project root)
-$ cd react && pnpm run relay:watch  # Or watch mode (uses nodemon)
 ```
 
 #### Port configuration
@@ -254,8 +225,7 @@ $ pnpm run dev:setup    # Apply configuration to current environment
 
 | Command | Description |
 |---------|-------------|
-| `pnpm run build:d` | Relay watch + React dev server (concurrent) |
-| `pnpm run server:d` | React dev server only |
+| `pnpm run build:d` | TypeScript watch + Relay watch + React dev server (concurrent) |
 | `pnpm run wsproxy` | WebSocket proxy (required for dev) |
 | `pnpm run build` | Full production build |
 | `pnpm run build:react-only` | Build only React app |
@@ -301,7 +271,7 @@ If environment variables are not set, default values will be used.
 On a terminal:
 
 ```console
-$ pnpm run server:d  # To run dev. web server
+$ pnpm run build:d   # To run dev server
 ```
 
 On another terminal:
@@ -350,7 +320,7 @@ $ cd ./react && pnpm run test  # For ./react
 On a terminal:
 
 ```console
-$ pnpm run server:d    # To run test server
+$ pnpm run build:d     # To run dev server
 ```
 
 OR
@@ -640,7 +610,7 @@ $ pnpm run electron:d  # OR, ./node_modules/electron/cli.js .
 The electron app reads the configuration from `./build/electron-app/app/config.toml`, which is copied from the root `config.toml` file during `make clean && make dep`.
 
 If you configure `[server].webServerURL`, the electron app will load the web contents (including `config.toml`) from the designated server.
-The server may be either a `pnpm run server:d` instance or a `./py -m ai.backend.web.server` daemon from the mono-repo.
+The server may be either a `pnpm run build:d` instance or a `./py -m ai.backend.web.server` daemon from the mono-repo.
 This is known as the "web shell" mode and allows live edits of the web UI while running it inside the electron app.
 
 ### Localization

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "build": "rm -rf build/web && mkdir -p build/web && pnpm run copyindex && pnpm run copyresource && pnpm run copyconfig && pnpm run -r --stream build",
     "build:react-only": "pnpm run --prefix ./react build:only",
     "server:p": "serve build/web",
-    "server:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && HOST=$BAI_WEBUI_DEV_HOST PORT=$BAI_WEBUI_DEV_REACT_PORT PROXY=http://localhost:$BAI_WEBUI_DEV_WEBDEV_PORT pnpm --prefix ./react run start",
     "build:d": "eval \"$(node scripts/dev-config.js env)\" && node scripts/dev-config.js update && concurrently --kill-others -c \"auto\" --names \"tsc,react-relay,react\" \"tsc --watch --preserveWatchOutput\" \"cd react && pnpm run relay:watch\" \"HOST=$BAI_WEBUI_DEV_HOST BAI_WEBUI_DEV_PROXY= PORT=$BAI_WEBUI_DEV_REACT_PORT pnpm --prefix ./react run start\"",
     "electron:d": "electron build/electron-app --dev",
     "electron:d:hmr": "LIVE_DEBUG=1 electron build/electron-app --dev",

--- a/react/README.md
+++ b/react/README.md
@@ -18,7 +18,7 @@ react/
 ## Development
 
 ```console
-$ pnpm run server:d   # Start React dev server (default port: 9081)
+$ pnpm run build:d    # Start dev server (TypeScript watch + Relay watch + React dev server, default port: 9081)
 $ pnpm run wsproxy    # Start websocket proxy (required for local dev)
 ```
 


### PR DESCRIPTION
Resolves #5618(FR-2154)

## Summary
- Remove the deprecated `pnpm run server:d` script from `package.json` — it started only the React dev server without TypeScript watch or Relay watch, which is insufficient after the full React + Relay migration
- Update all references across documentation and build files to use `pnpm run build:d` (which runs TypeScript watch + Relay watch + React dev server concurrently)

## Changes
- `package.json`: Remove `server:d` script
- `Makefile`: Update `test_web` target and `test_electron_hmr` comment
- `CLAUDE.md`, `AGENTS.md`: Consolidate dev workflow docs to reference `build:d`
- `README.md`: Remove "Option B: React dev server only" section, update command reference table and all remaining `server:d` mentions
- `react/README.md`: Update dev command
- `DEV_ENVIRONMENT.md`: Update all multi-instance examples
- `.github/copilot-instructions.md`: Update build/dev section
- `.claude/skills/backend-ai-guide/examples/webui-integration-example.md`: Update local run example

## Verification
```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```

## Test plan
- [ ] `pnpm run build:d` starts TypeScript watch, Relay watch, and React dev server concurrently
- [ ] `make test_web` runs `build:d` correctly
- [ ] No remaining references to `server:d` in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)