### PR TITLE
fix(FR-2319): fix resource bar graph alignment in agent table

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAgentTable.tsx
@@ -47,8 +47,10 @@ const isEnableSorter = (key: string) => {
   return _.includes(availableAgentSorterKeys, key);
 };
 
-export interface BAIAgentTableProps
-  extends Omit<BAITableProps<any>, 'dataSource' | 'columns' | 'onChangeOrder'> {
+export interface BAIAgentTableProps extends Omit<
+  BAITableProps<any>,
+  'dataSource' | 'columns' | 'onChangeOrder'
+> {
   agentsFragment: BAIAgentTableFragment$key;
   onClickAgentName?: (agent: AgentNodeInList) => void;
   onChangeOrder?: (
@@ -187,7 +189,8 @@ const BAIAgentTable: React.FC<BAIAgentTableProps> = ({
                     <BAIFlex
                       key={key}
                       justify="between"
-                      style={{ minWidth: 220 }}
+                      style={{ width: '100%' }}
+                      gap={'xs'}
                     >
                       <BAIFlex gap="xxs">
                         <ResourceTypeIcon key={key} type={key} />
@@ -233,7 +236,8 @@ const BAIAgentTable: React.FC<BAIAgentTableProps> = ({
                     <BAIFlex
                       key={'mem'}
                       justify="between"
-                      style={{ minWidth: 220 }}
+                      style={{ width: '100%' }}
+                      gap={'xs'}
                     >
                       <BAIFlex gap="xxs">
                         <ResourceTypeIcon type={'mem'} />
@@ -275,8 +279,8 @@ const BAIAgentTable: React.FC<BAIAgentTableProps> = ({
                     <BAIFlex
                       key={key}
                       justify="between"
-                      style={{ minWidth: 220 }}
-                      gap="xxs"
+                      gap={'xs'}
+                      style={{ width: '100%' }}
                     >
                       <BAIFlex gap="xxs">
                         <ResourceTypeIcon key={key} type={key} />

--- a/react/src/components/AgentList.tsx
+++ b/react/src/components/AgentList.tsx
@@ -272,6 +272,7 @@ const AgentList: React.FC<AgentListProps> = ({
         </BAIFlex>
       </BAIFlex>
       <BAIAgentTable
+        resizable
         agentsFragment={filterOutEmpty(
           agent_nodes?.edges.map((e) => e?.node) ?? [],
         )}


### PR DESCRIPTION
Resolves #6083 ([FR-2319](https://lablup.atlassian.net/browse/FR-2319))

## Summary
- Fix resource bar graph alignment in agent table by replacing `minWidth: 220` with `width: '100%'` and consistent `gap: 'xs'` spacing
- Ensures Core, GiB, and fGPU bar graphs render with proper vertical alignment

![CleanShot 2026-03-23 at 14.29.29@2x.png](https://app.graphite.com/user-attachments/assets/3a092f36-4b88-4380-a671-7a19c314b221.png)

## Test plan
- [ ] Navigate to Admin > Agent page
- [ ] Verify resource allocation bars are properly aligned across all resource types
- [ ] Check alignment at different screen widths

[FR-2319]: https://lablup.atlassian.net/browse/FR-2319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