### PR TITLE
feat(FR-2378): filter environment options to vLLM-only when vLLM runtime selected

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -65,6 +65,7 @@ export type ImageEnvironmentFormInput = {
 interface ImageEnvironmentSelectFormItemsProps {
   filter?: (image: Image) => boolean;
   showPrivate?: boolean;
+  extra?: React.ReactNode;
 }
 
 function compareVersions(version1: string, version2: string): number {
@@ -96,7 +97,7 @@ const isPrivateImage = (image: Image) => {
 
 const ImageEnvironmentSelectFormItems: React.FC<
   ImageEnvironmentSelectFormItemsProps
-> = ({ filter, showPrivate }) => {
+> = ({ filter, showPrivate, extra }) => {
   const form = Form.useFormInstance<ImageEnvironmentFormInput>();
   const environments = Form.useWatch('environments', { form, preserve: true });
   const baiClient = useSuspendedBackendaiClient();
@@ -418,6 +419,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
           },
         ]}
         style={{ marginBottom: 10 }}
+        extra={extra}
       >
         <BAISelect
           ref={envSelectRef}

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -278,6 +278,16 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
     allValues: ServiceLauncherFormValue,
   ) => {
     if (changedValues.runtimeVariant) {
+      // Reset environment selection when runtime variant changes
+      // as the previous selection may not be compatible with the new runtime
+      form.setFieldsValue({
+        environments: {
+          environment: undefined,
+          version: undefined,
+          image: undefined,
+          customizedTag: undefined,
+        },
+      });
       setEnvironmentVariablesForRuntimeVariant(
         changedValues.runtimeVariant,
         allValues,

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1209,17 +1209,53 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                             disabled={hasAutoScalingRules}
                           />
                         </Form.Item>
-                        <ImageEnvironmentSelectFormItems
-                        // //TODO: test with real inference images
-                        // filter={(image) => {
-                        //   return !!_.find(image?.labels, (label) => {
-                        //     return (
-                        //       label?.key === "ai.backend.role" &&
-                        //       label.value === "INFERENCE" //['COMPUTE', 'INFERENCE', 'SYSTEM']
-                        //     );
-                        //   });
-                        // }}
-                        />
+                        <Form.Item noStyle dependencies={['runtimeVariant']}>
+                          {({ getFieldValue }) => {
+                            const runtimeVariant =
+                              getFieldValue('runtimeVariant');
+                            const isVllm = runtimeVariant === 'vllm';
+                            return (
+                              <ImageEnvironmentSelectFormItems
+                                filter={
+                                  isVllm
+                                    ? (image) => {
+                                        const fullName = [
+                                          image?.registry,
+                                          image?.namespace,
+                                          image?.base_image_name,
+                                          image?.name,
+                                        ]
+                                          .filter(Boolean)
+                                          .join('/')
+                                          .toLowerCase();
+                                        const hasVllmLabel = _.some(
+                                          image?.labels,
+                                          (label) =>
+                                            label?.value
+                                              ?.toLowerCase()
+                                              .includes('vllm') ||
+                                            label?.key
+                                              ?.toLowerCase()
+                                              .includes('vllm'),
+                                        );
+                                        return (
+                                          fullName.includes('vllm') ||
+                                          hasVllmLabel
+                                        );
+                                      }
+                                    : undefined
+                                }
+                                extra={
+                                  isVllm
+                                    ? t(
+                                        'modelService.OnlyVllmCompatibleEnvironmentsShown',
+                                      )
+                                    : undefined
+                                }
+                              />
+                            );
+                          }}
+                        </Form.Item>
                         {endpoint && !wantToChangeResource ? (
                           <Form.Item
                             label={

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -25,12 +25,8 @@ import {
 import InputNumberWithSlider from '../InputNumberWithSlider';
 import ResourcePresetSelect from '../ResourcePresetSelect';
 import SharedMemoryFormItems from './SharedMemoryFormItems';
-import {
-  CaretDownOutlined,
-  InfoCircleOutlined,
-  ReloadOutlined,
-} from '@ant-design/icons';
-import { Button, Card, Col, Form, Radio, Row, Tooltip, theme } from 'antd';
+import { CaretDownOutlined, ReloadOutlined } from '@ant-design/icons';
+import { Button, Card, Col, Divider, Form, Radio, Row, theme } from 'antd';
 import {
   useResourceSlotsDetails,
   BAIFlex,
@@ -55,7 +51,7 @@ export const RESOURCE_ALLOCATION_INITIAL_FORM_VALUES: DeepPartial<ResourceAlloca
       accelerator: 0,
     },
     num_of_sessions: 1,
-    cluster_mode: 'multi-node',
+    cluster_mode: 'single-node',
     cluster_size: 1,
     enabledAutomaticShmem: true,
     agent: ['auto'],
@@ -1334,6 +1330,15 @@ const ResourceAllocationFormItems: React.FC<
       )}
       <Form.Item
         label={t('session.launcher.ClusterMode')}
+        tooltip={
+          <BAIFlex direction="column" align="start">
+            {t('session.launcher.SingleNode')}
+            <Trans i18nKey={'session.launcher.DescSingleNode'} />
+            <Divider style={{ backgroundColor: token.colorBorder }} />
+            {t('session.launcher.MultiNode')}
+            <Trans i18nKey={'session.launcher.DescMultiNode'} />
+          </BAIFlex>
+        }
         required
         dependencies={['agent']}
       >
@@ -1359,31 +1364,11 @@ const ResourceAllocationFormItems: React.FC<
                         ])
                       }
                     >
-                      <Radio.Button value="multi-node">
-                        {t('session.launcher.MultiNode')}
-                        <Tooltip
-                          title={
-                            <Trans i18nKey={'session.launcher.DescMultiNode'} />
-                          }
-                        >
-                          <InfoCircleOutlined
-                            style={{ marginLeft: token.marginXXS }}
-                          />
-                        </Tooltip>
-                      </Radio.Button>
                       <Radio.Button value="single-node">
                         {t('session.launcher.SingleNode')}
-                        <Tooltip
-                          title={
-                            <Trans
-                              i18nKey={'session.launcher.DescSingleNode'}
-                            />
-                          }
-                        >
-                          <InfoCircleOutlined
-                            style={{ marginLeft: token.marginXXS }}
-                          />
-                        </Tooltip>
+                      </Radio.Button>
+                      <Radio.Button value="multi-node">
+                        {t('session.launcher.MultiNode')}
                       </Radio.Button>
                     </Radio.Group>
                   </Form.Item>

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -25,8 +25,12 @@ import {
 import InputNumberWithSlider from '../InputNumberWithSlider';
 import ResourcePresetSelect from '../ResourcePresetSelect';
 import SharedMemoryFormItems from './SharedMemoryFormItems';
-import { CaretDownOutlined, ReloadOutlined } from '@ant-design/icons';
-import { Button, Card, Col, Divider, Form, Radio, Row, theme } from 'antd';
+import {
+  CaretDownOutlined,
+  InfoCircleOutlined,
+  ReloadOutlined,
+} from '@ant-design/icons';
+import { Button, Card, Col, Form, Radio, Row, Tooltip, theme } from 'antd';
 import {
   useResourceSlotsDetails,
   BAIFlex,
@@ -51,7 +55,7 @@ export const RESOURCE_ALLOCATION_INITIAL_FORM_VALUES: DeepPartial<ResourceAlloca
       accelerator: 0,
     },
     num_of_sessions: 1,
-    cluster_mode: 'single-node',
+    cluster_mode: 'multi-node',
     cluster_size: 1,
     enabledAutomaticShmem: true,
     agent: ['auto'],
@@ -1330,15 +1334,6 @@ const ResourceAllocationFormItems: React.FC<
       )}
       <Form.Item
         label={t('session.launcher.ClusterMode')}
-        tooltip={
-          <BAIFlex direction="column" align="start">
-            {t('session.launcher.SingleNode')}
-            <Trans i18nKey={'session.launcher.DescSingleNode'} />
-            <Divider style={{ backgroundColor: token.colorBorder }} />
-            {t('session.launcher.MultiNode')}
-            <Trans i18nKey={'session.launcher.DescMultiNode'} />
-          </BAIFlex>
-        }
         required
         dependencies={['agent']}
       >
@@ -1364,11 +1359,31 @@ const ResourceAllocationFormItems: React.FC<
                         ])
                       }
                     >
