### PR TITLE
feat(FR-2307): add sidebar TOC and prev/next navigation to HelpDocumentModal

### DIFF
--- a/react/src/components/HelpDocumentModal.tsx
+++ b/react/src/components/HelpDocumentModal.tsx
@@ -2,15 +2,64 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { ExportOutlined } from '@ant-design/icons';
+import { useDocNavigation } from '../hooks/useDocNavigation';
+import {
+  ExportOutlined,
+  LeftOutlined,
+  MenuFoldOutlined,
+  MenuUnfoldOutlined,
+  RightOutlined,
+} from '@ant-design/icons';
+import useResizeObserver from '@react-hook/resize-observer';
 import { Button, Spin, Tooltip, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIModal, type BAIModalProps } from 'backend.ai-ui';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Markdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
+
+const TOC_WIDTH = 240;
+const COLLAPSE_BREAKPOINT = 768;
+const ADMIN_DOC_PATH = 'admin_menu/admin_menu.md';
+
+interface AdminSubSection {
+  anchor: string;
+  title: string;
+}
+
+/**
+ * Parse h2 headings and their preceding anchor IDs from admin_menu markdown.
+ * Pattern: <a id="anchor-id"></a>\n\n## Heading Title
+ */
+function parseAdminSubSections(markdownText: string): AdminSubSection[] {
+  const sections: AdminSubSection[] = [];
+  const lines = markdownText.split('\n');
+
+  let lastAnchor: string | null = null;
+  for (const line of lines) {
+    const anchorMatch = line.match(/<a\s+id=["']([^"']+)["']\s*\/?>\s*<\/a>/);
+    if (anchorMatch) {
+      lastAnchor = anchorMatch[1];
+      continue;
+    }
+    const h2Match = line.match(/^##\s+(.+)$/);
+    if (h2Match && lastAnchor) {
+      sections.push({ anchor: lastAnchor, title: h2Match[1].trim() });
+      lastAnchor = null;
+    } else if (h2Match) {
+      // h2 without preceding anchor — use slugified title
+      const slug = h2Match[1]
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+      sections.push({ anchor: slug, title: h2Match[1].trim() });
+    }
+  }
+  return sections;
+}
 
 const useStyles = createStyles(({ token, css }) => ({
   docsBody: css`
@@ -103,6 +152,71 @@ const useStyles = createStyles(({ token, css }) => ({
       color: ${token.colorLink};
     }
   `,
+  tocSidebar: css`
+    width: ${TOC_WIDTH}px;
+    min-width: ${TOC_WIDTH}px;
+    overflow-y: auto;
+    border-right: ${token.lineWidth}px solid ${token.colorBorderSecondary};
+    background: ${token.colorBgLayout};
+    padding: ${token.paddingSM}px 0;
+    transition: all ${token.motionDurationMid};
+  `,
+  tocSidebarCollapsed: css`
+    width: 0;
+    min-width: 0;
+    padding: 0;
+    overflow: hidden;
+    border-right: none;
+  `,
+  tocItem: css`
+    display: block;
+    padding: ${token.paddingXS}px ${token.paddingMD}px;
+    color: ${token.colorText};
+    cursor: pointer;
+    font-size: ${token.fontSize}px;
+    line-height: 1.5;
+    border-left: ${token.lineWidthBold}px solid transparent;
+    transition: all ${token.motionDurationFast};
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &:hover {
+      background: ${token.colorFillQuaternary};
+      color: ${token.colorPrimary};
+    }
+  `,
+  tocSubItem: css`
+    padding-left: ${token.paddingMD + token.paddingSM}px;
+    font-size: ${token.fontSizeSM}px;
+  `,
+  tocItemActive: css`
+    background: ${token.colorPrimaryBg};
+    color: ${token.colorPrimary};
+    font-weight: ${token.fontWeightStrong};
+    border-left-color: ${token.colorPrimary};
+
+    &:hover {
+      background: ${token.colorPrimaryBg};
+    }
+  `,
+  tocSectionHeader: css`
+    padding: ${token.paddingSM}px ${token.paddingMD}px ${token.paddingXXS}px;
+    margin-top: ${token.marginSM}px;
+    border-top: ${token.lineWidth}px solid ${token.colorBorderSecondary};
+    font-size: ${token.fontSize}px;
+    font-weight: ${token.fontWeightStrong};
+    color: ${token.colorText};
+  `,
+  prevNextBar: css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: ${token.paddingMD}px ${token.paddingXL}px;
+    border-top: ${token.lineWidth}px solid ${token.colorBorderSecondary};
+    background: ${token.colorBgElevated};
+    flex-shrink: 0;
+  `,
 }));
 
 interface HelpDocumentModalProps extends Omit<
@@ -126,48 +240,121 @@ const HelpDocumentModal: React.FC<HelpDocumentModalProps> = ({
   'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const { styles } = useStyles();
+  const { styles, cx } = useStyles();
+
+  const [activeDocPath, setActiveDocPath] = useState(docPath);
   const [markdown, setMarkdown] = useState<string>('');
   const [loading, setLoading] = useState(false);
+  const [tocCollapsed, setTocCollapsed] = useState(false);
+  const [adminSubSections, setAdminSubSections] = useState<AdminSubSection[]>(
+    [],
+  );
   const docsBodyRef = useRef<HTMLDivElement>(null);
+  const tocActiveRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { navItems, currentIndex, prevItem, nextItem } = useDocNavigation(
+    docLang,
+    activeDocPath,
+  );
+
+  // Sync activeDocPath when initial docPath prop changes (route change)
+  useEffect(() => {
+    setActiveDocPath(docPath);
+  }, [docPath]);
+
+  // Responsive: auto-collapse TOC based on container width
+  useResizeObserver(containerRef, (entry: ResizeObserverEntry) => {
+    setTocCollapsed(entry.contentRect.width < COLLAPSE_BREAKPOINT);
+  });
 
   const basePath = `/packages/backend.ai-webui-docs/src/${docLang}/`;
-  // Separate anchor from file path (e.g., "admin_menu/admin_menu.md#section-id")
-  const [filePath, anchor] = docPath.split('#');
+  const [filePath, anchor] = activeDocPath.split('#');
   const mdURL = basePath + filePath;
 
-  const fetchMarkdown = useCallback(async () => {
-    setLoading(true);
+  // Fetch admin_menu.md to extract h2 sub-sections for TOC
+  const fetchAdminSubSections = useCallback(async () => {
     try {
-      const res = await fetch(mdURL);
-      if (!res.ok) throw new Error(`${res.status}`);
+      const res = await fetch(basePath + ADMIN_DOC_PATH);
+      if (!res.ok) return;
       const text = await res.text();
-      // Strip HTML comments (<!-- ... -->) and
-      // admonition fences (:::note, :::warning, etc.) for simple rendering
-      const cleaned = text
-        .replace(/<!--[\s\S]*?-->/g, '')
-        .replace(/^:::\w+(?:\[.*?\])?\s*$/gm, '')
-        .replace(/^:::\s*$/gm, '');
-      setMarkdown(cleaned);
-      // Scroll to anchor element instantly, or reset to top
-      requestAnimationFrame(() => {
-        if (anchor) {
-          const target = docsBodyRef.current?.querySelector(
-            `#${CSS.escape(anchor)}`,
-          );
-          target?.scrollIntoView({ behavior: 'instant' });
-        } else {
-          docsBodyRef.current?.scrollTo(0, 0);
-        }
-      });
+      setAdminSubSections(parseAdminSubSections(text));
     } catch {
-      setMarkdown(
-        `> ${t('webui.menu.HelpDocumentNotFound', { docLang, docPath: filePath })}`,
-      );
-    } finally {
-      setLoading(false);
+      setAdminSubSections([]);
     }
