### PR TITLE
fix(FR-2372): correct misleading SSH keypair private key warning message

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2543,7 +2543,7 @@
     "SSHKeypairEnterManually": "SSH-Schlüsselpaar",
     "SSHKeypairEnterManuallyFinished": "SSH-Keypair wurde erfolgreich registriert.",
     "SSHKeypairGeneration": "SSH-Schlüsselpaargenerierung",
-    "SSHKeypairGenerationWarning": "Sie können den privaten Schlüssel nicht erneut abrufen. Bei Bedarf auf Ihrer lokalen Festplatte speichern.",
+    "SSHKeypairGenerationWarning": "Wir empfehlen, den privaten Schlüssel jetzt der Einfachheit halber zu speichern. Sie können ihn später nach dem Starten einer Sitzung unter /home/work/id_container abrufen.",
     "SSHKeypairManagement": "SSH-Schlüsselpaarverwaltung",
     "SessionTerminationDialog": "Die Beendigung der Sitzung kann nicht rückgängig gemacht werden. Möchten Sie fortfahren, um die Sitzung zu beenden?",
     "ShellEnvironments": "Shell-Umgebungen",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2541,7 +2541,7 @@
     "SSHKeypairEnterManually": "Ζεύγος κλειδιών SSH",
     "SSHKeypairEnterManuallyFinished": "Το ζεύγος κλειδιών SSH καταχωρήθηκε με επιτυχία.",
     "SSHKeypairGeneration": "Δημιουργία SSH Keypair",
-    "SSHKeypairGenerationWarning": "Δεν μπορείτε να πάρετε ξανά ιδιωτικό κλειδί. Αποθηκεύστε στον τοπικό σας δίσκο εάν χρειάζεται.",
+    "SSHKeypairGenerationWarning": "Συνιστούμε να αποθηκεύσετε το ιδιωτικό κλειδί τώρα για ευκολία. Μπορείτε να το ανακτήσετε αργότερα από /home/work/id_container μετά την εκκίνηση μιας συνεδρίας.",
     "SSHKeypairManagement": "Διαχείριση SSH Keypair",
     "SessionTerminationDialog": "Δεν είναι δυνατή η αναίρεση του τερματισμού περιόδου σύνδεσης. Θέλετε να συνεχίσετε για να τερματίσετε τη συνεδρία;",
     "ShellEnvironments": "Περιβάλλον Shell",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2551,7 +2551,7 @@
     "SSHKeypairEnterManually": "SSH Keypair",
     "SSHKeypairEnterManuallyFinished": "SSH Keypair has been successfully registered.",
     "SSHKeypairGeneration": "SSH Keypair Generation",
-    "SSHKeypairGenerationWarning": "You cannot get private key again. Store on your local disk if needed.",
+    "SSHKeypairGenerationWarning": "We recommend saving the private key now for convenience. You can retrieve it later from /home/work/id_container after starting a session.",
     "SSHKeypairManagement": "SSH Keypair Management",
     "SessionTerminationDialog": "Session termination cannot be undone. Do you want to proceed to terminate the session?",
     "ShellEnvironments": "Shell Environments",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2541,7 +2541,7 @@
     "SSHKeypairEnterManually": "Par de claves SSH",
     "SSHKeypairEnterManuallyFinished": "El par de claves SSH se ha registrado correctamente.",
     "SSHKeypairGeneration": "Generación de pares de claves SSH",
-    "SSHKeypairGenerationWarning": "No puede obtener la clave privada de nuevo. Guárdela en su disco local si es necesario.",
+    "SSHKeypairGenerationWarning": "Se recomienda guardar la clave privada ahora para mayor comodidad. Puede recuperarla más tarde desde /home/work/id_container después de iniciar una sesión.",
     "SSHKeypairManagement": "Gestión de pares de claves SSH",
     "SessionTerminationDialog": "La finalización de la sesión no se puede deshacer. ¿Desea finalizar la sesión?",
     "ShellEnvironments": "Entornos de conchas",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2541,7 +2541,7 @@
     "SSHKeypairEnterManually": "SSH-avainpari",
     "SSHKeypairEnterManuallyFinished": "SSH-avainpari on rekisteröity onnistuneesti.",
     "SSHKeypairGeneration": "SSH-avainparin luominen",
