### PR TITLE
chore: fix untranslated toTextKey in auto-diagnostics notification

### DIFF
--- a/react/src/hooks/useAutoDiagnostics.ts
+++ b/react/src/hooks/useAutoDiagnostics.ts
@@ -64,7 +64,7 @@ export function useAutoDiagnostics(): void {
       duration: 0,
       open: true,
       to: '/diagnostics',
-      toTextKey: 'diagnostics.ViewDiagnostics',
+      toTextKey: t('diagnostics.ViewDiagnostics'),
     });
     try {
       sessionStorage.setItem(AUTO_DIAGNOSTICS_DISMISSED_KEY, '1');


### PR DESCRIPTION
Resolves #6115

## Summary
- Fix `toTextKey` in auto-diagnostics notification to pass translated string via `t()` instead of raw i18n key

## Test plan
- [ ] Verify diagnostics notification link displays translated text instead of raw key