### PR TITLE
feat(FR-2392): add multi-step async notification system

### DIFF
--- a/react/src/components/BAIMultiStepNotificationItem.tsx
+++ b/react/src/components/BAIMultiStepNotificationItem.tsx
@@ -1,0 +1,431 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { NotificationState } from '../hooks/useBAINotification';
+import BAINotificationBackgroundProgress from './BAINotificationBackgroundProgress';
+import {
+  CheckCircleOutlined,
+  ClockCircleOutlined,
+  CloseCircleOutlined,
+  DownOutlined,
+  LoadingOutlined,
+  MinusCircleOutlined,
+} from '@ant-design/icons';
+import { Button, List, Typography, theme } from 'antd';
+import { createStyles } from 'antd-style';
+import { BAIFlex } from 'backend.ai-ui';
+import dayjs from 'dayjs';
+import React, { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const SLIDE_DURATION = 300;
+
+const useStyles = createStyles(({ css, token }) => ({
+  stepSlider: css`
+    position: relative;
+    overflow: hidden;
+    height: 20px;
+  `,
+  stepSlide: css`
+    position: absolute;
+    left: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    gap: ${token.marginXXS}px;
+    height: 20px;
+    transition:
+      transform ${SLIDE_DURATION}ms ease-in-out,
+      opacity ${SLIDE_DURATION}ms ease-in-out;
+  `,
+  // Visible position (center)
+  slideCenter: css`
+    transform: translateY(0);
+    opacity: 1;
+  `,
+  // Exited upward (out of view)
+  slideUp: css`
+    transform: translateY(-100%);
+    opacity: 0;
+  `,
+  // Waiting below (before entering)
+  slideDown: css`
+    transform: translateY(100%);
+    opacity: 0;
+  `,
+  // Instantly position without transition (used to place new element below before animating in)
+  noTransition: css`
+    transition: none !important;
+  `,
+  expandToggle: css`
+    cursor: pointer;
+    user-select: none;
+    &:hover {
+      opacity: 0.7;
+    }
+  `,
+  expandIcon: css`
+    transition: transform 0.2s ease;
+    font-size: 10px;
+  `,
+  expandIconOpen: css`
+    transform: rotate(0deg);
+  `,
+  expandIconClosed: css`
+    transform: rotate(-90deg);
+  `,
+  stepList: css`
+    overflow: hidden;
+    transition:
+      max-height 0.25s ease-in-out,
+      opacity 0.25s ease-in-out;
+  `,
+  stepListExpanded: css`
+    max-height: 200px;
+    opacity: 1;
+  `,
+  stepListCollapsed: css`
+    max-height: 0;
+    opacity: 0;
+  `,
+}));
+
+const StepIcon: React.FC<{
+  status: string;
+  size?: number;
+  animated?: boolean;
+}> = ({ status, size = 14, animated = false }) => {
+  const { token } = theme.useToken();
+
+  if (status === 'resolved') {
+    return (
+      <CheckCircleOutlined
+        style={{ color: token.colorSuccess, fontSize: size }}
+      />
+    );
+  }
+  if (status === 'rejected') {
+    return (
+      <CloseCircleOutlined
+        style={{ color: token.colorError, fontSize: size }}
+      />
+    );
+  }
+  if (status === 'pending') {
+    return animated ? (
+      <LoadingOutlined style={{ color: token.colorInfo, fontSize: size }} />
+    ) : (
+      <ClockCircleOutlined style={{ color: token.colorInfo, fontSize: size }} />
+    );
+  }
+  if (status === 'cancelled') {
+    return (
+      <MinusCircleOutlined
+        style={{ color: token.colorTextDisabled, fontSize: size }}
+      />
+    );
+  }
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        border: `1px solid ${token.colorBorder}`,
+      }}
+    />
+  );
+};
+
+const BAIMultiStepNotificationItem: React.FC<{
+  notification: NotificationState;
+  onRetry?: () => void;
+  onCancel?: () => void;
+  showDate?: boolean;
+}> = ({ notification, onRetry, onCancel, showDate }) => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { styles } = useStyles();
+  const { multiStep } = notification;
+
+  const [expanded, setExpanded] = useState(false);
+
+  // Two-element animation: outgoing slides up, incoming slides up from below
+  const prevStepRef = useRef(multiStep?.currentStep ?? 0);
+  const [outgoing, setOutgoing] = useState<number | null>(null);
+  const [incoming, setIncoming] = useState(multiStep?.currentStep ?? 0);
+  // 'idle' = no animation, 'animating' = transition in progress
+  const [phase, setPhase] = useState<'idle' | 'ready' | 'animating'>('idle');
+
+  useEffect(() => {
+    const newStep = multiStep?.currentStep ?? 0;
+    if (newStep !== prevStepRef.current) {
+      const prev = prevStepRef.current;
+      prevStepRef.current = newStep;
+
+      // Phase 1: place outgoing at center, incoming at bottom (no transition)
+      setOutgoing(prev);
+      setIncoming(newStep);
+      setPhase('ready');
+    }
+  }, [multiStep?.currentStep]);
+
+  useEffect(() => {
+    if (phase === 'ready') {
+      // Phase 2: after one frame, start the transition
+      const raf = requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          setPhase('animating');
+        });
+      });
+      return () => cancelAnimationFrame(raf);
+    }
+    if (phase === 'animating') {
+      // Phase 3: after transition ends, clean up
+      const timeout = setTimeout(() => {
+        setOutgoing(null);
+        setPhase('idle');
+      }, SLIDE_DURATION);
+      return () => clearTimeout(timeout);
+    }
+  }, [phase]);
+
+  if (!multiStep) return null;
+
+  const { currentStep, totalSteps, steps, overallStatus } = multiStep;
+  const currentStepDef = steps[currentStep];
+
+  const overallIcon =
+    overallStatus === 'completed' ? (
+      <CheckCircleOutlined style={{ color: token.colorSuccess }} />
+    ) : overallStatus === 'failed' ? (
+      <CloseCircleOutlined style={{ color: token.colorError }} />
+    ) : overallStatus === 'cancelled' ? (
+      <MinusCircleOutlined style={{ color: token.colorTextDisabled }} />
+    ) : (
+      <ClockCircleOutlined style={{ color: token.colorInfo }} />
+    );
+
+  const stepLabel =
+    overallStatus === 'completed'
+      ? t('notification.AllStepsCompleted')
+      : overallStatus === 'failed'
+        ? t('notification.StepFailed')
+        : overallStatus === 'cancelled'
+          ? t('notification.Cancelled')
+          : currentStepDef
+            ? t('notification.StepProgress', {
+                current: currentStep + 1,
+                total: totalSteps,
+                label: currentStepDef.label,
+              })
+            : t('notification.StepProgress', {
+                current: currentStep + 1,
+                total: totalSteps,
+                label: '',
+              });
+
+  const currentStepProgress = currentStepDef?.progress;
+
+  const showRetry = onRetry != null && overallStatus === 'failed';
+  const showCancel = onCancel != null && overallStatus === 'running';
+  const actionButton = notification.extraData?.actionButton as
+    | { label: string; onClick: () => void }
+    | undefined;
+
+  // showDate is true when rendered inside the Drawer (detail view)
+  const isDetailView = showDate === true;
+
+  const isTerminal =
+    overallStatus === 'completed' ||
+    overallStatus === 'failed' ||
+    overallStatus === 'cancelled';
+
+  const incomingStepDef = steps[incoming];
+  const outgoingStepDef = outgoing != null ? steps[outgoing] : null;
+
+  return (
+    <List.Item>
+      <BAIFlex direction="column" align="stretch" gap={'xxs'}>
+        {/* Header: icon + message */}
+        <BAIFlex
+          direction="row"
+          align="start"
+          gap={'xs'}
+          style={{ paddingRight: token.paddingMD }}
+        >
+          <BAIFlex style={{ height: 22 }}>{overallIcon}</BAIFlex>
+          <Typography.Paragraph style={{ fontWeight: 500 }}>
+            {notification.message}
+          </Typography.Paragraph>
+        </BAIFlex>
+
+        {/* Current step: icon + counter + animated label */}
+        <BAIFlex
+          direction="row"
+          align="center"
+          gap={'xxs'}
+          className={isDetailView ? styles.expandToggle : undefined}
+          onClick={isDetailView ? () => setExpanded((v) => !v) : undefined}
+        >
+          <StepIcon
+            status={
+              isTerminal
+                ? overallStatus === 'completed'
+                  ? 'resolved'
+                  : overallStatus === 'failed'
+                    ? 'rejected'
+                    : 'cancelled'
+                : (incomingStepDef?.status ?? 'idle')
+            }
+            animated={!isTerminal}
+          />
+          {!isTerminal && (
+            <Typography.Text
+              style={{ fontSize: token.fontSizeSM, whiteSpace: 'nowrap' }}
+              type="secondary"
+            >
+              {currentStep + 1}/{totalSteps}
+            </Typography.Text>
+          )}
+          {isTerminal ? (
+            <Typography.Text
+              style={{ fontSize: token.fontSizeSM }}
+              type="secondary"
+            >
+              {stepLabel}
+            </Typography.Text>
+          ) : (
+            <div className={styles.stepSlider} style={{ flex: 1 }}>
+              {outgoing != null && outgoingStepDef && (
+                <div
+                  className={`${styles.stepSlide} ${
+                    phase === 'ready' ? styles.slideCenter : styles.slideUp
+                  }`}
+                >
+                  <Typography.Text style={{ fontSize: token.fontSizeSM }}>
+                    {outgoingStepDef.label}
+                  </Typography.Text>
+                </div>
+              )}
+              <div
+                className={`${styles.stepSlide} ${
+                  phase === 'ready'
+                    ? `${styles.slideDown} ${styles.noTransition}`
+                    : styles.slideCenter
+                }`}
+              >
+                <Typography.Text style={{ fontSize: token.fontSizeSM }}>
+                  {incomingStepDef?.label}
+                </Typography.Text>
+              </div>
+            </div>
+          )}
+          {isDetailView && totalSteps > 1 && (
+            <DownOutlined
+              className={`${styles.expandIcon} ${
+                expanded ? styles.expandIconOpen : styles.expandIconClosed
+              }`}
+              style={{ color: token.colorTextSecondary }}
+            />
+          )}
+        </BAIFlex>
+
+        {/* Expandable step list: Drawer only */}
+        {isDetailView && (
+          <div
+            className={`${styles.stepList} ${
+              expanded ? styles.stepListExpanded : styles.stepListCollapsed
+            }`}
+          >
+            <BAIFlex
+              direction="column"
+              align="stretch"
+              gap={'xxs'}
+              style={{ paddingTop: token.paddingXXS }}
+            >
+              {steps.map((step, idx) => (
+                <BAIFlex
+                  key={idx}
+                  direction="row"
+                  align="center"
+                  gap={'xxs'}
+                  style={{ opacity: step.status === 'idle' ? 0.4 : 1 }}
+                >
+                  <BAIFlex style={{ width: 16, justifyContent: 'center' }}>
+                    <StepIcon
+                      status={step.status}
+                      size={12}
+                      animated={step.status === 'pending'}
+                    />
+                  </BAIFlex>
+                  <Typography.Text
+                    style={{
+                      fontSize: token.fontSizeSM,
+                      color:
+                        step.status === 'idle'
+                          ? token.colorTextDisabled
+                          : undefined,
+                    }}
+                  >
+                    {step.label}
+                  </Typography.Text>
+                </BAIFlex>
+              ))}
+            </BAIFlex>
+          </div>
+        )}
+
+        {/* Buttons: retry / cancel / action */}
+        <BAIFlex direction="row" align="end" gap={'xxs'} justify="end">
+          <BAIFlex gap={'xxs'}>
+            {showRetry && (
+              <Button type="link" size="small" onClick={onRetry}>
+                {t('button.Retry')}
+              </Button>
+            )}
+            {showCancel && (
+              <Button type="link" size="small" onClick={onCancel}>
+                {t('button.Cancel')}
+              </Button>
+            )}
+            {actionButton && (
+              <Button type="link" size="small" onClick={actionButton.onClick}>
+                {actionButton.label}
+              </Button>
+            )}
+          </BAIFlex>
+        </BAIFlex>
+
+        {/* Progress bar for SSE steps */}
+        <BAIFlex direction="row" align="center" justify="end" gap={'sm'}>
+          {notification.backgroundTask &&
+            (currentStepProgress != null ||
+              notification.backgroundTask.percent != null) && (
+              <BAINotificationBackgroundProgress
+                backgroundTask={{
+                  ...notification.backgroundTask,
+                  percent:
+                    currentStepProgress ?? notification.backgroundTask.percent,
+                }}
+                showDate={showDate}
+              />
+            )}
+          {isDetailView && (
+            <BAIFlex>
+              <Typography.Text type="secondary">
+                {dayjs(notification.created).format('lll')}
+              </Typography.Text>
+            </BAIFlex>
+          )}
+        </BAIFlex>
+      </BAIFlex>
+    </List.Item>
+  );
+};
+
+export default BAIMultiStepNotificationItem;

