### PR TITLE
feat(FR-2300): add category field to DiagnosticResult type

### DIFF
--- a/react/src/diagnostics/rules/__tests__/configRules.test.ts
+++ b/react/src/diagnostics/rules/__tests__/configRules.test.ts
@@ -39,6 +39,7 @@ describe('checkBlocklistValidity', () => {
     );
     expect(result).not.toBeNull();
     expect(result?.severity).toBe('warning');
+    expect(result?.category).toBe('config');
     expect(result?.id).toBe('config-invalid-blocklist');
     expect(result?.interpolationValues?.entries).toBe(
       'nonexistent-menu, another-bad',

--- a/react/src/diagnostics/rules/__tests__/cspRules.test.ts
+++ b/react/src/diagnostics/rules/__tests__/cspRules.test.ts
@@ -76,6 +76,7 @@ describe('checkCspConnectSrc', () => {
     expect(result).not.toBeNull();
     expect(result?.id).toBe('csp-connect-src-api');
     expect(result?.severity).toBe('critical');
+    expect(result?.category).toBe('csp');
     expect(result?.interpolationValues?.endpoint).toBe(
       'https://api.example.com',
     );
@@ -175,6 +176,7 @@ describe('checkCspWsConnectSrc', () => {
     expect(result).not.toBeNull();
     expect(result?.id).toBe('csp-connect-src-ws');
     expect(result?.severity).toBe('critical');
+    expect(result?.category).toBe('csp');
   });
 
   it('should return null for invalid proxy URL', () => {
@@ -254,6 +256,7 @@ describe('checkCspScriptSrc', () => {
     expect(result).not.toBeNull();
     expect(result?.id).toBe('csp-script-src-blocked');
     expect(result?.severity).toBe('critical');
+    expect(result?.category).toBe('csp');
   });
 
   it('should accept nonce-based policies as allowing scripts', () => {
@@ -296,6 +299,7 @@ describe('checkCspStyleSrc', () => {
     expect(result).not.toBeNull();
     expect(result?.id).toBe('csp-style-src-no-inline');
     expect(result?.severity).toBe('warning');
+    expect(result?.category).toBe('csp');
   });
 
   it('should accept nonce-based policies as allowing inline styles', () => {

--- a/react/src/diagnostics/rules/__tests__/endpointRules.test.ts
+++ b/react/src/diagnostics/rules/__tests__/endpointRules.test.ts
@@ -30,6 +30,7 @@ describe('checkSslMismatch', () => {
     );
     expect(result).not.toBeNull();
     expect(result?.severity).toBe('warning');
+    expect(result?.category).toBe('endpoint');
     expect(result?.id).toBe('ssl-mismatch');
   });
 
@@ -69,6 +70,7 @@ describe('checkEndpointReachability', () => {
     );
     expect(result).not.toBeNull();
     expect(result?.severity).toBe('critical');
+    expect(result?.category).toBe('endpoint');
     expect(result?.id).toBe('endpoint-unreachable');
     expect(result?.interpolationValues?.error).toBe('Connection refused');
   });

--- a/react/src/diagnostics/rules/__tests__/storageProxyRules.test.ts
+++ b/react/src/diagnostics/rules/__tests__/storageProxyRules.test.ts
@@ -30,6 +30,7 @@ describe('checkStorageVolumeHealth', () => {
     const result = checkStorageVolumeHealth(volume);
     expect(result).not.toBeNull();
     expect(result?.severity).toBe('warning');
+    expect(result?.category).toBe('storage');
     expect(result?.interpolationValues?.percentage).toBe('95');
   });
 

--- a/react/src/diagnostics/rules/configRules.ts
+++ b/react/src/diagnostics/rules/configRules.ts
@@ -45,6 +45,7 @@ export function checkPlaceholderValues(
         results.push({
           id: `config-placeholder-${section}-${field}`,
           severity: 'warning',
+          category: 'config',
           titleKey: 'diagnostics.PlaceholderValue',
           descriptionKey: 'diagnostics.PlaceholderValueDesc',
           remediationKey: 'diagnostics.PlaceholderValueFix',
@@ -84,6 +85,7 @@ export function checkBlocklistValidity(
     return {
       id: 'config-invalid-blocklist',
       severity: 'warning',
+      category: 'config',
       titleKey: 'diagnostics.InvalidBlocklistEntries',
       descriptionKey: 'diagnostics.InvalidBlocklistEntriesDesc',
       remediationKey: 'diagnostics.InvalidBlocklistEntriesFix',
@@ -122,6 +124,7 @@ export function checkConnectionMode(
     results.push({
       id: 'config-invalid-connection-mode',
       severity: 'warning',
+      category: 'config',
       titleKey: 'diagnostics.InvalidConnectionMode',
       descriptionKey: 'diagnostics.InvalidConnectionModeDesc',
       remediationKey: 'diagnostics.InvalidConnectionModeFix',
@@ -142,6 +145,7 @@ export function checkConnectionMode(
       results.push({
         id: 'config-connection-mode-mismatch',
         severity: 'warning',
+        category: 'config',
         titleKey: 'diagnostics.ConnectionModeMismatch',
         descriptionKey: 'diagnostics.ConnectionModeMismatchDesc',
         remediationKey: 'diagnostics.ConnectionModeMismatchFix',
@@ -209,6 +213,7 @@ export function checkUrlFields(rawConfig: Record<string, unknown>): {
       issues.push({
         id: `config-invalid-url-${section}-${field}`,
         severity: 'warning',
+        category: 'config',
         titleKey: 'diagnostics.InvalidConfigUrl',
         descriptionKey: 'diagnostics.InvalidConfigUrlDesc',
         remediationKey: 'diagnostics.InvalidConfigUrlFix',
@@ -374,6 +379,7 @@ function checkNumericRanges(
       results.push({
         id: `config-${section}-${range.field}`,
         severity: 'warning',
+        category: 'config',
         titleKey: 'diagnostics.ResourceLimitOutOfRange',
         descriptionKey: 'diagnostics.ResourceLimitOutOfRangeDesc',
         remediationKey: 'diagnostics.ResourceLimitOutOfRangeFix',
@@ -425,6 +431,7 @@ export function checkImageReferences(
       results.push({
         id: `config-invalid-image-ref-${field}`,
         severity: 'warning',
+        category: 'config',
         titleKey: 'diagnostics.InvalidImageReference',
         descriptionKey: 'diagnostics.InvalidImageReferenceDesc',
         remediationKey: 'diagnostics.InvalidImageReferenceFix',
@@ -472,6 +479,7 @@ export function checkPluginConfiguration(
       results.push({
         id: 'config-invalid-plugin-names',
         severity: 'warning',
+        category: 'config',
         titleKey: 'diagnostics.InvalidPluginNames',
         descriptionKey: 'diagnostics.InvalidPluginNamesDesc',
         remediationKey: 'diagnostics.InvalidPluginNamesFix',
@@ -498,6 +506,7 @@ export function checkPluginConfiguration(
       results.push({
         id: `config-invalid-plugin-${key}`,
         severity: 'warning',
+        category: 'config',
         titleKey: 'diagnostics.InvalidPluginFilename',
         descriptionKey: 'diagnostics.InvalidPluginFilenameDesc',
         remediationKey: 'diagnostics.InvalidPluginFilenameFix',

--- a/react/src/diagnostics/rules/cspRules.ts
+++ b/react/src/diagnostics/rules/cspRules.ts
@@ -139,6 +139,7 @@ export function checkCspConnectSrc(
     return {
       id: 'csp-connect-src-api',
       severity: 'critical',
+      category: 'csp',
       titleKey: 'diagnostics.CspApiEndpointBlocked',
       descriptionKey: 'diagnostics.CspApiEndpointBlockedDesc',
       remediationKey: 'diagnostics.CspApiEndpointBlockedFix',
@@ -179,6 +180,7 @@ export function checkCspWsConnectSrc(
     return {
       id: 'csp-connect-src-ws',
       severity: 'critical',
+      category: 'csp',
       titleKey: 'diagnostics.CspWsProxyBlocked',
       descriptionKey: 'diagnostics.CspWsProxyBlockedDesc',
       remediationKey: 'diagnostics.CspWsProxyBlockedFix',
@@ -216,6 +218,7 @@ export function checkCspScriptSrc(
     return {
       id: 'csp-script-src-blocked',
       severity: 'critical',
+      category: 'csp',
       titleKey: 'diagnostics.CspScriptSrcBlocked',
       descriptionKey: 'diagnostics.CspScriptSrcBlockedDesc',
       remediationKey: 'diagnostics.CspScriptSrcBlockedFix',
@@ -252,6 +255,7 @@ export function checkCspStyleSrc(
     return {
       id: 'csp-style-src-no-inline',
       severity: 'warning',
+      category: 'csp',
       titleKey: 'diagnostics.CspStyleSrcNoInline',
       descriptionKey: 'diagnostics.CspStyleSrcNoInlineDesc',
       remediationKey: 'diagnostics.CspStyleSrcNoInlineFix',

--- a/react/src/diagnostics/rules/endpointRules.ts
+++ b/react/src/diagnostics/rules/endpointRules.ts
@@ -36,6 +36,7 @@ export function checkSslMismatch(
     return {
       id: 'ssl-mismatch',
       severity: 'warning',
+      category: 'endpoint',
       titleKey: 'diagnostics.SslMismatch',
       descriptionKey: 'diagnostics.SslMismatchDesc',
       remediationKey: 'diagnostics.SslMismatchFix',
@@ -64,6 +65,7 @@ export function checkEndpointReachability(
     return {
       id: 'endpoint-unreachable',
       severity: 'critical',
+      category: 'endpoint',
       titleKey: 'diagnostics.EndpointUnreachable',
       descriptionKey: 'diagnostics.EndpointUnreachableDesc',
       remediationKey: 'diagnostics.EndpointUnreachableFix',

--- a/react/src/diagnostics/rules/storageProxyRules.ts
+++ b/react/src/diagnostics/rules/storageProxyRules.ts
@@ -35,6 +35,7 @@ export function checkStorageVolumeHealth(
     return {
       id: `storage-volume-health-${volume.id}`,
       severity: 'warning',
+      category: 'storage',
       titleKey: 'diagnostics.StorageVolumeHighUsage',
       descriptionKey: 'diagnostics.StorageVolumeHighUsageDesc',
       remediationKey: 'diagnostics.StorageVolumeHighUsageFix',

--- a/react/src/hooks/useCspDiagnostics.ts
+++ b/react/src/hooks/useCspDiagnostics.ts
@@ -37,6 +37,7 @@ export function useCspDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'csp-not-set',
         severity: 'passed',
+        category: 'csp',
         titleKey: 'diagnostics.CspNotSet',
         descriptionKey: 'diagnostics.CspNotSetDesc',
       });
@@ -54,6 +55,7 @@ export function useCspDiagnostics(): DiagnosticResult[] {
         results.push({
           id: 'csp-connect-src-api-passed',
           severity: 'passed',
+          category: 'csp',
           titleKey: 'diagnostics.CspApiEndpointAllowed',
           descriptionKey: 'diagnostics.CspApiEndpointAllowedDesc',
           interpolationValues: { endpoint: apiEndpoint },
@@ -70,6 +72,7 @@ export function useCspDiagnostics(): DiagnosticResult[] {
         results.push({
           id: 'csp-connect-src-ws-passed',
           severity: 'passed',
+          category: 'csp',
           titleKey: 'diagnostics.CspWsProxyAllowed',
           descriptionKey: 'diagnostics.CspWsProxyAllowedDesc',
           interpolationValues: { proxyUrl },
@@ -85,6 +88,7 @@ export function useCspDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'csp-script-src-passed',
         severity: 'passed',
+        category: 'csp',
         titleKey: 'diagnostics.CspScriptSrcPassed',
         descriptionKey: 'diagnostics.CspScriptSrcPassedDesc',
       });
@@ -98,6 +102,7 @@ export function useCspDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'csp-style-src-passed',
         severity: 'passed',
+        category: 'csp',
         titleKey: 'diagnostics.CspStyleSrcPassed',
         descriptionKey: 'diagnostics.CspStyleSrcPassedDesc',
       });

--- a/react/src/hooks/useEndpointDiagnostics.ts
+++ b/react/src/hooks/useEndpointDiagnostics.ts
@@ -65,6 +65,7 @@ export function useEndpointDiagnostics(): {
         diagnostics.push({
           id: 'endpoint-reachable-passed',
           severity: 'passed',
+          category: 'endpoint',
           titleKey: 'diagnostics.EndpointReachable',
           descriptionKey: 'diagnostics.EndpointReachableDesc',
           interpolationValues: { endpoint: apiEndpoint },

--- a/react/src/hooks/useStorageProxyDiagnostics.ts
+++ b/react/src/hooks/useStorageProxyDiagnostics.ts
@@ -41,6 +41,7 @@ export function useStorageProxyDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'storage-no-volumes',
         severity: 'passed',
+        category: 'storage',
         titleKey: 'diagnostics.StorageNoVolumes',
         descriptionKey: 'diagnostics.StorageNoVolumesDesc',
       });
@@ -87,6 +88,7 @@ export function useStorageProxyDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'storage-health-passed',
         severity: 'passed',
+        category: 'storage',
         titleKey: 'diagnostics.StorageHealthPassed',
         descriptionKey: 'diagnostics.StorageHealthPassedDesc',
         interpolationValues: { count: String(items.length) },

--- a/react/src/hooks/useWebServerConfigDiagnostics.ts
+++ b/react/src/hooks/useWebServerConfigDiagnostics.ts
@@ -49,6 +49,7 @@ export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
       results.push({
         ...sslCheck,
         id: 'config-ssl-mismatch',
+        category: 'config',
         titleKey: 'diagnostics.ConfigSslMismatch',
         descriptionKey: 'diagnostics.ConfigSslMismatchDesc',
       });
@@ -56,6 +57,7 @@ export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'config-ssl-match-passed',
         severity: 'passed',
+        category: 'config',
         titleKey: 'diagnostics.ConfigSslMatchPassed',
         descriptionKey: 'diagnostics.ConfigSslMatchPassedDesc',
       });
@@ -67,6 +69,7 @@ export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'config-missing-proxy-url',
         severity: 'info',
+        category: 'config',
         titleKey: 'diagnostics.MissingProxyUrl',
         descriptionKey: 'diagnostics.MissingProxyUrlDesc',
       });
@@ -74,6 +77,7 @@ export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'config-proxy-url-passed',
         severity: 'passed',
+        category: 'config',
         titleKey: 'diagnostics.ProxyUrlConfigured',
         descriptionKey: 'diagnostics.ProxyUrlConfiguredDesc',
         interpolationValues: { proxyUrl },
@@ -88,6 +92,7 @@ export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'config-blocklist-valid',
         severity: 'passed',
+        category: 'config',
         titleKey: 'diagnostics.BlocklistValid',
         descriptionKey: 'diagnostics.BlocklistValidDesc',
         interpolationValues: { count: String(blockList.length) },
@@ -115,6 +120,7 @@ export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'config-connection-mode-consistent',
         severity: 'passed',
+        category: 'config',
         titleKey: 'diagnostics.ConnectionModeConsistent',
         descriptionKey: 'diagnostics.ConnectionModeConsistentDesc',
         interpolationValues: { connectionMode: connectionMode.toUpperCase() },
@@ -130,6 +136,7 @@ export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
         results.push({
           id: 'config-urls-valid',
           severity: 'passed',
+          category: 'config',
           titleKey: 'diagnostics.ConfigUrlsValid',
           descriptionKey: 'diagnostics.ConfigUrlsValidDesc',
         });
@@ -151,6 +158,7 @@ export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'config-resource-limits-passed',
         severity: 'passed',
+        category: 'config',
         titleKey: 'diagnostics.ResourceLimitsPassed',
         descriptionKey: 'diagnostics.ResourceLimitsPassedDesc',
       });
@@ -181,6 +189,7 @@ export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
         results.push({
           id: 'config-image-references-passed',
           severity: 'passed',
+          category: 'config',
           titleKey: 'diagnostics.ImageReferencesPassed',
           descriptionKey: 'diagnostics.ImageReferencesPassedDesc',
         });
@@ -205,6 +214,7 @@ export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
       results.push({
         id: 'config-plugin-valid',
         severity: 'passed',
+        category: 'config',
         titleKey: 'diagnostics.PluginConfigValid',
         descriptionKey: 'diagnostics.PluginConfigValidDesc',
         interpolationValues: { plugins: pluginNames },

--- a/react/src/types/diagnostics.ts
+++ b/react/src/types/diagnostics.ts
@@ -5,9 +5,12 @@
 
 export type DiagnosticSeverity = 'critical' | 'warning' | 'info' | 'passed';
 
+export type DiagnosticCategory = 'config' | 'csp' | 'endpoint' | 'storage';
+
 export interface DiagnosticResult {
   id: string;
   severity: DiagnosticSeverity;
+  category: DiagnosticCategory;
   titleKey: string;
   descriptionKey: string;
   remediationKey?: string;


### PR DESCRIPTION
Resolves #5966 (FR-2300)

## Summary
- Add `DiagnosticCategory` type (`'config' | 'csp' | 'endpoint' | 'storage'`) to the `DiagnosticResult` interface
- Populate `category` field across all diagnostic rule functions and hook inline results
- Update test assertions to verify the new `category` field

## Changed Files
- `react/src/types/diagnostics.ts` — add `DiagnosticCategory` type and `category` field
- `react/src/diagnostics/rules/configRules.ts` — add `category: 'config'`
- `react/src/diagnostics/rules/cspRules.ts` — add `category: 'csp'`
- `react/src/diagnostics/rules/endpointRules.ts` — add `category: 'endpoint'`
- `react/src/diagnostics/rules/storageProxyRules.ts` — add `category: 'storage'`
- `react/src/hooks/useCspDiagnostics.ts` — add category to inline results
- `react/src/hooks/useEndpointDiagnostics.ts` — add category to inline results
- `react/src/hooks/useStorageProxyDiagnostics.ts` — add category to inline results
- `react/src/hooks/useWebServerConfigDiagnostics.ts` — add category to inline results
- `react/src/diagnostics/rules/__tests__/*.test.ts` — assert category field