### PR TITLE
e2e(FR-2234): add E2E tests for Resource Policy management page

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -31,7 +31,7 @@
 | Environment | `/environment` | 24 | 18 | 🔶 75% |
 | Configurations | `/settings` | 10 | 8 | 🔶 80% |
 | Resources | `/agent-summary`, `/agent` | 8 | 1 | 🔶 13% |
-| Resource Policy | `/resource-policy` | 13 | 0 | ❌ 0% |
+| Resource Policy | `/resource-policy` | 13 | 10 | 🔶 77% |
 | User Credentials | `/credential` | 16 | 6 | 🔶 38% |
 | Maintenance | `/maintenance` | 3 | 2 | 🔶 67% |
 | User Settings | `/usersettings` | 10 | 0 | ❌ 0% |
@@ -468,7 +468,7 @@
 
 ### 16. Resource Policy (`/resource-policy`)
 
-**Test files:** None (visual regression only)
+**Test files:** `e2e/resource-policy/resource-policy.spec.ts`
 
 **Tabs:** Keypair Policies | User Policies | Project Policies
 
@@ -479,11 +479,11 @@
 
 | Feature | Status | Test |
 |---------|--------|------|
-| Keypair policy list rendering | ❌ | - |
-| Create keypair policy → KeypairResourcePolicySettingModal | ❌ | - |
+| Keypair policy list rendering | ✅ | `Admin can see Keypair policy list with expected columns` |
+| Create keypair policy → KeypairResourcePolicySettingModal | ✅ | `Admin can create a Keypair policy` |
 | View keypair policy → KeypairResourcePolicyInfoModal | ❌ | - |
-| Edit keypair policy → KeypairResourcePolicySettingModal | ❌ | - |
-| Delete keypair policy | ❌ | - |
+| Edit keypair policy → KeypairResourcePolicySettingModal | ✅ | `Admin can edit a Keypair policy` |
+| Delete keypair policy | ✅ | `Admin can delete a Keypair policy` |
 
 #### User Policies Tab
 **Primary action:** "+" → `UserResourcePolicySettingModal`
@@ -491,10 +491,10 @@
 
 | Feature | Status | Test |
 |---------|--------|------|
-| User policy list rendering | ❌ | - |
-| Create user policy → UserResourcePolicySettingModal | ❌ | - |
+| User policy list rendering | ✅ | `Admin can see User policy list` |
+| Create user policy → UserResourcePolicySettingModal | ✅ | `Admin can create a User policy` |
 | Edit user policy → UserResourcePolicySettingModal | ❌ | - |
-| Delete user policy → Popconfirm | ❌ | - |
+| Delete user policy → Popconfirm | ✅ | `Admin can delete a User policy` |
 
 #### Project Policies Tab
 **Primary action:** "+" → `ProjectResourcePolicySettingModal`
@@ -502,12 +502,12 @@
 
 | Feature | Status | Test |
 |---------|--------|------|
-| Project policy list rendering | ❌ | - |
-| Create project policy → ProjectResourcePolicySettingModal | ❌ | - |
+| Project policy list rendering | ✅ | `Admin can see Project policy list` |
+| Create project policy → ProjectResourcePolicySettingModal | ✅ | `Admin can create a Project policy` |
 | Edit project policy → ProjectResourcePolicySettingModal | ❌ | - |
-| Delete project policy → Popconfirm | ❌ | - |
+| Delete project policy → Popconfirm | ✅ | `Admin can delete a Project policy` |
 
-**Coverage: ❌ 0/13 features**
+**Coverage: 🔶 10/13 features**
 
 ---
 