--- a/react/src/components/WEBUINotificationDrawer.tsx
+++ b/react/src/components/WEBUINotificationDrawer.tsx
@@ -5,6 +5,7 @@
 import { useWebUINavigate } from '../hooks';
 import { useBAINotificationState } from '../hooks/useBAINotification';
 import BAIGeneralNotificationItem from './BAIGeneralNotificationItem';
+import BAIMultiStepNotificationItem from './BAIMultiStepNotificationItem';
 import BAINodeNotificationItem from './BAINodeNotificationItem';
 import { MoreOutlined } from '@ant-design/icons';
 import {
@@ -135,6 +136,13 @@ const WEBUINotificationDrawer: React.FC<Props> = ({ ...drawerProps }) => {
             <BAINodeNotificationItem
               notification={item}
               nodeFrgmt={item.node || null}
+              showDate
+            />
+          ) : item.multiStep ? (
+            <BAIMultiStepNotificationItem
+              notification={item}
+              onRetry={item.onRetry ?? undefined}
+              onCancel={item.onCancel ?? undefined}
               showDate
             />
           ) : (

--- a/react/src/hooks/__tests__/useMultiStepNotification.test.tsx
+++ b/react/src/hooks/__tests__/useMultiStepNotification.test.tsx
@@ -1,0 +1,467 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { listenToBackgroundTask } from '../../helper';
+import { useMultiStepNotification } from '../useMultiStepNotification';
+import { renderHook, act } from '@testing-library/react';
+
+const mockUpsertNotification = jest.fn();
+
+jest.mock('../useBAINotification', () => ({
+  useSetBAINotification: () => ({
+    upsertNotification: mockUpsertNotification,
+    deleteNotification: jest.fn(),
+    updateNotification: jest.fn(),
+  }),
+  CLOSING_DURATION: 4,
+}));
+
+jest.mock('../../helper', () => ({
+  listenToBackgroundTask: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (params) {
+        return Object.entries(params).reduce(
+          (str, [k, v]) => str.replace(`{{${k}}}`, String(v)),
+          key,
+        );
+      }
+      return key;
+    },
+  }),
+}));
+
+const mockedListenToBackgroundTask =
+  listenToBackgroundTask as jest.MockedFunction<typeof listenToBackgroundTask>;
+
+const baseConfig = {
+  key: 'test-notification',
+  message: 'Test Notification',
+};
+
+describe('useMultiStepNotification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('sequential Promise flow', () => {
+    it('transitions from idle -> running -> completed for 3 steps', async () => {
+      const steps = [
+        {
+          label: 'Step 1',
+          type: 'promise' as const,
+          executor: jest.fn().mockResolvedValue('result1'),
+        },
+        {
+          label: 'Step 2',
+          type: 'promise' as const,
+          executor: jest.fn().mockResolvedValue('result2'),
+        },
+        {
+          label: 'Step 3',
+          type: 'promise' as const,
+          executor: jest.fn().mockResolvedValue('result3'),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useMultiStepNotification({ ...baseConfig, steps }),
+      );
+
+      expect(result.current.state.overallStatus).toBe('idle');
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      expect(result.current.state.overallStatus).toBe('completed');
+      expect(result.current.state.totalSteps).toBe(3);
+      expect(steps[0].executor).toHaveBeenCalledTimes(1);
+      expect(steps[1].executor).toHaveBeenCalledTimes(1);
+      expect(steps[2].executor).toHaveBeenCalledTimes(1);
+      expect(mockUpsertNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backgroundTask: { status: 'resolved' },
+        }),
+      );
+    });
+  });
+
+  describe('step failure and retry', () => {
+    it('sets failed state when a step rejects, then retry resumes from that step', async () => {
+      const error = new Error('Step 2 failed');
+      const step2Executor = jest
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValueOnce('result2');
+
+      const steps = [
+        {
+          label: 'Step 1',
+          type: 'promise' as const,
+          executor: jest.fn().mockResolvedValue('result1'),
+        },
+        {
+          label: 'Step 2',
+          type: 'promise' as const,
+          executor: step2Executor,
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useMultiStepNotification({ ...baseConfig, steps }),
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      expect(result.current.state.overallStatus).toBe('failed');
+      expect(result.current.state.steps[1].status).toBe('rejected');
+
+      await act(async () => {
+        result.current.retry();
+      });
+
+      expect(result.current.state.overallStatus).toBe('completed');
+      // Step 1 executor should only have been called once (not re-run on retry)
+      expect(steps[0].executor).toHaveBeenCalledTimes(1);
+      // Step 2 executor should have been called twice (once failed, once succeeded)
+      expect(step2Executor).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('data chaining', () => {
+    it('passes step 1 result as prevResult to step 2', async () => {
+      const step2Executor = jest.fn().mockResolvedValue('result2');
+      const steps = [
+        {
+          label: 'Step 1',
+          type: 'promise' as const,
+          executor: jest.fn().mockResolvedValue('result-from-step1'),
+        },
+        {
+          label: 'Step 2',
+          type: 'promise' as const,
+          executor: step2Executor,
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useMultiStepNotification({ ...baseConfig, steps }),
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      expect(result.current.state.overallStatus).toBe('completed');
+      expect(step2Executor).toHaveBeenCalledWith(
+        'result-from-step1',
+        expect.any(AbortSignal),
+      );
+    });
+  });
+
+  describe('eager execution (dependsOn: false)', () => {
+    it('starts independent step immediately without waiting for previous step', async () => {
+      const executionOrder: string[] = [];
+
+      let resolveStep1!: (v: string) => void;
+      const step1Promise = new Promise<string>((resolve) => {
+        resolveStep1 = resolve;
+      });
+
+      const steps = [
+        {
+          label: 'Step 1',
+          type: 'promise' as const,
+          executor: jest.fn(() => {
+            executionOrder.push('step1-started');
+            return step1Promise;
+          }),
+        },
+        {
+          label: 'Step 2 (eager)',
+          type: 'promise' as const,
+          dependsOn: false,
+          executor: jest.fn(() => {
+            executionOrder.push('step2-started');
+            return Promise.resolve('eager-result');
+          }),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useMultiStepNotification({ ...baseConfig, steps }),
+      );
+
+      await act(async () => {
+        result.current.start();
+        // Both steps should have started before step 1 resolves
+        resolveStep1('step1-done');
+      });
+
+      expect(result.current.state.overallStatus).toBe('completed');
+      // Eager step starts immediately alongside step 1
+      expect(executionOrder).toContain('step1-started');
+      expect(executionOrder).toContain('step2-started');
+    });
+  });
+
+  describe('cancel', () => {
+    it('cancels while running and sets cancelled state', async () => {
+      let resolveStep!: (v: string) => void;
+      const pendingStep = new Promise<string>((resolve) => {
+        resolveStep = resolve;
+      });
+
+      const steps = [
+        {
+          label: 'Long Step',
+          type: 'promise' as const,
+          executor: jest.fn(() => pendingStep),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useMultiStepNotification({ ...baseConfig, steps }),
+      );
+
+      // Start but don't resolve the pending promise
+      act(() => {
+        result.current.start();
+      });
+
+      // Cancel while running
+      act(() => {
+        result.current.cancel();
+      });
+
+      expect(result.current.state.overallStatus).toBe('cancelled');
+      expect(mockUpsertNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backgroundTask: { status: 'rejected' },
+        }),
+      );
+
+      // Cleanup: resolve the pending promise
+      resolveStep('done');
+    });
+  });
+
+  describe('start() guard', () => {
+    it('does nothing if already running', async () => {
+      let resolveStep!: (v: string) => void;
+      const pendingStep = new Promise<string>((resolve) => {
+        resolveStep = resolve;
+      });
+
+      const steps = [
+        {
+          label: 'Step 1',
+          type: 'promise' as const,
+          executor: jest.fn(() => pendingStep),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useMultiStepNotification({ ...baseConfig, steps }),
+      );
+
+      act(() => {
+        result.current.start();
+      });
+
+      expect(result.current.state.overallStatus).toBe('running');
+
+      // Try to start again while running - should be a no-op
+      act(() => {
+        result.current.start();
+      });
+
+      // Executor should only have been called once
+      expect(steps[0].executor).toHaveBeenCalledTimes(1);
+
+      // Cleanup
+      await act(async () => {
+        resolveStep('done');
+      });
+    });
+  });
+
+  describe('retry() guard', () => {
+    it('does nothing if not in failed state', async () => {
+      const steps = [
+        {
+          label: 'Step 1',
+          type: 'promise' as const,
+          executor: jest.fn().mockResolvedValue('result1'),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useMultiStepNotification({ ...baseConfig, steps }),
+      );
+
+      // Do not call start(), so status remains 'idle'
+      expect(result.current.state.overallStatus).toBe('idle');
+
+      act(() => {
+        result.current.retry();
+      });
+
+      // Executor should not have been called
+      expect(steps[0].executor).not.toHaveBeenCalled();
+    });
+
+    it('does nothing after successful completion', async () => {
+      const steps = [
+        {
+          label: 'Step 1',
+          type: 'promise' as const,
+          executor: jest.fn().mockResolvedValue('result1'),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useMultiStepNotification({ ...baseConfig, steps }),
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      expect(result.current.state.overallStatus).toBe('completed');
+
+      const callCount = steps[0].executor.mock.calls.length;
+
+      act(() => {
+        result.current.retry();
+      });
+
+      // Executor should not have been called again
+      expect(steps[0].executor).toHaveBeenCalledTimes(callCount);
+    });
+  });
+
+  describe('SSE step', () => {
+    it('listens to background task and resolves on done', async () => {
+      let onDoneCallback!: () => void;
+
+      mockedListenToBackgroundTask.mockImplementation((_taskId, handlers) => {
+        onDoneCallback = handlers.onDone as () => void;
+        return jest.fn(); // cleanup function
+      });
+
+      const steps = [
+        {
+          label: 'SSE Step',
+          type: 'sse' as const,
+          executor: jest.fn().mockReturnValue({ taskId: 'task-123' }),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useMultiStepNotification({ ...baseConfig, steps }),
+      );
+
+      act(() => {
+        result.current.start();
+      });
+
+      expect(mockedListenToBackgroundTask).toHaveBeenCalledWith(
+        'task-123',
+        expect.any(Object),
+      );
+
+      await act(async () => {
+        onDoneCallback();
+      });
+
+      expect(result.current.state.overallStatus).toBe('completed');
+    });
+
+    it('transitions to failed state on SSE task failure', async () => {
+      let onTaskFailedCallback!: (data: unknown) => void;
+
+      mockedListenToBackgroundTask.mockImplementation((_taskId, handlers) => {
+        onTaskFailedCallback = handlers.onTaskFailed as (data: unknown) => void;
+        return jest.fn();
+      });
+
+      const steps = [
+        {
+          label: 'SSE Step',
+          type: 'sse' as const,
+          executor: jest.fn().mockReturnValue({ taskId: 'task-456' }),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useMultiStepNotification({ ...baseConfig, steps }),
+      );
+
+      act(() => {
+        result.current.start();
+      });
+
+      await act(async () => {
+        onTaskFailedCallback({ message: 'Task failed' });
+      });
+
+      expect(result.current.state.overallStatus).toBe('failed');
+    });
+  });
+
+  describe('desktop notification', () => {
+    it('skips desktop notification for intermediate steps but not for the final step', async () => {
+      const steps = [
+        {
+          label: 'Step 1',
+          type: 'promise' as const,
+          executor: jest.fn().mockResolvedValue('result1'),
+        },
+        {
+          label: 'Step 2',
+          type: 'promise' as const,
+          executor: jest.fn().mockResolvedValue('result2'),
+        },
+      ];
+
+      const { result } = renderHook(() =>
+        useMultiStepNotification({ ...baseConfig, steps }),
+      );
+
+      await act(async () => {
+        result.current.start();
+      });
+
+      // Find calls with skipDesktopNotification
+      const callsWithSkip = mockUpsertNotification.mock.calls.filter(
+        (call) => call[0].skipDesktopNotification === true,
+      );
+      const callsWithoutSkip = mockUpsertNotification.mock.calls.filter(
+        (call) =>
+          call[0].skipDesktopNotification === false ||
+          call[0].skipDesktopNotification === undefined,
+      );
+
+      // Intermediate steps should skip desktop notifications
+      expect(callsWithSkip.length).toBeGreaterThan(0);
+      // Final resolved notification should NOT skip desktop notification
+      const finalResolvedCall = mockUpsertNotification.mock.calls.find(
+        (call) => call[0].backgroundTask?.status === 'resolved',
+      );
+      expect(finalResolvedCall).toBeDefined();
+      expect(finalResolvedCall?.[0].skipDesktopNotification).toBeFalsy();
+
+      // Suppress unused variable warning
+      void callsWithoutSkip;
+    });
+  });
+});

--- a/react/src/hooks/useBAINotification.tsx
+++ b/react/src/hooks/useBAINotification.tsx
@@ -4,6 +4,7 @@
  */
 import { useWebUINavigate } from '.';
 import BAIGeneralNotificationItem from '../components/BAIGeneralNotificationItem';
+import BAIMultiStepNotificationItem from '../components/BAIMultiStepNotificationItem';
 import { SSEEventHandlerTypes, listenToBackgroundTask } from '../helper';
 import { useBAISettingUserState } from './useBAISetting';
 import { App } from 'antd';
@@ -75,8 +76,19 @@ export interface NotificationState<T = any> extends Omit<
   backgroundTask?: BackgroundTaskConfig<T>;
   extraDescription?: ReactNode | null;
   onCancel?: (() => void) | null;
+  onRetry?: (() => void) | null;
   skipDesktopNotification?: boolean;
   extraData: any;
+  multiStep?: {
+    currentStep: number;
+    totalSteps: number;
+    steps: Array<{
+      label: string;
+      status: 'idle' | 'pending' | 'resolved' | 'rejected' | 'cancelled';
+      progress?: number;
+    }>;
+    overallStatus: 'idle' | 'running' | 'completed' | 'failed' | 'cancelled';
+  };
 }
 
 interface NotificationOptions {
@@ -435,6 +447,12 @@ export const useSetBAINotification = () => {
               <BAINodeNotificationItem
                 notification={newNotification}
                 nodeFrgmt={newNotification.node}
+              />
+            ) : newNotification.multiStep ? (
+              <BAIMultiStepNotificationItem
+                notification={newNotification}
+                onRetry={newNotification.onRetry ?? undefined}
+                onCancel={newNotification.onCancel ?? undefined}
               />
             ) : (
               <BAIGeneralNotificationItem

--- a/react/src/hooks/useMultiStepNotification.tsx
+++ b/react/src/hooks/useMultiStepNotification.tsx
@@ -1,0 +1,813 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { listenToBackgroundTask } from '../helper';
+import { CLOSING_DURATION, useSetBAINotification } from './useBAINotification';
+import _ from 'lodash';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Lifecycle states for a single step in a multi-step notification sequence.
+ * - `idle`: Step has not started yet
+ * - `pending`: Step is currently executing
+ * - `resolved`: Step completed successfully
+ * - `rejected`: Step failed with an error
+ * - `cancelled`: Step was cancelled before completion
+ */
+export type StepStatus =
+  | 'idle'
+  | 'pending'
+  | 'resolved'
+  | 'rejected'
+  | 'cancelled';
+
+/**
+ * Type of async work a step performs.
+ * - `promise`: Step wraps a standard Promise
+ * - `sse`: Step uses Server-Sent Events (SSE) via a background task ID
+ */
+export type StepType = 'promise' | 'sse';
+
+/**
+ * Configuration for the action button displayed alongside a notification step.
+ */
+export interface StepActionButton {
+  label: string;
+  onClick: () => void;
+}
+
+/**
+ * Per-status action button overrides for a step.
+ * Each key corresponds to a `StepStatus` value that may show a button.
+ */
+export interface StepActionButtons {
+  pending?: StepActionButton;
+  resolved?: StepActionButton;
+  rejected?: StepActionButton;
+  cancelled?: StepActionButton;
+}
+
+/**
+ * Per-status notification message overrides for a step.
+ * Matches the existing `backgroundTask.onChange` pattern in `useBAINotification`.
+ */
+export interface StepOnChange {
+  pending?: string;
+  resolved?: string;
+  rejected?: string;
+}
+
+/**
+ * Configuration for a single step in a multi-step notification sequence.
+ *
+ * @template T - The resolved value type of this step's executor
+ * @template P - The resolved value type of the previous step (passed as `prevResult`)
+ */
+export interface StepDefinition<T = unknown, P = unknown> {
+  /**
+   * Human-readable label displayed in the notification step counter.
+   */
+  label: string;
+
+  /**
+   * The type of async work this step performs.
+   */
+  type: StepType;
+
+  /**
+   * The async work to execute for this step.
+   *
+   * For `type: 'promise'`, return a `Promise<T>`.
+   * For `type: 'sse'`, return an object with a `taskId` string that identifies
+   * the background task to listen to via SSE.
+   *
+   * @param prevResult - The resolved result of the previous step, or `undefined`
+   *   if this is the first step or `dependsOn` is `false`.
+   * @param signal - An `AbortSignal` that is aborted when `cancel()` is called.
+   */
+  executor: (
+    prevResult: P | undefined,
+    signal: AbortSignal,
+  ) => Promise<T> | { taskId: string };
+
+  /**
+   * Whether this step depends on the previous step's result.
+   * When `false`, the step starts immediately after the previous step begins
+   * (eager execution). Defaults to `true`.
+   */
+  dependsOn?: boolean;
+
+  /**
+   * Notification message overrides for each status transition of this step.
+   * Follows the same pattern as `backgroundTask.onChange` in `useBAINotification`.
+   */
+  onChange?: StepOnChange;
+
+  /**
+   * Per-status action button configurations for this step's notification.
+   */
+  actionButtons?: StepActionButtons;
+}
+
+/**
+ * Runtime state of a single step during execution.
+ *
+ * @template T - The resolved value type of this step
+ */
+export interface StepState<T = unknown> {
+  /**
+   * Current lifecycle status of the step.
+   */
+  status: StepStatus;
+
+  /**
+   * The resolved value from the step's executor, available when `status` is `'resolved'`.
+   */
+  result?: T;
+
+  /**
+   * The error thrown by the step's executor, available when `status` is `'rejected'`.
+   */
+  error?: Error;
+
+  /**
+   * Progress percentage (0–100) for SSE-type steps.
+   * Updated as SSE progress events are received.
+   */
+  progress?: number;
+}
+
+/**
+ * Action button configuration for the final notification state
+ * (e.g., shown when all steps complete or the sequence is cancelled).
+ */
+export interface FinalStateActionButtons {
+  primary?: StepActionButton;
+}
+
+/**
+ * Top-level configuration object passed to `useMultiStepNotification`.
+ */
+export interface MultiStepNotificationConfig {
+  /**
+   * Notification key used for upsert operations. Must be unique per notification instance.
+   */
+  key: string;
+
+  /**
+   * Title displayed in the notification.
+   */
+  message: string;
+
+  /**
+   * Ordered list of steps to execute in sequence.
+   */
+  steps: StepDefinition[];
+
+  /**
+   * Configuration for the final notification state shown after all steps complete successfully.
+   */
+  onAllCompleted?: {
+    message: string;
+    actionButtons?: FinalStateActionButtons;
+  };
+
+  /**
+   * Configuration for the notification state shown when the sequence is cancelled.
+   */
+  onCancelled?: {
+    message: string;
+  };
+}
+
+/**
+ * Overall status of the multi-step notification sequence.
+ */
+export type OverallStatus =
+  | 'idle'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+/**
+ * Aggregated runtime state of the multi-step notification sequence.
+ */
+export interface MultiStepState {
+  /**
+   * Zero-based index of the currently executing step.
+   */
+  currentStep: number;
+
+  /**
+   * Total number of steps in the sequence.
+   */
+  totalSteps: number;
+
+  /**
+   * Individual runtime states for each step, indexed in the same order as
+   * `MultiStepNotificationConfig.steps`.
+   */
+  steps: StepState[];
+
+  /**
+   * Aggregate status of the entire step sequence.
+   */
+  overallStatus: OverallStatus;
+}
+
+/**
+ * Controls and state returned by the `useMultiStepNotification` hook.
+ */
+export interface MultiStepControls {
+  /**
+   * Starts the step sequence from the beginning.
+   * Has no effect if the sequence is already running.
+   */
+  start: () => void;
+
+  /**
+   * Retries the sequence from the first failed step.
+   * Has no effect if the sequence is not in a failed state.
+   */
+  retry: () => void;
+
+  /**
+   * Cancels the currently running sequence.
+   * Aborts the active step's signal and transitions the sequence to `'cancelled'`.
+   * Has no effect if the sequence is not running.
+   */
+  cancel: () => void;
+
+  /**
+   * Current runtime state of the multi-step sequence.
+   */
+  state: MultiStepState;
+}
+
+function createInitialStepStates(count: number): StepState[] {
+  return Array.from({ length: count }, () => ({
+    status: 'idle' as StepStatus,
+  }));
+}
+
+function buildMultiStepData(
+  steps: StepDefinition[],
+  stepStates: StepState[],
+  currentStep: number,
+  overallStatus: OverallStatus,
+) {
+  return {
+    currentStep,
+    totalSteps: steps.length,
+    steps: steps.map((step, idx) => ({
+      label: step.label,
+      status: stepStates[idx]?.status ?? 'idle',
+      progress: stepStates[idx]?.progress,
+    })),
+    overallStatus,
+  };
+}
+
+// no-op handler to suppress unhandled promise rejections
+const noop = () => {};
+
+/**
+ * Hook for managing multi-step async notification sequences.
+ *
+ * Each step can be a `Promise`-based or SSE-based task. Steps are executed
+ * sequentially, with optional eager execution via `dependsOn: false`.
+ * The notification is updated at each step transition.
+ *
+ * @param config - Configuration for the multi-step notification sequence.
+ * @returns Controls and state for managing the sequence.
+ *
+ * @example
+ * ```tsx
+ * const { start, cancel, state } = useMultiStepNotification({
+ *   key: 'my-workflow',
+ *   message: 'Running workflow…',
+ *   steps: [
+ *     {
+ *       label: 'Upload',
+ *       type: 'promise',
+ *       executor: async (_prev, signal) => uploadFile(signal),
+ *     },
+ *     {
+ *       label: 'Process',
+ *       type: 'sse',
+ *       executor: (prevResult) => ({ taskId: prevResult.taskId }),
+ *     },
+ *   ],
+ *   onAllCompleted: { message: 'Workflow complete' },
+ * });
+ * ```
+ */
+export function useMultiStepNotification(
+  config: MultiStepNotificationConfig,
+): MultiStepControls {
+  'use memo';
+
+  const { t } = useTranslation();
+  const { upsertNotification } = useSetBAINotification();
+
+  const stepStatesRef = useRef<StepState[]>(
+    createInitialStepStates(config.steps.length),
+  );
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const sseCleanupMapRef = useRef<Map<number, () => void>>(new Map());
+  /**
+   * Cache of eagerly-started promises for steps with `dependsOn === false`.
+   * Keyed by step index. Entries are deleted once the step is resolved/rejected
+   * in the sequential display loop.
+   */
+  const eagerResultsRef = useRef<Map<number, Promise<unknown>>>(new Map());
+  const isMountedRef = useRef(true);
+
+  // Unmount cleanup: abort running sequence and clean up SSE connections
+  useEffect(() => {
+    const sseCleanupMap = sseCleanupMapRef.current;
+    return () => {
+      isMountedRef.current = false;
+      abortControllerRef.current?.abort();
+      sseCleanupMap.forEach((cleanup) => cleanup());
+      sseCleanupMap.clear();
+    };
+  }, []);
+
+  const [multiStepState, setMultiStepState] = useState<MultiStepState>({
+    currentStep: 0,
+    totalSteps: config.steps.length,
+    steps: createInitialStepStates(config.steps.length),
+    overallStatus: 'idle',
+  });
+
+  const syncState = useCallback(
+    (overallStatus: OverallStatus, currentStep: number) => {
+      if (!isMountedRef.current) return;
+      const snapshot = _.cloneDeep(stepStatesRef.current);
+      setMultiStepState({
+        currentStep,
+        totalSteps: config.steps.length,
+        steps: snapshot,
+        overallStatus,
+      });
+    },
+    [config.steps.length],
+  );
+
+  const runFromStep = useCallback(
+    async (startIndex: number) => {
+      const { key, message, steps, onAllCompleted } = config;
+      const total = steps.length;
+
+      // Guard: empty steps
+      if (total === 0) {
+        syncState('completed', 0);
+        return;
+      }
+
+      abortControllerRef.current = new AbortController();
+      const { signal } = abortControllerRef.current;
+
+      const defaultStepDescription = (idx: number) =>
+        t('notification.StepProgress', {
+          current: idx + 1,
+          total,
+          label: steps[idx]?.label ?? '',
+        });
+
+      // Open notification as pending
+      upsertNotification({
+        key,
+        message,
+        backgroundTask: { status: 'pending' },
+        description: defaultStepDescription(startIndex),
+        open: true,
+        duration: 0,
+        multiStep: buildMultiStepData(
+          steps,
+          stepStatesRef.current,
+          startIndex,
+          'running',
+        ),
+      });
+
+      syncState('running', startIndex);
+
+      let prevResult: unknown = undefined;
+
+      // Preserve results from already-completed steps before startIndex
+      for (let i = 0; i < startIndex; i++) {
+        const existingState = stepStatesRef.current[i];
+        if (existingState?.status === 'resolved') {
+          prevResult = existingState.result;
+        }
+      }
+
+      // Fire eager (independent) steps immediately in parallel before entering
+      // the sequential display loop. Steps with `dependsOn === false` do not
+      // need a previous result so they can start right away.
+      for (let i = startIndex; i < total; i++) {
+        const step = steps[i];
+        if (
+          step.dependsOn === false &&
+          stepStatesRef.current[i]?.status !== 'resolved'
+        ) {
+          stepStatesRef.current[i] = { status: 'pending' };
+          const eagerStepIndex = i;
+          const eagerPromise = (async () => {
+            const executorResult = step.executor(undefined as never, signal);
+            if (executorResult instanceof Promise) {
+              return executorResult;
+            }
+            // SSE eager step – wrap in a promise identical to the sequential path
+            const sseResult = executorResult as { taskId: string };
+            return new Promise<unknown>((resolve, reject) => {
+              const cleanup = listenToBackgroundTask(sseResult.taskId, {
+                onUpdated: _.throttle(
+                  () => {
+                    // Progress updates for eager SSE steps are intentionally
+                    // suppressed here; the sequential display loop will reflect
+                    // progress once the display catches up to this step index.
+                  },
+                  100,
+                  { leading: true, trailing: false },
+                ),
+                onDone: () => {
+                  resolve(sseResult);
+                },
+                onTaskFailed: (data: any) => {
+                  reject(new Error(data?.message || 'Background task failed'));
+                },
+                onFailed: (data: any) => {
+                  reject(new Error(data?.message || 'Background task failed'));
+                },
+                onTaskCancelled: () => {
+                  reject(new Error('Background task cancelled'));
+                },
+              });
+              sseCleanupMapRef.current.set(eagerStepIndex, cleanup);
+
+              // Wire abort signal to reject this SSE promise on cancel
+              signal.addEventListener(
+                'abort',
+                () => {
+                  cleanup();
+                  reject(new Error('Cancelled'));
+                },
+                { once: true },
+              );
+            });
+          })();
+          // Attach .catch(noop) to prevent unhandled rejection if the
+          // sequential loop exits early (e.g., earlier step fails).
+          eagerPromise.catch(noop);
+          eagerResultsRef.current.set(i, eagerPromise);
+        }
+      }
+
+      for (let i = startIndex; i < total; i++) {
+        // Stop the loop if cancel() was called between steps
+        if (signal.aborted) return;
+
+        const step = steps[i];
+
+        // Update step to pending
+        stepStatesRef.current[i] = { status: 'pending' };
+        syncState('running', i);
+
+        const stepPendingDescription =
+          step.onChange?.pending ?? defaultStepDescription(i);
+
+        upsertNotification({
+          key,
+          message,
+          backgroundTask: { status: 'pending' },
+          description: stepPendingDescription,
+          open: true,
+          duration: 0,
+          multiStep: buildMultiStepData(
+            steps,
+            stepStatesRef.current,
+            i,
+            'running',
+          ),
+          ...(step.actionButtons?.pending
+            ? {
+                extraData: {
+                  actionButton: step.actionButtons.pending,
+                },
+              }
+            : {}),
+        });
+
+        try {
+          if (eagerResultsRef.current.has(i)) {
+            // This step was eagerly started – await its cached promise.
+            // If it already resolved the await returns immediately; if still
+            // pending we wait here just as in the normal sequential path.
+            const result = await eagerResultsRef.current.get(i)!;
+            eagerResultsRef.current.delete(i);
+
+            // Guard: cancel may have happened while awaiting
+            if (signal.aborted) return;
+
+            stepStatesRef.current[i] = { status: 'resolved', result };
+            prevResult = result;
+          } else {
+            const executorInput =
+              step.dependsOn === false ? undefined : prevResult;
+            const executorResult = step.executor(
+              executorInput as never,
+              signal,
+            );
+
+            if (executorResult instanceof Promise) {
+              const result = await executorResult;
+
+              // Guard: cancel may have happened while awaiting
+              if (signal.aborted) return;
+
+              stepStatesRef.current[i] = { status: 'resolved', result };
+              prevResult = result;
+            } else {
+              // SSE step - listen to background task via SSE
+              const sseResult = executorResult as { taskId: string };
+              const result = await new Promise<unknown>((resolve, reject) => {
+                const cleanup = listenToBackgroundTask(sseResult.taskId, {
+                  onUpdated: _.throttle(
+                    (data: any) => {
+                      const ratio =
+                        data.total_progress > 0
+                          ? data.current_progress / data.total_progress
+                          : 0;
+                      stepStatesRef.current[i] = {
+                        ...stepStatesRef.current[i],
+                        status: 'pending',
+                        progress: ratio * 100,
+                      };
+                      syncState('running', i);
+                      upsertNotification({
+                        key,
+                        message,
+                        backgroundTask: {
+                          status: 'pending',
+                          percent: ratio * 100,
+                        },
+                        description: stepPendingDescription,
+                        open: true,
+                        duration: 0,
+                        skipDesktopNotification: true,
+                        multiStep: buildMultiStepData(
+                          steps,
+                          stepStatesRef.current,
+                          i,
+                          'running',
+                        ),
+                      });
+                    },
+                    100,
+                    { leading: true, trailing: false },
+                  ),
+                  onDone: () => {
+                    resolve(sseResult);
+                  },
+                  onTaskFailed: (data: any) => {
+                    reject(
+                      new Error(data?.message || 'Background task failed'),
+                    );
+                  },
+                  onFailed: (data: any) => {
+                    reject(
+                      new Error(data?.message || 'Background task failed'),
+                    );
+                  },
+                  onTaskCancelled: () => {
+                    reject(new Error('Background task cancelled'));
+                  },
+                });
+                sseCleanupMapRef.current.set(i, cleanup);
+
+                // Wire abort signal to reject this SSE promise on cancel
+                signal.addEventListener(
+                  'abort',
+                  () => {
+                    cleanup();
+                    reject(new Error('Cancelled'));
+                  },
+                  { once: true },
+                );
+              });
+
+              // Guard: cancel may have happened while awaiting
+              if (signal.aborted) return;
+
+              stepStatesRef.current[i] = { status: 'resolved', result };
+              prevResult = result;
+            }
+          }
+
+          // Update description after step resolved (intermediate steps skip desktop notification)
+          const isLastStep = i === total - 1;
+          const stepResolvedDescription =
+            step.onChange?.resolved ?? defaultStepDescription(i);
+
+          upsertNotification({
+            key,
+            message,
+            backgroundTask: { status: 'pending' },
+            description: stepResolvedDescription,
+            open: true,
+            duration: 0,
+            skipDesktopNotification: !isLastStep,
+            multiStep: buildMultiStepData(
+              steps,
+              stepStatesRef.current,
+              i,
+              'running',
+            ),
+            ...(step.actionButtons?.resolved
+              ? {
+                  extraData: {
+                    actionButton: step.actionButtons.resolved,
+                  },
+                }
+              : {}),
+          });
+
+          syncState('running', i);
+        } catch (err) {
+          // If the error is due to abort/cancel, treat as cancellation
+          // and let cancel() handle the state transition.
+          if (signal.aborted) return;
+
+          const error = err instanceof Error ? err : new Error(String(err));
+          stepStatesRef.current[i] = { status: 'rejected', error };
+          // Remove the cached eager promise for this step so retry re-executes it
+          eagerResultsRef.current.delete(i);
+
+          const stepRejectedDescription =
+            step.onChange?.rejected ?? error.message;
+
+          upsertNotification({
+            key,
+            message,
+            backgroundTask: { status: 'rejected' },
+            description: stepRejectedDescription,
+            open: true,
+            duration: CLOSING_DURATION,
+            multiStep: buildMultiStepData(
+              steps,
+              stepStatesRef.current,
+              i,
+              'failed',
+            ),
+            ...(step.actionButtons?.rejected
+              ? {
+                  extraData: {
+                    actionButton: step.actionButtons.rejected,
+                  },
+                }
+              : {}),
+          });
+
+          syncState('failed', i);
+          return;
+        }
+      }
+
+      // All steps completed
+      const completedMessage = onAllCompleted?.message ?? message;
+      upsertNotification({
+        key,
+        message: completedMessage,
+        backgroundTask: { status: 'resolved' },
+        open: true,
+        duration: CLOSING_DURATION,
+        multiStep: buildMultiStepData(
+          steps,
+          stepStatesRef.current,
+          total - 1,
+          'completed',
+        ),
+        ...(onAllCompleted?.actionButtons?.primary
+          ? {
+              extraData: {
+                actionButton: onAllCompleted.actionButtons.primary,
+              },
+            }
+          : {}),
+      });
+
+      syncState('completed', total - 1);
+    },
+    [config, upsertNotification, syncState, t],
+  );
+
+  const start = useCallback(() => {
+    if (multiStepState.overallStatus === 'running') return;
+
+    // Reset all step states and clear any cached eager promises
+    stepStatesRef.current = createInitialStepStates(config.steps.length);
+    eagerResultsRef.current.clear();
+
+    runFromStep(0);
+  }, [multiStepState.overallStatus, config.steps.length, runFromStep]);
+
+  const retry = useCallback(() => {
+    // Retry is only valid from a failed state; cancelled sequences must use start()
+    if (multiStepState.overallStatus !== 'failed') return;
+
+    const firstFailedIndex = _.findIndex(
+      stepStatesRef.current,
+      (s) => s.status === 'rejected',
+    );
+
+    if (firstFailedIndex < 0) return;
+
+    // Reset failed and subsequent steps to idle.
+    // Preserve already-resolved eager steps so they are not re-executed.
+    for (let i = firstFailedIndex; i < stepStatesRef.current.length; i++) {
+      const step = config.steps[i];
+      const isEagerResolved =
+        step?.dependsOn === false &&
+        stepStatesRef.current[i]?.status === 'resolved';
+      if (!isEagerResolved) {
+        stepStatesRef.current[i] = { status: 'idle' };
+      }
+    }
+
+    // Clear any stale eager promises for steps that were not yet resolved
+    eagerResultsRef.current.forEach((_, idx) => {
+      if (stepStatesRef.current[idx]?.status !== 'resolved') {
+        eagerResultsRef.current.delete(idx);
+      }
+    });
+
+    runFromStep(firstFailedIndex);
+  }, [multiStepState.overallStatus, config.steps, runFromStep]);
+
+  const cancel = useCallback(() => {
+    if (multiStepState.overallStatus !== 'running') return;
+
+    abortControllerRef.current?.abort();
+    // Clean up all active SSE connections
+    sseCleanupMapRef.current.forEach((cleanup) => cleanup());
+    sseCleanupMapRef.current.clear();
+
+    // Mark any pending steps as cancelled
+    for (let i = 0; i < stepStatesRef.current.length; i++) {
+      if (stepStatesRef.current[i]?.status === 'pending') {
+        stepStatesRef.current[i] = { status: 'cancelled' };
+      }
+    }
+
+    // Clear eager results
+    eagerResultsRef.current.clear();
+
+    const { key, message, steps, onCancelled } = config;
+    const cancelledMessage = onCancelled?.message ?? message;
+    const currentStepDef = steps[multiStepState.currentStep];
+    const cancelledActionButton = currentStepDef?.actionButtons?.cancelled;
+
+    upsertNotification({
+      key,
+      message: cancelledMessage,
+      backgroundTask: { status: 'rejected' },
+      description: cancelledMessage,
+      open: true,
+      duration: CLOSING_DURATION,
+      multiStep: buildMultiStepData(
+        steps,
+        stepStatesRef.current,
+        multiStepState.currentStep,
+        'cancelled',
+      ),
+      ...(cancelledActionButton
+        ? {
+            extraData: {
+              actionButton: cancelledActionButton,
+            },
+          }
+        : {}),
+    });
+
+    syncState('cancelled', multiStepState.currentStep);
+  }, [
+    multiStepState.overallStatus,
+    multiStepState.currentStep,
+    config,
+    upsertNotification,
+    syncState,
+  ]);
+
+  return {
+    start,
+    retry,
+    cancel,
+    state: multiStepState,
+  };
+}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -150,6 +150,7 @@
     "Refresh": "Aktualisierung",
     "RefreshModelInformation": "Modellinformationen aktualisieren",
     "Reset": "Zurücksetzen",
+    "Retry": "Wiederholen",
     "Save": "speichern",
     "SaveAndClose": "Speichern und schließen",
     "SaveChanges": "Änderungen speichern",
@@ -1436,13 +1437,18 @@
     "Version": "Ausführung"
   },
   "notification": {
+    "AllStepsCompleted": "Alle Schritte abgeschlossen",
     "AreYouSureToClearAllNotifications": "Sind Sie sicher, dass Sie alle Benachrichtigungen gelöscht haben?",
+    "Cancelled": "Abgebrochen",
     "ClearNotifications": "Klare Benachrichtigungen",
     "Initializing": "Initialisieren...",
     "NoNotification": "Keine Benachrichtigung.",
     "Notifications": "Benachrichtigungen",
     "SeeDetail": "Details anzeigen",
     "SeeSummary": "Details ausblenden",
+    "Step": "Schritt",
+    "StepFailed": "Schritt fehlgeschlagen",
+    "StepProgress": "Schritt {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Erfolgreich aktualisiert",
     "Visit": "Besuch"
   },

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -150,6 +150,7 @@
     "Refresh": "Φρεσκάρω",
     "RefreshModelInformation": "Ανανέωση πληροφοριών μοντέλου",
     "Reset": "Επαναφορά",
+    "Retry": "Επανάληψη",
     "Save": "Σώσει",
     "SaveAndClose": "Αποθήκευσε και κλείσε",
     "SaveChanges": "Αποθήκευσε τις αλλαγές",
@@ -1434,13 +1435,18 @@
     "Version": "Εκδοχή"
   },
   "notification": {
+    "AllStepsCompleted": "Όλα τα βήματα ολοκληρώθηκαν",
     "AreYouSureToClearAllNotifications": "Είστε βέβαιοι ότι θα διαγράψετε όλες τις ειδοποιήσεις;",
+    "Cancelled": "Ακυρώθηκε",
     "ClearNotifications": "Εκκαθάριση ειδοποιήσεων",
     "Initializing": "Αρχικοποίηση ...",
     "NoNotification": "Καμία ειδοποίηση.",
     "Notifications": "Ειδοποιήσεις",
     "SeeDetail": "Εμφάνιση λεπτομερειών",
     "SeeSummary": "Απόκρυψη λεπτομερειών",
+    "Step": "Βήμα",
+    "StepFailed": "Το βήμα απέτυχε",
+    "StepProgress": "Βήμα {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Ενημερώθηκε με επιτυχία",
     "Visit": "Επίσκεψη"
   },

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -150,6 +150,7 @@
     "Refresh": "Refresh",
     "RefreshModelInformation": "Refresh Model Information",
     "Reset": "Reset",
+    "Retry": "Retry",
     "Save": "Save",
     "SaveAndClose": "Save And Close",
     "SaveChanges": "Save Changes",
@@ -1435,13 +1436,18 @@
     "Version": "Version"
   },
   "notification": {
+    "AllStepsCompleted": "All steps completed",
     "AreYouSureToClearAllNotifications": "Are you sure to clear all notifications?",
+    "Cancelled": "Cancelled",
     "ClearNotifications": "Clear Notifications",
     "Initializing": "Initializing...",
     "NoNotification": "No Notification.",
     "Notifications": "Notifications",
     "SeeDetail": "See Details",
     "SeeSummary": "Hide Details",
+    "Step": "Step",
+    "StepFailed": "Step failed",
+    "StepProgress": "Step {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Successfully Updated",
     "Visit": "Visit"
   },

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -150,6 +150,7 @@
     "Refresh": "Actualizar",
     "RefreshModelInformation": "Actualizar información del modelo",
     "Reset": "Restablecer",
+    "Retry": "Reintentar",
     "Save": "Guardar",
     "SaveAndClose": "Guardar y cerrar",
     "SaveChanges": "Guardar cambios",
@@ -1434,13 +1435,18 @@
     "Version": "Versión"
   },
   "notification": {
+    "AllStepsCompleted": "Todos los pasos completados",
     "AreYouSureToClearAllNotifications": "¿Estás seguro de borrar todas las notificaciones?",
+    "Cancelled": "Cancelado",
     "ClearNotifications": "Borrar notificaciones",
     "Initializing": "Inicializando...",
     "NoNotification": "Sin notificación.",
     "Notifications": "Notificaciones",
     "SeeDetail": "Ver detalles",
     "SeeSummary": "Ocultar detalles",
+    "Step": "Paso",
+    "StepFailed": "Paso fallido",
+    "StepProgress": "Paso {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Actualizado con éxito",
     "Visit": "Visite"
   },

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -150,6 +150,7 @@
     "Refresh": "Päivitä",
     "RefreshModelInformation": "Päivitä mallin tiedot",
     "Reset": "Nollaa",
+    "Retry": "Yritä uudelleen",
     "Save": "Tallenna",
     "SaveAndClose": "Tallenna ja sulje",
     "SaveChanges": "Tallenna muutokset",
@@ -1434,13 +1435,18 @@
     "Version": "Versio"
   },
   "notification": {
+    "AllStepsCompleted": "Kaikki vaiheet suoritettu",
     "AreYouSureToClearAllNotifications": "Oletko varma, että tyhjennät kaikki ilmoitukset?",
+    "Cancelled": "Peruutettu",
     "ClearNotifications": "Tyhjennä ilmoitukset",
     "Initializing": "Aloitetaan...",
     "NoNotification": "Ei ilmoitusta.",
     "Notifications": "Ilmoitukset",
     "SeeDetail": "Näytä tiedot",
     "SeeSummary": "Piilota tiedot",
+    "Step": "Vaihe",
+    "StepFailed": "Vaihe epäonnistui",
+    "StepProgress": "Vaihe {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Päivitetty onnistuneesti",
     "Visit": "Käy osoitteessa"
   },

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -150,6 +150,7 @@
     "Refresh": "Rafraîchir",
     "RefreshModelInformation": "Actualiser les informations sur le modèle",
     "Reset": "Réinitialisation",
+    "Retry": "Réessayer",
     "Save": "Sauvegarder",
     "SaveAndClose": "Sauver et fermer",
     "SaveChanges": "Sauvegarder les modifications",
@@ -1434,13 +1435,18 @@
     "Version": "Version"
   },
   "notification": {
+    "AllStepsCompleted": "Toutes les étapes terminées",
     "AreYouSureToClearAllNotifications": "Êtes-vous sûr d'avoir effacé toutes les notifications ?",
+    "Cancelled": "Annulé",
     "ClearNotifications": "Effacer les notifications",
     "Initializing": "Initialisation...",
     "NoNotification": "Aucune notification.",
     "Notifications": "Notifications",
     "SeeDetail": "Voir les détails",
     "SeeSummary": "Masquer les détails",
+    "Step": "Étape",
+    "StepFailed": "Étape échouée",
+    "StepProgress": "Étape {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Mise à jour réussie",
     "Visit": "Visite"
   },

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -150,6 +150,7 @@
     "Refresh": "Segarkan",
     "RefreshModelInformation": "Menyegarkan Informasi Model",
     "Reset": "Atur Ulang",
+    "Retry": "Coba lagi",
     "Save": "Simpan",
     "SaveAndClose": "Simpan dan Tutup",
     "SaveChanges": "Simpan Perubahan",
@@ -1436,13 +1437,18 @@
     "Version": "Versi: kapan"
   },
   "notification": {
+    "AllStepsCompleted": "Semua langkah selesai",
     "AreYouSureToClearAllNotifications": "Apakah Anda yakin untuk menghapus semua notifikasi?",
+    "Cancelled": "Dibatalkan",
     "ClearNotifications": "Hapus Notifikasi",
     "Initializing": "Inisialisasi...",
     "NoNotification": "Tidak Ada Pemberitahuan.",
     "Notifications": "Pemberitahuan",
     "SeeDetail": "Lihat Detail",
     "SeeSummary": "Sembunyikan Detail",
+    "Step": "Langkah",
+    "StepFailed": "Langkah gagal",
+    "StepProgress": "Langkah {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Berhasil Diperbarui",
     "Visit": "Kunjungi"
   },

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -150,6 +150,7 @@
     "Refresh": "ricaricare",
     "RefreshModelInformation": "Aggiornare le informazioni sul modello",
     "Reset": "Reset",
+    "Retry": "Riprova",
     "Save": "Salva",
     "SaveAndClose": "Salva e chiudi",
     "SaveChanges": "Salvare le modifiche",
@@ -1434,13 +1435,18 @@
     "Version": "Versione"
   },
   "notification": {
+    "AllStepsCompleted": "Tutti i passaggi completati",
     "AreYouSureToClearAllNotifications": "Sei sicuro di cancellare tutte le notifiche?",
+    "Cancelled": "Annullato",
     "ClearNotifications": "Notifiche chiare",
     "Initializing": "Inizializzazione in corso...",
     "NoNotification": "Nessuna notifica.",
     "Notifications": "Notifiche",
     "SeeDetail": "Vedi dettagli",
     "SeeSummary": "Nascondi dettagli",
+    "Step": "Passaggio",
+    "StepFailed": "Passaggio fallito",
+    "StepProgress": "Passaggio {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Aggiornato con successo",
     "Visit": "Visitare"
   },

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -150,6 +150,7 @@
     "Refresh": "更新",
     "RefreshModelInformation": "モデル情報の更新",
     "Reset": "初期化",
+    "Retry": "再試行",
     "Save": "セーブ",
     "SaveAndClose": "保存して閉じます",
     "SaveChanges": "変更内容を保存",
@@ -1436,13 +1437,18 @@
     "Version": "バージョン"
   },
   "notification": {
+    "AllStepsCompleted": "すべてのステップが完了しました",
     "AreYouSureToClearAllNotifications": "すべての通知をクリアしてもよろしいですか?",
+    "Cancelled": "キャンセルされました",
     "ClearNotifications": "通知をクリアする",
     "Initializing": "初期化中...",
     "NoNotification": "通知はありません。",
     "Notifications": "通知",
     "SeeDetail": "詳細を見る",
     "SeeSummary": "詳細を隠す",
+    "Step": "ステップ",
+    "StepFailed": "ステップが失敗しました",
+    "StepProgress": "ステップ {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "正常に更新されました",
     "Visit": "訪問"
   },

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -150,6 +150,7 @@
     "Refresh": "새로고침",
     "RefreshModelInformation": "모델 정보 새로고침",
     "Reset": "초기화",
+    "Retry": "재시도",
     "Save": "저장",
     "SaveAndClose": "저장 후 닫기",
     "SaveChanges": "변경사항 저장",
@@ -1437,13 +1438,18 @@
     "Version": "버전"
   },
   "notification": {
+    "AllStepsCompleted": "모든 단계 완료",
     "AreYouSureToClearAllNotifications": "모든 알림을 삭제하시겠습니까?",
+    "Cancelled": "취소됨",
     "ClearNotifications": "모든 알림 삭제",
     "Initializing": "초기화 중...",
     "NoNotification": "알림이 없습니다.",
     "Notifications": "알림",
     "SeeDetail": "상세보기",
     "SeeSummary": "접기",
+    "Step": "단계",
+    "StepFailed": "단계 실패",
+    "StepProgress": "{{current}}/{{total}} 단계: {{label}}",
     "SuccessfullyUpdated": "수정되었습니다.",
     "Visit": "방문"
   },

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -150,6 +150,7 @@
     "Refresh": "Сэргээх",
     "RefreshModelInformation": "Загварын мэдээллийг шинэчлэх",
     "Reset": "Дахин тохируулах",
+    "Retry": "Дахин оролдох",
     "Save": "Хадгалах",
     "SaveAndClose": "Хадгалах, хаах",
     "SaveChanges": "Өөрчлөлтүүдийг хадгалах",
@@ -1435,13 +1436,18 @@
     "Version": "Хувилбар"
   },
   "notification": {
+    "AllStepsCompleted": "Бүх алхам дууссан",
     "AreYouSureToClearAllNotifications": "Та бүх мэдэгдлийг арилгахдаа итгэлтэй байна уу?",
+    "Cancelled": "Цуцлагдсан",
     "ClearNotifications": "Мэдэгдлийг арилгах",
     "Initializing": "Эхлүүлж байна ...",
     "NoNotification": "Мэдэгдэл байхгүй.",
     "Notifications": "Мэдэгдэл",
     "SeeDetail": "Дэлгэрэнгүйг үзэх",
     "SeeSummary": "Дэлгэрэнгүйг нуух",
+    "Step": "Алхам",
+    "StepFailed": "Алхам амжилтгүй",
+    "StepProgress": "Алхам {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Амжилттай шинэчлэгдсэн",
     "Visit": "Айлчлах"
   },

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -150,6 +150,7 @@
     "Refresh": "Segarkan",
     "RefreshModelInformation": "Refresh Model Maklumat",
     "Reset": "Tetapkan semula",
+    "Retry": "Cuba semula",
     "Save": "Jimat",
     "SaveAndClose": "Simpan dan tutup",
     "SaveChanges": "Simpan Perubahan",
@@ -1434,13 +1435,18 @@
     "Version": "Versi"
   },
   "notification": {
+    "AllStepsCompleted": "Semua langkah selesai",
     "AreYouSureToClearAllNotifications": "Adakah anda pasti mengosongkan semua pemberitahuan?",
+    "Cancelled": "Dibatalkan",
     "ClearNotifications": "Kosongkan Pemberitahuan",
     "Initializing": "Memulakan ...",
     "NoNotification": "Tiada Pemberitahuan.",
     "Notifications": "Pemberitahuan",
     "SeeDetail": "Lihat Perincian",
     "SeeSummary": "Sembunyikan Perincian",
+    "Step": "Langkah",
+    "StepFailed": "Langkah gagal",
+    "StepProgress": "Langkah {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Berjaya Dikemas kini",
     "Visit": "Lawati"
   },

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -150,6 +150,7 @@
     "Refresh": "Odświeżać",
     "RefreshModelInformation": "Odświeżanie informacji o modelu",
     "Reset": "Reset",
+    "Retry": "Ponów",
     "Save": "Zapisać",
     "SaveAndClose": "Zapisz i zamknij",
     "SaveChanges": "Zapisz zmiany",
@@ -1434,13 +1435,18 @@
     "Version": "Wersja"
   },
   "notification": {
+    "AllStepsCompleted": "Wszystkie kroki zakończone",
     "AreYouSureToClearAllNotifications": "Czy na pewno wyczyścić wszystkie powiadomienia?",
+    "Cancelled": "Anulowano",
     "ClearNotifications": "Wyczyść powiadomienia",
     "Initializing": "Inicjowanie...",
     "NoNotification": "Brak powiadomienia.",
     "Notifications": "Powiadomienia",
     "SeeDetail": "Zobacz szczegóły",
     "SeeSummary": "Ukryj szczegóły",
+    "Step": "Krok",
+    "StepFailed": "Krok nie powiódł się",
+    "StepProgress": "Krok {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Pomyślnie zaktualizowano",
     "Visit": "Wizyta"
   },

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -150,6 +150,7 @@
     "Refresh": "Atualizar",
     "RefreshModelInformation": "Atualizar informações sobre o modelo",
     "Reset": "Reiniciar",
