### PR TITLE
feat(#6001): add search and highlight support to HelpDocumentModal

### DIFF
--- a/react/src/components/HelpDocumentModal.tsx
+++ b/react/src/components/HelpDocumentModal.tsx
@@ -16,7 +16,7 @@ import {
   UpOutlined,
 } from '@ant-design/icons';
 import useResizeObserver from '@react-hook/resize-observer';
-import { Button, Input, Spin, Tooltip, theme } from 'antd';
+import { Button, Input, type InputRef, Spin, Tooltip, theme } from 'antd';
 import { createStyles } from 'antd-style';
 import { BAIModal, type BAIModalProps } from 'backend.ai-ui';
 import React, {
@@ -134,8 +134,6 @@ function rehypeSearchHighlight(query: string) {
               tagName: 'mark',
               properties: {
                 'data-search-match': String(matchCounter.value),
-                style:
-                  'background-color: #fde68a; border-radius: 2px; padding: 0 1px;',
               },
               children: [
                 { type: 'text', value: text.slice(idx, idx + query.length) },
@@ -290,6 +288,13 @@ const useStyles = createStyles(({ token, css }) => ({
     }
     mark[data-search-match] {
       scroll-margin-top: ${token.marginLG}px;
+      background-color: ${token.colorWarningBg};
+      border-radius: ${token.borderRadiusXS}px;
+      padding: 0 1px;
+    }
+    mark[data-search-match].active-match {
+      background-color: ${token.colorWarning};
+      color: ${token.colorWhite};
     }
   `,
   tocSidebar: css`
@@ -440,7 +445,7 @@ const HelpDocumentModal: React.FC<HelpDocumentModalProps> = ({
   const docsBodyRef = useRef<HTMLDivElement>(null);
   const tocActiveRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const floatingSearchInputRef = useRef<HTMLInputElement>(null);
+  const floatingSearchInputRef = useRef<InputRef>(null);
 
   const { navItems, currentIndex, prevItem, nextItem } = useDocNavigation(
     docLang,
@@ -567,14 +572,9 @@ const HelpDocumentModal: React.FC<HelpDocumentModalProps> = ({
 
     const marks = container.querySelectorAll('mark[data-search-match]');
     marks.forEach((mark, i) => {
-      const el = mark as HTMLElement;
+      mark.classList.toggle('active-match', i === activeMatchIndex);
       if (i === activeMatchIndex) {
-        el.style.backgroundColor = '#f97316';
-        el.style.color = 'white';
-        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      } else {
-        el.style.backgroundColor = '#fde68a';
-        el.style.color = 'inherit';
+        mark.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
     });
   }, [
@@ -621,7 +621,7 @@ const HelpDocumentModal: React.FC<HelpDocumentModalProps> = ({
         setShowFloatingSearch(true);
         requestAnimationFrame(() => {
           floatingSearchInputRef.current?.focus();
-          floatingSearchInputRef.current?.select();
+          floatingSearchInputRef.current?.select?.();
         });
         return;
       }
@@ -742,6 +742,7 @@ const HelpDocumentModal: React.FC<HelpDocumentModalProps> = ({
             styles.tocSidebar,
             tocCollapsed && styles.tocSidebarCollapsed,
           )}
+          inert={tocCollapsed || undefined}
         >
           {/* Fixed search area */}
           <div className={styles.tocSearchArea}>
@@ -891,7 +892,7 @@ const HelpDocumentModal: React.FC<HelpDocumentModalProps> = ({
           {showFloatingSearch ? (
             <div className={styles.floatingSearchBar}>
               <Input
-                ref={floatingSearchInputRef as React.Ref<any>}
+                ref={floatingSearchInputRef}
                 placeholder={t('webui.menu.SearchDocs')}
                 prefix={<SearchOutlined />}
                 size="small"
@@ -904,7 +905,10 @@ const HelpDocumentModal: React.FC<HelpDocumentModalProps> = ({
                 <>
                   <span className={styles.matchNavInfo}>
                     {currentDocMatchCount > 0
-                      ? `${activeMatchIndex + 1}/${currentDocMatchCount}`
+                      ? t('webui.menu.MatchCount', {
+                          current: activeMatchIndex + 1,
+                          total: currentDocMatchCount,
+                        })
                       : t('webui.menu.NoSearchResults')}
                   </span>
                   <Button
@@ -1017,10 +1021,9 @@ const HelpDocumentModal: React.FC<HelpDocumentModalProps> = ({
                         ? filePath.substring(0, filePath.lastIndexOf('/') + 1)
                         : '';
                       // Normalize the path (handle ../ and ./)
-                      const resolvedPath = new URL(
-                        href,
-                        `http://d/${currentDir}`,
-                      ).pathname.slice(1); // strip leading /
+                      const parsed = new URL(href, `http://d/${currentDir}`);
+                      const resolvedPath =
+                        parsed.pathname.slice(1) + (parsed.hash || ''); // preserve #anchor
                       return (
                         <a
                           {...props}
@@ -1068,7 +1071,10 @@ const HelpDocumentModal: React.FC<HelpDocumentModalProps> = ({
             >
               <span className={styles.matchNavInfo}>
                 {currentDocMatchCount > 0
-                  ? `${activeMatchIndex + 1} / ${currentDocMatchCount} ${t('webui.menu.Matches')}`
+                  ? t('webui.menu.MatchCount', {
+                      current: activeMatchIndex + 1,
+                      total: currentDocMatchCount,
+                    })
                   : t('webui.menu.NoSearchResults')}
               </span>
               <Button

--- a/react/src/hooks/useDocSearch.ts
+++ b/react/src/hooks/useDocSearch.ts
@@ -72,8 +72,7 @@ async function fetchWithConcurrencyLimit(
 
 /**
  * Find the doc path containing a given anchor ID (e.g., "set-preopen-ports").
- * Searches the module-level raw-markdown cache for `<a id="anchorId">` or
- * headings that would produce the given slug.
+ * Searches the module-level raw-markdown cache for `<a id="anchorId">` tags.
  */
 export function findDocPathByAnchor(anchorId: string): string | null {
   const pattern = new RegExp(
@@ -101,6 +100,7 @@ export function useDocSearch(
   const [rawQuery, setRawQuery] = useState('');
   const [query, setQuery] = useState('');
   const [indexing, setIndexing] = useState(false);
+  const [cacheRevision, setCacheRevision] = useState(0);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prefetchingRef = useRef(false);
@@ -148,13 +148,14 @@ export function useDocSearch(
             const text = await res.text();
             docCache.set(item.path, cleanMarkdown(text));
           } catch {
-            // Skip documents that fail to fetch
+            // Failed to fetch this document — skip indexing it
           }
         });
 
       fetchWithConcurrencyLimit(tasks, CONCURRENT_FETCHES).finally(() => {
         setIndexing(false);
         prefetchingRef.current = false;
+        setCacheRevision((prev) => prev + 1);
       });
     }, PREFETCH_DELAY_MS);
 
@@ -199,7 +200,8 @@ export function useDocSearch(
     }
 
     return searchResults;
-  }, [query, modalOpen, navItems]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, modalOpen, navItems, cacheRevision]);
 
   const totalMatches = results.reduce((sum, r) => sum + r.matchCount, 0);
 

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2548,6 +2548,7 @@
       "Logs": "Protokolle",
       "LogsErrors": "Protokolle / Fehler",
       "Maintenance": "Instandhaltung",
+      "MatchCount": "{{current}} / {{total}} Treffer",
       "Matches": "Treffer",
       "MyAccount": "Benutzerinformationen ändern",
       "MyAccountInformation": "Benutzerinformationen ändern",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2546,6 +2546,7 @@
       "Logs": "Κούτσουρα",
       "LogsErrors": "Αρχεία καταγραφής / σφάλματα",
       "Maintenance": "Συντήρηση",
+      "MatchCount": "{{current}} / {{total}} αντιστοιχίες",
       "Matches": "αντιστοιχίες",
       "MyAccount": "Αλλαγή πληροφοριών χρήστη",
       "MyAccountInformation": "Αλλαγή πληροφοριών χρήστη",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2547,6 +2547,7 @@
       "Logs": "Logs",
       "LogsErrors": "Logs / Errors",
       "Maintenance": "Maintenance",
+      "MatchCount": "{{current}} / {{total}} matches",
       "Matches": "matches",
       "MyAccount": "My Account",
       "MyAccountInformation": "My Account Information",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2546,6 +2546,7 @@
       "Logs": "Registros",
       "LogsErrors": "Registros / Errores",
       "Maintenance": "Mantenimiento",
+      "MatchCount": "{{current}} / {{total}} coincidencias",
       "Matches": "coincidencias",
       "MyAccount": "Mi cuenta",
       "MyAccountInformation": "Información de mi cuenta",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2546,6 +2546,7 @@
       "Logs": "Lokit",
       "LogsErrors": "Lokit / virheet",
       "Maintenance": "Huolto",
+      "MatchCount": "{{current}} / {{total}} osumaa",
       "Matches": "osumaa",
       "MyAccount": "Oma tili",
       "MyAccountInformation": "Tilini tiedot",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2546,6 +2546,7 @@
       "Logs": "Journaux",
       "LogsErrors": "Journaux / Erreurs",
       "Maintenance": "Maintenance",
+      "MatchCount": "{{current}} / {{total}} correspondances",
       "Matches": "correspondances",
       "MyAccount": "Modifier les informations utilisateur",
       "MyAccountInformation": "Modifier les informations utilisateur",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2549,6 +2549,7 @@
       "Logs": "Log",
       "LogsErrors": "Log / Galat",
       "Maintenance": "Pemeliharaan",
+      "MatchCount": "{{current}} / {{total}} kecocokan",
       "Matches": "kecocokan",
       "MyAccount": "Akun Saya",
       "MyAccountInformation": "Informasi Akun Saya",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2546,6 +2546,7 @@
       "Logs": "Registri",
       "LogsErrors": "Registri/Errori",
       "Maintenance": "Manutenzione",
+      "MatchCount": "{{current}} / {{total}} corrispondenze",
       "Matches": "corrispondenze",
       "MyAccount": "Modifica informazioni utente",
       "MyAccountInformation": "Modifica informazioni utente User",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2548,6 +2548,7 @@
       "Logs": "ログ",
       "LogsErrors": "ログ/エラー",
       "Maintenance": "補修(メンテナンス)",
+      "MatchCount": "{{current}} / {{total}} 件一致",
       "Matches": "件一致",
       "MyAccount": "ユーザー情報の変更",
       "MyAccountInformation": "ユーザー情報の変更",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2550,6 +2550,7 @@
       "Logs": "로그",
       "LogsErrors": "로그 / 에러기록",
       "Maintenance": "관리",
+      "MatchCount": "{{current}} / {{total}}개 일치",
       "Matches": "개 일치",
       "MyAccount": "사용자 정보 변경",
       "MyAccountInformation": "사용자 정보 변경",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2548,6 +2548,7 @@
       "Logs": "Бүртгэл",
       "LogsErrors": "Лог / Алдаа",
       "Maintenance": "Техникийн дэмжлэг",
+      "MatchCount": "{{current}} / {{total}} тохирсон",
       "Matches": "тохирсон",
       "MyAccount": "Хэрэглэгчийн мэдээллийг өөрчлөх",
       "MyAccountInformation": "Хэрэглэгчийн мэдээллийг өөрчлөх",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2546,6 +2546,7 @@
       "Logs": "Log",
       "LogsErrors": "Log / Kesalahan",
       "Maintenance": "Penyelenggaraan",
+      "MatchCount": "{{current}} / {{total}} padanan",
       "Matches": "padanan",
       "MyAccount": "Tukar Maklumat Pengguna",
       "MyAccountInformation": "Tukar Maklumat Pengguna",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2546,6 +2546,7 @@
       "Logs": "Dzienniki",
       "LogsErrors": "Dzienniki / Błędy",
       "Maintenance": "Konserwacja",
+      "MatchCount": "{{current}} / {{total}} dopasowań",
       "Matches": "dopasowań",
       "MyAccount": "Zmień informacje o użytkowniku",
       "MyAccountInformation": "Zmień informacje o użytkowniku",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2546,6 +2546,7 @@
       "Logs": "Histórico",
       "LogsErrors": "Logs / erros",
       "Maintenance": "Manutenção",
+      "MatchCount": "{{current}} / {{total}} correspondências",
       "Matches": "correspondências",
       "MyAccount": "Alterar informações do usuário",
       "MyAccountInformation": "Alterar as informações do usuário",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2548,6 +2548,7 @@
       "Logs": "Histórico",
       "LogsErrors": "Logs / erros",
       "Maintenance": "Manutenção",
+      "MatchCount": "{{current}} / {{total}} correspondências",
       "Matches": "correspondências",
       "MyAccount": "Alterar informações do usuário",
       "MyAccountInformation": "Alterar as informações do usuário",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2546,6 +2546,7 @@
       "Logs": "Журналы",
       "LogsErrors": "Журналы / ошибки",
       "Maintenance": "Обслуживание",
+      "MatchCount": "{{current}} / {{total}} совпадений",
       "Matches": "совпадений",
       "MyAccount": "Изменить информацию о пользователе",
       "MyAccountInformation": "Изменить информацию о пользователе",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2548,6 +2548,7 @@
       "Logs": "บันทึก",
       "LogsErrors": "บันทึก / ข้อผิดพลาด",
       "Maintenance": "การบำรุงรักษา",
+      "MatchCount": "{{current}} / {{total}} รายการที่ตรงกัน",
       "Matches": "รายการที่ตรงกัน",
       "MyAccount": "บัญชีของฉัน",
       "MyAccountInformation": "ข้อมูลบัญชีของฉัน",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2546,6 +2546,7 @@
       "Logs": "Kütükler",
       "LogsErrors": "Günlükler / Hatalar",
       "Maintenance": "Bakım",
+      "MatchCount": "{{current}} / {{total}} eşleşme",
       "Matches": "eşleşme",
       "MyAccount": "Kullanıcı Bilgilerini Değiştir",
       "MyAccountInformation": "Kullanıcı Bilgilerini Değiştir",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2548,6 +2548,7 @@
       "Logs": "Nhật ký",
       "LogsErrors": "Nhật ký / Lỗi",
       "Maintenance": "Bảo trì",
+      "MatchCount": "{{current}} / {{total}} kết quả",
       "Matches": "kết quả",
       "MyAccount": "Thay đổi thông tin người dùng",
       "MyAccountInformation": "Thay đổi thông tin người dùng",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2548,6 +2548,7 @@
       "Logs": "日志",
       "LogsErrors": "日志/错误",
       "Maintenance": "维护",
+      "MatchCount": "{{current}} / {{total}} 个匹配",
       "Matches": "个匹配",
       "MyAccount": "更改用户信息",
       "MyAccountInformation": "更改用户信息",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2550,6 +2550,7 @@
       "Logs": "日誌",
       "LogsErrors": "日誌/錯誤",
       "Maintenance": "維護",
+      "MatchCount": "{{current}} / {{total}} 個符合",
       "Matches": "個符合",
       "MyAccount": "更改用戶信息",
       "MyAccountInformation": "更改用戶信息",


### PR DESCRIPTION
Resolves #6001
Resolves #6002
Resolves #6003
Resolves #6004
Resolves #6005
Resolves #6006
Resolves #6007

## Summary

- Add full-text search across all help documentation pages with `useDocSearch` hook
- TOC sidebar search input with match count badges per document
- Content text highlighting via rehype plugin (HAST-level AST transformation)
- Match navigation bar with "N of M matches" and up/down navigation
- Floating search bar triggered by Ctrl+F/Cmd+F keyboard shortcut (auto-focused on modal open)
- i18n translations for search UI strings (22 languages)
- Internal `.md` link navigation within modal (resolves relative paths)
- Cross-document anchor fallback (searches cached docs when anchor not found in current page)
- ESC key closes search without closing modal (`stopPropagation`)

## Sub-tasks

- #6002: `useDocSearch` hook — document pre-fetching, caching, full-text search
- #6003: TOC search input + match count badges
- #6004: Content text highlighting via rehype plugin
- #6005: Match navigation bar (prev/next with counter)
- #6006: Floating search bar (Ctrl+F/Cmd+F shortcut)
- #6007: i18n translations for all 22 languages

## Key Technical Decisions

- **Rehype plugin over DOM TreeWalker**: Avoids React DOM reconciliation conflicts (`NotFoundError`)
- **Module-level cache**: Document cache persists across modal open/close, invalidated only on language change
- **Delayed pre-fetch (1.5s) with concurrency limit (4)**: Prevents overwhelming the dev server
- **`useDeferredValue`**: Keeps search input responsive while deferring highlight rendering
- **Cross-doc anchor lookup**: `findDocPathByAnchor()` searches cached markdown for `<a id="...">` when same-page anchor not found
- **Internal** **`.md`** **link handling**: Resolves relative paths (`../page.md#anchor`) and navigates within modal via `handleNavigate`

## Files Changed

- `react/src/hooks/useDocSearch.ts` (new)
- `react/src/components/HelpDocumentModal.tsx` (modified)
- `resources/i18n/*.json` (22 files)

![image.png](https://app.graphite.com/user-attachments/assets/66eace44-7d08-457b-a7c1-e8d1b9fbb657.png)

