### PR TITLE
feat(FR-2239): add bulk role assign/revoke mutations

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1207,6 +1207,54 @@ input AssignRoleInput
   roleId: UUID!
 }
 
+"""Added in 26.3.0. Input for bulk assigning a role to multiple users"""
+input BulkAssignRoleInput
+  @join__type(graph: STRAWBERRY)
+{
+  roleId: UUID!
+  userIds: [UUID!]!
+}
+
+"""Added in 26.3.0. Payload for bulk role assignment mutation."""
+type BulkAssignRolePayload
+  @join__type(graph: STRAWBERRY)
+{
+  assigned: [RoleAssignment!]!
+  failed: [BulkAssignRoleError!]!
+}
+
+"""Added in 26.3.0. Error information for a failed user in bulk role assignment."""
+type BulkAssignRoleError
+  @join__type(graph: STRAWBERRY)
+{
+  userId: UUID!
+  message: String!
+}
+
+"""Added in 26.3.0. Input for bulk revoking a role from multiple users"""
+input BulkRevokeRoleInput
+  @join__type(graph: STRAWBERRY)
+{
+  roleId: UUID!
+  userIds: [UUID!]!
+}
+
+"""Added in 26.3.0. Payload for bulk role revocation mutation."""
+type BulkRevokeRolePayload
+  @join__type(graph: STRAWBERRY)
+{
+  revoked: [RoleAssignment!]!
+  failed: [BulkRevokeRoleError!]!
+}
+
+"""Added in 26.3.0. Error information for a failed user in bulk role revocation."""
+type BulkRevokeRoleError
+  @join__type(graph: STRAWBERRY)
+{
+  userId: UUID!
+  message: String!
+}
+
 """Added in 24.03.9."""
 type AssociateScalingGroupsWithDomain
   @join__type(graph: GRAPHENE)

