### PR TITLE
fix(FR-2283): fix type selection options missing in storage folder creation dialog

### DIFF
--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -2133,13 +2133,17 @@ class VFolder {
    * Get allowed types of folders
    *
    */
-  async list_allowed_types(): Promise<any> {
+  async list_allowed_types(): Promise<string[]> {
     let rqst = this.client.newSignedRequest(
       'GET',
       `${this.urlPrefix}/_/allowed_types`,
       null,
     );
-    return this.client._wrapWithPromise(rqst);
+    return this.client
+      ._wrapWithPromise(rqst)
+      .then((res: string[] | { type: string[] }) =>
+        Array.isArray(res) ? res : (res?.type ?? []),
+      );
   }
 
   /**


### PR DESCRIPTION
Resolves #5915 ([FR-2283](https://lablup.atlassian.net/browse/FR-2283))

## Summary
- Fix `list_allowed_types()` in backend.ai-client-esm.ts to correctly extract the `type` array from the API response
- The API returns `{ "type": ["user", "group"] }` but the code expected a plain `string[]`, causing `_.includes(object, 'user')` to return false and hiding both radio buttons
- Add proper return type annotation `Promise<string[]>` and handle both response shapes

## Files Changed
- `src/lib/backend.ai-client-esm.ts`

[FR-2283]: https://lablup.atlassian.net/browse/FR-2283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