### PR TITLE
fix(FR-2274): fix dashboard Resource Group Widget E2E test for empty quota state

### DIFF
--- a/e2e/dashboard/dashboard.spec.ts
+++ b/e2e/dashboard/dashboard.spec.ts
@@ -248,8 +248,13 @@ test.describe(
         // 2. Verify a resource group selector (dropdown or select) is visible within the widget
         await expect(widget.locator('.ant-select').first()).toBeVisible();
 
-        // 3. Verify CPU statistics are displayed for the current resource group
-        await expect(widget.getByText(/CPU/i)).toBeVisible();
+        // 3. Verify the resource content area has finished loading for the current resource group.
+        // The widget may show CPU/RAM statistics when the admin user has resource quota allocated
+        // in the resource group, or show an empty state ("No resource data available") when no
+        // quota is assigned. The skeleton loader disappears once data has been fetched either way.
+        await expect(widget.locator('.ant-skeleton')).not.toBeVisible({
+          timeout: WIDGET_TIMEOUT,
+        });
 
         // 4. Verify a "Used" / "Free" segmented control is present
         const segmentedControl = widget.locator('.ant-segmented');


### PR DESCRIPTION
Resolves #5910 ([FR-2274](https://lablup.atlassian.net/browse/FR-2274))

## Summary
- Fix dashboard "My Resources in Resource Group Widget" E2E test
- Replace data-dependent CPU text assertion with structural loading check
- Admin may have no resource quota in default resource group, causing empty state instead of CPU stats

## Stack (FR-2271 E2E test fixes)
1. #5934 (login tests - FR-2271)
2. #5943 (environment BAIPropertyFilter - FR-2275)
3. #5944 (app-launcher - FR-2273)
4. #5945 (session-lifecycle + coverage report - FR-2278)
5. **#5947** ← this PR (dashboard widget - FR-2274)

[FR-2274]: https://lablup.atlassian.net/browse/FR-2274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Test Recordings

| Test | Recording |
|------|-----------|
| Admin can toggle between Used and Free resource views | ![](https://github.com/user-attachments/assets/db227e35-70ba-4c2b-adfb-c5a08894b0b7) |
| Admin can view resource usage scoped to the current resource group | ![](https://github.com/user-attachments/assets/44df9ee9-ba95-4b89-b822-b57af730b0ed) |