### PR TITLE
feat(FR-2245): implement BAIAdminModelServiceSelect for RBAC permission modal

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminModelServiceSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminModelServiceSelect.tsx
@@ -1,0 +1,267 @@
+import { BAIAdminModelServiceSelectPaginatedQuery } from '../../__generated__/BAIAdminModelServiceSelectPaginatedQuery.graphql';
+import { BAIAdminModelServiceSelectValueQuery } from '../../__generated__/BAIAdminModelServiceSelectValueQuery.graphql';
+import { toGlobalId, toLocalId } from '../../helper';
+import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
+import { useFetchKey } from '../../hooks';
+import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import TotalFooter from '../TotalFooter';
+import { useControllableValue } from 'ahooks';
+import { GetRef, Skeleton } from 'antd';
+import _ from 'lodash';
+import {
+  useDeferredValue,
+  useImperativeHandle,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export type ModelServiceNode = NonNullable<
+  NonNullable<
+    BAIAdminModelServiceSelectPaginatedQuery['response']['deployments']
+  >['edges'][number]
+>['node'];
+
+export interface BAIAdminModelServiceSelectRef {
+  refetch: () => void;
+}
+
+export interface BAIAdminModelServiceSelectProps extends Omit<
+  BAISelectProps,
+  'options' | 'labelInValue' | 'ref'
+> {
+  ref?: React.Ref<BAIAdminModelServiceSelectRef>;
+}
+
+const BAIAdminModelServiceSelect: React.FC<BAIAdminModelServiceSelectProps> = ({
+  loading,
+  ref,
+  ...selectProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+  const [controllableValue, setControllableValue] = useControllableValue<
+    string | string[] | undefined
+  >(selectProps);
+  const [controllableOpen, setControllableOpen] = useControllableValue<boolean>(
+    selectProps,
+    {
+      valuePropName: 'open',
+      trigger: 'onOpenChange',
+      defaultValuePropName: 'defaultOpen',
+    },
+  );
+  const deferredOpen = useDeferredValue(controllableOpen);
+  const [searchStr, setSearchStr] = useState<string>();
+  const debouncedDeferredValue = useDebouncedDeferredValue(searchStr);
+  const [optimisticSearchStr, setOptimisticSearchStr] =
+    useOptimistic(searchStr);
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  // Defer query refetch to prevent flickering during selection
+  const deferredControllableValue = useDeferredValue(controllableValue);
+
+  // Use single-node query to resolve selected value's label
+  // DeploymentFilter does not support id-based filtering,
+  // so we use the deployment(id:) query instead
+  const { deployment: selectedDeployment } =
+    useLazyLoadQuery<BAIAdminModelServiceSelectValueQuery>(
+      graphql`
+        query BAIAdminModelServiceSelectValueQuery(
+          $id: ID!
+          $skipSelected: Boolean!
+        ) {
+          deployment(id: $id) @skip(if: $skipSelected) {
+            id
+            metadata {
+              name
+            }
+          }
+        }
+      `,
+      {
+        id: !_.isEmpty(deferredControllableValue)
+          ? toGlobalId(
+              'ModelDeployment',
+              _.isArray(deferredControllableValue)
+                ? (deferredControllableValue[0] ?? '')
+                : (deferredControllableValue ?? ''),
+            )
+          : '',
+        skipSelected: _.isEmpty(deferredControllableValue),
+      },
+      {
+        fetchPolicy: !_.isEmpty(deferredControllableValue)
+          ? 'store-or-network'
+          : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+    );
+
+  const { paginationData, result, loadNext, isLoadingNext } =
+    useLazyPaginatedQuery<
+      BAIAdminModelServiceSelectPaginatedQuery,
+      ModelServiceNode
+    >(
+      graphql`
+        query BAIAdminModelServiceSelectPaginatedQuery(
+          $offset: Int!
+          $limit: Int!
+          $filter: DeploymentFilter
+        ) {
+          deployments(offset: $offset, limit: $limit, filter: $filter) {
+            count
+            edges {
+              node {
+                id
+                metadata {
+                  name
+                }
+              }
+            }
+          }
+        }
+      `,
+      { limit: 10 },
+      {
+        filter: debouncedDeferredValue
+          ? { name: { contains: debouncedDeferredValue } }
+          : null,
+      },
+      {
+        fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+      {
+        getTotal: (result) => result.deployments?.count ?? undefined,
+        getItem: (result) =>
+          result.deployments?.edges?.map((edge) => edge?.node),
+        getId: (item) => (item?.id ? toLocalId(item.id) : item?.id),
+      },
+    );
+
+  // Expose refetch function through ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: () => {
+        startRefetchTransition(() => {
+          updateFetchKey();
+        });
+      },
+    }),
+    [updateFetchKey, startRefetchTransition],
+  );
+
+  // Use raw UUID (toLocalId) as value instead of Relay global ID
+  const availableOptions = _.map(paginationData, (item) => ({
+    label: item?.metadata?.name,
+    value: item?.id ? toLocalId(item.id) : item?.id,
+  }));
+
+  const controllableValueWithLabel = selectedDeployment
+    ? [
+        {
+          label: selectedDeployment.metadata?.name,
+          value: toLocalId(selectedDeployment.id),
+        },
+      ]
+    : !_.isEmpty(deferredControllableValue)
+      ? _.castArray(deferredControllableValue).map((value) => ({
+          label: value,
+          value: value,
+        }))
+      : undefined;
+
+  const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
+    controllableValueWithLabel,
+  );
+
+  return (
+    <BAISelect
+      ref={selectRef}
+      placeholder={t('comp:BAIAdminModelServiceSelect.SelectModelService')}
+      loading={
+        loading ||
+        controllableValue !== deferredControllableValue ||
+        searchStr !== debouncedDeferredValue ||
+        isPendingRefetch
+      }
+      {...selectProps}
+      searchAction={async (value) => {
+        setOptimisticSearchStr(value);
+        setSearchStr(value);
+        await selectProps.searchAction?.(value);
+      }}
+      showSearch={
+        selectProps.showSearch === false
+          ? false
+          : {
+              searchValue: optimisticSearchStr,
+              autoClearSearchValue: true,
+              ...(_.isObject(selectProps.showSearch)
+                ? _.omit(selectProps.showSearch, ['searchValue'])
+                : {}),
+              filterOption: false,
+            }
+      }
+      value={
+        controllableValue !== deferredControllableValue
+          ? optimisticValueWithLabel
+          : controllableValueWithLabel
+      }
+      labelInValue
+      onChange={(value, option) => {
+        const castedValue = _.isEmpty(value) ? [] : _.castArray(value);
+        const valueWithOriginalLabel = castedValue.map((v) => {
+          // If label is string, use it directly; if React element, find from options
+          const label = _.isString(v.label)
+            ? v.label
+            : (availableOptions.find((opt) => opt.value === v.value)?.label ??
+              v.value);
+          return {
+            label,
+            value: v.value,
+          };
+        });
+        setOptimisticValueWithLabel(valueWithOriginalLabel);
+        const isMultiple =
+          selectProps.mode === 'multiple' || selectProps.mode === 'tags';
+        const idArray = castedValue.map((v) => _.toString(v.value));
+        setControllableValue(
+          isMultiple ? idArray : (idArray[0] ?? undefined),
+          option,
+        );
+      }}
+      options={availableOptions}
+      endReached={() => {
+        loadNext();
+      }}
+      open={controllableOpen}
+      onOpenChange={setControllableOpen}
+      notFoundContent={
+        _.isUndefined(paginationData) ? (
+          <Skeleton.Input active size="small" block />
+        ) : undefined
+      }
+      footer={
+        _.isNumber(result.deployments?.count) &&
+        result.deployments.count > 0 ? (
+          <TotalFooter
+            loading={isLoadingNext}
+            total={result.deployments.count}
+          />
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BAIAdminModelServiceSelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -93,6 +93,12 @@ export type {
   ProjectNode,
   BAIProjectSelectRef,
 } from './BAIProjectSelect';
+export { default as BAIAdminModelServiceSelect } from './BAIAdminModelServiceSelect';
+export type {
+  BAIAdminModelServiceSelectProps,
+  BAIAdminModelServiceSelectRef,
+  ModelServiceNode,
+} from './BAIAdminModelServiceSelect';
 export { default as BAIHuggingFaceRegistrySettingModal } from './BAIHuggingFaceRegistrySettingModal';
 export type {
   BAIHuggingFaceRegistrySettingModalProps,

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Es wurden Artefakte nicht aktiviert.",
     "SuccessfullyActivated": "Erfolgreich aktivierte Artefakte."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Modell-Service auswählen"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Ressourcengruppe auswählen"
   },

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Αποτυχία ενεργοποίησης αντικειμένων.",
     "SuccessfullyActivated": "Επιτυχώς ενεργοποιημένα αντικείμενα."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Επιλέξτε Υπηρεσία Μοντέλου"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Επιλέξτε ομάδα πόρων"
   },

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Failed to activate artifacts.",
     "SuccessfullyActivated": "Successfully activated artifacts."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Select Model Service"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Select resource group"
   },

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "No se pudo activar artefactos.",
     "SuccessfullyActivated": "Artefactos activados con éxito."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Seleccionar servicio de modelo"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Seleccionar grupo de recursos"
   },

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Artefaktien aktivointi epäonnistui.",
     "SuccessfullyActivated": "Onnistuneesti aktivoidut esineet."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Valitse mallipalvelu"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Valitse resurssiryhmä"
   },

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Échec de l'activation des artefacts.",
     "SuccessfullyActivated": "Artefacts activés avec succès."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Sélectionner un service de modèle"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Sélectionner un groupe de ressources"
   },

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Gagal mengaktifkan artefak.",
     "SuccessfullyActivated": "Artefak yang berhasil diaktifkan."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Pilih Layanan Model"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Pilih grup sumber daya"
   },

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Non è riuscito ad attivare artefatti.",
     "SuccessfullyActivated": "Artefatti attivati con successo."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Seleziona servizio modello"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Seleziona gruppo di risorse"
   },

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "アーティファクトをアクティブにすることができませんでした。",
     "SuccessfullyActivated": "正常にアクティブ化されたアーティファクト。"
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "モデルサービスを選択"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "リソースグループを選択"
   },

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "아티팩트를 활성화하는 데 실패했습니다.",
     "SuccessfullyActivated": "성공적으로 아티팩트를 활성화했습니다."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "모델 서비스를 선택해주세요"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "리소스 그룹을 선택해주세요"
   },

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Олдворуудыг идэвхжүүлж чадсангүй.",
     "SuccessfullyActivated": "Амжилттай идэвхжүүлсэн олдворууд."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Моделийн үйлчилгээ сонгох"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Ресурсын бүлэг сонгох"
   },

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Gagal mengaktifkan artifak.",
     "SuccessfullyActivated": "Artifak yang berjaya diaktifkan."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Pilih Perkhidmatan Model"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Pilih kumpulan sumber"
   },

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Nie udało się aktywować artefaktów.",
     "SuccessfullyActivated": "Pomyślnie aktywowane artefakty."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Wybierz usługę modelu"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Wybierz grupę zasobów"
   },

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Falhou em ativar artefatos.",
     "SuccessfullyActivated": "Artefatos ativados com sucesso."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Selecionar serviço de modelo"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Selecionar grupo de recursos"
   },

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Falhou em ativar artefatos.",
     "SuccessfullyActivated": "Artefatos ativados com sucesso."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Selecionar serviço de modelo"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Selecionar grupo de recursos"
   },

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Не удалось активировать артефакты.",
     "SuccessfullyActivated": "Успешно активированные артефакты."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Выберите сервис модели"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Выберите группу ресурсов"
   },

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "ไม่สามารถเปิดใช้งานสิ่งประดิษฐ์ได้",
     "SuccessfullyActivated": "สิ่งประดิษฐ์ที่เปิดใช้งานสำเร็จ"
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "เลือกบริการโมเดล"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "เลือกกลุ่มทรัพยากร"
   },

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Eserleri etkinleştiremedi.",
     "SuccessfullyActivated": "Başarıyla etkinleştirilmiş eserler."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Model hizmeti seçin"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Kaynak grubunu seçin"
   },

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "Không thể kích hoạt hiện vật.",
     "SuccessfullyActivated": "Cổ vật được kích hoạt thành công."
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "Chọn dịch vụ mô hình"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "Chọn nhóm tài nguyên"
   },

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "未能激活伪影。",
     "SuccessfullyActivated": "成功激活的工件。"
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "选择模型服务"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "选择资源组"
   },

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -26,6 +26,9 @@
     "FailedToActivateArtifacts": "未能激活偽影。",
     "SuccessfullyActivated": "成功激活的工件。"
   },
