### PR TITLE
feat(FR-2413): Filter model store list by cloneable vfolder with MOUNT_IN_SESSION permission

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2788,6 +2788,25 @@ type CreateDeploymentPayload
   deployment: ModelDeployment!
 }
 
+"""Added in UNRELEASED. Create deployment revision preset input."""
+input CreateDeploymentRevisionPresetInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Runtime variant ID."""
+  runtimeVariantId: UUID!
+
+  """Preset name."""
+  name: String!
+}
+
+"""Added in UNRELEASED. Create deployment revision preset payload."""
+type CreateDeploymentRevisionPresetPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """The created preset."""
+  preset: DeploymentRevisionPreset!
+}
+
 type CreateDomain
   @join__type(graph: GRAPHENE)
 {
@@ -2958,6 +2977,31 @@ type CreateKeypairResourcePolicyPayloadGQL
 {
   """Created keypair resource policy."""
   keypairResourcePolicy: KeypairResourcePolicyV2!
+}
+
+"""Added in UNRELEASED. Create model card payload."""
+type CreateModelCardPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """The created model card."""
+  modelCard: ModelCardV2!
+}
+
+"""Added in UNRELEASED. Create model card input."""
+input CreateModelCardV2Input
+  @join__type(graph: STRAWBERRY)
+{
+  """Model card name."""
+  name: String!
+
+  """VFolder ID."""
+  vfolderId: UUID!
+
+  """Project ID."""
+  projectId: UUID!
+
+  """Domain name."""
+  domainName: String!
 }
 
 """Added in 24.12.0."""
@@ -3257,6 +3301,65 @@ input CreateRoleInput
   name: String!
   description: String = null
   source: RoleSource! = CUSTOM
+}
+
+"""Added in UNRELEASED. Input for creating a runtime variant."""
+input CreateRuntimeVariantInput
+  @join__type(graph: STRAWBERRY)
+{
+  """
+  Unique short identifier for the runtime engine (e.g., 'vllm', 'sglang').
+  """
+  name: String!
+
+  """Human-readable description of the runtime engine."""
+  description: String = null
+}
+
+"""Added in UNRELEASED. Payload for runtime variant creation."""
+type CreateRuntimeVariantPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """The created runtime variant."""
+  runtimeVariant: RuntimeVariant!
+}
+
+"""Added in UNRELEASED. Create preset input."""
+input CreateRuntimeVariantPresetInput
+  @join__type(graph: STRAWBERRY)
+{
+  """The runtime variant this preset belongs to."""
+  runtimeVariantId: UUID!
+
+  """Human-readable name of the configurable parameter."""
+  name: String!
+
+  """Detailed explanation of what this parameter controls."""
+  description: String = null
+
+  """
+  How the value is applied: 'env' for environment variable, 'args' for command-line argument.
+  """
+  presetTarget: String!
+
+  """Data type for validation (e.g., 'str', 'int', 'float', 'bool')."""
+  valueType: String!
+
+  """The default value shown to users when creating a deployment."""
+  defaultValue: String = null
+
+  """
+  For 'env' target, the environment variable name; for 'args' target, the CLI flag name.
+  """
+  key: String!
+}
+
+"""Added in UNRELEASED. Create preset payload."""
+type CreateRuntimeVariantPresetPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """The created preset."""
+  preset: RuntimeVariantPreset!
 }
 
 type CreateScalingGroup
@@ -3657,6 +3760,14 @@ type DeleteDeploymentPayload
   id: ID!
 }
 
+"""Added in UNRELEASED. Delete deployment revision preset payload."""
+type DeleteDeploymentRevisionPresetPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """ID of the deleted preset."""
+  id: UUID!
+}
+
 """Instead of deleting the domain, just mark it as inactive."""
 type DeleteDomain
   @join__type(graph: GRAPHENE)
@@ -3741,6 +3852,14 @@ type DeleteKeypairResourcePolicyPayloadGQL
 {
   """Name of the deleted keypair resource policy."""
   name: String!
+}
+
+"""Added in UNRELEASED. Delete model card payload."""
+type DeleteModelCardPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """ID of the deleted model card."""
+  id: UUID!
 }
 
 """Added in 24.12.0."""
@@ -3892,6 +4011,22 @@ type DeleteRolePayload
   @join__type(graph: STRAWBERRY)
 {
   """ID of the deleted role"""
+  id: UUID!
+}
+
+"""Added in UNRELEASED. Payload for runtime variant deletion."""
+type DeleteRuntimeVariantPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """ID of the deleted runtime variant."""
+  id: UUID!
+}
+
+"""Added in UNRELEASED. Delete preset payload."""
+type DeleteRuntimeVariantPresetPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """ID of the deleted preset."""
   id: UUID!
 }
 
@@ -4108,6 +4243,132 @@ type DeploymentPolicy implements Node
   strategySpec: DeploymentStrategySpec!
   createdAt: DateTime!
   updatedAt: DateTime!
+}
+
+"""
+Added in UNRELEASED. A reusable deployment configuration template. Users select a preset when deploying a model to automatically populate resource allocation, execution settings, and runtime-specific parameters. Each preset is designed for a specific runtime variant and captures the full configuration needed to launch an inference service.
+"""
+type DeploymentRevisionPreset implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """The unique database identifier of this deployment preset."""
+  rowId: UUID!
+
+  """The runtime variant this preset is designed for (e.g., vLLM, SGLang)."""
+  runtimeVariantId: UUID!
+
+  """Display name of this deployment configuration template."""
+  name: String!
+
+  """Detailed explanation of when and why to use this preset configuration."""
+  description: String
+
+  """
+  Display ordering among presets of the same runtime variant, with lower values shown first.
+  """
+  rank: Int!
+
+  """
+  Cluster topology settings defining single-node or multi-node deployment.
+  """
+  cluster: PresetClusterSpec!
+
+  """Compute resource allocation including CPU, memory, and accelerators."""
+  resource: PresetResourceAllocation!
+
+  """
+  Container execution configuration including image, startup command, and environment.
+  """
+  execution: PresetExecutionSpec!
+
+  """
+  Parsed model definition specifying health checks, ports, and service configuration for the inference endpoint.
+  """
+  modelDefinition: ModelDefinition
+
+  """
+  List of runtime variant preset values applied when using this deployment preset to auto-configure runtime parameters.
+  """
+  presetValues: [DeploymentRevisionPresetValueEntry!]!
+
+  """Timestamp when this deployment preset was created."""
+  createdAt: DateTime!
+
+  """Timestamp of the last modification to this deployment preset."""
+  updatedAt: DateTime
+}
+
+"""Added in UNRELEASED. Paginated list of deployment revision presets."""
+type DeploymentRevisionPresetConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [DeploymentRevisionPresetEdge!]!
+  count: Int!
+}
+
+"""An edge in a connection."""
+type DeploymentRevisionPresetEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: DeploymentRevisionPreset!
+}
+
+"""Added in UNRELEASED. Filter for deployment revision presets."""
+input DeploymentRevisionPresetFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Name filter."""
+  name: StringFilter = null
+
+  """Variant ID filter."""
+  runtimeVariantId: UUID = null
+}
+
+"""
+Added in UNRELEASED. Order specification for deployment revision presets.
+"""
+input DeploymentRevisionPresetOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """Field to order by."""
+  field: DeploymentRevisionPresetOrderField!
+
+  """ASC or DESC."""
+  direction: String! = "ASC"
+}
+
+"""Added in UNRELEASED. Order fields for deployment revision presets."""
+enum DeploymentRevisionPresetOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  NAME @join__enumValue(graph: STRAWBERRY)
+  RANK @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in UNRELEASED. A mapping of a runtime variant preset to a specific value, used to auto-configure runtime parameters when this deployment preset is applied.
+"""
+type DeploymentRevisionPresetValueEntry
+  @join__type(graph: STRAWBERRY)
+{
+  """Runtime variant preset ID."""
+  presetId: UUID!
+
+  """Value for this preset."""
+  value: String!
 }
 
 """Added in 24.09.0. Scope for deployment scheduling history query"""
@@ -7293,6 +7554,131 @@ type ModelCardEdge
 }
 
 """