+    "Retry": "Tentar novamente",
     "Save": "Salve ",
     "SaveAndClose": "Salvar e fechar",
     "SaveChanges": "Salvar alterações",
@@ -1434,13 +1435,18 @@
     "Version": "Versão"
   },
   "notification": {
+    "AllStepsCompleted": "Todas as etapas concluídas",
     "AreYouSureToClearAllNotifications": "Tem certeza de que deseja limpar todas as notificações?",
+    "Cancelled": "Cancelado",
     "ClearNotifications": "Limpar notificações",
     "Initializing": "Inicializando ...",
     "NoNotification": "Nenhuma notificação.",
     "Notifications": "Notificações",
     "SeeDetail": "Ver detalhes",
     "SeeSummary": "Ocultar detalhes",
+    "Step": "Etapa",
+    "StepFailed": "Etapa falhou",
+    "StepProgress": "Etapa {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Atualizado com sucesso",
     "Visit": "Visita"
   },

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -150,6 +150,7 @@
     "Refresh": "Atualizar",
     "RefreshModelInformation": "Atualizar informações sobre o modelo",
     "Reset": "Reiniciar",
+    "Retry": "Tentar novamente",
     "Save": "Salve ",
     "SaveAndClose": "Salvar e fechar",
     "SaveChanges": "Salvar alterações",
