### PR TITLE
refactor: add internal Suspense boundary to ModelBrandIcon and improve grid responsiveness

### DIFF
--- a/react/src/components/ModelBrandIcon.tsx
+++ b/react/src/components/ModelBrandIcon.tsx
@@ -6,7 +6,7 @@ import { findBrandIconLoader } from '../helper/modelBrandIcons';
 import { RobotOutlined } from '@ant-design/icons';
 import type { IconType } from '@lobehub/icons/es/types';
 import { theme } from 'antd';
-import React, { use } from 'react';
+import React, { Suspense, use } from 'react';
 
 export interface ModelBrandIconProps {
   modelName: string;
@@ -33,6 +33,26 @@ function getIconPromise(modelName: string): Promise<IconType | null> {
   return promise;
 }
 
+const DefaultIcon: React.FC<{
+  size: number;
+  style?: React.CSSProperties;
+  className?: string;
+}> = ({ size, style, className }) => {
+  'use memo';
+  const { token } = theme.useToken();
+  return (
+    <RobotOutlined
+      className={className}
+      style={{
+        fontSize: size,
+        color: token.colorTextSecondary,
+        flexShrink: 0,
+        ...style,
+      }}
+    />
+  );
+};
+
 /**
  * Inner component that renders the resolved icon SVG.
  * Separated to avoid "component created during render" lint error.
@@ -54,32 +74,21 @@ const ResolvedIcon: React.FC<{
 };
 
 /**
- * Displays a brand SVG icon for a known model via @lobehub/icons,
- * or a generic robot icon as fallback.
+ * Inner component that uses `use()` to resolve the icon.
+ * Separated so that Suspense is contained within ModelBrandIcon
+ * and does not propagate to the parent tree.
  */
-const ModelBrandIcon: React.FC<ModelBrandIconProps> = ({
-  modelName,
-  size = 14,
-  style,
-  className,
-}) => {
+const SuspendingIcon: React.FC<{
+  modelName: string;
+  size: number;
+  style?: React.CSSProperties;
+  className?: string;
+}> = ({ modelName, size, style, className }) => {
   'use memo';
-
-  const { token } = theme.useToken();
   const resolvedIcon = use(getIconPromise(modelName));
 
   if (!resolvedIcon) {
-    return (
-      <RobotOutlined
-        className={className}
-        style={{
-          fontSize: size,
-          color: token.colorTextSecondary,
-          flexShrink: 0,
-          ...style,
-        }}
-      />
-    );
+    return <DefaultIcon size={size} style={style} className={className} />;
   }
 
   return (
@@ -89,6 +98,32 @@ const ModelBrandIcon: React.FC<ModelBrandIconProps> = ({
       style={style}
       className={className}
     />
+  );
+};
+
+/**
+ * Displays a brand SVG icon for a known model via @lobehub/icons,
+ * or a generic robot icon as fallback.
+ * Uses internal Suspense boundary so loading never propagates to parent.
+ */
+const ModelBrandIcon: React.FC<ModelBrandIconProps> = ({
+  modelName,
+  size = 14,
+  style,
+  className,
+}) => {
+  'use memo';
+  return (
+    <Suspense
+      fallback={<DefaultIcon size={size} style={style} className={className} />}
+    >
+      <SuspendingIcon
+        modelName={modelName}
+        size={size}
+        style={style}
+        className={className}
+      />
+    </Suspense>
   );
 };
 

--- a/react/src/pages/ModelStoreListPage.tsx
+++ b/react/src/pages/ModelStoreListPage.tsx
@@ -242,7 +242,7 @@ const ModelStoreListPage: React.FC = () => {
             })
             .sort((a, b) => localeCompare(a?.name, b?.name)) as Array<ModelCard>
         )?.map((item) => (
-          <Col key={item?.id} xs={24} sm={24} md={24} lg={12}>
+          <Col key={item?.id} xs={24} sm={24} md={24} lg={24} xl={12} xxl={8}>
             <Card
               hoverable
               style={{ height: '100%' }}


### PR DESCRIPTION
Resolves #6320

## Summary
- Add internal `Suspense` boundary to `ModelBrandIcon` so that `use()` icon loading never propagates to parent Suspense trees
- Extract `DefaultIcon` component to show a fallback robot icon during loading and when no brand icon is found
- Improve `ModelStoreListPage` grid responsiveness with `xl={12}` and `xxl={8}` breakpoints