### PR TITLE
refactor(FR-2053): migrate endpoint route table to Strawberry routes query with BAIRouteNodes

### DIFF
--- a/.claude/skills/create-relay-nodes-component/SKILL.md
+++ b/.claude/skills/create-relay-nodes-component/SKILL.md
@@ -2,7 +2,7 @@
 name: create-relay-nodes-component
 description: |
   Generate Relay-based Nodes components with BAITable integration following
-  established patterns (BAIUserNodes, SessionNodes, BAISchedulingHistoryNodes).
+  established patterns (BAIUserNodes, SessionNodes, BAISchedulingHistoryNodes, BAIRouteNodes).
   Automatically creates component file with GraphQL fragment, type definitions,
   column configurations, and customization patterns. Minimal user input required -
   just provide GraphQL type name and the skill generates a complete starting template.
@@ -15,11 +15,11 @@ allowed-tools: Read, Write, Glob, Grep, AskUserQuestion
 
 This skill generates reusable Relay-based Nodes components that:
 
-- Follow established patterns from BAIUserNodes, SessionNodes, BAISchedulingHistoryNodes
+- Follow established patterns from BAISchedulingHistoryNodes, BAIRouteNodes, BAISessionHistorySubStepNodes
 - Integrate seamlessly with BAITable for data display
 - Use Relay fragments for efficient GraphQL data fetching
 - Support column customization via `customizeColumns` pattern
-- Include sorting, filtering, and table features out of the box
+- Include sorting with `disableSorter` toggle and table features out of the box
 - Provide complete starting templates with TODOs for customization
 
 ## When to Use
@@ -36,12 +36,12 @@ Activate this skill when users ask to:
 ### Minimal User Input
 
 **1. GraphQL Type Name** (Required)
-- Examples: `UserNode`, `ComputeSessionNode`, `SessionSchedulingHistoryConnection`
+- Examples: `UserNode`, `ComputeSessionNode`, `SessionSchedulingHistory`
 - This determines all other naming and structure
 
 **2. Component Location** (Optional - has smart defaults)
 - Default for `*Node` types: `packages/backend.ai-ui/src/components/`
-- Default for `*Connection` types: `packages/backend.ai-ui/src/components/fragments/`
+- Default for other types: `packages/backend.ai-ui/src/components/fragments/`
 - User can override if needed
 
 ### Auto-Generated Details
