### PR TITLE
e2e: add E2E tests for forgot password flow

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-03-12
+> **Last Updated:** 2026-03-24
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -12,11 +12,12 @@
 
 **Scope:** Coverage metrics apply only to the routes listed below and do **not** include all entries from `react/src/routes.tsx`. Routes such as `/admin-dashboard` (not yet exposed in menu) and `/ai-agent` (experimental) are currently out of scope.
 
-**Overall (in-scope routes): 215 / 372 features covered (58%)**
+**Overall (in-scope routes): 231 / 388 features covered (60%)**
 
 | Page | Route | Features | Covered | Status |
 |------|-------|:--------:|:-------:|:------:|
-| Authentication | `/interactive-login` | 16 | 14 | 🔶 88% |
+| Authentication | `/interactive-login` | 23 | 21 | 🔶 91% |
+| Change Password | `/change-password` | 9 | 9 | ✅ 100% |
 | Start Page | `/start` | 8 | 6 | 🔶 75% |
 | Dashboard | `/dashboard` | 9 | 7 | 🔶 78% |
 | Session List | `/session` | 20 | 12 | 🔶 60% |
@@ -44,7 +45,7 @@
 | App Launcher | (modal) | 18 | 10 | 🔶 56% |
 | Chat | `/chat/:id?` | 6 | 6 | ✅ 100% |
 | Plugin System | (config-based) | 12 | 12 | ✅ 100% |
-| **Total** | | **319** | **166** | **52%** |
+| **Total** | | **335** | **182** | **54%** |
 
 ---
 
@@ -63,7 +64,7 @@
 
 ### 1. Authentication (`/interactive-login`)
 
-**Test files:** [`e2e/auth/login.spec.ts`](auth/login.spec.ts), [`e2e/auth/password-expiry.spec.ts`](auth/password-expiry.spec.ts)
+**Test files:** [`e2e/auth/login.spec.ts`](auth/login.spec.ts), [`e2e/auth/password-expiry.spec.ts`](auth/password-expiry.spec.ts), [`e2e/auth/forgot-password.spec.ts`](auth/forgot-password.spec.ts)
 
 | Feature | Status | Test |
 |---------|--------|------|
@@ -80,10 +81,36 @@
 | Password change empty validation | ✅ | `password change form shows a validation error when submitted empty` |
 | Password change same-password rejection | ✅ | `password change form rejects a new password that is the same as the current one` |
 | Full password change flow (real account) | ✅ | `user can complete the password change flow with a real account and re-login is attempted` |
+| Forgot password modal open/close | ✅ | `User can open the forgot password modal from login page`, `User can close the modal and return to login form` |
+| Forgot password email send success | ✅ | `User can send a password change email successfully` |
+| Forgot password email send error | ✅ | `User sees an error when email sending fails` |
+| Forgot password form validation (empty) | ✅ | `User cannot submit without email` |
+| Forgot password form validation (invalid email) | ✅ | `User cannot submit with invalid email format` |
+| Forgot password link config-driven visibility | ✅ | `"Forgot password?" link is hidden when config is disabled` |
 | OAuth/SSO login flow | ❌ | - |
 | Session persistence | ❌ | - |
 
-**Coverage: 🔶 14/16 features**
+**Coverage: 🔶 21/23 features**
+
+---
+
+### 1b. Change Password (`/change-password`)
+
+**Test files:** [`e2e/auth/forgot-password.spec.ts`](auth/forgot-password.spec.ts)
+
+| Feature | Status | Test |
+|---------|--------|------|
+| Display password change form with valid token | ✅ | `User sees the password change form with a valid token` |
+| Successful password change | ✅ | `User can successfully change password with valid token` |
+| Redirect to login after success | ✅ | `User is redirected to login page after closing the success modal` |
+| Invalid token view (no token) | ✅ | `User sees invalid token view when accessing the page without a token` |
+| Invalid token view (server rejection) | ✅ | `User sees invalid token view when server rejects the token` |
+| Email mismatch error | ✅ | `User sees email mismatch error when email does not match the token` |
+| Form validation (empty fields) | ✅ | `User cannot submit with empty fields` |
+| Form validation (weak password) | ✅ | `User cannot submit with a weak password` |
+| Form validation (password mismatch) | ✅ | `User cannot submit when passwords do not match` |
+
+**Coverage: ✅ 9/9 features**
 
 ---
 
