### PR TITLE
feat(FR-2317): add AdminVFolderNodeListPage for superadmin data management

### DIFF
--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -10,7 +10,6 @@ import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
-import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { isDeletedCategory } from '../pages/VFolderNodeListPage';
 import EditableVFolderName from './EditableVFolderName';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
@@ -18,7 +17,7 @@ import InviteFolderSettingModal from './InviteFolderSettingModal';
 import SharedFolderPermissionInfoModal from './SharedFolderPermissionInfoModal';
 import VFolderNodeIdenticon from './VFolderNodeIdenticon';
 import VFolderPermissionCell from './VFolderPermissionCell';
-import { CheckCircleOutlined, UserOutlined } from '@ant-design/icons';
+import { UserOutlined } from '@ant-design/icons';
 import {
   Alert,
   App,
@@ -81,7 +80,6 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { message } = App.useApp();
-  const currentProject = useCurrentProjectValue();
   const baiClient = useSuspendedBackendaiClient();
   const [currentUser] = useCurrentUserInfo();
   const [hoveredColumn, setHoveredColumn] = useState<string | null>();
@@ -106,7 +104,9 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
         host
         ownership_type
         user
+        user_email
         group
+        group_name
         usage_mode
         permissions @since(version: "24.09.0")
         ...VFolderPermissionCellFragment
@@ -422,6 +422,13 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
             sorter: true,
           },
           {
+            key: 'permissions',
+            title: t('data.folders.MountPermission'),
+            render: (_perm: string, vfolder) => {
+              return <VFolderPermissionCell vfolderFrgmt={vfolder} />;
+            },
+          },
+          {
             key: 'ownership_type',
             title: t('data.folders.Type'),
             dataIndex: 'ownership_type',
@@ -442,23 +449,14 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
             },
             sorter: true,
           },
