### PR TITLE
feat(FR-2427): update resource-policy tab names with resource policy suffix

### DIFF
--- a/react/src/pages/ResourcePolicyPage.tsx
+++ b/react/src/pages/ResourcePolicyPage.tsx
@@ -42,15 +42,15 @@ const ResourcePolicyPage: React.FC<ResourcePolicyPageProps> = () => {
       tabList={filterOutEmpty([
         {
           key: 'keypair',
-          label: t('resourcePolicy.Keypair'),
+          label: t('resourcePolicy.KeypairResourcePolicy'),
         },
         {
           key: 'user',
-          label: t('resourcePolicy.User'),
+          label: t('resourcePolicy.UserResourcePolicy'),
         },
         {
           key: 'project',
-          label: t('resourcePolicy.Project'),
+          label: t('resourcePolicy.ProjectResourcePolicy'),
         },
       ])}
     >

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1772,7 +1772,7 @@
     "PolicyName": "Versicherungsname",
     "PolicyNameEmpty": "Der Richtlinienname darf nicht leer sein.",
     "Project": "Projekt",
-    "ProjectResourcePolicy": "Projektressourcenrichtlinie",
+    "ProjectResourcePolicy": "Projekt-Ressourcenrichtlinie",
     "ResourcePolicy": "Ressourcenrichtlinie",
     "ResourcePolicyNameAlreadyExists": "Der Name der Ressourcenrichtlinie ist bereits vorhanden. \nBitte ändern Sie den hinzuzufügenden Namen.",
     "Resources": "Ressourcen",
@@ -1785,7 +1785,7 @@
     "Unlimited": "Unbegrenzt",
     "UpdateResourcePolicy": "Ressourcenrichtlinie aktualisieren",
     "User": "Benutzer",
-    "UserResourcePolicy": "Benutzerressourcenrichtlinie"
+    "UserResourcePolicy": "Benutzer-Ressourcenrichtlinie"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Sie sind dabei, diese Voreinstellung zu löschen:",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1752,7 +1752,7 @@
     "IdleTimeout": "Χρονικό όριο αδράνειας",
     "IdleTimeoutSec": "Χρονικό όριο αδράνειας (δευτ.)",
     "Keypair": "Keypair",
-    "KeypairResourcePolicy": "Πολιτική πόρων ζεύγους κλειδιών",
+    "KeypairResourcePolicy": "Πολιτική πόρων Keypair",
     "MaxConcurrentSFTPSessions": "Max ταυτόχρονες συνεδρίες SFTP",
     "MaxCustomizedImageCount": "Μέγιστος προσαρμοσμένος αριθμός εικόνων",
     "MaxFolderCount": "Μέγιστος αριθμός φακέλων",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1752,7 +1752,7 @@
     "IdleTimeout": "Tiempo de inactividad",
     "IdleTimeoutSec": "Tiempo de espera (seg.)",
     "Keypair": "Par de claves",
-    "KeypairResourcePolicy": "Política de recursos de par de claves",
+    "KeypairResourcePolicy": "Política de recursos de Keypair",
     "MaxConcurrentSFTPSessions": "Sesiones SFTP concurrentes máximas",
     "MaxCustomizedImageCount": "Número máximo de imágenes personalizadas",
     "MaxFolderCount": "Número máximo de carpetas",
@@ -1770,7 +1770,7 @@
     "PolicyName": "Nombre de la póliza",
     "PolicyNameEmpty": "El nombre de la política no debe estar vacío.",
     "Project": "Proyecto",
-    "ProjectResourcePolicy": "Política de recursos del proyecto",
+    "ProjectResourcePolicy": "Política de recursos de proyecto",
     "ResourcePolicy": "Política de recursos",
     "ResourcePolicyNameAlreadyExists": "El nombre de la política de recursos ya existe. \nCambie el nombre para agregarlo.",
     "Resources": "Recursos",
@@ -1783,7 +1783,7 @@
     "Unlimited": "Sin límites",
     "UpdateResourcePolicy": "Actualizar la política de recursos",
     "User": "Usuario",
-    "UserResourcePolicy": "Política de recursos del usuario"
+    "UserResourcePolicy": "Política de recursos de usuario"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Está a punto de borrar este preajuste:",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1770,7 +1770,7 @@
     "PolicyName": "Politiikan nimi",
     "PolicyNameEmpty": "Käytännön nimi ei saa olla tyhjä.",
     "Project": "Projekti",
-    "ProjectResourcePolicy": "Projektin resurssipolitiikka",
+    "ProjectResourcePolicy": "Projektin resurssikäytäntö",
     "ResourcePolicy": "Resurssipolitiikka",
     "ResourcePolicyNameAlreadyExists": "Resurssikäytännön nimi on jo olemassa. \nMuuta lisättävä nimi.",
     "Resources": "Resurssit",
@@ -1783,7 +1783,7 @@
     "Unlimited": "Rajoittamaton",
     "UpdateResourcePolicy": "Resurssipolitiikan päivittäminen",
     "User": "Käyttäjä",
-    "UserResourcePolicy": "Käyttäjäresurssikäytäntö"
+    "UserResourcePolicy": "Käyttäjän resurssikäytäntö"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Olet poistamassa tätä esiasetusta:",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1752,7 +1752,7 @@
     "IdleTimeout": "Délai d'inactivité",
     "IdleTimeoutSec": "Délai d'inactivité (sec.)",
     "Keypair": "Paire de clés",
-    "KeypairResourcePolicy": "Politique de ressources de paires de clés",
+    "KeypairResourcePolicy": "Politique de ressources Keypair",
     "MaxConcurrentSFTPSessions": "Sessions SFTP max simultanées",
     "MaxCustomizedImageCount": "Nombre maximal d'images personnalisées",
     "MaxFolderCount": "Nombre maximum de dossiers",
@@ -1770,7 +1770,7 @@
     "PolicyName": "Nom de la politique",
     "PolicyNameEmpty": "Le nom de la stratégie ne doit pas être vide.",
     "Project": "Projet",
-    "ProjectResourcePolicy": "Politique des ressources du projet",
+    "ProjectResourcePolicy": "Politique de ressources projet",
     "ResourcePolicy": "Politique de ressources",
     "ResourcePolicyNameAlreadyExists": "Le nom de la stratégie de ressources existe déjà. \nVeuillez modifier le nom à ajouter.",
     "Resources": "Ressources",
@@ -1783,7 +1783,7 @@
     "Unlimited": "Illimité",
     "UpdateResourcePolicy": "Mettre à jour la politique de ressources",
     "User": "Utilisateur",
-    "UserResourcePolicy": "Politique des ressources utilisateur"
+    "UserResourcePolicy": "Politique de ressources utilisateur"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Vous êtes sur le point de supprimer ce préréglage :",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1754,7 +1754,7 @@
     "IdleTimeout": "Batas Waktu Diam",
     "IdleTimeoutSec": "Waktu tunggu menganggur (dtk.)",
     "Keypair": "pasangan kunci",
-    "KeypairResourcePolicy": "Kebijakan Sumber Daya Pasangan Kunci",
+    "KeypairResourcePolicy": "Kebijakan Sumber Daya Keypair",
     "MaxConcurrentSFTPSessions": "Sesi SFTP Max Concurrent",
     "MaxCustomizedImageCount": "Jumlah Gambar Khusus Maksimum",
     "MaxFolderCount": "Jumlah Folder Maks",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1752,7 +1752,7 @@
     "IdleTimeout": "Timeout di inattività",
     "IdleTimeoutSec": "Timeout di inattività (sec.)",
     "Keypair": "Coppia di chiavi",
-    "KeypairResourcePolicy": "Politica delle risorse per la coppia di chiavi",
+    "KeypairResourcePolicy": "Policy risorse Keypair",
     "MaxConcurrentSFTPSessions": "Sessioni SFTP con contenitori massimi",
     "MaxCustomizedImageCount": "Conteggio massimo di immagini personalizzate",
     "MaxFolderCount": "Conteggio massimo cartelle",
@@ -1770,7 +1770,7 @@
     "PolicyName": "Nome criterio Policy",
     "PolicyNameEmpty": "Il nome del criterio non deve essere vuoto.",
     "Project": "Progetto",
-    "ProjectResourcePolicy": "Criterio risorse del progetto",
+    "ProjectResourcePolicy": "Policy risorse progetto",
     "ResourcePolicy": "Politica delle risorse",
     "ResourcePolicyNameAlreadyExists": "Il nome della policy delle risorse esiste già. \nSi prega di modificare il nome da aggiungere.",
     "Resources": "risorse",
@@ -1783,7 +1783,7 @@
     "Unlimited": "Illimitato",
     "UpdateResourcePolicy": "Aggiorna la politica delle risorse",
     "User": "Utente",
-    "UserResourcePolicy": "Politica sulle risorse utente"
+    "UserResourcePolicy": "Policy risorse utente"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Stai per eliminare questo preset:",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1754,7 +1754,7 @@
     "IdleTimeout": "アイドルタイムアウト",
     "IdleTimeoutSec": "アイドルタイムアウト（秒）",
     "Keypair": "キーペア",
-    "KeypairResourcePolicy": "キーペアのリソースポリシー",
+    "KeypairResourcePolicy": "キーペアリソースポリシー",
     "MaxConcurrentSFTPSessions": "Max Concurrent SFTPセッション",
     "MaxCustomizedImageCount": "カスタマイズされた画像の最大数",
     "MaxFolderCount": "最大フォルダ数",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1753,7 +1753,7 @@
     "IdleTimeout": "Сул зогсолтын хугацаа",
     "IdleTimeoutSec": "Сул зогсолт (сек.)",
     "Keypair": "Товчлуур",
-    "KeypairResourcePolicy": "Түлхүүрийн нөөцийн бодлого",
+    "KeypairResourcePolicy": "Keypair нөөцийн бодлого",
     "MaxConcurrentSFTPSessions": "Макс тохиролцсон SFTP хуралдаанууд",
     "MaxCustomizedImageCount": "Хамгийн их тохируулсан зургийн тоо",
     "MaxFolderCount": "Хамгийн их хавтасны тоо",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1752,7 +1752,7 @@
     "IdleTimeout": "Tamat Masa Terbiar",
     "IdleTimeoutSec": "Tamat waktu tunggu (sek.)",
     "Keypair": "Pasangan kekunci",
-    "KeypairResourcePolicy": "Dasar Sumber Pasangan Kunci",
+    "KeypairResourcePolicy": "Dasar Sumber Keypair",
     "MaxConcurrentSFTPSessions": "Sesi SFTP bersamaan Max",
     "MaxCustomizedImageCount": "Kiraan Imej Tersuai Maks",
     "MaxFolderCount": "Kiraan Folder Maks",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1752,7 +1752,7 @@
     "IdleTimeout": "Limit czasu bezczynności",
     "IdleTimeoutSec": "Limit czasu bezczynności (sek.)",
     "Keypair": "Para kluczy",
-    "KeypairResourcePolicy": "Polityka zasobów pary kluczy",
+    "KeypairResourcePolicy": "Polityka zasobów Keypair",
     "MaxConcurrentSFTPSessions": "Max równoległe sesje SFTP",
     "MaxCustomizedImageCount": "Maksymalna dostosowana liczba obrazów",
     "MaxFolderCount": "Maksymalna liczba folderów",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1752,7 +1752,7 @@
     "IdleTimeout": "Tempo limite ocioso",
     "IdleTimeoutSec": "Tempo limite ocioso (seg.)",
     "Keypair": "Par de chaves",
-    "KeypairResourcePolicy": "Política de recursos de par de chaves",
+    "KeypairResourcePolicy": "Política de recursos de Keypair",
     "MaxConcurrentSFTPSessions": "Sessões SFTP simultâneas máximas",
     "MaxCustomizedImageCount": "Contagem máxima de imagens personalizadas",
     "MaxFolderCount": "Contagem máxima de pastas",
@@ -1770,7 +1770,7 @@
     "PolicyName": "Nome da política",
     "PolicyNameEmpty": "O nome da política não deve estar vazio.",
     "Project": "Projeto",
-    "ProjectResourcePolicy": "Política de Recursos do Projeto",
+    "ProjectResourcePolicy": "Política de recursos de projeto",
     "ResourcePolicy": "Política de Recursos",
     "ResourcePolicyNameAlreadyExists": "O nome da política de recursos já existe. \nPor favor, altere o nome para adicionar.",
     "Resources": "Recursos",
@@ -1783,7 +1783,7 @@
     "Unlimited": "Ilimitado",
     "UpdateResourcePolicy": "Política de atualização de recursos",
     "User": "Do utilizador",
-    "UserResourcePolicy": "Política de Recursos do Usuário"
+    "UserResourcePolicy": "Política de recursos de usuário"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Você está prestes a excluir esta predefinição:",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1754,7 +1754,7 @@
     "IdleTimeout": "Tempo limite ocioso",
     "IdleTimeoutSec": "Tempo limite ocioso (seg.)",
     "Keypair": "Par de chaves",
-    "KeypairResourcePolicy": "Política de recursos de par de chaves",
+    "KeypairResourcePolicy": "Política de recursos de Keypair",
     "MaxConcurrentSFTPSessions": "Sessões SFTP simultâneas máximas",
     "MaxCustomizedImageCount": "Contagem máxima de imagens personalizadas",
     "MaxFolderCount": "Contagem máxima de pastas",
@@ -1772,7 +1772,7 @@
     "PolicyName": "Nome da política",
     "PolicyNameEmpty": "O nome da política não deve estar vazio.",
     "Project": "Projeto",
-    "ProjectResourcePolicy": "Política de Recursos do Projeto",
+    "ProjectResourcePolicy": "Política de recursos de projeto",
     "ResourcePolicy": "Política de Recursos",
     "ResourcePolicyNameAlreadyExists": "O nome da política de recursos já existe. \nPor favor, altere o nome para adicionar.",
     "Resources": "Recursos",
@@ -1785,7 +1785,7 @@
     "Unlimited": "Ilimitado",
     "UpdateResourcePolicy": "Política de atualização de recursos",
     "User": "Do utilizador",
-    "UserResourcePolicy": "Política de Recursos do Usuário"
+    "UserResourcePolicy": "Política de recursos de utilizador"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Você está prestes a excluir esta predefinição:",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1752,7 +1752,7 @@
     "IdleTimeout": "Тайм-аут простоя",
     "IdleTimeoutSec": "Тайм-аут простоя (сек.)",
     "Keypair": "Ключевая пара",
-    "KeypairResourcePolicy": "Политика ресурсов пары ключей",
+    "KeypairResourcePolicy": "Политика ресурсов Keypair",
     "MaxConcurrentSFTPSessions": "Максимальные параллельные сеансы SFTP",
     "MaxCustomizedImageCount": "Максимальное количество индивидуальных изображений",
     "MaxFolderCount": "Максимальное количество папок",
@@ -1770,7 +1770,7 @@
     "PolicyName": "Название политики",
     "PolicyNameEmpty": "Имя политики не должно быть пустым.",
     "Project": "Проект",
-    "ProjectResourcePolicy": "Ресурсная политика проекта",
+    "ProjectResourcePolicy": "Политика ресурсов проекта",
     "ResourcePolicy": "Политика ресурсов",
     "ResourcePolicyNameAlreadyExists": "Название политики ресурсов уже существует. \nПожалуйста, измените имя, чтобы добавить.",
     "Resources": "Ресурсы",
@@ -1783,7 +1783,7 @@
     "Unlimited": "Безлимитный",
     "UpdateResourcePolicy": "Обновить политику ресурсов",
     "User": "Пользователь",
-    "UserResourcePolicy": "Политика пользовательских ресурсов"
+    "UserResourcePolicy": "Политика ресурсов пользователя"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Вы собираетесь удалить этот пресет:",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1754,7 +1754,7 @@
     "IdleTimeout": "หมดเวลาเมื่อไม่มีการใช้งาน",
     "IdleTimeoutSec": "หมดเวลาเมื่อไม่มีการใช้งาน (วินาที)",
     "Keypair": "คู่คีย์",
-    "KeypairResourcePolicy": "นโยบายทรัพยากรคู่คีย์",
+    "KeypairResourcePolicy": "นโยบายทรัพยากร Keypair",
     "MaxConcurrentSFTPSessions": "เซสชัน SFTP ที่เกิดขึ้นพร้อมกันสูงสุด",
     "MaxCustomizedImageCount": "จำนวนอิมเมจที่กำหนดเองสูงสุด",
     "MaxFolderCount": "จำนวนโฟลเดอร์สูงสุด",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1752,7 +1752,7 @@
     "IdleTimeout": "Boşta Kalma Zaman Aşımı",
     "IdleTimeoutSec": "Boşta kalma zaman aşımı (sn.)",
     "Keypair": "Anahtar çifti",
-    "KeypairResourcePolicy": "Anahtar Çifti Kaynak Politikası",
+    "KeypairResourcePolicy": "Keypair Kaynak Politikası",
     "MaxConcurrentSFTPSessions": "Maksimum eşzamanlı SFTP oturumları",
     "MaxCustomizedImageCount": "Maksimum Özelleştirilmiş Görüntü Sayısı",
     "MaxFolderCount": "Maksimum Klasör Sayısı",
@@ -1783,7 +1783,7 @@
     "Unlimited": "Sınırsız",
     "UpdateResourcePolicy": "Kaynak Politikasını Güncelle",
     "User": "Kullanıcı",
-    "UserResourcePolicy": "Kullanıcı Kaynağı Politikası"
+    "UserResourcePolicy": "Kullanıcı Kaynak Politikası"
   },
   "resourcePreset": {
     "AboutToDeletePreset": "Bu ön ayarı silmek üzeresiniz:",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1754,7 +1754,7 @@
     "IdleTimeout": "Hết thời gian chờ",
     "IdleTimeoutSec": "Thời gian chờ không hoạt động (giây)",
     "Keypair": "Cặp khóa",
-    "KeypairResourcePolicy": "Chính sách tài nguyên cặp khóa",
+    "KeypairResourcePolicy": "Chính sách tài nguyên Keypair",
     "MaxConcurrentSFTPSessions": "Phiên SFTP đồng thời tối đa",
     "MaxCustomizedImageCount": "Số lượng hình ảnh tùy chỉnh tối đa",
     "MaxFolderCount": "Số lượng thư mục tối đa",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1772,7 +1772,7 @@
     "PolicyName": "政策名称",
     "PolicyNameEmpty": "策略名称不应为空。",
     "Project": "项目",
-    "ProjectResourcePolicy": "项目资源政策",
+    "ProjectResourcePolicy": "项目资源策略",
     "ResourcePolicy": "资源政策",
     "ResourcePolicyNameAlreadyExists": "资源策略名称已存在。\n请更改名称以添加。",
     "Resources": "资源",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1774,7 +1774,7 @@
     "PolicyName": "政策名稱",
     "PolicyNameEmpty": "策略名稱不應為空。",
     "Project": "專案",
-    "ProjectResourcePolicy": "專案資源政策",
+    "ProjectResourcePolicy": "專案資源策略",
     "ResourcePolicy": "資源政策",
     "ResourcePolicyNameAlreadyExists": "資源策略名稱已存在。\n請更改名稱以新增。",
     "Resources": "資源",


### PR DESCRIPTION
Resolves #6301 (FR-2427)

## Summary
- Update resource-policy page tab names from "Keypair / User / Project" to "Keypair Resource Policy / User Resource Policy / Project Resource Policy"
- Update i18n translations in 19 locale files (en.json and ko.json already had correct values)

## Test plan
- [ ] Go to resource-policy page
- [ ] Verify tabs show: "Keypair Resource Policy", "User Resource Policy", "Project Resource Policy"

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6312/20260401-155418-before-tabs.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6312/20260401-155400-after-tabs.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)