+Added in UNRELEASED. Represents a registered AI model with metadata extracted from model-definition.yaml. A model card links to a VFolder containing the actual model files and belongs to a MODEL_STORE type project for access control scoping.
+"""
+type ModelCardV2 implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """The unique database identifier of this model card."""
+  rowId: UUID!
+
+  """Display name of the registered model."""
+  name: String!
+
+  """
+  The VFolder that stores the actual model files, weights, and configuration.
+  """
+  vfolderId: UUID!
+
+  """
+  The domain this model card belongs to, used for access control scoping.
+  """
+  domainName: String!
+
+  """
+  The MODEL_STORE type project this model card is associated with for access control.
+  """
+  projectId: UUID!
+
+  """The user who registered this model card."""
+  creatorId: UUID!
+
+  """
+  Model metadata including authorship, classification, framework info, and licensing extracted from model-definition.yaml.
+  """
+  metadata: ModelCardV2Metadata!
+
+  """
+  README content from the model VFolder, typically containing usage instructions and model documentation.
+  """
+  readme: String
+
+  """Timestamp when this model card was registered."""
+  createdAt: DateTime!
+
+  """Timestamp of the last modification to this model card."""
+  updatedAt: DateTime
+}
+
+"""Added in UNRELEASED. Paginated list of model cards."""
+type ModelCardV2Connection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [ModelCardV2Edge!]!
+  count: Int!
+}
+
+"""An edge in a connection."""
+type ModelCardV2Edge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: ModelCardV2!
+}
+
+"""Added in UNRELEASED. Filter for model cards."""
+input ModelCardV2Filter
+  @join__type(graph: STRAWBERRY)
+{
+  """Name filter."""
+  name: StringFilter = null
+
+  """Domain filter."""
+  domainName: String = null
+
+  """Project filter."""
+  projectId: UUID = null
+}
+
+"""
+Added in UNRELEASED. Metadata extracted from the model-definition.yaml file in the model VFolder. Contains authorship, classification, and framework information used for discovery and compatibility checks.
+"""
+type ModelCardV2Metadata
+  @join__type(graph: STRAWBERRY)
+{
+  author: String
+  title: String
+  modelVersion: String
+  description: String
+  task: String
+  category: String
+  architecture: String
+  framework: [String!]!
+  label: [String!]!
+  license: String
+}
+
+"""Added in UNRELEASED. Order specification."""
+input ModelCardV2OrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """Field to order by."""
+  field: ModelCardV2OrderField!
+
+  """ASC or DESC."""
+  direction: String! = "ASC"
+}
+
+"""Added in UNRELEASED. Order fields for model cards."""
+enum ModelCardV2OrderField
+  @join__type(graph: STRAWBERRY)
+{
+  NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
 Added in UNRELEASED. Configuration for a single model in the model definition.
 """
 type ModelConfig
