### PR TITLE
feat(FR-2269): add E2E test for login after self-service signup

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-03-10
+> **Last Updated:** 2026-03-12
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -12,11 +12,11 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 160 / 319 features covered (50%)**
+**Overall (in-scope routes): 162 / 322 features covered (50%)**
 
 | Page | Route | Features | Covered | Status |
 |------|-------|:--------:|:-------:|:------:|
-| Authentication | `/interactive-login` | 16 | 14 | 🔶 88% |
+| Authentication | `/interactive-login` | 19 | 16 | 🔶 84% |
 | Start Page | `/start` | 8 | 6 | 🔶 75% |
 | Dashboard | `/dashboard` | 9 | 7 | 🔶 78% |
 | Session List | `/session` | 20 | 12 | 🔶 60% |
@@ -44,7 +44,7 @@
 | App Launcher | (modal) | 18 | 10 | 🔶 56% |
 | Chat | `/chat/:id?` | 6 | 0 | ❌ 0% |
 | Plugin System | (config-based) | 12 | 12 | ✅ 100% |
-| **Total** | | **319** | **160** | **50%** |
+| **Total** | | **322** | **162** | **50%** |
 
 ---
 
@@ -63,7 +63,7 @@
 
 ### 1. Authentication (`/interactive-login`)
 
-**Test files:** [`e2e/auth/login.spec.ts`](auth/login.spec.ts), [`e2e/auth/password-expiry.spec.ts`](auth/password-expiry.spec.ts)
+**Test files:** [`e2e/auth/login.spec.ts`](auth/login.spec.ts), [`e2e/auth/password-expiry.spec.ts`](auth/password-expiry.spec.ts), [`e2e/auth/signup.spec.ts`](auth/signup.spec.ts)
 
 | Feature | Status | Test |
 |---------|--------|------|
@@ -80,10 +80,13 @@
 | Password change empty validation | ✅ | `password change form shows a validation error when submitted empty` |
 | Password change same-password rejection | ✅ | `password change form rejects a new password that is the same as the current one` |
 | Full password change flow (real account) | ✅ | `user can complete the password change flow with a real account and re-login is attempted` |
+| Self-service signup (success path) | ✅ | `user can open the signup modal and sign up successfully` |
+| Self-service signup (duplicate email error) | ✅ | `signup with an already-registered email shows an error` |
+| Login after self-service signup | 🚧 | `user can log in with newly signed-up credentials` (fixme: blocked by FR-2268) |
 | OAuth/SSO login flow | ❌ | - |
 | Session persistence | ❌ | - |
 
-**Coverage: 🔶 14/16 features**
+**Coverage: 🔶 16/19 features**
 
 ---
 