--- a/e2e/resource-policy/resource-policy.spec.ts
+++ b/e2e/resource-policy/resource-policy.spec.ts
@@ -1,0 +1,333 @@
+// spec: Resource Policy page tests
+import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import test, { expect, type Page } from '@playwright/test';
+
+const TEST_RUN_ID = Date.now().toString(36);
+
+async function cleanupPolicy(page: Page, policyName: string) {
+  const row = page.getByRole('row').filter({ hasText: policyName });
+  const isVisible = await row.isVisible({ timeout: 2000 }).catch(() => false);
+  if (isVisible) {
+    await row.getByRole('button', { name: 'delete' }).click();
+    await page.getByRole('button', { name: 'Delete', exact: true }).click();
+    await expect(row).toBeHidden({ timeout: 10000 });
+  }
+}
+
+test.describe(
+  'Resource Policy',
+  { tag: ['@critical', '@resource-policy', '@functional'] },
+  () => {
+    test.describe.serial('Keypair Resource Policy CRUD', () => {
+      const KEYPAIR_POLICY_NAME = `e2e-kp-policy-${TEST_RUN_ID}`;
+
+      test('Admin can see Keypair policy list with expected columns', async ({
+        page,
+        request,
+      }) => {
+        await loginAsAdmin(page, request);
+        await navigateTo(page, 'resource-policy');
+
+        // Verify Keypair tab is selected by default
+        await expect(
+          page.getByRole('tab', { name: 'Keypair', selected: true }),
+        ).toBeVisible();
+
+        // Verify table columns
+        await expect(
+          page.getByRole('columnheader', { name: 'Name' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: 'Concurrency' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: 'Cluster Size' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: 'Control' }),
+        ).toBeVisible();
+
+        // Verify default policy row exists
+        const defaultRow = page.getByRole('row').filter({ hasText: 'default' });
+        await expect(defaultRow).toBeVisible();
+
+        // Cleanup any leftover test policy
+        await cleanupPolicy(page, KEYPAIR_POLICY_NAME);
+      });
+
+      test('Admin can create a Keypair policy', async ({ page, request }) => {
+        await loginAsAdmin(page, request);
+        await navigateTo(page, 'resource-policy');
+
+        // Click Create button
+        await page.getByRole('button', { name: 'Create' }).click();
+
+        // Verify Create Resource Policy dialog appears
+        const modal = page.getByRole('dialog', {
+          name: 'Create Resource Policy',
+        });
+        await expect(modal).toBeVisible();
+
+        // Fill in the policy name
+        await modal
+          .getByRole('textbox', { name: 'Name' })
+          .fill(KEYPAIR_POLICY_NAME);
+
+        // Click OK
+        await modal.getByRole('button', { name: 'OK' }).click();
+
+        // Verify modal closes
+        await expect(modal).toBeHidden({ timeout: 10000 });
+
+        // Verify new policy appears in the table
+        await expect(
+          page.getByRole('cell', { name: KEYPAIR_POLICY_NAME, exact: true }),
+        ).toBeVisible({ timeout: 10000 });
+      });
+
+      test('Admin can edit a Keypair policy', async ({ page, request }) => {
+        await loginAsAdmin(page, request);
+        await navigateTo(page, 'resource-policy');
+
+        // Find the test policy row and click setting
+        const policyRow = page
+          .getByRole('row')
+          .filter({ hasText: KEYPAIR_POLICY_NAME });
+        await expect(policyRow).toBeVisible();
+        await policyRow.getByRole('button', { name: 'setting' }).click();
+
+        // Verify Update dialog appears
+        const modal = page.getByRole('dialog');
+        await expect(modal).toBeVisible();
+
+        // Change Cluster Size to 2
+        const clusterSizeInput = modal.getByRole('spinbutton', {
+          name: 'Cluster Size',
+        });
+        await clusterSizeInput.fill('2');
+
+        // Click OK
+        await modal.getByRole('button', { name: 'OK' }).click();
+
+        // Verify modal closes
+        await expect(modal).toBeHidden({ timeout: 10000 });
+
+        // Verify the cluster size value is updated in the table
+        const updatedRow = page
+          .getByRole('row')
+          .filter({ hasText: KEYPAIR_POLICY_NAME });
+        await expect(
+          updatedRow.getByRole('cell', { name: '2', exact: true }),
+        ).toBeVisible({ timeout: 10000 });
+      });
+
+      test('Admin can delete a Keypair policy', async ({ page, request }) => {
+        await loginAsAdmin(page, request);
+        await navigateTo(page, 'resource-policy');
+
+        // Find the test policy row
+        const policyRow = page
+          .getByRole('row')
+          .filter({ hasText: KEYPAIR_POLICY_NAME });
+        await expect(policyRow).toBeVisible();
+
+        // Click delete button
+        await policyRow.getByRole('button', { name: 'delete' }).click();
+
+        // Confirm deletion in popconfirm
+        await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+        // Verify the policy is removed
+        await expect(
+          page.getByRole('row').filter({ hasText: KEYPAIR_POLICY_NAME }),
+        ).toBeHidden({ timeout: 10000 });
+      });
+    });
+
+    test.describe.serial('User Resource Policy CRUD', () => {
+      const USER_POLICY_NAME = `e2e-user-policy-${TEST_RUN_ID}`;
+
+      test('Admin can see User policy list', async ({ page, request }) => {
+        await loginAsAdmin(page, request);
+        await navigateTo(page, 'resource-policy');
+
+        // Switch to User tab
+        await page.getByRole('tab', { name: 'User' }).click();
+        await expect(
+          page.getByRole('tab', { name: 'User', selected: true }),
+        ).toBeVisible();
+
+        // Verify table columns
+        await expect(
+          page.getByRole('columnheader', { name: 'Name' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: 'Max Folder Count' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: 'Control' }),
+        ).toBeVisible();
+
+        // Verify default policy row exists
+        const defaultRow = page.getByRole('row').filter({ hasText: 'default' });
+        await expect(defaultRow).toBeVisible();
+
+        // Cleanup
+        await cleanupPolicy(page, USER_POLICY_NAME);
+      });
+
+      test('Admin can create a User policy', async ({ page, request }) => {
+        await loginAsAdmin(page, request);
+        await navigateTo(page, 'resource-policy');
+
+        // Switch to User tab
+        await page.getByRole('tab', { name: 'User' }).click();
+
+        // Click Create button
+        await page.getByRole('button', { name: 'Create' }).click();
+
+        // Verify dialog appears
+        const modal = page.getByRole('dialog', {
+          name: 'Create Resource Policy',
+        });
+        await expect(modal).toBeVisible();
+
+        // Fill in policy name
+        await modal
+          .getByRole('textbox', { name: 'Name' })
+          .fill(USER_POLICY_NAME);
+
+        // Fill required fields
+        await modal
+          .getByRole('spinbutton', {
+            name: 'Max Session Count Per Model Session',
+          })
+          .fill('10');
+        await modal
+          .getByRole('spinbutton', { name: 'Max Customized Image Count' })
+          .fill('3');
+
+        // Click OK and wait for response
+        await modal.getByRole('button', { name: 'OK' }).click();
+
+        // Verify modal closes (may take time for API call)
+        await expect(modal).toBeHidden({ timeout: 30000 });
+
+        // Verify new policy appears
+        await expect(
+          page.getByRole('cell', { name: USER_POLICY_NAME, exact: true }),
+        ).toBeVisible({ timeout: 10000 });
+      });
+
+      test('Admin can delete a User policy', async ({ page, request }) => {
+        await loginAsAdmin(page, request);
+        await navigateTo(page, 'resource-policy');
+
+        // Switch to User tab
+        await page.getByRole('tab', { name: 'User' }).click();
+
+        // Find and delete the test policy
+        const policyRow = page
+          .getByRole('row')
+          .filter({ hasText: USER_POLICY_NAME });
+        await expect(policyRow).toBeVisible();
+        await policyRow.getByRole('button', { name: 'delete' }).click();
+
+        // Confirm deletion in popconfirm
+        await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+        // Verify removal
+        await expect(
+          page.getByRole('row').filter({ hasText: USER_POLICY_NAME }),
+        ).toBeHidden({ timeout: 10000 });
+      });
+    });
+
+    test.describe.serial('Project Resource Policy CRUD', () => {
+      const PROJECT_POLICY_NAME = `e2e-proj-policy-${TEST_RUN_ID}`;
+
+      test('Admin can see Project policy list', async ({ page, request }) => {
+        await loginAsAdmin(page, request);
+        await navigateTo(page, 'resource-policy');
+
+        // Switch to Project tab
+        await page.getByRole('tab', { name: 'Project' }).click();
+        await expect(
+          page.getByRole('tab', { name: 'Project', selected: true }),
+        ).toBeVisible();
+
+        // Verify table columns
+        await expect(
+          page.getByRole('columnheader', { name: 'Name' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: 'Max Folder Count' }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole('columnheader', { name: 'Control' }),
+        ).toBeVisible();
+
+        // Verify default policy row
+        const defaultRow = page.getByRole('row').filter({ hasText: 'default' });
+        await expect(defaultRow).toBeVisible();
+
+        // Cleanup
+        await cleanupPolicy(page, PROJECT_POLICY_NAME);
+      });
+
+      test('Admin can create a Project policy', async ({ page, request }) => {
+        await loginAsAdmin(page, request);
+        await navigateTo(page, 'resource-policy');
+
+        // Switch to Project tab
+        await page.getByRole('tab', { name: 'Project' }).click();
+
+        // Click Create button
+        await page.getByRole('button', { name: 'Create' }).click();
+
+        // Verify dialog appears
+        const modal = page.getByRole('dialog');
+        await expect(modal).toBeVisible();
+
+        // Fill in policy name
+        await modal
+          .getByRole('textbox', { name: 'Name' })
+          .fill(PROJECT_POLICY_NAME);
+
+        // Click OK
+        await modal.getByRole('button', { name: 'OK' }).click();
+
+        // Verify modal closes
+        await expect(modal).toBeHidden({ timeout: 10000 });
+
+        // Verify new policy appears
+        await expect(
+          page.getByRole('cell', { name: PROJECT_POLICY_NAME, exact: true }),
+        ).toBeVisible({ timeout: 10000 });
+      });
+
+      test('Admin can delete a Project policy', async ({ page, request }) => {
+        await loginAsAdmin(page, request);
+        await navigateTo(page, 'resource-policy');
+
+        // Switch to Project tab
+        await page.getByRole('tab', { name: 'Project' }).click();
+
+        // Find and delete the test policy
+        const policyRow = page
+          .getByRole('row')
+          .filter({ hasText: PROJECT_POLICY_NAME });
+        await expect(policyRow).toBeVisible();
+        await policyRow.getByRole('button', { name: 'delete' }).click();
+
+        // Confirm deletion in popconfirm
+        await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+        // Verify removal
+        await expect(
+          page.getByRole('row').filter({ hasText: PROJECT_POLICY_NAME }),
+        ).toBeHidden({ timeout: 10000 });
+      });
+    });
+  },
+);


### PR DESCRIPTION
Resolves [FR-2234](https://lablup.atlassian.net/browse/FR-2234)

## Summary
- Add E2E tests for Resource Policy page (`/resource-policy`): all three tabs (Keypair, User, Project)
- Cover CRUD operations: list columns/default row, create, edit (Keypair only), delete
- 10 serial tests with cleanup helpers for test isolation

## Test plan
- [x] `pnpm exec playwright test e2e/resource-policy/resource-policy.spec.ts` — 10/10 passing

## E2E Test Recordings

| Test | Recording |
|------|-----------|
| Admin can create a Keypair policy | ![Create Keypair Policy](https://github.com/user-attachments/assets/76f15a72-1913-4905-b55a-c4e5eb9fe8e9) |
| Admin can delete a Project policy | ![Delete Project Policy](https://github.com/user-attachments/assets/6b544d30-65c8-49fc-9a9c-cb02c5c3742d) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-2234]: https://lablup.atlassian.net/browse/FR-2234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