-          {
-            key: 'permissions',
-            title: t('data.folders.MountPermission'),
-            render: (_perm: string, vfolder) => {
-              return <VFolderPermissionCell vfolderFrgmt={vfolder} />;
-            },
-          },
+
           {
             key: 'owner',
             title: t('data.folders.Owner'),
             render: (__, vfolder) =>
-              vfolder?.user === currentUser?.uuid ||
-              (vfolder?.group === currentProject?.id && baiClient.is_admin) ? (
-                <BAIFlex justify="center">
-                  <CheckCircleOutlined />
-                </BAIFlex>
-              ) : null,
+              vfolder.ownership_type === 'user'
+                ? vfolder?.user_email
+                : vfolder?.group_name,
           },
         ]}
         {...tableProps}

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -88,7 +88,6 @@ export const VALID_MENU_KEYS = [
   'pipeline',
   // adminMenu keys
   'admin-session',
-  'admin-data',
   'credential',
   'environment',
   'scheduler',
@@ -97,6 +96,7 @@ export const VALID_MENU_KEYS = [
   // superAdminMenu keys
   'admin-serving',
   'admin-dashboard',
+  'admin-data',
   'agent',
   'settings',
   'maintenance',
@@ -288,11 +288,6 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
       key: 'admin-session',
     },
     {
-      label: <WebUILink to="/admin-data">{t('webui.menu.Data')}</WebUILink>,
-      icon: <CloudUploadOutlined style={{ color: token.colorInfo }} />,
-      key: 'admin-data',
-    },
-    {
       label: <WebUILink to="/credential">{t('webui.menu.Users')}</WebUILink>,
       icon: <UserOutlined style={{ color: token.colorInfo }} />,
       key: 'credential',
@@ -335,6 +330,11 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
       ),
       icon: <BAIEndpointsIcon style={{ color: token.colorInfo }} />,
       key: 'admin-serving',
+    },
+    {
+      label: <WebUILink to="/admin-data">{t('webui.menu.Data')}</WebUILink>,
+      icon: <CloudUploadOutlined style={{ color: token.colorInfo }} />,
+      key: 'admin-data',
     },
     {
       label: <WebUILink to="/agent">{t('webui.menu.Resources')}</WebUILink>,

--- a/react/src/pages/AdminVFolderNodeListPage.tsx
+++ b/react/src/pages/AdminVFolderNodeListPage.tsx
@@ -5,6 +5,7 @@
 import type {
   AdminVFolderNodeListPageQuery,
   AdminVFolderNodeListPageQuery$data,
+  AdminVFolderNodeListPageQuery$variables,
 } from '../__generated__/AdminVFolderNodeListPageQuery.graphql';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import BAITabs from '../components/BAITabs';
@@ -12,7 +13,8 @@ import DeleteVFolderModal from '../components/DeleteVFolderModal';
 import RestoreVFolderModal from '../components/RestoreVFolderModal';
 import VFolderNodes, { VFolderNodeInList } from '../components/VFolderNodes';
 import { handleRowSelectionChange } from '../helper';
-import { useSuspendedBackendaiClient } from '../hooks';
+import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
+import { isDeletedCategory } from './VFolderNodeListPage';
 import { useToggle } from 'ahooks';
 import { Badge, Button, theme, Tooltip } from 'antd';
 import {
@@ -28,19 +30,12 @@ import {
   useUpdatableState,
 } from 'backend.ai-ui';
 import _ from 'lodash';
-import React, { useDeferredValue, useMemo, useRef, useState } from 'react';
+import React, { useDeferredValue, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from 'src/hooks/reactPaginationQueryOptions';
 import { useBAISettingUserState } from 'src/hooks/useBAISetting';
 import { StringParam, useQueryParams, withDefault } from 'use-query-params';
-
-export const isDeletedCategory = (status?: string | null) => {
-  return _.includes(
-    ['delete-pending', 'delete-ongoing', 'delete-complete', 'delete-error'],
-    status,
-  );
-};
 
 type VFolderNodesType = NonNullableNodeOnEdges<
   AdminVFolderNodeListPageQuery$data['vfolder_nodes']
@@ -58,22 +53,19 @@ const VFOLDER_STATUSES = [
   'DELETE_ERROR',
 ];
 
-interface AdminVFolderNodeListPageProps {}
-
 const FILTER_BY_STATUS_CATEGORY = {
   active:
     'status != "DELETE_PENDING" & status != "DELETE_ONGOING" & status != "DELETE_ERROR" & status != "DELETE_COMPLETE"',
   deleted: 'status in ["DELETE_PENDING", "DELETE_ONGOING", "DELETE_ERROR"]',
 };
 
-const AdminVFolderNodeListPage: React.FC<AdminVFolderNodeListPageProps> = ({
-  ...props
-}) => {
+const AdminVFolderNodeListPage: React.FC = (props) => {
   'use memo';
 
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const baiClient = useSuspendedBackendaiClient();
+  const domainName = useCurrentDomainValue();
 
   const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
     'table_column_overrides.AdminVFolderNodeListPage',
@@ -105,6 +97,8 @@ const AdminVFolderNodeListPage: React.FC<AdminVFolderNodeListPageProps> = ({
   const queryMapRef = useRef({
     [queryParams.statusCategory]: { queryParams, tablePaginationOption },
   });
+
+  // eslint-disable-next-line react-hooks/refs
   queryMapRef.current[queryParams.statusCategory] = {
     queryParams,
     tablePaginationOption,
@@ -129,31 +123,22 @@ const AdminVFolderNodeListPage: React.FC<AdminVFolderNodeListPageProps> = ({
 
   const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
 
-  const queryVariables = useMemo(
-    () => ({
-      offset: baiPaginationOption.offset,
-      first: baiPaginationOption.first,
-      filter: mergeFilterValues([
-        queryParams.statusCategory === 'active' ||
-        queryParams.statusCategory === undefined
-          ? FILTER_BY_STATUS_CATEGORY['active']
-          : FILTER_BY_STATUS_CATEGORY['deleted'],
-        queryParams.filter,
-        usageModeFilter,
-      ]),
-      order: queryParams.order,
-      filterForActiveCount: FILTER_BY_STATUS_CATEGORY['active'],
-      filterForDeletedCount: FILTER_BY_STATUS_CATEGORY['deleted'],
-    }),
-    [
-      baiPaginationOption.offset,
-      baiPaginationOption.first,
-      queryParams.statusCategory,
+  const queryVariables: AdminVFolderNodeListPageQuery$variables = {
+    offset: baiPaginationOption.offset,
+    first: baiPaginationOption.first,
+    filter: mergeFilterValues([
+      queryParams.statusCategory === 'active' ||
+      queryParams.statusCategory === undefined
+        ? FILTER_BY_STATUS_CATEGORY['active']
+        : FILTER_BY_STATUS_CATEGORY['deleted'],
       queryParams.filter,
-      queryParams.order,
       usageModeFilter,
-    ],
-  );
+    ]),
+    order: queryParams.order,
+    filterForActiveCount: FILTER_BY_STATUS_CATEGORY['active'],
+    filterForDeletedCount: FILTER_BY_STATUS_CATEGORY['deleted'],
+    scope_id: `domain:${domainName}`,
+  };
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const deferredFetchKey = useDeferredValue(fetchKey);
 
@@ -167,12 +152,14 @@ const AdminVFolderNodeListPage: React.FC<AdminVFolderNodeListPageProps> = ({
           $order: String
           $filterForActiveCount: String
           $filterForDeletedCount: String
+          $scope_id: ScopeField
         ) {
           vfolder_nodes(
             offset: $offset
             first: $first
             filter: $filter
             order: $order
+            scope_id: $scope_id
           ) {
             edges @required(action: THROW) {
               node @required(action: THROW) {

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -49,7 +49,6 @@ import React, {
   Suspense,
   useDeferredValue,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -97,6 +96,8 @@ const CARD_MIN_HEIGHT = 200;
 const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
   ...props
 }) => {
+  'use memo';
+
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const { lg } = Grid.useBreakpoint();
@@ -166,34 +167,23 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
 
   const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
 
-  const queryVariables: VFolderNodeListPageQuery$variables = useMemo(
-    () => ({
-      scopeId: `project:${currentProject.id}`,
-      offset: baiPaginationOption.offset,
-      first: baiPaginationOption.first,
-      filter: mergeFilterValues([
-        queryParams.statusCategory === 'active' ||
-        queryParams.statusCategory === undefined
-          ? FILTER_BY_STATUS_CATEGORY['active']
-          : FILTER_BY_STATUS_CATEGORY['deleted'],
-        queryParams.filter,
-        usageModeFilter,
-      ]),
-      order: queryParams.order,
-      permission: 'read_attribute',
-      filterForActiveCount: FILTER_BY_STATUS_CATEGORY['active'],
-      filterForDeletedCount: FILTER_BY_STATUS_CATEGORY['deleted'],
-    }),
-    [
-      currentProject.id,
-      baiPaginationOption.offset,
-      baiPaginationOption.first,
-      queryParams.statusCategory,
+  const queryVariables: VFolderNodeListPageQuery$variables = {
+    scopeId: `project:${currentProject.id}`,
+    offset: baiPaginationOption.offset,
+    first: baiPaginationOption.first,
+    filter: mergeFilterValues([
+      queryParams.statusCategory === 'active' ||
+      queryParams.statusCategory === undefined
+        ? FILTER_BY_STATUS_CATEGORY['active']
+        : FILTER_BY_STATUS_CATEGORY['deleted'],
       queryParams.filter,
-      queryParams.order,
       usageModeFilter,
-    ],
-  );
+    ]),
+    order: queryParams.order,
+    permission: 'read_attribute',
+    filterForActiveCount: FILTER_BY_STATUS_CATEGORY['active'],
+    filterForDeletedCount: FILTER_BY_STATUS_CATEGORY['deleted'],
+  };
   const deferredQueryVariables = useDeferredValue(queryVariables);
   const deferredFetchKey = useDeferredValue(fetchKey);
 

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -415,6 +415,7 @@ export const mainLayoutChildRoutes: RouteObject[] = [
     path: '/admin-data',
     handle: { labelKey: 'webui.menu.Data' },
     Component: () => {
+      useSuspendedBackendaiClient();
       return (
         <Suspense fallback={<Skeleton active />}>
           <AdminVFolderNodeListPage />


### PR DESCRIPTION
Resolves #6119 (FR-2317)

## Summary
- Add `AdminVFolderNodeListPage` at `/admin-data` for superadmin to view all VFolders across projects/domains
- Remove upper cards (Create Folder action, StorageStatusPanelCard, QuotaPerStorageVolumePanelCard) — admin does not create folders
- change project scope filtering (`scopeId`) to domain scope for domain level
- Keep folder table with tabs (active/deleted), filters, pagination, bulk delete/restore
- Register route at `/admin-data` in `routes.tsx`
- Add `admin-data` to `VALID_MENU_KEYS` and add menu item to `adminMenu` in `useWebUIMenuItems.tsx`

## Verification
- Relay: compiled 262 reader, 152 normalization, 290 operation text (pass)
- ESLint: no errors on changed files (pass)
- Prettier: all files pass format check (pass)
- TypeScript: no errors (pass)

## Files changed
- `react/src/pages/AdminVFolderNodeListPage.tsx` — new page (created)
- `react/src/routes.tsx` — add `/admin-data` route
- `react/src/hooks/useWebUIMenuItems.tsx` — add `admin-data` to menu keys and admin menu