+  "comp:BAIAdminModelServiceSelect": {
+    "SelectModelService": "選擇模型服務"
+  },
   "comp:BAIAdminResourceGroupSelect": {
     "PlaceHolder": "選擇資源群組"
   },

--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -14,6 +14,7 @@ import { CreatePermissionModalUpdateMutation } from '../__generated__/CreatePerm
 import { App, Form, Select, type SelectProps } from 'antd';
 import {
   BAIAdminResourceGroupSelect,
+  BAIAdminModelServiceSelect,
   BAIModal,
   BAIModalProps,
   BAIProjectSelect,
@@ -34,9 +35,9 @@ const RBAC_ELEMENT_TYPES: ReadonlyArray<RBACElementType> = [
   'VFOLDER',
   'RESOURCE_GROUP',
   'SESSION',
+  'MODEL_DEPLOYMENT',
   // TODO: Scope ID select to be implemented in separate stacks
   // 'DEPLOYMENT',
-  // 'MODEL_DEPLOYMENT',
   // 'KEYPAIR',
   // 'CONTAINER_REGISTRY',
   // 'STORAGE_HOST',
@@ -96,11 +97,9 @@ const DomainScopeIdSelect: React.FC<SelectProps> = (props) => {
     <Select
       showSearch
       {...props}
-      options={[
-        { value: '*', label: '* (All)' },
-        ...(domains?.map((d) => ({ value: d?.name ?? '', label: d?.name })) ??
-          []),
-      ]}
+      options={
+        domains?.map((d) => ({ value: d?.name ?? '', label: d?.name })) ?? []
+      }
     />
   );
 };
@@ -177,6 +176,17 @@ const ScopeIdSelect: React.FC<ScopeIdSelectProps> = ({
       </Suspense>
     );
   }
+  if (scopeType === 'MODEL_DEPLOYMENT') {
+    return (
+      <Suspense fallback={<Select {...selectProps} loading disabled />}>
+        <BAIAdminModelServiceSelect
+          placeholder={selectProps.placeholder}
+          value={selectProps.value as string | undefined}
+          onChange={(val, option) => selectProps.onChange?.(val as any, option)}
+        />
+      </Suspense>
+    );
+  }
   if (scopeType === 'RESOURCE_GROUP') {
     return (
       <Suspense fallback={<Select {...selectProps} loading disabled />}>
@@ -189,7 +199,7 @@ const ScopeIdSelect: React.FC<ScopeIdSelectProps> = ({
       showSearch
       {...selectProps}
       disabled={!scopeType || selectProps.disabled}
-      options={[{ value: '*', label: '* (All)' }]}
+      options={[]}
     />
   );
 };

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1540,7 +1540,7 @@
       "KERNEL": "Kernel",
       "KEYPAIR": "Schlüsselpaar",
       "KEYPAIR_RESOURCE_POLICY": "Schlüsselpaar-Ressourcenrichtlinie",
-      "MODEL_DEPLOYMENT": "Modell-Deployment",
+      "MODEL_DEPLOYMENT": "Modell-Service",
       "NETWORK": "Netzwerk",
       "NOTIFICATION_CHANNEL": "Benachrichtigungskanal",
       "NOTIFICATION_RULE": "Benachrichtigungsregel",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1538,7 +1538,7 @@
       "KERNEL": "Πυρήνας",
       "KEYPAIR": "Keypair",
       "KEYPAIR_RESOURCE_POLICY": "Πολιτική πόρων Keypair",
-      "MODEL_DEPLOYMENT": "Model Deployment",
+      "MODEL_DEPLOYMENT": "Υπηρεσία Μοντέλου",
       "NETWORK": "Δίκτυο",
       "NOTIFICATION_CHANNEL": "Κανάλι ειδοποιήσεων",
       "NOTIFICATION_RULE": "Κανόνας ειδοποίησης",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1547,7 +1547,7 @@
       "KERNEL": "Kernel",
       "KEYPAIR": "Keypair",
       "KEYPAIR_RESOURCE_POLICY": "Keypair Resource Policy",
-      "MODEL_DEPLOYMENT": "Model Deployment",
+      "MODEL_DEPLOYMENT": "Model Service",
       "NETWORK": "Network",
       "NOTIFICATION_CHANNEL": "Notification Channel",
       "NOTIFICATION_RULE": "Notification Rule",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1538,7 +1538,7 @@
       "KERNEL": "Núcleo",
       "KEYPAIR": "Par de claves",
       "KEYPAIR_RESOURCE_POLICY": "Política de recursos de par de claves",
-      "MODEL_DEPLOYMENT": "Implementación de modelo",
+      "MODEL_DEPLOYMENT": "Servicio de modelo",
       "NETWORK": "Red",
       "NOTIFICATION_CHANNEL": "Canal de notificaciones",
       "NOTIFICATION_RULE": "Regla de notificación",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1538,7 +1538,7 @@
       "KERNEL": "Ydin",
       "KEYPAIR": "Avainpari",
       "KEYPAIR_RESOURCE_POLICY": "Avainparin resurssikäytäntö",
-      "MODEL_DEPLOYMENT": "Mallin käyttöönotto",
+      "MODEL_DEPLOYMENT": "Mallipalvelu",
       "NETWORK": "Verkko",
       "NOTIFICATION_CHANNEL": "Ilmoituskanava",
       "NOTIFICATION_RULE": "Ilmoitussääntö",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1538,7 +1538,7 @@
       "KERNEL": "Noyau",
       "KEYPAIR": "Paire de clés",
       "KEYPAIR_RESOURCE_POLICY": "Politique de ressources de paire de clés",
-      "MODEL_DEPLOYMENT": "Déploiement de modèle",
+      "MODEL_DEPLOYMENT": "Service de modèle",
       "NETWORK": "Réseau",
       "NOTIFICATION_CHANNEL": "Canal de notification",
       "NOTIFICATION_RULE": "Règle de notification",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1540,7 +1540,7 @@
       "KERNEL": "Inti",
       "KEYPAIR": "Keypair",
       "KEYPAIR_RESOURCE_POLICY": "Kebijakan Sumber Daya Keypair",
-      "MODEL_DEPLOYMENT": "Model Deployment",
+      "MODEL_DEPLOYMENT": "Layanan Model",
       "NETWORK": "Jaringan",
       "NOTIFICATION_CHANNEL": "Saluran Notifikasi",
       "NOTIFICATION_RULE": "Aturan Notifikasi",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1538,7 +1538,7 @@
       "KERNEL": "Kernel",
       "KEYPAIR": "Keypair",
       "KEYPAIR_RESOURCE_POLICY": "Policy risorse Keypair",
-      "MODEL_DEPLOYMENT": "Model Deployment",
+      "MODEL_DEPLOYMENT": "Servizio modello",
       "NETWORK": "Rete",
       "NOTIFICATION_CHANNEL": "Canale di notifica",
       "NOTIFICATION_RULE": "Regola di notifica",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1540,7 +1540,7 @@
       "KERNEL": "カーネル",
       "KEYPAIR": "キーペア",
       "KEYPAIR_RESOURCE_POLICY": "キーペアリソースポリシー",
-      "MODEL_DEPLOYMENT": "モデルデプロイメント",
+      "MODEL_DEPLOYMENT": "モデルサービス",
       "NETWORK": "ネットワーク",
       "NOTIFICATION_CHANNEL": "通知チャンネル",
       "NOTIFICATION_RULE": "通知ルール",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1549,7 +1549,7 @@
       "KERNEL": "커널",
       "KEYPAIR": "키페어",
       "KEYPAIR_RESOURCE_POLICY": "키페어 자원 정책",
-      "MODEL_DEPLOYMENT": "모델 배포",
+      "MODEL_DEPLOYMENT": "모델 서비스",
       "NETWORK": "네트워크",
       "NOTIFICATION_CHANNEL": "알림 채널",
       "NOTIFICATION_RULE": "알림 규칙",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1539,7 +1539,7 @@
       "KERNEL": "Цөм",
       "KEYPAIR": "Keypair",
       "KEYPAIR_RESOURCE_POLICY": "Keypair нөөцийн бодлого",
-      "MODEL_DEPLOYMENT": "Model Deployment",
+      "MODEL_DEPLOYMENT": "Моделийн үйлчилгээ",
       "NETWORK": "Сүлжээ",
       "NOTIFICATION_CHANNEL": "Мэдэгдлийн суваг",
       "NOTIFICATION_RULE": "Мэдэгдлийн дүрэм",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1538,7 +1538,7 @@
       "KERNEL": "Kernel",
       "KEYPAIR": "Keypair",
       "KEYPAIR_RESOURCE_POLICY": "Dasar Sumber Keypair",
-      "MODEL_DEPLOYMENT": "Model Deployment",
+      "MODEL_DEPLOYMENT": "Perkhidmatan Model",
       "NETWORK": "Rangkaian",
       "NOTIFICATION_CHANNEL": "Saluran Pemberitahuan",
       "NOTIFICATION_RULE": "Peraturan Pemberitahuan",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1538,7 +1538,7 @@
       "KERNEL": "Jądro",
       "KEYPAIR": "Para kluczy",
       "KEYPAIR_RESOURCE_POLICY": "Polityka zasobów pary kluczy",
-      "MODEL_DEPLOYMENT": "Wdrożenie modelu",
+      "MODEL_DEPLOYMENT": "Usługa modelu",
       "NETWORK": "Sieć",
       "NOTIFICATION_CHANNEL": "Kanał powiadomień",
       "NOTIFICATION_RULE": "Reguła powiadomień",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1538,7 +1538,7 @@
       "KERNEL": "Kernel",
       "KEYPAIR": "Par de chaves",
       "KEYPAIR_RESOURCE_POLICY": "Política de recursos do par de chaves",
-      "MODEL_DEPLOYMENT": "Implantação de modelo",
+      "MODEL_DEPLOYMENT": "Serviço de modelo",
       "NETWORK": "Rede",
       "NOTIFICATION_CHANNEL": "Canal de notificação",
       "NOTIFICATION_RULE": "Regra de notificação",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1540,7 +1540,7 @@
       "KERNEL": "Kernel",
       "KEYPAIR": "Par de chaves",
       "KEYPAIR_RESOURCE_POLICY": "Política de recursos do par de chaves",
-      "MODEL_DEPLOYMENT": "Implementação de modelo",
+      "MODEL_DEPLOYMENT": "Serviço de modelo",
       "NETWORK": "Rede",
       "NOTIFICATION_CHANNEL": "Canal de notificação",
       "NOTIFICATION_RULE": "Regra de notificação",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1538,7 +1538,7 @@
       "KERNEL": "Ядро",
       "KEYPAIR": "Ключевая пара",
       "KEYPAIR_RESOURCE_POLICY": "Политика ресурсов ключевой пары",
-      "MODEL_DEPLOYMENT": "Развёртывание модели",
+      "MODEL_DEPLOYMENT": "Сервис модели",
       "NETWORK": "Сеть",
       "NOTIFICATION_CHANNEL": "Канал уведомлений",
       "NOTIFICATION_RULE": "Правило уведомлений",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1540,7 +1540,7 @@
       "KERNEL": "เคอร์เนล",
       "KEYPAIR": "Keypair",
       "KEYPAIR_RESOURCE_POLICY": "นโยบายทรัพยากร Keypair",
-      "MODEL_DEPLOYMENT": "Model Deployment",
+      "MODEL_DEPLOYMENT": "บริการโมเดล",
       "NETWORK": "เครือข่าย",
       "NOTIFICATION_CHANNEL": "ช่องทางการแจ้งเตือน",
       "NOTIFICATION_RULE": "กฎการแจ้งเตือน",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1538,7 +1538,7 @@
       "KERNEL": "Çekirdek",
       "KEYPAIR": "Keypair",
       "KEYPAIR_RESOURCE_POLICY": "Keypair Kaynak Politikası",
-      "MODEL_DEPLOYMENT": "Model Dağıtımı",
+      "MODEL_DEPLOYMENT": "Model Hizmeti",
       "NETWORK": "Ağ",
       "NOTIFICATION_CHANNEL": "Bildirim Kanalı",
       "NOTIFICATION_RULE": "Bildirim Kuralı",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1540,7 +1540,7 @@
       "KERNEL": "Kernel",
       "KEYPAIR": "Keypair",
       "KEYPAIR_RESOURCE_POLICY": "Chính sách tài nguyên Keypair",
-      "MODEL_DEPLOYMENT": "Triển khai mô hình",
+      "MODEL_DEPLOYMENT": "Dịch vụ mô hình",
       "NETWORK": "Mạng",
       "NOTIFICATION_CHANNEL": "Kênh thông báo",
       "NOTIFICATION_RULE": "Quy tắc thông báo",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1540,7 +1540,7 @@
       "KERNEL": "核心",
       "KEYPAIR": "密钥对",
       "KEYPAIR_RESOURCE_POLICY": "密钥对资源策略",
-      "MODEL_DEPLOYMENT": "模型部署",
+      "MODEL_DEPLOYMENT": "模型服务",
       "NETWORK": "网络",
       "NOTIFICATION_CHANNEL": "通知渠道",
       "NOTIFICATION_RULE": "通知规则",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1542,7 +1542,7 @@
       "KERNEL": "核心",
       "KEYPAIR": "金鑰組",
       "KEYPAIR_RESOURCE_POLICY": "金鑰組資源原則",
-      "MODEL_DEPLOYMENT": "模型部署",
+      "MODEL_DEPLOYMENT": "模型服務",
       "NETWORK": "網路",
       "NOTIFICATION_CHANNEL": "通知頻道",
       "NOTIFICATION_RULE": "通知規則",


### PR DESCRIPTION
Resolves #5864 (FR-2245)

## Summary
- Implement `BAIModelDeploymentSelect` component using Pattern B (Strawberry) with paginated query and search
- Add i18n keys for model deployment select placeholder in en/ko locale files
- Integrate into `CreatePermissionModal` as scope ID selector for `MODEL_DEPLOYMENT` type

## Test plan
- [ ] Verify BAIModelDeploymentSelect renders with search and pagination
- [ ] Verify CreatePermissionModal shows Model Deployment option in scope type dropdown