### PR TITLE
fix: increase Node.js heap memory limit for dev server to prevent OOM crashes

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -82,7 +82,7 @@
     "zod": "^4.3.6"
   },
   "scripts": {
-    "start": "craco start",
+    "start": "NODE_OPTIONS='--max-old-space-size=4096' craco start",
     "build": "pnpm run build:only && cp -r ./build/* ../build/web/",
     "build:only": "pnpm run relay && craco build",
     "test": "NODE_OPTIONS='$NODE_OPTIONS --no-deprecation --experimental-vm-modules' jest",


### PR DESCRIPTION
Resolves #6016

## Summary
- Set `NODE_OPTIONS='--max-old-space-size=4096'` in `react/package.json` `start` script to prevent webpack dev server OOM crashes during local development

## Test plan
- [ ] Run `pnpm run dev` and verify dev server starts without OOM crashes
- [ ] Verify the dev server remains stable during extended development sessions