### PR TITLE
fix(FR-2291): change CPU step value from 0.1 to 1 in ResourceGroup Fair Share modal

### DIFF
--- a/react/src/components/FairShareItems/ResourceGroupFairShareSettingModal.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupFairShareSettingModal.tsx
@@ -291,7 +291,7 @@ const ResourceGroupFairShareSettingModal: React.FC<
                 },
               ]}
             >
-              <InputNumber min={1} step={0.1} style={{ width: '100%' }} />
+              <InputNumber min={1} step={1} style={{ width: '100%' }} />
             </Form.Item>
           </Col>
         </Row>
@@ -312,6 +312,8 @@ const ResourceGroupFairShareSettingModal: React.FC<
           >
             <Row gutter={[24, 16]}>
               {_.map(resourceGroup?.fairShareSpec?.resourceWeights, (entry) => {
+                const isSharesType = _.endsWith(entry?.resourceType, 'shares');
+                const step = isSharesType ? 0.1 : 1;
                 return (
                   <Col
                     span={12}
@@ -328,7 +330,7 @@ const ResourceGroupFairShareSettingModal: React.FC<
                     >
                       <InputNumber
                         min={1}
-                        step={0.1}
+                        step={step}
                         style={{ width: '100%' }}
                       />
                     </Form.Item>


### PR DESCRIPTION
Resolves #5924 ([FR-2291](https://lablup.atlassian.net/browse/FR-2291))

## Summary
- Fix InputNumber `step` values in ResourceGroup Fair Share Settings modal based on resource type
- `defaultWeight`: changed step from `0.1` to `1` (weights are whole numbers)
- `resourceWeights`: step is now resource-type-aware — `shares`-type accelerators use `0.1`, all others (cpu, mem, device-type accelerators) use `1`
- Follows the same pattern as `ResourceAllocationFormItems.tsx`

## Files Changed
- `react/src/components/FairShareItems/ResourceGroupFairShareSettingModal.tsx`

[FR-2291]: https://lablup.atlassian.net/browse/FR-2291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