### PR TITLE
fix(FR-2199): normalize endpoint URL to prevent double-slash in API requests

### DIFF
--- a/e2e/.agent-output/test-plan-endpoint-normalization.md
+++ b/e2e/.agent-output/test-plan-endpoint-normalization.md
@@ -1,0 +1,101 @@
+# Test Plan: Endpoint URL Normalization (FR-2199)
+
+## Overview
+
+**Bug**: Endpoints with trailing slashes (e.g., `http://127.0.0.1:8090/`) caused double-slash
+in API request URLs (e.g., `http://127.0.0.1:8090//func/...`), resulting in login failure.
+
+**Fix**:
+1. `LoginView.tsx` - `resolveEndpoint()` now strips trailing slashes via `.replace(/\/+$/, '')`
+2. `LoginView.tsx` - `handleSubmit()` now passes the validated `ep` to `connectUsingSession()`
+   and `connectUsingAPI()` (previously ignored)
+3. `backend.ai-client-esm.ts` - `ClientConfig` constructor strips trailing slashes before
+   constructing request URLs
+
+**Regression risk**: Any change to endpoint handling in the login flow.
+
+---
+
+## Test Files
+
+| File | Type | Purpose |
+|------|------|---------|
+| `e2e/auth/login.spec.ts` | E2E (Playwright) | Extend with trailing slash scenarios |
+| `src/lib/backend.ai-client-esm.test.ts` | Unit (Jest) | Verify `ClientConfig` normalization |
+
+---
+
+## E2E Test Scenarios (Playwright)
+
+Target file: `e2e/auth/login.spec.ts`
+Test describe: `Endpoint URL normalization`
+Tags: `@regression`, `@auth`, `@functional`
+
+### Scenario 1: Login with single trailing slash on endpoint
+**Actor**: User
+**Precondition**: Session-based login mode, empty apiEndpoint in config
+**Steps**:
+1. Navigate to login page
+2. Fill valid credentials (admin email + password)
+3. Expand Advanced section and enter endpoint with trailing slash: `{webServerEndpoint}/`
+4. Click Login button
+**Expected**: Redirect to `/start`, breadcrumb shows "Start" — confirms no double-slash error
+
+### Scenario 2: Login with multiple trailing slashes on endpoint
+**Actor**: User
+**Precondition**: Same as Scenario 1
+**Steps**:
+1. Navigate to login page
+2. Fill valid credentials
+3. Enter endpoint with multiple trailing slashes: `{webServerEndpoint}///`
+4. Click Login button
+**Expected**: Redirect to `/start` — all trailing slashes are stripped
+
+### Scenario 3: No API request contains double-slash after normalization
+**Actor**: User
+**Precondition**: Network request interception enabled
+**Steps**:
+1. Navigate to login page
+2. Intercept all outgoing requests
+3. Login with trailing-slash endpoint
+4. Inspect captured API request URLs
+**Expected**: No captured URL contains `//` after the protocol part (`://`)
+
+---
+
+## Unit Test Scenarios (Jest)
+
+Target file: `src/lib/backend.ai-client-esm.test.ts`
+Test class: `ClientConfig`
+
+### Scenario U1: Single trailing slash is stripped
+- Input: `new ClientConfig('key', 'secret', 'http://api.example.com/', 'API')`
+- Expected: `config._endpoint === 'http://api.example.com'`
+
+### Scenario U2: Multiple trailing slashes are stripped
+- Input: endpoint = `'http://api.example.com///'`
+- Expected: `config._endpoint === 'http://api.example.com'`
+
+### Scenario U3: Endpoint without trailing slash is unchanged
+- Input: endpoint = `'http://api.example.com'`
+- Expected: `config._endpoint === 'http://api.example.com'`
+
+### Scenario U4: Endpoint with path component — only trailing slash stripped
+- Input: endpoint = `'http://api.example.com/v2/'`
+- Expected: `config._endpoint === 'http://api.example.com/v2'`
+
+### Scenario U5: Default endpoint is used when none provided
+- Input: `new ClientConfig('key', 'secret', undefined, 'API')`
+- Expected: `config._endpoint === 'https://api.backend.ai'`
+
+### Scenario U6: `_endpointHost` is derived from the normalized endpoint
+- Input: endpoint = `'https://api.example.com/'`
+- Expected: `config._endpointHost === 'api.example.com'`
+
+---
+
+## Out of Scope
+
+- API mode login with trailing slash (same normalization path; covered transitively)
+- Electron app login (separate build path; not covered by Playwright E2E)
+- Test that Backend.AI server rejects double-slash requests (server behavior, not WebUI)

--- a/e2e/auth/login.spec.ts
+++ b/e2e/auth/login.spec.ts
@@ -55,6 +55,70 @@ test.describe('Login', { tag: ['@smoke', '@auth', '@functional'] }, () => {
   });
 });
 
