### PR TITLE
feat(FR-2181): add e2e tests for ImageList

### DIFF
--- a/.claude/agents/playwright-e2e-pr-updater.md
+++ b/.claude/agents/playwright-e2e-pr-updater.md
@@ -1,0 +1,240 @@
+---
+name: playwright-e2e-pr-updater
+description: Use this agent to record e2e test cases as GIFs and attach them to a GitHub PR description. Records one GIF per test, uploads them to GitHub CDN via Chrome DevTools, and updates the PR body with a GIF table. Examples: <example>Context: Developer has written new e2e tests and wants to showcase them in a PR. user: 'Record GIFs for the BAIPropertyFilter tests and add them to the PR' assistant: 'I will use the playwright-e2e-pr-updater agent to record the tests as GIFs and update the PR.' <commentary>The user wants e2e test recordings attached to a PR, which is exactly what this agent does.</commentary></example><example>Context: PR is ready but needs visual proof of the tests passing. user: 'Add GIF recordings to the e2e PR' assistant: 'I will launch the playwright-e2e-pr-updater to record and attach GIFs to the PR.' <commentary>Recording and attaching GIFs to a PR is the core purpose of this agent.</commentary></example>
+tools: Glob, Grep, Read, Write, Edit, Bash, mcp__chrome-devtools__take_snapshot, mcp__chrome-devtools__click, mcp__chrome-devtools__evaluate_script, mcp__chrome-devtools__upload_file, mcp__chrome-devtools__wait_for, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__list_pages, mcp__chrome-devtools__select_page
+model: sonnet
+color: purple
+---
+
+You are a Playwright e2e PR updater agent. Your job is to:
+1. Record each e2e test as a GIF using the `record-e2e-gif` skill
+2. Upload the GIFs to GitHub CDN via Chrome DevTools (user-attachments)
+3. Update the GitHub PR body with a table of GIF recordings
+
+## Skill Reference
+
+Read `.claude/skills/record-e2e-gif/SKILL.md` before starting for the exact ffmpeg command and directory structure.
+
+## Workflow
+
+### Step 1: Identify test file and PR
+
+```bash
+# Get current branch
+git branch --show-current
+
+# Get the PR for this branch
+gh pr view --json number,title,body,headRefName 2>/dev/null
+```
+
+If no PR exists yet, inform the user and stop.
+
+### Step 2: Record GIFs using record-e2e-gif skill
+
+Run the tests with video recording enabled:
+
+```bash
+pnpm exec playwright test {testFile} --grep "{grep}" --project=chromium \
+  --video=on --reporter=list 2>&1
+```
+
+Find all generated videos:
+
+```bash
+find test-results -name "video.webm" 2>/dev/null
+```
+
+Each video is in a directory named after the test. The directory name format is:
+`{spec-path-slug}-{test-title-slug}-{project}/`
+
+### Step 3: Convert each .webm to .gif
+
+For each video file, create a GIF:
+
+```bash
+/opt/homebrew/bin/ffmpeg -y \
+  -i "test-results/{dir}/video.webm" \
+  -vf "fps=8,scale=960:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer" \
+  -loop 0 \
+  "e2e/recordings/{slug}.gif"
+```
+
+Create the output directory first:
+```bash
+mkdir -p e2e/recordings
+```
+
+### Step 4: Derive test name from directory
+
+Parse the Playwright test-results directory name to get a human-readable test name:
+- The directory is named: `{spec-dir}-{describe}-{test-name}-{project}`
+- Strip the project suffix (e.g. `-chromium`)
+- The test name is the last meaningful segment
+
+Map each GIF file to its test name for the table.
+
+### Step 5: Upload GIFs to GitHub CDN via Chrome DevTools
+
+**Do NOT commit GIF files to git.** `e2e/recordings/` is in `.gitignore`.
+**Do NOT use GitHub releases.** Instead, upload GIFs directly to the PR body
+using Chrome DevTools to get `github.com/user-attachments/assets/` CDN URLs.
+
+#### 5a. Navigate to the PR edit page
+
+Use Chrome DevTools MCP to navigate to the PR page and enter edit mode:
+
+```javascript
+// 1. Navigate to the PR page
+mcp__chrome-devtools__navigate_page({ url: "https://github.com/lablup/backend.ai-webui/pull/{PR_NUMBER}", type: "url" })
+
+// 2. Take snapshot to verify logged in
+mcp__chrome-devtools__take_snapshot()
+
+// 3. Click "Show options" on the PR body (first comment)
+// Find the button with "Show options" near the PR author's comment
+mcp__chrome-devtools__click({ uid: "{options_button_uid}" })
+
+// 4. Click "Edit comment"
+mcp__chrome-devtools__click({ uid: "{edit_comment_uid}" })
+```
+
+#### 5b. Upload GIFs via file input
+
+Once in edit mode, find and use the hidden file input to upload GIFs:
+
+```javascript
+// 1. Find the file input for the PR body edit
+mcp__chrome-devtools__evaluate_script({
+  function: `() => {
+    const inputs = document.querySelectorAll('input[type="file"]');
+    return Array.from(inputs).map((el, i) => ({ index: i, id: el.id }));
+  }`
+})
+
+// 2. Make the file input visible (it's hidden by default)
+mcp__chrome-devtools__evaluate_script({
+  function: `() => {
+    const input = document.getElementById('{file_input_id}');
+    input.style.display = 'block';
+    input.style.position = 'fixed';
+    input.style.top = '50px';
+    input.style.left = '50px';
+    input.style.width = '200px';
+    input.style.height = '40px';
+    input.style.zIndex = '99999';
+    input.style.opacity = '1';
+    input.setAttribute('role', 'button');
+    input.setAttribute('aria-label', 'Upload GIF files');
+    return 'Done';
+  }`
+})
+
+// 3. Take snapshot to get the file input's uid
+mcp__chrome-devtools__take_snapshot()
+
+// 4. Upload each GIF file one by one
+mcp__chrome-devtools__upload_file({
+  uid: "{file_input_uid}",
+  filePath: "/absolute/path/to/e2e/recordings/{slug}.gif"
+})
+// Repeat for each GIF file
+```
+
+#### 5c. Collect CDN URLs and build table
+
+After all uploads complete, extract the CDN URLs from the textarea:
+
+```javascript
+mcp__chrome-devtools__evaluate_script({
+  function: `() => {
+    const textarea = document.getElementById('{textarea_id}');
+    const regex = /!\\[([^\\]]*)\\]\\((https:\\/\\/github\\.com\\/user-attachments\\/assets\\/[^\\)]+)\\)/g;
+    const uploads = [];
+    let match;
+    while ((match = regex.exec(textarea.value)) !== null) {
+      uploads.push({ name: match[1], url: match[2] });
+    }
+    return uploads;
+  }`
+})
+```
+
+#### 5d. Set the final PR body content
+
+Replace the textarea content with a properly formatted markdown table:
+
+```javascript
+mcp__chrome-devtools__evaluate_script({
+  function: `() => {
+    const textarea = document.getElementById('{textarea_id}');
+    const newContent = '{header_content}' + '\\n' + tableRows;
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype, 'value'
+    ).set;
+    nativeInputValueSetter.call(textarea, newContent);
+    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    textarea.dispatchEvent(new Event('change', { bubbles: true }));
+    return 'Content updated';
+  }`
+})
+```
+
+#### 5e. Save the PR body
+
+Submit the form to save changes:
+
+```javascript
+// Hide the file input
+mcp__chrome-devtools__evaluate_script({
+  function: `() => {
+    document.getElementById('{file_input_id}').style.display = 'none';
+    return 'Hidden';
+  }`
+})
+
+// Submit the form via the Update comment button
+mcp__chrome-devtools__evaluate_script({
+  function: `() => {
+    const buttons = Array.from(document.querySelectorAll('button'));
+    const updateBtn = buttons.find(b => b.textContent.trim() === 'Update comment');
+    const form = updateBtn.closest('form');
+    form.requestSubmit(updateBtn);
+    return 'Submitted';
+  }`
+})
+
+// Wait for the update to complete
+mcp__chrome-devtools__wait_for({ text: ["edited"] })
+```
+
+The resulting URLs will be in the format:
+```
+https://github.com/user-attachments/assets/{uuid}
+```
+
+### Step 6: Verify the PR body
+
+After saving, verify the PR body renders correctly:
+
+```javascript
+mcp__chrome-devtools__evaluate_script({
+  function: `() => {
+    const images = document.querySelectorAll('img[src*="user-attachments"], img[src*="private-user-images"]');
+    return { imageCount: images.length };
+  }`
+})
+```
+
+### Step 7: Report completion
+
+Print the PR URL and a summary of what was done.
+
+## Notes
+
+- If ffmpeg is not at `/opt/homebrew/bin/ffmpeg`, try `which ffmpeg` to find it
+- Skipped tests produce no video — omit them from the table
+- If a GIF exceeds 10 MB, reduce fps to 5 or scale to 720px
+- `e2e/recordings/` is in `.gitignore` — GIFs must NEVER be committed to git
+- **NEVER upload GIFs as GitHub release assets** — use Chrome DevTools file upload instead
+- The user must be logged into GitHub in Chrome for this workflow to work
+- GitHub CDN URLs (`user-attachments/assets/`) render correctly in markdown and persist indefinitely