@@ -985,6 +1012,7 @@ To efficiently build new E2E tests, these POMs should be created:
 | Page Route | Functional Tests | Visual Tests | Priority |
 |------------|:---:|:---:|:---:|
 | `/interactive-login` | 🔶 | ✅ | - |
+| `/change-password` | ✅ | ❌ | - |
 | `/start` | 🔶 | ✅ | - |
 | `/dashboard` | 🔶 | ✅ | - |
 | `/session` | 🔶 | ✅ | P3 |

--- a/e2e/auth/forgot-password.spec.ts
+++ b/e2e/auth/forgot-password.spec.ts
@@ -1,0 +1,600 @@
+// E2E tests for the "Forgot Password" flow.
+//
+// The feature spans two surfaces:
+//   1. Login page (/): "Forgot password? Change" link → ChangePasswordEmailModal
+//      (requires allowAnonymousChangePassword=true in config.toml + SESSION mode)
+//   2. Change password page (/change-password?token=JWT): ChangePasswordView
+//      (direct page navigation; no login required)
+//
+// Mock strategy:
+//   - config.toml: Intercepted via modifyConfigToml() with allowAnonymousChangePassword=true (Part 1)
+//   - POST /cloud/send-password-change-email → mocked per-test (Part 1)
+//   - POST /cloud/change-password → mocked per-test (Part 2)
+//   - All other requests hit the real server.
+//
+// No resource cleanup needed — all tests use mocked API responses; no real data is created.
+import { modifyConfigToml, webuiEndpoint } from '../utils/test-util';
+import { test, expect, type Page } from '@playwright/test';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const TEST_EMAIL = 'test@example.com';
+const TEST_PASSWORD = 'NewPass1!';
+
+/**
+ * A real JWT-format token used in Part 2 tests.
+ * The server is always mocked so the actual token payload does not matter,
+ * but using a properly-structured JWT keeps the app's token-presence check happy.
+ */
+const TEST_TOKEN =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' +
+  '.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyX2lkIjoiZmE5Y2UxOTItOGNhYi00ZDg1LTkwZDctMjVhYzdkMWY1YWUwIiwianRpIjoiNWI0OTg5YWMtYTlhNy00NjhjLTkzZTctNDQ5MDM1MWQ0MGEyIiwiZXhwIjoxNzc0MzM2NDk0fQ' +
+  '.xLoegTxPn3pR4JgLyyKhUBCD_NYhZGKRVuV08AXZm1g';
+
+// ── Mock response bodies ──────────────────────────────────────────────────────
+
+const SEND_EMAIL_SUCCESS = {};
+
+const SEND_EMAIL_ERROR_400 = {
+  type: 'https://api.backend.ai/probs/invalid-api-params',
+  title: 'Missing or invalid API parameters.',
+  error_code: 'api_generic_invalid-parameters',
+  msg: 'Unable to send email',
+};
+
+const CHANGE_PASSWORD_SUCCESS = {};
+
+const CHANGE_PASSWORD_ERROR_INVALID_TOKEN = {
+  type: 'https://api.backend.ai/probs/invalid-api-params',
+  title: 'Missing or invalid API parameters.',
+  error_code: 'api_generic_invalid-parameters',
+  msg: 'Invalid or expired token',
+};
+
+const CHANGE_PASSWORD_ERROR_EMAIL_MISMATCH = {
+  type: 'https://api.backend.ai/probs/invalid-api-params',
+  title: 'Missing or invalid API parameters.',
+  error_code: 'api_generic_invalid-parameters',
+  msg: 'Email mismatch',
+};
+
+// ── Helper functions ──────────────────────────────────────────────────────────
+
+/**
+ * Open the "Send change password email" modal from the login page.
+ * Assumes the page has already been navigated to webuiEndpoint with the
+ * allowAnonymousChangePassword config in place.
+ */
+async function openForgotPasswordModal(page: Page): Promise<void> {
+  await page.getByText('Change').click();
+  await expect(
+    page.getByRole('dialog', { name: 'Send change password email' }),
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+// ── Part 1: Forgot password email modal ──────────────────────────────────────
+
+test.describe('Forgot password email modal', () => {
+  test.beforeEach(async ({ page, request }) => {
+    // Enable the "Forgot password?" link by setting allowAnonymousChangePassword=true
+    await modifyConfigToml(page, request, {
+      general: {
+        connectionMode: 'SESSION',
+        allowAnonymousChangePassword: true,
+      },
+    });
+    await page.goto(webuiEndpoint);
+  });
+
+  test(
+    'User can open the forgot password modal from login page',
+    { tag: ['@regression', '@auth', '@functional', '@smoke'] },
+    async ({ page }) => {
+      // 1. Verify "Forgot password?" text is visible on the login page
+      await expect(page.getByText('Forgot password?')).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // 2. Click "Change" link to open the ChangePasswordEmailModal
+      await openForgotPasswordModal(page);
+
+      // 3. Verify modal title, email input, and Send button are all present
+      await expect(
+        page.getByRole('dialog', { name: 'Send change password email' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('textbox', { name: 'Email', exact: true }),
+      ).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Send' })).toBeVisible();
+    },
+  );
+
+  test(
+    'User can send a password change email successfully',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // Mock the send-password-change-email endpoint to return success
+      await page.route('**/cloud/send-password-change-email', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(SEND_EMAIL_SUCCESS),
+        });
+      });
+
+      // 1. Open the forgot password modal
+      await openForgotPasswordModal(page);
+
+      // 2. Enter a valid email address
+      await page
+        .getByRole('textbox', { name: 'Email', exact: true })
+        .fill(TEST_EMAIL);
+
+      // 3. Click the Send button
+      await page.getByRole('button', { name: 'Send' }).click();
+
+      // 4. Verify success notification appears and modal closes
+      await expect(
+        page.getByText('A verification email has been sent.'),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.getByRole('dialog', { name: 'Send change password email' }),
+      ).toBeHidden({ timeout: 10_000 });
+    },
+  );
+
+  test(
+    'User sees an error when email sending fails',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // Mock the send-password-change-email endpoint to return 400
+      await page.route('**/cloud/send-password-change-email', async (route) => {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify(SEND_EMAIL_ERROR_400),
+        });
+      });
+
+      // 1. Open the forgot password modal
+      await openForgotPasswordModal(page);
+
+      // 2. Enter an unregistered email address
+      await page
+        .getByRole('textbox', { name: 'Email', exact: true })
+        .fill('nonexistent@example.com');
+
+      // 3. Click the Send button
+      await page.getByRole('button', { name: 'Send' }).click();
+
+      // 4. Verify error notification appears and modal stays open
+      await expect(
+        page.getByText(
+          'This email address is not registered. Please contact your administrator.',
+        ),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.getByRole('dialog', { name: 'Send change password email' }),
+      ).toBeVisible();
+    },
+  );
+
+  test(
+    'User cannot submit without email',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // 1. Open the forgot password modal
+      await openForgotPasswordModal(page);
+
+      // 2. Click Send without entering any email
+      await page.getByRole('button', { name: 'Send' }).click();
+
+      // 3. Verify form validation error appears and no API call is attempted
+      await expect(
+        page.locator('.ant-form-item-explain-error').first(),
+      ).toBeVisible({ timeout: 10_000 });
+    },
+  );
+
+  test(
+    'User cannot submit with invalid email format',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // 1. Open the forgot password modal
+      await openForgotPasswordModal(page);
+
+      // 2. Enter an invalid email format
+      await page
+        .getByRole('textbox', { name: 'Email', exact: true })
+        .fill('not-an-email');
+
+      // 3. Click the Send button
+      await page.getByRole('button', { name: 'Send' }).click();
+
+      // 4. Verify email validation error appears
+      await expect(page.getByText('Invalid email address')).toBeVisible({
+        timeout: 10_000,
+      });
+    },
+  );
+
+  test(
+    'User can close the modal and return to login form',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // 1. Open the forgot password modal
+      await openForgotPasswordModal(page);
+
+      // 2. Click Cancel to close the modal
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      // 3. Verify the modal closes and login form is still accessible
+      await expect(
+        page.getByRole('dialog', { name: 'Send change password email' }),
+      ).toBeHidden({ timeout: 10_000 });
+      await expect(page.getByLabel('Email or Username')).toBeVisible();
+      await expect(page.getByLabel('Password')).toBeVisible();
+    },
+  );
+
+  test(
+    '"Forgot password?" link is hidden when config is disabled',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page, request }) => {
+      // Override config to disable allowAnonymousChangePassword
+      await modifyConfigToml(page, request, {
+        general: {
+          connectionMode: 'SESSION',
+          allowAnonymousChangePassword: false,
+        },
+      });
+      await page.goto(webuiEndpoint);
+
+      // Verify "Forgot password?" text and "Change" link are not visible
+      await expect(page.getByText('Forgot password?')).toBeHidden();
+      await expect(page.getByText('Change')).toBeHidden();
+    },
+  );
+});
+
+// ── Part 2: Change password page ─────────────────────────────────────────────
+
+test.describe('Change password page', () => {
+  const changePasswordUrl = `${webuiEndpoint}/change-password?token=${TEST_TOKEN}`;
+
+  test(
+    'User sees the password change form with a valid token',
+    { tag: ['@regression', '@auth', '@functional', '@smoke'] },
+    async ({ page }) => {
+      // 1. Navigate directly to the change-password page with a token in the URL
+      await page.goto(changePasswordUrl);
+      await expect(
+        page.getByRole('dialog', { name: 'Change Password' }),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // 2. Verify all form fields and the Update button are visible
+      await expect(
+        page.getByRole('textbox', { name: 'Enter email address' }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('textbox', { name: 'New password', exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole('textbox', { name: 'New password (again)' }),
+      ).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Update' })).toBeVisible();
+
+      // 3. Verify modal is not closable (no X close button in dialog header)
+      await expect(
+        page
+          .getByRole('dialog', { name: 'Change Password' })
+          .getByRole('button', { name: 'Close' }),
+      ).toBeHidden();
+    },
+  );
+
+  test(
+    'User can successfully change password with valid token',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // Mock the change-password endpoint to return success
+      await page.route('**/cloud/change-password', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(CHANGE_PASSWORD_SUCCESS),
+        });
+      });
+
+      // 1. Navigate to the change-password page
+      await page.goto(changePasswordUrl);
+      await expect(
+        page.getByRole('dialog', { name: 'Change Password' }),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // 2. Fill in the form
+      await page
+        .getByRole('textbox', { name: 'Enter email address' })
+        .fill(TEST_EMAIL);
+      await page
+        .getByRole('textbox', { name: 'New password', exact: true })
+        .fill(TEST_PASSWORD);
+      await page
+        .getByRole('textbox', { name: 'New password (again)' })
+        .fill(TEST_PASSWORD);
+
+      // 3. Click Update
+      await page.getByRole('button', { name: 'Update' }).click();
+
+      // 4. Verify success view appears with the success message and Close button
+      await expect(
+        page.getByText('Password is successfully changed'),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+    },
+  );
+
+  test(
+    'User is redirected to login page after closing the success modal',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // Mock the change-password endpoint to return success
+      await page.route('**/cloud/change-password', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(CHANGE_PASSWORD_SUCCESS),
+        });
+      });
+
+      // 1. Navigate and complete the password change flow
+      await page.goto(changePasswordUrl);
+      await expect(
+        page.getByRole('dialog', { name: 'Change Password' }),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+
+      await page
+        .getByRole('textbox', { name: 'Enter email address' })
+        .fill(TEST_EMAIL);
+      await page
+        .getByRole('textbox', { name: 'New password', exact: true })
+        .fill(TEST_PASSWORD);
+      await page
+        .getByRole('textbox', { name: 'New password (again)' })
+        .fill(TEST_PASSWORD);
+      await page.getByRole('button', { name: 'Update' }).click();
+
+      // 2. Verify success message is shown
+      await expect(
+        page.getByText('Password is successfully changed'),
+      ).toBeVisible({ timeout: 10_000 });
+
+      // 3. Click Close and verify redirect to login page
+      await page.getByRole('button', { name: 'Close' }).click();
+      await page.waitForURL(webuiEndpoint + '/', { timeout: 10_000 });
+      await expect(page.getByLabel('Email or Username')).toBeVisible({
+        timeout: 10_000,
+      });
+    },
+  );
+
+  test(
+    'User sees invalid token view when accessing the page without a token',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // 1. Navigate to the change-password page without a token parameter
+      await page.goto(`${webuiEndpoint}/change-password`);
+
+      // 2. Verify Invalid Token modal is displayed with the error message
+      await expect(
+        page.getByRole('dialog', { name: 'Invalid Token' }),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(
+        page.getByText(
+          'Issued token to change password has error. Please send another email for changing password and try again.',
+        ),
+      ).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+
+      // 3. Click Close and verify redirect to login page
+      await page.getByRole('button', { name: 'Close' }).click();
+      await page.waitForURL(webuiEndpoint + '/', { timeout: 10_000 });
+      await expect(page.getByLabel('Email or Username')).toBeVisible({
+        timeout: 10_000,
+      });
+    },
+  );
+
+  test(
+    'User sees invalid token view when server rejects the token',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // Mock the change-password endpoint to return an invalid token error
+      await page.route('**/cloud/change-password', async (route) => {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify(CHANGE_PASSWORD_ERROR_INVALID_TOKEN),
+        });
+      });
+
+      // 1. Navigate to the change-password page with a token
+      await page.goto(changePasswordUrl);
+      await expect(
+        page.getByRole('dialog', { name: 'Change Password' }),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // 2. Fill in the form and submit
+      await page
+        .getByRole('textbox', { name: 'Enter email address' })
+        .fill(TEST_EMAIL);
+      await page
+        .getByRole('textbox', { name: 'New password', exact: true })
+        .fill(TEST_PASSWORD);
+      await page
+        .getByRole('textbox', { name: 'New password (again)' })
+        .fill(TEST_PASSWORD);
+      await page.getByRole('button', { name: 'Update' }).click();
+
+      // 3. Verify Invalid Token view is shown (component transitions state)
+      await expect(
+        page.getByRole('dialog', { name: 'Invalid Token' }),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+    },
+  );
+
+  test(
+    'User sees email mismatch error when email does not match the token',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // Mock the change-password endpoint to return an email mismatch error
+      await page.route('**/cloud/change-password', async (route) => {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify(CHANGE_PASSWORD_ERROR_EMAIL_MISMATCH),
+        });
+      });
+
+      // 1. Navigate to the change-password page with a token
+      await page.goto(changePasswordUrl);
+      await expect(
+        page.getByRole('dialog', { name: 'Change Password' }),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // 2. Fill in the form with the wrong email and submit
+      await page
+        .getByRole('textbox', { name: 'Enter email address' })
+        .fill('wrong@example.com');
+      await page
+        .getByRole('textbox', { name: 'New password', exact: true })
+        .fill(TEST_PASSWORD);
+      await page
+        .getByRole('textbox', { name: 'New password (again)' })
+        .fill(TEST_PASSWORD);
+      await page.getByRole('button', { name: 'Update' }).click();
+
+      // 3. Verify inline email mismatch error and that view stays on change-password state
+      await expect(
+        page.getByText(
+          'The email address does not match the one used for the password change request.',
+        ),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+      await expect(
+        page.getByRole('dialog', { name: 'Change Password' }),
+      ).toBeVisible();
+    },
+  );
+
+  test(
+    'User cannot submit with empty fields',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // 1. Navigate to the change-password page with a token
+      await page.goto(changePasswordUrl);
+      await expect(
+        page.getByRole('dialog', { name: 'Change Password' }),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // 2. Click Update without filling any fields
+      await page.getByRole('button', { name: 'Update' }).click();
+
+      // 3. Verify validation errors appear for all three fields
+      await expect(
+        page.locator('.ant-form-item-explain-error').first(),
+      ).toBeVisible({ timeout: 10_000 });
+    },
+  );
+
+  test(
+    'User cannot submit with a weak password',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // 1. Navigate to the change-password page with a token
+      await page.goto(changePasswordUrl);
+      await expect(
+        page.getByRole('dialog', { name: 'Change Password' }),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // 2. Fill email with valid value but use a weak password that fails the pattern
+      await page
+        .getByRole('textbox', { name: 'Enter email address' })
+        .fill(TEST_EMAIL);
+      await page
+        .getByRole('textbox', { name: 'New password', exact: true })
+        .fill('abc');
+      await page
+        .getByRole('textbox', { name: 'New password (again)' })
+        .fill('abc');
+
+      // 3. Click Update and verify password pattern validation error
+      await page.getByRole('button', { name: 'Update' }).click();
+      await expect(
+        page
+          .locator('.ant-form-item-explain-error')
+          .filter({
+            hasText:
+              'At least 1 alphabet, 1 number and 1 special character is required with at least 8 chars.',
+          })
+          .first(),
+      ).toBeVisible({ timeout: 10_000 });
+    },
+  );
+
+  test(
+    'User cannot submit when passwords do not match',
+    { tag: ['@regression', '@auth', '@functional'] },
+    async ({ page }) => {
+      // 1. Navigate to the change-password page with a token
+      await page.goto(changePasswordUrl);
+      await expect(
+        page.getByRole('dialog', { name: 'Change Password' }),
+      ).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // 2. Fill email and two different passwords that both pass the pattern individually
+      await page
+        .getByRole('textbox', { name: 'Enter email address' })
+        .fill(TEST_EMAIL);
+      await page
+        .getByRole('textbox', { name: 'New password', exact: true })
+        .fill('NewPass1!');
+      await page
+        .getByRole('textbox', { name: 'New password (again)' })
+        .fill('DiffPass2@');
+
+      // 3. Click Update and verify the password mismatch error notification
+      await page.getByRole('button', { name: 'Update' }).click();
+      await expect(page.getByText('Password mismatch')).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // 4. Verify view stays on the change-password dialog (not invalid-token)
+      await expect(
+        page.getByRole('dialog', { name: 'Change Password' }),
+      ).toBeVisible();
+    },
+  );
+});


