### PR TITLE
feat(FR-2183): add activate and delete actions for inactive tab

### DIFF
--- a/react/src/components/MyKeypairManagementModal.tsx
+++ b/react/src/components/MyKeypairManagementModal.tsx
@@ -19,6 +19,7 @@ import {
   Tag,
   theme,
   Tooltip,
+  Typography,
 } from 'antd';
 import {
   BAIButton,
@@ -620,11 +621,11 @@ const MyKeypairManagementModal: React.FC<MyKeypairManagementModalProps> = ({
         open={!!deletingKeypairAccessKey}
         title={t('credential.DeleteKeypair')}
         content={
-          <div style={{ marginBottom: token.marginSM }}>
+          <Typography.Text style={{ marginBottom: token.marginSM }}>
             {t('credential.DeleteKeypairWarning', {
               accessKey: deletingKeypairAccessKey,
             })}
-          </div>
+          </Typography.Text>
         }
         confirmText={t('credential.PermanentlyDelete')}
         inputLabel={t('credential.TypePermanentlyDelete', {


### PR DESCRIPTION
Resolves #6096(FR-2183)

## Summary
- Add action column to the Inactive tab with Activate and Delete actions
- Activate action reuses the existing `updateMyKeypair` mutation with `isActive: true`
- Delete action uses `BAIConfirmModalWithInput` requiring access key confirmation, backed by new `revokeMyKeypair` mutation
- Add i18n keys for activate/delete actions and success messages