### PR TITLE
feat(FR-2187): add labels management command to jira.sh

### DIFF
--- a/.claude/agents/fiber-leader.md
+++ b/.claude/agents/fiber-leader.md
@@ -124,13 +124,16 @@ For `needs-backend` issues where no backend work exists, also create a backend r
 
 ### 6. Summary
 
+Issue keys in the summary table MUST be hyperlinks to the Jira issue page.
+Use the format `[FR-XXXX](https://lablup.atlassian.net/browse/FR-XXXX)`.
+
 ```
 Issues created!
 
 | # | Jira Key | Title | Classification |
 |---|----------|-------|---------------|
-| 1 | FR-XXXX | ... | auto-mergeable |
-| 2 | FR-YYYY | ... | needs-review |
+| 1 | [FR-XXXX](https://lablup.atlassian.net/browse/FR-XXXX) | ... | auto-mergeable |
+| 2 | [FR-YYYY](https://lablup.atlassian.net/browse/FR-YYYY) | ... | needs-review |
 
 Next: Run /fiber-do FR-XXXX to implement individually
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ Production build (`pnpm run build`) runs these steps sequentially:
     - `bash scripts/jira.sh update FR-XXXX [--assignee me] [--sprint current] [--parent FR-XXXX]`
     - `bash scripts/jira.sh search "JQL query" [--limit 20]`
     - `bash scripts/jira.sh comment FR-XXXX "Comment text"`
+    - `bash scripts/jira.sh labels FR-XXXX --add "l1,l2"` / `--remove "l1,l2"` / `--set "l1,l2"` (manage labels)
     - `bash scripts/jira.sh link --from FR-XXXX --to FR-YYYY --type blocks` (link types: blocks, relates, clones, duplicate)
     - **Epic linking**: When creating issues under an Epic, ALWAYS use `--parent FR-XXXX` to link them. Issues created without `--parent` will be orphaned and not visible under the Epic.
     - **Issue linking**: When Epics or issues have dependencies or relationships, use `jira.sh link` to connect them (e.g. `--type blocks` for dependencies, `--type relates` for related work).

--- a/scripts/jira.sh
+++ b/scripts/jira.sh
@@ -19,6 +19,9 @@
 #   jira.sh update  FR-XXXX [--assignee me] [--sprint current] [--parent FR-XXXX] [--desc "..."] [--comment "text"]
 #   jira.sh search  "JQL query" [--limit 20]
 #   jira.sh comment FR-XXXX "Comment text"
+#   jira.sh labels  FR-XXXX --add "l1,l2"         Add labels (keeps existing)
+#   jira.sh labels  FR-XXXX --remove "l1,l2"      Remove specific labels
+#   jira.sh labels  FR-XXXX --set "l1,l2"          Replace all labels
 #   jira.sh link    --from FR-XXXX --to FR-YYYY [--type blocks|relates|clones|duplicate]
 #   jira.sh myself
 
@@ -596,6 +599,71 @@ cmd_link() {
   echo "Linked: ${from} --[${link_type}]--> ${to}"
 }
 
+cmd_labels() {
+  local key=${1:?labels: issue key required}; shift
+  local add="" remove="" set_labels="" has_set=false
+  while (( $# )); do
+    case $1 in
+      --add)    add=$2;        shift 2 ;;
+      --remove) remove=$2;     shift 2 ;;
+      --set)    set_labels=$2; has_set=true; shift 2 ;;
+      *) die "labels: unknown flag $1" ;;
+    esac
+  done
+
+  if $has_set && [[ -n "$add" || -n "$remove" ]]; then
+    die "labels: --set cannot be combined with --add or --remove"
+  fi
+
+  # Trim whitespace safely (no xargs — avoids mangling labels starting with -)
+  _trim() { sed 's/^[[:space:]]*//;s/[[:space:]]*$//'; }
+
+  if $has_set; then
+    # Replace all labels (--set "" clears all labels)
+    local labels_json="[]"
+    if [[ -n "$set_labels" ]]; then
+      IFS=',' read -ra SET_ARR <<< "$set_labels"
+      for lbl in "${SET_ARR[@]}"; do
+        lbl=$(echo "$lbl" | _trim)
+        [[ -z "$lbl" ]] && continue
+        labels_json=$(echo "$labels_json" | jq --arg v "$lbl" '. + [$v]')
+      done
+    fi
+    api PUT "/issue/${key}" -d "$(jq -n --argjson l "$labels_json" '{fields:{labels:$l}}')"
+    echo "Labels set on ${key}: ${set_labels:-<cleared>}"
+    return
+  fi
+
+  if [[ -z "$add" && -z "$remove" ]]; then
+    # No operation specified — show current labels
+    api GET "/issue/${key}?fields=labels" | jq -r '.fields.labels | join(", ")'
+    return
+  fi
+
+  # Build update operations array
+  local ops="[]"
+  if [[ -n "$add" ]]; then
+    IFS=',' read -ra ADD_ARR <<< "$add"
+    for lbl in "${ADD_ARR[@]}"; do
+      lbl=$(echo "$lbl" | _trim)
+      [[ -z "$lbl" ]] && continue
+      ops=$(echo "$ops" | jq --arg v "$lbl" '. + [{"add": $v}]')
+    done
+  fi
+  if [[ -n "$remove" ]]; then
+    IFS=',' read -ra RM_ARR <<< "$remove"
+    for lbl in "${RM_ARR[@]}"; do
+      lbl=$(echo "$lbl" | _trim)
+      [[ -z "$lbl" ]] && continue
+      ops=$(echo "$ops" | jq --arg v "$lbl" '. + [{"remove": $v}]')
+    done
+  fi
+
+  api PUT "/issue/${key}" -d "$(jq -n --argjson ops "$ops" '{update:{labels:$ops}}')"
+  [[ -n "$add" ]] && echo "Labels added to ${key}: ${add}"
+  [[ -n "$remove" ]] && echo "Labels removed from ${key}: ${remove}"
+}
+
 # ── Main ─────────────────────────────────────────────────────
 require_jq
 cmd=${1:-help}; shift 2>/dev/null || true
@@ -611,11 +679,14 @@ Commands:
   update    FR-XXXX [--assignee me] [--sprint current] [--parent FR-XXXX] [--desc "..."] [--comment "text"]
   search    "JQL query" [--limit 20]
   comment   FR-XXXX "Comment text"
+  labels    FR-XXXX [--add "l1,l2"] [--remove "l1,l2"] [--set "l1,l2"]
   link      --from FR-XXXX --to FR-YYYY [--type blocks|relates|clones|duplicate]
   check-dup --labels "l1,l2" [--include-done]   Check for duplicate issues by labels
   myself    Show current user info
 
 The --parent flag links an issue to a parent Epic (e.g. --parent FR-1234).
+The labels command manages labels: --add appends, --remove deletes specific labels,
+  --set replaces all labels. With no flags, shows current labels.
 The link command creates issue links (e.g. "FR-1 blocks FR-2", "FR-1 relates to FR-2").
 Description and comment fields accept Markdown, which is automatically
 converted to Atlassian Document Format (ADF) for proper Jira rendering.
@@ -632,6 +703,7 @@ USAGE
       update)    cmd_update "$@" ;;
       search)    cmd_search "$@" ;;
       comment)   cmd_comment "$@" ;;
+      labels)    cmd_labels "$@" ;;
       link)      cmd_link "$@" ;;
       check-dup) cmd_check_dup "$@" ;;
       myself)    cmd_myself ;;


### PR DESCRIPTION
Resolves #5680 ([FR-2187](https://lablup.atlassian.net/browse/FR-2187))

## Summary
- Add `labels` subcommand to `jira.sh` supporting `--add`, `--remove`, and `--set` operations
- Update `AGENTS.md` with labels command documentation
- Update `fiber-leader` agent summary table to use Jira hyperlinks

## Test plan
- [ ] `bash scripts/jira.sh labels FR-XXXX` — shows current labels
- [ ] `bash scripts/jira.sh labels FR-XXXX --add "test-label"` — adds label
- [ ] `bash scripts/jira.sh labels FR-XXXX --remove "test-label"` — removes label
- [ ] `bash scripts/jira.sh labels FR-XXXX --set "l1,l2"` — replaces all labels

[FR-2187]: https://lablup.atlassian.net/browse/FR-2187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