### PR TITLE
fix(FR-2408): add missing BAINameActionCell component files

### DIFF
--- a/.specs/FR-2408-bai-name-action-cell/spec.md
+++ b/.specs/FR-2408-bai-name-action-cell/spec.md
@@ -1,0 +1,227 @@
+# BAINameActionCell — Reusable Table Cell Layout Component
+
+> **Status**: Implemented
+> **Date**: 2026-03-28
+> **Issue**: [FR-2408](https://lablup.atlassian.net/browse/FR-2408)
+> **Implemented**: PR [#6247](https://github.com/lablup/backend.ai-webui/pull/6247)
+
+## Overview
+
+A reusable table cell layout component that combines a title area (icon + text) with responsive action buttons. When the column is wide enough, all action buttons are visible; as the column narrows, actions collapse one-by-one into a "more" overflow menu. This standardizes the repeated pattern of title + hover action buttons seen in `VFolderNodes` and other table components.
+
+## Problem Statement
+
+Currently, table components like `VFolderNodes` implement the title + action buttons pattern manually:
+
+- Hover state management via `onCell` + `onMouseEnter/onMouseLeave` + `useState` (causes React re-renders)
+- Manual `Tooltip` wrapping for each action button
+- Manual `BAIFlex` layout for button alignment
+- No responsive overflow handling — action buttons overflow or get clipped when the column is narrow
+- Separate "controls" column required, wasting horizontal space
+
+This leads to code duplication, inconsistent UX, and no responsive behavior for action buttons.
+
+## User Stories
+
+- **As a developer**, I want a declarative component where I define actions as a config array (key, title, icon, onClick, type) and the component handles layout, tooltips, hover visibility, and responsive overflow automatically.
+- **As a developer**, I want the title area to support navigation via `to` (React Router) or `onTitleClick`, with automatic ellipsis when space is limited.
+- **As a user**, I want to see action buttons when I hover over a table row, without them taking up space when I'm not interacting.
+- **As a user**, when the column is narrow, I want a "more" button that shows all available actions in a dropdown menu with icons and labels.
+
+## Requirements
+
+### Must Have
+
+- [x] Reusable component (`BAINameActionCell`) placed in `packages/backend.ai-ui/src/components/Table/`
+- [x] Title area with optional icon, text content, and navigation support (`to` or `onTitleClick`)
+- [x] Title auto-ellipsis with tooltip on overflow (via `BAIText` / `BAILink`)
+- [x] Actions defined as a config array with: `key`, `title`, `icon`, `onClick`, `action` (async), `type` (default/danger), `disabled`, `disabledReason`
+- [x] CSS-only hover visibility (`opacity` + `pointer-events`) — no React state needed
+- [x] Keyboard accessibility via `:focus-within`
+- [x] ResizeObserver-based responsive overflow calculation with `requestAnimationFrame` debounce
+- [x] Actions collapse right-to-left into a "more" (`MoreOutlined`) dropdown menu
+- [x] Overflow menu shows all actions with icon + title (full discoverability)
+- [x] `showActions` prop: `'hover'` (default) or `'always'`
+- [x] `minVisibleActions` prop to guarantee minimum visible action count
+- [x] Danger-type actions styled with error colors in both button and menu form
+- [x] Disabled actions with `disabledReason` shown as tooltip
+- [x] Async `action` prop using `useTransition` for automatic loading state (mirrors `BAIButton.action`)
+- [x] Exported from `packages/backend.ai-ui/src/components/Table/index.ts`
+
+### Nice to Have
+
+- [ ] Integration example: migrate `VFolderNodes` name + controls columns into a single column using `BAINameActionCell`
+
+## Component API
+
+### BAINameActionCellAction
+
+```typescript
+interface BAINameActionCellAction {
+  key: string;                        // Unique key for React rendering
+  title: string;                      // Tooltip on buttons, text in menu
+  icon?: React.ReactNode;             // Icon for both button and menu
+  onClick?: () => void;               // Sync click handler
+  action?: () => Promise<void>;       // Async handler with auto-loading (useTransition)
+  type?: 'default' | 'danger';        // Visual style
+  disabled?: boolean;                 // Disable the action
+  disabledReason?: string;            // Tooltip when disabled
+}
+```
+
+### BAINameActionCellProps
+
+```typescript
+interface BAINameActionCellProps {
+  // Title area (left side)
+  icon?: React.ReactNode;             // Icon before title
+  title?: React.ReactNode;            // Title text or custom content
+  to?: LinkProps['to'];               // React Router navigation
+  onTitleClick?: (e: React.MouseEvent) => void;  // Title click handler
+
+  // Actions area (right side)
+  actions?: BAINameActionCellAction[]; // Action definitions
+
+  // Behavior
+  showActions?: 'hover' | 'always';   // Default: 'hover'
+  minVisibleActions?: number;          // Default: 0
+
+  // Styling
+  style?: React.CSSProperties;
+  className?: string;
+}
+```
+
+## Layout Structure
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  [icon]  Title text (ellipsis...)    [📝] [🔗] [🗑️] [...] │
+│  ├── titleArea (flex: 1) ──────┤  ├── actionsArea ────┤ │
+└─────────────────────────────────────────────────────────┘
+```
+
+- **titleArea**: `flex: 1, min-width: 0` — fills remaining space, ellipsis on overflow
+- **actionsArea**: `flex-shrink: 0` — fixed width, shown on hover
+
+## Behavior Details
+
+### Hover Visibility (CSS-only)
+
+- Default state: `opacity: 0` + `pointer-events: none`
+- On `:hover` or `:focus-within`: `opacity: 1` + `pointer-events: auto`
+- Transition: `opacity 0.15s ease`
+- No React state management — zero re-renders for hover
+
+### Responsive Overflow
+
+- `ResizeObserver` monitors container width
+- `requestAnimationFrame` debounces calculation to prevent infinite loops
+- Actions collapse right-to-left (last action overflows first)
+- When overflow occurs, a `MoreOutlined` button appears
+- More menu contains **all** actions (not just overflowed), ensuring full discoverability
+
+```
+Wide:     [Edit] [Share] [Copy] [Delete]
+Medium:   [Edit] [Share] [...]
+Narrow:   [Edit] [...]
+Minimum:  [...]
+```
+
+### Title Rendering
+
+| Props provided       | Renders as   | Behavior                        |
+|----------------------|--------------|----------------------------------|
+| `to`                 | `BAILink`    | React Router link + ellipsis     |
+| `onTitleClick`       | `BAILink`    | Clickable text + ellipsis        |
+| Neither              | `BAIText`    | Plain text + tooltip on overflow |
+
+### Action Rendering
+
+| Context         | Icon button                      | Overflow menu item              |
+|-----------------|----------------------------------|---------------------------------|
+| Normal          | `BAIButton type="text" size="small"` + Tooltip | Icon + title text        |
+| Danger          | `danger` prop on BAIButton       | `danger: true` on menu item     |
+| Disabled        | `disabled` + `disabledReason` tooltip | `disabled` on menu item    |
+| Async (`action`)| `BAIButton.action` (useTransition) | `startTransition` wrapper     |
+
+## Implementation Details
+
+### Key Dependencies
+
+| Component  | Source                              | Usage                           |
+|------------|-------------------------------------|---------------------------------|
+| `BAIText`  | `../BAIText`                        | Ellipsis with ResizeObserver    |
+| `BAILink`  | `../BAILink`                        | Navigation + ellipsis           |
+| `BAIButton`| `../BAIButton`                      | Action buttons (async support)  |
+| `Dropdown` | `antd`                              | Overflow menu                   |
+| `Tooltip`  | `antd`                              | Action button labels            |
+| `createStyles` | `antd-style`                    | CSS-in-JS (project convention)  |
+
+### Performance
+
+- CSS-only hover: zero React re-renders for show/hide
+- `ResizeObserver` callback debounced via `requestAnimationFrame`
+- Cleanup on unmount: `ro.disconnect()` + `cancelAnimationFrame(rafId)`
+- `visibleCount` reset when `actions` array length changes
+- `'use memo'` directive for React Compiler optimization
+
+### Accessibility
+
+- `:focus-within` ensures keyboard users can discover actions via Tab
+- `aria-label="More actions"` on the overflow button
+- antd `Dropdown` + `Menu` provides `role="menu"` and `role="menuitem"` automatically
+- Disabled actions communicate reason via tooltip
+
+## Storybook Stories
+
+| Story              | Description                                        |
+|--------------------|----------------------------------------------------|
+| Basic              | Icon + title + 4 actions (edit, share, copy, delete)|
+| WithNavigation     | `to` prop for React Router link                    |
+| AlwaysShowActions  | `showActions: 'always'`                            |
+| WithDisabledAction | Disabled action with `disabledReason`              |
+| LongTitle          | Narrow container (300px), ellipsis behavior         |
+| ResponsiveOverflow | Interactive slider to resize container              |
+| TitleOnly          | No actions, title only                             |
+| AsyncAction        | `action` prop with 2s delay, loading spinner        |
+
+## Usage Example
+
+```tsx
+// VFolderNodes — replacing separate name + controls columns
+{
+  key: 'name',
+  title: t('data.folders.Name'),
+  render: (_name, vfolder) => (
+    <BAINameActionCell
+      icon={<VFolderNodeIdenticon vfolderNodeIdenticonFrgmt={vfolder} />}
+      title={vfolder.name}
+      to={generateFolderPath(toLocalId(vfolder?.id))}
+      actions={[
+        {
+          key: 'share',
+          title: t('button.Share'),
+          icon: <BAIShareAltIcon />,
+          onClick: () => setInviteFolderId(toLocalId(vfolder?.id)),
+        },
+        {
+          key: 'delete',
+          title: t('data.folders.MoveToTrash'),
+          icon: <BAITrashBinIcon />,
+          type: 'danger',
+          onClick: () => handleDelete(vfolder),
+        },
+      ]}
+    />
+  ),
+}
+```
+
+## File Manifest
+
+| File | Action |
+|------|--------|
+| `packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx` | Created |
+| `packages/backend.ai-ui/src/components/Table/BAINameActionCell.stories.tsx` | Created |
+| `packages/backend.ai-ui/src/components/Table/index.ts` | Modified (export added) |

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.stories.tsx
@@ -1,0 +1,425 @@
+import { BAILocale } from '../../locale';
+import { BAIConfigProvider } from '../provider';
+import { BAIClient } from '../provider/BAIClientProvider';
+import BAINameActionCell from './BAINameActionCell';
+import type { BAINameActionCellAction } from './BAINameActionCell';
+import {
+  CopyOutlined,
+  DeleteOutlined,
+  EditOutlined,
+  FolderOutlined,
+  ShareAltOutlined,
+} from '@ant-design/icons';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import enUS from 'antd/locale/en_US';
+import koKR from 'antd/locale/ko_KR';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockClient = {} as BAIClient;
+const mockClientPromise = Promise.resolve(mockClient);
+const mockAnonymousClientFactory = () => mockClient;
+
+const locales = {
+  en: { lang: 'en', antdLocale: enUS },
+  ko: { lang: 'ko', antdLocale: koKR },
+} as const;
+
+const meta: Meta<typeof BAINameActionCell> = {
+  title: 'Table/BAINameActionCell',
+  component: BAINameActionCell,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+BAINameActionCell is a reusable table cell layout component that combines a title area (icon + text) with responsive action buttons.
+
+## Features
+
+- **Hover actions**: Action buttons appear on hover by default
+- **Responsive overflow**: Actions collapse into a "more" menu when the cell is too narrow
+- **Navigation support**: Title can be a link via \`to\` prop (React Router)
+- **Ellipsis**: Title auto-truncates with tooltip when space is limited
+- **Action types**: Supports default and danger action styles
+- **Async actions**: Supports \`action\` prop for automatic loading state
+        `,
+      },
+    },
+  },
+  argTypes: {
+    title: {
+      control: { type: 'text' },
+      description: 'Primary title text displayed in the cell.',
+      table: {
+        type: { summary: 'string | React.ReactNode' },
+        defaultValue: { summary: '-' },
+      },
+    },
+    to: {
+      control: { type: 'text' },
+      description:
+        'Optional React Router path. When set, the title is rendered as a link.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    actions: {
+      control: false,
+      description:
+        'List of action definitions rendered as buttons or in the overflow menu.',
+      table: {
+        type: { summary: 'BAINameActionCellAction[]' },
+        defaultValue: { summary: '[]' },
+      },
+    },
+    showActions: {
+      control: { type: 'inline-radio' },
+      description: 'When to show the actions area.',
+      table: {
+        type: { summary: "'hover' | 'always'" },
+        defaultValue: { summary: "'hover'" },
+      },
+    },
+    minVisibleActions: {
+      control: { type: 'number' },
+      description:
+        'Minimum number of actions to keep visible before collapsing into the "more" menu.',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '0' },
+      },
+    },
+    icon: {
+      control: false,
+      description: 'Optional icon rendered before the title.',
+      table: {
+        type: { summary: 'React.ReactNode' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      const locale = context.globals.locale || 'en';
+      const baiLocale: BAILocale =
+        locales[locale as keyof typeof locales] || locales.en;
+
+      return (
+        <MemoryRouter>
+          <BAIConfigProvider
+            locale={baiLocale}
+            clientPromise={mockClientPromise}
+            anonymousClientFactory={mockAnonymousClientFactory}
+          >
+            <Story />
+          </BAIConfigProvider>
+        </MemoryRouter>
+      );
+    },
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BAINameActionCell>;
+
+const sampleActions: BAINameActionCellAction[] = [
+  {
+    key: 'edit',
+    title: 'Edit',
+    icon: <EditOutlined />,
+    onClick: () => console.log('Edit clicked'),
+  },
+  {
+    key: 'share',
+    title: 'Share',
+    icon: <ShareAltOutlined />,
+    onClick: () => console.log('Share clicked'),
+  },
+  {
+    key: 'copy',
+    title: 'Copy',
+    icon: <CopyOutlined />,
+    onClick: () => console.log('Copy clicked'),
+  },
+  {
+    key: 'delete',
+    title: 'Delete',
+    icon: <DeleteOutlined />,
+    type: 'danger',
+    onClick: () => console.log('Delete clicked'),
+  },
+];
+
+export const Default: Story = {
+  name: 'Basic',
+  parameters: {
+    docs: {
+      description: {
+        story: 'Default cell with icon, title, and hover action buttons.',
+      },
+    },
+  },
+  args: {
+    icon: <FolderOutlined />,
+    title: 'My Project Folder',
+    actions: sampleActions,
+  },
+};
+
+export const WithNavigation: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Title rendered as a React Router link using the `to` prop.',
+      },
+    },
+  },
+  args: {
+    icon: <FolderOutlined />,
+    title: 'Navigable Folder',
+    to: '/folders/123',
+    actions: sampleActions.slice(0, 2),
+  },
+};
+
+export const AlwaysShowActions: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Actions are always visible, not just on hover.',
+      },
+    },
+  },
+  args: {
+    icon: <FolderOutlined />,
+    title: 'Always Visible Actions',
+    actions: sampleActions,
+    showActions: 'always',
+  },
+};
+
+export const WithDisabledAction: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Disabled actions show a reason tooltip and cannot be clicked.',
+      },
+    },
+  },
+  args: {
+    icon: <FolderOutlined />,
+    title: 'Has Disabled Action',
+    actions: [
+      ...sampleActions.slice(0, 2),
+      {
+        key: 'restore',
+        title: 'Restore',
+        icon: <CopyOutlined />,
+        disabled: true,
+        disabledReason: 'Cannot restore pipeline folders',
+      },
+    ],
+  },
+};
+
+export const LongTitle: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Long titles are truncated with an ellipsis tooltip.',
+      },
+    },
+  },
+  args: {
+    icon: <FolderOutlined />,
+    title:
+      'This is a very long folder name that should be truncated with ellipsis when the column is narrow',
+    actions: sampleActions,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 300 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const ResponsiveOverflow: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Drag the slider to see actions collapse into the overflow menu.',
+      },
+    },
+  },
+  render: () => {
+    const [width, setWidth] = React.useState(400);
+    return (
+      <div>
+        <div style={{ marginBottom: 16 }}>
+          <label>
+            Container width: {width}px
+            <input
+              type="range"
+              min={120}
+              max={600}
+              value={width}
+              onChange={(e) => setWidth(Number(e.target.value))}
+              style={{ marginLeft: 8, width: 200 }}
+            />
+          </label>
+        </div>
+        <div
+          style={{
+            width,
+            border: '1px solid #d9d9d9',
+            padding: '8px 12px',
+            borderRadius: 4,
+          }}
+        >
+          <BAINameActionCell
+            icon={<FolderOutlined />}
+            title="Resize to see overflow"
+            actions={sampleActions}
+            showActions="always"
+          />
+        </div>
+      </div>
+    );
+  },
+};
+
+export const ResponsiveOverflowWithLink: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Responsive overflow combined with a navigable title link.',
+      },
+    },
+  },
+  render: () => {
+    const [width, setWidth] = React.useState(400);
+    return (
+      <div>
+        <div style={{ marginBottom: 16 }}>
+          <label>
+            Container width: {width}px
+            <input
+              type="range"
+              min={120}
+              max={600}
+              value={width}
+              onChange={(e) => setWidth(Number(e.target.value))}
+              style={{ marginLeft: 8, width: 200 }}
+            />
+          </label>
+        </div>
+        <div
+          style={{
+            width,
+            border: '1px solid #d9d9d9',
+            padding: '8px 12px',
+            borderRadius: 4,
+          }}
+        >
+          <BAINameActionCell
+            icon={<FolderOutlined />}
+            title="This is a long navigable folder name for ellipsis testing"
+            to="/folders/123"
+            actions={sampleActions}
+            showActions="always"
+          />
+        </div>
+      </div>
+    );
+  },
+};
+
+export const MenuOnlyActions: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Actions with `showInMenu: "always"` are always placed in the dropdown menu.',
+      },
+    },
+  },
+  args: {
+    icon: <FolderOutlined />,
+    title: 'Some actions are menu-only',
+    actions: [
+      {
+        key: 'edit',
+        title: 'Edit',
+        icon: <EditOutlined />,
+        onClick: () => console.log('Edit clicked'),
+      },
+      {
+        key: 'share',
+        title: 'Share',
+        icon: <ShareAltOutlined />,
+        onClick: () => console.log('Share clicked'),
+      },
+      {
+        key: 'copy',
+        title: 'Copy',
+        icon: <CopyOutlined />,
+        showInMenu: 'always',
+        onClick: () => console.log('Copy clicked'),
+      },
+      {
+        key: 'delete',
+        title: 'Delete',
+        icon: <DeleteOutlined />,
+        type: 'danger',
+        showInMenu: 'always',
+        onClick: () => console.log('Delete clicked'),
+      },
+    ],
+    showActions: 'always',
+  },
+};
+
+export const TitleOnly: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Cell without any actions — only icon and title.',
+      },
+    },
+  },
+  args: {
+    icon: <FolderOutlined />,
+    title: 'No actions, title only',
+  },
+};
+
+export const AsyncAction: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Async action with automatic loading state via the `action` prop.',
+      },
+    },
+  },
+  args: {
+    icon: <FolderOutlined />,
+    title: 'With Async Action',
+    actions: [
+      {
+        key: 'deploy',
+        title: 'Deploy (takes 2s)',
+        icon: <CopyOutlined />,
+        action: () => new Promise((resolve) => setTimeout(resolve, 2000)),
+      },
+    ],
+    showActions: 'always',
+  },
+};

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
@@ -1,0 +1,375 @@
+import { useEventNotStable } from '../../hooks/useEventNotStable';
+import BAIButton from '../BAIButton';
+import BAILink from '../BAILink';
+import BAIText from '../BAIText';
+import { MoreOutlined } from '@ant-design/icons';
+import { Dropdown, theme, Tooltip } from 'antd';
+import type { MenuProps } from 'antd';
+import { createStyles } from 'antd-style';
+import React, { useEffect, useRef, useState, useTransition } from 'react';
+import type { LinkProps } from 'react-router-dom';
+
+export interface BAINameActionCellAction {
+  /** Unique key for React rendering and overflow tracking */
+  key: string;
+  /** Label shown as tooltip on icon buttons and as text in overflow menu */
+  title: string;
+  /** Icon rendered in both button and menu form */
+  icon?: React.ReactNode;
+  /** Click handler */
+  onClick?: () => void;
+  /** Async click handler with automatic loading state (mirrors BAIButton.action) */
+  action?: () => Promise<void>;
+  /**
+   * Visual style type:
+   * - 'default': colorInfo text on colorInfoBg background
+   * - 'danger': colorError text on colorErrorBg background
+   */
+  type?: 'default' | 'danger';
+  /** Whether the action is disabled */
+  disabled?: boolean;
+  /** Tooltip text when disabled */
+  disabledReason?: string;
+  /** Custom style override for the action button */
+  style?: React.CSSProperties;
+  /**
+   * Where to show the action:
+   * - 'auto': shown as button when space allows, otherwise in more menu (default)
+   * - 'always': always shown only in the more menu
+   */
+  showInMenu?: 'auto' | 'always';
+}
+
+export interface BAINameActionCellProps {
+  /** Icon displayed before the title text */
+  icon?: React.ReactNode;
+  /** Title text or custom content */
+  title?: React.ReactNode;
+  /** React Router path for making the title a link */
+  to?: LinkProps['to'];
+  /** Click handler for the title (used when `to` is not provided) */
+  onTitleClick?: (e: React.MouseEvent) => void;
+  /** Action definitions rendered as icon buttons, collapsing into overflow menu */
+  actions?: BAINameActionCellAction[];
+  /** When to show the actions area. Default: 'hover' */
+  showActions?: 'hover' | 'always';
+  /** Minimum number of action buttons to keep visible before overflow. Default: 0 */
+  minVisibleActions?: number;
+  style?: React.CSSProperties;
+  className?: string;
+}
+
+const useStyles = createStyles(({ css, token }) => ({
+  wrapper: css`
+    display: flex;
+    align-items: center;
+    gap: ${token.marginXS}px;
+    width: 100%;
+    min-width: 0;
+    overflow: hidden;
+    position: relative;
+  `,
+  titleArea: css`
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: ${token.marginXXS}px;
+    overflow: hidden;
+  `,
+  titleIcon: css`
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+  `,
+  actionsArea: css`
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  `,
+  actionsAreaHover: css`
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    max-width: 0;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+  `,
+  hoverWrapper: css`
+    &:hover .bai-name-action-cell-actions,
+    &:has(:focus-visible) .bai-name-action-cell-actions {
+      max-width: none;
+      overflow: visible;
+      opacity: 1;
+      pointer-events: auto;
+    }
+  `,
+  actionButtonDefault: css`
+    color: ${token.colorInfo};
+    background-color: transparent;
+    transition:
+      background-color 0.2s ease,
+      color 0.2s ease;
+    &:not(:disabled):hover {
+      color: ${token.colorInfo} !important;
+      background-color: ${token.colorInfoBg} !important;
+    }
+  `,
+  actionButtonDanger: css`
+    color: ${token.colorError};
+    background-color: transparent;
+    transition:
+      background-color 0.2s ease,
+      color 0.2s ease;
+    &:not(:disabled):hover {
+      color: ${token.colorError} !important;
+      background-color: ${token.colorErrorBg} !important;
+    }
+  `,
+  actionButtonDisabled: css`
+    color: ${token.colorTextDisabled};
+    background-color: ${token.colorBgContainerDisabled};
+  `,
+}));
+
+// Estimated width per action button (icon button small size)
+const ACTION_BUTTON_WIDTH = 24;
+const MORE_BUTTON_WIDTH = 24;
+const ACTIONS_GAP = 2;
+
+const BAINameActionCell: React.FC<BAINameActionCellProps> = ({
+  icon,
+  title,
+  to,
+  onTitleClick,
+  actions,
+  showActions = 'hover',
+  minVisibleActions = 0,
+  style,
+  className,
+}) => {
+  'use memo';
+  const { styles, cx } = useStyles();
+  const { token } = theme.useToken();
+  const [, startTransition] = useTransition();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const titleAreaRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState<number>(
+    actions?.length ?? 0,
+  );
+
+  // Split actions into button-candidates (auto) and menu-only (always)
+  const autoActions = actions?.filter((a) => a.showInMenu !== 'always') ?? [];
+  const menuOnlyActions =
+    actions?.filter((a) => a.showInMenu === 'always') ?? [];
+  const autoActionCount = autoActions.length;
+
+  // Reset visibleCount when auto actions change
+  useEffect(() => {
+    setVisibleCount(autoActionCount);
+  }, [autoActionCount]);
+
+  const calculateVisibleActions = useEventNotStable(
+    (containerWidth: number) => {
+      const titleIcon = titleAreaRef.current?.querySelector(
+        '.bai-name-action-cell-title-icon',
+      );
+      const titleIconWidth = titleIcon ? titleIcon.clientWidth : 0;
+      const minTitleReserve = titleIconWidth + token.marginXXS + 40;
+      // Account for the more button which is always shown when menuOnlyActions exist
+      const moreButtonReserve =
+        menuOnlyActions.length > 0 ? MORE_BUTTON_WIDTH + ACTIONS_GAP : 0;
+      const availableWidth =
+        (showActions === 'hover'
+          ? containerWidth
+          : containerWidth - minTitleReserve) - moreButtonReserve;
+
+      if (availableWidth <= 0) {
+        setVisibleCount(Math.max(0, minVisibleActions));
+        return;
+      }
+
+      const totalButtonsWidth = (width: number, count: number) =>
+        count * width + Math.max(0, count - 1) * ACTIONS_GAP;
+
+      if (
+        totalButtonsWidth(ACTION_BUTTON_WIDTH, autoActionCount) <=
+        availableWidth
+      ) {
+        setVisibleCount(autoActionCount);
+        return;
+      }
+
+      const widthForMoreButton =
+        menuOnlyActions.length > 0 ? 0 : MORE_BUTTON_WIDTH + ACTIONS_GAP;
+      const remainingWidth = availableWidth - widthForMoreButton;
+
+      let count = 0;
+      for (let i = 0; i < autoActionCount; i++) {
+        const neededWidth = totalButtonsWidth(ACTION_BUTTON_WIDTH, i + 1);
+        if (neededWidth <= remainingWidth) {
+          count = i + 1;
+        } else {
+          break;
+        }
+      }
+
+      setVisibleCount(Math.max(count, minVisibleActions));
+    },
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || autoActionCount === 0) return;
+
+    calculateVisibleActions(container.clientWidth);
+    let rafId: number;
+    const ro = new ResizeObserver((entries) => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        const width = entries[0]?.contentRect.width ?? container.clientWidth;
+        calculateVisibleActions(width);
+      });
+    });
+    ro.observe(container);
+    return () => {
+      ro.disconnect();
+      cancelAnimationFrame(rafId);
+    };
+  }, [autoActionCount, calculateVisibleActions]);
+
+  const hasOverflow = visibleCount < autoActionCount;
+  const visibleActions = autoActions.slice(0, visibleCount);
+
+  // More menu: overflowed auto actions + menu-only actions
+  const hasMoreMenu = hasOverflow || menuOnlyActions.length > 0;
+  const toMenuItem = (action: BAINameActionCellAction) => ({
+    key: action.key,
+    label: action.title,
+    icon: action.icon,
+    danger: action.type === 'danger',
+    disabled: action.disabled,
+    onClick: () => {
+      action.onClick?.();
+      if (action.action) {
+        startTransition(async () => {
+          await action.action!();
+        });
+      }
+    },
+  });
+  const menuItems: MenuProps['items'] = [
+    ...autoActions.slice(visibleCount).map(toMenuItem),
+    ...(hasOverflow && menuOnlyActions.length > 0
+      ? [{ type: 'divider' as const }]
+      : []),
+    ...menuOnlyActions.map(toMenuItem),
+  ];
+
+  const renderTitle = () => {
+    if (to) {
+      return (
+        <BAILink
+          to={to}
+          type="hover"
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            display: 'block',
+            minWidth: 0,
+          }}
+        >
+          {title}
+        </BAILink>
+      );
+    }
+    if (onTitleClick) {
+      return (
+        <BAILink type="hover" onClick={onTitleClick} ellipsis>
+          {title}
+        </BAILink>
+      );
+    }
+    return (
+      <BAIText ellipsis={{ tooltip: true }} style={{ flex: 1, minWidth: 0 }}>
+        {title}
+      </BAIText>
+    );
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={cx(
+        styles.wrapper,
+        showActions === 'hover' && styles.hoverWrapper,
+        className,
+      )}
+      style={style}
+    >
+      <div ref={titleAreaRef} className={styles.titleArea}>
+        {icon && (
+          <span
+            className={cx(styles.titleIcon, 'bai-name-action-cell-title-icon')}
+          >
+            {icon}
+          </span>
+        )}
+        {renderTitle()}
+      </div>
+      {(autoActionCount > 0 || menuOnlyActions.length > 0) && (
+        <div
+          className={cx(
+            showActions === 'hover'
+              ? styles.actionsAreaHover
+              : styles.actionsArea,
+            'bai-name-action-cell-actions',
+          )}
+        >
+          {visibleActions.map((action) => {
+            const buttonClassName = action.disabled
+              ? styles.actionButtonDisabled
+              : action.type === 'danger'
+                ? styles.actionButtonDanger
+                : styles.actionButtonDefault;
+
+            return (
+              <Tooltip
+                key={action.key}
+                title={action.disabled ? action.disabledReason : action.title}
+              >
+                <BAIButton
+                  type="text"
+                  size="small"
+                  icon={action.icon}
+                  disabled={action.disabled}
+                  className={buttonClassName}
+                  style={action.style}
+                  onClick={action.onClick}
+                  action={action.action}
+                />
+              </Tooltip>
+            );
+          })}
+          {hasMoreMenu && (
+            <Dropdown menu={{ items: menuItems }} trigger={['click']}>
+              <BAIButton
+                type="text"
+                size="small"
+                icon={<MoreOutlined />}
+                aria-label="More actions"
+              />
+            </Dropdown>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BAINameActionCell;

--- a/packages/backend.ai-ui/src/components/Table/index.ts
+++ b/packages/backend.ai-ui/src/components/Table/index.ts
@@ -1,4 +1,6 @@
 export { default as BAITable } from './BAITable';
+export { default as BAINameActionCell } from './BAINameActionCell';
+export type { BAINameActionCellAction } from './BAINameActionCell';
 export type {
   BAITableProps,
   BAIColumnType,


### PR DESCRIPTION
## Summary
- BAINameActionCell component, stories, and Table/index.ts export were lost during stacked PR squash-merge process
- VFolderNodes already imports and uses this component (from #6249), causing compilation errors on main
- Restores the 3 files from PR #6247 that were not included in the squash merge of #6241

## Files Added/Modified
- `packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx` (new)
- `packages/backend.ai-ui/src/components/Table/BAINameActionCell.stories.tsx` (new)
- `packages/backend.ai-ui/src/components/Table/index.ts` (export added)
- `.specs/FR-2408-bai-name-action-cell/spec.md` (new)

## Test plan
- [ ] Verify `pnpm run build` succeeds without TypeScript errors
- [ ] Verify VFolderNodes renders correctly with BAINameActionCell

🤖 Generated with [Claude Code](https://claude.com/claude-code)