-    "SSHKeypairGenerationWarning": "Et voi saada yksityistä avainta uudelleen. Tallenna tarvittaessa paikalliselle levylle.",
+    "SSHKeypairGenerationWarning": "Suosittelemme tallentamaan yksityisen avaimen nyt mukavuuden vuoksi. Voit hakea sen myöhemmin osoitteesta /home/work/id_container istunnon käynnistämisen jälkeen.",
     "SSHKeypairManagement": "SSH-avainparin hallinta",
     "SessionTerminationDialog": "Istunnon lopettamista ei voi peruuttaa. Haluatko jatkaa istunnon lopettamista?",
     "ShellEnvironments": "Shell-ympäristöt",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2541,7 +2541,7 @@
     "SSHKeypairEnterManually": "Couple de clés SSH",
     "SSHKeypairEnterManuallyFinished": "La paire de clés SSH a été enregistrée avec succès.",
     "SSHKeypairGeneration": "Génération de paires de clés SSH",
-    "SSHKeypairGenerationWarning": "Vous ne pouvez plus obtenir de clé privée. Stockez sur votre disque local si nécessaire.",
+    "SSHKeypairGenerationWarning": "Nous vous recommandons de sauvegarder la clé privée maintenant pour plus de commodité. Vous pourrez la récupérer ultérieurement depuis /home/work/id_container après avoir démarré une session.",
     "SSHKeypairManagement": "Gestion des paires de clés SSH",
     "SessionTerminationDialog": "L'arrêt de la session ne peut pas être annulé. Voulez-vous continuer pour terminer la session ?",
     "ShellEnvironments": "Environnements Shell",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2544,7 +2544,7 @@
     "SSHKeypairEnterManually": "SSH Keypair",
     "SSHKeypairEnterManuallyFinished": "SSH Keypair telah berhasil didaftarkan.",
     "SSHKeypairGeneration": "Pembuatan Pasangan Kunci SSH",
-    "SSHKeypairGenerationWarning": "Anda tidak bisa mendapatkan kunci pribadi lagi. Simpan di disk lokal Anda jika diperlukan.",
+    "SSHKeypairGenerationWarning": "Kami sarankan untuk menyimpan kunci pribadi sekarang demi kemudahan. Anda dapat mengambilnya nanti dari /home/work/id_container setelah memulai sesi.",
     "SSHKeypairManagement": "Manajemen Pasangan Kunci SSH",
     "SessionTerminationDialog": "Penghentian sesi tidak dapat diurungkan. Apakah Anda ingin melanjutkan untuk mengakhiri sesi?",
     "ShellEnvironments": "Lingkungan Shell",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2541,7 +2541,7 @@
     "SSHKeypairEnterManually": "Coppia di chiavi SSH",
     "SSHKeypairEnterManuallyFinished": "La coppia di chiavi SSH è stata registrata con successo.",
     "SSHKeypairGeneration": "Generazione di coppie di chiavi SSH",
-    "SSHKeypairGenerationWarning": "Non puoi ottenere di nuovo la chiave privata. Memorizzare sul disco locale, se necessario.",
+    "SSHKeypairGenerationWarning": "Si consiglia di salvare la chiave privata ora per comodità. È possibile recuperarla in seguito da /home/work/id_container dopo aver avviato una sessione.",
     "SSHKeypairManagement": "Gestione delle coppie di chiavi SSH",
     "SessionTerminationDialog": "La chiusura della sessione non può essere annullata. Vuoi procedere per terminare la sessione?",
     "ShellEnvironments": "Ambienti shell",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2543,7 +2543,7 @@
     "SSHKeypairEnterManually": "SSHキーペア入力",
     "SSHKeypairEnterManuallyFinished": "SSHキーフェア登録が正常に完了しました。",
     "SSHKeypairGeneration": "SSHキーペアの生成",
