### PR TITLE
e2e(FR-2434): add E2E test for allowed IP restriction enforcement during active session

### DIFF
--- a/e2e/E2E_COVERAGE_REPORT.md
+++ b/e2e/E2E_COVERAGE_REPORT.md
@@ -1,6 +1,6 @@
 # E2E Test Coverage Report
 
-> **Last Updated:** 2026-03-31
+> **Last Updated:** 2026-04-01
 > **Router Source:** [`react/src/routes.tsx`](../react/src/routes.tsx)
 > **E2E Root:** [`e2e/`](.)
 >
@@ -33,7 +33,7 @@
 | Configurations | `/settings` | 10 | 8 | 🔶 80% |
 | Resources | `/agent-summary`, `/agent` | 10 | 3 | 🔶 30% |
 | Resource Policy | `/resource-policy` | 13 | 10 | 🔶 77% |
-| User Credentials | `/credential` | 19 | 12 | 🔶 63% |
+| User Credentials | `/credential` | 20 | 13 | 🔶 65% |
 | Maintenance | `/maintenance` | 3 | 2 | 🔶 67% |
 | User Settings | `/usersettings` | 10 | 0 | ❌ 0% |
 | Project | `/project` | 6 | 5 | 🔶 83% |
@@ -584,7 +584,7 @@
 
 ### 17. User Credentials (`/credential`)
 
-**Test files:** [`e2e/user/user-crud.spec.ts`](user/user-crud.spec.ts), [`e2e/user/bulk-user-creation.spec.ts`](user/bulk-user-creation.spec.ts), [`e2e/credential/credential-keypair.spec.ts`](credential/credential-keypair.spec.ts)
+**Test files:** [`e2e/user/user-crud.spec.ts`](user/user-crud.spec.ts), [`e2e/user/bulk-user-creation.spec.ts`](user/bulk-user-creation.spec.ts), [`e2e/credential/credential-keypair.spec.ts`](credential/credential-keypair.spec.ts), [`e2e/user-profile/user-ip-restriction-enforcement.spec.ts`](user-profile/user-ip-restriction-enforcement.spec.ts)
 
 **Tabs:** Users | Credentials
 
@@ -607,6 +607,7 @@
 | Reactivate user | ✅ | `Admin can reactivate an inactive user` |
 | Purge user → PurgeUsersModal | ✅ | `Admin can deactivate and permanently delete` |
 | Deleted user login blocked | ✅ | `Deleted user cannot log in` |
+| Allowed IP restriction enforcement (active session) | ✅ | `User can access pages when their current IP is in the allowed list` / `User is denied access after admin revokes their IP` |
 | User name click → UserInfoModal | ❌ | - |
 | Bulk edit → UpdateUsersModal | ❌ | - |
 | User table filtering | ❌ | - |
@@ -627,7 +628,7 @@
 | Edit keypair → KeypairSettingModal | ❌ | - |
 | SSH key management → SSHKeypairManagementModal | ❌ | - |
 
-**Coverage: 🔶 12/19 features**
+**Coverage: 🔶 13/20 features**
 
 ---
 

