### PR TITLE
fix(FR-2363): merge defaultColumnOverrides with columnOverrides in BAITable

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAITable.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAITable.tsx
@@ -268,8 +268,9 @@ const BAITable = <RecordType extends object = any>({
   // Merge defaultColumnOverrides with columnOverrides so that defaults apply
   // for columns not explicitly overridden by the user.
   const effectiveColumnOverrides = useMemo(() => {
-    const defaults = tableSettings?.defaultColumnOverrides;
-    return defaults ? { ...defaults, ...columnOverrides } : columnOverrides;
+    const defaults = tableSettings?.defaultColumnOverrides ?? {};
+    const overrides = columnOverrides ?? {};
+    return { ...defaults, ...overrides };
   }, [tableSettings, columnOverrides]);
   const [isColumnSettingModalOpen, setIsColumnSettingModalOpen] =
     useState(false);


### PR DESCRIPTION
Resolves #6126 ([FR-2363](https://lablup.atlassian.net/browse/FR-2363))

## Summary
- Merge `defaultColumnOverrides` with `columnOverrides` in BAITable so that default column visibility settings apply for columns not explicitly overridden by the user
- Previously `defaultColumnOverrides` was only used as the initial value for `useControllableValue`, but once `columnOverrides` was provided as a controlled prop, defaults were ignored
- The column setting modal now also reflects the effective (merged) override state

## Test plan
- [ ] Verify that passing `defaultColumnOverrides: { someColumn: { hidden: false } }` makes `defaultHidden: true` columns visible by default
- [ ] Verify that user-set overrides still take precedence over defaults
- [ ] Verify that the column setting modal correctly shows the merged state

[FR-2363]: https://lablup.atlassian.net/browse/FR-2363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