### PR TITLE
test(FR-126): add E2E Playwright tests for session template CRUD operations

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -41,7 +41,7 @@
 | Information | `/information` | 2 | 2 | ✅ 100% |
 | Reservoir | `/reservoir`, `/reservoir/:artifactId` | 18 | 0 | ❌ 0% |
 | Branding | `/branding` | 14 | 0 | ❌ 0% |
-| Admin Session | `/admin-session` | 6 | 6 | ✅ 100% |
+| Admin Session | `/admin-session` | 7 | 7 | ✅ 100% |
 | App Launcher | (modal) | 18 | 10 | 🔶 56% |
 | Chat | `/chat/:id?` | 6 | 0 | ❌ 0% |
 | Plugin System | (config-based) | 12 | 12 | ✅ 100% |
@@ -949,7 +949,7 @@
 | Delete session template | ✅ | `Admin can delete a session template` |
 | Form validation (required fields) | ✅ | `Create modal shows validation error when required fields are empty` |
 
-**Coverage: ✅ 6/6 features** (Filtering test: 🔶 partial via `Admin can search for a specific session template by name in table`)
+**Coverage: ✅ 7/7 features** (Filtering test: 🔶 partial via `Admin can search for a specific session template by name in table`)
 
 ---
 

--- a/e2e/session-template/session-template.spec.ts
+++ b/e2e/session-template/session-template.spec.ts
@@ -136,10 +136,15 @@ async function deleteTemplateByNameInUI(
     .filter({ has: page.locator('[data-icon="delete"]') })
     .click();
 
-  // Confirm the modal dialog
-  const confirmModal = page.locator('.ant-modal-confirm');
+  // BAIConfirmModalWithInput requires typing the template name to confirm
+  const confirmModal = page.getByRole('dialog');
   await expect(confirmModal).toBeVisible({ timeout: 5000 });
-  await confirmModal.getByRole('button', { name: 'Delete' }).click();
+
+  // Type the template name in the confirmation input
+  await confirmModal.getByRole('textbox').fill(templateName);
+
+  // Click the OK/Delete button (now enabled after typing correct text)
+  await confirmModal.getByRole('button', { name: 'OK' }).click();
 
   // Wait for row to disappear
   await expect(row).toBeHidden({ timeout: 10000 });
@@ -292,10 +297,11 @@ test.describe(
           .filter({ has: page.locator('[data-icon="delete"]') })
           .click();
 
-        // Confirm deletion in modal dialog
-        const confirmModal = page.locator('.ant-modal-confirm');
+        // BAIConfirmModalWithInput: type template name to confirm deletion
+        const confirmModal = page.getByRole('dialog');
         await expect(confirmModal).toBeVisible({ timeout: 5000 });
-        await confirmModal.getByRole('button', { name: 'Delete' }).click();
+        await confirmModal.getByRole('textbox').fill(TEST_TEMPLATE_NAME_EDITED);
+        await confirmModal.getByRole('button', { name: 'OK' }).click();
 
         // Verify the template is removed from the table
         await expect(
@@ -409,13 +415,20 @@ test.describe(
     test.describe.serial('Session Template Filtering', () => {
       const FILTER_TEMPLATE_NAME = `${TEST_TEMPLATE_PREFIX}filter-${TEST_RUN_ID}`;
 
-      test.afterAll(async ({ page, request }) => {
+      test.afterAll(async ({ browser }) => {
         // Cleanup: remove the filter test template if it exists
-        await loginAsAdmin(page, request);
-        await navigateToSessionTemplateTab(page);
-        await deleteTemplateByNameInUI(page, FILTER_TEMPLATE_NAME).catch(
-          () => {},
-        );
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        const request = context.request;
+        try {
+          await loginAsAdmin(page, request);
+          await navigateToSessionTemplateTab(page);
+          await deleteTemplateByNameInUI(page, FILTER_TEMPLATE_NAME).catch(
+            () => {},
+          );
+        } finally {
+          await context.close();
+        }
       });
 
       test('Admin can search for a specific session template by name in table', async ({


### PR DESCRIPTION
Resolves #5842(FR-126)

## Summary
- Add comprehensive E2E tests for session template CRUD operations
- Tests cover: navigation, create, verify, edit, delete, validation, session type variants, and filtering
- Robust dropdown selectors using form field IDs with explicit close waits
- Add `afterAll` cleanup to CRUD serial block to ensure test templates are deleted after test runs
- Fix `deleteTemplateByNameInUI` to use `waitFor` instead of `isVisible` for reliable row detection in cleanup