### PR TITLE
feat(FR-2430): add copyable name icon on hover to BAINameActionCell

### DIFF
--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.stories.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.stories.tsx
@@ -430,6 +430,24 @@ export const CopyableNameWithLink: Story = {
   },
 };
 
+export const CopyableNameWithAlwaysVisibleActions: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Copyable name with action buttons always visible (not hover-only). Verifies copy icon positioning alongside persistent actions.',
+      },
+    },
+  },
+  args: {
+    icon: <FolderOutlined />,
+    title: 'Copyable With Always Actions',
+    actions: sampleActions.slice(0, 2),
+    copyable: true,
+    showActions: 'always',
+  },
+};
+
 export const TitleOnly: Story = {
   parameters: {
     docs: {

--- a/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
+++ b/packages/backend.ai-ui/src/components/Table/BAINameActionCell.tsx
@@ -134,15 +134,6 @@ const useStyles = createStyles(({ css, token }) => ({
     color: ${token.colorTextDisabled};
     background-color: ${token.colorBgContainerDisabled};
   `,
-  copyableHover: css`
-    .ant-typography-copy {
-      opacity: 0;
-      transition: opacity 0.15s ease;
-    }
-    &:hover .ant-typography-copy {
-      opacity: 1;
-    }
-  `,
 }));
 
 // Estimated width per action button (icon button small size)
@@ -280,10 +271,14 @@ const BAINameActionCell: React.FC<BAINameActionCellProps> = ({
     ...menuOnlyActions.map(toMenuItem),
   ];
 
+  const copyableConfig = copyable
+    ? { text: typeof title === 'string' ? title : '' }
+    : undefined;
+
   const renderTitle = () => {
     if (to) {
       return (
-        <>
+        <BAIText copyable={copyableConfig} ellipsis={{ tooltip: true }}>
           <BAILink
             to={to}
             type="hover"
@@ -297,35 +292,23 @@ const BAINameActionCell: React.FC<BAINameActionCellProps> = ({
           >
             {title}
           </BAILink>
-          {copyable && (
-            <BAIText
-              copyable={{ text: String(title) }}
-              style={{ flexShrink: 0 }}
-            />
-          )}
-        </>
+        </BAIText>
       );
     }
     if (onTitleClick) {
       return (
-        <>
+        <BAIText copyable={copyableConfig} ellipsis={{ tooltip: true }}>
           <BAILink type="hover" onClick={onTitleClick} ellipsis>
             {title}
           </BAILink>
-          {copyable && (
-            <BAIText
-              copyable={{ text: String(title) }}
-              style={{ flexShrink: 0 }}
-            />
-          )}
-        </>
+        </BAIText>
       );
     }
     return (
       <BAIText
         ellipsis={{ tooltip: true }}
-        copyable={copyable ? { text: String(title) } : undefined}
-        style={{ flex: 1, minWidth: 0 }}
+        copyable={copyableConfig}
+        style={{ minWidth: 0 }}
       >
         {title}
       </BAIText>
@@ -342,10 +325,7 @@ const BAINameActionCell: React.FC<BAINameActionCellProps> = ({
       )}
       style={style}
     >
-      <div
-        ref={titleAreaRef}
-        className={cx(styles.titleArea, copyable && styles.copyableHover)}
-      >
+      <div ref={titleAreaRef} className={styles.titleArea}>
         {icon && (
           <span
             className={cx(styles.titleIcon, 'bai-name-action-cell-title-icon')}


### PR DESCRIPTION
Resolves #6304(FR-2430)

## Summary
- Add `copyable` boolean prop to `BAINameActionCell` component
- Copy icon appears on hover next to the name text using BAIText copyable feature
- Add Storybook stories: `CopyableName` and `CopyableNameWithLink`
- Guard `String(title)` with type check to prevent `[object Object]` for non-string ReactNode

## Test plan
- [ ] Verify copy icon appears on hover in BAINameActionCell when `copyable` is true
- [ ] Verify clicking copies the name text to clipboard
- [ ] Check Storybook stories render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)