@@ -1436,13 +1437,18 @@
     "Version": "Versão"
   },
   "notification": {
+    "AllStepsCompleted": "Todas as etapas concluídas",
     "AreYouSureToClearAllNotifications": "Tem certeza de que deseja limpar todas as notificações?",
+    "Cancelled": "Cancelado",
     "ClearNotifications": "Limpar notificações",
     "Initializing": "Inicializando ...",
     "NoNotification": "Nenhuma notificação.",
     "Notifications": "Notificações",
     "SeeDetail": "Ver detalhes",
     "SeeSummary": "Ocultar detalhes",
+    "Step": "Etapa",
+    "StepFailed": "Etapa falhou",
+    "StepProgress": "Etapa {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Atualizado com sucesso",
     "Visit": "Visita"
   },

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -150,6 +150,7 @@
     "Refresh": "Обновить",
     "RefreshModelInformation": "Обновить информацию о модели",
     "Reset": "Перезагрузить",
+    "Retry": "Повторить",
     "Save": "Сохранить",
     "SaveAndClose": "Сохрани и закрой",
     "SaveChanges": "Сохранить изменения",
@@ -1434,13 +1435,18 @@
     "Version": "Версия"
   },
   "notification": {
+    "AllStepsCompleted": "Все шаги завершены",
     "AreYouSureToClearAllNotifications": "Вы уверены, что удалите все уведомления?",
+    "Cancelled": "Отменено",
     "ClearNotifications": "Очистить уведомления",
     "Initializing": "Инициализация ...",
     "NoNotification": "Нет уведомлений.",
     "Notifications": "Уведомления",
     "SeeDetail": "Подробнее",
     "SeeSummary": "Скрыть подробности",
+    "Step": "Шаг",
+    "StepFailed": "Шаг не выполнен",
+    "StepProgress": "Шаг {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Успешно обновлено",
     "Visit": "Посещение"
   },

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -150,6 +150,7 @@
     "Refresh": "รีเฟรช",
     "RefreshModelInformation": "รีเฟรชข้อมูลโมเดล",
     "Reset": "รีเซ็ต",
