### PR TITLE
fix(FR-2412): display resource amounts for terminated sessions in session list table

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionSlotCell.tsx
@@ -45,9 +45,13 @@ const SessionSlotCell: React.FC<OccupiedSlotViewProps> = ({
 
   const { liveStat } = useSessionLiveStat(session);
 
+  const parsedOccupiedSlots = JSON.parse(session.occupied_slots || '{}');
   const occupiedSlots: {
     [key in ResourceSlotName]?: string;
-  } = JSON.parse(session.occupied_slots || '{}');
+  } =
+    Object.keys(parsedOccupiedSlots).length > 0
+      ? parsedOccupiedSlots
+      : JSON.parse(session.requested_slots || '{}');
 
   if (type === 'cpu') {
     const CPUOccupiedSlot = parseFloat(occupiedSlots.cpu ?? '1');


### PR DESCRIPTION
Resolves #6260 (FR-2412)

## Summary

Fix terminated sessions showing `-` for resource amounts (CPU, RAM, GPU) in the session list table, while the detail panel displays them correctly.

## Root Cause

`SessionSlotCell.tsx` reads from `occupied_slots` to display resource amounts. For terminated sessions, the backend returns `occupied_slots` as `"{}"` (empty JSON object string, not `null`). Since `"{}"` is truthy, the simple `||` fallback to `requested_slots` does not trigger. `JSON.parse("{}")` returns `{}`, so all resource columns render `-`.

The detail panel (`SessionDetailContent.tsx`) uses `requested_slots` directly, which persists after termination.

## Fix

Parse `occupied_slots` first, then check if the result has any keys. If empty, fall back to `requested_slots`:

```typescript
const parsedOccupiedSlots = JSON.parse(session.occupied_slots || '{}' );
const occupiedSlots = Object.keys(parsedOccupiedSlots).length > 0
  ? parsedOccupiedSlots
  : JSON.parse(session.requested_slots || '{}' );
```

## Verification

Relay, Lint, Format, TypeScript - all pass (scripts/verify.sh)

Manually verified on live server (https://3398ac.public.isla-sorna.backend.ai):
- Before fix: All terminated sessions show `-` for CPU, Memory columns
- After fix: Terminated sessions correctly show resource amounts (e.g., CPU: 1, Memory: 1 GiB or 0.313 GiB)

## Test plan

- [x] Verified terminated sessions show CPU and Memory amounts in session list table
- [x] Verified active/running sessions still show occupied_slots correctly
- [ ] Verify AI Accelerator column shows GPU amounts for sessions that had GPU allocated