### PR TITLE
feat(FR-1427): add resource-aware warning for cluster size selection

### DIFF
--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -1377,7 +1377,13 @@ const ResourceAllocationFormItems: React.FC<
                   <Form.Item
                     noStyle
                     shouldUpdate={(prev, next) =>
-                      prev.cluster_mode !== next.cluster_mode
+                      prev.cluster_mode !== next.cluster_mode ||
+                      prev.resource?.cpu !== next.resource?.cpu ||
+                      prev.resource?.mem !== next.resource?.mem ||
+                      prev.resource?.accelerator !==
+                        next.resource?.accelerator ||
+                      prev.resource?.acceleratorType !==
+                        next.resource?.acceleratorType
                     }
                   >
                     {() => {
@@ -1388,24 +1394,95 @@ const ResourceAllocationFormItems: React.FC<
                         form.getFieldValue('cluster_mode') === 'single-node'
                           ? t('session.launcher.Container')
                           : t('session.launcher.Node');
+
+                      // Calculate max cluster size that can start immediately
+                      // based on current resource allocation and remaining resources
+                      const currentResource = form.getFieldValue('resource');
+                      const maxClusterCandidates: number[] = [];
+                      if (
+                        Number.isFinite(remaining.cpu) &&
+                        currentResource?.cpu > 0
+                      ) {
+                        maxClusterCandidates.push(
+                          Math.floor(remaining.cpu! / currentResource.cpu),
+                        );
+                      }
+                      if (
+                        Number.isFinite(remaining.mem) &&
+                        currentResource?.mem
+                      ) {
+                        const memBytes =
+                          convertToBinaryUnit(currentResource.mem, '')
+                            ?.number || 0;
+                        if (memBytes > 0) {
+                          maxClusterCandidates.push(
+                            Math.floor(remaining.mem! / memBytes),
+                          );
+                        }
+                      }
+                      const accelType = currentResource?.acceleratorType;
+                      const accelValue = currentResource?.accelerator || 0;
+                      if (
+                        accelType &&
+                        accelValue > 0 &&
+                        Number.isFinite(remaining.accelerators[accelType])
+                      ) {
+                        maxClusterCandidates.push(
+                          Math.floor(
+                            remaining.accelerators[accelType]! / accelValue,
+                          ),
+                        );
+                      }
+                      const maxImmediateClusterSize =
+                        maxClusterCandidates.length > 0
+                          ? _.min(maxClusterCandidates)
+                          : undefined;
+
+                      // Use resource-aware remaining mark instead of raw remaining.cpu
+                      // Clamp to slider max so the mark doesn't render outside the range
+                      const remainingMarkValue =
+                        _.isNumber(maxImmediateClusterSize) &&
+                        maxImmediateClusterSize >= 1
+                          ? _.isNumber(derivedClusterSizeMaxLimit)
+                            ? Math.min(
+                                maxImmediateClusterSize,
+                                derivedClusterSizeMaxLimit,
+                              )
+                            : maxImmediateClusterSize
+                          : undefined;
+
                       return (
                         <Form.Item
                           name={'cluster_size'}
                           label={t('session.launcher.ClusterSize')}
                           required
+                          dependencies={[
+                            ['resource', 'cpu'],
+                            ['resource', 'mem'],
+                            ['resource', 'accelerator'],
+                            ['resource', 'acceleratorType'],
+                          ]}
                           rules={[
                             {
                               warningOnly: true,
                               validator: async (_rule, value: number) => {
-                                if (showRemainingWarning) {
-                                  const minCPU = _.min([
-                                    remaining.cpu,
-                                    keypairResourcePolicy.max_containers_per_session,
-                                  ]);
-                                  if (_.isNumber(minCPU) && value > minCPU) {
+                                if (showRemainingWarning && value > 1) {
+                                  // Only show cluster-specific warning when at least 1 cluster
+                                  // can start immediately. When maxImmediateClusterSize is 0,
+                                  // per-resource warnings already cover the situation.
+                                  if (
+                                    _.isNumber(maxImmediateClusterSize) &&
+                                    maxImmediateClusterSize >= 1 &&
+                                    value > maxImmediateClusterSize
+                                  ) {
                                     return Promise.reject(
                                       t(
-                                        'session.launcher.EnqueueComputeSessionWarning',
+                                        'session.launcher.ClusterSizeExceedsImmediateCapacity',
+                                        {
+                                          maxClusterSize:
+                                            maxImmediateClusterSize,
+                                          unit: clusterUnit,
+                                        },
                                       ),
                                     );
                                   }
@@ -1437,9 +1514,9 @@ const ResourceAllocationFormItems: React.FC<
                               marks: {
                                 1: '1',
                                 // remaining mark code should be located before max mark code to prevent overlapping when it is same value
-                                ...(remaining.cpu
+                                ...(remainingMarkValue
                                   ? {
-                                      [remaining.cpu]: {
+                                      [remainingMarkValue]: {
                                         label: <RemainingMark />,
                                       },
                                     }

--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -425,15 +425,17 @@ const SessionLauncherPreview: React.FC<{
         }}
       >
         <BAIFlex direction="column" align="stretch">
-          {_.some(
+          {(_.some(
             form.getFieldValue('resource'),
             (_v, key: keyof SessionLauncherFormValue['resource']) => {
               return (
-                // @ts-ignore
-                form.getFieldWarning(['resource', key]).length > 0
+                (form.getFieldWarning(['resource', key] as any) as any[])
+                  .length > 0
               );
             },
-          ) && (
+          ) ||
+            (form.getFieldWarning(['cluster_size'] as any) as any[]).length >
+              0) && (
             <Alert
               type="warning"
               showIcon

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1862,6 +1862,7 @@
       "CleaningUpTensorBoardProxy": "TensorBoard-Proxy bereinigen...",
       "ClusterMode": "Cluster-Modus",
       "ClusterSize": "Clustergröße",
+      "ClusterSizeExceedsImmediateCapacity": "Mit den ausgewählten Ressourcen können sofort bis zu {{maxClusterSize}} {{unit}} gestartet werden. Die Sitzung könnte in die Warteschlange geraten.",
       "ConfirmAndLaunch": "Bestätigen und starten",
       "Container": "Container",
       "Core": "Ader",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1860,6 +1860,7 @@
       "CleaningUpTensorBoardProxy": "Καθαρισμός proxy του TensorBoard...",
       "ClusterMode": "Λειτουργία συμπλέγματος",
       "ClusterSize": "Μέγεθος συμπλέγματος",
+      "ClusterSizeExceedsImmediateCapacity": "Με τους επιλεγμένους πόρους, έως και {{maxClusterSize}} {{unit}} μπορούν να ξεκινήσουν αμέσως. Η συνεδρία ενδέχεται να βρίσκεται σε αναμονή.",
       "ConfirmAndLaunch": "Επιβεβαίωση και εκκίνηση",
       "Container": "Δοχείο",
       "Core": "Πυρήνας",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1907,6 +1907,7 @@
       "CleaningUpTensorBoardProxy": "Clean up TensorBoard proxy...",
       "ClusterMode": "Cluster mode",
       "ClusterSize": "Cluster size",
+      "ClusterSizeExceedsImmediateCapacity": "With the selected resources, up to {{maxClusterSize}} {{unit}}(s) can start immediately. The session may be pending.",
       "ConfirmAndLaunch": "Confirm and Launch",
       "Container": "Container",
       "Core": "Core",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1860,6 +1860,7 @@
       "CleaningUpTensorBoardProxy": "Limpiar el proxy de TensorBoard...",
       "ClusterMode": "Modo clúster",
       "ClusterSize": "Tamaño del grupo",
+      "ClusterSizeExceedsImmediateCapacity": "Con los recursos seleccionados, hasta {{maxClusterSize}} {{unit}}(s) pueden iniciarse inmediatamente. La sesión puede quedar en estado pendiente.",
       "ConfirmAndLaunch": "Confirmar y lanzar",
       "Container": "Contenedor",
       "Core": "Núcleo",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1860,6 +1860,7 @@
       "CleaningUpTensorBoardProxy": "Siivotaan TensorBoard-välityspalvelinta...",
       "ClusterMode": "Cluster-tila",
       "ClusterSize": "Klusterin koko",
+      "ClusterSizeExceedsImmediateCapacity": "Valituilla resursseilla enintään {{maxClusterSize}} {{unit}} voi käynnistyä välittömästi. Istunto saattaa jäädä odotustilaan.",
       "ConfirmAndLaunch": "Vahvista ja käynnistä",
       "Container": "Kontti",
       "Core": "Ydin",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1860,6 +1860,7 @@
       "CleaningUpTensorBoardProxy": "Nettoyage du proxy TensorBoard...",
       "ClusterMode": "Mode cluster",
       "ClusterSize": "Taille de cluster",
+      "ClusterSizeExceedsImmediateCapacity": "Avec les ressources sélectionnées, jusqu'à {{maxClusterSize}} {{unit}}(s) peuvent démarrer immédiatement. La session peut être en attente.",
       "ConfirmAndLaunch": "Confirmer et lancer",
       "Container": "Container",
       "Core": "Cœur",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1862,6 +1862,7 @@
       "CleaningUpTensorBoardProxy": "Membersihkan proxy TensorBoard...",
       "ClusterMode": "Modus klaster",
       "ClusterSize": "Ukuran klaster",
+      "ClusterSizeExceedsImmediateCapacity": "Dengan sumber daya yang dipilih, hingga {{maxClusterSize}} {{unit}} dapat langsung dimulai. Sesi mungkin akan berada dalam status tertunda.",
       "ConfirmAndLaunch": "Konfirmasi dan luncurkan",
       "Container": "Kontainer",
       "Core": "Core",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1860,6 +1860,7 @@
       "CleaningUpTensorBoardProxy": "Pulisci il proxy di TensorBoard...",
       "ClusterMode": "Modalità cluster",
       "ClusterSize": "Dimensione del cluster",
+      "ClusterSizeExceedsImmediateCapacity": "Con le risorse selezionate, fino a {{maxClusterSize}} {{unit}} possono avviarsi immediatamente. La sessione potrebbe essere in attesa.",
       "ConfirmAndLaunch": "Confermare e lanciare",
       "Container": "Contenitore",
       "Core": "Nucleo",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1862,6 +1862,7 @@
       "CleaningUpTensorBoardProxy": "TensorBoard プロキシをクリーンアップ中...",
       "ClusterMode": "クラスターモード",
       "ClusterSize": "クラスターサイズ",
+      "ClusterSizeExceedsImmediateCapacity": "選択したリソースでは、最大 {{maxClusterSize}} 個の{{unit}}をすぐに起動できます。セッションが保留状態になる可能性があります。",
       "ConfirmAndLaunch": "レビューと開始",
       "Container": "コンテナ",
       "Core": "芯",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1909,6 +1909,7 @@
       "CleaningUpTensorBoardProxy": "TensorBoard 프록시 초기화 중...",
       "ClusterMode": "클러스터 모드 설정",
       "ClusterSize": "클러스터 크기",
+      "ClusterSizeExceedsImmediateCapacity": "선택한 자원으로는 최대 {{maxClusterSize}}개의 {{unit}}만 즉시 시작할 수 있습니다. 세션이 대기 상태가 될 수 있습니다.",
       "ConfirmAndLaunch": "검토 및 시작",
       "Container": "컨테이너",
       "Core": "코어",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1861,6 +1861,7 @@
       "CleaningUpTensorBoardProxy": "TensorBoard проксийг цэвэрлэх...",
       "ClusterMode": "Кластер горим",
       "ClusterSize": "Кластерийн хэмжээ",
+      "ClusterSizeExceedsImmediateCapacity": "Сонгосон нөөцөөр дээд тал нь {{maxClusterSize}} {{unit}} шууд эхлэх боломжтой. Сессия хүлээлтийн төлөвт орж болзошгүй.",
       "ConfirmAndLaunch": "Шалгасан тул эхлүүлж болно",
       "Container": "Контейнер",
       "Core": "Цөм",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1860,6 +1860,7 @@
       "CleaningUpTensorBoardProxy": "Bersihkan proksi TensorBoard...",
       "ClusterMode": "Mod kluster",
       "ClusterSize": "Saiz kluster",
+      "ClusterSizeExceedsImmediateCapacity": "Dengan sumber yang dipilih, sehingga {{maxClusterSize}} {{unit}} boleh dimulakan dengan segera. Sesi mungkin berada dalam keadaan menunggu.",
       "ConfirmAndLaunch": "Sahkan dan Lancarkan",
       "Container": "Bekas",
       "Core": "Teras",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1860,6 +1860,7 @@
       "CleaningUpTensorBoardProxy": "Usuń proxy TensorBoard...",
       "ClusterMode": "Tryb klastra",
       "ClusterSize": "Wielkość klastra",
+      "ClusterSizeExceedsImmediateCapacity": "Przy wybranych zasobach do {{maxClusterSize}} {{unit}} może uruchomić się natychmiast. Sesja może przejść w stan oczekiwania.",
       "ConfirmAndLaunch": "Potwierdź i uruchom",
       "Container": "Pojemnik",
       "Core": "Rdzeń",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1860,6 +1860,7 @@
       "CleaningUpTensorBoardProxy": "Limpando o proxy do TensorBoard...",
       "ClusterMode": "Modo de cluster",
       "ClusterSize": "Tamanho do cluster",
+      "ClusterSizeExceedsImmediateCapacity": "Com os recursos selecionados, até {{maxClusterSize}} {{unit}}(s) podem iniciar imediatamente. A sessão pode ficar pendente.",
       "ConfirmAndLaunch": "Confirmar e lançar",
       "Container": "Recipiente",
       "Core": "Testemunho",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1862,6 +1862,7 @@
       "CleaningUpTensorBoardProxy": "Limpando o proxy do TensorBoard...",
       "ClusterMode": "Modo de cluster",
       "ClusterSize": "Tamanho do cluster",
+      "ClusterSizeExceedsImmediateCapacity": "Com os recursos selecionados, até {{maxClusterSize}} {{unit}}(s) podem iniciar imediatamente. A sessão pode ficar pendente.",
       "ConfirmAndLaunch": "Confirmar e lançar",
       "Container": "Recipiente",
       "Core": "Testemunho",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1860,6 +1860,7 @@
       "CleaningUpTensorBoardProxy": "Очистить прокси TensorBoard...",
       "ClusterMode": "Кластерный режим",
       "ClusterSize": "Размер кластера",
+      "ClusterSizeExceedsImmediateCapacity": "При выбранных ресурсах немедленно может запуститься до {{maxClusterSize}} {{unit}}. Сессия может перейти в состояние ожидания.",
       "ConfirmAndLaunch": "Подтверждение и запуск",
       "Container": "Контейнер",
       "Core": "Ядро",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1862,6 +1862,7 @@
       "CleaningUpTensorBoardProxy": "กำลังล้างพร็อกซีของ TensorBoard...",
       "ClusterMode": "โหมดคลัสเตอร์",
       "ClusterSize": "ขนาดคลัสเตอร์",
+      "ClusterSizeExceedsImmediateCapacity": "ด้วยทรัพยากรที่เลือก สามารถเริ่มต้นได้สูงสุด {{maxClusterSize}} {{unit}}ทันที เซสชันอาจอยู่ในสถานะรอดำเนินการ",
       "ConfirmAndLaunch": "ยืนยันและเริ่ม",
       "Container": "คอนเทนเนอร์",
       "Core": "คอร์",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1860,6 +1860,7 @@
       "CleaningUpTensorBoardProxy": "TensorBoard proxy'si temizleniyor...",
       "ClusterMode": "küme modu",
       "ClusterSize": "Küme boyutu",
+      "ClusterSizeExceedsImmediateCapacity": "Seçilen kaynaklarla en fazla {{maxClusterSize}} {{unit}} hemen başlatılabilir. Oturum bekleme durumuna geçebilir.",
       "ConfirmAndLaunch": "Onaylayın ve Başlatın",
       "Container": "Konteyner",
       "Core": "çekirdek",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1862,6 +1862,7 @@
       "CleaningUpTensorBoardProxy": "Đang dọn dẹp proxy TensorBoard...",
       "ClusterMode": "Chế độ cụm",
       "ClusterSize": "Kích thước cụm",
+      "ClusterSizeExceedsImmediateCapacity": "Với các tài nguyên đã chọn, tối đa {{maxClusterSize}} {{unit}} có thể khởi động ngay lập tức. Phiên có thể ở trạng thái chờ.",
       "ConfirmAndLaunch": "Xác nhận và khởi chạy",
       "Container": "Thùng đựng hàng",
       "Core": "Cốt lõi",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1862,6 +1862,7 @@
       "CleaningUpTensorBoardProxy": "清理 TensorBoard 代理...",
       "ClusterMode": "集群模式",
       "ClusterSize": "簇的大小",
+      "ClusterSizeExceedsImmediateCapacity": "使用所选资源，最多可立即启动 {{maxClusterSize}} 个{{unit}}。会话可能处于待处理状态。",
       "ConfirmAndLaunch": "确认并启动",
       "Container": "容器",
       "Core": "核",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1864,6 +1864,7 @@
       "CleaningUpTensorBoardProxy": "清理 TensorBoard 代理...",
       "ClusterMode": "集群模式",
       "ClusterSize": "簇的大小",
+      "ClusterSizeExceedsImmediateCapacity": "使用所選資源，最多可立即啟動 {{maxClusterSize}} 個{{unit}}。工作階段可能處於待處理狀態。",
       "ConfirmAndLaunch": "确认并启动",
       "Container": "容器",
       "Core": "核",


### PR DESCRIPTION
Resolves #4221(FR-1427)

## Summary

- Add resource-aware warning for cluster size selection in session launcher
- When cluster size > 1, calculates the max clusters that can start immediately based on `remaining resources / per-container allocation` across CPU, memory, and accelerators
- Shows a specific warning: "With the selected resources, up to X cluster(s) can start immediately. The session may be pending."
- Updates the remaining mark on the cluster size slider to reflect the resource-aware max
- Preview panel now also surfaces cluster_size warnings

## Context

When customers set cluster mode to single-node with large cluster sizes, they get a generic "Could not find a contiguous resource region" error after waiting. This change proactively warns users at the form level about resource capacity before session creation.

## Approach (per Teams discussion)

Keep individual resource warnings as-is (per container). Add warning only on the cluster size selector showing max immediate capacity. This is the minimal-effort approach that avoids restructuring the session launcher form layout.

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6025/20260317-192511-before-cluster-size.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6025/20260317-192511-after-cluster-size.png) |
| Cluster size = 1, no warning | Cluster size = 3, warning shown: "With the selected resources, up to 1 cluster(s) can start immediately" |

## Verification

```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```

## Test plan

- [ ] Open session launcher, select resources (e.g., 8 GPU)
- [ ] Set cluster mode to single-node, increase cluster size
- [ ] Verify warning appears when cluster_size × resources > remaining resources
- [ ] Verify remaining mark on slider reflects resource-aware calculation
- [ ] Verify preview panel shows warning when cluster size exceeds capacity
- [ ] Verify no warning when cluster_size = 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)