### PR TITLE
fix(FR-2241): pass Global ID instead of raw UUID to vfolder_node query

### DIFF
--- a/react/src/components/VFolderLazyView.tsx
+++ b/react/src/components/VFolderLazyView.tsx
@@ -5,7 +5,7 @@
 import { useWebUINavigate } from '../hooks';
 import VFolderNodeIdenticon from './VFolderNodeIdenticon';
 import { Typography } from 'antd';
-import { BAIFlex, toLocalId } from 'backend.ai-ui';
+import { BAIFlex, toGlobalId, toLocalId } from 'backend.ai-ui';
 import React from 'react';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useLocation } from 'react-router-dom';
@@ -33,7 +33,7 @@ const VFolderLazyView: React.FC<VFolderLazyViewProps> = ({
         }
       }
     `,
-    { id: uuid },
+    { id: toGlobalId('VirtualFolderNode', uuid) },
   );
 
   return (


### PR DESCRIPTION
Resolves #(FR-2241)

## Summary
- Fix VFolderLazyView passing raw UUID instead of Global ID to `vfolder_node` GraphQL query
- Use `toGlobalId('VirtualFolderNode', uuid)` to properly encode the ID before querying
- This bug was introduced in PR #4950 (FR-1871) when VFolderLazyView was refactored from REST API to GraphQL, and has been present since v26.1.0-rc.1

## Test plan
- [ ] Open a view that uses VFolderLazyView (e.g., Model Card Modal as superadmin)
- [ ] Verify that vfolder name and identicon are displayed correctly
- [ ] Verify clicking the folder link navigates properly