--- a/e2e/user-profile/user-ip-restriction-enforcement.spec.ts
+++ b/e2e/user-profile/user-ip-restriction-enforcement.spec.ts
@@ -1,0 +1,239 @@
+import { PurgeUsersModal } from '../utils/classes/user/PurgeUsersModal';
+import {
+  KeyPairModal,
+  UserSettingModal,
+} from '../utils/classes/user/UserSettingModal';
+import {
+  loginAsAdmin,
+  loginAsCreatedAccount,
+  navigateTo,
+} from '../utils/test-util';
+import {
+  clickRowAction,
+  openProfileModal,
+  getCurrentClientIp,
+  addIpTags,
+  removeAllIpTags,
+  deriveDifferentIp,
+} from '../utils/user-profile-util';
+import test, { expect } from '@playwright/test';
+
+// Generate unique identifiers for this test run
+const TEST_RUN_ID = Date.now().toString(36);
+const EMAIL = `e2e-ip-restrict-${TEST_RUN_ID}@lablup.com`;
+const USERNAME = `e2e-ip-restrict-${TEST_RUN_ID}`;
+const PASSWORD = 'testing@123';
+
+test.describe.serial(
+  'IP restriction enforcement during active session',
+  { tag: ['@functional', '@regression', '@user-profile'] },
+  () => {
+    let currentClientIp: string;
+
+    test('Admin can create a test user', async ({ page, request }) => {
+      // 1. Login as admin
+      await loginAsAdmin(page, request);
+
+      // 2. Navigate to credential page
+      await navigateTo(page, 'credential');
+      await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+
+      // 3. Create the test user
+      await page.getByRole('button', { name: 'Create User' }).click();
+      const userSettingModal = new UserSettingModal(page);
+      await userSettingModal.createUser(EMAIL, USERNAME, PASSWORD);
+
+      // 4. Handle the key pair modal
+      const keyPairModal = new KeyPairModal(page);
+      await keyPairModal.waitForVisible();
+      await keyPairModal.close();
+      await userSettingModal.waitForHidden();
+
+      // 5. Verify user appears in Active users list
+      await expect(page.getByRole('cell', { name: EMAIL })).toBeVisible({
+        timeout: 10000,
+      });
+    });
+
+    test('User can access pages when their current IP is in the allowed list', async ({
+      browser,
+    }) => {
+      // Create a context for the test user
+      const userContext = await browser.newContext();
+      const userPage = await userContext.newPage();
+      const userRequest = userContext.request;
+
+      // 1. Login as the created user
+      await loginAsCreatedAccount(userPage, userRequest, EMAIL, PASSWORD);
+
+      // 2. Open profile modal and get the current client IP
+      await openProfileModal(userPage);
+      currentClientIp = await getCurrentClientIp(userPage);
+      expect(currentClientIp).toBeTruthy();
+
+      // Close profile modal
+      await userPage
+        .locator('.ant-modal')
+        .getByRole('button', { name: 'Cancel' })
+        .click();
+
+      // 3. Now use admin to set allowed IP for this user to their current IP
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+      const adminRequest = adminContext.request;
+
+      await loginAsAdmin(adminPage, adminRequest);
+      await navigateTo(adminPage, 'credential');
+      await expect(adminPage.getByRole('tab', { name: 'Users' })).toBeVisible();
+
+      // Find and edit the test user
+      const userRow = adminPage.getByRole('row').filter({ hasText: EMAIL });
+      await expect(userRow).toBeVisible();
+      await clickRowAction(adminPage, userRow, 'Edit');
+
+      // Wait for edit modal
+      const editModal = UserSettingModal.forEdit(adminPage);
+      await editModal.waitForVisible();
+
+      // Add the current client IP to allowed list
+      const modal = editModal.getModal();
+      await addIpTags(modal, [currentClientIp]);
+      await editModal.clickOk();
+      await editModal.waitForHidden();
+
+      await adminContext.close();
+
+      // 4. Verify user can still access pages normally
+      await navigateTo(userPage, 'summary');
+      await expect(userPage.getByTestId('user-dropdown-button')).toBeVisible({
+        timeout: 15000,
+      });
+
+      // Navigate to another page to confirm access is working
+      await navigateTo(userPage, 'job');
+      await expect(userPage.getByTestId('user-dropdown-button')).toBeVisible({
+        timeout: 15000,
+      });
+
+      await userContext.close();
+    });
+
+    test('User is denied access after admin revokes their IP and sets an arbitrary IP', async ({
+      browser,
+    }) => {
+      // 1. Login as the test user in a fresh context
+      const userContext = await browser.newContext();
+      const userPage = await userContext.newPage();
+      const userRequest = userContext.request;
+
+      await loginAsCreatedAccount(userPage, userRequest, EMAIL, PASSWORD);
+
+      // Verify user can navigate initially
+      await navigateTo(userPage, 'summary');
+      await expect(userPage.getByTestId('user-dropdown-button')).toBeVisible({
+        timeout: 15000,
+      });
+
+      // 2. Admin revokes the user's current IP and sets an arbitrary one
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+      const adminRequest = adminContext.request;
+
+      await loginAsAdmin(adminPage, adminRequest);
+      await navigateTo(adminPage, 'credential');
+      await expect(adminPage.getByRole('tab', { name: 'Users' })).toBeVisible();
+
+      // Find and edit the test user
+      const userRow = adminPage.getByRole('row').filter({ hasText: EMAIL });
+      await expect(userRow).toBeVisible();
+      await clickRowAction(adminPage, userRow, 'Edit');
+
+      const editModal = UserSettingModal.forEdit(adminPage);
+      await editModal.waitForVisible();
+
+      // Remove existing IP tags and add an arbitrary IP
+      const modal = editModal.getModal();
+      await removeAllIpTags(modal);
+      const arbitraryAllowedIp = deriveDifferentIp(currentClientIp);
+      await addIpTags(modal, [arbitraryAllowedIp]);
+      await editModal.clickOk();
+      await editModal.waitForHidden();
+
+      await adminContext.close();
+
+      // 3. Verify user is denied access when navigating
+      // After admin changed allowed IP, navigating should trigger an IP check
+      await navigateTo(userPage, 'job');
+
+      // The user should see either:
+      // - A login page (redirected due to unauthorized)
+      // - An error notification about IP restriction
+      // - The user dropdown is no longer visible (logged out)
+      // We check for the login form or an error indicator
+      await expect(
+        userPage
+          .getByLabel('Email or Username')
+          .or(userPage.getByText(/Unauthorized/i))
+          .or(userPage.getByText(/allowed/i))
+          .or(userPage.getByText(/restricted/i))
+          .or(userPage.getByText(/blocked/i)),
+      ).toBeVisible({ timeout: 30000 });
+
+      await userContext.close();
+    });
+
+    test('Admin can clean up: remove IP restriction and delete test user', async ({
+      page,
+      request,
+    }) => {
+      test.setTimeout(60000);
+      // 1. Login as admin
+      await loginAsAdmin(page, request);
+
+      // 2. Navigate to credential page
+      await navigateTo(page, 'credential');
+      await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+
+      // 3. Edit user to clear IP restrictions first (to avoid issues with deactivation)
+      const userRow = page.getByRole('row').filter({ hasText: EMAIL });
+      const isActive = await userRow
+        .isVisible({ timeout: 2000 })
+        .catch(() => false);
+
+      if (isActive) {
+        await clickRowAction(page, userRow, 'Edit');
+        const editModal = UserSettingModal.forEdit(page);
+        await editModal.waitForVisible();
+
+        const modal = editModal.getModal();
+        await removeAllIpTags(modal);
+        await editModal.clickOk();
+        await editModal.waitForHidden();
+
+        // 4. Deactivate the user (no popconfirm — mutation fires directly)
+        await expect(userRow).toBeVisible();
+        await clickRowAction(page, userRow, 'Deactivate');
+        await expect(userRow).toBeHidden({ timeout: 10000 });
+      }
+
+      // 5. Switch to Inactive and purge the user
+      // Re-navigate to credential page to clear any stale state
+      await navigateTo(page, 'credential');
+      await expect(page.getByRole('tab', { name: 'Users' })).toBeVisible();
+      await page.getByText('Inactive', { exact: true }).click();
+      const inactiveUserRow = page.getByRole('row').filter({ hasText: EMAIL });
+      await expect(inactiveUserRow).toBeVisible({ timeout: 10000 });
+
+      // Use dispatchEvent to bypass DOM detachment during table re-renders
+      await inactiveUserRow.getByRole('checkbox').dispatchEvent('click');
+      await page.getByRole('button', { name: 'trash bin' }).click();
+
+      const purgeModal = new PurgeUsersModal(page);
+      await purgeModal.waitForVisible();
+      await purgeModal.confirmDeletion();
+
+      // 6. Verify user is deleted
+      await expect(inactiveUserRow).toBeHidden({ timeout: 10000 });
+    });
+  },
+);