-    "SSHKeypairGenerationWarning": "秘密鍵を再度取得することはできません。必要に応じてローカルディスクに保存します。",
+    "SSHKeypairGenerationWarning": "秘密鍵は利便性のために今すぐ保存することをお勧めします。後からセッション起動後に /home/work/id_container で確認できます。",
     "SSHKeypairManagement": "SSHキーペア管理",
     "SessionTerminationDialog": "セッションの終了は元に戻せません。セッションの終了に進みますか？",
     "ShellEnvironments": "シェル環境",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2554,7 +2554,7 @@
     "SSHKeypairEnterManually": "SSH 키페어 입력",
     "SSHKeypairEnterManuallyFinished": "SSH 키페어 등록이 완료되었습니다.",
     "SSHKeypairGeneration": "SSH 키페어 생성",
-    "SSHKeypairGenerationWarning": "비밀 키는 다시 받을 수 없습니다. 필요한 경우 로컬 디스크에 저장하시기 바랍니다.",
+    "SSHKeypairGenerationWarning": "비밀 키는 편의를 위해 지금 저장해 두시는 것을 권장합니다. 이후에는 세션 실행 후 /home/work/id_container 파일에서 확인할 수 있습니다.",
     "SSHKeypairManagement": "SSH 키페어 관리",
     "SessionTerminationDialog": "세션 종료는 취소할 수 없습니다. 종료하시겠습니까?",
     "ShellEnvironments": "쉘 스크립트 환경",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2543,7 +2543,7 @@
     "SSHKeypairEnterManually": "SSH товчлуурын хослол",
     "SSHKeypairEnterManuallyFinished": "SSH Keypair амжилттай бүртгэгдлээ.",
     "SSHKeypairGeneration": "SSH товчлуурын үе",
-    "SSHKeypairGenerationWarning": "Та хувийн түлхүүрийг дахин авах боломжгүй. Шаардлагатай бол локал диск дээрээ хадгална уу.",
+    "SSHKeypairGenerationWarning": "Тухтай байхын тулд хувийн түлхүүрийг одоо хадгалахыг зөвлөж байна. Сессийг эхлүүлсний дараа /home/work/id_container файлаас дараа нь авах боломжтой.",
     "SSHKeypairManagement": "SSH товчлуурын менежмент",
     "SessionTerminationDialog": "Session дуусахыг цуцлах боломжгүй. Та хуралдааныг зогсоохыг хүсч байна уу?",
     "ShellEnvironments": "Shell Environments",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2541,7 +2541,7 @@
     "SSHKeypairEnterManually": "SSH Keypair",
     "SSHKeypairEnterManuallyFinished": "SSH Keypair telah berjaya didaftarkan.",
     "SSHKeypairGeneration": "Penjanaan Keypair SSH",
-    "SSHKeypairGenerationWarning": "Anda tidak boleh mendapatkan kunci peribadi lagi. Simpan pada cakera tempatan anda jika diperlukan.",
+    "SSHKeypairGenerationWarning": "Kami mengesyorkan anda menyimpan kunci peribadi sekarang untuk kemudahan. Anda boleh mendapatkannya kemudian dari /home/work/id_container selepas memulakan sesi.",
     "SSHKeypairManagement": "Pengurusan Keypair SSH",
     "SessionTerminationDialog": "Penamatan sesi tidak boleh dibuat asal. Adakah anda mahu meneruskan untuk menamatkan sesi?",
     "ShellEnvironments": "Persekitaran Shell",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2541,7 +2541,7 @@
     "SSHKeypairEnterManually": "Para kluczy SSH",
     "SSHKeypairEnterManuallyFinished": "Para kluczy SSH została pomyślnie zarejestrowana.",
     "SSHKeypairGeneration": "Generowanie par kluczy SSH",
-    "SSHKeypairGenerationWarning": "Nie możesz ponownie uzyskać klucza prywatnego. W razie potrzeby przechowuj na dysku lokalnym.",
+    "SSHKeypairGenerationWarning": "Zalecamy zapisanie klucza prywatnego teraz dla wygody. Można go później pobrać z /home/work/id_container po uruchomieniu sesji.",
     "SSHKeypairManagement": "Zarządzanie parami kluczy SSH",
     "SessionTerminationDialog": "Zakończenia sesji nie można cofnąć. Czy chcesz kontynuować, aby zakończyć sesję?",
     "ShellEnvironments": "Środowiska powłoki",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2541,7 +2541,7 @@
     "SSHKeypairEnterManually": "Par de chaves SSH",
     "SSHKeypairEnterManuallyFinished": "O par de chaves SSH foi registado com sucesso.",
     "SSHKeypairGeneration": "Geração de par de chaves SSH",
