### PR TITLE
feat(FR-2247): implement BAIContainerRegistrySelect for RBAC permission modal

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIContainerRegistrySelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIContainerRegistrySelect.tsx
@@ -1,0 +1,321 @@
+import { BAIContainerRegistrySelectPaginatedQuery } from '../../__generated__/BAIContainerRegistrySelectPaginatedQuery.graphql';
+import { BAIContainerRegistrySelectValueQuery } from '../../__generated__/BAIContainerRegistrySelectValueQuery.graphql';
+import { toLocalId } from '../../helper';
+import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
+import { useFetchKey } from '../../hooks';
+import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import { mergeFilterValues } from '../BAIPropertyFilter';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import BAIText from '../BAIText';
+import TotalFooter from '../TotalFooter';
+import { useControllableValue } from 'ahooks';
+import { GetRef, Skeleton } from 'antd';
+import _ from 'lodash';
+import {
+  useDeferredValue,
+  useImperativeHandle,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export type ContainerRegistryNode = NonNullable<
+  NonNullable<
+    BAIContainerRegistrySelectPaginatedQuery['response']['container_registry_nodes']
+  >['edges'][number]
+>['node'];
+
+export interface BAIContainerRegistrySelectRef {
+  refetch: () => void;
+}
+
+export interface BAIContainerRegistrySelectProps
+  extends Omit<BAISelectProps, 'options' | 'labelInValue' | 'ref'> {
+  filter?: string;
+  valuePropName?: 'id' | 'row_id';
+  onChange?: (value: string | string[] | undefined, option: any) => void;
+  ref?: React.Ref<BAIContainerRegistrySelectRef>;
+}
+
+const BAIContainerRegistrySelect: React.FC<BAIContainerRegistrySelectProps> = ({
+  loading,
+  filter,
+  valuePropName = 'id',
+  ref,
+  ...selectProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+  const [controllableValue, setControllableValue] = useControllableValue<
+    string | string[] | undefined
+  >(selectProps, {
+    valuePropName: 'value',
+    trigger: 'onChange',
+  });
+  const [controllableOpen, setControllableOpen] =
+    useControllableValue<boolean>(selectProps, {
+      valuePropName: 'open',
+      trigger: 'onOpenChange',
+      defaultValuePropName: 'defaultOpen',
+    });
+
+  const deferredOpen = useDeferredValue(controllableOpen);
+  const [searchStr, setSearchStr] = useState<string>();
+  const debouncedDeferredValue = useDebouncedDeferredValue(searchStr);
+  const [optimisticSearchStr, setOptimisticSearchStr] =
+    useOptimistic(searchStr);
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  // Defer query refetch to prevent flickering during selection
+  const deferredControllableValue = useDeferredValue(controllableValue);
+
+  const { container_registry_nodes: selectedRegistryNodes } =
+    useLazyLoadQuery<BAIContainerRegistrySelectValueQuery>(
+      graphql`
+        query BAIContainerRegistrySelectValueQuery(
+          $selectedFilter: String
+          $first: Int!
+          $skipSelected: Boolean!
+        ) {
+          container_registry_nodes(filter: $selectedFilter, first: $first)
+            @skip(if: $skipSelected) {
+            edges {
+              node {
+                id
+                row_id
+                name
+              }
+            }
+          }
+        }
+      `,
+      {
+        selectedFilter: mergeFilterValues(
+          [
+            !_.isEmpty(deferredControllableValue)
+              ? mergeFilterValues(
+                  _.castArray(deferredControllableValue).map((value) => {
+                    // Convert Global ID to local UUID for filtering when valuePropName is 'id'
+                    const filterValue =
+                      valuePropName === 'id' ? toLocalId(value) : value;
+                    return valuePropName === 'id'
+                      ? `id == "${filterValue}"`
+                      : `row_id == "${filterValue}"`;
+                  }),
+                  '|',
+                )
+              : null,
+            filter,
+          ],
+          '&',
+        ),
+        first: _.castArray(deferredControllableValue).length,
+        skipSelected: _.isEmpty(deferredControllableValue),
+      },
+      {
+        fetchPolicy: !_.isEmpty(deferredControllableValue)
+          ? 'store-or-network'
+          : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+    );
+
+  const { paginationData, result, loadNext, isLoadingNext } =
+    useLazyPaginatedQuery<
+      BAIContainerRegistrySelectPaginatedQuery,
+      ContainerRegistryNode
+    >(
+      graphql`
+        query BAIContainerRegistrySelectPaginatedQuery(
+          $offset: Int!
+          $limit: Int!
+          $filter: String
+        ) {
+          container_registry_nodes(
+            offset: $offset
+            first: $limit
+            filter: $filter
+            order: "name"
+          ) {
+            count
+            edges {
+              node {
+                id
+                row_id
+                name
+              }
+            }
+          }
+        }
+      `,
+      { limit: 10 },
+      {
+        filter: mergeFilterValues([
+          filter,
+          debouncedDeferredValue
+            ? `name ilike "%${debouncedDeferredValue}%"`
+            : null,
+        ]),
+      },
+      {
+        fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+      {
+        getTotal: (result) =>
+          result.container_registry_nodes?.count ?? undefined,
+        getItem: (result) =>
+          result.container_registry_nodes?.edges?.map((edge) => edge?.node),
+        getId: (item) => item?.id,
+      },
+    );
+
+  // Expose refetch function through ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: () => {
+        startRefetchTransition(() => {
+          updateFetchKey();
+        });
+      },
+    }),
+    [updateFetchKey, startRefetchTransition],
+  );
+
+  const availableOptions = _.map(paginationData, (item) => ({
+    label: item?.name,
+    value: item?.[valuePropName],
+  }));
+
+  const controllableValueWithLabel = selectedRegistryNodes?.edges
+    ? // Sort by deferredControllableValue order to maintain selection order
+      _.castArray(deferredControllableValue)
+        .map((value) => {
+          const edge = selectedRegistryNodes.edges.find(
+            (edge) => edge?.node?.[valuePropName] === value,
+          );
+          return edge
+            ? {
+                label: edge.node?.name,
+                value: edge.node?.[valuePropName],
+              }
+            : null;
+        })
+        .filter(
+          (item): item is { label: string | null | undefined; value: string | null | undefined } =>
+            item !== null,
+        )
+    : !_.isEmpty(deferredControllableValue)
+      ? _.castArray(deferredControllableValue).map((value) => ({
+          label: value,
+          value: value,
+        }))
+      : undefined;
+
+  const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
+    controllableValueWithLabel,
+  );
+
+  return (
+    <BAISelect
+      ref={selectRef}
+      placeholder={t('comp:BAIContainerRegistrySelect.SelectContainerRegistry')}
+      loading={
+        loading ||
+        controllableValue !== deferredControllableValue ||
+        searchStr !== debouncedDeferredValue ||
+        isPendingRefetch
+      }
+      {...selectProps}
+      searchAction={async (value) => {
+        setOptimisticSearchStr(value);
+        setSearchStr(value);
+        await selectProps.searchAction?.(value);
+      }}
+      showSearch={
+        selectProps.showSearch === false
+          ? false
+          : {
+              searchValue: optimisticSearchStr,
+              autoClearSearchValue: true,
+              ...(_.isObject(selectProps.showSearch)
+                ? _.omit(selectProps.showSearch, ['searchValue'])
+                : {}),
+              filterOption: false,
+            }
+      }
+      value={
+        controllableValue !== deferredControllableValue
+          ? optimisticValueWithLabel
+          : controllableValueWithLabel
+      }
+      labelInValue
+      labelRender={({ label }) => {
+        return valuePropName === 'id' && _.isString(label) ? (
+          <BAIText monospace>{toLocalId(label)}</BAIText>
+        ) : (
+          label
+        );
+      }}
+      optionRender={({ label }) => {
+        return valuePropName === 'id' && _.isString(label) ? (
+          <BAIText monospace>{toLocalId(label)}</BAIText>
+        ) : (
+          label
+        );
+      }}
+      onChange={(value, option) => {
+        // _.castArray to handle both single and multiple mode uniformly
+        const valueArray = _.isEmpty(value) ? [] : _.castArray(value);
+
+        // In multiple mode, when removing tags, value.label is a React element
+        // So we need to find the original label from availableOptions
+        const valueWithOriginalLabel = valueArray.map((v) => {
+          // If label is string, use it directly; if React element, find from options
+          const label = _.isString(v.label)
+            ? v.label
+            : (availableOptions.find((opt) => opt.value === v.value)?.label ??
+              v.value);
+          return {
+            label,
+            value: v.value,
+          };
+        });
+
+        setOptimisticValueWithLabel(valueWithOriginalLabel);
+
+        const idArray = valueArray.map((v) => _.toString(v.value));
+        setControllableValue(idArray, option);
+      }}
+      options={availableOptions}
+      endReached={() => {
+        loadNext();
+      }}
+      open={controllableOpen}
+      onOpenChange={setControllableOpen}
+      notFoundContent={
+        _.isUndefined(paginationData) ? (
+          <Skeleton.Input active size="small" block />
+        ) : undefined
+      }
+      footer={
+        _.isNumber(result.container_registry_nodes?.count) &&
+        result.container_registry_nodes.count > 0 ? (
+          <TotalFooter
+            loading={isLoadingNext}
+            total={result.container_registry_nodes.count}
+          />
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BAIContainerRegistrySelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -87,6 +87,12 @@ export type {
   ProjectNode,
   BAIProjectSelectRef,
 } from './BAIProjectSelect';
+export { default as BAIContainerRegistrySelect } from './BAIContainerRegistrySelect';
+export type {
+  BAIContainerRegistrySelectProps,
+  ContainerRegistryNode,
+  BAIContainerRegistrySelectRef,
+} from './BAIContainerRegistrySelect';
 export { default as BAIHuggingFaceRegistrySettingModal } from './BAIHuggingFaceRegistrySettingModal';
 export type {
   BAIHuggingFaceRegistrySettingModalProps,

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -242,6 +242,9 @@
   "comp:BAITestButton": {
     "Test": "Test"
   },
+  "comp:BAIContainerRegistrySelect": {
+    "SelectContainerRegistry": "Select Container Registry"
+  },
   "comp:BAIUserSelect": {
     "SelectUser": "Select User"
   },

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -239,6 +239,9 @@
   "comp:BAITestButton": {
     "Test": "테스트"
   },
+  "comp:BAIContainerRegistrySelect": {
+    "SelectContainerRegistry": "컨테이너 레지스트리를 선택해주세요"
+  },
   "comp:BAIUserSelect": {
     "SelectUser": "사용자를 선택해주세요"
   },

--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -13,6 +13,7 @@ import { CreatePermissionModalUpdateMutation } from '../__generated__/CreatePerm
 import { App, Form, Select, type SelectProps } from 'antd';
 import {
   BAIAdminResourceGroupSelect,
+  BAIContainerRegistrySelect,
   BAIModal,
   BAIModalProps,
   BAIProjectSelect,
@@ -31,12 +32,12 @@ const RBAC_ELEMENT_TYPES: ReadonlyArray<RBACElementType> = [
   'USER',
   'VFOLDER',
   'RESOURCE_GROUP',
+  'CONTAINER_REGISTRY',
   // TODO: Scope ID select to be implemented in separate stacks
   // 'SESSION',
   // 'DEPLOYMENT',
   // 'MODEL_DEPLOYMENT',
   // 'KEYPAIR',
-  // 'CONTAINER_REGISTRY',
   // 'STORAGE_HOST',
   // 'IMAGE',
   // 'ARTIFACT',
@@ -168,6 +169,17 @@ const ScopeIdSelect: React.FC<ScopeIdSelectProps> = ({
     return (
       <Suspense fallback={<Select {...selectProps} loading disabled />}>
         <ResourceGroupScopeIdSelect {...selectProps} />
+      </Suspense>
+    );
+  }
+  if (scopeType === 'CONTAINER_REGISTRY') {
+    return (
+      <Suspense fallback={<Select {...selectProps} loading disabled />}>
+        <BAIContainerRegistrySelect
+          placeholder={selectProps.placeholder}
+          value={selectProps.value as string | undefined}
+          onChange={(val, option) => selectProps.onChange?.(val as any, option)}
+        />
       </Suspense>
     );
   }


### PR DESCRIPTION
Resolves #5866 (FR-2247)

## Summary

- Add `BAIContainerRegistrySelect` component using Pattern B (dynamic infinite scroll) for Container Registry selection in the RBAC permission modal
- Implement paginated GraphQL queries (`container_registry_nodes`) with search by name
- Export component from `packages/backend.ai-ui/src/components/fragments`
- Integrate into `CreatePermissionModal` as the scope ID select for `CONTAINER_REGISTRY` scope type
- Add i18n translation keys for English and Korean

## Changes

- `packages/backend.ai-ui/src/components/fragments/BAIContainerRegistrySelect.tsx` — new Pattern B infinite scroll select component
- `packages/backend.ai-ui/src/components/fragments/index.ts` — export new component
- `packages/backend.ai-ui/src/locale/en.json` — add `comp:BAIContainerRegistrySelect.SelectContainerRegistry` key
- `packages/backend.ai-ui/src/locale/ko.json` — add Korean translation
- `react/src/components/CreatePermissionModal.tsx` — import component, add `CONTAINER_REGISTRY` to `RBAC_ELEMENT_TYPES`, add `scopeType === 'CONTAINER_REGISTRY'` branch

## Verification

Relay, Lint, Format, and TypeScript verified manually using the main repo's toolchain (worktree without node_modules).

## Test plan

- [ ] TypeScript check passes (`tsc --noEmit`)
- [ ] Relay compiler runs without errors
- [ ] Container Registry scope type appears in the scope type dropdown
- [ ] Selecting Container Registry scope type renders the registry select with search/pagination
- [ ] Registry names display correctly in the select options