### PR TITLE
fix(FR-2315): add missing form field dependencies for validation recalculation

### DIFF
--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -961,7 +961,10 @@ const ResourceAllocationFormItems: React.FC<
                             />
                           ),
                         }}
-                        dependencies={[['resource', 'acceleratorType']]}
+                        dependencies={[
+                          ['resource', 'acceleratorType'],
+                          'cluster_size',
+                        ]}
                         rules={[
                           {
                             required:

--- a/react/src/components/SessionFormItems/SharedMemoryFormItems.tsx
+++ b/react/src/components/SessionFormItems/SharedMemoryFormItems.tsx
@@ -136,7 +136,7 @@ const SharedMemoryFormItems: React.FC<SharedMemoryFormItemsProps> = ({
                   noStyle
                   name={['resource', 'shmem']}
                   hidden={getFieldValue('enabledAutomaticShmem')}
-                  dependencies={[['resource', 'mem']]}
+                  dependencies={[['resource', 'mem'], 'enabledAutomaticShmem']}
                   rules={[
                     {
                       required: true,


### PR DESCRIPTION
Resolves #6028(FR-2315)

## Summary

- Added `'cluster_size'` to the `dependencies` array on the `resource/accelerator` Form.Item in `ResourceAllocationFormItems.tsx`. Its validator calls `form.getFieldValue('cluster_size')` to check if discrete accelerator values are required (when `cluster_size >= 2`), but without the dependency the validation was not re-triggered when cluster size changed.
- Added `'enabledAutomaticShmem'` to the `dependencies` array on the inner `resource/shmem` Form.Item in `SharedMemoryFormItems.tsx`. Its validators call `getFieldValue('enabledAutomaticShmem')` to skip or apply shmem validation rules, but without the dependency those validators were not re-triggered when the automatic shmem toggle changed.

## Verification

```
=== Relay ===
--- Relay: PASS ---

=== Lint ===
--- Lint: PASS ---

=== Format ===
--- Format: PASS ---

=== TypeScript ===
src/hooks/useWebUIMenuItems.tsx(615,7): error TS2304: Cannot find name 'SUPERADMIN_ONLY_HIDDEN_PATHS'.
--- TypeScript: FAIL (pre-existing error unrelated to this PR) ---
```

## Changes

| File | Change |
|------|--------|
| `react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx` | Added `'cluster_size'` to `resource/accelerator` Form.Item dependencies |
| `react/src/components/SessionFormItems/SharedMemoryFormItems.tsx` | Added `'enabledAutomaticShmem'` to `resource/shmem` Form.Item dependencies |