### PR TITLE
feat(FR-2255): implement BAIKeypairResourcePolicySelect for RBAC permission modal

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIKeypairResourcePolicySelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIKeypairResourcePolicySelect.tsx
@@ -1,0 +1,46 @@
+import { BAIKeypairResourcePolicySelectQuery } from '../../__generated__/BAIKeypairResourcePolicySelectQuery.graphql';
+import BAISelect, { BAISelectProps } from '../BAISelect';
+import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+export interface BAIKeypairResourcePolicySelectProps extends Omit<
+  BAISelectProps,
+  'options'
+> {}
+
+const BAIKeypairResourcePolicySelect = ({
+  ...selectProps
+}: BAIKeypairResourcePolicySelectProps) => {
+  const { t } = useTranslation();
+  const { keypair_resource_policies } =
+    useLazyLoadQuery<BAIKeypairResourcePolicySelectQuery>(
+      graphql`
+        query BAIKeypairResourcePolicySelectQuery {
+          keypair_resource_policies {
+            name
+          }
+        }
+      `,
+      {},
+      {},
+    );
+
+  return (
+    <BAISelect
+      options={_.map(_.sortBy(keypair_resource_policies, 'name'), (policy) => {
+        return {
+          label: policy?.name,
+          value: policy?.name,
+        };
+      })}
+      showSearch
+      placeholder={t(
+        'comp:BAIKeypairResourcePolicySelect.SelectKeypairResourcePolicy',
+      )}
+      {...selectProps}
+    />
+  );
+};
+
+export default BAIKeypairResourcePolicySelect;

--- a/packages/backend.ai-ui/src/components/fragments/index.ts
+++ b/packages/backend.ai-ui/src/components/fragments/index.ts
@@ -115,6 +115,8 @@ export type {
   ProjectNode,
   BAIProjectSelectRef,
 } from './BAIProjectSelect';
+export { default as BAIKeypairResourcePolicySelect } from './BAIKeypairResourcePolicySelect';
+export type { BAIKeypairResourcePolicySelectProps } from './BAIKeypairResourcePolicySelect';
 export { default as BAIKeypairSelect } from './BAIKeypairSelect';
 export type {
   BAIKeypairSelectProps,

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -143,6 +143,9 @@
     "SuccessFullyPulled": "Successfully requested pull for {{count}} versions.",
     "Version": "Version"
   },
+  "comp:BAIKeypairResourcePolicySelect": {
+    "SelectKeypairResourcePolicy": "Select Keypair Resource Policy"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "Select Keypair"
   },

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -143,6 +143,9 @@
     "SuccessFullyPulled": "{{count}}개 버전에 대한 가져오기 요청을 성공적으로 보냈습니다.",
     "Version": "버전"
   },
+  "comp:BAIKeypairResourcePolicySelect": {
+    "SelectKeypairResourcePolicy": "키페어 리소스 정책을 선택해주세요"
+  },
   "comp:BAIKeypairSelect": {
     "SelectKeypair": "키페어를 선택해주세요"
   },

--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -18,6 +18,7 @@ import {
   BAIArtifactRevisionSelect,
   BAIArtifactSelect,
   BAIAdminModelServiceSelect,
+  BAIKeypairResourcePolicySelect,
   BAIKeypairSelect,
   BAIModal,
   BAIModalProps,
@@ -49,11 +50,11 @@ const RBAC_ELEMENT_TYPES: ReadonlyArray<RBACElementType> = [
   'ARTIFACT_REVISION',
   'RESOURCE_PRESET',
   'USER_RESOURCE_POLICY',
+  'KEYPAIR_RESOURCE_POLICY',
   // TODO: Scope ID select to be implemented in separate stacks
   // 'KEYPAIR',
   // 'IMAGE',
   // 'ARTIFACT_REGISTRY',
-  // 'KEYPAIR_RESOURCE_POLICY',
   // 'PROJECT_RESOURCE_POLICY',
   // 'ROLE',
   // TODO: No management UI in WebUI yet
@@ -254,6 +255,17 @@ const ScopeIdSelect: React.FC<ScopeIdSelectProps> = ({
     return (
       <Suspense fallback={<Select {...selectProps} loading disabled />}>
         <BAIUserResourcePolicySelect
+          placeholder={selectProps.placeholder}
+          value={selectProps.value}
+          onChange={selectProps.onChange}
+        />
+      </Suspense>
+    );
+  }
+  if (scopeType === 'KEYPAIR_RESOURCE_POLICY') {
+    return (
+      <Suspense fallback={<Select {...selectProps} loading disabled />}>
+        <BAIKeypairResourcePolicySelect
           placeholder={selectProps.placeholder}
           value={selectProps.value}
           onChange={selectProps.onChange}


### PR DESCRIPTION
Resolves #5874(FR-2255)

## Summary
- Implement `BAIKeypairResourcePolicySelect` component using simple array pattern with client-side search
- Add i18n keys for keypair resource policy select placeholder in en/ko locale files
- Integrate into `CreatePermissionModal` as scope ID selector for `KEYPAIR_RESOURCE_POLICY` type

## Test plan
- [ ] Verify BAIKeypairResourcePolicySelect renders with all keypair resource policies
- [ ] Verify CreatePermissionModal shows Keypair Resource Policy option in scope type dropdown