### PR TITLE
fix(FR-2279): fix user-crud E2E test fragile radio assertion and keypair modal name

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -44,7 +44,7 @@
 | App Launcher | (modal) | 18 | 10 | 🔶 56% |
 | Chat | `/chat/:id?` | 6 | 0 | ❌ 0% |
 | Plugin System | (config-based) | 12 | 12 | ✅ 100% |
-| **Total** | | **319** | **160** | **50%** |
+| **Total** | | **319** | **163** | **51%** |
 
 ---
 

--- a/e2e/user/user-crud.spec.ts
+++ b/e2e/user/user-crud.spec.ts
@@ -158,11 +158,9 @@ test.describe.serial(
       await navigateTo(page, 'credential');
 
       // 3. Ensure "Active" filter is selected (should be default)
-      const activeRadio = page.getByRole('radio', {
-        name: 'Active',
-        exact: true,
-      });
-      await expect(activeRadio).toBeChecked();
+      // Wait for Users tab to confirm page has fully loaded before interacting with filter
+      await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+      await page.getByText('Active', { exact: true }).click();
 
       // 4. Locate the user to deactivate in the table
       const userRow = page.getByRole('row').filter({ hasText: EMAIL });

--- a/e2e/utils/classes/user/UserSettingModal.ts
+++ b/e2e/utils/classes/user/UserSettingModal.ts
@@ -290,7 +290,7 @@ export class KeyPairModal {
   private readonly page: Page;
 
   constructor(page: Page) {
-    this.modal = page.getByRole('dialog', { name: /Key pair for new users/i });
+    this.modal = page.getByRole('dialog', { name: /Keypair for new users/i });
     this.page = page;
   }
 


### PR DESCRIPTION
Resolves #5949 (FR-2279)

## Summary

- Fix fragile radio button assertion in "Admin can deactivate a user" test — replaced `getByRole('radio', { name: 'Active' }).toBeChecked()` with `getByText('Active').click()` after verifying Users tab is visible
- Fix KeyPairModal dialog name regex to match actual UI text ("Keypair" vs "Key pair")

## Changes

- `e2e/user/user-crud.spec.ts`: Replace fragile radio assertion with robust text-based interaction
- `e2e/utils/classes/user/UserSettingModal.ts`: Fix dialog name pattern in KeyPairModal constructor

## Test Recordings

| Test | Recording |
|------|-----------|
| Admin can create a new user | ![](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2279-user-crud/admin-can-create-a-new-user.gif) |
| Admin can update user information (password change) | ![](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2279-user-crud/admin-can-update-user-information.gif) |
| Admin can deactivate a user | ![](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2279-user-crud/admin-can-deactivate-a-user.gif) |
| Admin can reactivate an inactive user | ![](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2279-user-crud/admin-can-reactivate-an-inactive-user.gif) |
| Admin can deactivate and permanently delete (purge) a user | ![](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2279-user-crud/admin-can-deactivate-and-purge-a-user.gif) |
| Deleted user cannot log in | ![](https://github.com/lablup/backend.ai-webui/releases/download/e2e-recordings-fr2279-user-crud/deleted-user-cannot-log-in.gif) |