### PR TITLE
e2e(FR-2236): add E2E tests for Statistics, Information, and Agent Summary pages

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 91 / 273 features covered (33%)**
+**Overall (in-scope routes): 95 / 273 features covered (35%)**
 
 | Page | Route | Features | Covered | Status |
 |------|-------|:--------:|:-------:|:------:|
@@ -30,19 +30,19 @@
 | My Environment | `/my-environment` | 2 | 2 | ✅ 100% |
 | Environment | `/environment` | 24 | 18 | 🔶 75% |
 | Configurations | `/settings` | 10 | 8 | 🔶 80% |
-| Resources | `/agent-summary`, `/agent` | 8 | 1 | 🔶 13% |
+| Resources | `/agent-summary`, `/agent` | 8 | 3 | 🔶 38% |
 | Resource Policy | `/resource-policy` | 13 | 10 | 🔶 77% |
 | User Credentials | `/credential` | 16 | 9 | 🔶 56% |
 | Maintenance | `/maintenance` | 3 | 2 | 🔶 67% |
 | User Settings | `/usersettings` | 10 | 0 | ❌ 0% |
 | Project | `/project` | 6 | 5 | 🔶 83% |
-| Statistics | `/statistics` | 2 | 0 | ❌ 0% |
+| Statistics | `/statistics` | 2 | 2 | ✅ 100% |
 | Scheduler | `/scheduler` | 6 | 0 | ❌ 0% |
 | Reservoir | `/reservoir`, `/reservoir/:artifactId` | 18 | 0 | ❌ 0% |
 | Branding | `/branding` | 14 | 0 | ❌ 0% |
 | App Launcher | (modal) | 18 | 10 | 🔶 56% |
 | Chat | `/chat/:id?` | 6 | 0 | ❌ 0% |
-| **Total** | | **273** | **91** | **33%** |
+| **Total** | | **273** | **95** | **35%** |
 
 ---
 
@@ -431,9 +431,16 @@
 
 ### 15. Resources (`/agent-summary`, `/agent`)
 
-**Test files:** [`e2e/agent/agent.spec.ts`](agent/agent.spec.ts)
+**Test files:** [`e2e/agent/agent.spec.ts`](agent/agent.spec.ts), `e2e/agent-summary/agent-summary.spec.ts`
 
 **Tabs:** Agents | Storage Proxies | Resource Groups
+
+#### Agent Summary (`/agent-summary`)
+
+| Feature | Status | Test |
+|---------|--------|------|
+| Agent Summary list with columns | ✅ | `Admin can see Agent Summary page with expected columns` |
+| Connected/Terminated filter switching | ✅ | `Admin can switch between Connected and Terminated agents` |
 
 #### Agents Tab
 **Table link:** Agent name → `AgentDetailDrawer`
@@ -462,7 +469,7 @@
 | Edit resource group → ResourceGroupSettingModal | ❌ | - |
 | Delete resource group → Popconfirm | ❌ | - |
 
-**Coverage: 🔶 1/8 features**
+**Coverage: 🔶 3/8 features**
 
 ---
 
@@ -623,16 +630,16 @@
 
 ### 21. Statistics (`/statistics`)
 
-**Test files:** None
+**Test files:** `e2e/statistics/statistics.spec.ts`
 
 **Tabs:** Usage History | User Session History (conditional)
 
 | Feature | Status | Test |
 |---------|--------|------|
-| Allocation history tab | ❌ | - |
-| User session history tab | ❌ | - |
+| Allocation history tab | ✅ | `Admin can see Statistics page with Allocation History tab` |
+| User session history tab | ✅ | `Admin can switch to User Session History tab` |
 
-**Coverage: ❌ 0/2 features**
+**Coverage: ✅ 2/2 features**
 
 ---
 
@@ -923,17 +930,17 @@ To efficiently build new E2E tests, these POMs should be created:
 | `/settings` (config) | ✅ | ✅ | - |
 | `/agent-summary` | 🔶 | ✅ | P3 |
 | `/agent` | 🔶 | ✅ | P3 |
-| `/resource-policy` | ❌ | ✅ | **P2** |
+| `/resource-policy` | 🔶 | ✅ | P2 |
 | `/credential` | 🔶 | ✅ | P2 |
 | `/maintenance` | 🔶 | ✅ | - |
-| `/project` | ❌ | ❌ | **P2** |
-| `/statistics` | ❌ | ❌ | P3 |
+| `/project` | 🔶 | ❌ | P2 |
+| `/statistics` | ✅ | ❌ | - |
 | `/usersettings` | ❌ | ❌ | **P2** |
 | `/scheduler` | ❌ | ❌ | P3 |
 | `/reservoir` | ❌ | ❌ | P3 |
 | `/branding` | ❌ | ❌ | P3 |
 | `/chat/:id?` | ❌ | ❌ | P3 |
-| `/information` | ❌ | ✅ | P3 |
+| `/information` | 🔶 | ✅ | P3 |
 | App Launcher (modal) | 🔶 | ❌ | - |
 
 ---

