### PR TITLE
feat(FR-70): display private tag in Environment page for private images

### DIFF
--- a/react/src/components/ImageList.test.tsx
+++ b/react/src/components/ImageList.test.tsx
@@ -297,3 +297,75 @@ describe('ImageList project scope contract (ADR-0001, FR-3415)', () => {
     });
   });
 });
+
+/**
+ * The Status column also carries the private marker (FR-70).
+ *
+ * A private image can be installed but is hidden from the session launcher's
+ * environment picker, so the Environments list is the only place an admin can
+ * learn why it is unselectable. The marker is orthogonal to install state:
+ * both can show on the same row.
+ */
+describe('ImageList private marker (FR-70)', () => {
+  const renderWithImages = (
+    images: Array<{ id: string; installed: boolean; features?: string }>,
+  ) => {
+    const environment: RelayMockEnvironment = createMockEnvironment();
+    environment.mock.queueOperationResolver((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        ImageConnection: () => ({
+          count: images.length,
+          edges: images.map((image) => ({
+            node: {
+              id: image.id,
+              row_id: image.id,
+              installed: image.installed,
+              labels: image.features
+                ? [{ key: 'ai.backend.features', value: image.features }]
+                : [],
+            },
+          })),
+        }),
+      }),
+    );
+    render(
+      <RelayEnvironmentProvider environment={environment}>
+        <NuqsTestingAdapter searchParams="">
+          <Suspense fallback={null}>
+            <ImageList project={null} onChangeProject={vi.fn()} />
+          </Suspense>
+        </NuqsTestingAdapter>
+      </RelayEnvironmentProvider>,
+    );
+  };
+
+  it('marks an image whose `ai.backend.features` label contains `private`', async () => {
+    renderWithImages([{ id: 'img-private', installed: true, features: 'private' }]);
+
+    expect(await screen.findByText('environment.Private')).toBeInTheDocument();
+  });
+
+  it('leaves an image without the label unmarked', async () => {
+    renderWithImages([{ id: 'img-public', installed: true }]);
+
+    expect(await screen.findByText('environment.Installed')).toBeInTheDocument();
+    expect(screen.queryByText('environment.Private')).not.toBeInTheDocument();
+  });
+
+  it('shows the install state and the private marker together', async () => {
+    renderWithImages([
+      { id: 'img-private', installed: true, features: 'private' },
+    ]);
+
+    expect(await screen.findByText('environment.Installed')).toBeInTheDocument();
+    expect(screen.getByText('environment.Private')).toBeInTheDocument();
+  });
+
+  it('does not match a feature that merely contains the word', async () => {
+    renderWithImages([
+      { id: 'img-nonprivate', installed: true, features: 'nonprivate' },
+    ]);
+
+    expect(screen.queryByText('environment.Private')).not.toBeInTheDocument();
+  });
+});

--- a/react/src/components/ImageList.test.tsx
+++ b/react/src/components/ImageList.test.tsx
@@ -340,9 +340,14 @@ describe('ImageList private marker (FR-70)', () => {
   };
 
   it('marks an image whose `ai.backend.features` label contains `private`', async () => {
-    renderWithImages([{ id: 'img-private', installed: true, features: 'private' }]);
+    // Uninstalled on purpose: an installed fixture here would still pass if
+    // the marker were accidentally gated on install state.
+    renderWithImages([
+      { id: 'img-private', installed: false, features: 'private' },
+    ]);
 
     expect(await screen.findByText('environment.Private')).toBeInTheDocument();
+    expect(screen.queryByText('environment.Installed')).not.toBeInTheDocument();
   });
 
   it('leaves an image without the label unmarked', async () => {
@@ -366,6 +371,9 @@ describe('ImageList private marker (FR-70)', () => {
       { id: 'img-nonprivate', installed: true, features: 'nonprivate' },
     ]);
 
+    // Await the row's own badge first — asserting absence while the list is
+    // still suspended would pass without ever rendering the fixture.
+    expect(await screen.findByText('environment.Installed')).toBeInTheDocument();
     expect(screen.queryByText('environment.Private')).not.toBeInTheDocument();
   });
 });

