### PR TITLE
feat: support PORT env variable in dev-config for Portless compatibility

### DIFF
--- a/scripts/dev-config.js
+++ b/scripts/dev-config.js
@@ -56,6 +56,14 @@ class DevConfig {
   }
 
   getPorts() {
+    // If PORT is already set (e.g., by Portless), use it directly
+    const envPort = process.env.PORT || this.env.PORT;
+    if (envPort && !isNaN(envPort)) {
+      return {
+        react: parseInt(envPort),
+      };
+    }
+
     const offset = this.getPortOffset();
     return {
       react: this.basePorts.react + offset,

--- a/scripts/dev-config.test.ts
+++ b/scripts/dev-config.test.ts
@@ -23,6 +23,7 @@ describe("DevConfig", () => {
   beforeEach(() => {
     delete process.env.BAI_WEBUI_DEV_PORT_OFFSET;
     delete process.env.HOST;
+    delete process.env.PORT;
     delete process.env.THEME_HEADER_COLOR;
     delete process.env.BAI_WEBUI_DEV_REACT_PORT;
     delete process.env.BAI_WEBUI_DEV_HOST;
@@ -68,6 +69,35 @@ describe("DevConfig", () => {
       const config = createIsolatedConfig();
       const ports = config.getPorts();
       expect(ports.react).toBe(9091);
+    });
+
+    it("should use PORT env variable when set (e.g., by Portless)", () => {
+      process.env.PORT = "3456";
+      const config = createIsolatedConfig();
+      const ports = config.getPorts();
+      expect(ports.react).toBe(3456);
+    });
+
+    it("should prefer PORT env over port offset", () => {
+      process.env.PORT = "3456";
+      process.env.BAI_WEBUI_DEV_PORT_OFFSET = "10";
+      const config = createIsolatedConfig();
+      const ports = config.getPorts();
+      expect(ports.react).toBe(3456);
+    });
+
+    it("should read PORT from env file", () => {
+      const config = createIsolatedConfig();
+      config.env = { PORT: "4567" };
+      const ports = config.getPorts();
+      expect(ports.react).toBe(4567);
+    });
+
+    it("should ignore non-numeric PORT", () => {
+      process.env.PORT = "abc";
+      const config = createIsolatedConfig();
+      const ports = config.getPorts();
+      expect(ports.react).toBe(9081);
     });
   });
 


### PR DESCRIPTION
Resolves #6041

## Summary
- `scripts/dev-config.js`: `getPorts()` now checks `PORT` env variable first (set by Portless) before falling back to `9081 + offset`
- `scripts/dev-config.test.ts`: Added 4 tests covering PORT env variable handling (direct use, priority over offset, env file, non-numeric ignored)

## Test plan
- [ ] Run `npx jest scripts/dev-config.test.ts` — all 45 tests pass
- [ ] Run dev server with `PORT=3000 pnpm run dev` and verify it uses port 3000
- [ ] Run dev server without PORT set and verify it uses default 9081