### PR TITLE
feat(FR-2220): implement role list page with query, table, and filters

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2391,9 +2391,60 @@ input ContainerRegistryScope
 scalar ContainerRegistryScopeField
   @join__type(graph: GRAPHENE)
 
+"""Added in 26.4.0. Container registry type."""
+enum ContainerRegistryType
+  @join__type(graph: STRAWBERRY)
+{
+  DOCKER @join__enumValue(graph: STRAWBERRY)
+  HARBOR @join__enumValue(graph: STRAWBERRY)
+  HARBOR2 @join__enumValue(graph: STRAWBERRY)
+  GITHUB @join__enumValue(graph: STRAWBERRY)
+  GITLAB @join__enumValue(graph: STRAWBERRY)
+  ECR @join__enumValue(graph: STRAWBERRY)
+  ECR_PUB @join__enumValue(graph: STRAWBERRY)
+  LOCAL @join__enumValue(graph: STRAWBERRY)
+  OCP @join__enumValue(graph: STRAWBERRY)
+}
+
 """Added in 24.09.0."""
 scalar ContainerRegistryTypeField
   @join__type(graph: GRAPHENE)
+
+"""Added in 26.4.0. Container registry node."""
+type ContainerRegistryV2 implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """URL of the container registry"""
+  url: String!
+
+  """Name of the container registry"""
+  registryName: String!
+
+  """Type of the container registry"""
+  type: ContainerRegistryType!
+
+  """Project or namespace within the registry"""
+  project: String
+
+  """Username for registry authentication"""
+  username: String
+
+  """Masked password for registry authentication"""
+  password: String
+
+  """Whether SSL verification is enabled"""
+  sslVerify: Boolean
+
+  """Whether this registry is globally accessible"""
+  isGlobal: Boolean
+
+  """Extra metadata for the container registry"""
+  extra: JSON
+}
 
 """Added in 25.6.0."""
 type ContainerUtilizationMetric
@@ -4595,9 +4646,10 @@ union EntityNode
   @join__unionMember(graph: STRAWBERRY, member: "NotificationRule")
   @join__unionMember(graph: STRAWBERRY, member: "ModelDeployment")
   @join__unionMember(graph: STRAWBERRY, member: "ResourceGroup")
+  @join__unionMember(graph: STRAWBERRY, member: "ContainerRegistryV2")
   @join__unionMember(graph: STRAWBERRY, member: "ArtifactRevision")
   @join__unionMember(graph: STRAWBERRY, member: "Role")
- = UserV2 | ProjectV2 | DomainV2 | VirtualFolderNode | ImageV2 | ComputeSessionNode | Artifact | ArtifactRegistry | AppConfig | NotificationChannel | NotificationRule | ModelDeployment | ResourceGroup | ArtifactRevision | Role
+ = UserV2 | ProjectV2 | DomainV2 | VirtualFolderNode | ImageV2 | ComputeSessionNode | Artifact | ArtifactRegistry | AppConfig | NotificationChannel | NotificationRule | ModelDeployment | ResourceGroup | ContainerRegistryV2 | ArtifactRevision | Role
 
 """Added in 26.3.0. Order by specification for entity associations"""
 input EntityOrderBy
@@ -7986,6 +8038,11 @@ type Mutation
   switchMyMainAccessKey(input: SwitchMyMainAccessKeyInput!): SwitchMyMainAccessKeyPayload! @join__field(graph: STRAWBERRY)
 
   """
+  Update a keypair owned by the current user (e.g. toggle active state). The keypair must be owned by the current user.
+  """
+  updateMyKeypair(input: UpdateMyKeypairInput!): UpdateMyKeypairPayload! @join__field(graph: STRAWBERRY)
+
+  """
   Added in 26.4.0. Update the current user's allowed client IP list. Set allowed_client_ip to null to remove all IP restrictions. When force is false, the operation fails if the current request IP would be excluded by the new allowlist (lockout prevention).
   """
   updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload! @join__field(graph: STRAWBERRY)