--- a/e2e/agent-summary/agent-summary.spec.ts
+++ b/e2e/agent-summary/agent-summary.spec.ts
@@ -1,0 +1,71 @@
+// spec: Agent Summary page tests
+import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import test, { expect } from '@playwright/test';
+
+test.describe(
+  'Agent Summary',
+  { tag: ['@functional', '@agent-summary'] },
+  () => {
+    test('Admin can see Agent Summary page with expected columns', async ({
+      page,
+      request,
+    }) => {
+      await loginAsAdmin(page, request);
+      await navigateTo(page, 'agent-summary');
+
+      // Verify Agent Summary tab is selected
+      await expect(
+        page.getByRole('tab', { name: 'Agent Summary', selected: true }),
+      ).toBeVisible();
+
+      // Verify table columns
+      await expect(
+        page.getByRole('columnheader', { name: 'ID' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Architecture' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Allocation' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Resource Group' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('columnheader', { name: 'Schedulable' }),
+      ).toBeVisible();
+
+      // Verify Connected/Terminated radio filter
+      const radioGroup = page.getByRole('radiogroup');
+      await expect(radioGroup).toBeVisible();
+      await expect(
+        radioGroup.getByText('Connected', { exact: true }),
+      ).toBeVisible();
+      await expect(radioGroup.getByText('Terminated')).toBeVisible();
+    });
+
+    test('Admin can switch between Connected and Terminated agents', async ({
+      page,
+      request,
+    }) => {
+      await loginAsAdmin(page, request);
+      await navigateTo(page, 'agent-summary');
+
+      // Click Terminated
+      await page.getByText('Terminated').click();
+
+      // Verify the table is still visible (may show "No data")
+      await expect(
+        page.getByRole('columnheader', { name: 'ID' }),
+      ).toBeVisible();
+
+      // Switch back to Connected
+      await page.getByText('Connected', { exact: true }).click();
+
+      // Table should still be visible
+      await expect(
+        page.getByRole('columnheader', { name: 'ID' }),
+      ).toBeVisible();
+    });
+  },
+);

--- a/e2e/information/information.spec.ts
+++ b/e2e/information/information.spec.ts
@@ -1,0 +1,37 @@
+// spec: Information page tests
+import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import test, { expect } from '@playwright/test';
+
+test.describe('Information', { tag: ['@functional', '@information'] }, () => {
+  test('Admin can see Information page with server details', async ({
+    page,
+    request,
+  }) => {
+    await loginAsAdmin(page, request);
+    await navigateTo(page, 'information');
+
+    // Verify page title in breadcrumb
+    await expect(page.getByText('Information').first()).toBeVisible();
+
+    // Verify Core section
+    await expect(page.getByText('Core')).toBeVisible();
+    await expect(page.getByText('Manager version')).toBeVisible();
+    await expect(page.getByText('API version')).toBeVisible();
+
+    // Verify Security section
+    await expect(page.getByText('Security', { exact: true })).toBeVisible();
+
+    // Verify Component section
+    await expect(page.getByText('Component')).toBeVisible();
+    await expect(
+      page.getByText('Docker version', { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByText('PostgreSQL version', { exact: true }),
+    ).toBeVisible();
+
+    // Verify License section
+    await expect(page.getByText('License', { exact: true })).toBeVisible();
+    await expect(page.getByText('License Type', { exact: true })).toBeVisible();
+  });
+});

--- a/e2e/statistics/statistics.spec.ts
+++ b/e2e/statistics/statistics.spec.ts
@@ -1,0 +1,51 @@
+// spec: Statistics page tests
+import { loginAsAdmin, navigateTo } from '../utils/test-util';
+import test, { expect } from '@playwright/test';
+
+test.describe('Statistics', { tag: ['@functional', '@statistics'] }, () => {
+  test('Admin can see Statistics page with Allocation History tab', async ({
+    page,
+    request,
+  }) => {
+    await loginAsAdmin(page, request);
+    await navigateTo(page, 'statistics');
+
+    // Verify Allocation History tab is selected by default
+    await expect(
+      page.getByRole('tab', { name: 'Allocation History', selected: true }),
+    ).toBeVisible();
+
+    // Verify Period selector exists
+    await expect(page.getByText(/Period/)).toBeVisible();
+
+    // Verify chart sections exist
+    await expect(page.getByText('Sessions').first()).toBeVisible();
+    await expect(page.getByText('CPU').first()).toBeVisible();
+    await expect(page.getByText('Memory').first()).toBeVisible();
+  });
+
+  test('Admin can switch to User Session History tab', async ({
+    page,
+    request,
+  }) => {
+    await loginAsAdmin(page, request);
+    await navigateTo(page, 'statistics');
+
+    // User Session History tab is conditional (requires user-metrics support)
+    const userSessionTab = page.getByRole('tab', {
+      name: 'User Session History',
+    });
+    const isTabVisible = await userSessionTab
+      .isVisible({ timeout: 3000 })
+      .catch(() => false);
+    test.skip(!isTabVisible, 'User Session History tab not available');
+
+    await userSessionTab.click();
+    await expect(
+      page.getByRole('tab', {
+        name: 'User Session History',
+        selected: true,
+      }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
Resolves [FR-2236](https://lablup.atlassian.net/browse/FR-2236)

## Summary
- Add E2E tests for Statistics page (2 tests: Allocation History tab rendering, tab switching)
- Add E2E tests for Information page (1 test: Core, Security, Component, License sections)
- Add E2E tests for Agent Summary page (2 tests: table columns, Connected/Terminated radio filter)
- All 5 tests are read-only page verifications with no backend mutation dependencies

## Test plan
- [x] `pnpm exec playwright test e2e/statistics/statistics.spec.ts` — 2 passed
- [x] `pnpm exec playwright test e2e/information/information.spec.ts` — 1 passed
- [x] `pnpm exec playwright test e2e/agent-summary/agent-summary.spec.ts` — 2 passed

## E2E Test Recordings

| Test | Recording |
|------|-----------|
| Statistics - Allocation History tab | ![Statistics](https://github.com/user-attachments/assets/0250f119-e7c4-43de-a119-32f0eaf13ff6) |
| Agent Summary - Connected/Terminated filter | ![Agent Summary](https://github.com/user-attachments/assets/cd80aec7-9c67-499d-957b-3cd9d8118807) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FR-2236]: https://lablup.atlassian.net/browse/FR-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