### PR TITLE
fix: remove redundant pnpm store config causing post-install cache error

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,19 +36,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
-      - name: Configure pnpm store
-        run: pnpm config set store-dir ~/.pnpm-store
-      # - name: Get pnpm store directory
-      #   shell: bash
-      #   run: |
-      #     echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      # - uses: actions/cache@v4
-      #   name: Setup pnpm cache
-      #   with:
-      #     path: ${{ env.STORE_PATH }}
-      #     key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-pnpm-store-
       - name: Install Dependencies
         # CI defaults to --frozen-lockfile, which blocks merging git branch lockfiles.
         # pnpm-workspace.yaml's mergeGitBranchLockfilesBranchPattern auto-merges


### PR DESCRIPTION
Resolves #5878

## Summary
- Remove manual `pnpm config set store-dir ~/.pnpm-store` step that caused path mismatch with `actions/setup-node`'s built-in pnpm cache
- Clean up commented-out manual `actions/cache` configuration
- Let `actions/setup-node` with `cache: 'pnpm'` handle store path detection and caching automatically

## Test plan
- [ ] Trigger a release build and verify "Post Install Node.js" step no longer fails with "Path Validation Error"