### PR TITLE
feat(FR-2300): add toggle to hide passed diagnostics results

### DIFF
--- a/react/src/components/CspDiagnosticsSection.tsx
+++ b/react/src/components/CspDiagnosticsSection.tsx
@@ -4,13 +4,27 @@
  */
 import { useCspDiagnostics } from '../hooks/useCspDiagnostics';
 import DiagnosticResultList from './DiagnosticResultList';
+import { useEffect } from 'react';
 
-const CspDiagnosticsSection: React.FC = () => {
+interface CspDiagnosticsSectionProps {
+  hidePassed?: boolean;
+  onHasIssues?: (hasIssues: boolean) => void;
+}
+
+const CspDiagnosticsSection: React.FC<CspDiagnosticsSectionProps> = ({
+  hidePassed = false,
+  onHasIssues,
+}) => {
   'use memo';
 
   const results = useCspDiagnostics();
+  const hasIssues = results.some((r) => r.severity !== 'passed');
 
-  return <DiagnosticResultList results={results} />;
+  useEffect(() => {
+    onHasIssues?.(hasIssues);
+  }, [hasIssues, onHasIssues]);
+
+  return <DiagnosticResultList results={results} hidePassed={hidePassed} />;
 };
 
 export default CspDiagnosticsSection;

--- a/react/src/components/DiagnosticResultList.tsx
+++ b/react/src/components/DiagnosticResultList.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 interface DiagnosticResultListProps {
   results: DiagnosticResult[];
   loading?: boolean;
+  hidePassed?: boolean;
 }
 
 const severityToAlertType = {
@@ -23,6 +24,7 @@ const severityToAlertType = {
 const DiagnosticResultList: React.FC<DiagnosticResultListProps> = ({
   results,
   loading = false,
+  hidePassed = false,
 }) => {
   'use memo';
 
@@ -35,7 +37,9 @@ const DiagnosticResultList: React.FC<DiagnosticResultListProps> = ({
 
   // Separate issues from passed checks for visual grouping
   const issues = results.filter((r) => r.severity !== 'passed');
-  const passed = results.filter((r) => r.severity === 'passed');
+  const passed = hidePassed
+    ? []
+    : results.filter((r) => r.severity === 'passed');
 
   return (
     <BAIFlex direction="column" align="stretch" gap="sm">

--- a/react/src/components/EndpointDiagnosticsSection.tsx
+++ b/react/src/components/EndpointDiagnosticsSection.tsx
@@ -4,13 +4,35 @@
  */
 import { useEndpointDiagnostics } from '../hooks/useEndpointDiagnostics';
 import DiagnosticResultList from './DiagnosticResultList';
+import { useEffect } from 'react';
 
-const EndpointDiagnosticsSection: React.FC = () => {
+interface EndpointDiagnosticsSectionProps {
+  hidePassed?: boolean;
+  onHasIssues?: (hasIssues: boolean) => void;
+}
+
+const EndpointDiagnosticsSection: React.FC<EndpointDiagnosticsSectionProps> = ({
+  hidePassed = false,
+  onHasIssues,
+}) => {
   'use memo';
 
   const { results, isLoading } = useEndpointDiagnostics();
+  const hasIssues = results.some((r) => r.severity !== 'passed');
 
-  return <DiagnosticResultList results={results} loading={isLoading} />;
+  useEffect(() => {
+    if (!isLoading) {
+      onHasIssues?.(hasIssues);
+    }
+  }, [hasIssues, isLoading, onHasIssues]);
+
+  return (
+    <DiagnosticResultList
+      results={results}
+      loading={isLoading}
+      hidePassed={hidePassed}
+    />
+  );
 };
 
 export default EndpointDiagnosticsSection;

--- a/react/src/components/StorageProxyDiagnosticsSection.tsx
+++ b/react/src/components/StorageProxyDiagnosticsSection.tsx
@@ -4,13 +4,26 @@
  */
 import { useStorageProxyDiagnostics } from '../hooks/useStorageProxyDiagnostics';
 import DiagnosticResultList from './DiagnosticResultList';
+import { useEffect } from 'react';
 
-const StorageProxyDiagnosticsSection: React.FC = () => {
+interface StorageProxyDiagnosticsSectionProps {
+  hidePassed?: boolean;
+  onHasIssues?: (hasIssues: boolean) => void;
+}
+
+const StorageProxyDiagnosticsSection: React.FC<
+  StorageProxyDiagnosticsSectionProps
+> = ({ hidePassed = false, onHasIssues }) => {
   'use memo';
 
   const results = useStorageProxyDiagnostics();
+  const hasIssues = results.some((r) => r.severity !== 'passed');
 
-  return <DiagnosticResultList results={results} />;
+  useEffect(() => {
+    onHasIssues?.(hasIssues);
+  }, [hasIssues, onHasIssues]);
+
+  return <DiagnosticResultList results={results} hidePassed={hidePassed} />;
 };
 
 export default StorageProxyDiagnosticsSection;

--- a/react/src/components/WebServerConfigDiagnosticsSection.tsx
+++ b/react/src/components/WebServerConfigDiagnosticsSection.tsx
@@ -4,13 +4,26 @@
  */
 import { useWebServerConfigDiagnostics } from '../hooks/useWebServerConfigDiagnostics';
 import DiagnosticResultList from './DiagnosticResultList';
+import { useEffect } from 'react';
 
-const WebServerConfigDiagnosticsSection: React.FC = () => {
+interface WebServerConfigDiagnosticsSectionProps {
+  hidePassed?: boolean;
+  onHasIssues?: (hasIssues: boolean) => void;
+}
+
+const WebServerConfigDiagnosticsSection: React.FC<
+  WebServerConfigDiagnosticsSectionProps
+> = ({ hidePassed = false, onHasIssues }) => {
   'use memo';
 
   const results = useWebServerConfigDiagnostics();
+  const hasIssues = results.some((r) => r.severity !== 'passed');
 
-  return <DiagnosticResultList results={results} />;
+  useEffect(() => {
+    onHasIssues?.(hasIssues);
+  }, [hasIssues, onHasIssues]);
+
+  return <DiagnosticResultList results={results} hidePassed={hidePassed} />;
 };
 
 export default WebServerConfigDiagnosticsSection;

--- a/react/src/pages/DiagnosticsPage.tsx
+++ b/react/src/pages/DiagnosticsPage.tsx
@@ -7,14 +7,15 @@ import EndpointDiagnosticsSection from '../components/EndpointDiagnosticsSection
 import StorageProxyDiagnosticsSection from '../components/StorageProxyDiagnosticsSection';
 import WebServerConfigDiagnosticsSection from '../components/WebServerConfigDiagnosticsSection';
 import { ReloadOutlined } from '@ant-design/icons';
-import { Collapse, Skeleton } from 'antd';
+import { Collapse, Skeleton, Switch, Typography } from 'antd';
 import { BAIButton, BAICard, BAIFlex } from 'backend.ai-ui';
-import { Suspense, useState, useTransition } from 'react';
+import { Suspense, useCallback, useMemo, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 import ErrorBoundaryWithNullFallback from 'src/components/ErrorBoundaryWithNullFallback';
 import { StringParam, useQueryParam, withDefault } from 'use-query-params';
 
 type TabKey = 'diagnostics';
+type SectionKey = 'csp' | 'storage' | 'endpoint' | 'config';
 
 const tabParam = withDefault(StringParam, 'diagnostics');
 
@@ -25,12 +26,97 @@ const DiagnosticsPage = () => {
   const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
   const [refreshKey, setRefreshKey] = useState(0);
   const [isPending, startTransition] = useTransition();
+  const [showOnlyFailed, setShowOnlyFailed] = useState(false);
+  const [sectionsWithIssues, setSectionsWithIssues] = useState<
+    Record<SectionKey, boolean>
+  >({
+    csp: true,
+    storage: true,
+    endpoint: true,
+    config: true,
+  });
 
   const handleRefresh = () => {
     startTransition(() => {
       setRefreshKey((prev) => prev + 1);
     });
   };
+
+  const createHasIssuesCallback = useCallback(
+    (key: SectionKey) => (hasIssues: boolean) => {
+      setSectionsWithIssues((prev) => {
+        if (prev[key] === hasIssues) return prev;
+        return { ...prev, [key]: hasIssues };
+      });
+    },
+    [],
+  );
+
+  const allItems = useMemo(
+    () => [
+      {
+        key: 'csp' as SectionKey,
+        label: t('diagnostics.ContentSecurityPolicy'),
+        children: (
+          <ErrorBoundaryWithNullFallback>
+            <Suspense fallback={<Skeleton active />}>
+              <CspDiagnosticsSection
+                hidePassed={showOnlyFailed}
+                onHasIssues={createHasIssuesCallback('csp')}
+              />
+            </Suspense>
+          </ErrorBoundaryWithNullFallback>
+        ),
+      },
+      {
+        key: 'storage' as SectionKey,
+        label: t('diagnostics.StorageProxy'),
+        children: (
+          <ErrorBoundaryWithNullFallback>
+            <Suspense fallback={<Skeleton active />}>
+              <StorageProxyDiagnosticsSection
+                hidePassed={showOnlyFailed}
+                onHasIssues={createHasIssuesCallback('storage')}
+              />
+            </Suspense>
+          </ErrorBoundaryWithNullFallback>
+        ),
+      },
+      {
+        key: 'endpoint' as SectionKey,
+        label: t('diagnostics.EndpointConnectivity'),
+        children: (
+          <ErrorBoundaryWithNullFallback>
+            <Suspense fallback={<Skeleton active />}>
+              <EndpointDiagnosticsSection
+                hidePassed={showOnlyFailed}
+                onHasIssues={createHasIssuesCallback('endpoint')}
+              />
+            </Suspense>
+          </ErrorBoundaryWithNullFallback>
+        ),
+      },
+      {
+        key: 'config' as SectionKey,
+        label: t('diagnostics.WebServerConfig'),
+        children: (
+          <ErrorBoundaryWithNullFallback>
+            <Suspense fallback={<Skeleton active />}>
+              <WebServerConfigDiagnosticsSection
+                hidePassed={showOnlyFailed}
+                onHasIssues={createHasIssuesCallback('config')}
+              />
+            </Suspense>
+          </ErrorBoundaryWithNullFallback>
+        ),
+      },
+    ],
+    [t, showOnlyFailed, createHasIssuesCallback],
+  );
+
+  const visibleItems = showOnlyFailed
+    ? allItems.filter((item) => sectionsWithIssues[item.key])
+    : allItems;
 
   return (
     <BAICard
@@ -43,13 +129,23 @@ const DiagnosticsPage = () => {
         },
       ]}
       tabBarExtraContent={
-        <BAIButton
-          icon={<ReloadOutlined spin={isPending} />}
-          onClick={handleRefresh}
-          loading={isPending}
-        >
-          {t('diagnostics.Refresh')}
-        </BAIButton>
+        <BAIFlex gap="sm" align="center">
+          <Switch
+            size="small"
+            checked={showOnlyFailed}
+            onChange={setShowOnlyFailed}
+          />
+          <Typography.Text>
+            {t('diagnostics.ShowOnlyFailedItems')}
+          </Typography.Text>
+          <BAIButton
+            icon={<ReloadOutlined spin={isPending} />}
+            onClick={handleRefresh}
+            loading={isPending}
+          >
+            {t('diagnostics.Refresh')}
+          </BAIButton>
+        </BAIFlex>
       }
     >
       {curTabKey === 'diagnostics' && (
@@ -57,52 +153,7 @@ const DiagnosticsPage = () => {
           <Collapse
             key={refreshKey}
             defaultActiveKey={['csp', 'storage', 'endpoint', 'config']}
-            items={[
-              {
-                key: 'csp',
-                label: t('diagnostics.ContentSecurityPolicy'),
-                children: (
-                  <ErrorBoundaryWithNullFallback>
-                    <Suspense fallback={<Skeleton active />}>
-                      <CspDiagnosticsSection />
-                    </Suspense>
-                  </ErrorBoundaryWithNullFallback>
-                ),
-              },
-              {
-                key: 'storage',
-                label: t('diagnostics.StorageProxy'),
-                children: (
-                  <ErrorBoundaryWithNullFallback>
-                    <Suspense fallback={<Skeleton active />}>
-                      <StorageProxyDiagnosticsSection />
-                    </Suspense>
-                  </ErrorBoundaryWithNullFallback>
-                ),
-              },
-              {
-                key: 'endpoint',
-                label: t('diagnostics.EndpointConnectivity'),
-                children: (
-                  <ErrorBoundaryWithNullFallback>
-                    <Suspense fallback={<Skeleton active />}>
-                      <EndpointDiagnosticsSection />
-                    </Suspense>
-                  </ErrorBoundaryWithNullFallback>
-                ),
-              },
-              {
-                key: 'config',
-                label: t('diagnostics.WebServerConfig'),
-                children: (
-                  <ErrorBoundaryWithNullFallback>
-                    <Suspense fallback={<Skeleton active />}>
-                      <WebServerConfigDiagnosticsSection />
-                    </Suspense>
-                  </ErrorBoundaryWithNullFallback>
-                ),
-              },
-            ]}
+            items={visibleItems}
           />
         </BAIFlex>
       )}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Überprüfen Sie den {{section}}-Abschnitt in config.toml und setzen Sie {{field}} auf einen Wert zwischen {{min}} und {{max}}.",
     "ResourceLimitsPassed": "Ressourcenlimits OK",
     "ResourceLimitsPassedDesc": "Alle Ressourcenlimit-Konfigurationen liegen innerhalb vernünftiger Bereiche.",
+    "ShowOnlyFailedItems": "Nur fehlgeschlagene Elemente anzeigen",
     "SslMismatch": "SSL-Protokoll-Inkongruenz",
     "SslMismatchDesc": "Das API-Endpunkt-Protokoll ({{apiProtocol}}) und das Proxy-URL-Protokoll ({{proxyProtocol}}) verwenden unterschiedliche SSL-Einstellungen.",
     "SslMismatchFix": "Stellen Sie sicher, dass beide Endpunkte dasselbe Protokoll verwenden (beide HTTPS oder beide HTTP).",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Ελέγξτε την ενότητα {{section}} στο config.toml και ορίστε το {{field}} σε τιμή μεταξύ {{min}} και {{max}}.",
     "ResourceLimitsPassed": "Όρια πόρων OK",
     "ResourceLimitsPassedDesc": "Όλες οι διαμορφώσεις ορίου πόρων είναι εντός λογικών εύρους.",
+    "ShowOnlyFailedItems": "Εμφάνιση μόνο αποτυχημένων",
     "SslMismatch": "Ασυμφωνία πρωτοκόλλου SSL",
     "SslMismatchDesc": "Το πρωτόκολλο του API endpoint ({{apiProtocol}}) και το πρωτόκολλο του proxy URL ({{proxyProtocol}}) χρησιμοποιούν διαφορετικές ρυθμίσεις SSL.",
     "SslMismatchFix": "Βεβαιωθείτε ότι και τα δύο endpoints χρησιμοποιούν το ίδιο πρωτόκολλο (και τα δύο HTTPS ή και τα δύο HTTP).",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -714,6 +714,7 @@
     "ResourceLimitOutOfRangeFix": "Review the {{section}} section in config.toml and set {{field}} to a value between {{min}} and {{max}}.",
     "ResourceLimitsPassed": "Resource Limits OK",
     "ResourceLimitsPassedDesc": "All resource limit configurations are within reasonable ranges.",
+    "ShowOnlyFailedItems": "Show only failed items",
     "StorageHealthPassed": "Storage Volume Usage OK",
     "StorageHealthPassedDesc": "All {{count}} volume(s) are within normal capacity.",
     "StorageNoVolumes": "No Storage Volumes",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Revise la sección {{section}} en config.toml y configure {{field}} con un valor entre {{min}} y {{max}}.",
     "ResourceLimitsPassed": "Límites de recursos OK",
     "ResourceLimitsPassedDesc": "Todas las configuraciones de límite de recursos están dentro de rangos razonables.",
+    "ShowOnlyFailedItems": "Mostrar solo los elementos fallidos",
     "SslMismatch": "Incompatibilidad de protocolo SSL",
     "SslMismatchDesc": "El protocolo del endpoint de API ({{apiProtocol}}) y el protocolo de la URL del proxy ({{proxyProtocol}}) utilizan configuraciones SSL diferentes.",
     "SslMismatchFix": "Asegúrese de que ambos endpoints utilicen el mismo protocolo (ambos HTTPS o ambos HTTP).",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Tarkista {{section}}-osio config.toml-tiedostossa ja aseta {{field}} arvoksi väliltä {{min}} ja {{max}}.",
     "ResourceLimitsPassed": "Resurssirajat OK",
     "ResourceLimitsPassedDesc": "Kaikki resurssirajakokoonpanot ovat kohtuullisissa rajoissa.",
+    "ShowOnlyFailedItems": "Näytä vain epäonnistuneet",
     "SslMismatch": "SSL-protokollan ristiriita",
     "SslMismatchDesc": "API-päätepisteen protokolla ({{apiProtocol}}) ja välityspalvelimen URL-protokolla ({{proxyProtocol}}) käyttävät eri SSL-asetuksia.",
     "SslMismatchFix": "Varmista, että molemmat päätepisteet käyttävät samaa protokollaa (molemmat HTTPS tai molemmat HTTP).",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Consultez la section {{section}} dans config.toml et définissez {{field}} sur une valeur entre {{min}} et {{max}}.",
     "ResourceLimitsPassed": "Limites de ressources OK",
     "ResourceLimitsPassedDesc": "Toutes les configurations de limite de ressources sont dans des plages raisonnables.",
+    "ShowOnlyFailedItems": "Afficher uniquement les échecs",
     "SslMismatch": "Incohérence du protocole SSL",
     "SslMismatchDesc": "Le protocole du point de terminaison API ({{apiProtocol}}) et le protocole de l'URL du proxy ({{proxyProtocol}}) utilisent des paramètres SSL différents.",
     "SslMismatchFix": "Assurez-vous que les deux points de terminaison utilisent le même protocole (tous deux HTTPS ou tous deux HTTP).",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Tinjau bagian {{section}} di config.toml dan atur {{field}} ke nilai antara {{min}} dan {{max}}.",
     "ResourceLimitsPassed": "Batas Sumber Daya OK",
     "ResourceLimitsPassedDesc": "Semua konfigurasi batas sumber daya berada dalam rentang yang wajar.",
+    "ShowOnlyFailedItems": "Tampilkan hanya item gagal",
     "SslMismatch": "Ketidakcocokan Protokol SSL",
     "SslMismatchDesc": "Protokol endpoint API ({{apiProtocol}}) dan protokol URL proxy ({{proxyProtocol}}) menggunakan pengaturan SSL yang berbeda.",
     "SslMismatchFix": "Pastikan kedua endpoint menggunakan protokol yang sama (keduanya HTTPS atau keduanya HTTP).",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Rivedi la sezione {{section}} in config.toml e imposta {{field}} su un valore tra {{min}} e {{max}}.",
     "ResourceLimitsPassed": "Limiti risorse OK",
     "ResourceLimitsPassedDesc": "Tutte le configurazioni dei limiti delle risorse rientrano in intervalli ragionevoli.",
+    "ShowOnlyFailedItems": "Mostra solo gli elementi non superati",
     "SslMismatch": "Mancata corrispondenza del protocollo SSL",
     "SslMismatchDesc": "Il protocollo dell'endpoint API ({{apiProtocol}}) e il protocollo dell'URL del proxy ({{proxyProtocol}}) utilizzano impostazioni SSL diverse.",
     "SslMismatchFix": "Assicurarsi che entrambi gli endpoint utilizzino lo stesso protocollo (entrambi HTTPS o entrambi HTTP).",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "config.tomlの{{section}}セクションを確認し、{{field}}を{{min}}から{{max}}の間の値に設定してください。",
     "ResourceLimitsPassed": "リソース制限 OK",
     "ResourceLimitsPassedDesc": "すべてのリソース制限設定が適切な範囲内です。",
+    "ShowOnlyFailedItems": "失敗した項目のみ表示",
     "SslMismatch": "SSLプロトコルの不一致",
     "SslMismatchDesc": "APIエンドポイントのプロトコル（{{apiProtocol}}）とプロキシURLのプロトコル（{{proxyProtocol}}）が異なるSSL設定を使用しています。",
     "SslMismatchFix": "両方のエンドポイントが同じプロトコルを使用していることを確認してください（両方ともHTTPSまたは両方ともHTTP）。",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -705,6 +705,7 @@
     "ResourceLimitOutOfRangeFix": "config.toml의 {{section}} 섹션을 검토하고 {{field}}를 {{min}}과 {{max}} 사이의 값으로 설정하세요.",
     "ResourceLimitsPassed": "리소스 제한 정상",
     "ResourceLimitsPassedDesc": "모든 리소스 제한 설정이 적절한 범위 내에 있습니다.",
+    "ShowOnlyFailedItems": "실패한 항목만 표시",
     "SslMismatch": "SSL 프로토콜 불일치",
     "SslMismatchDesc": "API 엔드포인트 프로토콜({{apiProtocol}})과 프록시 URL 프로토콜({{proxyProtocol}})이 서로 다른 SSL 설정을 사용합니다.",
     "SslMismatchFix": "두 엔드포인트가 동일한 프로토콜을 사용하도록 설정하세요(둘 다 HTTPS 또는 둘 다 HTTP).",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "config.toml дахь {{section}} хэсгийг харж, {{field}}-ийг {{min}} ба {{max}} хооронд утганд тохируулна уу.",
     "ResourceLimitsPassed": "Нөөцийн хязгаар OK",
     "ResourceLimitsPassedDesc": "Бүх нөөцийн хязгаарын тохиргоо боломжийн хүрээнд байна.",
+    "ShowOnlyFailedItems": "Зөвхөн алдаатай зүйлсийг харуулах",
     "SslMismatch": "SSL протоколын зөрчил",
     "SslMismatchDesc": "API эндпойнтын протокол ({{apiProtocol}}) болон прокси URL-ийн протокол ({{proxyProtocol}}) өөр өөр SSL тохиргоо ашиглаж байна.",
     "SslMismatchFix": "Хоёр эндпойнт ижил протокол ашиглаж байгаа эсэхийг шалгаарай (хоёулаа HTTPS эсвэл хоёулаа HTTP).",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Semak bahagian {{section}} dalam config.toml dan tetapkan {{field}} kepada nilai antara {{min}} dan {{max}}.",
     "ResourceLimitsPassed": "Had Sumber OK",
     "ResourceLimitsPassedDesc": "Semua konfigurasi had sumber berada dalam julat yang munasabah.",
+    "ShowOnlyFailedItems": "Tunjukkan item gagal sahaja",
     "SslMismatch": "Ketidakpadanan Protokol SSL",
     "SslMismatchDesc": "Protokol titik akhir API ({{apiProtocol}}) dan protokol URL proksi ({{proxyProtocol}}) menggunakan tetapan SSL yang berbeza.",
     "SslMismatchFix": "Pastikan kedua-dua titik akhir menggunakan protokol yang sama (kedua-duanya HTTPS atau kedua-duanya HTTP).",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Przejrzyj sekcję {{section}} w pliku config.toml i ustaw {{field}} na wartość między {{min}} a {{max}}.",
     "ResourceLimitsPassed": "Limity zasobów OK",
     "ResourceLimitsPassedDesc": "Wszystkie konfiguracje limitów zasobów mieszczą się w rozsądnych zakresach.",
+    "ShowOnlyFailedItems": "Pokaż tylko elementy z błędami",
     "SslMismatch": "Niezgodność protokołu SSL",
     "SslMismatchDesc": "Protokół punktu końcowego API ({{apiProtocol}}) i protokół URL serwera proxy ({{proxyProtocol}}) używają różnych ustawień SSL.",
     "SslMismatchFix": "Upewnij się, że oba punkty końcowe używają tego samego protokołu (oba HTTPS lub oba HTTP).",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Revise a seção {{section}} no config.toml e defina {{field}} com um valor entre {{min}} e {{max}}.",
     "ResourceLimitsPassed": "Limites de recursos OK",
     "ResourceLimitsPassedDesc": "Todas as configurações de limite de recursos estão dentro de intervalos razoáveis.",
+    "ShowOnlyFailedItems": "Mostrar apenas itens com falha",
     "SslMismatch": "Incompatibilidade de protocolo SSL",
     "SslMismatchDesc": "O protocolo do endpoint da API ({{apiProtocol}}) e o protocolo da URL do proxy ({{proxyProtocol}}) usam configurações SSL diferentes.",
     "SslMismatchFix": "Certifique-se de que ambos os endpoints usem o mesmo protocolo (ambos HTTPS ou ambos HTTP).",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Reveja a secção {{section}} no config.toml e defina {{field}} com um valor entre {{min}} e {{max}}.",
     "ResourceLimitsPassed": "Limites de recursos OK",
     "ResourceLimitsPassedDesc": "Todas as configurações de limite de recursos estão dentro de intervalos razoáveis.",
+    "ShowOnlyFailedItems": "Mostrar apenas itens com falha",
     "SslMismatch": "Incompatibilidade do protocolo SSL",
     "SslMismatchDesc": "O protocolo do endpoint da API ({{apiProtocol}}) e o protocolo do URL do proxy ({{proxyProtocol}}) utilizam definições SSL diferentes.",
     "SslMismatchFix": "Certifique-se de que ambos os endpoints utilizam o mesmo protocolo (ambos HTTPS ou ambos HTTP).",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Проверьте раздел {{section}} в config.toml и установите {{field}} на значение между {{min}} и {{max}}.",
     "ResourceLimitsPassed": "Ограничения ресурсов OK",
     "ResourceLimitsPassedDesc": "Все конфигурации ограничений ресурсов находятся в разумных пределах.",
+    "ShowOnlyFailedItems": "Показать только неуспешные",
     "SslMismatch": "Несоответствие протокола SSL",
     "SslMismatchDesc": "Протокол конечной точки API ({{apiProtocol}}) и протокол URL прокси ({{proxyProtocol}}) используют разные настройки SSL.",
     "SslMismatchFix": "Убедитесь, что обе конечные точки используют один и тот же протокол (оба HTTPS или оба HTTP).",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "ตรวจสอบส่วน {{section}} ใน config.toml และตั้งค่า {{field}} เป็นค่าระหว่าง {{min}} ถึง {{max}}",
     "ResourceLimitsPassed": "ขีดจำกัดทรัพยากรผ่าน",
     "ResourceLimitsPassedDesc": "การกำหนดค่าขีดจำกัดทรัพยากรทั้งหมดอยู่ในช่วงที่สมเหตุสมผล",
+    "ShowOnlyFailedItems": "แสดงเฉพาะรายการที่ล้มเหลว",
     "SslMismatch": "โปรโตคอล SSL ไม่ตรงกัน",
     "SslMismatchDesc": "โปรโตคอลของ API endpoint ({{apiProtocol}}) และโปรโตคอลของ proxy URL ({{proxyProtocol}}) ใช้การตั้งค่า SSL ที่แตกต่างกัน",
     "SslMismatchFix": "ตรวจสอบให้แน่ใจว่าทั้งสอง endpoint ใช้โปรโตคอลเดียวกัน (ทั้งสอง HTTPS หรือทั้งสอง HTTP)",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "config.toml dosyasındaki {{section}} bölümünü inceleyin ve {{field}}'ı {{min}} ile {{max}} arasında bir değere ayarlayın.",
     "ResourceLimitsPassed": "Kaynak Sınırları Tamam",
     "ResourceLimitsPassedDesc": "Tüm kaynak sınırı yapılandırmaları makul aralıklarda.",
+    "ShowOnlyFailedItems": "Yalnızca başarısız öğeleri göster",
     "SslMismatch": "SSL Protokol Uyumsuzluğu",
     "SslMismatchDesc": "API uç noktası protokolü ({{apiProtocol}}) ve proxy URL protokolü ({{proxyProtocol}}) farklı SSL ayarları kullanıyor.",
     "SslMismatchFix": "Her iki uç noktanın da aynı protokolü kullandığından emin olun (her ikisi de HTTPS veya her ikisi de HTTP).",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "Xem lại phần {{section}} trong config.toml và đặt {{field}} thành giá trị trong khoảng {{min}} đến {{max}}.",
     "ResourceLimitsPassed": "Giới hạn tài nguyên OK",
     "ResourceLimitsPassedDesc": "Tất cả cấu hình giới hạn tài nguyên đều trong phạm vi hợp lý.",
+    "ShowOnlyFailedItems": "Chỉ hiển thị mục lỗi",
     "SslMismatch": "Không khớp giao thức SSL",
     "SslMismatchDesc": "Giao thức của API endpoint ({{apiProtocol}}) và giao thức của proxy URL ({{proxyProtocol}}) sử dụng các cài đặt SSL khác nhau.",
     "SslMismatchFix": "Đảm bảo cả hai endpoint sử dụng cùng giao thức (cả hai đều HTTPS hoặc cả hai đều HTTP).",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -704,6 +704,7 @@
     "ResourceLimitOutOfRangeFix": "检查 config.toml 中的 {{section}} 部分，将 {{field}} 设置为 {{min}} 到 {{max}} 之间的值。",
     "ResourceLimitsPassed": "资源限制正常",
     "ResourceLimitsPassedDesc": "所有资源限制配置均在合理范围内。",
+    "ShowOnlyFailedItems": "仅显示失败项",
     "SslMismatch": "SSL协议不匹配",
     "SslMismatchDesc": "API端点协议（{{apiProtocol}}）和代理URL协议（{{proxyProtocol}}）使用了不同的SSL设置。",
     "SslMismatchFix": "确保两个端点使用相同的协议（都使用HTTPS或都使用HTTP）。",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -705,6 +705,7 @@
     "ResourceLimitOutOfRangeFix": "檢查 config.toml 中的 {{section}} 部分，將 {{field}} 設置為 {{min}} 到 {{max}} 之間的值。",
     "ResourceLimitsPassed": "資源限制正常",
     "ResourceLimitsPassedDesc": "所有資源限制配置均在合理範圍內。",
+    "ShowOnlyFailedItems": "僅顯示失敗項目",
     "SslMismatch": "SSL協議不匹配",
     "SslMismatchDesc": "API端點協議（{{apiProtocol}}）和代理URL協議（{{proxyProtocol}}）使用了不同的SSL設定。",
     "SslMismatchFix": "確保兩個端點使用相同的協議（都使用HTTPS或都使用HTTP）。",


### PR DESCRIPTION
Resolves #5966 (FR-2300)

## Summary
- Add "Show only failed items" toggle switch to the Diagnostics page header
- When enabled, hide passed diagnostic results and collapse empty sections (sections with no issues)
- Add `hidePassed` prop to all diagnostic section components and `DiagnosticResultList`
- Add `onHasIssues` callback to sections to track which sections have issues for filtering
- Add `diagnostics.ShowOnlyFailedItems` i18n key with correct translations across all 21 languages

## Changed Files
- `react/src/pages/DiagnosticsPage.tsx` — toggle state, `sectionsWithIssues` filter
- `react/src/components/DiagnosticResultList.tsx` — `hidePassed` prop filtering
- `react/src/components/CspDiagnosticsSection.tsx` — `hidePassed`, `onHasIssues` props
- `react/src/components/EndpointDiagnosticsSection.tsx` — `hidePassed`, `onHasIssues` props
- `react/src/components/StorageProxyDiagnosticsSection.tsx` — `hidePassed`, `onHasIssues` props
- `react/src/components/WebServerConfigDiagnosticsSection.tsx` — `hidePassed`, `onHasIssues` props
- `resources/i18n/*.json` — `ShowOnlyFailedItems` key (21 languages)