### PR TITLE
feat(FR-2432): make current IP address copyable in UserProfileSettingModal

### DIFF
--- a/react/src/components/UserProfileSettingModal.tsx
+++ b/react/src/components/UserProfileSettingModal.tsx
@@ -22,7 +22,12 @@ import {
   Tag,
   Typography,
 } from 'antd';
-import { BAIModal, BAISelect, useErrorMessageResolver } from 'backend.ai-ui';
+import {
+  BAIModal,
+  BAISelect,
+  BAIText,
+  useErrorMessageResolver,
+} from 'backend.ai-ui';
 import _ from 'lodash';
 import React, { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -284,11 +289,16 @@ const UserProfileSettingModal: React.FC<Props> = ({
                     {t('credential.AllowedClientIPHint')}
                   </Typography.Text>
                   <br />
-                  <Typography.Text type="secondary">
+                  <BAIText
+                    type="secondary"
+                    copyable={
+                      currentClientIp ? { text: currentClientIp } : false
+                    }
+                  >
                     {t('credential.CurrentClientIp', {
                       ip: currentClientIp,
                     })}
-                  </Typography.Text>
+                  </BAIText>
                 </>
               }
               rules={[


### PR DESCRIPTION
Resolves #6306(FR-2432)

## Summary
- Replace `Typography.Text` with `BAIText` for the current client IP display in UserProfileSettingModal
- Use `copyable={{ text: currentClientIp }}` so only the IP address value is copied

## Test plan
- [ ] Open UserProfileSettingModal
- [ ] Verify copy icon appears next to IP address
- [ ] Click copy icon — only the IP value is copied

## Screenshots

| After (copyable IP) |
|-------|
| ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6309/20260401-155446-after-copyable-ip.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)