### PR TITLE
fix: fix registry delete cancel E2E test strict mode violation

### DIFF
--- a/e2e/environment/registry.spec.ts
+++ b/e2e/environment/registry.spec.ts
@@ -551,10 +551,11 @@ test.describe(
       await confirmDialog.getByRole('button', { name: 'Cancel' }).click();
       await expect(confirmDialog).toBeHidden();
 
-      // Registry row is still present
+      // Registry row is still present (use first() since multiple rows may share the same registry name)
       const rowAfterCancel = page
         .locator('.ant-table-tbody .ant-table-row')
-        .filter({ hasText: registryName! });
+        .filter({ hasText: registryName! })
+        .first();
       await expect(rowAfterCancel).toBeVisible();
     });
 


### PR DESCRIPTION
Resolves #5954

## Summary
- Fix registry delete cancel E2E test failing due to Playwright strict mode violation
- `filter({ hasText: registryName })` matched multiple table rows sharing the same registry name (e.g., `cr.backend.ai`)
- Added `.first()` after the filter to verify at least one matching row remains visible after canceling deletion