-  }, [mdURL, anchor, docLang, filePath, t]);
+  }, [basePath]);
+
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const fetchMarkdown = useCallback(
+    async (url: string, anchorId?: string, displayPath?: string) => {
+      abortControllerRef.current?.abort();
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      setLoading(true);
+      try {
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) throw new Error(`${res.status}`);
+        const text = await res.text();
+        if (controller.signal.aborted) return;
+        const cleaned = text
+          .replace(/<!--[\s\S]*?-->/g, '')
+          .replace(/^:::\w+(?:\[.*?\])?\s*$/gm, '')
+          .replace(/^:::\s*$/gm, '');
+        setMarkdown(cleaned);
+        requestAnimationFrame(() => {
+          if (anchorId) {
+            const target = docsBodyRef.current?.querySelector(
+              `#${CSS.escape(anchorId)}`,
+            );
+            target?.scrollIntoView({ behavior: 'instant' });
+          } else {
+            docsBodyRef.current?.scrollTo(0, 0);
+          }
+        });
+      } catch (e) {
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        setMarkdown(
+          `> ${t('webui.menu.HelpDocumentNotFound', { docLang, docPath: displayPath ?? url })}`,
+        );
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    },
+    [docLang, t],
+  );
+
+  // Fetch markdown when activeDocPath changes
+  useEffect(() => {
+    if (modalProps.open && activeDocPath) {
+      fetchMarkdown(mdURL, anchor, filePath);
+    }
+  }, [activeDocPath, modalProps.open, mdURL, anchor, filePath, fetchMarkdown]);
+
+  // Auto-scroll TOC to keep active item visible
+  useEffect(() => {
+    tocActiveRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [currentIndex, activeDocPath]);
+
+  const handleNavigate = useCallback((path: string) => {
+    setActiveDocPath(path);
+  }, []);
+
+  // Compute image base path for url transforms
+  const imageBasePath =
+    basePath +
+    (filePath.includes('/')
+      ? filePath.substring(0, filePath.lastIndexOf('/') + 1)
+      : '');
+
+  // Check if a sub-section is the currently active anchor
+  const activeAnchor = filePath === ADMIN_DOC_PATH ? anchor : undefined;
+
+  // Determine if the current path is in the admin section (admin_menu or its sub-section)
+  const isInAdminDoc = filePath === ADMIN_DOC_PATH;
 
   return (
     <BAIModal
@@ -194,7 +381,14 @@ const HelpDocumentModal: React.FC<HelpDocumentModalProps> = ({
       width="70vw"
       afterOpenChange={(isOpen) => {
         if (isOpen) {
-          fetchMarkdown();
+          setActiveDocPath(docPath);
+          const openFilePath = docPath.split('#')[0];
+          fetchMarkdown(
+            basePath + openFilePath,
+            docPath.split('#')[1],
+            openFilePath,
+          );
+          fetchAdminSubSections();
         } else {
           setMarkdown('');
         }
@@ -202,77 +396,237 @@ const HelpDocumentModal: React.FC<HelpDocumentModalProps> = ({
       styles={{
         body: {
           padding: 0,
+          paddingTop: 0,
+          paddingBottom: 0,
           display: 'flex',
-          flexDirection: 'column',
+          flexDirection: 'row',
+          overflow: 'hidden',
         },
       }}
       {...modalProps}
     >
-      {loading ? (
+      <div
+        ref={containerRef}
+        style={{ display: 'flex', flex: 1, overflow: 'hidden' }}
+      >
+        {/* TOC Sidebar */}
+        <div
+          className={cx(
+            styles.tocSidebar,
+            tocCollapsed && styles.tocSidebarCollapsed,
+          )}
+        >
+          {navItems.map((item, idx) => {
+            const isAdminDoc = item.path === ADMIN_DOC_PATH;
+
+            // Skip admin_menu entry itself — replaced by section header + sub-items
+            if (isAdminDoc) {
+              return (
+                <React.Fragment key={item.path}>
+                  {/* Admin section header */}
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    className={styles.tocSectionHeader}
+                    style={{ cursor: 'pointer' }}
+                    onClick={() => handleNavigate(ADMIN_DOC_PATH)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleNavigate(ADMIN_DOC_PATH);
+                      }
+                    }}
+                  >
+                    {t('webui.menu.Administration')}
+                  </div>
+                  {/* Admin sub-sections */}
+                  {adminSubSections.map((sub) => (
+                    <div
+                      key={sub.anchor}
+                      role="button"
+                      tabIndex={0}
+                      ref={
+                        isInAdminDoc && activeAnchor === sub.anchor
+                          ? tocActiveRef
+                          : undefined
+                      }
+                      className={cx(
+                        styles.tocItem,
+                        styles.tocSubItem,
+                        isInAdminDoc &&
+                          activeAnchor === sub.anchor &&
+                          styles.tocItemActive,
+                      )}
+                      onClick={() =>
+                        handleNavigate(`${ADMIN_DOC_PATH}#${sub.anchor}`)
+                      }
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          handleNavigate(`${ADMIN_DOC_PATH}#${sub.anchor}`);
+                        }
+                      }}
+                      title={sub.title}
+                    >
+                      {sub.title}
+                    </div>
+                  ))}
+                </React.Fragment>
+              );
+            }
+
+            // For post-admin items, no special treatment — they render normally
+            return (
+              <div
+                key={item.path}
+                role="button"
+                tabIndex={0}
+                ref={
+                  idx === currentIndex && !isInAdminDoc
+                    ? tocActiveRef
+                    : undefined
+                }
+                className={cx(
+                  styles.tocItem,
+                  idx === currentIndex && !isInAdminDoc && styles.tocItemActive,
+                )}
+                onClick={() => handleNavigate(item.path)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleNavigate(item.path);
+                  }
+                }}
+                title={item.title}
+              >
+                {item.title}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Content area */}
         <div
           style={{
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
             flex: 1,
-            minHeight: token.controlHeightLG * 10,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+            position: 'relative',
           }}
         >
-          <Spin />
-        </div>
-      ) : (
-        <div ref={docsBodyRef} className={styles.docsBody}>
-          <Markdown
-            remarkPlugins={[remarkGfm]}
-            rehypePlugins={[rehypeRaw]}
-            urlTransform={(url) => {
-              // Resolve relative image paths to the docs directory
-              if (
-                url.startsWith('images/') ||
-                url.startsWith('../images/') ||
-                url.startsWith('./images/')
-              ) {
-                const dirPath = docPath.includes('/')
-                  ? docPath.substring(0, docPath.lastIndexOf('/') + 1)
-                  : '';
-                return basePath + dirPath + url;
-              }
-              return url;
+          {/* TOC toggle button */}
+          <Button
+            type="text"
+            size="small"
+            icon={tocCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
+            onClick={() => setTocCollapsed((prev) => !prev)}
+            aria-label={
+              tocCollapsed
+                ? 'Expand table of contents'
+                : 'Collapse table of contents'
+            }
+            aria-expanded={!tocCollapsed}
+            style={{
+              position: 'absolute',
+              top: token.paddingXXS,
+              left: token.paddingXS,
+              zIndex: 1,
             }}
-            components={{
-              a: ({ href, children, ...props }) => {
-                if (href?.startsWith('#')) {
-                  return (
-                    <a
-                      {...props}
-                      href={href}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        const target = document.getElementById(href.slice(1));
-                        target?.scrollIntoView({ behavior: 'smooth' });
-                      }}
-                    >
-                      {children}
-                    </a>
-                  );
-                }
-                return (
-                  <a
-                    href={href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    {...props}
+          />
+
+          {loading ? (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                flex: 1,
+                minHeight: token.controlHeightLG * 10,
+              }}
+            >
+              <Spin />
+            </div>
+          ) : (
+            <div ref={docsBodyRef} className={styles.docsBody}>
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                urlTransform={(url) => {
+                  if (
+                    url.startsWith('images/') ||
+                    url.startsWith('../images/') ||
+                    url.startsWith('./images/')
+                  ) {
+                    return imageBasePath + url;
+                  }
+                  return url;
+                }}
+                components={{
+                  a: ({ href, children, ...props }) => {
+                    if (href?.startsWith('#')) {
+                      return (
+                        <a
+                          {...props}
+                          href={href}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            const target = document.getElementById(
+                              href.slice(1),
+                            );
+                            target?.scrollIntoView({ behavior: 'smooth' });
+                          }}
+                        >
+                          {children}
+                        </a>
+                      );
+                    }
+                    return (
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        {...props}
+                      >
+                        {children}
+                      </a>
+                    );
+                  },
+                }}
+              >
+                {markdown}
+              </Markdown>
+            </div>
+          )}
+
+          {/* Prev/Next navigation bar */}
+          {(prevItem || nextItem) && !loading ? (
+            <div className={styles.prevNextBar}>
+              <div>
+                {prevItem ? (
+                  <Button
+                    type="text"
+                    icon={<LeftOutlined />}
+                    onClick={() => handleNavigate(prevItem.path)}
                   >
-                    {children}
-                  </a>
-                );
-              },
-            }}
-          >
-            {markdown}
-          </Markdown>
+                    {prevItem.title}
+                  </Button>
+                ) : null}
+              </div>
+              <div>
+                {nextItem ? (
+                  <Button
+                    type="text"
+                    onClick={() => handleNavigate(nextItem.path)}
+                  >
+                    {nextItem.title} <RightOutlined />
+                  </Button>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
         </div>
-      )}
+      </div>
     </BAIModal>
   );
 };

--- a/react/src/hooks/useDocNavigation.ts
+++ b/react/src/hooks/useDocNavigation.ts
@@ -1,0 +1,118 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { useCallback, useEffect, useState } from 'react';
+
+export interface DocNavItem {
+  title: string;
+  path: string;
+}
+
+interface UseDocNavigationResult {
+  navItems: DocNavItem[];
+  currentIndex: number;
+  prevItem: DocNavItem | null;
+  nextItem: DocNavItem | null;
+  loading: boolean;
+}
+
+/**
+ * Parses the flat navigation structure from book.config.yaml.
+ * The YAML is simple enough (title/path pairs under language keys)
+ * that a lightweight regex-based parser suffices without adding a
+ * full YAML library dependency.
+ */
+function parseNavigation(yamlText: string, lang: string): DocNavItem[] {
+  const items: DocNavItem[] = [];
+  const lines = yamlText.split('\n');
+
+  let inNavigation = false;
+  let inTargetLang = false;
+  let currentTitle: string | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+
+    if (trimmed === 'navigation:') {
+      inNavigation = true;
+      continue;
+    }
+
+    if (!inNavigation) continue;
+
+    // Detect language key (e.g., "  en:")
+    const langMatch = trimmed.match(/^(\w{2}):$/);
+    if (langMatch) {
+      if (inTargetLang) break; // We've passed our target language section
+      inTargetLang = langMatch[1] === lang;
+      continue;
+    }
+
+    if (!inTargetLang) continue;
+
+    // Parse title line (e.g., "    - title: Overview")
+    const titleMatch = trimmed.match(/^- title:\s*(.+)$/);
+    if (titleMatch) {
+      currentTitle = titleMatch[1].trim();
+      continue;
+    }
+
+    // Parse path line (e.g., "      path: overview/overview.md")
+    const pathMatch = trimmed.match(/^path:\s*(.+)$/);
+    if (pathMatch && currentTitle !== null) {
+      items.push({ title: currentTitle, path: pathMatch[1].trim() });
+      currentTitle = null;
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Hook that fetches book.config.yaml and provides navigation data
+ * for the help documentation modal.
+ *
+ * @param docLang - Current documentation language (en, ko, ja, th)
+ * @param currentDocPath - Currently displayed doc path (may include #anchor)
+ */
+export function useDocNavigation(
+  docLang: string,
+  currentDocPath: string,
+): UseDocNavigationResult {
+  'use memo';
+
+  const [navItems, setNavItems] = useState<DocNavItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchNavigation = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        '/packages/backend.ai-webui-docs/src/book.config.yaml',
+      );
+      if (!res.ok) throw new Error(`${res.status}`);
+      const text = await res.text();
+      setNavItems(parseNavigation(text, docLang));
+    } catch {
+      setNavItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [docLang]);
+
+  useEffect(() => {
+    fetchNavigation();
+  }, [fetchNavigation]);
+
+  // Strip anchor from current path for matching against nav items
+  const basePath = currentDocPath.split('#')[0];
+  const currentIndex = navItems.findIndex((item) => item.path === basePath);
+  const prevItem = currentIndex > 0 ? navItems[currentIndex - 1] : null;
+  const nextItem =
+    currentIndex >= 0 && currentIndex < navItems.length - 1
+      ? navItems[currentIndex + 1]
+      : null;
+
+  return { navItems, currentIndex, prevItem, nextItem, loading };
+}


### PR DESCRIPTION
Resolves #5997(FR-2307)

## Summary
- Add left sidebar TOC panel showing full documentation structure from `book.config.yaml`
  - Localized titles per language (en, ko, ja, th)
  - Active document highlighted with primary color and left border
  - Auto-scrolls to keep active item visible
  - Administration section header with indented sub-items parsed from `admin_menu.md` h2 headings
  - Post-admin items (Troubleshooting, Appendix, etc.) rendered as regular items
- Add bottom prev/next navigation bar with adjacent document titles
  - Hidden at first/last document boundaries
- Responsive: TOC auto-collapses on narrow viewports (`< 768px`) with toggle button
- Internal `activeDocPath` state for in-modal document navigation without route changes
- New `useDocNavigation` hook that fetches and parses `book.config.yaml` at runtime
- All styling uses antd design tokens (no hardcoded px values)

## Changed Files
- `react/src/components/HelpDocumentModal.tsx` — TOC sidebar, prev/next bar, admin sub-section support, responsive collapse
- `react/src/hooks/useDocNavigation.ts` — New hook for navigation data from `book.config.yaml`