### PR TITLE
feat(FR-2213): add minimize, maximize, and fullscreen mode to BAIModal

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIModal.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIModal.stories.tsx
@@ -1,11 +1,25 @@
 import BAIButton from './BAIButton';
 import BAIFlex from './BAIFlex';
 import BAIModal from './BAIModal';
+import type { WindowState } from './BAIModal';
 import BAIText from './BAIText';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { App } from 'antd';
 import { useState } from 'react';
 
+/**
+ * BAIModal extends Ant Design's Modal with dragging, confirm-before-close,
+ * sticky headers, type variants, and window management controls.
+ *
+ * Key features:
+ * - Draggable modal header
+ * - Confirm before close with async support
+ * - Sticky title for scrollable content
+ * - Warning/error type variants
+ * - Window controls: minimize, maximize, fullscreen
+ *
+ * @see BAIModal.tsx for implementation details
+ */
 const meta: Meta<typeof BAIModal> = {
   title: 'Modal/BAIModal',
   component: BAIModal,
@@ -25,11 +39,18 @@ const meta: Meta<typeof BAIModal> = {
 | \`onConfirmClose\` | \`() => void \\| Promise<boolean>\` | - | Callback before close; return false/reject to prevent |
 | \`stickyTitle\` | \`boolean\` | \`false\` | Makes the header sticky when body content is scrolled |
 | \`type\` | \`'normal' \\| 'warning' \\| 'error'\` | \`'normal'\` | Visual variant that changes the header title color |
+| \`windowActions\` | \`Array<'minimize' \\| 'maximize' \\| 'fullscreen'>\` | - | Control which window actions are available. When provided (non-empty), window controls are rendered in the header. |
+| \`onWindowStateChange\` | \`(state: WindowState) => void\` | - | Callback when modal window state changes |
+| \`minimizedPlacement\` | \`'bottomRight' \\| 'bottomLeft' \\| 'topRight' \\| 'topLeft'\` | \`'bottomRight'\` | Placement of the minimized modal bar |
 
 ## Additional Features
 - **Fixed z-index**: Uses \`DEFAULT_BAI_MODAL_Z_INDEX = 1001\`
 - **Centered by default**: \`centered\` defaults to \`true\`
 - **Consistent styling**: Standard header, body, footer styles with dividers
+- **Window controls**: Minimize (compact bar), maximize (viewport with margin), fullscreen (full viewport)
+- **Scroll unlock when minimized**: Page scroll lock is overridden when modal is minimized, allowing full page interaction
+- **Minimized hover effect**: The header area of the minimized bar shows a background-color hover transition
+- **Keyboard accessible minimized bar**: Press Enter or Space on the minimized bar to restore the modal
 
 For all other props, refer to [Ant Design Modal](https://ant.design/components/modal).
         `,
@@ -81,6 +102,38 @@ For all other props, refer to [Ant Design Modal](https://ant.design/components/m
       table: {
         type: { summary: "'normal' | 'warning' | 'error'" },
         defaultValue: { summary: 'normal' },
+      },
+    },
+    windowActions: {
+      control: false,
+      description:
+        'Control which window actions are available. When provided (non-empty), window controls are rendered in the header.',
+      table: {
+        type: {
+          summary: "Array<'minimize' | 'maximize' | 'fullscreen'>",
+        },
+      },
+    },
+    onWindowStateChange: {
+      action: 'windowStateChanged',
+      description: 'Callback when modal window state changes.',
+      table: {
+        type: {
+          summary:
+            "(state: 'default' | 'minimized' | 'maximized' | 'fullscreen') => void",
+        },
+      },
+    },
+    minimizedPlacement: {
+      control: { type: 'select' },
+      options: ['bottomRight', 'bottomLeft', 'topRight', 'topLeft'],
+      description:
+        'Placement of the minimized modal bar. Similar to Ant Design notification placement.',
+      table: {
+        type: {
+          summary: "'bottomRight' | 'bottomLeft' | 'topRight' | 'topLeft'",
+        },
+        defaultValue: { summary: 'bottomRight' },
       },
     },
   },
@@ -156,7 +209,7 @@ export const DraggableModal: Story = {
     docs: {
       description: {
         story:
-          'Demonstrates the draggable feature. Hover over the drag handle icon (☰) in the modal header to activate dragging. The modal can be moved around the viewport while staying within bounds.',
+          'Demonstrates the draggable feature. Hover over the drag handle icon in the modal header to activate dragging. The modal can be moved around the viewport while staying within bounds.',
       },
     },
   },
@@ -195,8 +248,8 @@ export const DraggableModal: Story = {
         >
           <BAIFlex direction="column" gap="sm">
             <BAIText>
-              Hover over the drag handle icon (☰) to the left of the title,
-              then drag this modal around!
+              Hover over the drag handle icon to the left of the title, then
+              drag this modal around!
             </BAIText>
             <BAIText>
               The modal will stay within the viewport bounds and cannot be
@@ -408,7 +461,7 @@ export const TypeVariants: Story = {
           onOk={() => setOpenNormal(false)}
           onCancel={() => setOpenNormal(false)}
         >
-          <BAIText>Normal type — default title color.</BAIText>
+          <BAIText>Normal type -- default title color.</BAIText>
         </BAIModal>
 
         <BAIModal
@@ -418,7 +471,7 @@ export const TypeVariants: Story = {
           onOk={() => setOpenWarning(false)}
           onCancel={() => setOpenWarning(false)}
         >
-          <BAIText>Warning type — title in amber/orange color.</BAIText>
+          <BAIText>Warning type -- title in amber/orange color.</BAIText>
         </BAIModal>
 
         <BAIModal
@@ -428,7 +481,423 @@ export const TypeVariants: Story = {
           onOk={() => setOpenError(false)}
           onCancel={() => setOpenError(false)}
         >
-          <BAIText>Error type — title in red color.</BAIText>
+          <BAIText>Error type -- title in red color.</BAIText>
+        </BAIModal>
+      </BAIFlex>
+    );
+  },
+};
+
+// Window controls story - all controls enabled
+export const WindowControls: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the `windowActions` feature with all actions enabled. The modal header shows minimize, maximize, and fullscreen buttons. Click each button to toggle the corresponding state; clicking the same button again returns to the default state.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+    const [currentState, setCurrentState] = useState<WindowState>('default');
+
+    return (
+      <BAIFlex direction="column" gap="md" align="start">
+        <BAIButton type="primary" onClick={() => setOpen(true)}>
+          Open Modal with Window Controls
+        </BAIButton>
+        <BAIText>
+          Current state: <strong>{currentState}</strong>
+        </BAIText>
+        <BAIModal
+          title="Window Controls Modal"
+          open={open}
+          windowActions={['minimize', 'maximize', 'fullscreen']}
+          onWindowStateChange={setCurrentState}
+          onOk={() => setOpen(false)}
+          onCancel={() => {
+            setOpen(false);
+            setCurrentState('default');
+          }}
+          footer={
+            <BAIFlex justify="end" gap="sm">
+              <BAIButton
+                onClick={() => {
+                  setOpen(false);
+                  setCurrentState('default');
+                }}
+              >
+                Cancel
+              </BAIButton>
+              <BAIButton
+                type="primary"
+                onClick={() => {
+                  setOpen(false);
+                  setCurrentState('default');
+                }}
+              >
+                OK
+              </BAIButton>
+            </BAIFlex>
+          }
+        >
+          <LongModalContent />
+        </BAIModal>
+      </BAIFlex>
+    );
+  },
+};
+
+// Minimized state story
+export const MinimizedState: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `Demonstrates the minimize/restore flow. Click the minimize button (minus icon) in the header to collapse the modal to a compact bar at the corner of the viewport.
+
+**Behaviors when minimized:**
+- The modal backdrop mask is removed so the page is visible
+- Page scrolling and interactions are unlocked (scroll lock override applied)
+- The minimized bar header shows a **hover effect** (background-color transition on \`.ant-modal-header\`)
+- Click anywhere on the minimized bar to restore the modal
+- Press **Enter** or **Space** while the bar is focused to restore via keyboard`,
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <BAIButton type="primary" onClick={() => setOpen(true)}>
+          Open Minimizable Modal
+        </BAIButton>
+        <BAIModal
+          title="Minimizable Modal"
+          open={open}
+          windowActions={['minimize']}
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        >
+          <BAIFlex direction="column" gap="md">
+            <BAIText>
+              Click the <strong>minus icon</strong> in the modal header to
+              minimize this modal. It will collapse to a compact bar showing
+              only the title at the bottom of the viewport.
+            </BAIText>
+            <BAIText>
+              Click the minus icon again on the minimized bar to restore the
+              modal to its default size.
+            </BAIText>
+          </BAIFlex>
+        </BAIModal>
+      </>
+    );
+  },
+};
+
+// Maximized state story
+export const MaximizedState: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the maximize/restore flow. Click the maximize button (border icon) to expand the modal to fill the viewport with a 24px margin on each side. Click the button again (now showing overlapping squares) to restore.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <BAIButton type="primary" onClick={() => setOpen(true)}>
+          Open Maximizable Modal
+        </BAIButton>
+        <BAIModal
+          title="Maximizable Modal"
+          open={open}
+          windowActions={['maximize']}
+          draggable
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        >
+          <BAIFlex direction="column" gap="md">
+            <BAIText>
+              Click the <strong>border icon</strong> in the modal header to
+              maximize this modal. It will expand to fill the viewport with a
+              24px margin.
+            </BAIText>
+            <BAIText>
+              Note: Dragging is automatically disabled when the modal is
+              maximized and re-enabled when restored.
+            </BAIText>
+          </BAIFlex>
+        </BAIModal>
+      </>
+    );
+  },
+};
+
+// Fullscreen state story
+export const FullscreenState: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the fullscreen/exit flow. Click the fullscreen button to expand the modal to fill the entire viewport with no margin and no border-radius. Click the exit fullscreen button to restore.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <BAIButton type="primary" onClick={() => setOpen(true)}>
+          Open Fullscreen Modal
+        </BAIButton>
+        <BAIModal
+          title="Fullscreen Modal"
+          open={open}
+          windowActions={['fullscreen']}
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        >
+          <BAIFlex direction="column" gap="md">
+            <BAIText>
+              Click the <strong>fullscreen icon</strong> in the modal header to
+              expand this modal to fill the entire viewport (100vw x 100vh) with
+              no margin and no border-radius.
+            </BAIText>
+            <BAIText>
+              Click the exit fullscreen icon to restore the modal to its default
+              size.
+            </BAIText>
+          </BAIFlex>
+        </BAIModal>
+      </>
+    );
+  },
+};
+
+// Minimized placement story
+export const MinimizedPlacement: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the `minimizedPlacement` prop. Each modal minimizes to a different corner of the viewport. Default placement is `bottomRight`.',
+      },
+    },
+  },
+  render: () => {
+    const [openBR, setOpenBR] = useState(false);
+    const [openBL, setOpenBL] = useState(false);
+    const [openTR, setOpenTR] = useState(false);
+    const [openTL, setOpenTL] = useState(false);
+
+    return (
+      <BAIFlex gap="md" wrap="wrap">
+        <BAIButton type="primary" onClick={() => setOpenBR(true)}>
+          Bottom Right (default)
+        </BAIButton>
+        <BAIButton type="primary" onClick={() => setOpenBL(true)}>
+          Bottom Left
+        </BAIButton>
+        <BAIButton type="primary" onClick={() => setOpenTR(true)}>
+          Top Right
+        </BAIButton>
+        <BAIButton type="primary" onClick={() => setOpenTL(true)}>
+          Top Left
+        </BAIButton>
+
+        <BAIModal
+          title="Bottom Right"
+          open={openBR}
+          windowActions={['minimize']}
+          minimizedPlacement="bottomRight"
+          onOk={() => setOpenBR(false)}
+          onCancel={() => setOpenBR(false)}
+        >
+          <BAIText>
+            Minimizes to <strong>bottom-right</strong> corner (default).
+          </BAIText>
+        </BAIModal>
+
+        <BAIModal
+          title="Bottom Left"
+          open={openBL}
+          windowActions={['minimize']}
+          minimizedPlacement="bottomLeft"
+          onOk={() => setOpenBL(false)}
+          onCancel={() => setOpenBL(false)}
+        >
+          <BAIText>
+            Minimizes to <strong>bottom-left</strong> corner.
+          </BAIText>
+        </BAIModal>
+
+        <BAIModal
+          title="Top Right"
+          open={openTR}
+          windowActions={['minimize']}
+          minimizedPlacement="topRight"
+          onOk={() => setOpenTR(false)}
+          onCancel={() => setOpenTR(false)}
+        >
+          <BAIText>
+            Minimizes to <strong>top-right</strong> corner.
+          </BAIText>
+        </BAIModal>
+
+        <BAIModal
+          title="Top Left"
+          open={openTL}
+          windowActions={['minimize']}
+          minimizedPlacement="topLeft"
+          onOk={() => setOpenTL(false)}
+          onCancel={() => setOpenTL(false)}
+        >
+          <BAIText>
+            Minimizes to <strong>top-left</strong> corner.
+          </BAIText>
+        </BAIModal>
+      </BAIFlex>
+    );
+  },
+};
+
+// Scroll behavior when minimized story
+export const ScrollBehaviorWhenMinimized: Story = {
+  name: 'Scroll Unlock When Minimized',
+  parameters: {
+    docs: {
+      description: {
+        story: `Demonstrates that page scroll and interaction are fully unlocked when the modal is minimized.
+
+When a modal is open, Ant Design / rc-component locks page scrolling (injects \`html body { overflow-y: hidden }\`).
+BAIModal overrides this with a higher-specificity rule when minimized, so users can scroll the page content
+behind the minimized bar without closing the modal.
+
+Additionally:
+- The minimized modal wrapper has \`pointer-events: none\`, so all clicks pass through to the page
+- Only the minimized bar itself has \`pointer-events: auto\` so it remains clickable
+- The minimized bar header shows a **hover effect** (background-color transition) when hovered
+- Pressing **Enter** or **Space** on the minimized bar restores the modal (keyboard accessible)`,
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <BAIFlex direction="column" gap="md" style={{ position: 'relative' }}>
+        <BAIButton type="primary" onClick={() => setOpen(true)}>
+          Open Modal Then Minimize
+        </BAIButton>
+        <BAIText type="secondary">
+          After minimizing the modal, you can scroll this content and interact
+          with the buttons below — the page is fully unlocked.
+        </BAIText>
+        {Array.from({ length: 10 }, (_, i) => (
+          <BAIFlex key={i} gap="sm" align="center">
+            <BAIText>
+              Scrollable page content row {i + 1} — interactive while modal is
+              minimized
+            </BAIText>
+            <BAIButton size="small">Click me</BAIButton>
+          </BAIFlex>
+        ))}
+        <BAIModal
+          title="Scroll Unlock Demo"
+          open={open}
+          windowActions={['minimize']}
+          minimizedPlacement="bottomRight"
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        >
+          <BAIFlex direction="column" gap="md">
+            <BAIText>
+              Click the <strong>minus icon</strong> to minimize this modal. The
+              page behind will become scrollable and interactive.
+            </BAIText>
+            <BAIText type="secondary">
+              The minimized bar shows a <strong>hover effect</strong> on the
+              header area. Press <strong>Enter</strong> or{' '}
+              <strong>Space</strong> on the bar to restore via keyboard.
+            </BAIText>
+          </BAIFlex>
+        </BAIModal>
+      </BAIFlex>
+    );
+  },
+};
+
+// Selective window actions story
+export const SelectiveWindowActions: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates the `windowActions` prop for selectively enabling specific window controls. Each modal shows a different combination of window action buttons.',
+      },
+    },
+  },
+  render: () => {
+    const [openMinMax, setOpenMinMax] = useState(false);
+    const [openMaxFull, setOpenMaxFull] = useState(false);
+    const [openMinOnly, setOpenMinOnly] = useState(false);
+
+    return (
+      <BAIFlex gap="md" wrap="wrap">
+        <BAIButton type="primary" onClick={() => setOpenMinMax(true)}>
+          Minimize + Maximize
+        </BAIButton>
+        <BAIButton type="primary" onClick={() => setOpenMaxFull(true)}>
+          Maximize + Fullscreen
+        </BAIButton>
+        <BAIButton type="primary" onClick={() => setOpenMinOnly(true)}>
+          Minimize Only
+        </BAIButton>
+
+        <BAIModal
+          title="Minimize + Maximize"
+          open={openMinMax}
+          windowActions={['minimize', 'maximize']}
+          onOk={() => setOpenMinMax(false)}
+          onCancel={() => setOpenMinMax(false)}
+        >
+          <BAIText>
+            This modal has only <strong>minimize</strong> and{' '}
+            <strong>maximize</strong> buttons. No fullscreen option.
+          </BAIText>
+        </BAIModal>
+
+        <BAIModal
+          title="Maximize + Fullscreen"
+          open={openMaxFull}
+          windowActions={['maximize', 'fullscreen']}
+          onOk={() => setOpenMaxFull(false)}
+          onCancel={() => setOpenMaxFull(false)}
+        >
+          <BAIText>
+            This modal has only <strong>maximize</strong> and{' '}
+            <strong>fullscreen</strong> buttons. No minimize option.
+          </BAIText>
+        </BAIModal>
+
+        <BAIModal
+          title="Minimize Only"
+          open={openMinOnly}
+          windowActions={['minimize']}
+          onOk={() => setOpenMinOnly(false)}
+          onCancel={() => setOpenMinOnly(false)}
+        >
+          <BAIText>
+            This modal has only the <strong>minimize</strong> button.
+          </BAIText>
         </BAIModal>
       </BAIFlex>
     );

--- a/packages/backend.ai-ui/src/components/BAIModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIModal.tsx
@@ -1,17 +1,34 @@
 // @ts-ignore
 import BAIFlex from './BAIFlex';
-import { HolderOutlined } from '@ant-design/icons';
-import { Modal, theme, type ModalProps } from 'antd';
+import {
+  BlockOutlined,
+  BorderOutlined,
+  CloseOutlined,
+  FullscreenExitOutlined,
+  FullscreenOutlined,
+  HolderOutlined,
+  MinusOutlined,
+} from '@ant-design/icons';
+import { Button, Modal, Tooltip, theme, type ModalProps } from 'antd';
 import { createStyles } from 'antd-style';
 import classNames from 'classnames';
 import _ from 'lodash';
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import Draggable, {
   type DraggableData,
   type DraggableEvent,
 } from 'react-draggable';
+import { useTranslation } from 'react-i18next';
 
 export const DEFAULT_BAI_MODAL_Z_INDEX = 1001;
+
+export type WindowState = 'default' | 'minimized' | 'maximized' | 'fullscreen';
+export type WindowAction = 'minimize' | 'maximize' | 'fullscreen';
+export type MinimizedPlacement =
+  | 'bottomRight'
+  | 'bottomLeft'
+  | 'topRight'
+  | 'topLeft';
 
 export interface BAIModalProps extends ModalProps {
   /** Enable dragging modal by header */
@@ -30,6 +47,12 @@ export interface BAIModalProps extends ModalProps {
   stickyTitle?: boolean;
   /** Visual variant that changes the header title color */
   type?: 'normal' | 'warning' | 'error';
+  /** Control which window actions are available. When provided (non-empty), window controls are rendered in the header. */
+  windowActions?: Array<WindowAction>;
+  /** Callback when modal window state changes */
+  onWindowStateChange?: (state: WindowState) => void;
+  /** Placement of the minimized modal bar. Defaults to 'bottomRight'. */
+  minimizedPlacement?: MinimizedPlacement;
 }
 
 const useStyles = createStyles(
@@ -40,11 +63,35 @@ const useStyles = createStyles(
       type,
       colorWarning,
       colorError,
+      windowState,
+      hasWindowControls,
+      minimizedPlacement,
+      marginLG,
+      borderRadiusLG,
+      borderRadiusSM,
+      controlHeightSM,
+      paddingXXS,
+      colorTextSecondary,
+      colorTextBase,
+      colorFillSecondary,
+      colorFillTertiary,
     }: {
       stickyTitle: boolean;
       type: 'normal' | 'warning' | 'error';
       colorWarning: string;
       colorError: string;
+      windowState: WindowState;
+      hasWindowControls: boolean;
+      minimizedPlacement: MinimizedPlacement;
+      marginLG: number;
+      borderRadiusLG: number;
+      borderRadiusSM: number;
+      controlHeightSM: number;
+      paddingXXS: number;
+      colorTextSecondary: string;
+      colorTextBase: string;
+      colorFillSecondary: string;
+      colorFillTertiary: string;
     },
   ) => ({
     modal: css`
@@ -52,14 +99,19 @@ const useStyles = createStyles(
         overflow: hidden;
       }
       .ant-modal-close {
-        width: 26px;
-        height: 26px;
-        top: 22px;
-        right: 18px;
+        width: ${controlHeightSM}px;
+        height: ${controlHeightSM}px;
+        top: calc(
+          (var(--general-modal-header-height, 69px) - ${controlHeightSM}px) / 2
+        );
+        right: calc(
+          (var(--general-modal-header-height, 69px) - ${controlHeightSM}px) / 2
+        );
         -webkit-app-region: no-drag;
       }
       .ant-modal-title {
-        margin-right: 36px;
+        margin-right: ${hasWindowControls ? '0' : '36px'};
+        ${hasWindowControls ? 'width: 100%; max-width: 100%;' : ''}
         ${type === 'warning' ? `color: ${colorWarning};` : ''}
         ${type === 'error' ? `color: ${colorError};` : ''}
       }
@@ -73,6 +125,142 @@ const useStyles = createStyles(
         }
       `
         : ''}
+
+      ${windowState === 'maximized'
+        ? `
+        &.ant-modal {
+          width: calc(100vw - ${marginLG * 2}px) !important;
+          max-width: calc(100vw - ${marginLG * 2}px) !important;
+          top: 0;
+          padding: 0;
+          margin: ${marginLG}px auto;
+        }
+        .ant-modal-content,
+        .ant-modal-container {
+          height: calc(100vh - ${marginLG * 2}px);
+          display: flex;
+          flex-direction: column;
+          border-radius: ${borderRadiusLG}px;
+        }
+        .ant-modal-body {
+          flex: 1;
+          max-height: none !important;
+          overflow: auto;
+        }
+      `
+        : ''}
+
+      ${windowState === 'fullscreen'
+        ? `
+        &.ant-modal {
+          width: 100vw !important;
+          max-width: 100vw !important;
+          height: 100vh !important;
+          top: 0 !important;
+          padding: 0 !important;
+          margin: 0 !important;
+        }
+        .ant-modal-content,
+        .ant-modal-container {
+          height: 100vh;
+          display: flex;
+          flex-direction: column;
+          border-radius: 0;
+        }
+        .ant-modal-body {
+          flex: 1;
+          max-height: none !important;
+          overflow: auto;
+        }
+      `
+        : ''}
+
+      ${windowState === 'minimized'
+        ? `
+        &.ant-modal {
+          width: min(320px, calc(100vw - ${marginLG * 2}px)) !important;
+          max-width: min(320px, calc(100vw - ${marginLG * 2}px)) !important;
+          position: fixed;
+          padding: 0;
+          margin: 0;
+          cursor: pointer;
+          pointer-events: auto;
+          ${minimizedPlacement.includes('bottom') ? 'top: auto !important; bottom: 0;' : 'top: 0 !important; bottom: auto;'}
+          ${minimizedPlacement.includes('Right') ? `right: ${marginLG}px; left: auto;` : `left: ${marginLG}px; right: auto;`}
+        }
+        .ant-modal-content,
+        .ant-modal-container {
+          ${minimizedPlacement.includes('bottom') ? `border-radius: ${borderRadiusLG}px ${borderRadiusLG}px 0 0;` : `border-radius: 0 0 ${borderRadiusLG}px ${borderRadiusLG}px;`}
+        }
+        .ant-modal-header {
+          background: transparent !important;
+          transition: background-color 0.2s ease;
+          border-radius: inherit;
+        }
+        .ant-modal-header:hover {
+          background-color: ${colorFillTertiary} !important;
+        }
+        .ant-modal-body,
+        .ant-modal-footer {
+          display: none !important;
+        }
+        .ant-modal-title {
+          max-width: 75%;
+          overflow: hidden;
+        }
+      `
+        : ''}
+
+      .ant-modal-content {
+        transition:
+          height 0.3s ease,
+          border-radius 0.3s ease;
+      }
+    `,
+    minimizedTitleContent: css`
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+
+      & * {
+        display: inline !important;
+        white-space: nowrap !important;
+        vertical-align: middle;
+      }
+    `,
+    windowControlsContainer: css`
+      display: flex;
+      align-items: center;
+      gap: ${paddingXXS}px;
+      flex-shrink: 0;
+      margin-left: auto;
+      -webkit-app-region: no-drag;
+    `,
+    windowControlButton: css`
+      &.ant-btn {
+        width: ${controlHeightSM}px;
+        height: ${controlHeightSM}px;
+        min-width: ${controlHeightSM}px;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        border-radius: ${borderRadiusSM}px;
+        background: transparent;
+        color: ${colorTextSecondary};
+        cursor: pointer;
+        overflow: hidden;
+        transition:
+          color 0.2s,
+          background-color 0.2s;
+
+        &:hover {
+          color: ${colorTextBase};
+          background-color: ${colorFillSecondary};
+        }
+      }
     `,
   }),
 );
@@ -83,15 +271,64 @@ const BAIModal: React.FC<BAIModalProps> = ({
   onConfirmClose,
   stickyTitle = false,
   type = 'normal',
+  windowActions,
+  onWindowStateChange,
+  minimizedPlacement = 'bottomRight',
   ...modalProps
 }) => {
   'use memo';
+  const { t } = useTranslation();
   const { token } = theme.useToken();
+  const [windowState, setWindowState] = useState<WindowState>('default');
+
+  // Reset window state when the modal is closed programmatically (e.g., parent sets open={false})
+  useEffect(() => {
+    if (!modalProps.open && windowState !== 'default') {
+      setWindowState('default');
+      onWindowStateChange?.('default');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modalProps.open]);
+
+  // Override rc-component/portal scroll lock when minimized.
+  // The portal injects `html body { overflow-y: hidden }` via a <style> tag.
+  // We counter it with a higher-specificity rule.
+  useEffect(() => {
+    if (windowState === 'minimized' && modalProps.open) {
+      const styleId = 'bai-modal-minimized-scroll-unlock';
+      let style = document.getElementById(styleId) as HTMLStyleElement | null;
+      if (!style) {
+        style = document.createElement('style');
+        style.id = styleId;
+        document.head.appendChild(style);
+      }
+      style.textContent = 'html body { overflow-y: auto !important; }';
+      return () => {
+        style?.remove();
+      };
+    }
+  }, [windowState, modalProps.open]);
+
+  const hasWindowControls = windowActions && windowActions.length > 0;
+  const activeActions: WindowAction[] = windowActions ?? [];
+
   const { styles } = useStyles({
     stickyTitle,
     type,
     colorWarning: token.colorWarning,
     colorError: token.colorError,
+    windowState: hasWindowControls ? windowState : 'default',
+    hasWindowControls: !!hasWindowControls,
+    minimizedPlacement,
+    marginLG: token.marginLG,
+    borderRadiusLG: token.borderRadiusLG,
+    borderRadiusSM: token.borderRadiusSM,
+    controlHeightSM: token.controlHeightSM,
+    paddingXXS: token.paddingXXS,
+    colorTextSecondary: token.colorTextSecondary,
+    colorTextBase: token.colorTextBase,
+    colorFillSecondary: token.colorFillSecondary,
+    colorFillTertiary: token.colorFillTertiary,
   });
   const [disabled, setDisabled] = useState(true);
   const [bounds, setBounds] = useState({
@@ -101,6 +338,19 @@ const BAIModal: React.FC<BAIModalProps> = ({
     right: 0,
   }); //draggable space
   const draggleRef = useRef<HTMLDivElement>(null);
+
+  const handleWindowStateChange = (action: WindowAction) => {
+    const targetState: WindowState =
+      action === 'minimize'
+        ? 'minimized'
+        : action === 'maximize'
+          ? 'maximized'
+          : 'fullscreen';
+
+    const newState = windowState === targetState ? 'default' : targetState;
+    setWindowState(newState);
+    onWindowStateChange?.(newState);
+  };
 
   const handleDrag = (_e: DraggableEvent, uiData: DraggableData) => {
     const { clientWidth, clientHeight } = window.document.documentElement; //browserWidth, browserHeight
@@ -131,18 +381,168 @@ const BAIModal: React.FC<BAIModalProps> = ({
         return;
       }
     }
+    // Reset window state when closing
+    if (windowState !== 'default') {
+      setWindowState('default');
+      onWindowStateChange?.('default');
+    }
     modalProps.onCancel?.(e);
+  };
+
+  const isDraggingDisabled =
+    windowState === 'maximized' || windowState === 'fullscreen';
+
+  const renderWindowControls = () => {
+    if (!hasWindowControls) return null;
+    if (windowState === 'minimized') return null;
+
+    return (
+      <div className={styles.windowControlsContainer}>
+        {activeActions.includes('minimize') && (
+          <Tooltip title={t('comp:BAIModal.Minimize')}>
+            <Button
+              className={styles.windowControlButton}
+              type="text"
+              size="small"
+              icon={<MinusOutlined />}
+              onClick={() => handleWindowStateChange('minimize')}
+              aria-label={t('comp:BAIModal.Minimize')}
+            />
+          </Tooltip>
+        )}
+        {activeActions.includes('maximize') && (
+          <Tooltip
+            title={
+              windowState === 'maximized'
+                ? t('comp:BAIModal.Restore')
+                : t('comp:BAIModal.Maximize')
+            }
+          >
+            <Button
+              className={styles.windowControlButton}
+              type="text"
+              size="small"
+              icon={
+                windowState === 'maximized' ? (
+                  <BlockOutlined />
+                ) : (
+                  <BorderOutlined />
+                )
+              }
+              onClick={() => handleWindowStateChange('maximize')}
+              aria-label={
+                windowState === 'maximized'
+                  ? t('comp:BAIModal.Restore')
+                  : t('comp:BAIModal.Maximize')
+              }
+            />
+          </Tooltip>
+        )}
+        {activeActions.includes('fullscreen') && (
+          <Tooltip
+            title={
+              windowState === 'fullscreen'
+                ? t('comp:BAIModal.ExitFullscreen')
+                : t('comp:BAIModal.Fullscreen')
+            }
+          >
+            <Button
+              className={styles.windowControlButton}
+              type="text"
+              size="small"
+              icon={
+                windowState === 'fullscreen' ? (
+                  <FullscreenExitOutlined />
+                ) : (
+                  <FullscreenOutlined />
+                )
+              }
+              onClick={() => handleWindowStateChange('fullscreen')}
+              aria-label={
+                windowState === 'fullscreen'
+                  ? t('comp:BAIModal.ExitFullscreen')
+                  : t('comp:BAIModal.Fullscreen')
+              }
+            />
+          </Tooltip>
+        )}
+        {modalProps.closable !== false && (
+          <Tooltip title={t('general.button.Close')}>
+            <Button
+              className={styles.windowControlButton}
+              type="text"
+              size="small"
+              icon={<CloseOutlined />}
+              onClick={(e) =>
+                handleCancel(
+                  e as unknown as React.MouseEvent<HTMLButtonElement>,
+                )
+              }
+              aria-label={t('general.button.Close')}
+            />
+          </Tooltip>
+        )}
+      </div>
+    );
   };
 
   return (
     <Modal
       {...modalProps}
-      centered={modalProps.centered ?? true}
+      centered={
+        windowState === 'default' ? (modalProps.centered ?? true) : false
+      }
       className={classNames(`bai-modal ${className ?? ''}`, styles.modal)}
-      wrapClassName={modalProps.draggable ? 'draggable' : ''}
+      wrapClassName={classNames(
+        modalProps.draggable && !isDraggingDisabled ? 'draggable' : '',
+        windowState === 'maximized' ? 'bai-modal-maximized' : '',
+        windowState === 'fullscreen' ? 'bai-modal-fullscreen' : '',
+        windowState === 'minimized' ? 'bai-modal-minimized' : '',
+      )}
       onCancel={handleCancel}
+      closable={hasWindowControls ? false : modalProps.closable}
+      mask={
+        windowState === 'minimized'
+          ? false
+          : typeof modalProps.mask === 'object'
+            ? {
+                blur: false,
+                ...modalProps.mask,
+                closable:
+                  modalProps.mask?.closable ?? modalProps.maskClosable ?? true,
+              }
+            : {
+                blur: false,
+                enabled: modalProps.mask ?? true,
+                closable: modalProps.maskClosable ?? true,
+              }
+      }
       styles={{
         ...modalProps.styles,
+        wrapper: {
+          ...(!_.isFunction(modalProps.styles) && modalProps.styles?.wrapper),
+          ...(windowState === 'maximized'
+            ? {
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }
+            : {}),
+          ...(windowState === 'fullscreen'
+            ? {
+                display: 'flex',
+                alignItems: 'flex-start',
+                justifyContent: 'flex-start',
+                overflow: 'hidden',
+              }
+            : {}),
+          ...(windowState === 'minimized'
+            ? {
+                pointerEvents: 'none' as const,
+                overflow: 'hidden',
+              }
+            : {}),
+        },
         header: {
           marginBottom: 0,
           borderBottom: `1px solid var(--token-colorBorder, ${token.colorBorder})`,
@@ -156,15 +556,34 @@ const BAIModal: React.FC<BAIModalProps> = ({
         },
         body: {
           padding: `var(--general-modal-body-padding, 0 24px)`,
-          maxHeight: 'calc(100vh - 69px - 57px - 48px)',
+          maxHeight:
+            windowState === 'default'
+              ? `calc(100vh - var(--general-modal-header-height, 69px) - ${token.controlHeight + token.paddingSM * 2 + token.lineWidth}px - ${token.marginLG * 2}px)`
+              : 'none',
           overflow: 'auto',
           paddingTop: token.paddingMD,
           paddingBottom: token.paddingMD,
           ...(!_.isFunction(modalProps.styles) && modalProps.styles?.body),
+          ...(windowState !== 'default' ? { flex: 1, maxHeight: 'none' } : {}),
         },
         container: {
           padding: `var(--general-modal-content-padding, 0)`,
           ...(!_.isFunction(modalProps.styles) && modalProps.styles?.container),
+          ...(windowState === 'maximized'
+            ? {
+                height: `calc(100vh - ${token.marginLG * 2}px)`,
+                display: 'flex',
+                flexDirection: 'column' as const,
+              }
+            : {}),
+          ...(windowState === 'fullscreen'
+            ? {
+                height: '100vh',
+                display: 'flex',
+                flexDirection: 'column' as const,
+                borderRadius: 0,
+              }
+            : {}),
         },
         footer: {
           borderTop: '1px solid',
@@ -177,28 +596,91 @@ const BAIModal: React.FC<BAIModalProps> = ({
         },
       }}
       title={
-        <BAIFlex gap={'xs'}>
-          <HolderOutlined
-            style={{
-              cursor: modalProps.draggable ? 'move' : '',
-              display: !modalProps.draggable ? 'none' : '',
-              // @ts-ignore
-              '-webkit-app-region': 'no-drag',
-            }}
-            onMouseOver={() => {
-              if (disabled) {
-                setDisabled(false);
-              }
-            }}
-            onMouseLeave={() => {
-              setDisabled(true);
-            }}
-          />
-          {modalProps.title}
-        </BAIFlex>
+        hasWindowControls ? (
+          <BAIFlex
+            gap={'xs'}
+            justify="between"
+            align="center"
+            style={{ width: '100%', overflow: 'hidden' }}
+          >
+            <BAIFlex gap={'xs'} style={{ overflow: 'hidden', flex: 1 }}>
+              <HolderOutlined
+                style={{
+                  cursor:
+                    modalProps.draggable && !isDraggingDisabled ? 'move' : '',
+                  display: !modalProps.draggable ? 'none' : '',
+                  // @ts-ignore
+                  '-webkit-app-region': 'no-drag',
+                }}
+                onMouseOver={() => {
+                  if (disabled && !isDraggingDisabled) {
+                    setDisabled(false);
+                  }
+                }}
+                onMouseLeave={() => {
+                  setDisabled(true);
+                }}
+              />
+              <div
+                className={
+                  windowState === 'minimized'
+                    ? styles.minimizedTitleContent
+                    : undefined
+                }
+                style={{
+                  overflow: 'hidden',
+                  flex: 1,
+                  minWidth: 0,
+                }}
+              >
+                {modalProps.title}
+              </div>
+            </BAIFlex>
+            {renderWindowControls()}
+          </BAIFlex>
+        ) : (
+          <BAIFlex gap={'xs'}>
+            <HolderOutlined
+              style={{
+                cursor: modalProps.draggable ? 'move' : '',
+                display: !modalProps.draggable ? 'none' : '',
+                // @ts-ignore
+                '-webkit-app-region': 'no-drag',
+              }}
+              onMouseOver={() => {
+                if (disabled) {
+                  setDisabled(false);
+                }
+              }}
+              onMouseLeave={() => {
+                setDisabled(true);
+              }}
+            />
+            {modalProps.title}
+          </BAIFlex>
+        )
       }
-      modalRender={(modal) =>
-        modalProps.draggable ? (
+      modalRender={(modal) => {
+        if (windowState === 'minimized') {
+          return (
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={() => handleWindowStateChange('minimize')}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleWindowStateChange('minimize');
+                }
+              }}
+              style={{ cursor: 'pointer' }}
+            >
+              {modal}
+            </div>
+          );
+        }
+
+        return modalProps.draggable && !isDraggingDisabled ? (
           <Draggable
             disabled={disabled}
             bounds={bounds}
@@ -209,8 +691,8 @@ const BAIModal: React.FC<BAIModalProps> = ({
           </Draggable>
         ) : (
           modal
-        )
-      }
+        );
+      }}
       zIndex={DEFAULT_BAI_MODAL_Z_INDEX}
     />
   );

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Schlüsselpaar auswählen"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Die folgenden Ordner werden aktualisiert.",
     "ProjectResourcePolicy": "Projektressourcenrichtlinie",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Επιλέξτε ζεύγος κλειδιών"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Οι ακόλουθοι φάκελοι θα ενημερωθούν.",
     "ProjectResourcePolicy": "Πολιτική πόρων έργου",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -141,6 +141,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Select Keypair"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "The following folder(s) will be updated.",
     "ProjectResourcePolicy": "Project Resource Policy",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Seleccionar par de claves"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Se actualizará(n) la(s) siguiente(s) carpeta(s).",
     "ProjectResourcePolicy": "Política de recursos del proyecto",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Valitse avainpari"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Seuraavat kansiot päivitetään.",
     "ProjectResourcePolicy": "Projektin resurssipolitiikka",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Sélectionner une paire de clés"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Le(s) dossier(s) suivant(s) sera(ont) mis à jour.",
     "ProjectResourcePolicy": "Politique de ressources du projet",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Pilih Keypair"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Folder berikut akan diperbarui.",
     "ProjectResourcePolicy": "Kebijakan Sumber Daya Proyek",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Seleziona coppia di chiavi"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "La cartella o le cartelle seguenti verranno aggiornate.",
     "ProjectResourcePolicy": "Politica delle risorse del progetto",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "キーペアを選択"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "全画面終了",
+    "Fullscreen": "全画面",
+    "Maximize": "最大化",
+    "Minimize": "最小化",
+    "Restore": "復元"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "以下のフォルダーが更新されます.",
     "ProjectResourcePolicy": "プロジェクトのリソースポリシー",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -141,6 +141,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "키페어를 선택해주세요"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "전체 화면 종료",
+    "Fullscreen": "전체 화면",
+    "Maximize": "최대화",
+    "Minimize": "최소화",
+    "Restore": "복원"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "다음 폴더(들)이 업데이트됩니다.",
     "ProjectResourcePolicy": "프로젝트 리소스 정책",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Түлхүүрийн хос сонгох"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Дараах хавтас(ууд) шинэчлэгдэх болно.",
     "ProjectResourcePolicy": "Төслийн нөөцийн бодлого",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Pilih Pasangan Kunci"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Folder berikut akan dikemas kini.",
     "ProjectResourcePolicy": "Polisi Sumber Projek",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Wybierz parę kluczy"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Poniższe foldery zostaną zaktualizowane.",
     "ProjectResourcePolicy": "Polityka zasobów projektu",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -137,6 +137,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Selecionar par de chaves"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "A(s) pasta(s) a seguir será(ão) atualizada(s).",
     "ProjectResourcePolicy": "Política de Recursos do Projeto",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Selecionar par de chaves"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "A(s) pasta(s) a seguir será(ão) atualizada(s).",
     "ProjectResourcePolicy": "Política de Recursos do Projeto",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Выберите пару ключей"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Будут обновлены следующие папки.",
     "ProjectResourcePolicy": "Политика ресурсов проекта",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "เลือกคู่คีย์"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "โฟลเดอร์ต่อไปนี้จะถูกอัปเดต.",
     "ProjectResourcePolicy": "นโยบายทรัพยากรโครงการ",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Anahtar Çifti Seçin"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Aşağıdaki klasör(ler) güncellenecek.",
     "ProjectResourcePolicy": "Proje Kaynak Politikası",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Chọn cặp khóa"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "Exit fullscreen",
+    "Fullscreen": "Fullscreen",
+    "Maximize": "Maximize",
+    "Minimize": "Minimize",
+    "Restore": "Restore"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "Thư mục sau sẽ được cập nhật.",
     "ProjectResourcePolicy": "Chính sách tài nguyên dự án",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "选择密钥对"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "退出全屏",
+    "Fullscreen": "全屏",
+    "Maximize": "最大化",
+    "Minimize": "最小化",
+    "Restore": "还原"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "以下文件夹将被更新。",
     "ProjectResourcePolicy": "项目资源策略",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -138,6 +138,13 @@
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "選擇金鑰對"
   },
+  "comp:BAIModal": {
+    "ExitFullscreen": "退出全螢幕",
+    "Fullscreen": "全螢幕",
+    "Maximize": "最大化",
+    "Minimize": "最小化",
+    "Restore": "還原"
+  },
   "comp:BAIProjectBulkEditModal": {
     "FollowingFoldersWillBeUpdated": "下列資料夾將會更新。",
     "ProjectResourcePolicy": "專案資源政策",


### PR DESCRIPTION
Resolves #5743(FR-2213)

## Summary

Add window management controls (minimize, maximize, fullscreen) to `BAIModal` component, enabling users to resize and reposition modals similar to desktop window managers.

### New Props
- `windowControls` - enables all three window control buttons (minimize, maximize, fullscreen)
- `windowActions` - selectively enable specific controls (e.g., `['minimize', 'fullscreen']`). Also enables window controls automatically when provided, so `windowControls` is not needed alongside it.
- `onWindowStateChange` - callback fired on state transitions
- `minimizedPlacement` - configurable corner for minimized bar (`bottomRight`, `bottomLeft`, `topRight`, `topLeft`; default: `bottomRight`)

### Modal States
- **Default**: unchanged current behavior
- **Minimized**: collapses to compact bar (title only) anchored at configurable corner of viewport
- **Maximized**: fills viewport with 24px margin (`calc(100vw - 48px) x calc(100vh - 48px)`)
- **Fullscreen**: fills entire viewport (100vw x 100vh, no border-radius)

### Behavior
- Toggle: clicking the same control button returns to default state
- Dragging is automatically disabled in maximized/fullscreen states
- Window state resets to default on modal close
- Fully backward compatible when `windowControls` is not set
- Control buttons match existing close button style (26x26px)
- Uses Ant Design icons: MinusOutlined, BorderOutlined/BlockOutlined, FullscreenOutlined/FullscreenExitOutlined
- Page scroll and interactions are unlocked when modal is minimized (scroll lock override)
- Minimized bar header shows background-color hover transition effect
- Keyboard accessible: press Enter or Space on minimized bar to restore
- Hardcoded px values replaced with antd design tokens for consistency

### Title Rendering
- When `windowControls`/`windowActions` is enabled, title uses a `<div>` wrapper with `flex: 1` and `minWidth: 0`, allowing complex title layouts (e.g., flex containers with action buttons) to render properly with full-width justify
- When minimized, title content is forced to single-line display by collapsing all descendant elements to `display: inline`, with `text-overflow: ellipsis` truncation and `max-width: 75%` to preserve right-side breathing room — no consumer-side state tracking needed

### Storybook Stories
- WindowControls - all controls with state indicator
- MinimizedState - minimize/restore flow
- MaximizedState - maximize/restore flow with draggable
- FullscreenState - fullscreen/exit flow
- MinimizedPlacement - all four corner placements
- SelectiveWindowActions - different combinations of controls

### Files Changed
- `packages/backend.ai-ui/src/components/BAIModal.tsx` - core implementation
- `packages/backend.ai-ui/src/components/BAIModal.stories.tsx` - Storybook stories
- `packages/backend.ai-ui/src/locale/*.json` - i18n translations for minimize tooltip (22 languages)

### Verification
```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```