--- a/.claude/agents/playwright-test-reviewer.md
+++ b/.claude/agents/playwright-test-reviewer.md
@@ -1,0 +1,247 @@
+---
+name: playwright-test-reviewer
+description: Use this agent to review newly written or modified Playwright e2e tests for code quality, locator robustness, test isolation, naming conventions, and project-specific best practices. Produces a review report and applies fixes. Examples: <example>Context: Developer has written new e2e tests and wants them reviewed before committing. user: 'Review the e2e tests I just wrote' assistant: 'I'll use the playwright-test-reviewer agent to review and improve the tests.' <commentary> The user wants quality review of newly written e2e tests, which is exactly what this reviewer agent does. </commentary></example><example>Context: After generator or healer agent has run, user wants a quality check. user: 'Check the e2e tests for issues before committing' assistant: 'I'll launch the playwright-test-reviewer to check for locator quality, isolation, and convention issues.' <commentary> Pre-commit review of e2e tests is the core purpose of this agent. </commentary></example>
+tools: Glob, Grep, Read, Write, Edit, Bash
+model: sonnet
+color: orange
+---
+
+You are an expert Playwright test reviewer specializing in test quality, robustness, and maintainability.
+Your mission is to review e2e test code and produce a structured report, then apply fixes directly.
+
+## Reference files
+
+Before reviewing, read these project files as the source of truth:
+
+- `e2e/E2E-TEST-NAMING-GUIDELINES.md` — naming conventions
+- `e2e/utils/test-util.ts` — available auth/navigation helpers
+- `e2e/utils/test-util-antd.ts` — Ant Design-specific utilities
+- `.claude/agents/playwright-test-healer.md` — anti-patterns and best practices (networkidle, waitForTimeout, fallback logic, modal locators, icon locators)
+
+## Workflow
+
+### Step 1: Identify files to review
+
+If the user specifies files, use those. Otherwise, find recently modified test files:
+
+```bash
+git diff --name-only HEAD -- 'e2e/**/*.spec.ts' 'e2e/**/*.test.ts'
+```
+
+Read each target test file fully.
+
+### Step 2: Run the tests to see current state
+
+```bash
+pnpm exec playwright test <file> --project=chromium 2>&1 | tail -30
+```
+
+Note which tests pass, fail, or are skipped.
+
+### Step 3: Review checklist
+
+For each test file, check all items below.
+
+---
+
+#### 3.1 Locator quality
+
+**Prefer role/aria-based locators over CSS class selectors.**
+
+| Pattern | Verdict |
+|---|---|
+| `getByRole(...)`, `getByLabel(...)`, `getByText(...)` | ✅ Preferred |
+| `locator('[aria-label="..."]')` | ✅ Acceptable |
+| `locator('[data-testid="..."]')` | ✅ Acceptable |
+| `locator('.ant-modal-content')`, `.ant-table-row`, `.ant-btn` | ⚠️ Brittle — use role-based |
+| `locator('.anticon-*')` | ❌ Forbidden — use `[aria-label="..."]` |
+
+Exception: `.ant-spin-spinning` for loading spinner detection is acceptable when no semantic alternative exists, but prefer `waitFor` on a concrete element instead.
+
+**Ant Design specific migrations:**
+
+```typescript
+// ❌ Brittle CSS class
+page.locator('.ant-modal-content')
+page.locator('.ant-table-row')
+page.locator('.ant-tag').filter(...)
+
+// ✅ Role/aria-based
+page.getByRole('dialog', { name: /Title/i })
+page.getByRole('row')
+page.getByRole('status') // or specific tag locator via aria
+```
+
+---
+
+#### 3.2 Anti-patterns (from healer guidelines)
+
+- **`waitForLoadState('networkidle')`** — forbidden, replace with element assertions
+- **`page.waitForTimeout()`** — avoid for polling/readiness; use `expect.poll()` instead
+- **Silent fallbacks** — `.catch(() => {})` on spinner waits is acceptable ONLY for non-critical spinner detection. Do NOT use try-catch to silently continue on assertion failures.
+- **Unnecessary visibility checks with fallback**: `if (await el.isVisible()) { ... } else { ... }` — remove these; let Playwright fail fast
+- **`test.only`** — forbidden in committed code
+
+---
+
+#### 3.3 Test isolation
+
+Each test must be independently runnable (no shared mutable state between tests):
+
+- [ ] `beforeEach` fully re-navigates and sets up state
+- [ ] No variables mutated across tests without reset in `beforeEach`
+- [ ] Tests that create server resources (sessions, users) have `afterEach` cleanup
+- [ ] Tests that only READ data (filters, views) do NOT need cleanup
+
+---
+
+#### 3.4 Cleanup correctness
+
+- [ ] Filters applied during a test are removed before test ends (prevents leaking state into next test via URL params)
+- [ ] Modal dialogs opened during a test are closed
+- [ ] For resource-creating tests: use `afterEach` with try-catch cleanup
+
+---
+
+#### 3.5 Dead code and misleading signatures
+
+- [ ] Helper function parameters that don't affect behavior must be removed or documented
+- [ ] Unused imports removed
+- [ ] `test.skip()` without explanation has a comment
+
+---
+
+#### 3.6 Environment-dependent hardcoded values
+
+Flag values that may not exist in all test environments:
+
+- Image names like `'python'`, `'pytorch'` — may not be installed
+- Registry names like `'cr'`, `'index.docker.io'` — cluster-specific
+- Enum values like `'ALIVE'`, `'COMPUTE'`, `'x86_64'` — safe (predefined by backend)
+- Non-existent sentinel values like `'zzz-nonexistent-xyzzy'` — safe
+
+For risky values, add a comment explaining the assumption, or use a `test.fixme()` with explanation.
+
+---
+
+#### 3.7 Naming conventions
+
+From `e2e/E2E-TEST-NAMING-GUIDELINES.md`:
+
+- Format: `[Actor] can/cannot [action] [when/with/in condition]`
+- Actor: `Admin`, `User`, `Domain admin`
+- Avoid vague names like `'renders correctly'` or `'works'`
+
+---
+
+#### 3.8 Tag consistency
+
+- `@regression` — always include for functional tests
+- `@functional` — for behavior tests
+- `@visual` — for screenshot tests
+- Feature tags like `@environment`, `@session`, `@filter` — must match directory/feature
+- Verify tags at both `describe` and individual `test` level are appropriate
+
+---
+
+#### 3.9 Navigation helpers
+
+Prefer project utilities over raw click chains:
+
+```typescript
+// ✅ Use navigateTo utility
+import { navigateTo } from '../utils/test-util';
+await navigateTo(page, 'environment');
+
+// ⚠️ Verbose manual navigation (acceptable if navigateTo doesn't support the route)
+await page.getByRole('menuitem', { name: 'Admin Settings' }).click();
+await page.getByRole('menuitem', { name: 'Environments' }).click();
+```
+
+If both `describe` blocks in the same file navigate to the same page differently, unify them.
+
+---
+
+#### 3.10 `beforeEach` efficiency
+
+- [ ] `beforeEach` waits for a meaningful element (not just URL), indicating the page is ready
+- [ ] Prefer role/aria-based readiness check over CSS class: `page.getByRole('combobox', { name: 'Filter property selector' })` instead of `page.locator('.ant-space-compact')`
+
+---
+
+### Step 4: Generate review report
+
+Create the report at `e2e/.agent-output/e2e-review-report-{topic}.md`:
+
+```markdown
+# E2E Test Review Report — {topic}
+
+**File(s) reviewed**: `e2e/...`
+**Test run result**: N passed / N failed / N skipped
+
+## Summary
+- Issues found: N critical, N warnings, N minor
+
+## Critical Issues (Must Fix)
+1. **[Category]** Description — `file.spec.ts:line`
+   Fix: `code suggestion`
+
+## Warnings (Should Fix)
+1. **[Category]** Description — `file.spec.ts:line`
+   Suggestion: `code suggestion`
+
+## Minor / Informational
+1. Description
+
+## Checklist
+- [x] Locator quality
+- [x] No networkidle
+- [ ] Environment-dependent values documented
+- ...
+```
+
+Ensure the output directory exists:
+```bash
+mkdir -p e2e/.agent-output
+```
+
+---
+
+### Step 5: Apply fixes
+
+After writing the report, **automatically apply all Critical and Warning fixes** using Edit tool:
+
+1. Replace brittle CSS locators with role/aria-based equivalents
+2. Remove dead parameters from helper functions
+3. Replace `waitForLoadState('networkidle')` with element assertions
+4. Unify navigation approach if inconsistent across describe blocks
+5. Add comments for environment-dependent hardcoded values
+6. Fix naming convention violations
+
+For each fix, note what changed and why in a brief inline comment if the change is non-obvious.
+
+Do NOT:
+- Change test logic or assertions without strong justification
+- Rename tests unless the name violates the naming convention
+- Add new test scenarios (that's the generator's job)
+- Remove tests (that's the human's decision)
+
+---
+
+### Step 6: Re-run tests to verify fixes didn't break anything
+
+```bash
+pnpm exec playwright test <file> --project=chromium 2>&1 | tail -20
+```
+
+If any previously passing tests now fail, revert the relevant fix and mark it as a warning instead.
+
+---
+
+### Step 7: Present summary
+
+Return a concise summary to the user:
+- Number of issues found by severity
+- What was fixed automatically
+- What requires human judgment (environment-specific values, test logic changes)
+- Report file location

