### PR TITLE
fix(FR-2217): use Out/In terminology in autoscaling rules table

### DIFF
--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -618,7 +618,9 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
                 title: t('autoScalingRule.ScalingType'),
                 fixed: 'left',
                 render: (_text, row) =>
-                  (row?.step_size || 0) > 0 ? 'Up' : 'Down',
+                  (row?.step_size || 0) > 0
+                    ? t('autoScalingRule.ScaleOut')
+                    : t('autoScalingRule.ScaleIn'),
               },
               {
                 title: t('autoScalingRule.MetricSource'),


### PR DESCRIPTION
Resolves #5756(FR-2217)

## Summary
- Replace hardcoded `'Up'`/`'Down'` strings with i18n keys `autoScalingRule.ScaleOut`/`autoScalingRule.ScaleIn` in the EndpointDetailPage autoscaling rules table
- Consistent with AutoScalingRuleEditorModal which already uses the correct terminology

## Test plan
- [ ] View autoscaling rules table on endpoint detail page → verify "Scale Out"/"Scale In" labels
- [ ] Check multiple languages for correct translation