### PR TITLE
test(FR-2295): add serving deploy lifecycle integration test

### DIFF
--- a/e2e/serving/fixtures/mock_openai_server.py
+++ b/e2e/serving/fixtures/mock_openai_server.py
@@ -1,0 +1,168 @@
+"""
+Lightweight mock OpenAI-compatible server for Backend.AI E2E testing.
+
+Serves two endpoints:
+  GET  /v1/models          -> model list
+  POST /v1/chat/completions -> SSE streaming chat response
+
+Uses only Python stdlib — no external dependencies required.
+The response content includes SERVICE_ID env var for differentiating
+between multiple deployed services in sync tests.
+"""
+
+import json
+import os
+import time
+import uuid
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+SERVICE_ID = os.environ.get("SERVICE_ID", "A")
+MODEL_ID = os.environ.get("MODEL_ID", f"mock-model-{SERVICE_ID.lower()}")
+PORT = int(os.environ.get("PORT", "8000"))
+
+
+class MockOpenAIHandler(BaseHTTPRequestHandler):
+    def _send_cors_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization")
+
+    def do_OPTIONS(self):
+        """Handle CORS preflight requests."""
+        self.send_response(204)
+        self._send_cors_headers()
+        self.end_headers()
+
+    def do_GET(self):
+        if self.path == "/v1/models" or self.path.startswith("/v1/models?"):
+            self._serve_models()
+        elif self.path == "/health" or self.path == "/":
+            self._serve_health()
+        else:
+            self._not_found()
+
+    def do_POST(self):
+        if self.path == "/v1/chat/completions":
+            self._serve_chat_completions()
+        else:
+            self._not_found()
+
+    def _serve_health(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self._send_cors_headers()
+        self.end_headers()
+        self.wfile.write(json.dumps({"status": "ok"}).encode())
+
+    def _serve_models(self):
+        body = {
+            "object": "list",
+            "data": [{"id": MODEL_ID, "object": "model", "owned_by": "mock"}],
+        }
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self._send_cors_headers()
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+    def _serve_chat_completions(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(content_length) if content_length else b"{}"
+        try:
+            req = json.loads(raw)
+        except json.JSONDecodeError:
+            req = {}
+
+        stream = req.get("stream", False)
+        user_msg = ""
+        for msg in req.get("messages", []):
+            if msg.get("role") == "user":
+                content = msg.get("content", "")
+                if isinstance(content, str):
+                    user_msg = content
+
+        reply = f"Response from Service {SERVICE_ID}: echo '{user_msg}'"
+
+        if stream:
+            self._stream_response(reply)
+        else:
+            self._non_stream_response(reply)
+
+    def _non_stream_response(self, content):
+        body = {
+            "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": MODEL_ID,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": content},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+        }
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self._send_cors_headers()
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+    def _stream_response(self, content):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        self._send_cors_headers()
+        self.end_headers()
+
+        chat_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
+        created = int(time.time())
+
+        chunk1 = {
+            "id": chat_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": MODEL_ID,
+            "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
+        }
+        self.wfile.write(f"data: {json.dumps(chunk1)}\n\n".encode())
+        self.wfile.flush()
+
+        chunk2 = {
+            "id": chat_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": MODEL_ID,
+            "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None}],
+        }
+        self.wfile.write(f"data: {json.dumps(chunk2)}\n\n".encode())
+        self.wfile.flush()
+
+        chunk3 = {
+            "id": chat_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": MODEL_ID,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        }
+        self.wfile.write(f"data: {json.dumps(chunk3)}\n\n".encode())
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+    def _not_found(self):
+        self.send_response(404)
+        self.send_header("Content-Type", "application/json")
+        self._send_cors_headers()
+        self.end_headers()
+        self.wfile.write(json.dumps({"error": "not found"}).encode())
+
+    def log_message(self, format, *args):
+        pass
+
+
+if __name__ == "__main__":
+    server = HTTPServer(("0.0.0.0", PORT), MockOpenAIHandler)
+    print(f"Mock OpenAI server (Service {SERVICE_ID}) listening on port {PORT}")
+    server.serve_forever()

--- a/e2e/serving/fixtures/model-definition.yaml
+++ b/e2e/serving/fixtures/model-definition.yaml
@@ -1,0 +1,12 @@
+models:
+  - name: "mock-openai"
+    model_path: "/models"
+    service:
+      start_command:
+        - python3
+        - /models/mock_openai_server.py
+      port: 8000
+      health_check:
+        path: /health
+        initial_delay: 5.0
+        max_retries: 10

--- a/e2e/serving/serving-deploy-lifecycle.spec.ts
+++ b/e2e/serving/serving-deploy-lifecycle.spec.ts
@@ -1,0 +1,453 @@
+// FR-2295: Integration E2E test for model service deploy lifecycle.
+// Tests the full lifecycle: vfolder creation -> file upload -> service deploy
+// via ServiceLauncher UI -> HEALTHY status -> service termination -> cleanup.
+import { FolderExplorerModal } from '../utils/classes/vfolder/FolderExplorerModal';
+import { sweepServices, sweepVFolders } from '../utils/cleanup-util';
+import {
+  loginAsAdmin,
+  navigateTo,
+  createVFolderAndVerify,
+  moveToTrashAndVerify,
+  deleteForeverAndVerifyFromTrash,
+} from '../utils/test-util';
+import { test, expect, Page } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+function shortId(): string {
+  return Math.random().toString(36).slice(2, 8);
+}
+
+const SERVICE_NAME = `e2e-svc-${shortId()}`;
+const VFOLDER_NAME = `e2e-mod-${shortId()}`;
+
+// Fallback image if defaultSessionEnvironment is not set in config.toml
+const DEFAULT_PYTHON_IMAGE =
+  'cr.backend.ai/stable/python:3.9-ubuntu20.04@x86_64';
+
+// Resolved at runtime from config.toml's defaultSessionEnvironment
+let resolvedImage = DEFAULT_PYTHON_IMAGE;
+
+/**
+ * Reads defaultSessionEnvironment from the WebUI config via backendaiclient.
+ * Must be called after login (backendaiclient is initialized).
+ */
+async function resolveDefaultImage(page: Page): Promise<string> {
+  const image = await page.evaluate(() => {
+    const client = (globalThis as any).backendaiclient;
+    return client?._config?.default_session_environment || '';
+  });
+  return image || DEFAULT_PYTHON_IMAGE;
+}
+
+// Max time to wait for service health check
+const SERVICE_READY_TIMEOUT = 180_000; // 3 minutes
+const HEALTH_CHECK_INTERVAL = 5_000; // 5 seconds
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Locates the BAIFetchKeyButton (refresh/reload button) on the serving page.
+ * The button renders a ReloadOutlined icon with title="Refresh".
+ */
+function getTableRefreshButton(page: Page) {
+  return page
+    .locator('button')
+    .filter({ has: page.locator('.anticon-reload') })
+    .first();
+}
+
+/**
+ * Opens the FolderExplorerModal for a given vfolder and uploads fixture files.
+ */
+async function uploadFixturesToVFolder(
+  page: Page,
+  folderName: string,
+  pythonImage: string = DEFAULT_PYTHON_IMAGE,
+): Promise<void> {
+  await navigateTo(page, 'data');
+  await page.waitForLoadState('networkidle');
+  const folderLink = page.getByRole('link', { name: folderName }).first();
+  await expect(folderLink).toBeVisible({ timeout: 15000 });
+  await folderLink.click();
+
+  const modal = new FolderExplorerModal(page);
+  await modal.waitForOpen();
+  await modal.verifyFileExplorerLoaded();
+
+  const uploadButton = await modal.getUploadButton();
+  await uploadButton.click();
+
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    page.getByRole('button', { name: 'file-add Upload Files' }).click(),
+  ]);
+
+  const mockServerContent = fs.readFileSync(
+    path.join(FIXTURES_DIR, 'mock_openai_server.py'),
+    'utf-8',
+  );
+  const modelDefContent = fs.readFileSync(
+    path.join(FIXTURES_DIR, 'model-definition.yaml'),
+    'utf-8',
+  );
+
+  const serviceDefContent = [
+    '[custom.environment]',
+    `image = "${pythonImage}"`,
+    'architecture = "x86_64"',
+    '',
+    '[custom.resource_slots]',
+    'cpu = 1',
+    'mem = "512m"',
+  ].join('\n');
+
+  await fileChooser.setFiles([
+    {
+      name: 'mock_openai_server.py',
+      mimeType: 'text/x-python',
+      buffer: Buffer.from(mockServerContent),
+    },
+    {
+      name: 'model-definition.yaml',
+      mimeType: 'application/x-yaml',
+      buffer: Buffer.from(modelDefContent),
+    },
+    {
+      name: 'service-definition.toml',
+      mimeType: 'application/toml',
+      buffer: Buffer.from(serviceDefContent),
+    },
+  ]);
+
+  await modal.verifyFileVisible('mock_openai_server.py');
+  await modal.verifyFileVisible('model-definition.yaml');
+  await modal.verifyFileVisible('service-definition.toml');
+
+  await modal.close();
+}
+
+/**
+ * Creates a model service via the ServiceLauncher UI form.
+ */
+async function createServiceViaUI(
+  page: Page,
+  serviceName: string,
+  vfolderName: string,
+): Promise<void> {
+  await navigateTo(page, 'service/start');
+
+  // Fill service name
+  const serviceNameInput = page.getByLabel('Service Name').first();
+  await expect(serviceNameInput).toBeVisible({ timeout: 10000 });
+  await serviceNameInput.fill(serviceName);
+
+  // Select model storage vfolder
+  const modelStorageSelect = page.getByRole('combobox', {
+    name: 'Model Storage to mount',
+  });
+  await expect(modelStorageSelect).toBeVisible({ timeout: 10000 });
+  await modelStorageSelect.click();
+  await modelStorageSelect.fill(vfolderName);
+
+  await page
+    .locator('.ant-select-item-option')
+    .filter({ hasText: vfolderName })
+    .first()
+    .click({ timeout: 10000 });
+
+  // Select environment image
+  const envSelect = page.getByRole('combobox', {
+    name: /Environments \/ Version/i,
+  });
+  await expect(envSelect).toBeVisible({ timeout: 10000 });
+  await envSelect.click();
+  await envSelect.fill('python');
+
+  await page
+    .locator('.ant-select-item-option')
+    .filter({ hasText: /python/i })
+    .first()
+    .click({ timeout: 10000 });
+
+  // Select resource group - click to open dropdown, search, then select option
+  const resourceGroupSelect = page
+    .getByRole('combobox', { name: 'Resource Group' })
+    .first();
+  await expect(resourceGroupSelect).toBeVisible({ timeout: 10000 });
+  await resourceGroupSelect.click();
+  await resourceGroupSelect.fill('default');
+  await page
+    .locator('.ant-select-item-option')
+    .filter({ hasText: /default/i })
+    .first()
+    .click({ timeout: 10000 });
+
+  // Check "Open To Public"
+  const openToPublicCheckbox = page.getByLabel('Open To Public');
+  await openToPublicCheckbox.scrollIntoViewIfNeeded();
+  await expect(openToPublicCheckbox).toBeVisible({ timeout: 5000 });
+  if (!(await openToPublicCheckbox.isChecked())) {
+    await openToPublicCheckbox.check({ force: true });
+  }
+  await expect(openToPublicCheckbox).toBeChecked({ timeout: 3000 });
+
+  // Submit
+  const createButton = page.getByRole('button', { name: 'Create' });
+  await expect(createButton).toBeEnabled({ timeout: 5000 });
+  await createButton.click();
+
+  // Wait for redirect to serving page and verify the service appears
+  await page.waitForURL('**/serving', { timeout: 15000 });
+  await expect(
+    page.getByRole('row').filter({ hasText: serviceName }).first(),
+  ).toBeVisible({ timeout: 15000 });
+}
+
+/**
+ * Polls the serving table until the service shows HEALTHY status.
+ * Uses the table's refresh button (BAIFetchKeyButton) instead of full page
+ * reload, which is lighter and avoids resetting the DOM state.
+ */
+async function waitForServiceReady(
+  page: Page,
+  serviceName: string,
+): Promise<void> {
+  await navigateTo(page, 'serving');
+
+  const refreshButton = getTableRefreshButton(page);
+  await expect(refreshButton).toBeVisible({ timeout: 10000 });
+
+  await expect
+    .poll(
+      async () => {
+        // Click the table refresh button to fetch latest data
+        await refreshButton.click();
+        // Wait briefly for the data to load after refresh
+        await page.waitForTimeout(2000);
+        const serviceRow = page
+          .getByRole('row')
+          .filter({ hasText: serviceName });
+        const healthyBadge = serviceRow.getByText(/HEALTHY/i);
+        return await healthyBadge
+          .isVisible({ timeout: 2000 })
+          .catch(() => false);
+      },
+      {
+        message: `Waiting for service "${serviceName}" to become HEALTHY`,
+        timeout: SERVICE_READY_TIMEOUT,
+        intervals: [HEALTH_CHECK_INTERVAL],
+      },
+    )
+    .toBe(true);
+}
+
+/**
+ * Terminates a model service by name via the serving list row action.
+ */
+async function terminateService(
+  page: Page,
+  serviceName: string,
+): Promise<void> {
+  await navigateTo(page, 'serving');
+
+  // Wait for the serving table to fully load before checking for the service.
+  const refreshButton = getTableRefreshButton(page);
+  await expect(refreshButton).toBeVisible({ timeout: 15000 });
+  await refreshButton.click();
+
+  // Wait for at least one visible data row to appear, indicating the
+  // table has loaded its data from the API. Exclude Ant Design's hidden
+  // measure row (ant-table-measure-row) which is always present but hidden.
+  await expect(page.locator('tbody tr.ant-table-row').first()).toBeVisible({
+    timeout: 15000,
+  });
+
+  const serviceRow = page.getByRole('row').filter({ hasText: serviceName });
+  if ((await serviceRow.count()) === 0) {
+    console.log(
+      `Service "${serviceName}" not found, may already be terminated`,
+    );
+    return;
+  }
+
+  const deleteButton = serviceRow
+    .getByRole('button', { name: 'delete' })
+    .first();
+  await expect(deleteButton).toBeVisible({ timeout: 5000 });
+  await deleteButton.click();
+
+  const confirmButton = page
+    .locator('.ant-modal-confirm')
+    .getByRole('button', { name: 'Delete' })
+    .first();
+  await expect(confirmButton).toBeVisible({ timeout: 5000 });
+  await confirmButton.click();
+
+  await expect(page.getByRole('row').filter({ hasText: serviceName }))
+    .toHaveCount(0, { timeout: 60000 })
+    .catch(() => {
+      console.log(`Service "${serviceName}" still visible, may be DESTROYING`);
+    });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe(
+  'Serving -- Model Service Deploy Lifecycle',
+  { tag: ['@integration', '@serving'] },
+  () => {
+    test.describe.configure({ mode: 'serial' });
+    test.setTimeout(240_000); // 4 minutes per test (3 min polling + overhead)
+
+    test.afterAll(async ({ browser, request }, testInfo) => {
+      testInfo.setTimeout(300_000);
+
+      const context = await browser.newContext();
+      const page = await context.newPage();
+
+      try {
+        await loginAsAdmin(page, request);
+      } catch {
+        console.log('afterAll: login failed, skipping cleanup');
+        await context.close();
+        return;
+      }
+
+      try {
+        await terminateService(page, SERVICE_NAME);
+      } catch {
+        console.log(`Could not terminate service ${SERVICE_NAME}`);
+      }
+
+      try {
+        await sweepServices(page);
+      } catch {
+        console.log('Could not sweep services');
+      }
+
+      try {
+        await moveToTrashAndVerify(page, VFOLDER_NAME);
+        await deleteForeverAndVerifyFromTrash(page, VFOLDER_NAME);
+      } catch {
+        console.log(`Could not delete vfolder ${VFOLDER_NAME}`);
+      }
+
+      try {
+        await sweepVFolders(page);
+      } catch {
+        console.log('Could not sweep vfolders');
+      }
+
+      await context.close();
+    });
+
+    test('Admin can create a model vfolder and upload mock server files', async ({
+      page,
+      request,
+    }) => {
+      await loginAsAdmin(page, request);
+
+      // Resolve image from config.toml's defaultSessionEnvironment
+      resolvedImage = await resolveDefaultImage(page);
+
+      // Create model vfolder
+      await createVFolderAndVerify(page, VFOLDER_NAME, 'model');
+
+      // Upload mock server fixtures
+      await uploadFixturesToVFolder(page, VFOLDER_NAME, resolvedImage);
+
+      // Verify vfolder exists with uploaded files
+      await navigateTo(page, 'data');
+      const folderLink = page.getByRole('link', { name: VFOLDER_NAME }).first();
+      await expect(folderLink).toBeVisible({ timeout: 10000 });
+      await folderLink.click();
+
+      const modal = new FolderExplorerModal(page);
+      await modal.waitForOpen();
+      await modal.verifyFileVisible('mock_openai_server.py');
+      await modal.verifyFileVisible('model-definition.yaml');
+      await modal.verifyFileVisible('service-definition.toml');
+      await modal.close();
+    });
+
+    test('Admin can deploy a model service via ServiceLauncher UI', async ({
+      page,
+      request,
+    }) => {
+      await loginAsAdmin(page, request);
+
+      await createServiceViaUI(page, SERVICE_NAME, VFOLDER_NAME);
+
+      // Verify service appears in the serving list
+      await navigateTo(page, 'serving');
+      const serviceRow = page
+        .getByRole('row')
+        .filter({ hasText: SERVICE_NAME });
+      await expect(serviceRow.first()).toBeVisible({ timeout: 15000 });
+    });
+
+    test('Deployed service reaches HEALTHY status', async ({
+      page,
+      request,
+    }) => {
+      await loginAsAdmin(page, request);
+
+      await waitForServiceReady(page, SERVICE_NAME);
+
+      // Verify the service row shows HEALTHY
+      const serviceRow = page
+        .getByRole('row')
+        .filter({ hasText: SERVICE_NAME });
+      await expect(serviceRow.getByText(/HEALTHY/i).first()).toBeVisible({
+        timeout: 5000,
+      });
+    });
+
+    test('Admin can terminate a deployed service', async ({
+      page,
+      request,
+    }) => {
+      await loginAsAdmin(page, request);
+
+      await terminateService(page, SERVICE_NAME);
+
+      // Verify service is removed or in DESTROYING state.
+      // Click the table refresh button to get latest data.
+      await navigateTo(page, 'serving');
+      const refreshButton = getTableRefreshButton(page);
+      await expect(refreshButton).toBeVisible({ timeout: 15000 });
+      await refreshButton.click();
+      await page.waitForTimeout(2000);
+
+      // Service should eventually disappear
+      await expect
+        .poll(
+          async () => {
+            await refreshButton.click();
+            await page.waitForTimeout(2000);
+            return await page
+              .getByRole('row')
+              .filter({ hasText: SERVICE_NAME })
+              .count();
+          },
+          {
+            message: `Waiting for service "${SERVICE_NAME}" to be removed`,
+            timeout: 60_000,
+            intervals: [5_000],
+          },
+        )
+        .toBe(0);
+    });
+  },
+);

--- a/e2e/utils/cleanup-util.ts
+++ b/e2e/utils/cleanup-util.ts
@@ -1,0 +1,139 @@
+/**
+ * Reusable cleanup utilities for e2e tests.
+ * Sweep-deletes services and vfolders matching e2e naming patterns.
+ */
+import { navigateTo } from './test-util';
+import { Page } from '@playwright/test';
+
+/**
+ * Locates the BAIFetchKeyButton (refresh/reload button) by the ReloadOutlined icon.
+ */
+function getTableRefreshButton(page: Page) {
+  return page
+    .locator('button')
+    .filter({ has: page.locator('.anticon-reload') })
+    .first();
+}
+
+/**
+ * Deletes all services matching the given pattern from the serving page.
+ * Uses the table refresh button + delete icon button + Ant Design confirm modal.
+ */
+export async function sweepServices(
+  page: Page,
+  pattern: RegExp = /e2e-svc-/i,
+  maxIterations = 20,
+): Promise<number> {
+  await navigateTo(page, 'serving');
+
+  const refreshButton = getTableRefreshButton(page);
+  let deleted = 0;
+
+  while (deleted < maxIterations) {
+    if (await refreshButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await refreshButton.click();
+      await page.waitForTimeout(2000);
+    }
+
+    const serviceRow = page
+      .getByRole('row')
+      .filter({ hasText: pattern })
+      .first();
+    if ((await serviceRow.count()) === 0) break;
+
+    const deleteBtn = serviceRow
+      .getByRole('button', { name: 'delete' })
+      .first();
+    if (!(await deleteBtn.isVisible({ timeout: 3000 }).catch(() => false))) {
+      console.log('Service row found but no delete button, skipping');
+      break;
+    }
+    await deleteBtn.click();
+
+    const confirmBtn = page
+      .locator('.ant-modal-confirm')
+      .getByRole('button', { name: 'Delete' })
+      .first();
+    if (await confirmBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await confirmBtn.click();
+    }
+
+    await page.waitForTimeout(3000);
+    deleted++;
+  }
+
+  if (deleted > 0) {
+    console.log(`Swept ${deleted} service(s) matching ${pattern}`);
+  }
+  return deleted;
+}
+
+/**
+ * Trashes and permanently deletes all vfolders matching the given pattern.
+ * Step 1: Move matching folders to Trash from the active tab.
+ * Step 2: Delete them forever from the Trash tab.
+ */
+export async function sweepVFolders(
+  page: Page,
+  pattern: RegExp = /e2e-mod-/i,
+  maxIterations = 20,
+): Promise<number> {
+  await navigateTo(page, 'data');
+  let trashed = 0;
+
+  // Step 1: Move to trash
+  while (trashed < maxIterations) {
+    const modRow = page.getByRole('row').filter({ hasText: pattern }).first();
+    if ((await modRow.count()) === 0) break;
+
+    const trashBtn = modRow.getByRole('button', { name: 'trash bin' }).first();
+    if (!(await trashBtn.isVisible({ timeout: 3000 }).catch(() => false)))
+      break;
+    await trashBtn.click();
+
+    const moveBtn = page.getByRole('button', { name: 'Move' });
+    if (await moveBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await moveBtn.click();
+    }
+    await page.waitForTimeout(2000);
+    trashed++;
+  }
+
+  if (trashed === 0) return 0;
+
+  // Step 2: Delete forever from Trash
+  await navigateTo(page, 'data');
+  await page.getByRole('tab', { name: 'Trash' }).click();
+  await page.waitForTimeout(2000);
+
+  let deletedForever = 0;
+  while (deletedForever < maxIterations) {
+    const trashedRow = page
+      .getByRole('row')
+      .filter({ hasText: pattern })
+      .first();
+    if ((await trashedRow.count()) === 0) break;
+
+    // Extract folder name for the confirmation input
+    const rowText = (await trashedRow.textContent()) || '';
+    const nameMatch = rowText.match(new RegExp(pattern.source, 'i'));
+    // Try to get the full folder name (e.g. e2e-mod-a-abc123)
+    const fullMatch = rowText.match(/e2e-mod-[a-z]-[a-z0-9]+/i);
+    const folderName = fullMatch?.[0] || nameMatch?.[0];
+    if (!folderName) break;
+
+    await trashedRow.getByRole('button').nth(1).click();
+    const confirmInput = page.locator('#confirmText');
+    if (await confirmInput.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await confirmInput.fill(folderName);
+      await page.getByRole('button', { name: 'Delete forever' }).click();
+      await page.waitForTimeout(3000);
+    }
+    deletedForever++;
+  }
+
+  console.log(
+    `Swept ${trashed} vfolder(s) to trash, deleted ${deletedForever} forever`,
+  );
+  return deletedForever;
+}


### PR DESCRIPTION
Resolves #5938 (FR-2295)

## Summary

- Add integration E2E test for model service deploy lifecycle (vfolder creation → file upload → service deploy via ServiceLauncher UI → HEALTHY status → service termination → cleanup)
- Include mock OpenAI-compatible server (`mock_openai_server.py`) and model definition fixtures for realistic service deployment testing
- Remove chat-integration tests (endpoint proxy returns HTML instead of forwarding to container, making chat tests non-functional)
- Read default session image from `config.toml`'s `defaultSessionEnvironment` via `backendaiclient._config.default_session_environment` at runtime

### Test Structure (serial, `@integration @serving`)

1. **Admin can create a model vfolder and upload mock server files** — creates model-type vfolder, uploads `mock_openai_server.py`, `model-definition.yaml`, `service-definition.toml`
2. **Admin can deploy a model service via ServiceLauncher UI** — fills ServiceLauncher form and submits
3. **Deployed service reaches HEALTHY status** — polls serving table until HEALTHY badge appears (up to 5 min)
4. **Admin can terminate a deployed service** — deletes service and verifies removal

> **Note**: Mock-based chat E2E tests (sending messages, receiving streaming responses) are covered in PR #5933.

### Files

- `e2e/serving/serving-deploy-lifecycle.spec.ts` — main test file
- `e2e/serving/fixtures/mock_openai_server.py` — lightweight mock OpenAI server (stdlib only)
- `e2e/serving/fixtures/model-definition.yaml` — [Backend.AI](http://Backend.AI) model definition
- `e2e/utils/cleanup-util.ts` — reusable cleanup utilities for sweeping e2e services/vfolders
- Removed: `e2e/chat-integration/` (entire directory)

## How to Test

### Prerequisites

This is an **integration test** that requires a full [Backend.AI](http://Backend.AI) cluster running locally or accessible remotely.

1. **Running** [**Backend.AI**](http://Backend.AI) **cluster** with:
    - Manager, Agent, Webserver, and Storage Proxy all operational
    - At least one container image installed (the test reads `defaultSessionEnvironment` from `config.toml`)
    - Model service support enabled
2. **Environment setup**:

    Edit `e2e/envs/.env.playwright` with your cluster's values:
3. **`config.toml`** **must have** **`defaultSessionEnvironment`** **set** to a valid image that exists in your cluster. The `SessionLauncher` reads this value at runtime to select the default container image for session/service creation. Example:

### Running the tests

```bash
# Run only the serving deploy lifecycle tests
npx playwright test e2e/serving/ --reporter=list

# Run with specific tag
npx playwright test --grep "@serving" --reporter=list
```

### Expected results

- All 4 tests should pass sequentially (total ~6-8 min depending on cluster speed)
- The test automatically cleans up created vfolders and services after completion

## Test Recordings

<details>
<summary>1\. Admin can create a model vfolder and upload mock server files</summary>

![vfolder-upload](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/pr-5940/nd-upload-mock-server-files.gif)

</details>

<details>
<summary>2\. Admin can deploy a model service via ServiceLauncher UI</summary>

![service-deploy](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/pr-5940/vice-via-ServiceLauncher-UI.gif)

</details>

<details>
<summary>3\. Deployed service reaches HEALTHY status</summary>

![healthy-status](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/pr-5940/vice-reaches-HEALTHY-status.gif)

</details>

<details>
<summary>4\. Admin can terminate a deployed service</summary>

![terminate-service](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/pr-5940/erminate-a-deployed-service.gif)

</details>