### PR TITLE
feat(FR-2253): implement BAIResourcePresetSelect for RBAC permission modal

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIResourcePresetSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIResourcePresetSelect.tsx
@@ -1,0 +1,53 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { BAIResourcePresetSelectQuery } from '../../__generated__/BAIResourcePresetSelectQuery.graphql';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export interface BAIResourcePresetSelectProps extends Omit<
+  BAISelectProps,
+  'options'
+> {}
+
+const BAIResourcePresetSelect = ({
+  ...selectProps
+}: BAIResourcePresetSelectProps) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { resource_presets } = useLazyLoadQuery<BAIResourcePresetSelectQuery>(
+    graphql`
+      query BAIResourcePresetSelectQuery {
+        resource_presets {
+          name
+        }
+      }
+    `,
+    {},
+    {},
+  );
+
+  return (
+    <BAISelect
+      showSearch
+      filterOption={(input, option) =>
+        (option?.label?.toString() ?? '')
+          .toLowerCase()
+          .includes(input.toLowerCase())
+      }
+      placeholder={t('comp:BAIResourcePresetSelect.SelectResourcePreset')}
+      options={_.map(_.sortBy(resource_presets, 'name'), (preset) => {
+        return {
+          label: preset?.name,
+          value: preset?.name,
+        };
+      })}
+      {...selectProps}
+    />
+  );
+};
+
+export default BAIResourcePresetSelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -87,6 +87,8 @@ export { default as BAIProjectSettingModal } from './BAIProjectSettingModal';
 export type { BAIProjectSettingModalFragmentKey } from './BAIProjectSettingModal';
 export { default as BAIProjectResourcePolicySelect } from './BAIProjectResourcePolicySelect';
 export type { BAIProjectResourcePolicySelectProps } from './BAIProjectResourcePolicySelect';
+export { default as BAIResourcePresetSelect } from './BAIResourcePresetSelect';
+export type { BAIResourcePresetSelectProps } from './BAIResourcePresetSelect';
 export { default as BAIResourceGroupSelect } from './BAIResourceGroupSelect';
 export type { BAIResourceGroupSelectProps } from './BAIResourceGroupSelect';
 export { default as BAIProjectBulkEditModal } from './BAIProjectBulkEditModal';

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -220,6 +220,9 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "Select Resource Group"
   },
+  "comp:BAIResourcePresetSelect": {
+    "SelectResourcePreset": "Select Resource Preset"
+  },
   "comp:BAIResourceWithSteppedProgress": {
     "Unlimited": "Unlimited"
   },

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -220,6 +220,9 @@
   "comp:BAIResourceGroupSelect": {
     "SelectResourceGroup": "리소스 그룹을 선택해주세요"
   },
+  "comp:BAIResourcePresetSelect": {
+    "SelectResourcePreset": "리소스 프리셋을 선택해주세요"
+  },
   "comp:BAIRouteNodes": {
     "CreatedAt": "생성일",
     "RouteId": "라우트 ID",

--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -21,6 +21,7 @@ import {
   BAIKeypairSelect,
   BAIModal,
   BAIModalProps,
+  BAIResourcePresetSelect,
   BAIStorageHostSelect,
   BAIProjectSelect,
   BAIAdminSessionSelect,
@@ -45,11 +46,11 @@ const RBAC_ELEMENT_TYPES: ReadonlyArray<RBACElementType> = [
   'STORAGE_HOST',
   'ARTIFACT',
   'ARTIFACT_REVISION',
+  'RESOURCE_PRESET',
   // TODO: Scope ID select to be implemented in separate stacks
   // 'KEYPAIR',
   // 'IMAGE',
   // 'ARTIFACT_REGISTRY',
-  // 'RESOURCE_PRESET',
   // 'USER_RESOURCE_POLICY',
   // 'KEYPAIR_RESOURCE_POLICY',
   // 'PROJECT_RESOURCE_POLICY',
@@ -233,6 +234,17 @@ const ScopeIdSelect: React.FC<ScopeIdSelectProps> = ({
           placeholder={selectProps.placeholder}
           value={selectProps.value as string | undefined}
           onChange={(val, option) => selectProps.onChange?.(val as any, option)}
+        />
+      </Suspense>
+    );
+  }
+  if (scopeType === 'RESOURCE_PRESET') {
+    return (
+      <Suspense fallback={<Select {...selectProps} loading disabled />}>
+        <BAIResourcePresetSelect
+          placeholder={selectProps.placeholder}
+          value={selectProps.value}
+          onChange={selectProps.onChange}
         />
       </Suspense>
     );


### PR DESCRIPTION
Resolves #5872(FR-2253)

## Summary
- Implement `BAIResourcePresetSelect` component using simple array pattern with client-side search
- Add i18n keys for resource preset select placeholder in en/ko locale files
- Integrate into `CreatePermissionModal` as scope ID selector for `RESOURCE_PRESET` type

## Test plan
- [ ] Verify BAIResourcePresetSelect renders with all resource presets
- [ ] Verify CreatePermissionModal shows Resource Preset option in scope type dropdown