-                      <Radio.Button value="single-node">
-                        {t('session.launcher.SingleNode')}
-                      </Radio.Button>
                       <Radio.Button value="multi-node">
                         {t('session.launcher.MultiNode')}
+                        <Tooltip
+                          title={
+                            <Trans i18nKey={'session.launcher.DescMultiNode'} />
+                          }
+                        >
+                          <InfoCircleOutlined
+                            style={{ marginLeft: token.marginXXS }}
+                          />
+                        </Tooltip>
+                      </Radio.Button>
+                      <Radio.Button value="single-node">
+                        {t('session.launcher.SingleNode')}
+                        <Tooltip
+                          title={
+                            <Trans
+                              i18nKey={'session.launcher.DescSingleNode'}
+                            />
+                          }
+                        >
+                          <InfoCircleOutlined
+                            style={{ marginLeft: token.marginXXS }}
+                          />
+                        </Tooltip>
                       </Radio.Button>
                     </Radio.Group>
                   </Form.Item>

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1329,6 +1329,7 @@
     "NotInProject": "This model service belongs to a different project. Please switch to the corresponding project to edit this service.",
     "NumberOfReplicas": "Number of replicas",
     "OnlyAllowsNonNegativeIntegers": "Only allows non-negative integers",
+    "OnlyVllmCompatibleEnvironmentsShown": "Only vLLM-compatible environments are shown for the selected runtime.",
     "OpenToPublic": "Open To Public",
     "Owner": "Owner",
     "PlayYourModelNow": "Play your model now!",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1331,6 +1331,7 @@
     "NotInProject": "이 모델 서비스는 다른 프로젝트에 속해 있습니다. 해당 프로젝트로 이동 후 수정해 주세요.",
     "NumberOfReplicas": "복제본 수",
     "OnlyAllowsNonNegativeIntegers": "0 이상을 입력해 주세요.",
