### PR TITLE
fix(FR-2357): use pnpm publish to resolve catalog protocol in backend.ai-ui

### DIFF
--- a/.github/workflows/publish-backend.ai-ui.yml
+++ b/.github/workflows/publish-backend.ai-ui.yml
@@ -59,7 +59,7 @@ jobs:
         if: github.ref_type == 'branch'
         run: |
           cd packages/backend.ai-ui
-          npm publish --tag canary --access public --no-git-checks
+          pnpm publish --tag canary --access public --no-git-checks
 
       - name: Determine npm tag and publish strategy
         if: github.ref_type == 'tag'
@@ -83,4 +83,4 @@ jobs:
         if: github.ref_type == 'tag' && steps.determine-tag.outputs.should_publish == 'true'
         run: |
           cd packages/backend.ai-ui
-          npm publish --tag ${{ steps.determine-tag.outputs.npm_tag }} --access public --no-git-checks
+          pnpm publish --tag ${{ steps.determine-tag.outputs.npm_tag }} --access public --no-git-checks


### PR DESCRIPTION
Resolves #6105 ([FR-2357](https://lablup.atlassian.net/browse/FR-2357))

## Summary
- Replace `npm publish` with `pnpm publish` in the backend.ai-ui publish workflow
- `pnpm publish` resolves `catalog:` protocol specifiers to actual versions at publish time, which `npm publish` cannot do
- This fixes the `ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER` error when consumers install the published canary package

## Test plan
- [ ] Canary publish workflow succeeds on next push to main
- [ ] Published package.json contains resolved version specifiers instead of `catalog:`

[FR-2357]: https://lablup.atlassian.net/browse/FR-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