### PR TITLE
fix: make plugins copy optional in serve-release script

### DIFF
--- a/scripts/serve-release.sh
+++ b/scripts/serve-release.sh
@@ -65,9 +65,13 @@ else
     rm "${DOWNLOAD_PATH}"
 fi
 
-echo "Overwriting config.toml and plugins to extracted folder..."
+echo "Overwriting config.toml to extracted folder..."
 cp "${PROJECT_ROOT}/config.toml" "${EXTRACTED_FOLDER}/"
-cp -r "${PROJECT_ROOT}/dist/plugins" "${EXTRACTED_FOLDER}/dist/"
+if [ -d "${PROJECT_ROOT}/dist/plugins" ]; then
+    echo "Copying plugins to extracted folder..."
+    mkdir -p "${EXTRACTED_FOLDER}/dist/"
+    cp -r "${PROJECT_ROOT}/dist/plugins" "${EXTRACTED_FOLDER}/dist/"
+fi
 
 echo "Starting server in ${EXTRACTED_FOLDER}..."
 cd "${EXTRACTED_FOLDER}"


### PR DESCRIPTION
Resolves #6138

## Summary
- Make `dist/plugins` copy conditional in `serve-release.sh` — only copies when the directory exists
- Prevents script failure when `dist/plugins` is not present in the project root

## Test plan
- [ ] Run `./scripts/serve-release.sh 26.3.1` without `dist/plugins` directory — should succeed
- [ ] Create a `dist/plugins` directory with test content and verify it gets copied