### PR TITLE
feat(FR-2406): add Start Service action for model folders in VFolderNodeListPage

### DIFF
--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -10,6 +10,7 @@ import { useSuspendedBackendaiClient, useWebUINavigate } from '../hooks';
 import { useCurrentUserInfo } from '../hooks/backendai';
 import { useTanMutation } from '../hooks/reactQueryAlias';
 import { useSetBAINotification } from '../hooks/useBAINotification';
+import { useModelServiceLauncher } from '../hooks/useModelServiceLauncher';
 import { isDeletedCategory } from '../pages/VFolderNodeListPage';
 import EditableVFolderName from './EditableVFolderName';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
@@ -41,6 +42,7 @@ import {
   BAIConfirmModalWithInput,
   BAIVFolderDeleteButton,
   BAITag,
+  useSearchVFolderFiles,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import React, { useState } from 'react';
@@ -63,6 +65,112 @@ export const statusTagColor = {
 };
 
 export type VFolderNodeInList = NonNullable<VFolderNodesFragment$data[number]>;
+
+interface VFolderStartServiceButtonProps {
+  vfolder: VFolderNodeInList;
+}
+
+/**
+ * Button component for starting a model service from a model-type vfolder.
+ * Validates that model-definition.yaml and service-definition.toml exist
+ * before attempting to create the service.
+ */
+const VFolderStartServiceButton: React.FC<VFolderStartServiceButtonProps> = ({
+  vfolder,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { upsertNotification } = useSetBAINotification();
+  const {
+    mutationToCreateService,
+    createServiceNotificationMsg,
+    createServiceInput,
+  } = useModelServiceLauncher();
+
+  const vfolderId = toLocalId(vfolder.id ?? '');
+  const { files: folderFiles } = useSearchVFolderFiles(vfolderId);
+
+  const hasModelDefinition = _.some(
+    folderFiles?.items,
+    (file) =>
+      file?.name === 'model-definition.yaml' ||
+      file?.name === 'model-definition.yml',
+  );
+  const hasServiceDefinition = _.some(
+    folderFiles?.items,
+    (file) => file?.name === 'service-definition.toml',
+  );
+
+  const handleStartService = () => {
+    if (!hasModelDefinition) {
+      upsertNotification({
+        key: `vfolder-model-def-missing-${vfolder.id}`,
+        open: true,
+        message: t('modelService.StartService'),
+        description: t('modelService.ModelDefinitionRequired'),
+        type: 'error',
+        to: `/data?folder=${vfolderId}`,
+        toText: t('modelService.GoToFolder'),
+      });
+      return;
+    }
+
+    if (!hasServiceDefinition) {
+      upsertNotification({
+        key: `vfolder-service-def-missing-${vfolder.id}`,
+        open: true,
+        message: t('modelService.StartService'),
+        description: t('modelService.ServiceDefinitionRequired'),
+        type: 'warning',
+        to: `/serving/start?modelFolderID=${vfolderId}`,
+        toText: t('modelService.StartNewService'),
+      });
+      return;
+    }
+
+    const notificationKey = `start-service-${vfolder.id}-${Date.now()}`;
+    const serviceInput = createServiceInput(
+      vfolder.name ?? '',
+      vfolderId,
+      '',
+    );
+
+    mutationToCreateService.mutate(serviceInput, {
+      onSuccess: (result) => {
+        createServiceNotificationMsg(
+          result,
+          vfolder.name ?? '',
+          notificationKey,
+        );
+      },
+      onError: (error) => {
+        upsertNotification({
+          key: notificationKey,
+          open: true,
+          message: t('modelService.StartService'),
+          description:
+            (error as { message?: string })?.message ??
+            t('modelService.FailedToStartService'),
+          type: 'error',
+        });
+      },
+    });
+  };
+
+  return (
+    <Tooltip title={t('modelService.StartService')} placement="left">
+      <Button
+        size="small"
+        type="text"
+        loading={mutationToCreateService.isPending}
+        onClick={handleStartService}
+      >
+        {t('modelService.StartService')}
+      </Button>
+    </Tooltip>
+  );
+};
+
 interface VFolderNodesProps extends Omit<
   BAITableProps<VFolderNodeInList>,
   'dataSource' | 'columns'
@@ -215,12 +323,17 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
             title: t('data.folders.Control'),
             render: (__, vfolder) => {
               const isPipelineFolder = vfolder?.usage_mode === 'data';
+              const isModelFolder = vfolder?.usage_mode === 'model';
               const hasDeletePermission = _.includes(
                 vfolder?.permissions,
                 'delete_vfolder',
               );
               return (
                 <BAIFlex gap={'xs'}>
+                  {/* Start Service (model folders only) */}
+                  {isModelFolder && !isDeletedCategory(vfolder?.status) && (
+                    <VFolderStartServiceButton vfolder={vfolder} />
+                  )}
                   {/* Share */}
                   {!isDeletedCategory(vfolder?.status) && (
                     <Tooltip title={t('button.Share')} placement="left">

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1316,6 +1316,7 @@
     "GenerateNewToken": "Generate new token",
     "GenerateToken": "Generate Token",
     "GeneratedTokens": "Generated Tokens",
+    "GoToFolder": "Go to folder",
     "GoToServiceDetailPage": "Go to service detail page",
     "Image": "Image",
     "ModelDefinitionPath": "Model Definition File Path",


### PR DESCRIPTION
Resolves #6238(FR-2406)

## Summary

- Add `VFolderStartServiceButton` sub-component to `VFolderNodes` for model-type vfolders (`usage_mode == 'model'`)
- Validate that `model-definition.yaml` and `service-definition.toml` exist in the folder before creating a service
- Show appropriate error/warning notifications with navigation links when definition files are missing
- Use `useModelServiceLauncher` hook (extracted in FR-2404) to create the service via `POST /services`
- Show service creation progress via BAI notification with polling until active routes appear
- Add `modelService.GoToFolder` i18n key

## Flow

1. User clicks "Start Service" on a model-type folder row
2. `useSearchVFolderFiles` checks for `model-definition.yaml` and `service-definition.toml`
3. If `model-definition.yaml` is missing → error notification with link to folder explorer
4. If `service-definition.toml` is missing → warning notification with link to service launcher
5. If both files exist → create service via `POST /services` and show progress notification
6. On completion → notification links to `/chat?endpointId=...` or `/serving/:id`

## UI Placement

- "Start Service" button added to controls column for model-type folders only
- Hidden for folders in deleted category (trash bin)

## Changed Files

- `react/src/components/VFolderNodes.tsx` — added `VFolderStartServiceButton` sub-component and row action
- `resources/i18n/en.json` — added `modelService.GoToFolder` key

## Verification

- Pre-existing TypeScript errors in `VFolderNodeListPage.tsx` and `routes.tsx` are not introduced by this PR
- Prettier formatting passes
- No new ESLint errors introduced