### PR TITLE
feat(FR-2183): rename MyKeypairInfoModal to legacy and add @since branching

### DIFF
--- a/react/src/components/MyKeypairInfoModalLegacy.tsx
+++ b/react/src/components/MyKeypairInfoModalLegacy.tsx
@@ -1,8 +1,9 @@
+// TODO: Remove after 27.4.0 (legacy compatibility for backends < 26.4.0)
 /**
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { MyKeypairInfoModalQuery } from '../__generated__/MyKeypairInfoModalQuery.graphql';
+import { MyKeypairInfoModalLegacyQuery } from '../__generated__/MyKeypairInfoModalLegacyQuery.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanQuery } from '../hooks/reactQueryAlias';
@@ -12,11 +13,11 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 
-interface MyKeypairInfoModalProps extends BAIModalProps {
+interface MyKeypairInfoModalLegacyProps extends BAIModalProps {
   onRequestClose: () => void;
 }
 
-const MyKeypairInfoModal: React.FC<MyKeypairInfoModalProps> = ({
+const MyKeypairInfoModalLegacy: React.FC<MyKeypairInfoModalLegacyProps> = ({
   onRequestClose,
   ...baiModalProps
 }) => {
@@ -39,9 +40,9 @@ const MyKeypairInfoModal: React.FC<MyKeypairInfoModalProps> = ({
     staleTime: 0,
   });
 
-  const { user } = useLazyLoadQuery<MyKeypairInfoModalQuery>(
+  const { user } = useLazyLoadQuery<MyKeypairInfoModalLegacyQuery>(
     graphql`
-      query MyKeypairInfoModalQuery($email: String) {
+      query MyKeypairInfoModalLegacyQuery($email: String) {
         user(email: $email) {
           email
           main_access_key @since(version: "23.09.7")
@@ -110,4 +111,4 @@ const MyKeypairInfoModal: React.FC<MyKeypairInfoModalProps> = ({
   );
 };
 
-export default MyKeypairInfoModal;
+export default MyKeypairInfoModalLegacy;

--- a/react/src/components/MyKeypairManagementModal.tsx
+++ b/react/src/components/MyKeypairManagementModal.tsx
@@ -1,0 +1,32 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { BAIModal, BAIModalProps } from 'backend.ai-ui';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface MyKeypairManagementModalProps extends BAIModalProps {
+  onRequestClose: () => void;
+}
+
+// TODO: Implement full keypair self-service management (FR-2183)
+const MyKeypairManagementModal: React.FC<MyKeypairManagementModalProps> = ({
+  onRequestClose,
+  ...baiModalProps
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <BAIModal
+      {...baiModalProps}
+      title={t('userSettings.MyKeypairInfo')}
+      centered
+      onCancel={onRequestClose}
+      destroyOnHidden
+      footer={null}
+    />
+  );
+};
+
+export default MyKeypairManagementModal;

--- a/react/src/pages/UserSettingsPage.tsx
+++ b/react/src/pages/UserSettingsPage.tsx
@@ -3,10 +3,12 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import ErrorLogList from '../components/ErrorLogList';
-import MyKeypairInfoModal from '../components/MyKeypairInfoModal';
+import MyKeypairInfoModalLegacy from '../components/MyKeypairInfoModalLegacy';
+import MyKeypairManagementModal from '../components/MyKeypairManagementModal';
 import SSHKeypairManagementModal from '../components/SSHKeypairManagementModal';
 import SettingList, { SettingGroup } from '../components/SettingList';
 import ShellScriptEditModal from '../components/ShellScriptEditModal';
+import { useSuspendedBackendaiClient } from '../hooks';
 import {
   useBAISettingGeneralState,
   useBAISettingUserState,
@@ -33,6 +35,7 @@ const UserPreferencesPage = () => {
 
   const { t } = useTranslation();
   const { message } = App.useApp();
+  const baiClient = useSuspendedBackendaiClient();
   const [curTabKey, setCurTabKey] = useQueryParam('tab', tabParam);
 
   const { themeMode, setThemeMode } = useThemeMode();
@@ -396,10 +399,17 @@ const UserPreferencesPage = () => {
           )}
         </Suspense>
       </Card>
-      <MyKeypairInfoModal
-        open={isOpenSSHKeypairInfoModal}
-        onRequestClose={toggleSSHKeypairInfoModal}
-      />
+      {baiClient?.supports('my-keypairs') ? (
+        <MyKeypairManagementModal
+          open={isOpenSSHKeypairInfoModal}
+          onRequestClose={toggleSSHKeypairInfoModal}
+        />
+      ) : (
+        <MyKeypairInfoModalLegacy
+          open={isOpenSSHKeypairInfoModal}
+          onRequestClose={toggleSSHKeypairInfoModal}
+        />
+      )}
       <SSHKeypairManagementModal
         open={isOpenSSHKeypairManagementModal}
         onRequestClose={toggleSSHKeypairManagementModal}

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -895,6 +895,7 @@ class Client {
     }
     if (this.isManagerVersionCompatibleWith('26.4.0')) {
       this._features['update-user-v2'] = true;
+      this._features['my-keypairs'] = true;
     }
   }
 


### PR DESCRIPTION
Resolves #6092(FR-2183)

## Changes

- Rename `MyKeypairInfoModal.tsx` to `MyKeypairInfoModalLegacy.tsx` with TODO comment for removal after 27.4.0
- Add placeholder `MyKeypairManagementModal.tsx` for backend >= 26.4.0
- In `UserSettingsPage.tsx`, use `baiClient.isManagerVersionCompatibleWith('26.4.0')` to conditionally render the new management modal or the legacy modal

## Verification

`bash scripts/verify.sh` → `=== ALL PASS ===`

**Checklist:** (if applicable)

- [ ] Documentation
- [x] Minimum required manager version (26.4.0 for new modal)
- [ ] Specific setting for review
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after