### PR TITLE
feat(FR-2401): replace refresh button with auto-refresh button on endpoint detail page

### DIFF
--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -40,7 +40,6 @@ import {
   FolderOutlined,
   LoadingOutlined,
   PlusOutlined,
-  ReloadOutlined,
   SettingOutlined,
   SyncOutlined,
   WarningOutlined,
@@ -75,6 +74,7 @@ import {
   useFetchKey,
   useSemanticColorMap,
   BAITable,
+  BAIFetchKeyButton,
 } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
 import _ from 'lodash';
@@ -613,18 +613,19 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           ) : (
             <></>
           )}
-          <Button
+          <BAIFetchKeyButton
             loading={isPendingRefetch}
-            icon={<ReloadOutlined />}
+            value={fetchKey}
+            autoUpdateDelay={10_000}
             disabled={isEndpointInDestroyingCategory(endpoint)}
-            onClick={() => {
+            onChange={() => {
               startRefetchTransition(() => {
                 updateFetchKey();
               });
             }}
           >
             {t('button.Refresh')}
-          </Button>
+          </BAIFetchKeyButton>
         </BAIFlex>
       </BAIFlex>
       {isProjectMismatch && endpoint?.project && (


### PR DESCRIPTION
Resolves #6230 ([FR-2401](https://lablup.atlassian.net/browse/FR-2401))

## Summary
- Replace manual `Button` with `BAIFetchKeyButton` on the endpoint detail page
- Enable automatic periodic refresh with 10-second interval for monitoring endpoint status changes
- Remove unused `ReloadOutlined` import

## Test plan
- [ ] Navigate to endpoint detail page and verify auto-refresh triggers every 10 seconds
- [ ] Verify manual refresh still works via button click
- [ ] Verify button is disabled when endpoint is in destroying state

[FR-2401]: https://lablup.atlassian.net/browse/FR-2401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