### PR TITLE
feat(FR-34): add Create Session button to CustomizedImageList

### DIFF
--- a/react/src/components/CustomizedImageList.tsx
+++ b/react/src/components/CustomizedImageList.tsx
@@ -13,13 +13,16 @@ import { getImageFullName, localeCompare } from '../helper';
 import {
   useBackendAIImageMetaData,
   useSuspendedBackendaiClient,
+  useWebUINavigate,
 } from '../hooks';
 import { useHiddenColumnKeysSetting } from '../hooks/useHiddenColumnKeysSetting';
+import { SessionLauncherFormValue } from '../pages/SessionLauncherPage';
 import AliasedImageDoubleTags from './AliasedImageDoubleTags';
 import { ImageTags } from './ImageTags';
 import TextHighlighter from './TextHighlighter';
 import {
   DeleteOutlined,
+  PlayCircleOutlined,
   ReloadOutlined,
   SearchOutlined,
   SettingOutlined,
@@ -50,6 +53,7 @@ const CustomizedImageList: React.FC = () => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
+  const webuiNavigate = useWebUINavigate();
   const baiClient = useSuspendedBackendaiClient();
   const supportExtendedImageInfo =
     baiClient?.supports('extended-image-info') ?? false;
@@ -243,6 +247,22 @@ const CustomizedImageList: React.FC = () => {
       key: 'control',
       render: (_text, row) => (
         <BAIFlex direction="row" align="stretch" justify="center" gap="xxs">
+          <Button
+            type="text"
+            icon={<PlayCircleOutlined />}
+            title={t('start.button.StartSession')}
+            onClick={() => {
+              const launcherValue: DeepPartial<SessionLauncherFormValue> = {
+                environments: {
+                  version: getImageFullName(row) || '',
+                },
+              };
+              const params = new URLSearchParams();
+              params.set('step', '0');
+              params.set('formValues', JSON.stringify(launcherValue));
+              webuiNavigate(`/session/start?${params.toString()}`);
+            }}
+          />
           <Button
             type="text"
             icon={<DeleteOutlined />}


### PR DESCRIPTION
Resolves #2908(FR-34)

## Summary
- Add a "Start Session" button (PlayCircleOutlined icon) to the control column of the CustomizedImageList component
- Clicking the button navigates to the session launcher page (`/session/start`) with the selected image pre-filled in the form via URL parameters
- Uses the same navigation pattern as StartPage.tsx for consistency

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6014/20260316-213132-before.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6014/20260316-213143-after.png) |

> Control column: **Before** has only a delete (🗑) button. **After** adds a play (▶) button before the delete button for navigating to session creation with the image pre-selected.

## Test plan
- [ ] Navigate to My Environments (customized image list)
- [ ] Verify the new play icon button appears in the Control column before the delete button
- [ ] Click the play button for an image and verify navigation to session launcher with the image pre-selected
- [ ] Verify the delete button still works as expected

## Verification
```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)