--- a/.claude/skills/record-e2e-gif/SKILL.md
+++ b/.claude/skills/record-e2e-gif/SKILL.md
@@ -1,0 +1,67 @@
+# record-e2e-gif Skill
+
+Record Playwright e2e tests as GIF animations, one GIF per test case.
+
+## Prerequisites
+
+- `ffmpeg` must be installed (`/opt/homebrew/bin/ffmpeg` on macOS)
+- Playwright dev server must be running. The endpoint is read from `e2e/envs/.env.playwright` (`E2E_WEBUI_ENDPOINT`). Do NOT hardcode the port — it varies per environment.
+
+## How It Works
+
+1. Run specified Playwright tests with `--video=on` (Playwright saves `.webm` per test in `test-results/`)
+2. For each `.webm` file, convert to `.gif` using ffmpeg with palette optimization
+3. Save GIFs to `e2e/recordings/{spec-name}/` directory
+4. Return a map of test name → GIF file path
+
+## Usage
+
+When invoked, ask for or accept:
+- `testFile`: path to the spec file (e.g. `e2e/environment/environment.spec.ts`)
+- `grep`: optional test name pattern to filter (e.g. `BAIPropertyFilter`)
+- `project`: browser project, default `chromium`
+- `outputDir`: output directory for GIFs, default `e2e/recordings`
+
+## Recording Command
+
+```bash
+pnpm exec playwright test {testFile} --grep "{grep}" --project={project} \
+  --video=on --reporter=list 2>&1
+```
+
+Videos are saved to `test-results/*/video.webm` (one directory per test).
+
+## Conversion Command (per video)
+
+```bash
+/opt/homebrew/bin/ffmpeg -y \
+  -i "{input.webm}" \
+  -vf "fps=8,scale=960:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer" \
+  -loop 0 \
+  "{output.gif}"
+```
+
+- `fps=8`: 8 frames per second (smooth enough, small file size)
+- `scale=960:-1`: 960px wide, height auto
+- `palettegen/paletteuse`: two-pass palette for high quality GIF
+
+## Finding Test Name from Directory
+
+Playwright names test result directories as:
+`{spec-dir}-{describe-name}-{test-name}-{project}/`
+
+Parse the directory name to derive a slug for the GIF filename:
+- Strip the browser suffix (`-chromium`)
+- Replace spaces and special chars with `-`
+- Truncate to 60 chars
+
+## Output Format
+
+Return a markdown table suitable for embedding in a PR description:
+
+```markdown
+| Test | Recording |
+|------|-----------|
+| Admin can see the BAIPropertyFilter | ![](e2e/recordings/.../test-name.gif) |
+| Admin can filter by name | ![](e2e/recordings/.../test-name.gif) |
+```

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ scripts/temp-releases/
 packages/backend.ai-webui-docs/.agent-output/
 
 
