### PR TITLE
fix(FR-2206): Update device metadata for Tenstorrent Wormhole™ n300

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIResourceNumberWithIcon.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIResourceNumberWithIcon.stories.tsx
@@ -126,12 +126,12 @@ const mockDeviceMetaData: DeviceMetaData = {
     number_format: { binary: false, round_length: 0 },
     display_icon: 'hyperaccel',
   },
-  // TT-N300
+  // Tenstorrent Wormhole™ n300
   'tt-n300.device': {
     slot_name: 'tt-n300.device',
-    description: 'Tenstorrent TT-N300',
-    human_readable_name: 'TT-N300',
-    display_unit: 'TT-N300',
+    description: 'Tenstorrent Wormhole™ n300',
+    human_readable_name: 'Tenstorrent Wormhole™ n300 Device',
+    display_unit: 'n300',
     number_format: { binary: false, round_length: 0 },
     display_icon: 'tenstorrent',
   },
@@ -328,7 +328,7 @@ export const ResourceTypes: Story = {
       </BAIFlex>
       {/* Tenstorrent */}
       <BAIFlex gap="sm" align="center">
-        <span style={{ width: 160 }}>Tenstorrent TT-N300:</span>
+        <span style={{ width: 160 }}>Tenstorrent Wormhole™ n300:</span>
         <BAIResourceNumberWithIcon type="tt-n300.device" value="2" />
       </BAIFlex>
     </BAIFlex>

--- a/resources/device_metadata.json
+++ b/resources/device_metadata.json
@@ -157,9 +157,9 @@
     },
     "tt-n300.device": {
       "slot_name": "tt-n300.device",
-      "description": "Tenstorrent N300",
-      "human_readable_name": "Tenstorrent N300 Device",
-      "display_unit": "N300",
+      "description": "Tenstorrent Wormhole™ n300",
+      "human_readable_name": "Tenstorrent Wormhole™ n300 Device",
+      "display_unit": "n300",
       "number_format": {
         "binary": false,
         "round_length": 0


### PR DESCRIPTION
Follow-up of #5105 and resolves #5730 (FR-2206)

This pull request updates the naming and metadata for the Tenstorrent N300 device to use its full product name, "Tenstorrent Wormhole™ n300", across the UI and metadata files. The changes ensure consistency in display and description for this device.

**Device Metadata Updates:**

* Updated the `description`, `human_readable_name`, and `display_unit` fields for `tt-n300.device` in `resources/device_metadata.json` to "Tenstorrent Wormhole™ n300" and "n300" respectively.
* Modified the mock device metadata in `BAIResourceNumberWithIcon.stories.tsx` to use the new naming and display unit for `tt-n300.device`.

**UI Display Updates:**

* Changed the label for Tenstorrent N300 in the resource type story example to "Tenstorrent Wormhole™ n300" for consistency with the updated metadata.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

Ref
- https://tenstorrent.com/ko/hardware/wormhole
