### PR TITLE
fix(FR-2364): remove nullable artifactRevision size check that caused successful imports to show as errors

### DIFF
--- a/react/src/components/ImportArtifactRevisionToFolderModal.tsx
+++ b/react/src/components/ImportArtifactRevisionToFolderModal.tsx
@@ -117,7 +117,6 @@ const ImportArtifactRevisionToFolderModal = ({
             artifactRevision {
               id
               version
-              size
               artifact {
                 id
                 name
@@ -185,13 +184,7 @@ const ImportArtifactRevisionToFolderModal = ({
                     return;
                   }
 
-                  if (
-                    res.importArtifacts.artifactRevisions?.count > 0 &&
-                    !_.some(
-                      res.importArtifacts.tasks,
-                      (task) => _.toNumber(task?.artifactRevision?.size) === 0,
-                    )
-                  ) {
+                  if (res.importArtifacts.artifactRevisions?.count > 0) {
                     message.success(
                       t(
                         'importArtifactRevisionToFolderModal.SuccessfullyImported',


### PR DESCRIPTION
Resolves #6129 ([FR-2364](https://lablup.atlassian.net/browse/FR-2364))

## Summary
- Removed the `artifactRevision.size === 0` check from the import success condition in `ImportArtifactRevisionToFolderModal`
- `artifactRevision.size` is nullable, so `_.toNumber(null)` returns `0`, which incorrectly triggered the error path even on successful imports

## Test plan
- [ ] Import artifacts and verify success message is displayed correctly
- [ ] Verify that actual errors still show error messages

[FR-2364]: https://lablup.atlassian.net/browse/FR-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