+    "Retry": "ลองใหม่",
     "Save": "บันทึก",
     "SaveAndClose": "บันทึกและปิด",
     "SaveChanges": "บันทึกการเปลี่ยนแปลง",
@@ -1436,13 +1437,18 @@
     "Version": "เวอร์ชัน"
   },
   "notification": {
+    "AllStepsCompleted": "ขั้นตอนทั้งหมดเสร็จสมบูรณ์",
     "AreYouSureToClearAllNotifications": "คุณแน่ใจหรือไม่ที่จะล้างการแจ้งเตือนทั้งหมด?",
+    "Cancelled": "ยกเลิกแล้ว",
     "ClearNotifications": "ล้างการแจ้งเตือน",
     "Initializing": "กำลังเริ่มต้น...",
     "NoNotification": "ไม่มีการแจ้งเตือน",
     "Notifications": "การแจ้งเตือน",
     "SeeDetail": "ดูรายละเอียด",
     "SeeSummary": "ซ่อนรายละเอียด",
+    "Step": "ขั้นตอน",
+    "StepFailed": "ขั้นตอนล้มเหลว",
+    "StepProgress": "ขั้นตอน {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "อัปเดตสำเร็จแล้ว",
     "Visit": "เยี่ยมชม"
   },

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -150,6 +150,7 @@
     "Refresh": "Yenile",
     "RefreshModelInformation": "Model Bilgilerini Yenile",
     "Reset": "Sıfırla",
