### PR TITLE
feat(FR-2256): integrate BAIProjectResourcePolicySelect into RBAC permission modal

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectResourcePolicySelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectResourcePolicySelect.tsx
@@ -1,14 +1,19 @@
 import { BAIProjectResourcePolicySelectQuery } from '../../__generated__/BAIProjectResourcePolicySelectQuery.graphql';
 import BAISelect, { BAISelectProps } from '../BAISelect';
 import _ from 'lodash';
+import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
-export interface BAIProjectResourcePolicySelectProps
-  extends Omit<BAISelectProps, 'options'> {}
+export interface BAIProjectResourcePolicySelectProps extends Omit<
+  BAISelectProps,
+  'options'
+> {}
 
 const BAIProjectResourcePolicySelect = ({
   ...selectProps
 }: BAIProjectResourcePolicySelectProps) => {
+  'use memo';
+  const { t } = useTranslation();
   const { project_resource_policies } =
     useLazyLoadQuery<BAIProjectResourcePolicySelectQuery>(
       graphql`
@@ -25,6 +30,9 @@ const BAIProjectResourcePolicySelect = ({
 
   return (
     <BAISelect
+      placeholder={t(
+        'comp:BAIProjectResourcePolicySelect.SelectProjectResourcePolicy',
+      )}
       options={_.map(_.sortBy(project_resource_policies, 'name'), (policy) => {
         return {
           label: policy?.name,

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -154,6 +154,9 @@
     "ProjectResourcePolicy": "Project Resource Policy",
     "UpdateMultipleProjects": "Update Multiple Projects"
   },
+  "comp:BAIProjectResourcePolicySelect": {
+    "SelectProjectResourcePolicy": "Select Project Resource Policy"
+  },
   "comp:BAIProjectSelect": {
     "SelectProject": "Select Project"
   },

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -154,6 +154,9 @@
     "ProjectResourcePolicy": "프로젝트 리소스 정책",
     "UpdateMultipleProjects": "프로젝트 일괄 업데이트"
   },
+  "comp:BAIProjectResourcePolicySelect": {
+    "SelectProjectResourcePolicy": "프로젝트 리소스 정책을 선택해주세요"
+  },
   "comp:BAIProjectSelect": {
     "SelectProject": "프로젝트를 선택해주세요"
   },

--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -22,6 +22,7 @@ import {
   BAIKeypairSelect,
   BAIModal,
   BAIModalProps,
+  BAIProjectResourcePolicySelect,
   BAIResourcePresetSelect,
   BAIStorageHostSelect,
   BAIProjectSelect,
@@ -51,11 +52,11 @@ const RBAC_ELEMENT_TYPES: ReadonlyArray<RBACElementType> = [
   'RESOURCE_PRESET',
   'USER_RESOURCE_POLICY',
   'KEYPAIR_RESOURCE_POLICY',
+  'PROJECT_RESOURCE_POLICY',
   // TODO: Scope ID select to be implemented in separate stacks
   // 'KEYPAIR',
   // 'IMAGE',
   // 'ARTIFACT_REGISTRY',
-  // 'PROJECT_RESOURCE_POLICY',
   // 'ROLE',
   // TODO: No management UI in WebUI yet
   // 'DEPLOYMENT',
@@ -266,6 +267,17 @@ const ScopeIdSelect: React.FC<ScopeIdSelectProps> = ({
     return (
       <Suspense fallback={<Select {...selectProps} loading disabled />}>
         <BAIKeypairResourcePolicySelect
+          placeholder={selectProps.placeholder}
+          value={selectProps.value}
+          onChange={selectProps.onChange}
+        />
+      </Suspense>
+    );
+  }
+  if (scopeType === 'PROJECT_RESOURCE_POLICY') {
+    return (
+      <Suspense fallback={<Select {...selectProps} loading disabled />}>
+        <BAIProjectResourcePolicySelect
           placeholder={selectProps.placeholder}
           value={selectProps.value}
           onChange={selectProps.onChange}


### PR DESCRIPTION
Resolves #5875(FR-2256)

## Summary
- Update existing `BAIProjectResourcePolicySelect` component to add i18n placeholder and `use memo` directive
- Add i18n keys for project resource policy select placeholder in en/ko locale files
- Integrate into `CreatePermissionModal` as scope ID selector for `PROJECT_RESOURCE_POLICY` type

## Test plan
- [ ] Verify BAIProjectResourcePolicySelect renders with updated placeholder
- [ ] Verify CreatePermissionModal shows Project Resource Policy option in scope type dropdown