-    "SSHKeypairGenerationWarning": "Você não pode obter a chave privada novamente. Armazene em seu disco local, se necessário.",
+    "SSHKeypairGenerationWarning": "Recomendamos salvar a chave privada agora por conveniência. Você pode recuperá-la mais tarde em /home/work/id_container após iniciar uma sessão.",
     "SSHKeypairManagement": "Gerenciamento de par de chaves SSH",
     "SessionTerminationDialog": "O encerramento da sessão não pode ser desfeito. Você deseja prosseguir para encerrar a sessão?",
     "ShellEnvironments": "Ambientes Shell",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2543,7 +2543,7 @@
     "SSHKeypairEnterManually": "Par de chaves SSH",
     "SSHKeypairEnterManuallyFinished": "O par de chaves SSH foi registado com sucesso.",
     "SSHKeypairGeneration": "Geração de par de chaves SSH",
-    "SSHKeypairGenerationWarning": "Você não pode obter a chave privada novamente. Armazene em seu disco local, se necessário.",
+    "SSHKeypairGenerationWarning": "Recomendamos guardar a chave privada agora por conveniência. Pode recuperá-la mais tarde a partir de /home/work/id_container após iniciar uma sessão.",
     "SSHKeypairManagement": "Gerenciamento de par de chaves SSH",
     "SessionTerminationDialog": "O encerramento da sessão não pode ser desfeito. Você deseja prosseguir para encerrar a sessão?",
     "ShellEnvironments": "Ambientes Shell",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2541,7 +2541,7 @@
     "SSHKeypairEnterManually": "Пара ключей SSH",
     "SSHKeypairEnterManuallyFinished": "Пара ключей SSH успешно зарегистрирована.",
     "SSHKeypairGeneration": "Создание пары ключей SSH",
-    "SSHKeypairGenerationWarning": "Вы не можете снова получить закрытый ключ. При необходимости сохраните на локальном диске.",
+    "SSHKeypairGenerationWarning": "Рекомендуем сохранить закрытый ключ сейчас для удобства. Позже его можно получить из /home/work/id_container после запуска сессии.",
     "SSHKeypairManagement": "Управление парой ключей SSH",
     "SessionTerminationDialog": "Завершение сеанса нельзя отменить. Вы хотите продолжить, чтобы завершить сеанс?",
     "ShellEnvironments": "Оболочка среды",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2543,7 +2543,7 @@
     "SSHKeypairEnterManually": "คู่คีย์ SSH",
     "SSHKeypairEnterManuallyFinished": "ลงทะเบียนคู่คีย์ SSH สำเร็จแล้ว",
     "SSHKeypairGeneration": "การสร้างคู่คีย์ SSH",
-    "SSHKeypairGenerationWarning": "คุณไม่สามารถรับคีย์ส่วนตัวอีกครั้ง เก็บไว้ในดิสก์ในเครื่องของคุณหากจำเป็น",
+    "SSHKeypairGenerationWarning": "แนะนำให้บันทึกคีย์ส่วนตัวไว้ตอนนี้เพื่อความสะดวก สามารถดึงมาได้ในภายหลังจาก /home/work/id_container หลังจากเริ่มเซสชัน",
     "SSHKeypairManagement": "การจัดการคู่คีย์ SSH",
     "SessionTerminationDialog": "การยุติเซสชันไม่สามารถยกเลิกได้ คุณต้องการดำเนินการต่อเพื่อยุติเซสชันหรือไม่?",
     "ShellEnvironments": "สภาพแวดล้อมเชลล์",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2541,7 +2541,7 @@
     "SSHKeypairEnterManually": "SSH Anahtar Çifti",
     "SSHKeypairEnterManuallyFinished": "SSH Anahtar Çifti başarıyla kaydedildi.",
     "SSHKeypairGeneration": "SSH Anahtar Çifti Oluşturma",