+    "Retry": "Yeniden Dene",
     "Save": "Kayıt etmek",
     "SaveAndClose": "Kaydet ve kapat",
     "SaveChanges": "Değişiklikleri Kaydet",
@@ -1434,13 +1435,18 @@
     "Version": "Sürüm"
   },
   "notification": {
+    "AllStepsCompleted": "Tüm adımlar tamamlandı",
     "AreYouSureToClearAllNotifications": "Tüm bildirimleri temizlediğinizden emin misiniz?",
+    "Cancelled": "İptal edildi",
     "ClearNotifications": "Bildirimleri Temizle",
     "Initializing": "Başlatılıyor...",
     "NoNotification": "Bildirim yok.",
     "Notifications": "Bildirimler",
     "SeeDetail": "Ayrıntıları gör",
     "SeeSummary": "Ayrıntıları gizle",
+    "Step": "Adım",
+    "StepFailed": "Adım başarısız oldu",
+    "StepProgress": "Adım {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Başarıyla güncellendi",
     "Visit": "Ziyaret etmek"
   },

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -150,6 +150,7 @@
     "Refresh": "Làm tươi",
     "RefreshModelInformation": "Làm mới thông tin mô hình",
     "Reset": "Cài lại",
+    "Retry": "Thử lại",
     "Save": "Tiết kiệm",
     "SaveAndClose": "Lưu và đóng",
     "SaveChanges": "Lưu thay đổi",
