### PR TITLE
refactor(FR-1533): Refactor ActiveAgents to use Relay refetchable fragment

### DIFF
--- a/react/src/components/ActiveAgents.tsx
+++ b/react/src/components/ActiveAgents.tsx
@@ -2,84 +2,134 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import AgentList from './AgentList';
+import { ActiveAgentsFragment$key } from '../__generated__/ActiveAgentsFragment.graphql';
+import AgentDetailDrawer from './AgentDetailDrawer';
 import { theme } from 'antd';
-import { BAIBoardItemTitle, BAIFetchKeyButton, BAIFlex } from 'backend.ai-ui';
-import { useTransition } from 'react';
+import {
+  filterOutEmpty,
+  filterOutNullAndUndefined,
+  BAIAgentTable,
+  BAIBoardItemTitle,
+  BAIFetchKeyButton,
+  BAIFlex,
+  BAIUnmountAfterClose,
+} from 'backend.ai-ui';
+import { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
+import { graphql, useRefetchableFragment } from 'react-relay';
 
 interface ActiveAgentsProps {
-  fetchKey?: string;
-  onChangeFetchKey?: (key: string) => void;
+  queryRef: ActiveAgentsFragment$key;
+  isRefetching?: boolean;
 }
 
-// TODO: Refactor this component with agent_nodes.
-// ref: https://lablup.atlassian.net/browse/FR-1533
 const ActiveAgents: React.FC<ActiveAgentsProps> = ({
-  fetchKey,
-  onChangeFetchKey,
+  queryRef,
+  isRefetching,
 }) => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+
+  const [data, refetch] = useRefetchableFragment(
+    graphql`
+      fragment ActiveAgentsFragment on Query
+      @refetchable(queryName: "ActiveAgentsRefetchQuery") {
+        active_agent_nodes: agent_nodes(
+          first: 5
+          filter: "status == \"ALIVE\""
+          order: "-first_contact"
+        ) {
+          edges {
+            node {
+              id
+              ...BAIAgentTableFragment
+              ...AgentDetailDrawerFragment
+            }
+          }
+        }
+      }
+    `,
+    queryRef,
+  );
+
+  const agentNodes = filterOutNullAndUndefined(
+    data.active_agent_nodes?.edges.map((e) => e?.node),
+  );
+
+  const selectedAgent = agentNodes.find((a) => a.id === selectedAgentId);
 
   return (
-    <BAIFlex
-      direction="column"
-      align="stretch"
-      style={{
-        paddingInline: token.paddingXL,
-        height: '100%',
-      }}
-    >
-      <BAIBoardItemTitle
-        title={t('activeAgent.ActiveAgents')}
-        tooltip={t('activeAgent.ActiveAgentsTooltip', {
-          count: 5,
-        })}
-        extra={
-          <BAIFetchKeyButton
-            size="small"
-            loading={isPendingRefetch}
-            value=""
-            onChange={(newFetchKey) => {
-              startRefetchTransition(() => {
-                onChangeFetchKey?.(newFetchKey);
-              });
-            }}
-            type="text"
-            style={{
-              backgroundColor: 'transparent',
-            }}
-          />
-        }
-      />
-
-      {/* Scrollable Content Section */}
+    <>
       <BAIFlex
         direction="column"
         align="stretch"
         style={{
-          flex: 1,
-          overflowY: 'auto',
-          overflowX: 'hidden',
+          paddingInline: token.paddingXL,
+          height: '100%',
         }}
       >
-        <AgentList
-          fetchKey={fetchKey}
-          onChangeFetchKey={onChangeFetchKey}
-          headerProps={{
-            style: { display: 'none' },
+        <BAIBoardItemTitle
+          title={t('activeAgent.ActiveAgents')}
+          tooltip={t('activeAgent.ActiveAgentsTooltip', {
+            count: 5,
+          })}
+          extra={
+            <BAIFetchKeyButton
+              size="small"
+              loading={isPendingRefetch || isRefetching}
+              value=""
+              onChange={() => {
+                startRefetchTransition(() => {
+                  refetch(
+                    {},
+                    {
+                      fetchPolicy: 'network-only',
+                    },
+                  );
+                });
+              }}
+              type="text"
+              style={{
+                backgroundColor: 'transparent',
+              }}
+            />
+          }
+        />
+
+        {/* Scrollable Content Section */}
+        <BAIFlex
+          direction="column"
+          align="stretch"
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            overflowX: 'hidden',
           }}
-          tableProps={{
-            pagination: {
+        >
+          <BAIAgentTable
+            agentsFragment={filterOutEmpty(agentNodes)}
+            onClickAgentName={(agent) => {
+              setSelectedAgentId(agent.id);
+            }}
+            pagination={{
               pageSize: 3,
               showSizeChanger: false,
-            },
+            }}
+          />
+        </BAIFlex>
+      </BAIFlex>
+      <BAIUnmountAfterClose>
+        <AgentDetailDrawer
+          agentNodeFrgmt={selectedAgent}
+          open={!!selectedAgentId}
+          onRequestClose={() => {
+            setSelectedAgentId(null);
           }}
         />
-      </BAIFlex>
-    </BAIFlex>
+      </BAIUnmountAfterClose>
+    </>
   );
 };
 

--- a/react/src/pages/AdminDashboardPage.tsx
+++ b/react/src/pages/AdminDashboardPage.tsx
@@ -61,6 +61,7 @@ const AdminDashboardPage: React.FC = () => {
         $isSuperAdmin: Boolean!
         $agentNodeFilter: String!
       ) {
+        ...ActiveAgentsFragment
         ...SessionCountDashboardItemFragment @arguments(scopeId: $scopeId)
         ...RecentlyCreatedSessionFragment @arguments(scopeId: $scopeId)
         ...TotalResourceWithinResourceGroupFragment
@@ -180,8 +181,8 @@ const AdminDashboardPage: React.FC = () => {
             }
           >
             <ActiveAgents
-              fetchKey={fetchKey}
-              onChangeFetchKey={() => updateFetchKey()}
+              queryRef={queryRef}
+              isRefetching={isPendingIntervalRefetch}
             />
           </Suspense>
         ),

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -62,6 +62,7 @@ const DashboardPage: React.FC = () => {
         $isSuperAdmin: Boolean!
         $agentNodeFilter: String!
       ) {
+        ...ActiveAgentsFragment @include(if: $isSuperAdmin) @alias
         ...SessionCountDashboardItemFragment @arguments(scopeId: $scopeId)
         ...RecentlyCreatedSessionFragment @arguments(scopeId: $scopeId)
         ...TotalResourceWithinResourceGroupFragment
@@ -218,10 +219,12 @@ const DashboardPage: React.FC = () => {
               <Skeleton active style={{ padding: `0px ${token.marginMD}px` }} />
             }
           >
-            <ActiveAgents
-              fetchKey={fetchKey}
-              onChangeFetchKey={() => updateFetchKey()}
-            />
+            {queryRef.ActiveAgentsFragment && (
+              <ActiveAgents
+                queryRef={queryRef.ActiveAgentsFragment}
+                isRefetching={isPendingIntervalRefetch}
+              />
+            )}
           </Suspense>
         ),
       },


### PR DESCRIPTION
Resolves #4364(FR-1533)

## Summary

- Refactored `ActiveAgents` component to use `useRefetchableFragment` instead of `fetchKey`/`onChangeFetchKey` callback-based pattern
- Added `ActiveAgentsFragment` on `Query` type with `@refetchable` directive, using a field alias (`active_agent_nodes`) to avoid Relay argument conflicts with `TotalResourceWithinResourceGroup`
- Updated `DashboardPage` and `AdminDashboardPage` to spread `...ActiveAgentsFragment` in their queries and pass `queryRef`/`isRefetching` props
- Added `BAIAgentTable` from `backend.ai-ui` for rendering agents in the dashboard widget (replacing the full `AgentList` dependency)
- Added `AgentDetailDrawer` integration for clicking on agent names in the dashboard widget
- Removed the TODO comment referencing FR-1533

## Changes

### `react/src/components/ActiveAgents.tsx`
- Interface changed from `{ fetchKey, onChangeFetchKey }` to `{ queryRef, isRefetching }` matching `RecentlyCreatedSession` pattern
- Uses `useRefetchableFragment` with `ActiveAgentsFragment` on `Query` type
- Refetch button calls `refetch({}, { fetchPolicy: 'network-only' })` inside `startRefetchTransition`
- Renders agents via `BAIAgentTable` with `AgentDetailDrawer` support

### `react/src/pages/DashboardPage.tsx`
- Added `...ActiveAgentsFragment @include(if: $isSuperAdmin) @alias` to `DashboardPageQuery`
- Changed `<ActiveAgents>` to receive `queryRef` and `isRefetching` instead of `fetchKey`

### `react/src/pages/AdminDashboardPage.tsx`
- Added `...ActiveAgentsFragment` to `AdminDashboardPageQuery`
- Changed `<ActiveAgents>` to receive `queryRef` and `isRefetching` instead of `fetchKey`

## Verification

```
=== Relay ===
--- Relay: PASS ---
=== Lint ===
--- Lint: PASS ---
=== Format ===
--- Format: PASS ---
=== TypeScript ===
--- TypeScript: PASS ---
=== ALL PASS ===
```