### PR TITLE
chore: update package.yml runner from self-hosted to macos-latest

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: read
       repository-projects: read
       statuses: read
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: macos-latest
     environment: app-packaging
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
## Summary
- Remove `self-hosted` runner label and use `macos-latest` for the `build_mac` job in `package.yml`
- Backport of changes already applied to the 26.2 branch (commits b4e78b6, 9d9b5eb)

## Test plan
- [ ] Verify the `Build and Release Packages` workflow triggers correctly on release
- [ ] Confirm macOS build succeeds on GitHub-hosted `macos-latest` runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)