### PR TITLE
fix: correct onCancel type signatures for modal components

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIDeleteArtifactRevisionsModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIDeleteArtifactRevisionsModal.tsx
@@ -30,12 +30,14 @@ export type BAIDeleteArtifactRevisionsModalArtifactFragmentKey =
 export type BAIDeleteArtifactRevisionsModalArtifactRevisionFragmentKey =
   BAIDeleteArtifactRevisionsModalArtifactRevisionFragment$key;
 
-export interface BAIDeleteArtifactRevisionsModalProps
-  extends Omit<ModalProps, 'onOk' | 'onCancel'> {
+export interface BAIDeleteArtifactRevisionsModalProps extends Omit<
+  ModalProps,
+  'onOk' | 'onCancel'
+> {
   selectedArtifactFrgmt: BAIDeleteArtifactRevisionsModalArtifactFragment$key | null;
   selectedArtifactRevisionFrgmt: BAIDeleteArtifactRevisionsModalArtifactRevisionFragment$key;
   onOk: (e: React.MouseEvent<HTMLElement>) => void;
-  onCancel: (e: React.MouseEvent<HTMLElement>) => void;
+  onCancel: NonNullable<ModalProps['onCancel']>;
 }
 
 const BAIDeleteArtifactRevisionsModal = ({

--- a/packages/backend.ai-ui/src/components/fragments/BAIImportArtifactModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIImportArtifactModal.tsx
@@ -29,8 +29,10 @@ export type BAIImportArtifactModalArtifactFragmentKey =
 export type BAIImportArtifactModalArtifactRevisionFragmentKey =
   BAIImportArtifactModalArtifactRevisionFragment$key;
 
-export interface BAIImportArtifactModalProps
-  extends Omit<ModalProps, 'onOk' | 'onCancel'> {
+export interface BAIImportArtifactModalProps extends Omit<
+  ModalProps,
+  'onOk' | 'onCancel'
+> {
   selectedArtifactFrgmt: BAIImportArtifactModalArtifactFragment$key | null;
   selectedArtifactRevisionFrgmt: BAIImportArtifactModalArtifactRevisionFragment$key;
   onOk: (
@@ -44,7 +46,7 @@ export interface BAIImportArtifactModalProps
       };
     }[],
   ) => void;
-  onCancel: (e: React.MouseEvent<HTMLElement>) => void;
+  onCancel: NonNullable<ModalProps['onCancel']>;
   connectionIds?: string[];
 }
 

--- a/react/src/components/SessionSchedulingHistoryModal.tsx
+++ b/react/src/components/SessionSchedulingHistoryModal.tsx
@@ -100,7 +100,17 @@ const SessionSchedulingHistoryModal = ({
           height: '100vh',
         },
       }}
-      footer={<BAIButton onClick={onCancel}>{t('button.Close')}</BAIButton>}
+      footer={
+        <BAIButton
+          onClick={(e) =>
+            onCancel?.(
+              e as Parameters<NonNullable<BAIModalProps['onCancel']>>[0],
+            )
+          }
+        >
+          {t('button.Close')}
+        </BAIButton>
+      }
       onCancel={onCancel}
       {...modalProps}
     >


### PR DESCRIPTION
## Summary

- Correct `onCancel` type signatures in `BAIDeleteArtifactRevisionsModal` and `BAIImportArtifactModal` to match Ant Design 6 Modal's actual type (`React.KeyboardEvent<HTMLElement> | React.MouseEvent<HTMLButtonElement>`)
- Fix `SessionSchedulingHistoryModal` footer button to properly bridge `BAIButton.onClick` type with `BAIModalProps.onCancel`

## Test plan

- [ ] Verify modals close correctly via close button click
- [ ] Verify modals close correctly via Escape key
- [ ] TypeScript compilation passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)