### PR TITLE
feat(FR-2254): implement BAIUserResourcePolicySelect for RBAC permission modal

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIUserResourcePolicySelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIUserResourcePolicySelect.tsx
@@ -1,0 +1,52 @@
+import { BAIUserResourcePolicySelectQuery } from '../../__generated__/BAIUserResourcePolicySelectQuery.graphql';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export interface BAIUserResourcePolicySelectProps extends Omit<
+  BAISelectProps,
+  'options'
+> {}
+
+const BAIUserResourcePolicySelect = ({
+  ...selectProps
+}: BAIUserResourcePolicySelectProps) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { user_resource_policies } =
+    useLazyLoadQuery<BAIUserResourcePolicySelectQuery>(
+      graphql`
+        query BAIUserResourcePolicySelectQuery {
+          user_resource_policies {
+            name
+          }
+        }
+      `,
+      {},
+      {},
+    );
+
+  return (
+    <BAISelect
+      placeholder={t(
+        'comp:BAIUserResourcePolicySelect.SelectUserResourcePolicy',
+      )}
+      options={_.map(_.sortBy(user_resource_policies, 'name'), (policy) => {
+        return {
+          label: policy?.name,
+          value: policy?.name,
+        };
+      })}
+      showSearch
+      filterOption={(input, option) =>
+        ((option?.label as string) ?? '')
+          .toLowerCase()
+          .includes(input.toLowerCase())
+      }
+      {...selectProps}
+    />
+  );
+};
+
+export default BAIUserResourcePolicySelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -95,6 +95,8 @@ export { default as BAIProjectBulkEditModal } from './BAIProjectBulkEditModal';
 export type { BAIProjectBulkEditModalProps } from './BAIProjectBulkEditModal';
 export { default as BAIAgentTable } from './BAIAgentTable';
 export type { BAIAgentTableProps, AgentNodeInList } from './BAIAgentTable';
+export { default as BAIUserResourcePolicySelect } from './BAIUserResourcePolicySelect';
+export type { BAIUserResourcePolicySelectProps } from './BAIUserResourcePolicySelect';
 export { default as BAIVFolderSelect } from './BAIVFolderSelect';
 export type {
   BAIVFolderSelectProps,

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -269,6 +269,9 @@
   "comp:BAITestButton": {
     "Test": "Test"
   },
+  "comp:BAIUserResourcePolicySelect": {
+    "SelectUserResourcePolicy": "Select User Resource Policy"
+  },
   "comp:BAIUserSelect": {
     "SelectUser": "Select User"
   },

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -266,6 +266,9 @@
   "comp:BAITestButton": {
     "Test": "테스트"
   },
+  "comp:BAIUserResourcePolicySelect": {
+    "SelectUserResourcePolicy": "사용자 리소스 정책을 선택해주세요"
+  },
   "comp:BAIUserSelect": {
     "SelectUser": "사용자를 선택해주세요"
   },

--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -25,6 +25,7 @@ import {
   BAIStorageHostSelect,
   BAIProjectSelect,
   BAIAdminSessionSelect,
+  BAIUserResourcePolicySelect,
   BAIUserSelect,
   BAIVFolderSelect,
   useBAILogger,
@@ -47,11 +48,11 @@ const RBAC_ELEMENT_TYPES: ReadonlyArray<RBACElementType> = [
   'ARTIFACT',
   'ARTIFACT_REVISION',
   'RESOURCE_PRESET',
+  'USER_RESOURCE_POLICY',
   // TODO: Scope ID select to be implemented in separate stacks
   // 'KEYPAIR',
   // 'IMAGE',
   // 'ARTIFACT_REGISTRY',
-  // 'USER_RESOURCE_POLICY',
   // 'KEYPAIR_RESOURCE_POLICY',
   // 'PROJECT_RESOURCE_POLICY',
   // 'ROLE',
@@ -242,6 +243,17 @@ const ScopeIdSelect: React.FC<ScopeIdSelectProps> = ({
     return (
       <Suspense fallback={<Select {...selectProps} loading disabled />}>
         <BAIResourcePresetSelect
+          placeholder={selectProps.placeholder}
+          value={selectProps.value}
+          onChange={selectProps.onChange}
+        />
+      </Suspense>
+    );
+  }
+  if (scopeType === 'USER_RESOURCE_POLICY') {
+    return (
+      <Suspense fallback={<Select {...selectProps} loading disabled />}>
+        <BAIUserResourcePolicySelect
           placeholder={selectProps.placeholder}
           value={selectProps.value}
           onChange={selectProps.onChange}


### PR DESCRIPTION
Resolves #5873(FR-2254)

## Summary
- Implement `BAIUserResourcePolicySelect` component using simple array pattern with client-side search
- Add i18n keys for user resource policy select placeholder in en/ko locale files
- Integrate into `CreatePermissionModal` as scope ID selector for `USER_RESOURCE_POLICY` type

## Test plan
- [ ] Verify BAIUserResourcePolicySelect renders with all user resource policies
- [ ] Verify CreatePermissionModal shows User Resource Policy option in scope type dropdown