--- a/e2e/auth/signup.spec.ts
+++ b/e2e/auth/signup.spec.ts
@@ -1,0 +1,229 @@
+// spec: e2e/auth/signup.spec.ts
+// Covers: FR-2269 — Add E2E test for login after self-service signup
+import { PurgeUsersModal } from '../utils/classes/user/PurgeUsersModal';
+import {
+  loginAsAdmin,
+  loginAsCreatedAccount,
+  modifyConfigToml,
+  navigateTo,
+  webServerEndpoint,
+  webuiEndpoint,
+} from '../utils/test-util';
+import { test, expect } from '@playwright/test';
+
+// Generate a unique identifier per test run to avoid conflicts with leftover data
+const TEST_RUN_ID = Date.now().toString(36);
+const SIGNUP_EMAIL = `e2e-signup-${TEST_RUN_ID}@lablup.com`;
+const SIGNUP_USERNAME = `e2e-signup-${TEST_RUN_ID}`;
+// Password must satisfy: ≥8 chars, ≥1 digit, ≥1 letter, ≥1 special char
+const SIGNUP_PASSWORD = 'Signup@123';
+
+/**
+ * Navigate to the credential page and clean up the test account if it exists.
+ * Follows the same deactivate → purge pattern used in user-crud.spec.ts.
+ */
+async function cleanupSignupTestUser(page: any) {
+  await navigateTo(page, 'credential');
+  await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+
+  // Check Active tab first
+  const activeUserRow = page.getByRole('row').filter({ hasText: SIGNUP_EMAIL });
+  const isActiveVisible = await activeUserRow
+    .isVisible({ timeout: 2000 })
+    .catch(() => false);
+
+  if (isActiveVisible) {
+    await activeUserRow.getByRole('button', { name: 'Deactivate' }).click();
+    const popconfirm = page.locator('.ant-popconfirm');
+    await popconfirm.getByRole('button', { name: 'Deactivate' }).click();
+    await expect(activeUserRow).toBeHidden({ timeout: 10_000 });
+  }
+
+  // Switch to Inactive tab and purge if present
+  await page.getByText('Inactive', { exact: true }).click();
+  const inactiveUserRow = page
+    .getByRole('row')
+    .filter({ hasText: SIGNUP_EMAIL });
+  const isInactiveVisible = await inactiveUserRow
+    .isVisible({ timeout: 2000 })
+    .catch(() => false);
+
+  if (isInactiveVisible) {
+    await inactiveUserRow.getByRole('checkbox').click();
+    await page.getByRole('button', { name: 'trash bin' }).click();
+
+    const purgeModal = new PurgeUsersModal(page);
+    await purgeModal.waitForVisible();
+    await purgeModal.confirmDeletion();
+    await expect(inactiveUserRow).toBeHidden({ timeout: 10_000 });
+  }
+
+  // Return to Active tab
+  await page.getByText('Active', { exact: true }).click();
+}
+
+test.describe.serial(
+  'Self-service signup flow',
+  { tag: ['@smoke', '@auth', '@functional'] },
+  () => {
+    test.beforeEach(async ({ page, request }) => {
+      // Enable signup in config.toml and allow immediate login without email confirmation.
+      // Set apiEndpoint to the backend server so showSignupDialog() can resolve a non-empty
+      // endpoint and open the signup modal (an empty endpoint causes an "API Endpoint is empty"
+      // notification instead of opening the modal).
+      await modifyConfigToml(page, request, {
+        general: {
+          connectionMode: 'SESSION',
+          apiEndpoint: webServerEndpoint,
+          apiEndpointText: webServerEndpoint,
+          signupSupport: true,
+          allowSignupWithoutConfirmation: true,
+        },
+      });
+      await page.goto(webuiEndpoint);
+      // Remove webpack-dev-server overlay if present so it does not block clicks
+      await page
+        .evaluate(() => {
+          const overlay = document.getElementById(
+            'webpack-dev-server-client-overlay',
+          );
+          if (overlay) overlay.remove();
+        })
+        .catch(() => {});
+    });
+
+    test('user can open the signup modal and sign up successfully', async ({
+      page,
+    }) => {
+      // The "Sign up" control is rendered as a Typography.Link, not a button
+      const signUpLink = page.getByRole('link', { name: 'Sign up' });
+      await expect(signUpLink).toBeVisible({ timeout: 10_000 });
+      await signUpLink.click();
+
+      // Wait for the signup modal specifically (not the login modal)
+      const signupModal = page.getByRole('dialog', { name: /Signup/i });
+      await expect(signupModal).toBeVisible({ timeout: 5_000 });
+
+      // Fill the signup form
+      await signupModal.getByLabel('Email').fill(SIGNUP_EMAIL);
+      await signupModal.getByLabel('UserName').fill(SIGNUP_USERNAME);
+      // Use nth(0) to target the first Password field (not Verify Password)
+      await signupModal.getByLabel('Password').nth(0).fill(SIGNUP_PASSWORD);
+      await signupModal.getByLabel('Verify Password').fill(SIGNUP_PASSWORD);
+
+      // Check the Terms of Service / Privacy Policy agreement checkbox
+      await signupModal.getByRole('checkbox').click();
+
+      // Submit the form via the primary "Signup" button inside the modal footer
+      await signupModal.getByRole('button', { name: 'Signup' }).click();
+
+      // When allowSignupWithoutConfirmation is true the modal closes without an
+      // error toast — verify it disappears within a reasonable timeout
+      await expect(signupModal).toBeHidden({ timeout: 15_000 });
+
+      // Ensure no error alert is shown
+      await expect(page.getByRole('alert'))
+        .toBeHidden({ timeout: 3_000 })
+        .catch(() => {
+          // getByRole('alert') may not exist at all, which is also fine
+        });
+    });
+
+    // FR-2268: Login after self-service signup is currently broken.
+    // Mark as fixme until that bug is resolved.
+    test.fixme('user can log in with newly signed-up credentials', async ({
+      page,
+      request,
+    }) => {
+      await loginAsCreatedAccount(page, request, SIGNUP_EMAIL, SIGNUP_PASSWORD);
+
+      await expect(page).toHaveURL(/\/start/, { timeout: 15_000 });
+      await expect(
+        page.getByTestId('webui-breadcrumb').getByText('Start'),
+      ).toBeVisible();
+    });
+
+    test('signup with an already-registered email shows an error', async ({
+      page,
+    }) => {
+      // The "Sign up" control is rendered as a Typography.Link, not a button
+      const signUpLink = page.getByRole('link', { name: 'Sign up' });
+      await expect(signUpLink).toBeVisible({ timeout: 10_000 });
+      await signUpLink.click();
+
+      // Wait for the signup modal specifically (not the login modal)
+      const signupModal = page.getByRole('dialog', { name: /Signup/i });
+      await expect(signupModal).toBeVisible({ timeout: 5_000 });
+
+      // Use the same email that was registered in the first test
+      await signupModal.getByLabel('Email').fill(SIGNUP_EMAIL);
+      await signupModal.getByLabel('UserName').fill(SIGNUP_USERNAME + '-dup');
+      await signupModal.getByLabel('Password').nth(0).fill(SIGNUP_PASSWORD);
+      await signupModal.getByLabel('Verify Password').fill(SIGNUP_PASSWORD);
+      await signupModal.getByRole('checkbox').click();
+      await signupModal.getByRole('button', { name: 'Signup' }).click();
+
+      // An error message should be displayed (the modal stays open)
+      await expect(
+        page.getByRole('alert').or(page.locator('.ant-message-error')),
+      ).toBeVisible({ timeout: 10_000 });
+
+      // Modal must still be open (signup was rejected)
+      await expect(signupModal).toBeVisible();
+    });
+
+    // Stub for the email-confirmation path.
+    // Requires a test SMTP server or email mock — skipped until that
+    // infrastructure is available.
+    test.fixme('signup without allowSignupWithoutConfirmation shows email-sent dialog', async ({
+      page,
+      request,
+    }) => {
+      // Override config to require email confirmation
+      await modifyConfigToml(page, request, {
+        general: {
+          signupSupport: true,
+          allowSignupWithoutConfirmation: false,
+        },
+      });
+      await page.goto(webuiEndpoint);
+
+      // The "Sign up" control is rendered as a Typography.Link, not a button
+      const signUpLink = page.getByRole('link', { name: 'Sign up' });
+      await signUpLink.click();
+
+      // Wait for the signup modal specifically (not the login modal)
+      const signupModal = page.getByRole('dialog', { name: /Signup/i });
+      await expect(signupModal).toBeVisible();
+
+      await signupModal
+        .getByLabel('Email')
+        .fill(`email-confirm-${TEST_RUN_ID}@lablup.com`);
+      await signupModal.getByLabel('UserName').fill(`email-confirm-${TEST_RUN_ID}`);
+      await signupModal.getByLabel('Password').nth(0).fill(SIGNUP_PASSWORD);
+      await signupModal.getByLabel('Verify Password').fill(SIGNUP_PASSWORD);
+      await signupModal.getByLabel('Invitation Token').fill('dummy-token');
+      await signupModal.getByRole('checkbox').click();
+      await signupModal.getByRole('button', { name: 'Signup' }).click();
+
+      // The "Thank you!" dialog should appear instead of closing the modal
+      await expect(page.getByText('Thank you!')).toBeVisible({
+        timeout: 10_000,
+      });
+    });
+
+    test.afterAll(async ({ browser }) => {
+      // Clean up the test account using an admin session
+      const context = await browser.newContext();
+      const page = await context.newPage();
+      const request = context.request;
+
+      try {
+        await loginAsAdmin(page, request);
+        await cleanupSignupTestUser(page);
+      } finally {
+        await context.close();
+      }
+    });
+  },
+);


### PR DESCRIPTION
Resolves #5908 ([FR-2269](https://lablup.atlassian.net/browse/FR-2269), [FR-2263](https://lablup.atlassian.net/browse/FR-2263))

## Summary
- Add `e2e/auth/signup.spec.ts` with E2E tests for self-service signup flow
- Test: user can open signup modal, fill form, and sign up successfully
- Test: duplicate email signup shows error
- `test.fixme`: login after signup (blocked by FR-2268 backend bug)
- `test.fixme`: email-confirmation path (needs test SMTP server)
- Cleanup: admin deactivates and purges test account in afterAll
- Tagged `@smoke`, `@auth`, `@functional`

## Files Changed
- `e2e/auth/signup.spec.ts` (new)

[FR-2269]: https://lablup.atlassian.net/browse/FR-2269
[FR-2263]: https://lablup.atlassian.net/browse/FR-2263