### PR TITLE
fix(FR-2272): add export-csv feature flag to useCSVExport hook

### DIFF
--- a/react/src/hooks/useCSVExport.ts
+++ b/react/src/hooks/useCSVExport.ts
@@ -1,3 +1,4 @@
+import { useSuspendedBackendaiClient } from '.';
 import { useCurrentUserRole } from './backendai';
 import { useSuspenseTanQuery } from './reactQueryAlias';
 import {
@@ -28,16 +29,24 @@ export const useCSVExport = (nodeKey: SupportedNodeKeys) => {
   'use memo';
 
   const { t } = useTranslation();
+  const baiClient = useSuspendedBackendaiClient();
   const baiRequestWithPromise = useBAISignedRequestWithPromise();
   const { getErrorMessage } = useErrorMessageResolver();
   const userRole = useCurrentUserRole();
 
   const isAdmin = userRole === 'superadmin' || userRole === 'admin';
+  const isExportCSVSupported = baiClient.supports('export-csv');
 
   const { data: supportedFields } = useSuspenseTanQuery<Array<string>>({
-    queryKey: ['CSVExport', 'supportedFields', nodeKey, isAdmin],
+    queryKey: [
+      'CSVExport',
+      'supportedFields',
+      nodeKey,
+      isAdmin,
+      isExportCSVSupported,
+    ],
     queryFn: () => {
-      if (!isAdmin) return [];
+      if (!isAdmin || !isExportCSVSupported) return [];
       return baiRequestWithPromise({
         method: 'GET',
         url: `/export/reports/${nodeKey}`,

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -890,6 +890,7 @@ class Client {
     if (this.isManagerVersionCompatibleWith('26.2.0')) {
       this._features['fair-share-scheduling'] = true;
       this._features['session-scheduling-history'] = true;
+      this._features['export-csv'] = true;
     }
   }
 


### PR DESCRIPTION
Resolves #5911 ([FR-2272](https://lablup.atlassian.net/browse/FR-2272), [FR-2267](https://lablup.atlassian.net/browse/FR-2267))

## Summary
- Add `export-csv` feature flag to backend client for manager >= 26.2.0
- Guard `useCSVExport` hook to skip CSV export API calls when the backend doesn't support the feature

[FR-2272]: https://lablup.atlassian.net/browse/FR-2272
[FR-2267]: https://lablup.atlassian.net/browse/FR-2267