@@ -9089,6 +9475,11 @@ type Mutation
   adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayloadGQL! @join__field(graph: STRAWBERRY)
 
   """
+  Added in UNRELEASED. Unassign users from a project. RBAC validates project admin permission.
+  """
+  unassignUsersFromProjectV2(projectId: UUID!, input: UnassignUsersFromProjectInput!): UnassignUsersFromProjectPayload! @join__field(graph: STRAWBERRY)
+
+  """
   Added in 26.2.0. Create a new user (admin only). Requires superadmin privileges. Automatically creates a default keypair for the user
   """
   adminCreateUserV2(input: CreateUserV2Input!): CreateUserV2Payload! @join__field(graph: STRAWBERRY)
@@ -9266,6 +9657,48 @@ type Mutation
 
   """Added in UNRELEASED. Delete a resource preset (admin only)."""
   adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Create a new runtime variant (superadmin only)."""
+  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Update a runtime variant (superadmin only)."""
+  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Delete a runtime variant (superadmin only)."""
+  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Create a runtime variant preset (superadmin only).
+  """
+  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Update a runtime variant preset (superadmin only).
+  """
+  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """
+  Added in UNRELEASED. Delete a runtime variant preset (superadmin only).
+  """
+  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Create a deployment revision preset."""
+  createDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Update a deployment revision preset."""
+  updateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Delete a deployment revision preset."""
+  deleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Create a model card (admin only)."""
+  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Update a model card (admin only)."""
+  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayloadGQL! @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Delete a model card (admin only)."""
+  adminDeleteModelCardV2(id: UUID!): DeleteModelCardPayloadGQL! @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. Terminate sessions within a project scope."""
   terminateProjectSessionsV2(scope: ProjectSessionV2Scope!, sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload! @join__field(graph: STRAWBERRY)
@@ -9839,6 +10272,70 @@ type PresetAvailabilityV2
 
   """Whether this preset can be used for session creation."""
   available: Boolean!
+}
+
+"""
+Added in UNRELEASED. Cluster topology settings for the deployment, defining whether the inference workload runs on a single node or is distributed across multiple nodes.
+"""
+type PresetClusterSpec
+  @join__type(graph: STRAWBERRY)
+{
+  """Cluster mode."""
+  clusterMode: String!
+
+  """Cluster size."""
+  clusterSize: Int!
+}
+
+"""
+Added in UNRELEASED. Container execution configuration for the deployment, including the inference server image, startup commands, and environment variables.
+"""
+type PresetExecutionSpec
+  @join__type(graph: STRAWBERRY)
+{
+  """Container image reference."""
+  image: String
+
+  """Startup command."""
+  startupCommand: String
+
+  """Bootstrap script."""
+  bootstrapScript: String
+
+  """Environment variables."""
+  environ: [EnvironmentVariableEntry!]!
+}
+
+"""
+Added in UNRELEASED. Compute resource allocation for the deployment, specifying CPU, memory, and accelerator requirements along with additional resource options.
+"""
+type PresetResourceAllocation
+  @join__type(graph: STRAWBERRY)
+{
+  """Resource slot allocations."""
+  resourceSlots: [ResourceSlotEntry!]!
+
+  """Additional resource options."""
+  resourceOpts: [ResourceOptsEntry!]!
+}
+
+"""
+Added in UNRELEASED. Specifies how a runtime variant preset value is applied to the inference container, either as an environment variable or a command-line argument.
+"""
+type PresetTargetSpec
+  @join__type(graph: STRAWBERRY)
+{
+  """Target: env or args."""
+  presetTarget: String!
+
+  """Value type: str, int, float, bool."""
+  valueType: String!
+
+  """Default value."""
+  defaultValue: String
+
+  """Env key or args flag."""
+  key: String!
 }
 
 """
@@ -11695,6 +12192,30 @@ type Query
   """Added in UNRELEASED. Get a single resource preset by ID (admin only)."""
   adminResourcePresetV2(id: UUID!): ResourcePresetV2 @join__field(graph: STRAWBERRY)
 
+  """Added in UNRELEASED. Search runtime variants."""
+  runtimeVariants(filter: RuntimeVariantFilter = null, orderBy: [RuntimeVariantOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RuntimeVariantConnection @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Get a single runtime variant by ID."""
+  runtimeVariant(id: UUID!): RuntimeVariant @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Search runtime variant presets."""
+  runtimeVariantPresets(filter: RuntimeVariantPresetFilter = null, orderBy: [RuntimeVariantPresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RuntimeVariantPresetConnection @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Get a single runtime variant preset by ID."""
+  runtimeVariantPreset(id: UUID!): RuntimeVariantPreset @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Search deployment revision presets."""
+  deploymentRevisionPresets(filter: DeploymentRevisionPresetFilter = null, orderBy: [DeploymentRevisionPresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DeploymentRevisionPresetConnection @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Get a single deployment revision preset by ID."""
+  deploymentRevisionPreset(id: UUID!): DeploymentRevisionPreset @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Search model cards."""
+  modelCardsV2(filter: ModelCardV2Filter = null, orderBy: [ModelCardV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelCardV2Connection @join__field(graph: STRAWBERRY)
+
+  """Added in UNRELEASED. Get a single model card by ID."""
+  modelCardV2(id: UUID!): ModelCardV2 @join__field(graph: STRAWBERRY)
+
   """
   Added in UNRELEASED. Get my keypair resource allocation (current user).
   """
@@ -11725,7 +12246,7 @@ type Query
   checkPresetAvailabilityV2(input: CheckPresetAvailabilityV2Input!): CheckPresetAvailabilityPayloadV2! @join__field(graph: STRAWBERRY)
 
   """Added in UNRELEASED. List virtual folders within a specific project."""
-  projectVfolders(projectId: UUID!, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection! @join__field(graph: STRAWBERRY)
+  projectVfolders(projectId: UUID!, filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Search virtual folders accessible to the current user with pagination and filtering.
@@ -13358,12 +13879,189 @@ type RoutingList implements PaginatedList
   total_count: Int!
 }
 
+"""
+Added in UNRELEASED. Represents an inference runtime engine definition (e.g., vLLM, SGLang, NIM, TGI). Previously hardcoded as an enum, runtime variants are now managed as dynamic database entities to allow administrators to register and configure new inference runtimes without code changes.
+"""
+type RuntimeVariant implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """The unique database identifier of this runtime variant."""
+  rowId: UUID!
+
+  """
+  Unique short identifier for the runtime engine (e.g., 'vllm', 'sglang', 'nim', 'tgi').
+  """
+  name: String!
+
+  """
+  Human-readable description explaining the runtime engine and its typical use cases.
+  """
+  description: String
+
+  """Timestamp when this runtime variant was registered."""
+  createdAt: DateTime!
+
+  """Timestamp of the last modification to this runtime variant."""
+  updatedAt: DateTime
+}
+
+"""Added in UNRELEASED. Paginated list of runtime variants."""
+type RuntimeVariantConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [RuntimeVariantEdge!]!
+  count: Int!
+}
+
+"""An edge in a connection."""
+type RuntimeVariantEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: RuntimeVariant!
+}
+
+"""Added in UNRELEASED. Filter for runtime variants."""
+input RuntimeVariantFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Name filter."""
+  name: StringFilter = null
+}
+
 """Added in 24.03.5."""
 type RuntimeVariantInfo
   @join__type(graph: GRAPHENE)
 {
   name: String
   human_readable_name: String
+}
+
+"""Added in UNRELEASED. Order specification."""
+input RuntimeVariantOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """Field to order by."""
+  field: RuntimeVariantOrderField!
+
+  """ASC or DESC."""
+  direction: String! = "ASC"
+}
+
+"""Added in UNRELEASED. Order fields for runtime variants."""
+enum RuntimeVariantOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  NAME @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
+}
+
+"""
+Added in UNRELEASED. Defines a configurable parameter for a runtime variant. Each preset maps a user-facing setting (e.g., tensor parallelism, quantization) to either an environment variable or a command-line argument that is applied to the inference container.
+"""
+type RuntimeVariantPreset implements Node
+  @join__implements(graph: STRAWBERRY, interface: "Node")
+  @join__type(graph: STRAWBERRY)
+{
+  """The Globally Unique ID of this object"""
+  id: ID!
+
+  """The unique database identifier of this preset."""
+  rowId: UUID!
+
+  """The runtime variant this preset belongs to."""
+  runtimeVariantId: UUID!
+
+  """
+  Human-readable name of the configurable parameter (e.g., 'Tensor Parallel Size', 'Quantization').
+  """
+  name: String!
+
+  """
+  Detailed explanation of what this parameter controls and how it affects inference behavior.
+  """
+  description: String
+
+  """
+  Display ordering among presets of the same runtime variant, with lower values shown first.
+  """
+  rank: Int!
+
+  """
+  Specification defining how the user-provided value is applied to the inference container.
+  """
+  targetSpec: PresetTargetSpec!
+
+  """Timestamp when this preset was created."""
+  createdAt: DateTime!
+
+  """Timestamp of the last modification to this preset."""
+  updatedAt: DateTime
+}
+
+"""Added in UNRELEASED. Paginated list of runtime variant presets."""
+type RuntimeVariantPresetConnection
+  @join__type(graph: STRAWBERRY)
+{
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+
+  """Contains the nodes in this connection"""
+  edges: [RuntimeVariantPresetEdge!]!
+  count: Int!
+}
+
+"""An edge in a connection."""
+type RuntimeVariantPresetEdge
+  @join__type(graph: STRAWBERRY)
+{
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: RuntimeVariantPreset!
+}
+
+"""Added in UNRELEASED. Filter for presets."""
+input RuntimeVariantPresetFilter
+  @join__type(graph: STRAWBERRY)
+{
+  """Name filter."""
+  name: StringFilter = null
+
+  """Variant ID filter."""
+  runtimeVariantId: UUID = null
+}
+
+"""Added in UNRELEASED. Order specification."""
+input RuntimeVariantPresetOrderBy
+  @join__type(graph: STRAWBERRY)
+{
+  """Field to order by."""
+  field: RuntimeVariantPresetOrderField!
+
+  """ASC or DESC."""
+  direction: String! = "ASC"
+}
+
+"""Added in UNRELEASED. Order fields for runtime variant presets."""
+enum RuntimeVariantPresetOrderField
+  @join__type(graph: STRAWBERRY)
+{
+  NAME @join__enumValue(graph: STRAWBERRY)
+  RANK @join__enumValue(graph: STRAWBERRY)
+  CREATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
 type ScalingGroup
@@ -14491,6 +15189,38 @@ input TrafficStatusFilter
   equals: TrafficStatus = null
 }
 
