### PR TITLE
feat(FR-2244): implement BAIAdminModelServiceSelect for RBAC permission modal

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeploymentSelect.tsx
@@ -1,0 +1,254 @@
+import { BAIDeploymentSelectPaginatedQuery } from '../../__generated__/BAIDeploymentSelectPaginatedQuery.graphql';
+import { BAIDeploymentSelectValueQuery } from '../../__generated__/BAIDeploymentSelectValueQuery.graphql';
+import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
+import { useFetchKey } from '../../hooks';
+import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import TotalFooter from '../TotalFooter';
+import { useControllableValue } from 'ahooks';
+import { GetRef, Skeleton } from 'antd';
+import _ from 'lodash';
+import {
+  useDeferredValue,
+  useImperativeHandle,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export type DeploymentNode = NonNullable<
+  NonNullable<
+    BAIDeploymentSelectPaginatedQuery['response']['deployments']
+  >['edges'][number]
+>['node'];
+
+export interface BAIDeploymentSelectRef {
+  refetch: () => void;
+}
+
+export interface BAIDeploymentSelectProps extends Omit<
+  BAISelectProps,
+  'options' | 'labelInValue' | 'ref'
+> {
+  ref?: React.Ref<BAIDeploymentSelectRef>;
+}
+
+const BAIDeploymentSelect: React.FC<BAIDeploymentSelectProps> = ({
+  loading,
+  ref,
+  ...selectProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+  const [controllableValue, setControllableValue] = useControllableValue<
+    string | string[] | undefined
+  >(selectProps);
+  const [controllableOpen, setControllableOpen] = useControllableValue<boolean>(
+    selectProps,
+    {
+      valuePropName: 'open',
+      trigger: 'onOpenChange',
+      defaultValuePropName: 'defaultOpen',
+    },
+  );
+  const deferredOpen = useDeferredValue(controllableOpen);
+  const [searchStr, setSearchStr] = useState<string>();
+  const debouncedDeferredValue = useDebouncedDeferredValue(searchStr);
+  const [optimisticSearchStr, setOptimisticSearchStr] =
+    useOptimistic(searchStr);
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  // Defer query refetch to prevent flickering during selection
+  const deferredControllableValue = useDeferredValue(controllableValue);
+
+  // NOTE: DeploymentFilter does not support filtering by id. The ValueQuery
+  // is always skipped; labels are preserved through the optimistic state.
+  useLazyLoadQuery<BAIDeploymentSelectValueQuery>(
+    graphql`
+      query BAIDeploymentSelectValueQuery(
+        $filter: DeploymentFilter
+        $first: Int!
+        $skipSelected: Boolean!
+      ) {
+        deployments(filter: $filter, first: $first) @skip(if: $skipSelected) {
+          edges {
+            node {
+              id
+              metadata {
+                name
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      filter: null,
+      first: 1,
+      // Always skip: DeploymentFilter has no id field, so id-based lookup
+      // is not possible. Labels are maintained via optimistic state.
+      skipSelected: true,
+    },
+    {
+      fetchPolicy: 'store-only',
+      fetchKey: deferredFetchKey,
+    },
+  );
+
+  const { paginationData, result, loadNext, isLoadingNext } =
+    useLazyPaginatedQuery<BAIDeploymentSelectPaginatedQuery, DeploymentNode>(
+      graphql`
+        query BAIDeploymentSelectPaginatedQuery(
+          $offset: Int!
+          $limit: Int!
+          $filter: DeploymentFilter
+        ) {
+          deployments(offset: $offset, limit: $limit, filter: $filter) {
+            count
+            edges {
+              node {
+                id
+                metadata {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      { limit: 10 },
+      {
+        filter: debouncedDeferredValue
+          ? { name: { iContains: debouncedDeferredValue } }
+          : null,
+      },
+      {
+        fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+      {
+        getTotal: (result) => result.deployments?.count ?? undefined,
+        getItem: (result) =>
+          result.deployments?.edges?.map((edge) => edge?.node),
+        getId: (item) => item?.id,
+      },
+    );
+
+  // Expose refetch function through ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: () => {
+        startRefetchTransition(() => {
+          updateFetchKey();
+        });
+      },
+    }),
+    [updateFetchKey, startRefetchTransition],
+  );
+
+  const availableOptions = _.map(paginationData, (item) => ({
+    label: item?.metadata?.name,
+    value: item?.id,
+  }));
+
+  // Since the ValueQuery is always skipped, derive label from optimistic state
+  // or fall back to showing the value (id) as the label.
+  const controllableValueWithLabel = !_.isEmpty(deferredControllableValue)
+    ? _.castArray(deferredControllableValue).map((value) => ({
+        label: value,
+        value: value,
+      }))
+    : undefined;
+
+  const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
+    controllableValueWithLabel,
+  );
+
+  return (
+    <BAISelect
+      ref={selectRef}
+      placeholder={t('comp:BAIDeploymentSelect.SelectDeployment')}
+      loading={
+        loading ||
+        controllableValue !== deferredControllableValue ||
+        searchStr !== debouncedDeferredValue ||
+        isPendingRefetch
+      }
+      {...selectProps}
+      searchAction={async (value) => {
+        setOptimisticSearchStr(value);
+        setSearchStr(value);
+        await selectProps.searchAction?.(value);
+      }}
+      showSearch={
+        selectProps.showSearch === false
+          ? false
+          : {
+              searchValue: optimisticSearchStr,
+              autoClearSearchValue: true,
+              ...(_.isObject(selectProps.showSearch)
+                ? _.omit(selectProps.showSearch, ['searchValue'])
+                : {}),
+              filterOption: false,
+            }
+      }
+      value={
+        controllableValue !== deferredControllableValue
+          ? optimisticValueWithLabel
+          : controllableValueWithLabel
+      }
+      labelInValue
+      onChange={(value, option) => {
+        const castedValue = _.isEmpty(value) ? [] : _.castArray(value);
+        const valueWithOriginalLabel = castedValue.map((v) => {
+          // If label is string, use it directly; if React element, find from options
+          const label = _.isString(v.label)
+            ? v.label
+            : (availableOptions.find((opt) => opt.value === v.value)?.label ??
+              v.value);
+          return {
+            label,
+            value: v.value,
+          };
+        });
+        setOptimisticValueWithLabel(valueWithOriginalLabel);
+        const isMultiple =
+          selectProps.mode === 'multiple' || selectProps.mode === 'tags';
+        const idArray = castedValue.map((v) => _.toString(v.value));
+        setControllableValue(
+          isMultiple ? idArray : (idArray[0] ?? undefined),
+          option,
+        );
+      }}
+      options={availableOptions}
+      endReached={() => {
+        loadNext();
+      }}
+      open={controllableOpen}
+      onOpenChange={setControllableOpen}
+      notFoundContent={
+        _.isUndefined(paginationData) ? (
+          <Skeleton.Input active size="small" block />
+        ) : undefined
+      }
+      footer={
+        _.isNumber(result.deployments?.count) &&
+        result.deployments.count > 0 ? (
+          <TotalFooter
+            loading={isLoadingNext}
+            total={result.deployments.count}
+          />
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BAIDeploymentSelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -117,6 +117,12 @@ export type {
   BAISchedulingHistoryNodesProps,
   SchedulingHistoryNodeInList,
 } from './BAISchedulingHistoryNodes';
+export { default as BAIDeploymentSelect } from './BAIDeploymentSelect';
+export type {
+  BAIDeploymentSelectProps,
+  BAIDeploymentSelectRef,
+  DeploymentNode,
+} from './BAIDeploymentSelect';
 export { default as BAIStorageHostSelect } from './BAIStorageHostSelect';
 export type {
   BAIStorageHostSelectProps,

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Erfolgreich entfernt {{count}} Versionen.",
     "Version": "Version"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Deployment auswählen"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Domäne auswählen"
   },

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Κατάργηση επιτυχώς {{count}} εκδόσεις.",
     "Version": "Εκδοχή"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Επιλέξτε ανάπτυξη"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Επιλέξτε τομέα"
   },

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -91,6 +91,9 @@
     "SuccessFullyRemoved": "Successfully removed {{count}} versions.",
     "Version": "Version"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Select Deployment"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Select Domain"
   },

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Las versiones {{count}} eliminadas con éxito.",
     "Version": "Versión"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Seleccionar despliegue"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Seleccionar dominio"
   },

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Poistettu onnistuneesti {{count}} versiot.",
     "Version": "Versio"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Valitse käyttöönotto"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Valitse toimialue"
   },

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Suppression avec succès des versions {{count}}.",
     "Version": "Version"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Sélectionner un déploiement"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Sélectionner un domaine"
   },

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Berhasil menghapus {{count}} versi.",
     "Version": "Versi"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Pilih Deployment"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Pilih Domain"
   },

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Rimosse correttamente {{count}} versioni.",
     "Version": "Versione"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Seleziona deployment"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Seleziona dominio"
   },

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "{{count}}バージョンを正常に削除しました。",
     "Version": "バージョン"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "デプロイメントを選択"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "ドメインを選択"
   },

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -91,6 +91,9 @@
     "SuccessFullyRemoved": "{{count}}개 버전을 성공적으로 제거했습니다.",
     "Version": "버전"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "배포를 선택해주세요"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "도메인 선택"
   },

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Амжилттай хассан {{тоолох} хувилбарууд.",
     "Version": "Таамаглал"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Байршуулалт сонгох"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Домен сонгох"
   },

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Berjaya dikeluarkan {{count}} versi.",
     "Version": "Versi"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Pilih Penggunaan"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Pilih Domain"
   },

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Pomyślnie usunięte wersje {{count}}.",
     "Version": "Wersja"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Wybierz wdrożenie"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Wybierz domenę"
   },

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Removido com sucesso {{count}} versões.",
     "Version": "Versão"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Selecionar implantação"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Selecionar Domínio"
   },

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Removido com sucesso {{count}} versões.",
     "Version": "Versão"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Selecionar implantação"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Selecionar domínio"
   },

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Успешно удалено {{count}} версии.",
     "Version": "Версия"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Выберите развёртывание"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Выберите домен"
   },

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "ลบเวอร์ชัน {{count}} สำเร็จ",
     "Version": "รุ่น"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "เลือกการปรับใช้"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "เลือกโดเมน"
   },

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "{{count}} sürümlerini başarıyla kaldırdı.",
     "Version": "Versiyon"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Dağıtım seçin"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Etki Alanı Seçin"
   },

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "Đã loại bỏ thành công các phiên bản {{count}}.",
     "Version": "Phiên bản"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "Chọn triển khai"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "Chọn miền"
   },

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "成功删除了{{count}}版本。",
     "Version": "版本"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "选择部署"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "选择域"
   },

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -88,6 +88,9 @@
     "SuccessFullyRemoved": "成功刪除了{{count}}版本。",
     "Version": "版本"
   },