--- a/react/src/components/AssignRoleModal.tsx
+++ b/react/src/components/AssignRoleModal.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
 interface AssignRoleModalProps extends BAIModalProps {
-  onAssign: (userId: string) => void;
+  onAssign: (userIds: string[]) => void;
 }
 
 const AssignRoleModal: React.FC<AssignRoleModalProps> = ({
@@ -19,7 +19,7 @@ const AssignRoleModal: React.FC<AssignRoleModalProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
-  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [selectedUserIds, setSelectedUserIds] = useState<string[]>([]);
   const [search, setSearch] = useState('');
   const deferredSearch = useDeferredValue(search);
 
@@ -55,23 +55,24 @@ const AssignRoleModal: React.FC<AssignRoleModalProps> = ({
       title={t('rbac.AssignUser')}
       okText={t('rbac.Assign')}
       onOk={() => {
-        if (selectedUserId) {
-          onAssign(selectedUserId);
+        if (selectedUserIds.length > 0) {
+          onAssign(selectedUserIds);
         }
       }}
-      okButtonProps={{ disabled: !selectedUserId }}
+      okButtonProps={{ disabled: selectedUserIds.length === 0 }}
       destroyOnClose
       afterClose={() => {
-        setSelectedUserId(null);
+        setSelectedUserIds([]);
         setSearch('');
       }}
       {...baiModalProps}
     >
       <Select
+        mode="multiple"
         style={{ width: '100%' }}
-        placeholder={t('rbac.SelectUser')}
-        value={selectedUserId}
-        onChange={(value) => setSelectedUserId(value)}
+        placeholder={t('rbac.SelectUsers')}
+        value={selectedUserIds}
+        onChange={(value) => setSelectedUserIds(value)}
         loading={deferredSearch !== search}
         showSearch={{
           searchValue: search,

--- a/react/src/components/RoleAssignmentTab.tsx
+++ b/react/src/components/RoleAssignmentTab.tsx
@@ -2,10 +2,10 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { RoleAssignmentTabAssignMutation } from '../__generated__/RoleAssignmentTabAssignMutation.graphql';
+import { RoleAssignmentTabBulkAssignMutation } from '../__generated__/RoleAssignmentTabBulkAssignMutation.graphql';
+import { RoleAssignmentTabBulkRevokeMutation } from '../__generated__/RoleAssignmentTabBulkRevokeMutation.graphql';
 import { RoleAssignmentTabFragment$key } from '../__generated__/RoleAssignmentTabFragment.graphql';
 import { RoleAssignmentOrderBy } from '../__generated__/RoleAssignmentTabRefetchQuery.graphql';
-import { RoleAssignmentTabRevokeMutation } from '../__generated__/RoleAssignmentTabRevokeMutation.graphql';
 import { convertToOrderBy } from '../helper';
 import AssignRoleModal from './AssignRoleModal';
 import { App } from 'antd';
@@ -40,6 +40,7 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
   const { modal, message } = App.useApp();
   const { logger } = useBAILogger();
   const [isAssignModalOpen, setIsAssignModalOpen] = useState(false);
+  const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
   const [filter, setFilter] = useState<GraphQLFilter>();
   const [order, setOrder] = useState<string | null>(null);
   const [isPendingRefetch, startRefetchTransition] = useTransition();
@@ -75,27 +76,42 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
     queryRef,
   );
 
-  const [commitAssignRole, isInFlightAssign] =
-    useMutation<RoleAssignmentTabAssignMutation>(graphql`
-      mutation RoleAssignmentTabAssignMutation($input: AssignRoleInput!) {
-        adminAssignRole(input: $input) {
-          id
-          userId
-          grantedBy
-          grantedAt
+  const [commitBulkAssignRole, isInFlightBulkAssign] =
+    useMutation<RoleAssignmentTabBulkAssignMutation>(graphql`
+      mutation RoleAssignmentTabBulkAssignMutation(
+        $input: BulkAssignRoleInput!
+      ) {
+        adminBulkAssignRole(input: $input) {
+          assigned {
+            id
+            userId
+            grantedBy
+            grantedAt
+          }
+          failed {
+            userId
+            message
+          }
         }
       }
     `);
 
-  const [commitRevokeRole] = useMutation<RoleAssignmentTabRevokeMutation>(
-    graphql`
-      mutation RoleAssignmentTabRevokeMutation($input: RevokeRoleInput!) {
-        adminRevokeRole(input: $input) {
-          id
+  const [commitBulkRevokeRole, isInFlightBulkRevoke] =
+    useMutation<RoleAssignmentTabBulkRevokeMutation>(graphql`
+      mutation RoleAssignmentTabBulkRevokeMutation(
+        $input: BulkRevokeRoleInput!
+      ) {
+        adminBulkRevokeRole(input: $input) {
+          revoked {
+            id
+          }
+          failed {
+            userId
+            message
+          }
         }
       }
-    `,
-  );
+    `);
 
   const assignments =
     data.adminRoleAssignments?.edges?.map((edge) => edge?.node) ?? [];
@@ -131,16 +147,23 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
     });
   };
 
-  const handleAssign = (userId: string) => {
-    commitAssignRole({
-      variables: { input: { userId, roleId } },
-      onCompleted: (_data, errors) => {
+  const handleBulkAssign = (userIds: string[]) => {
+    commitBulkAssignRole({
+      variables: { input: { userIds, roleId } },
+      onCompleted: (data, errors) => {
         if (errors && errors.length > 0) {
           logger.error(errors[0]);
           message.error(errors[0]?.message || t('general.ErrorOccurred'));
           return;
         }
-        message.success(t('rbac.UserAssigned'));
+        const failed = data.adminBulkAssignRole?.failed ?? [];
+        if (failed.length > 0) {
+          message.warning(
+            t('rbac.BulkAssignPartialFailure', { count: failed.length }),
+          );
+        } else {
+          message.success(t('rbac.UsersAssigned'));
+        }
         setIsAssignModalOpen(false);
         handleRefresh();
         onAssignmentChange?.();
@@ -152,24 +175,37 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
     });
   };
 
-  const handleRevoke = (userId: string) => {
+  const handleBulkRevoke = (userIds: string[]) => {
     modal.confirm({
       title: t('rbac.RevokeUser'),
-      content: t('rbac.ConfirmRevoke'),
+      content:
+        userIds.length > 1
+          ? t('rbac.ConfirmBulkRevoke', { count: userIds.length })
+          : t('rbac.ConfirmRevoke'),
       okText: t('rbac.RevokeUser'),
       okButtonProps: { danger: true, type: 'primary' },
       onOk: () =>
         new Promise<void>((resolve, reject) => {
-          commitRevokeRole({
-            variables: { input: { userId, roleId } },
-            onCompleted: (_data, errors) => {
+          commitBulkRevokeRole({
+            variables: { input: { userIds, roleId } },
+            onCompleted: (data, errors) => {
               if (errors && errors.length > 0) {
                 logger.error(errors[0]);
                 message.error(errors[0]?.message || t('general.ErrorOccurred'));
                 reject();
                 return;
               }
-              message.success(t('rbac.UserRevoked'));
+              const failed = data.adminBulkRevokeRole?.failed ?? [];
+              if (failed.length > 0) {
+                message.warning(
+                  t('rbac.BulkRevokePartialFailure', {
+                    count: failed.length,
+                  }),
+                );
+              } else {
+                message.success(t('rbac.UserRevoked'));
+              }
+              setSelectedRowKeys([]);
               handleRefresh();
               onAssignmentChange?.();
               resolve();
@@ -209,13 +245,31 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
           value={filter}
           onChange={handleFilterChange}
         />
-        <BAIButton
-          type="primary"
-          icon={<PlusIcon />}
-          onClick={() => setIsAssignModalOpen(true)}
-        >
-          {t('rbac.AssignUser')}
-        </BAIButton>
+        <BAIFlex gap="xs">
+          {selectedRowKeys.length > 0 && (
+            <BAIButton
+              danger
+              icon={<BAITrashBinIcon />}
+              loading={isInFlightBulkRevoke}
+              onClick={() => {
+                const userIds = assignments
+                  .filter((a) => selectedRowKeys.includes(a?.id ?? ''))
+                  .map((a) => a?.userId)
+                  .filter(Boolean) as string[];
+                handleBulkRevoke(userIds);
+              }}
+            >
+              {t('rbac.RevokeUser')} ({selectedRowKeys.length})
+            </BAIButton>
+          )}
+          <BAIButton
+            type="primary"
+            icon={<PlusIcon />}
+            onClick={() => setIsAssignModalOpen(true)}
+          >
+            {t('rbac.AssignUser')}
+          </BAIButton>
+        </BAIFlex>
       </BAIFlex>
       <BAITable
         rowKey="id"
@@ -223,6 +277,11 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
         loading={isPendingRefetch}
         size="small"
         pagination={false}
+        rowSelection={{
+          type: 'checkbox',
+          selectedRowKeys,
+          onChange: (keys) => setSelectedRowKeys(keys),
+        }}
         order={order}
         onChangeOrder={(newOrder) => {
           setOrder(newOrder ?? null);
@@ -277,7 +336,7 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
                 icon={<BAITrashBinIcon />}
                 size="small"
                 title={t('rbac.RevokeUser')}
-                onClick={() => handleRevoke(record?.userId)}
+                onClick={() => handleBulkRevoke([record?.userId])}
               />
             ),
           },
@@ -285,9 +344,9 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
       />
       <AssignRoleModal
         open={isAssignModalOpen}
-        confirmLoading={isInFlightAssign}
+        confirmLoading={isInFlightBulkAssign}
         onCancel={() => setIsAssignModalOpen(false)}
-        onAssign={handleAssign}
+        onAssign={handleBulkAssign}
       />
     </>
   );

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1456,6 +1456,9 @@
     "Assign": "Assign",
     "AssignUser": "Add User",
     "Assignments": "Assignments",
+    "BulkAssignPartialFailure": "{{count}} user(s) failed to be assigned.",
+    "BulkRevokePartialFailure": "{{count}} user(s) failed to be revoked.",
+    "ConfirmBulkRevoke": "Are you sure you want to remove {{count}} user(s) from the role?",
     "ConfirmDelete": "Are you sure you want to delete role \"{{name}}\"? This will soft-delete the role.",
     "ConfirmDeletePermission": "Are you sure you want to delete this permission?",
     "ConfirmPurge": "Are you sure you want to permanently remove role \"{{name}}\"? This action cannot be undone.",
@@ -1500,13 +1503,15 @@
     "ScopeId": "Scope ID",
     "ScopeType": "Scope Type",
     "SelectUser": "Search and select a user",
+    "SelectUsers": "Search and select users",
     "Source": "Source",
     "Status": "Status",
     "System": "System",
     "UserAlreadyAssigned": "User is already assigned to this role.",
     "UserAssigned": "User assigned to role successfully.",
     "UserNotAssigned": "User is not assigned to this role.",
-    "UserRevoked": "User removed from role successfully."
+    "UserRevoked": "User removed from role successfully.",
+    "UsersAssigned": "Users assigned to role successfully."
   },
   "registry": {
     "AddRegistry": "Add Registry",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1458,6 +1458,9 @@
     "Assign": "할당",
     "AssignUser": "사용자 추가",
     "Assignments": "할당",
+    "BulkAssignPartialFailure": "{{count}}명의 사용자 할당에 실패했습니다.",
+    "BulkRevokePartialFailure": "{{count}}명의 사용자 권한 해제에 실패했습니다.",
+    "ConfirmBulkRevoke": "{{count}}명의 사용자를 권한에서 제거하시겠습니까?",
     "ConfirmDelete": "\"{{name}}\" 권한을 삭제하시겠습니까? 소프트 삭제됩니다.",
     "ConfirmDeletePermission": "이 세부 권한을 삭제하시겠습니까?",
     "ConfirmPurge": "\"{{name}}\" 권한을 영구적으로 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
@@ -1502,13 +1505,15 @@
     "ScopeId": "범위 ID",
     "ScopeType": "범위 유형",
     "SelectUser": "사용자 검색 및 선택",
+    "SelectUsers": "사용자 검색 및 선택",
     "Source": "소스",
     "Status": "상태",
     "System": "시스템",
     "UserAlreadyAssigned": "사용자가 이미 이 권한에 할당되어 있습니다.",
     "UserAssigned": "사용자가 권한에 성공적으로 할당되었습니다.",
     "UserNotAssigned": "사용자가 이 권한에 할당되어 있지 않습니다.",
-    "UserRevoked": "사용자가 권한에서 성공적으로 제거되었습니다."
+    "UserRevoked": "사용자가 권한에서 성공적으로 제거되었습니다.",
+    "UsersAssigned": "사용자들이 역할에 성공적으로 할당되었습니다."
   },
   "registry": {
     "AddRegistry": "레지스트리 추가",


### PR DESCRIPTION
Resolves #5830 ([FR-2239](https://lablup.atlassian.net/browse/FR-2239))

## Summary
- Implement `adminBulkAssignRole` mutation for assigning a role to multiple users at once
- Implement `adminBulkRevokeRole` mutation for revoking a role from multiple users
- Update AssignRoleModal to support multiple user selection

## Test plan
- [ ] Select multiple users in the assign modal and assign them to a role
- [ ] Verify all selected users appear in the assignment table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-2239]: https://lablup.atlassian.net/browse/FR-2239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