### PR TITLE
feat(FR-2313): improve admin menu behavior based on RBAC admin role

### DIFF
--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -98,6 +98,7 @@ export const VALID_MENU_KEYS = [
   'admin-dashboard',
   'admin-data',
   'agent',
+  'project',
   'settings',
   'maintenance',
   'diagnostics',
@@ -107,6 +108,16 @@ export const VALID_MENU_KEYS = [
 ] as const;
 
 export type MenuKeys = (typeof VALID_MENU_KEYS)[number];
+
+/**
+ * Paths that are restricted to superadmin only but are not shown in the
+ * superAdminMenu (e.g., pages still under development or accessible only
+ * through internal navigation). These paths are included in the authorization
+ * check to prevent admin-role users from accessing them via direct URL.
+ */
+export const SUPERADMIN_ONLY_HIDDEN_PATHS = new Set([
+  'admin-dashboard',
+]);
 
 // Convert menu key to URL path
 // Most keys map directly to /${key}, with exceptions for backward compatibility
@@ -607,7 +618,12 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
     if (currentPathKey === '') return false;
 
     const isAdminOnlyPage = adminOnlyPageKeys.has(currentMenuKey);
-    const isSuperAdminOnlyPage = superAdminOnlyPageKeys.has(currentMenuKey);
+    // A page is superadmin-only if it appears in the superAdminMenu items
+    // OR if it is listed in SUPERADMIN_ONLY_HIDDEN_PATHS (pages that are
+    // restricted to superadmin but intentionally omitted from the visible menu).
+    const isSuperAdminOnlyPage =
+      superAdminOnlyPageKeys.has(currentMenuKey) ||
+      SUPERADMIN_ONLY_HIDDEN_PATHS.has(currentMenuKey);
 
     // Regular users (not admin, not superadmin) cannot access admin or superadmin pages
     if (


### PR DESCRIPTION
Resolves #6024(FR-2313)

## Summary

- Add `'project'` to `VALID_MENU_KEYS` to align the type definition with the actual `superAdminMenu` item already using this key
- Introduce `SUPERADMIN_ONLY_HIDDEN_PATHS` constant for pages that are superadmin-only but intentionally omitted from the visible `superAdminMenu` (e.g., `admin-dashboard` which is under development)
- Update `isCurrentPageUnauthorized` in `useWebUIMenuItems` to also block admin-role users from directly accessing paths listed in `SUPERADMIN_ONLY_HIDDEN_PATHS`, preventing unauthorized access via direct URL navigation

## Problem

The `/admin-dashboard` route exists and is accessible to admin-role users via direct URL because it was commented out from `superAdminMenu`. The `superAdminOnlyPageKeys` set was derived solely from visible menu items, so any page removed from the menu lost its authorization guard.

## Solution

- Separate the concept of "visible in menu" from "role-restricted". `SUPERADMIN_ONLY_HIDDEN_PATHS` holds paths that should be superadmin-restricted regardless of their menu visibility.
- The `isCurrentPageUnauthorized` check now includes both `superAdminOnlyPageKeys` (from menu items) and `SUPERADMIN_ONLY_HIDDEN_PATHS` (hidden paths), so admin users attempting to access these pages via direct URL will see the `Page401` unauthorized page.

## Verification

```
=== Relay ===
--- Relay: PASS ---

=== Lint ===
--- Lint: PASS ---

=== Format ===
--- Format: PASS ---

=== TypeScript ===
--- TypeScript: PASS ---

=== ALL PASS ===
```