@@ -10435,6 +10492,7 @@ enum RBACElementType
   NOTIFICATION_RULE @join__enumValue(graph: STRAWBERRY)
   DEPLOYMENT_TOKEN @join__enumValue(graph: STRAWBERRY)
   DEPLOYMENT_POLICY @join__enumValue(graph: STRAWBERRY)
+  DEPLOYMENT_REVISION @join__enumValue(graph: STRAWBERRY)
   ARTIFACT_REVISION @join__enumValue(graph: STRAWBERRY)
 }
 
@@ -12928,6 +12986,27 @@ input UpdateMyAllowedClientIPInput
 Added in 26.4.0. Payload for updating the current user's allowed client IP list.
 """
 type UpdateMyAllowedClientIPPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """Whether the update was successful."""
+  success: Boolean!
+}
+
+"""Input for updating a keypair owned by the current user."""
+input UpdateMyKeypairInput
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  Access key of the keypair to update. Must be owned by the current user.
+  """
+  accessKey: String!
+
+  """Target active state for the keypair."""
+  isActive: Boolean!
+}
+
+"""Payload returned after updating a keypair."""
+type UpdateMyKeypairPayload
   @join__type(graph: STRAWBERRY)
 {
   """Whether the update was successful."""

--- a/react/src/components/RoleNodes.tsx
+++ b/react/src/components/RoleNodes.tsx
@@ -1,0 +1,198 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  RoleNodesFragment$data,
+  RoleNodesFragment$key,
+} from '../__generated__/RoleNodesFragment.graphql';
+import {
+  DeleteOutlined,
+  EditOutlined,
+  ExclamationCircleOutlined,
+} from '@ant-design/icons';
+import {
+  BAIButton,
+  BAIColumnType,
+  BAILink,
+  BAITable,
+  BAITableProps,
+  BAITag,
+  filterOutEmpty,
+} from 'backend.ai-ui';
+import dayjs from 'dayjs';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment } from 'react-relay';
+
+export type RoleNodeInList = NonNullable<RoleNodesFragment$data[number]>;
+
+const availableRoleSorterKeys = ['name', 'created_at', 'updated_at'] as const;
+
+export const availableRoleSorterValues = [
+  ...availableRoleSorterKeys,
+  ...availableRoleSorterKeys.map((key) => `-${key}` as const),
+] as const;
+
+interface RoleNodesProps extends Omit<
+  BAITableProps<RoleNodeInList>,
+  'dataSource' | 'columns' | 'onChangeOrder'
+> {
+  rolesFrgmt: RoleNodesFragment$key;
+  onClickRoleName?: (role: RoleNodeInList) => void;
+  onClickEdit?: (role: RoleNodeInList) => void;
+  onClickDelete?: (role: RoleNodeInList) => void;
+  onClickPurge?: (role: RoleNodeInList) => void;
+  statusFilter?: string;
+  order?: string | null;
+  onChangeOrder?: (
+    order: (typeof availableRoleSorterValues)[number] | null,
+  ) => void;
+}
+
+const RoleNodes: React.FC<RoleNodesProps> = ({
+  rolesFrgmt,
+  onClickRoleName,
+  onClickEdit,
+  onClickDelete,
+  onClickPurge,
+  statusFilter,
+  order,
+  onChangeOrder,
+  ...tableProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+
+  const roles = useFragment(
+    graphql`
+      fragment RoleNodesFragment on Role @relay(plural: true) {
+        id @required(action: NONE)
+        name @required(action: NONE)
+        description
+        source
+        status
+        createdAt
+        updatedAt
+        ...RoleFormModalFragment
+      }
+    `,
+    rolesFrgmt,
+  );
+
+  const isDeletedFilter = statusFilter === 'DELETED';
+
+  const columns: BAIColumnType<RoleNodeInList>[] = filterOutEmpty([
+    {
+      key: 'name',
+      title: t('rbac.RoleName'),
+      dataIndex: 'name',
+      sorter: true,
+      fixed: 'left' as const,
+      render: (name: string, role: RoleNodeInList) => {
+        return onClickRoleName ? (
+          <BAILink
+            type="hover"
+            onClick={() => {
+              onClickRoleName(role);
+            }}
+          >
+            {name}
+          </BAILink>
+        ) : (
+          name
+        );
+      },
+    },
+    {
+      key: 'actions',
+      title: '',
+      width: 100,
+      render: (_: unknown, role: RoleNodeInList) => {
+        const isSystem = role.source === 'SYSTEM';
+        return (
+          <>
+            {isDeletedFilter ? (
+              <BAIButton
+                type="text"
+                danger
+                icon={<ExclamationCircleOutlined />}
+                size="small"
+                onClick={() => onClickPurge?.(role)}
+              />
+            ) : (
+              <>
+                <BAIButton
+                  type="text"
+                  icon={<EditOutlined />}
+                  size="small"
+                  disabled={isSystem}
+                  onClick={() => onClickEdit?.(role)}
+                />
+                <BAIButton
+                  type="text"
+                  danger
+                  icon={<DeleteOutlined />}
+                  size="small"
+                  onClick={() => onClickDelete?.(role)}
+                />
+              </>
+            )}
+          </>
+        );
+      },
+    },
+    {
+      key: 'description',
+      title: t('rbac.RoleDescription'),
+      dataIndex: 'description',
+      ellipsis: true,
+    },
+    {
+      key: 'source',
+      title: t('rbac.Source'),
+      dataIndex: 'source',
+      render: (source: string) => {
+        return (
+          <BAITag color={source === 'SYSTEM' ? 'default' : 'green'}>
+            {source === 'SYSTEM' ? t('rbac.System') : t('rbac.Custom')}
+          </BAITag>
+        );
+      },
+    },
+    {
+      key: 'createdAt',
+      title: t('general.CreatedAt'),
+      dataIndex: 'createdAt',
+      sorter: true,
+      render: (createdAt: string) =>
+        createdAt ? dayjs(createdAt).format('YYYY-MM-DD HH:mm') : '-',
+    },
+    {
+      key: 'updatedAt',
+      title: t('general.UpdatedAt'),
+      dataIndex: 'updatedAt',
+      sorter: true,
+      render: (updatedAt: string) =>
+        updatedAt ? dayjs(updatedAt).format('YYYY-MM-DD HH:mm') : '-',
+    },
+  ]);
+
+  return (
+    <BAITable<RoleNodeInList>
+      rowKey="id"
+      dataSource={roles as RoleNodeInList[]}
+      columns={columns}
+      scroll={{ x: 'max-content' }}
+      order={order}
+      onChangeOrder={(order) => {
+        onChangeOrder?.(
+          (order as (typeof availableRoleSorterValues)[number]) || null,
+        );
+      }}
+      {...tableProps}
+    />
+  );
+};
+
+export default RoleNodes;

--- a/react/src/pages/RBACManagementPage.tsx
+++ b/react/src/pages/RBACManagementPage.tsx
@@ -2,20 +2,216 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { Typography } from 'antd';
-import { BAICard } from 'backend.ai-ui';
+import {
+  RBACManagementPageQuery,
+  RoleOrderBy,
+} from '../__generated__/RBACManagementPageQuery.graphql';
+import BAIRadioGroup from '../components/BAIRadioGroup';
+import RoleNodes from '../components/RoleNodes';
+import type { RoleNodeInList } from '../components/RoleNodes';
+import { convertToOrderBy } from '../helper';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { Skeleton } from 'antd';
+import {
+  BAIButton,
+  BAICard,
+  BAIFetchKeyButton,
+  BAIFlex,
+  BAIGraphQLPropertyFilter,
+  type GraphQLFilter,
+  INITIAL_FETCH_KEY,
+  useFetchKey,
+} from 'backend.ai-ui';
+import { PlusIcon } from 'lucide-react';
+import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
+import { Suspense, useDeferredValue, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+const statusFilterValues = ['ACTIVE', 'INACTIVE', 'DELETED'] as const;
+const sourceFilterValues = ['all', 'SYSTEM', 'CUSTOM'] as const;
 
 const RBACManagementPage: React.FC = () => {
   'use memo';
 
   const { t } = useTranslation();
 
+  const {
+    baiPaginationOption,
+    tablePaginationOption,
+    setTablePaginationOption,
+  } = useBAIPaginationOptionStateOnSearchParam({
+    current: 1,
+    pageSize: 20,
+  });
+
+  const [queryParams, setQueryParams] = useQueryStates(
+    {
+      status: parseAsStringLiteral(statusFilterValues).withDefault('ACTIVE'),
+      source: parseAsStringLiteral(sourceFilterValues).withDefault('all'),
+      order: parseAsString,
+    },
+    {
+      history: 'replace',
+    },
+  );
+
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const [filter, setFilter] = useState<GraphQLFilter>();
+
+  const sourceFilter =
+    queryParams.source === 'all' ? null : [queryParams.source];
+
+  const queryVariables = {
+    filter: {
+      status: [queryParams.status],
+      ...(sourceFilter ? { source: sourceFilter } : {}),
+      ...filter,
+    },
+    orderBy: convertToOrderBy<RoleOrderBy>(queryParams.order),
+    limit: baiPaginationOption.limit,
+    offset: baiPaginationOption.offset,
+  };
+
+  const deferredQueryVariables = useDeferredValue(queryVariables);
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  const queryRef = useLazyLoadQuery<RBACManagementPageQuery>(
+    graphql`
+      query RBACManagementPageQuery(
+        $filter: RoleFilter
+        $orderBy: [RoleOrderBy!]
+        $limit: Int
+        $offset: Int
+      ) {
+        adminRoles(
+          filter: $filter
+          orderBy: $orderBy
+          limit: $limit
+          offset: $offset
+        ) {
+          count
+          edges {
+            node {
+              id
+              ...RoleNodesFragment
+            }
+          }
+        }
+      }
+    `,
+    deferredQueryVariables,
+    {
+      fetchPolicy:
+        deferredFetchKey === INITIAL_FETCH_KEY
+          ? 'store-and-network'
+          : 'network-only',
+      fetchKey: deferredFetchKey,
+    },
+  );
+
+  // State for modals/drawers (wired in later sub-tasks)
+  const [, setIsCreateModalOpen] = useState(false);
+  const [, setSelectedRoleForDetail] = useState<RoleNodeInList | null>(null);
+  const [, setSelectedRoleForEdit] = useState<RoleNodeInList | null>(null);
+  const [, setSelectedRoleForDelete] = useState<RoleNodeInList | null>(null);
+  const [, setSelectedRoleForPurge] = useState<RoleNodeInList | null>(null);
+
+  const roleNodes = queryRef.adminRoles?.edges?.map((edge) => edge?.node) ?? [];
+
   return (
-    <BAICard title={t('webui.menu.RBACManagement')}>
-      <Typography.Text type="secondary">
-        {t('rbac.PagePlaceholder')}
-      </Typography.Text>
+    <BAICard
+      variant="borderless"
+      title={t('webui.menu.RBACManagement')}
+      styles={{
+        header: {
+          borderBottom: 'none',
+        },
+        body: {
+          paddingTop: 0,
+        },
+      }}
+    >
+      <BAIFlex direction="column" align="stretch" gap={'sm'}>
+        <BAIFlex justify="between" wrap="wrap" gap={'sm'}>
+          <BAIFlex
+            gap={'sm'}
+            align="start"
+            wrap="wrap"
+            style={{ flexShrink: 1 }}
+          >
+            <BAIRadioGroup
+              optionType="button"
+              value={queryParams.status}
+              onChange={(e) => {
+                setQueryParams({ status: e.target.value });
+                setTablePaginationOption({ current: 1 });
+              }}
+              options={[
+                { label: t('rbac.Active'), value: 'ACTIVE' },
+                { label: t('rbac.Inactive'), value: 'INACTIVE' },
+                { label: t('rbac.Deleted'), value: 'DELETED' },
+              ]}
+            />
+            <BAIGraphQLPropertyFilter
+              filterProperties={[
+                {
+                  key: 'name',
+                  propertyLabel: t('rbac.RoleName'),
+                  type: 'string',
+                },
+              ]}
+              value={filter}
+              onChange={(value) => {
+                setFilter(value);
+                setTablePaginationOption({ current: 1 });
+              }}
+            />
+          </BAIFlex>
+          <BAIFlex gap={'xs'}>
+            <BAIFetchKeyButton
+              loading={
+                deferredQueryVariables !== queryVariables ||
+                deferredFetchKey !== fetchKey
+              }
+              value={fetchKey}
+              onChange={(newFetchKey) => {
+                updateFetchKey(newFetchKey);
+              }}
+            />
+            <BAIButton
+              type="primary"
+              icon={<PlusIcon />}
+              onClick={() => setIsCreateModalOpen(true)}
+            >
+              {t('rbac.CreateRole')}
+            </BAIButton>
+          </BAIFlex>
+        </BAIFlex>
+        <Suspense fallback={<Skeleton active />}>
+          <RoleNodes
+            rolesFrgmt={roleNodes}
+            statusFilter={deferredQueryVariables.filter.status?.[0]}
+            loading={deferredQueryVariables !== queryVariables}
+            order={queryParams.order}
+            onChangeOrder={(newOrder) =>
+              setQueryParams({ order: newOrder })
+            }
+            onClickRoleName={(role) => setSelectedRoleForDetail(role)}
+            onClickEdit={(role) => setSelectedRoleForEdit(role)}
+            onClickDelete={(role) => setSelectedRoleForDelete(role)}
+            onClickPurge={(role) => setSelectedRoleForPurge(role)}
+            pagination={{
+              pageSize: tablePaginationOption.pageSize,
+              current: tablePaginationOption.current,
+              total: queryRef.adminRoles?.count ?? 0,
+              onChange: (current, pageSize) => {
+                setTablePaginationOption({ current, pageSize });
+              },
+            }}
+          />
+        </Suspense>
+      </BAIFlex>
     </BAICard>
   );
 };

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1019,6 +1019,7 @@
     "ShowUsageGraph": "Show Usage",
     "StorageProxies": "Storages",
     "TotalItems": "Total {{total}} items",
+    "UpdatedAt": "Updated At",
     "Username": "Username",
     "ValueRequired": "Please enter {{ name }}",
     "validation": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1021,6 +1021,7 @@
     "ShowUsageGraph": "사용량 확인",
     "StorageProxies": "스토리지",
     "TotalItems": "총 {{ total }}개",
+    "UpdatedAt": "수정일",
     "Username": "사용자 이름",
     "ValueRequired": "{{ name }} 값을 입력해 주세요",
     "validation": {


### PR DESCRIPTION
Resolves #5759 (FR-2220)

## Summary
- Create `RoleNodes` fragment component with `@relay(plural: true)` on Role type
- Implement `RBACManagementPage` orchestrator with `adminRoles` query
- Add status filter (ACTIVE/INACTIVE/DELETED), source filter, and name search via `BAIPropertyFilter`
- Add pagination with `useBAIPaginationOptionStateOnSearchParam`
- Table columns: Name (clickable link), Actions (edit/delete/purge), Description, Source, CreatedAt, UpdatedAt

## Test plan
- [ ] Verify role list table renders with correct columns
- [ ] Verify status filter switches between ACTIVE/INACTIVE/DELETED
- [ ] Verify name search filters roles
- [ ] Verify pagination works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)