### PR TITLE
feat(FR-2300): add auto-diagnostics notification after login

### DIFF
--- a/react/src/hooks/useAutoDiagnostics.ts
+++ b/react/src/hooks/useAutoDiagnostics.ts
@@ -1,0 +1,90 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useSuspendedBackendaiClient } from '.';
+import type { DiagnosticResult } from '../types/diagnostics';
+import { useSetBAINotification } from './useBAINotification';
+import { useCspDiagnostics } from './useCspDiagnostics';
+import { useEndpointDiagnostics } from './useEndpointDiagnostics';
+import { useStorageProxyDiagnostics } from './useStorageProxyDiagnostics';
+import { useWebServerConfigDiagnostics } from './useWebServerConfigDiagnostics';
+import { useEffect, useEffectEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const AUTO_DIAGNOSTICS_DISMISSED_KEY = 'bai-auto-diagnostics-dismissed';
+
+/**
+ * Hook that runs a subset of critical diagnostic checks after login
+ * and shows a notification if any critical issue is found.
+ *
+ * - Only runs for superadmin users.
+ * - Uses sessionStorage to avoid re-showing the notification within the same session.
+ * - Runs asynchronously and does NOT block the login flow.
+ * - Reuses the existing diagnostics hooks for consistency with the diagnostics page.
+ */
+export function useAutoDiagnostics(): void {
+  'use memo';
+
+  const { t } = useTranslation();
+  const { upsertNotification } = useSetBAINotification();
+  const baiClient = useSuspendedBackendaiClient();
+
+  const isSuperAdmin: boolean = !!baiClient?.is_superadmin;
+
+  // Reuse existing diagnostics hooks to avoid duplicating API requests
+  const { results: endpointResults } = useEndpointDiagnostics();
+  const cspResults = useCspDiagnostics();
+  const configResults = useWebServerConfigDiagnostics();
+  const storageResults = useStorageProxyDiagnostics();
+
+  // Compute critical results by filtering results from the shared hooks
+  const criticalResults: DiagnosticResult[] = (() => {
+    if (!isSuperAdmin) return [];
+
+    const allResults: DiagnosticResult[] = [
+      ...endpointResults,
+      ...cspResults,
+      ...configResults,
+      ...storageResults,
+    ];
+
+    return allResults.filter(
+      (r) => r.severity === 'critical' || r.severity === 'warning',
+    );
+  })();
+
+  // useEffectEvent captures the latest callback values without making
+  // them dependencies of the useEffect below.
+  const showDiagnosticsNotification = useEffectEvent(() => {
+    upsertNotification({
+      key: 'auto-diagnostics-warning',
+      title: t('diagnostics.AutoDiagnosticsTitle'),
+      message: t('diagnostics.AutoDiagnosticsDesc'),
+      duration: 0,
+      open: true,
+      to: '/diagnostics',
+      toTextKey: 'diagnostics.ViewDiagnostics',
+    });
+    try {
+      sessionStorage.setItem(AUTO_DIAGNOSTICS_DISMISSED_KEY, '1');
+    } catch {
+      // sessionStorage write may fail in restrictive environments
+    }
+  });
+
+  useEffect(() => {
+    if (!isSuperAdmin) return;
+    if (criticalResults.length === 0) return;
+
+    // Check sessionStorage dismissal flag
+    try {
+      if (sessionStorage.getItem(AUTO_DIAGNOSTICS_DISMISSED_KEY)) return;
+    } catch {
+      // sessionStorage may be unavailable (e.g., iframe sandbox)
+      return;
+    }
+
+    showDiagnosticsNotification();
+  }, [isSuperAdmin, criticalResults]);
+}

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -14,6 +14,7 @@ import LoginView from './components/LoginView';
 import MainLayout from './components/MainLayout/MainLayout';
 import WebUINavigate from './components/WebUINavigate';
 import { useSuspendedBackendaiClient } from './hooks';
+import { useAutoDiagnostics } from './hooks/useAutoDiagnostics';
 import { useBAISettingUserState } from './hooks/useBAISetting';
 import { LogoutEventHandler } from './hooks/useLogout';
 import { useWebUIMenuItems } from './hooks/useWebUIMenuItems';
@@ -557,6 +558,16 @@ export const mainLayoutChildRoutes: RouteObject[] = [
 ];
 
 /**
+ * Component that runs auto-diagnostics checks after login and shows
+ * a notification if any critical issues are detected.
+ * Wraps the hook in a Suspense boundary so it won't block rendering.
+ */
+const AutoDiagnosticsEffect = () => {
+  useAutoDiagnostics();
+  return null;
+};
+
+/**
  * Root routes configuration
  */
 export const routes: RouteObject[] = [
@@ -630,6 +641,11 @@ export const routes: RouteObject[] = [
           <ErrorBoundaryWithNullFallback>
             <RoutingEventHandler />
           </ErrorBoundaryWithNullFallback>
+          <Suspense>
+            <ErrorBoundaryWithNullFallback>
+              <AutoDiagnosticsEffect />
+            </ErrorBoundaryWithNullFallback>
+          </Suspense>
           <Suspense>
             <ErrorBoundaryWithNullFallback>
               <LoginViewLazy />


### PR DESCRIPTION
Resolves #5966 (FR-2300)

## Summary
- Add auto-diagnostics hook (`useAutoDiagnostics`) that runs critical/warning configuration checks after superadmin login
- Reuse existing diagnostics hooks (`useEndpointDiagnostics`, `useCspDiagnostics`, `useWebServerConfigDiagnostics`, `useStorageProxyDiagnostics`) instead of making separate API requests
- Show a warning notification (bottom-right, non-blocking) when critical or warning issues are detected
- Include a "View Diagnostics" button in the notification that navigates to `/diagnostics`
- Use `sessionStorage` to avoid re-showing the notification within the same browser session
- Integrate `AutoDiagnosticsEffect` component into `routes.tsx` at the `'/'` route (not MainLayout)
- Add i18n keys for auto-diagnostics notification title, description, and "View Diagnostics" link

## Changed Files
- `react/src/routes.tsx` — mount `AutoDiagnosticsEffect` component at `'/'` route
- `react/src/hooks/useAutoDiagnostics.ts` — new hook reusing existing diagnostics hooks, with `warning` severity support