+"""
+Added in UNRELEASED. Error information for a user that failed to be unassigned.
+"""
+type UnassignUserError
+  @join__type(graph: STRAWBERRY)
+{
+  """UUID of the user that failed to be unassigned."""
+  userId: UUID!
+
+  """Error message describing the failure reason."""
+  message: String!
+}
+
+"""Added in UNRELEASED. Input for unassigning users from a project."""
+input UnassignUsersFromProjectInput
+  @join__type(graph: STRAWBERRY)
+{
+  """List of user UUIDs to unassign from the project."""
+  userIds: [UUID!]!
+}
+
+"""Added in UNRELEASED. Payload for user unassignment from project."""
+type UnassignUsersFromProjectPayload
+  @join__type(graph: STRAWBERRY)
+{
+  """List of users that were unassigned from the project."""
+  unassignedUsers: [UserV2!]!
+
+  """List of errors for users that could not be unassigned."""
+  failed: [UnassignUserError!]!
+}
+
 type UnloadImage
   @join__type(graph: GRAPHENE)
 {
@@ -14748,6 +15478,31 @@ type UpdateDeploymentPolicyPayload
   deploymentPolicy: DeploymentPolicy!
 }
 
+"""Added in UNRELEASED. Update deployment revision preset input."""
+input UpdateDeploymentRevisionPresetInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Preset ID."""
+  id: UUID!
+
+  """New name."""
+  name: String = null
+
+  """New description."""
+  description: String = null
+
+  """New rank."""
+  rank: Int = null
+}
+
+"""Added in UNRELEASED. Update deployment revision preset payload."""
+type UpdateDeploymentRevisionPresetPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """The updated preset."""
+  preset: DeploymentRevisionPreset!
+}
+
 """
 Added in UNRELEASED. Input for updating domain information. All fields optional.
 """
@@ -14833,6 +15588,28 @@ type UpdateKeypairResourcePolicyPayloadGQL
 {
   """Updated keypair resource policy."""
   keypairResourcePolicy: KeypairResourcePolicyV2!
+}
+
+"""Added in UNRELEASED. Update model card payload."""
+type UpdateModelCardPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """The updated model card."""
+  modelCard: ModelCardV2!
+}
+
+"""Added in UNRELEASED. Update model card input."""
+input UpdateModelCardV2Input
+  @join__type(graph: STRAWBERRY)
+{
+  """Model card ID."""
+  id: UUID!
+
+  """New name."""
+  name: String = null
+
+  """New description."""
+  description: String = null
 }
 
 """
