### PR TITLE
chore(FR-2298): update Jira tool references from fw-jira to jira-workflow skill

### DIFF
--- a/.jira.config
+++ b/.jira.config
@@ -1,15 +1,15 @@
 # Jira project configuration for Backend.AI WebUI
-# Used by the `fw-jira` CLI (fw plugin)
+# Read by the jira-workflow skill (fw plugin)
 
 JIRA_SITE="lablup.atlassian.net"
 JIRA_PROJECT="FR"
 
-# Custom fields applied to every new issue
-# Format: JSON object mapping field IDs to values
+# Custom fields auto-applied to every new issue
+# customfield_10173 = GitHub Repository (id:10232 = lablup/webui)
 JIRA_CUSTOM_FIELDS='{"customfield_10173":{"id":"10232"}}'
 
-# Team member nickname → accountId mapping
-# Usage: fw-jira update FR-XXXX --assignee jongeun
+# Team member nickname → Atlassian accountId mapping
+# Usage (via jira-workflow skill): jira update FR-XXXX --assignee jongeun
 JIRA_TEAM_MEMBERS='{
   "종은":"63240f6729083bbe8cc4d07d",
   "jongeun":"63240f6729083bbe8cc4d07d",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ Production build (`pnpm run build`) runs these steps sequentially:
   - GitHub PR content starts with `Resolves #1234(FR-1234)` where #1234 is the cloned issue number and FR-1234 is the Jira issue number
 
 - **Tool Requirements**:
-  - **Jira**: Use `fw-jira` CLI (fw plugin). See `jira-workflow` skill for full usage. Project config in `.jira.config`.
+  - **Jira**: Use `jira-workflow` skill (fw plugin). Project config in `.jira.config`.
   - **GitHub**: Use `gh` CLI (preferred) or GitHub MCP (`mcp__github__*`)
   - **Git/PR**: Use Graphite MCP (`mcp__graphite__run_gt_cmd`) for branch/commit/push
     - Do NOT use `git commit`, `git push`, `git checkout -b` directly


### PR DESCRIPTION
Resolves #5961(FR-2298)

## Summary
- Update `.jira.config` comments to reference `jira-workflow` skill instead of `fw-jira` CLI
- Update `AGENTS.md` tool requirements section with correct Jira tool name

## Test plan
- [ ] Verify `.jira.config` comments are accurate
- [ ] Verify `AGENTS.md` references match current tooling