+  "comp:BAIDeploymentSelect": {
+    "SelectDeployment": "選擇部署"
+  },
   "comp:BAIDomainSelect": {
     "SelectDomain": "選擇網域"
   },

--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -41,10 +41,7 @@ const RBAC_ELEMENT_TYPES: ReadonlyArray<RBACElementType> = [
   'CONTAINER_REGISTRY',
   'STORAGE_HOST',
   // TODO: Scope ID select to be implemented in separate stacks
-  // 'DEPLOYMENT',
   // 'KEYPAIR',
-  // 'CONTAINER_REGISTRY',
-  // 'STORAGE_HOST',
   // 'IMAGE',
   // 'ARTIFACT',
   // 'ARTIFACT_REGISTRY',
@@ -55,6 +52,7 @@ const RBAC_ELEMENT_TYPES: ReadonlyArray<RBACElementType> = [
   // 'PROJECT_RESOURCE_POLICY',
   // 'ROLE',
   // TODO: No management UI in WebUI yet
+  // 'DEPLOYMENT',
   // 'NOTIFICATION_CHANNEL',
   // 'NETWORK',
   // 'SESSION_TEMPLATE',


### PR DESCRIPTION
Resolves #5863(FR-2244)

## Summary
- Implement `BAIDeploymentSelect` component using Pattern B (Strawberry) with paginated query and search
- Add i18n keys for deployment select placeholder in en/ko locale files
- Integrate into `CreatePermissionModal` as scope ID selector for `DEPLOYMENT` type

## Test plan
- [ ] Verify BAIDeploymentSelect renders with search and pagination
- [ ] Verify CreatePermissionModal shows Deployment option in scope type dropdown
- [ ] Verify selecting DEPLOYMENT type shows the BAIDeploymentSelect for scope ID