@@ -15171,6 +15948,65 @@ type UpdateRouteTrafficStatusPayload
 {
   """The updated route"""
   route: Route!
+}
+
+"""Added in UNRELEASED. Input for updating a runtime variant."""
+input UpdateRuntimeVariantInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Runtime variant ID."""
+  id: UUID!
+
+  """New name."""
+  name: String = null
+
+  """New description."""
+  description: String = null
+}
+
+"""Added in UNRELEASED. Payload for runtime variant update."""
+type UpdateRuntimeVariantPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """The updated runtime variant."""
+  runtimeVariant: RuntimeVariant!
+}
+
+"""Added in UNRELEASED. Update preset input."""
+input UpdateRuntimeVariantPresetInput
+  @join__type(graph: STRAWBERRY)
+{
+  """Preset ID."""
+  id: UUID!
+
+  """New name."""
+  name: String = null
+
+  """New description."""
+  description: String = null
+
+  """New rank."""
+  rank: Int = null
+
+  """New target."""
+  presetTarget: String = null
+
+  """New value type."""
+  valueType: String = null
+
+  """New default value."""
+  defaultValue: String = null
+
+  """New key."""
+  key: String = null
+}
+
+"""Added in UNRELEASED. Update preset payload."""
+type UpdateRuntimeVariantPresetPayloadGQL
+  @join__type(graph: STRAWBERRY)
+{
+  """The updated preset."""
+  preset: RuntimeVariantPreset!
 }
 
 """
