### PR TITLE
fix(FR-2297): pass local session ID instead of global ID in route node click handler

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteNodes.tsx
@@ -134,7 +134,7 @@ const BAIRouteNodes = ({
               <BAILink
                 ellipsis
                 onClick={() => {
-                  onClickSessionId(sessionId);
+                  onClickSessionId(toLocalId(sessionId));
                 }}
               >
                 {toLocalId(sessionId)}


### PR DESCRIPTION
Resolves #5953 ([FR-2297](https://lablup.atlassian.net/browse/FR-2297))

## Summary
- Fix double base64 encoding of session ID when clicking session link in route nodes
- `onClickSessionId` was receiving the Relay global ID (already base64-encoded) instead of the local UUID, causing the downstream code to encode it again
- Apply `toLocalId()` to extract the UUID before passing it to the click handler

## Test plan
- [ ] Navigate to a route info page with session links
- [ ] Click on a session ID link
- [ ] Verify the session detail drawer/page opens correctly with the right session

[FR-2297]: https://lablup.atlassian.net/browse/FR-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