### PR TITLE
fix(FR-2385): comment out unsupported traffic ratio column in route list

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIRouteNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIRouteNodes.tsx
@@ -181,12 +181,13 @@ const BAIRouteNodes = ({
             </BAITag>
           ) : null,
       },
-      {
-        title: t('comp:BAIRouteNodes.TrafficRatio'),
-        dataIndex: 'trafficRatio',
-        key: 'trafficRatio',
-        sorter: isEnableSorter('trafficRatio'),
-      },
+      // TODO(needs-backend): Uncomment when the backend supports traffic ratio for routes
+      // {
+      //   title: t('comp:BAIRouteNodes.TrafficRatio'),
+      //   dataIndex: 'trafficRatio',
+      //   key: 'trafficRatio',
+      //   sorter: isEnableSorter('trafficRatio'),
+      // },
       {
         title: t('comp:BAIRouteNodes.CreatedAt'),
         dataIndex: 'createdAt',


### PR DESCRIPTION
Resolves #6179 (FR-2385)

## Summary
- Comment out unsupported TrafficRatio column in BAIRouteNodes route list table
- Add `TODO(needs-backend)` marker to re-enable when backend supports traffic ratio

## Test plan
- [ ] Verify route list table no longer shows an empty TrafficRatio column