### PR TITLE
fix(FR-2292): unify empty state display in Fair Share Resource Allocation column

### DIFF
--- a/react/src/components/FairShareItems/DomainFairShareTable.tsx
+++ b/react/src/components/FairShareItems/DomainFairShareTable.tsx
@@ -210,7 +210,9 @@ const DomainFairShareTable: React.FC<DomainFairShareTableProps> = ({
       key: 'totalUsage',
       dataIndex: ['calculationSnapshot', 'averageDailyDecayedUsage', 'entries'],
       render: (entries) => {
-        return _.isEmpty(entries) ? (
+        const hasData =
+          !_.isEmpty(entries) && _.some(entries, (e) => e.quantity > 0);
+        return !hasData ? (
           '-'
         ) : (
           <BAIFlex wrap="wrap" gap="sm" align="center">

--- a/react/src/components/FairShareItems/ProjectFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ProjectFairShareTable.tsx
@@ -200,7 +200,9 @@ const ProjectFairShareTable: React.FC<ProjectFairShareTableProps> = ({
       key: 'totalUsage',
       dataIndex: ['calculationSnapshot', 'averageDailyDecayedUsage', 'entries'],
       render: (entries) => {
-        return _.isEmpty(entries) ? (
+        const hasData =
+          !_.isEmpty(entries) && _.some(entries, (e) => e.quantity > 0);
+        return !hasData ? (
           '-'
         ) : (
           <BAIFlex wrap="wrap" gap="sm" align="center">

--- a/react/src/components/FairShareItems/UserFairShareTable.tsx
+++ b/react/src/components/FairShareItems/UserFairShareTable.tsx
@@ -196,7 +196,9 @@ const UserFairShareTable: React.FC<UserFairShareTableProps> = ({
       key: 'totalUsage',
       dataIndex: ['calculationSnapshot', 'averageDailyDecayedUsage', 'entries'],
       render: (entries) => {
-        return _.isEmpty(entries) ? (
+        const hasData =
+          !_.isEmpty(entries) && _.some(entries, (e) => e.quantity > 0);
+        return !hasData ? (
           '-'
         ) : (
           <BAIFlex wrap="wrap" gap="sm" align="center">


### PR DESCRIPTION
Resolves #5925 ([FR-2292](https://lablup.atlassian.net/browse/FR-2292))

## Summary
- Unify empty state display in Fair Share Resource Allocation column across Domain, Project, and User tables
- Both zero-filled entries and empty entries now consistently display `'-'` instead of showing `0 Core / Day` for one state and `-` for the other
- Changed condition from `_.isEmpty(entries)` to also check `_.some(entries, (e) => e.quantity > 0)`

## Files Changed
- `react/src/components/FairShareItems/DomainFairShareTable.tsx`
- `react/src/components/FairShareItems/ProjectFairShareTable.tsx`
- `react/src/components/FairShareItems/UserFairShareTable.tsx`

[FR-2292]: https://lablup.atlassian.net/browse/FR-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