### PR DESCRIPTION
Resolves #6134 ([FR-2365](https://lablup.atlassian.net/browse/FR-2365))

## Summary
- Add 16 E2E tests for the forgot password flow across two test describe blocks
- **Part 1** (7 tests): `ChangePasswordEmailModal` on the login page — covers modal open/close, successful email send, error handling (400), form validation, and config-driven visibility
- **Part 2** (9 tests): `ChangePasswordView` at `/change-password?token=JWT` — covers successful password change, redirect after success, invalid/expired token, email mismatch, and form validation (empty fields, weak password, password mismatch)
- All tests use Playwright `page.route()` API mocking — no real backend plugin required

## Test plan
- [ ] Run `pnpm exec playwright test e2e/auth/forgot-password.spec.ts` — all 16 tests should pass
- [ ] Verify tests work with `allowAnonymousChangePassword = true` config
- [ ] Confirm no interference with existing `password-expiry.spec.ts` tests

[FR-2365]: https://lablup.atlassian.net/browse/FR-2365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Test Recordings

### Forgot Password Email Modal

| Test | Recording |
|------|-----------|
| User can open the forgot password modal from login page | ![forgot-password-modal-open](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172150-forgot-password-modal-open.gif) |
| User can send a password change email successfully | ![forgot-password-send-email-success](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172158-forgot-password-send-email-success.gif) |
| User sees an error when email sending fails | ![forgot-password-send-email-error](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172205-forgot-password-send-email-error.gif) |
| User cannot submit without email | ![forgot-password-no-email](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172212-forgot-password-no-email.gif) |
| User cannot submit with invalid email format | ![forgot-password-invalid-email](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172219-forgot-password-invalid-email.gif) |
| User can close the modal and return to login form | ![forgot-password-close-modal](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172226-forgot-password-close-modal.gif) |
| "Forgot password?" link is hidden when config is disabled | ![forgot-password-link-hidden](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172232-forgot-password-link-hidden.gif) |

### Change Password Page

| Test | Recording |
|------|-----------|
| User sees the password change form with a valid token | ![change-password-valid-token](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172239-change-password-valid-token.gif) |
| User can successfully change password with valid token | ![change-password-success](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172245-change-password-success.gif) |
| User is redirected to login page after closing the success modal | ![change-password-redirect](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172251-change-password-redirect.gif) |
| User sees invalid token view when accessing the page without a token | ![change-password-no-token](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172258-change-password-no-token.gif) |
| User sees invalid token view when server rejects the token | ![change-password-server-rejects](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172305-change-password-server-rejects.gif) |
| User sees email mismatch error when email does not match the token | ![change-password-email-mismatch](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172312-change-password-email-mismatch.gif) |
| User cannot submit with empty fields | ![change-password-empty-fields](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172319-change-password-empty-fields.gif) |
| User cannot submit with a weak password | ![change-password-weak-password](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172325-change-password-weak-password.gif) |
| User cannot submit when passwords do not match | ![change-password-no-match](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6133/20260324-172332-change-password-no-match.gif) |