### PR TITLE
refactor(FR-1533): refactor ActiveAgents to use Relay refetchable fragment pattern

### DIFF
--- a/react/src/components/ActiveAgents.tsx
+++ b/react/src/components/ActiveAgents.tsx
@@ -2,84 +2,153 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import AgentList from './AgentList';
+import { ActiveAgentsFragment$key } from '../__generated__/ActiveAgentsFragment.graphql';
+import AgentDetailDrawer from './AgentDetailDrawer';
 import { theme } from 'antd';
-import { BAIBoardItemTitle, BAIFetchKeyButton, BAIFlex } from 'backend.ai-ui';
-import { useTransition } from 'react';
+import {
+  filterOutNullAndUndefined,
+  BAIAgentTable,
+  BAIBoardItemTitle,
+  BAIFetchKeyButton,
+  BAIFlex,
+  BAIUnmountAfterClose,
+} from 'backend.ai-ui';
+import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
+import { graphql, useRefetchableFragment } from 'react-relay';
 
 interface ActiveAgentsProps {
-  fetchKey?: string;
-  onChangeFetchKey?: (key: string) => void;
+  queryRef: ActiveAgentsFragment$key;
+  isRefetching?: boolean;
 }
 
-// TODO: Refactor this component with agent_nodes.
-// ref: https://lablup.atlassian.net/browse/FR-1533
 const ActiveAgents: React.FC<ActiveAgentsProps> = ({
-  fetchKey,
-  onChangeFetchKey,
+  queryRef,
+  isRefetching,
 }) => {
+  'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [order, setOrder] = useState<string>('-first_contact');
+
+  const [data, refetch] = useRefetchableFragment(
+    graphql`
+      fragment ActiveAgentsFragment on Query
+      @refetchable(queryName: "ActiveAgentsRefetchQuery")
+      @argumentDefinitions(
+        order: { type: "String", defaultValue: "-first_contact" }
+      ) {
+        active_agent_nodes: agent_nodes(
+          first: 5
+          filter: "status == \"ALIVE\""
+          order: $order
+        ) {
+          edges {
+            node {
+              id
+              ...BAIAgentTableFragment
+              ...AgentDetailDrawerFragment
+            }
+          }
+        }
+      }
+    `,
+    queryRef,
+  );
+
+  const agentNodes = filterOutNullAndUndefined(
+    data.active_agent_nodes?.edges.map((e) => e?.node),
+  );
+
+  const selectedAgent = agentNodes.find((a) => a.id === selectedAgentId);
+
+  // Auto-close drawer when selected agent disappears (e.g., goes offline during refetch)
+  useEffect(() => {
+    if (selectedAgentId && !selectedAgent) {
+      setSelectedAgentId(null);
+    }
+  }, [selectedAgentId, selectedAgent]);
 
   return (
-    <BAIFlex
-      direction="column"
-      align="stretch"
-      style={{
-        paddingInline: token.paddingXL,
-        height: '100%',
-      }}
-    >
-      <BAIBoardItemTitle
-        title={t('activeAgent.ActiveAgents')}
-        tooltip={t('activeAgent.ActiveAgentsTooltip', {
-          count: 5,
-        })}
-        extra={
-          <BAIFetchKeyButton
-            size="small"
-            loading={isPendingRefetch}
-            value=""
-            onChange={(newFetchKey) => {
-              startRefetchTransition(() => {
-                onChangeFetchKey?.(newFetchKey);
-              });
-            }}
-            type="text"
-            style={{
-              backgroundColor: 'transparent',
-            }}
-          />
-        }
-      />
-
-      {/* Scrollable Content Section */}
+    <>
       <BAIFlex
         direction="column"
         align="stretch"
         style={{
-          flex: 1,
-          overflowY: 'auto',
-          overflowX: 'hidden',
+          paddingInline: token.paddingXL,
+          height: '100%',
         }}
       >
-        <AgentList
-          fetchKey={fetchKey}
-          onChangeFetchKey={onChangeFetchKey}
-          headerProps={{
-            style: { display: 'none' },
+        <BAIBoardItemTitle
+          title={t('activeAgent.ActiveAgents')}
+          tooltip={t('activeAgent.ActiveAgentsTooltip', {
+            count: 5,
+          })}
+          extra={
+            <BAIFetchKeyButton
+              size="small"
+              loading={isPendingRefetch || isRefetching}
+              value=""
+              onChange={() => {
+                startRefetchTransition(() => {
+                  refetch(
+                    {},
+                    {
+                      fetchPolicy: 'network-only',
+                    },
+                  );
+                });
+              }}
+              type="text"
+              style={{
+                backgroundColor: 'transparent',
+              }}
+            />
+          }
+        />
+
+        {/* Scrollable Content Section */}
+        <BAIFlex
+          direction="column"
+          align="stretch"
+          style={{
+            flex: 1,
+            overflowY: 'auto',
+            overflowX: 'hidden',
           }}
-          tableProps={{
-            pagination: {
+        >
+          <BAIAgentTable
+            agentsFragment={agentNodes}
+            order={order}
+            onChangeOrder={(newOrder) => {
+              const orderValue = newOrder || '-first_contact';
+              setOrder(orderValue);
+              startRefetchTransition(() => {
+                refetch({ order: orderValue }, { fetchPolicy: 'network-only' });
+              });
+            }}
+            onClickAgentName={(agent) => {
+              setSelectedAgentId(agent.id);
+            }}
+            pagination={{
               pageSize: 3,
               showSizeChanger: false,
-            },
+            }}
+          />
+        </BAIFlex>
+      </BAIFlex>
+      <BAIUnmountAfterClose>
+        <AgentDetailDrawer
+          agentNodeFrgmt={selectedAgent ?? null}
+          open={!!selectedAgent}
+          onRequestClose={() => {
+            setSelectedAgentId(null);
           }}
         />
-      </BAIFlex>
-    </BAIFlex>
+      </BAIUnmountAfterClose>
+    </>
   );
 };
 

--- a/react/src/pages/AdminDashboardPage.tsx
+++ b/react/src/pages/AdminDashboardPage.tsx
@@ -72,6 +72,7 @@ const AdminDashboardPage: React.FC = () => {
             agentNodeFilter: $agentNodeFilter
           )
         ...AgentStatsFragment @skip(if: $skipAgentStats) @alias
+        ...ActiveAgentsFragment @alias
       }
     `,
     {
@@ -179,10 +180,12 @@ const AdminDashboardPage: React.FC = () => {
               <Skeleton active style={{ padding: `0px ${token.marginMD}px` }} />
             }
           >
-            <ActiveAgents
-              fetchKey={fetchKey}
-              onChangeFetchKey={() => updateFetchKey()}
-            />
+            {queryRef.ActiveAgentsFragment && (
+              <ActiveAgents
+                queryRef={queryRef.ActiveAgentsFragment}
+                isRefetching={isPendingIntervalRefetch}
+              />
+            )}
           </Suspense>
         ),
       },

--- a/react/src/pages/DashboardPage.tsx
+++ b/react/src/pages/DashboardPage.tsx
@@ -74,6 +74,7 @@ const DashboardPage: React.FC = () => {
             agentNodeFilter: $agentNodeFilter
           )
         ...AgentStatsFragment @include(if: $isSuperAdmin) @alias
+        ...ActiveAgentsFragment @include(if: $isSuperAdmin) @alias
       }
     `,
     {
@@ -229,10 +230,12 @@ const DashboardPage: React.FC = () => {
               <Skeleton active style={{ padding: `0px ${token.marginMD}px` }} />
             }
           >
-            <ActiveAgents
-              fetchKey={fetchKey}
-              onChangeFetchKey={() => updateFetchKey()}
-            />
+            {queryRef.ActiveAgentsFragment && (
+              <ActiveAgents
+                queryRef={queryRef.ActiveAgentsFragment}
+                isRefetching={isPendingIntervalRefetch}
+              />
+            )}
           </Suspense>
         ),
       },


### PR DESCRIPTION
Resolves #4364(FR-1533)

## Summary
- Refactor `ActiveAgents` to use its own `@refetchable` fragment pattern (following `RecentlyCreatedSession`)
- `ActiveAgents` now uses `useRefetchableFragment` + `BAIAgentTable` directly, instead of wrapping `AgentList`
- Add `...ActiveAgentsFragment` to `DashboardPageQuery` and `AdminDashboardPageQuery`
- `AgentList` remains unchanged (self-contained query orchestrator for ResourcesPage)

### Why this approach
The previous PRs (#5738, #5741) attempted to convert `AgentList` into a fragment component, which caused:
1. Loss of dashboard auto-refresh (parent interval no longer reached agent data)
2. URL state pollution (`nuqs` params leaking into dashboard)
3. Wrapper boilerplate in every parent page

This approach keeps `AgentList` as-is and gives `ActiveAgents` its own lightweight fragment, matching the proven `RecentlyCreatedSession` pattern.

### Changes
| Component | Role | Data Pattern |
|-----------|------|-------------|
| `AgentList` | Full agent list (Resources page) | `useLazyLoadQuery` (unchanged) |
| `ActiveAgents` | Dashboard widget | `useRefetchableFragment` (new) |
| `BAIAgentTable` | Shared table renderer | `useFragment` (unchanged) |

Supersedes #5738 and #5741.