### PR TITLE
fix: fix session-scheduling-history-modal E2E test strict mode violation

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-03-10
+> **Last Updated:** 2026-03-13
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -1019,3 +1019,12 @@ When adding new E2E tests:
 4. Update the "Coverage Matrix" quick reference
 5. Remove completed items from "Priority Recommendations"
 6. Update the "Last Updated" date at the top
+
+---
+
+## Changelog
+
+| Date | Change |
+| ---------- | ------ |
+| 2026-03-13 | Fix strict mode violation in `session-scheduling-history-modal.spec.ts`: scope history button locator to Session Info drawer with `exact: true` to avoid matching React Grab toolbar buttons |
+| 2026-03-10 | Initial report creation |

--- a/e2e/session/session-scheduling-history-modal.spec.ts
+++ b/e2e/session/session-scheduling-history-modal.spec.ts
@@ -83,7 +83,13 @@ test.describe(
      * Returns the modal locator.
      */
     async function openSchedulingHistoryModal(page: Page) {
-      const historyButton = page.getByRole('button', { name: 'history' });
+      // Scope to the Session Info drawer to avoid strict mode violation with the
+      // React Grab toolbar buttons ("Open history", "Copy all history items").
+      const drawer = page.getByRole('dialog', { name: 'Session Info' });
+      const historyButton = drawer.getByRole('button', {
+        name: 'history',
+        exact: true,
+      });
       await expect(historyButton).toBeVisible({ timeout: 5000 });
       await historyButton.click();
       const modal = page.getByRole('dialog', {
@@ -107,8 +113,13 @@ test.describe(
       const statusRow = page.getByRole('row', { name: /Status/ });
       await expect(statusRow).toBeVisible();
 
-      // 3. Verify the "history" button (HistoryOutlined icon) is visible next to the status tag
-      const historyButton = page.getByRole('button', { name: 'history' });
+      // 3. Verify the "history" button (HistoryOutlined icon) is visible next to the status tag.
+      // Scope to the drawer to avoid strict mode violation with React Grab toolbar buttons.
+      const drawer = page.getByRole('dialog', { name: 'Session Info' });
+      const historyButton = drawer.getByRole('button', {
+        name: 'history',
+        exact: true,
+      });
       await expect(historyButton).toBeVisible();
     });
 


### PR DESCRIPTION
Resolves #5959

## Summary
- Fix Playwright strict mode violation in all 19 `session-scheduling-history-modal.spec.ts` tests
- Scope `history` button locator to the `Session Info` drawer and add `exact: true` to avoid matching React Grab toolbar buttons (`Open history`, `Copy all history items`)
- Update E2E_COVERAGE_REPORT.md with changelog entry