### PR TITLE
feat(FR-2222): implement role detail drawer with metadata and tab placeholders

### DIFF
--- a/react/src/components/RoleDetailDrawer.tsx
+++ b/react/src/components/RoleDetailDrawer.tsx
@@ -1,0 +1,135 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { RoleDetailDrawerQuery } from '../__generated__/RoleDetailDrawerQuery.graphql';
+import RoleDetailDrawerContent from './RoleDetailDrawerContent';
+import { Drawer, Skeleton, Tooltip, Typography, theme } from 'antd';
+import { DrawerProps } from 'antd/lib';
+import {
+  BAIButton,
+  BAIFetchKeyButton,
+  BAIFlex,
+  toLocalId,
+  useFetchKey,
+} from 'backend.ai-ui';
+import { EditIcon } from 'lucide-react';
+import React, { Suspense, useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+interface RoleDetailDrawerProps extends DrawerProps {
+  roleId?: string;
+  onClickEdit?: () => void;
+}
+
+const RoleDetailDrawer: React.FC<RoleDetailDrawerProps> = ({
+  roleId,
+  onClickEdit,
+  ...drawerProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const [isPendingReload, startReloadTransition] = useTransition();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+
+  return (
+    <Drawer
+      title={t('rbac.RoleDetailInfo')}
+      width={800}
+      extra={
+        <BAIFetchKeyButton
+          loading={isPendingReload}
+          value={fetchKey}
+          onChange={(newFetchKey) => {
+            startReloadTransition(() => {
+              updateFetchKey(newFetchKey);
+            });
+          }}
+        />
+      }
+      {...drawerProps}
+    >
+      <Suspense fallback={<Skeleton active />}>
+        {roleId && (
+          <RoleDetailDrawerInner
+            roleId={roleId}
+            fetchKey={fetchKey}
+            onClickEdit={onClickEdit}
+          />
+        )}
+      </Suspense>
+    </Drawer>
+  );
+};
+
+interface RoleDetailDrawerInnerProps {
+  roleId: string;
+  fetchKey: string;
+  onClickEdit?: () => void;
+}
+
+const RoleDetailDrawerInner: React.FC<RoleDetailDrawerInnerProps> = ({
+  roleId,
+  fetchKey,
+  onClickEdit,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+
+  const data = useLazyLoadQuery<RoleDetailDrawerQuery>(
+    graphql`
+      query RoleDetailDrawerQuery($id: UUID!) {
+        adminRole(id: $id) {
+          name
+          source
+          ...RoleDetailDrawerContentFragment
+        }
+      }
+    `,
+    { id: toLocalId(roleId) },
+    {
+      fetchPolicy: 'network-only',
+      fetchKey,
+    },
+  );
+
+  if (!data.adminRole) {
+    return null;
+  }
+
+  const isCustom = data.adminRole.source === 'CUSTOM';
+
+  return (
+    <BAIFlex direction="column" gap={'sm'} align="stretch">
+      <BAIFlex
+        direction="row"
+        justify="between"
+        align="start"
+        style={{ alignSelf: 'stretch' }}
+        gap={'sm'}
+      >
+        <Typography.Title
+          level={3}
+          copyable
+          style={{ margin: 0, lineHeight: '1.6em' }}
+        >
+          {data.adminRole.name}
+        </Typography.Title>
+        {isCustom && onClickEdit && (
+          <Tooltip title={t('rbac.EditRole')}>
+            <BAIButton
+              size="large"
+              icon={<EditIcon style={{ color: token.colorInfo }} />}
+              onClick={onClickEdit}
+            />
+          </Tooltip>
+        )}
+      </BAIFlex>
+      <RoleDetailDrawerContent roleDetailFrgmt={data.adminRole} />
+    </BAIFlex>
+  );
+};
+
+export default RoleDetailDrawer;

--- a/react/src/components/RoleDetailDrawerContent.tsx
+++ b/react/src/components/RoleDetailDrawerContent.tsx
@@ -1,0 +1,120 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { RoleDetailDrawerContentFragment$key } from '../__generated__/RoleDetailDrawerContentFragment.graphql';
+import { Badge, Descriptions, Tabs, Tag } from 'antd';
+import dayjs from 'dayjs';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment } from 'react-relay';
+
+interface RoleDetailDrawerContentProps {
+  roleDetailFrgmt: RoleDetailDrawerContentFragment$key;
+  onTabReset?: () => void;
+}
+
+const RoleDetailDrawerContent: React.FC<RoleDetailDrawerContentProps> = ({
+  roleDetailFrgmt,
+  onTabReset: _onTabReset,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState('assignments');
+
+  const role = useFragment(
+    graphql`
+      fragment RoleDetailDrawerContentFragment on Role {
+        id
+        name
+        description
+        source
+        status
+        createdAt
+        updatedAt
+        deletedAt
+      }
+    `,
+    roleDetailFrgmt,
+  );
+
+  const sourceColor = role.source === 'SYSTEM' ? 'default' : 'green';
+  const statusColorMap: Record<string, string> = {
+    ACTIVE: 'green',
+    INACTIVE: 'orange',
+    DELETED: 'red',
+  };
+
+  return (
+    <>
+      <Descriptions
+        column={2}
+        bordered
+        size="small"
+        style={{ marginBottom: 16 }}
+      >
+        <Descriptions.Item label={t('rbac.RoleDescription')} span={2}>
+          {role.description || '-'}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('rbac.Source')}>
+          <Tag color={sourceColor}>
+            {role.source === 'SYSTEM' ? t('rbac.System') : t('rbac.Custom')}
+          </Tag>
+        </Descriptions.Item>
+        <Descriptions.Item label={t('rbac.Status')}>
+          <Tag color={statusColorMap[role.status] || 'default'}>
+            {role.status === 'ACTIVE'
+              ? t('rbac.Active')
+              : role.status === 'INACTIVE'
+                ? t('rbac.Inactive')
+                : t('rbac.Deleted')}
+          </Tag>
+        </Descriptions.Item>
+        <Descriptions.Item label={t('general.CreatedAt')}>
+          {role.createdAt
+            ? dayjs(role.createdAt).format('YYYY-MM-DD HH:mm:ss')
+            : '-'}
+        </Descriptions.Item>
+        <Descriptions.Item label={t('general.UpdatedAt')}>
+          {role.updatedAt
+            ? dayjs(role.updatedAt).format('YYYY-MM-DD HH:mm:ss')
+            : '-'}
+        </Descriptions.Item>
+      </Descriptions>
+      <Tabs
+        activeKey={activeTab}
+        onChange={setActiveTab}
+        items={[
+          {
+            key: 'assignments',
+            label: (
+              <>
+                {t('rbac.Assignments')}{' '}
+                <Badge count={0} showZero size="small" />
+              </>
+            ),
+            children: (
+              // TODO: Implement in ST-7 (FR-2225)
+              <div>{t('rbac.NoUsersAssigned')}</div>
+            ),
+          },
+          {
+            key: 'permissions',
+            label: (
+              <>
+                {t('rbac.Permissions')}{' '}
+                <Badge count={0} showZero size="small" />
+              </>
+            ),
+            children: (
+              // TODO: Implement in ST-8 (FR-2226)
+              <div>{t('rbac.NoPermissionsToDisplay')}</div>
+            ),
+          },
+        ]}
+      />
+    </>
+  );
+};
+
+export default RoleDetailDrawerContent;

--- a/react/src/components/RoleFormModal.tsx
+++ b/react/src/components/RoleFormModal.tsx
@@ -3,7 +3,7 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { RoleFormModalCreateMutation } from '../__generated__/RoleFormModalCreateMutation.graphql';
-import { RoleFormModalFragment$key } from '../__generated__/RoleFormModalFragment.graphql';
+import type { RoleFormModalFragment$key as _RoleFormModalFragment$key } from '../__generated__/RoleFormModalFragment.graphql';
 import { App, Form, Input } from 'antd';
 import { BAIModal, BAIModalProps } from 'backend.ai-ui';
 import React from 'react';

--- a/react/src/pages/RBACManagementPage.tsx
+++ b/react/src/pages/RBACManagementPage.tsx
@@ -7,6 +7,7 @@ import {
   RoleOrderBy,
 } from '../__generated__/RBACManagementPageQuery.graphql';
 import BAIRadioGroup from '../components/BAIRadioGroup';
+import RoleDetailDrawer from '../components/RoleDetailDrawer';
 import RoleFormModal from '../components/RoleFormModal';
 import RoleNodes from '../components/RoleNodes';
 import type { RoleNodeInList } from '../components/RoleNodes';
@@ -112,8 +113,15 @@ const RBACManagementPage: React.FC = () => {
   );
 
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  // State for drawer/modals (wired in later sub-tasks)
-  const [, setSelectedRoleForDetail] = useState<RoleNodeInList | null>(null);
+  const [{ roleDetail: selectedRoleId }, setRoleDetailParam] = useQueryStates(
+    {
+      roleDetail: parseAsString,
+    },
+    {
+      history: 'push',
+    },
+  );
+  // State for modals (wired in later sub-tasks)
   const [, setSelectedRoleForEdit] = useState<RoleNodeInList | null>(null);
   const [, setSelectedRoleForDelete] = useState<RoleNodeInList | null>(null);
   const [, setSelectedRoleForPurge] = useState<RoleNodeInList | null>(null);
@@ -198,7 +206,9 @@ const RBACManagementPage: React.FC = () => {
             onChangeOrder={(newOrder) =>
               setQueryParams({ order: newOrder })
             }
-            onClickRoleName={(role) => setSelectedRoleForDetail(role)}
+            onClickRoleName={(role) =>
+              setRoleDetailParam({ roleDetail: role.id })
+            }
             onClickEdit={(role) => setSelectedRoleForEdit(role)}
             onClickDelete={(role) => setSelectedRoleForDelete(role)}
             onClickPurge={(role) => setSelectedRoleForPurge(role)}
@@ -219,6 +229,21 @@ const RBACManagementPage: React.FC = () => {
           setIsCreateModalOpen(false);
           if (success) {
             updateFetchKey();
+          }
+        }}
+      />
+      <RoleDetailDrawer
+        open={!!selectedRoleId}
+        roleId={selectedRoleId || undefined}
+        onClose={() => setRoleDetailParam({ roleDetail: null })}
+        onClickEdit={() => {
+          if (selectedRoleId) {
+            setSelectedRoleForEdit(
+              (roleNodes.find((r) => r?.id === selectedRoleId) as
+                | RoleNodeInList
+                | undefined) ?? null,
+            );
+            setRoleDetailParam({ roleDetail: null });
           }
         }}
       />

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1480,6 +1480,7 @@
     "RoleCreated": "Role created successfully.",
     "RoleDeleted": "Role deleted successfully.",
     "RoleDescription": "Description",
+    "RoleDetailInfo": "Role Detail",
     "RoleName": "Role Name",
     "RoleNotFound": "Role not found.",
     "RolePurged": "Role permanently removed.",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1482,6 +1482,7 @@
     "RoleCreated": "역할이 성공적으로 생성되었습니다.",
     "RoleDeleted": "역할이 성공적으로 삭제되었습니다.",
     "RoleDescription": "설명",
+    "RoleDetailInfo": "역할 상세 정보",
     "RoleName": "역할 이름",
     "RoleNotFound": "역할을 찾을 수 없습니다.",
     "RolePurged": "역할이 영구적으로 삭제되었습니다.",


### PR DESCRIPTION
Resolves #5761(FR-2222)

## Summary
- Create `RoleDetailDrawer` with inner component using `useLazyLoadQuery` for `adminRole(id)`
- Create `RoleDetailDrawerContent` fragment component with metadata Descriptions and Tabs
- Show Description, Source (tag), Status (tag), CreatedAt, UpdatedAt
- Add Assignments and Permissions tabs (placeholder content for later sub-tasks)
- Edit button visible only for CUSTOM roles, refresh button via `BAIFetchKeyButton`

## Test plan
- [ ] Verify clicking role name opens detail drawer
- [ ] Verify metadata displays correctly (description, source, status, timestamps)
- [ ] Verify Edit button appears only for custom roles
- [ ] Verify refresh button reloads drawer data

🤖 Generated with [Claude Code](https://claude.com/claude-code)