+/**
+ * Regression tests for FR-2199: endpoint URL normalization.
+ *
+ * Trailing slashes on the endpoint must be stripped before API calls are made
+ * to prevent double-slash in request URLs (e.g. `http://host//func/...`).
+ */
+test.describe(
+  'Endpoint URL normalization (FR-2199)',
+  { tag: ['@regression', '@auth', '@functional'] },
+  () => {
+    test('user can login with endpoint that has a single trailing slash', async ({
+      page,
+    }) => {
+      await page.getByLabel('Email or Username').fill(userInfo.admin.email);
+      await page.getByLabel('Password').fill(userInfo.admin.password);
+      await fillEndpoint(page, webServerEndpoint + '/');
+      await page.getByLabel('Login', { exact: true }).click();
+
+      await expect(page).toHaveURL(/\/start/, { timeout: 15_000 });
+      await expect(
+        page.getByTestId('webui-breadcrumb').getByText('Start'),
+      ).toBeVisible();
+    });
+
+    test('user can login with endpoint that has multiple trailing slashes', async ({
+      page,
+    }) => {
+      await page.getByLabel('Email or Username').fill(userInfo.admin.email);
+      await page.getByLabel('Password').fill(userInfo.admin.password);
+      await fillEndpoint(page, webServerEndpoint + '///');
+      await page.getByLabel('Login', { exact: true }).click();
+
+      await expect(page).toHaveURL(/\/start/, { timeout: 15_000 });
+      await expect(
+        page.getByTestId('webui-breadcrumb').getByText('Start'),
+      ).toBeVisible();
+    });
+
+    test('API requests do not contain double-slash after endpoint normalization', async ({
+      page,
+    }) => {
+      const doubleSlashUrls: string[] = [];
+
+      // Intercept all requests and check for double-slash in the path
+      page.on('request', (req) => {
+        const url = req.url();
+        // Strip the protocol (https://) before checking for double-slash
+        const pathPart = url.replace(/^[^:]+:\/\//, '');
+        if (pathPart.includes('//')) {
+          doubleSlashUrls.push(url);
+        }
+      });
+
+      await page.getByLabel('Email or Username').fill(userInfo.admin.email);
+      await page.getByLabel('Password').fill(userInfo.admin.password);
+      await fillEndpoint(page, webServerEndpoint + '/');
+      await page.getByLabel('Login', { exact: true }).click();
+
+      await expect(page).toHaveURL(/\/start/, { timeout: 15_000 });
+      expect(doubleSlashUrls).toHaveLength(0);
+    });
+  },
+);
+
 test.describe(
   'Login failure cases',
   { tag: ['@critical', '@auth', '@functional'] },

--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -576,7 +576,7 @@ const LoginView: React.FC = () => {
         setIsLoading(false);
         return;
       }
-      await connectUsingSession(true);
+      await connectUsingSession(true, ep);
     } else {
       const apiKey = form.getFieldValue('api_key') || '';
       const secretKey = form.getFieldValue('secret_key') || '';
@@ -591,7 +591,7 @@ const LoginView: React.FC = () => {
         setIsLoading(false);
         return;
       }
-      await connectUsingAPI(true);
+      await connectUsingAPI(true, ep);
     }
   }, [
     loginConfig,
@@ -614,7 +614,7 @@ const LoginView: React.FC = () => {
         setApiEndpoint(ep);
       }
     }
-    return ep.trim();
+    return ep.trim().replace(/\/+$/, '');
   }, [apiEndpoint]);
 
   // Login method: attempts silent or interactive login depending on mode.

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -92,6 +92,7 @@ class ClientConfig {
     if (endpoint === undefined || endpoint === null) {
       endpoint = 'https://api.backend.ai';
     }
+    endpoint = endpoint.replace(/\/+$/, '');
     this._endpoint = endpoint;
     this._endpointHost = endpoint.replace(/^[^:]+:\/\//, '');
     if (connectionMode === 'API') {


### PR DESCRIPTION
Resolves #5714(FR-2199)

## Summary

- Strip trailing slashes from endpoint in `ClientConfig` constructor to prevent double-slash URLs (e.g. `endpoint//func/`) causing 404 errors
- Fix timing issue in `LoginView` where React async state update caused the original unstripped endpoint value to be passed to login functions
- Add trailing slash normalization in `resolveEndpoint` for consistency
- Add E2E regression tests for endpoint URL normalization

## Changes

### `src/lib/backend.ai-client-esm.ts`
- Normalize endpoint by stripping trailing slashes in `ClientConfig` constructor before storing — this is the primary defensive fix that protects ALL code paths

### `react/src/components/LoginView.tsx`
- Pass cleaned `ep` directly to `connectUsingSession(true, ep)` and `connectUsingAPI(true, ep)` to avoid React async state timing issue
- Add trailing slash removal in `resolveEndpoint()` for consistency

### `e2e/auth/login.spec.ts`
- Add 3 regression tests for endpoint URL normalization (FR-2199):
  1. Login with single trailing slash endpoint
  2. Login with multiple trailing slashes endpoint
  3. Verify no API requests contain double-slash after normalization

## Verification

```
=== Relay ===    --- Relay: PASS ---
=== Lint ===     --- Lint: PASS ---
=== Format ===   --- Format: PASS ---
=== TypeScript ===  --- TypeScript: PASS ---
=== ALL PASS ===
```

## Test Plan

- [x] E2E: `user can login with endpoint that has a single trailing slash`
- [x] E2E: `user can login with endpoint that has multiple trailing slashes`
- [x] E2E: `API requests do not contain double-slash after endpoint normalization`
- [ ] Enter endpoint with trailing slash (e.g. `https://example.com/`) on login page
- [ ] Verify login succeeds without 404 errors
- [ ] Verify API requests use single slash (e.g. `https://example.com/func/...`)
- [ ] Enter endpoint without trailing slash — verify no regression

## E2E Test Recordings

| Test | Recording |
|------|-----------|
| Login with single trailing slash | ![](https://github.com/user-attachments/assets/0bce5b81-5833-4e90-a1c7-9bf7b4015c90) |
| Login with multiple trailing slashes | ![](https://github.com/user-attachments/assets/eb3e4fb0-2a8c-4437-bda5-a3b316f2352a) |
| No double-slash in API requests | ![](https://github.com/user-attachments/assets/ae1089ac-35d7-463a-a20f-f83a382cea6b) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)