-    "SSHKeypairGenerationWarning": "Özel anahtarı tekrar alamazsınız. Gerekirse yerel diskinizde saklayın.",
+    "SSHKeypairGenerationWarning": "Kolaylık açısından özel anahtarı şimdi kaydetmenizi öneririz. Daha sonra bir oturum başlattıktan sonra /home/work/id_container dosyasından alabilirsiniz.",
     "SSHKeypairManagement": "SSH Anahtar Çifti Yönetimi",
     "SessionTerminationDialog": "Oturum sonlandırma geri alınamaz. Oturumu sonlandırmak için devam etmek istiyor musunuz?",
     "ShellEnvironments": "Kabuk Ortamları",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2543,7 +2543,7 @@
     "SSHKeypairEnterManually": "Cặp khóa SSH",
     "SSHKeypairEnterManuallyFinished": "Cặp khóa SSH đã được đăng ký thành công.",
     "SSHKeypairGeneration": "SSH Keypair Generation",
-    "SSHKeypairGenerationWarning": "Bạn không thể lấy lại khóa cá nhân. Lưu trữ trên đĩa cục bộ của bạn nếu cần.",
+    "SSHKeypairGenerationWarning": "Chúng tôi khuyên bạn nên lưu khóa riêng tư ngay bây giờ để thuận tiện. Bạn có thể lấy lại sau từ /home/work/id_container sau khi khởi động phiên.",
     "SSHKeypairManagement": "Quản lý cặp khóa SSH",
     "SessionTerminationDialog": "Không thể hoàn tác việc kết thúc phiên. Bạn có muốn tiếp tục kết thúc phiên này không?",
     "ShellEnvironments": "Môi trường Shell",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2543,7 +2543,7 @@
     "SSHKeypairEnterManually": "SSH 密钥对",
     "SSHKeypairEnterManuallyFinished": "SSH 密钥对已成功注册。",
     "SSHKeypairGeneration": "SSH 密钥对生成",
-    "SSHKeypairGenerationWarning": "您无法再次获取私钥。如果需要，存储在本地磁盘上。",
+    "SSHKeypairGenerationWarning": "建议您现在保存私钥以便使用。之后可以在启动会话后从 /home/work/id_container 获取。",
     "SSHKeypairManagement": "SSH 密钥对管理",
     "SessionTerminationDialog": "会话终止无法撤消。您要继续终止会话吗？",
     "ShellEnvironments": "外壳环境",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2545,7 +2545,7 @@
     "SSHKeypairEnterManually": "SSH 密钥对",
     "SSHKeypairEnterManuallyFinished": "SSH 密钥对已成功注册。",
     "SSHKeypairGeneration": "SSH 密鑰對生成",
-    "SSHKeypairGenerationWarning": "您無法再次獲取私鑰。如果需要，存儲在本地磁盤上。",
+    "SSHKeypairGenerationWarning": "建議您現在儲存私鑰以便使用。之後可以在啟動會話後從 /home/work/id_container 取得。",
     "SSHKeypairManagement": "SSH 密鑰對管理",
     "SessionTerminationDialog": "會話終止無法撤消。您要繼續終止會話嗎？",
     "ShellEnvironments": "外殼環境",


### PR DESCRIPTION
Resolves #6145(FR-2372)

## Summary

The SSH keypair generation modal displayed a warning stating the private key could not be retrieved again, which was inaccurate. The private key is actually accessible at `/home/work/id_container` after starting a session.

- Updated `SSHKeypairGenerationWarning` i18n key in all 21 language files
- Reordered message structure: save recommendation first (primary action), retrieval path second (supplementary info)
- Removed technical SFTP jargon that is not user-friendly
- Added "after starting a session" context to clarify when the file becomes available

**Before (ko):** "비밀 키는 다시 받을 수 없습니다. 필요한 경우 로컬 디스크에 저장하시기 바랍니다."
**After (ko):** "비밀 키는 편의를 위해 지금 저장해 두시는 것을 권장합니다. 이후에는 세션 실행 후 /home/work/id_container 파일에서 확인할 수 있습니다."

**Before (en):** "You cannot get private key again. Store on your local disk if needed."
**After (en):** "We recommend saving the private key now for convenience. You can retrieve it later from /home/work/id_container after starting a session."

## Test plan
- [ ] Open User Settings > SSH Keypair section
- [ ] Click to generate an SSH keypair
- [ ] Verify the warning message recommends saving first, with retrieval path as secondary info
- [ ] Verify the message no longer states "You cannot get private key again"
- [ ] Verify no mention of "SFTP session download" in the message