### PR TITLE
refactor(FR-2300): move checkSslMismatch to configRules

### DIFF
--- a/react/src/diagnostics/rules/__tests__/configRules.test.ts
+++ b/react/src/diagnostics/rules/__tests__/configRules.test.ts
@@ -2,7 +2,7 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { checkBlocklistValidity } from '../configRules';
+import { checkBlocklistValidity, checkSslMismatch } from '../configRules';
 import { describe, expect, it } from '@jest/globals';
 
 const validMenuKeys = [
@@ -20,6 +20,52 @@ const validMenuKeys = [
   'maintenance',
   'information',
 ];
+
+describe('checkSslMismatch', () => {
+  it('should return null when inputs are empty', () => {
+    expect(checkSslMismatch('', 'http://proxy.example.com')).toBeNull();
+    expect(checkSslMismatch('https://api.example.com', '')).toBeNull();
+  });
+
+  it('should return null when both use HTTPS', () => {
+    expect(
+      checkSslMismatch('https://api.example.com', 'https://proxy.example.com'),
+    ).toBeNull();
+  });
+
+  it('should return null when both use HTTP', () => {
+    expect(
+      checkSslMismatch('http://api.example.com', 'http://proxy.example.com'),
+    ).toBeNull();
+  });
+
+  it('should return warning when API is HTTPS but proxy is HTTP', () => {
+    const result = checkSslMismatch(
+      'https://api.example.com',
+      'http://proxy.example.com',
+    );
+    expect(result).not.toBeNull();
+    expect(result?.severity).toBe('warning');
+    expect(result?.category).toBe('config');
+    expect(result?.id).toBe('config-ssl-mismatch');
+  });
+
+  it('should return warning when API is HTTP but proxy is HTTPS', () => {
+    const result = checkSslMismatch(
+      'http://api.example.com',
+      'https://proxy.example.com',
+    );
+    expect(result).not.toBeNull();
+    expect(result?.severity).toBe('warning');
+  });
+
+  it('should return null for invalid URLs', () => {
+    expect(
+      checkSslMismatch('not-a-url', 'https://proxy.example.com'),
+    ).toBeNull();
+    expect(checkSslMismatch('https://api.example.com', 'not-a-url')).toBeNull();
+  });
+});
 
 describe('checkBlocklistValidity', () => {
   it('should return null when blocklist is empty', () => {

--- a/react/src/diagnostics/rules/__tests__/endpointRules.test.ts
+++ b/react/src/diagnostics/rules/__tests__/endpointRules.test.ts
@@ -2,54 +2,8 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { checkEndpointReachability, checkSslMismatch } from '../endpointRules';
+import { checkEndpointReachability } from '../endpointRules';
 import { describe, expect, it } from '@jest/globals';
-
-describe('checkSslMismatch', () => {
-  it('should return null when inputs are empty', () => {
-    expect(checkSslMismatch('', 'http://proxy.example.com')).toBeNull();
-    expect(checkSslMismatch('https://api.example.com', '')).toBeNull();
-  });
-
-  it('should return null when both use HTTPS', () => {
-    expect(
-      checkSslMismatch('https://api.example.com', 'https://proxy.example.com'),
-    ).toBeNull();
-  });
-
-  it('should return null when both use HTTP', () => {
-    expect(
-      checkSslMismatch('http://api.example.com', 'http://proxy.example.com'),
-    ).toBeNull();
-  });
-
-  it('should return warning when API is HTTPS but proxy is HTTP', () => {
-    const result = checkSslMismatch(
-      'https://api.example.com',
-      'http://proxy.example.com',
-    );
-    expect(result).not.toBeNull();
-    expect(result?.severity).toBe('warning');
-    expect(result?.category).toBe('endpoint');
-    expect(result?.id).toBe('ssl-mismatch');
-  });
-
-  it('should return warning when API is HTTP but proxy is HTTPS', () => {
-    const result = checkSslMismatch(
-      'http://api.example.com',
-      'https://proxy.example.com',
-    );
-    expect(result).not.toBeNull();
-    expect(result?.severity).toBe('warning');
-  });
-
-  it('should return null for invalid URLs', () => {
-    expect(
-      checkSslMismatch('not-a-url', 'https://proxy.example.com'),
-    ).toBeNull();
-    expect(checkSslMismatch('https://api.example.com', 'not-a-url')).toBeNull();
-  });
-});
 
 describe('checkEndpointReachability', () => {
   it('should return null when endpoint is empty', () => {

--- a/react/src/diagnostics/rules/configRules.ts
+++ b/react/src/diagnostics/rules/configRules.ts
@@ -63,6 +63,56 @@ export function checkPlaceholderValues(
 }
 
 // ---------------------------------------------------------------------------
+// SSL/TLS mismatch  (API endpoint vs proxy URL protocol)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check for SSL/TLS protocol mismatch between API endpoint and proxy URL.
+ * e.g., API endpoint uses HTTPS but proxy uses HTTP (or vice versa).
+ */
+export function checkSslMismatch(
+  apiEndpoint: string,
+  proxyUrl: string,
+): DiagnosticResult | null {
+  if (!apiEndpoint || !proxyUrl) return null;
+
+  let apiProtocol: string;
+  let proxyProtocol: string;
+
+  try {
+    apiProtocol = new URL(apiEndpoint).protocol;
+  } catch {
+    return null;
+  }
+
+  try {
+    proxyProtocol = new URL(proxyUrl).protocol;
+  } catch {
+    return null;
+  }
+
+  const apiIsSecure = apiProtocol === 'https:' || apiProtocol === 'wss:';
+  const proxyIsSecure = proxyProtocol === 'https:' || proxyProtocol === 'wss:';
+
+  if (apiIsSecure !== proxyIsSecure) {
+    return {
+      id: 'config-ssl-mismatch',
+      severity: 'warning',
+      category: 'config',
+      titleKey: 'diagnostics.SslMismatch',
+      descriptionKey: 'diagnostics.SslMismatchDesc',
+      remediationKey: 'diagnostics.SslMismatchFix',
+      interpolationValues: {
+        apiProtocol,
+        proxyProtocol,
+      },
+    };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Blocklist
 // ---------------------------------------------------------------------------
 

--- a/react/src/diagnostics/rules/endpointRules.ts
+++ b/react/src/diagnostics/rules/endpointRules.ts
@@ -5,52 +5,6 @@
 import type { DiagnosticResult } from '../../types/diagnostics';
 
 /**
- * Check for SSL/TLS protocol mismatch between API endpoint and proxy URL.
- * e.g., API endpoint uses HTTPS but proxy uses HTTP (or vice versa).
- */
-export function checkSslMismatch(
-  apiEndpoint: string,
-  proxyUrl: string,
-): DiagnosticResult | null {
-  if (!apiEndpoint || !proxyUrl) return null;
-
-  let apiProtocol: string;
-  let proxyProtocol: string;
-
-  try {
-    apiProtocol = new URL(apiEndpoint).protocol;
-  } catch {
-    return null;
-  }
-
-  try {
-    proxyProtocol = new URL(proxyUrl).protocol;
-  } catch {
-    return null;
-  }
-
-  const apiIsSecure = apiProtocol === 'https:' || apiProtocol === 'wss:';
-  const proxyIsSecure = proxyProtocol === 'https:' || proxyProtocol === 'wss:';
-
-  if (apiIsSecure !== proxyIsSecure) {
-    return {
-      id: 'ssl-mismatch',
-      severity: 'warning',
-      category: 'endpoint',
-      titleKey: 'diagnostics.SslMismatch',
-      descriptionKey: 'diagnostics.SslMismatchDesc',
-      remediationKey: 'diagnostics.SslMismatchFix',
-      interpolationValues: {
-        apiProtocol,
-        proxyProtocol,
-      },
-    };
-  }
-
-  return null;
-}
-
-/**
  * Check API endpoint reachability by inspecting a fetch result.
  * This is a pure function that evaluates a pre-fetched result.
  */

--- a/react/src/hooks/useWebServerConfigDiagnostics.ts
+++ b/react/src/hooks/useWebServerConfigDiagnostics.ts
@@ -11,10 +11,10 @@ import {
   checkPlaceholderValues,
   checkPluginConfiguration,
   checkResourceLimits,
+  checkSslMismatch,
   checkUrlFields,
   isPlaceholder,
 } from '../diagnostics/rules/configRules';
-import { checkSslMismatch } from '../diagnostics/rules/endpointRules';
 import type { DiagnosticResult } from '../types/diagnostics';
 import { useProxyUrl, useRawConfig } from './useWebUIConfig';
 import { VALID_MENU_KEYS } from './useWebUIMenuItems';
@@ -48,7 +48,6 @@ export function useWebServerConfigDiagnostics(): DiagnosticResult[] {
     if (sslCheck) {
       results.push({
         ...sslCheck,
-        id: 'config-ssl-mismatch',
         category: 'config',
         titleKey: 'diagnostics.ConfigSslMismatch',
         descriptionKey: 'diagnostics.ConfigSslMismatchDesc',


### PR DESCRIPTION
Resolves #5966 (FR-2300)

## Summary
- Move `checkSslMismatch` from `endpointRules.ts` to `configRules.ts` to better reflect its category as a config-level check
- Rename diagnostic id from `ssl-mismatch` to `config-ssl-mismatch` for consistency with the config category
- Update the diagnostic result category from `'endpoint'` to `'config'`
- Move corresponding tests from `endpointRules.test.ts` to `configRules.test.ts`
- Update import in `useWebServerConfigDiagnostics.ts` to reference the new location

## Changed Files
- `react/src/diagnostics/rules/configRules.ts` — added `checkSslMismatch` function
- `react/src/diagnostics/rules/endpointRules.ts` — removed `checkSslMismatch` function
- `react/src/diagnostics/rules/__tests__/configRules.test.ts` — added SSL mismatch tests
- `react/src/diagnostics/rules/__tests__/endpointRules.test.ts` — removed SSL mismatch tests
- `react/src/hooks/useWebServerConfigDiagnostics.ts` — updated import path