### PR TITLE
feat(FR-2230): expose global switchLanguage function for screenshot capture

### DIFF
--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -121,6 +121,12 @@ if (process.env.NODE_ENV === 'development') {
   isDebugModeByParam = urlParams.get('debug') === 'true';
 }
 
+if (typeof window !== 'undefined') {
+  window.switchLanguage = (lang: string) => {
+    window.dispatchEvent(new CustomEvent('langChanged', { detail: { lang } }));
+  };
+}
+
 i18n
   .use(initReactI18next) // passes i18n down to react-i18next
   .use(Backend)

--- a/react/src/react-app-env.d.ts
+++ b/react/src/react-app-env.d.ts
@@ -91,3 +91,7 @@ type NonNullableItem<T> = NonNullable<NonNullable<NonNullable<T>['items']>>[0];
 type NonNullableNodeOnEdges<T extends RelayConnection | null> = NonNullable<
   NonNullable<NonNullable<NonNullable<T>['edges'][0]>>['node']
 >;
+
+interface Window {
+  switchLanguage: (lang: string) => void;
+}


### PR DESCRIPTION
Resolves #5781(FR-2230)

## Summary
- Expose `window.switchLanguage(lang)` function that dispatches the existing `langChanged` CustomEvent
- Add TypeScript declaration to `react-app-env.d.ts`
- Enables docs-screenshot-capturer agent to switch UI language in-place without re-running E2E tests

## Test plan
- [ ] Open DevTools console, call `window.switchLanguage('ko')` → UI updates to Korean
- [ ] Cycle through en → ko → ja → verify no state corruption
- [ ] Verify no console errors during language switch