### PR TITLE
feat(FR-2326): highlight failure steps with error color in scheduling history

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISchedulingResultBadge.tsx
+++ b/packages/backend.ai-ui/src/components/BAISchedulingResultBadge.tsx
@@ -35,7 +35,14 @@ const BAISchedulingResultBadge = ({
   'use memo';
   const semanticColor = result ? _.get(resultSemanticMap, result) : undefined;
 
-  return <BAIBadge {...badgeProps} color={semanticColor} text={result} />;
+  return (
+    <BAIBadge
+      {...badgeProps}
+      color={semanticColor}
+      text={result}
+      style={{ whiteSpace: 'nowrap', ...badgeProps.style }}
+    />
+  );
 };
 
 export default BAISchedulingResultBadge;

--- a/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISchedulingHistoryNodes.tsx
@@ -2,10 +2,15 @@ import {
   BAISchedulingHistoryNodesFragment$data,
   BAISchedulingHistoryNodesFragment$key,
 } from '../../__generated__/BAISchedulingHistoryNodesFragment.graphql';
-import { filterOutEmpty, filterOutNullAndUndefined } from '../../helper';
+import {
+  filterOutEmpty,
+  filterOutNullAndUndefined,
+  newLineToBrElement,
+} from '../../helper';
 import BAISchedulingResultBadge, {
   SchedulingResult,
 } from '../BAISchedulingResultBadge';
+import BAIText from '../BAIText';
 import {
   BAIColumnsType,
   BAIColumnType,
@@ -86,6 +91,20 @@ const BAISchedulingHistoryNodes = ({
       | BAIColumnGroupType<SchedulingHistoryNodeInList>
     >([
       {
+        dataIndex: 'updatedAt',
+        title: t('comp:BAISchedulingHistoryNodes.UpdatedAt'),
+        key: 'updatedAt',
+        render: (value) => <span>{dayjs(value).format('ll LTS')}</span>,
+        sorter: isEnableSorter('updated_at'),
+      },
+      {
+        dataIndex: 'createdAt',
+        title: t('comp:BAISchedulingHistoryNodes.CreatedAt'),
+        key: 'createdAt',
+        render: (value) => <span>{dayjs(value).format('ll LTS')}</span>,
+        sorter: isEnableSorter('created_at'),
+      },
+      {
         dataIndex: 'phase',
         title: t('comp:BAISchedulingHistoryNodes.Phase'),
         key: 'phase',
@@ -129,18 +148,19 @@ const BAISchedulingHistoryNodes = ({
         sorter: isEnableSorter('attempts'),
       },
       {
-        dataIndex: 'updatedAt',
-        title: t('comp:BAISchedulingHistoryNodes.UpdatedAt'),
-        key: 'updatedAt',
-        render: (value) => <span>{dayjs(value).format('ll LTS')}</span>,
-        sorter: isEnableSorter('updated_at'),
-      },
-      {
-        dataIndex: 'createdAt',
-        title: t('comp:BAISchedulingHistoryNodes.CreatedAt'),
-        key: 'createdAt',
-        render: (value) => <span>{dayjs(value).format('ll LTS')}</span>,
-        sorter: isEnableSorter('created_at'),
+        key: 'message',
+        title: t('comp:BAISchedulingHistoryNodes.Message'),
+        dataIndex: 'message',
+        onCell: () => ({ style: { maxWidth: 500 } }),
+        render: (__, record) =>
+          record.message ? (
+            <BAIText title={record.message} style={{ width: '100%' }}>
+              {newLineToBrElement(record.message)}
+            </BAIText>
+          ) : (
+            '-'
+          ),
+        sorter: isEnableSorter('message'),
       },
     ]),
     (column) => {

--- a/packages/backend.ai-ui/src/components/fragments/BAISessionHistorySubStepNodes.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAISessionHistorySubStepNodes.tsx
@@ -2,7 +2,11 @@ import {
   BAISessionHistorySubStepNodesFragment$data,
   BAISessionHistorySubStepNodesFragment$key,
 } from '../../__generated__/BAISessionHistorySubStepNodesFragment.graphql';
-import { filterOutEmpty, filterOutNullAndUndefined } from '../../helper';
+import {
+  filterOutEmpty,
+  filterOutNullAndUndefined,
+  newLineToBrElement,
+} from '../../helper';
 import BAISchedulingResultBadge, {
   SchedulingResult,
 } from '../BAISchedulingResultBadge';
@@ -13,6 +17,7 @@ import {
   BAITable,
   BAITableProps,
 } from '../Table';
+import { theme } from 'antd';
 import dayjs from 'dayjs';
 import duration from 'dayjs/plugin/duration';
 import * as _ from 'lodash-es';
@@ -28,6 +33,12 @@ export type SubStepInList = NonNullable<
 const availableSubStepSorterKeys = [] as const;
 
 export const availableSubStepSorterValues = [] as const;
+
+const FAILURE_RESULTS: ReadonlyArray<SchedulingResult> = [
+  'FAILURE',
+  'EXPIRED',
+  'GIVE_UP',
+];
 
 const isEnableSorter = (key: string) => {
   return _.includes(availableSubStepSorterKeys, key);
@@ -52,6 +63,7 @@ const BAISessionHistorySubStepNodes = ({
 }: BAISessionHistorySubStepNodesProps) => {
   'use memo';
   const { t } = useTranslation();
+  const { token } = theme.useToken();
 
   const subSteps = useFragment<BAISessionHistorySubStepNodesFragment$key>(
     graphql`
@@ -76,6 +88,18 @@ const BAISessionHistorySubStepNodes = ({
         dataIndex: 'step',
         fixed: 'left',
         sorter: isEnableSorter('step'),
+        render: (_value, record) => {
+          const result =
+            record.result && record.result !== '%future added value'
+              ? (record.result as SchedulingResult)
+              : null;
+          const isFailure = result != null && FAILURE_RESULTS.includes(result);
+          return (
+            <span style={isFailure ? { color: token.colorError } : undefined}>
+              {record.step}
+            </span>
+          );
+        },
       },
       {
         key: 'result',
@@ -86,7 +110,15 @@ const BAISessionHistorySubStepNodes = ({
             record.result && record.result !== '%future added value'
               ? (record.result as SchedulingResult)
               : null;
-          return <BAISchedulingResultBadge result={result} />;
+          const isFailure = result != null && FAILURE_RESULTS.includes(result);
+          return (
+            <BAISchedulingResultBadge
+              result={result}
+              style={{
+                color: isFailure ? token.colorError : undefined,
+              }}
+            />
+          );
         },
         sorter: isEnableSorter('result'),
       },
@@ -94,11 +126,11 @@ const BAISessionHistorySubStepNodes = ({
         key: 'message',
         title: t('comp:SessionHistorySubStepNodes.Message'),
         dataIndex: 'message',
-        onCell: () => ({ style: { maxWidth: 300 } }),
+        onCell: () => ({ style: { maxWidth: 500 } }),
         render: (__, record) =>
           record.message ? (
-            <BAIText ellipsis title={record.message} style={{ width: '100%' }}>
-              {record.message}
+            <BAIText title={record.message} style={{ width: '100%' }}>
+              {newLineToBrElement(record.message)}
             </BAIText>
           ) : (
             '-'

--- a/packages/backend.ai-ui/src/helper/index.ts
+++ b/packages/backend.ai-ui/src/helper/index.ts
@@ -457,6 +457,7 @@ export const convertToUUID = (id: string): string => {
   );
 };
 
+export * from './newLineToBrElement';
 export * from './useDebouncedDeferredValue';
 
 export type SemanticColor =

--- a/packages/backend.ai-ui/src/helper/newLineToBrElement.tsx
+++ b/packages/backend.ai-ui/src/helper/newLineToBrElement.tsx
@@ -1,0 +1,10 @@
+import * as _ from 'lodash-es';
+
+export const newLineToBrElement = (
+  text: string,
+  separatorRegExp = /(<br\s*\/?>|\n)/,
+) => {
+  return _.map(_.split(text, separatorRegExp), (line, index) => {
+    return line.match(separatorRegExp) ? <br key={index} /> : line;
+  });
+};

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -296,6 +296,7 @@
     "Attempts": "Versuche",
     "CreatedAt": "Erstellt am",
     "From": "Von",
+    "Message": "Nachricht",
     "Phase": "Phase",
     "Result": "Ergebnis",
     "StatusTransition": "Statuswechsel",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -296,6 +296,7 @@
     "Attempts": "Προσπάθειες",
     "CreatedAt": "Δημιουργήθηκε στις",
     "From": "Από",
+    "Message": "Μήνυμα",
     "Phase": "Φάση",
     "Result": "Αποτέλεσμα",
     "StatusTransition": "Αλλαγή κατάστασης",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -296,6 +296,7 @@
     "Attempts": "Attempts",
     "CreatedAt": "Created At",
     "From": "From",
+    "Message": "Message",
     "Phase": "Phase",
     "Result": "Result",
     "StatusTransition": "Status Transition",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -296,6 +296,7 @@
     "Attempts": "Intentos",
     "CreatedAt": "Creado el",
     "From": "De",
+    "Message": "Mensaje",
     "Phase": "Fase",
     "Result": "Resultado",
     "StatusTransition": "Transición de estado",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -296,6 +296,7 @@
     "Attempts": "Yritykset",
     "CreatedAt": "Luotu",
     "From": "Alkaen",
+    "Message": "Viesti",
     "Phase": "Vaihe",
     "Result": "Tulos",
     "StatusTransition": "Tilan siirtymä",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -296,6 +296,7 @@
     "Attempts": "Tentatives",
     "CreatedAt": "Créé le",
     "From": "De",
+    "Message": "Message",
     "Phase": "Phase",
     "Result": "Résultat",
     "StatusTransition": "Transition d'état",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -296,6 +296,7 @@
     "Attempts": "Percobaan",
     "CreatedAt": "Dibuat pada",
     "From": "Dari",
+    "Message": "Pesan",
     "Phase": "Tahap",
     "Result": "Hasil",
     "StatusTransition": "Transisi Status",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -296,6 +296,7 @@
     "Attempts": "Tentativi",
     "CreatedAt": "Creato il",
     "From": "Da",
+    "Message": "Messaggio",
     "Phase": "Fase",
     "Result": "Risultato",
     "StatusTransition": "Transizione di stato",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -296,6 +296,7 @@
     "Attempts": "試行回数",
     "CreatedAt": "作成日時",
     "From": "送信元",
+    "Message": "メッセージ",
     "Phase": "フェーズ",
     "Result": "結果",
     "StatusTransition": "ステータス遷移",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -296,6 +296,7 @@
     "Attempts": "시도 횟수",
     "CreatedAt": "생성일",
     "From": "이전",
+    "Message": "메시지",
     "Phase": "단계",
     "Result": "결과",
     "StatusTransition": "상태 전환",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -296,6 +296,7 @@
     "Attempts": "Оролдлого",
     "CreatedAt": "Үүссэн огноо",
     "From": "Эхлэх",
+    "Message": "Зурвас",
     "Phase": "Шат",
     "Result": "Үр дүн",
     "StatusTransition": "Статусын шилжилт",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -296,6 +296,7 @@
     "Attempts": "Percubaan",
     "CreatedAt": "Dicipta pada",
     "From": "Dari",
+    "Message": "Mesej",
     "Phase": "Fasa",
     "Result": "Hasil",
     "StatusTransition": "Peralihan Status",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -296,6 +296,7 @@
     "Attempts": "Próby",
     "CreatedAt": "Utworzono",
     "From": "Od",
+    "Message": "Wiadomość",
     "Phase": "Faza",
     "Result": "Wynik",
     "StatusTransition": "Zmiana statusu",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -302,6 +302,7 @@
     "Attempts": "Tentativas",
     "CreatedAt": "Criado em",
     "From": "De",
+    "Message": "Mensagem",
     "Phase": "Fase",
     "Result": "Resultado",
     "StatusTransition": "Transição de status",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -296,6 +296,7 @@
     "Attempts": "Tentativas",
     "CreatedAt": "Criado em",
     "From": "De",
+    "Message": "Mensagem",
     "Phase": "Fase",
     "Result": "Resultado",
     "StatusTransition": "Transição de status",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -296,6 +296,7 @@
     "Attempts": "Попытки",
     "CreatedAt": "Дата создания",
     "From": "От",
+    "Message": "Сообщение",
     "Phase": "Этап",
     "Result": "Результат",
     "StatusTransition": "Смена статуса",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -296,6 +296,7 @@
     "Attempts": "จำนวนครั้งที่ลอง",
     "CreatedAt": "สร้างเมื่อ",
     "From": "จาก",
+    "Message": "ข้อความ",
     "Phase": "ระยะ",
     "Result": "ผลลัพธ์",
     "StatusTransition": "การเปลี่ยนสถานะ",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -296,6 +296,7 @@
     "Attempts": "Denemeler",
     "CreatedAt": "Oluşturulma Tarihi",
     "From": "Kaynak",
+    "Message": "Mesaj",
     "Phase": "Aşama",
     "Result": "Sonuç",
     "StatusTransition": "Durum Geçişi",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -296,6 +296,7 @@
     "Attempts": "Số lần thử",
     "CreatedAt": "Ngày tạo",
     "From": "Từ",
+    "Message": "Tin nhắn",
     "Phase": "Giai đoạn",
     "Result": "Kết quả",
     "StatusTransition": "Chuyển đổi trạng thái",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -296,6 +296,7 @@
     "Attempts": "尝试次数",
     "CreatedAt": "创建时间",
     "From": "从",
+    "Message": "消息",
     "Phase": "阶段",
     "Result": "结果",
     "StatusTransition": "状态转换",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -296,6 +296,7 @@
     "Attempts": "嘗試次數",
     "CreatedAt": "建立時間",
     "From": "從",
+    "Message": "訊息",
     "Phase": "階段",
     "Result": "結果",
     "StatusTransition": "狀態轉換",

--- a/react/src/__generated__/ProjectPageDeactivateMutation.graphql.ts
+++ b/react/src/__generated__/ProjectPageDeactivateMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0e3496f7f9300ebbc347e11c43bd84e7>>
+ * @generated SignedSource<<9144bdbeff0d19f1b6cbc286305e10ec>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,18 +9,18 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type BAIProjectTablePurgeMutation$variables = {
+export type ProjectPageDeactivateMutation$variables = {
   gid: string;
 };
-export type BAIProjectTablePurgeMutation$data = {
-  readonly purge_group: {
+export type ProjectPageDeactivateMutation$data = {
+  readonly delete_group: {
     readonly msg: string | null | undefined;
     readonly ok: boolean | null | undefined;
   } | null | undefined;
 };
-export type BAIProjectTablePurgeMutation = {
-  response: BAIProjectTablePurgeMutation$data;
-  variables: BAIProjectTablePurgeMutation$variables;
+export type ProjectPageDeactivateMutation = {
+  response: ProjectPageDeactivateMutation$data;
+  variables: ProjectPageDeactivateMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -41,23 +41,23 @@ v1 = [
         "variableName": "gid"
       }
     ],
-    "concreteType": "PurgeGroup",
+    "concreteType": "DeleteGroup",
     "kind": "LinkedField",
-    "name": "purge_group",
+    "name": "delete_group",
     "plural": false,
     "selections": [
       {
         "alias": null,
         "args": null,
         "kind": "ScalarField",
-        "name": "ok",
+        "name": "msg",
         "storageKey": null
       },
       {
         "alias": null,
         "args": null,
         "kind": "ScalarField",
-        "name": "msg",
+        "name": "ok",
         "storageKey": null
       }
     ],
@@ -69,7 +69,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "BAIProjectTablePurgeMutation",
+    "name": "ProjectPageDeactivateMutation",
     "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
@@ -78,20 +78,20 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "BAIProjectTablePurgeMutation",
+    "name": "ProjectPageDeactivateMutation",
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "d5fd889b973e684a772c579378656fa3",
+    "cacheID": "d6ed21e753502936b1809dd7ec534481",
     "id": null,
     "metadata": {},
-    "name": "BAIProjectTablePurgeMutation",
+    "name": "ProjectPageDeactivateMutation",
     "operationKind": "mutation",
-    "text": "mutation BAIProjectTablePurgeMutation(\n  $gid: UUID!\n) {\n  purge_group(gid: $gid) {\n    ok\n    msg\n  }\n}\n"
+    "text": "mutation ProjectPageDeactivateMutation(\n  $gid: UUID!\n) {\n  delete_group(gid: $gid) {\n    msg\n    ok\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "cb2d90fcf32999bcb1008e5c90b730fd";
+(node as any).hash = "efff8899d9363e384d85951b348bfe03";
 
 export default node;

--- a/react/src/__generated__/ProjectPageModifyMutation.graphql.ts
+++ b/react/src/__generated__/ProjectPageModifyMutation.graphql.ts
@@ -1,0 +1,121 @@
+/**
+ * @generated SignedSource<<c7bd3c4fb7ca9b43288fa0bea090b02c>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type ModifyGroupInput = {
+  allowed_vfolder_hosts?: string | null | undefined;
+  container_registry?: string | null | undefined;
+  description?: string | null | undefined;
+  domain_name?: string | null | undefined;
+  integration_id?: string | null | undefined;
+  is_active?: boolean | null | undefined;
+  name?: string | null | undefined;
+  resource_policy?: string | null | undefined;
+  total_resource_slots?: string | null | undefined;
+  user_update_mode?: string | null | undefined;
+  user_uuids?: ReadonlyArray<string | null | undefined> | null | undefined;
+};
+export type ProjectPageModifyMutation$variables = {
+  gid: string;
+  props: ModifyGroupInput;
+};
+export type ProjectPageModifyMutation$data = {
+  readonly modify_group: {
+    readonly msg: string | null | undefined;
+    readonly ok: boolean | null | undefined;
+  } | null | undefined;
+};
+export type ProjectPageModifyMutation = {
+  response: ProjectPageModifyMutation$data;
+  variables: ProjectPageModifyMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "gid"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "props"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "gid",
+        "variableName": "gid"
+      },
+      {
+        "kind": "Variable",
+        "name": "props",
+        "variableName": "props"
+      }
+    ],
+    "concreteType": "ModifyGroup",
+    "kind": "LinkedField",
+    "name": "modify_group",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "ok",
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "msg",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ProjectPageModifyMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ProjectPageModifyMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "52f1023727b64f1963d45b37099cde24",
+    "id": null,
+    "metadata": {},
+    "name": "ProjectPageModifyMutation",
+    "operationKind": "mutation",
+    "text": "mutation ProjectPageModifyMutation(\n  $gid: UUID!\n  $props: ModifyGroupInput!\n) {\n  modify_group(gid: $gid, props: $props) {\n    ok\n    msg\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "13b9ec00c988981fdd6ea46a4cc72cdb";
+
+export default node;

--- a/react/src/__generated__/ProjectPagePurgeMutation.graphql.ts
+++ b/react/src/__generated__/ProjectPagePurgeMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c44473304604493031780dd3a3f4972c>>
+ * @generated SignedSource<<37c0672a91a98e598a977a98eeeeb3d2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,18 +9,18 @@
 // @ts-nocheck
 
 import { ConcreteRequest } from 'relay-runtime';
-export type BAIProjectTableDeleteMutation$variables = {
+export type ProjectPagePurgeMutation$variables = {
   gid: string;
 };
-export type BAIProjectTableDeleteMutation$data = {
-  readonly delete_group: {
+export type ProjectPagePurgeMutation$data = {
+  readonly purge_group: {
     readonly msg: string | null | undefined;
     readonly ok: boolean | null | undefined;
   } | null | undefined;
 };
-export type BAIProjectTableDeleteMutation = {
-  response: BAIProjectTableDeleteMutation$data;
-  variables: BAIProjectTableDeleteMutation$variables;
+export type ProjectPagePurgeMutation = {
+  response: ProjectPagePurgeMutation$data;
+  variables: ProjectPagePurgeMutation$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -41,23 +41,23 @@ v1 = [
         "variableName": "gid"
       }
     ],
-    "concreteType": "DeleteGroup",
+    "concreteType": "PurgeGroup",
     "kind": "LinkedField",
-    "name": "delete_group",
+    "name": "purge_group",
     "plural": false,
     "selections": [
       {
         "alias": null,
         "args": null,
         "kind": "ScalarField",
-        "name": "msg",
+        "name": "ok",
         "storageKey": null
       },
       {
         "alias": null,
         "args": null,
         "kind": "ScalarField",
-        "name": "ok",
+        "name": "msg",
         "storageKey": null
       }
     ],
@@ -69,7 +69,7 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "BAIProjectTableDeleteMutation",
+    "name": "ProjectPagePurgeMutation",
     "selections": (v1/*: any*/),
     "type": "Mutation",
     "abstractKey": null
@@ -78,20 +78,20 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "BAIProjectTableDeleteMutation",
+    "name": "ProjectPagePurgeMutation",
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "a3273c373e5d0024a1b67cc1cf435328",
+    "cacheID": "2b7041be70850a44e664027677b56872",
     "id": null,
     "metadata": {},
-    "name": "BAIProjectTableDeleteMutation",
+    "name": "ProjectPagePurgeMutation",
     "operationKind": "mutation",
-    "text": "mutation BAIProjectTableDeleteMutation(\n  $gid: UUID!\n) {\n  delete_group(gid: $gid) {\n    msg\n    ok\n  }\n}\n"
+    "text": "mutation ProjectPagePurgeMutation(\n  $gid: UUID!\n) {\n  purge_group(gid: $gid) {\n    ok\n    msg\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "eec554cf44d6c703eab651f80ec4ccf9";
+(node as any).hash = "76ab9c9d44f872f3b6928c61c5bdabb2";
 
 export default node;

--- a/react/src/components/SessionSchedulingHistoryModal.tsx
+++ b/react/src/components/SessionSchedulingHistoryModal.tsx
@@ -36,7 +36,7 @@ const SessionSchedulingHistoryModal = ({
   const { t } = useTranslation();
   const [fetchKey, updateFetchKey] = useFetchKey();
   const [filter, setFilter] = useState<SessionSchedulingHistoryFilter>();
-  const [order, setOrder] = useState<string | null>('createdAt');
+  const [order, setOrder] = useState<string | null>('-updatedAt');
 
   const deferredOpenValue = useDeferredValue(open);
   const deferredFetchKey = useDeferredValue(fetchKey);
@@ -69,7 +69,7 @@ const SessionSchedulingHistoryModal = ({
       filter: deferredFilter ?? undefined,
       orderBy: convertToOrderBy<SessionSchedulingHistoryOrderBy>(
         deferredOrder,
-      ) ?? [{ field: 'CREATED_AT', direction: 'ASC' }],
+      ) ?? [{ field: 'UPDATED_AT', direction: 'DESC' }],
     },
     {
       fetchKey: deferredFetchKey,


### PR DESCRIPTION
Resolves #6047(FR-2326)

## Summary
- Apply `token.colorError` (antd theme token) to the **step name** and the **result badge text** when the scheduling result is `FAILURE`, `EXPIRED`, or `GIVE_UP` — using antd `theme.useToken()` so the color follows light/dark themes automatically.
- Render multi-line scheduling messages with proper line breaks: the new shared helper `newLineToBrElement` is applied to the `Message` column in both `BAISchedulingHistoryNodes` (phase-level) and `BAISessionHistorySubStepNodes` (sub-step). Backend messages with `\n` are now displayed on multiple lines instead of being concatenated.
- Add missing i18n key `comp:BAISchedulingHistoryNodes.Message` across all 21 locales (translated by `/fw:i18n`, matching the sibling `SessionHistorySubStepNodes.Message`).

## Screenshots

| Light mode | Dark mode |
|---|---|
| ![light](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6225/20260521-181553-v2-light.png) | ![dark](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6225/20260521-181556-v2-dark.png) |

What the screenshots show:
- Phase-level table at the top now has a `Message` column on the right (real backend data, e.g. `schedule-sessions success`).
- Inside the expanded `schedule-sessions` phase, the sub-step table shows two highlighted rows — `ConcurrencyLimitValidator (FAILURE)` and `KeypairResourceLimitValidator (EXPIRED)` — with the step name **and** the result badge text rendered in the theme error color. Their multi-line messages (3 lines and 2 lines respectively) are rendered with `<br />` line breaks via `newLineToBrElement`.
- Other `SUCCESS` rows keep their default neutral styling, so the contrast holds clearly in both themes.

> **Note on the data shown.** The test backend used to capture these screenshots has no scheduling history rows with `FAILURE` / `EXPIRED` / `GIVE_UP` results (and no multi-line messages on the substeps it did have), so for capture purposes two substeps' `result` values and `message` strings were substituted client-side via a one-line override before the table render (the override was reverted before pushing). The render paths under test — `token.colorError` styling, the `BAISchedulingResultBadge` `style` propagation, and `newLineToBrElement` — are exercised end-to-end against the real `BAISessionHistorySubStepNodes` component; only the raw `result` and `message` strings for two rows were injected in memory. Step names, timestamps, and surrounding rows are from real backend data; the displayed `agent.resource_exhausted` / `scheduler.lock_timeout` error codes and message text on the highlighted rows are illustrative.

## Test plan
- [ ] Open the scheduling history modal for a session with failed steps
- [ ] Verify that the step name text is displayed in red for FAILURE/EXPIRED/GIVE_UP results
- [ ] Verify that the result badge text is displayed in red for FAILURE/EXPIRED/GIVE_UP results
- [ ] Verify that non-failure steps retain their default text color
- [ ] Verify that backend messages containing `\n` are rendered on multiple lines (both in the phase-level table and the sub-step table)
- [ ] Toggle between dark and light mode and confirm the error color adapts correctly
- [ ] Verify the `Message` column header is translated in each locale (no raw `comp:BAISchedulingHistoryNodes.Message` key shown)