+    "OnlyVllmCompatibleEnvironmentsShown": "선택한 런타임에 대해 vLLM 호환 환경만 표시됩니다.",
     "OpenToPublic": "앱을 외부에 공개",
     "Owner": "소유자",
     "PlayYourModelNow": "모델을 바로 사용해보세요!",


### PR DESCRIPTION
Resolves #6159(FR-2378)

## Summary
- When vLLM runtime variant is selected in model service creation, the environment/image selector is now filtered to show only vLLM-compatible images
- Filter logic checks image name, namespace, base image name, and labels for 'vllm' (case-insensitive)
- A guidance message ("Only vLLM-compatible environments are shown for the selected runtime.") is displayed as `extra` text on the environment Form.Item when vLLM is selected
- No filter is applied when other runtimes (e.g., 'custom') are selected — all environments are shown
- Added `extra` prop to `ImageEnvironmentSelectFormItems` component for contextual guidance text
- Added i18n keys: `modelService.OnlyVllmCompatibleEnvironmentsShown` (en, ko)

## Verification
```
=== Relay ===
--- Relay: PASS ---

=== Lint ===
--- Lint: PASS ---

=== Format ===
--- Format: PASS ---

=== TypeScript ===
--- TypeScript: PASS ---

=== ALL PASS ===
```

## Test plan
- [ ] Create a new model service and select the vLLM runtime variant — verify only vLLM images appear in the environment selector
- [ ] Verify the guidance message appears below the environment selector when vLLM runtime is selected
- [ ] Switch runtime to 'custom' — verify all environments are shown and no guidance message appears
- [ ] Verify the form still works correctly when switching between runtimes