### PR TITLE
fix(FR-2198): apply round_length formatting to fGPU values in session and agent views

### DIFF
--- a/react/src/components/AgentNodeItems/AgentResources.tsx
+++ b/react/src/components/AgentNodeItems/AgentResources.tsx
@@ -142,6 +142,15 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
                     </Col>
                   );
                 } else if (parsedAvailableSlots[key]) {
+                  const roundLength =
+                    mergedResourceSlots?.[key]?.number_format?.round_length ||
+                    0;
+                  const formatSlotValue = (v: string | undefined | number) => {
+                    const str = String(v ?? 0);
+                    return roundLength > 0
+                      ? parseFloat(str).toFixed(roundLength)
+                      : str;
+                  };
                   return (
                     <Col xs={24} sm={12} key={key}>
                       <SimpleProgressWithLabel
@@ -158,7 +167,7 @@ const AgentResources: React.FC<AgentResourcesProps> = ({ agentNodeFrgmt }) => {
                             _.toNumber(parsedAvailableSlots[key] ?? 1)) *
                             100,
                         ).toString()}
-                        description={`${parsedOccupiedSlots[key] ?? 0} / ${parsedAvailableSlots[key] ?? 0} ${mergedResourceSlots?.[key]?.display_unit}`}
+                        description={`${formatSlotValue(parsedOccupiedSlots[key])} / ${formatSlotValue(parsedAvailableSlots[key])} ${mergedResourceSlots?.[key]?.display_unit}`}
                       />
                     </Col>
                   );

--- a/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
@@ -103,6 +103,10 @@ const SessionSlotCell: React.FC<OccupiedSlotViewProps> = ({
           const memStat = liveStat[statKey + '_mem'];
 
           const percentNumber = memStat?.pct ? parseFloat(memStat.pct) : 0;
+          const roundLength =
+            mergedResourceSlots?.[key]?.number_format?.round_length || 0;
+          const formattedValue =
+            roundLength > 0 ? parseFloat(value).toFixed(roundLength) : value;
           return (
             <BAIFlex
               direction="row"
@@ -121,7 +125,7 @@ const SessionSlotCell: React.FC<OccupiedSlotViewProps> = ({
                       : ''),
                   placement: 'left',
                 }}
-                text={value}
+                text={formattedValue}
               />
               <Divider type="vertical" />
               <Typography.Text>


### PR DESCRIPTION
Resolves FR-2198

## Summary

- `SessionSlotCell` (session list accelerator column) and `AgentResources` (agent resource allocation) were displaying raw server values (e.g. `16.000000`) from `occupied_slots` without applying `round_length` from device metadata
- Apply the same `round_length` formatting logic used in `ResourceNumber` / `BAIResourceNumberWithIcon` to ensure fGPU values display consistently (e.g. `16.0` with `round_length: 1`)

## Changes

- **`SessionSlotCell.tsx`**: Format accelerator `value` using `mergedResourceSlots[key].number_format.round_length` before passing to `UsageBadge`
- **`AgentResources.tsx`**: Format `parsedOccupiedSlots[key]` and `parsedAvailableSlots[key]` in the accelerator branch description

## Before / After

| View | Before | After |
|---|---|---|
| Session list accelerator column | `16.000000` | `16.0` |
| Agent resource allocation | `16.000000 / 16.000000 fGPU` | `16.0 / 16.0 fGPU` |