+e2e/recordings/

--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2025-02-09
+> **Last Updated:** 2026-03-03
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 67 / 269 features covered (25%)**
+**Overall (in-scope routes): 78 / 280 features covered (28%)**
 
 | Page | Route | Features | Covered | Status |
 |------|-------|:--------:|:-------:|:------:|
@@ -28,7 +28,7 @@
 | Model Store | `/model-store` | 6 | 0 | ❌ 0% |
 | Storage Host | `/storage-settings/:hostname` | 3 | 0 | ❌ 0% |
 | My Environment | `/my-environment` | 2 | 0 | ❌ 0% |
-| Environment | `/environment` | 13 | 3 | 🔶 23% |
+| Environment | `/environment` | 24 | 14 | 🔶 58% |
 | Configurations | `/settings` | 10 | 8 | 🔶 80% |
 | Resources | `/agent-summary`, `/agent` | 8 | 1 | 🔶 13% |
 | Resource Policy | `/resource-policy` | 13 | 0 | ❌ 0% |
@@ -42,7 +42,7 @@
 | Branding | `/branding` | 14 | 0 | ❌ 0% |
 | App Launcher | (modal) | 18 | 10 | 🔶 56% |
 | Chat | `/chat/:id?` | 6 | 0 | ❌ 0% |
