### PR TITLE
feat(FR-2411): apply BAINameActionCell to remaining table name columns

### DIFF
--- a/e2e/resource-policy/resource-policy.spec.ts
+++ b/e2e/resource-policy/resource-policy.spec.ts
@@ -8,6 +8,8 @@ async function cleanupPolicy(page: Page, policyName: string) {
   const row = page.getByRole('row').filter({ hasText: policyName });
   const isVisible = await row.isVisible({ timeout: 2000 }).catch(() => false);
   if (isVisible) {
+    // Hover over the name cell to reveal BAINameActionCell actions
+    await row.getByRole('cell').first().hover();
     await row.getByRole('button', { name: 'delete' }).click();
     await page.getByRole('button', { name: 'Delete', exact: true }).click();
     await expect(row).toBeHidden({ timeout: 10000 });
@@ -42,9 +44,6 @@ test.describe(
         ).toBeVisible();
         await expect(
           page.getByRole('columnheader', { name: 'Cluster Size' }),
-        ).toBeVisible();
-        await expect(
-          page.getByRole('columnheader', { name: 'Control' }),
         ).toBeVisible();
 
         // Verify default policy row exists
@@ -81,7 +80,7 @@ test.describe(
 
         // Verify new policy appears in the table
         await expect(
-          page.getByRole('cell', { name: KEYPAIR_POLICY_NAME, exact: true }),
+          page.getByRole('row').filter({ hasText: KEYPAIR_POLICY_NAME }),
         ).toBeVisible({ timeout: 10000 });
       });
 
@@ -89,11 +88,12 @@ test.describe(
         await loginAsAdmin(page, request);
         await navigateTo(page, 'resource-policy');
 
-        // Find the test policy row and click setting
+        // Find the test policy row, hover to reveal actions, and click setting
         const policyRow = page
           .getByRole('row')
           .filter({ hasText: KEYPAIR_POLICY_NAME });
         await expect(policyRow).toBeVisible();
+        await policyRow.getByRole('cell').first().hover();
         await policyRow.getByRole('button', { name: 'setting' }).click();
 
         // Verify Update dialog appears
@@ -131,10 +131,11 @@ test.describe(
           .filter({ hasText: KEYPAIR_POLICY_NAME });
         await expect(policyRow).toBeVisible();
 
-        // Click delete button
+        // Hover to reveal actions, then click delete button
+        await policyRow.getByRole('cell').first().hover();
         await policyRow.getByRole('button', { name: 'delete' }).click();
 
-        // Confirm deletion in popconfirm
+        // Confirm deletion in modal
         await page.getByRole('button', { name: 'Delete', exact: true }).click();
 
         // Verify the policy is removed
@@ -163,9 +164,6 @@ test.describe(
         ).toBeVisible();
         await expect(
           page.getByRole('columnheader', { name: 'Max Folder Count' }),
-        ).toBeVisible();
-        await expect(
-          page.getByRole('columnheader', { name: 'Control' }),
         ).toBeVisible();
 
         // Verify default policy row exists
@@ -215,7 +213,7 @@ test.describe(
 
         // Verify new policy appears
         await expect(
-          page.getByRole('cell', { name: USER_POLICY_NAME, exact: true }),
+          page.getByRole('row').filter({ hasText: USER_POLICY_NAME }),
         ).toBeVisible({ timeout: 10000 });
       });
 
@@ -231,9 +229,10 @@ test.describe(
           .getByRole('row')
           .filter({ hasText: USER_POLICY_NAME });
         await expect(policyRow).toBeVisible();
+        await policyRow.getByRole('cell').first().hover();
         await policyRow.getByRole('button', { name: 'delete' }).click();
 
-        // Confirm deletion in popconfirm
+        // Confirm deletion in modal
         await page.getByRole('button', { name: 'Delete', exact: true }).click();
 
         // Verify removal
@@ -262,9 +261,6 @@ test.describe(
         ).toBeVisible();
         await expect(
           page.getByRole('columnheader', { name: 'Max Folder Count' }),
-        ).toBeVisible();
-        await expect(
-          page.getByRole('columnheader', { name: 'Control' }),
         ).toBeVisible();
 
         // Verify default policy row
@@ -302,7 +298,7 @@ test.describe(
 
         // Verify new policy appears
         await expect(
-          page.getByRole('cell', { name: PROJECT_POLICY_NAME, exact: true }),
+          page.getByRole('row').filter({ hasText: PROJECT_POLICY_NAME }),
         ).toBeVisible({ timeout: 10000 });
       });
 
@@ -318,9 +314,10 @@ test.describe(
           .getByRole('row')
           .filter({ hasText: PROJECT_POLICY_NAME });
         await expect(policyRow).toBeVisible();
+        await policyRow.getByRole('cell').first().hover();
         await policyRow.getByRole('button', { name: 'delete' }).click();
 
-        // Confirm deletion in popconfirm
+        // Confirm deletion in modal
         await page.getByRole('button', { name: 'Delete', exact: true }).click();
 
         // Verify removal

--- a/e2e/serving/serving-deploy-lifecycle.spec.ts
+++ b/e2e/serving/serving-deploy-lifecycle.spec.ts
@@ -279,6 +279,8 @@ async function terminateService(
     return;
   }
 
+  // Hover over the name cell to reveal BAINameActionCell actions
+  await serviceRow.getByRole('cell').first().hover();
   const deleteButton = serviceRow
     .getByRole('button', { name: 'delete' })
     .first();

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
@@ -66,7 +66,6 @@ const useStyles = createStyles(({ css, token }) => ({
     gap: ${token.marginXS}px;
     width: 100%;
     min-width: 0;
-    overflow: hidden;
     position: relative;
   `,
   titleArea: css`
@@ -75,7 +74,6 @@ const useStyles = createStyles(({ css, token }) => ({
     display: flex;
     align-items: center;
     gap: ${token.marginXXS}px;
-    overflow: hidden;
   `,
   titleIcon: css`
     flex-shrink: 0;

--- a/react/src/components/ContainerRegistryList.tsx
+++ b/react/src/components/ContainerRegistryList.tsx
@@ -43,6 +43,7 @@ import {
   BAIFlex,
   BAIPropertyFilter,
   BAIModal,
+  BAINameActionCell,
   useBAILogger,
   useFetchKey,
   INITIAL_FETCH_KEY,
@@ -277,6 +278,41 @@ const ContainerRegistryList: React.FC<{
       title: t('registry.RegistryName'),
       dataIndex: 'registry_name',
       sorter: true,
+      fixed: 'left',
+      render: (name: string, record) => (
+        <BAINameActionCell
+          title={name}
+          showActions="always"
+          actions={[
+            {
+              key: 'edit',
+              title: t('button.Edit'),
+              icon: <SettingOutlined />,
+              onClick: () => {
+                setEditingRegistry(record);
+              },
+            },
+            {
+              key: 'delete',
+              title: t('button.Delete'),
+              icon: <DeleteOutlined />,
+              type: 'danger',
+              onClick: () => {
+                setDeletingRegistry(record);
+              },
+            },
+            {
+              key: 'rescan',
+              title: t('maintenance.RescanImages'),
+              icon: <SyncOutlined />,
+              onClick: () => {
+                record.registry_name &&
+                  rescanImage(record.registry_name, record.project);
+              },
+            },
+          ]}
+        />
+      ),
     },
     {
       key: 'url',
@@ -373,51 +409,6 @@ const ContainerRegistryList: React.FC<{
               });
             }}
           />
-        );
-      },
-    },
-    {
-      title: t('general.Control'),
-      fixed: 'right',
-      render(_value, record) {
-        return (
-          <BAIFlex>
-            <Tooltip title={t('button.Edit')}>
-              <Button
-                style={{
-                  color: token.colorInfo,
-                }}
-                type="text"
-                icon={<SettingOutlined />}
-                onClick={() => {
-                  setEditingRegistry(record);
-                }}
-              />
-            </Tooltip>
-            <Tooltip title={t('button.Delete')}>
-              <Button
-                danger
-                type="text"
-                icon={<DeleteOutlined />}
-                onClick={() => {
-                  setDeletingRegistry(record);
-                }}
-              />
-            </Tooltip>
-            <Tooltip title={t('maintenance.RescanImages')}>
-              <Button
-                type="text"
-                icon={
-                  <SyncOutlined
-                    onClick={() => {
-                      record.registry_name &&
-                        rescanImage(record.registry_name, record.project);
-                    }}
-                  />
-                }
-              />
-            </Tooltip>
-          </BAIFlex>
         );
       },
     },

--- a/react/src/components/EndpointList.tsx
+++ b/react/src/components/EndpointList.tsx
@@ -18,21 +18,20 @@ import {
   DeleteOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
-import { Button, Typography, theme, App, TablePaginationConfig } from 'antd';
+import { Typography, theme, App, TablePaginationConfig } from 'antd';
 import type { ColumnType } from 'antd/lib/table';
 import {
   filterOutEmpty,
   filterOutNullAndUndefined,
   BAITable,
   BAITableProps,
-  BAIFlex,
+  BAINameActionCell,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
-import { Link } from 'react-router-dom';
 
 type Endpoint = EndpointListFragment$data[number];
 
@@ -77,7 +76,6 @@ const EndpointList: React.FC<EndpointListProps> = ({
   const { message, modal } = App.useApp();
   const [currentUser] = useCurrentUserInfo();
   const baiClient = useSuspendedBackendaiClient();
-  const [optimisticDeletingId, setOptimisticDeletingId] = useState<string>();
   const webuiNavigate = useWebUINavigate();
 
   const endpoints = useFragment(
@@ -121,11 +119,75 @@ const EndpointList: React.FC<EndpointListProps> = ({
       dataIndex: 'name',
       fixed: 'left',
       render: (name, row) => (
-        <Link
+        <BAINameActionCell
+          title={name}
+          showActions="always"
           to={(isAdminMode ? '/admin-serving/' : '/serving/') + row.endpoint_id}
-        >
-          {name}
-        </Link>
+          actions={[
+            {
+              key: 'settings',
+              title: t('button.Settings'),
+              icon: <SettingOutlined />,
+              disabled:
+                isEndpointInDestroyingCategory(row) ||
+                (!isAdminMode &&
+                  !!row.created_user_email &&
+                  row.created_user_email !== currentUser.email),
+              onClick: () => {
+                webuiNavigate('/service/update/' + row.endpoint_id);
+              },
+            },
+            {
+              key: 'delete',
+              title: t('button.Delete'),
+              icon: <DeleteOutlined />,
+              type: 'danger',
+              disabled: isEndpointInDestroyingCategory(row),
+              onClick: () => {
+                modal.confirm({
+                  title: t('dialog.ask.DoYouWantToDeleteSomething', {
+                    name: row.name,
+                  }),
+                  content: t('dialog.warning.CannotBeUndone'),
+                  okText: t('button.Delete'),
+                  okButtonProps: {
+                    danger: true,
+                    type: 'primary',
+                  },
+                  onOk: () => {
+                    if (row.endpoint_id) {
+                      return new Promise<void>((resolve) => {
+                        terminateModelServiceMutation.mutate(row.endpoint_id!, {
+                          onSuccess: (res) => {
+                            onDeleted?.(row);
+                            if (res.success) {
+                              message.success(
+                                t('modelService.ServiceTerminated', {
+                                  name: row?.name,
+                                }),
+                              );
+                            } else {
+                              message.error(
+                                t('modelService.FailedToTerminateService'),
+                              );
+                            }
+                            resolve();
+                          },
+                          onError: () => {
+                            message.error(
+                              t('modelService.FailedToTerminateService'),
+                            );
+                            resolve();
+                          },
+                        });
+                      });
+                    }
+                  },
+                });
+              },
+            },
+          ]}
+        />
       ),
       sorter: true,
     },
@@ -156,99 +218,6 @@ const EndpointList: React.FC<EndpointListProps> = ({
         ) : (
           '-'
         ),
-    },
-    {
-      title: t('modelService.Controls'),
-      dataIndex: 'controls',
-      key: 'controls',
-      render: (_text, row) => (
-        <BAIFlex direction="row" align="stretch">
-          <Button
-            type="text"
-            icon={<SettingOutlined />}
-            style={
-              isEndpointInDestroyingCategory(row) ||
-              (!isAdminMode &&
-                !!row.created_user_email &&
-                row.created_user_email !== currentUser.email)
-                ? {
-                    color: token.colorTextDisabled,
-                  }
-                : {
-                    color: token.colorInfo,
-                  }
-            }
-            disabled={
-              isEndpointInDestroyingCategory(row) ||
-              (!isAdminMode &&
-                !!row.created_user_email &&
-                row.created_user_email !== currentUser.email)
-            }
-            onClick={() => {
-              webuiNavigate('/service/update/' + row.endpoint_id);
-            }}
-          />
-          <Button
-            type="text"
-            icon={
-              <DeleteOutlined
-                style={
-                  isEndpointInDestroyingCategory(row)
-                    ? undefined
-                    : {
-                        color: token.colorError,
-                      }
-                }
-              />
-            }
-            loading={
-              terminateModelServiceMutation.isPending &&
-              optimisticDeletingId === row.endpoint_id
-            }
-            disabled={isEndpointInDestroyingCategory(row)}
-            onClick={() => {
-              modal.confirm({
-                title: t('dialog.ask.DoYouWantToDeleteSomething', {
-                  name: row.name,
-                }),
-                content: t('dialog.warning.CannotBeUndone'),
-                okText: t('button.Delete'),
-                okButtonProps: {
-                  danger: true,
-                  type: 'primary',
-                },
-                onOk: () => {
-                  setOptimisticDeletingId(row?.endpoint_id || undefined);
-                  // FIXME: any better idea for handling result?
-                  row.endpoint_id &&
-                    terminateModelServiceMutation.mutate(row?.endpoint_id, {
-                      onSuccess: (res) => {
-                        onDeleted?.(row);
-                        // FIXME: temporally refer to mutate input to message
-                        if (res.success) {
-                          message.success(
-                            t('modelService.ServiceTerminated', {
-                              name: row?.name,
-                            }),
-                          );
-                        } else {
-                          message.error(
-                            t('modelService.FailedToTerminateService'),
-                          );
-                        }
-                      },
-                      onError: () => {
-                        message.error(
-                          t('modelService.FailedToTerminateService'),
-                        );
-                      },
-                    });
-                },
-              });
-            }}
-          />
-        </BAIFlex>
-      ),
     },
     {
       title: t('modelService.Status'),

--- a/react/src/components/FairShareItems/DomainFairShareTable.tsx
+++ b/react/src/components/FairShareItems/DomainFairShareTable.tsx
@@ -7,10 +7,9 @@ import DomainResourceGroupWarningIcon from './DomainResourceGroupWarningIcon';
 import { SettingOutlined } from '@ant-design/icons';
 import { Divider, theme, Typography } from 'antd';
 import {
-  BAIButton,
   BAIColumnsType,
   BAIFlex,
-  BAILink,
+  BAINameActionCell,
   BAIResourceNumberWithIcon,
   BAITable,
   BAITableProps,
@@ -18,7 +17,6 @@ import {
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
-import { ChevronRight } from 'lucide-react';
 import { parseAsStringLiteral, useQueryStates } from 'nuqs';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
@@ -125,33 +123,26 @@ const DomainFairShareTable: React.FC<DomainFairShareTableProps> = ({
       dataIndex: 'domainName',
       sorter: isEnableSorter('domainName'),
       render: (_name, record) => (
-        <BAIFlex gap="xxs" align="center">
-          <DomainResourceGroupWarningIcon domainFairShareFrgmt={record} />
-          <BAILink
-            icon={<ChevronRight />}
-            onClick={() =>
-              onClickDomainName?.(record?.domain?.basicInfo?.name || '')
-            }
-          >
-            {record?.domain?.basicInfo?.name || '-'}
-          </BAILink>
-        </BAIFlex>
-      ),
-    },
-    {
-      title: t('general.Control'),
-      key: 'control',
-      fixed: 'left',
-      render: (_text, record) => (
-        <BAIFlex direction="row" gap="xxs">
-          <BAIButton
-            type="text"
-            icon={<SettingOutlined style={{ color: token.colorInfo }} />}
-            onClick={() => {
-              onOpenWeightSetting?.(record);
-            }}
-          />
-        </BAIFlex>
+        <BAINameActionCell
+          icon={
+            <DomainResourceGroupWarningIcon domainFairShareFrgmt={record} />
+          }
+          title={record?.domain?.basicInfo?.name || '-'}
+          onTitleClick={() =>
+            onClickDomainName?.(record?.domain?.basicInfo?.name || '')
+          }
+          showActions="always"
+          actions={[
+            {
+              key: 'settings',
+              title: t('button.Settings'),
+              icon: <SettingOutlined />,
+              onClick: () => {
+                onOpenWeightSetting?.(record);
+              },
+            },
+          ]}
+        />
       ),
     },
     {

--- a/react/src/components/FairShareItems/ProjectFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ProjectFairShareTable.tsx
@@ -7,10 +7,9 @@ import ProjectResourceGroupWarningIcon from './ProjectResourceGroupWarningIcon';
 import { SettingOutlined } from '@ant-design/icons';
 import { Divider, theme, Typography } from 'antd';
 import {
-  BAIButton,
   BAIColumnsType,
   BAIFlex,
-  BAILink,
+  BAINameActionCell,
   BAIResourceNumberWithIcon,
   BAITable,
   BAITableProps,
@@ -18,7 +17,6 @@ import {
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
-import { ChevronRight } from 'lucide-react';
 import { parseAsStringLiteral, useQueryStates } from 'nuqs';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
@@ -121,31 +119,24 @@ const ProjectFairShareTable: React.FC<ProjectFairShareTableProps> = ({
       dataIndex: 'projectName',
       sorter: isEnableSorter('projectName'),
       render: (_name, record) => (
-        <BAIFlex gap="xxs" align="center">
-          <ProjectResourceGroupWarningIcon projectFairShareFrgmt={record} />
-          <BAILink
-            icon={<ChevronRight />}
-            onClick={() => onClickProjectName?.(record?.projectId)}
-          >
-            {record?.project?.basicInfo?.name}
-          </BAILink>
-        </BAIFlex>
-      ),
-    },
-    {
-      title: t('general.Control'),
-      key: 'control',
-      fixed: 'left',
-      render: (_text, record) => (
-        <BAIFlex direction="row" gap="xxs">
-          <BAIButton
-            type="text"
-            icon={<SettingOutlined style={{ color: token.colorInfo }} />}
-            onClick={() => {
-              onOpenWeightSetting?.(record);
-            }}
-          />
-        </BAIFlex>
+        <BAINameActionCell
+          icon={
+            <ProjectResourceGroupWarningIcon projectFairShareFrgmt={record} />
+          }
+          title={record?.project?.basicInfo?.name}
+          onTitleClick={() => onClickProjectName?.(record?.projectId)}
+          showActions="always"
+          actions={[
+            {
+              key: 'settings',
+              title: t('button.Settings'),
+              icon: <SettingOutlined />,
+              onClick: () => {
+                onOpenWeightSetting?.(record);
+              },
+            },
+          ]}
+        />
       ),
     },
     {

--- a/react/src/components/FairShareItems/ResourceGroupFairShareTable.tsx
+++ b/react/src/components/FairShareItems/ResourceGroupFairShareTable.tsx
@@ -5,11 +5,11 @@
 import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import ResourceGroupFairShareSettingModal from './ResourceGroupFairShareSettingModal';
 import { SettingOutlined } from '@ant-design/icons';
-import { Button, Divider, theme, Typography } from 'antd';
+import { Divider, theme, Typography } from 'antd';
 import { ColumnsType } from 'antd/es/table';
 import {
   BAIFlex,
-  BAILink,
+  BAINameActionCell,
   BAITable,
   BAITableProps,
   BAIUnmountAfterClose,
@@ -18,7 +18,6 @@ import {
   useResourceSlotsDetails,
 } from 'backend.ai-ui';
 import _ from 'lodash';
-import { ChevronRight } from 'lucide-react';
 import { parseAsString, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -120,29 +119,20 @@ const ResourceGroupFairShareTable: React.FC<
       fixed: 'left',
       dataIndex: 'name',
       sorter: isEnableSorter('name'),
-      render: (name) => (
-        <BAIFlex gap="xxs" align="center">
-          <BAILink
-            icon={<ChevronRight />}
-            onClick={() => onClickGroupName?.(name)}
-          >
-            {name}
-          </BAILink>
-        </BAIFlex>
-      ),
-    },
-    {
-      title: t('general.Control'),
-      key: 'control',
-      fixed: 'left',
-      render: (_text, record) => (
-        <BAIFlex direction="row" gap="xxs">
-          <Button
-            type="text"
-            icon={<SettingOutlined style={{ color: token.colorInfo }} />}
-            onClick={() => setSelectedResourceGroup(record)}
-          />
-        </BAIFlex>
+      render: (name, record) => (
+        <BAINameActionCell
+          title={name}
+          onTitleClick={() => onClickGroupName?.(name)}
+          showActions="always"
+          actions={[
+            {
+              key: 'settings',
+              title: t('button.Settings'),
+              icon: <SettingOutlined />,
+              onClick: () => setSelectedResourceGroup(record),
+            },
+          ]}
+        />
       ),
     },
     {

--- a/react/src/components/FairShareItems/UserFairShareTable.tsx
+++ b/react/src/components/FairShareItems/UserFairShareTable.tsx
@@ -6,9 +6,9 @@ import QuestionIconWithTooltip from '../QuestionIconWithTooltip';
 import { SettingOutlined } from '@ant-design/icons';
 import { Divider, theme, Typography } from 'antd';
 import {
-  BAIButton,
   BAIColumnsType,
   BAIFlex,
+  BAINameActionCell,
   BAIResourceNumberWithIcon,
   BAITable,
   BAITableProps,
@@ -117,7 +117,22 @@ const UserFairShareTable: React.FC<UserFairShareTableProps> = ({
       key: 'email',
       fixed: 'left',
       dataIndex: 'userEmail',
-      render: (_text, record) => record?.user?.basicInfo.email,
+      render: (_text, record) => (
+        <BAINameActionCell
+          title={record?.user?.basicInfo.email}
+          showActions="always"
+          actions={[
+            {
+              key: 'settings',
+              title: t('button.Settings'),
+              icon: <SettingOutlined />,
+              onClick: () => {
+                onOpenWeightSetting?.(record);
+              },
+            },
+          ]}
+        />
+      ),
       sorter: isEnableSorter('email'),
     },
     {
@@ -127,22 +142,6 @@ const UserFairShareTable: React.FC<UserFairShareTableProps> = ({
       dataIndex: 'userUsername',
       render: (_text, record) => record?.user?.basicInfo.username,
       sorter: isEnableSorter('username'),
-    },
-    {
-      title: t('general.Control'),
-      key: 'control',
-      fixed: 'left',
-      render: (_text, record) => (
-        <BAIFlex direction="row" gap="xxs">
-          <BAIButton
-            type="text"
-            icon={<SettingOutlined style={{ color: token.colorInfo }} />}
-            onClick={() => {
-              onOpenWeightSetting?.(record);
-            }}
-          />
-        </BAIFlex>
-      ),
     },
     {
       title: (

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -24,7 +24,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { App, Button, Dropdown, theme, Tooltip, Typography } from 'antd';
+import { App, Button, Dropdown, Tooltip, Typography } from 'antd';
 import { AnyObject } from 'antd/es/_util/type';
 import type { ColumnsType, ColumnType } from 'antd/es/table';
 import {
@@ -34,6 +34,7 @@ import {
   BAIFlex,
   BAIAllowedVfolderHostsWithPermission,
   BAIResourceNumberWithIcon,
+  BAINameActionCell,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { EllipsisIcon } from 'lucide-react';
@@ -50,7 +51,6 @@ interface KeypairResourcePolicyListProps {}
 const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
   props,
 ) => {
-  const { token } = theme.useToken();
   const { t } = useTranslation();
   const { message, modal } = App.useApp();
 
@@ -60,8 +60,6 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
   const [visibleColumnSettingModal, { toggle: toggleColumnSettingModal }] =
     useToggle();
   const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
-  const [inFlightResourcePolicyName, setInFlightResourcePolicyName] =
-    useState<string>();
   const [editingKeypairResourcePolicy, setEditingKeypairResourcePolicy] =
     useState<KeypairResourcePolicySettingModalFragment$key | null>();
   const [currentResourcePolicy, setCurrentResourcePolicy] =
@@ -99,15 +97,14 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
       },
     );
 
-  const [commitDelete, isInflightDelete] =
-    useMutation<KeypairResourcePolicyListMutation>(graphql`
-      mutation KeypairResourcePolicyListMutation($name: String!) {
-        delete_keypair_resource_policy(name: $name) {
-          ok
-          msg
-        }
+  const [commitDelete] = useMutation<KeypairResourcePolicyListMutation>(graphql`
+    mutation KeypairResourcePolicyListMutation($name: String!) {
+      delete_keypair_resource_policy(name: $name) {
+        ok
+        msg
       }
-    `);
+    }
+  `);
 
   const columns: ColumnsType<KeypairResourcePolicies> = filterOutEmpty([
     {
@@ -116,6 +113,102 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
       key: 'name',
       fixed: 'left',
       sorter: (a, b) => localeCompare(a?.name, b?.name),
+      render: (name: string, row: KeypairResourcePolicies) => (
+        <BAINameActionCell
+          title={name}
+          showActions="always"
+          actions={[
+            {
+              key: 'info',
+              title: t('button.Info'),
+              icon: <InfoCircleOutlined />,
+              onClick: () => {
+                startInfoModalOpenTransition(() => {
+                  setCurrentResourcePolicy(row || null);
+                });
+              },
+            },
+            {
+              key: 'settings',
+              title: t('button.Settings'),
+              icon: <SettingOutlined />,
+              onClick: () => {
+                setEditingKeypairResourcePolicy(row);
+              },
+            },
+            {
+              key: 'delete',
+              title: t('button.Delete'),
+              icon: <DeleteOutlined />,
+              type: 'danger',
+              onClick: () => {
+                modal.confirm({
+                  title: t('resourcePolicy.DeletePolicy'),
+                  content: (
+                    <BAIFlex direction="column" align="stretch">
+                      <BAIFlex gap={'xxs'}>
+                        <Typography.Text>
+                          {t('resourcePolicy.DeletePolicyDescription')}
+                        </Typography.Text>
+                        <Typography.Text strong>{row?.name}</Typography.Text>
+                      </BAIFlex>
+                      <br />
+                      <Typography.Text type="danger">
+                        {t('dialog.warning.CannotBeUndone')}
+                      </Typography.Text>
+                    </BAIFlex>
+                  ),
+                  okButtonProps: {
+                    danger: true,
+                  },
+                  okText: t('button.Delete'),
+                  onOk: () => {
+                    if (row?.name) {
+                      return new Promise<void>((resolve) => {
+                        commitDelete({
+                          variables: {
+                            name: row.name!,
+                          },
+                          onCompleted: (res, errors) => {
+                            if (!res?.delete_keypair_resource_policy?.ok) {
+                              message.error(
+                                res?.delete_keypair_resource_policy?.msg,
+                              );
+                              resolve();
+                              return;
+                            }
+                            if (errors && errors?.length > 0) {
+                              const errorMsgList = _.map(
+                                errors,
+                                (error) => error.message,
+                              );
+                              for (const error of errorMsgList) {
+                                message.error(error);
+                              }
+                            } else {
+                              startRefetchTransition(() =>
+                                updateKeypairResourcePolicyFetchKey(),
+                              );
+                              message.success(
+                                t('resourcePolicy.SuccessfullyDeleted'),
+                              );
+                            }
+                            resolve();
+                          },
+                          onError(err) {
+                            message.error(err?.message);
+                            resolve();
+                          },
+                        });
+                      });
+                    }
+                  },
+                });
+              },
+            },
+          ]}
+        />
+      ),
     },
     {
       title: t('resourcePolicy.ResourcePolicy'),
@@ -225,116 +318,6 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         ),
       render: (text) => (text ? text : '∞'),
     },
-    {
-      title: t('general.Control'),
-      key: 'control',
-      fixed: 'right',
-      render: (_text, row) => (
-        <BAIFlex direction="row" align="stretch">
-          <Button
-            type="text"
-            icon={<InfoCircleOutlined style={{ color: token.colorInfo }} />}
-            onClick={() => {
-              startInfoModalOpenTransition(() => {
-                setCurrentResourcePolicy(row || null);
-              });
-            }}
-          />
-          <Button
-            type="text"
-            icon={<SettingOutlined />}
-            style={{
-              color: token.colorInfo,
-            }}
-            onClick={() => {
-              setEditingKeypairResourcePolicy(row);
-            }}
-          />
-          <Button
-            type="text"
-            icon={
-              <DeleteOutlined
-                style={{
-                  color: token.colorError,
-                }}
-              />
-            }
-            loading={
-              isInflightDelete &&
-              inFlightResourcePolicyName ===
-                row?.name + keypairResourcePolicyFetchKey
-            }
-            disabled={
-              isInflightDelete &&
-              inFlightResourcePolicyName !==
-                row?.name + keypairResourcePolicyFetchKey
-            }
-            onClick={() => {
-              modal.confirm({
-                title: t('resourcePolicy.DeletePolicy'),
-                content: (
-                  <BAIFlex direction="column" align="stretch">
-                    <BAIFlex gap={'xxs'}>
-                      <Typography.Text>
-                        {t('resourcePolicy.DeletePolicyDescription')}
-                      </Typography.Text>
-                      <Typography.Text strong>{row?.name}</Typography.Text>
-                    </BAIFlex>
-                    <br />
-                    <Typography.Text type="danger">
-                      {t('dialog.warning.CannotBeUndone')}
-                    </Typography.Text>
-                  </BAIFlex>
-                ),
-                okButtonProps: {
-                  danger: true,
-                },
-                okText: t('button.Delete'),
-                onOk: () => {
-                  if (row?.name) {
-                    setInFlightResourcePolicyName(
-                      row.name + keypairResourcePolicyFetchKey,
-                    );
-                    commitDelete({
-                      variables: {
-                        name: row.name,
-                      },
-                      onCompleted: (res, errors) => {
-                        if (!res?.delete_keypair_resource_policy?.ok) {
-                          message.error(
-                            res?.delete_keypair_resource_policy?.msg,
-                          );
-                          return;
-                        }
-                        if (errors && errors?.length > 0) {
-                          const errorMsgList = _.map(
-                            errors,
-                            (error) => error.message,
-                          );
-                          for (const error of errorMsgList) {
-                            message.error(error);
-                          }
-                        } else {
-                          startRefetchTransition(() =>
-                            updateKeypairResourcePolicyFetchKey(),
-                          );
-                          message.success(
-                            t('resourcePolicy.SuccessfullyDeleted'),
-                          );
-                        }
-                      },
-                      onError(err) {
-                        message.error(err?.message);
-                      },
-                    });
-                  }
-                },
-              });
-            }}
-          />
-        </BAIFlex>
-      ),
-    },
   ]);
 
   const [hiddenColumnKeys, setHiddenColumnKeys] = useHiddenColumnKeysSetting(
@@ -347,10 +330,7 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
       return;
     }
 
-    const columnKeys = _.without(
-      _.map(columns, (column) => _.toString(column.key)),
-      'control',
-    );
+    const columnKeys = _.map(columns, (column) => _.toString(column.key));
     const responseData = _.map(keypair_resource_policies, (policy) => {
       return _.pick(
         policy,

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -25,7 +25,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { Button, Dropdown, message, Popconfirm, theme, Tooltip } from 'antd';
+import { App, Button, Dropdown, Tooltip } from 'antd';
 import type { ColumnType } from 'antd/es/table';
 import {
   filterOutEmpty,
@@ -33,6 +33,7 @@ import {
   BAITable,
   BAIFlex,
   useUpdatableState,
+  BAINameActionCell,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
@@ -52,16 +53,14 @@ interface ProjectResourcePolicyListProps {}
 const ProjectResourcePolicyList: React.FC<
   ProjectResourcePolicyListProps
 > = () => {
-  const { token } = theme.useToken();
   const { t } = useTranslation();
+  const { message, modal } = App.useApp();
   const [isRefetchPending, startRefetchTransition] = useTransition();
   const [projectResourcePolicyFetchKey, updateProjectResourcePolicyFetchKey] =
     useUpdatableState('initial-fetch');
   const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
   const [visibleColumnSettingModal, { toggle: toggleColumnSettingModal }] =
     useToggle();
-  const [inFlightResourcePolicyName, setInFlightResourcePolicyName] =
-    useState<string>();
   const [editingProjectResourcePolicy, setEditingProjectResourcePolicy] =
     useState<ProjectResourcePolicySettingModalFragment$key | null>();
 
@@ -96,15 +95,14 @@ const ProjectResourcePolicyList: React.FC<
       },
     );
 
-  const [commitDelete, isInflightDelete] =
-    useMutation<ProjectResourcePolicyListMutation>(graphql`
-      mutation ProjectResourcePolicyListMutation($name: String!) {
-        delete_project_resource_policy(name: $name) {
-          ok
-          msg
-        }
+  const [commitDelete] = useMutation<ProjectResourcePolicyListMutation>(graphql`
+    mutation ProjectResourcePolicyListMutation($name: String!) {
+      delete_project_resource_policy(name: $name) {
+        ok
+        msg
       }
-    `);
+    }
+  `);
 
   const columns = filterOutEmpty<ColumnType<ProjectResourcePolicies>>([
     {
@@ -113,6 +111,77 @@ const ProjectResourcePolicyList: React.FC<
       key: 'name',
       fixed: 'left',
       sorter: (a, b) => localeCompare(a?.name, b?.name),
+      render: (name: string, row: ProjectResourcePolicies) => (
+        <BAINameActionCell
+          title={name}
+          showActions="always"
+          actions={[
+            {
+              key: 'settings',
+              title: t('button.Settings'),
+              icon: <SettingOutlined />,
+              onClick: () => {
+                setEditingProjectResourcePolicy(row);
+              },
+            },
+            {
+              key: 'delete',
+              title: t('button.Delete'),
+              icon: <DeleteOutlined />,
+              type: 'danger',
+              onClick: () => {
+                modal.confirm({
+                  title: t('dialog.ask.DoYouWantToProceed'),
+                  content: t('dialog.warning.CannotBeUndone'),
+                  okType: 'danger',
+                  okText: t('button.Delete'),
+                  onOk: () => {
+                    if (row?.name) {
+                      return new Promise<void>((resolve) => {
+                        commitDelete({
+                          variables: {
+                            name: row.name,
+                          },
+                          onCompleted: (res, errors) => {
+                            if (!res?.delete_project_resource_policy?.ok) {
+                              message.error(
+                                res?.delete_project_resource_policy?.msg,
+                              );
+                              resolve();
+                              return;
+                            }
+                            if (errors && errors?.length > 0) {
+                              const errorMsgList = _.map(
+                                errors,
+                                (error) => error.message,
+                              );
+                              for (const error of errorMsgList) {
+                                message.error(error);
+                              }
+                            } else {
+                              startRefetchTransition(() =>
+                                updateProjectResourcePolicyFetchKey(),
+                              );
+                              message.success(
+                                t('resourcePolicy.SuccessfullyDeleted'),
+                              );
+                            }
+                            resolve();
+                          },
+                          onError(err) {
+                            message.error(err?.message);
+                            resolve();
+                          },
+                        });
+                      });
+                    }
+                  },
+                });
+              },
+            },
+          ]}
+        />
+      ),
     },
     {
       title: t('resourcePolicy.MaxVFolderCount'),
@@ -161,87 +230,6 @@ const ProjectResourcePolicyList: React.FC<
       render: (text) => dayjs(text).format('lll'),
       sorter: (a, b) => localeCompare(a?.created_at, b?.created_at),
     },
-    {
-      title: t('general.Control'),
-      fixed: 'right',
-      key: 'control',
-      render: (_text: any, row: ProjectResourcePolicies) => (
-        <BAIFlex direction="row" align="stretch">
-          <Button
-            type="text"
-            icon={<SettingOutlined />}
-            style={{
-              color: token.colorInfo,
-            }}
-            onClick={() => {
-              setEditingProjectResourcePolicy(row);
-            }}
-          />
-          <Popconfirm
-            title={t('dialog.ask.DoYouWantToProceed')}
-            description={t('dialog.warning.CannotBeUndone')}
-            okType="danger"
-            okText={t('button.Delete')}
-            onConfirm={() => {
-              if (row?.name) {
-                setInFlightResourcePolicyName(
-                  row.name + projectResourcePolicyFetchKey,
-                );
-                commitDelete({
-                  variables: {
-                    name: row.name,
-                  },
-                  onCompleted: (res, errors) => {
-                    if (!res?.delete_project_resource_policy?.ok) {
-                      message.error(res?.delete_project_resource_policy?.msg);
-                      return;
-                    }
-                    if (errors && errors?.length > 0) {
-                      const errorMsgList = _.map(
-                        errors,
-                        (error) => error.message,
-                      );
-                      for (const error of errorMsgList) {
-                        message.error(error);
-                      }
-                    } else {
-                      startRefetchTransition(() =>
-                        updateProjectResourcePolicyFetchKey(),
-                      );
-                      message.success(t('resourcePolicy.SuccessfullyDeleted'));
-                    }
-                  },
-                  onError(err) {
-                    message.error(err?.message);
-                  },
-                });
-              }
-            }}
-          >
-            <Button
-              type="text"
-              icon={
-                <DeleteOutlined
-                  style={{
-                    color: token.colorError,
-                  }}
-                />
-              }
-              loading={
-                isInflightDelete &&
-                inFlightResourcePolicyName ===
-                  row?.name + projectResourcePolicyFetchKey
-              }
-              disabled={
-                isInflightDelete &&
-                inFlightResourcePolicyName !==
-                  row?.name + projectResourcePolicyFetchKey
-              }
-            />
-          </Popconfirm>
-        </BAIFlex>
-      ),
-    },
   ]);
 
   const [hiddenColumnKeys, setHiddenColumnKeys] = useHiddenColumnKeysSetting(
@@ -254,10 +242,7 @@ const ProjectResourcePolicyList: React.FC<
       return;
     }
 
-    const columnkeys = _.without(
-      _.map(columns, (column) => _.toString(column.key)),
-      'control',
-    );
+    const columnkeys = _.map(columns, (column) => _.toString(column.key));
     const responseData = _.map(project_resource_policies, (policy) => {
       return _.pick(
         policy,

--- a/react/src/components/ResourceGroupList.tsx
+++ b/react/src/components/ResourceGroupList.tsx
@@ -20,15 +20,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import {
-  Alert,
-  App,
-  Button,
-  Popconfirm,
-  Tooltip,
-  Typography,
-  theme,
-} from 'antd';
+import { Alert, App, Button, Typography, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import {
   useUpdatableState,
@@ -38,6 +30,7 @@ import {
   BAIFlex,
   BAIConfirmModalWithInput,
   BAIFetchKeyButton,
+  BAINameActionCell,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { BanIcon, UndoIcon } from 'lucide-react';
@@ -64,7 +57,7 @@ type ResourceGroup = NonNullable<
 const ResourceGroupList: React.FC = () => {
   const { t } = useTranslation();
   const { token } = theme.useToken();
-  const { message } = App.useApp();
+  const { message, modal } = App.useApp();
   const [activeType, setActiveType] = useState<'active' | 'inactive'>('active');
   const [openCreateModal, { toggle: toggleOpenCreateModal }] = useToggle(false);
   const [openInfoModal, { toggle: toggleOpenInfoModal }] = useToggle(false);
@@ -102,7 +95,7 @@ const ResourceGroupList: React.FC = () => {
     },
   );
 
-  const [commitUpdateResourceGroup, isInflightCommitUpdateResourceGroup] =
+  const [commitUpdateResourceGroup] =
     useMutation<ResourceGroupListUpdateMutation>(graphql`
       mutation ResourceGroupListUpdateMutation(
         $name: String!
@@ -130,6 +123,105 @@ const ResourceGroupList: React.FC = () => {
       key: 'name',
       title: t('resourceGroup.Name'),
       dataIndex: 'name',
+      render: (name: string, record: ResourceGroup) => (
+        <BAINameActionCell
+          title={name}
+          showActions="always"
+          actions={[
+            {
+              key: 'info',
+              title: t('button.Info'),
+              icon: <InfoCircleOutlined />,
+              onClick: () => {
+                setSelectedResourceGroup(record);
+                toggleOpenInfoModal();
+              },
+            },
+            {
+              key: 'settings',
+              title: t('button.Settings'),
+              icon: <SettingOutlined />,
+              onClick: () => {
+                setSelectedResourceGroup(record);
+                toggleOpenCreateModal();
+              },
+            },
+            {
+              key: 'activate-deactivate',
+              title: record.is_active
+                ? t('resourceGroup.Deactivate')
+                : t('resourceGroup.Activate'),
+              icon: record.is_active ? <BanIcon /> : <UndoIcon />,
+              type: record.is_active ? 'danger' : 'default',
+              onClick: () => {
+                modal.confirm({
+                  title: record.is_active
+                    ? t('resourceGroup.DeactivateResourceGroup')
+                    : t('resourceGroup.ActivateResourceGroup'),
+                  content: record?.name,
+                  okType: record.is_active ? 'danger' : 'primary',
+                  okText: record.is_active
+                    ? t('resourceGroup.Deactivate')
+                    : t('resourceGroup.Activate'),
+                  onOk: () => {
+                    return new Promise<void>((resolve) => {
+                      commitUpdateResourceGroup({
+                        variables: {
+                          name: record.name ?? '',
+                          input: {
+                            is_active: !record.is_active,
+                          },
+                        },
+                        onCompleted: (
+                          { modify_scaling_group: res },
+                          errors,
+                        ) => {
+                          if (!res?.ok) {
+                            message.error(res?.msg);
+                            resolve();
+                            return;
+                          }
+                          if (errors && errors.length > 0) {
+                            const errorMsgList = _.map(
+                              errors,
+                              (error: PayloadError) => error.message,
+                            );
+                            for (const error of errorMsgList) {
+                              message.error(error);
+                            }
+                            resolve();
+                            return;
+                          }
+                          message.success(
+                            t('resourceGroup.ResourceGroupModified'),
+                          );
+                          startRefetchTransition(() => {
+                            updateFetchKey();
+                          });
+                          resolve();
+                        },
+                        onError: (err) => {
+                          message.error(err.message);
+                          resolve();
+                        },
+                      });
+                    });
+                  },
+                });
+              },
+            },
+            {
+              key: 'delete',
+              title: t('button.Delete'),
+              icon: <DeleteOutlined />,
+              type: 'danger',
+              onClick: () => {
+                setSelectedResourceGroupName(record?.name || '');
+              },
+            },
+          ]}
+        />
+      ),
     },
     {
       key: 'description',
@@ -165,115 +257,6 @@ const ResourceGroupList: React.FC = () => {
       title: t('resourceGroup.WsproxyAddress'),
       dataIndex: 'wsproxy_addr',
       render: (value) => value || '-',
-    },
-    {
-      key: 'controls',
-      title: t('general.Control'),
-      fixed: 'right',
-      render: (_, record) => {
-        return (
-          <BAIFlex>
-            <Button
-              type="text"
-              icon={<InfoCircleOutlined />}
-              style={{ color: token.colorSuccess }}
-              onClick={() => {
-                setSelectedResourceGroup(record);
-                toggleOpenInfoModal();
-              }}
-            />
-            <Button
-              type="text"
-              icon={<SettingOutlined />}
-              style={{
-                color: token.colorInfo,
-              }}
-              onClick={() => {
-                setSelectedResourceGroup(record);
-                toggleOpenCreateModal();
-              }}
-            />
-            <Tooltip
-              title={
-                record.is_active
-                  ? t('resourceGroup.Deactivate')
-                  : t('resourceGroup.Activate')
-              }
-            >
-              <Popconfirm
-                title={
-                  record.is_active
-                    ? t('resourceGroup.DeactivateResourceGroup')
-                    : t('resourceGroup.ActivateResourceGroup')
-                }
-                placement="left"
-                okType={record.is_active ? 'danger' : 'primary'}
-                okText={
-                  record.is_active
-                    ? t('resourceGroup.Deactivate')
-                    : t('resourceGroup.Activate')
-                }
-                description={record?.name}
-                onConfirm={() => {
-                  commitUpdateResourceGroup({
-                    variables: {
-                      name: record.name ?? '',
-                      input: {
-                        is_active: !record.is_active,
-                      },
-                    },
-                    onCompleted: ({ modify_scaling_group: res }, errors) => {
-                      if (!res?.ok) {
-                        message.error(res?.msg);
-                        return;
-                      }
-                      if (errors && errors.length > 0) {
-                        const errorMsgList = _.map(
-                          errors,
-                          (error: PayloadError) => error.message,
-                        );
-                        for (const error of errorMsgList) {
-                          message.error(error);
-                        }
-                        return;
-                      }
-                      message.success(t('resourceGroup.ResourceGroupModified'));
-                      startRefetchTransition(() => {
-                        updateFetchKey();
-                      });
-                    },
-                    onError: (err) => {
-                      message.error(err.message);
-                    },
-                  });
-                }}
-              >
-                <Button
-                  type="text"
-                  danger={!!record.is_active}
-                  icon={record.is_active ? <BanIcon /> : <UndoIcon />}
-                  loading={isInflightCommitUpdateResourceGroup}
-                />
-              </Popconfirm>
-            </Tooltip>
-            <Tooltip title={t('button.Delete')}>
-              <Button
-                type="text"
-                icon={
-                  <DeleteOutlined
-                    style={{
-                      color: token.colorError,
-                    }}
-                  />
-                }
-                onClick={() => {
-                  setSelectedResourceGroupName(record?.name || '');
-                }}
-              />
-            </Tooltip>
-          </BAIFlex>
-        );
-      },
     },
   ]);
 

--- a/react/src/components/ResourcePresetList.tsx
+++ b/react/src/components/ResourcePresetList.tsx
@@ -17,14 +17,7 @@ import {
   SettingOutlined,
   DeleteOutlined,
 } from '@ant-design/icons';
-import {
-  Tooltip,
-  Button,
-  theme,
-  App,
-  Typography,
-  TableColumnsType,
-} from 'antd';
+import { Tooltip, Button, App, Typography, TableColumnsType } from 'antd';
 import {
   filterOutEmpty,
   filterOutNullAndUndefined,
@@ -33,6 +26,7 @@ import {
   BAINumberWithUnit,
   useUpdatableState,
   BAIResourceNumberWithIcon,
+  BAINameActionCell,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import React, { Suspense, useState, useTransition } from 'react';
@@ -47,13 +41,10 @@ interface ResourcePresetListProps {}
 
 const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
   const { t } = useTranslation();
-  const { token } = theme.useToken();
   const { modal, message } = App.useApp();
   const [isRefetchPending, startRefetchTransition] = useTransition();
   const [resourcePresetsFetchKey, updateResourcePresetsFetchKey] =
     useUpdatableState('initial-fetch');
-  const [inFlightResourcePresetName, setInFlightResourcePresetName] =
-    useState<string>();
   const [editingResourcePreset, setEditingResourcePreset] =
     useState<ResourcePresetSettingModalFragment$key | null>(null);
   const [isCreating, setIsCreating] = useState(false);
@@ -81,21 +72,92 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
     },
   );
 
-  const [commitDelete, isInflightDelete] =
-    useMutation<ResourcePresetListDeleteMutation>(graphql`
-      mutation ResourcePresetListDeleteMutation($name: String!) {
-        delete_resource_preset(name: $name) {
-          ok
-          msg
-        }
+  const [commitDelete] = useMutation<ResourcePresetListDeleteMutation>(graphql`
+    mutation ResourcePresetListDeleteMutation($name: String!) {
+      delete_resource_preset(name: $name) {
+        ok
+        msg
       }
-    `);
+    }
+  `);
 
   const columns: TableColumnsType<ResourcePreset> = filterOutEmpty([
     {
       title: t('resourcePreset.Name'),
       dataIndex: 'name',
       sorter: (a, b) => localeCompare(a?.name, b?.name),
+      render: (name: string, record) => (
+        <BAINameActionCell
+          title={name}
+          showActions="always"
+          actions={[
+            {
+              key: 'edit',
+              title: t('button.Edit'),
+              icon: <SettingOutlined />,
+              onClick: () => {
+                if (record) {
+                  setEditingResourcePreset(record);
+                }
+              },
+            },
+            {
+              key: 'delete',
+              title: t('button.Delete'),
+              icon: <DeleteOutlined />,
+              type: 'danger',
+              onClick: () => {
+                modal.confirm({
+                  title: t('resourcePreset.DeleteResourcePreset'),
+                  content: (
+                    <>
+                      {t('resourcePreset.AboutToDeletePreset')}{' '}
+                      <Typography.Text strong>{record?.name}</Typography.Text>
+                    </>
+                  ),
+                  onOk: () => {
+                    return new Promise<void>((resolve) => {
+                      commitDelete({
+                        variables: {
+                          name: record?.name ?? '',
+                        },
+                        onCompleted: (res, errors) => {
+                          if (!res?.delete_resource_preset?.ok) {
+                            message.error(res?.delete_resource_preset?.msg);
+                          } else if (errors && errors?.length > 0) {
+                            const errorMsgList = _.map(
+                              errors,
+                              (err) => err?.message,
+                            );
+                            _.forEach(errorMsgList, (err) =>
+                              message.error(err),
+                            );
+                          } else {
+                            message.success(t('resourcePreset.Deleted'));
+                            startRefetchTransition(() => {
+                              updateResourcePresetsFetchKey();
+                            });
+                          }
+                          resolve();
+                        },
+                        onError: (error) => {
+                          message.error(error?.message);
+                          resolve();
+                        },
+                      });
+                    });
+                  },
+                  okText: t('button.Delete'),
+                  okType: 'primary',
+                  okButtonProps: {
+                    danger: true,
+                  },
+                });
+              },
+            },
+          ]}
+        />
+      ),
     },
     {
       title: t('resourcePreset.Resources'),
@@ -132,96 +194,6 @@ const ResourcePresetList: React.FC<ResourcePresetListProps> = () => {
       sorter: (a, b) =>
         localeCompare(a?.scaling_group_name, b?.scaling_group_name),
       render: (text) => text ?? '-',
-    },
-    {
-      title: t('general.Control'),
-      key: 'control',
-      fixed: 'right',
-      render: (_text, record) => (
-        <BAIFlex align="stretch">
-          <Tooltip title={t('button.Edit')}>
-            <Button
-              type="text"
-              icon={<SettingOutlined />}
-              style={{
-                color: token.colorInfo,
-              }}
-              onClick={() => {
-                if (record) {
-                  setEditingResourcePreset(record);
-                }
-              }}
-            />
-          </Tooltip>
-          <Tooltip title={t('button.Delete')}>
-            <Button
-              type="text"
-              icon={
-                <DeleteOutlined
-                  style={{
-                    color: token.colorError,
-                  }}
-                />
-              }
-              loading={
-                isInflightDelete &&
-                inFlightResourcePresetName ===
-                  record?.name + resourcePresetsFetchKey
-              }
-              disabled={
-                isInflightDelete &&
-                inFlightResourcePresetName !==
-                  record?.name + resourcePresetsFetchKey
-              }
-              onClick={() => {
-                modal.confirm({
-                  title: t('resourcePreset.DeleteResourcePreset'),
-                  content: (
-                    <>
-                      {t('resourcePreset.AboutToDeletePreset')}{' '}
-                      <Typography.Text strong>{record?.name}</Typography.Text>
-                    </>
-                  ),
-                  onOk: () => {
-                    setInFlightResourcePresetName(
-                      record?.name + resourcePresetsFetchKey,
-                    );
-                    commitDelete({
-                      variables: {
-                        name: record?.name ?? '',
-                      },
-                      onCompleted: (res, errors) => {
-                        if (!res?.delete_resource_preset?.ok) {
-                          message.error(res?.delete_resource_preset?.msg);
-                        } else if (errors && errors?.length > 0) {
-                          const errorMsgList = _.map(
-                            errors,
-                            (err) => err?.message,
-                          );
-                          _.forEach(errorMsgList, (err) => message.error(err));
-                        } else {
-                          message.success(t('resourcePreset.Deleted'));
-                          startRefetchTransition(() => {
-                            updateResourcePresetsFetchKey();
-                          });
-                        }
-                      },
-                      onError: (error) => {
-                        message.error(error?.message);
-                      },
-                    });
-                  },
-                  okText: t('button.Delete'),
-                  okType: 'primary',
-                  okButtonProps: {
-                    danger: true,
-                  },
-                });
-              }}
-            />
-          </Tooltip>
-        </BAIFlex>
-      ),
     },
   ]);
 

--- a/react/src/components/RoleAssignmentTab.tsx
+++ b/react/src/components/RoleAssignmentTab.tsx
@@ -14,6 +14,7 @@ import {
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
+  BAINameActionCell,
   BAITable,
   BAIText,
   BAITrashBinIcon,
@@ -366,23 +367,23 @@ const RoleAssignmentTab: React.FC<RoleAssignmentTabProps> = ({
             key: 'email',
             dataIndex: 'email',
             title: t('credential.UserID'),
-            render: (_, record) => record?.user?.basicInfo?.email || '-',
-            sorter: true,
-          },
-          {
-            key: 'control',
-            title: t('general.Control'),
-            width: 60,
+            fixed: 'left',
             render: (_, record) => (
-              <BAIButton
-                type="text"
-                danger
-                icon={<BAITrashBinIcon />}
-                size="small"
-                title={t('rbac.DeleteUser')}
-                onClick={() => handleBulkRevoke([record?.userId])}
+              <BAINameActionCell
+                title={record?.user?.basicInfo?.email || '-'}
+                showActions="always"
+                actions={[
+                  {
+                    key: 'delete',
+                    title: t('rbac.DeleteUser'),
+                    icon: <BAITrashBinIcon />,
+                    type: 'danger',
+                    onClick: () => handleBulkRevoke([record?.userId]),
+                  },
+                ]}
               />
             ),
+            sorter: true,
           },
           {
             key: 'username',

--- a/react/src/components/RolePermissionTab.tsx
+++ b/react/src/components/RolePermissionTab.tsx
@@ -7,12 +7,13 @@ import { RolePermissionTabFragment$key } from '../__generated__/RolePermissionTa
 import { PermissionOrderBy } from '../__generated__/RolePermissionTabRefetchQuery.graphql';
 import { convertToOrderBy } from '../helper';
 import CreatePermissionModal from './CreatePermissionModal';
-import { App, Tag, Tooltip, Typography, theme } from 'antd';
+import { App, Tag } from 'antd';
 import {
   BAIButton,
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
+  BAINameActionCell,
   BAITable,
   BAITrashBinIcon,
   type GraphQLFilter,
@@ -54,7 +55,6 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
-  const { token } = theme.useToken();
   const { modal, message } = App.useApp();
   const { logger } = useBAILogger();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -378,11 +378,25 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
               }
               const displayValue = label || value || '-';
               return (
-                <Tooltip title={displayValue} placement="topLeft">
-                  <Typography.Text ellipsis style={{ maxWidth: 200 }}>
-                    {displayValue}
-                  </Typography.Text>
-                </Tooltip>
+                <BAINameActionCell
+                  title={displayValue}
+                  showActions="always"
+                  actions={[
+                    {
+                      key: 'edit',
+                      title: t('button.Edit'),
+                      icon: <EditIcon />,
+                      onClick: () => handleEdit(record),
+                    },
+                    {
+                      key: 'delete',
+                      title: t('rbac.DeletePermission'),
+                      icon: <BAITrashBinIcon />,
+                      type: 'danger',
+                      onClick: () => handleDelete(toLocalId(record?.id)),
+                    },
+                  ]}
+                />
               );
             },
           },
@@ -403,29 +417,6 @@ const RolePermissionTab: React.FC<RolePermissionTabProps> = ({
               <Tag color="blue">
                 {t(`rbac.operations.${value}`, { defaultValue: value })}
               </Tag>
-            ),
-          },
-          {
-            key: 'control',
-            title: t('general.Control'),
-            width: 90,
-            render: (_, record) => (
-              <BAIFlex gap="xxs">
-                <BAIButton
-                  type="text"
-                  icon={<EditIcon style={{ color: token.colorInfo }} />}
-                  size="small"
-                  onClick={() => handleEdit(record)}
-                />
-                <BAIButton
-                  type="text"
-                  danger
-                  icon={<BAITrashBinIcon />}
-                  size="small"
-                  title={t('rbac.DeletePermission')}
-                  onClick={() => handleDelete(toLocalId(record?.id))}
-                />
-              </BAIFlex>
             ),
           },
         ]}

--- a/react/src/components/StorageProxyList.tsx
+++ b/react/src/components/StorageProxyList.tsx
@@ -8,14 +8,15 @@ import {
   convertUnitValue,
   toFixedFloorWithoutTrailingZeros,
 } from '../helper';
+import { useWebUINavigate } from '../hooks';
 import { useBAIPaginationOptionStateOnSearchParamLegacy } from '../hooks/reactPaginationQueryOptions';
 import { InfoCircleOutlined, SettingOutlined } from '@ant-design/icons';
-import { Button, type TableColumnsType, Tag, theme, Typography } from 'antd';
+import { type TableColumnsType, Tag, theme, Typography } from 'antd';
 import {
   filterOutNullAndUndefined,
   BAICephIcon,
   BAIFlex,
-  BAILink,
+  BAINameActionCell,
   BAIPureStorageIcon,
   BAITable,
   BAIFetchKeyButton,
@@ -78,6 +79,7 @@ type StorageVolume = NonNullable<
 const StorageProxyList = () => {
   const { token } = theme.useToken();
   const { t } = useTranslation();
+  const webuiNavigate = useWebUINavigate();
   const {
     baiPaginationOption,
     tablePaginationOption,
@@ -128,12 +130,54 @@ const StorageProxyList = () => {
       title: <>ID / {t('agent.Endpoint')}</>,
       key: 'id',
       dataIndex: 'id',
+      fixed: 'left',
       render: (value, record) => {
+        let perfMetricDisabled;
+        try {
+          const performanceMetric = JSON.parse(
+            record.performance_metric || '{}',
+          );
+          perfMetricDisabled = _.isEmpty(performanceMetric);
+        } catch {
+          perfMetricDisabled = true;
+        }
         return (
-          <BAIFlex direction="column" align="start">
-            <Typography.Text>{value}</Typography.Text>
-            <Typography.Text type="secondary">{record.path}</Typography.Text>
-          </BAIFlex>
+          <BAINameActionCell
+            title={
+              <BAIFlex direction="column" align="start">
+                <Typography.Text>{value}</Typography.Text>
+                <Typography.Text type="secondary">
+                  {record.path}
+                </Typography.Text>
+              </BAIFlex>
+            }
+            showActions="always"
+            actions={[
+              {
+                key: 'info',
+                title: t('button.Info'),
+                icon: <InfoCircleOutlined />,
+                disabled: perfMetricDisabled,
+                onClick: () => {
+                  const event = new CustomEvent(
+                    'backend-ai-selected-storage-proxy',
+                    {
+                      detail: record.id,
+                    },
+                  );
+                  document.dispatchEvent(event);
+                },
+              },
+              {
+                key: 'settings',
+                title: t('button.Settings'),
+                icon: <SettingOutlined />,
+                onClick: () => {
+                  webuiNavigate(`/storage-settings/${record.id}`);
+                },
+              },
+            ]}
+          />
         );
       },
     },
@@ -219,56 +263,6 @@ const StorageProxyList = () => {
               </Tag>
             ))}
           </BAIFlex>
-        );
-      },
-    },
-    {
-      title: t('general.Control'),
-      key: 'control',
-      width: 100,
-      fixed: 'right',
-      render: (_value, record) => {
-        let perfMetricDisabled;
-        try {
-          const performanceMetric = JSON.parse(
-            record.performance_metric || '{}',
-          );
-          perfMetricDisabled = _.isEmpty(performanceMetric);
-        } catch {
-          perfMetricDisabled = true;
-        }
-        return (
-          <>
-            <Button
-              disabled={perfMetricDisabled}
-              style={{
-                color: perfMetricDisabled
-                  ? token.colorTextDisabled
-                  : token.colorSuccess,
-              }}
-              icon={<InfoCircleOutlined />}
-              onClick={() => {
-                // This event is being listened to by the plugin
-                const event = new CustomEvent(
-                  'backend-ai-selected-storage-proxy',
-                  {
-                    detail: record.id,
-                  },
-                );
-                document.dispatchEvent(event);
-              }}
-              type="text"
-            />
-            <BAILink to={`/storage-settings/${record.id}`}>
-              <Button
-                style={{
-                  color: token.colorInfo,
-                }}
-                icon={<SettingOutlined />}
-                type="text"
-              />
-            </BAILink>
-          </>
         );
       },
     },

--- a/react/src/components/UserCredentialList.tsx
+++ b/react/src/components/UserCredentialList.tsx
@@ -20,13 +20,14 @@ import {
   ReloadOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
-import { App, Button, Popconfirm, Tag, Tooltip, Typography, theme } from 'antd';
+import { App, Button, Tag, Tooltip, Typography, theme } from 'antd';
 import {
   filterOutEmpty,
   filterOutNullAndUndefined,
   BAITable,
   BAIFlex,
   BAIPropertyFilter,
+  BAINameActionCell,
   useBAILogger,
   useUpdatableState,
   BAIText,
@@ -141,8 +142,8 @@ const UserCredentialList: React.FC = () => {
     },
   );
 
-  const [commitModifyKeypair, isInFlightCommitModifyKeypair] =
-    useMutation<UserCredentialListModifyMutation>(graphql`
+  const [commitModifyKeypair] = useMutation<UserCredentialListModifyMutation>(
+    graphql`
       mutation UserCredentialListModifyMutation(
         $access_key: String!
         $props: ModifyKeyPairInput!
@@ -152,17 +153,19 @@ const UserCredentialList: React.FC = () => {
           msg
         }
       }
-    `);
+    `,
+  );
 
-  const [commitDeleteKeypair, isInFlightCommitDeleteKeypair] =
-    useMutation<UserCredentialListDeleteMutation>(graphql`
+  const [commitDeleteKeypair] = useMutation<UserCredentialListDeleteMutation>(
+    graphql`
       mutation UserCredentialListDeleteMutation($access_key: String!) {
         delete_keypair(access_key: $access_key) {
           ok
           msg
         }
       }
-    `);
+    `,
+  );
 
   useEffect(() => {
     if (action === 'add') {
@@ -282,170 +285,192 @@ const UserCredentialList: React.FC = () => {
             sorter: true,
             // TODO: user_id field in keypair_list is used as user's email, but sorting is done by email field
             render: (_value, record) => {
-              return record.user_id;
-            },
-          },
-          {
-            key: 'control',
-            title: t('general.Control'),
-            fixed: 'left',
-            render: (_value, record) => {
+              const actions = [
+                {
+                  key: 'info',
+                  title: t('button.Info'),
+                  icon: <InfoCircleOutlined />,
+                  onClick: () => {
+                    startInfoModalOpenTransition(() => {
+                      setKeypairInfoModalFrgmt(record);
+                    });
+                  },
+                },
+                {
+                  key: 'settings',
+                  title: t('button.Settings'),
+                  icon: <SettingOutlined />,
+                  onClick: () => {
+                    startSettingModalOpenTransition(() => {
+                      setKeypairSettingModalFrgmt(record);
+                    });
+                  },
+                },
+                ...(queryParams.activeType === 'inactive'
+                  ? [
+                      {
+                        key: 'activate',
+                        title: t('credential.Activate'),
+                        icon: <UndoIcon />,
+                        onClick: () => {
+                          modal.confirm({
+                            title: t('credential.ActivateCredential'),
+                            content: record.user_id,
+                            okText: t('credential.Activate'),
+                            onOk: () => {
+                              return new Promise<void>((resolve) => {
+                                commitModifyKeypair({
+                                  variables: {
+                                    access_key: record.access_key ?? '',
+                                    props: {
+                                      is_active: true,
+                                    },
+                                  },
+                                  onCompleted: (res, errors) => {
+                                    if (!res?.modify_keypair?.ok || errors) {
+                                      message.error(res?.modify_keypair?.msg);
+                                      resolve();
+                                      return;
+                                    }
+                                    message.success(
+                                      t(
+                                        'credential.KeypairStatusUpdatedSuccessfully',
+                                      ),
+                                    );
+                                    updateFetchKey();
+                                    resolve();
+                                  },
+                                  onError: (error) => {
+                                    message.error(error?.message);
+                                    logger.error(error);
+                                    resolve();
+                                  },
+                                });
+                              });
+                            },
+                          });
+                        },
+                      },
+                    ]
+                  : []),
+                ...(queryParams.activeType === 'active'
+                  ? [
+                      {
+                        key: 'deactivate',
+                        title: t('credential.Deactivate'),
+                        icon: <BanIcon />,
+                        type: 'danger' as const,
+                        onClick: () => {
+                          modal.confirm({
+                            title: t('credential.DeactivateCredential'),
+                            content: record.user_id,
+                            okButtonProps: {
+                              danger: true,
+                            },
+                            okText: t('credential.Deactivate'),
+                            onOk: () => {
+                              return new Promise<void>((resolve) => {
+                                commitModifyKeypair({
+                                  variables: {
+                                    access_key: record.access_key ?? '',
+                                    props: {
+                                      is_active: false,
+                                    },
+                                  },
+                                  onCompleted: (res, errors) => {
+                                    if (!res?.modify_keypair?.ok || errors) {
+                                      message.error(res?.modify_keypair?.msg);
+                                      resolve();
+                                      return;
+                                    }
+                                    message.success(
+                                      t(
+                                        'credential.KeypairStatusUpdatedSuccessfully',
+                                      ),
+                                    );
+                                    updateFetchKey();
+                                    resolve();
+                                  },
+                                  onError: (error) => {
+                                    message.error(error?.message);
+                                    logger.error(error);
+                                    resolve();
+                                  },
+                                });
+                              });
+                            },
+                          });
+                        },
+                      },
+                    ]
+                  : [
+                      {
+                        key: 'delete',
+                        title: t('button.Delete'),
+                        icon: <DeleteOutlined />,
+                        type: 'danger' as const,
+                        onClick: () => {
+                          modal.confirm({
+                            title: t('credential.DeleteCredential'),
+                            content: (
+                              <BAIFlex direction="column" align="stretch">
+                                <Typography.Text>
+                                  {t(
+                                    'credential.YouAreAboutToDeleteCredential',
+                                  )}
+                                </Typography.Text>
+                                <Typography.Text strong>
+                                  {record.user_id}
+                                </Typography.Text>
+                                <br />
+                                <Typography.Text type="danger">
+                                  {t('dialog.warning.CannotBeUndone')}
+                                </Typography.Text>
+                              </BAIFlex>
+                            ),
+                            onOk: () => {
+                              return new Promise<void>((resolve) => {
+                                commitDeleteKeypair({
+                                  variables: {
+                                    access_key: record.access_key ?? '',
+                                  },
+                                  onCompleted: (res, errors) => {
+                                    if (!res?.delete_keypair?.ok || errors) {
+                                      message.error(res?.delete_keypair?.msg);
+                                      resolve();
+                                      return;
+                                    }
+                                    message.success(
+                                      t(
+                                        'credential.KeypairSuccessfullyDeleted',
+                                      ),
+                                    );
+                                    updateFetchKey();
+                                    resolve();
+                                  },
+                                  onError: (error) => {
+                                    message.error(error?.message);
+                                    logger.error(error);
+                                    resolve();
+                                  },
+                                });
+                              });
+                            },
+                            okButtonProps: {
+                              danger: true,
+                            },
+                            okText: t('button.Delete'),
+                          });
+                        },
+                      },
+                    ]),
+              ];
               return (
-                <BAIFlex gap={token.marginXS}>
-                  <Button
-                    type="text"
-                    icon={
-                      <InfoCircleOutlined style={{ color: token.colorInfo }} />
-                    }
-                    onClick={() => {
-                      startInfoModalOpenTransition(() => {
-                        setKeypairInfoModalFrgmt(record);
-                      });
-                    }}
-                  />
-                  <Button
-                    type="text"
-                    icon={
-                      <SettingOutlined style={{ color: token.colorInfo }} />
-                    }
-                    onClick={() => {
-                      startSettingModalOpenTransition(() => {
-                        setKeypairSettingModalFrgmt(record);
-                      });
-                    }}
-                  />
-                  {queryParams.activeType === 'inactive' && (
-                    <Tooltip title={t('credential.Activate')}>
-                      <Popconfirm
-                        title={t('credential.ActivateCredential')}
-                        description={record.user_id}
-                        okText={t('credential.Activate')}
-                        placement="left"
-                        onConfirm={() => {
-                          commitModifyKeypair({
-                            variables: {
-                              access_key: record.access_key ?? '',
-                              props: {
-                                is_active: true,
-                              },
-                            },
-                            onCompleted: (res, errors) => {
-                              if (!res?.modify_keypair?.ok || errors) {
-                                message.error(res?.modify_keypair?.msg);
-                                return;
-                              }
-                              message.success(
-                                t(
-                                  'credential.KeypairStatusUpdatedSuccessfully',
-                                ),
-                              );
-                              updateFetchKey();
-                            },
-                            onError: (error) => {
-                              message.error(error?.message);
-                              logger.error(error);
-                            },
-                          });
-                        }}
-                      >
-                        <Button type="text" icon={<UndoIcon />} />
-                      </Popconfirm>
-                    </Tooltip>
-                  )}
-                  {queryParams.activeType === 'active' ? (
-                    <Tooltip title={t('credential.Deactivate')}>
-                      <Popconfirm
-                        title={t('credential.DeactivateCredential')}
-                        description={record.user_id}
-                        okButtonProps={{
-                          loading: isInFlightCommitModifyKeypair,
-                        }}
-                        okType="danger"
-                        okText={t('credential.Deactivate')}
-                        placement="left"
-                        onConfirm={() => {
-                          commitModifyKeypair({
-                            variables: {
-                              access_key: record.access_key ?? '',
-                              props: {
-                                is_active: false,
-                              },
-                            },
-                            onCompleted: (res, errors) => {
-                              if (!res?.modify_keypair?.ok || errors) {
-                                message.error(res?.modify_keypair?.msg);
-                                return;
-                              }
-                              message.success(
-                                t(
-                                  'credential.KeypairStatusUpdatedSuccessfully',
-                                ),
-                              );
-                              updateFetchKey();
-                            },
-                            onError: (error) => {
-                              message.error(error?.message);
-                              logger.error(error);
-                            },
-                          });
-                        }}
-                      >
-                        <Button type="text" danger icon={<BanIcon />} />
-                      </Popconfirm>
-                    </Tooltip>
-                  ) : (
-                    <Button
-                      type="text"
-                      danger
-                      icon={<DeleteOutlined />}
-                      loading={isInFlightCommitDeleteKeypair}
-                      onClick={() => {
-                        modal.confirm({
-                          title: t('credential.DeleteCredential'),
-                          content: (
-                            <BAIFlex direction="column" align="stretch">
-                              <Typography.Text>
-                                {t('credential.YouAreAboutToDeleteCredential')}
-                              </Typography.Text>
-                              <Typography.Text strong>
-                                {record.user_id}
-                              </Typography.Text>
-                              <br />
-                              <Typography.Text type="danger">
-                                {t('dialog.warning.CannotBeUndone')}
-                              </Typography.Text>
-                            </BAIFlex>
-                          ),
-                          onOk: () => {
-                            commitDeleteKeypair({
-                              variables: {
-                                access_key: record.access_key ?? '',
-                              },
-                              onCompleted: (res, errors) => {
-                                if (!res?.delete_keypair?.ok || errors) {
-                                  message.error(res?.delete_keypair?.msg);
-                                  return;
-                                }
-                                message.success(
-                                  t('credential.KeypairSuccessfullyDeleted'),
-                                );
-                                updateFetchKey();
-                              },
-                              onError: (error) => {
-                                message.error(error?.message);
-                                logger.error(error);
-                              },
-                            });
-                          },
-                          okButtonProps: {
-                            danger: true,
-                          },
-                          okText: t('button.Delete'),
-                        });
-                      }}
-                    />
-                  )}
-                </BAIFlex>
+                <BAINameActionCell
+                  title={record.user_id}
+                  showActions="always"
+                  actions={actions}
+                />
               );
             },
           },

--- a/react/src/components/UserManagement.tsx
+++ b/react/src/components/UserManagement.tsx
@@ -13,9 +13,13 @@ import PurgeUsersModal from './PurgeUsersModal';
 import UpdateUsersModal from './UpdateUsersModal';
 import UserInfoModal from './UserInfoModal';
 import UserSettingModal from './UserSettingModal';
-import { EllipsisOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import {
+  EllipsisOutlined,
+  InfoCircleOutlined,
+  SettingOutlined,
+} from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { Button, theme, Popconfirm, App, Space, Dropdown } from 'antd';
+import { App, Button, Dropdown, Space, theme } from 'antd';
 import {
   filterOutEmpty,
   filterOutNullAndUndefined,
@@ -23,7 +27,6 @@ import {
   BAIPropertyFilter,
   mergeFilterValues,
   useBAILogger,
-  BAIColumnType,
   UserNodeInList,
   BAIFetchKeyButton,
   isValidUUID,
@@ -31,6 +34,7 @@ import {
   BAIButton,
   BAITrashBinIcon,
   BAIText,
+  BAINameActionCell,
   BAIUnmountAfterClose,
   INITIAL_FETCH_KEY,
   useFetchKey,
@@ -97,8 +101,6 @@ const UserManagement: React.FC<UserManagementProps> = () => {
     pageSize: 10,
   });
 
-  const [pendingUserId, setPendingUserId] = useState<string>();
-
   const statusFilter =
     queryParams.status === 'active'
       ? 'status == "active"'
@@ -157,127 +159,107 @@ const UserManagement: React.FC<UserManagementProps> = () => {
     },
   );
 
-  const [commitModifyUser, isInFlightCommitModifyUser] =
-    useMutation<UserManagementModifyMutation>(graphql`
-      mutation UserManagementModifyMutation(
-        $email: String!
-        $props: ModifyUserInput!
-      ) {
-        modify_user(email: $email, props: $props) {
-          ok
-          msg
-        }
+  const [commitModifyUser] = useMutation<UserManagementModifyMutation>(graphql`
+    mutation UserManagementModifyMutation(
+      $email: String!
+      $props: ModifyUserInput!
+    ) {
+      modify_user(email: $email, props: $props) {
+        ok
+        msg
       }
-    `);
+    }
+  `);
 
-  const controlColumn: BAIColumnType<UserNodeInList> = {
-    key: 'control',
-    title: t('general.Control'),
-    fixed: true,
-    required: true,
-    render: (__, record) => {
-      const isActive = record?.status === 'active';
-      return (
-        <BAIFlex gap={token.marginXXS}>
-          <Button
-            type="text"
-            title={t('credential.UserDetail')}
-            icon={<InfoCircleOutlined style={{ color: token.colorInfo }} />}
-            onClick={() => {
+  const renderEmailWithActions = (__: unknown, record: UserNodeInList) => {
+    const isActive = record?.status === 'active';
+    return (
+      <BAINameActionCell
+        title={record.email}
+        showActions="always"
+        actions={filterOutEmpty([
+          {
+            key: 'info',
+            title: t('credential.UserDetail'),
+            icon: <InfoCircleOutlined />,
+            onClick: () => {
               startInfoModalOpenTransition(() => {
                 setEmailForInfoModal(record?.email || null);
               });
-            }}
-          />
-          <Button
-            type="text"
-            title={t('button.Edit')}
-            icon={<EditIcon style={{ color: token.colorInfo }} />}
-            onClick={() => {
+            },
+          },
+          {
+            key: 'edit',
+            title: t('button.Edit'),
+            icon: <SettingOutlined />,
+            onClick: () => {
               startSettingModalOpenTransition(() => {
                 setEmailForSettingModal(record?.email || null);
               });
-            }}
-          />
-          <Popconfirm
-            title={
-              isActive
-                ? t('credential.DeactivateUser')
-                : t('credential.ActivateUser')
-            }
-            placement="left"
-            okType={isActive ? 'danger' : 'primary'}
-            okText={
-              isActive ? t('credential.Deactivate') : t('credential.Activate')
-            }
-            description={record?.email}
-            onConfirm={() => {
-              setPendingUserId(record?.id || '');
-              commitModifyUser({
-                variables: {
-                  email: record?.email || '',
-                  props: {
-                    status: isActive ? 'inactive' : 'active',
+            },
+          },
+          {
+            key: 'toggle-status',
+            title: isActive
+              ? t('credential.Deactivate')
+              : t('credential.Activate'),
+            icon: isActive ? <BanIcon /> : <UndoIcon />,
+            type: isActive ? ('danger' as const) : ('default' as const),
+            onClick: () => {
+              return new Promise<void>((resolve) => {
+                commitModifyUser({
+                  variables: {
+                    email: record?.email || '',
+                    props: {
+                      status: isActive ? 'inactive' : 'active',
+                    },
                   },
-                },
-                onCompleted: (res, errors) => {
-                  const errorMessage = errors?.[0]?.message;
-                  const notOkMessage =
-                    res?.modify_user?.ok === false
-                      ? res.modify_user.msg
-                      : undefined;
-                  if (res.modify_user?.ok === false || errors?.[0]) {
-                    message.error(
-                      notOkMessage || errorMessage || t('error.UnknownError'),
-                    );
-                    logger.error(res.modify_user?.msg, errorMessage);
-                    return;
-                  }
-                  message.success(t('credential.StatusUpdatedSuccessfully'));
-                  setSelectedUserList((prev) => {
-                    return prev.filter((user) => user?.node?.id !== record?.id);
-                  });
-                  updateFetchKey();
-                },
-                onError: (error) => {
-                  message.error(error?.message);
-                  logger.error(error);
-                },
+                  onCompleted: (res, errors) => {
+                    const errorMessage = errors?.[0]?.message;
+                    const notOkMessage =
+                      res?.modify_user?.ok === false
+                        ? res.modify_user.msg
+                        : undefined;
+                    if (res.modify_user?.ok === false || errors?.[0]) {
+                      message.error(
+                        notOkMessage || errorMessage || t('error.UnknownError'),
+                      );
+                      logger.error(res.modify_user?.msg, errorMessage);
+                      resolve();
+                      return;
+                    }
+                    message.success(t('credential.StatusUpdatedSuccessfully'));
+                    setSelectedUserList((prev) => {
+                      return prev.filter(
+                        (user) => user?.node?.id !== record?.id,
+                      );
+                    });
+                    updateFetchKey();
+                    resolve();
+                  },
+                  onError: (error) => {
+                    message.error(error?.message);
+                    logger.error(error);
+                    resolve();
+                  },
+                });
               });
-            }}
-          >
-            <Button
-              title={
-                isActive ? t('credential.Deactivate') : t('credential.Activate')
+            },
+          },
+          !isActive && {
+            key: 'purge',
+            title: t('credential.PermanentlyDelete'),
+            icon: <BAITrashBinIcon />,
+            type: 'danger' as const,
+            onClick: () => {
+              if (record?.id) {
+                setPurgeTargetId(record.id);
               }
-              type="text"
-              danger={isActive}
-              icon={isActive ? <BanIcon /> : <UndoIcon />}
-              disabled={
-                isInFlightCommitModifyUser && pendingUserId !== record?.id
-              }
-              loading={
-                isInFlightCommitModifyUser && pendingUserId === record?.id
-              }
-            />
-          </Popconfirm>
-          {!isActive && (
-            <Button
-              type="text"
-              danger
-              title={t('credential.PermanentlyDelete')}
-              aria-label={t('credential.PermanentlyDelete')}
-              icon={<BAITrashBinIcon />}
-              onClick={() => {
-                if (record?.id) {
-                  setPurgeTargetId(record.id);
-                }
-              }}
-            />
-          )}
-        </BAIFlex>
-      );
-    },
+            },
+          },
+        ])}
+      />
+    );
   };
 
   return (
@@ -456,8 +438,10 @@ const UserManagement: React.FC<UserManagementProps> = () => {
       <BAIUserNodes
         usersFrgmt={filterOutNullAndUndefined(_.map(user_nodes?.edges, 'node'))}
         customizeColumns={(baseColumns) => [
-          baseColumns[0],
-          controlColumn,
+          {
+            ...baseColumns[0],
+            render: renderEmailWithActions,
+          },
           ...baseColumns.slice(1),
         ]}
         scroll={{ x: 'max-content' }}

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -24,7 +24,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { App, Button, Dropdown, Popconfirm, theme, Tooltip } from 'antd';
+import { App, Button, Dropdown, Tooltip } from 'antd';
 import type { ColumnType } from 'antd/es/table';
 import {
   useUpdatableState,
@@ -32,6 +32,7 @@ import {
   filterOutNullAndUndefined,
   BAITable,
   BAIFlex,
+  BAINameActionCell,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
@@ -49,9 +50,8 @@ type UserResourcePolicies = NonNullable<
 interface UserResourcePolicyListProps {}
 
 const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
-  const { token } = theme.useToken();
   const { t } = useTranslation();
-  const { message } = App.useApp();
+  const { message, modal } = App.useApp();
 
   const [isRefetchPending, startRefetchTransition] = useTransition();
   const [userResourcePolicyFetchKey, updateUserResourcePolicyFetchKey] =
@@ -59,8 +59,6 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
   const [isCreatingPolicySetting, setIsCreatingPolicySetting] = useState(false);
   const [visibleColumnSettingModal, { toggle: toggleColumnSettingModal }] =
     useToggle();
-  const [inFlightResourcePolicyName, setInFlightResourcePolicyName] =
-    useState<string>();
   const [editingUserResourcePolicy, setEditingUserResourcePolicy] =
     useState<UserResourcePolicySettingModalFragment$key | null>();
 
@@ -92,15 +90,14 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
         fetchKey: userResourcePolicyFetchKey,
       },
     );
-  const [commitDelete, isInflightDelete] =
-    useMutation<UserResourcePolicyListMutation>(graphql`
-      mutation UserResourcePolicyListMutation($name: String!) {
-        delete_user_resource_policy(name: $name) {
-          ok
-          msg
-        }
+  const [commitDelete] = useMutation<UserResourcePolicyListMutation>(graphql`
+    mutation UserResourcePolicyListMutation($name: String!) {
+      delete_user_resource_policy(name: $name) {
+        ok
+        msg
       }
-    `);
+    }
+  `);
 
   const columns = filterOutEmpty<ColumnType<UserResourcePolicies>>([
     {
@@ -109,6 +106,77 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
       key: 'name',
       fixed: 'left',
       sorter: (a, b) => localeCompare(a?.name, b?.name),
+      render: (name: string, row: UserResourcePolicies) => (
+        <BAINameActionCell
+          title={name}
+          showActions="always"
+          actions={[
+            {
+              key: 'settings',
+              title: t('button.Settings'),
+              icon: <SettingOutlined />,
+              onClick: () => {
+                setEditingUserResourcePolicy(row);
+              },
+            },
+            {
+              key: 'delete',
+              title: t('button.Delete'),
+              icon: <DeleteOutlined />,
+              type: 'danger',
+              onClick: () => {
+                modal.confirm({
+                  title: t('dialog.ask.DoYouWantToProceed'),
+                  content: t('dialog.warning.CannotBeUndone'),
+                  okType: 'danger',
+                  okText: t('button.Delete'),
+                  onOk: () => {
+                    if (row?.name) {
+                      return new Promise<void>((resolve) => {
+                        commitDelete({
+                          variables: {
+                            name: row.name,
+                          },
+                          onCompleted: (res, errors) => {
+                            if (!res?.delete_user_resource_policy?.ok) {
+                              message.error(
+                                res?.delete_user_resource_policy?.msg,
+                              );
+                              resolve();
+                              return;
+                            }
+                            if (errors && errors.length > 0) {
+                              const errorMsgList = errors.map(
+                                (error) => error.message,
+                              );
+                              for (const error of errorMsgList) {
+                                message.error(error);
+                              }
+                              resolve();
+                              return;
+                            }
+                            startRefetchTransition(() =>
+                              updateUserResourcePolicyFetchKey(),
+                            );
+                            message.success(
+                              t('resourcePolicy.SuccessfullyDeleted'),
+                            );
+                            resolve();
+                          },
+                          onError(err) {
+                            message.error(err?.message);
+                            resolve();
+                          },
+                        });
+                      });
+                    }
+                  },
+                });
+              },
+            },
+          ]}
+        />
+      ),
     },
     {
       title: t('resourcePolicy.MaxVFolderCount'),
@@ -163,84 +231,6 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
       render: (text) => dayjs(text).format('lll'),
       sorter: (a, b) => localeCompare(a?.created_at, b?.created_at),
     },
-    {
-      title: t('general.Control'),
-      fixed: 'right',
-      key: 'control',
-      render: (_text: any, row: UserResourcePolicies) => (
-        <BAIFlex direction="row" align="stretch">
-          <Button
-            type="text"
-            icon={<SettingOutlined />}
-            style={{
-              color: token.colorInfo,
-            }}
-            onClick={() => {
-              setEditingUserResourcePolicy(row);
-            }}
-          />
-          <Popconfirm
-            title={t('dialog.ask.DoYouWantToProceed')}
-            description={t('dialog.warning.CannotBeUndone')}
-            okType="danger"
-            okText={t('button.Delete')}
-            onConfirm={() => {
-              if (row?.name) {
-                setInFlightResourcePolicyName(
-                  row.name + userResourcePolicyFetchKey,
-                );
-                commitDelete({
-                  variables: {
-                    name: row.name,
-                  },
-                  onCompleted: (res, errors) => {
-                    if (!res?.delete_user_resource_policy?.ok) {
-                      message.error(res?.delete_user_resource_policy?.msg);
-                      return;
-                    }
-                    if (errors && errors.length > 0) {
-                      const errorMsgList = errors.map((error) => error.message);
-                      for (const error of errorMsgList) {
-                        message.error(error);
-                      }
-                      return;
-                    }
-                    startRefetchTransition(() =>
-                      updateUserResourcePolicyFetchKey(),
-                    );
-                    message.success(t('resourcePolicy.SuccessfullyDeleted'));
-                  },
-                  onError(err) {
-                    message.error(err?.message);
-                  },
-                });
-              }
-            }}
-          >
-            <Button
-              type="text"
-              icon={
-                <DeleteOutlined
-                  style={{
-                    color: token.colorError,
-                  }}
-                />
-              }
-              loading={
-                isInflightDelete &&
-                inFlightResourcePolicyName ===
-                  row?.name + userResourcePolicyFetchKey
-              }
-              disabled={
-                isInflightDelete &&
-                inFlightResourcePolicyName !==
-                  row?.name + userResourcePolicyFetchKey
-              }
-            />
-          </Popconfirm>
-        </BAIFlex>
-      ),
-    },
   ]);
 
   const [hiddenColumnKeys, setHiddenColumnKeys] = useHiddenColumnKeysSetting(
@@ -256,10 +246,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
       return;
     }
 
-    const columnKeys = _.without(
-      _.map(columns, (column) => _.toString(column.key)),
-      'control',
-    );
+    const columnKeys = _.map(columns, (column) => _.toString(column.key));
     const responseData = _.map(user_resource_policies, (policy) => {
       return _.pick(
         policy,

--- a/react/src/pages/RBACManagementPage.tsx
+++ b/react/src/pages/RBACManagementPage.tsx
@@ -18,15 +18,16 @@ import RoleNodes, {
 } from '../components/RoleNodes';
 import { convertToOrderBy } from '../helper';
 import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
-import { App, Popconfirm, theme } from 'antd';
+import { App } from 'antd';
 import {
   BAIButton,
   BAICard,
   BAIFetchKeyButton,
   BAIFlex,
   BAIGraphQLPropertyFilter,
-  BAILink,
+  BAINameActionCell,
   BAITrashBinIcon,
+  filterOutEmpty,
   type GraphQLFilter,
   INITIAL_FETCH_KEY,
   toLocalId,
@@ -50,8 +51,6 @@ const RBACManagementPage: React.FC = () => {
   'use memo';
 
   const { t } = useTranslation();
-  const { token } = theme.useToken();
-
   const {
     baiPaginationOption,
     tablePaginationOption,
@@ -321,78 +320,59 @@ const RBACManagementPage: React.FC = () => {
           customizeColumns={(columns) => {
             const isDeletedFilter =
               deferredQueryVariables.filter.status?.in?.[0] === 'DELETED';
-            return [
-              ...columns.map((col) =>
-                col.key === 'name'
-                  ? {
-                      ...col,
-                      render: (name: string, role: RoleNodeInList) => (
-                        <BAILink
-                          type="hover"
-                          onClick={() =>
-                            setRoleDetailParam({ roleDetail: role.id })
-                          }
-                        >
-                          {name}
-                        </BAILink>
-                      ),
-                    }
-                  : col,
-              ),
-              {
-                key: 'control',
-                title: t('general.Control'),
-                fixed: 'left',
-                width: 100,
-                render: (_: unknown, role: RoleNodeInList) => (
-                  <BAIFlex gap={token.marginXXS}>
-                    {isDeletedFilter ? (
-                      <>
-                        <Popconfirm
-                          title={t('rbac.ActivateRole')}
-                          description={role.name}
-                          okText={t('rbac.Activate')}
-                          placement="left"
-                          onConfirm={() => handleActivateRole(role)}
-                        >
-                          <BAIButton
-                            type="text"
-                            title={t('rbac.Activate')}
-                            icon={<UndoIcon />}
-                            size="small"
-                          />
-                        </Popconfirm>
-                        <BAIButton
-                          type="text"
-                          danger
-                          title={t('rbac.PurgeRole')}
-                          icon={<BAITrashBinIcon />}
-                          size="small"
-                          onClick={() => handlePurgeRole(role)}
-                        />
-                      </>
-                    ) : (
-                      <Popconfirm
-                        title={t('rbac.DeactivateRole')}
-                        description={role.name}
-                        okType="danger"
-                        okText={t('rbac.Deactivate')}
-                        placement="left"
-                        onConfirm={() => handleDeactivateRole(role)}
-                      >
-                        <BAIButton
-                          type="text"
-                          danger
-                          title={t('rbac.Deactivate')}
-                          icon={<BanIcon />}
-                          size="small"
-                        />
-                      </Popconfirm>
-                    )}
-                  </BAIFlex>
-                ),
-              },
-            ];
+            return columns.map((col) =>
+              col.key === 'name'
+                ? {
+                    ...col,
+                    render: (name: string, role: RoleNodeInList) => (
+                      <BAINameActionCell
+                        title={name}
+                        showActions="always"
+                        onTitleClick={() =>
+                          setRoleDetailParam({ roleDetail: role.id })
+                        }
+                        actions={filterOutEmpty(
+                          isDeletedFilter
+                            ? [
+                                {
+                                  key: 'activate',
+                                  title: t('rbac.Activate'),
+                                  icon: <UndoIcon />,
+                                  onClick: () => {
+                                    return new Promise<void>((resolve) => {
+                                      handleActivateRole(role);
+                                      resolve();
+                                    });
+                                  },
+                                },
+                                {
+                                  key: 'purge',
+                                  title: t('rbac.PurgeRole'),
+                                  icon: <BAITrashBinIcon />,
+                                  type: 'danger' as const,
+                                  onClick: () => handlePurgeRole(role),
+                                },
+                              ]
+                            : [
+                                {
+                                  key: 'deactivate',
+                                  title: t('rbac.Deactivate'),
+                                  icon: <BanIcon />,
+                                  type: 'danger' as const,
+                                  onClick: () => {
+                                    return new Promise<void>((resolve) => {
+                                      handleDeactivateRole(role);
+                                      resolve();
+                                    });
+                                  },
+                                },
+                              ],
+                        )}
+                      />
+                    ),
+                  }
+                : col,
+            );
           }}
           pagination={{
             pageSize: tablePaginationOption.pageSize,


### PR DESCRIPTION
Resolves #6259 (FR-2411)

## Summary

Apply the `BAINameActionCell` component to all applicable table name columns across the codebase, replacing separate Control columns with integrated action buttons in the name cell.

### Tables updated (17 components):

**Admin — Resource Policies:**
- `KeypairResourcePolicyList` — Keypair resource policies (info, setting, delete)
- `UserResourcePolicyList` — User resource policies (setting, delete)
- `ProjectResourcePolicyList` — Project resource policies (setting, delete)

**Admin — Infrastructure:**
- `ResourceGroupList` — Resource groups (info, setting, activate/deactivate, delete)
- `ResourcePresetList` — Resource presets (setting, delete)
- `StorageProxyList` — Storage proxies (info, setting)
- `ContainerRegistryList` — Container registries (setting, delete, rescan)

**Admin — Users & RBAC:**
- `UserManagement` — Users table at credential?tab=users (info, edit, activate/deactivate, purge)
- `UserCredentialList` — Keypair credentials (info, setting, activate/deactivate, delete)
- `RBACManagementPage` — RBAC role list at /rbac (activate/deactivate, purge; with onTitleClick for detail drawer)
- `RoleAssignmentTab` — Role assignments (delete)
- `RolePermissionTab` — Role permissions (edit, delete)

**Service:**
- `EndpointList` — Model service endpoints (setting, delete; with navigation via `to` prop)

**Fair Share:**
- `DomainFairShareTable` — Domain fair share (setting; with icon + onTitleClick)
- `ProjectFairShareTable` — Project fair share (setting; with icon + onTitleClick)
- `ResourceGroupFairShareTable` — Resource group fair share (setting; with onTitleClick)
- `UserFairShareTable` — User fair share (setting; applied to email column)

### Key changes:
- All tables use `showActions="always"` for persistent action button visibility
- Action buttons moved from separate Control/Controls columns into `BAINameActionCell` actions prop
- Control columns removed from all migrated tables
- Destructive actions (deactivate, delete, purge) use `type: 'danger'` for visual distinction
- `Popconfirm`-wrapped buttons converted to `modal.confirm` pattern where needed
- `modal.confirm` `onOk` handlers return Promises for OK button loading feedback during mutations
- Dead state variables (`inFlightResourcePolicyName`, `optimisticDeletingId`, `pendingUserId`, etc.) and their setter calls removed
- `useWebUINavigate` used instead of `useNavigate` for shell navigation integration (StorageProxyList)
- Unused imports cleaned up across all files
- E2E test locators updated for BAINameActionCell DOM structure

## Screenshots

### Before / After (Keypair Resource Policy)
| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6273/20260331-144050-before-resource-policy.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6273/20260331-144054-after-resource-policy.png) |

**Key changes visible:**
- Name column now includes action buttons directly alongside the name text
- Separate "Control" column removed from the table
- Action buttons are always visible (not hover-only)
- Destructive actions (delete) shown in danger color

## Verification

Relay, Lint, Format, TypeScript — all pass (`scripts/verify.sh`)

E2E tests:
- `e2e/resource-policy/` — 10/10 passed
- `e2e/serving/` — 4/4 passed (1 pre-existing failure in route table, unrelated)

## Test plan

- [x] Verify name text is selectable/draggable in updated tables
- [x] Verify action buttons always visible in name cell
- [x] E2E resource policy tests pass (10/10)
- [x] E2E serving tests pass
- [x] Verify modal.confirm shows loading spinner on OK button during mutations
- [x] Verify destructive actions use danger type styling
- [ ] Verify RBAC role name click opens detail drawer
- [ ] Verify endpoint name click navigates to endpoint detail page
- [ ] Verify FairShare table names navigate to sub-views on click
- [ ] Visual check of all 17 updated tables in the UI