### PR TITLE
fix(FR-2306): replace typescript-json-schema with TS Compiler API for theme schema generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "copyconfig": "./scripts/copy-config.js && cp version.json build/web && cp manifest.json build/web",
     "copyindex": "cp index.html build/web",
     "prepare": "husky",
-    "theme-schema:update": "pnpm dlx typescript-json-schema \"./react/node_modules/antd/es/config-provider/context.d.ts\" ThemeConfig -o ./resources/antdThemeConfig.schema.json --esModuleInterop",
+    "theme-schema:update": "node scripts/gen-theme-schema.cjs",
     "dev:config": "node scripts/dev-config.js show",
     "dev:setup": "node scripts/dev-config.js update"
   },

--- a/resources/antdThemeConfig.schema.json
+++ b/resources/antdThemeConfig.schema.json
@@ -1,2072 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
-        "ComponentsConfig": {
-            "properties": {
-                "Affix": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Alert": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_1"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Anchor": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_2"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "App": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_64"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Avatar": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_3"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "BackTop": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_4"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Badge": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_5"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Breadcrumb": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_7"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Button": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_6"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Calendar": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_52"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Card": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_8"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Carousel": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_9"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Cascader": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_10"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Checkbox": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_11"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Collapse": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_13"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "ColorPicker": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_12"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "DatePicker": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_14"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Descriptions": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_15"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Divider": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_16"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Drawer": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_17"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Dropdown": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_18"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Empty": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_19"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Flex": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_20"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "FloatButton": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_21"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Form": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_22"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Grid": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_23"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Image": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_24"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Input": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_25"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "InputNumber": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_26"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Layout": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_27"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "List": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_28"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Mentions": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_29"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Menu": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_54"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Message": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_56"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Modal": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_55"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Notification": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_30"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Pagination": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_31"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Popconfirm": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_33"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Popover": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_32"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Progress": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_61"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "QRCode": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_63"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Radio": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_35"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Rate": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_34"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Result": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_36"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Segmented": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_37"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Select": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_38"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Skeleton": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_39"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Slider": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_40"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Space": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_60"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Spin": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_41"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Splitter": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_44"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Statistic": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_42"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Steps": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_53"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Switch": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_43"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Table": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_59"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Tabs": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_51"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Tag": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_45"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Timeline": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_49"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Tooltip": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_58"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Tour": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_62"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Transfer": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_50"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Tree": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_46"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "TreeSelect": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_47"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Typography": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_48"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ],
-                    "description": "Component only token. Which will handle additional calculation of alias token"
-                },
-                "Upload": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_57"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                },
-                "Wave": {
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/Partial<ComponentToken>_65"
-                        },
-                        {
-                            "$ref": "#/definitions/Partial<AliasToken>"
-                        },
-                        {
-                            "properties": {
-                                "algorithm": {
-                                    "anyOf": [
-                                        {
-                                            "items": {
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        {
-                                            "type": [
-                                                "object",
-                                                "boolean"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            },
-                            "type": "object"
-                        }
-                    ]
-                }
-            },
-            "type": "object"
-        },
         "Partial<AliasToken>": {
             "properties": {
                 "blue": {
@@ -2205,6 +139,9 @@
                 "colorBorderBg": {
                     "type": "string"
                 },
+                "colorBorderDisabled": {
+                    "type": "string"
+                },
                 "colorBorderSecondary": {
                     "type": "string"
                 },
@@ -2272,7 +209,6 @@
                     "type": "string"
                 },
                 "colorIcon": {
-                    "description": "/**",
                     "type": "string"
                 },
                 "colorIconHover": {
@@ -2896,13 +832,64 @@
                     "type": "number"
                 },
                 "linkDecoration": {
-                    "$ref": "#/definitions/Property.TextDecoration<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "linkFocusDecoration": {
-                    "$ref": "#/definitions/Property.TextDecoration<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "linkHoverDecoration": {
-                    "$ref": "#/definitions/Property.TextDecoration<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "magenta": {
                     "type": "string"
@@ -3380,7 +1367,16 @@
                 "screenXXL": {
                     "type": "number"
                 },
+                "screenXXLMax": {
+                    "type": "number"
+                },
                 "screenXXLMin": {
+                    "type": "number"
+                },
+                "screenXXXL": {
+                    "type": "number"
+                },
+                "screenXXXLMin": {
                     "type": "number"
                 },
                 "size": {
@@ -3396,7 +1392,6 @@
                     "type": "number"
                 },
                 "sizeMS": {
-                    "description": "Same as size by default, but could be larger in compact mode",
                     "type": "number"
                 },
                 "sizePopupArrow": {
@@ -3582,13 +1577,647 @@
         "Partial<ComponentToken>_1": {
             "properties": {
                 "defaultPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "withDescriptionIconSize": {
                     "type": "number"
                 },
                 "withDescriptionPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Partial<ComponentToken>_2": {
+            "properties": {
+                "linkPaddingBlock": {
+                    "type": "number"
+                },
+                "linkPaddingInlineStart": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "Partial<ComponentToken>_3": {
+            "properties": {
+                "containerSize": {
+                    "type": "number"
+                },
+                "containerSizeLG": {
+                    "type": "number"
+                },
+                "containerSizeSM": {
+                    "type": "number"
+                },
+                "groupBorderColor": {
+                    "type": "string"
+                },
+                "groupOverlapping": {
+                    "type": "number"
+                },
+                "groupSpace": {
+                    "type": "number"
+                },
+                "iconFontSize": {
+                    "type": "number"
+                },
+                "iconFontSizeLG": {
+                    "type": "number"
+                },
+                "iconFontSizeSM": {
+                    "type": "number"
+                },
+                "textFontSize": {
+                    "type": "number"
+                },
+                "textFontSizeLG": {
+                    "type": "number"
+                },
+                "textFontSizeSM": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "Partial<ComponentToken>_4": {
+            "properties": {
+                "zIndexPopup": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "Partial<ComponentToken>_5": {
+            "properties": {
+                "dotSize": {
+                    "type": "number"
+                },
+                "indicatorHeight": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "indicatorHeightSM": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "indicatorZIndex": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "statusSize": {
+                    "type": "number"
+                },
+                "textFontSize": {
+                    "type": "number"
+                },
+                "textFontSizeSM": {
+                    "type": "number"
+                },
+                "textFontWeight": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Partial<ComponentToken>_6": {
+            "properties": {
+                "borderColorDisabled": {
+                    "type": "string"
+                },
+                "contentFontSize": {
+                    "type": "number"
+                },
+                "contentFontSizeLG": {
+                    "type": "number"
+                },
+                "contentFontSizeSM": {
+                    "type": "number"
+                },
+                "contentLineHeight": {
+                    "type": "number"
+                },
+                "contentLineHeightLG": {
+                    "type": "number"
+                },
+                "contentLineHeightSM": {
+                    "type": "number"
+                },
+                "dangerColor": {
+                    "type": "string"
+                },
+                "dangerShadow": {
+                    "type": "string"
+                },
+                "dashedBgDisabled": {
+                    "type": "string"
+                },
+                "defaultActiveBg": {
+                    "type": "string"
+                },
+                "defaultActiveBorderColor": {
+                    "type": "string"
+                },
+                "defaultActiveColor": {
+                    "type": "string"
+                },
+                "defaultBg": {
+                    "type": "string"
+                },
+                "defaultBgDisabled": {
+                    "type": "string"
+                },
+                "defaultBorderColor": {
+                    "type": "string"
+                },
+                "defaultColor": {
+                    "type": "string"
+                },
+                "defaultGhostBorderColor": {
+                    "type": "string"
+                },
+                "defaultGhostColor": {
+                    "type": "string"
+                },
+                "defaultHoverBg": {
+                    "type": "string"
+                },
+                "defaultHoverBorderColor": {
+                    "type": "string"
+                },
+                "defaultHoverColor": {
+                    "type": "string"
+                },
+                "defaultShadow": {
+                    "type": "string"
+                },
+                "fontWeight": {
+                    "anyOf": [
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        {
+                            "const": "-moz-initial",
+                            "type": "string"
+                        },
+                        {
+                            "const": "inherit",
+                            "type": "string"
+                        },
+                        {
+                            "const": "initial",
+                            "type": "string"
+                        },
+                        {
+                            "const": "revert",
+                            "type": "string"
+                        },
+                        {
+                            "const": "revert-layer",
+                            "type": "string"
+                        },
+                        {
+                            "const": "unset",
+                            "type": "string"
+                        },
+                        {
+                            "const": "bold",
+                            "type": "string"
+                        },
+                        {
+                            "const": "normal",
+                            "type": "string"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        {
+                            "const": "bolder",
+                            "type": "string"
+                        },
+                        {
+                            "const": "lighter",
+                            "type": "string"
+                        }
+                    ]
+                },
+                "ghostBg": {
+                    "type": "string"
+                },
+                "iconGap": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "linkHoverBg": {
+                    "type": "string"
+                },
+                "onlyIconSize": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "onlyIconSizeLG": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "onlyIconSizeSM": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "paddingBlock": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "paddingBlockLG": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "paddingBlockSM": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "paddingInline": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "paddingInlineLG": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "paddingInlineSM": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "primaryColor": {
+                    "type": "string"
+                },
+                "primaryShadow": {
+                    "type": "string"
+                },
+                "solidTextColor": {
+                    "type": "string"
+                },
+                "textHoverBg": {
+                    "type": "string"
+                },
+                "textTextActiveColor": {
+                    "type": "string"
+                },
+                "textTextColor": {
+                    "type": "string"
+                },
+                "textTextHoverColor": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "Partial<ComponentToken>_7": {
+            "properties": {
+                "iconFontSize": {
+                    "type": "number"
+                },
+                "itemColor": {
+                    "type": "string"
+                },
+                "lastItemColor": {
+                    "type": "string"
+                },
+                "linkColor": {
+                    "type": "string"
+                },
+                "linkHoverColor": {
+                    "type": "string"
+                },
+                "separatorColor": {
+                    "type": "string"
+                },
+                "separatorMargin": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "Partial<ComponentToken>_8": {
+            "properties": {
+                "actionsBg": {
+                    "type": "string"
+                },
+                "actionsLiMargin": {
+                    "type": "string"
+                },
+                "bodyPadding": {
+                    "type": "number"
+                },
+                "bodyPaddingSM": {
+                    "type": "number"
+                },
+                "extraColor": {
+                    "type": "string"
+                },
+                "headerBg": {
+                    "type": "string"
+                },
+                "headerFontSize": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "headerFontSizeSM": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "headerHeight": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "headerHeightSM": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "headerPadding": {
+                    "type": "number"
+                },
+                "headerPaddingSM": {
+                    "type": "number"
+                },
+                "tabsMarginBottom": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "Partial<ComponentToken>_9": {
+            "properties": {
+                "arrowOffset": {
+                    "type": "number"
+                },
+                "arrowSize": {
+                    "type": "number"
+                },
+                "dotActiveWidth": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "dotGap": {
+                    "type": "number"
+                },
+                "dotHeight": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "dotOffset": {
+                    "type": "number"
+                },
+                "dotWidth": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "dotWidthActive": {
+                    "type": "number"
                 }
             },
             "type": "object"
@@ -3596,57 +2225,218 @@
         "Partial<ComponentToken>_10": {
             "properties": {
                 "controlItemWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "controlWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "dropdownHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "menuPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "optionPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "optionSelectedBg": {
                     "type": "string"
                 },
+                "optionSelectedColor": {
+                    "type": "string"
+                },
                 "optionSelectedFontWeight": {
-                    "$ref": "#/definitions/Property.FontWeight"
+                    "anyOf": [
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        {
+                            "const": "-moz-initial",
+                            "type": "string"
+                        },
+                        {
+                            "const": "inherit",
+                            "type": "string"
+                        },
+                        {
+                            "const": "initial",
+                            "type": "string"
+                        },
+                        {
+                            "const": "revert",
+                            "type": "string"
+                        },
+                        {
+                            "const": "revert-layer",
+                            "type": "string"
+                        },
+                        {
+                            "const": "unset",
+                            "type": "string"
+                        },
+                        {
+                            "const": "bold",
+                            "type": "string"
+                        },
+                        {
+                            "const": "normal",
+                            "type": "string"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        {
+                            "const": "bolder",
+                            "type": "string"
+                        },
+                        {
+                            "const": "lighter",
+                            "type": "string"
+                        }
+                    ]
                 }
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_11": {
-            "type": "object"
-        },
-        "Partial<ComponentToken>_12": {
-            "type": "object"
-        },
         "Partial<ComponentToken>_13": {
             "properties": {
+                "borderlessContentBg": {
+                    "type": "string"
+                },
+                "borderlessContentPadding": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
                 "contentBg": {
                     "type": "string"
                 },
                 "contentPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "headerBg": {
                     "type": "string"
                 },
                 "headerPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 }
             },
             "type": "object"
@@ -3799,6 +2589,9 @@
                 "labelBg": {
                     "type": "string"
                 },
+                "labelColor": {
+                    "type": "string"
+                },
                 "titleColor": {
                     "type": "string"
                 },
@@ -3814,16 +2607,53 @@
                     "type": "number"
                 },
                 "textPaddingInline": {
-                    "$ref": "#/definitions/Property.PaddingInline<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "verticalMarginInline": {
-                    "$ref": "#/definitions/Property.MarginInline<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 }
             },
             "type": "object"
         },
         "Partial<ComponentToken>_17": {
             "properties": {
+                "draggerSize": {
+                    "type": "number"
+                },
                 "footerPaddingBlock": {
                     "type": "number"
                 },
@@ -3839,32 +2669,29 @@
         "Partial<ComponentToken>_18": {
             "properties": {
                 "paddingBlock": {
-                    "$ref": "#/definitions/Property.PaddingBlock<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "zIndexPopup": {
                     "type": "number"
                 }
             },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_19": {
-            "type": "object"
-        },
-        "Partial<ComponentToken>_2": {
-            "properties": {
-                "linkPaddingBlock": {
-                    "type": "number"
-                },
-                "linkPaddingInlineStart": {
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_20": {
-            "type": "object"
-        },
-        "Partial<ComponentToken>_21": {
             "type": "object"
         },
         "Partial<ComponentToken>_22": {
@@ -3888,27 +2715,62 @@
                     "type": "number"
                 },
                 "labelHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "labelRequiredMarkColor": {
                     "type": "string"
                 },
                 "verticalLabelMargin": {
-                    "$ref": "#/definitions/Property.Margin<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "verticalLabelPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 }
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_23": {
-            "type": "object"
-        },
-        "Partial<ComponentToken>_24": {
+        "Partial<ComponentToken>_25": {
             "properties": {
                 "previewOperationColor": {
                     "type": "string"
@@ -3928,7 +2790,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_25": {
+        "Partial<ComponentToken>_26": {
             "properties": {
                 "activeBg": {
                     "type": "string"
@@ -3984,7 +2846,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_26": {
+        "Partial<ComponentToken>_27": {
             "properties": {
                 "activeBg": {
                     "type": "string"
@@ -4023,10 +2885,14 @@
                     "type": "string"
                 },
                 "handleVisible": {
-                    "description": "Default `auto`. Set `true` will always show the handle",
-                    "enum": [
-                        "auto",
-                        true
+                    "anyOf": [
+                        {
+                            "type": "boolean"
+                        },
+                        {
+                            "const": "auto",
+                            "type": "string"
+                        }
                     ]
                 },
                 "handleWidth": {
@@ -4071,7 +2937,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_27": {
+        "Partial<ComponentToken>_28": {
             "properties": {
                 "bodyBg": {
                     "type": "string"
@@ -4089,7 +2955,24 @@
                     "type": "string"
                 },
                 "footerPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "headerBg": {
                     "type": "string"
@@ -4098,13 +2981,34 @@
                     "type": "string"
                 },
                 "headerHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "headerPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "lightSiderBg": {
                     "type": "string"
@@ -4125,9 +3029,13 @@
                     "type": "string"
                 },
                 "triggerHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "zeroTriggerHeight": {
@@ -4139,22 +3047,60 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_28": {
+        "Partial<ComponentToken>_29": {
             "properties": {
                 "avatarMarginRight": {
-                    "$ref": "#/definitions/Property.MarginRight<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "contentWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "descriptionFontSize": {
                     "type": "number"
                 },
                 "emptyTextPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "footerBg": {
                     "type": "string"
@@ -4172,15 +3118,49 @@
                     "type": "string"
                 },
                 "metaMarginBottom": {
-                    "$ref": "#/definitions/Property.MarginBottom<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "titleMarginBottom": {
-                    "$ref": "#/definitions/Property.MarginBottom<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 }
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_29": {
+        "Partial<ComponentToken>_30": {
             "properties": {
                 "activeBg": {
                     "type": "string"
@@ -4195,15 +3175,23 @@
                     "type": "string"
                 },
                 "controlItemWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "dropdownHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "errorActiveShadow": {
@@ -4251,44 +3239,31 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_3": {
+        "Partial<ComponentToken>_31": {
             "properties": {
-                "containerSize": {
-                    "type": "number"
-                },
-                "containerSizeLG": {
-                    "type": "number"
-                },
-                "containerSizeSM": {
-                    "type": "number"
-                },
-                "groupBorderColor": {
+                "colorErrorBg": {
                     "type": "string"
                 },
-                "groupOverlapping": {
-                    "type": "number"
+                "colorInfoBg": {
+                    "type": "string"
                 },
-                "groupSpace": {
-                    "type": "number"
+                "colorSuccessBg": {
+                    "type": "string"
                 },
-                "textFontSize": {
-                    "type": "number"
+                "colorWarningBg": {
+                    "type": "string"
                 },
-                "textFontSizeLG": {
-                    "type": "number"
+                "progressBg": {
+                    "type": "string"
                 },
-                "textFontSizeSM": {
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_30": {
-            "properties": {
                 "width": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "zIndexPopup": {
@@ -4297,7 +3272,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_31": {
+        "Partial<ComponentToken>_32": {
             "properties": {
                 "itemActiveBg": {
                     "type": "string"
@@ -4305,7 +3280,13 @@
                 "itemActiveBgDisabled": {
                     "type": "string"
                 },
+                "itemActiveColor": {
+                    "type": "string"
+                },
                 "itemActiveColorDisabled": {
+                    "type": "string"
+                },
+                "itemActiveColorHover": {
                     "type": "string"
                 },
                 "itemBg": {
@@ -4320,6 +3301,9 @@
                 "itemSize": {
                     "type": "number"
                 },
+                "itemSizeLG": {
+                    "type": "number"
+                },
                 "itemSizeSM": {
                     "type": "number"
                 },
@@ -4329,34 +3313,38 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_32": {
+        "Partial<ComponentToken>_33": {
             "properties": {
                 "minWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "titleMinWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "width": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
-                "zIndexPopup": {
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_33": {
-            "properties": {
                 "zIndexPopup": {
                     "type": "number"
                 }
@@ -4364,6 +3352,14 @@
             "type": "object"
         },
         "Partial<ComponentToken>_34": {
+            "properties": {
+                "zIndexPopup": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "Partial<ComponentToken>_35": {
             "properties": {
                 "starBg": {
                     "type": "string"
@@ -4374,32 +3370,136 @@
                 "starHoverScale": {
                     "anyOf": [
                         {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        {
+                            "const": "-moz-initial",
+                            "type": "string"
+                        },
+                        {
+                            "const": "inherit",
+                            "type": "string"
+                        },
+                        {
+                            "const": "initial",
+                            "type": "string"
+                        },
+                        {
+                            "const": "revert",
+                            "type": "string"
+                        },
+                        {
+                            "const": "revert-layer",
+                            "type": "string"
+                        },
+                        {
+                            "const": "unset",
+                            "type": "string"
+                        },
+                        {
+                            "const": "none",
+                            "type": "string"
+                        },
+                        {
                             "items": {
                                 "type": "string"
                             },
                             "type": "array"
                         },
                         {
-                            "allOf": [
-                                {
-                                    "properties": {},
-                                    "type": "object"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "allOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "object"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "const": "-moz-initial",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "inherit",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "initial",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "revert",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "revert-layer",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "unset",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "const": "none",
+                                        "type": "string"
+                                    }
+                                ]
+                            },
+                            "type": "array"
                         },
                         {
                             "properties": {
-                                "_multi_value_": {
-                                    "type": "boolean"
-                                },
-                                "_skip_check_": {
-                                    "type": "boolean"
-                                },
                                 "value": {
                                     "anyOf": [
+                                        {
+                                            "allOf": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "type": "object"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "const": "-moz-initial",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "const": "inherit",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "const": "initial",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "const": "revert",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "const": "revert-layer",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "const": "unset",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "const": "none",
+                                            "type": "string"
+                                        },
                                         {
                                             "items": {
                                                 "type": "string"
@@ -4407,96 +3507,76 @@
                                             "type": "array"
                                         },
                                         {
-                                            "allOf": [
-                                                {
-                                                    "properties": {},
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "type": "string"
-                                                }
-                                            ]
-                                        },
-                                        {
                                             "items": {
                                                 "anyOf": [
                                                     {
-                                                        "items": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": "array"
-                                                    },
-                                                    {
                                                         "allOf": [
                                                             {
-                                                                "properties": {},
                                                                 "type": "object"
                                                             },
                                                             {
-                                                                "type": "string"
+                                                                "type": "object"
                                                             }
                                                         ]
                                                     },
                                                     {
-                                                        "enum": [
-                                                            "-moz-initial",
-                                                            "inherit",
-                                                            "initial",
-                                                            "none",
-                                                            "revert",
-                                                            "revert-layer",
-                                                            "unset"
-                                                        ],
+                                                        "const": "-moz-initial",
                                                         "type": "string"
+                                                    },
+                                                    {
+                                                        "const": "inherit",
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "const": "initial",
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "const": "revert",
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "const": "revert-layer",
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "const": "unset",
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "const": "none",
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "items": {
+                                                            "type": "object"
+                                                        },
+                                                        "type": "array"
                                                     }
                                                 ]
                                             },
                                             "type": "array"
-                                        },
-                                        {
-                                            "enum": [
-                                                "-moz-initial",
-                                                "inherit",
-                                                "initial",
-                                                "none",
-                                                "revert",
-                                                "revert-layer",
-                                                "unset"
-                                            ],
-                                            "type": "string"
                                         }
                                     ]
                                 }
                             },
                             "type": "object"
-                        },
-                        {
-                            "items": {
-                                "$ref": "#/definitions/Property.Transform"
-                            },
-                            "type": "array"
-                        },
-                        {
-                            "enum": [
-                                "-moz-initial",
-                                "inherit",
-                                "initial",
-                                "none",
-                                "revert",
-                                "revert-layer",
-                                "unset"
-                            ],
-                            "type": "string"
                         }
                     ]
                 },
                 "starSize": {
                     "type": "number"
+                },
+                "starSizeLG": {
+                    "type": "number"
+                },
+                "starSizeSM": {
+                    "type": "number"
                 }
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_35": {
+        "Partial<ComponentToken>_36": {
             "properties": {
                 "buttonBg": {
                     "type": "string"
@@ -4543,10 +3623,27 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_36": {
+        "Partial<ComponentToken>_37": {
             "properties": {
                 "extraMargin": {
-                    "$ref": "#/definitions/Property.Margin<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "iconFontSize": {
                     "type": "number"
@@ -4560,7 +3657,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_37": {
+        "Partial<ComponentToken>_38": {
             "properties": {
                 "itemActiveBg": {
                     "type": "string"
@@ -4584,15 +3681,19 @@
                     "type": "string"
                 },
                 "trackPadding": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 }
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_38": {
+        "Partial<ComponentToken>_39": {
             "properties": {
                 "activeBorderColor": {
                     "type": "string"
@@ -4640,10 +3741,54 @@
                     "type": "number"
                 },
                 "optionLineHeight": {
-                    "$ref": "#/definitions/Property.LineHeight<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "optionPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "optionSelectedBg": {
                     "type": "string"
@@ -4652,7 +3797,68 @@
                     "type": "string"
                 },
                 "optionSelectedFontWeight": {
-                    "$ref": "#/definitions/Property.FontWeight"
+                    "anyOf": [
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        {
+                            "const": "-moz-initial",
+                            "type": "string"
+                        },
+                        {
+                            "const": "inherit",
+                            "type": "string"
+                        },
+                        {
+                            "const": "initial",
+                            "type": "string"
+                        },
+                        {
+                            "const": "revert",
+                            "type": "string"
+                        },
+                        {
+                            "const": "revert-layer",
+                            "type": "string"
+                        },
+                        {
+                            "const": "unset",
+                            "type": "string"
+                        },
+                        {
+                            "const": "bold",
+                            "type": "string"
+                        },
+                        {
+                            "const": "normal",
+                            "type": "string"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        {
+                            "const": "bolder",
+                            "type": "string"
+                        },
+                        {
+                            "const": "lighter",
+                            "type": "string"
+                        }
+                    ]
                 },
                 "selectorBg": {
                     "type": "string"
@@ -4669,7 +3875,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_39": {
+        "Partial<ComponentToken>_40": {
             "properties": {
                 "blockRadius": {
                     "type": "number"
@@ -4693,23 +3899,19 @@
                     "type": "number"
                 },
                 "titleHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 }
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_4": {
-            "properties": {
-                "zIndexPopup": {
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_40": {
+        "Partial<ComponentToken>_41": {
             "properties": {
                 "controlSize": {
                     "type": "number"
@@ -4736,15 +3938,23 @@
                     "type": "string"
                 },
                 "handleLineWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "handleLineWidthHover": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "handleSize": {
@@ -4774,12 +3984,16 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_41": {
+        "Partial<ComponentToken>_42": {
             "properties": {
                 "contentHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "dotSize": {
@@ -4794,7 +4008,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_42": {
+        "Partial<ComponentToken>_43": {
             "properties": {
                 "contentFontSize": {
                     "type": "number"
@@ -4805,7 +4019,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_43": {
+        "Partial<ComponentToken>_44": {
             "properties": {
                 "handleBg": {
                     "type": "string"
@@ -4832,27 +4046,43 @@
                     "type": "number"
                 },
                 "trackHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "trackHeightSM": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "trackMinWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "trackMinWidthSM": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "trackPadding": {
@@ -4861,7 +4091,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_44": {
+        "Partial<ComponentToken>_45": {
             "properties": {
                 "resizeSpinnerSize": {
                     "type": "number"
@@ -4878,18 +4108,21 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_45": {
+        "Partial<ComponentToken>_46": {
             "properties": {
                 "defaultBg": {
                     "type": "string"
                 },
                 "defaultColor": {
                     "type": "string"
+                },
+                "solidTextColor": {
+                    "type": "string"
                 }
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_46": {
+        "Partial<ComponentToken>_47": {
             "properties": {
                 "directoryNodeSelectedBg": {
                     "type": "string"
@@ -4918,7 +4151,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_47": {
+        "Partial<ComponentToken>_48": {
             "properties": {
                 "indentSize": {
                     "type": "number"
@@ -4941,32 +4174,54 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_48": {
+        "Partial<ComponentToken>_49": {
             "properties": {
                 "titleMarginBottom": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "titleMarginTop": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 }
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_49": {
+        "Partial<ComponentToken>_50": {
             "properties": {
                 "dotBg": {
                     "type": "string"
                 },
                 "dotBorderWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "dotSize": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "itemPaddingBottom": {
@@ -4976,97 +4231,84 @@
                     "type": "string"
                 },
                 "tailWidth": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_5": {
-            "properties": {
-                "dotSize": {
-                    "type": "number"
-                },
-                "indicatorHeight": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "indicatorHeightSM": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "indicatorZIndex": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "statusSize": {
-                    "type": "number"
-                },
-                "textFontSize": {
-                    "type": "number"
-                },
-                "textFontSizeSM": {
-                    "type": "number"
-                },
-                "textFontWeight": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_50": {
-            "properties": {
-                "headerHeight": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "itemHeight": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "itemPaddingBlock": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "listHeight": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "listWidth": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "listWidthLG": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 }
             },
             "type": "object"
         },
         "Partial<ComponentToken>_51": {
+            "properties": {
+                "headerHeight": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "itemHeight": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "itemPaddingBlock": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "listHeight": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "listWidth": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                },
+                "listWidthLG": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "Partial<ComponentToken>_52": {
             "properties": {
                 "cardBg": {
                     "type": "string"
@@ -5075,10 +4317,13 @@
                     "type": "number"
                 },
                 "cardHeight": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
+                    "type": "number"
+                },
+                "cardHeightLG": {
+                    "type": "number"
+                },
+                "cardHeightSM": {
+                    "type": "number"
                 },
                 "cardPadding": {
                     "type": "string"
@@ -5146,7 +4391,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_52": {
+        "Partial<ComponentToken>_53": {
             "properties": {
                 "fullBg": {
                     "type": "string"
@@ -5158,27 +4403,39 @@
                     "type": "string"
                 },
                 "miniContentHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "monthControlWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "yearControlWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 }
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_53": {
+        "Partial<ComponentToken>_54": {
             "properties": {
                 "customIconFontSize": {
                     "type": "number"
@@ -5214,41 +4471,74 @@
                     "type": "string"
                 },
                 "navContentMaxWidth": {
-                    "$ref": "#/definitions/Property.MaxWidth<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "titleLineHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 }
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_54": {
+        "Partial<ComponentToken>_55": {
             "properties": {
                 "activeBarBorderWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "activeBarHeight": {
                     "type": "number"
                 },
                 "activeBarWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "collapsedIconSize": {
                     "type": "number"
                 },
                 "collapsedWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "colorActiveBarBorderSize": {
@@ -5258,9 +4548,13 @@
                     "type": "number"
                 },
                 "colorActiveBarWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "colorDangerItemBgActive": {
@@ -5378,9 +4672,13 @@
                     "type": "string"
                 },
                 "dropdownWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "groupTitleColor": {
@@ -5390,9 +4688,13 @@
                     "type": "number"
                 },
                 "groupTitleLineHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "horizontalItemBorderRadius": {
@@ -5411,10 +4713,54 @@
                     "type": "string"
                 },
                 "horizontalLineHeight": {
-                    "$ref": "#/definitions/Property.LineHeight<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "iconMarginInlineEnd": {
-                    "$ref": "#/definitions/Property.MarginInlineEnd<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "iconSize": {
                     "type": "number"
@@ -5435,9 +4781,13 @@
                     "type": "string"
                 },
                 "itemHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "itemHoverBg": {
@@ -5447,13 +4797,47 @@
                     "type": "string"
                 },
                 "itemMarginBlock": {
-                    "$ref": "#/definitions/Property.MarginBlock<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "itemMarginInline": {
                     "type": "number"
                 },
                 "itemPaddingInline": {
-                    "$ref": "#/definitions/Property.PaddingInline<string|number>"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
                 },
                 "itemSelectedBg": {
                     "type": "string"
@@ -5476,13 +4860,16 @@
                 "subMenuItemBorderRadius": {
                     "type": "number"
                 },
+                "subMenuItemSelectedColor": {
+                    "type": "string"
+                },
                 "zIndexPopup": {
                     "type": "number"
                 }
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_55": {
+        "Partial<ComponentToken>_56": {
             "properties": {
                 "contentBg": {
                     "type": "string"
@@ -5500,45 +4887,72 @@
                     "type": "number"
                 },
                 "titleLineHeight": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
-                }
-            },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_56": {
-            "properties": {
-                "contentBg": {
-                    "type": "string"
-                },
-                "contentPadding": {
-                    "$ref": "#/definitions/Property.Padding<string|number>"
-                },
-                "zIndexPopup": {
-                    "type": "number"
                 }
             },
             "type": "object"
         },
         "Partial<ComponentToken>_57": {
             "properties": {
-                "actionsColor": {
+                "contentBg": {
                     "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_58": {
-            "properties": {
+                },
+                "contentPadding": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
                 "zIndexPopup": {
                     "type": "number"
                 }
             },
             "type": "object"
         },
+        "Partial<ComponentToken>_58": {
+            "properties": {
+                "actionsColor": {
+                    "type": "string"
+                },
+                "pictureCardSize": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
         "Partial<ComponentToken>_59": {
+            "properties": {
+                "maxWidth": {
+                    "type": "number"
+                },
+                "zIndexPopup": {
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "Partial<ComponentToken>_60": {
             "properties": {
                 "bodySortBg": {
                     "type": "string"
@@ -5625,9 +5039,13 @@
                     "type": "string"
                 },
                 "selectionColumnWidth": {
-                    "type": [
-                        "string",
-                        "number"
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
                     ]
                 },
                 "stickyScrollBarBg": {
@@ -5639,138 +5057,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_6": {
-            "properties": {
-                "borderColorDisabled": {
-                    "type": "string"
-                },
-                "contentFontSize": {
-                    "type": "number"
-                },
-                "contentFontSizeLG": {
-                    "type": "number"
-                },
-                "contentFontSizeSM": {
-                    "type": "number"
-                },
-                "contentLineHeight": {
-                    "type": "number"
-                },
-                "contentLineHeightLG": {
-                    "type": "number"
-                },
-                "contentLineHeightSM": {
-                    "type": "number"
-                },
-                "dangerColor": {
-                    "type": "string"
-                },
-                "dangerShadow": {
-                    "type": "string"
-                },
-                "defaultActiveBg": {
-                    "type": "string"
-                },
-                "defaultActiveBorderColor": {
-                    "type": "string"
-                },
-                "defaultActiveColor": {
-                    "type": "string"
-                },
-                "defaultBg": {
-                    "type": "string"
-                },
-                "defaultBorderColor": {
-                    "type": "string"
-                },
-                "defaultColor": {
-                    "type": "string"
-                },
-                "defaultGhostBorderColor": {
-                    "type": "string"
-                },
-                "defaultGhostColor": {
-                    "type": "string"
-                },
-                "defaultHoverBg": {
-                    "type": "string"
-                },
-                "defaultHoverBorderColor": {
-                    "type": "string"
-                },
-                "defaultHoverColor": {
-                    "type": "string"
-                },
-                "defaultShadow": {
-                    "type": "string"
-                },
-                "fontWeight": {
-                    "$ref": "#/definitions/Property.FontWeight"
-                },
-                "ghostBg": {
-                    "type": "string"
-                },
-                "groupBorderColor": {
-                    "type": "string"
-                },
-                "linkHoverBg": {
-                    "type": "string"
-                },
-                "onlyIconSize": {
-                    "type": "number"
-                },
-                "onlyIconSizeLG": {
-                    "type": "number"
-                },
-                "onlyIconSizeSM": {
-                    "type": "number"
-                },
-                "paddingBlock": {
-                    "$ref": "#/definitions/Property.PaddingBlock<string|number>"
-                },
-                "paddingBlockLG": {
-                    "$ref": "#/definitions/Property.PaddingBlock<string|number>"
-                },
-                "paddingBlockSM": {
-                    "$ref": "#/definitions/Property.PaddingBlock<string|number>"
-                },
-                "paddingInline": {
-                    "$ref": "#/definitions/Property.PaddingInline<string|number>"
-                },
-                "paddingInlineLG": {
-                    "$ref": "#/definitions/Property.PaddingInline<string|number>"
-                },
-                "paddingInlineSM": {
-                    "$ref": "#/definitions/Property.PaddingInline<string|number>"
-                },
-                "primaryColor": {
-                    "type": "string"
-                },
-                "primaryShadow": {
-                    "type": "string"
-                },
-                "solidTextColor": {
-                    "type": "string"
-                },
-                "textHoverBg": {
-                    "type": "string"
-                },
-                "textTextActiveColor": {
-                    "type": "string"
-                },
-                "textTextColor": {
-                    "type": "string"
-                },
-                "textTextHoverColor": {
-                    "type": "string"
-                }
-            },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_60": {
-            "type": "object"
-        },
-        "Partial<ComponentToken>_61": {
+        "Partial<ComponentToken>_62": {
             "properties": {
                 "circleIconFontSize": {
                     "type": "string"
@@ -5793,7 +5080,7 @@
             },
             "type": "object"
         },
-        "Partial<ComponentToken>_62": {
+        "Partial<ComponentToken>_63": {
             "properties": {
                 "closeBtnSize": {
                     "type": "number"
@@ -5809,506 +5096,3662 @@
                 }
             },
             "type": "object"
-        },
-        "Partial<ComponentToken>_63": {
-            "type": "object"
-        },
-        "Partial<ComponentToken>_64": {
-            "type": "object"
-        },
-        "Partial<ComponentToken>_65": {
-            "type": "object"
-        },
-        "Partial<ComponentToken>_7": {
-            "properties": {
-                "iconFontSize": {
-                    "type": "number"
-                },
-                "itemColor": {
-                    "type": "string"
-                },
-                "lastItemColor": {
-                    "type": "string"
-                },
-                "linkColor": {
-                    "type": "string"
-                },
-                "linkHoverColor": {
-                    "type": "string"
-                },
-                "separatorColor": {
-                    "type": "string"
-                },
-                "separatorMargin": {
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_8": {
-            "properties": {
-                "actionsBg": {
-                    "type": "string"
-                },
-                "actionsLiMargin": {
-                    "type": "string"
-                },
-                "extraColor": {
-                    "type": "string"
-                },
-                "headerBg": {
-                    "type": "string"
-                },
-                "headerFontSize": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "headerFontSizeSM": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "headerHeight": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "headerHeightSM": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "tabsMarginBottom": {
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "Partial<ComponentToken>_9": {
-            "properties": {
-                "arrowOffset": {
-                    "type": "number"
-                },
-                "arrowSize": {
-                    "type": "number"
-                },
-                "dotActiveWidth": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "dotGap": {
-                    "type": "number"
-                },
-                "dotHeight": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "dotOffset": {
-                    "type": "number"
-                },
-                "dotWidth": {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "dotWidthActive": {
-                    "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "Property.FontWeight": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "number"
-                        }
-                    ]
-                },
-                {
-                    "enum": [
-                        "-moz-initial",
-                        "bold",
-                        "bolder",
-                        "inherit",
-                        "initial",
-                        "lighter",
-                        "normal",
-                        "revert",
-                        "revert-layer",
-                        "unset"
-                    ],
-                    "type": "string"
-                }
-            ]
-        },
-        "Property.LineHeight<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "number"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.Margin<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.MarginBlock<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.MarginBottom<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.MarginInline<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.MarginInlineEnd<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.MarginRight<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.MaxWidth<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.Padding<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.PaddingBlock<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.PaddingInline<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.TextDecoration<string|number>": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            ]
-        },
-        "Property.Transform": {
-            "anyOf": [
-                {
-                    "allOf": [
-                        {
-                            "properties": {},
-                            "type": "object"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                {
-                    "enum": [
-                        "-moz-initial",
-                        "inherit",
-                        "initial",
-                        "none",
-                        "revert",
-                        "revert-layer",
-                        "unset"
-                    ],
-                    "type": "string"
-                }
-            ]
         }
     },
     "properties": {
+        "token": {
+            "properties": {
+                "blue": {
+                    "type": "string"
+                },
+                "blue-1": {
+                    "type": "string"
+                },
+                "blue-10": {
+                    "type": "string"
+                },
+                "blue-2": {
+                    "type": "string"
+                },
+                "blue-3": {
+                    "type": "string"
+                },
+                "blue-4": {
+                    "type": "string"
+                },
+                "blue-5": {
+                    "type": "string"
+                },
+                "blue-6": {
+                    "type": "string"
+                },
+                "blue-7": {
+                    "type": "string"
+                },
+                "blue-8": {
+                    "type": "string"
+                },
+                "blue-9": {
+                    "type": "string"
+                },
+                "blue1": {
+                    "type": "string"
+                },
+                "blue10": {
+                    "type": "string"
+                },
+                "blue2": {
+                    "type": "string"
+                },
+                "blue3": {
+                    "type": "string"
+                },
+                "blue4": {
+                    "type": "string"
+                },
+                "blue5": {
+                    "type": "string"
+                },
+                "blue6": {
+                    "type": "string"
+                },
+                "blue7": {
+                    "type": "string"
+                },
+                "blue8": {
+                    "type": "string"
+                },
+                "blue9": {
+                    "type": "string"
+                },
+                "borderRadius": {
+                    "type": "number"
+                },
+                "borderRadiusLG": {
+                    "default": 8,
+                    "type": "number"
+                },
+                "borderRadiusOuter": {
+                    "default": 4,
+                    "type": "number"
+                },
+                "borderRadiusSM": {
+                    "default": 4,
+                    "type": "number"
+                },
+                "borderRadiusXS": {
+                    "default": 2,
+                    "type": "number"
+                },
+                "boxShadow": {
+                    "type": "string"
+                },
+                "boxShadowSecondary": {
+                    "type": "string"
+                },
+                "boxShadowTertiary": {
+                    "type": "string"
+                },
+                "colorBgBase": {
+                    "type": "string"
+                },
+                "colorBgBlur": {
+                    "type": "string"
+                },
+                "colorBgContainer": {
+                    "type": "string"
+                },
+                "colorBgContainerDisabled": {
+                    "type": "string"
+                },
+                "colorBgElevated": {
+                    "type": "string"
+                },
+                "colorBgLayout": {
+                    "type": "string"
+                },
+                "colorBgMask": {
+                    "type": "string"
+                },
+                "colorBgSolid": {
+                    "type": "string"
+                },
+                "colorBgSolidActive": {
+                    "type": "string"
+                },
+                "colorBgSolidHover": {
+                    "type": "string"
+                },
+                "colorBgSpotlight": {
+                    "type": "string"
+                },
+                "colorBgTextActive": {
+                    "type": "string"
+                },
+                "colorBgTextHover": {
+                    "type": "string"
+                },
+                "colorBorder": {
+                    "type": "string"
+                },
+                "colorBorderBg": {
+                    "type": "string"
+                },
+                "colorBorderDisabled": {
+                    "type": "string"
+                },
+                "colorBorderSecondary": {
+                    "type": "string"
+                },
+                "colorError": {
+                    "type": "string"
+                },
+                "colorErrorActive": {
+                    "type": "string"
+                },
+                "colorErrorBg": {
+                    "type": "string"
+                },
+                "colorErrorBgActive": {
+                    "type": "string"
+                },
+                "colorErrorBgFilledHover": {
+                    "type": "string"
+                },
+                "colorErrorBgHover": {
+                    "type": "string"
+                },
+                "colorErrorBorder": {
+                    "type": "string"
+                },
+                "colorErrorBorderHover": {
+                    "type": "string"
+                },
+                "colorErrorHover": {
+                    "type": "string"
+                },
+                "colorErrorOutline": {
+                    "type": "string"
+                },
+                "colorErrorText": {
+                    "type": "string"
+                },
+                "colorErrorTextActive": {
+                    "type": "string"
+                },
+                "colorErrorTextHover": {
+                    "type": "string"
+                },
+                "colorFill": {
+                    "type": "string"
+                },
+                "colorFillAlter": {
+                    "type": "string"
+                },
+                "colorFillContent": {
+                    "type": "string"
+                },
+                "colorFillContentHover": {
+                    "type": "string"
+                },
+                "colorFillQuaternary": {
+                    "type": "string"
+                },
+                "colorFillSecondary": {
+                    "type": "string"
+                },
+                "colorFillTertiary": {
+                    "type": "string"
+                },
+                "colorHighlight": {
+                    "type": "string"
+                },
+                "colorIcon": {
+                    "type": "string"
+                },
+                "colorIconHover": {
+                    "type": "string"
+                },
+                "colorInfo": {
+                    "type": "string"
+                },
+                "colorInfoActive": {
+                    "type": "string"
+                },
+                "colorInfoBg": {
+                    "type": "string"
+                },
+                "colorInfoBgHover": {
+                    "type": "string"
+                },
+                "colorInfoBorder": {
+                    "type": "string"
+                },
+                "colorInfoBorderHover": {
+                    "type": "string"
+                },
+                "colorInfoHover": {
+                    "type": "string"
+                },
+                "colorInfoText": {
+                    "type": "string"
+                },
+                "colorInfoTextActive": {
+                    "type": "string"
+                },
+                "colorInfoTextHover": {
+                    "type": "string"
+                },
+                "colorLink": {
+                    "type": "string"
+                },
+                "colorLinkActive": {
+                    "type": "string"
+                },
+                "colorLinkHover": {
+                    "type": "string"
+                },
+                "colorPrimary": {
+                    "type": "string"
+                },
+                "colorPrimaryActive": {
+                    "type": "string"
+                },
+                "colorPrimaryBg": {
+                    "type": "string"
+                },
+                "colorPrimaryBgHover": {
+                    "type": "string"
+                },
+                "colorPrimaryBorder": {
+                    "type": "string"
+                },
+                "colorPrimaryBorderHover": {
+                    "type": "string"
+                },
+                "colorPrimaryHover": {
+                    "type": "string"
+                },
+                "colorPrimaryText": {
+                    "type": "string"
+                },
+                "colorPrimaryTextActive": {
+                    "type": "string"
+                },
+                "colorPrimaryTextHover": {
+                    "type": "string"
+                },
+                "colorSplit": {
+                    "type": "string"
+                },
+                "colorSuccess": {
+                    "type": "string"
+                },
+                "colorSuccessActive": {
+                    "type": "string"
+                },
+                "colorSuccessBg": {
+                    "type": "string"
+                },
+                "colorSuccessBgHover": {
+                    "type": "string"
+                },
+                "colorSuccessBorder": {
+                    "type": "string"
+                },
+                "colorSuccessBorderHover": {
+                    "type": "string"
+                },
+                "colorSuccessHover": {
+                    "type": "string"
+                },
+                "colorSuccessText": {
+                    "type": "string"
+                },
+                "colorSuccessTextActive": {
+                    "type": "string"
+                },
+                "colorSuccessTextHover": {
+                    "type": "string"
+                },
+                "colorText": {
+                    "type": "string"
+                },
+                "colorTextBase": {
+                    "type": "string"
+                },
+                "colorTextDescription": {
+                    "type": "string"
+                },
+                "colorTextDisabled": {
+                    "type": "string"
+                },
+                "colorTextHeading": {
+                    "type": "string"
+                },
+                "colorTextLabel": {
+                    "type": "string"
+                },
+                "colorTextLightSolid": {
+                    "type": "string"
+                },
+                "colorTextPlaceholder": {
+                    "type": "string"
+                },
+                "colorTextQuaternary": {
+                    "type": "string"
+                },
+                "colorTextSecondary": {
+                    "type": "string"
+                },
+                "colorTextTertiary": {
+                    "type": "string"
+                },
+                "colorWarning": {
+                    "type": "string"
+                },
+                "colorWarningActive": {
+                    "type": "string"
+                },
+                "colorWarningBg": {
+                    "type": "string"
+                },
+                "colorWarningBgHover": {
+                    "type": "string"
+                },
+                "colorWarningBorder": {
+                    "type": "string"
+                },
+                "colorWarningBorderHover": {
+                    "type": "string"
+                },
+                "colorWarningHover": {
+                    "type": "string"
+                },
+                "colorWarningOutline": {
+                    "type": "string"
+                },
+                "colorWarningText": {
+                    "type": "string"
+                },
+                "colorWarningTextActive": {
+                    "type": "string"
+                },
+                "colorWarningTextHover": {
+                    "type": "string"
+                },
+                "colorWhite": {
+                    "default": "#FFFFFF",
+                    "type": "string"
+                },
+                "controlHeight": {
+                    "default": 32,
+                    "type": "number"
+                },
+                "controlHeightLG": {
+                    "type": "number"
+                },
+                "controlHeightSM": {
+                    "type": "number"
+                },
+                "controlHeightXS": {
+                    "type": "number"
+                },
+                "controlInteractiveSize": {
+                    "type": "number"
+                },
+                "controlItemBgActive": {
+                    "type": "string"
+                },
+                "controlItemBgActiveDisabled": {
+                    "type": "string"
+                },
+                "controlItemBgActiveHover": {
+                    "type": "string"
+                },
+                "controlItemBgHover": {
+                    "type": "string"
+                },
+                "controlOutline": {
+                    "type": "string"
+                },
+                "controlOutlineWidth": {
+                    "type": "number"
+                },
+                "controlPaddingHorizontal": {
+                    "type": "number"
+                },
+                "controlPaddingHorizontalSM": {
+                    "type": "number"
+                },
+                "controlTmpOutline": {
+                    "type": "string"
+                },
+                "cyan": {
+                    "type": "string"
+                },
+                "cyan-1": {
+                    "type": "string"
+                },
+                "cyan-10": {
+                    "type": "string"
+                },
+                "cyan-2": {
+                    "type": "string"
+                },
+                "cyan-3": {
+                    "type": "string"
+                },
+                "cyan-4": {
+                    "type": "string"
+                },
+                "cyan-5": {
+                    "type": "string"
+                },
+                "cyan-6": {
+                    "type": "string"
+                },
+                "cyan-7": {
+                    "type": "string"
+                },
+                "cyan-8": {
+                    "type": "string"
+                },
+                "cyan-9": {
+                    "type": "string"
+                },
+                "cyan1": {
+                    "type": "string"
+                },
+                "cyan10": {
+                    "type": "string"
+                },
+                "cyan2": {
+                    "type": "string"
+                },
+                "cyan3": {
+                    "type": "string"
+                },
+                "cyan4": {
+                    "type": "string"
+                },
+                "cyan5": {
+                    "type": "string"
+                },
+                "cyan6": {
+                    "type": "string"
+                },
+                "cyan7": {
+                    "type": "string"
+                },
+                "cyan8": {
+                    "type": "string"
+                },
+                "cyan9": {
+                    "type": "string"
+                },
+                "fontFamily": {
+                    "type": "string"
+                },
+                "fontFamilyCode": {
+                    "type": "string"
+                },
+                "fontSize": {
+                    "default": 14,
+                    "type": "number"
+                },
+                "fontSizeHeading1": {
+                    "default": 38,
+                    "type": "number"
+                },
+                "fontSizeHeading2": {
+                    "default": 30,
+                    "type": "number"
+                },
+                "fontSizeHeading3": {
+                    "default": 24,
+                    "type": "number"
+                },
+                "fontSizeHeading4": {
+                    "default": 20,
+                    "type": "number"
+                },
+                "fontSizeHeading5": {
+                    "default": 16,
+                    "type": "number"
+                },
+                "fontSizeIcon": {
+                    "type": "number"
+                },
+                "fontSizeLG": {
+                    "type": "number"
+                },
+                "fontSizeSM": {
+                    "type": "number"
+                },
+                "fontSizeXL": {
+                    "type": "number"
+                },
+                "fontWeightStrong": {
+                    "type": "number"
+                },
+                "geekblue": {
+                    "type": "string"
+                },
+                "geekblue-1": {
+                    "type": "string"
+                },
+                "geekblue-10": {
+                    "type": "string"
+                },
+                "geekblue-2": {
+                    "type": "string"
+                },
+                "geekblue-3": {
+                    "type": "string"
+                },
+                "geekblue-4": {
+                    "type": "string"
+                },
+                "geekblue-5": {
+                    "type": "string"
+                },
+                "geekblue-6": {
+                    "type": "string"
+                },
+                "geekblue-7": {
+                    "type": "string"
+                },
+                "geekblue-8": {
+                    "type": "string"
+                },
+                "geekblue-9": {
+                    "type": "string"
+                },
+                "geekblue1": {
+                    "type": "string"
+                },
+                "geekblue10": {
+                    "type": "string"
+                },
+                "geekblue2": {
+                    "type": "string"
+                },
+                "geekblue3": {
+                    "type": "string"
+                },
+                "geekblue4": {
+                    "type": "string"
+                },
+                "geekblue5": {
+                    "type": "string"
+                },
+                "geekblue6": {
+                    "type": "string"
+                },
+                "geekblue7": {
+                    "type": "string"
+                },
+                "geekblue8": {
+                    "type": "string"
+                },
+                "geekblue9": {
+                    "type": "string"
+                },
+                "gold": {
+                    "type": "string"
+                },
+                "gold-1": {
+                    "type": "string"
+                },
+                "gold-10": {
+                    "type": "string"
+                },
+                "gold-2": {
+                    "type": "string"
+                },
+                "gold-3": {
+                    "type": "string"
+                },
+                "gold-4": {
+                    "type": "string"
+                },
+                "gold-5": {
+                    "type": "string"
+                },
+                "gold-6": {
+                    "type": "string"
+                },
+                "gold-7": {
+                    "type": "string"
+                },
+                "gold-8": {
+                    "type": "string"
+                },
+                "gold-9": {
+                    "type": "string"
+                },
+                "gold1": {
+                    "type": "string"
+                },
+                "gold10": {
+                    "type": "string"
+                },
+                "gold2": {
+                    "type": "string"
+                },
+                "gold3": {
+                    "type": "string"
+                },
+                "gold4": {
+                    "type": "string"
+                },
+                "gold5": {
+                    "type": "string"
+                },
+                "gold6": {
+                    "type": "string"
+                },
+                "gold7": {
+                    "type": "string"
+                },
+                "gold8": {
+                    "type": "string"
+                },
+                "gold9": {
+                    "type": "string"
+                },
+                "green": {
+                    "type": "string"
+                },
+                "green-1": {
+                    "type": "string"
+                },
+                "green-10": {
+                    "type": "string"
+                },
+                "green-2": {
+                    "type": "string"
+                },
+                "green-3": {
+                    "type": "string"
+                },
+                "green-4": {
+                    "type": "string"
+                },
+                "green-5": {
+                    "type": "string"
+                },
+                "green-6": {
+                    "type": "string"
+                },
+                "green-7": {
+                    "type": "string"
+                },
+                "green-8": {
+                    "type": "string"
+                },
+                "green-9": {
+                    "type": "string"
+                },
+                "green1": {
+                    "type": "string"
+                },
+                "green10": {
+                    "type": "string"
+                },
+                "green2": {
+                    "type": "string"
+                },
+                "green3": {
+                    "type": "string"
+                },
+                "green4": {
+                    "type": "string"
+                },
+                "green5": {
+                    "type": "string"
+                },
+                "green6": {
+                    "type": "string"
+                },
+                "green7": {
+                    "type": "string"
+                },
+                "green8": {
+                    "type": "string"
+                },
+                "green9": {
+                    "type": "string"
+                },
+                "lime": {
+                    "type": "string"
+                },
+                "lime-1": {
+                    "type": "string"
+                },
+                "lime-10": {
+                    "type": "string"
+                },
+                "lime-2": {
+                    "type": "string"
+                },
+                "lime-3": {
+                    "type": "string"
+                },
+                "lime-4": {
+                    "type": "string"
+                },
+                "lime-5": {
+                    "type": "string"
+                },
+                "lime-6": {
+                    "type": "string"
+                },
+                "lime-7": {
+                    "type": "string"
+                },
+                "lime-8": {
+                    "type": "string"
+                },
+                "lime-9": {
+                    "type": "string"
+                },
+                "lime1": {
+                    "type": "string"
+                },
+                "lime10": {
+                    "type": "string"
+                },
+                "lime2": {
+                    "type": "string"
+                },
+                "lime3": {
+                    "type": "string"
+                },
+                "lime4": {
+                    "type": "string"
+                },
+                "lime5": {
+                    "type": "string"
+                },
+                "lime6": {
+                    "type": "string"
+                },
+                "lime7": {
+                    "type": "string"
+                },
+                "lime8": {
+                    "type": "string"
+                },
+                "lime9": {
+                    "type": "string"
+                },
+                "lineHeight": {
+                    "type": "number"
+                },
+                "lineHeightHeading1": {
+                    "default": 1.4,
+                    "type": "number"
+                },
+                "lineHeightHeading2": {
+                    "default": 1.35,
+                    "type": "number"
+                },
+                "lineHeightHeading3": {
+                    "default": 1.3,
+                    "type": "number"
+                },
+                "lineHeightHeading4": {
+                    "default": 1.25,
+                    "type": "number"
+                },
+                "lineHeightHeading5": {
+                    "default": 1.2,
+                    "type": "number"
+                },
+                "lineHeightLG": {
+                    "type": "number"
+                },
+                "lineHeightSM": {
+                    "type": "number"
+                },
+                "lineType": {
+                    "type": "string"
+                },
+                "lineWidth": {
+                    "type": "number"
+                },
+                "lineWidthBold": {
+                    "default": 1,
+                    "type": "number"
+                },
+                "lineWidthFocus": {
+                    "type": "number"
+                },
+                "linkDecoration": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "linkFocusDecoration": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "linkHoverDecoration": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "allOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "object"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "magenta": {
+                    "type": "string"
+                },
+                "magenta-1": {
+                    "type": "string"
+                },
+                "magenta-10": {
+                    "type": "string"
+                },
+                "magenta-2": {
+                    "type": "string"
+                },
+                "magenta-3": {
+                    "type": "string"
+                },
+                "magenta-4": {
+                    "type": "string"
+                },
+                "magenta-5": {
+                    "type": "string"
+                },
+                "magenta-6": {
+                    "type": "string"
+                },
+                "magenta-7": {
+                    "type": "string"
+                },
+                "magenta-8": {
+                    "type": "string"
+                },
+                "magenta-9": {
+                    "type": "string"
+                },
+                "magenta1": {
+                    "type": "string"
+                },
+                "magenta10": {
+                    "type": "string"
+                },
+                "magenta2": {
+                    "type": "string"
+                },
+                "magenta3": {
+                    "type": "string"
+                },
+                "magenta4": {
+                    "type": "string"
+                },
+                "magenta5": {
+                    "type": "string"
+                },
+                "magenta6": {
+                    "type": "string"
+                },
+                "magenta7": {
+                    "type": "string"
+                },
+                "magenta8": {
+                    "type": "string"
+                },
+                "magenta9": {
+                    "type": "string"
+                },
+                "margin": {
+                    "type": "number"
+                },
+                "marginLG": {
+                    "type": "number"
+                },
+                "marginMD": {
+                    "type": "number"
+                },
+                "marginSM": {
+                    "type": "number"
+                },
+                "marginXL": {
+                    "type": "number"
+                },
+                "marginXS": {
+                    "type": "number"
+                },
+                "marginXXL": {
+                    "type": "number"
+                },
+                "marginXXS": {
+                    "type": "number"
+                },
+                "motion": {
+                    "default": true,
+                    "type": "boolean"
+                },
+                "motionBase": {
+                    "type": "number"
+                },
+                "motionDurationFast": {
+                    "type": "string"
+                },
+                "motionDurationMid": {
+                    "type": "string"
+                },
+                "motionDurationSlow": {
+                    "type": "string"
+                },
+                "motionEaseInBack": {
+                    "type": "string"
+                },
+                "motionEaseInOut": {
+                    "type": "string"
+                },
+                "motionEaseInOutCirc": {
+                    "type": "string"
+                },
+                "motionEaseInQuint": {
+                    "type": "string"
+                },
+                "motionEaseOut": {
+                    "type": "string"
+                },
+                "motionEaseOutBack": {
+                    "type": "string"
+                },
+                "motionEaseOutCirc": {
+                    "type": "string"
+                },
+                "motionEaseOutQuint": {
+                    "type": "string"
+                },
+                "motionUnit": {
+                    "default": "100ms",
+                    "type": "number"
+                },
+                "opacityImage": {
+                    "type": "number"
+                },
+                "opacityLoading": {
+                    "type": "number"
+                },
+                "orange": {
+                    "type": "string"
+                },
+                "orange-1": {
+                    "type": "string"
+                },
+                "orange-10": {
+                    "type": "string"
+                },
+                "orange-2": {
+                    "type": "string"
+                },
+                "orange-3": {
+                    "type": "string"
+                },
+                "orange-4": {
+                    "type": "string"
+                },
+                "orange-5": {
+                    "type": "string"
+                },
+                "orange-6": {
+                    "type": "string"
+                },
+                "orange-7": {
+                    "type": "string"
+                },
+                "orange-8": {
+                    "type": "string"
+                },
+                "orange-9": {
+                    "type": "string"
+                },
+                "orange1": {
+                    "type": "string"
+                },
+                "orange10": {
+                    "type": "string"
+                },
+                "orange2": {
+                    "type": "string"
+                },
+                "orange3": {
+                    "type": "string"
+                },
+                "orange4": {
+                    "type": "string"
+                },
+                "orange5": {
+                    "type": "string"
+                },
+                "orange6": {
+                    "type": "string"
+                },
+                "orange7": {
+                    "type": "string"
+                },
+                "orange8": {
+                    "type": "string"
+                },
+                "orange9": {
+                    "type": "string"
+                },
+                "padding": {
+                    "type": "number"
+                },
+                "paddingContentHorizontal": {
+                    "type": "number"
+                },
+                "paddingContentHorizontalLG": {
+                    "type": "number"
+                },
+                "paddingContentHorizontalSM": {
+                    "type": "number"
+                },
+                "paddingContentVertical": {
+                    "type": "number"
+                },
+                "paddingContentVerticalLG": {
+                    "type": "number"
+                },
+                "paddingContentVerticalSM": {
+                    "type": "number"
+                },
+                "paddingLG": {
+                    "type": "number"
+                },
+                "paddingMD": {
+                    "type": "number"
+                },
+                "paddingSM": {
+                    "type": "number"
+                },
+                "paddingXL": {
+                    "type": "number"
+                },
+                "paddingXS": {
+                    "type": "number"
+                },
+                "paddingXXS": {
+                    "type": "number"
+                },
+                "pink": {
+                    "type": "string"
+                },
+                "pink-1": {
+                    "type": "string"
+                },
+                "pink-10": {
+                    "type": "string"
+                },
+                "pink-2": {
+                    "type": "string"
+                },
+                "pink-3": {
+                    "type": "string"
+                },
+                "pink-4": {
+                    "type": "string"
+                },
+                "pink-5": {
+                    "type": "string"
+                },
+                "pink-6": {
+                    "type": "string"
+                },
+                "pink-7": {
+                    "type": "string"
+                },
+                "pink-8": {
+                    "type": "string"
+                },
+                "pink-9": {
+                    "type": "string"
+                },
+                "pink1": {
+                    "type": "string"
+                },
+                "pink10": {
+                    "type": "string"
+                },
+                "pink2": {
+                    "type": "string"
+                },
+                "pink3": {
+                    "type": "string"
+                },
+                "pink4": {
+                    "type": "string"
+                },
+                "pink5": {
+                    "type": "string"
+                },
+                "pink6": {
+                    "type": "string"
+                },
+                "pink7": {
+                    "type": "string"
+                },
+                "pink8": {
+                    "type": "string"
+                },
+                "pink9": {
+                    "type": "string"
+                },
+                "purple": {
+                    "type": "string"
+                },
+                "purple-1": {
+                    "type": "string"
+                },
+                "purple-10": {
+                    "type": "string"
+                },
+                "purple-2": {
+                    "type": "string"
+                },
+                "purple-3": {
+                    "type": "string"
+                },
+                "purple-4": {
+                    "type": "string"
+                },
+                "purple-5": {
+                    "type": "string"
+                },
+                "purple-6": {
+                    "type": "string"
+                },
+                "purple-7": {
+                    "type": "string"
+                },
+                "purple-8": {
+                    "type": "string"
+                },
+                "purple-9": {
+                    "type": "string"
+                },
+                "purple1": {
+                    "type": "string"
+                },
+                "purple10": {
+                    "type": "string"
+                },
+                "purple2": {
+                    "type": "string"
+                },
+                "purple3": {
+                    "type": "string"
+                },
+                "purple4": {
+                    "type": "string"
+                },
+                "purple5": {
+                    "type": "string"
+                },
+                "purple6": {
+                    "type": "string"
+                },
+                "purple7": {
+                    "type": "string"
+                },
+                "purple8": {
+                    "type": "string"
+                },
+                "purple9": {
+                    "type": "string"
+                },
+                "red": {
+                    "type": "string"
+                },
+                "red-1": {
+                    "type": "string"
+                },
+                "red-10": {
+                    "type": "string"
+                },
+                "red-2": {
+                    "type": "string"
+                },
+                "red-3": {
+                    "type": "string"
+                },
+                "red-4": {
+                    "type": "string"
+                },
+                "red-5": {
+                    "type": "string"
+                },
+                "red-6": {
+                    "type": "string"
+                },
+                "red-7": {
+                    "type": "string"
+                },
+                "red-8": {
+                    "type": "string"
+                },
+                "red-9": {
+                    "type": "string"
+                },
+                "red1": {
+                    "type": "string"
+                },
+                "red10": {
+                    "type": "string"
+                },
+                "red2": {
+                    "type": "string"
+                },
+                "red3": {
+                    "type": "string"
+                },
+                "red4": {
+                    "type": "string"
+                },
+                "red5": {
+                    "type": "string"
+                },
+                "red6": {
+                    "type": "string"
+                },
+                "red7": {
+                    "type": "string"
+                },
+                "red8": {
+                    "type": "string"
+                },
+                "red9": {
+                    "type": "string"
+                },
+                "screenLG": {
+                    "type": "number"
+                },
+                "screenLGMax": {
+                    "type": "number"
+                },
+                "screenLGMin": {
+                    "type": "number"
+                },
+                "screenMD": {
+                    "type": "number"
+                },
+                "screenMDMax": {
+                    "type": "number"
+                },
+                "screenMDMin": {
+                    "type": "number"
+                },
+                "screenSM": {
+                    "type": "number"
+                },
+                "screenSMMax": {
+                    "type": "number"
+                },
+                "screenSMMin": {
+                    "type": "number"
+                },
+                "screenXL": {
+                    "type": "number"
+                },
+                "screenXLMax": {
+                    "type": "number"
+                },
+                "screenXLMin": {
+                    "type": "number"
+                },
+                "screenXS": {
+                    "type": "number"
+                },
+                "screenXSMax": {
+                    "type": "number"
+                },
+                "screenXSMin": {
+                    "type": "number"
+                },
+                "screenXXL": {
+                    "type": "number"
+                },
+                "screenXXLMax": {
+                    "type": "number"
+                },
+                "screenXXLMin": {
+                    "type": "number"
+                },
+                "screenXXXL": {
+                    "type": "number"
+                },
+                "screenXXXLMin": {
+                    "type": "number"
+                },
+                "size": {
+                    "default": 16,
+                    "type": "number"
+                },
+                "sizeLG": {
+                    "default": 24,
+                    "type": "number"
+                },
+                "sizeMD": {
+                    "default": 20,
+                    "type": "number"
+                },
+                "sizeMS": {
+                    "type": "number"
+                },
+                "sizePopupArrow": {
+                    "type": "number"
+                },
+                "sizeSM": {
+                    "default": 12,
+                    "type": "number"
+                },
+                "sizeStep": {
+                    "default": 4,
+                    "type": "number"
+                },
+                "sizeUnit": {
+                    "default": 4,
+                    "type": "number"
+                },
+                "sizeXL": {
+                    "default": 32,
+                    "type": "number"
+                },
+                "sizeXS": {
+                    "default": 8,
+                    "type": "number"
+                },
+                "sizeXXL": {
+                    "default": 48,
+                    "type": "number"
+                },
+                "sizeXXS": {
+                    "default": 4,
+                    "type": "number"
+                },
+                "volcano": {
+                    "type": "string"
+                },
+                "volcano-1": {
+                    "type": "string"
+                },
+                "volcano-10": {
+                    "type": "string"
+                },
+                "volcano-2": {
+                    "type": "string"
+                },
+                "volcano-3": {
+                    "type": "string"
+                },
+                "volcano-4": {
+                    "type": "string"
+                },
+                "volcano-5": {
+                    "type": "string"
+                },
+                "volcano-6": {
+                    "type": "string"
+                },
+                "volcano-7": {
+                    "type": "string"
+                },
+                "volcano-8": {
+                    "type": "string"
+                },
+                "volcano-9": {
+                    "type": "string"
+                },
+                "volcano1": {
+                    "type": "string"
+                },
+                "volcano10": {
+                    "type": "string"
+                },
+                "volcano2": {
+                    "type": "string"
+                },
+                "volcano3": {
+                    "type": "string"
+                },
+                "volcano4": {
+                    "type": "string"
+                },
+                "volcano5": {
+                    "type": "string"
+                },
+                "volcano6": {
+                    "type": "string"
+                },
+                "volcano7": {
+                    "type": "string"
+                },
+                "volcano8": {
+                    "type": "string"
+                },
+                "volcano9": {
+                    "type": "string"
+                },
+                "wireframe": {
+                    "default": false,
+                    "type": "boolean"
+                },
+                "yellow": {
+                    "type": "string"
+                },
+                "yellow-1": {
+                    "type": "string"
+                },
+                "yellow-10": {
+                    "type": "string"
+                },
+                "yellow-2": {
+                    "type": "string"
+                },
+                "yellow-3": {
+                    "type": "string"
+                },
+                "yellow-4": {
+                    "type": "string"
+                },
+                "yellow-5": {
+                    "type": "string"
+                },
+                "yellow-6": {
+                    "type": "string"
+                },
+                "yellow-7": {
+                    "type": "string"
+                },
+                "yellow-8": {
+                    "type": "string"
+                },
+                "yellow-9": {
+                    "type": "string"
+                },
+                "yellow1": {
+                    "type": "string"
+                },
+                "yellow10": {
+                    "type": "string"
+                },
+                "yellow2": {
+                    "type": "string"
+                },
+                "yellow3": {
+                    "type": "string"
+                },
+                "yellow4": {
+                    "type": "string"
+                },
+                "yellow5": {
+                    "type": "string"
+                },
+                "yellow6": {
+                    "type": "string"
+                },
+                "yellow7": {
+                    "type": "string"
+                },
+                "yellow8": {
+                    "type": "string"
+                },
+                "yellow9": {
+                    "type": "string"
+                },
+                "zIndexBase": {
+                    "default": 0,
+                    "type": "number"
+                },
+                "zIndexPopupBase": {
+                    "default": 1000,
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "components": {
+            "properties": {
+                "Affix": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Alert": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_1"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Anchor": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_2"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "App": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Avatar": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_3"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "BackTop": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_4"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Badge": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_5"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Breadcrumb": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_7"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Button": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_6"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Calendar": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_53"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Card": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_8"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Carousel": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_9"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Cascader": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_10"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Checkbox": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Collapse": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_13"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "ColorPicker": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "DatePicker": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_14"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Descriptions": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_15"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Divider": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_16"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Drawer": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_17"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Dropdown": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_18"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Empty": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Flex": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "FloatButton": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Form": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_22"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Grid": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Image": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_25"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Input": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_26"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "InputNumber": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_27"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Layout": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_28"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "List": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_29"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Masonry": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Mentions": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_30"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Menu": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_55"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Message": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_57"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Modal": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_56"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Notification": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_31"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Pagination": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_32"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Popconfirm": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_34"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Popover": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_33"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Progress": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_62"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "QRCode": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Radio": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_36"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Rate": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_35"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Result": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_37"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Segmented": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_38"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Select": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_39"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Skeleton": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_40"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Slider": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_41"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Space": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Spin": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_42"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Splitter": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_45"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Statistic": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_43"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Steps": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_54"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Switch": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_44"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Table": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_60"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Tabs": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_52"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Tag": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_46"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Timeline": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_50"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Tooltip": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_59"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Tour": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_63"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Transfer": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_51"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Tree": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_47"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "TreeSelect": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_48"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Typography": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_49"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Upload": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<ComponentToken>_58"
+                        },
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                },
+                "Wave": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/Partial<AliasToken>"
+                        },
+                        {
+                            "properties": {
+                                "algorithm": {
+                                    "anyOf": [
+                                        {
+                                            "items": {
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        {
+                                            "type": [
+                                                "object",
+                                                "boolean"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object"
+                        }
+                    ]
+                }
+            },
+            "type": "object"
+        },
         "algorithm": {
             "anyOf": [
                 {
-                    "items": {
-                        "type": "object"
-                    },
-                    "type": "array"
+                    "type": "object"
                 },
                 {
-                    "type": "object"
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
                 }
             ],
             "default": "defaultAlgorithm"
         },
-        "components": {
-            "$ref": "#/definitions/ComponentsConfig"
-        },
-        "cssVar": {
-            "anyOf": [
-                {
-                    "properties": {
-                        "key": {
-                            "type": "string"
-                        },
-                        "prefix": {
-                            "default": "ant",
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
-                },
-                {
-                    "type": "boolean"
-                }
-            ],
-            "default": false
+        "inherit": {
+            "type": "boolean",
+            "default": true
         },
         "hashed": {
-            "default": true,
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
         },
-        "inherit": {
-            "default": true,
-            "type": "boolean"
+        "cssVar": {
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "prefix": {
+                    "default": "ant",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "default": false
         },
-        "token": {
-            "$ref": "#/definitions/Partial<AliasToken>"
+        "zeroRuntime": {
+            "type": "boolean",
+            "default": true
         }
     },
     "type": "object"
 }
-

--- a/scripts/gen-theme-schema.cjs
+++ b/scripts/gen-theme-schema.cjs
@@ -1,0 +1,377 @@
+/**
+ * Generate antd ThemeConfig JSON Schema using TypeScript Compiler API.
+ *
+ * Unlike typescript-json-schema or ts-json-schema-generator, this script
+ * properly resolves mapped types like ComponentsConfig which uses
+ * `[key in keyof OverrideToken]` pattern.
+ *
+ * Each component in ComponentsConfig gets:
+ *   allOf: [ComponentToken, Partial<AliasToken>, { algorithm }]
+ * where Partial<AliasToken> is shared via $ref to avoid duplication.
+ *
+ * Usage: node scripts/gen-theme-schema.cjs [output-path]
+ * Default output: ./resources/antdThemeConfig.schema.json
+ */
+const ts = require('typescript');
+const path = require('path');
+const fs = require('fs');
+
+function parseDefault(val) {
+  if (val === 'true') return true;
+  if (val === 'false') return false;
+  if (val === 'undefined') return undefined;
+  if (val === 'null') return null;
+  const num = Number(val);
+  if (!isNaN(num) && val.trim() !== '') return num;
+  if (val.startsWith("'") || val.startsWith('"')) {
+    return val.slice(1, -1);
+  }
+  return val;
+}
+
+// Sort properties alphabetically for stable output
+function sortObjectKeys(obj) {
+  if (obj === null || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(sortObjectKeys);
+  const sorted = {};
+  for (const key of Object.keys(obj).sort()) {
+    sorted[key] = sortObjectKeys(obj[key]);
+  }
+  return sorted;
+}
+
+function generateSchema(outputPath) {
+  const contextFile = path.resolve(
+    __dirname,
+    '../react/node_modules/antd/es/config-provider/context.d.ts',
+  );
+  const componentsFile = path.resolve(
+    __dirname,
+    '../react/node_modules/antd/es/theme/interface/components.d.ts',
+  );
+
+  const program = ts.createProgram([contextFile, componentsFile], {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Node10,
+    esModuleInterop: true,
+    skipLibCheck: true,
+    baseUrl: path.resolve(__dirname, '..'),
+  });
+  const checker = program.getTypeChecker();
+
+  const sourceFile = program.getSourceFile(contextFile);
+  if (!sourceFile) {
+    console.error('Could not load', contextFile);
+    process.exit(1);
+  }
+
+  const componentsSf = program.getSourceFile(componentsFile);
+  if (!componentsSf) {
+    console.error('Could not load', componentsFile);
+    process.exit(1);
+  }
+
+  // Find ThemeConfig interface
+  let themeConfigType = null;
+  ts.forEachChild(sourceFile, (node) => {
+    if (ts.isInterfaceDeclaration(node) && node.name.text === 'ThemeConfig') {
+      themeConfigType = checker.getTypeAtLocation(node);
+    }
+  });
+
+  if (!themeConfigType) {
+    console.error('ThemeConfig not found');
+    process.exit(1);
+  }
+
+  // Find ComponentTokenMap interface (has the resolved component keys)
+  let componentTokenMapType = null;
+  ts.forEachChild(componentsSf, (node) => {
+    if (
+      ts.isInterfaceDeclaration(node) &&
+      node.name.text === 'ComponentTokenMap'
+    ) {
+      componentTokenMapType = checker.getTypeAtLocation(node);
+    }
+  });
+
+  // Schema generation helpers
+  function typeToSchema(type, anchorFile, depth = 0) {
+    if (depth > 8) return { type: 'object' };
+
+    // Handle union types
+    if (type.isUnion()) {
+      const filtered = type.types.filter(
+        (t) => !(t.flags & ts.TypeFlags.Undefined),
+      );
+      if (filtered.length === 1)
+        return typeToSchema(filtered[0], anchorFile, depth);
+
+      // Check for boolean (true | false union)
+      if (
+        filtered.length === 2 &&
+        filtered.every((t) => t.flags & ts.TypeFlags.BooleanLiteral)
+      ) {
+        return { type: 'boolean' };
+      }
+
+      const schemas = filtered.map((t) =>
+        typeToSchema(t, anchorFile, depth + 1),
+      );
+      const unique = [];
+      const seen = new Set();
+      for (const s of schemas) {
+        const key = JSON.stringify(s);
+        if (!seen.has(key)) {
+          seen.add(key);
+          unique.push(s);
+        }
+      }
+      if (unique.length === 1) return unique[0];
+      return { anyOf: unique };
+    }
+
+    // Handle intersection types
+    if (type.isIntersection()) {
+      // Flatten: merge all object property schemas together
+      const allProps = {};
+      for (const t of type.types) {
+        const s = typeToSchema(t, anchorFile, depth + 1);
+        if (s.properties) {
+          Object.assign(allProps, s.properties);
+        }
+      }
+      if (Object.keys(allProps).length > 0) {
+        return { properties: allProps, type: 'object' };
+      }
+      const schemas = type.types.map((t) =>
+        typeToSchema(t, anchorFile, depth + 1),
+      );
+      return { allOf: schemas };
+    }
+
+    // Primitives
+    if (type.flags & ts.TypeFlags.String) return { type: 'string' };
+    if (type.flags & ts.TypeFlags.Number) return { type: 'number' };
+    if (type.flags & ts.TypeFlags.Boolean) return { type: 'boolean' };
+    if (type.flags & ts.TypeFlags.Null) return { type: 'null' };
+    if (type.flags & ts.TypeFlags.StringLiteral)
+      return { type: 'string', const: type.value };
+    if (type.flags & ts.TypeFlags.NumberLiteral)
+      return { type: 'number', const: type.value };
+    if (type.flags & ts.TypeFlags.BooleanLiteral) return { type: 'boolean' };
+
+    // Array
+    if (checker.isArrayType(type)) {
+      const typeArgs = checker.getTypeArguments(type);
+      return {
+        type: 'array',
+        items: typeArgs.length
+          ? typeToSchema(typeArgs[0], anchorFile, depth + 1)
+          : { type: 'object' },
+      };
+    }
+
+    // Function types — just mark as object
+    const callSignatures = type.getCallSignatures();
+    if (callSignatures.length > 0 && type.getProperties().length === 0) {
+      return { type: 'object' };
+    }
+
+    // Object types with properties
+    const properties = type.getProperties();
+    if (properties.length > 0) {
+      return objectToSchema(properties, anchorFile, depth);
+    }
+
+    return { type: 'object' };
+  }
+
+  function objectToSchema(properties, anchorFile, depth) {
+    const props = {};
+    for (const prop of properties) {
+      if (prop.name.startsWith('_')) continue;
+
+      const propType = checker.getTypeOfSymbolAtLocation(prop, anchorFile);
+      props[prop.name] = typeToSchema(propType, anchorFile, depth + 1);
+
+      // Add default values from JSDoc
+      const jsDocTags = prop.getJsDocTags();
+      const defaultTag = jsDocTags.find((t) => t.name === 'default');
+      if (defaultTag && defaultTag.text) {
+        const defaultVal = defaultTag.text.map((t) => t.text).join('');
+        const parsed = parseDefault(defaultVal);
+        if (parsed !== undefined || defaultVal === 'null') {
+          props[prop.name].default = parsed;
+        }
+      }
+    }
+    return { properties: props, type: 'object' };
+  }
+
+  // Build Partial<AliasToken> schema from ThemeConfig.token
+  function buildAliasTokenSchema() {
+    const tokenSym = themeConfigType.getProperty('token');
+    if (!tokenSym) return { type: 'object' };
+
+    const tokenType = checker.getTypeOfSymbolAtLocation(tokenSym, sourceFile);
+    let resolved = tokenType;
+    if (resolved.isUnion()) {
+      const nonUndef = resolved.types.filter(
+        (t) => !(t.flags & ts.TypeFlags.Undefined),
+      );
+      if (nonUndef.length === 1) resolved = nonUndef[0];
+    }
+
+    const props = resolved.getProperties();
+    return objectToSchema(props, sourceFile, 0);
+  }
+
+  // Build ComponentsConfig schema by iterating ComponentTokenMap keys.
+  // Each component = allOf: [Partial<ComponentToken_N>, Partial<AliasToken>, { algorithm }]
+  // Partial<AliasToken> is shared via $ref in definitions.
+  function buildComponentsConfigSchema(definitions) {
+    if (!componentTokenMapType) {
+      console.error(
+        'ComponentTokenMap not found in',
+        componentsFile,
+        '— cannot generate component schemas.',
+      );
+      process.exit(1);
+    }
+
+    // Build and register Partial<AliasToken> as a shared definition
+    const aliasTokenSchema = buildAliasTokenSchema();
+    definitions['Partial<AliasToken>'] = aliasTokenSchema;
+
+    const componentKeys = componentTokenMapType.getProperties();
+    const props = {};
+    let compIdx = 0;
+
+    for (const compSym of componentKeys) {
+      const compTokenType = checker.getTypeOfSymbolAtLocation(
+        compSym,
+        componentsSf,
+      );
+
+      // Remove undefined from optional type
+      let resolved = compTokenType;
+      if (resolved.isUnion()) {
+        const nonUndef = resolved.types.filter(
+          (t) => !(t.flags & ts.TypeFlags.Undefined),
+        );
+        if (nonUndef.length === 1) resolved = nonUndef[0];
+      }
+
+      // Get component-specific token properties
+      const compProps = resolved.getProperties();
+      const compTokenSchema = objectToSchema(compProps, componentsSf, 2);
+
+      // Register component token as a definition if it has properties
+      const hasComponentTokenProps =
+        Object.keys(compTokenSchema.properties).length > 0;
+
+      const allOfParts = [];
+
+      if (hasComponentTokenProps) {
+        const defName =
+          compIdx === 0
+            ? 'Partial<ComponentToken>'
+            : `Partial<ComponentToken>_${compIdx}`;
+        definitions[defName] = compTokenSchema;
+        allOfParts.push({ $ref: `#/definitions/${defName}` });
+      }
+
+      // Add shared AliasToken ref
+      allOfParts.push({ $ref: '#/definitions/Partial<AliasToken>' });
+
+      // Add algorithm property
+      allOfParts.push({
+        properties: {
+          algorithm: {
+            anyOf: [
+              { items: { type: 'object' }, type: 'array' },
+              { type: ['object', 'boolean'] },
+            ],
+          },
+        },
+        type: 'object',
+      });
+
+      props[compSym.name] = { allOf: allOfParts };
+      compIdx++;
+    }
+
+    return { properties: props, type: 'object' };
+  }
+
+  // Generate definitions and ComponentsConfig
+  const definitions = {};
+  const componentsConfigSchema = buildComponentsConfigSchema(definitions);
+
+  // Generate schema for ThemeConfig top-level
+  const themeSchema = typeToSchema(themeConfigType, sourceFile);
+
+  // Replace the empty components schema with the properly resolved one
+  if (themeSchema.properties) {
+    themeSchema.properties.components = componentsConfigSchema;
+  }
+
+  const schema = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    definitions,
+    ...themeSchema,
+  };
+
+  // Sort definitions and inner properties
+  if (schema.definitions) {
+    for (const [key, val] of Object.entries(schema.definitions)) {
+      if (val && val.properties) {
+        schema.definitions[key] = {
+          ...val,
+          properties: sortObjectKeys(val.properties),
+        };
+      }
+    }
+  }
+  if (schema.properties) {
+    for (const [key, val] of Object.entries(schema.properties)) {
+      if (val && val.properties) {
+        schema.properties[key] = {
+          ...val,
+          properties: sortObjectKeys(val.properties),
+        };
+      }
+    }
+  }
+
+  const output = JSON.stringify(schema, null, 4) + '\n';
+  fs.writeFileSync(outputPath, output);
+
+  // Summary
+  const componentProps = schema.properties?.components?.properties
+    ? Object.keys(schema.properties.components.properties).length
+    : 0;
+  const tokenProps = schema.properties?.token?.properties
+    ? Object.keys(schema.properties.token.properties).length
+    : 0;
+  const defCount = Object.keys(schema.definitions || {}).length;
+  console.log(`Generated ${outputPath}`);
+  console.log(`  Components: ${componentProps} entries`);
+  console.log(`  Token properties: ${tokenProps} entries`);
+  console.log(`  Definitions: ${defCount}`);
+  console.log(`  Total lines: ${output.split('\n').length}`);
+
+  return schema;
+}
+
+// Run when executed directly
+if (require.main === module) {
+  const outputPath =
+    process.argv[2] ||
+    path.resolve(__dirname, '../resources/antdThemeConfig.schema.json');
+  generateSchema(outputPath);
+}
+
+module.exports = { parseDefault, sortObjectKeys, generateSchema };

--- a/scripts/gen-theme-schema.test.ts
+++ b/scripts/gen-theme-schema.test.ts
@@ -1,0 +1,178 @@
+// @ts-nocheck
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { parseDefault, sortObjectKeys, generateSchema } = require('./gen-theme-schema.cjs');
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+describe('gen-theme-schema', () => {
+  describe('parseDefault', () => {
+    it('parses boolean true', () => {
+      expect(parseDefault('true')).toBe(true);
+    });
+
+    it('parses boolean false', () => {
+      expect(parseDefault('false')).toBe(false);
+    });
+
+    it('parses undefined', () => {
+      expect(parseDefault('undefined')).toBeUndefined();
+    });
+
+    it('parses null as null (not undefined)', () => {
+      expect(parseDefault('null')).toBeNull();
+    });
+
+    it('parses integer numbers', () => {
+      expect(parseDefault('42')).toBe(42);
+      expect(parseDefault('0')).toBe(0);
+      expect(parseDefault('-1')).toBe(-1);
+    });
+
+    it('parses float numbers', () => {
+      expect(parseDefault('3.14')).toBe(3.14);
+      expect(parseDefault('0.5')).toBe(0.5);
+    });
+
+    it('strips single quotes from strings', () => {
+      expect(parseDefault("'hello'")).toBe('hello');
+    });
+
+    it('strips double quotes from strings', () => {
+      expect(parseDefault('"world"')).toBe('world');
+    });
+
+    it('returns raw string for unquoted non-numeric values', () => {
+      expect(parseDefault('some-value')).toBe('some-value');
+    });
+
+    it('does not parse empty string as number', () => {
+      expect(parseDefault('  ')).toBe('  ');
+    });
+  });
+
+  describe('sortObjectKeys', () => {
+    it('sorts object keys alphabetically', () => {
+      const result = sortObjectKeys({ c: 1, a: 2, b: 3 });
+      expect(Object.keys(result)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('sorts nested object keys', () => {
+      const result = sortObjectKeys({ z: { b: 1, a: 2 }, a: 3 });
+      expect(Object.keys(result)).toEqual(['a', 'z']);
+      expect(Object.keys(result.z)).toEqual(['a', 'b']);
+    });
+
+    it('handles arrays by sorting each element', () => {
+      const result = sortObjectKeys([{ b: 1, a: 2 }, { d: 3, c: 4 }]);
+      expect(Object.keys(result[0])).toEqual(['a', 'b']);
+      expect(Object.keys(result[1])).toEqual(['c', 'd']);
+    });
+
+    it('returns null as-is', () => {
+      expect(sortObjectKeys(null)).toBeNull();
+    });
+
+    it('returns primitives as-is', () => {
+      expect(sortObjectKeys(42)).toBe(42);
+      expect(sortObjectKeys('hello')).toBe('hello');
+      expect(sortObjectKeys(true)).toBe(true);
+    });
+
+    it('handles empty object', () => {
+      expect(sortObjectKeys({})).toEqual({});
+    });
+  });
+
+  describe('generateSchema (integration)', () => {
+    const antdContextPath = path.resolve(
+      __dirname,
+      '../react/node_modules/antd/es/config-provider/context.d.ts',
+    );
+    const hasAntd = fs.existsSync(antdContextPath);
+
+    // Skip integration tests if antd is not installed (e.g., in CI without node_modules)
+    const describeIfAntd = hasAntd ? describe : describe.skip;
+
+    describeIfAntd('with antd installed', () => {
+      let outputPath: string;
+      let tmpDir: string;
+
+      beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'theme-schema-'));
+        outputPath = path.join(tmpDir, 'test-schema.json');
+      });
+
+      afterEach(() => {
+        if (fs.existsSync(outputPath)) {
+          fs.unlinkSync(outputPath);
+        }
+        fs.rmdirSync(tmpDir);
+      });
+
+      it('generates a valid JSON schema file', () => {
+        const schema = generateSchema(outputPath);
+
+        expect(fs.existsSync(outputPath)).toBe(true);
+        const content = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+        expect(content.$schema).toBe('http://json-schema.org/draft-07/schema#');
+        expect(content.type).toBe('object');
+        expect(content.properties).toBeDefined();
+      });
+
+      it('includes component entries', () => {
+        const schema = generateSchema(outputPath);
+
+        expect(schema.properties.components).toBeDefined();
+        expect(schema.properties.components.properties).toBeDefined();
+        const componentKeys = Object.keys(schema.properties.components.properties);
+        expect(componentKeys.length).toBeGreaterThan(0);
+        // antd has many components, expect a reasonable count
+        expect(componentKeys).toContain('Button');
+        expect(componentKeys).toContain('Input');
+      });
+
+      it('includes token properties', () => {
+        const schema = generateSchema(outputPath);
+
+        expect(schema.properties.token).toBeDefined();
+        expect(schema.properties.token.properties).toBeDefined();
+        const tokenKeys = Object.keys(schema.properties.token.properties);
+        expect(tokenKeys.length).toBeGreaterThan(0);
+      });
+
+      it('includes shared AliasToken definition', () => {
+        const schema = generateSchema(outputPath);
+
+        expect(schema.definitions['Partial<AliasToken>']).toBeDefined();
+        expect(schema.definitions['Partial<AliasToken>'].type).toBe('object');
+      });
+
+      it('uses allOf structure for component entries', () => {
+        const schema = generateSchema(outputPath);
+        const buttonSchema = schema.properties.components.properties.Button;
+
+        expect(buttonSchema.allOf).toBeDefined();
+        expect(buttonSchema.allOf.length).toBeGreaterThanOrEqual(2);
+        // Should include Partial<AliasToken> ref
+        const refs = buttonSchema.allOf
+          .filter((p: any) => p.$ref)
+          .map((p: any) => p.$ref);
+        expect(refs).toContain('#/definitions/Partial<AliasToken>');
+      });
+
+      it('produces sorted output keys', () => {
+        const schema = generateSchema(outputPath);
+        const content = fs.readFileSync(outputPath, 'utf8');
+        const parsed = JSON.parse(content);
+
+        // Check that definitions keys are in sorted order within each definition
+        if (parsed.definitions['Partial<AliasToken>']?.properties) {
+          const keys = Object.keys(parsed.definitions['Partial<AliasToken>'].properties);
+          const sorted = [...keys].sort();
+          expect(keys).toEqual(sorted);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
Resolves ([FR-2306](https://lablup.atlassian.net/browse/FR-2306))

## Summary
- Replace `typescript-json-schema` (via `pnpm dlx`) with a custom script using TypeScript Compiler API for `theme-schema:update`
- Fix antd 6's `ComponentsConfig` mapped type (`[key in keyof OverrideToken]`) not being resolved, which caused all component token definitions to be lost
- Each component now properly includes `allOf: [ComponentToken, Partial<AliasToken>, { algorithm }]` with `Partial<AliasToken>` shared via `$ref`
- Generated schema: 67 components, 492 token properties, 57 definitions

## Test plan
- [x] `scripts/verify.sh` passes (Relay, Lint, Format, TypeScript)
- [ ] Open `resources/theme.json` and verify component token autocomplete works (e.g., Table, Button, Flex should show AliasToken properties)

[FR-2306]: https://lablup.atlassian.net/browse/FR-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