-| **Total** | | **269** | **67** | **25%** |
+| **Total** | | **280** | **78** | **28%** |
 
 ---
 
@@ -352,6 +352,7 @@
 
 #### Images Tab
 **Row actions:** `ImageInstallModal`, `ManageAppsModal`, `ManageImageResourceLimitModal`
+**Filter:** `BAIPropertyFilter` (Name, Architecture, Status, Type, Registry)
 
 | Feature | Status | Test |
 |---------|--------|------|
@@ -359,6 +360,18 @@
 | Image resource limit → ManageImageResourceLimitModal | ✅ | `user can modify image resource limit` |
 | Image app management → ManageAppsModal | ✅ | `user can manage apps` |
 | Image installation → ImageInstallModal | 🚧 | Skipped: `user can install image` |
+| BAIPropertyFilter UI rendering | ✅ | `Admin can see the BAIPropertyFilter on the Images tab` |
+| Filter by name (free text) | ✅ | `Admin can filter images by name using a text value` |
+| Filter by architecture (strict selection) | ✅ | `Admin can filter images by architecture using strict selection` |
+| Filter by status (strict selection) | ✅ | `Admin can filter images by status using strict selection` |
+| Filter by type (strict selection) | ✅ | `Admin can filter images by type using strict selection` |
+| Filter by registry (free text) | ✅ | `Admin can filter images by registry using a text value` |
+| Multiple filters with reset-all | ✅ | `Admin can apply multiple filters simultaneously and see reset-all button` |
+| Clear single filter tag | ✅ | `Admin can clear a single filter tag by clicking its close button` |
+| Clear all filters (reset-all button) | ✅ | `Admin can clear all filters at once using the reset-all button` |
+| Pagination reset on filter | ✅ | `Admin sees pagination reset to page 1 when a filter is applied on page 2` |
+| Strict selection rejects freeform | ✅ | `Admin cannot add a filter for architecture with an invalid freeform value` |
+| Empty state for non-matching filter | ✅ | `Admin sees empty state when filtering by a non-existent image name` |
 | Table column settings → TableColumnsSettingModal | ❌ | - |
 
 #### Resource Presets Tab
@@ -383,7 +396,7 @@
 | Edit registry → ContainerRegistryEditorModal | ❌ | - |
 | Delete registry → Popconfirm | ❌ | - |
 
-**Coverage: 🔶 3/13 features**
+**Coverage: 🔶 14/24 features**
 
 ---
 

--- a/e2e/environment/environment.spec.ts
+++ b/e2e/environment/environment.spec.ts
@@ -1,6 +1,7 @@
+// spec: Image list and environment management E2E tests
 import { loginAsAdmin, navigateTo } from '../utils/test-util';
 import { findColumnIndex } from '../utils/test-util-antd';
