### PR TITLE
fix(FR-2195): add theme.json to dev server file watcher for hot-reload

### DIFF
--- a/react/craco.config.cjs
+++ b/react/craco.config.cjs
@@ -88,6 +88,9 @@ module.exports = {
         // at runtime (they are not bundled by webpack), so a page reload is
         // needed to re-fetch the updated translations.
         path.resolve(__dirname, '../resources/i18n'),
+        // Watch theme.json so that theme customization changes during development
+        // trigger a full page reload.
+        path.resolve(__dirname, '../resources/theme.json'),
       ];
 
       const watchers = filesToWatch


### PR DESCRIPTION
Resolves #5706(FR-2195)

## Summary

- Added `resources/theme.json` to the `filesToWatch` array in `react/craco.config.cjs`
- This ensures that editing `theme.json` during development triggers an automatic full page reload, matching the existing pattern used for `config.toml`, `index.html`, and i18n translations

## What Changed

**`react/craco.config.cjs`** (1 line added):

```javascript
path.resolve(__dirname, '../resources/theme.json'),
```

Added after the `resources/i18n` watch entry. The existing `fs.watch` debounce mechanism (100ms timer sending `'static-changed'` WebSocket message) now covers `theme.json` changes automatically.

## Test Plan

- [ ] Start dev server with `pnpm run build:d`
- [ ] Edit `resources/theme.json` (e.g., change a color value)
- [ ] Verify the browser automatically reloads after the change
- [ ] Confirm the updated theme is applied without manual refresh