### PR TITLE
chore(FR-2178): clean up Lit references and fix Electron plugin loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,6 @@ test_electron_hmr: dep # For development with HMR, you have to run build:d first
 	@pnpm run electron:d:hmr
 proxy:
 	@node ./src/wsproxy/local_proxy.js
-run_tests:
-	@pnpm dlx testcafe chrome tests
 versiontag:
 	@printf "$(GREEN)Tagging version number / index...$(NC)\n"
 	@echo '{ "package": "${BUILD_VERSION}", "buildNumber": "${BUILD_NUMBER}", "buildDate": "${BUILD_DATE}.${BUILD_TIME}", "revision": "${REVISION_INDEX}" }' > version.json
@@ -45,7 +43,6 @@ versiontag:
 	@sed -i -E 's/"version": "\([^"]*\)"/"version": "${BUILD_VERSION}"/g' packages/backend.ai-ui/package.json
 	@sed -i -E 's/"version": "\([^"]*\)"/"version": "${BUILD_VERSION}"/g' electron-app/package.json
 	@sed -i -E 's/globalThis.buildNumber = "\([^"]*\)"/globalThis.buildNumber = "${BUILD_NUMBER}"/g' index.html
-	@sed -i -E 's/\<small class="sidebar-footer" style="font-size:9px;"\>\([^"]*\)\<\/small\>/\<small class="sidebar-footer" style="font-size:9px;"\>${BUILD_VERSION}.${BUILD_NUMBER}\<\/small\>/g' ./src/components/backend-ai-webui.ts
 	@printf "$(YELLOW)Finished$(NC)\n"
 compile_keepversion:
 	@pnpm run build
@@ -89,7 +86,6 @@ dep:
 		cp -Rp build/web/manifest build/electron-app; \
 		BUILD_TARGET=electron pnpm run build:react-only; \
 		cp -Rp react/build/* build/electron-app/app/; \
-		sed -i -E 's/\.\/dist\/components\/backend-ai-webui.js/es6:\/\/dist\/components\/backend-ai-webui.js/g' build/electron-app/app/index.html; \
 		mkdir -p ./build/electron-app/app/wsproxy; \
 		cp ./src/wsproxy/dist/wsproxy.js ./build/electron-app/app/wsproxy/wsproxy.js; \
 		cp ./preload.js ./build/electron-app/preload.js; \

--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -31,10 +31,11 @@ import {
   useConfigRefreshPageEffect,
   loginPluginState,
 } from '../hooks/useWebUIConfig';
+import { pluginApiEndpointState } from '../hooks/useWebUIPluginState';
 import LoginFormPanel from './LoginFormPanel';
 import { Button, Form, type MenuProps } from 'antd';
 import { BAIModal, BAIFlex } from 'backend.ai-ui';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -57,6 +58,7 @@ const LoginView: React.FC = () => {
 
   // Login plugin name from config
   const loginPlugin = useAtomValue(loginPluginState);
+  const setPluginApiEndpoint = useSetAtom(pluginApiEndpointState);
 
   // State
   const [loginConfig, setLoginConfig] = useState<LoginConfigState>(() =>
@@ -296,8 +298,9 @@ const LoginView: React.FC = () => {
       close();
       clearSavedLoginInfo();
       localStorage.setItem('backendaiwebui.api_endpoint', apiEndpoint);
+      setPluginApiEndpoint(apiEndpoint);
     },
-    [endpoints, close, clearSavedLoginInfo, apiEndpoint],
+    [endpoints, close, clearSavedLoginInfo, apiEndpoint, setPluginApiEndpoint],
   );
 
   const connectUsingSession = useCallback(

--- a/react/src/hooks/useWebUIConfig.ts
+++ b/react/src/hooks/useWebUIConfig.ts
@@ -242,8 +242,10 @@ export function useInitializeConfig(): {
     if (initRef.current) return;
     initRef.current = true;
 
+    // Electron uses es6:// protocol which resolves from app/ directory
+    // Web uses relative path from the HTML location
     const configPath = (globalThis as Record<string, unknown>).isElectron
-      ? './config.toml'
+      ? 'es6://config.toml'
       : '../../config.toml';
 
     const parsed = await fetchAndParseConfig(configPath);


### PR DESCRIPTION
Resolves #5667 ([FR-2178](https://lablup.atlassian.net/browse/FR-2178))

## Summary
- Remove stale Lit references from Makefile (`run_tests` target, `backend-ai-webui.ts` sed, `backend-ai-webui.js` es6 rewrite)
- Fix Electron `file://` protocol handler to correctly resolve paths with leading slashes and auto-prefix `app/` directory
- Fix Electron `es6://` protocol handler to strip trailing slashes
- Add try-catch around `config.toml` parsing and handle `webServerURL = '""'` edge case in Electron main process
- Fix Electron config loading path to use `es6://config.toml` instead of `./config.toml`
- Set `pluginApiEndpointState` in `LoginView.tsx` on successful login so Electron can load plugins from the correct API endpoint

## Test plan
- [ ] Run `make versiontag` — should not fail on missing `src/components/backend-ai-webui.ts`
- [ ] Run `make dep` — Electron build should complete without the removed `sed` line
- [ ] Launch Electron app (`pnpm run electron:d`) — verify login page loads correctly
- [ ] After login in Electron, verify plugins load from `${apiEndpoint}/dist/plugins/`
- [ ] Check DevTools console for `[PluginLoader] pluginApiEndpoint set to:` log message

[FR-2178]: https://lablup.atlassian.net/browse/FR-2178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