@@ -16571,6 +17407,7 @@ input VFolderFilter
   host: StringFilter = null
   status: VFolderOperationStatusFilter = null
   usageMode: VFolderUsageModeFilter = null
+  cloneable: Boolean = null
   createdAt: DateTimeFilter = null
   AND: [VFolderFilter!] = null
   OR: [VFolderFilter!] = null

--- a/react/src/pages/ModelStoreListPage.tsx
+++ b/react/src/pages/ModelStoreListPage.tsx
@@ -7,6 +7,9 @@ import { ModelStoreListPageQuery } from '../__generated__/ModelStoreListPageQuer
 import ModelBrandIcon from '../components/ModelBrandIcon';
 import ModelCardModal from '../components/ModelCardModal';
 import TextHighlighter from '../components/TextHighlighter';
+import { useCurrentDomainValue, useSuspendedBackendaiClient } from '../hooks';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { useMergedAllowedStorageHostPermission } from '../hooks/useMergedAllowedStorageHostPermission';
 import { ReloadOutlined, SearchOutlined } from '@ant-design/icons';
 import {
   Alert,
@@ -40,6 +43,19 @@ const ModelStoreListPage: React.FC = () => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
 
+  const baiClient = useSuspendedBackendaiClient();
+  const currentDomain = useCurrentDomainValue();
+  const currentProject = useCurrentProjectValue();
+  if (!currentProject.id) {
+    throw new Error('Project ID is required for ModelStoreListPage');
+  }
+  const { unitedAllowedPermissionByVolume } =
+    useMergedAllowedStorageHostPermission(
+      currentDomain,
+      currentProject.id,
+      baiClient?._config?.accessKey,
+    );
+
   const [search, setSearch] = useState<string>();
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
   const [selectedTasks, setSelectedTasks] = useState<string[]>([]);
@@ -65,6 +81,10 @@ const ModelStoreListPage: React.FC = () => {
               label
               modified_at
               error_msg
+              vfolder_node {
+                cloneable
+                host
+              }
               ...ModelCardModalFragment
             }
           }