--- a/react/src/components/ImageList.tsx
+++ b/react/src/components/ImageList.tsx
@@ -8,7 +8,7 @@ import {
   ImageListQuery$variables,
 } from '../__generated__/ImageListQuery.graphql';
 import { App } from '../app-shim';
-import { getImageFullName } from '../helper';
+import { getImageFullName, isPrivateImage } from '../helper';
 import {
   useBackendAIImageMetaData,
   useSuspendedBackendaiClient,
@@ -300,18 +300,29 @@ const ImageListInScope: React.FC<ImageListInScopeProps> = ({
       key: 'installed',
       // antd `Tag color="gold"` -> Astryx Badge via the repo-global Tag
       // lookup (ticket 13 policy): gold -> yellow.
-      render: (_text, row) =>
-        row?.id && installingImages.includes(row.id) ? (
-          <Badge
-            variant={badgeVariantForTagColor('gold')}
-            label={t('environment.Installing')}
-          />
-        ) : row?.installed ? (
-          <Badge
-            variant={badgeVariantForTagColor('gold')}
-            label={t('environment.Installed')}
-          />
-        ) : null,
+      render: (_text, row) => (
+        <BAIFlex direction="row" gap="xxs" wrap="wrap">
+          {row?.id && installingImages.includes(row.id) ? (
+            <Badge
+              variant={badgeVariantForTagColor('gold')}
+              label={t('environment.Installing')}
+            />
+          ) : row?.installed ? (
+            <Badge
+              variant={badgeVariantForTagColor('gold')}
+              label={t('environment.Installed')}
+            />
+          ) : null}
+          {/* An installed private image cannot be picked in the session
+              launcher, so surface the label here (FR-70). */}
+          {isPrivateImage(row) ? (
+            <Badge
+              variant={badgeVariantForTagColor('red')}
+              label={t('environment.Private')}
+            />
+          ) : null}
+        </BAIFlex>
+      ),
     },
     {
       title: t('environment.FullImagePath'),

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "Port muss zwischen 0 und 65534 . liegen",
     "PortMustBeUnique": "Port muss für jede App eindeutig sein",
     "PortReservedForInternalUse": "Die Ports 2000 bis 2003, 2200 und 7681 sind für den internen Gebrauch reserviert",
+    "Private": "Privat",
     "ProblemOccurred": "Problem aufgetreten",
     "Protocol": "Protokoll",
     "ProtocolMustBeOneOfSupported": "Protokoll muss 'http', 'tcp', 'preopen' und 'pty' sein",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "Η θύρα πρέπει να είναι μεταξύ 0 και 65534",
     "PortMustBeUnique": "Η θύρα πρέπει να είναι μοναδική για κάθε εφαρμογή",
     "PortReservedForInternalUse": "Οι θύρες 2000 έως 2003, 2200 και 7681 προορίζονται για εσωτερική χρήση",
+    "Private": "Ιδιωτικό",
     "ProblemOccurred": "Παρουσιάστηκε πρόβλημα",
     "Protocol": "Πρωτόκολλο",
     "ProtocolMustBeOneOfSupported": "Το πρωτόκολλο πρέπει να είναι ένα από τα \"http\", \"tcp\", \"preopen\" και \"pty\"",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1516,6 +1516,7 @@
     "PortMustBeInRange": "Port must be between 0 to 65534",
     "PortMustBeUnique": "Port must be unique for each app",
     "PortReservedForInternalUse": "Ports 2000 to 2003, 2200, and 7681 are reserved for internal use",
+    "Private": "Private",
     "ProblemOccurred": "Problem occurred",
     "Protocol": "Protocol",
     "ProtocolMustBeOneOfSupported": "Protocol must be one of 'http', 'tcp', 'preopen' and 'pty'",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "El puerto debe estar entre 0 y 65534",
     "PortMustBeUnique": "El puerto debe ser único para cada aplicación",
     "PortReservedForInternalUse": "Los puertos 2000 a 2003, 2200 y 7681 están reservados para uso interno.",
+    "Private": "Privado",
     "ProblemOccurred": "Se ha producido un problema",
     "Protocol": "Protocolo",
     "ProtocolMustBeOneOfSupported": "El protocolo debe ser uno de los siguientes: \"http\", \"tcp\", \"preopen\" y \"pty\".",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "Portin on oltava välillä 0-65534",
     "PortMustBeUnique": "Portin on oltava yksilöllinen jokaisessa sovelluksessa",
     "PortReservedForInternalUse": "Portit 2000-2003, 2200 ja 7681 on varattu sisäiseen käyttöön.",
+    "Private": "Yksityinen",
     "ProblemOccurred": "Ongelma ilmeni",
     "Protocol": "Pöytäkirja",
     "ProtocolMustBeOneOfSupported": "Protokollan on oltava jokin seuraavista: 'http', 'tcp', 'preopen' ja 'pty'.",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1530,6 +1530,7 @@
     "PortMustBeUnique": "Le port doit être unique pour chaque application",
     "PortReservedForInternalUse": "Les ports 2000 à 2003, 2200 et 7681 sont réservés à un usage interne",
     "Preset": "Preset",
+    "Private": "Privé",
     "ProblemOccurred": "Un problème est survenu",
     "Protocol": "Protocole",
     "ProtocolMustBeOneOfSupported": "Le protocole doit être l'un des 'http', 'tcp', 'preopen' et 'pty'",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1530,6 +1530,7 @@
     "PortMustBeUnique": "Port harus berbeda untuk setiap aplikasi",
     "PortReservedForInternalUse": "Port 2000 hingga 2003, 2200, dan 7681 dicadangkan untuk penggunaan internal",
     "Preset": "Preset",
+    "Private": "Privat",
     "ProblemOccurred": "Masalah terjadi",
     "Protocol": "Protokol",
     "ProtocolMustBeOneOfSupported": "Protokol harus salah satu dari 'http', 'tcp', 'preopen' dan 'pty'",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "La porta deve essere compresa tra 0 e 65534",
     "PortMustBeUnique": "La porta deve essere univoca per ogni app",
     "PortReservedForInternalUse": "Le porte da 2000 a 2003, 2200 e 7681 sono riservate per uso interno",
+    "Private": "Privato",
     "ProblemOccurred": "Si è verificato un problema",
     "Protocol": "Protocollo",
     "ProtocolMustBeOneOfSupported": "Il protocollo deve essere uno tra \"http\", \"tcp\", \"preopen\" e \"pty\"",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "ポートは0から65534の間でなければなりません",
     "PortMustBeUnique": "ポートはアプリごとに一意である必要があります",
     "PortReservedForInternalUse": "ポート2000〜2003、2200、および7681は内部使用のために予約されています",
+    "Private": "非公開",
     "ProblemOccurred": "問題が発生しました",
     "Protocol": "プロトコル",
     "ProtocolMustBeOneOfSupported": "プロトコルは、「http」、「tcp」、「preopen」、「pty」のいずれかである必要があります",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "포트는 0부터 65534까지의 번호여야 합니다",
     "PortMustBeUnique": "포트는 중복 사용이 불가능합니다",
     "PortReservedForInternalUse": "포트 2000부터 2003, 2200, 7681은 시스템 내부에서 사용 중입니다",
+    "Private": "비공개",
     "ProblemOccurred": "문제가 발생했습니다.",
     "Protocol": "프로토콜",
     "ProtocolMustBeOneOfSupported": "프로토콜은 'http', 'tcp', 'preopen', 'pty' 중 하나여야 합니다",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "Порт нь 0-ээс 65534 хооронд байх ёстой",
     "PortMustBeUnique": "Порт нь програм бүрийн хувьд өвөрмөц байх ёстой",
     "PortReservedForInternalUse": "2000-2003, 2200, 7681 портууд нь дотоод хэрэгцээнд зориулагдсан байдаг",
+    "Private": "Хувийн",
     "ProblemOccurred": "Асуудал гарсан",
     "Protocol": "Протокол",
     "ProtocolMustBeOneOfSupported": "Протокол нь 'http', 'tcp', 'preopen' ба 'pty' -ийн нэг байх ёстой.",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "Pelabuhan mestilah antara 0 hingga 65534",
     "PortMustBeUnique": "Port mesti unik untuk setiap aplikasi",
     "PortReservedForInternalUse": "Pelabuhan 2000 hingga 2003, 2200, dan 7681 dikhaskan untuk penggunaan dalaman",
+    "Private": "Peribadi",
     "ProblemOccurred": "Masalah berlaku",
     "Protocol": "Protokol",
     "ProtocolMustBeOneOfSupported": "Protokol mestilah salah satu dari 'http', 'tcp', 'preopen' dan 'pty'",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1530,6 +1530,7 @@
     "PortMustBeUnique": "Port musi być unikalny dla każdej aplikacji",
     "PortReservedForInternalUse": "Porty 2000 do 2003, 2200 i 7681 są zarezerwowane do użytku wewnętrznego",
     "Preset": "Preset",
+    "Private": "Prywatne",
     "ProblemOccurred": "Wystąpił problem",
     "Protocol": "Protokół",
     "ProtocolMustBeOneOfSupported": "Protokół musi być jednym z „http”, „tcp”, „preopen” i „pty”",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "A porta deve estar entre 0 e 65534",
     "PortMustBeUnique": "A porta deve ser única para cada aplicativo",
     "PortReservedForInternalUse": "As portas 2000 a 2003, 2200 e 7681 são reservadas para uso interno",
+    "Private": "Privado",
     "ProblemOccurred": "Problema ocorrido",
     "Protocol": "Protocolo",
     "ProtocolMustBeOneOfSupported": "O protocolo deve ser 'http', 'tcp', 'preopen' e 'pty'",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "A porta deve estar entre 0 e 65534",
     "PortMustBeUnique": "A porta deve ser única para cada aplicativo",
     "PortReservedForInternalUse": "As portas 2000 a 2003, 2200 e 7681 são reservadas para uso interno",
+    "Private": "Privado",
     "ProblemOccurred": "Problema ocorrido",
     "Protocol": "Protocolo",
     "ProtocolMustBeOneOfSupported": "O protocolo deve ser 'http', 'tcp', 'preopen' e 'pty'",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "Порт должен быть от 0 до 65534",
     "PortMustBeUnique": "Порт должен быть уникальным для каждого приложения.",
     "PortReservedForInternalUse": "Порты с 2000 по 2003, 2200 и 7681 зарезервированы для внутреннего использования.",
+    "Private": "Приватный",
     "ProblemOccurred": "Возникла проблема",
     "Protocol": "Протокол",
     "ProtocolMustBeOneOfSupported": "Протокол должен быть одним из http, tcp, preopen и pty.",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "พอร์ตต้องอยู่ระหว่าง 0 ถึง 65534",
     "PortMustBeUnique": "พอร์ตต้องไม่ซ้ำกันสำหรับแต่ละแอป",
     "PortReservedForInternalUse": "พอร์ต 2000 ถึง 2003, 2200 และ 7681 สงวนไว้สำหรับการใช้งานภายใน",
+    "Private": "ส่วนตัว",
     "ProblemOccurred": "เกิดปัญหา",
     "Protocol": "โปรโตคอล",
     "ProtocolMustBeOneOfSupported": "โปรโตคอลต้องเป็นหนึ่งใน 'http', 'tcp', 'preopen' และ 'pty'",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "Bağlantı noktası 0 ile 65534 arasında olmalıdır",
     "PortMustBeUnique": "Bağlantı noktası her uygulama için benzersiz olmalıdır",
     "PortReservedForInternalUse": "2000 - 2003, 2200 ve 7681 numaralı bağlantı noktaları dahili kullanım için ayrılmıştır",
+    "Private": "Özel",
     "ProblemOccurred": "Sorun oluştu",
     "Protocol": "Protokol",
     "ProtocolMustBeOneOfSupported": "Protokol 'http', 'tcp', 'preopen' ve 'pty'den biri olmalıdır",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "Cổng phải từ 0 đến 65534",
     "PortMustBeUnique": "Cổng phải là duy nhất cho mỗi ứng dụng",
     "PortReservedForInternalUse": "Các cổng 2000 đến 2003, 2200 và 7681 được dành riêng cho mục đích sử dụng nội bộ",
+    "Private": "Riêng tư",
     "ProblemOccurred": "Vấn đề đã xảy ra",
     "Protocol": "Giao thức",
     "ProtocolMustBeOneOfSupported": "Giao thức phải là một trong các 'http', 'tcp', 'preopen' và 'pty'",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1529,6 +1529,7 @@
     "PortMustBeInRange": "端口必须介于 0 到 65534 之间",
     "PortMustBeUnique": "每个应用程序的端口必须是唯一的",
     "PortReservedForInternalUse": "端口 2000 到 2003、2200 和 7681 保留供内部使用",
+    "Private": "私有",
     "ProblemOccurred": "出现问题",
     "Protocol": "协议",
     "ProtocolMustBeOneOfSupported": "协议必须是“http”、“tcp”、“preopen”和“pty”之一",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1530,6 +1530,7 @@
     "PortMustBeInRange": "端口必須介於 0 到 65534 之間",
     "PortMustBeUnique": "每個應用程序的端口必須是唯一的",
     "PortReservedForInternalUse": "端口 2000 到 2003、2200 和 7681 保留供內部使用",
+    "Private": "私有",
     "ProblemOccurred": "出現問題",
     "Protocol": "協議",
     "ProtocolMustBeOneOfSupported": "協議必須是“http”、“tcp”、“preopen”和“pty”之一",


### PR DESCRIPTION
Resolves #2221 (FR-70)

## Summary

An image carrying `private` in its `ai.backend.features` label is hidden from the session launcher's environment picker. An admin who installed such an image sees it listed as **installed** on the Environments page with no indication of why it cannot be selected — the original report's exact complaint.

- Mark private images with a red `Private` badge in the Environments list's **Status** column.
- The marker is orthogonal to install state, so the column renders a `BAIFlex` row and both badges can appear on the same image.
- Add the `environment.Private` i18n key to all 21 locale files, reusing each locale's existing `deployment.Private` wording so the term stays consistent.

## Rebased onto current main

This PR was opened in March 2026 and sat ~1250 commits behind `main`, spanning the antd→Astryx migration. It has been rebased and re-applied:

- **Dropped** the new `react/src/helper/image.ts` module and the `ImageEnvironmentSelectFormItems.tsx` edit. `main` has since landed the same `isPrivateImage` predicate in `react/src/helper/index.tsx`, and its `PartialImageRef` type already covers `EnvironmentImage`, so this PR just imports it. No new module, no duplicated logic.
- **Converted** the antd `<Tag color="red">` to an Astryx `<Badge>` through the repo-global `badgeVariantForTagColor` lookup, matching the sibling `Installing` / `Installed` badges in the same column.

## Test plan

Four tests added to `react/src/components/ImageList.test.tsx` (`ImageList private marker (FR-70)`):

- an image whose `ai.backend.features` label contains `private` renders the marker
- an image without the label does not
- install state and the private marker render together on the same row
- `nonprivate` does not match (the predicate splits on whitespace, not substring)

Verified these fail against the pre-change component (2 of the 4 fail; the negative cases pass either way, as expected) and pass after.

## Screenshots

The Environments list's Status column, showing the four cases side by side:
`Private` alone on an uninstalled private image, `installed` + `Private`
together on an installed one, `installed` alone where the label is absent, and
no marker for a `nonprivate` feature value.

| Light | Dark |
|---|---|
| ![Private tag, light theme](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6227/20260902-133804-private-tag-light.png) | ![Private tag, dark theme](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6227/20260902-133804-private-tag-dark.png) |

> Captured against a live manager on the merged commit. That deployment happens
> to host no image labelled `private`, so rather than relabel an image on a
> shared server the `ImageListQuery` response was patched in the browser to add
> `ai.backend.features: batch query private` to two rows and `nonprivate` to a
> third. The component, the theme and every other field are the real thing.

## Verification

```
bash scripts/verify.sh
=== ALL PASS ===
```

- Relay / Lint / Format / TypeScript / Astryx theme build / Astryx integration / Terminology — all PASS
- `pnpm vitest run src/components/ImageList.test.tsx src/pages/EnvironmentPage.test.tsx` — 19 passed

## Manual checks

- [ ] Open the Environments page and confirm images with `ai.backend.features: private` show the `Private` badge in the Status column
- [ ] Confirm the badge sits alongside the existing `Installed` / `Installing` badge rather than replacing it
- [ ] Confirm non-private images show no badge
- [ ] Confirm the badge is legible in both light and dark themes

