### PR TITLE
chore(FR-2296): add playwright-video.config.ts for e2e GIF recording workflow

### DIFF
--- a/e2e/VIDEO-RECORDING.md
+++ b/e2e/VIDEO-RECORDING.md
@@ -1,0 +1,76 @@
+# E2E Test Video Recording
+
+## Overview
+
+`playwright-video.config.ts` extends the base Playwright config to enable video recording for E2E tests. This is used to capture test runs as videos, which can then be converted to GIFs for PR documentation.
+
+## Configuration
+
+| Setting | Value | Description |
+|---------|-------|-------------|
+| `video` | `retain-on-failure` (default) | Records video only for failed tests |
+| `video` | `on` (with `PLAYWRIGHT_VIDEO=on`) | Records video for all tests |
+| `workers` | `1` | Single worker for deterministic, sequential recordings |
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLAYWRIGHT_VIDEO` | (unset) | Set to `on` to record all tests. Otherwise only failed tests are recorded. |
+
+## Usage
+
+### Record all tests with video
+
+```bash
+PLAYWRIGHT_VIDEO=on pnpm exec playwright test --config=playwright-video.config.ts
+```
+
+### Record specific test file
+
+```bash
+PLAYWRIGHT_VIDEO=on pnpm exec playwright test e2e/auth/login.spec.ts --config=playwright-video.config.ts
+```
+
+### Record only failed tests (default)
+
+```bash
+pnpm exec playwright test --config=playwright-video.config.ts
+```
+
+## Output Directory
+
+Videos are saved by Playwright to the `test-results/` directory:
+
+```
+test-results/
+├── auth-login-User-can-login-with-valid-credentials-chromium/
+│   └── video.webm
+├── auth-login-User-sees-error-on-invalid-password-chromium/
+│   └── video.webm
+└── ...
+```
+
+Each test gets its own subdirectory named as `{spec-dir}-{describe}-{test-name}-{project}/`.
+
+## Converting to GIF
+
+Use `ffmpeg` to convert `.webm` videos to optimized GIFs:
+
+```bash
+ffmpeg -y -i input.webm \
+  -vf "fps=8,scale=960:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer" \
+  -loop 0 output.gif
+```
+
+For large GIFs (>10MB), reduce quality:
+
+```bash
+ffmpeg -y -i input.webm \
+  -vf "fps=5,scale=720:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer" \
+  -loop 0 output.gif
+```
+
+## Integration with `/e2e-test record`
+
+The `/e2e-test record` command automatically uses this config to record tests and attach GIFs to PRs. See the [e2e-test command documentation](https://github.com/lablup/claude-mp) for details.

--- a/playwright-video.config.ts
+++ b/playwright-video.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+import baseConfig from './playwright.config';
+
+export default defineConfig({
+  ...baseConfig,
+  use: {
+    ...baseConfig.use,
+    video: process.env.PLAYWRIGHT_VIDEO === 'on' ? 'on' : 'retain-on-failure',
+  },
+  workers: 1,
+});


### PR DESCRIPTION
Resolves FR-2296

## Summary
- Add `playwright-video.config.ts` for e2e test GIF recording workflow
- Extends the base Playwright config with env-gated video recording (`retain-on-failure` by default, `on` when `PLAYWRIGHT_VIDEO=on`) and `workers: 1`
- Add `e2e/VIDEO-RECORDING.md` with configuration details, usage examples, and output directory explanation

## Usage

```bash
# 1. Run e2e tests with video recording (all tests)
PLAYWRIGHT_VIDEO=on pnpm exec playwright test e2e/agent/active-agents.spec.ts --config=playwright-video.config.ts --reporter=list

# 2. Run with default (record only failed tests)
pnpm exec playwright test --config=playwright-video.config.ts

# 3. Convert recorded .webm to GIF (per test)
/opt/homebrew/bin/ffmpeg -y -i test-results/*/video.webm \
  -vf "fps=8,scale=960:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer" \
  -loop 0 output.gif

# 4. Upload GIFs to PR body via GitHub CDN (drag-drop or Playwright MCP)
```

## Benefits

- **Improved PR review quality**: Reviewers can instantly see actual UI behavior as inline GIF animations without running the app locally
- **No separate environment required**: Reviewers can understand UI flows directly from the PR description
- **Visual regression detection**: Compare GIF recordings across PRs to spot unintended UI changes
- **Zero repo size impact**: GIFs are uploaded to GitHub CDN and embedded in PR body — never committed to git

## File Size Comparison

| Format | Per test | Inline rendering in PR |
|--------|----------|----------------------|
| WebM (raw) | 188~360KB | Not supported (download link only) |
| GIF (converted) | 912KB~2.3MB | Auto-plays inline |

GIF is ~5x larger but renders inline in PR descriptions, making it the preferred format for visual review.