### PR TITLE
feat(FR-2247): implement BAIAdminContainerRegistrySelect for RBAC permission modal

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIAdminContainerRegistrySelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAdminContainerRegistrySelect.tsx
@@ -1,0 +1,327 @@
+import { BAIAdminContainerRegistrySelectPaginatedQuery } from '../../__generated__/BAIAdminContainerRegistrySelectPaginatedQuery.graphql';
+import { BAIAdminContainerRegistrySelectValueQuery } from '../../__generated__/BAIAdminContainerRegistrySelectValueQuery.graphql';
+import { toLocalId } from '../../helper';
+import useDebouncedDeferredValue from '../../helper/useDebouncedDeferredValue';
+import { useFetchKey } from '../../hooks';
+import { useLazyPaginatedQuery } from '../../hooks/usePaginatedQuery';
+import { mergeFilterValues } from '../BAIPropertyFilter';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import TotalFooter from '../TotalFooter';
+import { useControllableValue } from 'ahooks';
+import { GetRef, Skeleton } from 'antd';
+import _ from 'lodash';
+import {
+  useDeferredValue,
+  useImperativeHandle,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export type ContainerRegistryNode = NonNullable<
+  NonNullable<
+    BAIAdminContainerRegistrySelectPaginatedQuery['response']['container_registry_nodes']
+  >['edges'][number]
+>['node'];
+
+export interface BAIAdminContainerRegistrySelectRef {
+  refetch: () => void;
+}
+
+export interface BAIAdminContainerRegistrySelectProps extends Omit<
+  BAISelectProps,
+  'options' | 'labelInValue' | 'ref'
+> {
+  filter?: string;
+  valuePropName?: 'id' | 'row_id';
+  onChange?: (value: string | string[] | undefined, option: any) => void;
+  ref?: React.Ref<BAIAdminContainerRegistrySelectRef>;
+}
+
+const BAIAdminContainerRegistrySelect: React.FC<
+  BAIAdminContainerRegistrySelectProps
+> = ({ loading, filter, valuePropName = 'id', ref, ...selectProps }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const selectRef = useRef<GetRef<typeof BAISelect>>(null);
+  const [controllableValue, setControllableValue] = useControllableValue<
+    string | string[] | undefined
+  >(selectProps, {
+    valuePropName: 'value',
+    trigger: 'onChange',
+  });
+  const [controllableOpen, setControllableOpen] = useControllableValue<boolean>(
+    selectProps,
+    {
+      valuePropName: 'open',
+      trigger: 'onOpenChange',
+      defaultValuePropName: 'defaultOpen',
+    },
+  );
+
+  const deferredOpen = useDeferredValue(controllableOpen);
+  const [searchStr, setSearchStr] = useState<string>();
+  const debouncedDeferredValue = useDebouncedDeferredValue(searchStr);
+  const [optimisticSearchStr, setOptimisticSearchStr] =
+    useOptimistic(searchStr);
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  // Defer query refetch to prevent flickering during selection
+  const deferredControllableValue = useDeferredValue(controllableValue);
+
+  const { container_registry_nodes: selectedRegistryNodes } =
+    useLazyLoadQuery<BAIAdminContainerRegistrySelectValueQuery>(
+      graphql`
+        query BAIAdminContainerRegistrySelectValueQuery(
+          $selectedFilter: String
+          $first: Int!
+          $skipSelected: Boolean!
+        ) {
+          container_registry_nodes(filter: $selectedFilter, first: $first)
+            @skip(if: $skipSelected) {
+            edges {
+              node {
+                id
+                row_id
+                registry_name
+                project
+              }
+            }
+          }
+        }
+      `,
+      {
+        selectedFilter: mergeFilterValues(
+          [
+            !_.isEmpty(deferredControllableValue)
+              ? mergeFilterValues(
+                  _.castArray(deferredControllableValue).map((value) => {
+                    // Convert Global ID to local UUID for filtering when valuePropName is 'id'
+                    const filterValue =
+                      valuePropName === 'id' ? toLocalId(value) : value;
+                    return valuePropName === 'id'
+                      ? `id == "${filterValue}"`
+                      : `row_id == "${filterValue}"`;
+                  }),
+                  '|',
+                )
+              : null,
+            filter,
+          ],
+          '&',
+        ),
+        first: _.castArray(deferredControllableValue).length,
+        skipSelected: _.isEmpty(deferredControllableValue),
+      },
+      {
+        fetchPolicy: !_.isEmpty(deferredControllableValue)
+          ? 'store-or-network'
+          : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+    );
+
+  const { paginationData, result, loadNext, isLoadingNext } =
+    useLazyPaginatedQuery<
+      BAIAdminContainerRegistrySelectPaginatedQuery,
+      ContainerRegistryNode
+    >(
+      graphql`
+        query BAIAdminContainerRegistrySelectPaginatedQuery(
+          $offset: Int!
+          $limit: Int!
+          $filter: String
+        ) {
+          container_registry_nodes(
+            offset: $offset
+            first: $limit
+            filter: $filter
+            order: "registry_name"
+          ) {
+            count
+            edges {
+              node {
+                id
+                row_id
+                registry_name
+                project
+              }
+            }
+          }
+        }
+      `,
+      { limit: 10 },
+      {
+        filter: mergeFilterValues([
+          filter,
+          debouncedDeferredValue
+            ? `registry_name ilike "%${debouncedDeferredValue}%"`
+            : null,
+        ]),
+      },
+      {
+        fetchPolicy: deferredOpen ? 'network-only' : 'store-only',
+        fetchKey: deferredFetchKey,
+      },
+      {
+        getTotal: (result) =>
+          result.container_registry_nodes?.count ?? undefined,
+        getItem: (result) =>
+          result.container_registry_nodes?.edges?.map((edge) => edge?.node),
+        getId: (item) => item?.id,
+      },
+    );
+
+  // Expose refetch function through ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: () => {
+        startRefetchTransition(() => {
+          updateFetchKey();
+        });
+      },
+    }),
+    [updateFetchKey, startRefetchTransition],
+  );
+
+  const formatLabel = (
+    registryName?: string | null,
+    project?: string | null,
+  ) => (project ? `${registryName} - ${project}` : (registryName ?? ''));
+
+  const availableOptions = _.map(paginationData, (item) => ({
+    label: formatLabel(item?.registry_name, item?.project),
+    value: item?.[valuePropName],
+  }));
+
+  const controllableValueWithLabel = selectedRegistryNodes?.edges
+    ? // Sort by deferredControllableValue order to maintain selection order
+      _.castArray(deferredControllableValue)
+        .map((value) => {
+          const edge = selectedRegistryNodes.edges.find(
+            (edge) => edge?.node?.[valuePropName] === value,
+          );
+          return edge
+            ? {
+                label: formatLabel(
+                  edge.node?.registry_name,
+                  edge.node?.project,
+                ),
+                value: edge.node?.[valuePropName],
+              }
+            : null;
+        })
+        .filter(
+          (
+            item,
+          ): item is {
+            label: string;
+            value: string | null | undefined;
+          } => item !== null,
+        )
+    : !_.isEmpty(deferredControllableValue)
+      ? _.castArray(deferredControllableValue).map((value) => ({
+          label: value,
+          value: value,
+        }))
+      : undefined;
+
+  const [optimisticValueWithLabel, setOptimisticValueWithLabel] = useState(
+    controllableValueWithLabel,
+  );
+
+  return (
+    <BAISelect
+      ref={selectRef}
+      placeholder={t(
+        'comp:BAIAdminContainerRegistrySelect.SelectContainerRegistry',
+      )}
+      loading={
+        loading ||
+        controllableValue !== deferredControllableValue ||
+        searchStr !== debouncedDeferredValue ||
+        isPendingRefetch
+      }
+      {...selectProps}
+      searchAction={async (value) => {
+        setOptimisticSearchStr(value);
+        setSearchStr(value);
+        await selectProps.searchAction?.(value);
+      }}
+      showSearch={
+        selectProps.showSearch === false
+          ? false
+          : {
+              searchValue: optimisticSearchStr,
+              autoClearSearchValue: true,
+              ...(_.isObject(selectProps.showSearch)
+                ? _.omit(selectProps.showSearch, ['searchValue'])
+                : {}),
+              filterOption: false,
+            }
+      }
+      value={
+        controllableValue !== deferredControllableValue
+          ? optimisticValueWithLabel
+          : controllableValueWithLabel
+      }
+      labelInValue
+      onChange={(value, option) => {
+        // _.castArray to handle both single and multiple mode uniformly
+        const valueArray = _.isEmpty(value) ? [] : _.castArray(value);
+
+        // In multiple mode, when removing tags, value.label is a React element
+        // So we need to find the original label from availableOptions
+        const valueWithOriginalLabel = valueArray.map((v) => {
+          // If label is string, use it directly; if React element, find from options
+          const label = _.isString(v.label)
+            ? v.label
+            : (availableOptions.find((opt) => opt.value === v.value)?.label ??
+              v.value);
+          return {
+            label,
+            value: v.value,
+          };
+        });
+
+        setOptimisticValueWithLabel(valueWithOriginalLabel);
+
+        const isMultiple =
+          selectProps.mode === 'multiple' || selectProps.mode === 'tags';
+        const idArray = valueArray.map((v) => _.toString(v.value));
+        setControllableValue(
+          isMultiple ? idArray : (idArray[0] ?? undefined),
+          option,
+        );
+      }}
+      options={availableOptions}
+      endReached={() => {
+        loadNext();
+      }}
+      open={controllableOpen}
+      onOpenChange={setControllableOpen}
+      notFoundContent={
+        _.isUndefined(paginationData) ? (
+          <Skeleton.Input active size="small" block />
+        ) : undefined
+      }
+      footer={
+        _.isNumber(result.container_registry_nodes?.count) &&
+        result.container_registry_nodes.count > 0 ? (
+          <TotalFooter
+            loading={isLoadingNext}
+            total={result.container_registry_nodes.count}
+          />
+        ) : undefined
+      }
+    />
+  );
+};
+
+export default BAIAdminContainerRegistrySelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -64,6 +64,12 @@ export {
 export type { BAIProjectTableProps } from './BAIProjectTable';
 export { default as BAIAllowedVfolderHostsWithPermission } from './BAIAllowedVfolderHostsWithPermission';
 export type { BAIAllowedVfolderHostsWithPermissionProps } from './BAIAllowedVfolderHostsWithPermission';
+export { default as BAIAdminContainerRegistrySelect } from './BAIAdminContainerRegistrySelect';
+export type {
+  BAIAdminContainerRegistrySelectProps,
+  BAIAdminContainerRegistrySelectRef,
+  ContainerRegistryNode,
+} from './BAIAdminContainerRegistrySelect';
 export { default as BAIDomainSelect } from './BAIDomainSelect';
 export { default as BAIProjectSettingModal } from './BAIProjectSettingModal';
 export type { BAIProjectSettingModalFragmentKey } from './BAIProjectSettingModal';

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -71,6 +71,9 @@
     "KeepAsIs": "Keep as is",
     "UndoChanges": "Undo changes"
   },
