### PR TITLE
fix(FR-2228): add email input field to password change modal

### DIFF
--- a/react/src/components/LoginFormPanel.tsx
+++ b/react/src/components/LoginFormPanel.tsx
@@ -127,6 +127,7 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
     title: string;
     content: string;
   } | null>(null);
+  const [showChangePasswordEmail, setShowChangePasswordEmail] = useState(false);
 
   // Derive effective help panel visibility: hidden when modal is closed
   const effectiveHelpPanel = isOpen ? helpPanel : null;
@@ -409,12 +410,7 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
                   </Typography.Text>
                   <Typography.Link
                     style={{ fontSize: 'inherit' }}
-                    onClick={() =>
-                      setHelpPanel({
-                        title: t('login.SendChangePasswordEmail'),
-                        content: t('login.DescChangePasswordEmail'),
-                      })
-                    }
+                    onClick={() => setShowChangePasswordEmail(true)}
                   >
                     {t('login.ChangePassword')}
                   </Typography.Link>
@@ -488,6 +484,12 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
           onSetNeedsOtpRegistration(false);
           onSetOtpRequired(true);
         }}
+      />
+
+      <SendChangePasswordEmailModal
+        open={showChangePasswordEmail}
+        apiEndpoint={apiEndpoint}
+        onCancel={() => setShowChangePasswordEmail(false)}
       />
 
       {/* Signup Modal */}
@@ -754,6 +756,96 @@ const TOTPActivateInline: React.FC<{
         />
       )}
     </BAIModal>
+  );
+};
+
+/**
+ * Modal for sending a password change email (anonymous / forgot-password flow).
+ */
+const SendChangePasswordEmailModal: React.FC<{
+  open: boolean;
+  apiEndpoint: string;
+  onCancel: () => void;
+}> = ({ open, apiEndpoint, onCancel }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { message } = App.useApp();
+  const [form] = Form.useForm<{ email: string }>();
+  const anonymousBaiClient = useAnonymousBackendaiClient({
+    api_endpoint: apiEndpoint,
+  });
+
+  useEffect(() => {
+    if (open) {
+      form.resetFields();
+    }
+  }, [open, form]);
+
+  const mutation = useTanMutation({
+    mutationFn: (body: { email: string }) => {
+      return baiSignedRequestWithPromise({
+        method: 'POST',
+        url: '/cloud/send-password-change-email',
+        body,
+        client: anonymousBaiClient,
+      });
+    },
+  });
+
+  const onSubmit = () => {
+    form.validateFields().then((values) => {
+      mutation.mutate(
+        { email: values.email },
+        {
+          onSuccess() {
+            message.success(t('login.EmailSent'));
+            onCancel();
+          },
+        },
+      );
+    });
+  };
+
+  return (
+    <Modal
+      open={open}
+      centered
+      onCancel={onCancel}
+      footer={null}
+      width={450}
+      destroyOnHidden
+      zIndex={1002}
+      getContainer={false}
+    >
+      <BAIFlex
+        direction="column"
+        justify="start"
+        align="stretch"
+        gap="md"
+        style={{
+          paddingTop: token.paddingMD,
+          paddingBottom: token.paddingMD,
+        }}
+      >
+        <Typography.Title level={4} style={{ margin: 0 }}>
+          {t('login.SendChangePasswordEmail')}
+        </Typography.Title>
+        <Typography.Text>{t('login.DescChangePasswordEmail')}</Typography.Text>
+        <Form form={form} layout="vertical" disabled={mutation.isPending}>
+          <Form.Item name="email" rules={[{ required: true, type: 'email' }]}>
+            <Input
+              prefix={<MailOutlined />}
+              placeholder={t('login.E-mailOrUsername')}
+              onPressEnter={onSubmit}
+            />
+          </Form.Item>
+        </Form>
+        <Button type="primary" onClick={onSubmit} loading={mutation.isPending}>
+          {t('login.EmailSendButton')}
+        </Button>
+      </BAIFlex>
+    </Modal>
   );
 };
 


### PR DESCRIPTION
Resolves #5776 ([FR-2228](https://lablup.atlassian.net/browse/FR-2228), [FR-2264](https://lablup.atlassian.net/browse/FR-2264))

The 'Change Password' link in the login form previously opened a help panel (sidebar) instead of a proper input UI. This meant users had no way to actually enter their email address to receive a password change link.

This PR extracts the forgot-password flow into a standalone `SendChangePasswordEmailModal` component with a proper email form input, fixing the broken user flow.

**Changes:**
- Added `SendChangePasswordEmailModal` as a dedicated React modal component
- Modal includes email input with validation and submit button
- Password change link now opens the modal instead of the help panel

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after

[FR-2228]: https://lablup.atlassian.net/browse/FR-2228
[FR-2264]: https://lablup.atlassian.net/browse/FR-2264