--- a/e2e/user-profile/user-profile.spec.ts
+++ b/e2e/user-profile/user-profile.spec.ts
@@ -1,67 +1,13 @@
 // spec: e2e/.agent-output/test-plan-user-profile-allowed-client-ip.md
 import { loginAsAdmin } from '../utils/test-util';
+import {
+  openProfileModal,
+  getCurrentClientIp,
+  getAllowedClientIpFormItem,
+  addIpTags,
+  removeAllIpTags,
+} from '../utils/user-profile-util';
 import test, { expect } from '@playwright/test';
-
-/**
- * Opens the User Profile Setting Modal by clicking the user dropdown
- * and selecting the "My Account" menu item.
- */
-async function openProfileModal(page: import('@playwright/test').Page) {
-  await page.getByTestId('user-dropdown-button').click();
-  await page.getByText('My Account').click();
-  // Wait for modal to be visible
-  await page.locator('.ant-modal').waitFor({ state: 'visible' });
-}
-
-/**
- * Reads the current client IP displayed in the modal's helper text.
- */
-async function getCurrentClientIp(
-  page: import('@playwright/test').Page,
-): Promise<string> {
-  const ipText = await page.getByText(/Current client IP:/).textContent();
-  // Extract IP from "Current client IP: x.x.x.x"
-  const match = ipText?.match(/Current client IP:\s*(.+)/);
-  return match?.[1]?.trim() ?? '';
-}
-
-/**
- * Gets the Allowed Client IP form item container within the modal.
- */
-function getAllowedClientIpFormItem(page: import('@playwright/test').Page) {
-  return page
-    .locator('.ant-modal')
-    .locator('.ant-form-item')
-    .filter({ hasText: 'Allowed client IPs' });
-}
-
-/**
- * Adds IP tags to the Allowed Client IP select field.
- */
-async function addIpTags(page: import('@playwright/test').Page, ips: string[]) {
-  const formItem = getAllowedClientIpFormItem(page);
-  const selectInput = formItem.getByRole('combobox');
-  for (const ip of ips) {
-    await selectInput.click();
-    await selectInput.fill(ip);
-    await selectInput.press('Enter');
-  }
-  // Blur the combobox so the Update/Cancel buttons become clickable
-  await selectInput.press('Tab');
-}
-
-/**
- * Removes all IP tags from the Allowed Client IP select field.
- */
-async function removeAllIpTags(page: import('@playwright/test').Page) {
-  const formItem = getAllowedClientIpFormItem(page);
-  const removeButtons = formItem.locator('.ant-tag .anticon-close');
-  const count = await removeButtons.count();
-  // Remove from last to first to avoid index shifting
-  for (let i = count - 1; i >= 0; i--) {
-    await removeButtons.nth(i).click();
-  }
-}
 
 test.describe(
   'User Profile Setting Modal',
@@ -103,9 +49,12 @@ test.describe(
         await loginAsAdmin(page, request);
         await openProfileModal(page);
 
-        const formItem = getAllowedClientIpFormItem(page);
+        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
 
-        await addIpTags(page, ['192.168.1.1', '10.0.0.1']);
+        await addIpTags(page.locator('.ant-modal'), [
+          '192.168.1.1',
+          '10.0.0.1',
+        ]);
 
         // Verify tags are created
         await expect(
@@ -128,9 +77,12 @@ test.describe(
         await loginAsAdmin(page, request);
         await openProfileModal(page);
 
-        const formItem = getAllowedClientIpFormItem(page);
+        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
 
-        await addIpTags(page, ['10.20.30.0/24', '192.168.0.0/16']);
+        await addIpTags(page.locator('.ant-modal'), [
+          '10.20.30.0/24',
+          '192.168.0.0/16',
+        ]);
 
         await expect(
           formItem.locator('.ant-tag').filter({ hasText: '10.20.30.0/24' }),
@@ -152,9 +104,9 @@ test.describe(
         await loginAsAdmin(page, request);
         await openProfileModal(page);
 
-        const formItem = getAllowedClientIpFormItem(page);
+        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
 
-        await addIpTags(page, ['not-an-ip']);
+        await addIpTags(page.locator('.ant-modal'), ['not-an-ip']);
 
         const redTag = formItem
           .locator('.ant-tag')
@@ -175,9 +127,13 @@ test.describe(
         await loginAsAdmin(page, request);
         await openProfileModal(page);
 
-        const formItem = getAllowedClientIpFormItem(page);
+        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
 
-        await addIpTags(page, ['192.168.1.1', 'invalid-ip', '10.0.0.0/8']);
+        await addIpTags(page.locator('.ant-modal'), [
+          '192.168.1.1',
+          'invalid-ip',
+          '10.0.0.0/8',
+        ]);
 
         const validTag = formItem
           .locator('.ant-tag')
@@ -207,9 +163,9 @@ test.describe(
         await loginAsAdmin(page, request);
         await openProfileModal(page);
 
-        const formItem = getAllowedClientIpFormItem(page);
+        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
 
-        await addIpTags(page, ['192.168.1.1']);
+        await addIpTags(page.locator('.ant-modal'), ['192.168.1.1']);
 
         const tag = formItem
           .locator('.ant-tag')
@@ -237,7 +193,7 @@ test.describe(
         const currentIp = await getCurrentClientIp(page);
 
         const fakeIp = currentIp === '10.0.0.1' ? '10.0.0.2' : '10.0.0.1';
-        await addIpTags(page, [fakeIp]);
+        await addIpTags(page.locator('.ant-modal'), [fakeIp]);
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -258,7 +214,7 @@ test.describe(
         const modal = page.locator('.ant-modal');
         const currentIp = await getCurrentClientIp(page);
 
-        await addIpTags(page, [currentIp]);
+        await addIpTags(page.locator('.ant-modal'), [currentIp]);
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -268,7 +224,7 @@ test.describe(
 
         // Cleanup: clear allowed IPs
         await openProfileModal(page);
-        await removeAllIpTags(page);
+        await removeAllIpTags(page.locator('.ant-modal'));
         await page
           .locator('.ant-modal')
           .getByRole('button', { name: 'Update' })
@@ -291,7 +247,7 @@ test.describe(
         const ipParts = currentIp.split('.');
         const cidrRange = `${ipParts[0]}.${ipParts[1]}.${ipParts[2]}.0/24`;
 
-        await addIpTags(page, [cidrRange]);
+        await addIpTags(page.locator('.ant-modal'), [cidrRange]);
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -301,7 +257,7 @@ test.describe(
 
         // Cleanup: clear allowed IPs
         await openProfileModal(page);
-        await removeAllIpTags(page);
+        await removeAllIpTags(page.locator('.ant-modal'));
         await page
           .locator('.ant-modal')
           .getByRole('button', { name: 'Update' })
@@ -322,7 +278,7 @@ test.describe(
         const currentIp = await getCurrentClientIp(page);
 
         // First, set an IP
-        await addIpTags(page, [currentIp]);
+        await addIpTags(page.locator('.ant-modal'), [currentIp]);
         await modal.getByRole('button', { name: 'Update' }).click();
         await expect(
           page.getByText('Profile has been successfully updated.'),
@@ -330,7 +286,7 @@ test.describe(
 
         // Reopen and remove all IPs
         await openProfileModal(page);
-        await removeAllIpTags(page);
+        await removeAllIpTags(page.locator('.ant-modal'));
         await page
           .locator('.ant-modal')
           .getByRole('button', { name: 'Update' })
@@ -341,7 +297,7 @@ test.describe(
 
         // Verify IPs are cleared
         await openProfileModal(page);
-        const formItem = getAllowedClientIpFormItem(page);
+        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
         await expect(formItem.locator('.ant-tag')).toHaveCount(0);
 
         await page
@@ -417,7 +373,7 @@ test.describe(
         await fullNameInput.clear();
         await fullNameInput.fill(testName);
 
-        await addIpTags(page, [currentIp]);
+        await addIpTags(page.locator('.ant-modal'), [currentIp]);
 
         await modal.getByRole('button', { name: 'Update' }).click();
 
@@ -433,7 +389,9 @@ test.describe(
           .inputValue();
         expect(savedName).toBe(testName);
 
-        const savedFormItem = getAllowedClientIpFormItem(page);
+        const savedFormItem = getAllowedClientIpFormItem(
+          page.locator('.ant-modal'),
+        );
         await expect(
           savedFormItem.locator('.ant-tag').filter({ hasText: currentIp }),
         ).toBeVisible();
@@ -444,7 +402,7 @@ test.describe(
           .locator('.ant-modal')
           .locator('input#full_name')
           .fill(originalName);
-        await removeAllIpTags(page);
+        await removeAllIpTags(page.locator('.ant-modal'));
         await page
           .locator('.ant-modal')
           .getByRole('button', { name: 'Update' })
@@ -562,7 +520,7 @@ test.describe(
 
         await fullNameInput.clear();
         await fullNameInput.fill('Should Not Be Saved');
-        await addIpTags(page, ['10.0.0.1']);
+        await addIpTags(page.locator('.ant-modal'), ['10.0.0.1']);
 
         await modal.getByRole('button', { name: 'Cancel' }).click();
         await page.locator('.ant-modal').waitFor({ state: 'hidden' });
@@ -575,7 +533,7 @@ test.describe(
           .inputValue();
         expect(restoredName).toBe(originalName);
 
-        const formItem = getAllowedClientIpFormItem(page);
+        const formItem = getAllowedClientIpFormItem(page.locator('.ant-modal'));
         await expect(
           formItem.locator('.ant-tag').filter({ hasText: '10.0.0.1' }),
         ).toHaveCount(0);

--- a/e2e/utils/user-profile-util.ts
+++ b/e2e/utils/user-profile-util.ts
@@ -1,0 +1,114 @@
+import type { Page, Locator } from '@playwright/test';
+
+/**
+ * Map of action titles to their Ant Design / Lucide icon selectors.
+ * BAINameActionCell renders icon-only buttons, so we locate by icon class.
+ */
+const ACTION_ICON_SELECTORS: Record<string, string> = {
+  Edit: '[aria-label="setting"]',
+  'User Detail': '[aria-label="info-circle"]',
+  Deactivate: '.lucide-ban',
+  Activate: '.lucide-undo-2',
+};
+
+/**
+ * Clicks a BAINameActionCell action by its title.
+ * Handles both directly visible icon buttons and overflow dropdown menu items.
+ */
+export async function clickRowAction(
+  page: Page,
+  row: Locator,
+  actionTitle: string,
+) {
+  await row.hover();
+
+  // Case 1: Actions overflowed into "More actions" dropdown
+  const moreButton = row.getByRole('button', { name: 'More actions' });
+  if (await moreButton.isVisible().catch(() => false)) {
+    await moreButton.click();
+    const menuItem = page.getByRole('menuitem', { name: actionTitle });
+    if (await menuItem.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await menuItem.click();
+      return;
+    }
+    await page.keyboard.press('Escape');
+  }
+
+  // Case 2: Actions are directly visible — find by icon selector
+  const iconSelector = ACTION_ICON_SELECTORS[actionTitle];
+  if (iconSelector) {
+    const icon = row.locator(iconSelector);
+    await icon.waitFor({ state: 'visible', timeout: 5000 });
+    await icon.click();
+    return;
+  }
+
+  throw new Error(`Action "${actionTitle}" not found in row`);
+}
+
+/**
+ * Opens the User Profile Setting Modal by clicking the user dropdown
+ * and selecting the "My Account" menu item.
+ */
+export async function openProfileModal(page: Page) {
+  await page.getByTestId('user-dropdown-button').click();
+  await page.getByText('My Account').click();
+  await page.locator('.ant-modal').waitFor({ state: 'visible' });
+}
+
+/**
+ * Reads the current client IP displayed in the modal's helper text.
+ */
+export async function getCurrentClientIp(page: Page): Promise<string> {
+  const ipText = await page.getByText(/Current client IP:/).textContent();
+  const match = ipText?.match(/Current client IP:\s*(.+)/);
+  return match?.[1]?.trim() ?? '';
+}
+
+/**
+ * Gets the Allowed Client IP form item container within a modal or page.
+ */
+export function getAllowedClientIpFormItem(container: Locator) {
+  return container
+    .locator('.ant-form-item')
+    .filter({ hasText: 'Allowed client IP' });
+}
+
+/**
+ * Adds IP tags to the Allowed Client IP select field within a container.
+ */
+export async function addIpTags(container: Locator, ips: string[]) {
+  const formItem = getAllowedClientIpFormItem(container);
+  const selectInput = formItem.getByRole('combobox');
+  for (const ip of ips) {
+    await selectInput.click();
+    await selectInput.fill(ip);
+    await selectInput.press('Enter');
+  }
+  await selectInput.press('Tab');
+}
+
+/**
+ * Removes all IP tags from the Allowed Client IP select field within a container.
+ */
+export async function removeAllIpTags(container: Locator) {
+  const formItem = getAllowedClientIpFormItem(container);
+  const removeButtons = formItem.locator('.ant-tag .anticon-close');
+  const count = await removeButtons.count();
+  for (let i = count - 1; i >= 0; i--) {
+    await removeButtons.nth(i).click();
+  }
+}
+
+/**
+ * Derives a guaranteed-different IP from the given IP by changing the last octet.
+ * Falls back to '99.99.99.99' if no valid IP is provided.
+ */
+export function deriveDifferentIp(currentIp: string): string {
+  if (!currentIp || !currentIp.trim()) return '99.99.99.99';
+  const parts = currentIp.trim().split('.');
+  if (parts.length !== 4) return '99.99.99.99';
+  const lastOctet = parseInt(parts[3], 10);
+  parts[3] = String(lastOctet === 255 ? lastOctet - 1 : lastOctet + 1);
+  return parts.join('.');
+}


### PR DESCRIPTION
Resolves #6316 (FR-2434) 

## Summary

- Add E2E test for IP-based access restriction enforcement during an active session
- Test flow: create user → admin sets allowed IP → verify access → admin revokes IP and sets arbitrary IP → verify access denied → cleanup (deactivate user)
- Uses multi-browser-context pattern (`browser.newContext()`) to maintain simultaneous admin and user sessions

## Known Issue

Due to a `purge_user` API error (`user_uuid must be set for RBAC validation`), test users created during the test run may not be permanently deleted. The cleanup step only deactivates the user. If you need full cleanup, please use a manager version **26.4.0 or above**, or modify `src/lib/backend.ai-client-esm.ts` to adjust the feature flag accordingly.

## Test Recordings

| Test | Recording |
|------|-----------|
| Admin can create a test user | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6318/admin-create-test-user.webm" controls width="600"></video> |
| Admin can clean up: remove IP restriction and delete test user | <video src="https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6318/admin-cleanup-delete-test-user.webm" controls width="600"></video> |

> **Note:** Tests 2–3 (*User can access pages when their current IP is in the allowed list*, *User is denied access after admin revokes their IP*) use `browser.newContext()` to create manual browser contexts for multi-session testing. Playwright's `video: "on"` config only applies to the built-in `page` fixture, so these manually created contexts were not recorded.

## Test plan

- [x] Run `npx playwright test e2e/user-profile/user-ip-restriction-enforcement.spec.ts` against a local Backend.AI cluster
- [x] Verify all 4 serial tests pass: user creation, IP allow verification, IP deny verification, cleanup
- [ ] Confirm no test user artifacts remain after test completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)