@@ -1436,13 +1437,18 @@
     "Version": "Phiên bản"
   },
   "notification": {
+    "AllStepsCompleted": "Tất cả các bước đã hoàn thành",
     "AreYouSureToClearAllNotifications": "Bạn có chắc chắn xóa tất cả thông báo không?",
+    "Cancelled": "Đã hủy",
     "ClearNotifications": "Xóa thông báo",
     "Initializing": "Đang khởi tạo ...",
     "NoNotification": "Không có thông báo.",
     "Notifications": "Thông báo",
     "SeeDetail": "Xem chi tiết",
     "SeeSummary": "Ẩn chi tiết",
+    "Step": "Bước",
+    "StepFailed": "Bước thất bại",
+    "StepProgress": "Bước {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "Cập nhật thành công",
     "Visit": "Chuyến thăm"
   },

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -150,6 +150,7 @@
     "Refresh": "刷新",
     "RefreshModelInformation": "刷新机型信息",
     "Reset": "重置",
+    "Retry": "重试",
     "Save": "保存",
     "SaveAndClose": "保存并关闭",
     "SaveChanges": "保存更改",
@@ -1436,13 +1437,18 @@
     "Version": "版本"
   },
   "notification": {
+    "AllStepsCompleted": "所有步骤已完成",
     "AreYouSureToClearAllNotifications": "您确定清除所有通知吗？",
+    "Cancelled": "已取消",
     "ClearNotifications": "清除通知",
     "Initializing": "正在初始化...",
     "NoNotification": "无通知。",
     "Notifications": "通知",
     "SeeDetail": "查看详情",
     "SeeSummary": "隐藏详情",
+    "Step": "步骤",
+    "StepFailed": "步骤失败",
+    "StepProgress": "步骤 {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "成功更新",
     "Visit": "访问"
   },

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -150,6 +150,7 @@
     "Refresh": "刷新",
     "RefreshModelInformation": "刷新机型信息",
     "Reset": "重置",