-import { expect, test } from '@playwright/test';
+import { expect, test, Page } from '@playwright/test';
 
 test.describe(
   'environment ',
@@ -267,6 +268,443 @@ test.describe(
       if (reinstallationText > 0) {
         await page.getByRole('button', { name: 'OK' }).nth(1).click();
       }
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Helper functions for BAIPropertyFilter interaction
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a filter using BAIPropertyFilter on the Image List page.
+ * BAIPropertyFilter.onSearch validates strict selection values against the options
+ * list internally, so clicking the search button works for both free-text and
+ * strict-selection properties.
+ */
+async function applyImageFilter(
+  page: Page,
+  propertyLabel: string,
+  value: string,
+) {
+  // Open the property selector combobox via its stable aria-label
+  await page.getByLabel('Filter property selector').click();
+  await page.getByRole('option', { name: propertyLabel, exact: true }).click();
+
+  const valueInput = page.locator('[aria-label="Filter value search"]');
+  await valueInput.fill(value);
+  await page.getByRole('button', { name: 'search' }).click();
+
+  // Wait for table to reflect updated results
+  await page
+    .locator('.ant-spin-spinning')
+    .waitFor({ state: 'detached', timeout: 10000 })
+    .catch(() => {});
+}
+
+/**
+ * Remove a specific filter tag by its displayed text.
+ * Scopes tag lookup to closable .ant-tag elements to avoid matching
+ * status badges or other non-closable tags in the table.
+ */
+async function removeFilterTag(page: Page, tagText: string) {
+  const tag = page
+    .locator('.ant-tag')
+    .filter({ has: page.locator('[aria-label="Close"]') })
+    .filter({ hasText: tagText });
+  await tag.locator('[aria-label="Close"]').click();
+
+  // Wait for any loading spinner to disappear after filter removal
+  await page
+    .locator('.ant-spin-spinning')
+    .waitFor({ state: 'detached', timeout: 10000 })
+    .catch(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// New describe block: ImageList - BAIPropertyFilter interaction tests
+// ---------------------------------------------------------------------------
+
+test.describe(
+  'ImageList - BAIPropertyFilter',
+  { tag: ['@regression', '@environment', '@functional', '@filter'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      await loginAsAdmin(page, request);
+      await page.getByRole('menuitem', { name: 'Admin Settings' }).click();
+      await page
+        .getByRole('menuitem', { name: 'file-done Environments' })
+        .click();
+      await expect(page).toHaveURL(/\/environment/);
+      // Wait for the BAIPropertyFilter and table to be ready
+      await expect(
+        page.getByRole('combobox', { name: 'Filter property selector' }),
+      ).toBeVisible();
+      await expect(page.getByRole('table')).toBeVisible();
+    });
+
+    // Scenario 2.1 — BAIPropertyFilter UI rendered
+    test('Admin can see the BAIPropertyFilter on the Images tab', async ({
+      page,
+    }) => {
+      // 1. Verify the Space.Compact container of BAIPropertyFilter is visible
+      await expect(page.locator('.ant-space-compact').first()).toBeVisible();
+
+      // 2. Verify the property selector combobox is present with its aria-label
+      await expect(
+        page.getByRole('combobox', { name: 'Filter property selector' }),
+      ).toBeVisible();
+
+      // 3. Verify the value search input is present with its aria-label
+      await expect(
+        page.locator('[aria-label="Filter value search"]'),
+      ).toBeVisible();
+
+      // 4. Verify the BAIPropertyFilter search button (Input.Search submit) exists
+      await expect(page.getByRole('button', { name: 'search' })).toBeVisible();
+    });
+
+    // Scenario 2.2 — Filter by name (free text)
+    test('Admin can filter images by name using a text value', async ({
+      page,
+    }) => {
+      // 1. Apply the Name filter with value "python" (assumes at least one python image is installed)
+      await applyImageFilter(page, 'Name', 'python');
+
+      // 2. Verify a filter tag "Name: python" appears below the filter inputs
+      const nameTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Name: python' });
+      await expect(nameTag).toBeVisible();
+
+      // 3. Verify the table is still visible (filtered results shown)
+      await expect(page.locator('.ant-table-content')).toBeVisible();
+
+      // 4. Cleanup: remove the filter tag
+      await removeFilterTag(page, 'Name: python');
+      await expect(nameTag).not.toBeVisible();
+    });
+
+    // Scenario 2.3 — Filter by architecture (strict selection)
+    test('Admin can filter images by architecture using strict selection', async ({
+      page,
+    }) => {
+      // 1. Apply Architecture filter with strict selection value "x86_64"
+      await applyImageFilter(page, 'Architecture', 'x86_64');
+
+      // 2. Verify filter tag "Architecture: x86_64" appears
+      const archTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Architecture: x86_64' });
+      await expect(archTag).toBeVisible();
+
+      // 3. Verify the table has at least one row with images
+      await expect(
+        page.locator('.ant-table-content .ant-table-row').first(),
+      ).toBeVisible();
+
+      // 4. Cleanup: remove the filter tag
+      await removeFilterTag(page, 'Architecture: x86_64');
+      await expect(archTag).not.toBeVisible();
+    });
+
+    // Scenario 2.4 — Filter by status (strict selection)
+    test('Admin can filter images by status using strict selection', async ({
+      page,
+    }) => {
+      // 1. Apply Status filter with strict selection value "ALIVE"
+      await applyImageFilter(page, 'Status', 'ALIVE');
+
+      // 2. Verify filter tag "Status: ALIVE" appears
+      const statusTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Status: ALIVE' });
+      await expect(statusTag).toBeVisible();
+
+      // 3. Verify the table is not empty (all installed images should be ALIVE)
+      await expect(
+        page.locator('.ant-table-content .ant-table-row').first(),
+      ).toBeVisible();
+
+      // 4. Cleanup: remove the filter tag
+      await removeFilterTag(page, 'Status: ALIVE');
+      await expect(statusTag).not.toBeVisible();
+    });
+
+    // Scenario 2.5 — Filter by type (strict selection)
+    test('Admin can filter images by type using strict selection', async ({
+      page,
+    }) => {
+      // 1. Apply Type filter with strict selection value "COMPUTE"
+      await applyImageFilter(page, 'Type', 'COMPUTE');
+
+      // 2. Verify filter tag "Type: COMPUTE" appears
+      const typeTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Type: COMPUTE' });
+      await expect(typeTag).toBeVisible();
+
+      // 3. Verify the table has at least one row
+      await expect(
+        page.locator('.ant-table-content .ant-table-row').first(),
+      ).toBeVisible();
+
+      // 4. Cleanup: remove the filter tag
+      await removeFilterTag(page, 'Type: COMPUTE');
+      await expect(typeTag).not.toBeVisible();
+    });
+
+    // Scenario 2.6 — Filter by registry (free text)
+    test('Admin can filter images by registry using a text value', async ({
+      page,
+    }) => {
+      // 1. Apply Registry filter with partial registry hostname "cr" (assumes cr.* registry exists)
+      await applyImageFilter(page, 'Registry', 'cr');
+
+      // 2. Verify filter tag "Registry: cr" appears
+      const registryTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Registry: cr' });
+      await expect(registryTag).toBeVisible();
+
+      // 3. Verify the table content is visible (rows exist for the registry)
+      await expect(page.locator('.ant-table-content')).toBeVisible();
+
+      // 4. Cleanup: remove the filter tag
+      await removeFilterTag(page, 'Registry: cr');
+      await expect(registryTag).not.toBeVisible();
+    });
+
+    // Scenario 2.7 — Multiple filters with reset-all button
+    test('Admin can apply multiple filters simultaneously and see reset-all button', async ({
+      page,
+    }) => {
+      // 1. Apply Name filter with value "python"
+      await applyImageFilter(page, 'Name', 'python');
+      const nameTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Name: python' });
+      await expect(nameTag).toBeVisible();
+
+      // 2. Apply Architecture filter with strict selection "x86_64"
+      await applyImageFilter(page, 'Architecture', 'x86_64');
+      const archTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Architecture: x86_64' });
+      await expect(archTag).toBeVisible();
+
+      // 3. Verify both tags are visible
+      await expect(nameTag).toBeVisible();
+      await expect(archTag).toBeVisible();
+
+      // 4. Verify the reset-all button appears (only shown when 2+ active filters)
+      const resetAllButton = page
+        .locator('button.ant-btn')
+        .filter({ has: page.locator('[aria-label="close-circle"]') });
+      await expect(resetAllButton).toBeVisible();
+
+      // 5. Cleanup: click reset-all to remove all filters at once
+      await resetAllButton.click();
+      await page
+        .locator('.ant-spin-spinning')
+        .waitFor({ state: 'detached', timeout: 10000 })
+        .catch(() => {});
+      await expect(nameTag).not.toBeVisible();
+      await expect(archTag).not.toBeVisible();
+    });
+
+    // Scenario 2.8 — Clear single filter tag
+    test('Admin can clear a single filter tag by clicking its close button', async ({
+      page,
+    }) => {
+      // 1. Apply Name filter with value "python"
+      await applyImageFilter(page, 'Name', 'python');
+      const nameTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Name: python' });
+      await expect(nameTag).toBeVisible();
+
+      // 2. Apply Architecture filter with strict selection "x86_64"
+      await applyImageFilter(page, 'Architecture', 'x86_64');
+      const archTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Architecture: x86_64' });
+      await expect(archTag).toBeVisible();
+
+      // 3. Verify the reset-all button appears with 2 active filters
+      const resetAllButton = page
+        .locator('button.ant-btn')
+        .filter({ has: page.locator('[aria-label="close-circle"]') });
+      await expect(resetAllButton).toBeVisible();
+
+      // 4. Remove only the Architecture tag by clicking its close button
+      await removeFilterTag(page, 'Architecture: x86_64');
+
+      // 5. Verify the Architecture tag is gone
+      await expect(archTag).not.toBeVisible();
+
+      // 6. Verify the Name tag still remains
+      await expect(nameTag).toBeVisible();
+
+      // 7. Verify the reset-all button disappears (only 1 tag remains)
+      await expect(resetAllButton).not.toBeVisible();
+
+      // 8. Remove the remaining Name tag
+      await removeFilterTag(page, 'Name: python');
+      await expect(nameTag).not.toBeVisible();
+    });
+
+    // Scenario 2.9 — Clear all with reset-all button
+    test('Admin can clear all filters at once using the reset-all button', async ({
+      page,
+    }) => {
+      // 1. Apply Name filter with value "python"
+      await applyImageFilter(page, 'Name', 'python');
+      const nameTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Name: python' });
+      await expect(nameTag).toBeVisible();
+
+      // 2. Apply Architecture filter with strict selection "x86_64"
+      await applyImageFilter(page, 'Architecture', 'x86_64');
+      const archTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Architecture: x86_64' });
+      await expect(archTag).toBeVisible();
+
+      // 3. Verify both filter tags and the reset-all button are visible
+      const resetAllButton = page
+        .locator('button.ant-btn')
+        .filter({ has: page.locator('[aria-label="close-circle"]') });
+      await expect(resetAllButton).toBeVisible();
+
+      // 4. Click the reset-all button to clear all filters at once
+      await resetAllButton.click();
+      await page
+        .locator('.ant-spin-spinning')
+        .waitFor({ state: 'detached', timeout: 10000 })
+        .catch(() => {});
+
+      // 5. Verify no filter tags remain
+      await expect(nameTag).not.toBeVisible();
+      await expect(archTag).not.toBeVisible();
+      await expect(resetAllButton).not.toBeVisible();
+
+      // 6. Verify the table shows results (returns to unfiltered state)
+      await expect(
+        page.locator('.ant-table-content .ant-table-row').first(),
+      ).toBeVisible();
+    });
+
+    // Scenario 2.10 — Pagination resets to page 1 when filter applied
+    test('Admin sees pagination reset to page 1 when a filter is applied on page 2', async ({
+      page,
+    }) => {
+      // 1. Check total row count to determine if there are enough images for page 2
+      const paginationTotal = page.locator('.ant-pagination-total-text');
+      const totalText = await paginationTotal.textContent().catch(() => '');
+      const totalMatch = totalText?.match(/of\s+(\d+)/);
+      const total = totalMatch ? parseInt(totalMatch[1], 10) : 0;
+
+      // Skip if not enough images for page 2 (default page size is 20)
+      if (total <= 20) {
+        test.skip();
+        return;
+      }
+
+      // 2. Navigate to page 2 by clicking the page 2 button in pagination
+      await page
+        .locator('.ant-pagination-item')
+        .filter({ hasText: '2' })
+        .click();
+      await page
+        .locator('.ant-spin-spinning')
+        .waitFor({ state: 'detached', timeout: 10000 })
+        .catch(() => {});
+
+      // 3. Verify we are on page 2
+      await expect(page.locator('.ant-pagination-item-active')).toHaveText('2');
+
+      // 4. Apply a Name filter with value "python"
+      await applyImageFilter(page, 'Name', 'python');
+      const nameTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Name: python' });
+      await expect(nameTag).toBeVisible();
+
+      // 5. Verify pagination has reset to page 1
+      await expect(page.locator('.ant-pagination-item-active')).toHaveText('1');
+
+      // 6. Cleanup: remove the filter tag
+      await removeFilterTag(page, 'Name: python');
+      await expect(nameTag).not.toBeVisible();
+    });
+
+    // Scenario 2.11 — Strict selection rejects freeform input
+    test('Admin cannot add a filter for architecture with an invalid freeform value', async ({
+      page,
+    }) => {
+      // 1. Select "Architecture" as the filter property
+      await page.getByLabel('Filter property selector').click();
+      await page
+        .getByRole('option', { name: 'Architecture', exact: true })
+        .click();
+
+      // 2. Type an invalid value not in the predefined strictSelection options
+      const valueInput = page.locator('[aria-label="Filter value search"]');
+      await valueInput.fill('arm64');
+
+      // 3. Click the search button to attempt to submit the freeform value
+      await page.getByRole('button', { name: 'search' }).click();
+      await page
+        .locator('.ant-spin-spinning')
+        .waitFor({ state: 'detached', timeout: 5000 })
+        .catch(() => {});
+
+      // 4. Verify no closable filter tag was created (strict selection rejects freeform input)
+      const filterTags = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') });
+      await expect(filterTags).toHaveCount(0);
+
+      // 5. Verify the table remains in its unfiltered state (rows visible)
+      await expect(
+        page.locator('.ant-table-content .ant-table-row').first(),
+      ).toBeVisible();
+    });
+
+    // Scenario 2.12 — Empty results when filtering non-existent name
+    test('Admin sees empty state when filtering by a non-existent image name', async ({
+      page,
+    }) => {
+      // 1. Apply a Name filter with a value that matches no images
+      await applyImageFilter(page, 'Name', 'zzz-nonexistent-image-000');
+
+      // 2. Verify a closable filter tag with the entered text is visible
+      const noResultsTag = page
+        .locator('.ant-tag')
+        .filter({ has: page.locator('[aria-label="Close"]') })
+        .filter({ hasText: 'Name: zzz-nonexistent-image-000' });
+      await expect(noResultsTag).toBeVisible();
+
+      // 3. Verify the table shows an empty state (Ant Design no-data placeholder)
+      await expect(page.locator('.ant-table-placeholder')).toBeVisible();
+
+      // 4. Cleanup: remove the filter tag
+      await removeFilterTag(page, 'Name: zzz-nonexistent-image-000');
+      await expect(noResultsTag).not.toBeVisible();
     });
   },
 );

--- a/e2e/visual_regression/environments/environments_page.test.ts
+++ b/e2e/visual_regression/environments/environments_page.test.ts
@@ -11,7 +11,10 @@ test.beforeEach(async ({ page, request }) => {
   });
   await loginAsVisualRegressionAdmin(page, request);
   await navigateTo(page, 'environment');
-  await page.locator('.ant-input-affix-wrapper').first().waitFor();
+  // Wait for the BAIPropertyFilter via its accessible combobox
+  await page
+    .getByRole('combobox', { name: 'Filter property selector' })
+    .waitFor({ state: 'visible' });
 });
 
 test.describe(


### PR DESCRIPTION
Resolves #5672 (FR-2181)

## Summary

Add Playwright e2e tests covering the `ImageList` page changes from FR-2117 (BAIPropertyFilter).

- 11 test scenarios for `BAIPropertyFilter` interaction on the Environments page
- Fix broken locator in `environments_page.test.ts` visual regression test (`.ant-input-affix-wrapper` → `.ant-space-compact`)
- Add `playwright-test-reviewer` agent for future e2e code quality reviews
- Add `record-e2e-gif` skill for recording e2e tests as GIFs

## Tests implemented

| # | Test | Scenario |
|---|------|----------|
| 2.1 | BAIPropertyFilter UI rendered | Combobox, value input, search button all visible |
| 2.2 | Filter by name (free text) | Apply name filter, verify tag, remove tag |
| 2.3 | Filter by architecture (strict) | x86_64 strict-selection filter |
| 2.4 | Filter by status (strict) | ALIVE strict-selection filter |
| 2.5 | Filter by type (strict) | COMPUTE strict-selection filter |
| 2.6 | Filter by registry (free text) | Partial registry hostname filter |
| 2.7 | Multiple filters + reset-all button | Apply 2 filters, verify reset-all appears |
| 2.8 | Clear single filter tag | Remove one tag, other remains, reset-all disappears |
| 2.9 | Clear all filters at once | Reset-all clears all active filters |
| 2.10 | Pagination resets to page 1 | Skipped if ≤20 images in environment |
| 2.11 | Strict rejects freeform input | Invalid value not added as filter tag |
| 2.12 | Empty state on no-match | Table shows placeholder when no results |

## Test Recordings

| Test Case | Recording |
|-----------|-----------|
| 2.1 BAIPropertyFilter UI rendered | ![01-bai-property-filter-ui-rendered](https://github.com/user-attachments/assets/08c3fe78-8025-44d0-847c-4b80005dd985) |
| 2.2 Filter by name | ![02-filter-by-name](https://github.com/user-attachments/assets/79ab7a4c-28fd-42c9-a61e-30debbaf4d02) |
| 2.3 Filter by architecture | ![03-filter-by-architecture](https://github.com/user-attachments/assets/22f35f91-5318-402a-ad8c-67b655798512) |
| 2.4 Filter by status | ![04-filter-by-status](https://github.com/user-attachments/assets/b043cfea-7b93-48da-8c00-a184ec8438f7) |
| 2.5 Filter by type | ![05-filter-by-type](https://github.com/user-attachments/assets/8535c921-587d-4031-aa62-8d449738538a) |
| 2.6 Filter by registry | ![06-filter-by-registry](https://github.com/user-attachments/assets/b0fd2ff1-4e61-44a7-8267-4309d8750925) |
| 2.7 Multiple filters + reset-all | ![07-multiple-filters-reset-all](https://github.com/user-attachments/assets/e26fdc92-dcd6-442f-aaf2-70abffe3c874) |
| 2.8 Clear single filter tag | ![08-clear-single-filter-tag](https://github.com/user-attachments/assets/359ef083-7099-45bc-b148-9ff560739aca) |
| 2.9 Clear all filters | ![09-clear-all-filters](https://github.com/user-attachments/assets/a590a624-f8e7-4b4b-ac3a-9436ccdae5fc) |
| 2.11 Strict rejects freeform | ![11-strict-rejects-freeform](https://github.com/user-attachments/assets/dd64e440-64f9-44a1-89cd-5418d4763397) |
| 2.12 Empty state | ![12-empty-state-no-results](https://github.com/user-attachments/assets/9e83dfcb-1197-49d3-8d81-98089f3472b4) |