### PR TITLE
refactor(FR-2211): Refactor AgentList to use Relay refetchable fragment

### DIFF
--- a/react/src/components/ActiveAgents.tsx
+++ b/react/src/components/ActiveAgents.tsx
@@ -2,134 +2,68 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { ActiveAgentsFragment$key } from '../__generated__/ActiveAgentsFragment.graphql';
-import AgentDetailDrawer from './AgentDetailDrawer';
+import { ActiveAgentsQuery } from '../__generated__/ActiveAgentsQuery.graphql';
+import AgentList from './AgentList';
 import { theme } from 'antd';
-import {
-  filterOutEmpty,
-  filterOutNullAndUndefined,
-  BAIAgentTable,
-  BAIBoardItemTitle,
-  BAIFetchKeyButton,
-  BAIFlex,
-  BAIUnmountAfterClose,
-} from 'backend.ai-ui';
-import { useState, useTransition } from 'react';
+import { BAIBoardItemTitle, BAIFlex } from 'backend.ai-ui';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useRefetchableFragment } from 'react-relay';
+import { graphql, useLazyLoadQuery } from 'react-relay';
 
-interface ActiveAgentsProps {
-  queryRef: ActiveAgentsFragment$key;
-  isRefetching?: boolean;
-}
-
-const ActiveAgents: React.FC<ActiveAgentsProps> = ({
-  queryRef,
-  isRefetching,
-}) => {
+const ActiveAgents: React.FC = () => {
+  'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const [isPendingRefetch, startRefetchTransition] = useTransition();
-  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
 
-  const [data, refetch] = useRefetchableFragment(
+  const queryRef = useLazyLoadQuery<ActiveAgentsQuery>(
     graphql`
-      fragment ActiveAgentsFragment on Query
-      @refetchable(queryName: "ActiveAgentsRefetchQuery") {
-        active_agent_nodes: agent_nodes(
-          first: 5
-          filter: "status == \"ALIVE\""
-          order: "-first_contact"
-        ) {
-          edges {
-            node {
-              id
-              ...BAIAgentTableFragment
-              ...AgentDetailDrawerFragment
-            }
-          }
-        }
+      query ActiveAgentsQuery {
+        ...AgentListFragment
       }
     `,
-    queryRef,
+    {},
   );
-
-  const agentNodes = filterOutNullAndUndefined(
-    data.active_agent_nodes?.edges.map((e) => e?.node),
-  );
-
-  const selectedAgent = agentNodes.find((a) => a.id === selectedAgentId);
 
   return (
-    <>
+    <BAIFlex
+      direction="column"
+      align="stretch"
+      style={{
+        paddingInline: token.paddingXL,
+        height: '100%',
+      }}
+    >
+      <BAIBoardItemTitle
+        title={t('activeAgent.ActiveAgents')}
+        tooltip={t('activeAgent.ActiveAgentsTooltip', {
+          count: 5,
+        })}
+      />
+
+      {/* Scrollable Content Section */}
       <BAIFlex
         direction="column"
         align="stretch"
         style={{
-          paddingInline: token.paddingXL,
-          height: '100%',
+          flex: 1,
+          overflowY: 'auto',
+          overflowX: 'hidden',
         }}
       >
-        <BAIBoardItemTitle
-          title={t('activeAgent.ActiveAgents')}
-          tooltip={t('activeAgent.ActiveAgentsTooltip', {
-            count: 5,
-          })}
-          extra={
-            <BAIFetchKeyButton
-              size="small"
-              loading={isPendingRefetch || isRefetching}
-              value=""
-              onChange={() => {
-                startRefetchTransition(() => {
-                  refetch(
-                    {},
-                    {
-                      fetchPolicy: 'network-only',
-                    },
-                  );
-                });
-              }}
-              type="text"
-              style={{
-                backgroundColor: 'transparent',
-              }}
-            />
-          }
-        />
-
-        {/* Scrollable Content Section */}
-        <BAIFlex
-          direction="column"
-          align="stretch"
-          style={{
-            flex: 1,
-            overflowY: 'auto',
-            overflowX: 'hidden',
+        <AgentList
+          queryRef={queryRef}
+          headerProps={{
+            style: { display: 'none' },
           }}
-        >
-          <BAIAgentTable
-            agentsFragment={filterOutEmpty(agentNodes)}
-            onClickAgentName={(agent) => {
-              setSelectedAgentId(agent.id);
-            }}
-            pagination={{
+          tableProps={{
+            pagination: {
               pageSize: 3,
               showSizeChanger: false,
-            }}
-          />
-        </BAIFlex>
-      </BAIFlex>
-      <BAIUnmountAfterClose>
-        <AgentDetailDrawer
-          agentNodeFrgmt={selectedAgent}
-          open={!!selectedAgentId}
-          onRequestClose={() => {
-            setSelectedAgentId(null);
+            },
           }}
         />
-      </BAIUnmountAfterClose>
-    </>
+      </BAIFlex>
+    </BAIFlex>
   );
 };
 

--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -3,22 +3,19 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import {
-  AgentListQuery,
-  AgentListQuery$data,
-  AgentListQuery$variables,
-} from '../__generated__/AgentListQuery.graphql';
+  AgentListFragment$key,
+  AgentListFragment$data,
+} from '../__generated__/AgentListFragment.graphql';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
 import { useThemeMode } from '../hooks/useThemeMode';
 import AgentDetailDrawer from './AgentDetailDrawer';
 import BAIRadioGroup from './BAIRadioGroup';
 import { ReloadOutlined } from '@ant-design/icons';
-import { useControllableValue } from 'ahooks';
 import { Button, type TableProps, Tag, theme, Tooltip } from 'antd';
 import {
   BAIFlex,
   BAIPropertyFilter,
   BAIFlexProps,
-  INITIAL_FETCH_KEY,
   mergeFilterValues,
   BAIColumnType,
   BAIDoubleTag,
@@ -29,32 +26,32 @@ import {
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { parseAsString, useQueryStates } from 'nuqs';
-import React, { useState, useDeferredValue } from 'react';
+import React, { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery } from 'react-relay';
+import { graphql, useRefetchableFragment } from 'react-relay';
 import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 
 type Agent = NonNullable<
-  NonNullable<AgentListQuery$data['agent_nodes']>['edges'][number]
+  NonNullable<AgentListFragment$data['agent_nodes']>['edges'][number]
 >['node'];
 
 interface AgentListProps {
+  queryRef: AgentListFragment$key;
   tableProps?: Omit<TableProps, 'dataSource'>;
   headerProps?: BAIFlexProps;
-  fetchKey?: string;
-  onChangeFetchKey?: (key: string) => void;
 }
 
 const AgentList: React.FC<AgentListProps> = ({
+  queryRef,
   tableProps,
   headerProps,
-  ...otherProps
 }) => {
   'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { isDarkMode } = useThemeMode();
   const [currentAgentInfo, setCurrentAgentInfo] = useState<Agent | null>();
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
   const [queryParams, setQueryParams] = useQueryStates({
     status: parseAsString.withDefault('ALIVE'),
     filter: parseAsString,
@@ -70,50 +67,33 @@ const AgentList: React.FC<AgentListProps> = ({
     pageSize: 10,
   });
 
-  const [fetchKey, setFetchKey] = useControllableValue(otherProps, {
-    valuePropName: 'fetchKey',
-    trigger: 'onChangeFetchKey',
-    defaultValue: INITIAL_FETCH_KEY,
-  });
-
   const statusFilter =
     queryParams.status === 'ALIVE'
       ? 'status == "ALIVE"'
       : 'status == "TERMINATED"';
 
-  const queryVariables: AgentListQuery$variables = {
+  const currentVariables = {
     offset: baiPaginationOption.offset,
     first: baiPaginationOption.limit,
     order: queryParams.order || '-first_contact',
     filter: mergeFilterValues([queryParams.filter, statusFilter]),
   };
 
-  const deferredQueryVariables = useDeferredValue(queryVariables);
-  const deferredFetchKey = useDeferredValue(fetchKey);
-
-  const updateFetchKey = () => {
-    setFetchKey(() => new Date().toISOString());
-  };
-
-  const { agent_nodes } = useLazyLoadQuery<AgentListQuery>(
+  const [data, refetch] = useRefetchableFragment(
     graphql`
-      query AgentListQuery(
-        $filter: String
-        $order: String
-        $offset: Int
-        $first: Int
-        $before: String
-        $after: String
-        $last: Int
-      ) {
+      fragment AgentListFragment on Query
+      @argumentDefinitions(
+        filter: { type: "String" }
+        order: { type: "String", defaultValue: "-first_contact" }
+        offset: { type: "Int" }
+        first: { type: "Int", defaultValue: 10 }
+      )
+      @refetchable(queryName: "AgentListRefetchQuery") {
         agent_nodes(
           filter: $filter
           order: $order
           offset: $offset
           first: $first
-          after: $after
-          before: $before
-          last: $last
         ) {
           edges {
             node {
@@ -127,15 +107,16 @@ const AgentList: React.FC<AgentListProps> = ({
         }
       }
     `,
-    deferredQueryVariables,
-    {
-      fetchKey: deferredFetchKey,
-      fetchPolicy:
-        deferredFetchKey === INITIAL_FETCH_KEY
-          ? 'store-and-network'
-          : 'network-only',
-    },
+    queryRef,
   );
+
+  const { agent_nodes } = data;
+
+  const doRefetch = (variables: typeof currentVariables = currentVariables) => {
+    startRefetchTransition(() => {
+      refetch(variables, { fetchPolicy: 'network-only' });
+    });
+  };
 
   const regionColumn: BAIColumnType<AgentNodeInList> = {
     title: t('agent.Region'),
@@ -223,6 +204,18 @@ const AgentList: React.FC<AgentListProps> = ({
             onChange={(e) => {
               setQueryParams({ status: e.target.value });
               setTablePaginationOption({ current: 1 });
+              const newStatusFilter =
+                e.target.value === 'ALIVE'
+                  ? 'status == "ALIVE"'
+                  : 'status == "TERMINATED"';
+              doRefetch({
+                ...currentVariables,
+                offset: 0,
+                filter: mergeFilterValues([
+                  queryParams.filter,
+                  newStatusFilter,
+                ]),
+              });
             }}
           />
 
@@ -258,14 +251,19 @@ const AgentList: React.FC<AgentListProps> = ({
             onChange={(value) => {
               setQueryParams({ filter: value || null });
               setTablePaginationOption({ current: 1 });
+              doRefetch({
+                ...currentVariables,
+                offset: 0,
+                filter: mergeFilterValues([value, statusFilter]),
+              });
             }}
           />
         </BAIFlex>
         <BAIFlex gap="xs">
           <Tooltip title={t('button.Refresh')}>
             <Button
-              loading={deferredFetchKey !== fetchKey}
-              onClick={() => updateFetchKey()}
+              loading={isPendingRefetch}
+              onClick={() => doRefetch()}
               icon={<ReloadOutlined />}
             ></Button>
           </Tooltip>
@@ -287,6 +285,7 @@ const AgentList: React.FC<AgentListProps> = ({
           regionColumn,
           ...baseColumns.slice(3),
         ]}
+        {...tableProps}
         pagination={{
           pageSize: tablePaginationOption.pageSize,
           total: agent_nodes?.count || 0,
@@ -300,22 +299,28 @@ const AgentList: React.FC<AgentListProps> = ({
                 current,
                 pageSize,
               });
+              doRefetch({
+                ...currentVariables,
+                offset: (current - 1) * pageSize,
+                first: pageSize,
+              });
             }
           },
+          ...tableProps?.pagination,
         }}
         order={queryParams.order}
         onChangeOrder={(order) => {
           setQueryParams({ order });
+          doRefetch({
+            ...currentVariables,
+            order: order || '-first_contact',
+          });
         }}
-        loading={
-          deferredQueryVariables !== queryVariables ||
-          deferredFetchKey !== fetchKey
-        }
+        loading={isPendingRefetch}
         tableSettings={{
           columnOverrides: columnOverrides,
           onColumnOverridesChange: setColumnOverrides,
         }}
-        {...tableProps}
       />
       <BAIUnmountAfterClose>
         <AgentDetailDrawer

--- a/react/src/pages/AdminDashboardPage.tsx
+++ b/react/src/pages/AdminDashboardPage.tsx
@@ -61,7 +61,6 @@ const AdminDashboardPage: React.FC = () => {
         $isSuperAdmin: Boolean!
         $agentNodeFilter: String!
       ) {
-        ...ActiveAgentsFragment
         ...SessionCountDashboardItemFragment @arguments(scopeId: $scopeId)
         ...RecentlyCreatedSessionFragment @arguments(scopeId: $scopeId)
         ...TotalResourceWithinResourceGroupFragment
@@ -180,10 +179,7 @@ const AdminDashboardPage: React.FC = () => {
               <Skeleton active style={{ padding: `0px ${token.marginMD}px` }} />
             }
           >
-            <ActiveAgents
-              queryRef={queryRef}
-              isRefetching={isPendingIntervalRefetch}
-            />
+            <ActiveAgents />
           </Suspense>
         ),
       },

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -62,7 +62,6 @@ const DashboardPage: React.FC = () => {
         $isSuperAdmin: Boolean!
         $agentNodeFilter: String!
       ) {
-        ...ActiveAgentsFragment @include(if: $isSuperAdmin) @alias
         ...SessionCountDashboardItemFragment @arguments(scopeId: $scopeId)
         ...RecentlyCreatedSessionFragment @arguments(scopeId: $scopeId)
         ...TotalResourceWithinResourceGroupFragment
@@ -219,12 +218,7 @@ const DashboardPage: React.FC = () => {
               <Skeleton active style={{ padding: `0px ${token.marginMD}px` }} />
             }
           >
-            {queryRef.ActiveAgentsFragment && (
-              <ActiveAgents
-                queryRef={queryRef.ActiveAgentsFragment}
-                isRefetching={isPendingIntervalRefetch}
-              />
-            )}
+            <ActiveAgents />
           </Suspense>
         ),
       },

--- a/react/src/pages/ResourcesPage.tsx
+++ b/react/src/pages/ResourcesPage.tsx
@@ -2,6 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { ResourcesPageAgentListQuery } from '../__generated__/ResourcesPageAgentListQuery.graphql';
 import AgentList from '../components/AgentList';
 import ResourceGroupList from '../components/ResourceGroupList';
 import StorageProxyList from '../components/StorageProxyList';
@@ -9,6 +10,7 @@ import { Skeleton } from 'antd';
 import { BAICard } from 'backend.ai-ui';
 import React, { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
 import BAIErrorBoundary from 'src/components/BAIErrorBoundary';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
@@ -17,6 +19,19 @@ type TabKey = 'agents' | 'storages' | 'resourceGroup';
 interface ResourcesPageProps {}
 
 const tabParam = withDefault(StringParam, 'agents');
+
+const ResourcesPageAgentListContent: React.FC = () => {
+  const queryRef = useLazyLoadQuery<ResourcesPageAgentListQuery>(
+    graphql`
+      query ResourcesPageAgentListQuery {
+        ...AgentListFragment
+      }
+    `,
+    {},
+  );
+
+  return <AgentList queryRef={queryRef} />;
+};
 
 const ResourcesPage: React.FC<ResourcesPageProps> = () => {
   const { t } = useTranslation();
@@ -46,7 +61,7 @@ const ResourcesPage: React.FC<ResourcesPageProps> = () => {
       <Suspense fallback={<Skeleton active />}>
         {curTabKey === 'agents' && (
           <BAIErrorBoundary>
-            <AgentList />
+            <ResourcesPageAgentListContent />
           </BAIErrorBoundary>
         )}
         {curTabKey === 'storages' && (


### PR DESCRIPTION
Resolves #5740(FR-2211)

## Summary
- Refactored `AgentList` component to use Relay `useRefetchableFragment` instead of the previous `useLazyLoadQuery` with `fetchKey` pattern
- `AgentList` now accepts a fragment key (`queryRef: AgentListFragment$key`) and manages its own refetching via `useRefetchableFragment`
- Updated `ResourcesPage` to use a query orchestrator component (`ResourcesPageAgentListContent`) that runs `useLazyLoadQuery` and passes the fragment ref to `AgentList`
- `ActiveAgents` is now self-contained with its own `useLazyLoadQuery`, spreading `AgentListFragment`
- Simplified `DashboardPage` and `AdminDashboardPage` by removing `ActiveAgentsFragment` from their queries
- Fixed pagination override bug: `tableProps` spread is applied before the internal `pagination` prop, with `tableProps.pagination` merged into it, ensuring pagination controls work correctly when `AgentList` is embedded with custom pagination (e.g., in the dashboard's ActiveAgents widget)