### PR TITLE
feat(FR-2318): add Admin Serving page for superadmin with modify/delete support

### DIFF
--- a/react/src/components/EndpointList.tsx
+++ b/react/src/components/EndpointList.tsx
@@ -92,6 +92,7 @@ const EndpointList: React.FC<EndpointListProps> = ({
         created_at
         replicas @since(version: "24.12.0")
         desired_session_count
+        project
         created_user_email
         ...EndpointOwnerInfoFragment
         ...EndpointStatusTagFragment
@@ -121,9 +122,19 @@ const EndpointList: React.FC<EndpointListProps> = ({
       dataIndex: 'name',
       fixed: 'left',
       render: (name, row) => (
-        <Link to={'/serving/' + row.endpoint_id}>{name}</Link>
+        <Link
+          to={(isAdminMode ? '/admin-serving/' : '/serving/') + row.endpoint_id}
+        >
+          {name}
+        </Link>
       ),
       sorter: true,
+    },
+    {
+      title: t('data.Project'),
+      dataIndex: 'project',
+      key: 'project',
+      defaultHidden: !isAdminMode,
     },
     {
       title: t('modelService.EndpointId'),

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -88,13 +88,13 @@ export const VALID_MENU_KEYS = [
   'pipeline',
   // adminMenu keys
   'admin-session',
-  'admin-serving',
   'credential',
   'environment',
   'scheduler',
   'resource-policy',
   'reservoir',
   // superAdminMenu keys
+  'admin-serving',
   'admin-dashboard',
   'agent',
   'settings',
@@ -287,13 +287,6 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
       key: 'admin-session',
     },
     {
-      label: (
-        <WebUILink to="/admin-serving">{t('webui.menu.Serving')}</WebUILink>
-      ),
-      icon: <BAIEndpointsIcon style={{ color: token.colorInfo }} />,
-      key: 'admin-serving',
-    },
-    {
       label: <WebUILink to="/credential">{t('webui.menu.Users')}</WebUILink>,
       icon: <UserOutlined style={{ color: token.colorInfo }} />,
       key: 'credential',
@@ -330,6 +323,13 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
   ]);
 
   const superAdminMenu: MenuProps['items'] = filterOutEmpty([
+    {
+      label: (
+        <WebUILink to="/admin-serving">{t('webui.menu.Serving')}</WebUILink>
+      ),
+      icon: <BAIEndpointsIcon style={{ color: token.colorInfo }} />,
+      key: 'admin-serving',
+    },
     {
       label: <WebUILink to="/agent">{t('webui.menu.Resources')}</WebUILink>,
       icon: <HddOutlined style={{ color: token.colorInfo }} />,

--- a/react/src/pages/AdminServingPage.tsx
+++ b/react/src/pages/AdminServingPage.tsx
@@ -44,10 +44,17 @@ const AdminServingPage: React.FC = () => {
 
   const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
 
+  const allowedLifecycleStages = ['active', 'destroyed'] as const;
+  const lifecycleStage = allowedLifecycleStages.includes(
+    queryParams.lifecycleStage as (typeof allowedLifecycleStages)[number],
+  )
+    ? queryParams.lifecycleStage
+    : 'active';
+
   const lifecycleStageFilter =
-    queryParams.lifecycleStage === 'active'
+    lifecycleStage === 'active'
       ? `lifecycle_stage != "destroyed"`
-      : `lifecycle_stage == "${queryParams.lifecycleStage}"`;
+      : `lifecycle_stage == "destroyed"`;
 
   const queryVariables = useMemo(
     () => ({
@@ -131,7 +138,7 @@ const AdminServingPage: React.FC = () => {
               style={{ flexShrink: 1 }}
             >
               <BAIRadioGroup
-                value={queryParams.lifecycleStage}
+                value={lifecycleStage}
                 onChange={(e) => {
                   setQuery({ lifecycleStage: e.target.value }, 'replaceIn');
                   setTablePaginationOption({ current: 1 });

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -381,16 +381,32 @@ export const mainLayoutChildRoutes: RouteObject[] = [
   {
     path: '/admin-serving',
     handle: { labelKey: 'webui.menu.Serving' },
-    Component: () => {
-      const { t } = useTranslation();
-      return (
-        <BAIErrorBoundary>
-          <Suspense fallback={<BAICard title={t('webui.menu.Serving')} loading />}>
-            <AdminServingPage />
+    children: [
+      {
+        index: true,
+        Component: () => {
+          const { t } = useTranslation();
+          return (
+            <BAIErrorBoundary>
+              <Suspense
+                fallback={<BAICard title={t('webui.menu.Serving')} loading />}
+              >
+                <AdminServingPage />
+              </Suspense>
+            </BAIErrorBoundary>
+          );
+        },
+      },
+      {
+        path: ':serviceId',
+        element: (
+          <Suspense fallback={<Skeleton active />}>
+            <EndpointDetailPage />
           </Suspense>
-        </BAIErrorBoundary>
-      );
-    },
+        ),
+        handle: { labelKey: 'modelService.RoutingInfo' },
+      },
+    ],
   },
   {
     path: '/environment',


### PR DESCRIPTION
Resolves #6121 (FR-2318)

## Summary

- Add new `AdminServingPage` for superadmin with full endpoint management (modify/delete) regardless of ownership
- Add `isAdminMode` prop to `EndpointList` to control admin-level button visibility and link routing
- Add `project` column to endpoint list in admin mode (hidden by default in user mode)
- Add `/admin-serving` route and superadmin menu item
- In admin mode, superadmin can modify/delete any service endpoint (not restricted by `created_user_email`)

**Checklist:** (if applicable)

- [ ] Minimum required manager version
- [ ] Test case(s) to demonstrate the difference of before/after