### PR TITLE
fix(FR-2282): fix subfolder creation path construction in filebrowser

### DIFF
--- a/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateDirectoryModal.tsx
+++ b/packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateDirectoryModal.tsx
@@ -37,9 +37,13 @@ const CreateDirectoryModal: React.FC<CreateDirectoryModalProps> = ({
     formRef.current
       ?.validateFields()
       .then((values) => {
+        const path =
+          currentPath === '.'
+            ? values.folderName
+            : `${currentPath}/${values.folderName}`;
         createDirectoryMutation
           .mutateAsync({
-            path: [currentPath, values.folderName].join('/'),
+            path,
             name: targetVFolderId,
           })
           .then(() => {
@@ -79,6 +83,18 @@ const CreateDirectoryModal: React.FC<CreateDirectoryModalProps> = ({
             {
               max: 255,
               message: t('comp:FileExplorer.MaxFolderNameLength'),
+            },
+            {
+              validator: (_, value) => {
+                if (value && (value.includes('/') || value.includes('\\'))) {
+                  return Promise.reject(
+                    new Error(
+                      t('comp:FileExplorer.InvalidFolderNameCharacters'),
+                    ),
+                  );
+                }
+                return Promise.resolve();
+              },
             },
           ]}
         >

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -271,6 +271,7 @@
     "FolderCreatedSuccessfully": "Folder created successfully.",
     "FolderName": "Folder Name",
     "InvalidFileNameCharacters": "File name must not contain path separators (/ or \\).",
+    "InvalidFolderNameCharacters": "Folder name must not contain path separators (/ or \\).",
     "MaxFileNameLength": "File name must be 255 characters or less.",
     "MaxFolderNameLength": "Folder name must be 255 characters or less.",
     "ModifiedAt": "Modified At",


### PR DESCRIPTION
Resolves #5913 ([FR-2282](https://lablup.atlassian.net/browse/FR-2282))

## Summary
- Fix subfolder creation path construction in `CreateDirectoryModal` when at root level
- When `currentPath` is `'.'` (root), the path was constructed as `./subfolder` which the mkdir API rejects; now uses just the folder name
- Add folder name validation to reject `/` and `\` characters (matching `CreateFileModal` behavior)
- Add i18n key `InvalidFolderNameCharacters` for the validation message

## Files Changed
- `packages/backend.ai-ui/src/components/baiClient/FileExplorer/CreateDirectoryModal.tsx`
- `packages/backend.ai-ui/src/locale/en.json`

[FR-2282]: https://lablup.atlassian.net/browse/FR-2282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