### PR TITLE
fix(FR-2174): fix cross-page link resolution bug in docs-toolkit

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
+++ b/packages/backend.ai-docs-toolkit/src/markdown-processor-web.ts
@@ -218,8 +218,16 @@ function rewriteCrossPageLinks(
   const reportedAnchors = new Set<string>();
   return html.replace(/href="#([^"]+)"/g, (fullMatch, anchorId: string) => {
     // Already a resolved ID (e.g., heading hash-links from the renderer) → skip
+    // But only if the ID belongs to the current chapter; otherwise fall through
+    // to cross-chapter resolution below.
     if (registry.resolvedIds.has(anchorId)) {
-      return fullMatch;
+      const entries = registry.anchors.get(anchorId);
+      const inCurrentChapter = entries?.some(
+        (e) => e.chapterSlug === currentChapterSlug,
+      );
+      if (inCurrentChapter || !entries) {
+        return fullMatch;
+      }
     }
 
     const entries = registry.anchors.get(anchorId);


### PR DESCRIPTION
Resolves #2219(FR-2174)

## Summary
- Fix a bug in `backend.ai-docs-toolkit`'s `rewriteCrossPageLinks` where fragment-only links (`#anchor`) pointing to anchors in other chapters were incorrectly skipped
- The `resolvedIds` early-exit check now verifies the anchor belongs to the current chapter before skipping cross-page resolution
- This fixes the broken `#quota-setting-panel` link in vfolder docs (and any other similar cross-page fragment links)

## Root Cause
The `rewriteCrossPageLinks` function checked if an anchor ID existed in `registry.resolvedIds` (a global set across all chapters) and skipped rewriting if found. This caused anchors from other chapters to be treated as same-page anchors, resulting in broken links.

## Test plan
- [ ] Build docs with `pnpm run build:web` in `packages/backend.ai-webui-docs`
- [ ] Verify `dist/web/en/vfolder.html` contains a cross-page link to admin-menu for quota-setting-panel
- [ ] Verify other cross-page fragment links also resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)