### PR TITLE
fix(FR-2157): prevent double rebuild on config.toml change

### DIFF
--- a/react/craco.config.cjs
+++ b/react/craco.config.cjs
@@ -93,21 +93,42 @@ module.exports = {
         path.resolve(__dirname, '../resources/theme.json'),
       ];
 
+      // Use a single shared debounce timer across all watchers so that
+      // simultaneous events (e.g. on macOS where FSEvents can fire watchers
+      // for sibling files in the same directory) coalesce into a single
+      // reload signal. This also handles editors that write files in
+      // multiple steps (e.g. write + rename).
+      // Store the debounce timer on devServer so it can be cleared during
+      // shutdown (see onListening below).
+      const sendReload = () => {
+        clearTimeout(devServer._reloadDebounceTimer);
+        devServer._reloadDebounceTimer = setTimeout(() => {
+          devServer.sendMessage(
+            devServer.webSocketServer.clients,
+            'static-changed',
+          );
+        }, 300);
+      };
+
       const watchers = filesToWatch
         .filter((file) => fs.existsSync(file))
         .map((file) => {
-          // Use a debounce timer to avoid rapid successive reloads from
-          // editors that write files in multiple steps (e.g. write + rename).
-          let debounceTimer;
-          return fs.watch(file, () => {
-            clearTimeout(debounceTimer);
-            debounceTimer = setTimeout(() => {
-              devServer.sendMessage(
-                devServer.webSocketServer.clients,
-                'static-changed',
-              );
-            }, 100);
+          const isDir = fs.statSync(file).isDirectory();
+          if (isDir) {
+            // Directories: use fs.watch (fs.watchFile doesn't work on dirs)
+            return fs.watch(file, () => sendReload());
+          }
+          // Files: use fs.watchFile (polling) so that watchers survive
+          // file replacements from editors that use atomic save
+          // (write temp → rename), which causes fs.watch to stop working
+          // because the original inode is replaced.
+          fs.watchFile(file, { interval: 500 }, (curr, prev) => {
+            if (curr.mtimeMs !== prev.mtimeMs) {
+              sendReload();
+            }
           });
+          // Return a close handle compatible with fs.watch watchers
+          return { close: () => fs.unwatchFile(file) };
         });
 
       // Store watchers on the devServer instance so onListening can patch
@@ -132,6 +153,9 @@ module.exports = {
       }
       const originalClose = devServer.server.close.bind(devServer.server);
       devServer.server.close = (callback) => {
+        // Clear any pending debounce timer to prevent sendReload from
+        // firing after the server has been shut down.
+        clearTimeout(devServer._reloadDebounceTimer);
         (devServer._fileWatchers || []).forEach((w) => w.close());
         originalClose(callback);
       };
@@ -306,23 +330,45 @@ module.exports = {
       });
       paths.appHtml = webuiIndexHtml;
 
-      // Configure webpack's own file watcher to ignore static assets that are
-      // served directly and don't need to be in the webpack module graph.
-      // This prevents webpack from triggering unnecessary rebuilds (and
-      // potential HMR fallback to full reload) when static files change.
+      // Configure webpack's own file watcher to ignore files that are not
+      // part of the webpack module graph. When webpack resolves aliases
+      // outside react/ (e.g. backend.ai-client-esm → ../dist/lib/...),
+      // enhanced-resolve walks up the directory tree and adds the project
+      // root as a context dependency. This causes webpack to watch ALL files
+      // in the project root, triggering unnecessary rebuilds when config
+      // files or editor temp files change (which leads to HMR "Cannot find
+      // update" → full page reload).
+      //
+      // We use a single RegExp instead of a string array because webpack
+      // validates that ignored arrays contain only strings (no RegExp),
+      // and we need pattern matching to catch editor temp files.
+      //
+      // The RegExp ignores:
+      // 1. node_modules everywhere
+      // 2. resources/ and manifest/ directories (static assets)
+      // 3. All files directly in the project root (config.toml, index.html,
+      //    editor temp files like .config.toml.XXXXX, etc.)
+      //
+      // NOT ignored (must remain watched):
+      // - dist/lib/backend.ai-client-esm.js (webpack alias, needs HMR)
+      // - packages/backend.ai-ui/src/** (workspace package, dev alias)
       if (env === 'development') {
+        const escapedRoot = path
+          .resolve(__dirname, '..')
+          .replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         webpackConfig.watchOptions = {
           ...webpackConfig.watchOptions,
-          ignored: [
-            // Ignore node_modules (standard exclusion for performance)
-            '**/node_modules/**',
-            // Note: dist/ is intentionally NOT ignored because
-            // backend.ai-client-esm.js (resolved via webpack alias) is part of
-            // the module graph and needs to trigger HMR when recompiled by
-            // `tsc --watch` (run concurrently in the dev script).
-            path.resolve(__dirname, '../resources/**'),
-            path.resolve(__dirname, '../manifest/**'),
-          ],
+          ignored: new RegExp(
+            [
+              'node_modules',
+              escapedRoot + '[\\\\/]resources[\\\\/]',
+              escapedRoot + '[\\\\/]manifest[\\\\/]',
+              // Match files directly in the project root (no deeper path
+              // separators). This catches config.toml, index.html, and any
+              // temp files created by editors during atomic save operations.
+              escapedRoot + '[\\\\/][^\\\\/]+$',
+            ].join('|'),
+          ),
         };
       }
 


### PR DESCRIPTION
Resolves #5621 ([FR-2157](https://lablup.atlassian.net/browse/FR-2157))

## Summary

When `config.toml` is modified during development, the browser was reloading **twice** instead of once. This was caused by two independent mechanisms both triggering reloads:

1. **webpack context dependency**: When webpack resolves aliases outside `react/` (e.g. `backend.ai-client-esm` → `../dist/lib/...`), `enhanced-resolve` walks up the directory tree and adds the project root as a context dependency. This causes webpack to detect `config.toml` changes → recompile → HMR finds no module updates → falls back to full page reload.

2. **`fs.watch` dying on atomic save**: IDEs like VS Code use atomic save (write temp → rename), which replaces the file's inode. `fs.watch` watches the old inode and stops detecting changes, leaving only the webpack-triggered reload (which itself fires twice due to temp file + rename events).

### Changes

- **`watchOptions.ignored`: string array → RegExp** — Ignore all files directly in the project root (`[^/]+$` pattern) to catch both config files AND editor temp files. `dist/` and `packages/` subdirectories remain watched for HMR.
- **`fs.watch` → `fs.watchFile` for individual files** — Polling-based watching (500ms interval) survives file replacements from atomic save. Directories (`resources/i18n`) still use `fs.watch`.
- **Shared debounce timer (300ms)** — All watchers share a single timer to coalesce rapid events into one reload signal.

## Verification
`scripts/verify.sh`: ALL PASS (Relay, Lint, Format, TypeScript)

Tested with Chrome DevTools monitoring:
- Server sends exactly 1 `static-changed` WebSocket message per config.toml edit
- webpack does NOT recompile (no "Compiling..." in terminal)
- Browser reloads exactly once

## Test plan
- [x] Run dev server and modify `config.toml` from IDE — verify only ONE reload occurs
- [ ] Verify HMR still works for React source changes
- [ ] Verify `dist/lib/backend.ai-client-esm.js` changes still trigger HMR
- [ ] Verify `index.html` changes still trigger a page reload
- [ ] Verify i18n translation file changes still trigger a page reload
- [ ] Verify `resources/theme.json` changes still trigger a page reload
- [ ] Production build (`pnpm run build`) completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-2157]: https://lablup.atlassian.net/browse/FR-2157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