+    "Retry": "重試",
     "Save": "保存",
     "SaveAndClose": "保存並關閉",
     "SaveChanges": "保存更改",
@@ -1438,13 +1439,18 @@
     "Version": "版本"
   },
   "notification": {
+    "AllStepsCompleted": "所有步驟已完成",
     "AreYouSureToClearAllNotifications": "您確定清除所有通知嗎？",
+    "Cancelled": "已取消",
     "ClearNotifications": "清除通知",
     "Initializing": "正在初始化...",
     "NoNotification": "無通知。",
     "Notifications": "通知",
     "SeeDetail": "查看詳情",
     "SeeSummary": "隱藏詳情",
+    "Step": "步驟",
+    "StepFailed": "步驟失敗",
+    "StepProgress": "步驟 {{current}}/{{total}}: {{label}}",
     "SuccessfullyUpdated": "成功更新",
     "Visit": "訪問"
   },


### PR DESCRIPTION
## Summary
- Implement `useMultiStepNotification` hook with sequential Promise and SSE step execution, eager execution (`dependsOn: false`), retry from failure, and cancellation support
- Add `BAIMultiStepNotificationItem` UI component for rendering multi-step progress in notifications
- Add i18n keys (`notification.StepProgress`, `AllStepsCompleted`, `StepFailed`, `Cancelled`, `button.Retry`) across all 21 locales
- Add unit tests for the hook covering sequential flow, retry, cancel, eager execution, SSE, and guard behaviors

Squash-merged from stacked PRs #6210, #6211, #6212, #6213, #6214, #6215, #6216, #6217, #6219.

## Test plan
- [ ] Verify unit tests pass: `cd react && pnpm test -- useMultiStepNotification`
- [ ] Verify lint/format/TypeScript pass: `bash scripts/verify.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)