### PR TITLE
chore(FR-2203): serve Storybook fonts via staticDirs from WebUI resources

### DIFF
--- a/packages/backend.ai-ui/.storybook/main.ts
+++ b/packages/backend.ai-ui/.storybook/main.ts
@@ -24,6 +24,9 @@ const config: StorybookConfig = {
   typescript: {
     reactDocgen: false,
   },
-  staticDirs: ['./public'],
+  staticDirs: [
+    './public',
+    { from: '../../../resources/fonts', to: '/fonts' },
+  ],
 };
 export default config;

--- a/packages/backend.ai-ui/.storybook/preview-head.html
+++ b/packages/backend.ai-ui/.storybook/preview-head.html
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="fonts/roboto/roboto.css">
+<link rel="stylesheet" href="fonts/ubuntu/ubuntu.css">

--- a/packages/backend.ai-ui/.storybook/preview.tsx
+++ b/packages/backend.ai-ui/.storybook/preview.tsx
@@ -1,8 +1,7 @@
-import { withGlobalProvider } from './decorators';
-import { DocsContainer } from './DocsContainer';
-import { localeItems } from './localeConfig';
 import { storybookDarkTheme, storybookLightTheme } from './BackendAITheme';
-import '../../../resources/fonts/fonts.css';
+import { DocsContainer } from './DocsContainer';
+import { withGlobalProvider } from './decorators';
+import { localeItems } from './localeConfig';
 import type { Preview } from '@storybook/react-vite';
 
 const preview: Preview = {
@@ -30,7 +29,6 @@ const preview: Preview = {
       toolbar: {
         icon: 'globe',
         items: localeItems,
-        showName: true,
         dynamicTitle: true,
       },
     },
@@ -43,7 +41,6 @@ const preview: Preview = {
           { value: 'default', title: 'Default (Ant Design)' },
           { value: 'webui', title: 'WebUI (Backend.AI)' },
         ],
-        showName: true,
         dynamicTitle: true,
       },
     },


### PR DESCRIPTION
Resolves #5726 ([FR-2203](https://lablup.atlassian.net/browse/FR-2203))

## Summary

- Serve Storybook fonts via `staticDirs` from WebUI `resources/fonts/` instead of importing the deleted `fonts.css`
- Add `preview-head.html` with `<link>` tags to load font CSS from the static `/fonts/` URL
- Remove deprecated `showName` toolbar option (removed in Storybook 10)
- Use `stories` array ordering with `titlePrefix: 'Docs Overview'` to prioritize the Introduction page as the initial entry

## Test plan

- [ ] Run `cd packages/backend.ai-ui && pnpm storybook` and verify fonts load correctly
- [ ] Run `pnpm build-storybook && npx serve storybook-static` and verify fonts load correctly
- [ ] Check Network tab for `fonts/roboto/roboto.css` and `fonts/ubuntu/ubuntu.css` returning 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-2203]: https://lablup.atlassian.net/browse/FR-2203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