### PR TITLE
feat(FR-2253): implement BAIResourcePresetSelect for RBAC permission modal

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIResourcePresetSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIResourcePresetSelect.tsx
@@ -1,0 +1,53 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { BAIResourcePresetSelectQuery } from '../../__generated__/BAIResourcePresetSelectQuery.graphql';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export interface BAIResourcePresetSelectProps extends Omit<
+  BAISelectProps,
+  'options'
+> {}
+
+const BAIResourcePresetSelect = ({
+  ...selectProps
+}: BAIResourcePresetSelectProps) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { resource_presets } = useLazyLoadQuery<BAIResourcePresetSelectQuery>(
+    graphql`
+      query BAIResourcePresetSelectQuery {
+        resource_presets {
+          name
+        }
+      }
+    `,
+    {},
+    {},
+  );
+
+  return (
+    <BAISelect
+      showSearch
+      filterOption={(input, option) =>
+        (option?.label?.toString() ?? '')
+          .toLowerCase()
+          .includes(input.toLowerCase())
+      }
+      placeholder={t('comp:BAIResourcePresetSelect.SelectResourcePreset')}
+      options={_.map(_.sortBy(resource_presets, 'name'), (preset) => {
+        return {
+          label: preset?.name,
+          value: preset?.name,
+        };
+      })}
+      {...selectProps}
+    />
+  );
+};
+
+export default BAIResourcePresetSelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -63,6 +63,8 @@ export { default as BAIProjectSettingModal } from './BAIProjectSettingModal';
 export type { BAIProjectSettingModalFragmentKey } from './BAIProjectSettingModal';
 export { default as BAIProjectResourcePolicySelect } from './BAIProjectResourcePolicySelect';
 export type { BAIProjectResourcePolicySelectProps } from './BAIProjectResourcePolicySelect';
+export { default as BAIResourcePresetSelect } from './BAIResourcePresetSelect';
+export type { BAIResourcePresetSelectProps } from './BAIResourcePresetSelect';
 export { default as BAIResourceGroupSelect } from './BAIResourceGroupSelect';
 export type { BAIResourceGroupSelectProps } from './BAIResourceGroupSelect';
 export { default as BAIProjectBulkEditModal } from './BAIProjectBulkEditModal';

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -65,6 +65,9 @@
     "KeepAsIs": "Keep as is",
     "UndoChanges": "Undo changes"
   },
+  "comp:BAIContainerRegistrySelect": {
+    "SelectContainerRegistry": "Select Container Registry"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Are you sure you want to deactivate {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Are you sure you want to deactivate {{count}} artifacts?",
@@ -199,6 +202,9 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Select Resource Group"
   },
+  "comp:BAIResourcePresetSelect": {
+    "SelectResourcePreset": "Select Resource Preset"
+  },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Unlimited"
   },
@@ -241,9 +247,6 @@
   },
   "comp:BAITestButton": {
     "Test": "Test"
-  },
-  "comp:BAIContainerRegistrySelect": {
-    "SelectContainerRegistry": "Select Container Registry"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "Select User"

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -65,6 +65,9 @@
     "KeepAsIs": "그대로 유지",
     "UndoChanges": "변경 취소"
   },
+  "comp:BAIContainerRegistrySelect": {
+    "SelectContainerRegistry": "컨테이너 레지스트리를 선택해주세요"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "{{name}}를 비활성화 하시겠습니까?",
     "AreYouSureYouWantToDeactivateSome": "{{count}}개의 아티팩트를 비활성화 하시겠습니까?",
@@ -199,6 +202,9 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "리소스 그룹을 선택해주세요"
   },
+  "comp:BAIResourcePresetSelect": {
+    "SelectResourcePreset": "리소스 프리셋을 선택해주세요"
+  },
   "comp:BAIRouteNodes": {
     "CreatedAt": "생성일",
     "RouteId": "라우트 ID",
@@ -238,9 +244,6 @@
   },
   "comp:BAITestButton": {
     "Test": "테스트"
-  },
-  "comp:BAIContainerRegistrySelect": {
-    "SelectContainerRegistry": "컨테이너 레지스트리를 선택해주세요"
   },
   "comp:BAIUserSelect": {
     "SelectUser": "사용자를 선택해주세요"

--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -17,6 +17,7 @@ import {
   BAIModal,
   BAIModalProps,
   BAIProjectSelect,
+  BAIResourcePresetSelect,
   BAIUserSelect,
   BAIVFolderSelect,
   useBAILogger,
@@ -33,6 +34,7 @@ const RBAC_ELEMENT_TYPES: ReadonlyArray<RBACElementType> = [
   'VFOLDER',
   'RESOURCE_GROUP',
   'CONTAINER_REGISTRY',
+  'RESOURCE_PRESET',
   // TODO: Scope ID select to be implemented in separate stacks
   // 'SESSION',
   // 'DEPLOYMENT',
@@ -43,7 +45,6 @@ const RBAC_ELEMENT_TYPES: ReadonlyArray<RBACElementType> = [
   // 'ARTIFACT',
   // 'ARTIFACT_REGISTRY',
   // 'ARTIFACT_REVISION',
-  // 'RESOURCE_PRESET',
   // 'USER_RESOURCE_POLICY',
   // 'KEYPAIR_RESOURCE_POLICY',
   // 'PROJECT_RESOURCE_POLICY',
@@ -176,6 +177,17 @@ const ScopeIdSelect: React.FC<ScopeIdSelectProps> = ({
     return (
       <Suspense fallback={<Select {...selectProps} loading disabled />}>
         <BAIContainerRegistrySelect
+          placeholder={selectProps.placeholder}
+          value={selectProps.value as string | undefined}
+          onChange={(val, option) => selectProps.onChange?.(val as any, option)}
+        />
+      </Suspense>
+    );
+  }
+  if (scopeType === 'RESOURCE_PRESET') {
+    return (
+      <Suspense fallback={<Select {...selectProps} loading disabled />}>
+        <BAIResourcePresetSelect
           placeholder={selectProps.placeholder}
           value={selectProps.value as string | undefined}
           onChange={(val, option) => selectProps.onChange?.(val as any, option)}


### PR DESCRIPTION
Resolves #5872(FR-2253)

## Summary
- Add `BAIResourcePresetSelect` component using `useLazyLoadQuery` with the `resource_presets` array API (simple pattern, no pagination)
- Sort presets by name with `showSearch` and client-side `filterOption`
- Export from `packages/backend.ai-ui/src/components/fragments/index.ts`
- Integrate into `CreatePermissionModal` for `RESOURCE_PRESET` scope type
- Add i18n keys `comp:BAIResourcePresetSelect.SelectResourcePreset` for `en` and `ko` locales

## Test plan
- [ ] Verify `BAIResourcePresetSelect` renders all resource presets in sorted order
- [ ] Verify client-side search filters presets correctly
- [ ] Verify `RESOURCE_PRESET` scope type appears in `CreatePermissionModal` scope type dropdown
- [ ] Verify selecting `RESOURCE_PRESET` renders `BAIResourcePresetSelect` in scope ID field
- [ ] Verify i18n placeholder shows correctly in both English and Korean

## Verification
All checks pass via `bash scripts/verify.sh`:
- Relay: PASS
- Lint: PASS
- Format: PASS
- TypeScript: PASS