### PR TITLE
feat(FR-2424): add BAIDeleteConfirmModal and apply to resource-policy tables

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIConfirmModalWithInput.tsx
+++ b/packages/backend.ai-ui/src/components/BAIConfirmModalWithInput.tsx
@@ -7,8 +7,10 @@ import { useTranslation } from 'react-i18next';
 
 const { Text } = Typography;
 
-export interface BAIConfirmModalWithInputProps
-  extends Omit<BAIModalProps, 'icon' | 'okButtonProps'> {
+export interface BAIConfirmModalWithInputProps extends Omit<
+  BAIModalProps,
+  'icon' | 'okButtonProps'
+> {
   confirmText: string;
   content: React.ReactNode;
   title: React.ReactNode;
@@ -64,7 +66,7 @@ const BAIConfirmModalWithInput: React.FC<BAIConfirmModalWithInputProps> = ({
         danger: true,
       }}
     >
-      <BAIFlex direction="column" justify="start" align="stretch">
+      <BAIFlex direction="column" justify="start" align="stretch" gap={'sm'}>
         {content}
         <Form form={form} style={{ width: '100%' }} preserve={false}>
           <Form.Item

--- a/packages/backend.ai-ui/src/components/BAIDeleteConfirmModal.stories.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDeleteConfirmModal.stories.tsx
@@ -1,0 +1,309 @@
+'use memo';
+
+import BAIButton from './BAIButton';
+import BAIDeleteConfirmModal from './BAIDeleteConfirmModal';
+import BAIFlex from './BAIFlex';
+import { DeleteOutlined, FolderOutlined } from '@ant-design/icons';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Checkbox, Space, Tag } from 'antd';
+import { useState } from 'react';
+
+const meta: Meta<typeof BAIDeleteConfirmModal> = {
+  title: 'Modal/BAIDeleteConfirmModal',
+  component: BAIDeleteConfirmModal,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+**BAIDeleteConfirmModal** is a unified delete confirmation modal for table row deletion.
+
+## Behavior
+- **Single item**: Simple confirm dialog with item name displayed. OK button is immediately enabled.
+- **Multiple items (2+)**: Requires typing confirmation text (localized "Delete") before OK is enabled.
+- **\`requireConfirmInput\`**: Forces text-input confirmation even for a single item.
+
+## Key Features
+- Accepts \`React.ReactNode\` for item labels (icons, tags, custom rendering)
+- Scrollable item list for large selections
+- \`extraContent\` slot for domain-specific additions (checkboxes, warnings)
+- Built on \`BAIConfirmModalWithInput\` (multi) and \`BAIModal\` (single)
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BAIDeleteConfirmModal>;
+
+export const SingleItem: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Single item deletion with simple confirm. No text input required.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <BAIButton
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => setOpen(true)}
+        >
+          Delete Item
+        </BAIButton>
+        <BAIDeleteConfirmModal
+          open={open}
+          items={[{ key: '1', label: 'my-important-resource' }]}
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const SingleItemWithInput: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Single item with `requireConfirmInput={true}`. User must type the item name to confirm.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <BAIButton
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => setOpen(true)}
+        >
+          Delete (Confirm Required)
+        </BAIButton>
+        <BAIDeleteConfirmModal
+          open={open}
+          items={[{ key: '1', label: 'production-database' }]}
+          requireConfirmInput
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const MultipleItems: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Multiple items require typing "Delete" to confirm. Shows scrollable item list.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+    const items = [
+      { key: '1', label: 'project-alpha' },
+      { key: '2', label: 'project-beta' },
+      { key: '3', label: 'project-gamma' },
+      { key: '4', label: 'project-delta' },
+      { key: '5', label: 'project-epsilon' },
+    ];
+    return (
+      <>
+        <BAIButton
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => setOpen(true)}
+        >
+          Delete 5 Items
+        </BAIButton>
+        <BAIDeleteConfirmModal
+          open={open}
+          items={items}
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const ManyItems: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Large selection (50 items) demonstrating scroll behavior within the item list.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+    const items = Array.from({ length: 50 }, (_, i) => ({
+      key: String(i),
+      label: `resource-${String(i + 1).padStart(3, '0')}`,
+    }));
+    return (
+      <>
+        <BAIButton
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => setOpen(true)}
+        >
+          Delete 50 Items
+        </BAIButton>
+        <BAIDeleteConfirmModal
+          open={open}
+          items={items}
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const CustomRenderedItems: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Items with ReactNode labels — icons, tags, and custom components.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+    const items = [
+      {
+        key: '1',
+        label: (
+          <Space>
+            <FolderOutlined />
+            <span>shared-dataset</span>
+            <Tag color="blue">Public</Tag>
+          </Space>
+        ),
+      },
+      {
+        key: '2',
+        label: (
+          <Space>
+            <FolderOutlined />
+            <span>model-weights-v2</span>
+            <Tag color="red">Private</Tag>
+          </Space>
+        ),
+      },
+      {
+        key: '3',
+        label: (
+          <Space>
+            <FolderOutlined />
+            <span>training-logs</span>
+            <Tag color="green">Archived</Tag>
+          </Space>
+        ),
+      },
+    ];
+    return (
+      <>
+        <BAIButton
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => setOpen(true)}
+        >
+          Delete Folders
+        </BAIButton>
+        <BAIDeleteConfirmModal
+          open={open}
+          items={items}
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const WithExtraContent: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Extra content slot with checkboxes, similar to PurgeUsersModal pattern.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+    const items = [
+      { key: '1', label: 'user-john@example.com' },
+      { key: '2', label: 'user-jane@example.com' },
+    ];
+    return (
+      <>
+        <BAIButton
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => setOpen(true)}
+        >
+          Purge Users
+        </BAIButton>
+        <BAIDeleteConfirmModal
+          open={open}
+          items={items}
+          extraContent={
+            <BAIFlex direction="column" align="start">
+              <Checkbox>Also delete shared folders</Checkbox>
+              <Checkbox>Terminate running sessions</Checkbox>
+            </BAIFlex>
+          }
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+export const EmptyItems: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Edge case: empty items array. OK button is disabled.',
+      },
+    },
+  },
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <BAIButton
+          danger
+          icon={<DeleteOutlined />}
+          onClick={() => setOpen(true)}
+        >
+          Delete (No Selection)
+        </BAIButton>
+        <BAIDeleteConfirmModal
+          open={open}
+          items={[]}
+          onOk={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </>
+    );
+  },
+};

--- a/packages/backend.ai-ui/src/components/BAIDeleteConfirmModal.tsx
+++ b/packages/backend.ai-ui/src/components/BAIDeleteConfirmModal.tsx
@@ -1,0 +1,187 @@
+import BAIConfirmModalWithInput from './BAIConfirmModalWithInput';
+import BAIFlex from './BAIFlex';
+import BAIModal, { type BAIModalProps } from './BAIModal';
+import BAIText from './BAIText';
+import { ExclamationCircleFilled } from '@ant-design/icons';
+import { theme, Typography, type InputProps } from 'antd';
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+const { Text } = Typography;
+
+export interface BAIDeleteConfirmModalItem {
+  /** Unique key for React list rendering */
+  key: string;
+  /** Display label — accepts ReactNode for custom rendering (icons, tags, etc.) */
+  label: React.ReactNode;
+}
+
+export interface BAIDeleteConfirmModalProps extends Omit<
+  BAIModalProps,
+  'title' | 'children'
+> {
+  /** Items to be deleted. */
+  items: BAIDeleteConfirmModalItem[];
+  /** Custom modal title. Defaults to "Delete" / "Delete N items". */
+  title?: React.ReactNode;
+  /** Description shown above the item list. Defaults to "Are you sure you want to delete?" */
+  description?: React.ReactNode;
+  /** Force text-input confirmation even for a single item. Default: false */
+  requireConfirmInput?: boolean;
+  /**
+   * Custom confirmation text the user must type.
+   * Defaults: single item → item label as string (falls back to localized "Delete" if label is ReactNode),
+   * multiple items → localized "Delete".
+   * When using ReactNode labels with requireConfirmInput, provide this prop explicitly.
+   */
+  confirmText?: string;
+  /** Label above the confirmation input. Default: "Type {confirmText} to confirm." */
+  inputLabel?: React.ReactNode;
+  /** Additional props for the confirmation Input. */
+  inputProps?: InputProps;
+  /** Content rendered between the item list and the input field (e.g. checkboxes). */
+  extraContent?: React.ReactNode;
+  /** Max height (px) of the scrollable item list. Default: 200. Set 0 for no limit. */
+  itemListMaxHeight?: number;
+}
+
+function extractTextFromNode(node: React.ReactNode): string | undefined {
+  if (typeof node === 'string') return node;
+  if (typeof node === 'number') return String(node);
+  return undefined;
+}
+
+const BAIDeleteConfirmModal: React.FC<BAIDeleteConfirmModalProps> = ({
+  items,
+  title,
+  description,
+  requireConfirmInput = false,
+  confirmText: confirmTextProp,
+  inputLabel,
+  inputProps,
+  extraContent,
+  itemListMaxHeight = 200,
+  onOk,
+  onCancel,
+  okText,
+  okButtonProps,
+  ...restModalProps
+}) => {
+  'use memo';
+
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+
+  const needsInput = items.length > 1 || requireConfirmInput;
+
+  const resolvedTitle =
+    title ??
+    (items.length > 1
+      ? t('comp:BAIDeleteConfirmModal.DeleteNItems', {
+          count: items.length,
+        })
+      : t('comp:BAIDeleteConfirmModal.DeleteItem'));
+
+  const resolvedDescription =
+    description ?? t('comp:BAIDeleteConfirmModal.AreYouSureToDelete');
+
+  const resolvedConfirmText =
+    confirmTextProp ??
+    (items.length === 1
+      ? (extractTextFromNode(items[0]?.label) ?? t('general.button.Delete'))
+      : t('general.button.Delete'));
+
+  const resolvedOkText = okText ?? t('general.button.Delete');
+
+  const resolvedInputLabel = inputLabel ?? (
+    <Trans
+      i18nKey="comp:BAIDeleteConfirmModal.TypeToConfirm"
+      values={{ confirmText: resolvedConfirmText }}
+      components={{ code: <BAIText code /> }}
+    />
+  );
+
+  const itemListContent =
+    items.length > 0 ? (
+      <div
+        role="list"
+        style={{
+          maxHeight: itemListMaxHeight || undefined,
+          overflowY: itemListMaxHeight ? 'auto' : undefined,
+          backgroundColor: token.colorFillQuaternary,
+          border: `1px solid ${token.colorBorderSecondary}`,
+          borderRadius: token.borderRadiusSM,
+          padding: token.paddingXS,
+          paddingInline: token.padding,
+        }}
+      >
+        <BAIFlex direction="column" align="stretch" gap="xxs">
+          {items.map((item) => (
+            <div key={item.key} role="listitem">
+              {item.label}
+            </div>
+          ))}
+        </BAIFlex>
+      </div>
+    ) : null;
+
+  const bodyContent = (
+    <BAIFlex direction="column" align="stretch" gap="xs">
+      <Text>{resolvedDescription}</Text>
+      {itemListContent}
+      <Text type="danger">
+        {t('comp:BAIDeleteConfirmModal.CannotBeUndone')}
+      </Text>
+      {extraContent}
+    </BAIFlex>
+  );
+
+  if (needsInput) {
+    return (
+      <BAIConfirmModalWithInput
+        {...restModalProps}
+        destroyOnHidden
+        title={resolvedTitle}
+        confirmText={resolvedConfirmText}
+        content={bodyContent}
+        inputLabel={resolvedInputLabel}
+        inputProps={inputProps}
+        okText={resolvedOkText}
+        okButtonProps={okButtonProps}
+        onOk={onOk}
+        onCancel={onCancel}
+      />
+    );
+  }
+
+  return (
+    <BAIModal
+      {...restModalProps}
+      destroyOnHidden
+      title={
+        <BAIFlex direction="column" justify="start" align="start">
+          <Text strong>
+            <ExclamationCircleFilled
+              style={{ color: token.colorWarning, marginRight: 5 }}
+            />
+            {resolvedTitle}
+          </Text>
+        </BAIFlex>
+      }
+      okText={resolvedOkText}
+      okButtonProps={{
+        danger: true,
+        disabled: items.length === 0,
+        ...okButtonProps,
+      }}
+      onOk={onOk}
+      onCancel={onCancel}
+    >
+      {bodyContent}
+    </BAIModal>
+  );
+};
+
+BAIDeleteConfirmModal.displayName = 'BAIDeleteConfirmModal';
+
+export default BAIDeleteConfirmModal;

--- a/packages/backend.ai-ui/src/components/index.ts
+++ b/packages/backend.ai-ui/src/components/index.ts
@@ -54,6 +54,11 @@ export { default as BAIModal } from './BAIModal';
 export type { BAIModalProps } from './BAIModal';
 export { default as BAIConfirmModalWithInput } from './BAIConfirmModalWithInput';
 export type { BAIConfirmModalWithInputProps } from './BAIConfirmModalWithInput';
+export { default as BAIDeleteConfirmModal } from './BAIDeleteConfirmModal';
+export type {
+  BAIDeleteConfirmModalProps,
+  BAIDeleteConfirmModalItem,
+} from './BAIDeleteConfirmModal';
 export { default as BAIButton } from './BAIButton';
 export type { BAIButtonProps } from './BAIButton';
 export { default as BAIFetchKeyButton } from './BAIFetchKeyButton';

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Erfolgreich entfernt {{count}} Versionen.",
     "Version": "Version"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Sind Sie sicher, dass Sie löschen möchten?",
+    "CannotBeUndone": "Diese Aktion kann nicht rückgängig gemacht werden.",
+    "DeleteItem": "Löschen",
+    "DeleteNItems": "{{count}} Elemente löschen",
+    "TypeToConfirm": "Geben Sie <code>{{confirmText}}</code> ein, um zu bestätigen."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Deployment auswählen"
   },

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Κατάργηση επιτυχώς {{count}} εκδόσεις.",
     "Version": "Εκδοχή"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Είστε σίγουροι ότι θέλετε να διαγράψετε;",
+    "CannotBeUndone": "Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
+    "DeleteItem": "Διαγραφή",
+    "DeleteNItems": "Διαγραφή {{count}} στοιχείων",
+    "TypeToConfirm": "Πληκτρολογήστε <code>{{confirmText}}</code> για επιβεβαίωση."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Επιλέξτε ανάπτυξη"
   },

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -91,6 +91,13 @@
     "SuccessFullyRemoved": "Successfully removed {{count}} versions.",
     "Version": "Version"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Are you sure you want to delete?",
+    "CannotBeUndone": "This action cannot be undone.",
+    "DeleteItem": "Delete",
+    "DeleteNItems": "Delete {{count}} items",
+    "TypeToConfirm": "Type <code>{{confirmText}}</code> to confirm."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Select Deployment"
   },

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Las versiones {{count}} eliminadas con éxito.",
     "Version": "Versión"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "¿Está seguro de que desea eliminar?",
+    "CannotBeUndone": "Esta acción no se puede deshacer.",
+    "DeleteItem": "Eliminar",
+    "DeleteNItems": "Eliminar {{count}} elementos",
+    "TypeToConfirm": "Escriba <code>{{confirmText}}</code> para confirmar."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Seleccionar despliegue"
   },

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Poistettu onnistuneesti {{count}} versiot.",
     "Version": "Versio"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Haluatko varmasti poistaa?",
+    "CannotBeUndone": "Tätä toimintoa ei voi peruuttaa.",
+    "DeleteItem": "Poista",
+    "DeleteNItems": "Poista {{count}} kohdetta",
+    "TypeToConfirm": "Kirjoita <code>{{confirmText}}</code> vahvistaaksesi."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Valitse käyttöönotto"
   },

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Suppression avec succès des versions {{count}}.",
     "Version": "Version"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Êtes-vous sûr de vouloir supprimer ?",
+    "CannotBeUndone": "Cette action est irréversible.",
+    "DeleteItem": "Supprimer",
+    "DeleteNItems": "Supprimer {{count}} éléments",
+    "TypeToConfirm": "Saisissez <code>{{confirmText}}</code> pour confirmer."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Sélectionner un déploiement"
   },

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Berhasil menghapus {{count}} versi.",
     "Version": "Versi"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Apakah Anda yakin ingin menghapus?",
+    "CannotBeUndone": "Tindakan ini tidak dapat dibatalkan.",
+    "DeleteItem": "Hapus",
+    "DeleteNItems": "Hapus {{count}} item",
+    "TypeToConfirm": "Ketik <code>{{confirmText}}</code> untuk mengonfirmasi."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Pilih Deployment"
   },

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Rimosse correttamente {{count}} versioni.",
     "Version": "Versione"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Sei sicuro di voler eliminare?",
+    "CannotBeUndone": "Questa azione non può essere annullata.",
+    "DeleteItem": "Elimina",
+    "DeleteNItems": "Elimina {{count}} elementi",
+    "TypeToConfirm": "Digita <code>{{confirmText}}</code> per confermare."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Seleziona deployment"
   },

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "{{count}}バージョンを正常に削除しました。",
     "Version": "バージョン"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "本当に削除しますか？",
+    "CannotBeUndone": "この操作は元に戻せません。",
+    "DeleteItem": "削除",
+    "DeleteNItems": "{{count}} 件を削除",
+    "TypeToConfirm": "<code>{{confirmText}}</code> と入力して確認してください。"
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "デプロイメントを選択"
   },

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -91,6 +91,13 @@
     "SuccessFullyRemoved": "{{count}}개 버전을 성공적으로 제거했습니다.",
     "Version": "버전"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "정말 삭제하시겠습니까?",
+    "CannotBeUndone": "이 작업은 되돌릴 수 없습니다.",
+    "DeleteItem": "삭제",
+    "DeleteNItems": "{{count}}개 항목 삭제",
+    "TypeToConfirm": "<code>{{confirmText}}</code>을(를) 입력하여 확인하세요."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "배포를 선택해주세요"
   },

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Амжилттай хассан {{тоолох} хувилбарууд.",
     "Version": "Таамаглал"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Та устгахдаа итгэлтэй байна уу?",
+    "CannotBeUndone": "Энэ үйлдлийг буцаах боломжгүй.",
+    "DeleteItem": "Устгах",
+    "DeleteNItems": "{{count}} зүйл устгах",
+    "TypeToConfirm": "Баталгаажуулахын тулд <code>{{confirmText}}</code> гэж бичнэ үү."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Байршуулалт сонгох"
   },

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Berjaya dikeluarkan {{count}} versi.",
     "Version": "Versi"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Adakah anda pasti mahu memadam?",
+    "CannotBeUndone": "Tindakan ini tidak dapat dibatalkan.",
+    "DeleteItem": "Padam",
+    "DeleteNItems": "Padam {{count}} item",
+    "TypeToConfirm": "Taip <code>{{confirmText}}</code> untuk mengesahkan."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Pilih Penggunaan"
   },

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Pomyślnie usunięte wersje {{count}}.",
     "Version": "Wersja"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Czy na pewno chcesz usunąć?",
+    "CannotBeUndone": "Tej operacji nie można cofnąć.",
+    "DeleteItem": "Usuń",
+    "DeleteNItems": "Usuń {{count}} elementów",
+    "TypeToConfirm": "Wpisz <code>{{confirmText}}</code>, aby potwierdzić."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Wybierz wdrożenie"
   },

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Removido com sucesso {{count}} versões.",
     "Version": "Versão"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Tem certeza que deseja excluir?",
+    "CannotBeUndone": "Esta ação não pode ser desfeita.",
+    "DeleteItem": "Excluir",
+    "DeleteNItems": "Excluir {{count}} itens",
+    "TypeToConfirm": "Digite <code>{{confirmText}}</code> para confirmar."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Selecionar implantação"
   },

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Removido com sucesso {{count}} versões.",
     "Version": "Versão"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Tem a certeza de que pretende eliminar?",
+    "CannotBeUndone": "Esta ação não pode ser anulada.",
+    "DeleteItem": "Eliminar",
+    "DeleteNItems": "Eliminar {{count}} itens",
+    "TypeToConfirm": "Escreva <code>{{confirmText}}</code> para confirmar."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Selecionar implantação"
   },

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Успешно удалено {{count}} версии.",
     "Version": "Версия"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Вы уверены, что хотите удалить?",
+    "CannotBeUndone": "Это действие нельзя отменить.",
+    "DeleteItem": "Удалить",
+    "DeleteNItems": "Удалить {{count}} элементов",
+    "TypeToConfirm": "Введите <code>{{confirmText}}</code> для подтверждения."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Выберите развёртывание"
   },

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "ลบเวอร์ชัน {{count}} สำเร็จ",
     "Version": "รุ่น"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "คุณแน่ใจหรือไม่ว่าต้องการลบ?",
+    "CannotBeUndone": "การกระทำนี้ไม่สามารถยกเลิกได้",
+    "DeleteItem": "ลบ",
+    "DeleteNItems": "ลบ {{count}} รายการ",
+    "TypeToConfirm": "พิมพ์ <code>{{confirmText}}</code> เพื่อยืนยัน"
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "เลือกการปรับใช้"
   },

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "{{count}} sürümlerini başarıyla kaldırdı.",
     "Version": "Versiyon"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Silmek istediğinizden emin misiniz?",
+    "CannotBeUndone": "Bu işlem geri alınamaz.",
+    "DeleteItem": "Sil",
+    "DeleteNItems": "{{count}} öğeyi sil",
+    "TypeToConfirm": "Onaylamak için <code>{{confirmText}}</code> yazın."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Dağıtım seçin"
   },

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "Đã loại bỏ thành công các phiên bản {{count}}.",
     "Version": "Phiên bản"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "Bạn có chắc chắn muốn xóa không?",
+    "CannotBeUndone": "Hành động này không thể hoàn tác.",
+    "DeleteItem": "Xóa",
+    "DeleteNItems": "Xóa {{count}} mục",
+    "TypeToConfirm": "Nhập <code>{{confirmText}}</code> để xác nhận."
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "Chọn triển khai"
   },

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "成功删除了{{count}}版本。",
     "Version": "版本"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "您确定要删除吗？",
+    "CannotBeUndone": "此操作无法撤销。",
+    "DeleteItem": "删除",
+    "DeleteNItems": "删除 {{count}} 个项目",
+    "TypeToConfirm": "输入 <code>{{confirmText}}</code> 以确认。"
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "选择部署"
   },

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -88,6 +88,13 @@
     "SuccessFullyRemoved": "成功刪除了{{count}}版本。",
     "Version": "版本"
   },
+  "comp:BAIDeleteConfirmModal": {
+    "AreYouSureToDelete": "您確定要刪除嗎？",
+    "CannotBeUndone": "此操作無法復原。",
+    "DeleteItem": "刪除",
+    "DeleteNItems": "刪除 {{count}} 個項目",
+    "TypeToConfirm": "輸入 <code>{{confirmText}}</code> 以確認。"
+  },
   "comp:BAIDeploymentSelect": {
     "SelectDeployment": "選擇部署"
   },

--- a/react/src/components/KeypairResourcePolicyList.tsx
+++ b/react/src/components/KeypairResourcePolicyList.tsx
@@ -24,7 +24,7 @@ import {
   SettingOutlined,
 } from '@ant-design/icons';
 import { useToggle } from 'ahooks';
-import { App, Button, Dropdown, Tooltip, Typography } from 'antd';
+import { App, Button, Dropdown, Tooltip } from 'antd';
 import { AnyObject } from 'antd/es/_util/type';
 import type { ColumnsType, ColumnType } from 'antd/es/table';
 import {
@@ -35,6 +35,7 @@ import {
   BAIAllowedVfolderHostsWithPermission,
   BAIResourceNumberWithIcon,
   BAINameActionCell,
+  BAIDeleteConfirmModal,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { EllipsisIcon } from 'lucide-react';
@@ -52,7 +53,7 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
   props,
 ) => {
   const { t } = useTranslation();
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
 
   const [keypairResourcePolicyFetchKey, updateKeypairResourcePolicyFetchKey] =
     useUpdatableState('initial-fetch');
@@ -64,6 +65,9 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
     useState<KeypairResourcePolicySettingModalFragment$key | null>();
   const [currentResourcePolicy, setCurrentResourcePolicy] =
     useState<KeypairResourcePolicyInfoModalFragment$key | null>(null);
+  const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
+    null,
+  );
   const [isPendingInfoModalOpen, startInfoModalOpenTransition] =
     useTransition();
 
@@ -142,68 +146,7 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
               icon: <DeleteOutlined />,
               type: 'danger',
               onClick: () => {
-                modal.confirm({
-                  title: t('resourcePolicy.DeletePolicy'),
-                  content: (
-                    <BAIFlex direction="column" align="stretch">
-                      <BAIFlex gap={'xxs'}>
-                        <Typography.Text>
-                          {t('resourcePolicy.DeletePolicyDescription')}
-                        </Typography.Text>
-                        <Typography.Text strong>{row?.name}</Typography.Text>
-                      </BAIFlex>
-                      <br />
-                      <Typography.Text type="danger">
-                        {t('dialog.warning.CannotBeUndone')}
-                      </Typography.Text>
-                    </BAIFlex>
-                  ),
-                  okButtonProps: {
-                    danger: true,
-                  },
-                  okText: t('button.Delete'),
-                  onOk: () => {
-                    if (row?.name) {
-                      return new Promise<void>((resolve) => {
-                        commitDelete({
-                          variables: {
-                            name: row.name!,
-                          },
-                          onCompleted: (res, errors) => {
-                            if (!res?.delete_keypair_resource_policy?.ok) {
-                              message.error(
-                                res?.delete_keypair_resource_policy?.msg,
-                              );
-                              resolve();
-                              return;
-                            }
-                            if (errors && errors?.length > 0) {
-                              const errorMsgList = _.map(
-                                errors,
-                                (error) => error.message,
-                              );
-                              for (const error of errorMsgList) {
-                                message.error(error);
-                              }
-                            } else {
-                              startRefetchTransition(() =>
-                                updateKeypairResourcePolicyFetchKey(),
-                              );
-                              message.success(
-                                t('resourcePolicy.SuccessfullyDeleted'),
-                              );
-                            }
-                            resolve();
-                          },
-                          onError(err) {
-                            message.error(err?.message);
-                            resolve();
-                          },
-                        });
-                      });
-                    }
-                  },
-                });
+                setDeletingPolicyName(row?.name ?? null);
               },
             },
           ]}
@@ -470,6 +413,50 @@ const KeypairResourcePolicyList: React.FC<KeypairResourcePolicyListProps> = (
         }}
         loading={isPendingInfoModalOpen}
         resourcePolicyFrgmt={currentResourcePolicy || null}
+      />
+      <BAIDeleteConfirmModal
+        open={!!deletingPolicyName}
+        items={
+          deletingPolicyName
+            ? [{ key: deletingPolicyName, label: deletingPolicyName }]
+            : []
+        }
+        title={t('resourcePolicy.DeletePolicy')}
+        description={t('resourcePolicy.DeletePolicyDescription')}
+        onOk={() => {
+          if (deletingPolicyName) {
+            return new Promise<void>((resolve) => {
+              commitDelete({
+                variables: { name: deletingPolicyName },
+                onCompleted: (res, errors) => {
+                  if (!res?.delete_keypair_resource_policy?.ok) {
+                    message.error(res?.delete_keypair_resource_policy?.msg);
+                    resolve();
+                    return;
+                  }
+                  if (errors && errors?.length > 0) {
+                    for (const error of errors) {
+                      message.error(error.message);
+                    }
+                  } else {
+                    startRefetchTransition(() =>
+                      updateKeypairResourcePolicyFetchKey(),
+                    );
+                    message.success(t('resourcePolicy.SuccessfullyDeleted'));
+                  }
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+                onError(err) {
+                  message.error(err?.message);
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+              });
+            });
+          }
+        }}
+        onCancel={() => setDeletingPolicyName(null)}
       />
     </BAIFlex>
   );

--- a/react/src/components/ProjectResourcePolicyList.tsx
+++ b/react/src/components/ProjectResourcePolicyList.tsx
@@ -34,6 +34,7 @@ import {
   BAIFlex,
   useUpdatableState,
   BAINameActionCell,
+  BAIDeleteConfirmModal,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
@@ -54,7 +55,7 @@ const ProjectResourcePolicyList: React.FC<
   ProjectResourcePolicyListProps
 > = () => {
   const { t } = useTranslation();
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const [isRefetchPending, startRefetchTransition] = useTransition();
   const [projectResourcePolicyFetchKey, updateProjectResourcePolicyFetchKey] =
     useUpdatableState('initial-fetch');
@@ -63,6 +64,9 @@ const ProjectResourcePolicyList: React.FC<
     useToggle();
   const [editingProjectResourcePolicy, setEditingProjectResourcePolicy] =
     useState<ProjectResourcePolicySettingModalFragment$key | null>();
+  const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
+    null,
+  );
 
   const baiClient = useSuspendedBackendaiClient();
   const supportMaxNetworkCount = baiClient?.supports('max_network_count');
@@ -130,53 +134,7 @@ const ProjectResourcePolicyList: React.FC<
               icon: <DeleteOutlined />,
               type: 'danger',
               onClick: () => {
-                modal.confirm({
-                  title: t('dialog.ask.DoYouWantToProceed'),
-                  content: t('dialog.warning.CannotBeUndone'),
-                  okType: 'danger',
-                  okText: t('button.Delete'),
-                  onOk: () => {
-                    if (row?.name) {
-                      return new Promise<void>((resolve) => {
-                        commitDelete({
-                          variables: {
-                            name: row.name,
-                          },
-                          onCompleted: (res, errors) => {
-                            if (!res?.delete_project_resource_policy?.ok) {
-                              message.error(
-                                res?.delete_project_resource_policy?.msg,
-                              );
-                              resolve();
-                              return;
-                            }
-                            if (errors && errors?.length > 0) {
-                              const errorMsgList = _.map(
-                                errors,
-                                (error) => error.message,
-                              );
-                              for (const error of errorMsgList) {
-                                message.error(error);
-                              }
-                            } else {
-                              startRefetchTransition(() =>
-                                updateProjectResourcePolicyFetchKey(),
-                              );
-                              message.success(
-                                t('resourcePolicy.SuccessfullyDeleted'),
-                              );
-                            }
-                            resolve();
-                          },
-                          onError(err) {
-                            message.error(err?.message);
-                            resolve();
-                          },
-                        });
-                      });
-                    }
-                  },
-                });
+                setDeletingPolicyName(row?.name ?? null);
               },
             },
           ]}
@@ -356,6 +314,50 @@ const ProjectResourcePolicyList: React.FC<
           setEditingProjectResourcePolicy(null);
           setIsCreatingPolicySetting(false);
         }}
+      />
+      <BAIDeleteConfirmModal
+        open={!!deletingPolicyName}
+        items={
+          deletingPolicyName
+            ? [{ key: deletingPolicyName, label: deletingPolicyName }]
+            : []
+        }
+        title={t('resourcePolicy.DeletePolicy')}
+        description={t('resourcePolicy.DeletePolicyDescription')}
+        onOk={() => {
+          if (deletingPolicyName) {
+            return new Promise<void>((resolve) => {
+              commitDelete({
+                variables: { name: deletingPolicyName },
+                onCompleted: (res, errors) => {
+                  if (!res?.delete_project_resource_policy?.ok) {
+                    message.error(res?.delete_project_resource_policy?.msg);
+                    resolve();
+                    return;
+                  }
+                  if (errors && errors?.length > 0) {
+                    for (const error of errors) {
+                      message.error(error.message);
+                    }
+                  } else {
+                    startRefetchTransition(() =>
+                      updateProjectResourcePolicyFetchKey(),
+                    );
+                    message.success(t('resourcePolicy.SuccessfullyDeleted'));
+                  }
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+                onError(err) {
+                  message.error(err?.message);
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+              });
+            });
+          }
+        }}
+        onCancel={() => setDeletingPolicyName(null)}
       />
     </BAIFlex>
   );

--- a/react/src/components/UserResourcePolicyList.tsx
+++ b/react/src/components/UserResourcePolicyList.tsx
@@ -33,6 +33,7 @@ import {
   BAITable,
   BAIFlex,
   BAINameActionCell,
+  BAIDeleteConfirmModal,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
@@ -51,7 +52,7 @@ interface UserResourcePolicyListProps {}
 
 const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
   const { t } = useTranslation();
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
 
   const [isRefetchPending, startRefetchTransition] = useTransition();
   const [userResourcePolicyFetchKey, updateUserResourcePolicyFetchKey] =
@@ -61,6 +62,9 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
     useToggle();
   const [editingUserResourcePolicy, setEditingUserResourcePolicy] =
     useState<UserResourcePolicySettingModalFragment$key | null>();
+  const [deletingPolicyName, setDeletingPolicyName] = useState<string | null>(
+    null,
+  );
 
   const { user_resource_policies } =
     useLazyLoadQuery<UserResourcePolicyListQuery>(
@@ -125,53 +129,7 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
               icon: <DeleteOutlined />,
               type: 'danger',
               onClick: () => {
-                modal.confirm({
-                  title: t('dialog.ask.DoYouWantToProceed'),
-                  content: t('dialog.warning.CannotBeUndone'),
-                  okType: 'danger',
-                  okText: t('button.Delete'),
-                  onOk: () => {
-                    if (row?.name) {
-                      return new Promise<void>((resolve) => {
-                        commitDelete({
-                          variables: {
-                            name: row.name,
-                          },
-                          onCompleted: (res, errors) => {
-                            if (!res?.delete_user_resource_policy?.ok) {
-                              message.error(
-                                res?.delete_user_resource_policy?.msg,
-                              );
-                              resolve();
-                              return;
-                            }
-                            if (errors && errors.length > 0) {
-                              const errorMsgList = errors.map(
-                                (error) => error.message,
-                              );
-                              for (const error of errorMsgList) {
-                                message.error(error);
-                              }
-                              resolve();
-                              return;
-                            }
-                            startRefetchTransition(() =>
-                              updateUserResourcePolicyFetchKey(),
-                            );
-                            message.success(
-                              t('resourcePolicy.SuccessfullyDeleted'),
-                            );
-                            resolve();
-                          },
-                          onError(err) {
-                            message.error(err?.message);
-                            resolve();
-                          },
-                        });
-                      });
-                    }
-                  },
-                });
+                setDeletingPolicyName(row?.name ?? null);
               },
             },
           ]}
@@ -360,6 +318,50 @@ const UserResourcePolicyList: React.FC<UserResourcePolicyListProps> = () => {
           setEditingUserResourcePolicy(null);
           setIsCreatingPolicySetting(false);
         }}
+      />
+      <BAIDeleteConfirmModal
+        open={!!deletingPolicyName}
+        items={
+          deletingPolicyName
+            ? [{ key: deletingPolicyName, label: deletingPolicyName }]
+            : []
+        }
+        title={t('resourcePolicy.DeletePolicy')}
+        description={t('resourcePolicy.DeletePolicyDescription')}
+        onOk={() => {
+          if (deletingPolicyName) {
+            return new Promise<void>((resolve) => {
+              commitDelete({
+                variables: { name: deletingPolicyName },
+                onCompleted: (res, errors) => {
+                  if (!res?.delete_user_resource_policy?.ok) {
+                    message.error(res?.delete_user_resource_policy?.msg);
+                    resolve();
+                    return;
+                  }
+                  if (errors && errors.length > 0) {
+                    for (const error of errors) {
+                      message.error(error.message);
+                    }
+                  } else {
+                    startRefetchTransition(() =>
+                      updateUserResourcePolicyFetchKey(),
+                    );
+                    message.success(t('resourcePolicy.SuccessfullyDeleted'));
+                  }
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+                onError(err) {
+                  message.error(err?.message);
+                  setDeletingPolicyName(null);
+                  resolve();
+                },
+              });
+            });
+          }
+        }}
+        onCancel={() => setDeletingPolicyName(null)}
       />
     </BAIFlex>
   );


### PR DESCRIPTION
Resolves #6308(FR-2424)

## Summary
- Add `BAIDeleteConfirmModal` — a unified delete confirmation modal component for table row deletion
  - Single item: simple confirm dialog with item name
  - Multiple items (2+): requires typing "Delete" to confirm
  - `requireConfirmInput` prop to force text-input even for single items
  - Items accept `React.ReactNode` for custom rendering
  - `extraContent` slot for domain-specific additions (checkboxes, etc.)
  - Scrollable item list in a styled container for many items
- Apply `BAIDeleteConfirmModal` to all 3 resource-policy tables:
  - `KeypairResourcePolicyList`
  - `UserResourcePolicyList`
  - `ProjectResourcePolicyList`
- Add i18n translations for all 21 languages
- Add Storybook stories (7 variants)

## Test plan
- [ ] Admin > Resource Policy > Keypair tab: delete a policy, confirm modal shows correctly
- [ ] Admin > Resource Policy > User tab: same
- [ ] Admin > Resource Policy > Project tab: same
- [ ] Storybook: verify all BAIDeleteConfirmModal stories render correctly