@@ -75,7 +75,7 @@ Use `AskUserQuestion` to get the GraphQL type name:
           description: "For Session entity list"
         },
         {
-          label: "SessionSchedulingHistoryConnection",
+          label: "SessionSchedulingHistory",
           description: "For connection-type entities"
         },
         {
@@ -129,7 +129,7 @@ Based on GraphQL type, auto-generate:
 // Example transformations:
 // UserNode → BAIUserNodes, User, usersFrgmt
 // ComputeSessionNode → BAIComputeSessionNodes, Session, sessionsFrgmt
-// SessionSchedulingHistoryConnection → BAISchedulingHistoryNodes, History, historiesFrgmt
+// Route → BAIRouteNodes, Route, routesFrgmt
 
 function generateComponentDetails(graphqlType: string) {
   // Remove "Node" or "Connection" suffix
@@ -160,24 +160,37 @@ function generateComponentDetails(graphqlType: string) {
 
 Create complete TypeScript file with this structure:
 
+**CRITICAL PATTERNS (must follow):**
+
+1. **Column keys must be camelCase** — `'createdAt'`, `'status'`, NOT `'CREATED_AT'`.
+   The query orchestrator uses `convertToOrderBy()` from `react/src/helper/index.tsx`
+   to convert camelCase to `{ field: 'CREATED_AT', direction: 'ASC' }` for Strawberry queries.
+
+2. **Use `filterOutEmpty` + `_.map` with `disableSorter`** — not `satisfies`.
+   This enables runtime sorter toggling.
+
+3. **Never hardcode `pagination={false}`** — let the consumer control pagination via `...tableProps`.
+
+4. **Callback props for domain-specific interactions** — use `onClickXxx` callbacks
+   instead of embedding navigation/modal logic. The consumer wires these up.
+
+5. **Use `'use memo'` directive** at the top of the component body for React Compiler optimization.
+
 ```typescript
-import {
-  BAITable,
-  BAITableProps,
-  BAIColumnType,
-  BAIText,
-  filterOutEmpty,
-  filterOutNullAndUndefined,
-} from '..'; // Adjust import path based on location
 import {
   {ComponentName}Fragment$data,
   {ComponentName}Fragment$key,
-} from '../__generated__/{ComponentName}Fragment.graphql';
-import dayjs from 'dayjs';
+} from '../../__generated__/{ComponentName}Fragment.graphql';
+import { filterOutEmpty, filterOutNullAndUndefined } from '../../helper';
+import {
+  BAIColumnsType,
+  BAIColumnType,
+  BAITable,
+  BAITableProps,
+} from '../Table';
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useFragment } from 'react-relay';
-import { graphql } from 'relay-runtime';
+import { graphql, useFragment } from 'react-relay';
 
 // =============================================================================
 // Type Definitions
@@ -185,12 +198,10 @@ import { graphql } from 'relay-runtime';
 
 export type {Entity}InList = NonNullable<{ComponentName}Fragment$data[number]>;
 
-// TODO: Add sortable field keys based on your GraphQL type
+// Sorter keys must be camelCase — convertToOrderBy() handles UPPER_SNAKE_CASE conversion
 const available{Entity}SorterKeys = [
-  'id',
-  'created_at',
-  'modified_at',
-  // Add more sortable fields here
+  'createdAt',
+  // TODO: Add more sortable fields in camelCase
 ] as const;
 
 export const available{Entity}SorterValues = [
@@ -206,88 +217,67 @@ const isEnableSorter = (key: string) => {
 // Props Interface
 // =============================================================================
 
-interface {ComponentName}Props
+export interface {ComponentName}Props
   extends Omit<
     BAITableProps<{Entity}InList>,
     'dataSource' | 'columns' | 'onChangeOrder'
   > {
   {fragmentProp}: {ComponentName}Fragment$key;
   customizeColumns?: (
-    baseColumns: BAIColumnType<{Entity}InList>[],
-  ) => BAIColumnType<{Entity}InList>[];
+    baseColumns: BAIColumnsType<{Entity}InList>,
+  ) => BAIColumnsType<{Entity}InList>;
   disableSorter?: boolean;
   onChangeOrder?: (
     order: (typeof available{Entity}SorterValues)[number] | null,
   ) => void;
+  // TODO: Add domain-specific callback props (e.g., onClickSessionId, onClickErrorData)
 }
 
 // =============================================================================
 // Component
 // =============================================================================
 
-const {ComponentName}: React.FC<{ComponentName}Props> = ({
+const {ComponentName} = ({
   {fragmentProp},
   customizeColumns,
   disableSorter,
   onChangeOrder,
   ...tableProps
-}) => {
+}: {ComponentName}Props) => {
   'use memo';
   const { t } = useTranslation();
 
   // TODO: Customize fragment fields based on your GraphQL schema
-  const data = useFragment(
+  const data = useFragment<{ComponentName}Fragment$key>(
     graphql`
       fragment {ComponentName}Fragment on {GraphQLType} @relay(plural: true) {
         id @required(action: NONE)
         # TODO: Add fields you need from the GraphQL type
-        # Common fields to consider:
-        # created_at
-        # modified_at
-        # status
-        # name
-        # email
       }
     `,
     {fragmentProp},
   );
 
   // =============================================================================
-  // Column Definitions
+  // Column Definitions — keys must be camelCase
   // =============================================================================
 
   const baseColumns = _.map(
     filterOutEmpty<BAIColumnType<{Entity}InList>>([
-      // TODO: Customize columns based on your data structure
       {
         key: 'id',
         title: 'ID',
-        render: (__, record) => (
-          <BAIText copyable ellipsis monospace style={{ maxWidth: 100 }}>
-            {record.id}
-          </BAIText>
-        ),
-        required: true,
+        dataIndex: 'id',
+        fixed: 'left',
       },
-      // TODO: Add more columns here
-      // Example column template:
+      // TODO: Add more columns with camelCase keys
       // {
-      //   key: 'field_name',
-      //   title: t('comp:{ComponentName}.FieldTitle'),
-      //   dataIndex: 'field_name',
-      //   sorter: isEnableSorter('field_name'),
-      //   render: (__, record) => {
-      //     return <BAIText>{record.field_name}</BAIText>;
-      //   },
+      //   key: 'createdAt',
+      //   title: t('comp:{ComponentName}.CreatedAt'),
+      //   dataIndex: 'createdAt',
+      //   sorter: isEnableSorter('createdAt'),
+      //   render: (value) => dayjs(value).format('ll LT'),
       // },
-      {
-        key: 'created_at',
-        title: t('comp:{ComponentName}.CreatedAt'),
-        dataIndex: 'created_at',
-        sorter: isEnableSorter('created_at'),
-        render: (__, record) => dayjs(record.created_at).format('lll'),
-        defaultSortOrder: 'descend',
-      },
     ]),
     (column) => {
       return disableSorter ? _.omit(column, 'sorter') : column;
@@ -300,9 +290,7 @@ const {ComponentName}: React.FC<{ComponentName}Props> = ({
 
   return (
     <BAITable
-      resizable
       rowKey={'id'}
-      size="small"
       dataSource={filterOutNullAndUndefined(data)}
       columns={allColumns}
       scroll={{ x: 'max-content' }}
@@ -317,154 +305,97 @@ const {ComponentName}: React.FC<{ComponentName}Props> = ({
 };
 
 export default {ComponentName};
-
-// =============================================================================
-// TODO List
-// =============================================================================
-
-/**
- * TODO: Complete the following steps to finalize this component:
- *
- * 1. **GraphQL Fragment**:
- *    - Add all required fields from the {GraphQLType} type
- *    - Consider performance: only request fields you'll display
- *    - Run `pnpm run relay` to generate TypeScript types
- *
- * 2. **Column Definitions**:
- *    - Customize the `baseColumns` array with your data fields
- *    - Add appropriate render functions for complex data types
- *    - Consider using specialized components (BAIText, BooleanTag, etc.)
- *
- * 3. **Sortable Fields**:
- *    - Update `available{Entity}SorterKeys` with sortable field names
- *    - Verify fields are actually sortable in your GraphQL API
- *    - Remove `sorter` prop from columns that shouldn't be sortable
- *
- * 4. **Internationalization**:
- *    - Add translation keys to `packages/backend.ai-ui/src/locale/en.json`:
- *      {
- *        "comp:{ComponentName}": {
- *          "FieldTitle": "Display Name",
- *          "CreatedAt": "Created At",
- *          // Add more field labels
- *        }
- *      }
- *    - Translate to all 21 supported languages
- *
- * 5. **TypeScript**:
- *    - Run `pnpm run typecheck` to verify no type errors
- *    - Fix any type mismatches or missing fields
- *
- * 6. **Usage Example**:
- *    // In a query orchestrator component:
- *    const data = useLazyLoadQuery(
- *      graphql`
- *        query MyQuery {
- *          items {
- *            ...{ComponentName}Fragment
- *          }
- *        }
- *      `,
- *      {},
- *    );
- *
- *    return (
- *      <{ComponentName}
- *        {fragmentProp}={data.items}
- *        customizeColumns={(baseColumns) => [
- *          // Optionally customize column order or add extra columns
- *          ...baseColumns,
- *        ]}
- *        onChangeOrder={(order) => {
- *          // Handle sorting change
- *        }}
- *      />
- *    );
- */
 ```
 
-### Step 5: Provide Next Steps to User
+### Step 5: Query Orchestrator Pattern
+
+When integrating into a page, follow this pattern for pagination/order
+that avoids full-page suspense on pagination changes:
+
+```typescript
+// In the query orchestrator (page component):
+import { useDeferredValue, useState } from 'react';
+import { convertToOrderBy } from '../helper';
+
+// Simple state — no need for useBAIPaginationOptionState unless URL persistence is needed
+const [routePagination, setRoutePagination] = useState({ current: 1, pageSize: 10 });
+const [routeOrder, setRouteOrder] = useState<string | null>(null);
+
+// useDeferredValue keeps previous UI visible while new data loads
+const deferredPagination = useDeferredValue(routePagination);
+const deferredOrder = useDeferredValue(routeOrder);
+
+// In query variables:
+const { data } = useLazyLoadQuery(query, {
+  // ... other vars
+  routeFirst: deferredPagination.pageSize,
+  routeOffset: (deferredPagination.current - 1) * deferredPagination.pageSize,
+  // convertToOrderBy converts camelCase 'createdAt' → { field: 'CREATED_AT', direction: 'ASC' }
+  routeOrderBy: convertToOrderBy(deferredOrder) ?? undefined,
+});
+
+// In JSX — pagination.onChange wires directly to state setter:
+<BAIRouteNodes
+  routesFrgmt={...}
+  order={routeOrder}
+  onChangeOrder={setRouteOrder}
+  pagination={{
+    ...routePagination,
+    total: data?.routes?.count,
+    showSizeChanger: true,
+    onChange: (page, pageSize) => {
+      setRoutePagination({ current: page, pageSize });
+    },
+  }}
+/>
+```
+
+**Key points:**
+- `useDeferredValue` wraps pagination/order state so React shows stale data while loading
+- `convertToOrderBy(camelCaseString)` converts to `{ field: 'UPPER_SNAKE', direction }` for Strawberry
+- `pagination` is passed via `...tableProps` — never hardcode `pagination={false}` in the Nodes component
+- For queries co-located in a parent query, use `@skipOnClient(if: $skip)` for feature-gated fields
+
+### Step 6: Provide Next Steps to User
 
 After generation, show comprehensive next steps:
 
 ````markdown
-✅ Component generated successfully!
+Component generated successfully!
 
-📁 **Generated File:**
+**Generated File:**
 `{full_path_to_generated_file}`
 
-📝 **Next Steps:**
+**Next Steps:**
 
 1. **Run Relay Compiler** to generate fragment types:
    ```bash
-   cd packages/backend.ai-ui && pnpm run relay
+   pnpm run relay
    ```
 
 2. **Customize GraphQL Fragment:**
-   - Open the generated file
-   - Find the `TODO` comment in the fragment definition
    - Add fields you need from {GraphQLType}
-   - Example fields: `name`, `email`, `status`, `created_at`
+   - Consider performance: only request fields you'll display
 
 3. **Define Table Columns:**
    - Customize the `baseColumns` array
-   - Add columns for each field you want to display
-   - Use appropriate render functions:
-     - `<BAIText>` for text fields
-     - `<BooleanTag>` for boolean flags
-     - `<StatusTag>` for status fields
-     - `dayjs().format()` for dates
+   - Use **camelCase** keys that match fragment field names
+   - Add callback props (`onClickXxx`) for interactive columns
 
 4. **Update Sortable Fields:**
-   - Edit `available{Entity}SorterKeys` array
+   - Edit `available{Entity}SorterKeys` with camelCase field names
    - Only include fields that support sorting in your API
-   - Remove `sorter` prop from non-sortable columns
 
 5. **Add Internationalization:**
-   - File: `packages/backend.ai-ui/src/locale/en.json`
-   - Add section for your component:
-     ```json
-     {
-       "comp:{ComponentName}": {
-         "FieldName": "Display Name",
-         "CreatedAt": "Created At"
-       }
-     }
-     ```
-   - Translate to all 21 supported languages
+   - Add translation keys to locale files
 
-6. **Verify TypeScript:**
+6. **Export from barrel:**
+   - Add export to the appropriate `index.ts`
+
+7. **Verify:**
    ```bash
-   pnpm run typecheck
+   bash scripts/verify.sh
    ```
-
-7. **Use in Parent Component:**
-   ```typescript
-   const data = useLazyLoadQuery(
-     graphql`
-       query ParentQuery {
-         items {
-           ...{ComponentName}Fragment
-         }
-       }
-     `,
-     {},
-   );
-
-   return <{ComponentName} {fragmentProp}={data.items} />;
-   ```
-
-📚 **Reference Components:**
-- `BAIUserNodes.tsx` - Full example with many columns
-- `BAISchedulingHistoryNodes.tsx` - Minimal example
-- `SessionNodes.tsx` - Complex example with custom cells
-
-🎯 **Key Patterns to Follow:**
-- ✅ Use `customizeColumns` for flexible column composition
-- ✅ Use `@required(action: NONE)` for critical fields
-- ✅ Filter out empty columns with `filterOutEmpty`
-- ✅ Use `'use memo'` directive for React Compiler optimization
-- ✅ Provide `onChangeOrder` callback for parent sorting control
 ````
 
 ## Architecture Pattern
@@ -475,8 +406,10 @@ Generated components follow the **Relay Fragment Architecture**:
 ┌─────────────────────────────────────┐
 │   Query Orchestrator Component      │
 │   - useLazyLoadQuery                │
-│   - Manages fetchKey, transitions   │
-│   - Passes fragment refs             │
+│   - useState for pagination/order   │
+│   - useDeferredValue for smoothness │
+│   - convertToOrderBy for Strawberry │
+│   - Passes fragment refs            │
 └───────────────┬─────────────────────┘
                 │ fragment ref
                 ▼
@@ -484,6 +417,9 @@ Generated components follow the **Relay Fragment Architecture**:
 │   Nodes Component (Generated)       │
 │   - useFragment                     │
 │   - Receives fragment ref as prop   │
+│   - baseColumns + customizeColumns  │
+│   - disableSorter toggle            │
+│   - onClickXxx callback props       │
 │   - Renders BAITable                │
 └─────────────────────────────────────┘
 ```
@@ -501,20 +437,17 @@ Generated components follow the **Relay Fragment Architecture**:
 
 ```typescript
 customizeColumns={(baseColumns) => [
-  baseColumns[0], // First column (usually ID)
+  ...baseColumns,
   {
     key: 'actions',
     title: 'Actions',
     fixed: 'right',
     render: (__, record) => (
-      <BAIFlex gap="xs">
-        <BAIButton size="small" onClick={() => handleEdit(record)}>
-          Edit
-        </BAIButton>
-      </BAIFlex>
+      <BAIButton size="small" onClick={() => handleEdit(record)}>
+        Edit
+      </BAIButton>
     ),
   },
-  ...baseColumns.slice(1), // Rest of columns
 ]}
 ```
 
@@ -532,93 +465,59 @@ customizeColumns={(baseColumns) =>
 customizeColumns={(baseColumns) => {
   const nameCol = baseColumns.find((col) => col.key === 'name');
   const others = baseColumns.filter((col) => col.key !== 'name');
-  return [nameCol, ...others];
+  return nameCol ? [nameCol, ...others] : others;
 }}
 ```
 
 ## Best Practices
 
-1. **Fragment Fields**
+1. **Column Keys**
+   - Always use **camelCase** keys matching GraphQL field names
+   - `convertToOrderBy()` handles conversion to `UPPER_SNAKE_CASE` for Strawberry `OrderBy` inputs
+   - Never use UPPER_SNAKE_CASE in column keys — that breaks `BAITable` order matching
+
+2. **Fragment Fields**
    - Only request fields you'll actually display
    - Use `@required(action: NONE)` for critical fields
    - Consider nested fragments for related data
 
-2. **Column Rendering**
-   - Use specialized BAI components (BAIText, BooleanTag, StatusTag)
-   - Format dates with dayjs consistently
-   - Handle null/undefined values gracefully
+3. **Pagination**
+   - Never hardcode `pagination={false}` in the Nodes component
+   - Let the consumer pass pagination via `...tableProps`
+   - Use `useDeferredValue` in the query orchestrator for smooth transitions
 
-3. **Sorting**
-   - Verify API supports sorting on each field
-   - Keep `availableSorterKeys` in sync with actual capabilities
-   - Provide descriptive column titles
+4. **Sorting**
+   - Use `disableSorter` prop to conditionally disable all sorters
+   - `filterOutEmpty` + `_.map` pattern handles sorter removal
+   - Keep `availableSorterKeys` in sync with API capabilities
 
-4. **Type Safety**
+5. **Callback Props**
+   - Use `onClickXxx` callbacks for domain-specific interactions (navigation, modals)
+   - Don't embed navigation logic inside the Nodes component — keep it presentation-only
+
+6. **Type Safety**
    - Always run Relay compiler after fragment changes
    - Use generated `$key` and `$data` types
    - Export type definitions for reuse
 
-5. **Internationalization**
-   - Use `t('comp:{ComponentName}.Key')` pattern
-   - Add translations for all 21 languages
-   - Keep translation keys descriptive
-
-## Troubleshooting
-
-### Type Errors After Generation
-
-**Problem:** TypeScript shows missing fragment type imports
-
-**Solution:** Run Relay compiler
-```bash
-cd packages/backend.ai-ui && pnpm run relay
-```
-
-### Import Path Issues
-
-**Problem:** Cannot resolve generated type imports
-
-**Solution:** Adjust import path based on file location:
-- `src/components/`: use `../__generated__/`
-- `src/components/fragments/`: use `../../__generated__/`
-
-### Missing Translations
-
-**Problem:** Column titles show translation keys
-
-**Solution:** Add keys to locale files:
-```json
-{
-  "comp:ComponentName": {
-    "FieldTitle": "Display Name"
-  }
-}
-```
-
-### Sorter Not Working
-
-**Problem:** Clicking column headers doesn't sort
-
-**Solution:**
-1. Check field is in `availableSorterKeys`
-2. Verify GraphQL API supports sorting on this field
-3. Implement `onChangeOrder` handler in parent component
+7. **React Compiler**
+   - Always include `'use memo'` directive at the top of the component body
 
 ## Reference Files
 
 | File | Purpose |
 |------|---------|
-| `BAIUserNodes.tsx` | Comprehensive example (15+ columns) |
-| `BAISchedulingHistoryNodes.tsx` | Minimal template |
-| `SessionNodes.tsx` | Complex example with fragments |
-| `.github/instructions/react.instructions.md` | React guidelines |
+| `BAISchedulingHistoryNodes.tsx` | Template with customizeColumns, disableSorter, expandable rows |
+| `BAISessionHistorySubStepNodes.tsx` | Minimal template with customizeColumns |
+| `BAIRouteNodes.tsx` | Template with callback props (onClickSessionId, onClickErrorData) |
+| `BAIAgentTable.tsx` | Complex example with many columns |
 
-Location: `packages/backend.ai-ui/src/components/`
+Location: `packages/backend.ai-ui/src/components/fragments/`
 
 ## Notes
 
 - Generated components are **starting templates** requiring customization
 - Components compile after running `pnpm run relay`
-- TODO comments guide customization steps
 - Follow `customizeColumns` pattern for flexibility
 - Always test with real GraphQL data before finalizing
+- Use `bash scripts/verify.sh` to validate Relay, Lint, Format, and TypeScript

--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteNodes.tsx
@@ -1,0 +1,224 @@
+import {
+  BAIRouteNodesFragment$data,
+  BAIRouteNodesFragment$key,
+} from '../../__generated__/BAIRouteNodesFragment.graphql';
+import {
+  SemanticColor,
+  filterOutEmpty,
+  filterOutNullAndUndefined,
+  toLocalId,
+  useSemanticColorMap,
+} from '../../helper';
+import BAIButton from '../BAIButton';
+import BAILink from '../BAILink';
+import BAITag from '../BAITag';
+import BAIText from '../BAIText';
+import {
+  BAIColumnsType,
+  BAIColumnType,
+  BAITable,
+  BAITableProps,
+} from '../Table';
+import { ExclamationCircleOutlined } from '@ant-design/icons';
+import { theme } from 'antd';
+import dayjs from 'dayjs';
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment } from 'react-relay';
+
+export type RouteNodeInList = NonNullable<BAIRouteNodesFragment$data[number]>;
+
+const availableRouteSorterKeys = [
+  'createdAt',
+  'status',
+  'trafficRatio',
+] as const;
+
+export const availableRouteSorterValues = [
+  ...availableRouteSorterKeys,
+  ...availableRouteSorterKeys.map((key) => `-${key}` as const),
+] as const;
+
+const isEnableSorter = (key: string) => {
+  return _.includes(availableRouteSorterKeys, key);
+};
+
+const routeStatusSemanticMap: Record<string, SemanticColor> = {
+  HEALTHY: 'success',
+  PROVISIONING: 'info',
+  UNHEALTHY: 'warning',
+  DEGRADED: 'warning',
+  FAILED_TO_START: 'error',
+};
+
+const trafficStatusSemanticMap: Record<string, SemanticColor> = {
+  ACTIVE: 'success',
+};
+
+export interface BAIRouteNodesProps extends Omit<
+  BAITableProps<RouteNodeInList>,
+  'dataSource' | 'onChangeOrder' | 'columns'
+> {
+  routesFrgmt: BAIRouteNodesFragment$key;
+  customizeColumns?: (
+    baseColumns: BAIColumnsType<RouteNodeInList>,
+  ) => BAIColumnsType<RouteNodeInList>;
+  disableSorter?: boolean;
+  onChangeOrder?: (
+    order: (typeof availableRouteSorterValues)[number] | null,
+  ) => void;
+  onClickSessionId?: (sessionId: string) => void;
+  onClickErrorData?: (errorData: unknown) => void;
+}
+
+const BAIRouteNodes = ({
+  routesFrgmt,
+  customizeColumns,
+  disableSorter,
+  onChangeOrder,
+  onClickSessionId,
+  onClickErrorData,
+  ...tableProps
+}: BAIRouteNodesProps) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const semanticColorMap = useSemanticColorMap();
+
+  const routes = useFragment<BAIRouteNodesFragment$key>(
+    graphql`
+      fragment BAIRouteNodesFragment on Route @relay(plural: true) {
+        id
+        status
+        trafficRatio
+        createdAt
+        errorData
+        session
+        trafficStatus
+      }
+    `,
+    routesFrgmt,
+  );
+
+  const baseColumns = _.map(
+    filterOutEmpty<BAIColumnType<RouteNodeInList>>([
+      {
+        title: t('comp:BAIRouteNodes.RouteId'),
+        dataIndex: 'id',
+        key: 'id',
+        fixed: 'left',
+        render: (_value, record) => (
+          <BAIText ellipsis>
+            {toLocalId(record.id)}
+            {!_.isEmpty(record.errorData) && (
+              <BAIButton
+                size="small"
+                type="text"
+                icon={<ExclamationCircleOutlined />}
+                style={{ color: token.colorError }}
+                onClick={() => {
+                  onClickErrorData?.(record.errorData);
+                }}
+              />
+            )}
+          </BAIText>
+        ),
+      },
+      {
+        title: t('comp:BAIRouteNodes.SessionId'),
+        dataIndex: 'session',
+        key: 'session',
+        render: (sessionId) =>
+          sessionId ? (
+            onClickSessionId ? (
+              <BAILink
+                ellipsis
+                onClick={() => {
+                  onClickSessionId(sessionId);
+                }}
+              >
+                {toLocalId(sessionId)}
+              </BAILink>
+            ) : (
+              <BAIText>{toLocalId(sessionId)}</BAIText>
+            )
+          ) : (
+            '-'
+          ),
+      },
+      {
+        title: t('comp:BAIRouteNodes.Status'),
+        dataIndex: 'status',
+        key: 'status',
+        sorter: isEnableSorter('status'),
+        render: (status) =>
+          status && status !== '%future added value' ? (
+            <BAITag
+              color={
+                semanticColorMap[routeStatusSemanticMap[status] ?? 'default']
+              }
+              style={{ marginRight: 0 }}
+            >
+              {status}
+            </BAITag>
+          ) : null,
+      },
+      {
+        title: t('comp:BAIRouteNodes.TrafficStatus'),
+        dataIndex: 'trafficStatus',
+        key: 'trafficStatus',
+        render: (trafficStatus) =>
+          trafficStatus && trafficStatus !== '%future added value' ? (
+            <BAITag
+              color={
+                semanticColorMap[
+                  trafficStatusSemanticMap[trafficStatus] ?? 'default'
+                ]
+              }
+              style={{ marginRight: 0 }}
+            >
+              {trafficStatus}
+            </BAITag>
+          ) : null,
+      },
+      {
+        title: t('comp:BAIRouteNodes.TrafficRatio'),
+        dataIndex: 'trafficRatio',
+        key: 'trafficRatio',
+        sorter: isEnableSorter('trafficRatio'),
+      },
+      {
+        title: t('comp:BAIRouteNodes.CreatedAt'),
+        dataIndex: 'createdAt',
+        key: 'createdAt',
+        sorter: isEnableSorter('createdAt'),
+        render: (value: string | null) =>
+          value ? <span>{dayjs(value).format('ll LT')}</span> : '-',
+      },
+    ]),
+    (column) => {
+      return disableSorter ? _.omit(column, 'sorter') : column;
+    },
+  );
+
+  const allColumns = customizeColumns
+    ? customizeColumns(baseColumns)
+    : baseColumns;
+
+  return (
+    <BAITable
+      rowKey={'id'}
+      dataSource={filterOutNullAndUndefined(routes)}
+      columns={allColumns}
+      scroll={{ x: 'max-content' }}
+      onChangeOrder={(order) => {
+        onChangeOrder?.(
+          (order as (typeof availableRouteSorterValues)[number]) || null,
+        );
+      }}
+      {...tableProps}
+    />
+  );
+};
+
+export default BAIRouteNodes;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -92,6 +92,8 @@ export type {
   BAIHuggingFaceRegistrySettingModalProps,
   BAIHuggingFaceRegistrySettingModalFragmentKey,
 } from './BAIHuggingFaceRegistrySettingModal';
+export { default as BAIRouteNodes } from './BAIRouteNodes';
+export type { BAIRouteNodesProps, RouteNodeInList } from './BAIRouteNodes';
 export { default as BAISchedulingHistoryNodes } from './BAISchedulingHistoryNodes';
 export type {
   BAISchedulingHistoryNodesProps,

--- a/packages/backend.ai-ui/src/helper/index.ts
+++ b/packages/backend.ai-ui/src/helper/index.ts
@@ -324,7 +324,8 @@ type KnownGlobalIdType =
   | 'ComputeSessionNode'
   | 'GroupNode'
   | 'UserNode'
-  | 'ProjectNode';
+  | 'ProjectNode'
+  | 'ModelDeployment';
 
 export const toGlobalId = (type: KnownGlobalIdType, id: string): string => {
   return btoa(`${type}:${id}`);

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Ressourcengruppe auswählen"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Erstellt am",
+    "RouteId": "Routen-ID",
+    "SessionId": "Sitzungs-ID",
+    "Status": "Status",
+    "TrafficRatio": "Traffic-Anteil",
+    "TrafficStatus": "Datenverkehrsstatus"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Versuche",
     "CreatedAt": "Erstellt am",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Επιλέξτε ομάδα πόρων"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Δημιουργήθηκε",
+    "RouteId": "ID διαδρομής",
+    "SessionId": "ID συνεδρίας",
+    "Status": "Κατάσταση",
+    "TrafficRatio": "Αναλογία κυκλοφορίας",
+    "TrafficStatus": "Κατάσταση δικτύου"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Προσπάθειες",
     "CreatedAt": "Δημιουργήθηκε στις",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -202,6 +202,14 @@
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Unlimited"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Created At",
+    "RouteId": "Route ID",
+    "SessionId": "Session ID",
+    "Status": "Status",
+    "TrafficRatio": "Traffic Ratio",
+    "TrafficStatus": "Traffic Status"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Attempts",
     "CreatedAt": "Created At",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Seleccionar grupo de recursos"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Fecha de creación",
+    "RouteId": "ID de ruta",
+    "SessionId": "ID de sesión",
+    "Status": "Estado",
+    "TrafficRatio": "Proporción de tráfico",
+    "TrafficStatus": "Estado del tráfico"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Intentos",
     "CreatedAt": "Creado el",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Valitse resurssiryhmä"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Luotu",
+    "RouteId": "Reitti-ID",
+    "SessionId": "Istunnon tunnus",
+    "Status": "Tila",
+    "TrafficRatio": "Liikenteen suhde",
+    "TrafficStatus": "Liikenteen tila"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Yritykset",
     "CreatedAt": "Luotu",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Sélectionner un groupe de ressources"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Créé le",
+    "RouteId": "ID de route",
+    "SessionId": "ID de session",
+    "Status": "Statut",
+    "TrafficRatio": "Ratio de trafic",
+    "TrafficStatus": "État du trafic"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Tentatives",
     "CreatedAt": "Créé le",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Pilih Grup Sumber Daya"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Dibuat pada",
+    "RouteId": "ID Rute",
+    "SessionId": "ID Sesi",
+    "Status": "Status",
+    "TrafficRatio": "Rasio Lalu Lintas",
+    "TrafficStatus": "Status Trafik"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Percobaan",
     "CreatedAt": "Dibuat pada",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Seleziona gruppo di risorse"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Creato il",
+    "RouteId": "ID percorso",
+    "SessionId": "ID sessione",
+    "Status": "Stato",
+    "TrafficRatio": "Rapporto di traffico",
+    "TrafficStatus": "Stato del traffico"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Tentativi",
     "CreatedAt": "Creato il",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "リソースグループを選択"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "作成日時",
+    "RouteId": "ルートID",
+    "SessionId": "セッションID",
+    "Status": "ステータス",
+    "TrafficRatio": "トラフィック比率",
+    "TrafficStatus": "トラフィック状況"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "試行回数",
     "CreatedAt": "作成日時",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "리소스 그룹을 선택해주세요"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "생성일",
+    "RouteId": "라우트 ID",
+    "SessionId": "세션 ID",
+    "Status": "상태",
+    "TrafficRatio": "트래픽 비율",
+    "TrafficStatus": "트래픽 상태"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "시도 횟수",
     "CreatedAt": "생성일",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Ресурсын бүлэг сонгох"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Үүсгэсэн огноо",
+    "RouteId": "Маршрутын ID",
+    "SessionId": "Сессийн ID",
+    "Status": "Төлөв",
+    "TrafficRatio": "Трафикийн харьцаа",
+    "TrafficStatus": "Трафикийн төлөв"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Оролдлого",
     "CreatedAt": "Үүссэн огноо",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Pilih Kumpulan Sumber"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Dicipta pada",
+    "RouteId": "ID Laluan",
+    "SessionId": "ID Sesi",
+    "Status": "Status",
+    "TrafficRatio": "Nisbah Trafik",
+    "TrafficStatus": "Status Trafik"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Percubaan",
     "CreatedAt": "Dicipta pada",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Wybierz grupę zasobów"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Utworzono",
+    "RouteId": "ID trasy",
+    "SessionId": "ID sesji",
+    "Status": "Status",
+    "TrafficRatio": "Udział ruchu",
+    "TrafficStatus": "Status ruchu"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Próby",
     "CreatedAt": "Utworzono",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -198,6 +198,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Selecionar grupo de recursos"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Criado em",
+    "RouteId": "ID da rota",
+    "SessionId": "ID da sessão",
+    "Status": "Status",
+    "TrafficRatio": "Proporção de Tráfego",
+    "TrafficStatus": "Status do Tráfego"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Tentativas",
     "CreatedAt": "Criado em",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Selecionar grupo de recursos"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Criado em",
+    "RouteId": "ID da Rota",
+    "SessionId": "ID da sessão",
+    "Status": "Estado",
+    "TrafficRatio": "Proporção de tráfego",
+    "TrafficStatus": "Status do tráfego"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Tentativas",
     "CreatedAt": "Criado em",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Выберите группу ресурсов"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Дата создания",
+    "RouteId": "ID маршрута",
+    "SessionId": "ID сессии",
+    "Status": "Статус",
+    "TrafficRatio": "Доля трафика",
+    "TrafficStatus": "Состояние трафика"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Попытки",
     "CreatedAt": "Дата создания",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "เลือกกลุ่มทรัพยากร"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "สร้างเมื่อ",
+    "RouteId": "รหัสเส้นทาง",
+    "SessionId": "รหัสเซสชัน",
+    "Status": "สถานะ",
+    "TrafficRatio": "สัดส่วนทราฟฟิก",
+    "TrafficStatus": "สถานะการรับส่งข้อมูล"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "จำนวนครั้งที่ลอง",
     "CreatedAt": "สร้างเมื่อ",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Kaynak Grubu Seç"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Oluşturulma tarihi",
+    "RouteId": "Rota Kimliği",
+    "SessionId": "Oturum Kimliği",
+    "Status": "Durum",
+    "TrafficRatio": "Trafik Oranı",
+    "TrafficStatus": "Trafik Durumu"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Denemeler",
     "CreatedAt": "Oluşturulma Tarihi",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Chọn nhóm tài nguyên"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "Ngày tạo",
+    "RouteId": "ID tuyến",
+    "SessionId": "ID phiên",
+    "Status": "Trạng thái",
+    "TrafficRatio": "Tỷ lệ lưu lượng",
+    "TrafficStatus": "Trạng thái lưu lượng"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "Số lần thử",
     "CreatedAt": "Ngày tạo",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "选择资源组"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "创建时间",
+    "RouteId": "路由 ID",
+    "SessionId": "会话 ID",
+    "Status": "状态",
+    "TrafficRatio": "流量比例",
+    "TrafficStatus": "流量状态"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "尝试次数",
     "CreatedAt": "创建时间",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -199,6 +199,14 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "選擇資源群組"
   },
+  "comp:BAIRouteNodes": {
+    "CreatedAt": "建立時間",
+    "RouteId": "路由 ID",
+    "SessionId": "工作階段 ID",
+    "Status": "狀態",
+    "TrafficRatio": "流量比例",
+    "TrafficStatus": "流量狀態"
+  },
   "comp:BAISchedulingHistoryNodes": {
     "Attempts": "嘗試次數",
     "CreatedAt": "建立時間",

--- a/react/src/components/EndpointStatusTag.tsx
+++ b/react/src/components/EndpointStatusTag.tsx
@@ -3,9 +3,16 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { EndpointStatusTagFragment$key } from '../__generated__/EndpointStatusTagFragment.graphql';
-import { Tag } from 'antd';
+import { BAITag, SemanticColor, useSemanticColorMap } from 'backend.ai-ui';
 import React from 'react';
 import { graphql, useFragment } from 'react-relay';
+
+const endpointStatusSemanticMap: Record<string, SemanticColor> = {
+  RUNNING: 'success',
+  HEALTHY: 'success',
+  PROVISIONING: 'info',
+  UNHEALTHY: 'warning',
+};
 
 interface EndpointStatusTagProps {
   endpointFrgmt: EndpointStatusTagFragment$key | null | undefined;
@@ -22,19 +29,16 @@ const EndpointStatusTag: React.FC<EndpointStatusTagProps> = ({
     `,
     endpointFrgmt,
   );
-  let color = 'default';
-  switch (endpoint?.status?.toUpperCase()) {
-    case 'RUNNING':
-    case 'HEALTHY':
-      color = 'success';
-      break;
+  const semanticColorMap = useSemanticColorMap();
+  const status = endpoint?.status?.toUpperCase() ?? '';
 
-    // case 'TERMINATED':
-    //   color = 'default';
-    //   break;
-  }
-
-  return <Tag color={color}>{endpoint?.status}</Tag>;
+  return (
+    <BAITag
+      color={semanticColorMap[endpointStatusSemanticMap[status] ?? 'default']}
+    >
+      {endpoint?.status}
+    </BAITag>
+  );
 };
 
 export default EndpointStatusTag;

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -7,12 +7,14 @@ import { EndpointDetailPageAutoScalingRuleDeleteMutation } from '../__generated_
 import {
   EndpointDetailPageQuery,
   EndpointDetailPageQuery$data,
+  RouteTrafficStatus,
 } from '../__generated__/EndpointDetailPageQuery.graphql';
 import { InferenceSessionErrorModalFragment$key } from '../__generated__/InferenceSessionErrorModalFragment.graphql';
 import AutoScalingRuleEditorModal, {
   COMPARATOR_LABELS,
 } from '../components/AutoScalingRuleEditorModal';
 import BAIJSONViewerModal from '../components/BAIJSONViewerModal';
+import BAIRadioGroup from '../components/BAIRadioGroup';
 import { isEndpointInDestroyingCategory } from '../components/EndpointList';
 import EndpointOwnerInfo from '../components/EndpointOwnerInfo';
 import EndpointStatusTag from '../components/EndpointStatusTag';
@@ -23,7 +25,7 @@ import InferenceSessionErrorModal from '../components/InferenceSessionErrorModal
 import SessionDetailDrawer from '../components/SessionDetailDrawer';
 import SwitchToProjectButton from '../components/SwitchToProjectButton';
 import VFolderLazyView from '../components/VFolderLazyView';
-import { baiSignedRequestWithPromise } from '../helper';
+import { baiSignedRequestWithPromise, convertToOrderBy } from '../helper';
 import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
@@ -61,10 +63,18 @@ import { DescriptionsItemType } from 'antd/es/descriptions';
 import {
   filterOutNullAndUndefined,
   BAIFlex,
+  BAIGraphQLPropertyFilter,
   BAIUnmountAfterClose,
   BAIText,
   BAIResourceNumberWithIcon,
-  useUpdatableState,
+  BAIRouteNodes,
+  BAITag,
+  GraphQLFilter,
+  SemanticColor,
+  toGlobalId,
+  useFetchKey,
+  useSemanticColorMap,
+  BAITable,
 } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
 import _ from 'lodash';
@@ -73,7 +83,12 @@ import {
   CircleArrowDownIcon,
   CircleArrowUpIcon,
 } from 'lucide-react';
-import React, { Suspense, useState, useTransition } from 'react';
+import React, {
+  Suspense,
+  useDeferredValue,
+  useState,
+  useTransition,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 import { useParams } from 'react-router-dom';
@@ -114,10 +129,24 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
     current: 1,
     pageSize: 100,
   });
+  const [routePagination, setRoutePagination] = useState({
+    current: 1,
+    pageSize: 10,
+  });
+  const [routeOrder, setRouteOrder] = useState<string | null>(null);
+  const [routeStatusCategory, setRouteStatusCategory] = useState<
+    'running' | 'finished'
+  >('running');
+  const [routePropertyFilter, setRoutePropertyFilter] =
+    useState<GraphQLFilter>();
+  const deferredRoutePagination = useDeferredValue(routePagination);
+  const deferredRouteOrder = useDeferredValue(routeOrder);
+  const deferredRouteStatusCategory = useDeferredValue(routeStatusCategory);
+  const deferredRoutePropertyFilter = useDeferredValue(routePropertyFilter);
   const { serviceId } = useParams<{
     serviceId: string;
   }>();
-  const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
+  const [fetchKey, updateFetchKey, INITIAL_FETCH_KEY] = useFetchKey();
   const [isPendingRefetch, startRefetchTransition] = useTransition();
   const [isPendingClearError, startClearErrorTransition] = useTransition();
   const [selectedSessionErrorForModal, setSelectedSessionErrorForModal] =
@@ -138,7 +167,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
   const [selectedSessionId, setSelectedSessionId] = useState<string>();
   const isSupportAutoScalingRule = baiClient.supports('auto-scaling-rule');
   const [errorDataForJSONModal, setErrorDataForJSONModal] = useState<string>();
-  const { endpoint, endpoint_token_list, endpoint_auto_scaling_rules } =
+  const { endpoint, endpoint_token_list, endpoint_auto_scaling_rules, routes } =
     useLazyLoadQuery<EndpointDetailPageQuery>(
       graphql`
         query EndpointDetailPageQuery(
@@ -154,6 +183,12 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           $autoScalingRules_first: Int
           $autoScalingRules_last: Int
           $skipScalingRules: Boolean!
+          $deploymentId: ID!
+          $routeFilter: RouteFilter
+          $routeOrderBy: [RouteOrderBy!]
+          $routeLimit: Int
+          $routeOffset: Int
+          $skipRouteNodes: Boolean!
         ) {
           endpoint(endpoint_id: $endpointId) {
             name
@@ -267,6 +302,20 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               }
             }
           }
+          routes(
+            deploymentId: $deploymentId
+            filter: $routeFilter
+            orderBy: $routeOrderBy
+            limit: $routeLimit
+            offset: $routeOffset
+          ) @skipOnClient(if: $skipRouteNodes) {
+            edges {
+              node {
+                ...BAIRouteNodesFragment
+              }
+            }
+            count
+          }
         }
       `,
       {
@@ -281,10 +330,36 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
         autoScalingRules_first: undefined,
         autoScalingRules_last: undefined,
         skipScalingRules: !isSupportAutoScalingRule,
+        deploymentId: toGlobalId('ModelDeployment', serviceId || ''),
+        routeFilter: {
+          status:
+            deferredRouteStatusCategory === 'running'
+              ? [
+                  'PROVISIONING',
+                  'HEALTHY',
+                  'UNHEALTHY',
+                  'DEGRADED',
+                  'TERMINATING',
+                ]
+              : ['TERMINATED', 'FAILED_TO_START'],
+          ...(deferredRoutePropertyFilter?.trafficStatus
+            ? {
+                trafficStatus: [
+                  deferredRoutePropertyFilter.trafficStatus as RouteTrafficStatus,
+                ],
+              }
+            : {}),
+        },
+        routeOrderBy: convertToOrderBy(deferredRouteOrder) ?? undefined,
+        routeLimit: deferredRoutePagination.pageSize,
+        routeOffset:
+          (deferredRoutePagination.current - 1) *
+          deferredRoutePagination.pageSize,
+        skipRouteNodes: !baiClient.supports('route-node'),
       },
       {
         fetchPolicy:
-          fetchKey === 'initial-fetch' ? 'store-and-network' : 'network-only',
+          fetchKey === INITIAL_FETCH_KEY ? 'store-and-network' : 'network-only',
         fetchKey,
       },
     );
@@ -332,22 +407,12 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
     }
   `);
 
-  // return color of tag by status
-  const applyStatusColor = (status: string = '') => {
-    let color = 'default';
-    switch (status.toUpperCase()) {
-      case 'HEALTHY':
-        color = 'success';
-        break;
-      case 'PROVISIONING':
-        color = 'processing';
-        break;
-      case 'UNHEALTHY':
-        color = 'warning';
-        break;
-    }
-    return color;
+  const legacyRouteStatusSemanticMap: Record<string, SemanticColor> = {
+    HEALTHY: 'success',
+    PROVISIONING: 'info',
+    UNHEALTHY: 'warning',
   };
+  const semanticColorMap = useSemanticColorMap();
 
   const autoScalingRules = _.map(endpoint_auto_scaling_rules?.edges, (edge) => {
     return edge?.node;
@@ -480,7 +545,9 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
     {
       label: t('session.launcher.EnvironmentVariable'),
       children: (
-        <Typography.Text style={{ fontFamily: 'monospace' }}>
+        <Typography.Text
+          style={{ fontFamily: 'monospace', wordBreak: 'break-all' }}
+        >
           {_.isEmpty(JSON.parse(endpoint?.environ || '{}'))
             ? '-'
             : endpoint?.environ}
@@ -610,7 +677,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
             </Button>
           }
         >
-          <Table
+          <BAITable
             scroll={{ x: 'max-content' }}
             rowKey={'id'}
             columns={[
@@ -824,8 +891,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
             pagination={false}
             showSorterTooltip={false}
             dataSource={autoScalingRules}
-            bordered
-          ></Table>
+          ></BAITable>
         </Card>
       )}
       <Card
@@ -843,7 +909,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           </Button>
         }
       >
-        <Table
+        <BAITable
           scroll={{ x: 'max-content' }}
           rowKey={'token'}
           columns={[
@@ -899,8 +965,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           showSorterTooltip={false}
           pagination={false}
           dataSource={filterOutNullAndUndefined(endpoint_token_list?.items)}
-          bordered
-        ></Table>
+        ></BAITable>
       </Card>
       <Card
         title={t('modelService.RoutesInfo')}
@@ -934,90 +999,179 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           ) : null
         }
       >
-        <Table
-          scroll={{ x: 'max-content' }}
-          columns={[
-            {
-              title: t('modelService.RouteId'),
-              dataIndex: 'routing_id',
-              fixed: 'left',
-              render: (_text, row) => (
-                <BAIText ellipsis>
-                  {row.routing_id}
-                  {!_.isEmpty(row.error_data) && (
-                    <Button
-                      size="small"
-                      type="text"
-                      icon={<ExclamationCircleOutlined />}
-                      style={{ color: token.colorError }}
-                      onClick={() => {
-                        setErrorDataForJSONModal(row?.error_data || ' ');
-                      }}
-                    />
-                  )}
-                </BAIText>
-              ),
-            },
-            {
-              title: t('modelService.SessionId'),
-              dataIndex: 'session',
-              render: (sessionId) => {
-                const matchedSessionError = endpoint?.errors?.find(
-                  (sessionError) => sessionError.session_id === sessionId,
-                );
-                return (
-                  <>
-                    {baiClient.supports('session-node') ? (
-                      <Typography.Link
-                        onClick={() => {
-                          setSelectedSessionId(sessionId);
-                        }}
-                      >
-                        {sessionId}
-                      </Typography.Link>
-                    ) : (
-                      <Typography.Text>{sessionId}</Typography.Text>
-                    )}
-                    {matchedSessionError && (
+        {baiClient.supports('route-node') ? (
+          <BAIFlex direction="column" align="stretch" gap="sm">
+            <BAIFlex
+              gap={'sm'}
+              align="start"
+              style={{ flexShrink: 1 }}
+              wrap="wrap"
+            >
+              <BAIRadioGroup
+                optionType="button"
+                value={routeStatusCategory}
+                onChange={(e) => {
+                  setRouteStatusCategory(e.target.value);
+                  setRoutePagination({ current: 1, pageSize: 10 });
+                }}
+                options={[
+                  {
+                    label: t('session.Running'),
+                    value: 'running',
+                  },
+                  {
+                    label: t('session.Finished'),
+                    value: 'finished',
+                  },
+                ]}
+              />
+              <BAIGraphQLPropertyFilter
+                value={routePropertyFilter}
+                onChange={(value) => {
+                  setRoutePropertyFilter(value ?? undefined);
+                  setRoutePagination({ current: 1, pageSize: 10 });
+                }}
+                filterProperties={[
+                  {
+                    key: 'trafficStatus',
+                    propertyLabel: t('modelService.TrafficStatus'),
+                    type: 'enum',
+                    valueMode: 'scalar',
+                    fixedOperator: 'equals',
+                    strictSelection: true,
+                    options: [
+                      { label: 'ACTIVE', value: 'ACTIVE' },
+                      { label: 'INACTIVE', value: 'INACTIVE' },
+                    ],
+                  },
+                ]}
+              />
+            </BAIFlex>
+            <BAIRouteNodes
+              routesFrgmt={filterOutNullAndUndefined(
+                routes?.edges?.map((edge) => edge?.node),
+              )}
+              order={routeOrder}
+              onChangeOrder={setRouteOrder}
+              loading={
+                mutationToSyncRoutes.isPending ||
+                deferredRoutePagination !== routePagination ||
+                deferredRouteOrder !== routeOrder ||
+                deferredRouteStatusCategory !== routeStatusCategory ||
+                deferredRoutePropertyFilter !== routePropertyFilter
+              }
+              onClickSessionId={setSelectedSessionId}
+              onClickErrorData={(errorData) =>
+                setErrorDataForJSONModal(
+                  typeof errorData === 'string'
+                    ? errorData
+                    : JSON.stringify(errorData),
+                )
+              }
+              pagination={{
+                ...routePagination,
+                total: routes?.count,
+                showSizeChanger: true,
+                onChange: (page, pageSize) => {
+                  setRoutePagination({ current: page, pageSize });
+                },
+              }}
+            />
+          </BAIFlex>
+        ) : (
+          <Table
+            scroll={{ x: 'max-content' }}
+            columns={[
+              {
+                title: t('modelService.RouteId'),
+                dataIndex: 'routing_id',
+                fixed: 'left',
+                render: (_text, row) => (
+                  <BAIText ellipsis>
+                    {row.routing_id}
+                    {!_.isEmpty(row.error_data) && (
                       <Button
                         size="small"
                         type="text"
                         icon={<ExclamationCircleOutlined />}
                         style={{ color: token.colorError }}
                         onClick={() => {
-                          setSelectedSessionErrorForModal(matchedSessionError);
+                          setErrorDataForJSONModal(row?.error_data || ' ');
                         }}
                       />
                     )}
-                  </>
-                );
-              },
-            },
-            {
-              title: t('modelService.Status'),
-              render: (_text, row) =>
-                row.status && (
-                  <>
-                    <Tag
-                      color={applyStatusColor(row?.status)}
-                      key={row?.status}
-                      style={{ marginRight: 0 }}
-                    >
-                      {row.status.toUpperCase()}
-                    </Tag>
-                  </>
+                  </BAIText>
                 ),
-            },
-            {
-              title: t('modelService.TrafficRatio'),
-              dataIndex: 'traffic_ratio',
-            },
-          ]}
-          pagination={false}
-          dataSource={endpoint?.routings as Routing[]}
-          rowKey={'routing_id'}
-          bordered
-        />
+              },
+              {
+                title: t('modelService.SessionId'),
+                dataIndex: 'session',
+                render: (sessionId) => {
+                  const matchedSessionError = endpoint?.errors?.find(
+                    (sessionError) => sessionError.session_id === sessionId,
+                  );
+                  return (
+                    <>
+                      {baiClient.supports('session-node') ? (
+                        <Typography.Link
+                          onClick={() => {
+                            setSelectedSessionId(sessionId);
+                          }}
+                        >
+                          {sessionId}
+                        </Typography.Link>
+                      ) : (
+                        <Typography.Text>{sessionId}</Typography.Text>
+                      )}
+                      {matchedSessionError && (
+                        <Button
+                          size="small"
+                          type="text"
+                          icon={<ExclamationCircleOutlined />}
+                          style={{ color: token.colorError }}
+                          onClick={() => {
+                            setSelectedSessionErrorForModal(
+                              matchedSessionError,
+                            );
+                          }}
+                        />
+                      )}
+                    </>
+                  );
+                },
+              },
+              {
+                title: t('modelService.Status'),
+                render: (_text, row) =>
+                  row.status && (
+                    <>
+                      <BAITag
+                        color={
+                          semanticColorMap[
+                            legacyRouteStatusSemanticMap[
+                              row?.status?.toUpperCase() ?? ''
+                            ] ?? 'default'
+                          ]
+                        }
+                        key={row?.status}
+                        style={{ marginRight: 0 }}
+                      >
+                        {row.status.toUpperCase()}
+                      </BAITag>
+                    </>
+                  ),
+              },
+              {
+                title: t('modelService.TrafficRatio'),
+                dataIndex: 'traffic_ratio',
+              },
+            ]}
+            pagination={false}
+            dataSource={endpoint?.routings as Routing[]}
+            rowKey={'routing_id'}
+            bordered
+          />
+        )}
       </Card>
       <InferenceSessionErrorModal
         open={!!selectedSessionErrorForModal}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1353,6 +1353,7 @@
     "TokenGenerated": "Token erzeugt",
     "TokenGenerationFailed": "Token-Generierung fehlgeschlagen. Bitte versuchen Sie es erneut.",
     "TrafficRatio": "Verkehrsdichte",
+    "TrafficStatus": "Traffic-Status",
     "UpdateService": "Update-Service",
     "UseExistingFolderConfirm": "Möchten Sie den Dienst mit dem vorhandenen Ordner {{folderName}} starten?",
     "Validate": "Bestätigen",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1351,6 +1351,7 @@
     "TokenGenerated": "Παραγόμενο Token",
     "TokenGenerationFailed": "Η δημιουργία του Token απέτυχε. παρακαλώ προσπαθήστε ξανά.",
     "TrafficRatio": "Αναλογία κυκλοφορίας",
+    "TrafficStatus": "Κατάσταση δικτυακής κίνησης",
     "UpdateService": "Υπηρεσία ενημέρωσης",
     "UseExistingFolderConfirm": "Θα θέλατε να ξεκινήσετε την υπηρεσία χρησιμοποιώντας το υπάρχον φάκελο {{folderName}};",
     "Validate": "Επικυρώνω",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1351,6 +1351,7 @@
     "TokenGenerated": "Token generated",
     "TokenGenerationFailed": "Token generation failed. please try again.",
     "TrafficRatio": "Traffic Ratio",
+    "TrafficStatus": "Traffic Status",
     "UpdateService": "Update Service",
     "UseExistingFolderConfirm": "Would you like to start the service using the existing {{folderName}} folder?",
     "Validate": "Validate",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1351,6 +1351,7 @@
     "TokenGenerated": "Token generado",
     "TokenGenerationFailed": "Generación de token fallida. Por favor, inténtelo de nuevo.",
     "TrafficRatio": "Ratio de tráfico",
+    "TrafficStatus": "Estado del tráfico",
     "UpdateService": "Servicio de actualización",
     "UseExistingFolderConfirm": "¿Le gustaría comenzar el servicio utilizando la carpeta existente {{folderName}}?",
     "Validate": "Validar",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1351,6 +1351,7 @@
     "TokenGenerated": "Tuotettu merkki",
     "TokenGenerationFailed": "Tokenin luominen epäonnistui. yritä uudelleen.",
     "TrafficRatio": "Liikennesuhde",
+    "TrafficStatus": "Verkkoliikenteen tila",
     "UpdateService": "Päivityspalvelu",
     "UseExistingFolderConfirm": "Haluatko aloittaa palvelun käyttämällä olemassa olevaa {{folderName}} -kansiota?",
     "Validate": "Vahvista",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1351,6 +1351,7 @@
     "TokenGenerated": "Jeton généré",
     "TokenGenerationFailed": "La génération de jetons a échoué. Veuillez réessayer.",
     "TrafficRatio": "Ratio de trafic",
+    "TrafficStatus": "État du trafic",
     "UpdateService": "Service de mise à jour",
     "UseExistingFolderConfirm": "Souhaitez-vous démarrer le service en utilisant le dossier {{folderName}} existant?",
     "Validate": "Valider",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1353,6 +1353,7 @@
     "TokenGenerated": "Token yang dihasilkan",
     "TokenGenerationFailed": "Pembuatan token gagal. silakan coba lagi.",
     "TrafficRatio": "Rasio Lalu Lintas",
+    "TrafficStatus": "Status Trafik",
     "UpdateService": "Layanan Pembaruan",
     "UseExistingFolderConfirm": "Apakah Anda ingin memulai layanan menggunakan folder {{folderName}} yang ada?",
     "Validate": "Mengesahkan",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1351,6 +1351,7 @@
     "TokenGenerated": "Gettone generato",
     "TokenGenerationFailed": "La generazione del token non è riuscita. Riprovare.",
     "TrafficRatio": "Rapporto di traffico",
+    "TrafficStatus": "Stato del traffico",
     "UpdateService": "Servizio di aggiornamento",
     "UseExistingFolderConfirm": "Vorresti avviare il servizio utilizzando la cartella {{folderName}} esistente?",
     "Validate": "Convalidare",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1353,6 +1353,7 @@
     "TokenGenerated": "トークン生成が完了しました。",
     "TokenGenerationFailed": "トークン生成に失敗しました。しばらくしてから再試行してください。",
     "TrafficRatio": "トラフィック率",
+    "TrafficStatus": "トラフィック状況",
     "UpdateService": "アップデートサービス",
     "UseExistingFolderConfirm": "既存の{{folderName}}フォルダーを使用してサービスを開始しますか？",
     "Validate": "確認",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1353,6 +1353,7 @@
     "TokenGenerated": "토큰 생성이 완료되었습니다.",
     "TokenGenerationFailed": "토큰 생성에 실패했습니다. 잠시 후 다시 시도해 주세요.",
     "TrafficRatio": "트래픽 비율",
+    "TrafficStatus": "트래픽 상태",
     "UpdateService": "서비스 업데이트",
     "UseExistingFolderConfirm": "이미 존재하는 {{ folderName }} 폴더를 이용해서 서비스를 시작할까요?",
     "Validate": "유효성 검사",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1352,6 +1352,7 @@
     "TokenGenerated": "Токен үүсгэсэн",
     "TokenGenerationFailed": "Токен үүсгэх амжилтгүй болсон. \nдахин оролдоно уу.",
     "TrafficRatio": "Замын хөдөлгөөний харьцаа",
+    "TrafficStatus": "Трафикийн байдал",
     "UpdateService": "Үйлчилгээг шинэчлэх",
     "UseExistingFolderConfirm": "Одоо байгаа {{folderName}} хавтас ашиглан үйлчилгээг эхлүүлэхийг хүсч байна уу?",
     "Validate": "Баталгаажуулах",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1351,6 +1351,7 @@
     "TokenGenerated": "Token dijana",
     "TokenGenerationFailed": "Penjanaan token gagal. \nsila cuba lagi.",
     "TrafficRatio": "Nisbah Trafik",
+    "TrafficStatus": "Status Lalu Lintas",
     "UpdateService": "Perkhidmatan Kemas Kini",
     "UseExistingFolderConfirm": "Adakah anda ingin memulakan perkhidmatan menggunakan folder {{folderName}} yang sedia ada?",
     "Validate": "Sahkan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1351,6 +1351,7 @@
     "TokenGenerated": "Wygenerowany token",
     "TokenGenerationFailed": "Generowanie tokena nie powiodło się. Spróbuj ponownie.",
     "TrafficRatio": "Współczynnik ruchu",
+    "TrafficStatus": "Stan ruchu sieciowego",
     "UpdateService": "Aktualizuj usługę",
     "UseExistingFolderConfirm": "Czy chciałbyś rozpocząć usługę za pomocą istniejącego folderu {{folderName}}?",
     "Validate": "Uprawomocnić",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1351,6 +1351,7 @@
     "TokenGenerated": "Token gerado",
     "TokenGenerationFailed": "A geração de tokens falhou. Por favor, tente novamente.",
     "TrafficRatio": "Rácio de tráfego",
+    "TrafficStatus": "Status do tráfego",
     "UpdateService": "Serviço de atualização",
     "UseExistingFolderConfirm": "Gostaria de iniciar o serviço usando a pasta {{folderName}} existente?",
     "Validate": "Validar",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1353,6 +1353,7 @@
     "TokenGenerated": "Token gerado",
     "TokenGenerationFailed": "A geração de tokens falhou. Por favor, tente novamente.",
     "TrafficRatio": "Rácio de tráfego",
+    "TrafficStatus": "Status do tráfego",
     "UpdateService": "Serviço de atualização",
     "UseExistingFolderConfirm": "Gostaria de iniciar o serviço usando a pasta {{folderName}} existente?",
     "Validate": "Validar",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1351,6 +1351,7 @@
     "TokenGenerated": "Сгенерированный токен",
     "TokenGenerationFailed": "Не удалось сгенерировать токен. Пожалуйста, попробуйте еще раз.",
     "TrafficRatio": "Коэффициент трафика",
+    "TrafficStatus": "Состояние трафика",
     "UpdateService": "Служба обновлений",
     "UseExistingFolderConfirm": "Хотели бы вы запустить службу, используя существующую папку {{folderName}}?",
     "Validate": "Подтвердить",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1353,6 +1353,7 @@
     "TokenGenerated": "สร้างโทเคนแล้ว",
     "TokenGenerationFailed": "การสร้างโทเคนล้มเหลว กรุณาลองอีกครั้ง",
     "TrafficRatio": "สัดส่วนการจราจร",
+    "TrafficStatus": "สถานะการรับส่งข้อมูล",
     "UpdateService": "อัปเดตบริการ",
     "UseExistingFolderConfirm": "คุณต้องการเริ่มบริการโดยใช้โฟลเดอร์ {{folderName}} ที่มีอยู่หรือไม่?",
     "Validate": "ตรวจสอบ",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1351,6 +1351,7 @@
     "TokenGenerated": "Token oluşturuldu",
     "TokenGenerationFailed": "Jeton üretimi başarısız oldu. lütfen tekrar deneyin.",
     "TrafficRatio": "Trafik Oranı",
+    "TrafficStatus": "Trafik Durumu",
     "UpdateService": "Güncelleme Hizmeti",
     "UseExistingFolderConfirm": "Hizmeti mevcut {{folderName}} klasörünü kullanarak başlatmak ister misiniz?",
     "Validate": "Doğrula",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1353,6 +1353,7 @@
     "TokenGenerated": "Mã thông báo được tạo",
     "TokenGenerationFailed": "Tạo mã thông báo không thành công. \nvui lòng thử lại.",
     "TrafficRatio": "Tỷ lệ lưu lượng truy cập",
+    "TrafficStatus": "Trạng thái lưu lượng",
     "UpdateService": "Dịch vụ cập nhật",
     "UseExistingFolderConfirm": "Bạn có muốn bắt đầu dịch vụ bằng thư mục {{folderName}} hiện có không?",
     "Validate": "Xác thực",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1353,6 +1353,7 @@
     "TokenGenerated": "生成的令牌",
     "TokenGenerationFailed": "令牌生成失败，请重试。",
     "TrafficRatio": "交通比率",
+    "TrafficStatus": "流量状态",
     "UpdateService": "更新服务",
     "UseExistingFolderConfirm": "您想使用现有{{folderName}}文件夹启动服务吗？",
     "Validate": "证实",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1355,6 +1355,7 @@
     "TokenGenerated": "生成的令牌",
     "TokenGenerationFailed": "令牌生成失败，请重试。",
     "TrafficRatio": "交通比率",
+    "TrafficStatus": "流量狀態",
     "UpdateService": "更新服務",
     "UseExistingFolderConfirm": "您想使用現有{{folderName}}文件夾啟動服務嗎？",
     "Validate": "證實",

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -878,6 +878,9 @@ class Client {
     if (this.isManagerVersionCompatibleWith('25.18.2')) {
       this._features['allow-only-ro-permission-for-model-project-folder'] = true;
     }
+    if (this.isManagerVersionCompatibleWith('25.19.0')) {
+      this._features['route-node'] = true;
+    }
     if (this.isManagerVersionCompatibleWith('26.1.0')) {
       this._features['model-try-content-button'] = true;
     }


### PR DESCRIPTION
Resolves #5805 ([FR-2053](https://lablup.atlassian.net/browse/FR-2053))

## Summary
- Create `BAIRouteNodes` Relay fragment component with BAITable integration for the endpoint routes table
- Add `route-node` feature flag for 25.19.0+ backends with legacy inline table fallback
- Add BAIRadioGroup toggle for running/finished route category filtering
- Add BAIGraphQLPropertyFilter for trafficStatus filtering
- Use offset-based pagination (`limit`/`offset`) with `orderBy` for Strawberry compatibility
- Wrap pagination/order/filter state with `useDeferredValue` for smooth transitions
- Add `ModelDeployment` to `KnownGlobalIdType` for `toGlobalId` conversion
- Add `createdAt` column to BAIRouteNodes table with date formatting and sorting support
- Unify status tag styles across endpoint pages using BUI `SemanticColor` + `useSemanticColorMap`
- Remove `status` from PropertyFilter to avoid overlap with category toggle (Radio Group controls status exclusively)
- Fix environ value overflow in Service Info section with `word-break: break-all`
- Add i18n translations for BAIRouteNodes columns in all 22 languages

![CleanShot 2026-03-10 at 13.43.26@2x.png](https://app.graphite.com/user-attachments/assets/f36b8300-f52f-4240-b9eb-74c8772d8f13.png)

## Test plan
- [ ] On 25.19.0+ backend: verify new BAIRouteNodes table renders with filtered routes
- [ ] Toggle between Running/Finished categories and verify correct routes display
- [ ] Use trafficStatus property filter to narrow results
- [ ] Verify pagination and sorting work correctly (including createdAt column)
- [ ] Verify status tags use consistent SemanticColor styling across endpoint list, Service Info, and Route Info
- [ ] Verify long environ values wrap correctly in Service Info section
- [ ] On older backend: verify legacy inline table renders unchanged
- [ ] Run `bash scripts/verify.sh` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-2053]: https://lablup.atlassian.net/browse/FR-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