+  "comp:BAIContainerRegistrySelect": {
+    "SelectContainerRegistry": "Select Container Registry"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "Are you sure you want to deactivate {{name}}?",
     "AreYouSureYouWantToDeactivateSome": "Are you sure you want to deactivate {{count}} artifacts?",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -71,6 +71,9 @@
     "KeepAsIs": "그대로 유지",
     "UndoChanges": "변경 취소"
   },
+  "comp:BAIContainerRegistrySelect": {
+    "SelectContainerRegistry": "컨테이너 레지스트리를 선택해주세요"
+  },
   "comp:BAIDeactivateArtifactsModal": {
     "AreYouSureYouWantToDeactivateOne": "{{name}}를 비활성화 하시겠습니까?",
     "AreYouSureYouWantToDeactivateSome": "{{count}}개의 아티팩트를 비활성화 하시겠습니까?",

--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -14,6 +14,7 @@ import { CreatePermissionModalUpdateMutation } from '../__generated__/CreatePerm
 import { App, Form, Select, type SelectProps } from 'antd';
 import {
   BAIAdminResourceGroupSelect,
+  BAIAdminContainerRegistrySelect,
   BAIAdminModelServiceSelect,
   BAIModal,
   BAIModalProps,
@@ -36,6 +37,7 @@ const RBAC_ELEMENT_TYPES: ReadonlyArray<RBACElementType> = [
   'RESOURCE_GROUP',
   'SESSION',
   'MODEL_DEPLOYMENT',
+  'CONTAINER_REGISTRY',
   // TODO: Scope ID select to be implemented in separate stacks
   // 'DEPLOYMENT',
   // 'KEYPAIR',
@@ -180,6 +182,18 @@ const ScopeIdSelect: React.FC<ScopeIdSelectProps> = ({
     return (
       <Suspense fallback={<Select {...selectProps} loading disabled />}>
         <BAIAdminModelServiceSelect
+          placeholder={selectProps.placeholder}
+          value={selectProps.value as string | undefined}
+          onChange={(val, option) => selectProps.onChange?.(val as any, option)}
+        />
+      </Suspense>
+    );
+  }
+  if (scopeType === 'CONTAINER_REGISTRY') {
+    return (
+      <Suspense fallback={<Select {...selectProps} loading disabled />}>
+        <BAIAdminContainerRegistrySelect
+          valuePropName="row_id"
           placeholder={selectProps.placeholder}
           value={selectProps.value as string | undefined}
           onChange={(val, option) => selectProps.onChange?.(val as any, option)}


### PR DESCRIPTION
Resolves #5866(FR-2247)

## Summary
- Implement `BAIContainerRegistrySelect` component using Pattern B (graphene connection) with paginated query and value resolution
- Add i18n keys for container registry select placeholder in en/ko locale files
- Integrate into `CreatePermissionModal` as scope ID selector for `CONTAINER_REGISTRY` type

## Test plan
- [ ] Verify BAIContainerRegistrySelect renders with search and pagination
- [ ] Verify CreatePermissionModal shows Container Registry option in scope type dropdown