### PR TITLE
fix(FR-2271): fix login E2E tests broken by display:none on login modal wrapper

### DIFF
--- a/react/src/components/LoginFormPanel.tsx
+++ b/react/src/components/LoginFormPanel.tsx
@@ -148,7 +148,6 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
         footer={null}
         width={modalWidth}
         getContainer={false}
-        mask={!needToResetPassword}
         title={
           <div style={{ textAlign: 'center' }}>
             <img
@@ -161,14 +160,8 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
         styles={{
           header: { borderBottom: 'none', paddingBottom: 0 },
           body: { padding: token.paddingLG, paddingTop: token.paddingSM },
-          // When needToResetPassword is true, hide the login modal wrapper via
-          // display:none while keeping open={true}. This preserves the Form
-          // instance (and its field values) that child modals depend on.
-          // Trade-off: screen readers may announce two open dialogs. A future
-          // refactor should decouple form state from modal lifecycle.
-          ...(needToResetPassword ? { wrapper: { display: 'none' } } : {}),
         }}
-        destroyOnHidden
+        destroyOnHidden={false}
       >
         {/* Mode switching: Segmented control */}
         {loginConfig.change_signin_support && (

--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -106,6 +106,10 @@ const LoginView: React.FC = () => {
     useRef<ReturnType<typeof createBackendAIClient>['client']>(null);
   const configRef = useRef<LoginConfigState>(loginConfig);
   const blockTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
+  // Track previous values to detect true -> false transitions for re-opening
+  // the login panel after child modals are dismissed.
+  const prevNeedsOtpRegistrationRef = useRef(false);
+  const prevNeedToResetPasswordRef = useRef(false);
 
   // Trigger config loading on mount
   useEffect(() => {
@@ -240,6 +244,27 @@ const LoginView: React.FC = () => {
       setShowSignupModal(true);
     }
   }, [loginConfig.signup_support, apiEndpoint]);
+
+  // Re-open the login panel when needsOtpRegistration transitions from true
+  // to false (i.e., after the TOTP registration modal is dismissed), so the
+  // user can enter their OTP code. Using useEffect + ref keeps the setter
+  // callback a pure state setter and avoids accidental re-opens from
+  // non-dismissal code paths.
+  useEffect(() => {
+    if (prevNeedsOtpRegistrationRef.current && !needsOtpRegistration) {
+      open();
+    }
+    prevNeedsOtpRegistrationRef.current = needsOtpRegistration;
+  }, [needsOtpRegistration, open]);
+
+  // Re-open the login panel when needToResetPassword transitions from true to
+  // false (i.e., after the password reset modal is cancelled or completed).
+  useEffect(() => {
+    if (prevNeedToResetPasswordRef.current && !needToResetPassword) {
+      open();
+    }
+    prevNeedToResetPasswordRef.current = needToResetPassword;
+  }, [needToResetPassword, open]);
 
   const close = useCallback(() => {
     // Cancel any pending block timer so a delayed timer from block()
@@ -404,12 +429,11 @@ const LoginView: React.FC = () => {
             showError,
           );
           if (!shouldOpenLoginPanel) {
-            // Don't close the login panel — its BAIModal uses destroyOnHidden,
-            // which would destroy the Form and clear field values needed by
-            // child modals (e.g., ResetPasswordRequiredInline reads username
-            // and currentPassword from form). Just dismiss the block overlay
-            // and let the child modal (zIndex=1002) appear above the login
-            // panel (zIndex=1001).
+            // Close the login panel so its form fields are inaccessible while
+            // the child modal (password reset or TOTP) is shown. The BAIModal
+            // uses destroyOnHidden={false}, which keeps the Form instance alive
+            // so form.setFieldValue() still works after the child modal completes
+            // and triggers re-login.
             //
             // Capture credentials explicitly for the password reset modal.
             // Reading form values via form.getFieldValue() at render time is
@@ -419,6 +443,7 @@ const LoginView: React.FC = () => {
               username: userId,
               password,
             };
+            setIsLoginPanelOpen(false);
             setIsBlockPanelOpen(false);
             setIsLoading(false);
             return;
@@ -875,8 +900,8 @@ const LoginView: React.FC = () => {
         onSetOtpRequired={setOtpRequired}
         onSetNeedsOtpRegistration={setNeedsOtpRegistration}
         onSetNeedToResetPassword={(v: boolean) => {
-          setNeedToResetPassword(v);
           if (!v) expiredCredentialsRef.current = null;
+          setNeedToResetPassword(v);
         }}
         onSetShowSignupModal={setShowSignupModal}
       />


### PR DESCRIPTION
Resolves #5910 ([FR-2271](https://lablup.atlassian.net/browse/FR-2271))

## Summary
- Fix login E2E tests broken by `display:none` on login modal wrapper
- Changed `destroyOnHidden` to `destroyOnHidden={false}` in `LoginFormPanel.tsx`
- Added `useRef` trackers and `useEffect` hooks in `LoginView.tsx` to call `open()` on true→false transitions

## Stack (FR-2271 E2E test fixes)
1. **#5934** ← this PR (login tests)
2. #5943 (environment BAIPropertyFilter - FR-2275)
3. #5944 (app-launcher - FR-2273)
4. #5945 (session-lifecycle - FR-2278)
5. #5946 (E2E coverage report update)

[FR-2271]: https://lablup.atlassian.net/browse/FR-2271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Test Recordings

All 7 login E2E tests pass. Recordings below:

| Test | Recording |
|------|-----------|
| Before Login - should display the login form | ![before-login](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2271-login/before-login-should-display-the-login-form.gif) |
| Login - should redirect to the Summary | ![login-summary](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2271-login/login-should-redirect-to-the-summary.gif) |
| Endpoint URL - single trailing slash | ![single-slash](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2271-login/endpoint-url-single-trailing-slash.gif) |
| Endpoint URL - multiple trailing slashes | ![multi-slash](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2271-login/endpoint-url-multiple-trailing-slashes.gif) |
| Endpoint URL - no double-slash after normalization | ![no-double-slash](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2271-login/endpoint-url-no-double-slash.gif) |
| Login failure - non-existent email | ![failure-email](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2271-login/login-failure-non-existent-email.gif) |
| Login failure - incorrect password | ![failure-password](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2271-login/login-failure-incorrect-password.gif) |