### PR TITLE
chore: update E2E coverage report to 51% (163/319 features)

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-03-10
+> **Last Updated:** 2026-03-12
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -12,7 +12,7 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 160 / 319 features covered (50%)**
+**Overall (in-scope routes): 163 / 319 features covered (51%)**
 
 | Page | Route | Features | Covered | Status |
 |------|-------|:--------:|:-------:|:------:|
@@ -24,7 +24,7 @@
 | Serving | `/serving` | 7 | 0 | ❌ 0% |
 | Endpoint Detail | `/serving/:serviceId` | 20 | 9 | 🔶 45% |
 | Service Launcher | `/service/start` | 5 | 0 | ❌ 0% |
-| VFolder / Data | `/data` | 38 | 25 | 🔶 66% |
+| VFolder / Data | `/data` | 38 | 28 | 🔶 74% |
 | Model Store | `/model-store` | 6 | 0 | ❌ 0% |
 | Storage Host | `/storage-settings/:hostname` | 3 | 0 | ❌ 0% |
 | My Environment | `/my-environment` | 2 | 2 | ✅ 100% |
@@ -266,7 +266,7 @@
 
 ### 9. Data / VFolder (`/data`)
 
-**Test files:** [`e2e/vfolder/vfolder-crud.spec.ts`](vfolder/vfolder-crud.spec.ts), [`e2e/vfolder/vfolder-explorer-modal.spec.ts`](vfolder/vfolder-explorer-modal.spec.ts), [`e2e/vfolder/vfolder-consecutive-deletion.spec.ts`](vfolder/vfolder-consecutive-deletion.spec.ts), [`e2e/vfolder/file-upload.spec.ts`](vfolder/file-upload.spec.ts), [`e2e/vfolder/file-upload-dnd.spec.ts`](vfolder/file-upload-dnd.spec.ts), [`e2e/vfolder/file-upload-duplicate.spec.ts`](vfolder/file-upload-duplicate.spec.ts), [`e2e/vfolder/file-upload-permissions.spec.ts`](vfolder/file-upload-permissions.spec.ts), [`e2e/vfolder/file-upload-subdirectory.spec.ts`](vfolder/file-upload-subdirectory.spec.ts), [`e2e/vfolder/file-create.spec.ts`](vfolder/file-create.spec.ts)
+**Test files:** [`e2e/vfolder/vfolder-crud.spec.ts`](vfolder/vfolder-crud.spec.ts), [`e2e/vfolder/vfolder-explorer-modal.spec.ts`](vfolder/vfolder-explorer-modal.spec.ts), [`e2e/vfolder/vfolder-consecutive-deletion.spec.ts`](vfolder/vfolder-consecutive-deletion.spec.ts), [`e2e/vfolder/vfolder-type-selection.spec.ts`](vfolder/vfolder-type-selection.spec.ts), [`e2e/vfolder/file-upload.spec.ts`](vfolder/file-upload.spec.ts), [`e2e/vfolder/file-upload-dnd.spec.ts`](vfolder/file-upload-dnd.spec.ts), [`e2e/vfolder/file-upload-duplicate.spec.ts`](vfolder/file-upload-duplicate.spec.ts), [`e2e/vfolder/file-upload-permissions.spec.ts`](vfolder/file-upload-permissions.spec.ts), [`e2e/vfolder/file-upload-subdirectory.spec.ts`](vfolder/file-upload-subdirectory.spec.ts), [`e2e/vfolder/file-create.spec.ts`](vfolder/file-create.spec.ts)
 
 **Tabs:** Active | Deleted
 **Filter (Active tab):** all | general | pipeline | automount | model
@@ -285,6 +285,9 @@
 | Create R/W folder | ✅ | `User can create Read & Write vFolder` |
 | Create R/O folder | ✅ | `User can create Read Only vFolder` |
 | Create auto-mount folder | ✅ | `User can create Auto Mount vFolder` |
+| Create User-type folder (type selection) | ✅ | `User can create a User-type vfolder with default selection` |
+| Create Project-type folder (admin) | ✅ | `Admin can create a Project-type vfolder` |
+| Project radio disabled (model mode, non-model-store) | ✅ | `Project radio is disabled when usage mode is model` |
 | Delete / trash / restore / purge | ✅ | `User can create, delete(move to trash), restore, delete forever` |
 | Consecutive deletion | ✅ | `User can create and permanently delete multiple VFolders` |
 | Share folder → InviteFolderSettingModal | ✅ | `User can share vFolder` |
@@ -317,7 +320,7 @@
 | Shared folder permission → SharedFolderPermissionInfoModal | ❌ | - |
 | File download | ❌ | - |
 
-**Coverage: 🔶 25/38 features (includes 1 skipped)**
+**Coverage: 🔶 28/38 features (includes 1 skipped)**
 
 ---
 


### PR DESCRIPTION
Part of #5910 ([FR-2271](https://lablup.atlassian.net/browse/FR-2271))

## Summary
- Update E2E coverage report from 50% to 51% (163/319 features)
- Add vfolder type selection tests to VFolder coverage section

## Stack (FR-2271 E2E test fixes)
1. #5934 (login tests - FR-2271)
2. #5943 (environment BAIPropertyFilter - FR-2275)
3. #5944 (app-launcher - FR-2273)
4. #5945 (session-lifecycle - FR-2278)
5. **#5946** ← this PR (E2E coverage report update)

[FR-2271]: https://lablup.atlassian.net/browse/FR-2271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