@@ -185,6 +205,18 @@ const ModelStoreListPage: React.FC = () => {
           model_cards?.edges
             ?.map((edge) => edge?.node)
             .filter((info) => {
+              // Filter by cloneable vfolder with MOUNT_IN_SESSION permission
+              if (!info?.vfolder_node?.cloneable) return false;
+              const host = info?.vfolder_node?.host;
+              if (
+                !host ||
+                !_.includes(
+                  unitedAllowedPermissionByVolume[host],
+                  'mount-in-session',
+                )
+              )
+                return false;
+
               let passSearchFilter = true;
               if (search) {
                 const searchLower = search.toLowerCase();


### PR DESCRIPTION
Resolves #6261 ([FR-2413](https://lablup.atlassian.net/browse/FR-2413))

## Summary
- Filter model store list to only show models with cloneable vfolders
- Filter by MOUNT_IN_SESSION storage host permission using `useMergedAllowedStorageHostPermission` hook
- Add `vfolder_node { cloneable, host }` to the ModelStoreListPage GraphQL query
- Throw error if `currentProject.id` is undefined

## Test plan
- [ ] Verify only cloneable model cards appear in the model store list
- [ ] Verify models on storage hosts without MOUNT_IN_SESSION permission are hidden
- [ ] Verify search and category/task/label filters still work correctly

[FR-2413]: https://lablup.atlassian.net/browse/FR-2413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