### PR TITLE
style(FR-2353): use white logo variant on login page in dark mode

### DIFF
--- a/react/src/components/LoginFormPanel.tsx
+++ b/react/src/components/LoginFormPanel.tsx
@@ -13,6 +13,7 @@ import { baiSignedRequestWithPromise } from '../helper';
 import type { LoginConfigState } from '../helper/loginConfig';
 import { useAnonymousBackendaiClient } from '../hooks';
 import { useTanMutation } from '../hooks/reactQueryAlias';
+import { useThemeMode } from '../hooks/useThemeMode';
 import SignupModal from './SignupModal';
 import {
   TOTPActivateForm,
@@ -119,6 +120,7 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
 
   const { t } = useTranslation();
   const { token } = theme.useToken();
+  const { isDarkMode } = useThemeMode();
 
   const [isEndpointExpanded, setIsEndpointExpanded] = useState(
     () => showEndpointInput && !isEndpointDisabled && apiEndpoint === '',
@@ -152,7 +154,11 @@ const LoginFormPanel: React.FC<LoginFormPanelProps> = ({
         title={
           <div style={{ textAlign: 'center' }}>
             <img
-              src="manifest/backend.ai-text.svg"
+              src={
+                isDarkMode
+                  ? 'manifest/backend.ai-text-bgdark.svg'
+                  : 'manifest/backend.ai-text.svg'
+              }
               alt="backend.ai"
               style={{ height: 35 }}
             />


### PR DESCRIPTION
Resolves #6087 ([FR-2353](https://lablup.atlassian.net/browse/FR-2353))

## Summary
- Switch Backend.AI logo on login page to white variant (`backend.ai-text-bgdark.svg`) in dark mode
- Uses `useThemeMode` hook, consistent with existing SplashModal pattern

## Test plan
- [ ] Open login page in dark mode — logo should be white/light
- [ ] Open login page in light mode — logo should remain dark (default)

![CleanShot 2026-03-23 at 15.05.44@2x.png](https://app.graphite.com/user-attachments/assets/47d31c3a-0410-4354-a895-87f2856430af.png)

[FR-2353]: https://lablup.atlassian.net/browse/FR-2353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