### PR TITLE
feat(FR-2435): replace separate RBAC combination queries with unified rbacPermissionMatrix API

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -1,73 +1,119 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
-{
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION) {
   query: Query
   mutation: Mutation
   subscription: Subscription
 }
 
-directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+directive @join__directive(
+  graphs: [join__Graph!]
+  name: String!
+  args: join__DirectiveArguments
+) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+  overrideLabel: String
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
-directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
 
-directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 
-directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
 
-directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
 
-"""Added in 25.16.0. An access token for model deployment."""
+"""
+Added in 25.16.0. An access token for model deployment.
+"""
 type AccessToken implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """The access token."""
+  """
+  The access token.
+  """
   token: String!
 
-  """The creation timestamp of the access token."""
+  """
+  The creation timestamp of the access token.
+  """
   createdAt: DateTime!
 
-  """The expiration timestamp of the access token."""
+  """
+  The expiration timestamp of the access token.
+  """
   validUntil: DateTime!
 }
 
-"""Added in 25.16.0. Connection for access tokens."""
-type AccessTokenConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 25.16.0. Connection for access tokens.
+"""
+type AccessTokenConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [AccessTokenEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type AccessTokenEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type AccessTokenEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: AccessToken!
 }
 
-"""Added in 25.16.0. """
-input AccessTokenFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.16.0.
+"""
+input AccessTokenFilter @join__type(graph: STRAWBERRY) {
   token: StringFilter = null
   validUntil: DateTimeFilter = null
   createdAt: DateTimeFilter = null
@@ -76,53 +122,55 @@ input AccessTokenFilter
   NOT: [AccessTokenFilter!] = null
 }
 
-"""Added in 25.16.0. """
-input AccessTokenOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.16.0.
+"""
+input AccessTokenOrderBy @join__type(graph: STRAWBERRY) {
   field: AccessTokenOrderField!
   direction: OrderDirection! = DESC
 }
 
-enum AccessTokenOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum AccessTokenOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
 """
 Added in 25.19.0. Input for activating a revision to be the current revision.
 """
-input ActivateRevisionInput
-  @join__type(graph: STRAWBERRY)
-{
+input ActivateRevisionInput @join__type(graph: STRAWBERRY) {
   deploymentId: ID!
   revisionId: ID!
 }
 
-"""Added in 25.19.0. Result of activating a revision."""
-type ActivateRevisionPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The deployment with the activated revision"""
+"""
+Added in 25.19.0. Result of activating a revision.
+"""
+type ActivateRevisionPayload @join__type(graph: STRAWBERRY) {
+  """
+  The deployment with the activated revision
+  """
   deployment: ModelDeployment!
 
-  """ID of the previously active revision"""
+  """
+  ID of the previously active revision
+  """
   previousRevisionId: ID
 
-  """ID of the newly activated revision"""
+  """
+  ID of the newly activated revision
+  """
   activatedRevisionId: ID!
 
-  """The deployment policy applied during activation"""
+  """
+  The deployment policy applied during activation
+  """
   deploymentPolicy: DeploymentPolicy!
 }
 
 """
 Added in 25.19.0. This enum represents the activeness status of a replica, indicating whether the deployment is currently active and able to serve requests.
 """
-enum ActivenessStatus
-  @join__type(graph: STRAWBERRY)
-{
+enum ActivenessStatus @join__type(graph: STRAWBERRY) {
   ACTIVE @join__enumValue(graph: STRAWBERRY)
   INACTIVE @join__enumValue(graph: STRAWBERRY)
 }
@@ -130,20 +178,22 @@ enum ActivenessStatus
 """
 Added in 26.4.0. Active resource usage overview for a domain or project. Shows the currently occupied resource slots and the number of active sessions.
 """
-type ActiveResourceOverview
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource slots currently occupied"""
+type ActiveResourceOverview @join__type(graph: STRAWBERRY) {
+  """
+  Resource slots currently occupied
+  """
   slots: ResourceSlot!
 
-  """Number of active sessions"""
+  """
+  Number of active sessions
+  """
   sessionCount: Int!
 }
 
-"""Added in 25.19.0. """
-input AddRevisionInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input AddRevisionInput @join__type(graph: STRAWBERRY) {
   name: String = null
   deploymentId: ID!
   clusterConfig: ClusterConfigInput!
@@ -159,103 +209,134 @@ input AddRevisionInput
   extraMounts: [ExtraVFolderMountInput!]
 }
 
-"""Added in 25.19.0. Payload for adding a revision."""
-type AddRevisionPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Added revision"""
+"""
+Added in 25.19.0. Payload for adding a revision.
+"""
+type AddRevisionPayload @join__type(graph: STRAWBERRY) {
+  """
+  Added revision
+  """
   revision: ModelRevision!
 }
 
-"""Added in UNRELEASED. Admin input for creating a keypair for a user."""
-input AdminCreateKeypairInput
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the target user."""
+"""
+Added in UNRELEASED. Admin input for creating a keypair for a user.
+"""
+input AdminCreateKeypairInput @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the target user.
+  """
   userId: UUID!
 
-  """Name of the resource policy to assign."""
+  """
+  Name of the resource policy to assign.
+  """
   resourcePolicy: String!
 
-  """Whether the keypair should be active."""
+  """
+  Whether the keypair should be active.
+  """
   isActive: Boolean! = true
 
-  """Whether the keypair has admin privileges."""
+  """
+  Whether the keypair has admin privileges.
+  """
   isAdmin: Boolean! = false
 
-  """API rate limit (requests per minute)."""
+  """
+  API rate limit (requests per minute).
+  """
   rateLimit: Int! = 30000
 }
 
 """
 Added in UNRELEASED. Payload returned after admin creates a keypair. The secret_key is only shown once.
 """
-type AdminCreateKeypairPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The newly created keypair."""
+type AdminCreateKeypairPayload @join__type(graph: STRAWBERRY) {
+  """
+  The newly created keypair.
+  """
   keypair: KeyPairGQL!
 
-  """The secret key. Only returned at creation time."""
+  """
+  The secret key. Only returned at creation time.
+  """
   secretKey: String!
 }
 
-"""Added in UNRELEASED. Payload returned after admin deletes a keypair."""
-type AdminDeleteKeypairPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The access key of the deleted keypair."""
+"""
+Added in UNRELEASED. Payload returned after admin deletes a keypair.
+"""
+type AdminDeleteKeypairPayload @join__type(graph: STRAWBERRY) {
+  """
+  The access key of the deleted keypair.
+  """
   accessKey: String!
 }
 
 """
 Added in UNRELEASED. Input for admin querying effective assignable resources for a specific user.
 """
-input AdminEffectiveResourceAllocationV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """Target user ID."""
+input AdminEffectiveResourceAllocationV2Input @join__type(graph: STRAWBERRY) {
+  """
+  Target user ID.
+  """
   userId: UUID!
 
-  """Project ID to check allocation for."""
+  """
+  Project ID to check allocation for.
+  """
   projectId: UUID!
 
-  """Resource group name to check allocation for."""
+  """
+  Resource group name to check allocation for.
+  """
   resourceGroupName: String!
 }
 
-"""Added in UNRELEASED. Admin input for updating a keypair."""
-input AdminUpdateKeypairInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Access key of the keypair to update."""
+"""
+Added in UNRELEASED. Admin input for updating a keypair.
+"""
+input AdminUpdateKeypairInput @join__type(graph: STRAWBERRY) {
+  """
+  Access key of the keypair to update.
+  """
   accessKey: String!
 
-  """New active state."""
+  """
+  New active state.
+  """
   isActive: Boolean = null
 
-  """New admin privilege state."""
+  """
+  New admin privilege state.
+  """
   isAdmin: Boolean = null
 
-  """New resource policy name."""
+  """
+  New resource policy name.
+  """
   resourcePolicy: String = null
 
-  """New API rate limit."""
+  """
+  New API rate limit.
+  """
   rateLimit: Int = null
 }
 
-"""Added in UNRELEASED. Payload returned after admin updates a keypair."""
-type AdminUpdateKeypairPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The updated keypair."""
+"""
+Added in UNRELEASED. Payload returned after admin updates a keypair.
+"""
+type AdminUpdateKeypairPayload @join__type(graph: STRAWBERRY) {
+  """
+  The updated keypair.
+  """
   keypair: KeyPairGQL!
 }
 
 type Agent implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   status: String
   status_changed: DateTime
@@ -276,7 +357,9 @@ type Agent implements Item
   local_config: JSONString
   container_count: Int
 
-  """Added in 25.4.0."""
+  """
+  Added in 25.4.0.
+  """
   gpu_alloc_map: UUIDFloatMap
   mem_slots: Int
   cpu_slots: Float
@@ -291,35 +374,45 @@ type Agent implements Item
   compute_containers(status: String): [ComputeContainer]
 }
 
-"""Added in 24.12.0."""
-type AgentConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 24.12.0.
+"""
+type AgentConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [AgentEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
-"""Added in 24.12.0. A Relay edge containing a `Agent` and its cursor."""
-type AgentEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+"""
+Added in 24.12.0. A Relay edge containing a `Agent` and its cursor.
+"""
+type AgentEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: AgentNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
-"""Added in 26.1.0. Filter options for querying agents"""
-input AgentFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.1.0. Filter options for querying agents
+"""
+input AgentFilter @join__type(graph: STRAWBERRY) {
   id: StringFilter = null
   status: AgentStatusFilter = null
   schedulable: Boolean = null
@@ -331,17 +424,18 @@ input AgentFilter
 
 type AgentList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [Agent]!
   total_count: Int!
 }
 
-"""Added in 26.1.0. Network-related information for an agent."""
-type AgentNetworkInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Logical region where the agent is deployed."""
+"""
+Added in 26.1.0. Network-related information for an agent.
+"""
+type AgentNetworkInfo @join__type(graph: STRAWBERRY) {
+  """
+  Logical region where the agent is deployed.
+  """
   region: String!
 
   """
@@ -350,12 +444,15 @@ type AgentNetworkInfo
   addr: String!
 }
 
-"""Added in 24.12.0."""
+"""
+Added in 24.12.0.
+"""
 type AgentNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
-  @join__type(graph: GRAPHENE)
-{
-  """The ID of the object"""
+  @join__type(graph: GRAPHENE) {
+  """
+  The ID of the object
+  """
   id: ID!
   row_id: String
   status: String
@@ -366,7 +463,9 @@ type AgentNode implements Node
   available_slots: JSONString
   occupied_slots: JSONString
 
-  """Agent's address with port. (bind/advertised host:port)"""
+  """
+  Agent's address with port. (bind/advertised host:port)
+  """
   addr: String
   architecture: String
   first_contact: DateTime
@@ -379,9 +478,19 @@ type AgentNode implements Node
   local_config: JSONString
   container_count: Int
 
-  """Added in 25.4.0."""
+  """
+  Added in 25.4.0.
+  """
   gpu_alloc_map: UUIDFloatMap
-  kernel_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): KernelConnection
+  kernel_nodes(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): KernelConnection
 
   """
   Added in 24.12.0. One of ['read_attribute', 'update_attribute', 'create_compute_session', 'create_service'].
@@ -389,18 +498,18 @@ type AgentNode implements Node
   permissions: [AgentPermissionField]
 }
 
-"""Added in 26.1.0. Options for ordering agents"""
-input AgentOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.1.0. Options for ordering agents
+"""
+input AgentOrderBy @join__type(graph: STRAWBERRY) {
   field: AgentOrderField!
   direction: OrderDirection! = ASC
 }
 
-"""Added in 26.1.0. Order by specification for agents"""
-enum AgentOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.1.0. Order by specification for agents
+"""
+enum AgentOrderField @join__type(graph: STRAWBERRY) {
   ID @join__enumValue(graph: STRAWBERRY)
   STATUS @join__enumValue(graph: STRAWBERRY)
   FIRST_CONTACT @join__enumValue(graph: STRAWBERRY)
@@ -408,10 +517,10 @@ enum AgentOrderField
   SCHEDULABLE @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.1.0. Permissions related to agent operations"""
-enum AgentPermission
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.1.0. Permissions related to agent operations
+"""
+enum AgentPermission @join__type(graph: STRAWBERRY) {
   READ_ATTRIBUTE @join__enumValue(graph: STRAWBERRY)
   UPDATE_ATTRIBUTE @join__enumValue(graph: STRAWBERRY)
   CREATE_COMPUTE_SESSION @join__enumValue(graph: STRAWBERRY)
@@ -421,15 +530,12 @@ enum AgentPermission
 """
 Added in 24.12.0. One of ['read_attribute', 'update_attribute', 'create_compute_session', 'create_service'].
 """
-scalar AgentPermissionField
-  @join__type(graph: GRAPHENE)
+scalar AgentPermissionField @join__type(graph: GRAPHENE)
 
 """
 Added in 25.15.0. Hardware resource capacity, usage, and availability of an agent.
 """
-type AgentResource
-  @join__type(graph: STRAWBERRY)
-{
+type AgentResource @join__type(graph: STRAWBERRY) {
   """
   Total hardware resource capacity available on the agent. Expressed as a JSON object containing resource slots.
   """
@@ -446,14 +552,18 @@ type AgentResource
   free: JSON!
 }
 
-"""Added in 26.3.0. Relay-style connection for per-slot agent resources."""
-type AgentResourceConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Relay-style connection for per-slot agent resources.
+"""
+type AgentResourceConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [AgentResourceSlotEdge!]!
   count: Int!
 }
@@ -464,15 +574,20 @@ Represents one row from the agent_resources table.
 """
 type AgentResourceSlot implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Resource slot identifier (e.g., 'cpu', 'mem', 'cuda.device')."""
+  """
+  Resource slot identifier (e.g., 'cpu', 'mem', 'cuda.device').
+  """
   slotName: String!
 
-  """Total hardware resource capacity for this slot on the agent."""
+  """
+  Total hardware resource capacity for this slot on the agent.
+  """
   capacity: Decimal!
 
   """
@@ -481,21 +596,25 @@ type AgentResourceSlot implements Node
   used: Decimal!
 }
 
-"""An edge in a connection."""
-type AgentResourceSlotEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type AgentResourceSlotEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: AgentResourceSlot!
 }
 
-"""Added in 26.3.0. Filter criteria for querying agent resource slots."""
-input AgentResourceSlotFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Filter criteria for querying agent resource slots.
+"""
+input AgentResourceSlotFilter @join__type(graph: STRAWBERRY) {
   slotName: StringFilter = null
   agentId: StringFilter = null
   AND: [AgentResourceSlotFilter!] = null
@@ -503,45 +622,41 @@ input AgentResourceSlotFilter
   NOT: [AgentResourceSlotFilter!] = null
 }
 
-"""Added in 26.3.0. Ordering specification for agent resource slots."""
-input AgentResourceSlotOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Ordering specification for agent resource slots.
+"""
+input AgentResourceSlotOrderBy @join__type(graph: STRAWBERRY) {
   field: AgentResourceSlotOrderField!
   direction: OrderDirection! = ASC
 }
 
-"""Added in 26.3.0. Fields available for ordering agent resource slots."""
-enum AgentResourceSlotOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Fields available for ordering agent resource slots.
+"""
+enum AgentResourceSlotOrderField @join__type(graph: STRAWBERRY) {
   SLOT_NAME @join__enumValue(graph: STRAWBERRY)
   CAPACITY @join__enumValue(graph: STRAWBERRY)
   USED @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.15.0. Aggregated resource statistics for an agent."""
-type AgentStats
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.15.0. Aggregated resource statistics for an agent.
+"""
+type AgentStats @join__type(graph: STRAWBERRY) {
   """
   Total hardware resource capacity, usage, and availability across all agents.
   """
   totalResource: AgentResource!
 }
 
-enum AgentStatus
-  @join__type(graph: STRAWBERRY)
-{
+enum AgentStatus @join__type(graph: STRAWBERRY) {
   ALIVE @join__enumValue(graph: STRAWBERRY)
   LOST @join__enumValue(graph: STRAWBERRY)
   RESTARTING @join__enumValue(graph: STRAWBERRY)
   TERMINATED @join__enumValue(graph: STRAWBERRY)
 }
 
-enum AgentStatusEnum
-  @join__type(graph: STRAWBERRY)
-{
+enum AgentStatusEnum @join__type(graph: STRAWBERRY) {
   ALIVE @join__enumValue(graph: STRAWBERRY)
   LOST @join__enumValue(graph: STRAWBERRY)
   RESTARTING @join__enumValue(graph: STRAWBERRY)
@@ -552,27 +667,31 @@ enum AgentStatusEnum
 Added in 24.09.0. Filter options for agent status within AgentFilter.
 It includes options to filter whether agent status is in a specific list or equals a specific value.
 """
-input AgentStatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """The in  field."""
+input AgentStatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  The in  field.
+  """
   in: [AgentStatusEnum!] = null
   equals: AgentStatusEnum = null
 }
 
-"""Added in 26.1.0. Status and lifecycle information for an agent."""
-type AgentStatusInfo
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.1.0. Status and lifecycle information for an agent.
+"""
+type AgentStatusInfo @join__type(graph: STRAWBERRY) {
   """
   Current operational status of the agent. One of: ALIVE, LOST, TERMINATED, RESTARTING.
   """
   status: AgentStatus!
 
-  """Timestamp when the agent last changed its status."""
+  """
+  Timestamp when the agent last changed its status.
+  """
   statusChanged: DateTime
 
-  """Timestamp when the agent first registered with the manager."""
+  """
+  Timestamp when the agent first registered with the manager.
+  """
   firstContact: DateTime
 
   """
@@ -586,11 +705,12 @@ type AgentStatusInfo
   schedulable: Boolean!
 }
 
-"""A schema for normal users."""
+"""
+A schema for normal users.
+"""
 type AgentSummary implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   status: String
   scaling_group: String
@@ -602,16 +722,15 @@ type AgentSummary implements Item
 
 type AgentSummaryList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [AgentSummary]!
   total_count: Int!
 }
 
-"""Added in 26.1.0. System and configuration information for an agent."""
-type AgentSystemInfo
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.1.0. System and configuration information for an agent.
+"""
+type AgentSystemInfo @join__type(graph: STRAWBERRY) {
   """
   Hardware architecture of the agent's host system (e.g., "x86_64", "aarch64"). Used to match compute sessions with compatible container images.
   """
@@ -622,7 +741,9 @@ type AgentSystemInfo
   """
   version: String!
 
-  """Legacy configuration flag, no longer actively used in the system."""
+  """
+  Legacy configuration flag, no longer actively used in the system.
+  """
   autoTerminateAbusingKernel: Boolean!
 
   """
@@ -631,12 +752,15 @@ type AgentSystemInfo
   computePlugins: ComputePlugins!
 }
 
-"""Added in 26.1.0. Strawberry-based Agent type replacing AgentNode."""
+"""
+Added in 26.1.0. Strawberry-based Agent type replacing AgentNode.
+"""
 type AgentV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
   """
@@ -669,95 +793,142 @@ type AgentV2 implements Node
   """
   scalingGroup: String!
 
-  """Added in 26.1.0. Load the container count for this agent."""
+  """
+  Added in 26.1.0. Load the container count for this agent.
+  """
   containerCount: Int!
 
   """
   Added in 26.2.0. List of kernels running on this agent with pagination support.
   """
-  kernels(filter: KernelV2Filter = null, orderBy: [KernelV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KernelV2Connection!
+  kernels(
+    filter: KernelV2Filter = null
+    orderBy: [KernelV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): KernelV2Connection!
 
   """
   Added in 26.3.0. List of sessions running on this agent with pagination support.
   """
-  sessions(filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection!
+  sessions(
+    filter: SessionV2Filter = null
+    orderBy: [SessionV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): SessionV2Connection!
 
-  """Added in 26.3.0. Per-slot resource capacity and usage for this agent."""
-  resourceSlots(filter: AgentResourceSlotFilter = null, orderBy: [AgentResourceSlotOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): AgentResourceConnection!
+  """
+  Added in 26.3.0. Per-slot resource capacity and usage for this agent.
+  """
+  resourceSlots(
+    filter: AgentResourceSlotFilter = null
+    orderBy: [AgentResourceSlotOrderBy!] = null
+    first: Int = null
+    after: String = null
+    last: Int = null
+    before: String = null
+    limit: Int = null
+    offset: Int = null
+  ): AgentResourceConnection!
 }
 
 """
 Added in 26.1.0. Relay-style connection type for paginated lists of agents.
 """
-type AgentV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type AgentV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [AgentV2Edge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type AgentV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type AgentV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: AgentV2!
 }
 
-type AliasImage
-  @join__type(graph: GRAPHENE)
-{
+type AliasImage @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in UNRELEASED. Payload containing allowed domain names."""
-type AllowedDomainsPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Allowed domain names."""
+"""
+Added in UNRELEASED. Payload containing allowed domain names.
+"""
+type AllowedDomainsPayload @join__type(graph: STRAWBERRY) {
+  """
+  Allowed domain names.
+  """
   items: [String!]!
 }
 
-"""Added in 25.3.0."""
-input AllowedGroups
-  @join__type(graph: GRAPHENE)
-{
-  """List of group_ids to add associations. Added in 25.3.0."""
+"""
+Added in 25.3.0.
+"""
+input AllowedGroups @join__type(graph: GRAPHENE) {
+  """
+  List of group_ids to add associations. Added in 25.3.0.
+  """
   add: [String] = []
 
-  """List of group_ids to remove associations. Added in 25.3.0."""
+  """
+  List of group_ids to remove associations. Added in 25.3.0.
+  """
   remove: [String] = []
 }
 
-"""Added in UNRELEASED. Payload containing allowed project IDs."""
-type AllowedProjectsPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Allowed project IDs."""
+"""
+Added in UNRELEASED. Payload containing allowed project IDs.
+"""
+type AllowedProjectsPayload @join__type(graph: STRAWBERRY) {
+  """
+  Allowed project IDs.
+  """
   items: [UUID!]!
 }
 
-"""Added in UNRELEASED. Payload containing allowed resource group names."""
-type AllowedResourceGroupsPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Allowed resource group names."""
+"""
+Added in UNRELEASED. Payload containing allowed resource group names.
+"""
+type AllowedResourceGroupsPayload @join__type(graph: STRAWBERRY) {
+  """
+  Allowed resource group names.
+  """
   items: [String!]!
 }
 
-"""Added in 25.16.0. App configuration data."""
-type AppConfig
-  @join__type(graph: STRAWBERRY)
-{
-  """Additional configuration data."""
+"""
+Added in 25.16.0. App configuration data.
+"""
+type AppConfig @join__type(graph: STRAWBERRY) {
+  """
+  Additional configuration data.
+  """
   extraConfig: JSON!
 }
 
@@ -766,19 +937,17 @@ Added in 24.09.0. Input for approving an artifact revision.
 
 Admin-only operation to approve artifact revisions for general use.
 """
-input ApproveArtifactInput
-  @join__type(graph: STRAWBERRY)
-{
+input ApproveArtifactInput @join__type(graph: STRAWBERRY) {
   artifactRevisionId: ID!
 }
 
 """
 Added in 25.14.0. Response payload for artifact revision approval operations. Contains the approved artifact revision. Admin-only operation.
 """
-type ApproveArtifactPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Approved artifact revision."""
+type ApproveArtifactPayload @join__type(graph: STRAWBERRY) {
+  """
+  Approved artifact revision.
+  """
   artifactRevision: ArtifactRevision!
 }
 
@@ -787,9 +956,10 @@ Added in 25.14.0. An artifact represents AI models, packages, images, or other r
 """
 type Artifact implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   name: String!
   type: ArtifactType!
@@ -802,13 +972,22 @@ type Artifact implements Node
   updatedAt: DateTime!
   availability: ArtifactAvailability!
 
-  """The revisions of this entity."""
-  revisions(filter: ArtifactRevisionFilter = null, orderBy: [ArtifactRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ArtifactRevisionConnection!
+  """
+  The revisions of this entity.
+  """
+  revisions(
+    filter: ArtifactRevisionFilter = null
+    orderBy: [ArtifactRevisionOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ArtifactRevisionConnection!
 }
 
-enum ArtifactAvailability
-  @join__type(graph: STRAWBERRY)
-{
+enum ArtifactAvailability @join__type(graph: STRAWBERRY) {
   ALIVE @join__enumValue(graph: STRAWBERRY)
   DELETED @join__enumValue(graph: STRAWBERRY)
 }
@@ -816,25 +995,31 @@ enum ArtifactAvailability
 """
 Added in 25.14.0. Paginated connection for artifacts with total count information. Used for relay-style pagination with cursor-based navigation.
 """
-type ArtifactConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ArtifactConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ArtifactEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type ArtifactEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ArtifactEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: Artifact!
 }
 
@@ -844,9 +1029,7 @@ source, and availability status.
 
 Supports logical operations (AND, OR, NOT) for complex filtering scenarios.
 """
-input ArtifactFilter
-  @join__type(graph: STRAWBERRY)
-{
+input ArtifactFilter @join__type(graph: STRAWBERRY) {
   type: [ArtifactType!] = null
   name: StringFilter = null
   registry: StringFilter = null
@@ -860,32 +1043,32 @@ input ArtifactFilter
 """
 Added in 25.14.0. Payload for artifact import progress subscription events. Provides real-time updates during the artifact import process, including progress percentage and current status.
 """
-type ArtifactImportProgressUpdatedPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Artifact revision ID."""
+type ArtifactImportProgressUpdatedPayload @join__type(graph: STRAWBERRY) {
+  """
+  Artifact revision ID.
+  """
   artifactId: ID!
 
-  """Import progress as a percentage."""
+  """
+  Import progress as a percentage.
+  """
   progress: Float!
 
-  """Current import status."""
+  """
+  Current import status.
+  """
   status: ArtifactStatus!
 }
 
 """
 Added in 24.09.0. Specifies the field and direction for ordering artifacts in queries.
 """
-input ArtifactOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input ArtifactOrderBy @join__type(graph: STRAWBERRY) {
   field: ArtifactOrderField!
   direction: OrderDirection! = ASC
 }
 
-enum ArtifactOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum ArtifactOrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   TYPE @join__enumValue(graph: STRAWBERRY)
   SIZE @join__enumValue(graph: STRAWBERRY)
@@ -893,20 +1076,28 @@ enum ArtifactOrderField
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.14.0. Artifact registry node."""
-type ArtifactRegistry
-  @join__type(graph: STRAWBERRY)
-{
-  """Internal identifier of the artifact registry metadata record."""
+"""
+Added in 25.14.0. Artifact registry node.
+"""
+type ArtifactRegistry @join__type(graph: STRAWBERRY) {
+  """
+  Internal identifier of the artifact registry metadata record.
+  """
   id: ID!
 
-  """Identifier of the actual registry implementation."""
+  """
+  Identifier of the actual registry implementation.
+  """
   registryId: ID!
 
-  """Name of the artifact registry."""
+  """
+  Name of the artifact registry.
+  """
   name: String!
 
-  """Type of the artifact registry."""
+  """
+  Type of the artifact registry.
+  """
   type: ArtifactRegistryType!
 }
 
@@ -915,9 +1106,10 @@ Added in 25.15.0. Represents common metadata for an artifact registry. All artif
 """
 type ArtifactRegistryMeta implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   name: String!
   registryId: ID!
@@ -928,38 +1120,40 @@ type ArtifactRegistryMeta implements Node
 """
 Added in 25.15.0. Relay-style connection for paginated artifact registry meta queries.
 """
-type ArtifactRegistryMetaConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ArtifactRegistryMetaConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ArtifactRegistryMetaEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type ArtifactRegistryMetaEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ArtifactRegistryMetaEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ArtifactRegistryMeta!
 }
 
-enum ArtifactRegistryType
-  @join__type(graph: STRAWBERRY)
-{
+enum ArtifactRegistryType @join__type(graph: STRAWBERRY) {
   HUGGINGFACE @join__enumValue(graph: STRAWBERRY)
   RESERVOIR @join__enumValue(graph: STRAWBERRY)
 }
 
-enum ArtifactRemoteStatus
-  @join__type(graph: STRAWBERRY)
-{
+enum ArtifactRemoteStatus @join__type(graph: STRAWBERRY) {
   SCANNED @join__enumValue(graph: STRAWBERRY)
   AVAILABLE @join__enumValue(graph: STRAWBERRY)
   FAILED @join__enumValue(graph: STRAWBERRY)
@@ -970,9 +1164,10 @@ Added in 25.14.0. A specific version/revision of an artifact containing the actu
 """
 type ArtifactRevision implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   status: ArtifactStatus!
 
@@ -996,32 +1191,40 @@ type ArtifactRevision implements Node
   """
   verificationResult: ArtifactVerificationResult
 
-  """The artifact of this entity."""
+  """
+  The artifact of this entity.
+  """
   artifact: Artifact!
 }
 
 """
 Added in 25.14.0. Paginated connection for artifact revisions with total count information. Used for relay-style pagination with cursor-based navigation.
 """
-type ArtifactRevisionConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ArtifactRevisionConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ArtifactRevisionEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type ArtifactRevisionEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ArtifactRevisionEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ArtifactRevision!
 }
 
@@ -1030,16 +1233,18 @@ Added in 25.14.0. Filter options for artifact revisions based on status, version
 
 Supports logical operations (AND, OR, NOT) for complex filtering scenarios.
 """
-input ArtifactRevisionFilter
-  @join__type(graph: STRAWBERRY)
-{
+input ArtifactRevisionFilter @join__type(graph: STRAWBERRY) {
   status: ArtifactRevisionStatusFilter = null
 
-  """Added in 25.16.0. Filter by remote synchronization status."""
+  """
+  Added in 25.16.0. Filter by remote synchronization status.
+  """
   remoteStatus: ArtifactRevisionRemoteStatusFilter = null
   version: StringFilter = null
 
-  """The artifact id field."""
+  """
+  The artifact id field.
+  """
   artifactId: UUIDFilter = null
   size: IntFilter = null
   AND: [ArtifactRevisionFilter!] = null
@@ -1050,29 +1255,27 @@ input ArtifactRevisionFilter
 """
 Added in 25.14.0. Represents a background task for importing an artifact revision. Contains the task ID for monitoring progress and the associated artifact revision being imported from external registries.
 """
-type ArtifactRevisionImportTask
-  @join__type(graph: STRAWBERRY)
-{
-  """Background task ID."""
+type ArtifactRevisionImportTask @join__type(graph: STRAWBERRY) {
+  """
+  Background task ID.
+  """
   taskId: ID
 
-  """Artifact revision data."""
+  """
+  Artifact revision data.
+  """
   artifactRevision: ArtifactRevision!
 }
 
 """
 Added in 24.09.0. Specifies the field and direction for ordering artifact revisions in queries.
 """
-input ArtifactRevisionOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input ArtifactRevisionOrderBy @join__type(graph: STRAWBERRY) {
   field: ArtifactRevisionOrderField!
   direction: OrderDirection! = ASC
 }
 
-enum ArtifactRevisionOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum ArtifactRevisionOrderField @join__type(graph: STRAWBERRY) {
   VERSION @join__enumValue(graph: STRAWBERRY)
   SIZE @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
@@ -1080,11 +1283,13 @@ enum ArtifactRevisionOrderField
   STATUS @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.16.0. """
-input ArtifactRevisionRemoteStatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """The in  field."""
+"""
+Added in 25.16.0.
+"""
+input ArtifactRevisionRemoteStatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  The in  field.
+  """
   in: [ArtifactRemoteStatus!] = null
   equals: ArtifactRemoteStatus = null
 }
@@ -1092,17 +1297,15 @@ input ArtifactRevisionRemoteStatusFilter
 """
 Added in 24.09.0. Filter for artifact revision status. Supports exact match or inclusion in a list of statuses.
 """
-input ArtifactRevisionStatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """The in  field."""
+input ArtifactRevisionStatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  The in  field.
+  """
   in: [ArtifactStatus!] = null
   equals: ArtifactStatus = null
 }
 
-enum ArtifactStatus
-  @join__type(graph: STRAWBERRY)
-{
+enum ArtifactStatus @join__type(graph: STRAWBERRY) {
   SCANNED @join__enumValue(graph: STRAWBERRY)
   PULLING @join__enumValue(graph: STRAWBERRY)
   PULLED @join__enumValue(graph: STRAWBERRY)
@@ -1119,25 +1322,21 @@ Added in 24.09.0. Input for subscribing to artifact status change notifications.
 Used with artifact_status_changed subscription to receive real-time updates
 when artifact revision statuses change.
 """
-input ArtifactStatusChangedInput
-  @join__type(graph: STRAWBERRY)
-{
+input ArtifactStatusChangedInput @join__type(graph: STRAWBERRY) {
   artifactRevisionIds: [ID!]!
 }
 
 """
 Added in 25.14.0. Payload for artifact status change subscription events. Provides real-time notifications when artifact revision statuses change during import, cleanup, or other operations.
 """
-type ArtifactStatusChangedPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated artifact revision."""
+type ArtifactStatusChangedPayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated artifact revision.
+  """
   artifactRevision: ArtifactRevision!
 }
 
-enum ArtifactType
-  @join__type(graph: STRAWBERRY)
-{
+enum ArtifactType @join__type(graph: STRAWBERRY) {
   MODEL @join__enumValue(graph: STRAWBERRY)
   PACKAGE @join__enumValue(graph: STRAWBERRY)
   IMAGE @join__enumValue(graph: STRAWBERRY)
@@ -1146,159 +1345,179 @@ enum ArtifactType
 """
 Added in 25.17.0. Complete verification result containing results from all configured verifiers. Artifacts undergo malware scanning through multiple verifiers after being imported. This type aggregates results from all verifiers that were run on the artifact.
 """
-type ArtifactVerificationResult
-  @join__type(graph: STRAWBERRY)
-{
-  """Results from each verifier that scanned the artifact."""
+type ArtifactVerificationResult @join__type(graph: STRAWBERRY) {
+  """
+  Results from each verifier that scanned the artifact.
+  """
   verifiers: [ArtifactVerifierResultEntry!]!
 }
 
 """
 Added in 26.1.0. A collection of metadata from an artifact verifier. Contains key-value pairs providing additional information about the verification.
 """
-type ArtifactVerifierMetadata
-  @join__type(graph: STRAWBERRY)
-{
-  """List of metadata entries."""
+type ArtifactVerifierMetadata @join__type(graph: STRAWBERRY) {
+  """
+  List of metadata entries.
+  """
   entries: [ArtifactVerifierMetadataEntry!]!
 }
 
 """
 Added in 26.1.0. A single key-value entry representing metadata from an artifact verifier. Contains additional information about the verification process.
 """
-type ArtifactVerifierMetadataEntry
-  @join__type(graph: STRAWBERRY)
-{
-  """The key identifier for this metadata entry."""
+type ArtifactVerifierMetadataEntry @join__type(graph: STRAWBERRY) {
+  """
+  The key identifier for this metadata entry.
+  """
   key: String!
 
-  """The value for this metadata entry."""
+  """
+  The value for this metadata entry.
+  """
   value: String!
 }
 
 """
 Added in 25.17.0. Result from a single malware verifier containing scan results and metadata. Each verifier scans the artifact for potential security issues and reports findings including infected file count, scan time, and any errors encountered.
 """
-type ArtifactVerifierResult
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the verification completed successfully."""
+type ArtifactVerifierResult @join__type(graph: STRAWBERRY) {
+  """
+  Whether the verification completed successfully.
+  """
   success: Boolean!
 
-  """Number of infected or suspicious files detected."""
+  """
+  Number of infected or suspicious files detected.
+  """
   infectedCount: Int!
 
-  """Timestamp when verification started."""
+  """
+  Timestamp when verification started.
+  """
   scannedAt: DateTime!
 
-  """Time taken to complete verification in seconds."""
+  """
+  Time taken to complete verification in seconds.
+  """
   scanTime: Float!
 
-  """Total number of files scanned."""
+  """
+  Total number of files scanned.
+  """
   scannedCount: Int!
 
-  """Additional metadata from the verifier."""
+  """
+  Additional metadata from the verifier.
+  """
   metadata: ArtifactVerifierMetadata!
 
-  """Fatal error message if the verifier failed to complete."""
+  """
+  Fatal error message if the verifier failed to complete.
+  """
   error: String
 }
 
 """
 Added in 25.17.0. Entry for a single verifier's result in the verification results. Associates a verifier name with its scan results.
 """
-type ArtifactVerifierResultEntry
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the verifier."""
+type ArtifactVerifierResultEntry @join__type(graph: STRAWBERRY) {
+  """
+  Name of the verifier.
+  """
   name: String!
 
-  """Scan result from this verifier."""
+  """
+  Scan result from this verifier.
+  """
   result: ArtifactVerifierResult!
 }
 
-"""Added in 26.3.0. Input for assigning a role to a user"""
-input AssignRoleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Input for assigning a role to a user
+"""
+input AssignRoleInput @join__type(graph: STRAWBERRY) {
   userId: UUID!
   roleId: UUID!
 }
 
-"""Added in 24.03.9."""
-type AssociateScalingGroupsWithDomain
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.03.9.
+"""
+type AssociateScalingGroupsWithDomain @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 24.03.9."""
-type AssociateScalingGroupsWithKeyPair
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.03.9.
+"""
+type AssociateScalingGroupsWithKeyPair @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 24.03.9."""
-type AssociateScalingGroupsWithUserGroup
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.03.9.
+"""
+type AssociateScalingGroupsWithUserGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-type AssociateScalingGroupWithDomain
-  @join__type(graph: GRAPHENE)
-{
+type AssociateScalingGroupWithDomain @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-type AssociateScalingGroupWithKeyPair
-  @join__type(graph: GRAPHENE)
-{
+type AssociateScalingGroupWithKeyPair @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-type AssociateScalingGroupWithUserGroup
-  @join__type(graph: GRAPHENE)
-{
+type AssociateScalingGroupWithUserGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 25.6.0."""
-type AuditLogConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 25.6.0.
+"""
+type AuditLogConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [AuditLogEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
-"""Added in 25.6.0. A Relay edge containing a `AuditLog` and its cursor."""
-type AuditLogEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+"""
+Added in 25.6.0. A Relay edge containing a `AuditLog` and its cursor.
+"""
+type AuditLogEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: AuditLogNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
-"""Added in 24.09.0. Filter criteria for querying audit logs."""
-input AuditLogFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Filter criteria for querying audit logs.
+"""
+input AuditLogFilter @join__type(graph: STRAWBERRY) {
   entityType: StringFilter = null
   operation: StringFilter = null
   status: AuditLogStatusFilter = null
@@ -1309,60 +1528,85 @@ input AuditLogFilter
   NOT: [AuditLogFilter!] = null
 }
 
-"""Added in 25.6.0."""
+"""
+Added in 25.6.0.
+"""
 type AuditLogNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
-  @join__type(graph: GRAPHENE)
-{
-  """The ID of the object"""
+  @join__type(graph: GRAPHENE) {
+  """
+  The ID of the object
+  """
   id: ID!
 
-  """UUID of the AuditLog row"""
+  """
+  UUID of the AuditLog row
+  """
   row_id: UUID!
 
-  """Added in 25.6.0. UUID of the action"""
+  """
+  Added in 25.6.0. UUID of the action
+  """
   action_id: UUID!
 
-  """Entity type of the AuditLog"""
+  """
+  Entity type of the AuditLog
+  """
   entity_type: String!
 
-  """Operation type of the AuditLog"""
+  """
+  Operation type of the AuditLog
+  """
   operation: String!
 
-  """Entity ID of the AuditLog"""
+  """
+  Entity ID of the AuditLog
+  """
   entity_id: String
 
-  """The time the AuditLog was reported"""
+  """
+  The time the AuditLog was reported
+  """
   created_at: DateTime!
 
-  """Request ID of the AuditLog"""
+  """
+  Request ID of the AuditLog
+  """
   request_id: String
 
-  """Added in 25.12.0, User ID that triggered the action"""
+  """
+  Added in 25.12.0, User ID that triggered the action
+  """
   triggered_by: String
 
-  """Description of the AuditLog"""
+  """
+  Description of the AuditLog
+  """
   description: String!
 
-  """Duration taken to perform the operation"""
+  """
+  Duration taken to perform the operation
+  """
   duration: String
 
-  """Status of the AuditLog"""
+  """
+  Status of the AuditLog
+  """
   status: String!
 }
 
-"""Added in 24.09.0. Ordering specification for audit logs."""
-input AuditLogOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Ordering specification for audit logs.
+"""
+input AuditLogOrderBy @join__type(graph: STRAWBERRY) {
   field: AuditLogOrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in 26.3.0. Fields available for ordering audit logs."""
-enum AuditLogOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Fields available for ordering audit logs.
+"""
+enum AuditLogOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   ENTITY_TYPE @join__enumValue(graph: STRAWBERRY)
   OPERATION @join__enumValue(graph: STRAWBERRY)
@@ -1375,9 +1619,7 @@ It provides a list of values, such as entity_type and status, that can be used i
 
 Added in 25.6.0.
 """
-type AuditLogSchema
-  @join__type(graph: GRAPHENE)
-{
+type AuditLogSchema @join__type(graph: GRAPHENE) {
   """
   Possible values of "AuditLogNode.entity_type"
   """
@@ -1389,21 +1631,23 @@ type AuditLogSchema
   status_variants: [String]
 }
 
-"""Added in 26.3.0. Status of an audit log entry."""
-enum AuditLogStatus
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Status of an audit log entry.
+"""
+enum AuditLogStatus @join__type(graph: STRAWBERRY) {
   SUCCESS @join__enumValue(graph: STRAWBERRY)
   ERROR @join__enumValue(graph: STRAWBERRY)
   UNKNOWN @join__enumValue(graph: STRAWBERRY)
   RUNNING @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 24.09.0. Filter for audit log status field."""
-input AuditLogStatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """The in  field."""
+"""
+Added in 24.09.0. Filter for audit log status field.
+"""
+input AuditLogStatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  The in  field.
+  """
   in: [AuditLogStatus!] = null
   notIn: [AuditLogStatus!] = null
 }
@@ -1413,39 +1657,60 @@ Added in 26.3.0. Represents an audit log entry tracking system operations.
 """
 type AuditLogV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """UUID of the action that generated this log."""
+  """
+  UUID of the action that generated this log.
+  """
   actionId: UUID!
 
-  """Type of entity this log relates to."""
+  """
+  Type of entity this log relates to.
+  """
   entityType: String!
 
-  """Operation performed (create, update, delete, etc.)."""
+  """
+  Operation performed (create, update, delete, etc.).
+  """
   operation: String!
 
-  """ID of the affected entity, if applicable."""
+  """
+  ID of the affected entity, if applicable.
+  """
   entityId: String
 
-  """Timestamp when the audit log was created."""
+  """
+  Timestamp when the audit log was created.
+  """
   createdAt: DateTime!
 
-  """Request ID that triggered this operation."""
+  """
+  Request ID that triggered this operation.
+  """
   requestId: String
 
-  """UUID string of the user who triggered the action."""
+  """
+  UUID string of the user who triggered the action.
+  """
   triggeredBy: String
 
-  """Human-readable description of the operation."""
+  """
+  Human-readable description of the operation.
+  """
   description: String!
 
-  """Duration of the operation as a string representation."""
+  """
+  Duration of the operation as a string representation.
+  """
   duration: String
 
-  """Status of the operation."""
+  """
+  Status of the operation.
+  """
   status: AuditLogStatus!
 
   """
@@ -1454,114 +1719,152 @@ type AuditLogV2 implements Node
   user: UserV2
 }
 
-"""Added in 26.3.0. Connection type for paginated audit log results."""
-type AuditLogV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Connection type for paginated audit log results.
+"""
+type AuditLogV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [AuditLogV2Edge!]!
 
-  """Total number of audit log entries matching the query."""
+  """
+  Total number of audit log entries matching the query.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type AuditLogV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type AuditLogV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: AuditLogV2!
 }
 
 """
 The comparator used to compare the metric value with the threshold. Added in 25.1.0.
 """
-enum AutoScalingMetricComparator
-  @join__type(graph: GRAPHENE)
-{
+enum AutoScalingMetricComparator @join__type(graph: GRAPHENE) {
   LESS_THAN @join__enumValue(graph: GRAPHENE)
   LESS_THAN_OR_EQUAL @join__enumValue(graph: GRAPHENE)
   GREATER_THAN @join__enumValue(graph: GRAPHENE)
   GREATER_THAN_OR_EQUAL @join__enumValue(graph: GRAPHENE)
 }
 
-"""The source type to fetch metrics. Added in 25.1.0."""
+"""
+The source type to fetch metrics. Added in 25.1.0.
+"""
 enum AutoScalingMetricSource
   @join__type(graph: GRAPHENE)
-  @join__type(graph: STRAWBERRY)
-{
+  @join__type(graph: STRAWBERRY) {
   KERNEL @join__enumValue(graph: GRAPHENE) @join__enumValue(graph: STRAWBERRY)
-  INFERENCE_FRAMEWORK @join__enumValue(graph: GRAPHENE) @join__enumValue(graph: STRAWBERRY)
+  INFERENCE_FRAMEWORK
+    @join__enumValue(graph: GRAPHENE)
+    @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.19.0. An auto-scaling rule for a model deployment."""
+"""
+Added in 25.19.0. An auto-scaling rule for a model deployment.
+"""
 type AutoScalingRule implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """The source of the scaling metric (e.g. KERNEL, INFERENCE_FRAMEWORK)."""
+  """
+  The source of the scaling metric (e.g. KERNEL, INFERENCE_FRAMEWORK).
+  """
   metricSource: AutoScalingMetricSource!
 
-  """The metric name field."""
+  """
+  The metric name field.
+  """
   metricName: String!
 
-  """The minimum threshold for scaling (e.g. 0.5)."""
+  """
+  The minimum threshold for scaling (e.g. 0.5).
+  """
   minThreshold: Decimal
 
-  """The maximum threshold for scaling (e.g. 21.0)."""
+  """
+  The maximum threshold for scaling (e.g. 21.0).
+  """
   maxThreshold: Decimal
 
-  """The step size for scaling (e.g. 1)."""
+  """
+  The step size for scaling (e.g. 1).
+  """
   stepSize: Int!
 
-  """The time window in seconds for scaling (e.g. 60)."""
+  """
+  The time window in seconds for scaling (e.g. 60).
+  """
   timeWindow: Int!
 
-  """The minimum number of replicas (e.g. 1)."""
+  """
+  The minimum number of replicas (e.g. 1).
+  """
   minReplicas: Int
 
-  """The maximum number of replicas (e.g. 10)."""
+  """
+  The maximum number of replicas (e.g. 10).
+  """
   maxReplicas: Int
   createdAt: DateTime!
   lastTriggeredAt: DateTime!
 }
 
-"""Added in 25.19.0. Connection for auto-scaling rules."""
-type AutoScalingRuleConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 25.19.0. Connection for auto-scaling rules.
+"""
+type AutoScalingRuleConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [AutoScalingRuleEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type AutoScalingRuleEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type AutoScalingRuleEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: AutoScalingRule!
 }
 
-"""Added in 25.19.0. """
-input AutoScalingRuleFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input AutoScalingRuleFilter @join__type(graph: STRAWBERRY) {
   createdAt: DateTimeFilter = null
   lastTriggeredAt: DateTimeFilter = null
   AND: [AutoScalingRuleFilter!] = null
@@ -1569,83 +1872,104 @@ input AutoScalingRuleFilter
   NOT: [AutoScalingRuleFilter!] = null
 }
 
-"""Added in 25.19.0. """
-input AutoScalingRuleOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input AutoScalingRuleOrderBy @join__type(graph: STRAWBERRY) {
   field: AutoScalingRuleOrderField!
   direction: OrderDirection! = DESC
 }
 
-enum AutoScalingRuleOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum AutoScalingRuleOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.8.0."""
-type AvailableServiceConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 25.8.0.
+"""
+type AvailableServiceConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [AvailableServiceEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
 """
 Added in 25.8.0. A Relay edge containing a `AvailableService` and its cursor.
 """
-type AvailableServiceEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+type AvailableServiceEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: AvailableServiceNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
-"""Available services for configuration. Added in 25.8.0."""
+"""
+Available services for configuration. Added in 25.8.0.
+"""
 type AvailableServiceNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
-  @join__type(graph: GRAPHENE)
-{
-  """The ID of the object"""
+  @join__type(graph: GRAPHENE) {
+  """
+  The ID of the object
+  """
   id: ID!
 
-  """Possible values of "Config.service". Added in 25.8.0."""
+  """
+  Possible values of "Config.service". Added in 25.8.0.
+  """
   service_variants: [String]!
 }
 
-"""Added in 24.3.0. Background task event payload."""
-type BackgroundTaskEventPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the background task."""
+"""
+Added in 24.3.0. Background task event payload.
+"""
+type BackgroundTaskEventPayload @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the background task.
+  """
   taskId: ID!
 
-  """Type of the background task event."""
+  """
+  Type of the background task event.
+  """
   eventType: BgtaskEventType!
 
-  """Human-readable message for this event."""
+  """
+  Human-readable message for this event.
+  """
   message: String!
 
-  """Current progress value. Only populated for UPDATED events."""
+  """
+  Current progress value. Only populated for UPDATED events.
+  """
   currentProgress: Float
 
-  """Total progress value. Only populated for UPDATED events."""
+  """
+  Total progress value. Only populated for UPDATED events.
+  """
   totalProgress: Float
 }
 
-"""Added in 24.3.0. Type of background task event"""
-enum BgtaskEventType
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.3.0. Type of background task event
+"""
+enum BgtaskEventType @join__type(graph: STRAWBERRY) {
   UPDATED @join__enumValue(graph: STRAWBERRY)
   DONE @join__enumValue(graph: STRAWBERRY)
   CANCELLED @join__enumValue(graph: STRAWBERRY)
@@ -1656,38 +1980,37 @@ enum BgtaskEventType
 BigInt is an extension of the regular graphene.Int scalar type
 to support integers outside the range of a signed 32-bit integer.
 """
-scalar BigInt
-  @join__type(graph: GRAPHENE)
+scalar BigInt @join__type(graph: GRAPHENE)
 
 """
 Added in UNRELEASED. Binary size with both raw bytes and human-readable format.
 """
-type BinarySizeInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Size in bytes."""
+type BinarySizeInfo @join__type(graph: STRAWBERRY) {
+  """
+  Size in bytes.
+  """
   value: Int!
 
-  """Size in human-readable format (e.g., '1g', '512m')."""
+  """
+  Size in human-readable format (e.g., '1g', '512m').
+  """
   display: String!
 }
 
 """
 Added in UNRELEASED. Binary size input accepting bytes integer or human-readable string.
 """
-input BinarySizeInput
-  @join__type(graph: STRAWBERRY)
-{
+input BinarySizeInput @join__type(graph: STRAWBERRY) {
   """
   Size as bytes integer or human-readable format (e.g., '536870912', '512m', '1g').
   """
   expr: String!
 }
 
-"""Added in 25.19.0. Configuration for blue-green deployment strategy."""
-input BlueGreenConfigInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0. Configuration for blue-green deployment strategy.
+"""
+input BlueGreenConfigInput @join__type(graph: STRAWBERRY) {
   autoPromote: Boolean! = false
   promoteDelaySeconds: Int! = 0
 }
@@ -1695,307 +2018,357 @@ input BlueGreenConfigInput
 """
 Added in 26.3.0. Error information for a failed user in bulk role assignment.
 """
-type BulkAssignRoleError
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the user that failed"""
+type BulkAssignRoleError @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the user that failed
+  """
   userId: UUID!
 
-  """Error message describing the failure"""
+  """
+  Error message describing the failure
+  """
   message: String!
 }
 
-"""Added in 26.3.0. Input for bulk assigning a role to multiple users"""
-input BulkAssignRoleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Input for bulk assigning a role to multiple users
+"""
+input BulkAssignRoleInput @join__type(graph: STRAWBERRY) {
   roleId: UUID!
   userIds: [UUID!]!
 }
 
-"""Added in 26.3.0. Payload for bulk role assignment mutation."""
-type BulkAssignRolePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Successfully created role assignments"""
+"""
+Added in 26.3.0. Payload for bulk role assignment mutation.
+"""
+type BulkAssignRolePayload @join__type(graph: STRAWBERRY) {
+  """
+  Successfully created role assignments
+  """
   assigned: [RoleAssignment!]!
 
-  """Users that failed to be assigned"""
+  """
+  Users that failed to be assigned
+  """
   failed: [BulkAssignRoleError!]!
 }
 
-"""Added in 26.2.0. Payload for bulk user creation mutation."""
-type BulkCreateUsersV2Payload
-  @join__type(graph: STRAWBERRY)
-{
-  """List of successfully created users."""
+"""
+Added in 26.2.0. Payload for bulk user creation mutation.
+"""
+type BulkCreateUsersV2Payload @join__type(graph: STRAWBERRY) {
+  """
+  List of successfully created users.
+  """
   createdUsers: [UserV2!]!
 
-  """List of errors for users that failed to create."""
+  """
+  List of errors for users that failed to create.
+  """
   failed: [BulkCreateUserV2Error!]!
 }
 
-"""Added in 26.2.0. Error information for a failed user in bulk creation."""
-type BulkCreateUserV2Error
-  @join__type(graph: STRAWBERRY)
-{
-  """Original position in the input list."""
+"""
+Added in 26.2.0. Error information for a failed user in bulk creation.
+"""
+type BulkCreateUserV2Error @join__type(graph: STRAWBERRY) {
+  """
+  Original position in the input list.
+  """
   index: Int!
 
-  """Username of the user that failed."""
+  """
+  Username of the user that failed.
+  """
   username: String!
 
-  """Email of the user that failed."""
+  """
+  Email of the user that failed.
+  """
   email: String!
 
-  """Error message describing the failure."""
+  """
+  Error message describing the failure.
+  """
   message: String!
 }
 
 """
 Added in 26.2.0. Input for bulk creating multiple users. Each user has individual specifications.
 """
-input BulkCreateUserV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """List of user creation inputs."""
+input BulkCreateUserV2Input @join__type(graph: STRAWBERRY) {
+  """
+  List of user creation inputs.
+  """
   users: [CreateUserV2Input!]!
 }
 
 """
 Added in 26.3.0. Input for permanently deleting multiple users. This action is irreversible.
 """
-input BulkPurgeUsersV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """List of user UUIDs to purge."""
+input BulkPurgeUsersV2Input @join__type(graph: STRAWBERRY) {
+  """
+  List of user UUIDs to purge.
+  """
   userIds: [UUID!]!
 
-  """Options for the purge operation."""
+  """
+  Options for the purge operation.
+  """
   options: BulkPurgeUsersV2Options = null
 }
 
-"""Added in 26.3.0. Options for bulk user purge operation."""
-input BulkPurgeUsersV2Options
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Options for bulk user purge operation.
+"""
+input BulkPurgeUsersV2Options @join__type(graph: STRAWBERRY) {
   """
   If true, migrate shared virtual folders to the admin user before purging.
   """
   purgeSharedVfolders: Boolean! = false
 
-  """If true, delegate endpoint ownership to the admin user before purging."""
+  """
+  If true, delegate endpoint ownership to the admin user before purging.
+  """
   delegateEndpointOwnership: Boolean! = false
 }
 
-"""Added in 26.3.0. Payload for bulk user permanent deletion mutation."""
-type BulkPurgeUsersV2Payload
-  @join__type(graph: STRAWBERRY)
-{
-  """Number of users successfully purged."""
+"""
+Added in 26.3.0. Payload for bulk user permanent deletion mutation.
+"""
+type BulkPurgeUsersV2Payload @join__type(graph: STRAWBERRY) {
+  """
+  Number of users successfully purged.
+  """
   purgedCount: Int!
 
-  """List of errors for users that failed to purge."""
+  """
+  List of errors for users that failed to purge.
+  """
   failed: [BulkPurgeUserV2Error!]!
 }
 
-"""Added in 26.3.0. Error information for a failed user in bulk purge."""
-type BulkPurgeUserV2Error
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the user that failed to purge."""
+"""
+Added in 26.3.0. Error information for a failed user in bulk purge.
+"""
+type BulkPurgeUserV2Error @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the user that failed to purge.
+  """
   userId: UUID!
 
-  """Error message describing the failure."""
+  """
+  Error message describing the failure.
+  """
   message: String!
 }
 
 """
 Added in 26.3.0. Error information for a failed user in bulk role revocation.
 """
-type BulkRevokeRoleError
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the user that failed"""
+type BulkRevokeRoleError @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the user that failed
+  """
   userId: UUID!
 
-  """Error message describing the failure"""
+  """
+  Error message describing the failure
+  """
   message: String!
 }
 
-"""Added in 26.3.0. Input for bulk revoking a role from multiple users"""
-input BulkRevokeRoleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Input for bulk revoking a role from multiple users
+"""
+input BulkRevokeRoleInput @join__type(graph: STRAWBERRY) {
   roleId: UUID!
   userIds: [UUID!]!
 }
 
-"""Added in 26.3.0. Payload for bulk role revocation mutation."""
-type BulkRevokeRolePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Successfully revoked role assignments"""
+"""
+Added in 26.3.0. Payload for bulk role revocation mutation.
+"""
+type BulkRevokeRolePayload @join__type(graph: STRAWBERRY) {
+  """
+  Successfully revoked role assignments
+  """
   revoked: [RoleAssignment!]!
 
-  """Users that failed to be revoked"""
+  """
+  Users that failed to be revoked
+  """
   failed: [BulkRevokeRoleError!]!
 }
 
-"""Added in 26.3.0. Payload for bulk user update mutation."""
-type BulkUpdateUsersV2Payload
-  @join__type(graph: STRAWBERRY)
-{
-  """List of successfully updated users."""
+"""
+Added in 26.3.0. Payload for bulk user update mutation.
+"""
+type BulkUpdateUsersV2Payload @join__type(graph: STRAWBERRY) {
+  """
+  List of successfully updated users.
+  """
   updatedUsers: [UserV2!]!
 
-  """List of errors for users that failed to update."""
+  """
+  List of errors for users that failed to update.
+  """
   failed: [BulkUpdateUserV2Error!]!
 }
 
-"""Added in 26.3.0. Error information for a failed user in bulk update."""
-type BulkUpdateUserV2Error
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the user that failed to update."""
+"""
+Added in 26.3.0. Error information for a failed user in bulk update.
+"""
+type BulkUpdateUserV2Error @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the user that failed to update.
+  """
   userId: UUID!
 
-  """Error message describing the failure."""
+  """
+  Error message describing the failure.
+  """
   message: String!
 }
 
 """
 Added in 26.3.0. Input for bulk updating multiple users. Each user has individual update specifications.
 """
-input BulkUpdateUserV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """List of user update inputs."""
+input BulkUpdateUserV2Input @join__type(graph: STRAWBERRY) {
+  """
+  List of user update inputs.
+  """
   users: [BulkUpdateUserV2ItemInput!]!
 }
 
 """
 Added in 26.3.0. Input for a single user update within a bulk operation. Pairs a user ID with the fields to update.
 """
-input BulkUpdateUserV2ItemInput
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the user to update."""
+input BulkUpdateUserV2ItemInput @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the user to update.
+  """
   userId: UUID!
 
-  """Fields to update for this user."""
+  """
+  Fields to update for this user.
+  """
   input: UpdateUserV2Input!
 }
 
 """
 Added in 26.1.0. Input for bulk upserting domain fair share weights. Allows updating multiple domains in a single transaction.
 """
-input BulkUpsertDomainFairShareWeightInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the scaling group (resource group) for all fair shares."""
+input BulkUpsertDomainFairShareWeightInput @join__type(graph: STRAWBERRY) {
+  """
+  Name of the scaling group (resource group) for all fair shares.
+  """
   resourceGroupName: String!
 
-  """List of domain weight updates to apply."""
+  """
+  List of domain weight updates to apply.
+  """
   inputs: [DomainWeightInputItem!]!
 }
 
 """
 Added in 26.1.0. Payload for bulk domain fair share weight upsert mutation.
 """
-type BulkUpsertDomainFairShareWeightPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Number of records upserted"""
+type BulkUpsertDomainFairShareWeightPayload @join__type(graph: STRAWBERRY) {
+  """
+  Number of records upserted
+  """
   upsertedCount: Int!
 }
 
 """
 Added in 26.1.0. Input for bulk upserting project fair share weights. Allows updating multiple projects in a single transaction.
 """
-input BulkUpsertProjectFairShareWeightInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the scaling group (resource group) for all fair shares."""
+input BulkUpsertProjectFairShareWeightInput @join__type(graph: STRAWBERRY) {
+  """
+  Name of the scaling group (resource group) for all fair shares.
+  """
   resourceGroupName: String!
 
-  """List of project weight updates to apply."""
+  """
+  List of project weight updates to apply.
+  """
   inputs: [ProjectWeightInputItem!]!
 }
 
 """
 Added in 26.1.0. Payload for bulk project fair share weight upsert mutation.
 """
-type BulkUpsertProjectFairShareWeightPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Number of records upserted"""
+type BulkUpsertProjectFairShareWeightPayload @join__type(graph: STRAWBERRY) {
+  """
+  Number of records upserted
+  """
   upsertedCount: Int!
 }
 
 """
 Added in 26.1.0. Input for bulk upserting user fair share weights. Allows updating multiple users in a single transaction.
 """
-input BulkUpsertUserFairShareWeightInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the scaling group (resource group) for all fair shares."""
+input BulkUpsertUserFairShareWeightInput @join__type(graph: STRAWBERRY) {
+  """
+  Name of the scaling group (resource group) for all fair shares.
+  """
   resourceGroupName: String!
 
-  """List of user weight updates to apply."""
+  """
+  List of user weight updates to apply.
+  """
   inputs: [UserWeightInputItem!]!
 }
 
 """
 Added in 26.1.0. Payload for bulk user fair share weight upsert mutation.
 """
-type BulkUpsertUserFairShareWeightPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Number of records upserted"""
+type BulkUpsertUserFairShareWeightPayload @join__type(graph: STRAWBERRY) {
+  """
+  Number of records upserted
+  """
   upsertedCount: Int!
 }
 
-"""Added in 24.09.1."""
-scalar Bytes
-  @join__type(graph: GRAPHENE)
+"""
+Added in 24.09.1.
+"""
+scalar Bytes @join__type(graph: GRAPHENE)
 
-scalar ByteSize
-  @join__type(graph: STRAWBERRY)
+scalar ByteSize @join__type(graph: STRAWBERRY)
 
 """
 Added in 24.09.0. Input for canceling an in-progress artifact import operation.
 
 Stops the download process and reverts the artifact revision status back to SCANNED.
 """
-input CancelArtifactInput
-  @join__type(graph: STRAWBERRY)
-{
+input CancelArtifactInput @join__type(graph: STRAWBERRY) {
   artifactRevisionId: ID!
 }
 
 """
 Added in 25.14.0. Response payload for canceling artifact import operations. Contains the artifact revision whose import was canceled, reverting its status back to SCANNED.
 """
-type CancelImportArtifactPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Artifact revision with cancelled import."""
+type CancelImportArtifactPayload @join__type(graph: STRAWBERRY) {
+  """
+  Artifact revision with cancelled import.
+  """
   artifactRevision: ArtifactRevision!
 }
 
-"""Added in 24.12.0"""
-type CheckAndTransitStatus
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.12.0
+"""
+type CheckAndTransitStatus @join__type(graph: GRAPHENE) {
   item: [ComputeSessionNode]
   client_mutation_id: String
 }
 
-"""Added in 24.12.0."""
-input CheckAndTransitStatusInput
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.12.0.
+"""
+input CheckAndTransitStatusInput @join__type(graph: GRAPHENE) {
   ids: [GlobalIDField]!
   client_mutation_id: String
 }
@@ -2003,23 +2376,25 @@ input CheckAndTransitStatusInput
 """
 Added in UNRELEASED. Payload containing preset availability check results.
 """
-type CheckPresetAvailabilityPayloadV2
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource presets with availability status."""
+type CheckPresetAvailabilityPayloadV2 @join__type(graph: STRAWBERRY) {
+  """
+  Resource presets with availability status.
+  """
   presets: [PresetAvailabilityV2!]!
 }
 
 """
 Added in UNRELEASED. Input for checking which resource presets are available.
 """
-input CheckPresetAvailabilityV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """Project ID to check availability for."""
+input CheckPresetAvailabilityV2Input @join__type(graph: STRAWBERRY) {
+  """
+  Project ID to check availability for.
+  """
   projectId: UUID!
 
-  """Resource group name to check availability for."""
+  """
+  Resource group name to check availability for.
+  """
   resourceGroupName: String!
 }
 
@@ -2029,26 +2404,24 @@ Added in 24.09.0. Input for cleaning up stored artifact revision data.
 Removes downloaded files from storage and transitions the artifact revision
 back to SCANNED status, freeing up storage space.
 """
-input CleanupArtifactRevisionsInput
-  @join__type(graph: STRAWBERRY)
-{
+input CleanupArtifactRevisionsInput @join__type(graph: STRAWBERRY) {
   artifactRevisionIds: [ID!]!
 }
 
 """
 Added in 25.14.0. Response payload for artifact revision cleanup operations. Contains the cleaned artifact revisions that have had their stored data removed, transitioning them back to SCANNED status to free storage space.
 """
-type CleanupArtifactRevisionsPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Cleaned up artifact revisions."""
+type CleanupArtifactRevisionsPayload @join__type(graph: STRAWBERRY) {
+  """
+  Cleaned up artifact revisions.
+  """
   artifactRevisions: ArtifactRevisionConnection!
 }
 
-"""Added in 25.6.0."""
-input ClearImageCustomResourceLimitKey
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.6.0.
+"""
+input ClearImageCustomResourceLimitKey @join__type(graph: GRAPHENE) {
   image_canonical: String!
 
   """
@@ -2057,16 +2430,14 @@ input ClearImageCustomResourceLimitKey
   architecture: String = null
 }
 
-"""Added in 25.6.0."""
-type ClearImageCustomResourceLimitPayload
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.6.0.
+"""
+type ClearImageCustomResourceLimitPayload @join__type(graph: GRAPHENE) {
   image_node: ImageNode
 }
 
-type ClearImages
-  @join__type(graph: GRAPHENE)
-{
+type ClearImages @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
@@ -2074,39 +2445,38 @@ type ClearImages
 """
 Added in 25.19.0. Cluster configuration for model deployment replicas. Defines the clustering mode and number of replicas.
 """
-type ClusterConfig
-  @join__type(graph: STRAWBERRY)
-{
+type ClusterConfig @join__type(graph: STRAWBERRY) {
   mode: ClusterMode!
   size: Int!
 }
 
-"""Added in 25.19.0. """
-input ClusterConfigInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ClusterConfigInput @join__type(graph: STRAWBERRY) {
   mode: ClusterMode!
   size: Int!
 }
 
-"""Added in 25.19.0. Cluster mode for compute sessions and deployments."""
-enum ClusterMode
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0. Cluster mode for compute sessions and deployments.
+"""
+enum ClusterMode @join__type(graph: STRAWBERRY) {
   SINGLE_NODE @join__enumValue(graph: STRAWBERRY)
   MULTI_NODE @join__enumValue(graph: STRAWBERRY)
 }
 
 type ComputeContainer implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   idx: Int
   role: String
   hostname: String
 
-  """Added in 24.03.1."""
+  """
+  Added in 24.03.1.
+  """
   kernel_id: UUID
   cluster_idx: Int
   local_rank: Int
@@ -2114,10 +2484,14 @@ type ComputeContainer implements Item
   cluster_hostname: String
   session_id: UUID
 
-  """Deprecated since 24.03.0; use image_object.name"""
+  """
+  Deprecated since 24.03.0; use image_object.name
+  """
   image: String
 
-  """Added in 24.03.0."""
+  """
+  Added in 24.03.0.
+  """
   image_object: ImageNode
   architecture: String
   registry: String
@@ -2142,8 +2516,7 @@ type ComputeContainer implements Item
 
 type ComputeContainerList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [ComputeContainer]!
   total_count: Int!
 }
@@ -2151,9 +2524,7 @@ type ComputeContainerList implements PaginatedList
 """
 Added in 26.1.0. A single compute plugin entry representing one plugin and its metadata.
 """
-type ComputePluginEntry
-  @join__type(graph: STRAWBERRY)
-{
+type ComputePluginEntry @join__type(graph: STRAWBERRY) {
   """
   Name of the compute plugin (e.g., 'cuda', 'rocm', 'tpu'). This identifier corresponds to the accelerator or resource type supported by the agent.
   """
@@ -2168,9 +2539,7 @@ type ComputePluginEntry
 """
 Added in 26.1.0. A collection of compute plugins available on an agent. Each entry specifies a plugin name and its associated metadata.
 """
-type ComputePlugins
-  @join__type(graph: STRAWBERRY)
-{
+type ComputePlugins @join__type(graph: STRAWBERRY) {
   """
   List of compute plugins. Each entry contains a plugin name and its metadata.
   """
@@ -2179,8 +2548,7 @@ type ComputePlugins
 
 type ComputeSession implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   session_id: UUID
   main_kernel_id: UUID
@@ -2189,7 +2557,9 @@ type ComputeSession implements Item
   type: String
   main_kernel_role: String
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   priority: Int
   image: String
   architecture: String
@@ -2230,7 +2600,9 @@ type ComputeSession implements Item
   occupying_slots: JSONString
   occupied_slots: JSONString
 
-  """Added in 24.03.0."""
+  """
+  Added in 24.03.0.
+  """
   requested_slots: JSONString
   num_queries: BigInt
   containers: [ComputeContainer]
@@ -2238,57 +2610,71 @@ type ComputeSession implements Item
   inference_metrics: JSONString
 }
 
-"""Added in 24.09.0."""
-type ComputeSessionConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 24.09.0.
+"""
+type ComputeSessionConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [ComputeSessionEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
 """
 Added in 24.09.0. A Relay edge containing a `ComputeSession` and its cursor.
 """
-type ComputeSessionEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+type ComputeSessionEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: ComputeSessionNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
 type ComputeSessionList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [ComputeSession]!
   total_count: Int!
 }
 
-"""Added in 24.09.0."""
+"""
+Added in 24.09.0.
+"""
 type ComputeSessionNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
   @join__type(graph: GRAPHENE, key: "id")
-  @join__type(graph: STRAWBERRY, key: "id", extension: true)
-{
-  """The ID of the object"""
+  @join__type(graph: STRAWBERRY, key: "id", extension: true) {
+  """
+  The ID of the object
+  """
   id: ID!
 
-  """ID of session."""
+  """
+  ID of session.
+  """
   row_id: UUID @join__field(graph: GRAPHENE)
   tag: String @join__field(graph: GRAPHENE)
   name: String @join__field(graph: GRAPHENE)
   type: String @join__field(graph: GRAPHENE)
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   priority: Int @join__field(graph: GRAPHENE)
   cluster_template: String @join__field(graph: GRAPHENE)
   cluster_mode: String @join__field(graph: GRAPHENE)
@@ -2297,7 +2683,9 @@ type ComputeSessionNode implements Node
   project_id: UUID @join__field(graph: GRAPHENE)
   user_id: UUID @join__field(graph: GRAPHENE)
 
-  """Added in 25.13.0."""
+  """
+  Added in 25.13.0.
+  """
   owner: UserNode @join__field(graph: GRAPHENE)
   access_key: String @join__field(graph: GRAPHENE)
 
@@ -2314,7 +2702,9 @@ type ComputeSessionNode implements Node
   starts_at: DateTime @join__field(graph: GRAPHENE)
   scheduled_at: DateTime @join__field(graph: GRAPHENE)
 
-  """Added in 25.13.0."""
+  """
+  Added in 25.13.0.
+  """
   queue_position: Int @join__field(graph: GRAPHENE)
   startup_command: String @join__field(graph: GRAPHENE)
   result: String @join__field(graph: GRAPHENE)
@@ -2329,40 +2719,93 @@ type ComputeSessionNode implements Node
   occupied_slots: JSONString @join__field(graph: GRAPHENE)
   requested_slots: JSONString @join__field(graph: GRAPHENE)
 
-  """Added in 25.4.0."""
+  """
+  Added in 25.4.0.
+  """
   image_references: [String] @join__field(graph: GRAPHENE)
 
-  """Added in 25.4.0."""
-  vfolder_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): VirtualFolderConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 25.4.0.
+  """
+  vfolder_nodes(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): VirtualFolderConnection @join__field(graph: GRAPHENE)
   num_queries: BigInt @join__field(graph: GRAPHENE)
   inference_metrics: JSONString @join__field(graph: GRAPHENE)
-  kernel_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): KernelConnection @join__field(graph: GRAPHENE)
+  kernel_nodes(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): KernelConnection @join__field(graph: GRAPHENE)
 
-  """Added in 24.09.0."""
-  dependents(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ComputeSessionConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 24.09.0.
+  """
+  dependents(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): ComputeSessionConnection @join__field(graph: GRAPHENE)
 
-  """Added in 24.09.0."""
-  dependees(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ComputeSessionConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 24.09.0.
+  """
+  dependees(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): ComputeSessionConnection @join__field(graph: GRAPHENE)
 
-  """Added in 24.09.0."""
-  graph(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ComputeSessionConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 24.09.0.
+  """
+  graph(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): ComputeSessionConnection @join__field(graph: GRAPHENE)
 }
 
-"""Deprecated since 24.09.0. use `ContainerRegistryNode` instead"""
+"""
+Deprecated since 24.09.0. use `ContainerRegistryNode` instead
+"""
 type ContainerRegistry implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
-  @join__type(graph: GRAPHENE)
-{
-  """The ID of the object"""
+  @join__type(graph: GRAPHENE) {
+  """
+  The ID of the object
+  """
   id: ID!
   hostname: String
   config: ContainerRegistryConfig
 }
 
-"""Deprecated since 24.09.0."""
-type ContainerRegistryConfig
-  @join__type(graph: GRAPHENE)
-{
+"""
+Deprecated since 24.09.0.
+"""
+type ContainerRegistryConfig @join__type(graph: GRAPHENE) {
   url: String!
   type: String!
   project: [String]
@@ -2370,98 +2813,142 @@ type ContainerRegistryConfig
   password: String
   ssl_verify: Boolean
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   is_global: Boolean
 }
 
-"""Added in 24.09.0."""
-type ContainerRegistryConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 24.09.0.
+"""
+type ContainerRegistryConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [ContainerRegistryEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
 """
 Added in 24.09.0. A Relay edge containing a `ContainerRegistry` and its cursor.
 """
-type ContainerRegistryEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+type ContainerRegistryEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: ContainerRegistryNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
-"""Added in 24.09.0."""
+"""
+Added in 24.09.0.
+"""
 type ContainerRegistryNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
-  @join__type(graph: GRAPHENE)
-{
-  """The ID of the object"""
+  @join__type(graph: GRAPHENE) {
+  """
+  The ID of the object
+  """
   id: ID!
 
-  """Added in 24.09.0. The UUID type id of DB container_registries row."""
+  """
+  Added in 24.09.0. The UUID type id of DB container_registries row.
+  """
   row_id: UUID
   name: String
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   url: String!
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   type: ContainerRegistryTypeField!
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   registry_name: String!
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   is_global: Boolean
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   project: String
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   username: String
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   password: String
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   ssl_verify: Boolean
 
-  """Added in 24.09.3."""
+  """
+  Added in 24.09.3.
+  """
   extra: JSONString
 
-  """Added in 25.3.0."""
-  allowed_groups(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): GroupConnection
+  """
+  Added in 25.3.0.
+  """
+  allowed_groups(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): GroupConnection
 }
 
 """
 Added in 26.2.0. Scope for querying images within a specific container registry.
 """
-input ContainerRegistryScope
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the container registry to scope the query to."""
+input ContainerRegistryScope @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the container registry to scope the query to.
+  """
   registryId: UUID!
 }
 
-"""Added in 25.3.0."""
-scalar ContainerRegistryScopeField
-  @join__type(graph: GRAPHENE)
+"""
+Added in 25.3.0.
+"""
+scalar ContainerRegistryScopeField @join__type(graph: GRAPHENE)
 
-"""Added in 26.4.0. Container registry type."""
-enum ContainerRegistryType
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.4.0. Container registry type.
+"""
+enum ContainerRegistryType @join__type(graph: STRAWBERRY) {
   DOCKER @join__enumValue(graph: STRAWBERRY)
   HARBOR @join__enumValue(graph: STRAWBERRY)
   HARBOR2 @join__enumValue(graph: STRAWBERRY)
@@ -2473,162 +2960,206 @@ enum ContainerRegistryType
   OCP @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 24.09.0."""
-scalar ContainerRegistryTypeField
-  @join__type(graph: GRAPHENE)
+"""
+Added in 24.09.0.
+"""
+scalar ContainerRegistryTypeField @join__type(graph: GRAPHENE)
 
-"""Added in UNRELEASED. Filter by container registry type."""
-input ContainerRegistryTypeFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Filter by container registry type.
+"""
+input ContainerRegistryTypeFilter @join__type(graph: STRAWBERRY) {
   equals: ContainerRegistryType = null
   notEquals: ContainerRegistryType = null
   in_: [ContainerRegistryType!] = null
   notIn: [ContainerRegistryType!] = null
 }
 
-"""Added in 26.4.0. Container registry node."""
+"""
+Added in 26.4.0. Container registry node.
+"""
 type ContainerRegistryV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """URL of the container registry"""
+  """
+  URL of the container registry
+  """
   url: String!
 
-  """Name of the container registry"""
+  """
+  Name of the container registry
+  """
   registryName: String!
 
-  """Type of the container registry"""
+  """
+  Type of the container registry
+  """
   type: ContainerRegistryType!
 
-  """Project or namespace within the registry"""
+  """
+  Project or namespace within the registry
+  """
   project: String
 
-  """Username for registry authentication"""
+  """
+  Username for registry authentication
+  """
   username: String
 
-  """Masked password for registry authentication"""
+  """
+  Masked password for registry authentication
+  """
   password: String
 
-  """Whether SSL verification is enabled"""
+  """
+  Whether SSL verification is enabled
+  """
   sslVerify: Boolean
 
-  """Whether this registry is globally accessible"""
+  """
+  Whether this registry is globally accessible
+  """
   isGlobal: Boolean
 
-  """Extra metadata for the container registry"""
+  """
+  Extra metadata for the container registry
+  """
   extra: JSON
 }
 
-"""Added in UNRELEASED. Paginated connection for container registries."""
-type ContainerRegistryV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in UNRELEASED. Paginated connection for container registries.
+"""
+type ContainerRegistryV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ContainerRegistryV2Edge!]!
 
-  """Total number of matching registries."""
+  """
+  Total number of matching registries.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type ContainerRegistryV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ContainerRegistryV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ContainerRegistryV2!
 }
 
-"""Added in UNRELEASED. Filter for container registries."""
-input ContainerRegistryV2Filter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Filter for container registries.
+"""
+input ContainerRegistryV2Filter @join__type(graph: STRAWBERRY) {
   registryName: StringFilter = null
   type: ContainerRegistryTypeFilter = null
   isGlobal: Boolean = null
 }
 
-"""Added in UNRELEASED. Ordering specification for container registries."""
-input ContainerRegistryV2OrderBy
-  @join__type(graph: STRAWBERRY)
-{
-  """Field to order by."""
+"""
+Added in UNRELEASED. Ordering specification for container registries.
+"""
+input ContainerRegistryV2OrderBy @join__type(graph: STRAWBERRY) {
+  """
+  Field to order by.
+  """
   field: ContainerRegistryV2OrderField! = REGISTRY_NAME
 
-  """Sort direction."""
+  """
+  Sort direction.
+  """
   direction: OrderDirection! = ASC
 }
 
 """
 Added in UNRELEASED. Fields available for ordering container registries.
 """
-enum ContainerRegistryV2OrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum ContainerRegistryV2OrderField @join__type(graph: STRAWBERRY) {
   REGISTRY_NAME @join__enumValue(graph: STRAWBERRY)
   URL @join__enumValue(graph: STRAWBERRY)
   TYPE @join__enumValue(graph: STRAWBERRY)
   IS_GLOBAL @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.6.0."""
-type ContainerUtilizationMetric
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.6.0.
+"""
+type ContainerUtilizationMetric @join__type(graph: GRAPHENE) {
   metric_name: String
 
-  """One of 'current', 'capacity'."""
+  """
+  One of 'current', 'capacity'.
+  """
   value_type: String
   values: [MetricResultValue]
 
-  """The maximum value of the metric in given time range. null if no data."""
+  """
+  The maximum value of the metric in given time range. null if no data.
+  """
   max_value: String
 
-  """The average value of the metric in given time range. null if no data."""
+  """
+  The average value of the metric in given time range. null if no data.
+  """
   avg_value: String
 }
 
-"""Added in 25.6.0."""
-type ContainerUtilizationMetricMetadata
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.6.0.
+"""
+type ContainerUtilizationMetricMetadata @join__type(graph: GRAPHENE) {
   metric_names: [String]
 }
 
 """
 Added in 25.16.0. Input for creating an access token for a model deployment.
 """
-input CreateAccessTokenInput
-  @join__type(graph: STRAWBERRY)
-{
-  """The ID of the model deployment for which the access token is created."""
+input CreateAccessTokenInput @join__type(graph: STRAWBERRY) {
+  """
+  The ID of the model deployment for which the access token is created.
+  """
   modelDeploymentId: ID!
 
-  """The expiration timestamp of the access token."""
+  """
+  The expiration timestamp of the access token.
+  """
   validUntil: DateTime!
 }
 
-"""Added in 25.16.0. Payload for creating an access token."""
-type CreateAccessTokenPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Created access token"""
+"""
+Added in 25.16.0. Payload for creating an access token.
+"""
+type CreateAccessTokenPayload @join__type(graph: STRAWBERRY) {
+  """
+  Created access token
+  """
   accessToken: AccessToken!
 }
 
-"""Added in 25.19.0. Input for creating an auto-scaling rule."""
-input CreateAutoScalingRuleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0. Input for creating an auto-scaling rule.
+"""
+input CreateAutoScalingRuleInput @join__type(graph: STRAWBERRY) {
   modelDeploymentId: ID!
   metricSource: AutoScalingMetricSource!
   metricName: String!
@@ -2640,25 +3171,27 @@ input CreateAutoScalingRuleInput
   maxReplicas: Int
 }
 
-"""Added in 25.19.0. Payload for creating an auto-scaling rule."""
-type CreateAutoScalingRulePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Created auto-scaling rule"""
+"""
+Added in 25.19.0. Payload for creating an auto-scaling rule.
+"""
+type CreateAutoScalingRulePayload @join__type(graph: STRAWBERRY) {
+  """
+  Created auto-scaling rule
+  """
   rule: AutoScalingRule!
 }
 
-"""Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead"""
-type CreateContainerRegistry
-  @join__type(graph: GRAPHENE)
-{
+"""
+Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead
+"""
+type CreateContainerRegistry @join__type(graph: GRAPHENE) {
   container_registry: ContainerRegistry
 }
 
-"""Deprecated since 24.09.0."""
-input CreateContainerRegistryInput
-  @join__type(graph: GRAPHENE)
-{
+"""
+Deprecated since 24.09.0.
+"""
+input CreateContainerRegistryInput @join__type(graph: GRAPHENE) {
   url: String!
   type: String!
   project: [String]
@@ -2666,113 +3199,153 @@ input CreateContainerRegistryInput
   password: String
   ssl_verify: Boolean
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   is_global: Boolean
 }
 
-"""Added in UNRELEASED. Input for creating a container registry."""
-input CreateContainerRegistryInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """URL of the container registry."""
+"""
+Added in UNRELEASED. Input for creating a container registry.
+"""
+input CreateContainerRegistryInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  URL of the container registry.
+  """
   url: String!
 
-  """Unique name of the container registry."""
+  """
+  Unique name of the container registry.
+  """
   registryName: String!
 
-  """Type of the container registry."""
+  """
+  Type of the container registry.
+  """
   type: ContainerRegistryType!
 
-  """Project or namespace."""
+  """
+  Project or namespace.
+  """
   project: String = null
 
-  """Username for authentication."""
+  """
+  Username for authentication.
+  """
   username: String = null
 
-  """Password for authentication."""
+  """
+  Password for authentication.
+  """
   password: String = null
 
-  """Whether to verify SSL."""
+  """
+  Whether to verify SSL.
+  """
   sslVerify: Boolean = null
 
-  """Whether globally accessible."""
+  """
+  Whether globally accessible.
+  """
   isGlobal: Boolean = null
 
-  """Extra metadata."""
+  """
+  Extra metadata.
+  """
   extra: JSON = null
 }
 
-"""Added in 24.09.0."""
-type CreateContainerRegistryNode
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.09.0.
+"""
+type CreateContainerRegistryNode @join__type(graph: GRAPHENE) {
   container_registry: ContainerRegistryNode
 }
 
-"""Added in 25.3.0."""
-input CreateContainerRegistryNodeInputV2
-  @join__type(graph: GRAPHENE)
-{
-  """Added in 25.3.0."""
+"""
+Added in 25.3.0.
+"""
+input CreateContainerRegistryNodeInputV2 @join__type(graph: GRAPHENE) {
+  """
+  Added in 25.3.0.
+  """
   url: String!
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   type: ContainerRegistryTypeField!
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   registry_name: String!
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   is_global: Boolean
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   project: String
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   username: String
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   password: String
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   ssl_verify: Boolean
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   extra: JSONString
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   allowed_groups: AllowedGroups
 }
 
-"""Added in 25.3.0."""
-type CreateContainerRegistryNodeV2
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.3.0.
+"""
+type CreateContainerRegistryNodeV2 @join__type(graph: GRAPHENE) {
   container_registry: ContainerRegistryNode
 }
 
 """
 Added in UNRELEASED. Payload for container registry create/update mutations.
 """
-type CreateContainerRegistryPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Created container registry."""
+type CreateContainerRegistryPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Created container registry.
+  """
   registry: ContainerRegistryV2!
 }
 
-"""Added in 25.3.0."""
-type CreateContainerRegistryQuota
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.3.0.
+"""
+type CreateContainerRegistryQuota @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 25.19.0. """
-input CreateDeploymentInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input CreateDeploymentInput @join__type(graph: STRAWBERRY) {
   metadata: ModelDeploymentMetadataInput!
   networkAccess: ModelDeploymentNetworkAccessInput!
   defaultDeploymentStrategy: DeploymentStrategyInput!
@@ -2780,74 +3353,90 @@ input CreateDeploymentInput
   initialRevision: CreateRevisionInput!
 }
 
-"""Added in 25.19.0. Payload for creating a model deployment."""
-type CreateDeploymentPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Created deployment"""
+"""
+Added in 25.19.0. Payload for creating a model deployment.
+"""
+type CreateDeploymentPayload @join__type(graph: STRAWBERRY) {
+  """
+  Created deployment
+  """
   deployment: ModelDeployment!
 }
 
-"""Added in UNRELEASED. Create deployment revision preset input."""
-input CreateDeploymentRevisionPresetInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Runtime variant ID."""
+"""
+Added in UNRELEASED. Create deployment revision preset input.
+"""
+input CreateDeploymentRevisionPresetInput @join__type(graph: STRAWBERRY) {
+  """
+  Runtime variant ID.
+  """
   runtimeVariantId: UUID!
 
-  """Preset name."""
+  """
+  Preset name.
+  """
   name: String!
 }
 
-"""Added in UNRELEASED. Create deployment revision preset payload."""
-type CreateDeploymentRevisionPresetPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """The created preset."""
+"""
+Added in UNRELEASED. Create deployment revision preset payload.
+"""
+type CreateDeploymentRevisionPresetPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  The created preset.
+  """
   preset: DeploymentRevisionPreset!
 }
 
-type CreateDomain
-  @join__type(graph: GRAPHENE)
-{
+type CreateDomain @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   domain: Domain
 }
 
-"""Added in UNRELEASED. Input for creating a new domain."""
-input CreateDomainInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Domain name. Must be unique across the system."""
+"""
+Added in UNRELEASED. Input for creating a new domain.
+"""
+input CreateDomainInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  Domain name. Must be unique across the system.
+  """
   name: String!
 
-  """Optional description."""
+  """
+  Optional description.
+  """
   description: String = null
 
-  """Whether the domain is active."""
+  """
+  Whether the domain is active.
+  """
   isActive: Boolean! = true
 
-  """Allowed Docker registry URLs."""
+  """
+  Allowed Docker registry URLs.
+  """
   allowedDockerRegistries: [String!] = null
 
-  """External integration identifier."""
+  """
+  External integration identifier.
+  """
   integrationId: String = null
 }
 
-"""Added in 24.12.0."""
-type CreateDomainNode
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.12.0.
+"""
+type CreateDomainNode @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   item: DomainNode
 }
 
-"""Added in 24.12.0."""
-input CreateDomainNodeInput
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.12.0.
+"""
+input CreateDomainNodeInput @join__type(graph: GRAPHENE) {
   name: String!
   description: String
   is_active: Boolean = true
@@ -2859,59 +3448,53 @@ input CreateDomainNodeInput
   scaling_groups: [String]
 }
 
-"""Added in 25.1.0."""
-type CreateEndpointAutoScalingRuleNode
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.1.0.
+"""
+type CreateEndpointAutoScalingRuleNode @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   rule: EndpointAutoScalingRuleNode
 }
 
-type CreateGroup
-  @join__type(graph: GRAPHENE)
-{
+type CreateGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   group: Group
 }
 
-"""Added in 25.14.0. """
-input CreateHuggingFaceRegistryInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.14.0.
+"""
+input CreateHuggingFaceRegistryInput @join__type(graph: STRAWBERRY) {
   name: String!
   url: String!
   token: String = null
 }
 
-"""Added in 25.14.0. Payload for creating a HuggingFace registry."""
-type CreateHuggingFaceRegistryPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Created HuggingFace registry"""
+"""
+Added in 25.14.0. Payload for creating a HuggingFace registry.
+"""
+type CreateHuggingFaceRegistryPayload @join__type(graph: STRAWBERRY) {
+  """
+  Created HuggingFace registry
+  """
   huggingfaceRegistry: HuggingFaceRegistry!
 }
 
-type CreateKeyPair
-  @join__type(graph: GRAPHENE)
-{
+type CreateKeyPair @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   keypair: KeyPair
 }
 
-type CreateKeyPairResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type CreateKeyPairResourcePolicy @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   resource_policy: KeyPairResourcePolicy
 }
 
-input CreateKeyPairResourcePolicyInput
-  @join__type(graph: GRAPHENE)
-{
+input CreateKeyPairResourcePolicyInput @join__type(graph: GRAPHENE) {
   default_for_unspecified: String!
   total_resource_slots: JSONString = "{}"
   max_session_lifetime: Int = 0
@@ -2924,99 +3507,135 @@ input CreateKeyPairResourcePolicyInput
   max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.4.")
   max_quota_scope_size: BigInt @deprecated(reason: "Deprecated since 23.09.6.")
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4.
+  """
   max_pending_session_count: Int
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4.
+  """
   max_pending_session_resource_slots: JSONString
 }
 
-"""Added in UNRELEASED. Input for creating a keypair resource policy."""
-input CreateKeypairResourcePolicyInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Policy name. Must be unique."""
+"""
+Added in UNRELEASED. Input for creating a keypair resource policy.
+"""
+input CreateKeypairResourcePolicyInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  Policy name. Must be unique.
+  """
   name: String!
 
-  """Default for unspecified resource slots (LIMITED or UNLIMITED)."""
+  """
+  Default for unspecified resource slots (LIMITED or UNLIMITED).
+  """
   defaultForUnspecified: String!
 
-  """Total resource slot limits."""
+  """
+  Total resource slot limits.
+  """
   totalResourceSlots: [ResourceSlotEntryInput!]!
 
-  """Maximum session lifetime in seconds."""
+  """
+  Maximum session lifetime in seconds.
+  """
   maxSessionLifetime: Int!
 
-  """Maximum concurrent sessions."""
+  """
+  Maximum concurrent sessions.
+  """
   maxConcurrentSessions: Int!
 
-  """Maximum containers per session."""
+  """
+  Maximum containers per session.
+  """
   maxContainersPerSession: Int!
 
-  """Idle timeout in seconds."""
+  """
+  Idle timeout in seconds.
+  """
   idleTimeout: Int!
 
-  """Maximum pending sessions. Null means unlimited."""
+  """
+  Maximum pending sessions. Null means unlimited.
+  """
   maxPendingSessionCount: Int = null
 
-  """Maximum pending session resource slots."""
+  """
+  Maximum pending session resource slots.
+  """
   maxPendingSessionResourceSlots: [ResourceSlotEntryInput!] = null
 
-  """Maximum concurrent SFTP sessions."""
+  """
+  Maximum concurrent SFTP sessions.
+  """
   maxConcurrentSftpSessions: Int! = 1
 
-  """Allowed vfolder host permissions."""
+  """
+  Allowed vfolder host permissions.
+  """
   allowedVfolderHosts: [VFolderHostPermissionEntryInput!]!
 }
 
 """
 Added in UNRELEASED. Payload for keypair resource policy create/update mutations.
 """
-type CreateKeypairResourcePolicyPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Created keypair resource policy."""
+type CreateKeypairResourcePolicyPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Created keypair resource policy.
+  """
   keypairResourcePolicy: KeypairResourcePolicyV2!
 }
 
-"""Added in UNRELEASED. Create model card payload."""
-type CreateModelCardPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """The created model card."""
+"""
+Added in UNRELEASED. Create model card payload.
+"""
+type CreateModelCardPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  The created model card.
+  """
   modelCard: ModelCardV2!
 }
 
-"""Added in UNRELEASED. Create model card input."""
-input CreateModelCardV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """Model card name."""
+"""
+Added in UNRELEASED. Create model card input.
+"""
+input CreateModelCardV2Input @join__type(graph: STRAWBERRY) {
+  """
+  Model card name.
+  """
   name: String!
 
-  """VFolder ID."""
+  """
+  VFolder ID.
+  """
   vfolderId: UUID!
 
-  """Project ID."""
+  """
+  Project ID.
+  """
   projectId: UUID!
 
-  """Domain name."""
+  """
+  Domain name.
+  """
   domainName: String!
 }
 
-"""Added in 24.12.0."""
-type CreateNetwork
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.12.0.
+"""
+type CreateNetwork @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   network: NetworkNode
 }
 
-"""Added in 24.09.0. Input for creating a notification channel"""
-input CreateNotificationChannelInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for creating a notification channel
+"""
+input CreateNotificationChannelInput @join__type(graph: STRAWBERRY) {
   name: String!
   description: String = null
   channelType: NotificationChannelType!
@@ -3024,40 +3643,46 @@ input CreateNotificationChannelInput
   enabled: Boolean! = true
 }
 
-"""Added in 26.3.0. Payload for create notification channel mutation."""
-type CreateNotificationChannelPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Created notification channel"""
+"""
+Added in 26.3.0. Payload for create notification channel mutation.
+"""
+type CreateNotificationChannelPayload @join__type(graph: STRAWBERRY) {
+  """
+  Created notification channel
+  """
   channel: NotificationChannel!
 }
 
-"""Added in 24.09.0. Input for creating a notification rule"""
-input CreateNotificationRuleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for creating a notification rule
+"""
+input CreateNotificationRuleInput @join__type(graph: STRAWBERRY) {
   name: String!
   description: String = null
 
-  """The rule type field."""
+  """
+  The rule type field.
+  """
   ruleType: NotificationRuleType!
   channelId: ID!
   messageTemplate: String!
   enabled: Boolean! = true
 }
 
-"""Added in 26.3.0. Payload for create notification rule mutation."""
-type CreateNotificationRulePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Created notification rule"""
+"""
+Added in 26.3.0. Payload for create notification rule mutation.
+"""
+type CreateNotificationRulePayload @join__type(graph: STRAWBERRY) {
+  """
+  Created notification rule
+  """
   rule: NotificationRule!
 }
 
-"""Added in 25.14.0. """
-input CreateObjectStorageInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.14.0.
+"""
+input CreateObjectStorageInput @join__type(graph: STRAWBERRY) {
   name: String!
   host: String!
   accessKey: String!
@@ -3066,18 +3691,20 @@ input CreateObjectStorageInput
   region: String!
 }
 
-"""Added in 25.14.0. Payload for creating an object storage."""
-type CreateObjectStoragePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Created object storage"""
+"""
+Added in 25.14.0. Payload for creating an object storage.
+"""
+type CreateObjectStoragePayload @join__type(graph: STRAWBERRY) {
+  """
+  Created object storage
+  """
   objectStorage: ObjectStorage!
 }
 
-"""Added in 26.3.0. Input for creating a scoped permission"""
-input CreatePermissionInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Input for creating a scoped permission
+"""
+input CreatePermissionInput @join__type(graph: STRAWBERRY) {
   roleId: UUID!
   scopeType: RBACElementType!
   scopeId: String!
@@ -3085,37 +3712,43 @@ input CreatePermissionInput
   operation: OperationType!
 }
 
-"""Added in UNRELEASED. Input for creating a new project."""
-input CreateProjectInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Project name. Must be unique within the domain."""
+"""
+Added in UNRELEASED. Input for creating a new project.
+"""
+input CreateProjectInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  Project name. Must be unique within the domain.
+  """
   name: String!
 
-  """Name of the domain this project belongs to."""
+  """
+  Name of the domain this project belongs to.
+  """
   domainName: String!
 
-  """Optional description."""
+  """
+  Optional description.
+  """
   description: String = null
 
-  """External integration identifier."""
+  """
+  External integration identifier.
+  """
   integrationId: String = null
 
-  """Name of the resource policy to apply."""
+  """
+  Name of the resource policy to apply.
+  """
   resourcePolicy: String = null
 }
 
-type CreateProjectResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type CreateProjectResourcePolicy @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   resource_policy: ProjectResourcePolicy
 }
 
-input CreateProjectResourcePolicyInput
-  @join__type(graph: GRAPHENE)
-{
+input CreateProjectResourcePolicyInput @join__type(graph: GRAPHENE) {
   """
   Added in 24.03.1 and 23.09.6. Limitation of the number of project vfolders.
   """
@@ -3133,65 +3766,85 @@ input CreateProjectResourcePolicyInput
   max_network_count: Int
 }
 
-"""Added in UNRELEASED. Input for creating a project resource policy."""
-input CreateProjectResourcePolicyInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Policy name. Must be unique."""
+"""
+Added in UNRELEASED. Input for creating a project resource policy.
+"""
+input CreateProjectResourcePolicyInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  Policy name. Must be unique.
+  """
   name: String!
 
-  """Maximum vfolders a project can have."""
+  """
+  Maximum vfolders a project can have.
+  """
   maxVfolderCount: Int!
 
-  """Maximum quota scope size (e.g., '1g', '536870912')."""
+  """
+  Maximum quota scope size (e.g., '1g', '536870912').
+  """
   maxQuotaScopeSize: BinarySizeInput!
 
-  """Maximum networks a project can create. -1 means unlimited."""
+  """
+  Maximum networks a project can create. -1 means unlimited.
+  """
   maxNetworkCount: Int!
 }
 
 """
 Added in UNRELEASED. Payload for project resource policy create/update mutations.
 """
-type CreateProjectResourcePolicyPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Created project resource policy."""
+type CreateProjectResourcePolicyPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Created project resource policy.
+  """
   projectResourcePolicy: ProjectResourcePolicyV2!
 }
 
-"""Added in 26.3.0. Input for creating a new query definition."""
-input CreateQueryDefinitionInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Human-readable identifier (must be unique)."""
+"""
+Added in 26.3.0. Input for creating a new query definition.
+"""
+input CreateQueryDefinitionInput @join__type(graph: STRAWBERRY) {
+  """
+  Human-readable identifier (must be unique).
+  """
   name: String!
 
-  """Prometheus metric name."""
+  """
+  Prometheus metric name.
+  """
   metricName: String!
 
-  """PromQL template with {labels}, {window}, {group_by} placeholders."""
+  """
+  PromQL template with {labels}, {window}, {group_by} placeholders.
+  """
   queryTemplate: String!
 
-  """Default time window."""
+  """
+  Default time window.
+  """
   timeWindow: String = null
 
-  """Query definition options including filter and group labels."""
+  """
+  Query definition options including filter and group labels.
+  """
   options: QueryDefinitionOptionsInput!
 }
 
-"""Added in 26.3.0. Payload returned after creating a query definition."""
-type CreateQueryDefinitionPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Created query definition."""
+"""
+Added in 26.3.0. Payload returned after creating a query definition.
+"""
+type CreateQueryDefinitionPayload @join__type(graph: STRAWBERRY) {
+  """
+  Created query definition.
+  """
   preset: QueryDefinition!
 }
 
-"""Added in 25.14.0. """
-input CreateReservoirRegistryInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.14.0.
+"""
+input CreateReservoirRegistryInput @join__type(graph: STRAWBERRY) {
   name: String!
   endpoint: String!
   accessKey: String!
@@ -3199,47 +3852,53 @@ input CreateReservoirRegistryInput
   apiVersion: String!
 }
 
-"""Added in 25.14.0. Payload for creating a reservoir registry."""
-type CreateReservoirRegistryPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Created Reservoir registry"""
+"""
+Added in 25.14.0. Payload for creating a reservoir registry.
+"""
+type CreateReservoirRegistryPayload @join__type(graph: STRAWBERRY) {
+  """
+  Created Reservoir registry
+  """
   reservoir: ReservoirRegistry!
 }
 
-"""Added in UNRELEASED. Input for creating a new resource group."""
-input CreateResourceGroupInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group name."""
+"""
+Added in UNRELEASED. Input for creating a new resource group.
+"""
+input CreateResourceGroupInput @join__type(graph: STRAWBERRY) {
+  """
+  Resource group name.
+  """
   name: String!
 
-  """Domain to create the resource group in."""
+  """
+  Domain to create the resource group in.
+  """
   domainName: String!
 
-  """Optional description."""
+  """
+  Optional description.
+  """
   description: String = null
 }
 
-"""Added in UNRELEASED. Payload for resource group creation."""
-type CreateResourceGroupPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Created resource group."""
+"""
+Added in UNRELEASED. Payload for resource group creation.
+"""
+type CreateResourceGroupPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Created resource group.
+  """
   resourceGroup: ResourceGroup!
 }
 
-type CreateResourcePreset
-  @join__type(graph: GRAPHENE)
-{
+type CreateResourcePreset @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   resource_preset: ResourcePreset
 }
 
-input CreateResourcePresetInput
-  @join__type(graph: GRAPHENE)
-{
+input CreateResourcePresetInput @join__type(graph: GRAPHENE) {
   resource_slots: JSONString!
   shared_memory: String
 
@@ -3249,37 +3908,45 @@ input CreateResourcePresetInput
   scaling_group_name: String
 }
 
-"""Added in UNRELEASED. Payload for resource preset creation."""
-type CreateResourcePresetPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Created resource preset."""
+"""
+Added in UNRELEASED. Payload for resource preset creation.
+"""
+type CreateResourcePresetPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Created resource preset.
+  """
   resourcePreset: ResourcePresetV2!
 }
 
-"""Added in UNRELEASED. Input for creating a new resource preset."""
-input CreateResourcePresetV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource preset name."""
+"""
+Added in UNRELEASED. Input for creating a new resource preset.
+"""
+input CreateResourcePresetV2Input @join__type(graph: STRAWBERRY) {
+  """
+  Resource preset name.
+  """
   name: String!
 
-  """Resource slot allocations."""
+  """
+  Resource slot allocations.
+  """
   resourceSlots: [ResourceSlotEntryInput!]!
 
-  """Shared memory size (e.g., expr: '512m' or '536870912')."""
+  """
+  Shared memory size (e.g., expr: '512m' or '536870912').
+  """
   sharedMemory: BinarySizeInput = null
 
-  """Resource group name. If null, the preset is global."""
+  """
+  Resource group name. If null, the preset is global.
+  """
   resourceGroupName: String = null
 }
 
 """
 Added in 25.19.0. Input for specifying revision configuration within a deployment.
 """
-input CreateRevisionInput
-  @join__type(graph: STRAWBERRY)
-{
+input CreateRevisionInput @join__type(graph: STRAWBERRY) {
   name: String = null
   clusterConfig: ClusterConfigInput!
   resourceConfig: ResourceConfigInput!
@@ -3294,47 +3961,57 @@ input CreateRevisionInput
   extraMounts: [ExtraVFolderMountInput!]
 }
 
-"""Added in 26.3.0. Input for creating a role"""
-input CreateRoleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Input for creating a role
+"""
+input CreateRoleInput @join__type(graph: STRAWBERRY) {
   name: String!
   description: String = null
   source: RoleSource! = CUSTOM
 }
 
-"""Added in UNRELEASED. Input for creating a runtime variant."""
-input CreateRuntimeVariantInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Input for creating a runtime variant.
+"""
+input CreateRuntimeVariantInput @join__type(graph: STRAWBERRY) {
   """
   Unique short identifier for the runtime engine (e.g., 'vllm', 'sglang').
   """
   name: String!
 
-  """Human-readable description of the runtime engine."""
+  """
+  Human-readable description of the runtime engine.
+  """
   description: String = null
 }
 
-"""Added in UNRELEASED. Payload for runtime variant creation."""
-type CreateRuntimeVariantPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """The created runtime variant."""
+"""
+Added in UNRELEASED. Payload for runtime variant creation.
+"""
+type CreateRuntimeVariantPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  The created runtime variant.
+  """
   runtimeVariant: RuntimeVariant!
 }
 
-"""Added in UNRELEASED. Create preset input."""
-input CreateRuntimeVariantPresetInput
-  @join__type(graph: STRAWBERRY)
-{
-  """The runtime variant this preset belongs to."""
+"""
+Added in UNRELEASED. Create preset input.
+"""
+input CreateRuntimeVariantPresetInput @join__type(graph: STRAWBERRY) {
+  """
+  The runtime variant this preset belongs to.
+  """
   runtimeVariantId: UUID!
 
-  """Human-readable name of the configurable parameter."""
+  """
+  Human-readable name of the configurable parameter.
+  """
   name: String!
 
-  """Detailed explanation of what this parameter controls."""
+  """
+  Detailed explanation of what this parameter controls.
+  """
   description: String = null
 
   """
@@ -3342,10 +4019,14 @@ input CreateRuntimeVariantPresetInput
   """
   presetTarget: String!
 
-  """Data type for validation (e.g., 'str', 'int', 'float', 'bool')."""
+  """
+  Data type for validation (e.g., 'str', 'int', 'float', 'bool').
+  """
   valueType: String!
 
-  """The default value shown to users when creating a deployment."""
+  """
+  The default value shown to users when creating a deployment.
+  """
   defaultValue: String = null
 
   """
@@ -3354,25 +4035,23 @@ input CreateRuntimeVariantPresetInput
   key: String!
 }
 
-"""Added in UNRELEASED. Create preset payload."""
-type CreateRuntimeVariantPresetPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """The created preset."""
+"""
+Added in UNRELEASED. Create preset payload.
+"""
+type CreateRuntimeVariantPresetPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  The created preset.
+  """
   preset: RuntimeVariantPreset!
 }
 
-type CreateScalingGroup
-  @join__type(graph: GRAPHENE)
-{
+type CreateScalingGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   scaling_group: ScalingGroup
 }
 
-input CreateScalingGroupInput
-  @join__type(graph: GRAPHENE)
-{
+input CreateScalingGroupInput @join__type(graph: GRAPHENE) {
   description: String = ""
   is_active: Boolean = true
   is_public: Boolean = true
@@ -3385,28 +4064,24 @@ input CreateScalingGroupInput
   use_host_network: Boolean = false
 }
 
-type CreateUser
-  @join__type(graph: GRAPHENE)
-{
+type CreateUser @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   user: User
 
-  """Added in 25.15.0."""
+  """
+  Added in 25.15.0.
+  """
   keypair: KeyPair
 }
 
-type CreateUserResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type CreateUserResourcePolicy @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   resource_policy: UserResourcePolicy
 }
 
-input CreateUserResourcePolicyInput
-  @join__type(graph: GRAPHENE)
-{
+input CreateUserResourcePolicyInput @join__type(graph: GRAPHENE) {
   """
   Added in 24.03.1 and 23.09.6. Limitation of the number of user vfolders.
   """
@@ -3429,129 +4104,174 @@ input CreateUserResourcePolicyInput
   max_customized_image_count: Int
 }
 
-"""Added in UNRELEASED. Input for creating a user resource policy."""
-input CreateUserResourcePolicyInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Policy name. Must be unique."""
+"""
+Added in UNRELEASED. Input for creating a user resource policy.
+"""
+input CreateUserResourcePolicyInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  Policy name. Must be unique.
+  """
   name: String!
 
-  """Maximum vfolders a user can create."""
+  """
+  Maximum vfolders a user can create.
+  """
   maxVfolderCount: Int!
 
-  """Maximum quota scope size (e.g., '1g', '536870912')."""
+  """
+  Maximum quota scope size (e.g., '1g', '536870912').
+  """
   maxQuotaScopeSize: BinarySizeInput!
 
-  """Maximum sessions per model session."""
+  """
+  Maximum sessions per model session.
+  """
   maxSessionCountPerModelSession: Int!
 
-  """Maximum customized images a user can create."""
+  """
+  Maximum customized images a user can create.
+  """
   maxCustomizedImageCount: Int!
 }
 
 """
 Added in UNRELEASED. Payload for user resource policy create/update mutations.
 """
-type CreateUserResourcePolicyPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Created user resource policy."""
+type CreateUserResourcePolicyPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Created user resource policy.
+  """
   userResourcePolicy: UserResourcePolicyV2!
 }
 
 """
 Added in 26.2.0. Input for creating a new user. Required fields: email, username, password, domain_name, need_password_change, status, role.
 """
-input CreateUserV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """User's email address. Must be unique across the system."""
+input CreateUserV2Input @join__type(graph: STRAWBERRY) {
+  """
+  User's email address. Must be unique across the system.
+  """
   email: String!
 
-  """Unique username for login."""
+  """
+  Unique username for login.
+  """
   username: String!
 
-  """Initial password for the user."""
+  """
+  Initial password for the user.
+  """
   password: String!
 
-  """Domain to assign the user to."""
+  """
+  Domain to assign the user to.
+  """
   domainName: String!
 
-  """If true, user must change password on first login."""
+  """
+  If true, user must change password on first login.
+  """
   needPasswordChange: Boolean!
 
-  """Initial account status."""
+  """
+  Initial account status.
+  """
   status: UserStatusV2!
 
-  """User role determining access permissions."""
+  """
+  User role determining access permissions.
+  """
   role: UserRoleV2!
 
-  """User's full display name."""
+  """
+  User's full display name.
+  """
   fullName: String = null
 
-  """Optional description or notes about the user."""
+  """
+  Optional description or notes about the user.
+  """
   description: String = null
 
-  """List of project (group) IDs to assign the user to."""
+  """
+  List of project (group) IDs to assign the user to.
+  """
   groupIds: [UUID!] = null
 
-  """Allowed client IP addresses or CIDR ranges."""
+  """
+  Allowed client IP addresses or CIDR ranges.
+  """
   allowedClientIp: [String!] = null
 
-  """Whether to enable TOTP two-factor authentication."""
+  """
+  Whether to enable TOTP two-factor authentication.
+  """
   totpActivated: Boolean! = false
 
-  """Name of the user resource policy to apply."""
+  """
+  Name of the user resource policy to apply.
+  """
   resourcePolicy: String! = "default"
 
-  """Whether this user can create sudo sessions."""
+  """
+  Whether this user can create sudo sessions.
+  """
   sudoSessionEnabled: Boolean! = false
 
-  """User ID (UID) for container processes."""
+  """
+  User ID (UID) for container processes.
+  """
   containerUid: Int = null
 
-  """Primary group ID (GID) for container processes."""
+  """
+  Primary group ID (GID) for container processes.
+  """
   containerMainGid: Int = null
 
-  """Supplementary group IDs for container processes."""
+  """
+  Supplementary group IDs for container processes.
+  """
   containerGids: [Int!] = null
 }
 
-"""Added in 26.2.0. Payload for user creation mutation."""
-type CreateUserV2Payload
-  @join__type(graph: STRAWBERRY)
-{
-  """The newly created user."""
+"""
+Added in 26.2.0. Payload for user creation mutation.
+"""
+type CreateUserV2Payload @join__type(graph: STRAWBERRY) {
+  """
+  The newly created user.
+  """
   user: UserV2!
 }
 
-"""Added in 25.16.0. Input for creating VFS storage"""
-input CreateVFSStorageInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.16.0. Input for creating VFS storage
+"""
+input CreateVFSStorageInput @join__type(graph: STRAWBERRY) {
   name: String!
   host: String!
   basePath: String!
 }
 
-"""Added in 25.16.0. Payload for creating VFS storage."""
-type CreateVFSStoragePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Created VFS storage"""
+"""
+Added in 25.16.0. Payload for creating VFS storage.
+"""
+type CreateVFSStoragePayload @join__type(graph: STRAWBERRY) {
+  """
+  Created VFS storage
+  """
   vfsStorage: VFSStorage!
 }
 
-"""Date (isoformat)"""
-scalar Date
-  @join__type(graph: STRAWBERRY)
+"""
+Date (isoformat)
+"""
+scalar Date @join__type(graph: STRAWBERRY)
 
 """
 Added in 24.09.0. Filter for date fields (not datetime) supporting range and equality operations.
 """
-input DateFilter
-  @join__type(graph: STRAWBERRY)
-{
+input DateFilter @join__type(graph: STRAWBERRY) {
   before: Date = null
   after: Date = null
   equals: Date = null
@@ -3563,37 +4283,32 @@ The `DateTime` scalar type represents a DateTime
 value as specified by
 [iso8601](https://en.wikipedia.org/wiki/ISO_8601).
 """
-scalar DateTime
-  @join__type(graph: GRAPHENE)
-  @join__type(graph: STRAWBERRY)
+scalar DateTime @join__type(graph: GRAPHENE) @join__type(graph: STRAWBERRY)
 
 """
 Added in 24.09.0. Filter for datetime fields supporting range and equality operations.
 """
-input DateTimeFilter
-  @join__type(graph: STRAWBERRY)
-{
+input DateTimeFilter @join__type(graph: STRAWBERRY) {
   before: DateTime = null
   after: DateTime = null
   equals: DateTime = null
   notEquals: DateTime = null
 }
 
-type DealiasImage
-  @join__type(graph: GRAPHENE)
-{
+type DealiasImage @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Decimal (fixed-point)"""
-scalar Decimal
-  @join__type(graph: STRAWBERRY)
+"""
+Decimal (fixed-point)
+"""
+scalar Decimal @join__type(graph: STRAWBERRY)
 
-"""Added in 25.15.0. """
-input DelegateeTarget
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.15.0.
+"""
+input DelegateeTarget @join__type(graph: STRAWBERRY) {
   delegateeReservoirId: ID!
   targetRegistryId: ID!
 }
@@ -3603,19 +4318,25 @@ Added in 24.09.0. Input type for delegated import of artifact revisions from a r
 Used to specify which artifact revisions should be imported from the remote registry source
 into the local reservoir registry storage.
 """
-input DelegateImportArtifactsInput
-  @join__type(graph: STRAWBERRY)
-{
-  """List of artifact revision IDs of delegatee artifact registry"""
+input DelegateImportArtifactsInput @join__type(graph: STRAWBERRY) {
+  """
+  List of artifact revision IDs of delegatee artifact registry
+  """
   artifactRevisionIds: [ID!]!
 
-  """ID of the reservoir registry to delegate the import request to"""
+  """
+  ID of the reservoir registry to delegate the import request to
+  """
   delegatorReservoirId: ID = null
 
-  """The artifact type field."""
+  """
+  The artifact type field.
+  """
   artifactType: ArtifactType = null
 
-  """The delegatee target field."""
+  """
+  The delegatee target field.
+  """
   delegateeTarget: DelegateeTarget = null
 
   """
@@ -3627,47 +4348,55 @@ input DelegateImportArtifactsInput
 """
 Added in 25.15.0. Response payload for delegated artifact import operation. Contains the imported artifact revisions and associated background tasks. The tasks can be monitored to track the progress of the import operation.
 """
-type DelegateImportArtifactsPayload
-  @join__type(graph: STRAWBERRY)
-{
+type DelegateImportArtifactsPayload @join__type(graph: STRAWBERRY) {
   """
   List of imported artifact revisions from the reservoir registry's remote registry.
   """
   artifactRevisions: ArtifactRevisionConnection!
 
-  """List of background tasks created for importing the artifact revisions."""
+  """
+  List of background tasks created for importing the artifact revisions.
+  """
   tasks: [ArtifactRevisionImportTask!]!
 }
 
 """
 Added in 24.09.0. Input type for delegated scanning of artifacts from a delegatee reservoir registry's remote registry.
 """
-input DelegateScanArtifactsInput
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the reservoir registry to delegate the scan request to"""
+input DelegateScanArtifactsInput @join__type(graph: STRAWBERRY) {
+  """
+  ID of the reservoir registry to delegate the scan request to
+  """
   delegatorReservoirId: ID = null
 
-  """Target delegatee reservoir registry and its remote registry to scan"""
+  """
+  Target delegatee reservoir registry and its remote registry to scan
+  """
   delegateeTarget: DelegateeTarget = null
 
-  """The limit field."""
+  """
+  The limit field.
+  """
   limit: Int!
 
-  """Filter artifacts by type (e.g., model, image, package)"""
+  """
+  Filter artifacts by type (e.g., model, image, package)
+  """
   artifactType: ArtifactType = null
 
-  """Search term to filter artifacts by name or description"""
+  """
+  Search term to filter artifacts by name or description
+  """
   search: String = null
 }
 
 """
 Added in 25.15.0. Response payload for delegated artifact scanning operation. Contains the list of artifacts discovered during the scan of a reservoir registry's remote registry. These artifacts are now available for import or direct use.
 """
-type DelegateScanArtifactsPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """List of artifacts discovered during the delegated scan."""
+type DelegateScanArtifactsPayload @join__type(graph: STRAWBERRY) {
+  """
+  List of artifacts discovered during the delegated scan.
+  """
   artifacts: [Artifact!]!
 }
 
@@ -3677,362 +4406,392 @@ Added in 24.09.0. Input for soft-deleting artifacts from the system.
 Marks artifacts as deleted without permanently removing them.
 Deleted artifacts can be restored using restore_artifacts.
 """
-input DeleteArtifactsInput
-  @join__type(graph: STRAWBERRY)
-{
+input DeleteArtifactsInput @join__type(graph: STRAWBERRY) {
   artifactIds: [ID!]!
 }
 
 """
 Added in 25.15.0. Response payload for artifact deletion operations. Contains the artifacts that were soft-deleted. These can be restored later.
 """
-type DeleteArtifactsPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """List of soft-deleted artifacts."""
+type DeleteArtifactsPayload @join__type(graph: STRAWBERRY) {
+  """
+  List of soft-deleted artifacts.
+  """
   artifacts: [Artifact!]!
 }
 
-"""Added in 25.16.0. Input for deleting an auto-scaling rule"""
-input DeleteAutoScalingRuleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.16.0. Input for deleting an auto-scaling rule
+"""
+input DeleteAutoScalingRuleInput @join__type(graph: STRAWBERRY) {
   id: ID!
 }
 
-"""Added in 25.19.0. Payload for deleting an auto-scaling rule."""
-type DeleteAutoScalingRulePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted auto-scaling rule"""
+"""
+Added in 25.19.0. Payload for deleting an auto-scaling rule.
+"""
+type DeleteAutoScalingRulePayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted auto-scaling rule
+  """
   id: ID!
 }
 
-"""Deprecated since 24.09.0. use `DeleteContainerRegistryNode` instead"""
-type DeleteContainerRegistry
-  @join__type(graph: GRAPHENE)
-{
+"""
+Deprecated since 24.09.0. use `DeleteContainerRegistryNode` instead
+"""
+type DeleteContainerRegistry @join__type(graph: GRAPHENE) {
   container_registry: ContainerRegistry
 }
 
-"""Added in 24.09.0."""
-type DeleteContainerRegistryNode
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.09.0.
+"""
+type DeleteContainerRegistryNode @join__type(graph: GRAPHENE) {
   container_registry: ContainerRegistryNode
 }
 
-"""Added in 25.3.0."""
-type DeleteContainerRegistryNodeV2
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.3.0.
+"""
+type DeleteContainerRegistryNodeV2 @join__type(graph: GRAPHENE) {
   container_registry: ContainerRegistryNode
 }
 
-"""Added in UNRELEASED. Payload for container registry deletion."""
-type DeleteContainerRegistryPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted container registry."""
+"""
+Added in UNRELEASED. Payload for container registry deletion.
+"""
+type DeleteContainerRegistryPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted container registry.
+  """
   id: String!
 }
 
-"""Added in 25.3.0."""
-type DeleteContainerRegistryQuota
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.3.0.
+"""
+type DeleteContainerRegistryQuota @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 25.19.0. """
-input DeleteDeploymentInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input DeleteDeploymentInput @join__type(graph: STRAWBERRY) {
   id: ID!
 }
 
-"""Added in 25.19.0. Payload for deleting a model deployment."""
-type DeleteDeploymentPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted deployment"""
+"""
+Added in 25.19.0. Payload for deleting a model deployment.
+"""
+type DeleteDeploymentPayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted deployment
+  """
   id: ID!
 }
 
-"""Added in UNRELEASED. Delete deployment revision preset payload."""
-type DeleteDeploymentRevisionPresetPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted preset."""
+"""
+Added in UNRELEASED. Delete deployment revision preset payload.
+"""
+type DeleteDeploymentRevisionPresetPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted preset.
+  """
   id: UUID!
 }
 
-"""Instead of deleting the domain, just mark it as inactive."""
-type DeleteDomain
-  @join__type(graph: GRAPHENE)
-{
+"""
+Instead of deleting the domain, just mark it as inactive.
+"""
+type DeleteDomain @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 25.16.0. Input for deleting domain-level app configuration"""
-input DeleteDomainConfigInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.16.0. Input for deleting domain-level app configuration
+"""
+input DeleteDomainConfigInput @join__type(graph: STRAWBERRY) {
   domainName: String!
 }
 
 """
 Added in 25.16.0. Payload returned after deleting domain-level app configuration. Indicates whether the deletion was successful.
 """
-type DeleteDomainConfigPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the deletion was successful."""
+type DeleteDomainConfigPayload @join__type(graph: STRAWBERRY) {
+  """
+  Whether the deletion was successful.
+  """
   deleted: Boolean!
 }
 
-"""Added in UNRELEASED. Payload for domain deletion mutation."""
-type DeleteDomainPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the deletion was successful."""
+"""
+Added in UNRELEASED. Payload for domain deletion mutation.
+"""
+type DeleteDomainPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Whether the deletion was successful.
+  """
   deleted: Boolean!
 }
 
-"""Added in 25.1.0."""
-type DeleteEndpointAutoScalingRuleNode
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.1.0.
+"""
+type DeleteEndpointAutoScalingRuleNode @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Instead of deleting the group, just mark it as inactive."""
-type DeleteGroup
-  @join__type(graph: GRAPHENE)
-{
+"""
+Instead of deleting the group, just mark it as inactive.
+"""
+type DeleteGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 25.14.0. """
-input DeleteHuggingFaceRegistryInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.14.0.
+"""
+input DeleteHuggingFaceRegistryInput @join__type(graph: STRAWBERRY) {
   id: ID!
 }
 
-"""Added in 25.14.0. Payload for deleting a HuggingFace registry."""
-type DeleteHuggingFaceRegistryPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted HuggingFace registry"""
+"""
+Added in 25.14.0. Payload for deleting a HuggingFace registry.
+"""
+type DeleteHuggingFaceRegistryPayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted HuggingFace registry
+  """
   id: UUID!
 }
 
-type DeleteKeyPair
-  @join__type(graph: GRAPHENE)
-{
+type DeleteKeyPair @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-type DeleteKeyPairResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type DeleteKeyPairResourcePolicy @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in UNRELEASED. Payload for keypair resource policy deletion."""
-type DeleteKeypairResourcePolicyPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the deleted keypair resource policy."""
+"""
+Added in UNRELEASED. Payload for keypair resource policy deletion.
+"""
+type DeleteKeypairResourcePolicyPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Name of the deleted keypair resource policy.
+  """
   name: String!
 }
 
-"""Added in UNRELEASED. Delete model card payload."""
-type DeleteModelCardPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted model card."""
+"""
+Added in UNRELEASED. Delete model card payload.
+"""
+type DeleteModelCardPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted model card.
+  """
   id: UUID!
 }
 
-"""Added in 24.12.0."""
-type DeleteNetwork
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.12.0.
+"""
+type DeleteNetwork @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 24.09.0. Input for deleting a notification channel"""
-input DeleteNotificationChannelInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for deleting a notification channel
+"""
+input DeleteNotificationChannelInput @join__type(graph: STRAWBERRY) {
   id: ID!
 }
 
-"""Added in 26.3.0. Payload for delete notification channel mutation."""
-type DeleteNotificationChannelPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted notification channel"""
+"""
+Added in 26.3.0. Payload for delete notification channel mutation.
+"""
+type DeleteNotificationChannelPayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted notification channel
+  """
   id: UUID!
 }
 
-"""Added in 24.09.0. Input for deleting a notification rule"""
-input DeleteNotificationRuleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for deleting a notification rule
+"""
+input DeleteNotificationRuleInput @join__type(graph: STRAWBERRY) {
   id: ID!
 }
 
-"""Added in 26.3.0. Payload for delete notification rule mutation."""
-type DeleteNotificationRulePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted notification rule"""
+"""
+Added in 26.3.0. Payload for delete notification rule mutation.
+"""
+type DeleteNotificationRulePayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted notification rule
+  """
   id: UUID!
 }
 
-"""Added in 25.14.0. """
-input DeleteObjectStorageInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.14.0.
+"""
+input DeleteObjectStorageInput @join__type(graph: STRAWBERRY) {
   id: ID!
 }
 
-"""Added in 25.14.0. Payload for deleting an object storage."""
-type DeleteObjectStoragePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted object storage"""
+"""
+Added in 25.14.0. Payload for deleting an object storage.
+"""
+type DeleteObjectStoragePayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted object storage
+  """
   id: UUID!
 }
 
-"""Added in 26.3.0. Input for deleting a scoped permission"""
-input DeletePermissionInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Input for deleting a scoped permission
+"""
+input DeletePermissionInput @join__type(graph: STRAWBERRY) {
   id: UUID!
 }
 
-"""Added in 26.3.0. Payload for delete permission mutation."""
-type DeletePermissionPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted permission"""
+"""
+Added in 26.3.0. Payload for delete permission mutation.
+"""
+type DeletePermissionPayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted permission
+  """
   id: UUID!
 }
 
-"""Added in UNRELEASED. Payload for project deletion mutation."""
-type DeleteProjectPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the deletion was successful."""
+"""
+Added in UNRELEASED. Payload for project deletion mutation.
+"""
+type DeleteProjectPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Whether the deletion was successful.
+  """
   deleted: Boolean!
 }
 
-type DeleteProjectResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type DeleteProjectResourcePolicy @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in UNRELEASED. Payload for project resource policy deletion."""
-type DeleteProjectResourcePolicyPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the deleted project resource policy."""
+"""
+Added in UNRELEASED. Payload for project resource policy deletion.
+"""
+type DeleteProjectResourcePolicyPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Name of the deleted project resource policy.
+  """
   name: String!
 }
 
-"""Added in 26.3.0. Payload returned after deleting a query definition."""
-type DeleteQueryDefinitionPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Deleted query definition ID"""
+"""
+Added in 26.3.0. Payload returned after deleting a query definition.
+"""
+type DeleteQueryDefinitionPayload @join__type(graph: STRAWBERRY) {
+  """
+  Deleted query definition ID
+  """
   id: UUID!
 }
 
-"""Added in 25.14.0. """
-input DeleteReservoirRegistryInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.14.0.
+"""
+input DeleteReservoirRegistryInput @join__type(graph: STRAWBERRY) {
   id: ID!
 }
 
-"""Added in 25.14.0. Payload for deleting a reservoir registry."""
-type DeleteReservoirRegistryPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted Reservoir registry"""
+"""
+Added in 25.14.0. Payload for deleting a reservoir registry.
+"""
+type DeleteReservoirRegistryPayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted Reservoir registry
+  """
   id: UUID!
 }
 
-"""Added in UNRELEASED. Payload for resource group deletion."""
-type DeleteResourceGroupPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the deleted resource group."""
+"""
+Added in UNRELEASED. Payload for resource group deletion.
+"""
+type DeleteResourceGroupPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the deleted resource group.
+  """
   id: String!
 }
 
-type DeleteResourcePreset
-  @join__type(graph: GRAPHENE)
-{
+type DeleteResourcePreset @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in UNRELEASED. Payload for resource preset deletion."""
-type DeleteResourcePresetPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the deleted resource preset."""
+"""
+Added in UNRELEASED. Payload for resource preset deletion.
+"""
+type DeleteResourcePresetPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the deleted resource preset.
+  """
   id: String!
 }
 
-"""Added in 26.3.0. Input for soft-deleting a role"""
-input DeleteRoleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Input for soft-deleting a role
+"""
+input DeleteRoleInput @join__type(graph: STRAWBERRY) {
   id: UUID!
 }
 
-"""Added in 26.3.0. Payload for delete role mutation."""
-type DeleteRolePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted role"""
+"""
+Added in 26.3.0. Payload for delete role mutation.
+"""
+type DeleteRolePayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted role
+  """
   id: UUID!
 }
 
-"""Added in UNRELEASED. Payload for runtime variant deletion."""
-type DeleteRuntimeVariantPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted runtime variant."""
+"""
+Added in UNRELEASED. Payload for runtime variant deletion.
+"""
+type DeleteRuntimeVariantPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted runtime variant.
+  """
   id: UUID!
 }
 
-"""Added in UNRELEASED. Delete preset payload."""
-type DeleteRuntimeVariantPresetPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted preset."""
+"""
+Added in UNRELEASED. Delete preset payload.
+"""
+type DeleteRuntimeVariantPresetPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted preset.
+  """
   id: UUID!
 }
 
-type DeleteScalingGroup
-  @join__type(graph: GRAPHENE)
-{
+type DeleteScalingGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
@@ -4042,9 +4801,7 @@ Instead of really deleting user, just mark the account as deleted status.
 
 All related keypairs will also be inactivated.
 """
-type DeleteUser
-  @join__type(graph: GRAPHENE)
-{
+type DeleteUser @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
@@ -4053,82 +4810,86 @@ type DeleteUser
 Added in 24.09.0. Input for deleting user-level app configuration.
 If user_id is not provided, the current user's configuration will be deleted.
 """
-input DeleteUserConfigInput
-  @join__type(graph: STRAWBERRY)
-{
+input DeleteUserConfigInput @join__type(graph: STRAWBERRY) {
   userId: ID = null
 }
 
 """
 Added in 25.16.0. Payload returned after deleting user-level app configuration. Indicates whether the deletion was successful.
 """
-type DeleteUserConfigPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the deletion was successful."""
+type DeleteUserConfigPayload @join__type(graph: STRAWBERRY) {
+  """
+  Whether the deletion was successful.
+  """
   deleted: Boolean!
 }
 
-type DeleteUserResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type DeleteUserResourcePolicy @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in UNRELEASED. Payload for user resource policy deletion."""
-type DeleteUserResourcePolicyPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the deleted user resource policy."""
+"""
+Added in UNRELEASED. Payload for user resource policy deletion.
+"""
+type DeleteUserResourcePolicyPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Name of the deleted user resource policy.
+  """
   name: String!
 }
 
 """
 Added in 26.2.0. Input for soft-deleting multiple users. Soft delete changes user status to DELETED but preserves data.
 """
-input DeleteUsersV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """List of user UUIDs to soft-delete."""
+input DeleteUsersV2Input @join__type(graph: STRAWBERRY) {
+  """
+  List of user UUIDs to soft-delete.
+  """
   userIds: [UUID!]!
 }
 
-"""Added in 26.2.0. Payload for bulk user soft-delete mutation."""
-type DeleteUsersV2Payload
-  @join__type(graph: STRAWBERRY)
-{
-  """Number of users successfully soft-deleted."""
+"""
+Added in 26.2.0. Payload for bulk user soft-delete mutation.
+"""
+type DeleteUsersV2Payload @join__type(graph: STRAWBERRY) {
+  """
+  Number of users successfully soft-deleted.
+  """
   deletedCount: Int!
 }
 
-"""Added in 26.2.0. Payload for single user soft-delete mutation."""
-type DeleteUserV2Payload
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the deletion was successful."""
+"""
+Added in 26.2.0. Payload for single user soft-delete mutation.
+"""
+type DeleteUserV2Payload @join__type(graph: STRAWBERRY) {
+  """
+  Whether the deletion was successful.
+  """
   success: Boolean!
 }
 
-"""Added in 25.16.0. Input for deleting VFS storage"""
-input DeleteVFSStorageInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.16.0. Input for deleting VFS storage
+"""
+input DeleteVFSStorageInput @join__type(graph: STRAWBERRY) {
   id: ID!
 }
 
-"""Added in 25.16.0. Payload for deleting VFS storage."""
-type DeleteVFSStoragePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the deleted VFS storage"""
+"""
+Added in 25.16.0. Payload for deleting VFS storage.
+"""
+type DeleteVFSStoragePayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the deleted VFS storage
+  """
   id: UUID!
 }
 
-"""Added in 25.19.0. """
-input DeploymentFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input DeploymentFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   status: DeploymentStatusFilter = null
   openToPublic: Boolean = null
@@ -4139,12 +4900,15 @@ input DeploymentFilter
   NOT: [DeploymentFilter!] = null
 }
 
-"""Added in 26.3.0. Deployment history record."""
+"""
+Added in 26.3.0. Deployment history record.
+"""
 type DeploymentHistory implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   deploymentId: ID!
   phase: String!
@@ -4159,33 +4923,41 @@ type DeploymentHistory implements Node
   updatedAt: DateTime!
 }
 
-"""Added in 26.3.0. Deployment history connection."""
-type DeploymentHistoryConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Deployment history connection.
+"""
+type DeploymentHistoryConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [DeploymentHistoryEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type DeploymentHistoryEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type DeploymentHistoryEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: DeploymentHistory!
 }
 
-"""Added in 24.09.0. Filter for deployment history"""
-input DeploymentHistoryFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Filter for deployment history
+"""
+input DeploymentHistoryFilter @join__type(graph: STRAWBERRY) {
   id: UUIDFilter = null
   deploymentId: UUIDFilter = null
   phase: StringFilter = null
@@ -4201,44 +4973,45 @@ input DeploymentHistoryFilter
   NOT: [DeploymentHistoryFilter!] = null
 }
 
-"""Added in 24.09.0. Order by specification for deployment history"""
-input DeploymentHistoryOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Order by specification for deployment history
+"""
+input DeploymentHistoryOrderBy @join__type(graph: STRAWBERRY) {
   field: DeploymentHistoryOrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in 26.3.0. Fields available for ordering deployment history"""
-enum DeploymentHistoryOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Fields available for ordering deployment history
+"""
+enum DeploymentHistoryOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.19.0. """
-input DeploymentOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input DeploymentOrderBy @join__type(graph: STRAWBERRY) {
   field: DeploymentOrderField!
   direction: OrderDirection! = DESC
 }
 
-enum DeploymentOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum DeploymentOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
   NAME @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.19.0. Deployment policy configuration."""
+"""
+Added in 25.19.0. Deployment policy configuration.
+"""
 type DeploymentPolicy implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   strategySpec: DeploymentStrategySpec!
   createdAt: DateTime!
@@ -4250,21 +5023,30 @@ Added in UNRELEASED. A reusable deployment configuration template. Users select 
 """
 type DeploymentRevisionPreset implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """The unique database identifier of this deployment preset."""
+  """
+  The unique database identifier of this deployment preset.
+  """
   rowId: UUID!
 
-  """The runtime variant this preset is designed for (e.g., vLLM, SGLang)."""
+  """
+  The runtime variant this preset is designed for (e.g., vLLM, SGLang).
+  """
   runtimeVariantId: UUID!
 
-  """Display name of this deployment configuration template."""
+  """
+  Display name of this deployment configuration template.
+  """
   name: String!
 
-  """Detailed explanation of when and why to use this preset configuration."""
+  """
+  Detailed explanation of when and why to use this preset configuration.
+  """
   description: String
 
   """
@@ -4277,7 +5059,9 @@ type DeploymentRevisionPreset implements Node
   """
   cluster: PresetClusterSpec!
 
-  """Compute resource allocation including CPU, memory, and accelerators."""
+  """
+  Compute resource allocation including CPU, memory, and accelerators.
+  """
   resource: PresetResourceAllocation!
 
   """
@@ -4295,64 +5079,82 @@ type DeploymentRevisionPreset implements Node
   """
   presetValues: [DeploymentRevisionPresetValueEntry!]!
 
-  """Timestamp when this deployment preset was created."""
+  """
+  Timestamp when this deployment preset was created.
+  """
   createdAt: DateTime!
 
-  """Timestamp of the last modification to this deployment preset."""
+  """
+  Timestamp of the last modification to this deployment preset.
+  """
   updatedAt: DateTime
 }
 
-"""Added in UNRELEASED. Paginated list of deployment revision presets."""
-type DeploymentRevisionPresetConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in UNRELEASED. Paginated list of deployment revision presets.
+"""
+type DeploymentRevisionPresetConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [DeploymentRevisionPresetEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type DeploymentRevisionPresetEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type DeploymentRevisionPresetEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: DeploymentRevisionPreset!
 }
 
-"""Added in UNRELEASED. Filter for deployment revision presets."""
-input DeploymentRevisionPresetFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Name filter."""
+"""
+Added in UNRELEASED. Filter for deployment revision presets.
+"""
+input DeploymentRevisionPresetFilter @join__type(graph: STRAWBERRY) {
+  """
+  Name filter.
+  """
   name: StringFilter = null
 
-  """Variant ID filter."""
+  """
+  Variant ID filter.
+  """
   runtimeVariantId: UUID = null
 }
 
 """
 Added in UNRELEASED. Order specification for deployment revision presets.
 """
-input DeploymentRevisionPresetOrderBy
-  @join__type(graph: STRAWBERRY)
-{
-  """Field to order by."""
+input DeploymentRevisionPresetOrderBy @join__type(graph: STRAWBERRY) {
+  """
+  Field to order by.
+  """
   field: DeploymentRevisionPresetOrderField!
 
-  """ASC or DESC."""
+  """
+  ASC or DESC.
+  """
   direction: String! = "ASC"
 }
 
-"""Added in UNRELEASED. Order fields for deployment revision presets."""
-enum DeploymentRevisionPresetOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Order fields for deployment revision presets.
+"""
+enum DeploymentRevisionPresetOrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   RANK @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
@@ -4361,30 +5163,32 @@ enum DeploymentRevisionPresetOrderField
 """
 Added in UNRELEASED. A mapping of a runtime variant preset to a specific value, used to auto-configure runtime parameters when this deployment preset is applied.
 """
-type DeploymentRevisionPresetValueEntry
-  @join__type(graph: STRAWBERRY)
-{
-  """Runtime variant preset ID."""
+type DeploymentRevisionPresetValueEntry @join__type(graph: STRAWBERRY) {
+  """
+  Runtime variant preset ID.
+  """
   presetId: UUID!
 
-  """Value for this preset."""
+  """
+  Value for this preset.
+  """
   value: String!
 }
 
-"""Added in 24.09.0. Scope for deployment scheduling history query"""
-input DeploymentScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Deployment ID to get history for"""
+"""
+Added in 24.09.0. Scope for deployment scheduling history query
+"""
+input DeploymentScope @join__type(graph: STRAWBERRY) {
+  """
+  Deployment ID to get history for
+  """
   deploymentId: UUID!
 }
 
 """
 Added in 25.19.0. This enum represents the deployment status of a model deployment, indicating its current state.
 """
-enum DeploymentStatus
-  @join__type(graph: STRAWBERRY)
-{
+enum DeploymentStatus @join__type(graph: STRAWBERRY) {
   PENDING @join__enumValue(graph: STRAWBERRY)
   SCALING @join__enumValue(graph: STRAWBERRY)
   DEPLOYING @join__enumValue(graph: STRAWBERRY)
@@ -4395,19 +5199,23 @@ enum DeploymentStatus
   STOPPED @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.19.0. Payload for deployment status changed event."""
-type DeploymentStatusChangedPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The deployment whose status changed"""
+"""
+Added in 25.19.0. Payload for deployment status changed event.
+"""
+type DeploymentStatusChangedPayload @join__type(graph: STRAWBERRY) {
+  """
+  The deployment whose status changed
+  """
   deployment: ModelDeployment!
 }
 
-"""Added in 25.19.0. """
-input DeploymentStatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """The in  field."""
+"""
+Added in 25.19.0.
+"""
+input DeploymentStatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  The in  field.
+  """
   in: [DeploymentStatus!] = null
   equals: DeploymentStatus = null
 }
@@ -4415,18 +5223,14 @@ input DeploymentStatusFilter
 """
 Added in 25.19.0. Represents the deployment strategy configuration that determines how updates are rolled out to replicas (e.g., rolling update, blue-green).
 """
-type DeploymentStrategyGQL
-  @join__type(graph: STRAWBERRY)
-{
+type DeploymentStrategyGQL @join__type(graph: STRAWBERRY) {
   type: DeploymentStrategyType!
 }
 
 """
 Added in 25.19.0. Deployment strategy configuration with discriminator pattern.
 """
-input DeploymentStrategyInput
-  @join__type(graph: STRAWBERRY)
-{
+input DeploymentStrategyInput @join__type(graph: STRAWBERRY) {
   type: DeploymentStrategyType!
   rollingUpdate: RollingUpdateConfigInput = null
   blueGreen: BlueGreenConfigInput = null
@@ -4435,84 +5239,68 @@ input DeploymentStrategyInput
 """
 Added in 25.19.0. Base interface for deployment strategy specifications.
 """
-interface DeploymentStrategySpec
-  @join__type(graph: STRAWBERRY)
-{
+interface DeploymentStrategySpec @join__type(graph: STRAWBERRY) {
   strategy: DeploymentStrategyType!
 }
 
 """
 Added in 25.19.0. This enum represents the deployment strategy type of a model deployment, indicating the strategy used for deployment.
 """
-enum DeploymentStrategyType
-  @join__type(graph: STRAWBERRY)
-{
+enum DeploymentStrategyType @join__type(graph: STRAWBERRY) {
   ROLLING @join__enumValue(graph: STRAWBERRY)
   BLUE_GREEN @join__enumValue(graph: STRAWBERRY)
 }
 
-type DisassociateAllScalingGroupsWithDomain
-  @join__type(graph: GRAPHENE)
-{
+type DisassociateAllScalingGroupsWithDomain @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-type DisassociateAllScalingGroupsWithGroup
-  @join__type(graph: GRAPHENE)
-{
+type DisassociateAllScalingGroupsWithGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 24.03.9."""
-type DisassociateScalingGroupsWithDomain
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.03.9.
+"""
+type DisassociateScalingGroupsWithDomain @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 24.03.9."""
-type DisassociateScalingGroupsWithKeyPair
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.03.9.
+"""
+type DisassociateScalingGroupsWithKeyPair @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 24.03.9."""
-type DisassociateScalingGroupsWithUserGroup
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.03.9.
+"""
+type DisassociateScalingGroupsWithUserGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-type DisassociateScalingGroupWithDomain
-  @join__type(graph: GRAPHENE)
-{
+type DisassociateScalingGroupWithDomain @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-type DisassociateScalingGroupWithKeyPair
-  @join__type(graph: GRAPHENE)
-{
+type DisassociateScalingGroupWithKeyPair @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-type DisassociateScalingGroupWithUserGroup
-  @join__type(graph: GRAPHENE)
-{
+type DisassociateScalingGroupWithUserGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-type Domain
-  @join__type(graph: GRAPHENE)
-{
+type Domain @join__type(graph: GRAPHENE) {
   name: String
   description: String
   is_active: Boolean
@@ -4528,41 +5316,55 @@ type Domain
 """
 Added in 26.2.0. Basic domain information. Contains identity and descriptive fields for the domain.
 """
-type DomainBasicInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Domain name (primary key)."""
+type DomainBasicInfo @join__type(graph: STRAWBERRY) {
+  """
+  Domain name (primary key).
+  """
   name: String!
 
-  """Optional description of the domain."""
+  """
+  Optional description of the domain.
+  """
   description: String
 
-  """External system integration identifier."""
+  """
+  External system integration identifier.
+  """
   integrationId: String
 }
 
-"""Added in 24.12.0"""
-type DomainConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 24.12.0
+"""
+type DomainConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [DomainEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
-"""Added in 24.12.0 A Relay edge containing a `Domain` and its cursor."""
-type DomainEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+"""
+Added in 24.12.0 A Relay edge containing a `Domain` and its cursor.
+"""
+type DomainEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: DomainNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
@@ -4571,27 +5373,40 @@ Added in 26.1.0. Domain-level fair share data representing scheduling priority f
 """
 type DomainFairShare implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Name of the scaling group this fair share belongs to."""
+  """
+  Name of the scaling group this fair share belongs to.
+  """
   resourceGroupName: String!
 
-  """Name of the domain this fair share is calculated for."""
+  """
+  Name of the domain this fair share is calculated for.
+  """
   domainName: String!
 
-  """Fair share specification parameters used for calculation."""
+  """
+  Fair share specification parameters used for calculation.
+  """
   spec: FairShareSpec!
 
-  """Snapshot of the most recent fair share calculation results."""
+  """
+  Snapshot of the most recent fair share calculation results.
+  """
   calculationSnapshot: FairShareCalculationSnapshot!
 
-  """Timestamp when this record was created."""
+  """
+  Timestamp when this record was created.
+  """
   createdAt: DateTime!
 
-  """Timestamp when this record was last updated."""
+  """
+  Timestamp when this record was last updated.
+  """
   updatedAt: DateTime!
 
   """
@@ -4608,46 +5423,52 @@ type DomainFairShare implements Node
 """
 Added in 26.1.0. Paginated connection for domain fair share records. Provides relay-style cursor-based pagination for efficient traversal of domain fair share data. Use 'edges' to access individual records with cursor information, or 'nodes' for direct data access.
 """
-type DomainFairShareConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type DomainFairShareConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [DomainFairShareEdge!]!
 
-  """Total number of domain fair share records matching the query criteria."""
+  """
+  Total number of domain fair share records matching the query criteria.
+  """
   count: Int!
 }
 
 """
 Added in 26.2.0. Nested filter for domain entity fields in domain fair share queries. Allows filtering by domain properties such as active status.
 """
-input DomainFairShareDomainNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Filter by domain active status."""
+input DomainFairShareDomainNestedFilter @join__type(graph: STRAWBERRY) {
+  """
+  Filter by domain active status.
+  """
   isActive: Boolean = null
 }
 
-"""An edge in a connection."""
-type DomainFairShareEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type DomainFairShareEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: DomainFairShare!
 }
 
 """
 Added in 26.1.0. Filter input for querying domain fair shares. Supports filtering by scaling group and domain name with various string matching operations. Multiple filters can be combined using AND, OR, and NOT logical operators.
 """
-input DomainFairShareFilter
-  @join__type(graph: STRAWBERRY)
-{
+input DomainFairShareFilter @join__type(graph: STRAWBERRY) {
   """
   Filter by scaling group name. Scaling groups define resource pool boundaries where domains compete for resources. Supports equals, contains, startsWith, and endsWith operations.
   """
@@ -4663,7 +5484,9 @@ input DomainFairShareFilter
   """
   domain: DomainFairShareDomainNestedFilter = null
 
-  """Combine multiple filters with AND logic. All conditions must match."""
+  """
+  Combine multiple filters with AND logic. All conditions must match.
+  """
   AND: [DomainFairShareFilter!] = null
 
   """
@@ -4680,9 +5503,7 @@ input DomainFairShareFilter
 """
 Added in 26.1.0. Specifies ordering for domain fair share query results. Combine field selection with direction to sort results. Default direction is DESC (descending).
 """
-input DomainFairShareOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input DomainFairShareOrderBy @join__type(graph: STRAWBERRY) {
   """
   The field to order by. See DomainFairShareOrderField for available options.
   """
@@ -4697,26 +5518,24 @@ input DomainFairShareOrderBy
 """
 Added in 26.1.0. Fields available for ordering domain fair share query results. FAIR_SHARE_FACTOR: Order by the calculated fair share factor (0-1 range, lower = higher priority). DOMAIN_NAME: Order alphabetically by domain name. CREATED_AT: Order by record creation timestamp. DOMAIN_IS_ACTIVE: Order by domain active status.
 """
-enum DomainFairShareOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum DomainFairShareOrderField @join__type(graph: STRAWBERRY) {
   FAIR_SHARE_FACTOR @join__enumValue(graph: STRAWBERRY)
   DOMAIN_NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   DOMAIN_IS_ACTIVE @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 24.09.0. """
-input DomainFairShareScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group to filter fair shares by."""
+"""
+Added in 24.09.0.
+"""
+input DomainFairShareScope @join__type(graph: STRAWBERRY) {
+  """
+  Resource group to filter fair shares by.
+  """
   resourceGroupName: String!
 }
 
-input DomainInput
-  @join__type(graph: GRAPHENE)
-{
+input DomainInput @join__type(graph: GRAPHENE) {
   description: String = ""
   is_active: Boolean = true
   total_resource_slots: JSONString = "{}"
@@ -4728,28 +5547,33 @@ input DomainInput
 """
 Added in 26.2.0. Domain lifecycle information. Contains activation status and timestamp tracking.
 """
-type DomainLifecycleInfo
-  @join__type(graph: STRAWBERRY)
-{
+type DomainLifecycleInfo @join__type(graph: STRAWBERRY) {
   """
   Whether the domain is active. Inactive domains cannot create new projects or perform operations.
   """
   isActive: Boolean!
 
-  """Timestamp when the domain was created."""
+  """
+  Timestamp when the domain was created.
+  """
   createdAt: DateTime!
 
-  """Timestamp when the domain was last modified."""
+  """
+  Timestamp when the domain was last modified.
+  """
   modifiedAt: DateTime!
 }
 
-"""Added in 24.12.0."""
+"""
+Added in 24.12.0.
+"""
 type DomainNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
   @join__type(graph: GRAPHENE, key: "id")
-  @join__type(graph: STRAWBERRY, key: "id", extension: true)
-{
-  """The ID of the object"""
+  @join__type(graph: STRAWBERRY, key: "id", extension: true) {
+  """
+  The ID of the object
+  """
   id: ID!
   name: String @join__field(graph: GRAPHENE)
   description: String @join__field(graph: GRAPHENE)
@@ -4761,29 +5585,36 @@ type DomainNode implements Node
   allowed_docker_registries: [String] @join__field(graph: GRAPHENE)
   dotfiles: Bytes @join__field(graph: GRAPHENE)
   integration_id: String @join__field(graph: GRAPHENE)
-  scaling_groups(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ScalingGroupConnection @join__field(graph: GRAPHENE)
+  scaling_groups(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): ScalingGroupConnection @join__field(graph: GRAPHENE)
 }
 
-"""Added in UNRELEASED. Payload for domain mutation responses."""
-type DomainPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """The domain entity."""
+"""
+Added in UNRELEASED. Payload for domain mutation responses.
+"""
+type DomainPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  The domain entity.
+  """
   domain: DomainV2!
 }
 
 """
 Added in 24.12.0. One of ['read_attribute', 'read_sensitive_attribute', 'update_attribute', 'create_user', 'create_project'].
 """
-scalar DomainPermissionValueField
-  @join__type(graph: GRAPHENE)
+scalar DomainPermissionValueField @join__type(graph: GRAPHENE)
 
 """
 Added in 26.2.0. Nested filter for projects belonging to a domain. Filters domains that have at least one project matching all specified conditions.
 """
-input DomainProjectNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
+input DomainProjectNestedFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   isActive: Boolean = null
 }
@@ -4791,9 +5622,7 @@ input DomainProjectNestedFilter
 """
 Added in 26.2.0. Scope for querying projects within a specific domain. Used to restrict project queries to a particular domain context.
 """
-input DomainProjectV2Scope
-  @join__type(graph: STRAWBERRY)
-{
+input DomainProjectV2Scope @join__type(graph: STRAWBERRY) {
   """
   Domain name to scope the query. Only projects belonging to this domain will be returned.
   """
@@ -4803,20 +5632,20 @@ input DomainProjectV2Scope
 """
 Added in 26.2.0. Domain container registry configuration. Contains allowed container registry URLs for this domain.
 """
-type DomainRegistryInfo
-  @join__type(graph: STRAWBERRY)
-{
+type DomainRegistryInfo @join__type(graph: STRAWBERRY) {
   """
   List of allowed container registry URLs. Empty list means no restrictions on registry access.
   """
   allowedDockerRegistries: [String!]!
 }
 
-"""Added in UNRELEASED. Payload for domain resource allocation query."""
-type DomainResourceAllocationV2
-  @join__type(graph: STRAWBERRY)
-{
-  """Domain resource usage."""
+"""
+Added in UNRELEASED. Payload for domain resource allocation query.
+"""
+type DomainResourceAllocationV2 @join__type(graph: STRAWBERRY) {
+  """
+  Domain resource usage.
+  """
   domain: ScopeResourceUsageV2!
 }
 
@@ -4825,18 +5654,25 @@ Added in 26.1.0. Domain-level usage bucket representing aggregated resource cons
 """
 type DomainUsageBucket implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Name of the domain this usage bucket belongs to."""
+  """
+  Name of the domain this usage bucket belongs to.
+  """
   domainName: String!
 
-  """Name of the scaling group this usage was recorded in."""
+  """
+  Name of the scaling group this usage was recorded in.
+  """
   resourceGroupName: String!
 
-  """Metadata about the usage measurement period and timestamps."""
+  """
+  Metadata about the usage measurement period and timestamps.
+  """
   metadata: UsageBucketMetadata!
 
   """
@@ -4862,19 +5698,30 @@ type DomainUsageBucket implements Node
   """
   Added in 26.1.0. Project usage buckets belonging to this domain. Returns paginated project-level usage history for all projects in this domain within the same scaling group.
   """
-  projectUsageBuckets(filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection!
+  projectUsageBuckets(
+    filter: ProjectUsageBucketFilter = null
+    orderBy: [ProjectUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectUsageBucketConnection!
 }
 
 """
 Added in 26.1.0. Paginated connection for domain usage bucket records. Provides relay-style cursor-based pagination for browsing historical usage data by time period. Use 'edges' to access individual records with cursor information, or 'nodes' for direct data access.
 """
-type DomainUsageBucketConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type DomainUsageBucketConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [DomainUsageBucketEdge!]!
 
   """
@@ -4883,23 +5730,25 @@ type DomainUsageBucketConnection
   count: Int!
 }
 
-"""An edge in a connection."""
-type DomainUsageBucketEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type DomainUsageBucketEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: DomainUsageBucket!
 }
 
 """
 Added in 26.1.0. Filter input for querying domain usage bucket records. Usage buckets contain historical resource consumption data aggregated by time period. Multiple filters can be combined using AND, OR, and NOT logical operators.
 """
-input DomainUsageBucketFilter
-  @join__type(graph: STRAWBERRY)
-{
+input DomainUsageBucketFilter @join__type(graph: STRAWBERRY) {
   """
   Filter by scaling group name. Scaling groups define where usage was recorded. Supports equals, contains, startsWith, and endsWith operations.
   """
@@ -4910,13 +5759,19 @@ input DomainUsageBucketFilter
   """
   domainName: StringFilter = null
 
-  """Filter by usage measurement period start date."""
+  """
+  Filter by usage measurement period start date.
+  """
   periodStart: DateFilter = null
 
-  """Filter by usage measurement period end date."""
+  """
+  Filter by usage measurement period end date.
+  """
   periodEnd: DateFilter = null
 
-  """Combine multiple filters with AND logic. All conditions must match."""
+  """
+  Combine multiple filters with AND logic. All conditions must match.
+  """
   AND: [DomainUsageBucketFilter!] = null
 
   """
@@ -4933,9 +5788,7 @@ input DomainUsageBucketFilter
 """
 Added in 26.1.0. Specifies ordering for domain usage bucket query results. Combine field selection with direction to sort results. Default direction is DESC (most recent first).
 """
-input DomainUsageBucketOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input DomainUsageBucketOrderBy @join__type(graph: STRAWBERRY) {
   """
   The field to order by. See UsageBucketOrderField for available options.
   """
@@ -4947,20 +5800,20 @@ input DomainUsageBucketOrderBy
   direction: OrderDirection! = DESC
 }
 
-"""Added in 24.09.0. """
-input DomainUsageScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group to filter usage buckets by."""
+"""
+Added in 24.09.0.
+"""
+input DomainUsageScope @join__type(graph: STRAWBERRY) {
+  """
+  Resource group to filter usage buckets by.
+  """
   resourceGroupName: String!
 }
 
 """
 Added in 26.2.0. Nested filter for users belonging to a domain. Filters domains that have at least one user matching all specified conditions.
 """
-input DomainUserNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
+input DomainUserNestedFilter @join__type(graph: STRAWBERRY) {
   username: StringFilter = null
   email: StringFilter = null
   isActive: Boolean = null
@@ -4969,9 +5822,7 @@ input DomainUserNestedFilter
 """
 Added in 26.2.0. Scope for querying users within a specific domain. Used to restrict user queries to a particular domain context.
 """
-input DomainUserV2Scope
-  @join__type(graph: STRAWBERRY)
-{
+input DomainUserV2Scope @join__type(graph: STRAWBERRY) {
   """
   Domain name to scope the user query. Only users belonging to this domain will be returned.
   """
@@ -4983,18 +5834,25 @@ Added in 26.2.0. Domain entity with structured field groups. Formerly DomainNode
 """
 type DomainV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY, key: "id")
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY, key: "id") {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Basic domain information including name and description."""
+  """
+  Basic domain information including name and description.
+  """
   basicInfo: DomainBasicInfo!
 
-  """Container registry configuration."""
+  """
+  Container registry configuration.
+  """
   registry: DomainRegistryInfo!
 
-  """Lifecycle information including activation status and timestamps."""
+  """
+  Lifecycle information including activation status and timestamps.
+  """
   lifecycle: DomainLifecycleInfo!
 
   """
@@ -5010,48 +5868,86 @@ type DomainV2 implements Node
   """
   Usage buckets for this domain, filtered by resource group. Returns aggregated resource usage statistics over time.
   """
-  usageBuckets(scope: DomainUsageScope!, filter: DomainUsageBucketFilter = null, orderBy: [DomainUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainUsageBucketConnection!
+  usageBuckets(
+    scope: DomainUsageScope!
+    filter: DomainUsageBucketFilter = null
+    orderBy: [DomainUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DomainUsageBucketConnection!
 
-  """Projects belonging to this domain."""
-  projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection!
+  """
+  Projects belonging to this domain.
+  """
+  projects(
+    filter: ProjectV2Filter = null
+    orderBy: [ProjectV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectV2Connection!
 
-  """Users belonging to this domain."""
-  users(filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection!
+  """
+  Users belonging to this domain.
+  """
+  users(
+    filter: UserV2Filter = null
+    orderBy: [UserV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserV2Connection!
 }
 
 """
 Added in 26.2.0. Paginated connection for domain records. Provides relay-style cursor-based pagination for efficient traversal of domain data. Use 'edges' to access individual records with cursor information, or 'nodes' for direct data access.
 """
-type DomainV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type DomainV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [DomainV2Edge!]!
 
-  """Total number of domain records matching the query criteria."""
+  """
+  Total number of domain records matching the query criteria.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type DomainV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type DomainV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: DomainV2!
 }
 
 """
 Added in 26.2.0. Filter input for querying domains. Supports filtering by name, description, active status, timestamps, and nested project/user filters. Multiple filters can be combined using AND, OR, and NOT logical operators.
 """
-input DomainV2Filter
-  @join__type(graph: STRAWBERRY)
-{
+input DomainV2Filter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   description: StringFilter = null
   isActive: Boolean = null
@@ -5067,9 +5963,7 @@ input DomainV2Filter
 """
 Added in 26.2.0. Specifies ordering for domain query results. Combine field selection with direction to sort results. Default direction is DESC (descending).
 """
-input DomainV2OrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input DomainV2OrderBy @join__type(graph: STRAWBERRY) {
   field: DomainV2OrderField! = CREATED_AT
   direction: OrderDirection! = DESC
 }
@@ -5077,9 +5971,7 @@ input DomainV2OrderBy
 """
 Added in 26.2.0. Fields available for ordering domain query results. CREATED_AT: Order by creation timestamp. MODIFIED_AT: Order by last modification timestamp. NAME: Order by domain name alphabetically. IS_ACTIVE: Order by active status. PROJECT_NAME: Order by project name (MIN aggregation). USER_USERNAME: Order by username (MIN aggregation). USER_EMAIL: Order by user email (MIN aggregation).
 """
-enum DomainV2OrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum DomainV2OrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   MODIFIED_AT @join__enumValue(graph: STRAWBERRY)
   NAME @join__enumValue(graph: STRAWBERRY)
@@ -5092,10 +5984,10 @@ enum DomainV2OrderField
 """
 Added in 26.1.0. Input item for a single domain weight in bulk upsert. Represents one domain's weight configuration.
 """
-input DomainWeightInputItem
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the domain to update weight for."""
+input DomainWeightInputItem @join__type(graph: STRAWBERRY) {
+  """
+  Name of the domain to update weight for.
+  """
   domainName: String!
 
   """
@@ -5104,11 +5996,13 @@ input DomainWeightInputItem
   weight: Decimal = null
 }
 
-"""Added in UNRELEASED. Breakdown of resource allocation by scope."""
-type EffectiveBreakdownV2
-  @join__type(graph: STRAWBERRY)
-{
-  """Keypair resource policy limits."""
+"""
+Added in UNRELEASED. Breakdown of resource allocation by scope.
+"""
+type EffectiveBreakdownV2 @join__type(graph: STRAWBERRY) {
+  """
+  Keypair resource policy limits.
+  """
   keypair: ScopeResourceUsageV2!
 
   """
@@ -5116,52 +6010,60 @@ type EffectiveBreakdownV2
   """
   project: ScopeResourceUsageV2
 
-  """Domain resource limits."""
+  """
+  Domain resource limits.
+  """
   domain: ScopeResourceUsageV2!
 
-  """Resource group physical resources. Null when hide_agents is enabled."""
+  """
+  Resource group physical resources. Null when hide_agents is enabled.
+  """
   resourceGroup: ResourceGroupUsageV2
 }
 
 """
 Added in UNRELEASED. Effective assignable resources considering all scope constraints.
 """
-type EffectiveResourceAllocationV2
-  @join__type(graph: STRAWBERRY)
-{
-  """Effective assignable resources (minimum across all scopes)."""
+type EffectiveResourceAllocationV2 @join__type(graph: STRAWBERRY) {
+  """
+  Effective assignable resources (minimum across all scopes).
+  """
   assignable: [ResourceLimitEntry!]!
 
-  """Per-scope breakdown of resource limits and usage."""
+  """
+  Per-scope breakdown of resource limits and usage.
+  """
   breakdown: EffectiveBreakdownV2!
 }
 
 """
 Added in UNRELEASED. Input for querying effective assignable resources.
 """
-input EffectiveResourceAllocationV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """Project ID to check allocation for."""
+input EffectiveResourceAllocationV2Input @join__type(graph: STRAWBERRY) {
+  """
+  Project ID to check allocation for.
+  """
   projectId: UUID!
 
-  """Resource group name to check allocation for."""
+  """
+  Resource group name to check allocation for.
+  """
   resourceGroupName: String!
 }
 
-"""Added in 24.09.0. Input for email message settings"""
-input EmailMessageInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for email message settings
+"""
+input EmailMessageInput @join__type(graph: STRAWBERRY) {
   fromEmail: String!
   toEmails: [String!]!
   subjectTemplate: String = null
 }
 
-"""Added in 24.09.0. Input for email notification channel configuration"""
-input EmailSpecInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for email notification channel configuration
+"""
+input EmailSpecInput @join__type(graph: STRAWBERRY) {
   smtp: SMTPConnectionInput!
   message: EmailMessageInput!
   auth: SMTPAuthInput = null
@@ -5169,13 +6071,15 @@ input EmailSpecInput
 
 type Endpoint implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   endpoint_id: UUID
-  image: String @deprecated(reason: "Deprecated since 23.09.9. use `image_object`")
+  image: String
+    @deprecated(reason: "Deprecated since 23.09.9. use `image_object`")
 
-  """Added in 23.09.9."""
+  """
+  Added in 23.09.9.
+  """
   image_object: ImageNode
   domain: String
   project: String
@@ -5184,28 +6088,47 @@ type Endpoint implements Item
   url: String
   model: UUID
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4.
+  """
   model_definition_path: String
-  model_mount_destiation: String @deprecated(reason: "Deprecated since 24.03.4; use `model_mount_destination` instead")
+  model_mount_destiation: String
+    @deprecated(
+      reason: "Deprecated since 24.03.4; use `model_mount_destination` instead"
+    )
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4.
+  """
   model_mount_destination: String
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4.
+  """
   extra_mounts: [VirtualFolderNode]
-  created_user: UUID @deprecated(reason: "Deprecated since 23.09.8. use `created_user_id`")
+  created_user: UUID
+    @deprecated(reason: "Deprecated since 23.09.8. use `created_user_id`")
 
-  """Added in 23.09.8."""
+  """
+  Added in 23.09.8.
+  """
   created_user_email: String
 
-  """Added in 23.09.8."""
+  """
+  Added in 23.09.8.
+  """
   created_user_id: UUID
-  session_owner: UUID @deprecated(reason: "Deprecated since 23.09.8. use `session_owner_id`")
+  session_owner: UUID
+    @deprecated(reason: "Deprecated since 23.09.8. use `session_owner_id`")
 
-  """Added in 23.09.8."""
+  """
+  Added in 23.09.8.
+  """
   session_owner_email: String
 
-  """Added in 23.09.8."""
+  """
+  Added in 23.09.8.
+  """
   session_owner_id: UUID
   tag: String
   startup_command: String
@@ -5215,14 +6138,19 @@ type Endpoint implements Item
   name: String
   resource_opts: JSONString
 
-  """Added in 24.12.0. Replaces `desired_session_count`."""
+  """
+  Added in 24.12.0. Replaces `desired_session_count`.
+  """
   replicas: Int
-  desired_session_count: Int @deprecated(reason: "Deprecated since 24.12.0. Use `replicas` instead.")
+  desired_session_count: Int
+    @deprecated(reason: "Deprecated since 24.12.0. Use `replicas` instead.")
   cluster_mode: String
   cluster_size: Int
   open_to_public: Boolean
 
-  """Added in 24.03.5."""
+  """
+  Added in 24.03.5.
+  """
   runtime_variant: RuntimeVariantInfo
   created_at: DateTime!
   destroyed_at: DateTime
@@ -5232,41 +6160,51 @@ type Endpoint implements Item
   lifecycle_stage: String
   errors: [InferenceSessionError!]!
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   live_stat: JSONString
 }
 
-"""Added in 25.1.0."""
-type EndpointAutoScalingRuleConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 25.1.0.
+"""
+type EndpointAutoScalingRuleConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [EndpointAutoScalingRuleEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
 """
 Added in 25.1.0. A Relay edge containing a `EndpointAutoScalingRule` and its cursor.
 """
-type EndpointAutoScalingRuleEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+type EndpointAutoScalingRuleEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: EndpointAutoScalingRuleNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
-"""Added in 25.1.0."""
-input EndpointAutoScalingRuleInput
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.1.0.
+"""
+input EndpointAutoScalingRuleInput @join__type(graph: GRAPHENE) {
   metric_source: AutoScalingMetricSource!
   metric_name: String!
   threshold: String!
@@ -5277,12 +6215,15 @@ input EndpointAutoScalingRuleInput
   max_replicas: Int
 }
 
-"""Added in 25.1.0."""
+"""
+Added in 25.1.0.
+"""
 type EndpointAutoScalingRuleNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
-  @join__type(graph: GRAPHENE, key: "id")
-{
-  """The ID of the object"""
+  @join__type(graph: GRAPHENE, key: "id") {
+  """
+  The ID of the object
+  """
   id: ID!
   row_id: UUID!
   metric_source: AutoScalingMetricSource!
@@ -5300,16 +6241,14 @@ type EndpointAutoScalingRuleNode implements Node
 
 type EndpointList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [Endpoint]!
   total_count: Int!
 }
 
 type EndpointToken implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE, key: "token")
-{
+  @join__type(graph: GRAPHENE, key: "token") {
   id: ID
   token: String!
   endpoint_id: UUID!
@@ -5322,28 +6261,46 @@ type EndpointToken implements Item
 
 type EndpointTokenList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [EndpointToken]!
   total_count: Int!
 }
 
-"""Added in 26.3.0. Entity connection."""
-type EntityConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in UNRELEASED. Entity with its allowed actions within a scope.
+"""
+type EntityActionInfo @join__type(graph: STRAWBERRY) {
+  """
+  Entity element type
+  """
+  entityType: RBACElementType!
+
+  """
+  Valid operations for this entity in the given scope
+  """
+  actions: [OperationInfo!]!
+}
+
+"""
+Added in 26.3.0. Entity connection.
+"""
+type EntityConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [EntityRefEdge!]!
   count: Int!
 }
 
-"""Added in 26.3.0. Filter for entity associations"""
-input EntityFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Filter for entity associations
+"""
+input EntityFilter @join__type(graph: STRAWBERRY) {
   entityType: RBACElementType = null
   entityId: StringFilter = null
   AND: [EntityFilter!] = null
@@ -5369,34 +6326,52 @@ union EntityNode
   @join__unionMember(graph: STRAWBERRY, member: "ResourceGroup")
   @join__unionMember(graph: STRAWBERRY, member: "ContainerRegistryV2")
   @join__unionMember(graph: STRAWBERRY, member: "ArtifactRevision")
-  @join__unionMember(graph: STRAWBERRY, member: "Role")
- = UserV2 | ProjectV2 | DomainV2 | VirtualFolderNode | ImageV2 | ComputeSessionNode | SessionV2 | Artifact | ArtifactRegistry | AppConfig | NotificationChannel | NotificationRule | ModelDeployment | ResourceGroup | ContainerRegistryV2 | ArtifactRevision | Role
+  @join__unionMember(graph: STRAWBERRY, member: "Role") =
+  | UserV2
+  | ProjectV2
+  | DomainV2
+  | VirtualFolderNode
+  | ImageV2
+  | ComputeSessionNode
+  | SessionV2
+  | Artifact
+  | ArtifactRegistry
+  | AppConfig
+  | NotificationChannel
+  | NotificationRule
+  | ModelDeployment
+  | ResourceGroup
+  | ContainerRegistryV2
+  | ArtifactRevision
+  | Role
 
 """
 Added in UNRELEASED. Valid entity-operation combination for RBAC actions.
 """
-type EntityOperationCombination
-  @join__type(graph: STRAWBERRY)
-{
-  """Entity element type"""
+type EntityOperationCombination @join__type(graph: STRAWBERRY) {
+  """
+  Entity element type
+  """
   entityType: RBACElementType!
 
-  """Valid operations for this entity"""
+  """
+  Valid operations for this entity
+  """
   operations: [OperationInfo!]!
 }
 
-"""Added in 26.3.0. Order by specification for entity associations"""
-input EntityOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Order by specification for entity associations
+"""
+input EntityOrderBy @join__type(graph: STRAWBERRY) {
   field: EntityOrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in 26.3.0. Entity ordering field"""
-enum EntityOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Entity ordering field
+"""
+enum EntityOrderField @join__type(graph: STRAWBERRY) {
   ENTITY_TYPE @join__enumValue(graph: STRAWBERRY)
   REGISTERED_AT @join__enumValue(graph: STRAWBERRY)
 }
@@ -5406,9 +6381,10 @@ Added in 26.3.0. Entity reference from the association_scopes_entities table.
 """
 type EntityRef implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   scopeType: RBACElementType!
   scopeId: String!
@@ -5416,40 +6392,46 @@ type EntityRef implements Node
   entityId: String!
   registeredAt: DateTime!
 
-  """The resolved entity object."""
+  """
+  The resolved entity object.
+  """
   entity: EntityNode
 }
 
-"""An edge in a connection."""
-type EntityRefEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type EntityRefEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: EntityRef!
 }
 
 """
 Added in 26.2.0. Common timestamp fields for entity lifecycle tracking. Reusable across different entity types.
 """
-type EntityTimestamps
-  @join__type(graph: STRAWBERRY)
-{
-  """Timestamp when this entity was created."""
+type EntityTimestamps @join__type(graph: STRAWBERRY) {
+  """
+  Timestamp when this entity was created.
+  """
   createdAt: DateTime
 
-  """Timestamp when this entity was last modified."""
+  """
+  Timestamp when this entity was last modified.
+  """
   modifiedAt: DateTime
 }
 
 """
 Added in 26.1.0. A single environment variable entry with name and value.
 """
-type EnvironmentVariableEntry
-  @join__type(graph: STRAWBERRY)
-{
+type EnvironmentVariableEntry @join__type(graph: STRAWBERRY) {
   name: String!
   value: String!
 }
@@ -5457,46 +6439,54 @@ type EnvironmentVariableEntry
 """
 Added in 26.1.0. A single environment variable entry with name and value.
 """
-input EnvironmentVariableEntryInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Environment variable name (e.g., CUDA_VISIBLE_DEVICES)."""
+input EnvironmentVariableEntryInput @join__type(graph: STRAWBERRY) {
+  """
+  Environment variable name (e.g., CUDA_VISIBLE_DEVICES).
+  """
   name: String!
 
-  """Environment variable value."""
+  """
+  Environment variable value.
+  """
   value: String!
 }
 
-"""Added in 26.1.0. A collection of environment variable entries."""
-type EnvironmentVariables
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.1.0. A collection of environment variable entries.
+"""
+type EnvironmentVariables @join__type(graph: STRAWBERRY) {
   entries: [EnvironmentVariableEntry!]!
 }
 
-"""Added in 26.1.0. A collection of environment variable entries."""
-input EnvironmentVariablesInput
-  @join__type(graph: STRAWBERRY)
-{
-  """List of environment variable entries."""
+"""
+Added in 26.1.0. A collection of environment variable entries.
+"""
+input EnvironmentVariablesInput @join__type(graph: STRAWBERRY) {
+  """
+  List of environment variable entries.
+  """
   entries: [EnvironmentVariableEntryInput!]!
 }
 
-"""Added in 26.3.0. Options for executing a query definition."""
-input ExecuteQueryDefinitionOptionsInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Label key-value pairs to filter by."""
+"""
+Added in 26.3.0. Options for executing a query definition.
+"""
+input ExecuteQueryDefinitionOptionsInput @join__type(graph: STRAWBERRY) {
+  """
+  Label key-value pairs to filter by.
+  """
   filterLabels: [MetricLabelEntryInput!] = null
 
-  """Label keys to group results by."""
+  """
+  Label keys to group results by.
+  """
   groupLabels: [String!] = null
 }
 
-"""Added in 24.03.4."""
-input ExtraMountInput
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.03.4.
+"""
+input ExtraMountInput @join__type(graph: GRAPHENE) {
   vfolder_id: String
   mount_destination: String
 
@@ -5514,19 +6504,19 @@ input ExtraMountInput
 """
 Added in 25.19.0. An extra virtual folder mount attached to a model revision.
 """
-type ExtraVFolderMountInfoGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """The vfolder of this entity."""
+type ExtraVFolderMountInfoGQL @join__type(graph: STRAWBERRY) {
+  """
+  The vfolder of this entity.
+  """
   vfolder: VirtualFolderNode!
   vfolderId: ID!
   mountDestination: String
 }
 
-"""Added in 25.19.0. """
-input ExtraVFolderMountInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ExtraVFolderMountInput @join__type(graph: STRAWBERRY) {
   vfolderId: ID!
   mountDestination: String
 }
@@ -5534,61 +6524,77 @@ input ExtraVFolderMountInput
 """
 Added in 26.1.0. Snapshot of the most recent fair share calculation results. Contains the computed fair share factor and the intermediate values used in the calculation.
 """
-type FairShareCalculationSnapshot
-  @join__type(graph: STRAWBERRY)
-{
+type FairShareCalculationSnapshot @join__type(graph: STRAWBERRY) {
   """
   Added in 26.2.0. Average daily decayed resource usage during the lookback period. Calculated as total_decayed_usage divided by lookback duration in days. For each resource type, this represents the average decayed amount consumed per day. Units match the resource type (e.g., CPU cores, memory bytes).
   """
   averageDailyDecayedUsage: ResourceSlot!
 
-  """Computed fair share factor (0-1 range)"""
+  """
+  Computed fair share factor (0-1 range)
+  """
   fairShareFactor: Decimal!
 
-  """Sum of decayed historical usage"""
+  """
+  Sum of decayed historical usage
+  """
   totalDecayedUsage: ResourceSlot!
 
-  """Single scalar representing weighted consumption"""
+  """
+  Single scalar representing weighted consumption
+  """
   normalizedUsage: Decimal!
 
-  """Start date of the lookback window"""
+  """
+  Start date of the lookback window
+  """
   lookbackStart: Date!
 
-  """End date of the lookback window"""
+  """
+  End date of the lookback window
+  """
   lookbackEnd: Date!
 
-  """Timestamp when calculation was performed"""
+  """
+  Timestamp when calculation was performed
+  """
   lastCalculatedAt: DateTime!
 }
 
 """
 Added in 26.1.0. Fair share calculation configuration for a resource group. Defines parameters for computing fair share factors across domains, projects, and users.
 """
-type FairShareScalingGroupSpec
-  @join__type(graph: STRAWBERRY)
-{
-  """Half-life for exponential decay in days"""
+type FairShareScalingGroupSpec @join__type(graph: STRAWBERRY) {
+  """
+  Half-life for exponential decay in days
+  """
   halfLifeDays: Int!
 
-  """Total lookback period in days"""
+  """
+  Total lookback period in days
+  """
   lookbackDays: Int!
 
-  """Granularity of decay buckets in days"""
+  """
+  Granularity of decay buckets in days
+  """
   decayUnitDays: Int!
 
-  """Default weight for entities without explicit weight"""
+  """
+  Default weight for entities without explicit weight
+  """
   defaultWeight: Decimal!
 
-  """Weights for each resource type"""
+  """
+  Weights for each resource type
+  """
   resourceWeights: [ResourceWeightEntry!]!
 }
 
 """
 Added in 26.1.0. Configuration parameters that control how fair share factors are calculated. These parameters determine the decay rate, lookback period, and resource weighting for usage aggregation.
 """
-type FairShareSpec
-  @join__type(graph: STRAWBERRY)
-{
+type FairShareSpec @join__type(graph: STRAWBERRY) {
   """
   Effective weight for this entity. Always the resolved value (either the explicitly set weight or the resource group's default_weight).
   """
@@ -5599,51 +6605,62 @@ type FairShareSpec
   """
   usesDefault: Boolean!
 
-  """Half-life for exponential decay in days"""
+  """
+  Half-life for exponential decay in days
+  """
   halfLifeDays: Int!
 
-  """Total lookback period in days"""
+  """
+  Total lookback period in days
+  """
   lookbackDays: Int!
 
-  """Granularity of decay buckets in days"""
+  """
+  Granularity of decay buckets in days
+  """
   decayUnitDays: Int!
 
-  """Weights for each resource type with default indicators"""
+  """
+  Weights for each resource type with default indicators
+  """
   resourceWeights: [ResourceWeightEntry!]!
 }
 
 """
 A string-serialized scalar represents a set of fields that's passed to a federated directive, such as @key, @requires, or @provides
 """
-scalar FieldSet
-  @join__type(graph: GRAPHENE)
+scalar FieldSet @join__type(graph: GRAPHENE)
 
-"""Deprecated since 25.4.0. Use `forget_image_by_id` instead."""
-type ForgetImage
-  @join__type(graph: GRAPHENE)
-{
+"""
+Deprecated since 25.4.0. Use `forget_image_by_id` instead.
+"""
+type ForgetImage @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 
-  """Added since 24.03.1."""
+  """
+  Added since 24.03.1.
+  """
   image: ImageNode
 }
 
-"""Added in 24.03.0."""
-type ForgetImageById
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.03.0.
+"""
+type ForgetImageById @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 
-  """Added since 24.03.1."""
+  """
+  Added since 24.03.1.
+  """
   image: ImageNode
 }
 
-"""Added in 25.14.0. """
-input GetPresignedDownloadURLInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.14.0.
+"""
+input GetPresignedDownloadURLInput @join__type(graph: STRAWBERRY) {
   artifactRevisionId: ID!
   key: String!
   expiration: Int = null
@@ -5652,41 +6669,42 @@ input GetPresignedDownloadURLInput
 """
 Added in 25.14.0. Payload for presigned download URL generation result.
 """
-type GetPresignedDownloadURLPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Presigned URL for downloading"""
+type GetPresignedDownloadURLPayload @join__type(graph: STRAWBERRY) {
+  """
+  Presigned URL for downloading
+  """
   presignedUrl: String!
 }
 
-"""Added in 25.14.0. """
-input GetPresignedUploadURLInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.14.0.
+"""
+input GetPresignedUploadURLInput @join__type(graph: STRAWBERRY) {
   artifactRevisionId: ID!
   key: String!
 }
 
-"""Added in 25.14.0. Payload for presigned upload URL generation result."""
-type GetPresignedUploadURLPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Presigned URL for uploading"""
+"""
+Added in 25.14.0. Payload for presigned upload URL generation result.
+"""
+type GetPresignedUploadURLPayload @join__type(graph: STRAWBERRY) {
+  """
+  Presigned URL for uploading
+  """
   presignedUrl: String!
 
-  """Additional fields required for the upload request"""
+  """
+  Additional fields required for the upload request
+  """
   fields: String!
 }
 
 """
 Added in 24.09.0. Global ID of GQL relay spec. Base64 encoded version of "<node type name>:<node id>". UUID or string type values are also allowed.
 """
-scalar GlobalIDField
-  @join__type(graph: GRAPHENE)
+scalar GlobalIDField @join__type(graph: GRAPHENE)
 
-type Group
-  @join__type(graph: GRAPHENE)
-{
+type Group @join__type(graph: GRAPHENE) {
   id: UUID
   name: String
   description: String
@@ -5699,43 +6717,57 @@ type Group
   integration_id: String
   resource_policy: String
 
-  """Added in 24.03.0."""
+  """
+  Added in 24.03.0.
+  """
   type: String
 
-  """Added in 24.03.0."""
+  """
+  Added in 24.03.0.
+  """
   container_registry: JSONString
   scaling_groups: [String]
 }
 
-"""Added in 24.03.0"""
-type GroupConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 24.03.0
+"""
+type GroupConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [GroupEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
-"""Added in 24.03.0 A Relay edge containing a `Group` and its cursor."""
-type GroupEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+"""
+Added in 24.03.0 A Relay edge containing a `Group` and its cursor.
+"""
+type GroupEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: GroupNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
-input GroupInput
-  @join__type(graph: GRAPHENE)
-{
-  """Added in 24.03.0. Available values: GENERAL, MODEL_STORE"""
+input GroupInput @join__type(graph: GRAPHENE) {
+  """
+  Added in 24.03.0. Available values: GENERAL, MODEL_STORE
+  """
   type: String = "GENERAL"
   description: String = ""
   is_active: Boolean = true
@@ -5745,19 +6777,24 @@ input GroupInput
   integration_id: String = ""
   resource_policy: String = "default"
 
-  """Added in 24.03.0"""
+  """
+  Added in 24.03.0
+  """
   container_registry: JSONString = "{}"
 }
 
 type GroupNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
   @join__type(graph: GRAPHENE, key: "id")
-  @join__type(graph: STRAWBERRY, key: "id", extension: true)
-{
-  """The ID of the object"""
+  @join__type(graph: STRAWBERRY, key: "id", extension: true) {
+  """
+  The ID of the object
+  """
   id: ID!
 
-  """Added in 24.03.7. The undecoded id value stored in DB."""
+  """
+  Added in 24.03.7. The undecoded id value stored in DB.
+  """
   row_id: UUID @join__field(graph: GRAPHENE)
   name: String @join__field(graph: GRAPHENE)
   description: String @join__field(graph: GRAPHENE)
@@ -5770,30 +6807,46 @@ type GroupNode implements Node
   integration_id: String @join__field(graph: GRAPHENE)
   resource_policy: String @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.7. One of ['GENERAL', 'MODEL_STORE']."""
+  """
+  Added in 24.03.7. One of ['GENERAL', 'MODEL_STORE'].
+  """
   type: String @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.7."""
+  """
+  Added in 24.03.7.
+  """
   container_registry: JSONString @join__field(graph: GRAPHENE)
   scaling_groups: [String] @join__field(graph: GRAPHENE)
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   registry_quota: BigInt @join__field(graph: GRAPHENE)
-  user_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): UserConnection @join__field(graph: GRAPHENE)
+  user_nodes(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): UserConnection @join__field(graph: GRAPHENE)
 }
 
 """
 Added in 25.3.0. One of ['read_attribute', 'read_sensitive_attribute', 'update_attribute', 'delete_project', 'associate_with_user'].
 """
-scalar GroupPermissionField
-  @join__type(graph: GRAPHENE)
+scalar GroupPermissionField @join__type(graph: GRAPHENE)
 
-"""Added in 25.14.0. HuggingFace registry node."""
+"""
+Added in 25.14.0. HuggingFace registry node.
+"""
 type HuggingFaceRegistry implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   url: String!
   name: String!
@@ -5803,51 +6856,68 @@ type HuggingFaceRegistry implements Node
 """
 Added in 25.14.0. Relay-style connection for paginated HuggingFace registry queries.
 """
-type HuggingFaceRegistryConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type HuggingFaceRegistryConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [HuggingFaceRegistryEdge!]!
 
-  """The count of this entity."""
+  """
+  The count of this entity.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type HuggingFaceRegistryEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type HuggingFaceRegistryEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: HuggingFaceRegistry!
 }
 
-type Image
-  @join__type(graph: GRAPHENE)
-{
+type Image @join__type(graph: GRAPHENE) {
   id: UUID
-  name: String @deprecated(reason: "Deprecated since 24.12.0. use `namespace` instead")
+  name: String
+    @deprecated(reason: "Deprecated since 24.12.0. use `namespace` instead")
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   namespace: String
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   base_image_name: String
 
-  """Added in 24.03.10."""
+  """
+  Added in 24.03.10.
+  """
   project: String
   humanized_name: String
   tag: String
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   tags: [KVPair]
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   version: String
   registry: String
   architecture: String
@@ -5857,7 +6927,9 @@ type Image
   aliases: [String]
   size_bytes: BigInt
 
-  """Added in 25.4.0."""
+  """
+  Added in 25.4.0.
+  """
   status: String
   resource_limits: [ResourceLimit]
   supported_accelerators: [String]
@@ -5869,74 +6941,97 @@ type Image
 """
 Added in 26.3.0. Nested filter for aliases belonging to an image. Filters images that have at least one alias matching all specified conditions.
 """
-input ImageAliasNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
+input ImageAliasNestedFilter @join__type(graph: STRAWBERRY) {
   """
   Filter by alias string. Supports equals, contains, startsWith, and endsWith.
   """
   alias: StringFilter = null
 }
 
-"""Added in 25.3.0."""
-type ImageConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 25.3.0.
+"""
+type ImageConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [ImageEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
-"""Added in 25.3.0. A Relay edge containing a `Image` and its cursor."""
-type ImageEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+"""
+Added in 25.3.0. A Relay edge containing a `Image` and its cursor.
+"""
+type ImageEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: ImageNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
-"""Added in 25.19.0. """
-input ImageInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ImageInput @join__type(graph: STRAWBERRY) {
   id: ID!
 }
 
 type ImageNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
   @join__type(graph: GRAPHENE, key: "id")
-  @join__type(graph: STRAWBERRY, key: "id", extension: true)
-{
-  """The ID of the object"""
+  @join__type(graph: STRAWBERRY, key: "id", extension: true) {
+  """
+  The ID of the object
+  """
   id: ID!
 
-  """Added in 24.03.4. The undecoded id value stored in DB."""
+  """
+  Added in 24.03.4. The undecoded id value stored in DB.
+  """
   row_id: UUID @join__field(graph: GRAPHENE)
-  name: String @join__field(graph: GRAPHENE) @deprecated(reason: "Deprecated since 24.12.0. use `namespace` instead")
+  name: String
+    @join__field(graph: GRAPHENE)
+    @deprecated(reason: "Deprecated since 24.12.0. use `namespace` instead")
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   namespace: String @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   base_image_name: String @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.10."""
+  """
+  Added in 24.03.10.
+  """
   project: String @join__field(graph: GRAPHENE)
   humanized_name: String @join__field(graph: GRAPHENE)
   tag: String @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   tags: [KVPair] @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   version: String @join__field(graph: GRAPHENE)
   registry: String @join__field(graph: GRAPHENE)
   architecture: String @join__field(graph: GRAPHENE)
@@ -5945,12 +7040,16 @@ type ImageNode implements Node
   labels: [KVPair] @join__field(graph: GRAPHENE)
   size_bytes: BigInt @join__field(graph: GRAPHENE)
 
-  """Added in 25.4.0."""
+  """
+  Added in 25.4.0.
+  """
   status: String @join__field(graph: GRAPHENE)
   resource_limits: [ResourceLimit] @join__field(graph: GRAPHENE)
   supported_accelerators: [String] @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.4. The array of image aliases."""
+  """
+  Added in 24.03.4. The array of image aliases.
+  """
   aliases: [String] @join__field(graph: GRAPHENE)
 
   """
@@ -5958,39 +7057,40 @@ type ImageNode implements Node
   """
   permissions: [ImagePermissionValueField] @join__field(graph: GRAPHENE)
 
-  """Added in 25.11.0. Indicates if the image is installed on any Agent."""
+  """
+  Added in 25.11.0. Indicates if the image is installed on any Agent.
+  """
   installed: Boolean @join__field(graph: GRAPHENE)
 
-  """Added in 25.12.0."""
+  """
+  Added in 25.12.0.
+  """
   type: ImageType @join__field(graph: GRAPHENE)
 }
 
 """
 Added in 25.3.0. One of ['read_attribute', 'update_attribute', 'create_container', 'forget_image'].
 """
-scalar ImagePermissionValueField
-  @join__type(graph: GRAPHENE)
+scalar ImagePermissionValueField @join__type(graph: GRAPHENE)
 
-input ImageRefType
-  @join__type(graph: GRAPHENE)
-{
+input ImageRefType @join__type(graph: GRAPHENE) {
   name: String!
   registry: String
   architecture: String
 }
 
-"""Added in 25.4.0."""
-enum ImageStatus
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.4.0.
+"""
+enum ImageStatus @join__type(graph: GRAPHENE) {
   ALIVE @join__enumValue(graph: GRAPHENE)
   DELETED @join__enumValue(graph: GRAPHENE)
 }
 
-"""Added in 25.12.0."""
-enum ImageType
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.12.0.
+"""
+enum ImageType @join__type(graph: GRAPHENE) {
   COMPUTE @join__enumValue(graph: GRAPHENE)
   SYSTEM @join__enumValue(graph: GRAPHENE)
   SERVICE @join__enumValue(graph: GRAPHENE)
@@ -6001,24 +7101,35 @@ Added in 26.2.0. Represents a container image in Backend.AI. Images are containe
 """
 type ImageV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Image identity information (name, architecture)."""
+  """
+  Image identity information (name, architecture).
+  """
   identity: ImageV2IdentityInfo!
 
-  """Image metadata (labels, digest, size, status, created_at)."""
+  """
+  Image metadata (labels, digest, size, status, created_at).
+  """
   metadata: ImageV2MetadataInfo!
 
-  """Runtime requirements (supported_accelerators)."""
+  """
+  Runtime requirements (supported_accelerators).
+  """
   requirements: ImageV2RequirementsInfo!
 
-  """Permission info for the current user. May be null."""
+  """
+  Permission info for the current user. May be null.
+  """
   permission: ImageV2PermissionInfo
 
-  """UUID of the container registry where this image is stored."""
+  """
+  UUID of the container registry where this image is stored.
+  """
   registryId: UUID!
 
   """
@@ -6026,8 +7137,17 @@ type ImageV2 implements Node
   """
   lastUsed: DateTime
 
-  """Added in 26.2.0. Aliases for this image."""
-  aliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null): ImageV2AliasConnection!
+  """
+  Added in 26.2.0. Aliases for this image.
+  """
+  aliases(
+    filter: ImageV2AliasFilter = null
+    orderBy: [ImageV2AliasOrderByGQL!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+  ): ImageV2AliasConnection!
 }
 
 """
@@ -6035,51 +7155,62 @@ Added in 26.2.0. Represents an alias for a container image. Aliases provide alte
 """
 type ImageV2Alias implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """The alias string for the image."""
+  """
+  The alias string for the image.
+  """
   alias: String!
 }
 
 """
 Added in 26.2.0. Relay-style connection for paginated image alias queries. Includes total count for pagination UI.
 """
-type ImageV2AliasConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ImageV2AliasConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ImageV2AliasEdge!]!
 
-  """Total count of aliases matching the query."""
+  """
+  Total count of aliases matching the query.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type ImageV2AliasEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ImageV2AliasEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ImageV2Alias!
 }
 
 """
 Added in 26.2.0. Filter options for image aliases. Supports filtering by alias string and image ID.
 """
-input ImageV2AliasFilter
-  @join__type(graph: STRAWBERRY)
-{
+input ImageV2AliasFilter @join__type(graph: STRAWBERRY) {
   alias: StringFilter = null
 
-  """Added in 26.4.0. Filter by image ID."""
+  """
+  Added in 26.4.0. Filter by image ID.
+  """
   imageId: UUIDFilter = null
   AND: [ImageV2AliasFilter!] = null
   OR: [ImageV2AliasFilter!] = null
@@ -6089,64 +7220,74 @@ input ImageV2AliasFilter
 """
 Added in 26.2.0. Specifies the field and direction for ordering image aliases in queries.
 """
-input ImageV2AliasOrderByGQL
-  @join__type(graph: STRAWBERRY)
-{
+input ImageV2AliasOrderByGQL @join__type(graph: STRAWBERRY) {
   field: ImageV2AliasOrderField!
   direction: OrderDirection! = ASC
 }
 
-"""Added in 26.2.0. Fields available for ordering image alias queries."""
-enum ImageV2AliasOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Fields available for ordering image alias queries.
+"""
+enum ImageV2AliasOrderField @join__type(graph: STRAWBERRY) {
   ALIAS @join__enumValue(graph: STRAWBERRY)
 }
 
 """
 Added in 26.2.0. Relay-style connection for paginated image queries. Includes total count for pagination UI.
 """
-type ImageV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ImageV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ImageV2Edge!]!
 
-  """Total count of images matching the query."""
+  """
+  Total count of images matching the query.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type ImageV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ImageV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ImageV2!
 }
 
 """
 Added in 26.2.0. Filter options for images based on various criteria such as status, name, and architecture. Supports logical operations (AND, OR, NOT) for complex filtering scenarios.
 """
-input ImageV2Filter
-  @join__type(graph: STRAWBERRY)
-{
+input ImageV2Filter @join__type(graph: STRAWBERRY) {
   status: ImageV2StatusFilter = null
   name: StringFilter = null
   architecture: StringFilter = null
 
-  """Added in 26.4.0. Filter by container registry ID."""
+  """
+  Added in 26.4.0. Filter by container registry ID.
+  """
   registryId: UUIDFilter = null
 
-  """Added in 26.3.0. Filter by nested alias conditions."""
+  """
+  Added in 26.3.0. Filter by nested alias conditions.
+  """
   alias: ImageAliasNestedFilter = null
 
-  """Added in 26.3.0. Filter by last used datetime (before/after)."""
+  """
+  Added in 26.3.0. Filter by last used datetime (before/after).
+  """
   lastUsed: DateTimeFilter = null
   AND: [ImageV2Filter!] = null
   OR: [ImageV2Filter!] = null
@@ -6156,25 +7297,27 @@ input ImageV2Filter
 """
 Added in 26.2.0. Identity information for an image. Contains the canonical name, namespace, and architecture.
 """
-type ImageV2IdentityInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Full canonical name of the image."""
+type ImageV2IdentityInfo @join__type(graph: STRAWBERRY) {
+  """
+  Full canonical name of the image.
+  """
   canonicalName: String!
 
-  """Image namespace/path within the registry."""
+  """
+  Image namespace/path within the registry.
+  """
   namespace: String!
 
-  """CPU architecture."""
+  """
+  CPU architecture.
+  """
   architecture: String!
 }
 
 """
 Added in 26.2.0. A key-value pair representing a Docker label on the image. Labels contain metadata about the image such as maintainer, version, etc.
 """
-type ImageV2LabelEntry
-  @join__type(graph: STRAWBERRY)
-{
+type ImageV2LabelEntry @join__type(graph: STRAWBERRY) {
   key: String!
   value: String!
 }
@@ -6182,54 +7325,64 @@ type ImageV2LabelEntry
 """
 Added in 26.2.0. Metadata information for an image. Contains tags, labels, digest, size, status, and creation timestamp.
 """
-type ImageV2MetadataInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Config digest for verification."""
+type ImageV2MetadataInfo @join__type(graph: STRAWBERRY) {
+  """
+  Config digest for verification.
+  """
   digest: String
 
-  """Image size in bytes."""
+  """
+  Image size in bytes.
+  """
   sizeBytes: Int!
 
-  """Image creation timestamp."""
+  """
+  Image creation timestamp.
+  """
   createdAt: DateTime
 
-  """Timestamp of the most recent session created with this image."""
+  """
+  Timestamp of the most recent session created with this image.
+  """
   lastUsedAt: DateTime
 
-  """Parsed tag components."""
+  """
+  Parsed tag components.
+  """
   tags: [ImageV2TagEntry!]!
 
-  """Docker labels."""
+  """
+  Docker labels.
+  """
   labels: [ImageV2LabelEntry!]!
 
-  """Image status (ALIVE or DELETED)."""
+  """
+  Image status (ALIVE or DELETED).
+  """
   status: ImageV2Status!
 }
 
 """
 Added in 26.2.0. Specifies the field and direction for ordering images in queries.
 """
-input ImageV2OrderByGQL
-  @join__type(graph: STRAWBERRY)
-{
+input ImageV2OrderByGQL @join__type(graph: STRAWBERRY) {
   field: ImageV2OrderField!
   direction: OrderDirection! = ASC
 }
 
-"""Added in 26.2.0. Fields available for ordering image queries."""
-enum ImageV2OrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Fields available for ordering image queries.
+"""
+enum ImageV2OrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   LAST_USED @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.2.0. Permission types for image operations."""
-enum ImageV2Permission
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Permission types for image operations.
+"""
+enum ImageV2Permission @join__type(graph: STRAWBERRY) {
   READ_ATTRIBUTE @join__enumValue(graph: STRAWBERRY)
   UPDATE_ATTRIBUTE @join__enumValue(graph: STRAWBERRY)
   CREATE_CONTAINER @join__enumValue(graph: STRAWBERRY)
@@ -6239,49 +7392,51 @@ enum ImageV2Permission
 """
 Added in 26.2.0. Permission information for an image. Contains the list of permissions the current user has on this image.
 """
-type ImageV2PermissionInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """List of permissions the user has on this image"""
+type ImageV2PermissionInfo @join__type(graph: STRAWBERRY) {
+  """
+  List of permissions the user has on this image
+  """
   permissions: [ImageV2Permission!]!
 }
 
 """
 Added in 26.2.0. Runtime requirements information for an image. Contains resource limits and supported accelerators.
 """
-type ImageV2RequirementsInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """List of supported accelerator types."""
+type ImageV2RequirementsInfo @join__type(graph: STRAWBERRY) {
+  """
+  List of supported accelerator types.
+  """
   supportedAccelerators: [String!]!
 
-  """Resource slot limits with string min/max values."""
+  """
+  Resource slot limits with string min/max values.
+  """
   resourceLimits: [ImageV2ResourceLimit!]!
 }
 
 """
 Added in 26.2.0. Resource limit specification for an image. Defines minimum and maximum values for a resource slot.
 """
-type ImageV2ResourceLimit
-  @join__type(graph: STRAWBERRY)
-{
+type ImageV2ResourceLimit @join__type(graph: STRAWBERRY) {
   key: String!
   min: String!
   max: String!
 }
 
-"""Added in 26.2.0. Scope for querying aliases within a specific image."""
-input ImageV2Scope
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the image to scope the query to."""
+"""
+Added in 26.2.0. Scope for querying aliases within a specific image.
+"""
+input ImageV2Scope @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the image to scope the query to.
+  """
   imageId: UUID!
 }
 
-"""Added in 26.2.0. Status of an image in the system."""
-enum ImageV2Status
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Status of an image in the system.
+"""
+enum ImageV2Status @join__type(graph: STRAWBERRY) {
   ALIVE @join__enumValue(graph: STRAWBERRY)
   DELETED @join__enumValue(graph: STRAWBERRY)
 }
@@ -6289,28 +7444,32 @@ enum ImageV2Status
 """
 Added in 26.3.0. Filter for image status with equality and membership operators.
 """
-input ImageV2StatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Matches images with this exact status."""
+input ImageV2StatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  Matches images with this exact status.
+  """
   equals: ImageV2Status = null
 
-  """Matches images whose status is in this list."""
+  """
+  Matches images whose status is in this list.
+  """
   in: [ImageV2Status!] = null
 
-  """Excludes images with this exact status."""
+  """
+  Excludes images with this exact status.
+  """
   notEquals: ImageV2Status = null
 
-  """Excludes images whose status is in this list."""
+  """
+  Excludes images whose status is in this list.
+  """
   notIn: [ImageV2Status!] = null
 }
 
 """
 Added in 26.2.0. A key-value pair representing a parsed tag component. Tags are extracted from the image reference (e.g., py311, cuda12.1).
 """
-type ImageV2TagEntry
-  @join__type(graph: STRAWBERRY)
-{
+type ImageV2TagEntry @join__type(graph: STRAWBERRY) {
   key: String!
   value: String!
 }
@@ -6321,12 +7480,12 @@ Added in 24.09.0. Input for importing scanned artifact revisions from external r
 Downloads artifact files from the external source and transitions them through:
 SCANNED → PULLING → PULLED → AVAILABLE status progression.
 """
-input ImportArtifactsInput
-  @join__type(graph: STRAWBERRY)
-{
+input ImportArtifactsInput @join__type(graph: STRAWBERRY) {
   artifactRevisionIds: [ID!]!
 
-  """Added in 26.1.0. Target vfolder ID to store the imported artifacts."""
+  """
+  Added in 26.1.0. Target vfolder ID to store the imported artifacts.
+  """
   vfolderId: ID = null
 
   """
@@ -6340,36 +7499,34 @@ Added in 24.09.0. Options for importing artifact revisions.
 
 Controls import behavior such as forcing re-download regardless of digest freshness.
 """
-input ImportArtifactsOptionsGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Force re-download regardless of digest freshness check."""
+input ImportArtifactsOptionsGQL @join__type(graph: STRAWBERRY) {
+  """
+  Force re-download regardless of digest freshness check.
+  """
   force: Boolean! = false
 }
 
 """
 Added in 25.14.0. Response payload for artifact import operations. Contains the imported artifact revisions and their associated background tasks. Tasks can be monitored to track the import progress from SCANNED to AVAILABLE status.
 """
-type ImportArtifactsPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """List of imported artifact revisions."""
+type ImportArtifactsPayload @join__type(graph: STRAWBERRY) {
+  """
+  List of imported artifact revisions.
+  """
   artifactRevisions: ArtifactRevisionConnection!
 
-  """List of import tasks created."""
+  """
+  List of import tasks created.
+  """
   tasks: [ArtifactRevisionImportTask!]!
 }
 
-type InferenceSessionError
-  @join__type(graph: GRAPHENE)
-{
+type InferenceSessionError @join__type(graph: GRAPHENE) {
   session_id: UUID
   errors: [InferenceSessionErrorInfo!]!
 }
 
-type InferenceSessionErrorInfo
-  @join__type(graph: GRAPHENE)
-{
+type InferenceSessionErrorInfo @join__type(graph: GRAPHENE) {
   src: String!
   name: String!
   repr: String!
@@ -6378,9 +7535,7 @@ type InferenceSessionErrorInfo
 """
 Added in 24.09.0. Filter for integer fields supporting equality and comparison operations.
 """
-input IntFilter
-  @join__type(graph: STRAWBERRY)
-{
+input IntFilter @join__type(graph: STRAWBERRY) {
   equals: Int = null
   notEquals: Int = null
   greaterThan: Int = null
@@ -6393,9 +7548,7 @@ input IntFilter
 Added in UNRELEASED. Input for a rolling-update budget value (oneOf).
 Provide exactly one of 'count' (absolute replica count) or 'percent' (0.0-1.0 fraction).
 """
-input IntOrPercentInput
-  @join__type(graph: STRAWBERRY)
-{
+input IntOrPercentInput @join__type(graph: STRAWBERRY) {
   count: Int
   percent: Float
 }
@@ -6403,10 +7556,10 @@ input IntOrPercentInput
 """
 Added in 26.2.0. Payload returned after issuing a new keypair. The secret_key is only shown once.
 """
-type IssueMyKeypairPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The newly created keypair."""
+type IssueMyKeypairPayload @join__type(graph: STRAWBERRY) {
+  """
+  The newly created keypair.
+  """
   keypair: KeyPairGQL!
 
   """
@@ -6415,9 +7568,7 @@ type IssueMyKeypairPayload
   secretKey: String!
 }
 
-interface Item
-  @join__type(graph: GRAPHENE)
-{
+interface Item @join__type(graph: GRAPHENE) {
   id: ID
 }
 
@@ -6426,8 +7577,16 @@ scalar join__DirectiveArguments
 scalar join__FieldSet
 
 enum join__Graph {
-  GRAPHENE @join__graph(name: "graphene", url: "http://host.docker.internal:8091/admin/gql")
-  STRAWBERRY @join__graph(name: "strawberry", url: "http://host.docker.internal:8091/admin/gql/strawberry")
+  GRAPHENE
+    @join__graph(
+      name: "graphene"
+      url: "http://host.docker.internal:8091/admin/gql"
+    )
+  STRAWBERRY
+    @join__graph(
+      name: "strawberry"
+      url: "http://host.docker.internal:8091/admin/gql/strawberry"
+    )
 }
 
 """
@@ -6435,7 +7594,9 @@ The `JSON` scalar type represents JSON values as specified by [ECMA-404](https:/
 """
 scalar JSON
   @join__type(graph: STRAWBERRY)
-  @specifiedBy(url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf")
+  @specifiedBy(
+    url: "https://ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf"
+  )
 
 """
 Allows use of a JSON String for input / output from the GraphQL schema.
@@ -6443,43 +7604,57 @@ Allows use of a JSON String for input / output from the GraphQL schema.
 Use of this type is *not recommended* as you lose the benefits of having a defined, static
 schema (one of the key benefits of GraphQL).
 """
-scalar JSONString
-  @join__type(graph: GRAPHENE)
+scalar JSONString @join__type(graph: GRAPHENE)
 
-"""Added in 24.09.0."""
-type KernelConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 24.09.0.
+"""
+type KernelConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [KernelEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
-"""Added in 24.09.0. A Relay edge containing a `Kernel` and its cursor."""
-type KernelEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+"""
+Added in 24.09.0. A Relay edge containing a `Kernel` and its cursor.
+"""
+type KernelEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: KernelNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
-"""Added in 24.09.0."""
+"""
+Added in 24.09.0.
+"""
 type KernelNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
-  @join__type(graph: GRAPHENE)
-{
-  """The ID of the object"""
+  @join__type(graph: GRAPHENE) {
+  """
+  The ID of the object
+  """
   id: ID!
 
-  """ID of kernel."""
+  """
+  ID of kernel.
+  """
   row_id: UUID
   cluster_idx: Int
   local_rank: Int
@@ -6488,7 +7663,9 @@ type KernelNode implements Node
   session_id: UUID
   image: ImageNode
 
-  """Added in 25.4.0."""
+  """
+  Added in 25.4.0.
+  """
   image_reference: String
 
   """
@@ -6519,38 +7696,47 @@ Represents one row from the resource_allocations table.
 """
 type KernelResourceAllocation implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Resource slot identifier (e.g., 'cpu', 'mem', 'cuda.device')."""
+  """
+  Resource slot identifier (e.g., 'cpu', 'mem', 'cuda.device').
+  """
   slotName: String!
 
-  """Amount of this resource slot originally requested for the kernel."""
+  """
+  Amount of this resource slot originally requested for the kernel.
+  """
   requested: Decimal!
 
-  """Amount currently used. May be null if not yet measured."""
+  """
+  Amount currently used. May be null if not yet measured.
+  """
   used: Decimal
 }
 
-"""An edge in a connection."""
-type KernelResourceAllocationEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type KernelResourceAllocationEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: KernelResourceAllocation!
 }
 
 """
 Added in 26.3.0. Filter criteria for querying kernel resource allocations.
 """
-input KernelResourceAllocationFilter
-  @join__type(graph: STRAWBERRY)
-{
+input KernelResourceAllocationFilter @join__type(graph: STRAWBERRY) {
   slotName: StringFilter = null
   AND: [KernelResourceAllocationFilter!] = null
   OR: [KernelResourceAllocationFilter!] = null
@@ -6560,9 +7746,7 @@ input KernelResourceAllocationFilter
 """
 Added in 26.3.0. Ordering specification for kernel resource allocations.
 """
-input KernelResourceAllocationOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input KernelResourceAllocationOrderBy @join__type(graph: STRAWBERRY) {
   field: KernelResourceAllocationOrderField!
   direction: OrderDirection! = ASC
 }
@@ -6570,9 +7754,7 @@ input KernelResourceAllocationOrderBy
 """
 Added in 26.3.0. Fields available for ordering kernel resource allocations.
 """
-enum KernelResourceAllocationOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum KernelResourceAllocationOrderField @join__type(graph: STRAWBERRY) {
   SLOT_NAME @join__enumValue(graph: STRAWBERRY)
   REQUESTED @join__enumValue(graph: STRAWBERRY)
   USED @join__enumValue(graph: STRAWBERRY)
@@ -6583,100 +7765,152 @@ Added in 26.2.0. Represents a kernel (compute container) in Backend.AI.
 """
 type KernelV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Startup command executed when the kernel starts."""
+  """
+  Startup command executed when the kernel starts.
+  """
   startupCommand: String
 
-  """Information about the session this kernel belongs to."""
+  """
+  Information about the session this kernel belongs to.
+  """
   sessionInfo: KernelV2SessionInfo!
 
-  """User and ownership information."""
+  """
+  User and ownership information.
+  """
   userInfo: KernelV2UserInfo!
 
-  """Network configuration and exposed ports."""
+  """
+  Network configuration and exposed ports.
+  """
   network: KernelV2NetworkInfo!
 
-  """Cluster configuration for distributed computing."""
+  """
+  Cluster configuration for distributed computing.
+  """
   cluster: KernelV2ClusterInfo!
 
-  """Resource allocation and agent information."""
+  """
+  Resource allocation and agent information.
+  """
   resource: KernelV2ResourceInfo!
 
-  """Lifecycle status and timestamps."""
+  """
+  Lifecycle status and timestamps.
+  """
   lifecycle: KernelV2LifecycleInfo!
 
-  """Added in 26.2.0. The agent running this kernel."""
+  """
+  Added in 26.2.0. The agent running this kernel.
+  """
   agent: AgentV2
 
-  """Added in 26.2.0. The user who owns this kernel."""
+  """
+  Added in 26.2.0. The user who owns this kernel.
+  """
   user: UserV2
 
-  """Added in 26.2.0. The project this kernel belongs to."""
+  """
+  Added in 26.2.0. The project this kernel belongs to.
+  """
   project: ProjectV2
 
-  """Added in 26.2.0. The domain this kernel belongs to."""
+  """
+  Added in 26.2.0. The domain this kernel belongs to.
+  """
   domain: DomainV2
 
-  """Added in 26.2.0. The resource group this kernel is assigned to."""
+  """
+  Added in 26.2.0. The resource group this kernel is assigned to.
+  """
   resourceGroup: ResourceGroup
 
-  """Added in 26.3.0. The session this kernel belongs to."""
+  """
+  Added in 26.3.0. The session this kernel belongs to.
+  """
   session: SessionV2
 
-  """Added in 26.3.0. Per-slot resource allocation for this kernel."""
-  resourceAllocations(filter: KernelResourceAllocationFilter = null, orderBy: [KernelResourceAllocationOrderBy!] = null, first: Int = null, after: String = null, last: Int = null, before: String = null, limit: Int = null, offset: Int = null): ResourceAllocationConnection!
+  """
+  Added in 26.3.0. Per-slot resource allocation for this kernel.
+  """
+  resourceAllocations(
+    filter: KernelResourceAllocationFilter = null
+    orderBy: [KernelResourceAllocationOrderBy!] = null
+    first: Int = null
+    after: String = null
+    last: Int = null
+    before: String = null
+    limit: Int = null
+    offset: Int = null
+  ): ResourceAllocationConnection!
 }
 
 """
 Added in 26.2.0. Cluster configuration for a kernel in distributed sessions.
 """
-type KernelV2ClusterInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """The role of this kernel in the cluster (e.g., main, sub)."""
+type KernelV2ClusterInfo @join__type(graph: STRAWBERRY) {
+  """
+  The role of this kernel in the cluster (e.g., main, sub).
+  """
   clusterRole: String!
 
-  """The index of this kernel within the cluster (0-based)."""
+  """
+  The index of this kernel within the cluster (0-based).
+  """
   clusterIdx: Int!
 
-  """The local rank of this kernel for distributed computing."""
+  """
+  The local rank of this kernel for distributed computing.
+  """
   localRank: Int!
 
-  """The hostname assigned to this kernel within the cluster network."""
+  """
+  The hostname assigned to this kernel within the cluster network.
+  """
   clusterHostname: String!
 }
 
-"""Added in 26.2.0. Connection type for paginated kernel results."""
-type KernelV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.2.0. Connection type for paginated kernel results.
+"""
+type KernelV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [KernelV2Edge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type KernelV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type KernelV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: KernelV2!
 }
 
-"""Added in 26.2.0. Filter criteria for querying kernels."""
-input KernelV2Filter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Filter criteria for querying kernels.
+"""
+input KernelV2Filter @join__type(graph: STRAWBERRY) {
   id: UUIDFilter = null
   status: KernelV2StatusFilter = null
   sessionId: UUIDFilter = null
@@ -6685,51 +7919,63 @@ input KernelV2Filter
   NOT: [KernelV2Filter!] = null
 }
 
-"""Added in 26.2.0. Lifecycle and status information for a kernel."""
-type KernelV2LifecycleInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Current status of the kernel."""
+"""
+Added in 26.2.0. Lifecycle and status information for a kernel.
+"""
+type KernelV2LifecycleInfo @join__type(graph: STRAWBERRY) {
+  """
+  Current status of the kernel.
+  """
   status: KernelV2Status!
 
-  """The result of the kernel execution."""
+  """
+  The result of the kernel execution.
+  """
   result: SessionV2Result!
 
-  """Timestamp when the kernel was created."""
+  """
+  Timestamp when the kernel was created.
+  """
   createdAt: DateTime
 
-  """Timestamp when the kernel was terminated."""
+  """
+  Timestamp when the kernel was terminated.
+  """
   terminatedAt: DateTime
 
-  """Scheduled start time for the kernel, if applicable."""
+  """
+  Scheduled start time for the kernel, if applicable.
+  """
   startsAt: DateTime
 }
 
-"""Added in 26.2.0. Network configuration for a kernel."""
-type KernelV2NetworkInfo
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Network configuration for a kernel.
+"""
+type KernelV2NetworkInfo @join__type(graph: STRAWBERRY) {
   """
   Collection of service ports exposed by this kernel. Typed as Any because this field holds a nested GQL type (ServicePortsGQL).
   """
   servicePorts: ServicePorts
 
-  """List of ports that are pre-opened for this kernel."""
+  """
+  List of ports that are pre-opened for this kernel.
+  """
   preopenPorts: [Int!]
 }
 
-"""Added in 26.2.0. Ordering specification for kernels."""
-input KernelV2OrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Ordering specification for kernels.
+"""
+input KernelV2OrderBy @join__type(graph: STRAWBERRY) {
   field: KernelV2OrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in 26.2.0. Fields available for ordering kernels."""
-enum KernelV2OrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Fields available for ordering kernels.
+"""
+enum KernelV2OrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   TERMINATED_AT @join__enumValue(graph: STRAWBERRY)
   STATUS @join__enumValue(graph: STRAWBERRY)
@@ -6738,19 +7984,23 @@ enum KernelV2OrderField
   CLUSTER_IDX @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.2.0. Resource allocation information for a kernel."""
-type KernelV2ResourceInfo
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Resource allocation information for a kernel.
+"""
+type KernelV2ResourceInfo @join__type(graph: STRAWBERRY) {
   """
   The ID of the agent running this kernel. Null if not yet assigned or hidden.
   """
   agentId: String
 
-  """The resource group (scaling group) this kernel is assigned to."""
+  """
+  The resource group (scaling group) this kernel is assigned to.
+  """
   resourceGroupName: String
 
-  """The container ID on the agent."""
+  """
+  The container ID on the agent.
+  """
   containerId: String
 
   """
@@ -6769,27 +8019,35 @@ type KernelV2ResourceInfo
   resourceOpts: ResourceOpts
 }
 
-"""Added in 26.2.0. Information about the session this kernel belongs to."""
-type KernelV2SessionInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """The unique identifier of the session this kernel belongs to."""
+"""
+Added in 26.2.0. Information about the session this kernel belongs to.
+"""
+type KernelV2SessionInfo @join__type(graph: STRAWBERRY) {
+  """
+  The unique identifier of the session this kernel belongs to.
+  """
   sessionId: UUID!
 
-  """The creation ID used when creating the session."""
+  """
+  The creation ID used when creating the session.
+  """
   creationId: String
 
-  """The name of the session."""
+  """
+  The name of the session.
+  """
   name: String
 
-  """The type of session (interactive, batch, inference, system)."""
+  """
+  The type of session (interactive, batch, inference, system).
+  """
   sessionType: SessionTypes!
 }
 
-"""Added in 26.2.0. Status of a kernel in its lifecycle."""
-enum KernelV2Status
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Status of a kernel in its lifecycle.
+"""
+enum KernelV2Status @join__type(graph: STRAWBERRY) {
   PENDING @join__enumValue(graph: STRAWBERRY)
   SCHEDULED @join__enumValue(graph: STRAWBERRY)
   PREPARING @join__enumValue(graph: STRAWBERRY)
@@ -6801,36 +8059,45 @@ enum KernelV2Status
   CANCELLED @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.2.0. Filter for kernel status."""
-input KernelV2StatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """The in  field."""
+"""
+Added in 26.2.0. Filter for kernel status.
+"""
+input KernelV2StatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  The in  field.
+  """
   in: [KernelV2Status!] = null
   notIn: [KernelV2Status!] = null
 }
 
-"""Added in 26.2.0. User and ownership information for a kernel."""
-type KernelV2UserInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """The UUID of the user who owns this kernel."""
+"""
+Added in 26.2.0. User and ownership information for a kernel.
+"""
+type KernelV2UserInfo @join__type(graph: STRAWBERRY) {
+  """
+  The UUID of the user who owns this kernel.
+  """
   userId: UUID
 
-  """The access key used to create this kernel."""
+  """
+  The access key used to create this kernel.
+  """
   accessKey: String
 
-  """The domain this kernel belongs to."""
+  """
+  The domain this kernel belongs to.
+  """
   domainName: String
 
-  """The group (project) ID this kernel belongs to."""
+  """
+  The group (project) ID this kernel belongs to.
+  """
   groupId: UUID
 }
 
 type KeyPair implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   user_id: String
   full_name: String
@@ -6844,7 +8111,9 @@ type KeyPair implements Item
   rate_limit: Int
   num_queries: Int
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   rolling_count: Int
   user: UUID
   projects: [String]
@@ -6853,31 +8122,36 @@ type KeyPair implements Item
   compute_sessions(status: String): [ComputeSession]
   concurrency_used: Int
   user_info: UserInfo
-  concurrency_limit: Int @deprecated(reason: "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field.")
+  concurrency_limit: Int
+    @deprecated(
+      reason: "Moved to KeyPairResourcePolicy object as the max_concurrent_sessions field."
+    )
 }
 
 """
 Added in UNRELEASED. Paginated connection for keypair records. Provides relay-style cursor-based pagination. Use 'edges' to access individual records with cursor information.
 """
-type KeyPairConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type KeyPairConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [KeyPairGQLEdge!]!
 
-  """Total number of keypair records matching the query criteria."""
+  """
+  Total number of keypair records matching the query criteria.
+  """
   count: Int!
 }
 
 """
 Added in UNRELEASED. Filter input for keypair queries. Supports filtering by active state, admin flag, and access key. Multiple filters can be combined using AND, OR, and NOT logical operators.
 """
-input KeypairFilter
-  @join__type(graph: STRAWBERRY)
-{
+input KeypairFilter @join__type(graph: STRAWBERRY) {
   isActive: Boolean = null
   isAdmin: Boolean = null
   accessKey: StringFilter = null
@@ -6894,59 +8168,84 @@ Added in UNRELEASED. Keypair entity representing an API access key. The access_k
 """
 type KeyPairGQL implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """The access key string."""
+  """
+  The access key string.
+  """
   accessKey: String!
 
-  """Whether the keypair is currently active."""
+  """
+  Whether the keypair is currently active.
+  """
   isActive: Boolean
 
-  """Whether the keypair has admin privileges."""
+  """
+  Whether the keypair has admin privileges.
+  """
   isAdmin: Boolean
 
-  """Timestamp when the keypair was created."""
+  """
+  Timestamp when the keypair was created.
+  """
   createdAt: DateTime
 
-  """Timestamp when the keypair was last modified."""
+  """
+  Timestamp when the keypair was last modified.
+  """
   modifiedAt: DateTime
 
-  """Timestamp when the keypair was last used for an API call."""
+  """
+  Timestamp when the keypair was last used for an API call.
+  """
   lastUsed: DateTime
 
-  """API rate limit (requests per minute)."""
+  """
+  API rate limit (requests per minute).
+  """
   rateLimit: Int!
 
-  """Total number of API queries made with this keypair."""
+  """
+  Total number of API queries made with this keypair.
+  """
   numQueries: Int!
 
-  """Name of the resource policy assigned to this keypair."""
+  """
+  Name of the resource policy assigned to this keypair.
+  """
   resourcePolicy: String!
 
-  """The SSH public key associated with this keypair."""
+  """
+  The SSH public key associated with this keypair.
+  """
   sshPublicKey: String
 
-  """UUID of the user who owns this keypair."""
+  """
+  UUID of the user who owns this keypair.
+  """
   userId: UUID!
 }
 
-"""An edge in a connection."""
-type KeyPairGQLEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type KeyPairGQLEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: KeyPairGQL!
 }
 
-input KeyPairInput
-  @join__type(graph: GRAPHENE)
-{
+input KeyPairInput @join__type(graph: GRAPHENE) {
   is_active: Boolean = true
   is_admin: Boolean = false
   resource_policy: String!
@@ -6956,8 +8255,7 @@ input KeyPairInput
 
 type KeyPairList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [KeyPair]!
   total_count: Int!
 }
@@ -6965,9 +8263,7 @@ type KeyPairList implements PaginatedList
 """
 Added in UNRELEASED. Specifies ordering for keypair query results. Default direction is DESC.
 """
-input KeypairOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input KeypairOrderBy @join__type(graph: STRAWBERRY) {
   field: KeypairOrderField! = CREATED_AT
   direction: OrderDirection! = DESC
 }
@@ -6975,9 +8271,7 @@ input KeypairOrderBy
 """
 Added in UNRELEASED. Fields available for ordering keypair query results. CREATED_AT: Order by creation timestamp. LAST_USED: Order by last used timestamp. ACCESS_KEY: Order by access key alphabetically. IS_ACTIVE: Order by active status.
 """
-enum KeypairOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum KeypairOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   LAST_USED @join__enumValue(graph: STRAWBERRY)
   ACCESS_KEY @join__enumValue(graph: STRAWBERRY)
@@ -6985,17 +8279,17 @@ enum KeypairOrderField
   RESOURCE_POLICY @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in UNRELEASED. Payload for keypair resource allocation query."""
-type KeypairResourceAllocationV2
-  @join__type(graph: STRAWBERRY)
-{
-  """Keypair resource usage."""
+"""
+Added in UNRELEASED. Payload for keypair resource allocation query.
+"""
+type KeypairResourceAllocationV2 @join__type(graph: STRAWBERRY) {
+  """
+  Keypair resource usage.
+  """
   keypair: ScopeResourceUsageV2!
 }
 
-type KeyPairResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type KeyPairResourcePolicy @join__type(graph: GRAPHENE) {
   name: String
   created_at: DateTime
   default_for_unspecified: String
@@ -7009,13 +8303,19 @@ type KeyPairResourcePolicy
   max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.4.")
   max_quota_scope_size: BigInt @deprecated(reason: "Deprecated since 23.09.6.")
 
-  """Added in 23.03.3."""
+  """
+  Added in 23.03.3.
+  """
   max_concurrent_sftp_sessions: Int
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4.
+  """
   max_pending_session_count: Int
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4.
+  """
   max_pending_session_resource_slots: JSONString
 }
 
@@ -7024,15 +8324,20 @@ Added in UNRELEASED. Keypair resource policy defining session and storage limits
 """
 type KeypairResourcePolicyV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Policy name."""
+  """
+  Policy name.
+  """
   name: String!
 
-  """Timestamp when the policy was created."""
+  """
+  Timestamp when the policy was created.
+  """
   createdAt: DateTime
 
   """
@@ -7040,65 +8345,91 @@ type KeypairResourcePolicyV2 implements Node
   """
   defaultForUnspecified: String!
 
-  """Total resource slot limits for sessions."""
+  """
+  Total resource slot limits for sessions.
+  """
   totalResourceSlots: [ResourceLimitEntry!]!
 
-  """Maximum session lifetime in seconds."""
+  """
+  Maximum session lifetime in seconds.
+  """
   maxSessionLifetime: Int!
 
-  """Maximum concurrent sessions allowed."""
+  """
+  Maximum concurrent sessions allowed.
+  """
   maxConcurrentSessions: Int!
 
-  """Maximum pending sessions. Null means unlimited."""
+  """
+  Maximum pending sessions. Null means unlimited.
+  """
   maxPendingSessionCount: Int
 
-  """Maximum resource slots for pending sessions. Null means unlimited."""
+  """
+  Maximum resource slots for pending sessions. Null means unlimited.
+  """
   maxPendingSessionResourceSlots: [ResourceLimitEntry!]
 
-  """Maximum concurrent SFTP sessions allowed."""
+  """
+  Maximum concurrent SFTP sessions allowed.
+  """
   maxConcurrentSftpSessions: Int!
 
-  """Maximum containers allowed per session."""
+  """
+  Maximum containers allowed per session.
+  """
   maxContainersPerSession: Int!
 
-  """Idle timeout for sessions in seconds."""
+  """
+  Idle timeout for sessions in seconds.
+  """
   idleTimeout: Int!
 
-  """Allowed vfolder host permissions."""
+  """
+  Allowed vfolder host permissions.
+  """
   allowedVfolderHosts: [VFolderHostPermissionEntry!]!
 }
 
 """
 Added in UNRELEASED. Paginated connection for keypair resource policies.
 """
-type KeypairResourcePolicyV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type KeypairResourcePolicyV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [KeypairResourcePolicyV2Edge!]!
 
-  """Total number of matching policies."""
+  """
+  Total number of matching policies.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type KeypairResourcePolicyV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type KeypairResourcePolicyV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: KeypairResourcePolicyV2!
 }
 
-"""Added in UNRELEASED. Filter for keypair resource policies."""
-input KeypairResourcePolicyV2Filter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Filter for keypair resource policies.
+"""
+input KeypairResourcePolicyV2Filter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   createdAt: DateTimeFilter = null
   maxSessionLifetime: IntFilter = null
@@ -7112,22 +8443,22 @@ input KeypairResourcePolicyV2Filter
 """
 Added in UNRELEASED. Ordering specification for keypair resource policies.
 """
-input KeypairResourcePolicyV2OrderBy
-  @join__type(graph: STRAWBERRY)
-{
-  """Field to order by."""
+input KeypairResourcePolicyV2OrderBy @join__type(graph: STRAWBERRY) {
+  """
+  Field to order by.
+  """
   field: KeypairResourcePolicyV2OrderField! = CREATED_AT
 
-  """Sort direction."""
+  """
+  Sort direction.
+  """
   direction: OrderDirection! = DESC
 }
 
 """
 Added in UNRELEASED. Fields available for ordering keypair resource policies.
 """
-enum KeypairResourcePolicyV2OrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum KeypairResourcePolicyV2OrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   MAX_SESSION_LIFETIME @join__enumValue(graph: STRAWBERRY)
@@ -7138,25 +8469,22 @@ enum KeypairResourcePolicyV2OrderField
   MAX_PENDING_SESSION_COUNT @join__enumValue(graph: STRAWBERRY)
 }
 
-type KVPair
-  @join__type(graph: GRAPHENE)
-{
+type KVPair @join__type(graph: GRAPHENE) {
   key: String
   value: String
 }
 
-input KVPairInput
-  @join__type(graph: GRAPHENE)
-{
+input KVPairInput @join__type(graph: GRAPHENE) {
   key: String
   value: String
 }
 
-"""Represents a main session."""
+"""
+Represents a main session.
+"""
 type LegacyComputeSession implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   tag: String
   sess_id: String
@@ -7210,8 +8538,7 @@ type LegacyComputeSession implements Item
 
 type LegacyComputeSessionList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [LegacyComputeSession]!
   total_count: Int!
 }
@@ -7233,19 +8560,17 @@ enum link__Purpose {
 """
 Added in 25.19.0. This enum represents the liveness status of a replica, indicating whether the deployment is currently running and able to serve requests.
 """
-enum LivenessStatus
-  @join__type(graph: STRAWBERRY)
-{
+enum LivenessStatus @join__type(graph: STRAWBERRY) {
   NOT_CHECKED @join__enumValue(graph: STRAWBERRY)
   HEALTHY @join__enumValue(graph: STRAWBERRY)
   UNHEALTHY @join__enumValue(graph: STRAWBERRY)
   DEGRADED @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in UNRELEASED. Result of a login attempt."""
-enum LoginAttemptResult
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Result of a login attempt.
+"""
+enum LoginAttemptResult @join__type(graph: STRAWBERRY) {
   SUCCESS @join__enumValue(graph: STRAWBERRY)
   FAILED_INVALID_CREDENTIALS @join__enumValue(graph: STRAWBERRY)
   FAILED_USER_INACTIVE @join__enumValue(graph: STRAWBERRY)
@@ -7255,10 +8580,10 @@ enum LoginAttemptResult
   FAILED_SESSION_ALREADY_EXISTS @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in UNRELEASED. Filter criteria for querying login history."""
-input LoginHistoryFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Filter criteria for querying login history.
+"""
+input LoginHistoryFilter @join__type(graph: STRAWBERRY) {
   domainName: StringFilter = null
   result: LoginHistoryResultFilter = null
   createdAt: DateTimeFilter = null
@@ -7267,30 +8592,32 @@ input LoginHistoryFilter
   NOT: [LoginHistoryFilter!] = null
 }
 
-"""Added in UNRELEASED. Ordering specification for login history."""
-input LoginHistoryOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Ordering specification for login history.
+"""
+input LoginHistoryOrderBy @join__type(graph: STRAWBERRY) {
   field: LoginHistoryOrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in UNRELEASED. Fields available for ordering login history."""
-enum LoginHistoryOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Fields available for ordering login history.
+"""
+enum LoginHistoryOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   RESULT @join__enumValue(graph: STRAWBERRY)
   DOMAIN_NAME @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in UNRELEASED. Filter for login attempt result field."""
-input LoginHistoryResultFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Filter for login attempt result field.
+"""
+input LoginHistoryResultFilter @join__type(graph: STRAWBERRY) {
   equals: LoginAttemptResult = null
 
-  """The in field."""
+  """
+  The in field.
+  """
   in: [LoginAttemptResult!] = null
   notIn: [LoginAttemptResult!] = null
 }
@@ -7300,58 +8627,77 @@ Added in UNRELEASED. Represents a login history entry tracking user authenticati
 """
 type LoginHistoryV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """UUID of the user who attempted to log in."""
+  """
+  UUID of the user who attempted to log in.
+  """
   userId: UUID!
 
-  """Domain name of the user at the time of the attempt."""
+  """
+  Domain name of the user at the time of the attempt.
+  """
   domainName: String!
 
-  """Result of the login attempt."""
+  """
+  Result of the login attempt.
+  """
   result: LoginAttemptResult!
 
-  """Detailed reason for the login failure."""
+  """
+  Detailed reason for the login failure.
+  """
   failReason: String
 
-  """Timestamp when the login attempt occurred."""
+  """
+  Timestamp when the login attempt occurred.
+  """
   createdAt: DateTime!
 }
 
 """
 Added in UNRELEASED. Connection type for paginated login history results.
 """
-type LoginHistoryV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type LoginHistoryV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [LoginHistoryV2Edge!]!
 
-  """Total number of login history entries matching the query."""
+  """
+  Total number of login history entries matching the query.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type LoginHistoryV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type LoginHistoryV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: LoginHistoryV2!
 }
 
-"""Added in UNRELEASED. Filter criteria for querying login sessions."""
-input LoginSessionFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Filter criteria for querying login sessions.
+"""
+input LoginSessionFilter @join__type(graph: STRAWBERRY) {
   status: LoginSessionStatusFilter = null
   accessKey: StringFilter = null
   createdAt: DateTimeFilter = null
@@ -7361,39 +8707,41 @@ input LoginSessionFilter
   NOT: [LoginSessionFilter!] = null
 }
 
-"""Added in UNRELEASED. Ordering specification for login sessions."""
-input LoginSessionOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Ordering specification for login sessions.
+"""
+input LoginSessionOrderBy @join__type(graph: STRAWBERRY) {
   field: LoginSessionOrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in UNRELEASED. Fields available for ordering login sessions."""
-enum LoginSessionOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Fields available for ordering login sessions.
+"""
+enum LoginSessionOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   STATUS @join__enumValue(graph: STRAWBERRY)
   LAST_ACCESSED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in UNRELEASED. Status of a login session."""
-enum LoginSessionStatus
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Status of a login session.
+"""
+enum LoginSessionStatus @join__type(graph: STRAWBERRY) {
   ACTIVE @join__enumValue(graph: STRAWBERRY)
   INVALIDATED @join__enumValue(graph: STRAWBERRY)
   REVOKED @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in UNRELEASED. Filter for login session status field."""
-input LoginSessionStatusFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Filter for login session status field.
+"""
+input LoginSessionStatusFilter @join__type(graph: STRAWBERRY) {
   equals: LoginSessionStatus = null
 
-  """The in field."""
+  """
+  The in field.
+  """
   in: [LoginSessionStatus!] = null
   notIn: [LoginSessionStatus!] = null
 }
@@ -7403,111 +8751,151 @@ Added in UNRELEASED. Represents a login session entry tracking user authenticati
 """
 type LoginSessionV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """UUID of the user who owns the session."""
+  """
+  UUID of the user who owns the session.
+  """
   userId: UUID!
 
-  """Access key associated with the session."""
+  """
+  Access key associated with the session.
+  """
   accessKey: String!
 
-  """Current status of the login session."""
+  """
+  Current status of the login session.
+  """
   status: LoginSessionStatus!
 
-  """Timestamp when the session was created."""
+  """
+  Timestamp when the session was created.
+  """
   createdAt: DateTime!
 
-  """Timestamp when the session was last accessed."""
+  """
+  Timestamp when the session was last accessed.
+  """
   lastAccessedAt: DateTime
 
-  """Timestamp when the session was invalidated."""
+  """
+  Timestamp when the session was invalidated.
+  """
   invalidatedAt: DateTime
 }
 
 """
 Added in UNRELEASED. Connection type for paginated login session results.
 """
-type LoginSessionV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type LoginSessionV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [LoginSessionV2Edge!]!
 
-  """Total number of login sessions matching the query."""
+  """
+  Total number of login sessions matching the query.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type LoginSessionV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type LoginSessionV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: LoginSessionV2!
 }
 
-"""Added in 26.3.0. Key-value label entry from Prometheus result."""
-type MetricLabelEntry
-  @join__type(graph: STRAWBERRY)
-{
-  """Label key"""
+"""
+Added in 26.3.0. Key-value label entry from Prometheus result.
+"""
+type MetricLabelEntry @join__type(graph: STRAWBERRY) {
+  """
+  Label key
+  """
   key: String!
 
-  """Label value"""
+  """
+  Label value
+  """
   value: String!
 }
 
-"""Added in 26.3.0. Key-value label entry for queries."""
-input MetricLabelEntryInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Label key."""
+"""
+Added in 26.3.0. Key-value label entry for queries.
+"""
+input MetricLabelEntryInput @join__type(graph: STRAWBERRY) {
+  """
+  Label key.
+  """
   key: String!
 
-  """Label value."""
+  """
+  Label value.
+  """
   value: String!
 }
 
-"""Added in 25.6.0. A pair of timestamp and value."""
-type MetricResultValue
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.6.0. A pair of timestamp and value.
+"""
+type MetricResultValue @join__type(graph: GRAPHENE) {
   timestamp: Float
   value: String
 }
 
 type ModelCard implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
-  @join__type(graph: GRAPHENE)
-{
-  """The ID of the object"""
+  @join__type(graph: GRAPHENE) {
+  """
+  The ID of the object
+  """
   id: ID!
   name: String
 
-  """Added in 24.03.8. ID of VFolder."""
+  """
+  Added in 24.03.8. ID of VFolder.
+  """
   row_id: UUID
   vfolder: VirtualFolder
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   vfolder_node: VirtualFolderNode
   author: String
 
-  """Human readable name of the model."""
+  """
+  Human readable name of the model.
+  """
   title: String
   version: String
 
-  """The time the model was created."""
+  """
+  The time the model was created.
+  """
   created_at: DateTime
 
-  """The last time the model was modified."""
+  """
+  The last time the model was modified.
+  """
   modified_at: DateTime
   description: String
   task: String
@@ -7524,32 +8912,44 @@ type ModelCard implements Node
   """
   readme_filetype: String
 
-  """Added in 24.03.8."""
+  """
+  Added in 24.03.8.
+  """
   error_msg: String
 }
 
-"""Added in 24.03.4"""
-type ModelCardConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 24.03.4
+"""
+type ModelCardConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [ModelCardEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
-"""Added in 24.03.4 A Relay edge containing a `ModelCard` and its cursor."""
-type ModelCardEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+"""
+Added in 24.03.4 A Relay edge containing a `ModelCard` and its cursor.
+"""
+type ModelCardEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: ModelCard
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
@@ -7558,15 +8958,20 @@ Added in UNRELEASED. Represents a registered AI model with metadata extracted fr
 """
 type ModelCardV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """The unique database identifier of this model card."""
+  """
+  The unique database identifier of this model card.
+  """
   rowId: UUID!
 
-  """Display name of the registered model."""
+  """
+  Display name of the registered model.
+  """
   name: String!
 
   """
@@ -7584,7 +8989,9 @@ type ModelCardV2 implements Node
   """
   projectId: UUID!
 
-  """The user who registered this model card."""
+  """
+  The user who registered this model card.
+  """
   creatorId: UUID!
 
   """
@@ -7597,56 +9004,72 @@ type ModelCardV2 implements Node
   """
   readme: String
 
-  """Timestamp when this model card was registered."""
+  """
+  Timestamp when this model card was registered.
+  """
   createdAt: DateTime!
 
-  """Timestamp of the last modification to this model card."""
+  """
+  Timestamp of the last modification to this model card.
+  """
   updatedAt: DateTime
 }
 
-"""Added in UNRELEASED. Paginated list of model cards."""
-type ModelCardV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in UNRELEASED. Paginated list of model cards.
+"""
+type ModelCardV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ModelCardV2Edge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type ModelCardV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ModelCardV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ModelCardV2!
 }
 
-"""Added in UNRELEASED. Filter for model cards."""
-input ModelCardV2Filter
-  @join__type(graph: STRAWBERRY)
-{
-  """Name filter."""
+"""
+Added in UNRELEASED. Filter for model cards.
+"""
+input ModelCardV2Filter @join__type(graph: STRAWBERRY) {
+  """
+  Name filter.
+  """
   name: StringFilter = null
 
-  """Domain filter."""
+  """
+  Domain filter.
+  """
   domainName: String = null
 
-  """Project filter."""
+  """
+  Project filter.
+  """
   projectId: UUID = null
 }
 
 """
 Added in UNRELEASED. Metadata extracted from the model-definition.yaml file in the model VFolder. Contains authorship, classification, and framework information used for discovery and compatibility checks.
 """
-type ModelCardV2Metadata
-  @join__type(graph: STRAWBERRY)
-{
+type ModelCardV2Metadata @join__type(graph: STRAWBERRY) {
   author: String
   title: String
   modelVersion: String
@@ -7659,21 +9082,25 @@ type ModelCardV2Metadata
   license: String
 }
 
-"""Added in UNRELEASED. Order specification."""
-input ModelCardV2OrderBy
-  @join__type(graph: STRAWBERRY)
-{
-  """Field to order by."""
+"""
+Added in UNRELEASED. Order specification.
+"""
+input ModelCardV2OrderBy @join__type(graph: STRAWBERRY) {
+  """
+  Field to order by.
+  """
   field: ModelCardV2OrderField!
 
-  """ASC or DESC."""
+  """
+  ASC or DESC.
+  """
   direction: String! = "ASC"
 }
 
-"""Added in UNRELEASED. Order fields for model cards."""
-enum ModelCardV2OrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Order fields for model cards.
+"""
+enum ModelCardV2OrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
 }
@@ -7681,58 +9108,70 @@ enum ModelCardV2OrderField
 """
 Added in UNRELEASED. Configuration for a single model in the model definition.
 """
-type ModelConfig
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the model."""
+type ModelConfig @join__type(graph: STRAWBERRY) {
+  """
+  Name of the model.
+  """
   name: String!
 
-  """Path to the model file."""
+  """
+  Path to the model file.
+  """
   modelPath: String!
 
-  """Configuration for the model service."""
+  """
+  Configuration for the model service.
+  """
   service: ModelServiceConfig
 
-  """Metadata about the model."""
+  """
+  Metadata about the model.
+  """
   metadata: ModelMetadata
 }
 
 """
 Added in 26.4.0. Configuration for a single model within a model definition.
 """
-input ModelConfigInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the model."""
+input ModelConfigInput @join__type(graph: STRAWBERRY) {
+  """
+  Name of the model.
+  """
   name: String!
 
-  """Path to the model file."""
+  """
+  Path to the model file.
+  """
   modelPath: String!
 
-  """Configuration for the model service."""
+  """
+  Configuration for the model service.
+  """
   service: ModelServiceConfigInput = null
 
-  """Metadata about the model."""
+  """
+  Metadata about the model.
+  """
   metadata: ModelMetadataInput = null
 }
 
 """
 Added in UNRELEASED. Model definition containing one or more model entries.
 """
-type ModelDefinition
-  @join__type(graph: STRAWBERRY)
-{
-  """List of models in the model definition."""
+type ModelDefinition @join__type(graph: STRAWBERRY) {
+  """
+  List of models in the model definition.
+  """
   models: [ModelConfig!]!
 }
 
 """
 Added in 26.4.0. Model definition containing a list of model configurations.
 """
-input ModelDefinitionInput
-  @join__type(graph: STRAWBERRY)
-{
-  """List of models in the model definition."""
+input ModelDefinitionInput @join__type(graph: STRAWBERRY) {
+  """
+  List of models in the model definition.
+  """
   models: [ModelConfigInput!]!
 }
 
@@ -7741,9 +9180,10 @@ Added in 25.19.0. Represents a model deployment in Backend.AI. A deployment is a
 """
 type ModelDeployment implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   metadata: ModelDeploymentMetadata!
   networkAccess: ModelDeploymentNetworkAccess!
@@ -7752,58 +9192,116 @@ type ModelDeployment implements Node
   replicaState: ReplicaState!
   createdUserId: ID!
 
-  """The created user of this entity."""
+  """
+  The created user of this entity.
+  """
   createdUser: UserNode!
 
-  """Added in 25.19.0. Deployment policy configuration."""
+  """
+  Added in 25.19.0. Deployment policy configuration.
+  """
   deploymentPolicy: DeploymentPolicy
 
-  """The revision history of this entity."""
-  revisionHistory(filter: ModelRevisionFilter = null, orderBy: [ModelRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelRevisionConnection!
+  """
+  The revision history of this entity.
+  """
+  revisionHistory(
+    filter: ModelRevisionFilter = null
+    orderBy: [ModelRevisionOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ModelRevisionConnection!
 
-  """The replicas of this entity."""
-  replicas(filter: ReplicaFilter = null, orderBy: [ReplicaOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelReplicaConnection!
+  """
+  The replicas of this entity.
+  """
+  replicas(
+    filter: ReplicaFilter = null
+    orderBy: [ReplicaOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ModelReplicaConnection!
 
-  """The auto scaling rules of this entity."""
-  autoScalingRules(filter: AutoScalingRuleFilter = null, orderBy: [AutoScalingRuleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AutoScalingRuleConnection!
+  """
+  The auto scaling rules of this entity.
+  """
+  autoScalingRules(
+    filter: AutoScalingRuleFilter = null
+    orderBy: [AutoScalingRuleOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): AutoScalingRuleConnection!
 
-  """The access tokens of this entity."""
-  accessTokens(filter: AccessTokenFilter = null, orderBy: [AccessTokenOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AccessTokenConnection!
+  """
+  The access tokens of this entity.
+  """
+  accessTokens(
+    filter: AccessTokenFilter = null
+    orderBy: [AccessTokenOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): AccessTokenConnection!
 }
 
-"""Added in 25.19.0. Connection for model deployments."""
-type ModelDeploymentConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 25.19.0. Connection for model deployments.
+"""
+type ModelDeploymentConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ModelDeploymentEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type ModelDeploymentEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ModelDeploymentEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ModelDeployment!
 }
 
 """
 Added in 25.19.0. Contains metadata information for a model deployment including its name, status, tags, and timestamps. Also provides access to the associated project and domain.
 """
-type ModelDeploymentMetadata
-  @join__type(graph: STRAWBERRY)
-{
-  """The project of this entity."""
+type ModelDeploymentMetadata @join__type(graph: STRAWBERRY) {
+  """
+  The project of this entity.
+  """
   project: GroupNode!
 
-  """The domain of this entity."""
+  """
+  The domain of this entity.
+  """
   domain: DomainNode!
   projectId: ID!
   domainName: String!
@@ -7814,10 +9312,10 @@ type ModelDeploymentMetadata
   updatedAt: DateTime!
 }
 
-"""Added in 25.19.0. """
-input ModelDeploymentMetadataInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ModelDeploymentMetadataInput @join__type(graph: STRAWBERRY) {
   projectId: ID!
   domainName: String!
   name: String = null
@@ -7827,175 +9325,247 @@ input ModelDeploymentMetadataInput
 """
 Added in 25.19.0. Provides network access configuration for a model deployment, including the endpoint URL, preferred domain name, and public access settings. Also manages access tokens for authentication.
 """
-type ModelDeploymentNetworkAccess
-  @join__type(graph: STRAWBERRY)
-{
+type ModelDeploymentNetworkAccess @join__type(graph: STRAWBERRY) {
   endpointUrl: String
   preferredDomainName: String
   openToPublic: Boolean!
 }
 
-"""Added in 25.19.0. """
-input ModelDeploymentNetworkAccessInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ModelDeploymentNetworkAccessInput @join__type(graph: STRAWBERRY) {
   preferredDomainName: String = null
   openToPublic: Boolean! = false
 }
 
-"""Added in UNRELEASED. Health check configuration for a model service."""
-type ModelHealthCheck
-  @join__type(graph: STRAWBERRY)
-{
-  """Interval in seconds between health checks."""
+"""
+Added in UNRELEASED. Health check configuration for a model service.
+"""
+type ModelHealthCheck @join__type(graph: STRAWBERRY) {
+  """
+  Interval in seconds between health checks.
+  """
   interval: Float!
 
-  """Path to check for health status."""
+  """
+  Path to check for health status.
+  """
   path: String!
 
-  """Maximum number of retries for health check."""
+  """
+  Maximum number of retries for health check.
+  """
   maxRetries: Int!
 
-  """Maximum time in seconds to wait for a health check response."""
+  """
+  Maximum time in seconds to wait for a health check response.
+  """
   maxWaitTime: Float!
 
-  """Expected HTTP status code for a healthy response."""
+  """
+  Expected HTTP status code for a healthy response.
+  """
   expectedStatusCode: Int!
 
-  """Initial delay in seconds before the first health check."""
+  """
+  Initial delay in seconds before the first health check.
+  """
   initialDelay: Float!
 }
 
-"""Added in 26.4.0. Health check configuration for a model service."""
-input ModelHealthCheckInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Interval in seconds between health checks."""
+"""
+Added in 26.4.0. Health check configuration for a model service.
+"""
+input ModelHealthCheckInput @join__type(graph: STRAWBERRY) {
+  """
+  Interval in seconds between health checks.
+  """
   interval: Float! = 10
 
-  """Path to check for health status."""
+  """
+  Path to check for health status.
+  """
   path: String!
 
-  """Maximum number of retries for health check."""
+  """
+  Maximum number of retries for health check.
+  """
   maxRetries: Int! = 10
 
-  """Maximum time in seconds to wait for a health check response."""
+  """
+  Maximum time in seconds to wait for a health check response.
+  """
   maxWaitTime: Float! = 15
 
-  """Expected HTTP status code for a healthy response."""
+  """
+  Expected HTTP status code for a healthy response.
+  """
   expectedStatusCode: Int! = 200
 
-  """Initial delay in seconds before the first health check."""
+  """
+  Initial delay in seconds before the first health check.
+  """
   initialDelay: Float! = 60
 }
 
-"""Added in UNRELEASED. Metadata describing a model entry."""
-type ModelMetadata
-  @join__type(graph: STRAWBERRY)
-{
-  """Author of the model."""
+"""
+Added in UNRELEASED. Metadata describing a model entry.
+"""
+type ModelMetadata @join__type(graph: STRAWBERRY) {
+  """
+  Author of the model.
+  """
   author: String
 
-  """Title of the model."""
+  """
+  Title of the model.
+  """
   title: String
 
-  """Version identifier of the model."""
+  """
+  Version identifier of the model.
+  """
   version: JSON
 
-  """Creation date of the model."""
+  """
+  Creation date of the model.
+  """
   created: String
 
-  """Last modification date of the model."""
+  """
+  Last modification date of the model.
+  """
   lastModified: String
 
-  """Description of the model."""
+  """
+  Description of the model.
+  """
   description: String
 
-  """Task type of the model."""
+  """
+  Task type of the model.
+  """
   task: String
 
-  """Category of the model."""
+  """
+  Category of the model.
+  """
   category: String
 
-  """Architecture metadata for the model."""
+  """
+  Architecture metadata for the model.
+  """
   architecture: String
 
-  """Frameworks used by the model."""
+  """
+  Frameworks used by the model.
+  """
   framework: [String!]
 
-  """Labels attached to the model."""
+  """
+  Labels attached to the model.
+  """
   label: [String!]
 
-  """License of the model."""
+  """
+  License of the model.
+  """
   license: String
 
-  """Minimum resource requirements for the model."""
+  """
+  Minimum resource requirements for the model.
+  """
   minResource: JSON
 }
 
 """
 Added in 26.4.0. Metadata about a model such as author, title, and resource requirements.
 """
-input ModelMetadataInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Author of the model."""
+input ModelMetadataInput @join__type(graph: STRAWBERRY) {
+  """
+  Author of the model.
+  """
   author: String = null
 
-  """Title of the model."""
+  """
+  Title of the model.
+  """
   title: String = null
 
-  """Version of the model."""
+  """
+  Version of the model.
+  """
   version: String = null
 
-  """Creation date of the model."""
+  """
+  Creation date of the model.
+  """
   created: String = null
 
-  """Last modified date of the model."""
+  """
+  Last modified date of the model.
+  """
   lastModified: String = null
 
-  """Description of the model."""
+  """
+  Description of the model.
+  """
   description: String = null
 
-  """Task type of the model."""
+  """
+  Task type of the model.
+  """
   task: String = null
 
-  """Category of the model."""
+  """
+  Category of the model.
+  """
   category: String = null
 
-  """Architecture of the model."""
+  """
+  Architecture of the model.
+  """
   architecture: String = null
 
-  """Frameworks used by the model."""
+  """
+  Frameworks used by the model.
+  """
   framework: [String!] = null
 
-  """Labels for the model."""
+  """
+  Labels for the model.
+  """
   label: [String!] = null
 
-  """License of the model."""
+  """
+  License of the model.
+  """
   license: String = null
 
-  """Minimum resource requirements for the model."""
+  """
+  Minimum resource requirements for the model.
+  """
   minResource: JSON = null
 }
 
 """
 Added in 25.19.0. Configuration for mounting the model data into the inference container. Specifies the virtual folder, mount destination, and model definition path.
 """
-type ModelMountConfig
-  @join__type(graph: STRAWBERRY)
-{
-  """The vfolder of this entity."""
+type ModelMountConfig @join__type(graph: STRAWBERRY) {
+  """
+  The vfolder of this entity.
+  """
   vfolder: VirtualFolderNode!
   vfolderId: ID!
   mountDestination: String!
   definitionPath: String!
 }
 
-"""Added in 25.19.0. """
-input ModelMountConfigInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ModelMountConfigInput @join__type(graph: STRAWBERRY) {
   vfolderId: ID!
   mountDestination: String!
   definitionPath: String!
@@ -8006,26 +9576,37 @@ Added in 25.19.0. A single replica instance of a model deployment. Each replica 
 """
 type ModelReplica implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   sessionId: ID!
   revisionId: ID!
 
-  """Whether the replica has been checked and its health state."""
+  """
+  Whether the replica has been checked and its health state.
+  """
   readinessStatus: ReadinessStatus!
 
-  """Whether the replica is currently running and able to serve requests."""
+  """
+  Whether the replica is currently running and able to serve requests.
+  """
   livenessStatus: LivenessStatus!
 
-  """Whether the replica is currently active and able to serve requests."""
+  """
+  Whether the replica is currently active and able to serve requests.
+  """
   activenessStatus: ActivenessStatus!
 
-  """Traffic weight for load balancing between replicas."""
+  """
+  Traffic weight for load balancing between replicas.
+  """
   weight: Int!
 
-  """Timestamp when the replica was created."""
+  """
+  Timestamp when the replica was created.
+  """
   createdAt: DateTime!
 
   """
@@ -8033,32 +9614,40 @@ type ModelReplica implements Node
   """
   session: ComputeSessionNode!
 
-  """The revision of this entity."""
+  """
+  The revision of this entity.
+  """
   revision: ModelRevision!
 }
 
 """
 Added in 25.19.0. A Relay-style connection for paginated access to model replicas. Includes total count for UI pagination display.
 """
-type ModelReplicaConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ModelReplicaConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ModelReplicaEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type ModelReplicaEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ModelReplicaEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ModelReplica!
 }
 
@@ -8067,25 +9656,36 @@ Added in 25.19.0. Represents a versioned configuration snapshot of a model deplo
 """
 type ModelRevision implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   imageId: ID!
 
-  """The name identifier for this revision."""
+  """
+  The name identifier for this revision.
+  """
   name: String!
 
-  """Cluster configuration for replica distribution."""
+  """
+  Cluster configuration for replica distribution.
+  """
   clusterConfig: ClusterConfig!
 
-  """Compute resource allocation settings."""
+  """
+  Compute resource allocation settings.
+  """
   resourceConfig: ResourceConfig!
 
-  """Runtime configuration for the inference framework."""
+  """
+  Runtime configuration for the inference framework.
+  """
   modelRuntimeConfig: ModelRuntimeConfig!
 
-  """Model data mount configuration."""
+  """
+  Model data mount configuration.
+  """
   modelMountConfig: ModelMountConfig
 
   """
@@ -8093,43 +9693,57 @@ type ModelRevision implements Node
   """
   modelDefinition: ModelDefinition
 
-  """Additional volume folder mounts."""
+  """
+  Additional volume folder mounts.
+  """
   extraMounts: [ExtraVFolderMountInfoGQL!]!
 
-  """Timestamp when the revision was created."""
+  """
+  Timestamp when the revision was created.
+  """
   createdAt: DateTime!
 
-  """The image of this entity."""
+  """
+  The image of this entity.
+  """
   image: ImageNode!
 }
 
-"""Added in 25.19.0. Connection for model revisions."""
-type ModelRevisionConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 25.19.0. Connection for model revisions.
+"""
+type ModelRevisionConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ModelRevisionEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type ModelRevisionEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ModelRevisionEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ModelRevision!
 }
 
-"""Added in 25.19.0. """
-input ModelRevisionFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ModelRevisionFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   deploymentId: ID = null
   AND: [ModelRevisionFilter!] = null
@@ -8137,18 +9751,18 @@ input ModelRevisionFilter
   NOT: [ModelRevisionFilter!] = null
 }
 
-"""Added in 25.19.0. """
-input ModelRevisionOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ModelRevisionOrderBy @join__type(graph: STRAWBERRY) {
   field: ModelRevisionOrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in 25.19.0. Fields available for ordering model revisions."""
-enum ModelRevisionOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0. Fields available for ordering model revisions.
+"""
+enum ModelRevisionOrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
 }
@@ -8156,68 +9770,82 @@ enum ModelRevisionOrderField
 """
 Added in 25.19.0. Runtime configuration for the inference framework. Includes the runtime variant, framework-specific configuration, and environment variables.
 """
-type ModelRuntimeConfig
-  @join__type(graph: STRAWBERRY)
-{
+type ModelRuntimeConfig @join__type(graph: STRAWBERRY) {
   runtimeVariant: String!
   inferenceRuntimeConfig: JSON
   environ: EnvironmentVariables
 }
 
-"""Added in 25.19.0. """
-input ModelRuntimeConfigInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ModelRuntimeConfigInput @join__type(graph: STRAWBERRY) {
   runtimeVariant: String!
   inferenceRuntimeConfig: JSON = null
 
-  """Environment variables for the service."""
+  """
+  Environment variables for the service.
+  """
   environ: EnvironmentVariablesInput = null
 }
 
-"""Added in UNRELEASED. Service configuration for a model entry."""
-type ModelServiceConfig
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Service configuration for a model entry.
+"""
+type ModelServiceConfig @join__type(graph: STRAWBERRY) {
   """
   List of pre-start actions to execute before starting the model service.
   """
   preStartActions: [PreStartAction!]!
 
-  """Command to start the model service."""
+  """
+  Command to start the model service.
+  """
   startCommand: JSON!
 
-  """Shell to use if start_command is a string."""
+  """
+  Shell to use if start_command is a string.
+  """
   shell: String!
 
-  """Port number for the model service."""
+  """
+  Port number for the model service.
+  """
   port: Int!
 
-  """Health check configuration for the model service."""
+  """
+  Health check configuration for the model service.
+  """
   healthCheck: ModelHealthCheck
 }
 
 """
 Added in 26.4.0. Service configuration for a model, including startup command and health check.
 """
-input ModelServiceConfigInput
-  @join__type(graph: STRAWBERRY)
-{
+input ModelServiceConfigInput @join__type(graph: STRAWBERRY) {
   """
   List of pre-start actions to execute before starting the model service.
   """
   preStartActions: [PreStartActionInput!]!
 
-  """Command to start the model service."""
+  """
+  Command to start the model service.
+  """
   startCommand: JSON!
 
-  """Shell to use if start_command is a string."""
+  """
+  Shell to use if start_command is a string.
+  """
   shell: String! = "/bin/bash"
 
-  """Port number for the model service. Must be greater than 1."""
+  """
+  Port number for the model service. Must be greater than 1.
+  """
   port: Int!
 
-  """Health check configuration for the model service."""
+  """
+  Health check configuration for the model service.
+  """
   healthCheck: ModelHealthCheckInput = null
 }
 
@@ -8227,55 +9855,47 @@ Added in 24.09.0. Specifies a target model for scanning operations.
 Used to identify specific models in external registries for detailed scanning.
 If revision is not specified, defaults to 'main' revision.
 """
-input ModelTarget
-  @join__type(graph: STRAWBERRY)
-{
+input ModelTarget @join__type(graph: STRAWBERRY) {
   modelId: String!
   revision: String = null
 }
 
-type ModifyAgent
-  @join__type(graph: GRAPHENE)
-{
+type ModifyAgent @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-input ModifyAgentInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyAgentInput @join__type(graph: GRAPHENE) {
   schedulable: Boolean
   scaling_group: String
 }
 
-input ModifyComputeSessionInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyComputeSessionInput @join__type(graph: GRAPHENE) {
   id: GlobalIDField!
   name: String
   priority: Int
   clientMutationId: String
 }
 
-"""Added in 24.09.0."""
-type ModifyComputeSessionPayload
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.09.0.
+"""
+type ModifyComputeSessionPayload @join__type(graph: GRAPHENE) {
   item: ComputeSessionNode
   clientMutationId: String
 }
 
-"""Deprecated since 24.09.0. use `ModifyContainerRegistryNode` instead"""
-type ModifyContainerRegistry
-  @join__type(graph: GRAPHENE)
-{
+"""
+Deprecated since 24.09.0. use `ModifyContainerRegistryNode` instead
+"""
+type ModifyContainerRegistry @join__type(graph: GRAPHENE) {
   container_registry: ContainerRegistry
 }
 
-"""Deprecated since 24.09.0."""
-input ModifyContainerRegistryInput
-  @join__type(graph: GRAPHENE)
-{
+"""
+Deprecated since 24.09.0.
+"""
+input ModifyContainerRegistryInput @join__type(graph: GRAPHENE) {
   url: String
   type: String
   project: [String]
@@ -8283,70 +9903,88 @@ input ModifyContainerRegistryInput
   password: String
   ssl_verify: Boolean
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   is_global: Boolean
 }
 
-"""Added in 24.09.0."""
-type ModifyContainerRegistryNode
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.09.0.
+"""
+type ModifyContainerRegistryNode @join__type(graph: GRAPHENE) {
   container_registry: ContainerRegistryNode
 }
 
-"""Added in 25.3.0."""
-input ModifyContainerRegistryNodeInputV2
-  @join__type(graph: GRAPHENE)
-{
-  """Added in 25.3.0."""
+"""
+Added in 25.3.0.
+"""
+input ModifyContainerRegistryNodeInputV2 @join__type(graph: GRAPHENE) {
+  """
+  Added in 25.3.0.
+  """
   url: String
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   type: ContainerRegistryTypeField
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   registry_name: String
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   is_global: Boolean
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   project: String
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   username: String
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   password: String
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   ssl_verify: Boolean
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   extra: JSONString
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   allowed_groups: AllowedGroups
 }
 
-"""Added in 25.3.0."""
-type ModifyContainerRegistryNodeV2
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.3.0.
+"""
+type ModifyContainerRegistryNodeV2 @join__type(graph: GRAPHENE) {
   container_registry: ContainerRegistryNode
 }
 
-type ModifyDomain
-  @join__type(graph: GRAPHENE)
-{
+type ModifyDomain @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   domain: Domain
 }
 
-input ModifyDomainInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyDomainInput @join__type(graph: GRAPHENE) {
   name: String
   description: String
   is_active: Boolean
@@ -8356,18 +9994,18 @@ input ModifyDomainInput
   integration_id: String
 }
 
-"""Added in 24.12.0."""
-type ModifyDomainNode
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.12.0.
+"""
+type ModifyDomainNode @join__type(graph: GRAPHENE) {
   item: DomainNode
   client_mutation_id: String
 }
 
-"""Added in 24.12.0."""
-input ModifyDomainNodeInput
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.12.0.
+"""
+input ModifyDomainNodeInput @join__type(graph: GRAPHENE) {
   id: GlobalIDField!
   description: String
   is_active: Boolean
@@ -8381,20 +10019,20 @@ input ModifyDomainNodeInput
   client_mutation_id: String
 }
 
-type ModifyEndpoint
-  @join__type(graph: GRAPHENE)
-{
+type ModifyEndpoint @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 
-  """Added in 23.09.8."""
+  """
+  Added in 23.09.8.
+  """
   endpoint: Endpoint
 }
 
-"""Added in 25.1.0."""
-input ModifyEndpointAutoScalingRuleInput
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.1.0.
+"""
+input ModifyEndpointAutoScalingRuleInput @join__type(graph: GRAPHENE) {
   metric_source: AutoScalingMetricSource
   metric_name: String
   threshold: String
@@ -8405,26 +10043,27 @@ input ModifyEndpointAutoScalingRuleInput
   max_replicas: Int
 }
 
-"""Added in 25.1.0."""
-type ModifyEndpointAutoScalingRuleNode
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.1.0.
+"""
+type ModifyEndpointAutoScalingRuleNode @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   rule: EndpointAutoScalingRuleNode
 }
 
-input ModifyEndpointInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyEndpointInput @join__type(graph: GRAPHENE) {
   resource_slots: JSONString
   resource_opts: JSONString
   cluster_mode: String
   cluster_size: Int
 
-  """Added in 24.12.0. Replaces `desired_session_count`."""
+  """
+  Added in 24.12.0. Replaces `desired_session_count`.
+  """
   replicas: Int
-  desired_session_count: Int @deprecated(reason: "Deprecated since 24.12.0. Use `replicas` instead.")
+  desired_session_count: Int
+    @deprecated(reason: "Deprecated since 24.12.0. Use `replicas` instead.")
   image: ImageRefType
   name: String
   resource_group: String
@@ -8440,24 +10079,24 @@ input ModifyEndpointInput
   """
   extra_mounts: [ExtraMountInput]
 
-  """Added in 24.03.5."""
+  """
+  Added in 24.03.5.
+  """
   environ: JSONString
 
-  """Added in 24.03.5."""
+  """
+  Added in 24.03.5.
+  """
   runtime_variant: String
 }
 
-type ModifyGroup
-  @join__type(graph: GRAPHENE)
-{
+type ModifyGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   group: Group
 }
 
-input ModifyGroupInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyGroupInput @join__type(graph: GRAPHENE) {
   name: String
   description: String
   is_active: Boolean
@@ -8469,20 +10108,18 @@ input ModifyGroupInput
   integration_id: String
   resource_policy: String
 
-  """Added in 24.03.0"""
+  """
+  Added in 24.03.0
+  """
   container_registry: JSONString = "{}"
 }
 
-type ModifyImage
-  @join__type(graph: GRAPHENE)
-{
+type ModifyImage @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-input ModifyImageInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyImageInput @join__type(graph: GRAPHENE) {
   name: String
   registry: String
   image: String
@@ -8497,16 +10134,12 @@ input ModifyImageInput
   resource_limits: [ResourceLimitInput]
 }
 
-type ModifyKeyPair
-  @join__type(graph: GRAPHENE)
-{
+type ModifyKeyPair @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-input ModifyKeyPairInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyKeyPairInput @join__type(graph: GRAPHENE) {
   is_active: Boolean
   is_admin: Boolean
   resource_policy: String
@@ -8514,16 +10147,12 @@ input ModifyKeyPairInput
   rate_limit: Int
 }
 
-type ModifyKeyPairResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type ModifyKeyPairResourcePolicy @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-input ModifyKeyPairResourcePolicyInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyKeyPairResourcePolicyInput @join__type(graph: GRAPHENE) {
   default_for_unspecified: String
   total_resource_slots: JSONString
   max_session_lifetime: Int
@@ -8536,39 +10165,39 @@ input ModifyKeyPairResourcePolicyInput
   max_vfolder_size: BigInt @deprecated(reason: "Deprecated since 23.09.4.")
   max_quota_scope_size: BigInt @deprecated(reason: "Deprecated since 23.09.6.")
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4.
+  """
   max_pending_session_count: Int
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4.
+  """
   max_pending_session_resource_slots: JSONString
 }
 
-"""Added in 24.12.0."""
-type ModifyNetwork
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.12.0.
+"""
+type ModifyNetwork @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   network: NetworkNode
 }
 
-"""Added in 24.12.0."""
-input ModifyNetworkInput
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.12.0.
+"""
+input ModifyNetworkInput @join__type(graph: GRAPHENE) {
   name: String!
 }
 
-type ModifyProjectResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type ModifyProjectResourcePolicy @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-input ModifyProjectResourcePolicyInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyProjectResourcePolicyInput @join__type(graph: GRAPHENE) {
   """
   Added in 24.03.1 and 23.09.6. Limitation of the number of project vfolders.
   """
@@ -8586,56 +10215,70 @@ input ModifyProjectResourcePolicyInput
   max_network_count: Int
 }
 
-"""Added in 26.3.0. Input for modifying an existing query definition."""
-input ModifyQueryDefinitionInput
-  @join__type(graph: STRAWBERRY)
-{
-  """New name."""
+"""
+Added in 26.3.0. Input for modifying an existing query definition.
+"""
+input ModifyQueryDefinitionInput @join__type(graph: STRAWBERRY) {
+  """
+  New name.
+  """
   name: String
 
-  """New metric name."""
+  """
+  New metric name.
+  """
   metricName: String
 
-  """New PromQL template."""
+  """
+  New PromQL template.
+  """
   queryTemplate: String
 
-  """New default time window."""
+  """
+  New default time window.
+  """
   timeWindow: String
 
-  """New query definition options."""
+  """
+  New query definition options.
+  """
   options: ModifyQueryDefinitionOptionsInput
 }
 
-"""Added in 26.3.0. Options for modifying an existing query definition."""
-input ModifyQueryDefinitionOptionsInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Allowed filter label keys."""
+"""
+Added in 26.3.0. Options for modifying an existing query definition.
+"""
+input ModifyQueryDefinitionOptionsInput @join__type(graph: STRAWBERRY) {
+  """
+  Allowed filter label keys.
+  """
   filterLabels: [String!] = null
 
-  """Allowed group-by label keys."""
+  """
+  Allowed group-by label keys.
+  """
   groupLabels: [String!] = null
 }
 
-"""Added in 26.3.0. Payload returned after modifying a query definition."""
-type ModifyQueryDefinitionPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated query definition."""
+"""
+Added in 26.3.0. Payload returned after modifying a query definition.
+"""
+type ModifyQueryDefinitionPayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated query definition.
+  """
   preset: QueryDefinition!
 }
 
-type ModifyResourcePreset
-  @join__type(graph: GRAPHENE)
-{
+type ModifyResourcePreset @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-input ModifyResourcePresetInput
-  @join__type(graph: GRAPHENE)
-{
-  """Added in 25.4.0. A name of resource preset."""
+input ModifyResourcePresetInput @join__type(graph: GRAPHENE) {
+  """
+  Added in 25.4.0. A name of resource preset.
+  """
   name: String
   resource_slots: JSONString
   shared_memory: String
@@ -8646,16 +10289,12 @@ input ModifyResourcePresetInput
   scaling_group_name: String
 }
 
-type ModifyScalingGroup
-  @join__type(graph: GRAPHENE)
-{
+type ModifyScalingGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-input ModifyScalingGroupInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyScalingGroupInput @join__type(graph: GRAPHENE) {
   description: String
   is_active: Boolean
   is_public: Boolean
@@ -8672,15 +10311,15 @@ input ModifyScalingGroupInput
 Input data for modifying configuration.
 Added in 25.8.0.
 """
-input ModifyServiceConfigNodeInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyServiceConfigNodeInput @join__type(graph: GRAPHENE) {
   """
   Service name. See AvailableService.service_variants for possible values. Added in 25.8.0.
   """
   service: String!
 
-  """Service configuration data to mutate. Added in 25.8.0."""
+  """
+  Service configuration data to mutate. Added in 25.8.0.
+  """
   configuration: JSONString!
 }
 
@@ -8688,24 +10327,20 @@ input ModifyServiceConfigNodeInput
 Payload for the ModifyServiceConfigNode mutation.
 Added in 25.8.0.
 """
-type ModifyServiceConfigNodePayload
-  @join__type(graph: GRAPHENE)
-{
-  """ServiceConfiguration Node. Added in 25.8.0."""
+type ModifyServiceConfigNodePayload @join__type(graph: GRAPHENE) {
+  """
+  ServiceConfiguration Node. Added in 25.8.0.
+  """
   service_config: ServiceConfigNode!
 }
 
-type ModifyUser
-  @join__type(graph: GRAPHENE)
-{
+type ModifyUser @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   user: User
 }
 
-input ModifyUserInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyUserInput @join__type(graph: GRAPHENE) {
   username: String
   password: String
   need_password_change: Boolean
@@ -8738,16 +10373,12 @@ input ModifyUserInput
   container_gids: [Int]
 }
 
-type ModifyUserResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type ModifyUserResourcePolicy @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-input ModifyUserResourcePolicyInput
-  @join__type(graph: GRAPHENE)
-{
+input ModifyUserResourcePolicyInput @join__type(graph: GRAPHENE) {
   """
   Added in 24.03.1 and 23.09.6. Limitation of the number of user vfolders.
   """
@@ -8773,85 +10404,113 @@ input ModifyUserResourcePolicyInput
 All available GraphQL mutations.
 Type name changed from 'Mutations' to 'Mutation' in 25.13.0
 """
-type Mutation
-  @join__type(graph: GRAPHENE)
-  @join__type(graph: STRAWBERRY)
-{
-  modify_agent(id: String!, props: ModifyAgentInput!): ModifyAgent @join__field(graph: GRAPHENE)
-  create_domain(name: String!, props: DomainInput!): CreateDomain @join__field(graph: GRAPHENE)
-  modify_domain(name: String!, props: ModifyDomainInput!): ModifyDomain @join__field(graph: GRAPHENE)
+type Mutation @join__type(graph: GRAPHENE) @join__type(graph: STRAWBERRY) {
+  modify_agent(id: String!, props: ModifyAgentInput!): ModifyAgent
+    @join__field(graph: GRAPHENE)
+  create_domain(name: String!, props: DomainInput!): CreateDomain
+    @join__field(graph: GRAPHENE)
+  modify_domain(name: String!, props: ModifyDomainInput!): ModifyDomain
+    @join__field(graph: GRAPHENE)
 
-  """Instead of deleting the domain, just mark it as inactive."""
+  """
+  Instead of deleting the domain, just mark it as inactive.
+  """
   delete_domain(name: String!): DeleteDomain @join__field(graph: GRAPHENE)
 
   """
   Completely delete domain from DB.
-  
+
   Domain-bound kernels will also be all deleted.
   To purge domain, there should be no users and groups in the target domain.
   """
   purge_domain(name: String!): PurgeDomain @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
-  create_domain_node(input: CreateDomainNodeInput!): CreateDomainNode @join__field(graph: GRAPHENE)
+  """
+  Added in 24.12.0.
+  """
+  create_domain_node(input: CreateDomainNodeInput!): CreateDomainNode
+    @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
-  modify_domain_node(input: ModifyDomainNodeInput!): ModifyDomainNode @join__field(graph: GRAPHENE)
-  create_group(name: String!, props: GroupInput!): CreateGroup @join__field(graph: GRAPHENE)
-  modify_group(gid: UUID!, props: ModifyGroupInput!): ModifyGroup @join__field(graph: GRAPHENE)
+  """
+  Added in 24.12.0.
+  """
+  modify_domain_node(input: ModifyDomainNodeInput!): ModifyDomainNode
+    @join__field(graph: GRAPHENE)
+  create_group(name: String!, props: GroupInput!): CreateGroup
+    @join__field(graph: GRAPHENE)
+  modify_group(gid: UUID!, props: ModifyGroupInput!): ModifyGroup
+    @join__field(graph: GRAPHENE)
 
-  """Instead of deleting the group, just mark it as inactive."""
+  """
+  Instead of deleting the group, just mark it as inactive.
+  """
   delete_group(gid: UUID!): DeleteGroup @join__field(graph: GRAPHENE)
 
   """
   Completely deletes a group from DB.
-  
+
   Group's vfolders and their data will also be lost
   as well as the kernels run from the group.
   There is no migration of the ownership for group folders.
   """
   purge_group(gid: UUID!): PurgeGroup @join__field(graph: GRAPHENE)
-  create_user(email: String!, props: UserInput!): CreateUser @join__field(graph: GRAPHENE)
-  modify_user(email: String!, props: ModifyUserInput!): ModifyUser @join__field(graph: GRAPHENE)
+  create_user(email: String!, props: UserInput!): CreateUser
+    @join__field(graph: GRAPHENE)
+  modify_user(email: String!, props: ModifyUserInput!): ModifyUser
+    @join__field(graph: GRAPHENE)
 
   """
   Instead of really deleting user, just mark the account as deleted status.
-  
+
   All related keypairs will also be inactivated.
   """
   delete_user(email: String!): DeleteUser @join__field(graph: GRAPHENE)
 
   """
   Delete user as well as all user-related DB informations such as keypairs, kernels, etc.
-  
+
   If target user has virtual folders, they can be purged together or migrated to the superadmin.
-  
+
   vFolder treatment policy:
     User-type:
     - vfolder is not shared: delete
     - vfolder is shared:
       + if purge_shared_vfolder is True: delete
       + else: change vfolder's owner to requested admin
-  
+
   This action cannot be undone.
   """
-  purge_user(email: String!, props: PurgeUserInput!): PurgeUser @join__field(graph: GRAPHENE)
+  purge_user(email: String!, props: PurgeUserInput!): PurgeUser
+    @join__field(graph: GRAPHENE)
 
-  """Added in 25.4.0."""
+  """
+  Added in 25.4.0.
+  """
   rescan_gpu_alloc_maps(
-    """Agent ID to rescan GPU alloc map"""
+    """
+    Agent ID to rescan GPU alloc map
+    """
     agent_id: String!
   ): RescanGPUAllocMaps @join__field(graph: GRAPHENE)
-  create_keypair(props: KeyPairInput!, user_id: String!): CreateKeyPair @join__field(graph: GRAPHENE)
-  modify_keypair(access_key: String!, props: ModifyKeyPairInput!): ModifyKeyPair @join__field(graph: GRAPHENE)
-  delete_keypair(access_key: String!): DeleteKeyPair @join__field(graph: GRAPHENE)
+  create_keypair(props: KeyPairInput!, user_id: String!): CreateKeyPair
+    @join__field(graph: GRAPHENE)
+  modify_keypair(
+    access_key: String!
+    props: ModifyKeyPairInput!
+  ): ModifyKeyPair @join__field(graph: GRAPHENE)
+  delete_keypair(access_key: String!): DeleteKeyPair
+    @join__field(graph: GRAPHENE)
   rescan_images(
-    """Added in 25.1.0."""
+    """
+    Added in 25.1.0.
+    """
     project: String
     registry: String
   ): RescanImages @join__field(graph: GRAPHENE)
-  preload_image(references: [String]!, target_agents: [String]!): PreloadImage @join__field(graph: GRAPHENE)
-  unload_image(references: [String]!, target_agents: [String]!): UnloadImage @join__field(graph: GRAPHENE)
+  preload_image(references: [String]!, target_agents: [String]!): PreloadImage
+    @join__field(graph: GRAPHENE)
+  unload_image(references: [String]!, target_agents: [String]!): UnloadImage
+    @join__field(graph: GRAPHENE)
   modify_image(
     """
     Changed to nullable in 26.1. If not provided, defaults to the Manager's architecture.
@@ -8861,31 +10520,51 @@ type Mutation
     target: String!
   ): ModifyImage @join__field(graph: GRAPHENE)
 
-  """Added in 25.6.0"""
-  clear_image_custom_resource_limit(key: ClearImageCustomResourceLimitKey!): ClearImageCustomResourceLimitPayload @join__field(graph: GRAPHENE)
+  """
+  Added in 25.6.0
+  """
+  clear_image_custom_resource_limit(
+    key: ClearImageCustomResourceLimitKey!
+  ): ClearImageCustomResourceLimitPayload @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.0"""
-  forget_image_by_id(image_id: String!): ForgetImageById @join__field(graph: GRAPHENE)
+  """
+  Added in 24.03.0
+  """
+  forget_image_by_id(image_id: String!): ForgetImageById
+    @join__field(graph: GRAPHENE)
 
-  """Deprecated since 25.4.0. Use `forget_image_by_id` instead."""
+  """
+  Deprecated since 25.4.0. Use `forget_image_by_id` instead.
+  """
   forget_image(
     """
     Changed to nullable in 26.1. If not provided, defaults to the Manager's architecture.
     """
     architecture: String = null
     reference: String!
-  ): ForgetImage @join__field(graph: GRAPHENE) @deprecated(reason: "Deprecated since 25.4.0. Use `forget_image_by_id` instead.")
+  ): ForgetImage
+    @join__field(graph: GRAPHENE)
+    @deprecated(
+      reason: "Deprecated since 25.4.0. Use `forget_image_by_id` instead."
+    )
 
-  """Added in 25.4.0"""
+  """
+  Added in 25.4.0
+  """
   purge_image_by_id(
     image_id: String!
 
-    """Added in 25.10.0."""
-    options: PurgeImageOptions = {remove_from_registry: false}
+    """
+    Added in 25.10.0.
+    """
+    options: PurgeImageOptions = { remove_from_registry: false }
   ): PurgeImageById @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.1"""
-  untag_image_from_registry(image_id: String!): UntagImageFromRegistry @join__field(graph: GRAPHENE)
+  """
+  Added in 24.03.1
+  """
+  untag_image_from_registry(image_id: String!): UntagImageFromRegistry
+    @join__field(graph: GRAPHENE)
   alias_image(
     alias: String!
 
@@ -8898,88 +10577,209 @@ type Mutation
   dealias_image(alias: String!): DealiasImage @join__field(graph: GRAPHENE)
   clear_images(registry: String): ClearImages @join__field(graph: GRAPHENE)
 
-  """Added in 25.4.0"""
-  purge_images(keys: [PurgeImagesKey]!, options: PurgeImagesOptions = {force: false, noprune: false}): PurgeImagesPayload @join__field(graph: GRAPHENE)
+  """
+  Added in 25.4.0
+  """
+  purge_images(
+    keys: [PurgeImagesKey]!
+    options: PurgeImagesOptions = { force: false, noprune: false }
+  ): PurgeImagesPayload @join__field(graph: GRAPHENE)
 
-  """Added in 24.09.0."""
-  modify_compute_session(input: ModifyComputeSessionInput!): ModifyComputeSessionPayload @join__field(graph: GRAPHENE)
-  create_keypair_resource_policy(name: String!, props: CreateKeyPairResourcePolicyInput!): CreateKeyPairResourcePolicy @join__field(graph: GRAPHENE)
-  modify_keypair_resource_policy(name: String!, props: ModifyKeyPairResourcePolicyInput!): ModifyKeyPairResourcePolicy @join__field(graph: GRAPHENE)
-  delete_keypair_resource_policy(name: String!): DeleteKeyPairResourcePolicy @join__field(graph: GRAPHENE)
-  create_user_resource_policy(name: String!, props: CreateUserResourcePolicyInput!): CreateUserResourcePolicy @join__field(graph: GRAPHENE)
-  modify_user_resource_policy(name: String!, props: ModifyUserResourcePolicyInput!): ModifyUserResourcePolicy @join__field(graph: GRAPHENE)
-  delete_user_resource_policy(name: String!): DeleteUserResourcePolicy @join__field(graph: GRAPHENE)
-  create_project_resource_policy(name: String!, props: CreateProjectResourcePolicyInput!): CreateProjectResourcePolicy @join__field(graph: GRAPHENE)
-  modify_project_resource_policy(name: String!, props: ModifyProjectResourcePolicyInput!): ModifyProjectResourcePolicy @join__field(graph: GRAPHENE)
-  delete_project_resource_policy(name: String!): DeleteProjectResourcePolicy @join__field(graph: GRAPHENE)
-  create_resource_preset(name: String!, props: CreateResourcePresetInput!): CreateResourcePreset @join__field(graph: GRAPHENE)
+  """
+  Added in 24.09.0.
+  """
+  modify_compute_session(
+    input: ModifyComputeSessionInput!
+  ): ModifyComputeSessionPayload @join__field(graph: GRAPHENE)
+  create_keypair_resource_policy(
+    name: String!
+    props: CreateKeyPairResourcePolicyInput!
+  ): CreateKeyPairResourcePolicy @join__field(graph: GRAPHENE)
+  modify_keypair_resource_policy(
+    name: String!
+    props: ModifyKeyPairResourcePolicyInput!
+  ): ModifyKeyPairResourcePolicy @join__field(graph: GRAPHENE)
+  delete_keypair_resource_policy(name: String!): DeleteKeyPairResourcePolicy
+    @join__field(graph: GRAPHENE)
+  create_user_resource_policy(
+    name: String!
+    props: CreateUserResourcePolicyInput!
+  ): CreateUserResourcePolicy @join__field(graph: GRAPHENE)
+  modify_user_resource_policy(
+    name: String!
+    props: ModifyUserResourcePolicyInput!
+  ): ModifyUserResourcePolicy @join__field(graph: GRAPHENE)
+  delete_user_resource_policy(name: String!): DeleteUserResourcePolicy
+    @join__field(graph: GRAPHENE)
+  create_project_resource_policy(
+    name: String!
+    props: CreateProjectResourcePolicyInput!
+  ): CreateProjectResourcePolicy @join__field(graph: GRAPHENE)
+  modify_project_resource_policy(
+    name: String!
+    props: ModifyProjectResourcePolicyInput!
+  ): ModifyProjectResourcePolicy @join__field(graph: GRAPHENE)
+  delete_project_resource_policy(name: String!): DeleteProjectResourcePolicy
+    @join__field(graph: GRAPHENE)
+  create_resource_preset(
+    name: String!
+    props: CreateResourcePresetInput!
+  ): CreateResourcePreset @join__field(graph: GRAPHENE)
   modify_resource_preset(
-    """Added in 25.4.0. ID of the resource preset."""
+    """
+    Added in 25.4.0. ID of the resource preset.
+    """
     id: UUID = null
     name: String = null @deprecated(reason: "Deprecated since 25.4.0.")
     props: ModifyResourcePresetInput!
   ): ModifyResourcePreset @join__field(graph: GRAPHENE)
   delete_resource_preset(
-    """Added in 25.4.0. ID of the resource preset."""
+    """
+    Added in 25.4.0. ID of the resource preset.
+    """
     id: UUID = null
     name: String = null @deprecated(reason: "Deprecated since 25.4.0.")
   ): DeleteResourcePreset @join__field(graph: GRAPHENE)
 
-  """Updates configuration for a given service. Added in 25.8.0."""
+  """
+  Updates configuration for a given service. Added in 25.8.0.
+  """
   modify_service_config(
-    """Added in 25.8.0."""
+    """
+    Added in 25.8.0.
+    """
     input: ModifyServiceConfigNodeInput!
   ): ModifyServiceConfigNodePayload @join__field(graph: GRAPHENE)
-  create_scaling_group(name: String!, props: CreateScalingGroupInput!): CreateScalingGroup @join__field(graph: GRAPHENE)
-  modify_scaling_group(name: String!, props: ModifyScalingGroupInput!): ModifyScalingGroup @join__field(graph: GRAPHENE)
-  delete_scaling_group(name: String!): DeleteScalingGroup @join__field(graph: GRAPHENE)
-  associate_scaling_group_with_domain(domain: String!, scaling_group: String!): AssociateScalingGroupWithDomain @join__field(graph: GRAPHENE)
+  create_scaling_group(
+    name: String!
+    props: CreateScalingGroupInput!
+  ): CreateScalingGroup @join__field(graph: GRAPHENE)
+  modify_scaling_group(
+    name: String!
+    props: ModifyScalingGroupInput!
+  ): ModifyScalingGroup @join__field(graph: GRAPHENE)
+  delete_scaling_group(name: String!): DeleteScalingGroup
+    @join__field(graph: GRAPHENE)
+  associate_scaling_group_with_domain(
+    domain: String!
+    scaling_group: String!
+  ): AssociateScalingGroupWithDomain @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.9"""
-  associate_scaling_groups_with_domain(domain: String!, scaling_groups: [String]!): AssociateScalingGroupsWithDomain @join__field(graph: GRAPHENE)
-  associate_scaling_group_with_user_group(scaling_group: String!, user_group: UUID!): AssociateScalingGroupWithUserGroup @join__field(graph: GRAPHENE)
+  """
+  Added in 24.03.9
+  """
+  associate_scaling_groups_with_domain(
+    domain: String!
+    scaling_groups: [String]!
+  ): AssociateScalingGroupsWithDomain @join__field(graph: GRAPHENE)
+  associate_scaling_group_with_user_group(
+    scaling_group: String!
+    user_group: UUID!
+  ): AssociateScalingGroupWithUserGroup @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.9"""
-  associate_scaling_groups_with_user_group(scaling_groups: [String]!, user_group: UUID!): AssociateScalingGroupsWithUserGroup @join__field(graph: GRAPHENE)
-  associate_scaling_group_with_keypair(access_key: String!, scaling_group: String!): AssociateScalingGroupWithKeyPair @join__field(graph: GRAPHENE)
+  """
+  Added in 24.03.9
+  """
+  associate_scaling_groups_with_user_group(
+    scaling_groups: [String]!
+    user_group: UUID!
+  ): AssociateScalingGroupsWithUserGroup @join__field(graph: GRAPHENE)
+  associate_scaling_group_with_keypair(
+    access_key: String!
+    scaling_group: String!
+  ): AssociateScalingGroupWithKeyPair @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.9"""
-  associate_scaling_groups_with_keypair(access_key: String!, scaling_groups: [String]!): AssociateScalingGroupsWithKeyPair @join__field(graph: GRAPHENE)
-  disassociate_scaling_group_with_domain(domain: String!, scaling_group: String!): DisassociateScalingGroupWithDomain @join__field(graph: GRAPHENE)
+  """
+  Added in 24.03.9
+  """
+  associate_scaling_groups_with_keypair(
+    access_key: String!
+    scaling_groups: [String]!
+  ): AssociateScalingGroupsWithKeyPair @join__field(graph: GRAPHENE)
+  disassociate_scaling_group_with_domain(
+    domain: String!
+    scaling_group: String!
+  ): DisassociateScalingGroupWithDomain @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.9"""
-  disassociate_scaling_groups_with_domain(domain: String!, scaling_groups: [String]!): DisassociateScalingGroupsWithDomain @join__field(graph: GRAPHENE)
-  disassociate_scaling_group_with_user_group(scaling_group: String!, user_group: UUID!): DisassociateScalingGroupWithUserGroup @join__field(graph: GRAPHENE)
+  """
+  Added in 24.03.9
+  """
+  disassociate_scaling_groups_with_domain(
+    domain: String!
+    scaling_groups: [String]!
+  ): DisassociateScalingGroupsWithDomain @join__field(graph: GRAPHENE)
+  disassociate_scaling_group_with_user_group(
+    scaling_group: String!
+    user_group: UUID!
+  ): DisassociateScalingGroupWithUserGroup @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.9"""
-  disassociate_scaling_groups_with_user_group(scaling_groups: [String]!, user_group: UUID!): DisassociateScalingGroupsWithUserGroup @join__field(graph: GRAPHENE)
-  disassociate_scaling_group_with_keypair(access_key: String!, scaling_group: String!): DisassociateScalingGroupWithKeyPair @join__field(graph: GRAPHENE)
+  """
+  Added in 24.03.9
+  """
+  disassociate_scaling_groups_with_user_group(
+    scaling_groups: [String]!
+    user_group: UUID!
+  ): DisassociateScalingGroupsWithUserGroup @join__field(graph: GRAPHENE)
+  disassociate_scaling_group_with_keypair(
+    access_key: String!
+    scaling_group: String!
+  ): DisassociateScalingGroupWithKeyPair @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.9"""
-  disassociate_scaling_groups_with_keypair(access_key: String!, scaling_groups: [String]!): DisassociateScalingGroupsWithKeyPair @join__field(graph: GRAPHENE)
-  disassociate_all_scaling_groups_with_domain(domain: String!): DisassociateAllScalingGroupsWithDomain @join__field(graph: GRAPHENE)
-  disassociate_all_scaling_groups_with_group(user_group: UUID!): DisassociateAllScalingGroupsWithGroup @join__field(graph: GRAPHENE)
-  set_quota_scope(props: QuotaScopeInput!, quota_scope_id: String!, storage_host_name: String!): SetQuotaScope @join__field(graph: GRAPHENE)
-  unset_quota_scope(quota_scope_id: String!, storage_host_name: String!): UnsetQuotaScope @join__field(graph: GRAPHENE)
+  """
+  Added in 24.03.9
+  """
+  disassociate_scaling_groups_with_keypair(
+    access_key: String!
+    scaling_groups: [String]!
+  ): DisassociateScalingGroupsWithKeyPair @join__field(graph: GRAPHENE)
+  disassociate_all_scaling_groups_with_domain(
+    domain: String!
+  ): DisassociateAllScalingGroupsWithDomain @join__field(graph: GRAPHENE)
+  disassociate_all_scaling_groups_with_group(
+    user_group: UUID!
+  ): DisassociateAllScalingGroupsWithGroup @join__field(graph: GRAPHENE)
+  set_quota_scope(
+    props: QuotaScopeInput!
+    quota_scope_id: String!
+    storage_host_name: String!
+  ): SetQuotaScope @join__field(graph: GRAPHENE)
+  unset_quota_scope(
+    quota_scope_id: String!
+    storage_host_name: String!
+  ): UnsetQuotaScope @join__field(graph: GRAPHENE)
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   create_container_registry_node(
-    """Added in 24.09.3."""
+    """
+    Added in 24.09.3.
+    """
     extra: JSONString
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     is_global: Boolean
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     password: String
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     project: String
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     registry_name: String!
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     ssl_verify: Boolean
 
     """
@@ -8987,34 +10787,58 @@ type Mutation
     """
     type: ContainerRegistryTypeField!
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     url: String!
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     username: String
-  ): CreateContainerRegistryNode @join__field(graph: GRAPHENE) @deprecated(reason: "Deprecated since 25.3.0. use `create_container_registry_node_v2` instead.")
+  ): CreateContainerRegistryNode
+    @join__field(graph: GRAPHENE)
+    @deprecated(
+      reason: "Deprecated since 25.3.0. use `create_container_registry_node_v2` instead."
+    )
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   modify_container_registry_node(
-    """Added in 24.09.3."""
+    """
+    Added in 24.09.3.
+    """
     extra: JSONString
 
-    """Object id. Can be either global id or object id. Added in 24.09.0."""
+    """
+    Object id. Can be either global id or object id. Added in 24.09.0.
+    """
     id: String!
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     is_global: Boolean
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     password: String
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     project: String
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     registry_name: String
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     ssl_verify: Boolean
 
     """
@@ -9022,507 +10846,953 @@ type Mutation
     """
     type: ContainerRegistryTypeField
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     url: String
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     username: String
-  ): ModifyContainerRegistryNode @join__field(graph: GRAPHENE) @deprecated(reason: "Deprecated since 25.3.0. use `modify_container_registry_node_v2` instead.")
+  ): ModifyContainerRegistryNode
+    @join__field(graph: GRAPHENE)
+    @deprecated(
+      reason: "Deprecated since 25.3.0. use `modify_container_registry_node_v2` instead."
+    )
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   delete_container_registry_node(
-    """Object id. Can be either global id or object id. Added in 24.09.0."""
+    """
+    Object id. Can be either global id or object id. Added in 24.09.0.
+    """
     id: String!
-  ): DeleteContainerRegistryNode @join__field(graph: GRAPHENE) @deprecated(reason: "Deprecated since 25.3.0. use `delete_container_registry_node_v2` instead.")
+  ): DeleteContainerRegistryNode
+    @join__field(graph: GRAPHENE)
+    @deprecated(
+      reason: "Deprecated since 25.3.0. use `delete_container_registry_node_v2` instead."
+    )
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   create_container_registry_node_v2(
-    """Added in 25.3.0."""
+    """
+    Added in 25.3.0.
+    """
     props: CreateContainerRegistryNodeInputV2!
   ): CreateContainerRegistryNodeV2 @join__field(graph: GRAPHENE)
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   modify_container_registry_node_v2(
-    """Object id. Can be either global id or object id. Added in 25.3.0."""
+    """
+    Object id. Can be either global id or object id. Added in 25.3.0.
+    """
     id: String!
 
-    """Added in 25.3.0."""
+    """
+    Added in 25.3.0.
+    """
     props: ModifyContainerRegistryNodeInputV2!
   ): ModifyContainerRegistryNodeV2 @join__field(graph: GRAPHENE)
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   delete_container_registry_node_v2(
-    """Object id. Can be either global id or object id. Added in 25.3.0."""
+    """
+    Object id. Can be either global id or object id. Added in 25.3.0.
+    """
     id: String!
   ): DeleteContainerRegistryNodeV2 @join__field(graph: GRAPHENE)
 
-  """Added in 25.1.0."""
-  create_endpoint_auto_scaling_rule_node(endpoint: String!, props: EndpointAutoScalingRuleInput!): CreateEndpointAutoScalingRuleNode @join__field(graph: GRAPHENE)
+  """
+  Added in 25.1.0.
+  """
+  create_endpoint_auto_scaling_rule_node(
+    endpoint: String!
+    props: EndpointAutoScalingRuleInput!
+  ): CreateEndpointAutoScalingRuleNode @join__field(graph: GRAPHENE)
 
-  """Added in 25.1.0."""
-  modify_endpoint_auto_scaling_rule_node(id: String!, props: ModifyEndpointAutoScalingRuleInput!): ModifyEndpointAutoScalingRuleNode @join__field(graph: GRAPHENE)
+  """
+  Added in 25.1.0.
+  """
+  modify_endpoint_auto_scaling_rule_node(
+    id: String!
+    props: ModifyEndpointAutoScalingRuleInput!
+  ): ModifyEndpointAutoScalingRuleNode @join__field(graph: GRAPHENE)
 
-  """Added in 25.1.0."""
-  delete_endpoint_auto_scaling_rule_node(id: String!): DeleteEndpointAutoScalingRuleNode @join__field(graph: GRAPHENE)
+  """
+  Added in 25.1.0.
+  """
+  delete_endpoint_auto_scaling_rule_node(
+    id: String!
+  ): DeleteEndpointAutoScalingRuleNode @join__field(graph: GRAPHENE)
 
-  """Added in 25.3.0."""
-  create_container_registry_quota(quota: BigInt!, scope_id: ScopeField!): CreateContainerRegistryQuota @join__field(graph: GRAPHENE)
+  """
+  Added in 25.3.0.
+  """
+  create_container_registry_quota(
+    quota: BigInt!
+    scope_id: ScopeField!
+  ): CreateContainerRegistryQuota @join__field(graph: GRAPHENE)
 
-  """Added in 25.3.0."""
-  update_container_registry_quota(quota: BigInt!, scope_id: ScopeField!): UpdateContainerRegistryQuota @join__field(graph: GRAPHENE)
+  """
+  Added in 25.3.0.
+  """
+  update_container_registry_quota(
+    quota: BigInt!
+    scope_id: ScopeField!
+  ): UpdateContainerRegistryQuota @join__field(graph: GRAPHENE)
 
-  """Added in 25.3.0."""
-  delete_container_registry_quota(scope_id: ScopeField!): DeleteContainerRegistryQuota @join__field(graph: GRAPHENE)
+  """
+  Added in 25.3.0.
+  """
+  delete_container_registry_quota(
+    scope_id: ScopeField!
+  ): DeleteContainerRegistryQuota @join__field(graph: GRAPHENE)
 
-  """Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead"""
-  create_container_registry(hostname: String!, props: CreateContainerRegistryInput!): CreateContainerRegistry @join__field(graph: GRAPHENE) @deprecated(reason: "Deprecated since 24.09.0. use `create_container_registry_node_v2` instead.")
+  """
+  Deprecated since 24.09.0. use `CreateContainerRegistryNode` instead
+  """
+  create_container_registry(
+    hostname: String!
+    props: CreateContainerRegistryInput!
+  ): CreateContainerRegistry
+    @join__field(graph: GRAPHENE)
+    @deprecated(
+      reason: "Deprecated since 24.09.0. use `create_container_registry_node_v2` instead."
+    )
 
-  """Deprecated since 24.09.0. use `ModifyContainerRegistryNode` instead"""
-  modify_container_registry(hostname: String!, props: ModifyContainerRegistryInput!): ModifyContainerRegistry @join__field(graph: GRAPHENE) @deprecated(reason: "Deprecated since 24.09.0. use `modify_container_registry_node_v2` instead.")
+  """
+  Deprecated since 24.09.0. use `ModifyContainerRegistryNode` instead
+  """
+  modify_container_registry(
+    hostname: String!
+    props: ModifyContainerRegistryInput!
+  ): ModifyContainerRegistry
+    @join__field(graph: GRAPHENE)
+    @deprecated(
+      reason: "Deprecated since 24.09.0. use `modify_container_registry_node_v2` instead."
+    )
 
-  """Deprecated since 24.09.0. use `DeleteContainerRegistryNode` instead"""
-  delete_container_registry(hostname: String!): DeleteContainerRegistry @join__field(graph: GRAPHENE) @deprecated(reason: "Deprecated since 24.09.0. use `delete_container_registry_node_v2` instead.")
-  modify_endpoint(endpoint_id: UUID!, props: ModifyEndpointInput!): ModifyEndpoint @join__field(graph: GRAPHENE)
+  """
+  Deprecated since 24.09.0. use `DeleteContainerRegistryNode` instead
+  """
+  delete_container_registry(hostname: String!): DeleteContainerRegistry
+    @join__field(graph: GRAPHENE)
+    @deprecated(
+      reason: "Deprecated since 24.09.0. use `delete_container_registry_node_v2` instead."
+    )
+  modify_endpoint(
+    endpoint_id: UUID!
+    props: ModifyEndpointInput!
+  ): ModifyEndpoint @join__field(graph: GRAPHENE)
 
-  """Added in 24.09.0."""
-  check_and_transit_session_status(input: CheckAndTransitStatusInput!): CheckAndTransitStatus @join__field(graph: GRAPHENE)
+  """
+  Added in 24.09.0.
+  """
+  check_and_transit_session_status(
+    input: CheckAndTransitStatusInput!
+  ): CheckAndTransitStatus @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
-  create_network(driver: String, name: String!, project_id: UUID!): CreateNetwork @join__field(graph: GRAPHENE)
+  """
+  Added in 24.12.0.
+  """
+  create_network(
+    driver: String
+    name: String!
+    project_id: UUID!
+  ): CreateNetwork @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
-  modify_network(network: String!, props: ModifyNetworkInput!): ModifyNetwork @join__field(graph: GRAPHENE)
+  """
+  Added in 24.12.0.
+  """
+  modify_network(network: String!, props: ModifyNetworkInput!): ModifyNetwork
+    @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   delete_network(network: String!): DeleteNetwork @join__field(graph: GRAPHENE)
 
   """
   Added in 25.14.0. Scan external registries to discover available artifacts. Searches HuggingFace or Reservoir registries for artifacts matching the specified criteria and registers them in the system with SCANNED status. The artifacts become available for import but are not downloaded until explicitly imported. This is the first step in the artifact workflow: Scan → Import → Use
   """
-  scanArtifacts(input: ScanArtifactsInput!): ScanArtifactsPayload! @join__field(graph: STRAWBERRY)
+  scanArtifacts(input: ScanArtifactsInput!): ScanArtifactsPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Perform detailed scanning of specific models. Unlike the general scan_artifacts operation, this performs immediate detailed scanning of specified models including README content and file sizes. Returns artifact revisions with complete metadata ready for use
   """
-  scanArtifactModels(input: ScanArtifactModelsInput!): ScanArtifactModelsPayload! @join__field(graph: STRAWBERRY)
+  scanArtifactModels(
+    input: ScanArtifactModelsInput!
+  ): ScanArtifactModelsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Import scanned artifact revisions from external registries. Downloads the actual files for the specified artifact revisions, transitioning them from SCANNED → PULLING → VERIFYING → AVAILABLE status. Returns background tasks that can be monitored for import progress. Once AVAILABLE, artifacts can be used by users in their sessions
   """
-  importArtifacts(input: ImportArtifactsInput!): ImportArtifactsPayload! @join__field(graph: STRAWBERRY)
+  importArtifacts(input: ImportArtifactsInput!): ImportArtifactsPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.16.0. Create or update user-level app configuration. The provided extra_config object will completely replace the existing configuration; existing keys not present in the new extra_config will be removed. These settings will override domain-level settings when configurations are merged for this user. If user_id is not provided, the current user's configuration will be updated. Users can only modify their own configuration, but admins can modify any user's configuration
   """
-  upsertUserAppConfig(input: UpsertUserConfigInput!): UpsertUserConfigPayload! @join__field(graph: STRAWBERRY)
+  upsertUserAppConfig(input: UpsertUserConfigInput!): UpsertUserConfigPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.16.0. Delete user-level app configuration. After deletion, the user will still receive domain-level configuration values when configurations are merged, as domain settings remain unaffected. If user_id is not provided, the current user's configuration will be deleted. Users can only delete their own configuration, but admins can delete any user's configuration
   """
-  deleteUserAppConfig(input: DeleteUserConfigInput!): DeleteUserConfigPayload! @join__field(graph: STRAWBERRY)
+  deleteUserAppConfig(input: DeleteUserConfigInput!): DeleteUserConfigPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.15.0. Triggers artifact scanning on a remote reservoir registry. This mutation instructs a reservoir-type registry to initiate a scan of artifacts from its associated remote reservoir registry source. The scan process will discover and catalog artifacts available in the remote reservoir, making them accessible through the local reservoir registry. Requirements: - The delegator registry must be of type 'reservoir' - The delegator reservoir registry must have a valid remote registry configuration
   """
-  delegateScanArtifacts(input: DelegateScanArtifactsInput!): DelegateScanArtifactsPayload! @join__field(graph: STRAWBERRY)
+  delegateScanArtifacts(
+    input: DelegateScanArtifactsInput!
+  ): DelegateScanArtifactsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.15.0. Trigger import of artifact revisions from a remote reservoir registry. This mutation instructs a reservoir-type registry to import specific artifact revisions that were previously discovered during a scan from its remote registry. Note that this operation does not import the artifacts directly into the local registry, but only into the delegator reservoir's storage. Requirements: - The delegator registry must be of type 'reservoir' - The delegator registry must have a valid remote registry configuration
   """
-  delegateImportArtifacts(input: DelegateImportArtifactsInput!): DelegateImportArtifactsPayload! @join__field(graph: STRAWBERRY)
+  delegateImportArtifacts(
+    input: DelegateImportArtifactsInput!
+  ): DelegateImportArtifactsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Update artifact metadata properties. Modifies artifact metadata such as readonly status and description. This operation does not affect the actual artifact files or revisions
   """
-  updateArtifact(input: UpdateArtifactInput!): UpdateArtifactPayload! @join__field(graph: STRAWBERRY)
+  updateArtifact(input: UpdateArtifactInput!): UpdateArtifactPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.15.0. Soft-delete artifacts from the system. Marks artifacts as deleted without permanently removing them. Deleted artifacts can be restored using the restore_artifacts mutation
   """
-  deleteArtifacts(input: DeleteArtifactsInput!): DeleteArtifactsPayload! @join__field(graph: STRAWBERRY)
+  deleteArtifacts(input: DeleteArtifactsInput!): DeleteArtifactsPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.15.0. Restore previously deleted artifacts. Reverses the soft-delete operation, making the artifacts available again for use in the system
   """
-  restoreArtifacts(input: RestoreArtifactsInput!): RestoreArtifactsPayload! @join__field(graph: STRAWBERRY)
+  restoreArtifacts(input: RestoreArtifactsInput!): RestoreArtifactsPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Clean up stored artifact revision data to free storage space. Removes the downloaded files for the specified artifact revisions and transitions them back to SCANNED status. The metadata remains, allowing the artifacts to be re-imported later if needed. Use this operation to manage storage usage by removing unused artifacts
   """
-  cleanupArtifactRevisions(input: CleanupArtifactRevisionsInput!): CleanupArtifactRevisionsPayload! @join__field(graph: STRAWBERRY)
+  cleanupArtifactRevisions(
+    input: CleanupArtifactRevisionsInput!
+  ): CleanupArtifactRevisionsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Cancel an in-progress artifact import operation. Stops the download process for the specified artifact revision and reverts its status back to SCANNED. The partially downloaded data is cleaned up
   """
-  cancelImportArtifact(input: CancelArtifactInput!): CancelImportArtifactPayload! @join__field(graph: STRAWBERRY)
+  cancelImportArtifact(
+    input: CancelArtifactInput!
+  ): CancelImportArtifactPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Create a new container registry (admin only)."""
-  adminCreateContainerRegistryV2(input: CreateContainerRegistryInputGQL!): CreateContainerRegistryPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Create a new container registry (admin only).
+  """
+  adminCreateContainerRegistryV2(
+    input: CreateContainerRegistryInputGQL!
+  ): CreateContainerRegistryPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Update a container registry (admin only)."""
-  adminUpdateContainerRegistryV2(input: UpdateContainerRegistryInputGQL!): UpdateContainerRegistryPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Update a container registry (admin only).
+  """
+  adminUpdateContainerRegistryV2(
+    input: UpdateContainerRegistryInputGQL!
+  ): UpdateContainerRegistryPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Delete a container registry (admin only)."""
-  adminDeleteContainerRegistryV2(id: String!): DeleteContainerRegistryPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Delete a container registry (admin only).
+  """
+  adminDeleteContainerRegistryV2(
+    id: String!
+  ): DeleteContainerRegistryPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Create model deployment."""
-  createModelDeployment(input: CreateDeploymentInput!): CreateDeploymentPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. Create model deployment.
+  """
+  createModelDeployment(
+    input: CreateDeploymentInput!
+  ): CreateDeploymentPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Update model deployment."""
-  updateModelDeployment(input: UpdateDeploymentInput!): UpdateDeploymentPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. Update model deployment.
+  """
+  updateModelDeployment(
+    input: UpdateDeploymentInput!
+  ): UpdateDeploymentPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Delete model deployment."""
-  deleteModelDeployment(input: DeleteDeploymentInput!): DeleteDeploymentPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. Delete model deployment.
+  """
+  deleteModelDeployment(
+    input: DeleteDeploymentInput!
+  ): DeleteDeploymentPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.16.0. Force syncs up-to-date replica information. In normal situations this will be automatically handled by Backend.AI schedulers.
   """
-  syncReplicas(input: SyncReplicaInput!): SyncReplicaPayload! @join__field(graph: STRAWBERRY)
+  syncReplicas(input: SyncReplicaInput!): SyncReplicaPayload!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Add model revision."""
-  addModelRevision(input: AddRevisionInput!): AddRevisionPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. Add model revision.
+  """
+  addModelRevision(input: AddRevisionInput!): AddRevisionPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Create or update the deployment policy for a given deployment (upsert semantics). If the deployment already has a policy, it is replaced entirely with the new configuration
   """
-  updateDeploymentPolicy(input: UpdateDeploymentPolicyInput!): UpdateDeploymentPolicyPayload! @join__field(graph: STRAWBERRY)
+  updateDeploymentPolicy(
+    input: UpdateDeploymentPolicyInput!
+  ): UpdateDeploymentPolicyPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Create a new notification channel (admin only)"""
-  adminCreateNotificationChannel(input: CreateNotificationChannelInput!): CreateNotificationChannelPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Create a new notification channel (admin only)
+  """
+  adminCreateNotificationChannel(
+    input: CreateNotificationChannelInput!
+  ): CreateNotificationChannelPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Update a notification channel (admin only)"""
-  adminUpdateNotificationChannel(input: UpdateNotificationChannelInput!): UpdateNotificationChannelPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Update a notification channel (admin only)
+  """
+  adminUpdateNotificationChannel(
+    input: UpdateNotificationChannelInput!
+  ): UpdateNotificationChannelPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Delete a notification channel (admin only)"""
-  adminDeleteNotificationChannel(input: DeleteNotificationChannelInput!): DeleteNotificationChannelPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Delete a notification channel (admin only)
+  """
+  adminDeleteNotificationChannel(
+    input: DeleteNotificationChannelInput!
+  ): DeleteNotificationChannelPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Validate a notification channel (admin only)"""
-  adminValidateNotificationChannel(input: ValidateNotificationChannelInput!): ValidateNotificationChannelPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Validate a notification channel (admin only)
+  """
+  adminValidateNotificationChannel(
+    input: ValidateNotificationChannelInput!
+  ): ValidateNotificationChannelPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Create a new notification rule (admin only)"""
-  adminCreateNotificationRule(input: CreateNotificationRuleInput!): CreateNotificationRulePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Create a new notification rule (admin only)
+  """
+  adminCreateNotificationRule(
+    input: CreateNotificationRuleInput!
+  ): CreateNotificationRulePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Update a notification rule (admin only)"""
-  adminUpdateNotificationRule(input: UpdateNotificationRuleInput!): UpdateNotificationRulePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Update a notification rule (admin only)
+  """
+  adminUpdateNotificationRule(
+    input: UpdateNotificationRuleInput!
+  ): UpdateNotificationRulePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Delete a notification rule (admin only)"""
-  adminDeleteNotificationRule(input: DeleteNotificationRuleInput!): DeleteNotificationRulePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Delete a notification rule (admin only)
+  """
+  adminDeleteNotificationRule(
+    input: DeleteNotificationRuleInput!
+  ): DeleteNotificationRulePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Validate a notification rule (admin only)"""
-  adminValidateNotificationRule(input: ValidateNotificationRuleInput!): ValidateNotificationRulePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Validate a notification rule (admin only)
+  """
+  adminValidateNotificationRule(
+    input: ValidateNotificationRuleInput!
+  ): ValidateNotificationRulePayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Create or update domain-level app configuration (admin only). The provided extra_config object will completely replace the existing configuration; existing keys not present in the new extra_config will be removed. All users in this domain will be affected by these settings when their configurations are merged, unless they have user-level configurations that override specific keys
   """
-  adminUpsertDomainAppConfig(input: UpsertDomainConfigInput!): UpsertDomainConfigPayload! @join__field(graph: STRAWBERRY)
+  adminUpsertDomainAppConfig(
+    input: UpsertDomainConfigInput!
+  ): UpsertDomainConfigPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Delete domain-level app configuration (admin only). All users in this domain may be affected by this deletion. After deletion, users will only receive their user-level configurations when configurations are merged, with no domain-level defaults
   """
-  adminDeleteDomainAppConfig(input: DeleteDomainConfigInput!): DeleteDomainConfigPayload! @join__field(graph: STRAWBERRY)
+  adminDeleteDomainAppConfig(
+    input: DeleteDomainConfigInput!
+  ): DeleteDomainConfigPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Create a new notification channel"""
-  createNotificationChannel(input: CreateNotificationChannelInput!): CreateNotificationChannelPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_create_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. Create a new notification channel
+  """
+  createNotificationChannel(
+    input: CreateNotificationChannelInput!
+  ): CreateNotificationChannelPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_create_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. Update a notification channel"""
-  updateNotificationChannel(input: UpdateNotificationChannelInput!): UpdateNotificationChannelPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_update_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. Update a notification channel
+  """
+  updateNotificationChannel(
+    input: UpdateNotificationChannelInput!
+  ): UpdateNotificationChannelPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_update_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. Delete a notification channel"""
-  deleteNotificationChannel(input: DeleteNotificationChannelInput!): DeleteNotificationChannelPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_delete_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. Delete a notification channel
+  """
+  deleteNotificationChannel(
+    input: DeleteNotificationChannelInput!
+  ): DeleteNotificationChannelPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_delete_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. Validate a notification channel"""
-  validateNotificationChannel(input: ValidateNotificationChannelInput!): ValidateNotificationChannelPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_validate_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. Validate a notification channel
+  """
+  validateNotificationChannel(
+    input: ValidateNotificationChannelInput!
+  ): ValidateNotificationChannelPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_validate_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. Create a new notification rule"""
-  createNotificationRule(input: CreateNotificationRuleInput!): CreateNotificationRulePayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_create_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. Create a new notification rule
+  """
+  createNotificationRule(
+    input: CreateNotificationRuleInput!
+  ): CreateNotificationRulePayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_create_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. Update a notification rule"""
-  updateNotificationRule(input: UpdateNotificationRuleInput!): UpdateNotificationRulePayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_update_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. Update a notification rule
+  """
+  updateNotificationRule(
+    input: UpdateNotificationRuleInput!
+  ): UpdateNotificationRulePayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_update_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. Delete a notification rule"""
-  deleteNotificationRule(input: DeleteNotificationRuleInput!): DeleteNotificationRulePayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_delete_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. Delete a notification rule
+  """
+  deleteNotificationRule(
+    input: DeleteNotificationRuleInput!
+  ): DeleteNotificationRulePayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_delete_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. Validate a notification rule"""
-  validateNotificationRule(input: ValidateNotificationRuleInput!): ValidateNotificationRulePayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_validate_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. Validate a notification rule
+  """
+  validateNotificationRule(
+    input: ValidateNotificationRuleInput!
+  ): ValidateNotificationRulePayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_validate_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in 25.16.0. Create or update domain-level app configuration. The provided extra_config object will completely replace the existing configuration; existing keys not present in the new extra_config will be removed. All users in this domain will be affected by these settings when their configurations are merged, unless they have user-level configurations that override specific keys. Requires admin privileges
   """
-  upsertDomainAppConfig(input: UpsertDomainConfigInput!): UpsertDomainConfigPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertDomainAppConfig(
+    input: UpsertDomainConfigInput!
+  ): UpsertDomainConfigPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_upsert_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in 25.16.0. Delete domain-level app configuration. All users in this domain may be affected by this deletion. After deletion, users will only receive their user-level configurations when configurations are merged, with no domain-level defaults. Requires admin privileges
   """
-  deleteDomainAppConfig(input: DeleteDomainConfigInput!): DeleteDomainConfigPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_delete_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  deleteDomainAppConfig(
+    input: DeleteDomainConfigInput!
+  ): DeleteDomainConfigPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_delete_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in 25.14.0. Create an object storage."""
-  createObjectStorage(input: CreateObjectStorageInput!): CreateObjectStoragePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Create an object storage.
+  """
+  createObjectStorage(
+    input: CreateObjectStorageInput!
+  ): CreateObjectStoragePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Update an object storage."""
-  updateObjectStorage(input: UpdateObjectStorageInput!): UpdateObjectStoragePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Update an object storage.
+  """
+  updateObjectStorage(
+    input: UpdateObjectStorageInput!
+  ): UpdateObjectStoragePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Create auto scaling rule."""
-  createAutoScalingRule(input: CreateAutoScalingRuleInput!): CreateAutoScalingRulePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. Create auto scaling rule.
+  """
+  createAutoScalingRule(
+    input: CreateAutoScalingRuleInput!
+  ): CreateAutoScalingRulePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Update auto scaling rule."""
-  updateAutoScalingRule(input: UpdateAutoScalingRuleInput!): UpdateAutoScalingRulePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. Update auto scaling rule.
+  """
+  updateAutoScalingRule(
+    input: UpdateAutoScalingRuleInput!
+  ): UpdateAutoScalingRulePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Delete auto scaling rule."""
-  deleteAutoScalingRule(input: DeleteAutoScalingRuleInput!): DeleteAutoScalingRulePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. Delete auto scaling rule.
+  """
+  deleteAutoScalingRule(
+    input: DeleteAutoScalingRuleInput!
+  ): DeleteAutoScalingRulePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Delete an object storage."""
-  deleteObjectStorage(input: DeleteObjectStorageInput!): DeleteObjectStoragePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Delete an object storage.
+  """
+  deleteObjectStorage(
+    input: DeleteObjectStorageInput!
+  ): DeleteObjectStoragePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Create a new VFS storage"""
-  createVFSStorage(input: CreateVFSStorageInput!): CreateVFSStoragePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. Create a new VFS storage
+  """
+  createVFSStorage(input: CreateVFSStorageInput!): CreateVFSStoragePayload!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Update an existing VFS storage"""
-  updateVFSStorage(input: UpdateVFSStorageInput!): UpdateVFSStoragePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. Update an existing VFS storage
+  """
+  updateVFSStorage(input: UpdateVFSStorageInput!): UpdateVFSStoragePayload!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Delete a VFS storage"""
-  deleteVFSStorage(input: DeleteVFSStorageInput!): DeleteVFSStoragePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. Delete a VFS storage
+  """
+  deleteVFSStorage(input: DeleteVFSStorageInput!): DeleteVFSStoragePayload!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 25.15.0. Registers a new namespace within a storage"""
-  registerStorageNamespace(input: RegisterStorageNamespaceInput!): RegisterStorageNamespacePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.15.0. Registers a new namespace within a storage
+  """
+  registerStorageNamespace(
+    input: RegisterStorageNamespaceInput!
+  ): RegisterStorageNamespacePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.15.0. Unregisters an existing namespace from a storage"""
-  unregisterStorageNamespace(input: UnregisterStorageNamespaceInput!): UnregisterStorageNamespacePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.15.0. Unregisters an existing namespace from a storage
+  """
+  unregisterStorageNamespace(
+    input: UnregisterStorageNamespaceInput!
+  ): UnregisterStorageNamespacePayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Create huggingface registry."""
-  createHuggingfaceRegistry(input: CreateHuggingFaceRegistryInput!): CreateHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Create huggingface registry.
+  """
+  createHuggingfaceRegistry(
+    input: CreateHuggingFaceRegistryInput!
+  ): CreateHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Update huggingface registry."""
-  updateHuggingfaceRegistry(input: UpdateHuggingFaceRegistryInput!): UpdateHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Update huggingface registry.
+  """
+  updateHuggingfaceRegistry(
+    input: UpdateHuggingFaceRegistryInput!
+  ): UpdateHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Delete huggingface registry."""
-  deleteHuggingfaceRegistry(input: DeleteHuggingFaceRegistryInput!): DeleteHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Delete huggingface registry.
+  """
+  deleteHuggingfaceRegistry(
+    input: DeleteHuggingFaceRegistryInput!
+  ): DeleteHuggingFaceRegistryPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Create reservoir registry."""
-  createReservoirRegistry(input: CreateReservoirRegistryInput!): CreateReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Create reservoir registry.
+  """
+  createReservoirRegistry(
+    input: CreateReservoirRegistryInput!
+  ): CreateReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Update reservoir registry."""
-  updateReservoirRegistry(input: UpdateReservoirRegistryInput!): UpdateReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Update reservoir registry.
+  """
+  updateReservoirRegistry(
+    input: UpdateReservoirRegistryInput!
+  ): UpdateReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Delete reservoir registry."""
-  deleteReservoirRegistry(input: DeleteReservoirRegistryInput!): DeleteReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Delete reservoir registry.
+  """
+  deleteReservoirRegistry(
+    input: DeleteReservoirRegistryInput!
+  ): DeleteReservoirRegistryPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Get a presigned download URL."""
-  getPresignedDownloadUrl(input: GetPresignedDownloadURLInput!): GetPresignedDownloadURLPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Get a presigned download URL.
+  """
+  getPresignedDownloadUrl(
+    input: GetPresignedDownloadURLInput!
+  ): GetPresignedDownloadURLPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Get a presigned upload URL."""
-  getPresignedUploadUrl(input: GetPresignedUploadURLInput!): GetPresignedUploadURLPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Get a presigned upload URL.
+  """
+  getPresignedUploadUrl(
+    input: GetPresignedUploadURLInput!
+  ): GetPresignedUploadURLPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Approve an artifact revision for general use. Admin-only operation to approve artifact revisions, typically used in environments with approval workflows for artifact deployment
   """
-  approveArtifactRevision(input: ApproveArtifactInput!): ApproveArtifactPayload! @join__field(graph: STRAWBERRY)
+  approveArtifactRevision(
+    input: ApproveArtifactInput!
+  ): ApproveArtifactPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Reject an artifact revision, preventing its use. Admin-only operation to reject artifact revisions, typically used in environments with approval workflows for artifact deployment
   """
-  rejectArtifactRevision(input: RejectArtifactInput!): RejectArtifactPayload! @join__field(graph: STRAWBERRY)
+  rejectArtifactRevision(input: RejectArtifactInput!): RejectArtifactPayload!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Create access token."""
-  createAccessToken(input: CreateAccessTokenInput!): CreateAccessTokenPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. Create access token.
+  """
+  createAccessToken(input: CreateAccessTokenInput!): CreateAccessTokenPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.19.0. Activate a specific revision to be the current revision
   """
-  activateDeploymentRevision(input: ActivateRevisionInput!): ActivateRevisionPayload! @join__field(graph: STRAWBERRY)
+  activateDeploymentRevision(
+    input: ActivateRevisionInput!
+  ): ActivateRevisionPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.19.0. Update the traffic status of a route"""
-  updateRouteTrafficStatus(input: UpdateRouteTrafficStatusInput!): UpdateRouteTrafficStatusPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.19.0. Update the traffic status of a route
+  """
+  updateRouteTrafficStatus(
+    input: UpdateRouteTrafficStatusInput!
+  ): UpdateRouteTrafficStatusPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Upsert domain fair share weight (admin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  adminUpsertDomainFairShareWeight(input: UpsertDomainFairShareWeightInput!): UpsertDomainFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminUpsertDomainFairShareWeight(
+    input: UpsertDomainFairShareWeightInput!
+  ): UpsertDomainFairShareWeightPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Upsert project fair share weight (admin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  adminUpsertProjectFairShareWeight(input: UpsertProjectFairShareWeightInput!): UpsertProjectFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminUpsertProjectFairShareWeight(
+    input: UpsertProjectFairShareWeightInput!
+  ): UpsertProjectFairShareWeightPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Upsert user fair share weight (admin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  adminUpsertUserFairShareWeight(input: UpsertUserFairShareWeightInput!): UpsertUserFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminUpsertUserFairShareWeight(
+    input: UpsertUserFairShareWeightInput!
+  ): UpsertUserFairShareWeightPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Bulk upsert domain fair share weights (admin only). Creates new records if they don't exist, or updates weights if they do
   """
-  adminBulkUpsertDomainFairShareWeight(input: BulkUpsertDomainFairShareWeightInput!): BulkUpsertDomainFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminBulkUpsertDomainFairShareWeight(
+    input: BulkUpsertDomainFairShareWeightInput!
+  ): BulkUpsertDomainFairShareWeightPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Bulk upsert project fair share weights (admin only). Creates new records if they don't exist, or updates weights if they do
   """
-  adminBulkUpsertProjectFairShareWeight(input: BulkUpsertProjectFairShareWeightInput!): BulkUpsertProjectFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminBulkUpsertProjectFairShareWeight(
+    input: BulkUpsertProjectFairShareWeightInput!
+  ): BulkUpsertProjectFairShareWeightPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Bulk upsert user fair share weights (admin only). Creates new records if they don't exist, or updates weights if they do
   """
-  adminBulkUpsertUserFairShareWeight(input: BulkUpsertUserFairShareWeightInput!): BulkUpsertUserFairShareWeightPayload! @join__field(graph: STRAWBERRY)
+  adminBulkUpsertUserFairShareWeight(
+    input: BulkUpsertUserFairShareWeightInput!
+  ): BulkUpsertUserFairShareWeightPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.1.0. Upsert domain fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  upsertDomainFairShareWeight(input: UpsertDomainFairShareWeightInput!): UpsertDomainFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertDomainFairShareWeight(
+    input: UpsertDomainFairShareWeightInput!
+  ): UpsertDomainFairShareWeightPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in 26.1.0. Upsert project fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  upsertProjectFairShareWeight(input: UpsertProjectFairShareWeightInput!): UpsertProjectFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertProjectFairShareWeight(
+    input: UpsertProjectFairShareWeightInput!
+  ): UpsertProjectFairShareWeightPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in 26.1.0. Upsert user fair share weight (superadmin only). Creates a new record if it doesn't exist, or updates the weight if it does
   """
-  upsertUserFairShareWeight(input: UpsertUserFairShareWeightInput!): UpsertUserFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  upsertUserFairShareWeight(
+    input: UpsertUserFairShareWeightInput!
+  ): UpsertUserFairShareWeightPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in 26.1.0. Bulk upsert domain fair share weights (superadmin only). Creates new records if they don't exist, or updates weights if they do
   """
-  bulkUpsertDomainFairShareWeight(input: BulkUpsertDomainFairShareWeightInput!): BulkUpsertDomainFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_bulk_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  bulkUpsertDomainFairShareWeight(
+    input: BulkUpsertDomainFairShareWeightInput!
+  ): BulkUpsertDomainFairShareWeightPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_bulk_upsert_domain_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in 26.1.0. Bulk upsert project fair share weights (superadmin only). Creates new records if they don't exist, or updates weights if they do
   """
-  bulkUpsertProjectFairShareWeight(input: BulkUpsertProjectFairShareWeightInput!): BulkUpsertProjectFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_bulk_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  bulkUpsertProjectFairShareWeight(
+    input: BulkUpsertProjectFairShareWeightInput!
+  ): BulkUpsertProjectFairShareWeightPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_bulk_upsert_project_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in 26.1.0. Bulk upsert user fair share weights (superadmin only). Creates new records if they don't exist, or updates weights if they do
   """
-  bulkUpsertUserFairShareWeight(input: BulkUpsertUserFairShareWeightInput!): BulkUpsertUserFairShareWeightPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_bulk_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  bulkUpsertUserFairShareWeight(
+    input: BulkUpsertUserFairShareWeightInput!
+  ): BulkUpsertUserFairShareWeightPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_bulk_upsert_user_fair_share_weight instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in 26.2.0. Update fair share configuration for a resource group (admin only). Only provided fields are updated; others retain their existing values. Resource weights are validated against capacity - only resource types available in the scaling group's capacity can be specified.
   """
-  adminUpdateResourceGroupFairShareSpec(input: UpdateResourceGroupFairShareSpecInput!): UpdateResourceGroupFairShareSpecPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateResourceGroupFairShareSpec(
+    input: UpdateResourceGroupFairShareSpecInput!
+  ): UpdateResourceGroupFairShareSpecPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Update resource group configuration (admin only). Only provided fields are updated; others retain their existing values. Supports all configuration fields except fair_share (use separate mutation).
   """
-  adminUpdateResourceGroup(input: UpdateResourceGroupInput!): UpdateResourceGroupPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateResourceGroup(
+    input: UpdateResourceGroupInput!
+  ): UpdateResourceGroupPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Create a new resource group (admin only)."""
-  adminCreateResourceGroupV2(input: CreateResourceGroupInput!): CreateResourceGroupPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Create a new resource group (admin only).
+  """
+  adminCreateResourceGroupV2(
+    input: CreateResourceGroupInput!
+  ): CreateResourceGroupPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Delete a resource group (admin only)."""
-  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Delete a resource group (admin only).
+  """
+  adminDeleteResourceGroupV2(name: String!): DeleteResourceGroupPayloadGQL!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Update allowed resource groups for a domain (admin only).
   """
-  adminUpdateAllowedResourceGroupsForDomainV2(input: UpdateAllowedResourceGroupsForDomainInput!): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateAllowedResourceGroupsForDomainV2(
+    input: UpdateAllowedResourceGroupsForDomainInput!
+  ): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Update allowed resource groups for a project (admin only).
   """
-  adminUpdateAllowedResourceGroupsForProjectV2(input: UpdateAllowedResourceGroupsForProjectInput!): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateAllowedResourceGroupsForProjectV2(
+    input: UpdateAllowedResourceGroupsForProjectInput!
+  ): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Update allowed domains for a resource group (admin only).
   """
-  adminUpdateAllowedDomainsForResourceGroupV2(input: UpdateAllowedDomainsForResourceGroupInput!): AllowedDomainsPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateAllowedDomainsForResourceGroupV2(
+    input: UpdateAllowedDomainsForResourceGroupInput!
+  ): AllowedDomainsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Update allowed projects for a resource group (admin only).
   """
-  adminUpdateAllowedProjectsForResourceGroupV2(input: UpdateAllowedProjectsForResourceGroupInput!): AllowedProjectsPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateAllowedProjectsForResourceGroupV2(
+    input: UpdateAllowedProjectsForResourceGroupInput!
+  ): AllowedProjectsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Update fair share configuration for a resource group (superadmin only). Only provided fields are updated; others retain their existing values. Resource weights are validated against capacity - only resource types available in the scaling group's capacity can be specified.
   """
-  updateResourceGroupFairShareSpec(input: UpdateResourceGroupFairShareSpecInput!): UpdateResourceGroupFairShareSpecPayload! @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_update_resource_group_fair_share_spec instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  updateResourceGroupFairShareSpec(
+    input: UpdateResourceGroupFairShareSpecInput!
+  ): UpdateResourceGroupFairShareSpecPayload!
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_update_resource_group_fair_share_spec instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in UNRELEASED. Create a new domain (admin only). Requires superadmin privileges.
   """
-  adminCreateDomainV2(input: CreateDomainInputGQL!): DomainPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateDomainV2(input: CreateDomainInputGQL!): DomainPayloadGQL!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Update a domain (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateDomainV2(domainName: String!, input: UpdateDomainInputGQL!): DomainPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateDomainV2(
+    domainName: String!
+    input: UpdateDomainInputGQL!
+  ): DomainPayloadGQL! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Soft-delete a domain (admin only). Requires superadmin privileges.
   """
-  adminDeleteDomainV2(domainName: String!): DeleteDomainPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteDomainV2(domainName: String!): DeleteDomainPayloadGQL!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Permanently purge a domain and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeDomainV2(domainName: String!): PurgeDomainPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminPurgeDomainV2(domainName: String!): PurgeDomainPayloadGQL!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Create a new project (admin only). Requires superadmin privileges.
   """
-  adminCreateProjectV2(input: CreateProjectInputGQL!): ProjectPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateProjectV2(input: CreateProjectInputGQL!): ProjectPayloadGQL!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Update a project (admin only). Requires superadmin privileges. Only provided fields will be updated.
   """
-  adminUpdateProjectV2(projectId: UUID!, input: UpdateProjectInputGQL!): ProjectPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateProjectV2(
+    projectId: UUID!
+    input: UpdateProjectInputGQL!
+  ): ProjectPayloadGQL! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Soft-delete a project (admin only). Requires superadmin privileges.
   """
-  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteProjectV2(projectId: UUID!): DeleteProjectPayloadGQL!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Permanently purge a project and all associated data (admin only). Requires superadmin privileges.
   """
-  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminPurgeProjectV2(projectId: UUID!): PurgeProjectPayloadGQL!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Unassign users from a project. RBAC validates project admin permission.
   """
-  unassignUsersFromProjectV2(projectId: UUID!, input: UnassignUsersFromProjectInput!): UnassignUsersFromProjectPayload! @join__field(graph: STRAWBERRY)
+  unassignUsersFromProjectV2(
+    projectId: UUID!
+    input: UnassignUsersFromProjectInput!
+  ): UnassignUsersFromProjectPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Create a new user (admin only). Requires superadmin privileges. Automatically creates a default keypair for the user
   """
-  adminCreateUserV2(input: CreateUserV2Input!): CreateUserV2Payload! @join__field(graph: STRAWBERRY)
+  adminCreateUserV2(input: CreateUserV2Input!): CreateUserV2Payload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Create multiple users in bulk (admin only). Requires superadmin privileges. Each user has individual specifications
   """
-  adminBulkCreateUsersV2(input: BulkCreateUserV2Input!): BulkCreateUsersV2Payload! @join__field(graph: STRAWBERRY)
+  adminBulkCreateUsersV2(
+    input: BulkCreateUserV2Input!
+  ): BulkCreateUsersV2Payload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Update multiple users in bulk (admin only). Requires superadmin privileges. Each user has individual update specifications
   """
-  adminBulkUpdateUsersV2(input: BulkUpdateUserV2Input!): BulkUpdateUsersV2Payload! @join__field(graph: STRAWBERRY)
+  adminBulkUpdateUsersV2(
+    input: BulkUpdateUserV2Input!
+  ): BulkUpdateUsersV2Payload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Update a user's information (admin only). Requires superadmin privileges. Only provided fields will be updated
   """
-  adminUpdateUserV2(userId: UUID!, input: UpdateUserV2Input!): UpdateUserV2Payload! @join__field(graph: STRAWBERRY)
+  adminUpdateUserV2(
+    userId: UUID!
+    input: UpdateUserV2Input!
+  ): UpdateUserV2Payload! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Update the current user's information. Users can only update their own profile. Some fields may be restricted based on user role
   """
-  updateUserV2(input: UpdateUserV2Input!): UpdateUserV2Payload! @join__field(graph: STRAWBERRY)
+  updateUserV2(input: UpdateUserV2Input!): UpdateUserV2Payload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Soft-delete a user (admin only). Requires superadmin privileges. Sets the user status to DELETED but preserves data
   """
-  adminDeleteUserV2(userId: UUID!): DeleteUserV2Payload! @join__field(graph: STRAWBERRY)
+  adminDeleteUserV2(userId: UUID!): DeleteUserV2Payload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Soft-delete multiple users (admin only). Requires superadmin privileges. Sets user status to DELETED but preserves data
   """
-  adminDeleteUsersV2(input: DeleteUsersV2Input!): DeleteUsersV2Payload! @join__field(graph: STRAWBERRY)
+  adminDeleteUsersV2(input: DeleteUsersV2Input!): DeleteUsersV2Payload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Permanently delete a user and all associated data (admin only). Requires superadmin privileges. This action is IRREVERSIBLE. All user data, sessions, and resources will be deleted
   """
-  adminPurgeUserV2(input: PurgeUserV2Input!): PurgeUserV2Payload! @join__field(graph: STRAWBERRY)
+  adminPurgeUserV2(input: PurgeUserV2Input!): PurgeUserV2Payload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Permanently delete multiple users in bulk (admin only). Requires superadmin privileges. This action is IRREVERSIBLE. All user data will be deleted
   """
-  adminBulkPurgeUsersV2(input: BulkPurgeUsersV2Input!): BulkPurgeUsersV2Payload! @join__field(graph: STRAWBERRY)
+  adminBulkPurgeUsersV2(
+    input: BulkPurgeUsersV2Input!
+  ): BulkPurgeUsersV2Payload! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Issue a new keypair for the current user. Settings (resource_policy, rate_limit, is_admin) are inherited from the main keypair. The secret_key is only returned at creation time.
@@ -9532,219 +11802,381 @@ type Mutation
   """
   Added in UNRELEASED. Revoke a keypair owned by the current user. The main access key cannot be revoked — switch it first.
   """
-  revokeMyKeypair(input: RevokeMyKeypairInput!): RevokeMyKeypairPayload! @join__field(graph: STRAWBERRY)
+  revokeMyKeypair(input: RevokeMyKeypairInput!): RevokeMyKeypairPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Switch the main access key for the current user. The target keypair must be active and owned by the user.
   """
-  switchMyMainAccessKey(input: SwitchMyMainAccessKeyInput!): SwitchMyMainAccessKeyPayload! @join__field(graph: STRAWBERRY)
+  switchMyMainAccessKey(
+    input: SwitchMyMainAccessKeyInput!
+  ): SwitchMyMainAccessKeyPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Update a keypair owned by the current user (e.g. toggle active state). The keypair must be owned by the current user.
   """
-  updateMyKeypair(input: UpdateMyKeypairInput!): UpdateMyKeypairPayload! @join__field(graph: STRAWBERRY)
+  updateMyKeypair(input: UpdateMyKeypairInput!): UpdateMyKeypairPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Admin creates a keypair for a specified user. The secret_key is only returned at creation time.
   """
-  adminCreateKeypairV2(input: AdminCreateKeypairInput!): AdminCreateKeypairPayload! @join__field(graph: STRAWBERRY)
+  adminCreateKeypairV2(
+    input: AdminCreateKeypairInput!
+  ): AdminCreateKeypairPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Admin updates a keypair (e.g. toggle active state, change resource policy).
   """
-  adminUpdateKeypairV2(input: AdminUpdateKeypairInput!): AdminUpdateKeypairPayload! @join__field(graph: STRAWBERRY)
+  adminUpdateKeypairV2(
+    input: AdminUpdateKeypairInput!
+  ): AdminUpdateKeypairPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Admin deletes a keypair by access key. Cannot delete a main access key.
   """
-  adminDeleteKeypairV2(accessKey: String!): AdminDeleteKeypairPayload! @join__field(graph: STRAWBERRY)
+  adminDeleteKeypairV2(accessKey: String!): AdminDeleteKeypairPayload!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Revoke a login session. (admin only)"""
-  adminRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Revoke a login session. (admin only)
+  """
+  adminRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Revoke a login session owned by the current user."""
-  myRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Revoke a login session owned by the current user.
+  """
+  myRevokeLoginSession(sessionId: UUID!): RevokeLoginSessionPayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.4.0. Update the current user's allowed client IP list. Set allowed_client_ip to null to remove all IP restrictions. When force is false, the operation fails if the current request IP would be excluded by the new allowlist (lockout prevention)
   """
-  updateMyAllowedClientIp(input: UpdateMyAllowedClientIPInput!): UpdateMyAllowedClientIPPayload! @join__field(graph: STRAWBERRY)
+  updateMyAllowedClientIp(
+    input: UpdateMyAllowedClientIPInput!
+  ): UpdateMyAllowedClientIPPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Create a new query definition (admin only)"""
-  adminCreatePrometheusQueryPreset(input: CreateQueryDefinitionInput!): CreateQueryDefinitionPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Create a new query definition (admin only)
+  """
+  adminCreatePrometheusQueryPreset(
+    input: CreateQueryDefinitionInput!
+  ): CreateQueryDefinitionPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Modify an existing query definition (admin only)."""
-  adminModifyPrometheusQueryPreset(id: ID!, input: ModifyQueryDefinitionInput!): ModifyQueryDefinitionPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Modify an existing query definition (admin only).
+  """
+  adminModifyPrometheusQueryPreset(
+    id: ID!
+    input: ModifyQueryDefinitionInput!
+  ): ModifyQueryDefinitionPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Delete a query definition (admin only)"""
-  adminDeletePrometheusQueryPreset(id: ID!): DeleteQueryDefinitionPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Delete a query definition (admin only)
+  """
+  adminDeletePrometheusQueryPreset(id: ID!): DeleteQueryDefinitionPayload!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Create a new role (admin only)."""
-  adminCreateRole(input: CreateRoleInput!): Role! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Create a new role (admin only).
+  """
+  adminCreateRole(input: CreateRoleInput!): Role!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Update an existing role (admin only)."""
-  adminUpdateRole(input: UpdateRoleInput!): Role! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Update an existing role (admin only).
+  """
+  adminUpdateRole(input: UpdateRoleInput!): Role!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Soft-delete a role (admin only)."""
-  adminDeleteRole(input: DeleteRoleInput!): DeleteRolePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Soft-delete a role (admin only).
+  """
+  adminDeleteRole(input: DeleteRoleInput!): DeleteRolePayload!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Permanently remove a role (admin only)."""
-  adminPurgeRole(input: PurgeRoleInput!): PurgeRolePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Permanently remove a role (admin only).
+  """
+  adminPurgeRole(input: PurgeRoleInput!): PurgeRolePayload!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Create a scoped permission (admin only)."""
-  adminCreatePermission(input: CreatePermissionInput!): Permission! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Create a scoped permission (admin only).
+  """
+  adminCreatePermission(input: CreatePermissionInput!): Permission!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Update a scoped permission (admin only)."""
-  adminUpdatePermission(input: UpdatePermissionInput!): Permission! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Update a scoped permission (admin only).
+  """
+  adminUpdatePermission(input: UpdatePermissionInput!): Permission!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Delete a scoped permission (admin only)."""
-  adminDeletePermission(input: DeletePermissionInput!): DeletePermissionPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Delete a scoped permission (admin only).
+  """
+  adminDeletePermission(
+    input: DeletePermissionInput!
+  ): DeletePermissionPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Assign a role to a user (admin only)."""
-  adminAssignRole(input: AssignRoleInput!): RoleAssignment! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Assign a role to a user (admin only).
+  """
+  adminAssignRole(input: AssignRoleInput!): RoleAssignment!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Revoke a role from a user (admin only)."""
-  adminRevokeRole(input: RevokeRoleInput!): RoleAssignment! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Revoke a role from a user (admin only).
+  """
+  adminRevokeRole(input: RevokeRoleInput!): RoleAssignment!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Bulk assign a role to multiple users (admin only)."""
-  adminBulkAssignRole(input: BulkAssignRoleInput!): BulkAssignRolePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Bulk assign a role to multiple users (admin only).
+  """
+  adminBulkAssignRole(input: BulkAssignRoleInput!): BulkAssignRolePayload!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Bulk revoke a role from multiple users (admin only)."""
-  adminBulkRevokeRole(input: BulkRevokeRoleInput!): BulkRevokeRolePayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Bulk revoke a role from multiple users (admin only).
+  """
+  adminBulkRevokeRole(input: BulkRevokeRoleInput!): BulkRevokeRolePayload!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Create a new keypair resource policy (admin only).
   """
-  adminCreateKeypairResourcePolicyV2(input: CreateKeypairResourcePolicyInputGQL!): CreateKeypairResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateKeypairResourcePolicyV2(
+    input: CreateKeypairResourcePolicyInputGQL!
+  ): CreateKeypairResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Update a keypair resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateKeypairResourcePolicyV2(name: String!, input: UpdateKeypairResourcePolicyInputGQL!): UpdateKeypairResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateKeypairResourcePolicyV2(
+    name: String!
+    input: UpdateKeypairResourcePolicyInputGQL!
+  ): UpdateKeypairResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Delete a keypair resource policy (admin only)."""
-  adminDeleteKeypairResourcePolicyV2(name: String!): DeleteKeypairResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Delete a keypair resource policy (admin only).
+  """
+  adminDeleteKeypairResourcePolicyV2(
+    name: String!
+  ): DeleteKeypairResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Create a new user resource policy (admin only)."""
-  adminCreateUserResourcePolicyV2(input: CreateUserResourcePolicyInputGQL!): CreateUserResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Create a new user resource policy (admin only).
+  """
+  adminCreateUserResourcePolicyV2(
+    input: CreateUserResourcePolicyInputGQL!
+  ): CreateUserResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Update a user resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateUserResourcePolicyV2(name: String!, input: UpdateUserResourcePolicyInputGQL!): UpdateUserResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateUserResourcePolicyV2(
+    name: String!
+    input: UpdateUserResourcePolicyInputGQL!
+  ): UpdateUserResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Delete a user resource policy (admin only)."""
-  adminDeleteUserResourcePolicyV2(name: String!): DeleteUserResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Delete a user resource policy (admin only).
+  """
+  adminDeleteUserResourcePolicyV2(
+    name: String!
+  ): DeleteUserResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Create a new project resource policy (admin only).
   """
-  adminCreateProjectResourcePolicyV2(input: CreateProjectResourcePolicyInputGQL!): CreateProjectResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateProjectResourcePolicyV2(
+    input: CreateProjectResourcePolicyInputGQL!
+  ): CreateProjectResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Update a project resource policy (admin only). Only provided fields will be updated.
   """
-  adminUpdateProjectResourcePolicyV2(name: String!, input: UpdateProjectResourcePolicyInputGQL!): UpdateProjectResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateProjectResourcePolicyV2(
+    name: String!
+    input: UpdateProjectResourcePolicyInputGQL!
+  ): UpdateProjectResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Delete a project resource policy (admin only)."""
-  adminDeleteProjectResourcePolicyV2(name: String!): DeleteProjectResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Delete a project resource policy (admin only).
+  """
+  adminDeleteProjectResourcePolicyV2(
+    name: String!
+  ): DeleteProjectResourcePolicyPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Create a new resource preset (admin only)."""
-  adminCreateResourcePresetV2(input: CreateResourcePresetV2Input!): CreateResourcePresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Create a new resource preset (admin only).
+  """
+  adminCreateResourcePresetV2(
+    input: CreateResourcePresetV2Input!
+  ): CreateResourcePresetPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Update a resource preset (admin only)."""
-  adminUpdateResourcePresetV2(input: UpdateResourcePresetV2Input!): UpdateResourcePresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Update a resource preset (admin only).
+  """
+  adminUpdateResourcePresetV2(
+    input: UpdateResourcePresetV2Input!
+  ): UpdateResourcePresetPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Delete a resource preset (admin only)."""
-  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Delete a resource preset (admin only).
+  """
+  adminDeleteResourcePresetV2(id: UUID!): DeleteResourcePresetPayloadGQL!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Create a new runtime variant (superadmin only)."""
-  adminCreateRuntimeVariant(input: CreateRuntimeVariantInput!): CreateRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Create a new runtime variant (superadmin only).
+  """
+  adminCreateRuntimeVariant(
+    input: CreateRuntimeVariantInput!
+  ): CreateRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Update a runtime variant (superadmin only)."""
-  adminUpdateRuntimeVariant(input: UpdateRuntimeVariantInput!): UpdateRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Update a runtime variant (superadmin only).
+  """
+  adminUpdateRuntimeVariant(
+    input: UpdateRuntimeVariantInput!
+  ): UpdateRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Delete a runtime variant (superadmin only)."""
-  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Delete a runtime variant (superadmin only).
+  """
+  adminDeleteRuntimeVariant(id: UUID!): DeleteRuntimeVariantPayloadGQL!
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Create a runtime variant preset (superadmin only).
   """
-  adminCreateRuntimeVariantPreset(input: CreateRuntimeVariantPresetInput!): CreateRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminCreateRuntimeVariantPreset(
+    input: CreateRuntimeVariantPresetInput!
+  ): CreateRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Update a runtime variant preset (superadmin only).
   """
-  adminUpdateRuntimeVariantPreset(input: UpdateRuntimeVariantPresetInput!): UpdateRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminUpdateRuntimeVariantPreset(
+    input: UpdateRuntimeVariantPresetInput!
+  ): UpdateRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Delete a runtime variant preset (superadmin only).
   """
-  adminDeleteRuntimeVariantPreset(id: UUID!): DeleteRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  adminDeleteRuntimeVariantPreset(
+    id: UUID!
+  ): DeleteRuntimeVariantPresetPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Create a deployment revision preset."""
-  createDeploymentRevisionPreset(input: CreateDeploymentRevisionPresetInput!): CreateDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Create a deployment revision preset.
+  """
+  createDeploymentRevisionPreset(
+    input: CreateDeploymentRevisionPresetInput!
+  ): CreateDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Update a deployment revision preset."""
-  updateDeploymentRevisionPreset(input: UpdateDeploymentRevisionPresetInput!): UpdateDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Update a deployment revision preset.
+  """
+  updateDeploymentRevisionPreset(
+    input: UpdateDeploymentRevisionPresetInput!
+  ): UpdateDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Delete a deployment revision preset."""
-  deleteDeploymentRevisionPreset(id: UUID!): DeleteDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Delete a deployment revision preset.
+  """
+  deleteDeploymentRevisionPreset(
+    id: UUID!
+  ): DeleteDeploymentRevisionPresetPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Create a model card (admin only)."""
-  adminCreateModelCardV2(input: CreateModelCardV2Input!): CreateModelCardPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Create a model card (admin only).
+  """
+  adminCreateModelCardV2(
+    input: CreateModelCardV2Input!
+  ): CreateModelCardPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Update a model card (admin only)."""
-  adminUpdateModelCardV2(input: UpdateModelCardV2Input!): UpdateModelCardPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Update a model card (admin only).
+  """
+  adminUpdateModelCardV2(
+    input: UpdateModelCardV2Input!
+  ): UpdateModelCardPayloadGQL! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Delete a model card (admin only)."""
-  adminDeleteModelCardV2(id: UUID!): DeleteModelCardPayloadGQL! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Delete a model card (admin only).
+  """
+  adminDeleteModelCardV2(id: UUID!): DeleteModelCardPayloadGQL!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Terminate sessions within a project scope."""
-  terminateProjectSessionsV2(scope: ProjectSessionV2Scope!, sessionIds: [ID!]!, forced: Boolean! = false): TerminateSessionsPayload! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Terminate sessions within a project scope.
+  """
+  terminateProjectSessionsV2(
+    scope: ProjectSessionV2Scope!
+    sessionIds: [ID!]!
+    forced: Boolean! = false
+  ): TerminateSessionsPayload! @join__field(graph: STRAWBERRY)
 }
 
 """
 Added in UNRELEASED. Query result returning the current client's IP address.
 """
-type MyClientIp
-  @join__type(graph: STRAWBERRY)
-{
-  """The client's IP address as seen by the server"""
+type MyClientIp @join__type(graph: STRAWBERRY) {
+  """
+  The client's IP address as seen by the server
+  """
   clientIp: String!
 }
 
-"""Added in 24.12.0."""
-type NetworkConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 24.12.0.
+"""
+type NetworkConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [NetworkEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
-"""Added in 24.12.0. A Relay edge containing a `Network` and its cursor."""
-type NetworkEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+"""
+Added in 24.12.0. A Relay edge containing a `Network` and its cursor.
+"""
+type NetworkEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: NetworkNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
-"""Added in 24.12.0."""
+"""
+Added in 24.12.0.
+"""
 type NetworkNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
-  @join__type(graph: GRAPHENE)
-{
-  """The ID of the object"""
+  @join__type(graph: GRAPHENE) {
+  """
+  The ID of the object
+  """
   id: ID!
   row_id: UUID
   name: String
@@ -9761,20 +12193,22 @@ type NetworkNode implements Node
 This GraphQL Relay Node extension is for running asynchronous resolvers and fine-grained handling of global id.
 Refer to: https://github.com/graphql-python/graphene/blob/master/graphene/relay/node.py
 """
-interface Node
-  @join__type(graph: GRAPHENE)
-  @join__type(graph: STRAWBERRY)
-{
-  """The ID of the object"""
+interface Node @join__type(graph: GRAPHENE) @join__type(graph: STRAWBERRY) {
+  """
+  The ID of the object
+  """
   id: ID!
 }
 
-"""Added in 26.3.0. Notification channel."""
+"""
+Added in 26.3.0. Notification channel.
+"""
 type NotificationChannel implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   name: String!
   description: String
@@ -9784,33 +12218,41 @@ type NotificationChannel implements Node
   createdAt: DateTime!
 }
 
-"""Added in 26.3.0. Notification channel connection."""
-type NotificationChannelConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Notification channel connection.
+"""
+type NotificationChannelConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [NotificationChannelEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type NotificationChannelEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type NotificationChannelEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: NotificationChannel!
 }
 
-"""Added in 24.09.0. Filter for notification channels"""
-input NotificationChannelFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Filter for notification channels
+"""
+input NotificationChannelFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   channelType: NotificationChannelTypeFilter = null
   enabled: Boolean = null
@@ -9819,45 +12261,45 @@ input NotificationChannelFilter
   NOT: [NotificationChannelFilter!] = null
 }
 
-"""Added in 24.09.0. Order by specification for notification channels"""
-input NotificationChannelOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Order by specification for notification channels
+"""
+input NotificationChannelOrderBy @join__type(graph: STRAWBERRY) {
   field: NotificationChannelOrderField!
   direction: OrderDirection! = ASC
 }
 
-"""Added in 26.3.0. Fields available for ordering notification channels"""
-enum NotificationChannelOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Fields available for ordering notification channels
+"""
+enum NotificationChannelOrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.3.0. Interface for notification channel specifications."""
-interface NotificationChannelSpec
-  @join__type(graph: STRAWBERRY)
-{
-  """Channel type discriminator"""
+"""
+Added in 26.3.0. Interface for notification channel specifications.
+"""
+interface NotificationChannelSpec @join__type(graph: STRAWBERRY) {
+  """
+  Channel type discriminator
+  """
   channelType: NotificationChannelType!
 }
 
 """
 Added in 24.09.0. Input for notification channel configuration. Exactly one of webhook or email must be set.
 """
-input NotificationChannelSpecInput
-  @join__type(graph: STRAWBERRY)
-{
+input NotificationChannelSpecInput @join__type(graph: STRAWBERRY) {
   webhook: WebhookSpecInput
   email: EmailSpecInput
 }
 
-"""Added in 26.3.0. Notification channel types"""
-enum NotificationChannelType
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Notification channel types
+"""
+enum NotificationChannelType @join__type(graph: STRAWBERRY) {
   WEBHOOK @join__enumValue(graph: STRAWBERRY)
   EMAIL @join__enumValue(graph: STRAWBERRY)
 }
@@ -9865,28 +12307,37 @@ enum NotificationChannelType
 """
 Added in 26.3.0. Filter for notification channel type with equality and membership operators.
 """
-input NotificationChannelTypeFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Matches channels with this exact type."""
+input NotificationChannelTypeFilter @join__type(graph: STRAWBERRY) {
+  """
+  Matches channels with this exact type.
+  """
   equals: NotificationChannelType = null
 
-  """Matches channels whose type is in this list."""
+  """
+  Matches channels whose type is in this list.
+  """
   in: [NotificationChannelType!] = null
 
-  """Excludes channels with this exact type."""
+  """
+  Excludes channels with this exact type.
+  """
   notEquals: NotificationChannelType = null
 
-  """Excludes channels whose type is in this list."""
+  """
+  Excludes channels whose type is in this list.
+  """
   notIn: [NotificationChannelType!] = null
 }
 
-"""Added in 26.3.0. Notification rule."""
+"""
+Added in 26.3.0. Notification rule.
+"""
 type NotificationRule implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   name: String!
   description: String
@@ -9897,33 +12348,41 @@ type NotificationRule implements Node
   createdAt: DateTime!
 }
 
-"""Added in 26.3.0. Notification rule connection."""
-type NotificationRuleConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Notification rule connection.
+"""
+type NotificationRuleConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [NotificationRuleEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type NotificationRuleEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type NotificationRuleEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: NotificationRule!
 }
 
-"""Added in 24.09.0. Filter for notification rules"""
-input NotificationRuleFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Filter for notification rules
+"""
+input NotificationRuleFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   ruleType: NotificationRuleTypeFilter = null
   enabled: Boolean = null
@@ -9932,27 +12391,27 @@ input NotificationRuleFilter
   NOT: [NotificationRuleFilter!] = null
 }
 
-"""Added in 24.09.0. Order by specification for notification rules"""
-input NotificationRuleOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Order by specification for notification rules
+"""
+input NotificationRuleOrderBy @join__type(graph: STRAWBERRY) {
   field: NotificationRuleOrderField!
   direction: OrderDirection! = ASC
 }
 
-"""Added in 26.3.0. Fields available for ordering notification rules"""
-enum NotificationRuleOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Fields available for ordering notification rules
+"""
+enum NotificationRuleOrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.3.0. Notification rule types"""
-enum NotificationRuleType
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Notification rule types
+"""
+enum NotificationRuleType @join__type(graph: STRAWBERRY) {
   SESSION_STARTED @join__enumValue(graph: STRAWBERRY)
   SESSION_TERMINATED @join__enumValue(graph: STRAWBERRY)
   ARTIFACT_DOWNLOAD_COMPLETED @join__enumValue(graph: STRAWBERRY)
@@ -9962,38 +12421,45 @@ enum NotificationRuleType
 """
 Added in 26.3.0. Filter for notification rule type with equality and membership operators.
 """
-input NotificationRuleTypeFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Matches rules with this exact type."""
+input NotificationRuleTypeFilter @join__type(graph: STRAWBERRY) {
+  """
+  Matches rules with this exact type.
+  """
   equals: NotificationRuleType = null
 
-  """Matches rules whose type is in this list."""
+  """
+  Matches rules whose type is in this list.
+  """
   in: [NotificationRuleType!] = null
 
-  """Excludes rules with this exact type."""
+  """
+  Excludes rules with this exact type.
+  """
   notEquals: NotificationRuleType = null
 
-  """Excludes rules whose type is in this list."""
+  """
+  Excludes rules whose type is in this list.
+  """
   notIn: [NotificationRuleType!] = null
 }
 
 """
 Added in 26.3.0. Display number format configuration for a resource slot type.
 """
-type NumberFormat
-  @join__type(graph: STRAWBERRY)
-{
+type NumberFormat @join__type(graph: STRAWBERRY) {
   binary: Boolean!
   roundLength: Int!
 }
 
-"""Added in 25.14.0. Object storage node."""
+"""
+Added in 25.14.0. Object storage node.
+"""
 type ObjectStorage implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   name: String!
   host: String!
@@ -10002,55 +12468,78 @@ type ObjectStorage implements Node
   endpoint: String!
   region: String!
 
-  """The namespaces of this entity."""
-  namespaces(before: String, after: String, first: Int, last: Int, limit: Int, offset: Int): StorageNamespaceConnection!
+  """
+  The namespaces of this entity.
+  """
+  namespaces(
+    before: String
+    after: String
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+  ): StorageNamespaceConnection!
 }
 
 """
 Added in 25.14.0. Relay-style connection for paginated object storage queries.
 """
-type ObjectStorageConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ObjectStorageConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ObjectStorageEdge!]!
 
-  """The count of this entity."""
+  """
+  The count of this entity.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type ObjectStorageEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ObjectStorageEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ObjectStorage!
 }
 
-"""Added in UNRELEASED. Information about a single RBAC operation."""
-type OperationInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Operation name"""
+"""
+Added in UNRELEASED. Information about a single RBAC operation.
+"""
+type OperationInfo @join__type(graph: STRAWBERRY) {
+  """
+  Operation name
+  """
   operation: String!
 
-  """Human-readable description"""
+  """
+  Human-readable description
+  """
   description: String!
 
-  """Required RBAC permission"""
+  """
+  Required RBAC permission
+  """
   requiredPermission: OperationType!
 }
 
-"""Added in 26.3.0. RBAC operation type"""
-enum OperationType
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. RBAC operation type
+"""
+enum OperationType @join__type(graph: STRAWBERRY) {
   CREATE @join__enumValue(graph: STRAWBERRY)
   READ @join__enumValue(graph: STRAWBERRY)
   UPDATE @join__enumValue(graph: STRAWBERRY)
@@ -10063,10 +12552,10 @@ enum OperationType
   GRANT_HARD_DELETE @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 24.09.0. Sort direction for ordering"""
-enum OrderDirection
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Sort direction for ordering
+"""
+enum OrderDirection @join__type(graph: STRAWBERRY) {
   ASC @join__enumValue(graph: STRAWBERRY)
   DESC @join__enumValue(graph: STRAWBERRY)
 }
@@ -10074,36 +12563,42 @@ enum OrderDirection
 """
 The Relay compliant `PageInfo` type, containing data necessary to paginate this connection.
 """
-type PageInfo
-  @join__type(graph: GRAPHENE)
-  @join__type(graph: STRAWBERRY)
-{
-  """When paginating forwards, are there more items?"""
+type PageInfo @join__type(graph: GRAPHENE) @join__type(graph: STRAWBERRY) {
+  """
+  When paginating forwards, are there more items?
+  """
   hasNextPage: Boolean!
 
-  """When paginating backwards, are there more items?"""
+  """
+  When paginating backwards, are there more items?
+  """
   hasPreviousPage: Boolean!
 
-  """When paginating backwards, the cursor to continue."""
+  """
+  When paginating backwards, the cursor to continue.
+  """
   startCursor: String
 
-  """When paginating forwards, the cursor to continue."""
+  """
+  When paginating forwards, the cursor to continue.
+  """
   endCursor: String
 }
 
-interface PaginatedList
-  @join__type(graph: GRAPHENE)
-{
+interface PaginatedList @join__type(graph: GRAPHENE) {
   items: [Item]!
   total_count: Int!
 }
 
-"""Added in 26.3.0. RBAC scoped permission."""
+"""
+Added in 26.3.0. RBAC scoped permission.
+"""
 type Permission implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   roleId: UUID!
   scopeType: RBACElementType!
@@ -10112,40 +12607,52 @@ type Permission implements Node
   operation: OperationType!
   createdAt: DateTime!
 
-  """The role this permission belongs to."""
+  """
+  The role this permission belongs to.
+  """
   role: Role
 
-  """The scope this permission applies to."""
+  """
+  The scope this permission applies to.
+  """
   scope: EntityNode
 }
 
-"""Added in 26.3.0. Permission connection."""
-type PermissionConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Permission connection.
+"""
+type PermissionConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [PermissionEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type PermissionEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type PermissionEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: Permission!
 }
 
-"""Added in 26.3.0. Filter for scoped permissions"""
-input PermissionFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Filter for scoped permissions
+"""
+input PermissionFilter @join__type(graph: STRAWBERRY) {
   roleId: UUID = null
   scopeType: RBACElementType = null
   entityType: RBACElementType = null
@@ -10158,9 +12665,7 @@ input PermissionFilter
 """
 Added in 26.4.0. Nested filter for permissions within a role assignment. Filters assignments where the assigned role has permissions matching all specified conditions.
 """
-input PermissionNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
+input PermissionNestedFilter @join__type(graph: STRAWBERRY) {
   scopeId: String = null
   scopeType: RBACElementType = null
   entityType: RBACElementType = null
@@ -10170,48 +12675,54 @@ input PermissionNestedFilter
   NOT: [PermissionNestedFilter!] = null
 }
 
-"""Added in 26.3.0. Order by specification for permissions"""
-input PermissionOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Order by specification for permissions
+"""
+input PermissionOrderBy @join__type(graph: STRAWBERRY) {
   field: PermissionOrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in 26.3.0. Permission ordering field"""
-enum PermissionOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Permission ordering field
+"""
+enum PermissionOrderField @join__type(graph: STRAWBERRY) {
   ID @join__enumValue(graph: STRAWBERRY)
   ENTITY_TYPE @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-type PredefinedAtomicPermission
-  @join__type(graph: GRAPHENE)
-{
+type PredefinedAtomicPermission @join__type(graph: GRAPHENE) {
   vfolder_host_permission_list: [String]
 }
 
-"""Added in 26.3.0. Preemption configuration for a resource group."""
-type PreemptionConfig
-  @join__type(graph: STRAWBERRY)
-{
-  """Sessions with priority <= this value are eligible for preemption."""
+"""
+Added in 26.3.0. Preemption configuration for a resource group.
+"""
+type PreemptionConfig @join__type(graph: STRAWBERRY) {
+  """
+  Sessions with priority <= this value are eligible for preemption.
+  """
   preemptiblePriority: Int!
 
-  """Tie-breaking order for same-priority sessions during preemption."""
+  """
+  Tie-breaking order for same-priority sessions during preemption.
+  """
   order: PreemptionOrder!
 
-  """How to preempt a session when preemption is triggered."""
+  """
+  How to preempt a session when preemption is triggered.
+  """
   mode: PreemptionMode!
 }
 
-"""Added in 26.3.0. Input for preemption configuration."""
-input PreemptionConfigInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Sessions with priority <= this value are preemptible. Default is 5."""
+"""
+Added in 26.3.0. Input for preemption configuration.
+"""
+input PreemptionConfigInput @join__type(graph: STRAWBERRY) {
+  """
+  Sessions with priority <= this value are preemptible. Default is 5.
+  """
   preemptiblePriority: Int! = 5
 
   """
@@ -10219,16 +12730,16 @@ input PreemptionConfigInput
   """
   order: PreemptionOrder! = OLDEST
 
-  """How to preempt sessions (TERMINATE, RESCHEDULE). Default is TERMINATE."""
+  """
+  How to preempt sessions (TERMINATE, RESCHEDULE). Default is TERMINATE.
+  """
   mode: PreemptionMode! = TERMINATE
 }
 
 """
 Added in 26.3.0. How to preempt a session when preemption is triggered.
 """
-enum PreemptionMode
-  @join__type(graph: STRAWBERRY)
-{
+enum PreemptionMode @join__type(graph: STRAWBERRY) {
   TERMINATE @join__enumValue(graph: STRAWBERRY)
   RESCHEDULE @join__enumValue(graph: STRAWBERRY)
 }
@@ -10236,159 +12747,191 @@ enum PreemptionMode
 """
 Added in 26.3.0. Tie-breaking order for same-priority sessions during preemption.
 """
-enum PreemptionOrder
-  @join__type(graph: STRAWBERRY)
-{
+enum PreemptionOrder @join__type(graph: STRAWBERRY) {
   OLDEST @join__enumValue(graph: STRAWBERRY)
   NEWEST @join__enumValue(graph: STRAWBERRY)
 }
 
-type PreloadImage
-  @join__type(graph: GRAPHENE)
-{
+type PreloadImage @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   task_id: String
 }
 
-"""Added in UNRELEASED. A resource preset with its availability status."""
-type PresetAvailabilityV2
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource preset UUID."""
+"""
+Added in UNRELEASED. A resource preset with its availability status.
+"""
+type PresetAvailabilityV2 @join__type(graph: STRAWBERRY) {
+  """
+  Resource preset UUID.
+  """
   id: String!
 
-  """Resource preset name."""
+  """
+  Resource preset name.
+  """
   name: String!
 
-  """Resource slot allocations."""
+  """
+  Resource slot allocations.
+  """
   resourceSlots: [ResourceSlotEntry!]!
 
-  """Shared memory size."""
+  """
+  Shared memory size.
+  """
   sharedMemory: BinarySizeInfo
 
-  """Resource group name. Null means global preset."""
+  """
+  Resource group name. Null means global preset.
+  """
   resourceGroupName: String
 
-  """Whether this preset can be used for session creation."""
+  """
+  Whether this preset can be used for session creation.
+  """
   available: Boolean!
 }
 
 """
 Added in UNRELEASED. Cluster topology settings for the deployment, defining whether the inference workload runs on a single node or is distributed across multiple nodes.
 """
-type PresetClusterSpec
-  @join__type(graph: STRAWBERRY)
-{
-  """Cluster mode."""
+type PresetClusterSpec @join__type(graph: STRAWBERRY) {
+  """
+  Cluster mode.
+  """
   clusterMode: String!
 
-  """Cluster size."""
+  """
+  Cluster size.
+  """
   clusterSize: Int!
 }
 
 """
 Added in UNRELEASED. Container execution configuration for the deployment, including the inference server image, startup commands, and environment variables.
 """
-type PresetExecutionSpec
-  @join__type(graph: STRAWBERRY)
-{
-  """Container image reference."""
+type PresetExecutionSpec @join__type(graph: STRAWBERRY) {
+  """
+  Container image reference.
+  """
   image: String
 
-  """Startup command."""
+  """
+  Startup command.
+  """
   startupCommand: String
 
-  """Bootstrap script."""
+  """
+  Bootstrap script.
+  """
   bootstrapScript: String
 
-  """Environment variables."""
+  """
+  Environment variables.
+  """
   environ: [EnvironmentVariableEntry!]!
 }
 
 """
 Added in UNRELEASED. Compute resource allocation for the deployment, specifying CPU, memory, and accelerator requirements along with additional resource options.
 """
-type PresetResourceAllocation
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource slot allocations."""
+type PresetResourceAllocation @join__type(graph: STRAWBERRY) {
+  """
+  Resource slot allocations.
+  """
   resourceSlots: [ResourceSlotEntry!]!
 
-  """Additional resource options."""
+  """
+  Additional resource options.
+  """
   resourceOpts: [ResourceOptsEntry!]!
 }
 
 """
 Added in UNRELEASED. Specifies how a runtime variant preset value is applied to the inference container, either as an environment variable or a command-line argument.
 """
-type PresetTargetSpec
-  @join__type(graph: STRAWBERRY)
-{
-  """Target: env or args."""
+type PresetTargetSpec @join__type(graph: STRAWBERRY) {
+  """
+  Target: env or args.
+  """
   presetTarget: String!
 
-  """Value type: str, int, float, bool."""
+  """
+  Value type: str, int, float, bool.
+  """
   valueType: String!
 
-  """Default value."""
+  """
+  Default value.
+  """
   defaultValue: String
 
-  """Env key or args flag."""
+  """
+  Env key or args flag.
+  """
   key: String!
 }
 
 """
 Added in UNRELEASED. A pre-start action to execute before starting the model service.
 """
-type PreStartAction
-  @join__type(graph: STRAWBERRY)
-{
-  """The name of the pre-start action to execute."""
+type PreStartAction @join__type(graph: STRAWBERRY) {
+  """
+  The name of the pre-start action to execute.
+  """
   action: String!
 
-  """Arguments for the pre-start action."""
+  """
+  Arguments for the pre-start action.
+  """
   args: JSON!
 }
 
 """
 Added in 26.4.0. Input for a pre-start action to execute before starting the model service.
 """
-input PreStartActionInput
-  @join__type(graph: STRAWBERRY)
-{
-  """The name of the pre-start action to execute."""
+input PreStartActionInput @join__type(graph: STRAWBERRY) {
+  """
+  The name of the pre-start action to execute.
+  """
   action: String!
 
-  """Arguments for the pre-start action."""
+  """
+  Arguments for the pre-start action.
+  """
   args: JSON!
 }
 
 """
 Added in 26.2.0. Basic project information. Contains identity and descriptive fields for the project.
 """
-type ProjectBasicInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Project name."""
+type ProjectBasicInfo @join__type(graph: STRAWBERRY) {
+  """
+  Project name.
+  """
   name: String!
 
-  """Optional description of the project."""
+  """
+  Optional description of the project.
+  """
   description: String
 
-  """Project type determining its purpose. See ProjectType enum."""
+  """
+  Project type determining its purpose. See ProjectType enum.
+  """
   type: ProjectTypeV2!
 
-  """External system integration identifier."""
+  """
+  External system integration identifier.
+  """
   integrationId: String
 }
 
 """
 Added in 26.2.0. Nested filter for the domain a project belongs to. Filters projects whose domain matches all specified conditions.
 """
-input ProjectDomainNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
+input ProjectDomainNestedFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   isActive: Boolean = null
 }
@@ -10398,30 +12941,45 @@ Added in 26.1.0. Project-level fair share data representing scheduling priority 
 """
 type ProjectFairShare implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Name of the scaling group this fair share belongs to."""
+  """
+  Name of the scaling group this fair share belongs to.
+  """
   resourceGroupName: String!
 
-  """UUID of the project this fair share is calculated for."""
+  """
+  UUID of the project this fair share is calculated for.
+  """
   projectId: UUID!
 
-  """Name of the domain the project belongs to."""
+  """
+  Name of the domain the project belongs to.
+  """
   domainName: String!
 
-  """Fair share specification parameters used for calculation."""
+  """
+  Fair share specification parameters used for calculation.
+  """
   spec: FairShareSpec!
 
-  """Snapshot of the most recent fair share calculation results."""
+  """
+  Snapshot of the most recent fair share calculation results.
+  """
   calculationSnapshot: FairShareCalculationSnapshot!
 
-  """Timestamp when this record was created."""
+  """
+  Timestamp when this record was created.
+  """
   createdAt: DateTime!
 
-  """Timestamp when this record was last updated."""
+  """
+  Timestamp when this record was last updated.
+  """
   updatedAt: DateTime!
 
   """
@@ -10443,13 +13001,15 @@ type ProjectFairShare implements Node
 """
 Added in 26.1.0. Paginated connection for project fair share records. Provides relay-style cursor-based pagination for efficient traversal of project fair share data. Use 'edges' to access individual records with cursor information, or 'nodes' for direct data access.
 """
-type ProjectFairShareConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ProjectFairShareConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ProjectFairShareEdge!]!
 
   """
@@ -10458,23 +13018,25 @@ type ProjectFairShareConnection
   count: Int!
 }
 
-"""An edge in a connection."""
-type ProjectFairShareEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ProjectFairShareEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ProjectFairShare!
 }
 
 """
 Added in 26.1.0. Filter input for querying project fair shares. Supports filtering by scaling group, project ID, and domain name. Multiple filters can be combined using AND, OR, and NOT logical operators.
 """
-input ProjectFairShareFilter
-  @join__type(graph: STRAWBERRY)
-{
+input ProjectFairShareFilter @join__type(graph: STRAWBERRY) {
   """
   Filter by scaling group name. Scaling groups define resource pool boundaries where projects compete for resources within their domain. Supports equals, contains, startsWith, and endsWith operations.
   """
@@ -10495,7 +13057,9 @@ input ProjectFairShareFilter
   """
   project: ProjectFairShareProjectNestedFilter = null
 
-  """Combine multiple filters with AND logic. All conditions must match."""
+  """
+  Combine multiple filters with AND logic. All conditions must match.
+  """
   AND: [ProjectFairShareFilter!] = null
 
   """
@@ -10512,9 +13076,7 @@ input ProjectFairShareFilter
 """
 Added in 26.1.0. Specifies ordering for project fair share query results. Combine field selection with direction to sort results. Default direction is DESC (descending).
 """
-input ProjectFairShareOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input ProjectFairShareOrderBy @join__type(graph: STRAWBERRY) {
   """
   The field to order by. See ProjectFairShareOrderField for available options.
   """
@@ -10529,9 +13091,7 @@ input ProjectFairShareOrderBy
 """
 Added in 26.1.0. Fields available for ordering project fair share query results. FAIR_SHARE_FACTOR: Order by the calculated fair share factor (0-1 range, lower = higher priority). CREATED_AT: Order by record creation timestamp. PROJECT_NAME: Order alphabetically by project name. PROJECT_IS_ACTIVE: Order by project active status.
 """
-enum ProjectFairShareOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum ProjectFairShareOrderField @join__type(graph: STRAWBERRY) {
   FAIR_SHARE_FACTOR @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   PROJECT_NAME @join__enumValue(graph: STRAWBERRY)
@@ -10541,33 +13101,37 @@ enum ProjectFairShareOrderField
 """
 Added in 26.2.0. Nested filter for project entity fields in project fair share queries. Allows filtering by project properties such as name, active status, and type.
 """
-input ProjectFairShareProjectNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
+input ProjectFairShareProjectNestedFilter @join__type(graph: STRAWBERRY) {
   """
   Filter by project name. Supports equals, contains, startsWith, and endsWith.
   """
   name: StringFilter = null
 
-  """Filter by project active status."""
+  """
+  Filter by project active status.
+  """
   isActive: Boolean = null
 
-  """Filter by project type (GENERAL, MODEL_STORE)."""
+  """
+  Filter by project type (GENERAL, MODEL_STORE).
+  """
   type: ProjectFairShareTypeEnumFilter = null
 }
 
-"""Added in 24.09.0. Scope parameters for filtering project fair shares."""
-input ProjectFairShareScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group to filter fair shares by."""
+"""
+Added in 24.09.0. Scope parameters for filtering project fair shares.
+"""
+input ProjectFairShareScope @join__type(graph: STRAWBERRY) {
+  """
+  Resource group to filter fair shares by.
+  """
   resourceGroupName: String!
 }
 
-"""Added in 26.2.0. Project type enum for fair share filtering."""
-enum ProjectFairShareTypeEnum
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Project type enum for fair share filtering.
+"""
+enum ProjectFairShareTypeEnum @join__type(graph: STRAWBERRY) {
   GENERAL @join__enumValue(graph: STRAWBERRY)
   MODEL_STORE @join__enumValue(graph: STRAWBERRY)
 }
@@ -10575,72 +13139,84 @@ enum ProjectFairShareTypeEnum
 """
 Added in 26.2.0. Filter for project type enum in fair share queries. Supports equals, in, not_equals, and not_in operations.
 """
-input ProjectFairShareTypeEnumFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Exact match for project type."""
+input ProjectFairShareTypeEnumFilter @join__type(graph: STRAWBERRY) {
+  """
+  Exact match for project type.
+  """
   equals: ProjectFairShareTypeEnum = null
 
-  """Match any of the provided types."""
+  """
+  Match any of the provided types.
+  """
   in: [ProjectFairShareTypeEnum!] = null
 
-  """Exclude exact type match."""
+  """
+  Exclude exact type match.
+  """
   notEquals: ProjectFairShareTypeEnum = null
 
-  """Exclude any of the provided types."""
+  """
+  Exclude any of the provided types.
+  """
   notIn: [ProjectFairShareTypeEnum!] = null
 }
 
 """
 Added in 26.2.0. Project lifecycle information. Contains activation status and timestamp tracking.
 """
-type ProjectLifecycleInfo
-  @join__type(graph: STRAWBERRY)
-{
+type ProjectLifecycleInfo @join__type(graph: STRAWBERRY) {
   """
   Whether the project is active. Inactive projects cannot create new sessions or perform operations.
   """
   isActive: Boolean
 
-  """Timestamp when the project was created."""
+  """
+  Timestamp when the project was created.
+  """
   createdAt: DateTime
 
-  """Timestamp when the project was last modified."""
+  """
+  Timestamp when the project was last modified.
+  """
   modifiedAt: DateTime
 }
 
 """
 Added in 26.2.0. Project's organizational context. Contains domain membership and resource policy information.
 """
-type ProjectOrganizationInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the domain this project belongs to."""
+type ProjectOrganizationInfo @join__type(graph: STRAWBERRY) {
+  """
+  Name of the domain this project belongs to.
+  """
   domainName: String!
 
-  """Name of the project resource policy applied to this project."""
+  """
+  Name of the project resource policy applied to this project.
+  """
   resourcePolicy: String!
 }
 
-"""Added in UNRELEASED. Payload for project mutation responses."""
-type ProjectPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """The project entity."""
+"""
+Added in UNRELEASED. Payload for project mutation responses.
+"""
+type ProjectPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  The project entity.
+  """
   project: ProjectV2!
 }
 
-"""Added in UNRELEASED. Payload for project resource allocation query."""
-type ProjectResourceAllocationV2
-  @join__type(graph: STRAWBERRY)
-{
-  """Project resource usage."""
+"""
+Added in UNRELEASED. Payload for project resource allocation query.
+"""
+type ProjectResourceAllocationV2 @join__type(graph: STRAWBERRY) {
+  """
+  Project resource usage.
+  """
   project: ScopeResourceUsageV2!
 }
 
-type ProjectResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type ProjectResourcePolicy @join__type(graph: GRAPHENE) {
   id: ID!
   name: String!
   created_at: DateTime!
@@ -10667,58 +13243,77 @@ Added in UNRELEASED. Project resource policy defining vfolder, quota, and networ
 """
 type ProjectResourcePolicyV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Policy name."""
+  """
+  Policy name.
+  """
   name: String!
 
-  """Timestamp when the policy was created."""
+  """
+  Timestamp when the policy was created.
+  """
   createdAt: DateTime
 
-  """Maximum vfolders a project can have."""
+  """
+  Maximum vfolders a project can have.
+  """
   maxVfolderCount: Int!
 
-  """Maximum quota scope size."""
+  """
+  Maximum quota scope size.
+  """
   maxQuotaScopeSize: BinarySizeInfo!
 
-  """Maximum networks a project can create. -1 means unlimited."""
+  """
+  Maximum networks a project can create. -1 means unlimited.
+  """
   maxNetworkCount: Int!
 }
 
 """
 Added in UNRELEASED. Paginated connection for project resource policies.
 """
-type ProjectResourcePolicyV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ProjectResourcePolicyV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ProjectResourcePolicyV2Edge!]!
 
-  """Total number of matching policies."""
+  """
+  Total number of matching policies.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type ProjectResourcePolicyV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ProjectResourcePolicyV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ProjectResourcePolicyV2!
 }
 
-"""Added in UNRELEASED. Filter for project resource policies."""
-input ProjectResourcePolicyV2Filter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Filter for project resource policies.
+"""
+input ProjectResourcePolicyV2Filter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   createdAt: DateTimeFilter = null
   maxVfolderCount: IntFilter = null
@@ -10729,22 +13324,22 @@ input ProjectResourcePolicyV2Filter
 """
 Added in UNRELEASED. Ordering specification for project resource policies.
 """
-input ProjectResourcePolicyV2OrderBy
-  @join__type(graph: STRAWBERRY)
-{
-  """Field to order by."""
+input ProjectResourcePolicyV2OrderBy @join__type(graph: STRAWBERRY) {
+  """
+  Field to order by.
+  """
   field: ProjectResourcePolicyV2OrderField! = CREATED_AT
 
-  """Sort direction."""
+  """
+  Sort direction.
+  """
   direction: OrderDirection! = DESC
 }
 
 """
 Added in UNRELEASED. Fields available for ordering project resource policies.
 """
-enum ProjectResourcePolicyV2OrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum ProjectResourcePolicyV2OrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   MAX_VFOLDER_COUNT @join__enumValue(graph: STRAWBERRY)
@@ -10755,19 +13350,17 @@ enum ProjectResourcePolicyV2OrderField
 """
 Added in UNRELEASED. Scope for session operations within a specific project.
 """
-input ProjectSessionV2Scope
-  @join__type(graph: STRAWBERRY)
-{
-  """Project UUID to scope the session operation."""
+input ProjectSessionV2Scope @join__type(graph: STRAWBERRY) {
+  """
+  Project UUID to scope the session operation.
+  """
   projectId: UUID!
 }
 
 """
 Added in 26.2.0. Project storage configuration. Contains allowed virtual folder hosts and their permissions.
 """
-type ProjectStorageInfo
-  @join__type(graph: STRAWBERRY)
-{
+type ProjectStorageInfo @join__type(graph: STRAWBERRY) {
   """
   Storage hosts accessible to this project with their permissions. Each entry specifies a host and the operations allowed on it. Empty list means no storage access.
   """
@@ -10777,9 +13370,7 @@ type ProjectStorageInfo
 """
 Added in 26.2.0. Project type determining its purpose and behavior. GENERAL: Standard project for general computation. MODEL_STORE: Project for model storage and management.
 """
-enum ProjectTypeV2
-  @join__type(graph: STRAWBERRY)
-{
+enum ProjectTypeV2 @join__type(graph: STRAWBERRY) {
   GENERAL @join__enumValue(graph: STRAWBERRY)
   MODEL_STORE @join__enumValue(graph: STRAWBERRY)
 }
@@ -10787,9 +13378,7 @@ enum ProjectTypeV2
 """
 Added in 26.2.0. Filter for ProjectTypeEnum fields. Supports equals, in, not_equals, and not_in operations.
 """
-input ProjectTypeV2EnumFilter
-  @join__type(graph: STRAWBERRY)
-{
+input ProjectTypeV2EnumFilter @join__type(graph: STRAWBERRY) {
   equals: ProjectTypeV2 = null
   in_: [ProjectTypeV2!] = null
   notEquals: ProjectTypeV2 = null
@@ -10801,21 +13390,30 @@ Added in 26.1.0. Project-level usage bucket representing aggregated resource con
 """
 type ProjectUsageBucket implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """UUID of the project this usage bucket belongs to."""
+  """
+  UUID of the project this usage bucket belongs to.
+  """
   projectId: UUID!
 
-  """Name of the domain the project belongs to."""
+  """
+  Name of the domain the project belongs to.
+  """
   domainName: String!
 
-  """Name of the scaling group this usage was recorded in."""
+  """
+  Name of the scaling group this usage was recorded in.
+  """
   resourceGroupName: String!
 
-  """Metadata about the usage measurement period and timestamps."""
+  """
+  Metadata about the usage measurement period and timestamps.
+  """
   metadata: UsageBucketMetadata!
 
   """
@@ -10841,19 +13439,30 @@ type ProjectUsageBucket implements Node
   """
   Added in 26.1.0. User usage buckets belonging to this project. Returns paginated user-level usage history for all users in this project within the same scaling group.
   """
-  userUsageBuckets(filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection!
+  userUsageBuckets(
+    filter: UserUsageBucketFilter = null
+    orderBy: [UserUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserUsageBucketConnection!
 }
 
 """
 Added in 26.1.0. Paginated connection for project usage bucket records. Provides relay-style cursor-based pagination for browsing historical usage data by time period. Use 'edges' to access individual records with cursor information, or 'nodes' for direct data access.
 """
-type ProjectUsageBucketConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ProjectUsageBucketConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ProjectUsageBucketEdge!]!
 
   """
@@ -10862,23 +13471,25 @@ type ProjectUsageBucketConnection
   count: Int!
 }
 
-"""An edge in a connection."""
-type ProjectUsageBucketEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ProjectUsageBucketEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ProjectUsageBucket!
 }
 
 """
 Added in 26.1.0. Filter input for querying project usage bucket records. Usage buckets contain historical resource consumption data aggregated by time period for projects. Multiple filters can be combined using AND, OR, and NOT logical operators.
 """
-input ProjectUsageBucketFilter
-  @join__type(graph: STRAWBERRY)
-{
+input ProjectUsageBucketFilter @join__type(graph: STRAWBERRY) {
   """
   Filter by scaling group name. Scaling groups define where usage was recorded. Supports equals, contains, startsWith, and endsWith operations.
   """
@@ -10894,13 +13505,19 @@ input ProjectUsageBucketFilter
   """
   domainName: StringFilter = null
 
-  """Filter by usage measurement period start date."""
+  """
+  Filter by usage measurement period start date.
+  """
   periodStart: DateFilter = null
 
-  """Filter by usage measurement period end date."""
+  """
+  Filter by usage measurement period end date.
+  """
   periodEnd: DateFilter = null
 
-  """Combine multiple filters with AND logic. All conditions must match."""
+  """
+  Combine multiple filters with AND logic. All conditions must match.
+  """
   AND: [ProjectUsageBucketFilter!] = null
 
   """
@@ -10917,9 +13534,7 @@ input ProjectUsageBucketFilter
 """
 Added in 26.1.0. Specifies ordering for project usage bucket query results. Combine field selection with direction to sort results. Default direction is DESC (most recent first).
 """
-input ProjectUsageBucketOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input ProjectUsageBucketOrderBy @join__type(graph: STRAWBERRY) {
   """
   The field to order by. See UsageBucketOrderField for available options.
   """
@@ -10934,19 +13549,17 @@ input ProjectUsageBucketOrderBy
 """
 Added in 24.09.0. Scope parameters for filtering project usage buckets.
 """
-input ProjectUsageScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group to filter usage buckets by."""
+input ProjectUsageScope @join__type(graph: STRAWBERRY) {
+  """
+  Resource group to filter usage buckets by.
+  """
   resourceGroupName: String!
 }
 
 """
 Added in 26.2.0. Nested filter for users belonging to a project. Filters projects that have at least one user matching all specified conditions.
 """
-input ProjectUserNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
+input ProjectUserNestedFilter @join__type(graph: STRAWBERRY) {
   username: StringFilter = null
   email: StringFilter = null
   isActive: Boolean = null
@@ -10955,9 +13568,7 @@ input ProjectUserNestedFilter
 """
 Added in 26.2.0. Scope for querying users within a specific project. Used to restrict user queries to members of a particular project.
 """
-input ProjectUserV2Scope
-  @join__type(graph: STRAWBERRY)
-{
+input ProjectUserV2Scope @join__type(graph: STRAWBERRY) {
   """
   Project UUID to scope the user query. Only users who are members of this project will be returned.
   """
@@ -10969,12 +13580,15 @@ Added in 26.2.0. Project entity with structured field groups. Formerly GroupNode
 """
 type ProjectV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY, key: "id")
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY, key: "id") {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Basic project information including name, type, and description."""
+  """
+  Basic project information including name, type, and description.
+  """
   basicInfo: ProjectBasicInfo!
 
   """
@@ -10982,10 +13596,14 @@ type ProjectV2 implements Node
   """
   organization: ProjectOrganizationInfo!
 
-  """Storage configuration and vfolder host permissions."""
+  """
+  Storage configuration and vfolder host permissions.
+  """
   storage: ProjectStorageInfo!
 
-  """Lifecycle information including activation status and timestamps."""
+  """
+  Lifecycle information including activation status and timestamps.
+  """
   lifecycle: ProjectLifecycleInfo!
 
   """
@@ -11001,48 +13619,77 @@ type ProjectV2 implements Node
   """
   Usage buckets for this project, filtered by resource group. Returns aggregated resource usage statistics over time.
   """
-  usageBuckets(scope: ProjectUsageScope!, filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection!
+  usageBuckets(
+    scope: ProjectUsageScope!
+    filter: ProjectUsageBucketFilter = null
+    orderBy: [ProjectUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectUsageBucketConnection!
 
-  """The domain this project belongs to."""
+  """
+  The domain this project belongs to.
+  """
   domain: DomainV2!
 
-  """Users who are members of this project."""
-  users(filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection!
+  """
+  Users who are members of this project.
+  """
+  users(
+    filter: UserV2Filter = null
+    orderBy: [UserV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserV2Connection!
 }
 
 """
 Added in 26.2.0. Paginated connection for project records. Provides relay-style cursor-based pagination for efficient traversal of project data. Use 'edges' to access individual records with cursor information, or 'nodes' for direct data access.
 """
-type ProjectV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ProjectV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ProjectV2Edge!]!
 
-  """Total number of project records matching the query criteria."""
+  """
+  Total number of project records matching the query criteria.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type ProjectV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ProjectV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ProjectV2!
 }
 
 """
 Added in 26.2.0. Filter input for querying projects. Supports filtering by ID, name, domain, type, active status, and timestamps. Multiple filters can be combined using AND, OR, and NOT logical operators.
 """
-input ProjectV2Filter
-  @join__type(graph: STRAWBERRY)
-{
+input ProjectV2Filter @join__type(graph: STRAWBERRY) {
   id: UUIDFilter = null
   name: StringFilter = null
   domainName: StringFilter = null
@@ -11060,9 +13707,7 @@ input ProjectV2Filter
 """
 Added in 26.2.0. Specifies ordering for project query results. Combine field selection with direction to sort results. Default direction is DESC (descending).
 """
-input ProjectV2OrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input ProjectV2OrderBy @join__type(graph: STRAWBERRY) {
   field: ProjectV2OrderField! = CREATED_AT
   direction: OrderDirection! = DESC
 }
@@ -11070,9 +13715,7 @@ input ProjectV2OrderBy
 """
 Added in 26.2.0. Fields available for ordering project query results. CREATED_AT: Order by creation timestamp. MODIFIED_AT: Order by last modification timestamp. NAME: Order by project name alphabetically. IS_ACTIVE: Order by active status. TYPE: Order by project type. DOMAIN_NAME: Order by domain name (scalar subquery). USER_USERNAME: Order by username (MIN aggregation). USER_EMAIL: Order by user email (MIN aggregation).
 """
-enum ProjectV2OrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum ProjectV2OrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   MODIFIED_AT @join__enumValue(graph: STRAWBERRY)
   NAME @join__enumValue(graph: STRAWBERRY)
@@ -11086,13 +13729,15 @@ enum ProjectV2OrderField
 """
 Added in 26.1.0. Input item for a single project weight in bulk upsert. Represents one project's weight configuration.
 """
-input ProjectWeightInputItem
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the project to update weight for."""
+input ProjectWeightInputItem @join__type(graph: STRAWBERRY) {
+  """
+  ID of the project to update weight for.
+  """
   projectId: UUID!
 
-  """Name of the domain this project belongs to."""
+  """
+  Name of the domain this project belongs to.
+  """
   domainName: String!
 
   """
@@ -11107,18 +13752,18 @@ Completely delete domain from DB.
 Domain-bound kernels will also be all deleted.
 To purge domain, there should be no users and groups in the target domain.
 """
-type PurgeDomain
-  @join__type(graph: GRAPHENE)
-{
+type PurgeDomain @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in UNRELEASED. Payload for domain permanent deletion mutation."""
-type PurgeDomainPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the purge was successful."""
+"""
+Added in UNRELEASED. Payload for domain permanent deletion mutation.
+"""
+type PurgeDomainPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Whether the purge was successful.
+  """
   purged: Boolean!
 }
 
@@ -11129,78 +13774,82 @@ Group's vfolders and their data will also be lost
 as well as the kernels run from the group.
 There is no migration of the ownership for group folders.
 """
-type PurgeGroup
-  @join__type(graph: GRAPHENE)
-{
+type PurgeGroup @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 25.4.0."""
-type PurgeImageById
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.4.0.
+"""
+type PurgeImageById @join__type(graph: GRAPHENE) {
   image: ImageNode
 }
 
-"""Added in 25.10.0."""
-input PurgeImageOptions
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.10.0.
+"""
+input PurgeImageOptions @join__type(graph: GRAPHENE) {
   """
   Untag the deleted image from the registry. Only available in the HarborV2 registry.
   """
   remove_from_registry: Boolean = false
 }
 
-"""Added in 25.6.0."""
-input PurgeImagesKey
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.6.0.
+"""
+input PurgeImagesKey @join__type(graph: GRAPHENE) {
   agent_id: String!
   images: [ImageRefType]!
 }
 
-"""Added in 25.6.0."""
-input PurgeImagesOptions
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.6.0.
+"""
+input PurgeImagesOptions @join__type(graph: GRAPHENE) {
   """
   Remove the images even if it is being used by stopped containers or has other tags, Added in 25.6.0.
   """
   force: Boolean = false
 
-  """Don't delete untagged parent images, Added in 25.6.0."""
+  """
+  Don't delete untagged parent images, Added in 25.6.0.
+  """
   noprune: Boolean = false
 }
 
-"""Added in 25.6.0."""
-type PurgeImagesPayload
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.6.0.
+"""
+type PurgeImagesPayload @join__type(graph: GRAPHENE) {
   task_id: String
 }
 
-"""Added in UNRELEASED. Payload for project permanent deletion mutation."""
-type PurgeProjectPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the purge was successful."""
+"""
+Added in UNRELEASED. Payload for project permanent deletion mutation.
+"""
+type PurgeProjectPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Whether the purge was successful.
+  """
   purged: Boolean!
 }
 
-"""Added in 26.3.0. Input for purging a role"""
-input PurgeRoleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Input for purging a role
+"""
+input PurgeRoleInput @join__type(graph: STRAWBERRY) {
   id: UUID!
 }
 
-"""Added in 26.3.0. Payload for purge role mutation."""
-type PurgeRolePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the purged role"""
+"""
+Added in 26.3.0. Payload for purge role mutation.
+"""
+type PurgeRolePayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the purged role
+  """
   id: UUID!
 }
 
@@ -11218,16 +13867,12 @@ vFolder treatment policy:
 
 This action cannot be undone.
 """
-type PurgeUser
-  @join__type(graph: GRAPHENE)
-{
+type PurgeUser @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-input PurgeUserInput
-  @join__type(graph: GRAPHENE)
-{
+input PurgeUserInput @join__type(graph: GRAPHENE) {
   purge_shared_vfolders: Boolean
 
   """
@@ -11239,66 +13884,83 @@ input PurgeUserInput
 """
 Added in 26.2.0. Input for permanently deleting a user and all associated data. This action is irreversible.
 """
-input PurgeUserV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the user to purge."""
+input PurgeUserV2Input @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the user to purge.
+  """
   userId: UUID!
 
-  """Added in UNRELEASED. Options for the purge operation."""
+  """
+  Added in UNRELEASED. Options for the purge operation.
+  """
   options: PurgeUserV2Options = null
 }
 
-"""Added in UNRELEASED. Options for single user purge operation."""
-input PurgeUserV2Options
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Options for single user purge operation.
+"""
+input PurgeUserV2Options @join__type(graph: STRAWBERRY) {
   """
   If true, migrate shared virtual folders to the admin user before purging.
   """
   purgeSharedVfolders: Boolean! = false
 
-  """If true, delegate endpoint ownership to the admin user before purging."""
+  """
+  If true, delegate endpoint ownership to the admin user before purging.
+  """
   delegateEndpointOwnership: Boolean! = false
 }
 
-"""Added in 26.2.0. Payload for single user permanent deletion mutation."""
-type PurgeUserV2Payload
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the purge was successful."""
+"""
+Added in 26.2.0. Payload for single user permanent deletion mutation.
+"""
+type PurgeUserV2Payload @join__type(graph: STRAWBERRY) {
+  """
+  Whether the purge was successful.
+  """
   success: Boolean!
 }
 
-type Query
-  @join__type(graph: GRAPHENE)
-  @join__type(graph: STRAWBERRY)
-{
+type Query @join__type(graph: GRAPHENE) @join__type(graph: STRAWBERRY) {
   node(
-    """The ID of the object"""
+    """
+    The ID of the object
+    """
     id: ID!
   ): Node @join__field(graph: GRAPHENE)
 
-  """Added in 25.6.0."""
+  """
+  Added in 25.6.0.
+  """
   audit_log_schema: AuditLogSchema @join__field(graph: GRAPHENE)
 
-  """Added in 25.6.0."""
+  """
+  Added in 25.6.0.
+  """
   audit_log_nodes(
     """
     Specifies the criteria used to narrow down the query results based on certain conditions.
     """
     filter: String
 
-    """Specifies the sorting order of the query result."""
+    """
+    Specifies the sorting order of the query result.
+    """
     order: String
 
-    """Specifies how many items to skip before beginning to return result."""
+    """
+    Specifies how many items to skip before beginning to return result.
+    """
     offset: Int
 
-    """If this value is provided, the query will be limited to that value."""
+    """
+    If this value is provided, the query will be limited to that value.
+    """
     before: String
 
-    """Queries the `last` number of results from the query result from last."""
+    """
+    Queries the `last` number of results from the query result from last.
+    """
     after: String
 
     """
@@ -11306,27 +13968,66 @@ type Query
     """
     first: Int
 
-    """If the given value is provided, the query will start from that value."""
+    """
+    If the given value is provided, the query will start from that value.
+    """
     last: Int
   ): AuditLogConnection @join__field(graph: GRAPHENE)
   agent(agent_id: String!): Agent @join__field(graph: GRAPHENE)
-  agent_list(limit: Int!, offset: Int!, filter: String, order: String, scaling_group: String, status: String): AgentList @join__field(graph: GRAPHENE)
-  agents(scaling_group: String, status: String): [Agent] @join__field(graph: GRAPHENE)
+  agent_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    scaling_group: String
+    status: String
+  ): AgentList @join__field(graph: GRAPHENE)
+  agents(scaling_group: String, status: String): [Agent]
+    @join__field(graph: GRAPHENE)
   agent_summary(agent_id: String!): AgentSummary @join__field(graph: GRAPHENE)
-  agent_summary_list(limit: Int!, offset: Int!, filter: String, order: String, scaling_group: String, status: String): AgentSummaryList @join__field(graph: GRAPHENE)
+  agent_summary_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    scaling_group: String
+    status: String
+  ): AgentSummaryList @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
-  domain_node(id: GlobalIDField!, permission: DomainPermissionValueField = "read_attribute"): DomainNode @join__field(graph: GRAPHENE)
+  """
+  Added in 24.12.0.
+  """
+  domain_node(
+    id: GlobalIDField!
+    permission: DomainPermissionValueField = "read_attribute"
+  ): DomainNode @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
-  domain_nodes(filter: String, order: String, permission: DomainPermissionValueField = "read_attribute", offset: Int, before: String, after: String, first: Int, last: Int): DomainConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 24.12.0.
+  """
+  domain_nodes(
+    filter: String
+    order: String
+    permission: DomainPermissionValueField = "read_attribute"
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): DomainConnection @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   agent_nodes(
-    """Added in 24.12.0. Default is `system`."""
+    """
+    Added in 24.12.0. Default is `system`.
+    """
     scope: ScopeField
 
-    """Added in 24.12.0. Default is create_compute_session."""
+    """
+    Added in 24.12.0. Default is create_compute_session.
+    """
     permission: AgentPermissionField = "create_compute_session"
     filter: String
     order: String
@@ -11339,24 +14040,38 @@ type Query
   domain(name: String): Domain @join__field(graph: GRAPHENE)
   domains(is_active: Boolean): [Domain] @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.0."""
+  """
+  Added in 24.03.0.
+  """
   group_node(id: String!): GroupNode @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.0."""
+  """
+  Added in 24.03.0.
+  """
   group_nodes(
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     filter: String
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     order: String
 
-    """Added in 25.3.0. Default is `system`."""
+    """
+    Added in 25.3.0. Default is `system`.
+    """
     scope: ScopeField
 
-    """Added in 25.3.0."""
+    """
+    Added in 25.3.0.
+    """
     container_registry_scope: ContainerRegistryScopeField
 
-    """Added in 25.3.0. Default is read_attribute."""
+    """
+    Added in 25.3.0. Default is read_attribute.
+    """
     permission: GroupPermissionField = "read_attribute"
     offset: Int
     before: String
@@ -11368,19 +14083,26 @@ type Query
     id: UUID!
     domain_name: String
 
-    """Added in 24.03.0."""
+    """
+    Added in 24.03.0.
+    """
     type: [String] = ["GENERAL"]
   ): Group @join__field(graph: GRAPHENE)
-  groups_by_name(name: String!, domain_name: String): [Group] @join__field(graph: GRAPHENE)
+  groups_by_name(name: String!, domain_name: String): [Group]
+    @join__field(graph: GRAPHENE)
   groups(
     domain_name: String
     is_active: Boolean
 
-    """Added in 24.03.0. Available values: GENERAL, MODEL_STORE"""
+    """
+    Added in 24.03.0. Available values: GENERAL, MODEL_STORE
+    """
     type: [String] = ["GENERAL"]
   ): [Group] @join__field(graph: GRAPHENE)
   image(
-    """Added in 24.03.1"""
+    """
+    Added in 24.03.1
+    """
     id: String
     reference: String
 
@@ -11394,9 +14116,14 @@ type Query
     Added in 19.09.0. If it is specified, fetch images installed on at least one agent.
     """
     is_installed: Boolean
-    is_operation: Boolean @deprecated(reason: "Deprecated since 24.03.4. This field is ignored if `load_filters` is specified and is not null.")
+    is_operation: Boolean
+      @deprecated(
+        reason: "Deprecated since 24.03.4. This field is ignored if `load_filters` is specified and is not null."
+      )
 
-    """Added in 25.4.0."""
+    """
+    Added in 25.4.0.
+    """
     filter_by_statuses: [ImageStatus] = [ALIVE]
 
     """
@@ -11407,29 +14134,44 @@ type Query
     """
     Added in 24.03.4. Allowed values are: [general, operational, customized]. When superuser queries with `customized` option set the resolver will return every customized images (including those not owned by caller). To list the owned images only call `customized_images`.
     """
-    image_filters: [String] = null @deprecated(reason: "Deprecated since 24.03.8. Use `load_filters` instead.")
+    image_filters: [String] = null
+      @deprecated(
+        reason: "Deprecated since 24.03.8. Use `load_filters` instead."
+      )
   ): [Image] @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.1"""
+  """
+  Added in 24.03.1
+  """
   customized_images: [ImageNode] @join__field(graph: GRAPHENE)
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   image_node(
     id: GlobalIDField!
     scope_id: ScopeField
 
-    """Default is read_attribute."""
+    """
+    Default is read_attribute.
+    """
     permission: ImagePermissionValueField = "read_attribute"
   ): ImageNode @join__field(graph: GRAPHENE)
 
-  """Added in 25.3.0."""
+  """
+  Added in 25.3.0.
+  """
   image_nodes(
     scope_id: ScopeField!
 
-    """Default is read_attribute."""
+    """
+    Default is read_attribute.
+    """
     permission: ImagePermissionValueField = "read_attribute"
 
-    """Added in 25.4.0."""
+    """
+    Added in 25.4.0.
+    """
     filter_by_statuses: [ImageStatus] = [ALIVE]
     filter: String
     order: String
@@ -11440,64 +14182,141 @@ type Query
     last: Int
   ): ImageConnection @join__field(graph: GRAPHENE)
 
-  """Added in 25.14.2. Returns information about the current user."""
+  """
+  Added in 25.14.2. Returns information about the current user.
+  """
   viewer: Viewer @join__field(graph: GRAPHENE)
   user(domain_name: String, email: String): User @join__field(graph: GRAPHENE)
-  user_from_uuid(domain_name: String, user_id: ID): User @join__field(graph: GRAPHENE)
-  users(domain_name: String, group_id: UUID, is_active: Boolean, status: String): [User] @join__field(graph: GRAPHENE)
-  user_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: UUID, is_active: Boolean, status: String): UserList @join__field(graph: GRAPHENE)
+  user_from_uuid(domain_name: String, user_id: ID): User
+    @join__field(graph: GRAPHENE)
+  users(
+    domain_name: String
+    group_id: UUID
+    is_active: Boolean
+    status: String
+  ): [User] @join__field(graph: GRAPHENE)
+  user_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: UUID
+    is_active: Boolean
+    status: String
+  ): UserList @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.0."""
+  """
+  Added in 24.03.0.
+  """
   user_node(id: String!): UserNode @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.0."""
-  user_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): UserConnection @join__field(graph: GRAPHENE)
-  keypair(domain_name: String, access_key: String): KeyPair @join__field(graph: GRAPHENE)
-  keypairs(domain_name: String, email: String, is_active: Boolean): [KeyPair] @join__field(graph: GRAPHENE)
-  keypair_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, email: String, is_active: Boolean): KeyPairList @join__field(graph: GRAPHENE)
-  keypair_resource_policy(name: String): KeyPairResourcePolicy @join__field(graph: GRAPHENE)
-  user_resource_policy(name: String): UserResourcePolicy @join__field(graph: GRAPHENE)
-  project_resource_policy(name: String!): ProjectResourcePolicy @join__field(graph: GRAPHENE)
-  keypair_resource_policies: [KeyPairResourcePolicy] @join__field(graph: GRAPHENE)
+  """
+  Added in 24.03.0.
+  """
+  user_nodes(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): UserConnection @join__field(graph: GRAPHENE)
+  keypair(domain_name: String, access_key: String): KeyPair
+    @join__field(graph: GRAPHENE)
+  keypairs(domain_name: String, email: String, is_active: Boolean): [KeyPair]
+    @join__field(graph: GRAPHENE)
+  keypair_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    email: String
+    is_active: Boolean
+  ): KeyPairList @join__field(graph: GRAPHENE)
+  keypair_resource_policy(name: String): KeyPairResourcePolicy
+    @join__field(graph: GRAPHENE)
+  user_resource_policy(name: String): UserResourcePolicy
+    @join__field(graph: GRAPHENE)
+  project_resource_policy(name: String!): ProjectResourcePolicy
+    @join__field(graph: GRAPHENE)
+  keypair_resource_policies: [KeyPairResourcePolicy]
+    @join__field(graph: GRAPHENE)
   user_resource_policies: [UserResourcePolicy] @join__field(graph: GRAPHENE)
-  project_resource_policies: [ProjectResourcePolicy] @join__field(graph: GRAPHENE)
+  project_resource_policies: [ProjectResourcePolicy]
+    @join__field(graph: GRAPHENE)
   resource_preset(name: String): ResourcePreset @join__field(graph: GRAPHENE)
 
-  """Added in 25.4.0."""
+  """
+  Added in 25.4.0.
+  """
   resource_preset_by_id(id: UUID): ResourcePreset @join__field(graph: GRAPHENE)
   resource_presets(
-    """Added in 25.4.0."""
+    """
+    Added in 25.4.0.
+    """
     filter: String
 
-    """Added in 25.4.0."""
+    """
+    Added in 25.4.0.
+    """
     order: String
   ): [ResourcePreset] @join__field(graph: GRAPHENE)
   scaling_group(name: String): ScalingGroup @join__field(graph: GRAPHENE)
-  scaling_groups(name: String, is_active: Boolean): [ScalingGroup] @join__field(graph: GRAPHENE)
+  scaling_groups(name: String, is_active: Boolean): [ScalingGroup]
+    @join__field(graph: GRAPHENE)
 
   """
   Added in 25.5.0. This query is available for all users. It returns the resource groups(=scaling groups) that the user has access to. Only name, is_active, own_session_occupied_resource_slots and accelerator_quantum_size fields are returned.
   """
-  accessible_scaling_groups(project_id: UUID!): [ScalingGroup] @join__field(graph: GRAPHENE)
-  scaling_groups_for_domain(domain: String!, is_active: Boolean): [ScalingGroup] @join__field(graph: GRAPHENE)
-  scaling_groups_for_user_group(user_group: String!, is_active: Boolean): [ScalingGroup] @join__field(graph: GRAPHENE)
-  scaling_groups_for_keypair(access_key: String!, is_active: Boolean): [ScalingGroup] @join__field(graph: GRAPHENE)
+  accessible_scaling_groups(project_id: UUID!): [ScalingGroup]
+    @join__field(graph: GRAPHENE)
+  scaling_groups_for_domain(
+    domain: String!
+    is_active: Boolean
+  ): [ScalingGroup] @join__field(graph: GRAPHENE)
+  scaling_groups_for_user_group(
+    user_group: String!
+    is_active: Boolean
+  ): [ScalingGroup] @join__field(graph: GRAPHENE)
+  scaling_groups_for_keypair(
+    access_key: String!
+    is_active: Boolean
+  ): [ScalingGroup] @join__field(graph: GRAPHENE)
   storage_volume(id: String): StorageVolume @join__field(graph: GRAPHENE)
-  storage_volume_list(limit: Int!, offset: Int!, filter: String, order: String): StorageVolumeList @join__field(graph: GRAPHENE)
+  storage_volume_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+  ): StorageVolumeList @join__field(graph: GRAPHENE)
   vfolder(id: String): VirtualFolder @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4.
+  """
   vfolder_node(id: String!): VirtualFolderNode @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.4."""
+  """
+  Added in 24.03.4.
+  """
   vfolder_nodes(
-    """Added in 24.12.0."""
+    """
+    Added in 24.12.0.
+    """
     scope_id: ScopeField
 
-    """Added in 24.09.0."""
-    project_id: UUID @deprecated(reason: "Deprecated since 24.12.0. use `scope_id` instead.")
+    """
+    Added in 24.09.0.
+    """
+    project_id: UUID
+      @deprecated(reason: "Deprecated since 24.12.0. use `scope_id` instead.")
 
-    """Added in 24.09.0."""
+    """
+    Added in 24.09.0.
+    """
     permission: VFolderPermissionValueField
     filter: String
     order: String
@@ -11507,36 +14326,92 @@ type Query
     first: Int
     last: Int
   ): VirtualFolderConnection @join__field(graph: GRAPHENE)
-  vfolder_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: UUID, access_key: String): VirtualFolderList @join__field(graph: GRAPHENE)
-  vfolder_permission_list(limit: Int!, offset: Int!, filter: String, order: String): VirtualFolderPermissionList @join__field(graph: GRAPHENE)
-  vfolder_own_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList @join__field(graph: GRAPHENE)
-  vfolder_invited_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList @join__field(graph: GRAPHENE)
-  vfolder_project_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, access_key: String): VirtualFolderList @join__field(graph: GRAPHENE)
-  vfolders(domain_name: String, group_id: String, access_key: String): [VirtualFolder] @join__field(graph: GRAPHENE)
+  vfolder_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: UUID
+    access_key: String
+  ): VirtualFolderList @join__field(graph: GRAPHENE)
+  vfolder_permission_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+  ): VirtualFolderPermissionList @join__field(graph: GRAPHENE)
+  vfolder_own_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    access_key: String
+  ): VirtualFolderList @join__field(graph: GRAPHENE)
+  vfolder_invited_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    access_key: String
+  ): VirtualFolderList @join__field(graph: GRAPHENE)
+  vfolder_project_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    access_key: String
+  ): VirtualFolderList @join__field(graph: GRAPHENE)
+  vfolders(
+    domain_name: String
+    group_id: String
+    access_key: String
+  ): [VirtualFolder] @join__field(graph: GRAPHENE)
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   compute_session_node(
     id: GlobalIDField!
 
-    """Added in 24.12.0."""
+    """
+    Added in 24.12.0.
+    """
     scope_id: ScopeField
 
-    """Added in 24.09.0."""
-    project_id: UUID @deprecated(reason: "Deprecated since 24.12.0. use `scope_id` instead.")
+    """
+    Added in 24.09.0.
+    """
+    project_id: UUID
+      @deprecated(reason: "Deprecated since 24.12.0. use `scope_id` instead.")
 
-    """Added in 24.09.0. Default is read_attribute."""
+    """
+    Added in 24.09.0. Default is read_attribute.
+    """
     permission: SessionPermissionValueField = "read_attribute"
   ): ComputeSessionNode @join__field(graph: GRAPHENE)
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   compute_session_nodes(
-    """Added in 24.12.0."""
+    """
+    Added in 24.12.0.
+    """
     scope_id: ScopeField
 
-    """Added in 24.09.0."""
-    project_id: UUID @deprecated(reason: "Deprecated since 24.12.0. use `scope_id` instead.")
+    """
+    Added in 24.09.0.
+    """
+    project_id: UUID
+      @deprecated(reason: "Deprecated since 24.12.0. use `scope_id` instead.")
 
-    """Added in 24.09.0. Default is read_attribute."""
+    """
+    Added in 24.09.0. Default is read_attribute.
+    """
     permission: SessionPermissionValueField = "read_attribute"
     filter: String
     order: String
@@ -11547,17 +14422,25 @@ type Query
     last: Int
   ): ComputeSessionConnection @join__field(graph: GRAPHENE)
 
-  """Added in 25.13.0."""
+  """
+  Added in 25.13.0.
+  """
   session_pending_queue(
     resource_group_id: String!
 
-    """Specifies how many items to skip before beginning to return result."""
+    """
+    Specifies how many items to skip before beginning to return result.
+    """
     offset: Int
 
-    """If this value is provided, the query will be limited to that value."""
+    """
+    If this value is provided, the query will be limited to that value.
+    """
     before: String
 
-    """Queries the `last` number of results from the query result from last."""
+    """
+    Queries the `last` number of results from the query result from last.
+    """
     after: String
 
     """
@@ -11565,17 +14448,50 @@ type Query
     """
     first: Int
 
-    """If the given value is provided, the query will start from that value."""
+    """
+    If the given value is provided, the query will start from that value.
+    """
     last: Int
   ): SessionPendingQueueConnection @join__field(graph: GRAPHENE)
   compute_session(id: UUID!): ComputeSession @join__field(graph: GRAPHENE)
   compute_container(id: UUID!): ComputeContainer @join__field(graph: GRAPHENE)
-  compute_session_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: String, access_key: String, status: String): ComputeSessionList @join__field(graph: GRAPHENE)
-  compute_container_list(limit: Int!, offset: Int!, filter: String, order: String, session_id: ID!, role: String): ComputeContainerList @join__field(graph: GRAPHENE)
-  legacy_compute_session_list(limit: Int!, offset: Int!, order_key: String, order_asc: Boolean, domain_name: String, group_id: String, access_key: String, status: String): LegacyComputeSessionList @join__field(graph: GRAPHENE)
-  legacy_compute_session(sess_id: String!, domain_name: String, access_key: String): LegacyComputeSession @join__field(graph: GRAPHENE)
+  compute_session_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: String
+    access_key: String
+    status: String
+  ): ComputeSessionList @join__field(graph: GRAPHENE)
+  compute_container_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    session_id: ID!
+    role: String
+  ): ComputeContainerList @join__field(graph: GRAPHENE)
+  legacy_compute_session_list(
+    limit: Int!
+    offset: Int!
+    order_key: String
+    order_asc: Boolean
+    domain_name: String
+    group_id: String
+    access_key: String
+    status: String
+  ): LegacyComputeSessionList @join__field(graph: GRAPHENE)
+  legacy_compute_session(
+    sess_id: String!
+    domain_name: String
+    access_key: String
+  ): LegacyComputeSession @join__field(graph: GRAPHENE)
 
-  """Added in 25.5.0."""
+  """
+  Added in 25.5.0.
+  """
   total_resource_slot(
     """
     `statuses` argument is an array of session statuses. Only sessions with the specified statuses will be queried to calculate the sum of total resource slots. The argument should be an array of the following valid status values: ['PENDING', 'DEPRIORITIZING', 'SCHEDULED', 'PREPARING', 'PULLING', 'PREPARED', 'CREATING', 'RUNNING', 'RESTARTING', 'RUNNING_DEGRADED', 'TERMINATING', 'TERMINATED', 'ERROR', 'CANCELLED'].
@@ -11591,64 +14507,193 @@ type Query
     domain_name: String
     resource_group_name: String
   ): TotalResourceSlot @join__field(graph: GRAPHENE)
-  vfolder_host_permissions: PredefinedAtomicPermission @join__field(graph: GRAPHENE)
+  vfolder_host_permissions: PredefinedAtomicPermission
+    @join__field(graph: GRAPHENE)
   endpoint(endpoint_id: UUID!): Endpoint @join__field(graph: GRAPHENE)
-  endpoint_list(limit: Int!, offset: Int!, filter: String, order: String, domain_name: String, group_id: String, user_uuid: String, project: UUID): EndpointList @join__field(graph: GRAPHENE)
+  endpoint_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    domain_name: String
+    group_id: String
+    user_uuid: String
+    project: UUID
+  ): EndpointList @join__field(graph: GRAPHENE)
   routing(routing_id: UUID!): Routing @join__field(graph: GRAPHENE)
-  routing_list(limit: Int!, offset: Int!, filter: String, order: String, endpoint_id: UUID): RoutingList @join__field(graph: GRAPHENE)
+  routing_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    endpoint_id: UUID
+  ): RoutingList @join__field(graph: GRAPHENE)
   endpoint_token(token: String!): EndpointToken @join__field(graph: GRAPHENE)
-  endpoint_token_list(limit: Int!, offset: Int!, filter: String, order: String, endpoint_id: UUID): EndpointTokenList @join__field(graph: GRAPHENE)
-  quota_scope(storage_host_name: String!, quota_scope_id: String!): QuotaScope @join__field(graph: GRAPHENE)
-  container_registry(hostname: String!): ContainerRegistry @join__field(graph: GRAPHENE) @deprecated(reason: "Deprecated since 24.9.0. use `container_registry_node` instead.")
-  container_registries: [ContainerRegistry] @join__field(graph: GRAPHENE) @deprecated(reason: "Deprecated since 24.9.0. use `container_registry_nodes_v2` instead.")
+  endpoint_token_list(
+    limit: Int!
+    offset: Int!
+    filter: String
+    order: String
+    endpoint_id: UUID
+  ): EndpointTokenList @join__field(graph: GRAPHENE)
+  quota_scope(storage_host_name: String!, quota_scope_id: String!): QuotaScope
+    @join__field(graph: GRAPHENE)
+  container_registry(hostname: String!): ContainerRegistry
+    @join__field(graph: GRAPHENE)
+    @deprecated(
+      reason: "Deprecated since 24.9.0. use `container_registry_node` instead."
+    )
+  container_registries: [ContainerRegistry]
+    @join__field(graph: GRAPHENE)
+    @deprecated(
+      reason: "Deprecated since 24.9.0. use `container_registry_nodes_v2` instead."
+    )
 
-  """Added in 24.09.0."""
-  container_registry_node(id: String!): ContainerRegistryNode @join__field(graph: GRAPHENE)
+  """
+  Added in 24.09.0.
+  """
+  container_registry_node(id: String!): ContainerRegistryNode
+    @join__field(graph: GRAPHENE)
 
-  """Added in 24.09.0."""
-  container_registry_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ContainerRegistryConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 24.09.0.
+  """
+  container_registry_nodes(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): ContainerRegistryConnection @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.0."""
+  """
+  Added in 24.03.0.
+  """
   model_card(id: String!): ModelCard @join__field(graph: GRAPHENE)
 
-  """Added in 24.03.0."""
-  model_cards(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ModelCardConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 24.03.0.
+  """
+  model_cards(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): ModelCardConnection @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   network(id: String!): NetworkNode @join__field(graph: GRAPHENE)
 
-  """Added in 24.12.0."""
-  networks(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): NetworkConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 24.12.0.
+  """
+  networks(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): NetworkConnection @join__field(graph: GRAPHENE)
 
-  """Added in 25.1.0."""
-  endpoint_auto_scaling_rule_node(id: String!): EndpointAutoScalingRuleNode @join__field(graph: GRAPHENE)
+  """
+  Added in 25.1.0.
+  """
+  endpoint_auto_scaling_rule_node(id: String!): EndpointAutoScalingRuleNode
+    @join__field(graph: GRAPHENE)
 
-  """Added in 25.1.0."""
-  endpoint_auto_scaling_rule_nodes(endpoint: String!, filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): EndpointAutoScalingRuleConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 25.1.0.
+  """
+  endpoint_auto_scaling_rule_nodes(
+    endpoint: String!
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): EndpointAutoScalingRuleConnection @join__field(graph: GRAPHENE)
 
-  """Added in 25.6.0."""
-  user_utilization_metric(user_id: UUID!, props: UserUtilizationMetricQueryInput!): UserUtilizationMetric @join__field(graph: GRAPHENE)
+  """
+  Added in 25.6.0.
+  """
+  user_utilization_metric(
+    user_id: UUID!
+    props: UserUtilizationMetricQueryInput!
+  ): UserUtilizationMetric @join__field(graph: GRAPHENE)
 
-  """Added in 25.6.0."""
-  container_utilization_metric_metadata: ContainerUtilizationMetricMetadata @join__field(graph: GRAPHENE)
+  """
+  Added in 25.6.0.
+  """
+  container_utilization_metric_metadata: ContainerUtilizationMetricMetadata
+    @join__field(graph: GRAPHENE)
 
-  """Added in 25.8.0."""
+  """
+  Added in 25.8.0.
+  """
   available_service: AvailableServiceNode @join__field(graph: GRAPHENE)
 
-  """Added in 25.8.0."""
-  available_services(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): AvailableServiceConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 25.8.0.
+  """
+  available_services(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): AvailableServiceConnection @join__field(graph: GRAPHENE)
 
-  """Added in 25.8.0."""
-  service_config(service: String!): ServiceConfigNode @join__field(graph: GRAPHENE)
+  """
+  Added in 25.8.0.
+  """
+  service_config(service: String!): ServiceConfigNode
+    @join__field(graph: GRAPHENE)
 
-  """Added in 25.8.0."""
-  service_configs(services: [String]!, filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ServiceConfigConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 25.8.0.
+  """
+  service_configs(
+    services: [String]!
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): ServiceConfigConnection @join__field(graph: GRAPHENE)
 
-  """Added in 25.15.0. Get aggregate agent resource statistics"""
+  """
+  Added in 25.15.0. Get aggregate agent resource statistics
+  """
   agentStats: AgentStats @join__field(graph: STRAWBERRY)
 
-  """Added in 26.1.0. List agents with filtering and pagination"""
-  agentsV2(filter: AgentFilter = null, orderBy: [AgentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AgentV2Connection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.1.0. List agents with filtering and pagination
+  """
+  agentsV2(
+    filter: AgentFilter = null
+    orderBy: [AgentOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): AgentV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Retrieve a specific artifact by its ID. Returns detailed information about the artifact including its metadata, registry information, and availability status.
@@ -11658,7 +14703,16 @@ type Query
   """
   Added in 25.14.0. Query artifacts with optional filtering, ordering, and pagination. Returns artifacts that are available in the system, discovered through scanning external registries like HuggingFace or Reservoir. By default, only shows ALIVE (non-deleted) artifacts. Use filters to narrow down results by type, name, registry, or availability. Supports cursor-based pagination for efficient browsing of large datasets.
   """
-  artifacts(filter: ArtifactFilter = null, orderBy: [ArtifactOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ArtifactConnection @join__field(graph: STRAWBERRY)
+  artifacts(
+    filter: ArtifactFilter = null
+    orderBy: [ArtifactOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ArtifactConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.14.0. Retrieve a specific artifact revision by its ID. Returns detailed information about the revision including its status, version, file size, and README content.
@@ -11668,7 +14722,16 @@ type Query
   """
   Added in 25.14.0. Query artifact revisions with optional filtering, ordering, and pagination. Returns specific versions/revisions of artifacts. Each revision represents a specific version of an artifact with its own status, file data, and metadata. Use filters to find revisions by status, version, or artifact ID. Supports cursor-based pagination for efficient browsing.
   """
-  artifactRevisions(filter: ArtifactRevisionFilter = null, orderBy: [ArtifactRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ArtifactRevisionConnection @join__field(graph: STRAWBERRY)
+  artifactRevisions(
+    filter: ArtifactRevisionFilter = null
+    orderBy: [ArtifactRevisionOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ArtifactRevisionConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.16.0. Retrieve user-level app configuration. Returns only the configuration set specifically for the user, without merging with domain config. This query is useful for checking what values are configured at the user level when you want to modify domain or user configurations separately. For actual configuration values to be applied, use mergedAppConfig instead. If user_id is not provided, returns the current user's configuration. Users can only access their own configuration, but admins can access any user's configuration.
@@ -11683,60 +14746,142 @@ type Query
   """
   Added in 25.16.0. List deployments with optional filtering and pagination (admin, all deployments).
   """
-  deployments(filter: DeploymentFilter = null, orderBy: [DeploymentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelDeploymentConnection @join__field(graph: STRAWBERRY)
+  deployments(
+    filter: DeploymentFilter = null
+    orderBy: [DeploymentOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ModelDeploymentConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Get a specific deployment by ID."""
+  """
+  Added in 25.16.0. Get a specific deployment by ID.
+  """
   deployment(id: ID!): ModelDeployment @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.16.0. List revisions with optional filtering and pagination (admin, all deployments).
   """
-  revisions(filter: ModelRevisionFilter = null, orderBy: [ModelRevisionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelRevisionConnection @join__field(graph: STRAWBERRY)
+  revisions(
+    filter: ModelRevisionFilter = null
+    orderBy: [ModelRevisionOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ModelRevisionConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Get a specific revision by ID."""
+  """
+  Added in 25.16.0. Get a specific revision by ID.
+  """
   revision(id: ID!): ModelRevision @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.16.0. List replicas with optional filtering and pagination (admin, all deployments).
   """
-  replicas(filter: ReplicaFilter = null, orderBy: [ReplicaOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelReplicaConnection @join__field(graph: STRAWBERRY)
+  replicas(
+    filter: ReplicaFilter = null
+    orderBy: [ReplicaOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ModelReplicaConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Get a specific replica by ID."""
+  """
+  Added in 25.16.0. Get a specific replica by ID.
+  """
   replica(id: ID!): ModelReplica @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. List available notification rule types"""
+  """
+  Added in UNRELEASED. List available notification rule types
+  """
   notificationRuleTypes: [NotificationRuleType!] @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Get an object storage by ID"""
+  """
+  Added in 25.14.0. Get an object storage by ID
+  """
   objectStorage(id: ID!): ObjectStorage @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. List all object storages"""
-  objectStorages(before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ObjectStorageConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. List all object storages
+  """
+  objectStorages(
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ObjectStorageConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Get a VFS storage by ID"""
+  """
+  Added in 25.16.0. Get a VFS storage by ID
+  """
   vfsStorage(id: ID!): VFSStorage @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. List all VFS storages"""
-  vfsStorages(before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFSStorageConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.16.0. List all VFS storages
+  """
+  vfsStorages(
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): VFSStorageConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Get a HuggingFace registry by ID"""
-  huggingfaceRegistry(id: ID!): HuggingFaceRegistry @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. Get a HuggingFace registry by ID
+  """
+  huggingfaceRegistry(id: ID!): HuggingFaceRegistry
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. List all HuggingFace registries"""
-  huggingfaceRegistries(before: String = null, after: String = null, first: Int = null, last: Int = null, offset: Int = null, limit: Int = null): HuggingFaceRegistryConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. List all HuggingFace registries
+  """
+  huggingfaceRegistries(
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    offset: Int = null
+    limit: Int = null
+  ): HuggingFaceRegistryConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. Get a reservoir registry by ID"""
+  """
+  Added in 25.14.0. Get a reservoir registry by ID
+  """
   reservoirRegistry(id: ID!): ReservoirRegistry @join__field(graph: STRAWBERRY)
 
-  """Added in 25.14.0. List all reservoir registries"""
-  reservoirRegistries(before: String = null, after: String = null, first: Int = null, last: Int = null, offset: Int = null, limit: Int = null): ReservoirRegistryConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.14.0. List all reservoir registries
+  """
+  reservoirRegistries(
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    offset: Int = null
+    limit: Int = null
+  ): ReservoirRegistryConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Retrieve a specific image by its ID. Returns detailed information about the image including its identity, metadata, resource requirements, and permission settings.
   """
   imageV2(id: ID!): ImageV2 @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. Query a single kernel by ID."""
+  """
+  Added in 26.2.0. Query a single kernel by ID.
+  """
   kernelV2(id: UUID!): KernelV2 @join__field(graph: STRAWBERRY)
 
   """
@@ -11744,183 +14889,512 @@ type Query
   """
   imageAlias(id: ID!): ImageV2Alias @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List resource groups (admin only)"""
-  adminResourceGroups(filter: ResourceGroupFilter = null, orderBy: [ResourceGroupOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourceGroupConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. List resource groups (admin only)
+  """
+  adminResourceGroups(
+    filter: ResourceGroupFilter = null
+    orderBy: [ResourceGroupOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ResourceGroupConnection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get a single resource group by name (admin only)."""
-  adminResourceGroupV2(name: String!): ResourceGroup @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Get a single resource group by name (admin only).
+  """
+  adminResourceGroupV2(name: String!): ResourceGroup
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Get allowed resource groups for a domain (admin only).
   """
-  adminAllowedResourceGroupsForDomainV2(domainName: String!): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
+  adminAllowedResourceGroupsForDomainV2(
+    domainName: String!
+  ): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Get allowed resource groups for a project (admin only).
   """
-  adminAllowedResourceGroupsForProjectV2(projectId: UUID!): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
+  adminAllowedResourceGroupsForProjectV2(
+    projectId: UUID!
+  ): AllowedResourceGroupsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Get allowed domains for a resource group (admin only).
   """
-  adminAllowedDomainsForResourceGroupV2(resourceGroupName: String!): AllowedDomainsPayload! @join__field(graph: STRAWBERRY)
+  adminAllowedDomainsForResourceGroupV2(
+    resourceGroupName: String!
+  ): AllowedDomainsPayload! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Get allowed projects for a resource group (admin only).
   """
-  adminAllowedProjectsForResourceGroupV2(resourceGroupName: String!): AllowedProjectsPayload! @join__field(graph: STRAWBERRY)
+  adminAllowedProjectsForResourceGroupV2(
+    resourceGroupName: String!
+  ): AllowedProjectsPayload! @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Query service catalog entries. Admin only."""
-  adminServiceCatalogs(filter: ServiceCatalogFilter = null, orderBy: [ServiceCatalogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): [ServiceCatalog!]! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Query service catalog entries. Admin only.
+  """
+  adminServiceCatalogs(
+    filter: ServiceCatalogFilter = null
+    orderBy: [ServiceCatalogOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): [ServiceCatalog!]! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. List session scheduling history (admin only)"""
-  adminSessionSchedulingHistories(filter: SessionSchedulingHistoryFilter = null, orderBy: [SessionSchedulingHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionSchedulingHistoryConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. List session scheduling history (admin only)
+  """
+  adminSessionSchedulingHistories(
+    filter: SessionSchedulingHistoryFilter = null
+    orderBy: [SessionSchedulingHistoryOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): SessionSchedulingHistoryConnection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. List deployment history (admin only)"""
-  adminDeploymentHistories(filter: DeploymentHistoryFilter = null, orderBy: [DeploymentHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DeploymentHistoryConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. List deployment history (admin only)
+  """
+  adminDeploymentHistories(
+    filter: DeploymentHistoryFilter = null
+    orderBy: [DeploymentHistoryOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DeploymentHistoryConnection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. List route history (admin only)"""
-  adminRouteHistories(filter: RouteHistoryFilter = null, orderBy: [RouteHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RouteHistoryConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. List route history (admin only)
+  """
+  adminRouteHistories(
+    filter: RouteHistoryFilter = null
+    orderBy: [RouteHistoryOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): RouteHistoryConnection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get a notification channel by ID (admin only)"""
-  adminNotificationChannel(id: ID!): NotificationChannel @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Get a notification channel by ID (admin only)
+  """
+  adminNotificationChannel(id: ID!): NotificationChannel
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. List notification channels (admin only)"""
-  adminNotificationChannels(filter: NotificationChannelFilter = null, orderBy: [NotificationChannelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): NotificationChannelConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. List notification channels (admin only)
+  """
+  adminNotificationChannels(
+    filter: NotificationChannelFilter = null
+    orderBy: [NotificationChannelOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): NotificationChannelConnection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get a notification rule by ID (admin only)"""
-  adminNotificationRule(id: ID!): NotificationRule @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Get a notification rule by ID (admin only)
+  """
+  adminNotificationRule(id: ID!): NotificationRule
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. List notification rules (admin only)"""
-  adminNotificationRules(filter: NotificationRuleFilter = null, orderBy: [NotificationRuleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): NotificationRuleConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. List notification rules (admin only)
+  """
+  adminNotificationRules(
+    filter: NotificationRuleFilter = null
+    orderBy: [NotificationRuleOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): NotificationRuleConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Retrieve domain-level app configuration (admin only). Returns only the configuration set specifically for the domain, without merging. This query is useful for checking what values are configured at the domain level when you want to modify domain or user configurations separately. For actual configuration values to be applied, use mergedAppConfig instead.
   """
-  adminDomainAppConfig(domainName: String!): AppConfig @join__field(graph: STRAWBERRY)
+  adminDomainAppConfig(domainName: String!): AppConfig
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. Get domain fair share data (admin only)."""
-  adminDomainFairShare(resourceGroupName: String!, domainName: String!): DomainFairShare @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. Get domain fair share data (admin only).
+  """
+  adminDomainFairShare(
+    resourceGroupName: String!
+    domainName: String!
+  ): DomainFairShare @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List domain fair shares (admin only)."""
-  adminDomainFairShares(filter: DomainFairShareFilter = null, orderBy: [DomainFairShareOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainFairShareConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. List domain fair shares (admin only).
+  """
+  adminDomainFairShares(
+    filter: DomainFairShareFilter = null
+    orderBy: [DomainFairShareOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DomainFairShareConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. Get project fair share data (admin only)."""
-  adminProjectFairShare(resourceGroupName: String!, projectId: UUID!): ProjectFairShare @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. Get project fair share data (admin only).
+  """
+  adminProjectFairShare(
+    resourceGroupName: String!
+    projectId: UUID!
+  ): ProjectFairShare @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List project fair shares (admin only)."""
-  adminProjectFairShares(filter: ProjectFairShareFilter = null, orderBy: [ProjectFairShareOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectFairShareConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. List project fair shares (admin only).
+  """
+  adminProjectFairShares(
+    filter: ProjectFairShareFilter = null
+    orderBy: [ProjectFairShareOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectFairShareConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. Get user fair share data (admin only)."""
-  adminUserFairShare(resourceGroupName: String!, projectId: UUID!, userUuid: UUID!): UserFairShare @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. Get user fair share data (admin only).
+  """
+  adminUserFairShare(
+    resourceGroupName: String!
+    projectId: UUID!
+    userUuid: UUID!
+  ): UserFairShare @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List user fair shares (admin only)."""
-  adminUserFairShares(filter: UserFairShareFilter = null, orderBy: [UserFairShareOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserFairShareConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. List user fair shares (admin only).
+  """
+  adminUserFairShares(
+    filter: UserFairShareFilter = null
+    orderBy: [UserFairShareOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserFairShareConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List domain usage buckets (admin only)."""
-  adminDomainUsageBuckets(filter: DomainUsageBucketFilter = null, orderBy: [DomainUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainUsageBucketConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. List domain usage buckets (admin only).
+  """
+  adminDomainUsageBuckets(
+    filter: DomainUsageBucketFilter = null
+    orderBy: [DomainUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DomainUsageBucketConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List project usage buckets (admin only)."""
-  adminProjectUsageBuckets(filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. List project usage buckets (admin only).
+  """
+  adminProjectUsageBuckets(
+    filter: ProjectUsageBucketFilter = null
+    orderBy: [ProjectUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectUsageBucketConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List user usage buckets (admin only)."""
-  adminUserUsageBuckets(filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. List user usage buckets (admin only).
+  """
+  adminUserUsageBuckets(
+    filter: UserUsageBucketFilter = null
+    orderBy: [UserUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserUsageBucketConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Query images with optional filtering, ordering, and pagination (admin only). Returns container images available in the system. Images are container specifications that define runtime environments for compute sessions. Use filters to narrow down results by status, name, or architecture. Supports both cursor-based and offset-based pagination.
   """
-  adminImagesV2(filter: ImageV2Filter = null, orderBy: [ImageV2OrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection @join__field(graph: STRAWBERRY)
+  adminImagesV2(
+    filter: ImageV2Filter = null
+    orderBy: [ImageV2OrderByGQL!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ImageV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Query kernels with pagination and filtering. (admin only)
   """
-  adminKernelsV2(filter: KernelV2Filter = null, orderBy: [KernelV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KernelV2Connection @join__field(graph: STRAWBERRY)
+  adminKernelsV2(
+    filter: KernelV2Filter = null
+    orderBy: [KernelV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): KernelV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Query audit logs with pagination and filtering. (admin only)
   """
-  adminAuditLogsV2(filter: AuditLogFilter = null, orderBy: [AuditLogOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): AuditLogV2Connection! @join__field(graph: STRAWBERRY)
+  adminAuditLogsV2(
+    filter: AuditLogFilter = null
+    orderBy: [AuditLogOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): AuditLogV2Connection! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. List container registries with filtering, ordering, and pagination (admin only).
   """
-  adminContainerRegistriesV2(filter: ContainerRegistryV2Filter = null, orderBy: [ContainerRegistryV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ContainerRegistryV2Connection @join__field(graph: STRAWBERRY)
+  adminContainerRegistriesV2(
+    filter: ContainerRegistryV2Filter = null
+    orderBy: [ContainerRegistryV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ContainerRegistryV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Query login sessions with pagination and filtering. (admin only)
   """
-  adminLoginSessionsV2(filter: LoginSessionFilter = null, orderBy: [LoginSessionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginSessionV2Connection! @join__field(graph: STRAWBERRY)
+  adminLoginSessionsV2(
+    filter: LoginSessionFilter = null
+    orderBy: [LoginSessionOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): LoginSessionV2Connection! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Query login history with pagination and filtering. (admin only)
   """
-  adminLoginHistoryV2(filter: LoginHistoryFilter = null, orderBy: [LoginHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginHistoryV2Connection! @join__field(graph: STRAWBERRY)
+  adminLoginHistoryV2(
+    filter: LoginHistoryFilter = null
+    orderBy: [LoginHistoryOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): LoginHistoryV2Connection! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Query sessions with pagination and filtering. (admin only)
   """
-  adminSessionsV2(filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection! @join__field(graph: STRAWBERRY)
+  adminSessionsV2(
+    filter: SessionV2Filter = null
+    orderBy: [SessionV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): SessionV2Connection! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. List sessions within a specific project. Requires project membership or higher privileges.
   """
-  projectSessionsV2(scope: ProjectSessionV2Scope!, filter: SessionV2Filter = null, orderBy: [SessionV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionV2Connection! @join__field(graph: STRAWBERRY)
+  projectSessionsV2(
+    scope: ProjectSessionV2Scope!
+    filter: SessionV2Filter = null
+    orderBy: [SessionV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): SessionV2Connection! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Returns a single resource slot type by slot_name, or null.
   """
-  resourceSlotType(slotName: String!): ResourceSlotType @join__field(graph: STRAWBERRY)
+  resourceSlotType(slotName: String!): ResourceSlotType
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Returns resource slot types with pagination and filtering.
   """
-  resourceSlotTypes(filter: ResourceSlotTypeFilter = null, orderBy: [ResourceSlotTypeOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourceSlotTypeConnection! @join__field(graph: STRAWBERRY)
+  resourceSlotTypes(
+    filter: ResourceSlotTypeFilter = null
+    orderBy: [ResourceSlotTypeOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ResourceSlotTypeConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Query image aliases with optional filtering, ordering, and pagination. Returns image aliases that provide alternative names for container images. Use filters to search by alias string. Supports both cursor-based and offset-based pagination.
   """
-  adminImageAliases(filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
+  adminImageAliases(
+    filter: ImageV2AliasFilter = null
+    orderBy: [ImageV2AliasOrderByGQL!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Get a single query definition by ID (admin only)."""
-  adminPrometheusQueryPreset(id: ID!): QueryDefinition @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. Get a single query definition by ID (admin only).
+  """
+  adminPrometheusQueryPreset(id: ID!): QueryDefinition
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. List query definitions with filtering and pagination (admin only).
   """
-  adminPrometheusQueryPresets(filter: QueryDefinitionFilter = null, orderBy: [QueryDefinitionOrderBy!] = null, limit: Int = null, offset: Int = null): QueryDefinitionConnection @join__field(graph: STRAWBERRY)
+  adminPrometheusQueryPresets(
+    filter: QueryDefinitionFilter = null
+    orderBy: [QueryDefinitionOrderBy!] = null
+    limit: Int = null
+    offset: Int = null
+  ): QueryDefinitionConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Execute a query definition by ID and return the result (admin only).
   """
-  adminPrometheusQueryPresetResult(id: ID!, timeRange: QueryTimeRangeInput = null, options: ExecuteQueryDefinitionOptionsInput = null, timeWindow: String = null): QueryDefinitionExecuteResult! @join__field(graph: STRAWBERRY)
+  adminPrometheusQueryPresetResult(
+    id: ID!
+    timeRange: QueryTimeRangeInput = null
+    options: ExecuteQueryDefinitionOptionsInput = null
+    timeWindow: String = null
+  ): QueryDefinitionExecuteResult! @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. Get a single role by ID (admin only)."""
+  """
+  Added in 26.3.0. Get a single role by ID (admin only).
+  """
   adminRole(id: UUID!): Role @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. List roles with filtering and pagination (admin only).
   """
-  adminRoles(filter: RoleFilter = null, orderBy: [RoleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleConnection! @join__field(graph: STRAWBERRY)
+  adminRoles(
+    filter: RoleFilter = null
+    orderBy: [RoleOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): RoleConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. List scoped permissions with filtering and pagination (admin only).
   """
-  adminPermissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection! @join__field(graph: STRAWBERRY)
+  adminPermissions(
+    filter: PermissionFilter = null
+    orderBy: [PermissionOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): PermissionConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. List role assignments with filtering and pagination (admin only).
   """
-  adminRoleAssignments(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection! @join__field(graph: STRAWBERRY)
+  adminRoleAssignments(
+    filter: RoleAssignmentFilter = null
+    orderBy: [RoleAssignmentOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): RoleAssignmentConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. Search entity associations (admin only). Optionally filter by entity_type and entity_id.
   """
-  adminEntities(filter: EntityFilter = null, orderBy: [EntityOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): EntityConnection! @join__field(graph: STRAWBERRY)
+  adminEntities(
+    filter: EntityFilter = null
+    orderBy: [EntityOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): EntityConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. List keypairs owned by the current authenticated user. Supports filtering, ordering, and both cursor-based and offset-based pagination.
   """
-  myKeypairs(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection! @join__field(graph: STRAWBERRY)
+  myKeypairs(
+    filter: KeypairFilter = null
+    orderBy: [KeypairOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): KeyPairConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Get a single keypair by access key (admin only). Requires superadmin privileges.
@@ -11930,162 +15404,596 @@ type Query
   """
   Added in UNRELEASED. List all keypairs with filtering and pagination (admin only). Requires superadmin privileges.
   """
-  adminKeypairsV2(filter: KeypairFilter = null, orderBy: [KeypairOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeyPairConnection! @join__field(graph: STRAWBERRY)
+  adminKeypairsV2(
+    filter: KeypairFilter = null
+    orderBy: [KeypairOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): KeyPairConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Query login sessions of the current user with pagination and filtering.
   """
-  myLoginSessionsV2(filter: LoginSessionFilter = null, orderBy: [LoginSessionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginSessionV2Connection! @join__field(graph: STRAWBERRY)
+  myLoginSessionsV2(
+    filter: LoginSessionFilter = null
+    orderBy: [LoginSessionOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): LoginSessionV2Connection! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Query login history of the current user with pagination and filtering.
   """
-  myLoginHistoryV2(filter: LoginHistoryFilter = null, orderBy: [LoginHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): LoginHistoryV2Connection! @join__field(graph: STRAWBERRY)
+  myLoginHistoryV2(
+    filter: LoginHistoryFilter = null
+    orderBy: [LoginHistoryOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): LoginHistoryV2Connection! @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.3.0. List roles assigned to the current authenticated user.
   """
-  myRoles(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection! @join__field(graph: STRAWBERRY)
+  myRoles(
+    filter: RoleAssignmentFilter = null
+    orderBy: [RoleAssignmentOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): RoleAssignmentConnection! @join__field(graph: STRAWBERRY)
 
-  """Added in 26.3.0. List valid RBAC scope-entity type combinations."""
-  rbacScopeEntityCombinations: [ScopeEntityCombination!]! @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.3.0. List valid RBAC scope-entity type combinations.
+  """
+  rbacScopeEntityCombinations: [ScopeEntityCombination!]!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. List valid RBAC entity-operation combinations."""
-  rbacEntityOperationCombinations: [EntityOperationCombination!]! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. List valid RBAC entity-operation combinations.
+  """
+  rbacEntityOperationCombinations: [EntityOperationCombination!]!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. Query kernels within a specific session."""
-  sessionKernelsV2(scope: SessionScope!, filter: KernelV2Filter = null, orderBy: [KernelV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KernelV2Connection @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. List complete RBAC scope-entity-operation combinations (permission matrix).
+  """
+  rbacPermissionMatrix: [ScopeEntityOperationCombination!]!
+    @join__field(graph: STRAWBERRY)
+
+  """
+  Added in 26.2.0. Query kernels within a specific session.
+  """
+  sessionKernelsV2(
+    scope: SessionScope!
+    filter: KernelV2Filter = null
+    orderBy: [KernelV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): KernelV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Get domain fair share data within resource group scope.
   """
-  rgDomainFairShare(scope: ResourceGroupDomainScope!, domainName: String!): DomainFairShare @join__field(graph: STRAWBERRY)
+  rgDomainFairShare(
+    scope: ResourceGroupDomainScope!
+    domainName: String!
+  ): DomainFairShare @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List domain fair shares within resource group scope."""
-  rgDomainFairShares(scope: ResourceGroupDomainScope!, filter: RGDomainFairShareFilter = null, orderBy: [DomainFairShareOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainFairShareConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. List domain fair shares within resource group scope.
+  """
+  rgDomainFairShares(
+    scope: ResourceGroupDomainScope!
+    filter: RGDomainFairShareFilter = null
+    orderBy: [DomainFairShareOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DomainFairShareConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Get project fair share data within resource group scope.
   """
-  rgProjectFairShare(scope: ResourceGroupProjectScope!, projectId: UUID!): ProjectFairShare @join__field(graph: STRAWBERRY)
+  rgProjectFairShare(
+    scope: ResourceGroupProjectScope!
+    projectId: UUID!
+  ): ProjectFairShare @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List project fair shares within resource group scope."""
-  rgProjectFairShares(scope: ResourceGroupProjectScope!, filter: RGProjectFairShareFilter = null, orderBy: [ProjectFairShareOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectFairShareConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. List project fair shares within resource group scope.
+  """
+  rgProjectFairShares(
+    scope: ResourceGroupProjectScope!
+    filter: RGProjectFairShareFilter = null
+    orderBy: [ProjectFairShareOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectFairShareConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. Get user fair share data within resource group scope."""
-  rgUserFairShare(scope: ResourceGroupUserScope!, userUuid: UUID!): UserFairShare @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. Get user fair share data within resource group scope.
+  """
+  rgUserFairShare(
+    scope: ResourceGroupUserScope!
+    userUuid: UUID!
+  ): UserFairShare @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List user fair shares within resource group scope."""
-  rgUserFairShares(scope: ResourceGroupUserScope!, filter: RGUserFairShareFilter = null, orderBy: [UserFairShareOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserFairShareConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. List user fair shares within resource group scope.
+  """
+  rgUserFairShares(
+    scope: ResourceGroupUserScope!
+    filter: RGUserFairShareFilter = null
+    orderBy: [UserFairShareOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserFairShareConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. List domain usage buckets within resource group scope. This API is not yet implemented.
   """
-  rgDomainUsageBuckets(scope: ResourceGroupDomainScope!, filter: DomainUsageBucketFilter = null, orderBy: [DomainUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainUsageBucketConnection @join__field(graph: STRAWBERRY)
+  rgDomainUsageBuckets(
+    scope: ResourceGroupDomainScope!
+    filter: DomainUsageBucketFilter = null
+    orderBy: [DomainUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DomainUsageBucketConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. List project usage buckets within resource group scope. This API is not yet implemented.
   """
-  rgProjectUsageBuckets(scope: ResourceGroupProjectScope!, filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection @join__field(graph: STRAWBERRY)
+  rgProjectUsageBuckets(
+    scope: ResourceGroupProjectScope!
+    filter: ProjectUsageBucketFilter = null
+    orderBy: [ProjectUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectUsageBucketConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. List user usage buckets within resource group scope. This API is not yet implemented.
   """
-  rgUserUsageBuckets(scope: ResourceGroupUserScope!, filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection @join__field(graph: STRAWBERRY)
+  rgUserUsageBuckets(
+    scope: ResourceGroupUserScope!
+    filter: UserUsageBucketFilter = null
+    orderBy: [UserUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserUsageBucketConnection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Query images within a specific container registry with optional filtering, ordering, and pagination. Returns container images that belong to the specified registry. Use filters to narrow down results by status, name, or architecture. Supports both cursor-based and offset-based pagination.
   """
-  containerRegistryImagesV2(scope: ContainerRegistryScope!, filter: ImageV2Filter = null, orderBy: [ImageV2OrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2Connection @join__field(graph: STRAWBERRY)
+  containerRegistryImagesV2(
+    scope: ContainerRegistryScope!
+    filter: ImageV2Filter = null
+    orderBy: [ImageV2OrderByGQL!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ImageV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Query image aliases within a specific image with optional filtering, ordering, and pagination. Returns image aliases that belong to the specified image. Supports both cursor-based and offset-based pagination.
   """
-  imageScopedAliases(scope: ImageV2Scope!, filter: ImageV2AliasFilter = null, orderBy: [ImageV2AliasOrderByGQL!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
+  imageScopedAliases(
+    scope: ImageV2Scope!
+    filter: ImageV2AliasFilter = null
+    orderBy: [ImageV2AliasOrderByGQL!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ImageV2AliasConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. Get scheduling history for a specific session."""
-  sessionScopedSchedulingHistories(scope: SessionScope!, filter: SessionSchedulingHistoryFilter = null, orderBy: [SessionSchedulingHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionSchedulingHistoryConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. Get scheduling history for a specific session.
+  """
+  sessionScopedSchedulingHistories(
+    scope: SessionScope!
+    filter: SessionSchedulingHistoryFilter = null
+    orderBy: [SessionSchedulingHistoryOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): SessionSchedulingHistoryConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. Get scheduling history for a specific deployment."""
-  deploymentScopedSchedulingHistories(scope: DeploymentScope!, filter: DeploymentHistoryFilter = null, orderBy: [DeploymentHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DeploymentHistoryConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. Get scheduling history for a specific deployment.
+  """
+  deploymentScopedSchedulingHistories(
+    scope: DeploymentScope!
+    filter: DeploymentHistoryFilter = null
+    orderBy: [DeploymentHistoryOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DeploymentHistoryConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. Get scheduling history for a specific route."""
-  routeScopedSchedulingHistories(scope: RouteScope!, filter: RouteHistoryFilter = null, orderBy: [RouteHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RouteHistoryConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. Get scheduling history for a specific route.
+  """
+  routeScopedSchedulingHistories(
+    scope: RouteScope!
+    filter: RouteHistoryFilter = null
+    orderBy: [RouteHistoryOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): RouteHistoryConnection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List resource groups"""
-  resourceGroups(filter: ResourceGroupFilter = null, orderBy: [ResourceGroupOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourceGroupConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_resource_groups instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in 26.2.0. List resource groups
+  """
+  resourceGroups(
+    filter: ResourceGroupFilter = null
+    orderBy: [ResourceGroupOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ResourceGroupConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_resource_groups instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in 25.16.0. Retrieve domain-level app configuration. Returns only the configuration set specifically for the domain, without merging. This query is useful for checking what values are configured at the domain level when you want to modify domain or user configurations separately. For actual configuration values to be applied, use mergedAppConfig instead. Requires admin privileges.
   """
-  domainAppConfig(domainName: String!): AppConfig @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  domainAppConfig(domainName: String!): AppConfig
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_domain_app_config instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in 26.1.0. Get domain fair share data (superadmin only)."""
-  domainFairShare(resourceGroupName: String!, domainName: String!): DomainFairShare @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_domain_fair_share instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in 26.1.0. Get domain fair share data (superadmin only).
+  """
+  domainFairShare(
+    resourceGroupName: String!
+    domainName: String!
+  ): DomainFairShare
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_domain_fair_share instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in 26.1.0. List domain fair shares (superadmin only)."""
-  domainFairShares(filter: DomainFairShareFilter = null, orderBy: [DomainFairShareOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainFairShareConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_domain_fair_shares instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in 26.1.0. List domain fair shares (superadmin only).
+  """
+  domainFairShares(
+    filter: DomainFairShareFilter = null
+    orderBy: [DomainFairShareOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DomainFairShareConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_domain_fair_shares instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in 26.1.0. Get project fair share data (superadmin only)."""
-  projectFairShare(resourceGroupName: String!, projectId: UUID!): ProjectFairShare @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_project_fair_share instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in 26.1.0. Get project fair share data (superadmin only).
+  """
+  projectFairShare(
+    resourceGroupName: String!
+    projectId: UUID!
+  ): ProjectFairShare
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_project_fair_share instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in 26.1.0. List project fair shares (superadmin only)."""
-  projectFairShares(filter: ProjectFairShareFilter = null, orderBy: [ProjectFairShareOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectFairShareConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_project_fair_shares instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in 26.1.0. List project fair shares (superadmin only).
+  """
+  projectFairShares(
+    filter: ProjectFairShareFilter = null
+    orderBy: [ProjectFairShareOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectFairShareConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_project_fair_shares instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in 26.1.0. Get user fair share data (superadmin only)."""
-  userFairShare(resourceGroupName: String!, projectId: UUID!, userUuid: UUID!): UserFairShare @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_user_fair_share instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in 26.1.0. Get user fair share data (superadmin only).
+  """
+  userFairShare(
+    resourceGroupName: String!
+    projectId: UUID!
+    userUuid: UUID!
+  ): UserFairShare
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_user_fair_share instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in 26.1.0. List user fair shares (superadmin only)."""
-  userFairShares(filter: UserFairShareFilter = null, orderBy: [UserFairShareOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserFairShareConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_user_fair_shares instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in 26.1.0. List user fair shares (superadmin only).
+  """
+  userFairShares(
+    filter: UserFairShareFilter = null
+    orderBy: [UserFairShareOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserFairShareConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_user_fair_shares instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in 26.1.0. List domain usage buckets (superadmin only)."""
-  domainUsageBuckets(filter: DomainUsageBucketFilter = null, orderBy: [DomainUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainUsageBucketConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_domain_usage_buckets instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in 26.1.0. List domain usage buckets (superadmin only).
+  """
+  domainUsageBuckets(
+    filter: DomainUsageBucketFilter = null
+    orderBy: [DomainUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DomainUsageBucketConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_domain_usage_buckets instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in 26.1.0. List project usage buckets (superadmin only)."""
-  projectUsageBuckets(filter: ProjectUsageBucketFilter = null, orderBy: [ProjectUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectUsageBucketConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_project_usage_buckets instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in 26.1.0. List project usage buckets (superadmin only).
+  """
+  projectUsageBuckets(
+    filter: ProjectUsageBucketFilter = null
+    orderBy: [ProjectUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectUsageBucketConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_project_usage_buckets instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in 26.1.0. List user usage buckets (superadmin only)."""
-  userUsageBuckets(filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_user_usage_buckets instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in 26.1.0. List user usage buckets (superadmin only).
+  """
+  userUsageBuckets(
+    filter: UserUsageBucketFilter = null
+    orderBy: [UserUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserUsageBucketConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_user_usage_buckets instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. Get a notification channel by ID"""
-  notificationChannel(id: ID!): NotificationChannel @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. Get a notification channel by ID
+  """
+  notificationChannel(id: ID!): NotificationChannel
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_notification_channel instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. List notification channels"""
-  notificationChannels(filter: NotificationChannelFilter = null, orderBy: [NotificationChannelOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): NotificationChannelConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_notification_channels instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. List notification channels
+  """
+  notificationChannels(
+    filter: NotificationChannelFilter = null
+    orderBy: [NotificationChannelOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): NotificationChannelConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_notification_channels instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. Get a notification rule by ID"""
-  notificationRule(id: ID!): NotificationRule @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. Get a notification rule by ID
+  """
+  notificationRule(id: ID!): NotificationRule
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_notification_rule instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. List notification rules"""
-  notificationRules(filter: NotificationRuleFilter = null, orderBy: [NotificationRuleOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): NotificationRuleConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_notification_rules instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. List notification rules
+  """
+  notificationRules(
+    filter: NotificationRuleFilter = null
+    orderBy: [NotificationRuleOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): NotificationRuleConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_notification_rules instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in 25.14.0. Get the default artifact registry for a given artifact type
   """
-  defaultArtifactRegistry(artifactType: ArtifactType!): ArtifactRegistry @join__field(graph: STRAWBERRY)
+  defaultArtifactRegistry(artifactType: ArtifactType!): ArtifactRegistry
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in 25.16.0. Get configuration JSON Schemas for all inference runtimes.
   """
   inferenceRuntimeConfigs: JSON! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.16.0. Get JSON Schema for inference runtime configuration"""
+  """
+  Added in 25.16.0. Get JSON Schema for inference runtime configuration
+  """
   inferenceRuntimeConfig(name: String!): JSON! @join__field(graph: STRAWBERRY)
 
-  """Added in 25.19.0. Get a specific route by ID."""
+  """
+  Added in 25.19.0. Get a specific route by ID.
+  """
   route(id: ID!): Route @join__field(graph: STRAWBERRY)
 
-  """Added in 25.19.0. List routes for a deployment with optional filters."""
-  routes(deploymentId: ID!, filter: RouteFilter = null, orderBy: [RouteOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RouteConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in 25.19.0. List routes for a deployment with optional filters.
+  """
+  routes(
+    deploymentId: ID!
+    filter: RouteFilter = null
+    orderBy: [RouteOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): RouteConnection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. List session scheduling history (superadmin only)"""
-  sessionSchedulingHistories(filter: SessionSchedulingHistoryFilter = null, orderBy: [SessionSchedulingHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): SessionSchedulingHistoryConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_session_scheduling_histories instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. List session scheduling history (superadmin only)
+  """
+  sessionSchedulingHistories(
+    filter: SessionSchedulingHistoryFilter = null
+    orderBy: [SessionSchedulingHistoryOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): SessionSchedulingHistoryConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_session_scheduling_histories instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. List deployment history (superadmin only)"""
-  deploymentHistories(filter: DeploymentHistoryFilter = null, orderBy: [DeploymentHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DeploymentHistoryConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_deployment_histories instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. List deployment history (superadmin only)
+  """
+  deploymentHistories(
+    filter: DeploymentHistoryFilter = null
+    orderBy: [DeploymentHistoryOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DeploymentHistoryConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_deployment_histories instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
-  """Added in UNRELEASED. List route history (superadmin only)"""
-  routeHistories(filter: RouteHistoryFilter = null, orderBy: [RouteHistoryOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RouteHistoryConnection @join__field(graph: STRAWBERRY) @deprecated(reason: "Use admin_route_histories instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide.")
+  """
+  Added in UNRELEASED. List route history (superadmin only)
+  """
+  routeHistories(
+    filter: RouteHistoryFilter = null
+    orderBy: [RouteHistoryOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): RouteHistoryConnection
+    @join__field(graph: STRAWBERRY)
+    @deprecated(
+      reason: "Use admin_route_histories instead. This API will be removed after v26.3.0. See BEP-1041 for migration guide."
+    )
 
   """
   Added in 26.2.0. Get a single user by UUID (admin only). Requires superadmin privileges. Returns an error if user is not found.
@@ -12095,12 +16003,31 @@ type Query
   """
   Added in 26.2.0. List all users with filtering and pagination (admin only). Requires superadmin privileges.
   """
-  adminUsersV2(filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection @join__field(graph: STRAWBERRY)
+  adminUsersV2(
+    filter: UserV2Filter = null
+    orderBy: [UserV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. List users within a specific domain. Requires domain admin privileges or higher.
   """
-  domainUsersV2(scope: DomainUserV2Scope!, filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection @join__field(graph: STRAWBERRY)
+  domainUsersV2(
+    scope: DomainUserV2Scope!
+    filter: UserV2Filter = null
+    orderBy: [UserV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Get the current client's IP address as seen by the server. Useful for configuring IP allowlists.
@@ -12115,7 +16042,17 @@ type Query
   """
   Added in 26.2.0. List users within a specific project. Requires project membership or higher privileges.
   """
-  projectUsersV2(scope: ProjectUserV2Scope!, filter: UserV2Filter = null, orderBy: [UserV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserV2Connection @join__field(graph: STRAWBERRY)
+  projectUsersV2(
+    scope: ProjectUserV2Scope!
+    filter: UserV2Filter = null
+    orderBy: [UserV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Get a single domain by name. Returns an error if domain is not found.
@@ -12125,10 +16062,31 @@ type Query
   """
   Added in 26.2.0. List all domains with filtering and pagination (admin only). Requires superadmin privileges.
   """
-  adminDomainsV2(filter: DomainV2Filter = null, orderBy: [DomainV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainV2Connection @join__field(graph: STRAWBERRY)
+  adminDomainsV2(
+    filter: DomainV2Filter = null
+    orderBy: [DomainV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DomainV2Connection @join__field(graph: STRAWBERRY)
 
-  """Added in 26.2.0. List domains within resource group scope."""
-  rgDomainsV2(scope: ResourceGroupDomainScope!, filter: DomainV2Filter = null, orderBy: [DomainV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DomainV2Connection @join__field(graph: STRAWBERRY)
+  """
+  Added in 26.2.0. List domains within resource group scope.
+  """
+  rgDomainsV2(
+    scope: ResourceGroupDomainScope!
+    filter: DomainV2Filter = null
+    orderBy: [DomainV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DomainV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Get a single project by ID. Returns an error if project is not found.
@@ -12138,12 +16096,31 @@ type Query
   """
   Added in 26.2.0. List all projects with filtering and pagination (admin only). Requires superadmin privileges.
   """
-  adminProjectsV2(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection @join__field(graph: STRAWBERRY)
+  adminProjectsV2(
+    filter: ProjectV2Filter = null
+    orderBy: [ProjectV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. List projects within a specific domain. Requires domain admin privileges or higher.
   """
-  domainProjectsV2(scope: DomainProjectV2Scope!, filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection @join__field(graph: STRAWBERRY)
+  domainProjectsV2(
+    scope: DomainProjectV2Scope!
+    filter: ProjectV2Filter = null
+    orderBy: [ProjectV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in 26.2.0. Get the domain that a project belongs to. Returns an error if project or domain is not found.
@@ -12153,105 +16130,247 @@ type Query
   """
   Added in UNRELEASED. Get a single keypair resource policy by name (admin only).
   """
-  adminKeypairResourcePolicyV2(name: String!): KeypairResourcePolicyV2 @join__field(graph: STRAWBERRY)
+  adminKeypairResourcePolicyV2(name: String!): KeypairResourcePolicyV2
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. List all keypair resource policies with pagination (admin only).
   """
-  adminKeypairResourcePoliciesV2(filter: KeypairResourcePolicyV2Filter = null, orderBy: [KeypairResourcePolicyV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): KeypairResourcePolicyV2Connection @join__field(graph: STRAWBERRY)
+  adminKeypairResourcePoliciesV2(
+    filter: KeypairResourcePolicyV2Filter = null
+    orderBy: [KeypairResourcePolicyV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): KeypairResourcePolicyV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Get a single user resource policy by name (admin only).
   """
-  adminUserResourcePolicyV2(name: String!): UserResourcePolicyV2 @join__field(graph: STRAWBERRY)
+  adminUserResourcePolicyV2(name: String!): UserResourcePolicyV2
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. List all user resource policies with pagination (admin only).
   """
-  adminUserResourcePoliciesV2(filter: UserResourcePolicyV2Filter = null, orderBy: [UserResourcePolicyV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserResourcePolicyV2Connection @join__field(graph: STRAWBERRY)
+  adminUserResourcePoliciesV2(
+    filter: UserResourcePolicyV2Filter = null
+    orderBy: [UserResourcePolicyV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserResourcePolicyV2Connection @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Get a single project resource policy by name (admin only).
   """
-  adminProjectResourcePolicyV2(name: String!): ProjectResourcePolicyV2 @join__field(graph: STRAWBERRY)
+  adminProjectResourcePolicyV2(name: String!): ProjectResourcePolicyV2
+    @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. List all project resource policies with pagination (admin only).
   """
-  adminProjectResourcePoliciesV2(filter: ProjectResourcePolicyV2Filter = null, orderBy: [ProjectResourcePolicyV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectResourcePolicyV2Connection @join__field(graph: STRAWBERRY)
+  adminProjectResourcePoliciesV2(
+    filter: ProjectResourcePolicyV2Filter = null
+    orderBy: [ProjectResourcePolicyV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectResourcePolicyV2Connection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get the current user's keypair resource policy."""
-  myKeypairResourcePolicyV2: KeypairResourcePolicyV2 @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Get the current user's keypair resource policy.
+  """
+  myKeypairResourcePolicyV2: KeypairResourcePolicyV2
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get the current user's user resource policy."""
+  """
+  Added in UNRELEASED. Get the current user's user resource policy.
+  """
   myUserResourcePolicyV2: UserResourcePolicyV2 @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. List resource presets (admin only)."""
-  adminResourcePresetsV2(filter: ResourcePresetFilter = null, orderBy: [ResourcePresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ResourcePresetConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. List resource presets (admin only).
+  """
+  adminResourcePresetsV2(
+    filter: ResourcePresetFilter = null
+    orderBy: [ResourcePresetOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ResourcePresetConnection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get a single resource preset by ID (admin only)."""
-  adminResourcePresetV2(id: UUID!): ResourcePresetV2 @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Get a single resource preset by ID (admin only).
+  """
+  adminResourcePresetV2(id: UUID!): ResourcePresetV2
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Search runtime variants."""
-  runtimeVariants(filter: RuntimeVariantFilter = null, orderBy: [RuntimeVariantOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RuntimeVariantConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Search runtime variants.
+  """
+  runtimeVariants(
+    filter: RuntimeVariantFilter = null
+    orderBy: [RuntimeVariantOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): RuntimeVariantConnection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get a single runtime variant by ID."""
+  """
+  Added in UNRELEASED. Get a single runtime variant by ID.
+  """
   runtimeVariant(id: UUID!): RuntimeVariant @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Search runtime variant presets."""
-  runtimeVariantPresets(filter: RuntimeVariantPresetFilter = null, orderBy: [RuntimeVariantPresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RuntimeVariantPresetConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Search runtime variant presets.
+  """
+  runtimeVariantPresets(
+    filter: RuntimeVariantPresetFilter = null
+    orderBy: [RuntimeVariantPresetOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): RuntimeVariantPresetConnection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get a single runtime variant preset by ID."""
-  runtimeVariantPreset(id: UUID!): RuntimeVariantPreset @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Get a single runtime variant preset by ID.
+  """
+  runtimeVariantPreset(id: UUID!): RuntimeVariantPreset
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Search deployment revision presets."""
-  deploymentRevisionPresets(filter: DeploymentRevisionPresetFilter = null, orderBy: [DeploymentRevisionPresetOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): DeploymentRevisionPresetConnection @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Search deployment revision presets.
+  """
+  deploymentRevisionPresets(
+    filter: DeploymentRevisionPresetFilter = null
+    orderBy: [DeploymentRevisionPresetOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): DeploymentRevisionPresetConnection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get a single deployment revision preset by ID."""
-  deploymentRevisionPreset(id: UUID!): DeploymentRevisionPreset @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Get a single deployment revision preset by ID.
+  """
+  deploymentRevisionPreset(id: UUID!): DeploymentRevisionPreset
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Search model cards."""
-  modelCardsV2(filter: ModelCardV2Filter = null, orderBy: [ModelCardV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ModelCardV2Connection @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Search model cards.
+  """
+  modelCardsV2(
+    filter: ModelCardV2Filter = null
+    orderBy: [ModelCardV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ModelCardV2Connection @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get a single model card by ID."""
+  """
+  Added in UNRELEASED. Get a single model card by ID.
+  """
   modelCardV2(id: UUID!): ModelCardV2 @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Get my keypair resource allocation (current user).
   """
-  myKeypairResourceAllocationV2: KeypairResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  myKeypairResourceAllocationV2: KeypairResourceAllocationV2!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get project resource allocation (project usage)."""
-  projectResourceAllocationV2(projectId: UUID!): ProjectResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Get project resource allocation (project usage).
+  """
+  projectResourceAllocationV2(projectId: UUID!): ProjectResourceAllocationV2!
+    @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get domain resource allocation (admin only)."""
-  adminDomainResourceAllocationV2(domainName: String!): DomainResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Get domain resource allocation (admin only).
+  """
+  adminDomainResourceAllocationV2(
+    domainName: String!
+  ): DomainResourceAllocationV2! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. Get resource group resource allocation."""
-  resourceGroupResourceAllocationV2(resourceGroupName: String!): ResourceGroupResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. Get resource group resource allocation.
+  """
+  resourceGroupResourceAllocationV2(
+    resourceGroupName: String!
+  ): ResourceGroupResourceAllocationV2! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Get effective resource allocation for the current user.
   """
-  effectiveResourceAllocationV2(input: EffectiveResourceAllocationV2Input!): EffectiveResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  effectiveResourceAllocationV2(
+    input: EffectiveResourceAllocationV2Input!
+  ): EffectiveResourceAllocationV2! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Get effective resource allocation for a specific user (admin only).
   """
-  adminEffectiveResourceAllocationV2(input: AdminEffectiveResourceAllocationV2Input!): EffectiveResourceAllocationV2! @join__field(graph: STRAWBERRY)
+  adminEffectiveResourceAllocationV2(
+    input: AdminEffectiveResourceAllocationV2Input!
+  ): EffectiveResourceAllocationV2! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Check which resource presets are available for session creation.
   """
-  checkPresetAvailabilityV2(input: CheckPresetAvailabilityV2Input!): CheckPresetAvailabilityPayloadV2! @join__field(graph: STRAWBERRY)
+  checkPresetAvailabilityV2(
+    input: CheckPresetAvailabilityV2Input!
+  ): CheckPresetAvailabilityPayloadV2! @join__field(graph: STRAWBERRY)
 
-  """Added in UNRELEASED. List virtual folders within a specific project."""
-  projectVfolders(projectId: UUID!, filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection! @join__field(graph: STRAWBERRY)
+  """
+  Added in UNRELEASED. List virtual folders within a specific project.
+  """
+  projectVfolders(
+    projectId: UUID!
+    filter: VFolderFilter = null
+    orderBy: [VFolderOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): VFolderConnection! @join__field(graph: STRAWBERRY)
 
   """
   Added in UNRELEASED. Search virtual folders accessible to the current user with pagination and filtering.
   """
-  myVfolders(filter: VFolderFilter = null, orderBy: [VFolderOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): VFolderConnection! @join__field(graph: STRAWBERRY)
+  myVfolders(
+    filter: VFolderFilter = null
+    orderBy: [VFolderOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): VFolderConnection! @join__field(graph: STRAWBERRY)
 }
 
 """
@@ -12259,163 +16378,218 @@ Added in 26.3.0. Prometheus query definition entity implementing Relay Node patt
 """
 type QueryDefinition implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Human-readable query definition identifier."""
+  """
+  Human-readable query definition identifier.
+  """
   name: String!
 
-  """Prometheus metric name."""
+  """
+  Prometheus metric name.
+  """
   metricName: String!
 
-  """PromQL template with placeholders."""
+  """
+  PromQL template with placeholders.
+  """
   queryTemplate: String!
 
-  """Default time window. Falls back to server config if null."""
+  """
+  Default time window. Falls back to server config if null.
+  """
   timeWindow: String
 
-  """Query definition options including filter and group labels."""
+  """
+  Query definition options including filter and group labels.
+  """
   options: QueryDefinitionOptions!
 
-  """Creation timestamp."""
+  """
+  Creation timestamp.
+  """
   createdAt: DateTime!
 
-  """Last update timestamp."""
+  """
+  Last update timestamp.
+  """
   updatedAt: DateTime!
 }
 
-"""Added in 26.3.0. Paginated connection for query definition records."""
-type QueryDefinitionConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Paginated connection for query definition records.
+"""
+type QueryDefinitionConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [QueryDefinitionEdge!]!
 
-  """Total number of query definition records matching the query criteria."""
+  """
+  Total number of query definition records matching the query criteria.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type QueryDefinitionEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type QueryDefinitionEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: QueryDefinition!
 }
 
-"""Added in 26.3.0. Result from executing a query definition."""
-type QueryDefinitionExecuteResult
-  @join__type(graph: STRAWBERRY)
-{
-  """Prometheus response status."""
+"""
+Added in 26.3.0. Result from executing a query definition.
+"""
+type QueryDefinitionExecuteResult @join__type(graph: STRAWBERRY) {
+  """
+  Prometheus response status.
+  """
   status: String!
 
-  """Result type (e.g., matrix)."""
+  """
+  Result type (e.g., matrix).
+  """
   resultType: String!
 
-  """Metric result entries."""
+  """
+  Metric result entries.
+  """
   result: [QueryDefinitionMetricResult!]!
 }
 
-"""Added in 26.3.0. Filter input for querying query definitions."""
-input QueryDefinitionFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Filter by name."""
+"""
+Added in 26.3.0. Filter input for querying query definitions.
+"""
+input QueryDefinitionFilter @join__type(graph: STRAWBERRY) {
+  """
+  Filter by name.
+  """
   name: StringFilter = null
 }
 
-"""Added in 26.3.0. Single metric result from Prometheus query."""
-type QueryDefinitionMetricResult
-  @join__type(graph: STRAWBERRY)
-{
-  """Label key-value pairs for this series"""
+"""
+Added in 26.3.0. Single metric result from Prometheus query.
+"""
+type QueryDefinitionMetricResult @join__type(graph: STRAWBERRY) {
+  """
+  Label key-value pairs for this series
+  """
   metric: [MetricLabelEntry!]!
 
-  """Data points (timestamp, value) for this series"""
+  """
+  Data points (timestamp, value) for this series
+  """
   values: [QueryDefinitionMetricResultValue!]!
 }
 
-"""Added in 26.3.0. Single timestamp-value pair from Prometheus."""
-type QueryDefinitionMetricResultValue
-  @join__type(graph: STRAWBERRY)
-{
-  """Unix timestamp of the data point"""
+"""
+Added in 26.3.0. Single timestamp-value pair from Prometheus.
+"""
+type QueryDefinitionMetricResultValue @join__type(graph: STRAWBERRY) {
+  """
+  Unix timestamp of the data point
+  """
   timestamp: Float!
 
-  """Metric value as a string to preserve precision"""
+  """
+  Metric value as a string to preserve precision
+  """
   value: String!
 }
 
-"""Added in 26.3.0. Options for query definition label governance."""
-type QueryDefinitionOptions
-  @join__type(graph: STRAWBERRY)
-{
-  """Allowed filter label keys"""
+"""
+Added in 26.3.0. Options for query definition label governance.
+"""
+type QueryDefinitionOptions @join__type(graph: STRAWBERRY) {
+  """
+  Allowed filter label keys
+  """
   filterLabels: [String!]!
 
-  """Allowed group-by label keys"""
+  """
+  Allowed group-by label keys
+  """
   groupLabels: [String!]!
 }
 
-"""Added in 26.3.0. Options for query definition labels."""
-input QueryDefinitionOptionsInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Allowed filter label keys."""
+"""
+Added in 26.3.0. Options for query definition labels.
+"""
+input QueryDefinitionOptionsInput @join__type(graph: STRAWBERRY) {
+  """
+  Allowed filter label keys.
+  """
   filterLabels: [String!]!
 
-  """Allowed group-by label keys."""
+  """
+  Allowed group-by label keys.
+  """
   groupLabels: [String!]!
 }
 
-"""Added in 26.3.0. Specifies ordering for query definition results."""
-input QueryDefinitionOrderBy
-  @join__type(graph: STRAWBERRY)
-{
-  """The field to order by."""
+"""
+Added in 26.3.0. Specifies ordering for query definition results.
+"""
+input QueryDefinitionOrderBy @join__type(graph: STRAWBERRY) {
+  """
+  The field to order by.
+  """
   field: QueryDefinitionOrderField!
 
-  """Sort direction."""
+  """
+  Sort direction.
+  """
   direction: OrderDirection! = DESC
 }
 
 """
 Added in 26.3.0. Fields available for ordering query definition results.
 """
-enum QueryDefinitionOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum QueryDefinitionOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
   NAME @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.3.0. Time range for Prometheus query."""
-input QueryTimeRangeInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Start of the time range."""
+"""
+Added in 26.3.0. Time range for Prometheus query.
+"""
+input QueryTimeRangeInput @join__type(graph: STRAWBERRY) {
+  """
+  Start of the time range.
+  """
   start: DateTime!
 
-  """End of the time range."""
+  """
+  End of the time range.
+  """
   end: DateTime!
 
-  """Query resolution step (e.g., '60s')."""
+  """
+  Query resolution step (e.g., '60s').
+  """
   step: String!
 }
 
-type QuotaDetails
-  @join__type(graph: GRAPHENE)
-{
+type QuotaDetails @join__type(graph: GRAPHENE) {
   usage_bytes: BigInt
   usage_count: BigInt
   hard_limit_bytes: BigInt
@@ -12423,26 +16597,21 @@ type QuotaDetails
 
 type QuotaScope implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID!
   quota_scope_id: String!
   storage_host_name: String!
   details: QuotaDetails!
 }
 
-input QuotaScopeInput
-  @join__type(graph: GRAPHENE)
-{
+input QuotaScopeInput @join__type(graph: GRAPHENE) {
   hard_limit_bytes: BigInt
 }
 
 """
 Added in 26.3.0. Unified RBAC element type for scope-entity relationships
 """
-enum RBACElementType
-  @join__type(graph: STRAWBERRY)
-{
+enum RBACElementType @join__type(graph: STRAWBERRY) {
   DOMAIN @join__enumValue(graph: STRAWBERRY)
   PROJECT @join__enumValue(graph: STRAWBERRY)
   USER @join__enumValue(graph: STRAWBERRY)
@@ -12483,18 +16652,16 @@ enum RBACElementType
 """
 Added in 25.19.0. This enum represents the readiness status of a replica, indicating whether the deployment has been checked and its health state.
 """
-enum ReadinessStatus
-  @join__type(graph: STRAWBERRY)
-{
+enum ReadinessStatus @join__type(graph: STRAWBERRY) {
   NOT_CHECKED @join__enumValue(graph: STRAWBERRY)
   HEALTHY @join__enumValue(graph: STRAWBERRY)
   UNHEALTHY @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.15.0. Input type for registering a storage namespace."""
-input RegisterStorageNamespaceInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.15.0. Input type for registering a storage namespace.
+"""
+input RegisterStorageNamespaceInput @join__type(graph: STRAWBERRY) {
   storageId: UUID!
   namespace: String!
 }
@@ -12502,10 +16669,10 @@ input RegisterStorageNamespaceInput
 """
 Added in 25.15.0. Payload returned after storage namespace registration.
 """
-type RegisterStorageNamespacePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the registered storage namespace"""
+type RegisterStorageNamespacePayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the registered storage namespace
+  """
   id: UUID!
 }
 
@@ -12514,26 +16681,24 @@ Added in 24.09.0. Input for rejecting an artifact revision.
 
 Admin-only operation to reject artifact revisions, preventing their use.
 """
-input RejectArtifactInput
-  @join__type(graph: STRAWBERRY)
-{
+input RejectArtifactInput @join__type(graph: STRAWBERRY) {
   artifactRevisionId: ID!
 }
 
 """
 Added in 25.14.0. Response payload for artifact revision rejection operations. Contains the rejected artifact revision. Admin-only operation.
 """
-type RejectArtifactPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Rejected artifact revision."""
+type RejectArtifactPayload @join__type(graph: STRAWBERRY) {
+  """
+  Rejected artifact revision.
+  """
   artifactRevision: ArtifactRevision!
 }
 
-"""Added in 25.19.0. """
-input ReplicaFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ReplicaFilter @join__type(graph: STRAWBERRY) {
   status: ReplicaStatusFilter = null
   trafficStatus: TrafficStatusFilter = null
   AND: [ReplicaFilter!] = null
@@ -12541,17 +16706,15 @@ input ReplicaFilter
   NOT: [ReplicaFilter!] = null
 }
 
-"""Added in 25.19.0. """
-input ReplicaOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ReplicaOrderBy @join__type(graph: STRAWBERRY) {
   field: ReplicaOrderField!
   direction: OrderDirection! = DESC
 }
 
-enum ReplicaOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum ReplicaOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   ID @join__enumValue(graph: STRAWBERRY)
 }
@@ -12559,18 +16722,14 @@ enum ReplicaOrderField
 """
 Added in 25.19.0. Represents the current replica state of a deployment, including the desired replica count and access to the list of active replicas.
 """
-type ReplicaState
-  @join__type(graph: STRAWBERRY)
-{
+type ReplicaState @join__type(graph: STRAWBERRY) {
   desiredReplicaCount: Int!
 }
 
 """
 Added in 25.19.0. This enum represents the provisioning status of a replica.
 """
-enum ReplicaStatus
-  @join__type(graph: STRAWBERRY)
-{
+enum ReplicaStatus @join__type(graph: STRAWBERRY) {
   PROVISIONING @join__enumValue(graph: STRAWBERRY)
   HEALTHY @join__enumValue(graph: STRAWBERRY)
   UNHEALTHY @join__enumValue(graph: STRAWBERRY)
@@ -12580,44 +16739,49 @@ enum ReplicaStatus
   FAILED_TO_START @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.19.0. Payload for replica status changed event."""
-type ReplicaStatusChangedPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The replica whose status changed"""
+"""
+Added in 25.19.0. Payload for replica status changed event.
+"""
+type ReplicaStatusChangedPayload @join__type(graph: STRAWBERRY) {
+  """
+  The replica whose status changed
+  """
   replica: ModelReplica!
 }
 
-"""Added in 25.19.0. """
-input ReplicaStatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """The in  field."""
+"""
+Added in 25.19.0.
+"""
+input ReplicaStatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  The in  field.
+  """
   in: [ReplicaStatus!] = null
   equals: ReplicaStatus = null
 }
 
-"""Added in 25.4.0."""
-type RescanGPUAllocMaps
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.4.0.
+"""
+type RescanGPUAllocMaps @join__type(graph: GRAPHENE) {
   task_id: UUID
 }
 
-type RescanImages
-  @join__type(graph: GRAPHENE)
-{
+type RescanImages @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   task_id: UUID
 }
 
-"""Added in 25.14.0. Reservoir registry node."""
+"""
+Added in 25.14.0. Reservoir registry node.
+"""
 type ReservoirRegistry implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   name: String!
   endpoint: String!
@@ -12625,41 +16789,51 @@ type ReservoirRegistry implements Node
   secretKey: String!
   apiVersion: String!
 
-  """The remote artifact registries of this entity."""
+  """
+  The remote artifact registries of this entity.
+  """
   remoteArtifactRegistries: ArtifactRegistryMetaConnection!
 }
 
 """
 Added in 25.14.0. Relay-style connection for paginated reservoir registry queries.
 """
-type ReservoirRegistryConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ReservoirRegistryConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ReservoirRegistryEdge!]!
 
-  """The count of this entity."""
+  """
+  The count of this entity.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type ReservoirRegistryEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ReservoirRegistryEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ReservoirRegistry!
 }
 
-"""Added in 26.2.0. Resource allocation with requested and used slots."""
-type ResourceAllocation
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Resource allocation with requested and used slots.
+"""
+type ResourceAllocation @join__type(graph: STRAWBERRY) {
   """
   The resource slots originally requested. Typed as Any because this field holds a nested GQL type (ResourceSlotGQL).
   """
@@ -12674,13 +16848,15 @@ type ResourceAllocation
 """
 Added in 26.3.0. Relay-style connection for per-slot kernel resource allocations.
 """
-type ResourceAllocationConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ResourceAllocationConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [KernelResourceAllocationEdge!]!
   count: Int!
 }
@@ -12688,23 +16864,25 @@ type ResourceAllocationConnection
 """
 Added in 25.19.0. Compute resource configuration for the deployment. Specifies CPU, memory, GPU allocations and additional resource options.
 """
-type ResourceConfig
-  @join__type(graph: STRAWBERRY)
-{
-  """The resource group of this entity."""
+type ResourceConfig @join__type(graph: STRAWBERRY) {
+  """
+  The resource group of this entity.
+  """
   resourceGroup: ScalingGroupNode!
   resourceGroupName: String!
   resourceSlots: ResourceSlot!
   resourceOpts: ResourceOpts
 }
 
-"""Added in 25.19.0. """
-input ResourceConfigInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ResourceConfigInput @join__type(graph: STRAWBERRY) {
   resourceGroup: ResourceGroupInput!
 
-  """Added in 26.1.0. Resources allocated for the deployment."""
+  """
+  Added in 26.1.0. Resources allocated for the deployment.
+  """
   resourceSlots: ResourceSlotInput!
 
   """
@@ -12713,12 +16891,15 @@ input ResourceConfigInput
   resourceOpts: ResourceOptsInput = null
 }
 
-"""Added in 26.1.0. Resource group with structured configuration"""
+"""
+Added in 26.1.0. Resource group with structured configuration
+"""
 type ResourceGroup implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
   """
@@ -12726,7 +16907,9 @@ type ResourceGroup implements Node
   """
   name: String!
 
-  """Added in 26.2.0. Status information including active and public flags."""
+  """
+  Added in 26.2.0. Status information including active and public flags.
+  """
   status: ResourceGroupStatus!
 
   """
@@ -12734,7 +16917,9 @@ type ResourceGroup implements Node
   """
   metadata: ResourceGroupMetadata!
 
-  """Added in 26.2.0. Network configuration for the resource group."""
+  """
+  Added in 26.2.0. Network configuration for the resource group.
+  """
   network: ResourceGroupNetworkConfig!
 
   """
@@ -12753,41 +16938,51 @@ type ResourceGroup implements Node
   resourceInfo: ResourceInfo!
 }
 
-"""Added in 26.2.0. Resource group connection"""
-type ResourceGroupConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.2.0. Resource group connection
+"""
+type ResourceGroupConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ResourceGroupEdge!]!
   count: Int!
 }
 
-"""Added in 24.09.0. Resource group scope for domain-level operations"""
-input ResourceGroupDomainScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group name to scope the operation"""
+"""
+Added in 24.09.0. Resource group scope for domain-level operations
+"""
+input ResourceGroupDomainScope @join__type(graph: STRAWBERRY) {
+  """
+  Resource group name to scope the operation
+  """
   resourceGroupName: String!
 }
 
-"""An edge in a connection."""
-type ResourceGroupEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ResourceGroupEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ResourceGroup!
 }
 
-"""Added in 26.1.0. Filter for resource groups"""
-input ResourceGroupFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.1.0. Filter for resource groups
+"""
+input ResourceGroupFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   description: StringFilter = null
   isActive: Boolean = null
@@ -12797,29 +16992,35 @@ input ResourceGroupFilter
   NOT: [ResourceGroupFilter!] = null
 }
 
-"""Added in 25.19.0. """
-input ResourceGroupInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input ResourceGroupInput @join__type(graph: STRAWBERRY) {
   name: String!
 }
 
-"""Added in 26.2.0. Metadata for a resource group."""
-type ResourceGroupMetadata
-  @join__type(graph: STRAWBERRY)
-{
-  """Human-readable description of the resource group."""
+"""
+Added in 26.2.0. Metadata for a resource group.
+"""
+type ResourceGroupMetadata @join__type(graph: STRAWBERRY) {
+  """
+  Human-readable description of the resource group.
+  """
   description: String
 
-  """Timestamp when the resource group was created."""
+  """
+  Timestamp when the resource group was created.
+  """
   createdAt: DateTime!
 }
 
-"""Added in 26.2.0. Network configuration for a resource group."""
-type ResourceGroupNetworkConfig
-  @join__type(graph: STRAWBERRY)
-{
-  """WebSocket proxy address for this resource group."""
+"""
+Added in 26.2.0. Network configuration for a resource group.
+"""
+type ResourceGroupNetworkConfig @join__type(graph: STRAWBERRY) {
+  """
+  WebSocket proxy address for this resource group.
+  """
   wsproxyAddr: String
 
   """
@@ -12828,18 +17029,18 @@ type ResourceGroupNetworkConfig
   useHostNetwork: Boolean!
 }
 
-"""Added in 26.1.0. Order by specification for resource groups"""
-input ResourceGroupOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.1.0. Order by specification for resource groups
+"""
+input ResourceGroupOrderBy @join__type(graph: STRAWBERRY) {
   field: ResourceGroupOrderField!
   direction: OrderDirection! = ASC
 }
 
-"""Added in 26.1.0. Fields available for ordering resource groups"""
-enum ResourceGroupOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.1.0. Fields available for ordering resource groups
+"""
+enum ResourceGroupOrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   IS_ACTIVE @join__enumValue(graph: STRAWBERRY)
@@ -12848,181 +17049,215 @@ enum ResourceGroupOrderField
 """
 Added in 24.09.0. Resource group + domain scope for project-level operations
 """
-input ResourceGroupProjectScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group name to scope the operation"""
+input ResourceGroupProjectScope @join__type(graph: STRAWBERRY) {
+  """
+  Resource group name to scope the operation
+  """
   resourceGroupName: String!
 
-  """Domain name to scope the operation"""
+  """
+  Domain name to scope the operation
+  """
   domainName: String!
 }
 
 """
 Added in UNRELEASED. Payload for resource group resource allocation query.
 """
-type ResourceGroupResourceAllocationV2
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group resource usage."""
+type ResourceGroupResourceAllocationV2 @join__type(graph: STRAWBERRY) {
+  """
+  Resource group resource usage.
+  """
   resourceGroup: ResourceGroupUsageV2!
 }
 
-"""Added in 26.2.0. Scheduler configuration for a resource group."""
-type ResourceGroupSchedulerConfig
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Scheduler configuration for a resource group.
+"""
+type ResourceGroupSchedulerConfig @join__type(graph: STRAWBERRY) {
   """
   Type of scheduler used for session scheduling (fifo, lifo, drf, fair-share).
   """
   type: SchedulerType!
 
-  """Preemption configuration for this resource group."""
+  """
+  Preemption configuration for this resource group.
+  """
   preemption: PreemptionConfig!
 }
 
-"""Added in 26.2.0. Status information for a resource group."""
-type ResourceGroupStatus
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the resource group is active and can accept new sessions."""
+"""
+Added in 26.2.0. Status information for a resource group.
+"""
+type ResourceGroupStatus @join__type(graph: STRAWBERRY) {
+  """
+  Whether the resource group is active and can accept new sessions.
+  """
   isActive: Boolean!
 
-  """Whether the resource group is publicly accessible to all users."""
+  """
+  Whether the resource group is publicly accessible to all users.
+  """
   isPublic: Boolean!
 }
 
 """
 Added in UNRELEASED. Resource usage for a resource group (agent-level physical resources).
 """
-type ResourceGroupUsageV2
-  @join__type(graph: STRAWBERRY)
-{
-  """Total agent capacity."""
+type ResourceGroupUsageV2 @join__type(graph: STRAWBERRY) {
+  """
+  Total agent capacity.
+  """
   capacity: [ResourceSlotEntry!]!
 
-  """Currently occupied by sessions."""
+  """
+  Currently occupied by sessions.
+  """
   used: [ResourceSlotEntry!]!
 
-  """Free resources (capacity - used)."""
+  """
+  Free resources (capacity - used).
+  """
   free: [ResourceSlotEntry!]!
 
-  """Largest single-agent free resources."""
+  """
+  Largest single-agent free resources.
+  """
   maxPerNode: [ResourceSlotEntry!]!
 }
 
 """
 Added in 24.09.0. Resource group + domain + project scope for user-level operations
 """
-input ResourceGroupUserScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group name to scope the operation"""
+input ResourceGroupUserScope @join__type(graph: STRAWBERRY) {
+  """
+  Resource group name to scope the operation
+  """
   resourceGroupName: String!
 
-  """Domain name to scope the operation"""
+  """
+  Domain name to scope the operation
+  """
   domainName: String!
 
-  """Project ID to scope the operation"""
+  """
+  Project ID to scope the operation
+  """
   projectId: String!
 }
 
 """
 Added in 26.1.0. Resource information for a resource group. Provides aggregated resource metrics including capacity, used, and free resources.
 """
-type ResourceInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Total available resources"""
+type ResourceInfo @join__type(graph: STRAWBERRY) {
+  """
+  Total available resources
+  """
   capacity: ResourceSlot!
 
-  """Currently occupied resources"""
+  """
+  Currently occupied resources
+  """
   used: ResourceSlot!
 
-  """Available resources (capacity - used)"""
+  """
+  Available resources (capacity - used)
+  """
   free: ResourceSlot!
 }
 
-type ResourceLimit
-  @join__type(graph: GRAPHENE)
-{
+type ResourceLimit @join__type(graph: GRAPHENE) {
   key: String
   min: String
-  max: String @deprecated(reason: "Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete.")
+  max: String
+    @deprecated(
+      reason: "Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete."
+    )
 }
 
-"""Added in UNRELEASED. A resource limit entry that may be unlimited."""
-type ResourceLimitEntry
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource type identifier (e.g., cpu, mem, cuda.shares)"""
+"""
+Added in UNRELEASED. A resource limit entry that may be unlimited.
+"""
+type ResourceLimitEntry @join__type(graph: STRAWBERRY) {
+  """
+  Resource type identifier (e.g., cpu, mem, cuda.shares)
+  """
   resourceType: String!
 
-  """Limit quantity. Null when unlimited."""
+  """
+  Limit quantity. Null when unlimited.
+  """
   quantity: Decimal
 
-  """Whether this resource type has no limit."""
+  """
+  Whether this resource type has no limit.
+  """
   unlimited: Boolean!
 }
 
-input ResourceLimitInput
-  @join__type(graph: GRAPHENE)
-{
+input ResourceLimitInput @join__type(graph: GRAPHENE) {
   key: String
   min: String
-  max: String @deprecated(reason: "Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete.")
+  max: String
+    @deprecated(
+      reason: "Deprecated since 25.14.0. The max slot limit validation has been removed as it was deemed obsolete."
+    )
 }
 
 """
 Added in 26.1.0. A collection of additional resource options for a deployment. Contains key-value pairs for resource configuration like shared memory.
 """
-type ResourceOpts
-  @join__type(graph: STRAWBERRY)
-{
-  """List of resource option entries."""
+type ResourceOpts @join__type(graph: STRAWBERRY) {
+  """
+  List of resource option entries.
+  """
   entries: [ResourceOptsEntry!]!
 }
 
 """
 Added in 26.1.0. A single key-value entry representing a resource option. Contains additional resource configuration such as shared memory settings.
 """
-type ResourceOptsEntry
-  @join__type(graph: STRAWBERRY)
-{
-  """The name of this resource option (e.g., 'shmem')."""
+type ResourceOptsEntry @join__type(graph: STRAWBERRY) {
+  """
+  The name of this resource option (e.g., 'shmem').
+  """
   name: String!
 
-  """The value for this resource option (e.g., '64m')."""
+  """
+  The value for this resource option (e.g., '64m').
+  """
   value: String!
 }
 
 """
 Added in 26.1.0. A single key-value entry representing a resource option.
 """
-input ResourceOptsEntryInput
-  @join__type(graph: STRAWBERRY)
-{
-  """The name of this resource option (e.g., 'shmem')."""
+input ResourceOptsEntryInput @join__type(graph: STRAWBERRY) {
+  """
+  The name of this resource option (e.g., 'shmem').
+  """
   name: String!
 
-  """The value for this resource option (e.g., '64m')."""
+  """
+  The value for this resource option (e.g., '64m').
+  """
   value: String!
 }
 
 """
 Added in 26.1.0. A collection of additional resource options for input.
 """
-input ResourceOptsInput
-  @join__type(graph: STRAWBERRY)
-{
-  """List of resource option entries."""
+input ResourceOptsInput @join__type(graph: STRAWBERRY) {
+  """
+  List of resource option entries.
+  """
   entries: [ResourceOptsEntryInput!]!
 }
 
-type ResourcePreset
-  @join__type(graph: GRAPHENE)
-{
-  """Added in 25.4.0. ID of the resource preset."""
+type ResourcePreset @join__type(graph: GRAPHENE) {
+  """
+  Added in 25.4.0. ID of the resource preset.
+  """
   id: UUID
   name: String
   resource_slots: JSONString
@@ -13034,22 +17269,26 @@ type ResourcePreset
   scaling_group_name: String
 }
 
-"""Added in UNRELEASED. Resource preset connection."""
-type ResourcePresetConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in UNRELEASED. Resource preset connection.
+"""
+type ResourcePresetConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ResourcePresetV2Edge!]!
   count: Int!
 }
 
-"""Added in UNRELEASED. Filter for resource presets."""
-input ResourcePresetFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Filter for resource presets.
+"""
+input ResourcePresetFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   resourceGroupName: StringFilter = null
   AND: [ResourcePresetFilter!] = null
@@ -13057,96 +17296,115 @@ input ResourcePresetFilter
   NOT: [ResourcePresetFilter!] = null
 }
 
-"""Added in UNRELEASED. Order by specification for resource presets."""
-input ResourcePresetOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Order by specification for resource presets.
+"""
+input ResourcePresetOrderBy @join__type(graph: STRAWBERRY) {
   field: ResourcePresetOrderField!
   direction: OrderDirection! = ASC
 }
 
-"""Added in UNRELEASED. Fields available for ordering resource presets."""
-enum ResourcePresetOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Fields available for ordering resource presets.
+"""
+enum ResourcePresetOrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in UNRELEASED. Resource preset with resource slot allocations."""
+"""
+Added in UNRELEASED. Resource preset with resource slot allocations.
+"""
 type ResourcePresetV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Resource preset name."""
+  """
+  Resource preset name.
+  """
   name: String!
 
-  """Resource slot allocations for this preset."""
+  """
+  Resource slot allocations for this preset.
+  """
   resourceSlots: [ResourceSlotEntry!]!
 
-  """Shared memory size with both bytes and human-readable format."""
+  """
+  Shared memory size with both bytes and human-readable format.
+  """
   sharedMemory: BinarySizeInfo
 
-  """Resource group name. Null means global preset."""
+  """
+  Resource group name. Null means global preset.
+  """
   resourceGroupName: String
 }
 
-"""An edge in a connection."""
-type ResourcePresetV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ResourcePresetV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ResourcePresetV2!
 }
 
 """
 Added in 26.1.0. A collection of compute resource allocations. Represents the resources consumed, allocated, or available for a workload. Each entry specifies a resource type and its quantity.
 """
-type ResourceSlot
-  @join__type(graph: STRAWBERRY)
-{
-  """List of resource allocations"""
+type ResourceSlot @join__type(graph: STRAWBERRY) {
+  """
+  List of resource allocations
+  """
   entries: [ResourceSlotEntry!]!
 }
 
 """
 Added in 26.1.0. A single entry representing one resource type and its allocated quantity. Resource types include compute resources (cpu, mem), accelerators (cuda.shares, cuda.device, rocm.device), and custom resources defined by plugins.
 """
-type ResourceSlotEntry
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource type identifier (e.g., cpu, mem, cuda.shares)"""
+type ResourceSlotEntry @join__type(graph: STRAWBERRY) {
+  """
+  Resource type identifier (e.g., cpu, mem, cuda.shares)
+  """
   resourceType: String!
 
-  """Quantity of the resource"""
+  """
+  Quantity of the resource
+  """
   quantity: Decimal!
 }
 
 """
 Added in 26.1.0. A single entry representing one resource type and its allocated quantity.
 """
-input ResourceSlotEntryInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource type identifier (e.g., 'cpu', 'mem', 'cuda.device')."""
+input ResourceSlotEntryInput @join__type(graph: STRAWBERRY) {
+  """
+  Resource type identifier (e.g., 'cpu', 'mem', 'cuda.device').
+  """
   resourceType: String!
 
-  """Quantity of the resource as a decimal string."""
+  """
+  Quantity of the resource as a decimal string.
+  """
   quantity: String!
 }
 
 """
 Added in 26.1.0. A collection of compute resource allocations for input.
 """
-input ResourceSlotInput
-  @join__type(graph: STRAWBERRY)
-{
-  """List of resource allocations."""
+input ResourceSlotInput @join__type(graph: STRAWBERRY) {
+  """
+  List of resource allocations.
+  """
   entries: [ResourceSlotEntryInput!]!
 }
 
@@ -13156,9 +17414,10 @@ and formatting rules for a specific resource (e.g., cpu, mem, cuda.device).
 """
 type ResourceSlotType implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
   """
@@ -13166,13 +17425,19 @@ type ResourceSlotType implements Node
   """
   slotName: String!
 
-  """Category of the slot type (e.g., 'count', 'bytes', 'unique-count')."""
+  """
+  Category of the slot type (e.g., 'count', 'bytes', 'unique-count').
+  """
   slotType: String!
 
-  """Human-readable name for display in UIs."""
+  """
+  Human-readable name for display in UIs.
+  """
   displayName: String!
 
-  """Longer description of what this resource slot represents."""
+  """
+  Longer description of what this resource slot represents.
+  """
   description: String!
 
   """
@@ -13180,45 +17445,57 @@ type ResourceSlotType implements Node
   """
   displayUnit: String!
 
-  """Icon identifier for UI rendering (e.g., 'cpu', 'memory', 'gpu')."""
+  """
+  Icon identifier for UI rendering (e.g., 'cpu', 'memory', 'gpu').
+  """
   displayIcon: String!
 
-  """Number formatting rules (binary vs decimal prefix, rounding)."""
+  """
+  Number formatting rules (binary vs decimal prefix, rounding).
+  """
   numberFormat: NumberFormat!
 
-  """Display ordering rank. Lower values appear first."""
+  """
+  Display ordering rank. Lower values appear first.
+  """
   rank: Int!
 }
 
 """
 Added in 26.3.0. Relay-style connection for paginated resource slot types.
 """
-type ResourceSlotTypeConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type ResourceSlotTypeConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [ResourceSlotTypeEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type ResourceSlotTypeEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type ResourceSlotTypeEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: ResourceSlotType!
 }
 
-"""Added in 26.3.0. Filter criteria for querying resource slot types."""
-input ResourceSlotTypeFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Filter criteria for querying resource slot types.
+"""
+input ResourceSlotTypeFilter @join__type(graph: STRAWBERRY) {
   slotName: StringFilter = null
   slotType: StringFilter = null
   displayName: StringFilter = null
@@ -13227,18 +17504,18 @@ input ResourceSlotTypeFilter
   NOT: [ResourceSlotTypeFilter!] = null
 }
 
-"""Added in 26.3.0. Ordering specification for resource slot types."""
-input ResourceSlotTypeOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Ordering specification for resource slot types.
+"""
+input ResourceSlotTypeOrderBy @join__type(graph: STRAWBERRY) {
   field: ResourceSlotTypeOrderField!
   direction: OrderDirection! = ASC
 }
 
-"""Added in 26.3.0. Fields available for ordering resource slot types."""
-enum ResourceSlotTypeOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Fields available for ordering resource slot types.
+"""
+enum ResourceSlotTypeOrderField @join__type(graph: STRAWBERRY) {
   SLOT_NAME @join__enumValue(graph: STRAWBERRY)
   RANK @join__enumValue(graph: STRAWBERRY)
   DISPLAY_NAME @join__enumValue(graph: STRAWBERRY)
@@ -13247,25 +17524,27 @@ enum ResourceSlotTypeOrderField
 """
 Added in 26.2.0. Resource weight with default indicator. Shows whether this resource type's weight was explicitly set or uses default.
 """
-type ResourceWeightEntry
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource type identifier"""
+type ResourceWeightEntry @join__type(graph: STRAWBERRY) {
+  """
+  Resource type identifier
+  """
   resourceType: String!
 
-  """Weight multiplier for this resource type"""
+  """
+  Weight multiplier for this resource type
+  """
   weight: Decimal!
 
-  """Whether this resource uses the resource group's default weight"""
+  """
+  Whether this resource uses the resource group's default weight
+  """
   usesDefault: Boolean!
 }
 
 """
 Added in 26.1.0. Input for a single resource weight entry. Specifies how much a resource type contributes to fair share calculations.
 """
-input ResourceWeightEntryInput
-  @join__type(graph: STRAWBERRY)
-{
+input ResourceWeightEntryInput @join__type(graph: STRAWBERRY) {
   """
   Resource type identifier (e.g., 'cpu', 'mem', 'cuda.shares'). Must match the resource types used in the cluster.
   """
@@ -13282,52 +17561,54 @@ Added in 24.09.0. Input for restoring previously deleted artifacts.
 
 Reverses the soft-delete operation, making the artifacts available again.
 """
-input RestoreArtifactsInput
-  @join__type(graph: STRAWBERRY)
-{
+input RestoreArtifactsInput @join__type(graph: STRAWBERRY) {
   artifactIds: [ID!]!
 }
 
 """
 Added in 25.15.0. Response payload for artifact restoration operations. Contains the artifacts that were restored from soft-deleted state.
 """
-type RestoreArtifactsPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """List of restored artifacts."""
+type RestoreArtifactsPayload @join__type(graph: STRAWBERRY) {
+  """
+  List of restored artifacts.
+  """
   artifacts: [Artifact!]!
 }
 
-"""Added in UNRELEASED. Payload returned after revoking a login session."""
-type RevokeLoginSessionPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the revocation was successful"""
+"""
+Added in UNRELEASED. Payload returned after revoking a login session.
+"""
+type RevokeLoginSessionPayload @join__type(graph: STRAWBERRY) {
+  """
+  Whether the revocation was successful
+  """
   success: Boolean!
 }
 
 """
 Added in 24.09.0. Input for revoking a keypair owned by the current user.
 """
-input RevokeMyKeypairInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Access key of the keypair to revoke. Must not be the main access key."""
+input RevokeMyKeypairInput @join__type(graph: STRAWBERRY) {
+  """
+  Access key of the keypair to revoke. Must not be the main access key.
+  """
   accessKey: String!
 }
 
-"""Added in 26.2.0. Payload returned after revoking a keypair."""
-type RevokeMyKeypairPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the revocation was successful."""
+"""
+Added in 26.2.0. Payload returned after revoking a keypair.
+"""
+type RevokeMyKeypairPayload @join__type(graph: STRAWBERRY) {
+  """
+  Whether the revocation was successful.
+  """
   success: Boolean!
 }
 
-"""Added in 26.3.0. Input for revoking a role from a user"""
-input RevokeRoleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Input for revoking a role from a user
+"""
+input RevokeRoleInput @join__type(graph: STRAWBERRY) {
   userId: UUID!
   roleId: UUID!
 }
@@ -13335,93 +17616,132 @@ input RevokeRoleInput
 """
 Added in 26.2.0. Filter for domain fair shares within a resource group scope. References resource group membership columns to avoid excluding domains without fair share records.
 """
-input RGDomainFairShareFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Filter by scaling group name."""
+input RGDomainFairShareFilter @join__type(graph: STRAWBERRY) {
+  """
+  Filter by scaling group name.
+  """
   resourceGroup: StringFilter = null
 
-  """Filter by domain name."""
+  """
+  Filter by domain name.
+  """
   domainName: StringFilter = null
 
-  """Filter by domain properties."""
+  """
+  Filter by domain properties.
+  """
   domain: DomainFairShareDomainNestedFilter = null
 
-  """Combine with AND logic."""
+  """
+  Combine with AND logic.
+  """
   AND: [RGDomainFairShareFilter!] = null
 
-  """Combine with OR logic."""
+  """
+  Combine with OR logic.
+  """
   OR: [RGDomainFairShareFilter!] = null
 
-  """Negate filters."""
+  """
+  Negate filters.
+  """
   NOT: [RGDomainFairShareFilter!] = null
 }
 
 """
 Added in 26.2.0. Filter for project fair shares within a resource group scope. References resource group membership columns to avoid excluding projects without fair share records.
 """
-input RGProjectFairShareFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Filter by scaling group name."""
+input RGProjectFairShareFilter @join__type(graph: STRAWBERRY) {
+  """
+  Filter by scaling group name.
+  """
   resourceGroup: StringFilter = null
 
-  """Filter by project UUID."""
+  """
+  Filter by project UUID.
+  """
   projectId: UUIDFilter = null
 
-  """Filter by domain name."""
+  """
+  Filter by domain name.
+  """
   domainName: StringFilter = null
 
-  """Filter by project properties."""
+  """
+  Filter by project properties.
+  """
   project: ProjectFairShareProjectNestedFilter = null
 
-  """Combine with AND logic."""
+  """
+  Combine with AND logic.
+  """
   AND: [RGProjectFairShareFilter!] = null
 
-  """Combine with OR logic."""
+  """
+  Combine with OR logic.
+  """
   OR: [RGProjectFairShareFilter!] = null
 
-  """Negate filters."""
+  """
+  Negate filters.
+  """
   NOT: [RGProjectFairShareFilter!] = null
 }
 
 """
 Added in 26.2.0. Filter for user fair shares within a resource group scope. References resource group membership columns to avoid excluding users without fair share records.
 """
-input RGUserFairShareFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Filter by scaling group name."""
+input RGUserFairShareFilter @join__type(graph: STRAWBERRY) {
+  """
+  Filter by scaling group name.
+  """
   resourceGroup: StringFilter = null
 
-  """Filter by user UUID."""
+  """
+  Filter by user UUID.
+  """
   userUuid: UUIDFilter = null
 
-  """Filter by project UUID."""
+  """
+  Filter by project UUID.
+  """
   projectId: UUIDFilter = null
 
-  """Filter by domain name."""
+  """
+  Filter by domain name.
+  """
   domainName: StringFilter = null
 
-  """Filter by user properties."""
+  """
+  Filter by user properties.
+  """
   user: UserFairShareUserNestedFilter = null
 
-  """Combine with AND logic."""
+  """
+  Combine with AND logic.
+  """
   AND: [RGUserFairShareFilter!] = null
 
-  """Combine with OR logic."""
+  """
+  Combine with OR logic.
+  """
   OR: [RGUserFairShareFilter!] = null
 
-  """Negate filters."""
+  """
+  Negate filters.
+  """
   NOT: [RGUserFairShareFilter!] = null
 }
 
-"""Added in 26.3.0. RBAC role."""
+"""
+Added in 26.3.0. RBAC role.
+"""
 type Role implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   name: String!
   description: String
@@ -13431,65 +17751,108 @@ type Role implements Node
   updatedAt: DateTime!
   deletedAt: DateTime
 
-  """Added in 26.3.0. Permissions associated with this role."""
-  permissions(filter: PermissionFilter = null, orderBy: [PermissionOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): PermissionConnection!
+  """
+  Added in 26.3.0. Permissions associated with this role.
+  """
+  permissions(
+    filter: PermissionFilter = null
+    orderBy: [PermissionOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): PermissionConnection!
 
-  """Added in 26.3.0. Users assigned to this role."""
-  users(filter: RoleAssignmentFilter = null, orderBy: [RoleAssignmentOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): RoleAssignmentConnection!
+  """
+  Added in 26.3.0. Users assigned to this role.
+  """
+  users(
+    filter: RoleAssignmentFilter = null
+    orderBy: [RoleAssignmentOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): RoleAssignmentConnection!
 }
 
-"""Added in 26.3.0. RBAC role assignment (user-role association)."""
+"""
+Added in 26.3.0. RBAC role assignment (user-role association).
+"""
 type RoleAssignment implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """The assigned user ID."""
+  """
+  The assigned user ID.
+  """
   userId: UUID!
 
-  """The assigned role ID."""
+  """
+  The assigned role ID.
+  """
   roleId: UUID!
 
-  """The user who granted this assignment."""
+  """
+  The user who granted this assignment.
+  """
   grantedBy: UUID
   grantedAt: DateTime!
 
-  """The assigned role."""
+  """
+  The assigned role.
+  """
   role: Role
 
-  """The assigned user."""
+  """
+  The assigned user.
+  """
   user: UserV2
 }
 
-"""Added in 26.3.0. Role assignment connection."""
-type RoleAssignmentConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Role assignment connection.
+"""
+type RoleAssignmentConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [RoleAssignmentEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type RoleAssignmentEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type RoleAssignmentEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: RoleAssignment!
 }
 
-"""Added in 26.3.0. Filter for role assignments"""
-input RoleAssignmentFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Filter for role assignments
+"""
+input RoleAssignmentFilter @join__type(graph: STRAWBERRY) {
   roleId: UUID = null
   role: RoleAssignmentRoleNestedFilter = null
   permission: PermissionNestedFilter = null
@@ -13500,18 +17863,18 @@ input RoleAssignmentFilter
   NOT: [RoleAssignmentFilter!] = null
 }
 
-"""Added in 26.3.0. Order by specification for role assignments"""
-input RoleAssignmentOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Order by specification for role assignments
+"""
+input RoleAssignmentOrderBy @join__type(graph: STRAWBERRY) {
   field: RoleAssignmentOrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in 26.3.0. Role assignment ordering field"""
-enum RoleAssignmentOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Role assignment ordering field
+"""
+enum RoleAssignmentOrderField @join__type(graph: STRAWBERRY) {
   USERNAME @join__enumValue(graph: STRAWBERRY)
   EMAIL @join__enumValue(graph: STRAWBERRY)
   GRANTED_AT @join__enumValue(graph: STRAWBERRY)
@@ -13520,9 +17883,7 @@ enum RoleAssignmentOrderField
 """
 Added in 26.3.0. Nested filter for roles within a role assignment. Filters assignments that have a role matching all specified conditions.
 """
-input RoleAssignmentRoleNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
+input RoleAssignmentRoleNestedFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   source: RoleSourceFilter = null
   status: RoleStatusFilter = null
@@ -13531,33 +17892,41 @@ input RoleAssignmentRoleNestedFilter
   NOT: [RoleAssignmentRoleNestedFilter!] = null
 }
 
-"""Added in 26.3.0. Role connection."""
-type RoleConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Role connection.
+"""
+type RoleConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [RoleEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type RoleEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type RoleEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: Role!
 }
 
-"""Added in 26.3.0. Filter for roles"""
-input RoleFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Filter for roles
+"""
+input RoleFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   source: RoleSourceFilter = null
   status: RoleStatusFilter = null
@@ -13566,27 +17935,27 @@ input RoleFilter
   NOT: [RoleFilter!] = null
 }
 
-"""Added in 26.3.0. Order by specification for roles"""
-input RoleOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Order by specification for roles
+"""
+input RoleOrderBy @join__type(graph: STRAWBERRY) {
   field: RoleOrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in 26.3.0. Role ordering field"""
-enum RoleOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Role ordering field
+"""
+enum RoleOrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.3.0. Role definition source"""
-enum RoleSource
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Role definition source
+"""
+enum RoleSource @join__type(graph: STRAWBERRY) {
   SYSTEM @join__enumValue(graph: STRAWBERRY)
   CUSTOM @join__enumValue(graph: STRAWBERRY)
 }
@@ -13594,26 +17963,32 @@ enum RoleSource
 """
 Added in 26.3.0. Filter for role source with equality and membership operators.
 """
-input RoleSourceFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Matches roles with this exact source."""
+input RoleSourceFilter @join__type(graph: STRAWBERRY) {
+  """
+  Matches roles with this exact source.
+  """
   equals: RoleSource = null
 
-  """Matches roles whose source is in this list."""
+  """
+  Matches roles whose source is in this list.
+  """
   in: [RoleSource!] = null
 
-  """Excludes roles with this exact source."""
+  """
+  Excludes roles with this exact source.
+  """
   notEquals: RoleSource = null
 
-  """Excludes roles whose source is in this list."""
+  """
+  Excludes roles whose source is in this list.
+  """
   notIn: [RoleSource!] = null
 }
 
-"""Added in 26.3.0. Role status"""
-enum RoleStatus
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Role status
+"""
+enum RoleStatus @join__type(graph: STRAWBERRY) {
   ACTIVE @join__enumValue(graph: STRAWBERRY)
   INACTIVE @join__enumValue(graph: STRAWBERRY)
   DELETED @join__enumValue(graph: STRAWBERRY)
@@ -13622,44 +17997,53 @@ enum RoleStatus
 """
 Added in 26.3.0. Filter for role status with equality and membership operators.
 """
-input RoleStatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Matches roles with this exact status."""
+input RoleStatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  Matches roles with this exact status.
+  """
   equals: RoleStatus = null
 
-  """Matches roles whose status is in this list."""
+  """
+  Matches roles whose status is in this list.
+  """
   in: [RoleStatus!] = null
 
-  """Excludes roles with this exact status."""
+  """
+  Excludes roles with this exact status.
+  """
   notEquals: RoleStatus = null
 
-  """Excludes roles whose status is in this list."""
+  """
+  Excludes roles whose status is in this list.
+  """
   notIn: [RoleStatus!] = null
 }
 
 """
 Added in 25.19.0. Configuration for rolling update strategy. Defaults: max_surge=50%, max_unavailable=0%.
 """
-input RollingUpdateConfigInput
-  @join__type(graph: STRAWBERRY)
-{
+input RollingUpdateConfigInput @join__type(graph: STRAWBERRY) {
   maxSurge: IntOrPercentInput
   maxUnavailable: IntOrPercentInput
 }
 
-"""Added in 25.19.0. Represents a route for a model deployment."""
+"""
+Added in 25.19.0. Represents a route for a model deployment.
+"""
 type Route implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   deploymentId: ID!
   sessionId: ID
   revisionId: ID
 
-  """The current status of the route indicating its health state."""
+  """
+  The current status of the route indicating its health state.
+  """
   status: RouteStatus!
 
   """
@@ -13667,16 +18051,24 @@ type Route implements Node
   """
   trafficStatus: RouteTrafficStatus!
 
-  """The traffic ratio for load balancing."""
+  """
+  The traffic ratio for load balancing.
+  """
   trafficRatio: Float!
 
-  """The timestamp when the route was created."""
+  """
+  The timestamp when the route was created.
+  """
   createdAt: DateTime
 
-  """Error data if the route is in a failed state."""
+  """
+  Error data if the route is in a failed state.
+  """
   errorData: JSON
 
-  """The deployment this route belongs to."""
+  """
+  The deployment this route belongs to.
+  """
   deployment: ModelDeployment!
 
   """
@@ -13684,39 +18076,51 @@ type Route implements Node
   """
   session: ID
 
-  """The revision associated with the route."""
+  """
+  The revision associated with the route.
+  """
   revision: ModelRevision
 }
 
-"""Added in 25.19.0. Connection type for paginated route results."""
-type RouteConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 25.19.0. Connection type for paginated route results.
+"""
+type RouteConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [RouteEdge!]!
 
-  """Total number of routes matching the filter criteria."""
+  """
+  Total number of routes matching the filter criteria.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type RouteEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type RouteEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: Route!
 }
 
-"""Added in 25.19.0. Filter for routes."""
-input RouteFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0. Filter for routes.
+"""
+input RouteFilter @join__type(graph: STRAWBERRY) {
   status: [RouteStatus!] = null
   trafficStatus: [RouteTrafficStatus!] = null
   AND: [RouteFilter!] = null
@@ -13724,12 +18128,15 @@ input RouteFilter
   NOT: [RouteFilter!] = null
 }
 
-"""Added in 26.3.0. Route history record."""
+"""
+Added in 26.3.0. Route history record.
+"""
 type RouteHistory implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   routeId: ID!
   deploymentId: ID!
@@ -13745,33 +18152,41 @@ type RouteHistory implements Node
   updatedAt: DateTime!
 }
 
-"""Added in 26.3.0. Route history connection."""
-type RouteHistoryConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Route history connection.
+"""
+type RouteHistoryConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [RouteHistoryEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type RouteHistoryEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type RouteHistoryEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: RouteHistory!
 }
 
-"""Added in 24.09.0. Filter for route history"""
-input RouteHistoryFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Filter for route history
+"""
+input RouteHistoryFilter @join__type(graph: STRAWBERRY) {
   id: UUIDFilter = null
   routeId: UUIDFilter = null
   deploymentId: UUIDFilter = null
@@ -13788,53 +18203,53 @@ input RouteHistoryFilter
   NOT: [RouteHistoryFilter!] = null
 }
 
-"""Added in 24.09.0. Order by specification for route history"""
-input RouteHistoryOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Order by specification for route history
+"""
+input RouteHistoryOrderBy @join__type(graph: STRAWBERRY) {
   field: RouteHistoryOrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in 26.3.0. Fields available for ordering route history"""
-enum RouteHistoryOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Fields available for ordering route history
+"""
+enum RouteHistoryOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.19.0. Order by specification for routes."""
-input RouteOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0. Order by specification for routes.
+"""
+input RouteOrderBy @join__type(graph: STRAWBERRY) {
   field: RouteOrderField!
   direction: OrderDirection! = ASC
 }
 
-"""Added in 25.19.0. Fields available for ordering routes"""
-enum RouteOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0. Fields available for ordering routes
+"""
+enum RouteOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   STATUS @join__enumValue(graph: STRAWBERRY)
   TRAFFIC_RATIO @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 24.09.0. Scope for route scheduling history query"""
-input RouteScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Route ID to get history for"""
+"""
+Added in 24.09.0. Scope for route scheduling history query
+"""
+input RouteScope @join__type(graph: STRAWBERRY) {
+  """
+  Route ID to get history for
+  """
   routeId: UUID!
 }
 
 """
 Added in 25.19.0. Route status indicating the health and lifecycle state of a route.
 """
-enum RouteStatus
-  @join__type(graph: STRAWBERRY)
-{
+enum RouteStatus @join__type(graph: STRAWBERRY) {
   PROVISIONING @join__enumValue(graph: STRAWBERRY)
   HEALTHY @join__enumValue(graph: STRAWBERRY)
   UNHEALTHY @join__enumValue(graph: STRAWBERRY)
@@ -13847,17 +18262,14 @@ enum RouteStatus
 """
 Added in 25.19.0. Traffic routing status for a route. Controls whether traffic should be sent to this route.
 """
-enum RouteTrafficStatus
-  @join__type(graph: STRAWBERRY)
-{
+enum RouteTrafficStatus @join__type(graph: STRAWBERRY) {
   ACTIVE @join__enumValue(graph: STRAWBERRY)
   INACTIVE @join__enumValue(graph: STRAWBERRY)
 }
 
 type Routing implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   routing_id: UUID
   endpoint: String
@@ -13867,14 +18279,15 @@ type Routing implements Item
   created_at: DateTime
   error_data: JSONString
 
-  """Added in 24.12.0."""
+  """
+  Added in 24.12.0.
+  """
   live_stat: JSONString
 }
 
 type RoutingList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [Routing]!
   total_count: Int!
 }
@@ -13884,12 +18297,15 @@ Added in UNRELEASED. Represents an inference runtime engine definition (e.g., vL
 """
 type RuntimeVariant implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """The unique database identifier of this runtime variant."""
+  """
+  The unique database identifier of this runtime variant.
+  """
   rowId: UUID!
 
   """
@@ -13902,67 +18318,85 @@ type RuntimeVariant implements Node
   """
   description: String
 
-  """Timestamp when this runtime variant was registered."""
+  """
+  Timestamp when this runtime variant was registered.
+  """
   createdAt: DateTime!
 
-  """Timestamp of the last modification to this runtime variant."""
+  """
+  Timestamp of the last modification to this runtime variant.
+  """
   updatedAt: DateTime
 }
 
-"""Added in UNRELEASED. Paginated list of runtime variants."""
-type RuntimeVariantConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in UNRELEASED. Paginated list of runtime variants.
+"""
+type RuntimeVariantConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [RuntimeVariantEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type RuntimeVariantEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type RuntimeVariantEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: RuntimeVariant!
 }
 
-"""Added in UNRELEASED. Filter for runtime variants."""
-input RuntimeVariantFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Name filter."""
+"""
+Added in UNRELEASED. Filter for runtime variants.
+"""
+input RuntimeVariantFilter @join__type(graph: STRAWBERRY) {
+  """
+  Name filter.
+  """
   name: StringFilter = null
 }
 
-"""Added in 24.03.5."""
-type RuntimeVariantInfo
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 24.03.5.
+"""
+type RuntimeVariantInfo @join__type(graph: GRAPHENE) {
   name: String
   human_readable_name: String
 }
 
-"""Added in UNRELEASED. Order specification."""
-input RuntimeVariantOrderBy
-  @join__type(graph: STRAWBERRY)
-{
-  """Field to order by."""
+"""
+Added in UNRELEASED. Order specification.
+"""
+input RuntimeVariantOrderBy @join__type(graph: STRAWBERRY) {
+  """
+  Field to order by.
+  """
   field: RuntimeVariantOrderField!
 
-  """ASC or DESC."""
+  """
+  ASC or DESC.
+  """
   direction: String! = "ASC"
 }
 
-"""Added in UNRELEASED. Order fields for runtime variants."""
-enum RuntimeVariantOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Order fields for runtime variants.
+"""
+enum RuntimeVariantOrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
 }
@@ -13972,15 +18406,20 @@ Added in UNRELEASED. Defines a configurable parameter for a runtime variant. Eac
 """
 type RuntimeVariantPreset implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """The unique database identifier of this preset."""
+  """
+  The unique database identifier of this preset.
+  """
   rowId: UUID!
 
-  """The runtime variant this preset belongs to."""
+  """
+  The runtime variant this preset belongs to.
+  """
   runtimeVariantId: UUID!
 
   """
@@ -14003,70 +18442,88 @@ type RuntimeVariantPreset implements Node
   """
   targetSpec: PresetTargetSpec!
 
-  """Timestamp when this preset was created."""
+  """
+  Timestamp when this preset was created.
+  """
   createdAt: DateTime!
 
-  """Timestamp of the last modification to this preset."""
+  """
+  Timestamp of the last modification to this preset.
+  """
   updatedAt: DateTime
 }
 
-"""Added in UNRELEASED. Paginated list of runtime variant presets."""
-type RuntimeVariantPresetConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in UNRELEASED. Paginated list of runtime variant presets.
+"""
+type RuntimeVariantPresetConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [RuntimeVariantPresetEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type RuntimeVariantPresetEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type RuntimeVariantPresetEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: RuntimeVariantPreset!
 }
 
-"""Added in UNRELEASED. Filter for presets."""
-input RuntimeVariantPresetFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Name filter."""
+"""
+Added in UNRELEASED. Filter for presets.
+"""
+input RuntimeVariantPresetFilter @join__type(graph: STRAWBERRY) {
+  """
+  Name filter.
+  """
   name: StringFilter = null
 
-  """Variant ID filter."""
+  """
+  Variant ID filter.
+  """
   runtimeVariantId: UUID = null
 }
 
-"""Added in UNRELEASED. Order specification."""
-input RuntimeVariantPresetOrderBy
-  @join__type(graph: STRAWBERRY)
-{
-  """Field to order by."""
+"""
+Added in UNRELEASED. Order specification.
+"""
+input RuntimeVariantPresetOrderBy @join__type(graph: STRAWBERRY) {
+  """
+  Field to order by.
+  """
   field: RuntimeVariantPresetOrderField!
 
-  """ASC or DESC."""
+  """
+  ASC or DESC.
+  """
   direction: String! = "ASC"
 }
 
-"""Added in UNRELEASED. Order fields for runtime variant presets."""
-enum RuntimeVariantPresetOrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Order fields for runtime variant presets.
+"""
+enum RuntimeVariantPresetOrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   RANK @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-type ScalingGroup
-  @join__type(graph: GRAPHENE)
-{
+type ScalingGroup @join__type(graph: GRAPHENE) {
   name: String
   description: String
   is_active: Boolean
@@ -14080,10 +18537,14 @@ type ScalingGroup
   scheduler_opts: JSONString
   use_host_network: Boolean
 
-  """Added in 25.5.0."""
+  """
+  Added in 25.5.0.
+  """
   accelerator_quantum_size: Float
 
-  """Added in 24.03.7."""
+  """
+  Added in 24.03.7.
+  """
   agent_count_by_status(
     """
     Possible states of an agent. Should be one of ['ALIVE', 'LOST', 'RESTARTING', 'TERMINATED']. Default is 'ALIVE'.
@@ -14091,7 +18552,9 @@ type ScalingGroup
     status: String = "ALIVE"
   ): Int
 
-  """Added in 24.03.7."""
+  """
+  Added in 24.03.7.
+  """
   agent_total_resource_slots_by_status(
     """
     Possible states of an agent. Should be one of ['ALIVE', 'LOST', 'RESTARTING', 'TERMINATED']. Default is 'ALIVE'.
@@ -14110,40 +18573,51 @@ type ScalingGroup
   own_session_occupied_resource_slots: JSONString
 }
 
-"""Added in 24.12.0."""
-type ScalingGroupConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 24.12.0.
+"""
+type ScalingGroupConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [ScalingGroupEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
 """
 Added in 24.12.0. A Relay edge containing a `ScalingGroup` and its cursor.
 """
-type ScalingGroupEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+type ScalingGroupEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: ScalingGroupNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
-"""Added in 24.12.0."""
+"""
+Added in 24.12.0.
+"""
 type ScalingGroupNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
   @join__type(graph: GRAPHENE, key: "id")
-  @join__type(graph: STRAWBERRY, key: "id", extension: true)
-{
-  """The ID of the object"""
+  @join__type(graph: STRAWBERRY, key: "id", extension: true) {
+  """
+  The ID of the object
+  """
   id: ID!
   name: String @join__field(graph: GRAPHENE)
   description: String @join__field(graph: GRAPHENE)
@@ -14166,9 +18640,7 @@ Scans multiple specified models and retrieves detailed information including
 README content and file sizes. This operation performs immediate detailed scanning
 unlike the general scan_artifacts which only retrieves basic metadata.
 """
-input ScanArtifactModelsInput
-  @join__type(graph: STRAWBERRY)
-{
+input ScanArtifactModelsInput @join__type(graph: STRAWBERRY) {
   models: [ModelTarget!]!
   registryId: UUID = null
 }
@@ -14176,10 +18648,10 @@ input ScanArtifactModelsInput
 """
 Added in 25.14.0. Response payload for batch model scanning operations. Contains the artifact revisions discovered during detailed scanning of specific models, including README content and file size information.
 """
-type ScanArtifactModelsPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Artifact revisions discovered during model scanning."""
+type ScanArtifactModelsPayload @join__type(graph: STRAWBERRY) {
+  """
+  Artifact revisions discovered during model scanning.
+  """
   artifactRevision: ArtifactRevisionConnection!
 }
 
@@ -14189,12 +18661,12 @@ Added in 24.09.0. Input for scanning artifacts from external registries (Hugging
 Discovers available artifacts and registers their metadata in the system.
 Artifacts remain in SCANNED status until explicitly imported via import_artifacts.
 """
-input ScanArtifactsInput
-  @join__type(graph: STRAWBERRY)
-{
+input ScanArtifactsInput @join__type(graph: STRAWBERRY) {
   registryId: ID = null
 
-  """The limit field."""
+  """
+  The limit field.
+  """
   limit: Int!
   artifactType: ArtifactType = null
   search: String = null
@@ -14203,48 +18675,52 @@ input ScanArtifactsInput
 """
 Added in 25.14.0. Response payload for artifact scanning operations. Contains the list of artifacts discovered during scanning of external registries. These artifacts are registered with SCANNED status and can be imported for actual use.
 """
-type ScanArtifactsPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """List of scanned artifacts."""
+type ScanArtifactsPayload @join__type(graph: STRAWBERRY) {
+  """
+  List of scanned artifacts.
+  """
   artifacts: [Artifact!]!
 }
 
 """
 Added in 26.2.0. Type of scheduler used for session scheduling in a resource group.
 """
-enum SchedulerType
-  @join__type(graph: STRAWBERRY)
-{
+enum SchedulerType @join__type(graph: STRAWBERRY) {
   FIFO @join__enumValue(graph: STRAWBERRY)
   LIFO @join__enumValue(graph: STRAWBERRY)
   DRF @join__enumValue(graph: STRAWBERRY)
   FAIR_SHARE @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.15.0. Scheduling event broadcast payload."""
-type SchedulingBroadcastEventPayload
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.15.0. Scheduling event broadcast payload.
+"""
+type SchedulingBroadcastEventPayload @join__type(graph: STRAWBERRY) {
   """
   The session ID associated with the replica. This can be null right after replica creation.
   """
   session: ComputeSessionNode!
 
-  """UUID of the session being scheduled."""
+  """
+  UUID of the session being scheduled.
+  """
   sessionId: ID!
 
-  """Status transition that occurred during session scheduling."""
+  """
+  Status transition that occurred during session scheduling.
+  """
   statusTransition: SchedulingStatus!
 
-  """Human-readable reason for this status transition."""
+  """
+  Human-readable reason for this status transition.
+  """
   reason: String!
 }
 
-"""Added in 26.3.0. Scheduling result status"""
-enum SchedulingResult
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Scheduling result status
+"""
+enum SchedulingResult @join__type(graph: STRAWBERRY) {
   SUCCESS @join__enumValue(graph: STRAWBERRY)
   FAILURE @join__enumValue(graph: STRAWBERRY)
   STALE @join__enumValue(graph: STRAWBERRY)
@@ -14257,21 +18733,21 @@ enum SchedulingResult
 """
 Added in 26.3.0. Filter for scheduling result with equality and membership operators.
 """
-input SchedulingResultFilter
-  @join__type(graph: STRAWBERRY)
-{
+input SchedulingResultFilter @join__type(graph: STRAWBERRY) {
   equals: SchedulingResult = null
 
-  """The in  field."""
+  """
+  The in  field.
+  """
   in: [SchedulingResult!] = null
   notEquals: SchedulingResult = null
   notIn: [SchedulingResult!] = null
 }
 
-"""Added in 24.3.0. Status of session scheduling transitions"""
-enum SchedulingStatus
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.3.0. Status of session scheduling transitions
+"""
+enum SchedulingStatus @join__type(graph: STRAWBERRY) {
   PENDING @join__enumValue(graph: STRAWBERRY)
   SCHEDULED @join__enumValue(graph: STRAWBERRY)
   PREPARING @join__enumValue(graph: STRAWBERRY)
@@ -14288,84 +18764,129 @@ enum SchedulingStatus
 """
 Added in 26.3.0. Valid scope-entity type combination for RBAC permissions.
 """
-type ScopeEntityCombination
-  @join__type(graph: STRAWBERRY)
-{
-  """Scope element type"""
+type ScopeEntityCombination @join__type(graph: STRAWBERRY) {
+  """
+  Scope element type
+  """
   scopeType: RBACElementType!
 
-  """Valid entity types for this scope type"""
+  """
+  Valid entity types for this scope type
+  """
   validEntityTypes: [RBACElementType!]!
+}
+
+"""
+Added in UNRELEASED. Scope-entity-operation combination for RBAC permission matrix.
+"""
+type ScopeEntityOperationCombination @join__type(graph: STRAWBERRY) {
+  """
+  Scope element type
+  """
+  scopeType: RBACElementType!
+
+  """
+  Entities and their valid operations within this scope
+  """
+  entities: [EntityActionInfo!]!
 }
 
 """
 Added in 24.12.0. A string value in the format '<SCOPE_TYPE>:<SCOPE_ID>'. <SCOPE_TYPE> should be one of [system, domain, project, user]. <SCOPE_ID> should be the ID value of the scope. e.g. `domain:default`, `user:123e4567-e89b-12d3-a456-426614174000`.
 """
-scalar ScopeField
-  @join__type(graph: GRAPHENE)
+scalar ScopeField @join__type(graph: GRAPHENE)
 
 """
 Added in UNRELEASED. Resource usage for a single scope (keypair, project, domain).
 """
-type ScopeResourceUsageV2
-  @join__type(graph: STRAWBERRY)
-{
-  """Policy-defined resource limits."""
+type ScopeResourceUsageV2 @join__type(graph: STRAWBERRY) {
+  """
+  Policy-defined resource limits.
+  """
   limits: [ResourceLimitEntry!]!
 
-  """Currently occupied resources."""
+  """
+  Currently occupied resources.
+  """
   used: [ResourceSlotEntry!]!
 
-  """Assignable resources within policy limits (limits - used)."""
+  """
+  Assignable resources within policy limits (limits - used).
+  """
   assignable: [ResourceLimitEntry!]!
 }
 
-"""Added in 26.3.0. A registered service instance in the catalog."""
+"""
+Added in 26.3.0. A registered service instance in the catalog.
+"""
 type ServiceCatalog implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Logical group name (e.g., 'manager', 'agent', 'storage-proxy')."""
+  """
+  Logical group name (e.g., 'manager', 'agent', 'storage-proxy').
+  """
   serviceGroup: String!
 
-  """Unique instance identifier within the group."""
+  """
+  Unique instance identifier within the group.
+  """
   instanceId: String!
 
-  """Human-readable display name."""
+  """
+  Human-readable display name.
+  """
   displayName: String!
 
-  """Version of the service instance."""
+  """
+  Version of the service instance.
+  """
   version: String!
 
-  """Labels for categorization and filtering."""
+  """
+  Labels for categorization and filtering.
+  """
   labels: JSON!
 
-  """Health status of the service."""
+  """
+  Health status of the service.
+  """
   status: ServiceCatalogStatus!
 
-  """When the service instance started."""
+  """
+  When the service instance started.
+  """
   startupTime: DateTime!
 
-  """When the service was first registered."""
+  """
+  When the service was first registered.
+  """
   registeredAt: DateTime!
 
-  """Last heartbeat timestamp."""
+  """
+  Last heartbeat timestamp.
+  """
   lastHeartbeat: DateTime!
 
-  """Hash of the service configuration."""
+  """
+  Hash of the service configuration.
+  """
   configHash: String!
 
-  """Endpoints exposed by this service instance."""
+  """
+  Endpoints exposed by this service instance.
+  """
   endpoints: [ServiceCatalogEndpoint!]!
 }
 
-"""Added in 26.3.0. An endpoint exposed by a service instance."""
-type ServiceCatalogEndpoint
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. An endpoint exposed by a service instance.
+"""
+type ServiceCatalogEndpoint @join__type(graph: STRAWBERRY) {
   role: String!
   scope: String!
   address: String!
@@ -14374,10 +18895,10 @@ type ServiceCatalogEndpoint
   metadata: JSON
 }
 
-"""Added in 26.3.0. Filter for service catalog queries."""
-input ServiceCatalogFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Filter for service catalog queries.
+"""
+input ServiceCatalogFilter @join__type(graph: STRAWBERRY) {
   """
   Filter by service group name. Supports equals, contains, startsWith, and endsWith.
   """
@@ -14395,9 +18916,7 @@ input ServiceCatalogFilter
 """
 Added in 26.3.0. Specifies the field and direction for ordering service catalog queries.
 """
-input ServiceCatalogOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input ServiceCatalogOrderBy @join__type(graph: STRAWBERRY) {
   field: ServiceCatalogOrderField!
   direction: OrderDirection! = ASC
 }
@@ -14405,17 +18924,15 @@ input ServiceCatalogOrderBy
 """
 Added in 26.3.0. Fields available for ordering service catalog queries.
 """
-enum ServiceCatalogOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum ServiceCatalogOrderField @join__type(graph: STRAWBERRY) {
   SERVICE_GROUP @join__enumValue(graph: STRAWBERRY)
   REGISTERED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.3.0. Health status of a service in the catalog."""
-enum ServiceCatalogStatus
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Health status of a service in the catalog.
+"""
+enum ServiceCatalogStatus @join__type(graph: STRAWBERRY) {
   HEALTHY @join__enumValue(graph: STRAWBERRY)
   UNHEALTHY @join__enumValue(graph: STRAWBERRY)
   DEREGISTERED @join__enumValue(graph: STRAWBERRY)
@@ -14424,55 +18941,72 @@ enum ServiceCatalogStatus
 """
 Added in 26.3.0. Filter for ServiceCatalogStatus enum fields. Supports equals, in, not_equals, and not_in operations.
 """
-input ServiceCatalogStatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """Exact match for service catalog status."""
+input ServiceCatalogStatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  Exact match for service catalog status.
+  """
   equals: ServiceCatalogStatus = null
 
-  """Match any of the provided statuses."""
+  """
+  Match any of the provided statuses.
+  """
   in: [ServiceCatalogStatus!] = null
 
-  """Exclude exact status match."""
+  """
+  Exclude exact status match.
+  """
   notEquals: ServiceCatalogStatus = null
 
-  """Exclude any of the provided statuses."""
+  """
+  Exclude any of the provided statuses.
+  """
   notIn: [ServiceCatalogStatus!] = null
 }
 
-"""Added in 25.8.0."""
-type ServiceConfigConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 25.8.0.
+"""
+type ServiceConfigConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [ServiceConfigEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
 """
 Added in 25.8.0. A Relay edge containing a `ServiceConfig` and its cursor.
 """
-type ServiceConfigEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+type ServiceConfigEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: ServiceConfigNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
-"""Configuration data for a specific service. Added in 25.8.0."""
+"""
+Configuration data for a specific service. Added in 25.8.0.
+"""
 type ServiceConfigNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
-  @join__type(graph: GRAPHENE)
-{
-  """The ID of the object"""
+  @join__type(graph: GRAPHENE) {
+  """
+  The ID of the object
+  """
   id: ID!
 
   """
@@ -14480,39 +19014,51 @@ type ServiceConfigNode implements Node
   """
   service: String!
 
-  """Configuration data. Added in 25.8.0."""
+  """
+  Configuration data. Added in 25.8.0.
+  """
   configuration: JSONString!
 
-  """JSON schema of the configuration. Added in 25.8.0."""
+  """
+  JSON schema of the configuration. Added in 25.8.0.
+  """
   schema: JSONString!
 }
 
 """
 Added in 26.2.0. A single service port entry representing an exposed service. Contains port mapping and protocol information for accessing services.
 """
-type ServicePortEntry
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the service"""
+type ServicePortEntry @join__type(graph: STRAWBERRY) {
+  """
+  Name of the service
+  """
   name: String!
 
-  """Protocol type (http, tcp, preopen, internal)"""
+  """
+  Protocol type (http, tcp, preopen, internal)
+  """
   protocol: ServicePortProtocol!
 
-  """Port numbers inside the container"""
+  """
+  Port numbers inside the container
+  """
   containerPorts: [Int!]!
 
-  """Mapped port numbers on the host"""
+  """
+  Mapped port numbers on the host
+  """
   hostPorts: [Int]!
 
-  """Whether this port is used for inference endpoints"""
+  """
+  Whether this port is used for inference endpoints
+  """
   isInference: Boolean!
 }
 
-"""Added in 26.2.0. Protocol type for service ports."""
-enum ServicePortProtocol
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.2.0. Protocol type for service ports.
+"""
+enum ServicePortProtocol @join__type(graph: STRAWBERRY) {
   HTTP @join__enumValue(graph: STRAWBERRY)
   TCP @join__enumValue(graph: STRAWBERRY)
   PREOPEN @join__enumValue(graph: STRAWBERRY)
@@ -14524,52 +19070,62 @@ enum ServicePortProtocol
 """
 Added in 26.2.0. A collection of exposed service ports. Each entry defines a service accessible through the compute session.
 """
-type ServicePorts
-  @join__type(graph: STRAWBERRY)
-{
-  """List of service port entries"""
+type ServicePorts @join__type(graph: STRAWBERRY) {
+  """
+  List of service port entries
+  """
   entries: [ServicePortEntry!]!
 }
 
-"""Added in 25.13.0."""
-type SessionPendingQueueConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 25.13.0.
+"""
+type SessionPendingQueueConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [SessionPendingQueueEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
 """
 Added in 25.13.0. A Relay edge containing a `SessionPendingQueue` and its cursor.
 """
-type SessionPendingQueueEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+type SessionPendingQueueEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: ComputeSessionNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
 """
 Added in 24.09.0. One of ['read_attribute', 'update_attribute', 'delete_session', 'start_app', 'execute', 'convert_to_image'].
 """
-scalar SessionPermissionValueField
-  @join__type(graph: GRAPHENE)
+scalar SessionPermissionValueField @join__type(graph: GRAPHENE)
 
-"""Added in 26.3.0. Session scheduling history record."""
+"""
+Added in 26.3.0. Session scheduling history record.
+"""
 type SessionSchedulingHistory implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   sessionId: ID!
   phase: String!
@@ -14584,33 +19140,41 @@ type SessionSchedulingHistory implements Node
   updatedAt: DateTime!
 }
 
-"""Added in 26.3.0. Session scheduling history connection."""
-type SessionSchedulingHistoryConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Session scheduling history connection.
+"""
+type SessionSchedulingHistoryConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [SessionSchedulingHistoryEdge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type SessionSchedulingHistoryEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type SessionSchedulingHistoryEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: SessionSchedulingHistory!
 }
 
-"""Added in 24.09.0. Filter for session scheduling history"""
-input SessionSchedulingHistoryFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Filter for session scheduling history
+"""
+input SessionSchedulingHistoryFilter @join__type(graph: STRAWBERRY) {
   id: UUIDFilter = null
   sessionId: UUIDFilter = null
   phase: StringFilter = null
@@ -14629,9 +19193,7 @@ input SessionSchedulingHistoryFilter
 """
 Added in 24.09.0. Order by specification for session scheduling history
 """
-input SessionSchedulingHistoryOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input SessionSchedulingHistoryOrderBy @join__type(graph: STRAWBERRY) {
   field: SessionSchedulingHistoryOrderField!
   direction: OrderDirection! = DESC
 }
@@ -14639,66 +19201,85 @@ input SessionSchedulingHistoryOrderBy
 """
 Added in 26.3.0. Fields available for ordering session scheduling history
 """
-enum SessionSchedulingHistoryOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum SessionSchedulingHistoryOrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   UPDATED_AT @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 24.09.0. Scope for session scheduling history query"""
-input SessionScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Session ID to get history for"""
+"""
+Added in 24.09.0. Scope for session scheduling history query
+"""
+input SessionScope @join__type(graph: STRAWBERRY) {
+  """
+  Session ID to get history for
+  """
   sessionId: UUID!
 }
 
-enum SessionTypes
-  @join__type(graph: STRAWBERRY)
-{
+enum SessionTypes @join__type(graph: STRAWBERRY) {
   INTERACTIVE @join__enumValue(graph: STRAWBERRY)
   BATCH @join__enumValue(graph: STRAWBERRY)
   INFERENCE @join__enumValue(graph: STRAWBERRY)
   SYSTEM @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.3.0. Represents a compute session in Backend.AI."""
+"""
+Added in 26.3.0. Represents a compute session in Backend.AI.
+"""
 type SessionV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   domainName: String!
   userId: ID!
   projectId: ID!
 
-  """Metadata including domain, project, and user information."""
+  """
+  Metadata including domain, project, and user information.
+  """
   metadata: SessionV2MetadataInfo!
 
-  """Resource allocation and cluster information."""
+  """
+  Resource allocation and cluster information.
+  """
   resource: SessionV2ResourceInfo!
 
-  """Lifecycle status and timestamps."""
+  """
+  Lifecycle status and timestamps.
+  """
   lifecycle: SessionV2LifecycleInfo!
 
-  """Runtime execution configuration."""
+  """
+  Runtime execution configuration.
+  """
   runtime: SessionV2RuntimeInfo!
 
-  """Network configuration."""
+  """
+  Network configuration.
+  """
   network: SessionV2NetworkInfo!
 
-  """Added in 26.3.0. The domain this session belongs to."""
+  """
+  Added in 26.3.0. The domain this session belongs to.
+  """
   domain: DomainV2
 
-  """Added in 26.3.0. The user who owns this session."""
+  """
+  Added in 26.3.0. The user who owns this session.
+  """
   user: UserV2
 
-  """Added in 26.3.0. The project this session belongs to."""
+  """
+  Added in 26.3.0. The project this session belongs to.
+  """
   project: ProjectV2
 
-  """Added in 26.3.0. The resource group this session is assigned to."""
+  """
+  Added in 26.3.0. The resource group this session is assigned to.
+  """
   resourceGroup: ResourceGroup
 
   """
@@ -14706,37 +19287,47 @@ type SessionV2 implements Node
   """
   images: ImageV2Connection!
 
-  """Added in 26.3.0. The kernels belonging to this session."""
+  """
+  Added in 26.3.0. The kernels belonging to this session.
+  """
   kernels: KernelV2Connection!
 }
 
-"""Added in 26.3.0. Connection type for paginated session results."""
-type SessionV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 26.3.0. Connection type for paginated session results.
+"""
+type SessionV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [SessionV2Edge!]!
   count: Int!
 }
 
-"""An edge in a connection."""
-type SessionV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type SessionV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: SessionV2!
 }
 
-"""Added in 26.3.0. Filter criteria for querying sessions."""
-input SessionV2Filter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Filter criteria for querying sessions.
+"""
+input SessionV2Filter @join__type(graph: STRAWBERRY) {
   id: UUIDFilter = null
   status: SessionV2StatusFilter = null
   name: StringFilter = null
@@ -14748,52 +19339,78 @@ input SessionV2Filter
   NOT: [SessionV2Filter!] = null
 }
 
-"""Added in 26.3.0. Lifecycle status and timestamps for a session."""
-type SessionV2LifecycleInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Current status of the session."""
+"""
+Added in 26.3.0. Lifecycle status and timestamps for a session.
+"""
+type SessionV2LifecycleInfo @join__type(graph: STRAWBERRY) {
+  """
+  Current status of the session.
+  """
   status: SessionV2Status!
 
-  """Result of the session execution (success, failure, etc.)."""
+  """
+  Result of the session execution (success, failure, etc.).
+  """
   result: SessionV2Result!
 
-  """Timestamp when the session was created."""
+  """
+  Timestamp when the session was created.
+  """
   createdAt: DateTime
 
-  """Timestamp when the session was terminated. Null if still active."""
+  """
+  Timestamp when the session was terminated. Null if still active.
+  """
   terminatedAt: DateTime
 
-  """Scheduled start time for the session, if applicable."""
+  """
+  Scheduled start time for the session, if applicable.
+  """
   startsAt: DateTime
 
-  """Batch execution timeout in seconds. Applicable to batch sessions."""
+  """
+  Batch execution timeout in seconds. Applicable to batch sessions.
+  """
   batchTimeout: Int
 }
 
-"""Added in 26.3.0. Metadata information for a session."""
-type SessionV2MetadataInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Server-generated unique token for tracking session creation."""
+"""
+Added in 26.3.0. Metadata information for a session.
+"""
+type SessionV2MetadataInfo @join__type(graph: STRAWBERRY) {
+  """
+  Server-generated unique token for tracking session creation.
+  """
   creationId: String!
 
-  """Human-readable name of the session."""
+  """
+  Human-readable name of the session.
+  """
   name: String!
 
-  """Type of the session (interactive, batch, inference)."""
+  """
+  Type of the session (interactive, batch, inference).
+  """
   sessionType: SessionV2Type!
 
-  """Access key used to create this session."""
+  """
+  Access key used to create this session.
+  """
   accessKey: String!
 
-  """Cluster mode for distributed sessions (single-node, multi-node)."""
+  """
+  Cluster mode for distributed sessions (single-node, multi-node).
+  """
   clusterMode: ClusterMode!
 
-  """Number of nodes in the cluster."""
+  """
+  Number of nodes in the cluster.
+  """
   clusterSize: Int!
 
-  """Scheduling priority of the session."""
+  """
+  Scheduling priority of the session.
+  """
   priority: Int!
 
   """
@@ -14801,36 +19418,44 @@ type SessionV2MetadataInfo
   """
   isPreemptible: Boolean!
 
-  """Optional user-provided tag for the session."""
+  """
+  Optional user-provided tag for the session.
+  """
   tag: String
 }
 
-"""Added in 26.3.0. Network configuration for a session."""
-type SessionV2NetworkInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the session uses the host network directly."""
+"""
+Added in 26.3.0. Network configuration for a session.
+"""
+type SessionV2NetworkInfo @join__type(graph: STRAWBERRY) {
+  """
+  Whether the session uses the host network directly.
+  """
   useHostNetwork: Boolean!
 
-  """Type of network used by the session."""
+  """
+  Type of network used by the session.
+  """
   networkType: String
 
-  """ID of the network if applicable."""
+  """
+  ID of the network if applicable.
+  """
   networkId: String
 }
 
-"""Added in 26.3.0. Ordering specification for sessions."""
-input SessionV2OrderBy
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Ordering specification for sessions.
+"""
+input SessionV2OrderBy @join__type(graph: STRAWBERRY) {
   field: SessionV2OrderField!
   direction: OrderDirection! = DESC
 }
 
-"""Added in 26.3.0. Fields available for ordering sessions."""
-enum SessionV2OrderField
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Fields available for ordering sessions.
+"""
+enum SessionV2OrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   TERMINATED_AT @join__enumValue(graph: STRAWBERRY)
   STATUS @join__enumValue(graph: STRAWBERRY)
@@ -14838,43 +19463,47 @@ enum SessionV2OrderField
   NAME @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.3.0. Resource allocation information for a session."""
-type SessionV2ResourceInfo
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Resource allocation information for a session.
+"""
+type SessionV2ResourceInfo @join__type(graph: STRAWBERRY) {
   """
   Resource allocation with requested and occupied slots. Typed as Any because this field holds a nested GQL type (ResourceAllocationGQL).
   """
   allocation: ResourceAllocation!
 
-  """The resource group (scaling group) this session is assigned to."""
+  """
+  The resource group (scaling group) this session is assigned to.
+  """
   resourceGroupName: String
 }
 
 """
 Added in 26.3.0. Result status of a session or kernel execution. Indicates the final outcome after the session/kernel has terminated. UNDEFINED: The session has not yet finished or its result is unknown. SUCCESS: The session completed normally without errors. FAILURE: The session terminated abnormally due to an error or user cancellation.
 """
-enum SessionV2Result
-  @join__type(graph: STRAWBERRY)
-{
+enum SessionV2Result @join__type(graph: STRAWBERRY) {
   UNDEFINED @join__enumValue(graph: STRAWBERRY)
   SUCCESS @join__enumValue(graph: STRAWBERRY)
   FAILURE @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.3.0. Runtime execution configuration for a session."""
-type SessionV2RuntimeInfo
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Runtime execution configuration for a session.
+"""
+type SessionV2RuntimeInfo @join__type(graph: STRAWBERRY) {
   """
   Environment variables for the session. Typed as Any because this field holds a nested GQL type (EnvironmentVariablesGQL).
   """
   environ: EnvironmentVariables
 
-  """Bootstrap script to run before the main process."""
+  """
+  Bootstrap script to run before the main process.
+  """
   bootstrapScript: String
 
-  """Startup command to execute when the session starts."""
+  """
+  Startup command to execute when the session starts.
+  """
   startupCommand: String
 
   """
@@ -14883,10 +19512,10 @@ type SessionV2RuntimeInfo
   callbackUrl: String
 }
 
-"""Added in 26.3.0. Status of a session in its lifecycle."""
-enum SessionV2Status
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Status of a session in its lifecycle.
+"""
+enum SessionV2Status @join__type(graph: STRAWBERRY) {
   PENDING @join__enumValue(graph: STRAWBERRY)
   SCHEDULED @join__enumValue(graph: STRAWBERRY)
   PREPARING @join__enumValue(graph: STRAWBERRY)
@@ -14899,43 +19528,43 @@ enum SessionV2Status
   CANCELLED @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 26.3.0. Filter for session status."""
-input SessionV2StatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """The in  field."""
+"""
+Added in 26.3.0. Filter for session status.
+"""
+input SessionV2StatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  The in  field.
+  """
   in: [SessionV2Status!] = null
   notIn: [SessionV2Status!] = null
 }
 
-"""Added in 26.3.0. Type of compute session."""
-enum SessionV2Type
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Type of compute session.
+"""
+enum SessionV2Type @join__type(graph: STRAWBERRY) {
   INTERACTIVE @join__enumValue(graph: STRAWBERRY)
   BATCH @join__enumValue(graph: STRAWBERRY)
   INFERENCE @join__enumValue(graph: STRAWBERRY)
   SYSTEM @join__enumValue(graph: STRAWBERRY)
 }
 
-type SetQuotaScope
-  @join__type(graph: GRAPHENE)
-{
+type SetQuotaScope @join__type(graph: GRAPHENE) {
   quota_scope: QuotaScope
 }
 
-"""Added in 24.09.0. Input for SMTP authentication credentials"""
-input SMTPAuthInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for SMTP authentication credentials
+"""
+input SMTPAuthInput @join__type(graph: STRAWBERRY) {
   username: String = null
   password: String = null
 }
 
-"""Added in 24.09.0. Input for SMTP server connection settings"""
-input SMTPConnectionInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for SMTP server connection settings
+"""
+input SMTPConnectionInput @join__type(graph: STRAWBERRY) {
   host: String!
   port: Int!
   useTls: Boolean! = true
@@ -14945,13 +19574,15 @@ input SMTPConnectionInput
 """
 Added in 25.14.0. Information about the source or registry of an artifact. Contains the name and URL of the registry where the artifact is stored or originates from.
 """
-type SourceInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the registry or source."""
+type SourceInfo @join__type(graph: STRAWBERRY) {
+  """
+  Name of the registry or source.
+  """
   name: String
 
-  """URL of the registry or source."""
+  """
+  URL of the registry or source.
+  """
   url: String
 }
 
@@ -14965,43 +19596,53 @@ Implementation varies by storage type:
 """
 type StorageNamespace implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   storageId: ID!
   namespace: String!
 }
 
-"""Added in 25.15.0. Storage namespace connection for pagination."""
-type StorageNamespaceConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 25.15.0. Storage namespace connection for pagination.
+"""
+type StorageNamespaceConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [StorageNamespaceEdge!]!
 
-  """The count of this entity."""
+  """
+  The count of this entity.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type StorageNamespaceEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type StorageNamespaceEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: StorageNamespace!
 }
 
 type StorageVolume implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   backend: String
   fsprefix: String
@@ -15011,17 +19652,20 @@ type StorageVolume implements Item
   performance_metric: JSONString
   usage: JSONString
 
-  """Added in 24.03.0. Name of the proxy which this volume belongs to."""
+  """
+  Added in 24.03.0. Name of the proxy which this volume belongs to.
+  """
   proxy: String
 
-  """Added in 24.03.0. Name of the storage."""
+  """
+  Added in 24.03.0. Name of the storage.
+  """
   name: String
 }
 
 type StorageVolumeList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [StorageVolume]!
   total_count: Int!
 }
@@ -15029,9 +19673,7 @@ type StorageVolumeList implements PaginatedList
 """
 Added in 24.09.0. Filter for string fields supporting equality, containment, prefix/suffix, and case-insensitive variants.
 """
-input StringFilter
-  @join__type(graph: STRAWBERRY)
-{
+input StringFilter @join__type(graph: STRAWBERRY) {
   contains: String = null
   startsWith: String = null
   endsWith: String = null
@@ -15041,48 +19683,70 @@ input StringFilter
   notEndsWith: String = null
   notEquals: String = null
 
-  """The i contains field."""
+  """
+  The i contains field.
+  """
   iContains: String = null
 
-  """The i starts with field."""
+  """
+  The i starts with field.
+  """
   iStartsWith: String = null
 
-  """The i ends with field."""
+  """
+  The i ends with field.
+  """
   iEndsWith: String = null
 
-  """The i equals field."""
+  """
+  The i equals field.
+  """
   iEquals: String = null
 
-  """The i not contains field."""
+  """
+  The i not contains field.
+  """
   iNotContains: String = null
 
-  """The i not starts with field."""
+  """
+  The i not starts with field.
+  """
   iNotStartsWith: String = null
 
-  """The i not ends with field."""
+  """
+  The i not ends with field.
+  """
   iNotEndsWith: String = null
 
-  """The i not equals field."""
+  """
+  The i not equals field.
+  """
   iNotEquals: String = null
 }
 
-type Subscription
-  @join__type(graph: STRAWBERRY)
-{
+type Subscription @join__type(graph: STRAWBERRY) {
   """
   Added in 25.14.0. Subscribe to real-time artifact status change notifications. Receives updates when artifact revision statuses change during import, cleanup, or other operations.
   """
-  artifactStatusChanged(input: ArtifactStatusChangedInput!): ArtifactStatusChangedPayload!
+  artifactStatusChanged(
+    input: ArtifactStatusChangedInput!
+  ): ArtifactStatusChangedPayload!
 
   """
   Added in 25.14.0. Subscribe to real-time artifact import progress updates. Receives progress notifications during artifact import operations, including percentage completed and current status.
   """
-  artifactImportProgressUpdated(artifactRevisionId: ID!): ArtifactImportProgressUpdatedPayload!
+  artifactImportProgressUpdated(
+    artifactRevisionId: ID!
+  ): ArtifactImportProgressUpdatedPayload!
 
-  """Added in 25.16.0. Subscribe to deployment status changes."""
+  """
+  Added in 25.16.0. Subscribe to deployment status changes.
+  """
   deploymentStatusChanged: DeploymentStatusChangedPayload!
 
-  """Added in 25.16.0. Subscribe to replica status changes."""
+  """
+  Added in 25.16.0. Subscribe to replica status changes.
+  """
   replicaStatusChanged(revisionId: ID!): ReplicaStatusChangedPayload!
 
   """
@@ -15096,10 +19760,10 @@ type Subscription
   backgroundTaskEvents(taskId: ID!): BackgroundTaskEventPayload!
 }
 
-"""Added in 26.3.0. Sub-step result in scheduling history."""
-type SubStepResultGQL
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Sub-step result in scheduling history.
+"""
+type SubStepResultGQL @join__type(graph: STRAWBERRY) {
   step: String!
   result: SchedulingResult!
   errorCode: String
@@ -15111,60 +19775,71 @@ type SubStepResultGQL
 """
 Added in 24.09.0. Input for switching the main access key of the current user.
 """
-input SwitchMyMainAccessKeyInput
-  @join__type(graph: STRAWBERRY)
-{
+input SwitchMyMainAccessKeyInput @join__type(graph: STRAWBERRY) {
   """
   Access key to set as the new main access key. Must be active and owned by the user.
   """
   accessKey: String!
 }
 
-"""Added in 26.2.0. Payload returned after switching the main access key."""
-type SwitchMyMainAccessKeyPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the switch was successful."""
+"""
+Added in 26.2.0. Payload returned after switching the main access key.
+"""
+type SwitchMyMainAccessKeyPayload @join__type(graph: STRAWBERRY) {
+  """
+  Whether the switch was successful.
+  """
   success: Boolean!
 }
 
-"""Added in 25.19.0. """
-input SyncReplicaInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input SyncReplicaInput @join__type(graph: STRAWBERRY) {
   modelDeploymentId: ID!
 }
 
-"""Added in 25.19.0. Payload for replica sync mutation result."""
-type SyncReplicaPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the sync succeeded"""
+"""
+Added in 25.19.0. Payload for replica sync mutation result.
+"""
+type SyncReplicaPayload @join__type(graph: STRAWBERRY) {
+  """
+  Whether the sync succeeded
+  """
   success: Boolean!
 }
 
-"""Added in UNRELEASED. Payload returned after terminating sessions."""
-type TerminateSessionsPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Sessions cancelled from PENDING."""
+"""
+Added in UNRELEASED. Payload returned after terminating sessions.
+"""
+type TerminateSessionsPayload @join__type(graph: STRAWBERRY) {
+  """
+  Sessions cancelled from PENDING.
+  """
   cancelled: [ID!]!
 
-  """Sessions marked TERMINATING."""
+  """
+  Sessions marked TERMINATING.
+  """
   terminating: [ID!]!
 
-  """Sessions force-terminated."""
+  """
+  Sessions force-terminated.
+  """
   forceTerminated: [ID!]!
 
-  """Sessions already terminated or not found."""
+  """
+  Sessions already terminated or not found.
+  """
   skipped: [ID!]!
 }
 
-"""Added in 25.5.0."""
+"""
+Added in 25.5.0.
+"""
 type TotalResourceSlot implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   occupied_slots: JSONString
   requested_slots: JSONString
@@ -15173,18 +19848,18 @@ type TotalResourceSlot implements Item
 """
 Added in 25.19.0. This enum represents the traffic status of a replica.
 """
-enum TrafficStatus
-  @join__type(graph: STRAWBERRY)
-{
+enum TrafficStatus @join__type(graph: STRAWBERRY) {
   ACTIVE @join__enumValue(graph: STRAWBERRY)
   INACTIVE @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 25.19.0. """
-input TrafficStatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """The in  field."""
+"""
+Added in 25.19.0.
+"""
+input TrafficStatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  The in  field.
+  """
   in: [TrafficStatus!] = null
   equals: TrafficStatus = null
 }
@@ -15192,47 +19867,53 @@ input TrafficStatusFilter
 """
 Added in UNRELEASED. Error information for a user that failed to be unassigned.
 """
-type UnassignUserError
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the user that failed to be unassigned."""
+type UnassignUserError @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the user that failed to be unassigned.
+  """
   userId: UUID!
 
-  """Error message describing the failure reason."""
+  """
+  Error message describing the failure reason.
+  """
   message: String!
 }
 
-"""Added in UNRELEASED. Input for unassigning users from a project."""
-input UnassignUsersFromProjectInput
-  @join__type(graph: STRAWBERRY)
-{
-  """List of user UUIDs to unassign from the project."""
+"""
+Added in UNRELEASED. Input for unassigning users from a project.
+"""
+input UnassignUsersFromProjectInput @join__type(graph: STRAWBERRY) {
+  """
+  List of user UUIDs to unassign from the project.
+  """
   userIds: [UUID!]!
 }
 
-"""Added in UNRELEASED. Payload for user unassignment from project."""
-type UnassignUsersFromProjectPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """List of users that were unassigned from the project."""
+"""
+Added in UNRELEASED. Payload for user unassignment from project.
+"""
+type UnassignUsersFromProjectPayload @join__type(graph: STRAWBERRY) {
+  """
+  List of users that were unassigned from the project.
+  """
   unassignedUsers: [UserV2!]!
 
-  """List of errors for users that could not be unassigned."""
+  """
+  List of errors for users that could not be unassigned.
+  """
   failed: [UnassignUserError!]!
 }
 
-type UnloadImage
-  @join__type(graph: GRAPHENE)
-{
+type UnloadImage @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
   task_id: String
 }
 
-"""Added in 25.15.0. Input type for unregistering a storage namespace."""
-input UnregisterStorageNamespaceInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.15.0. Input type for unregistering a storage namespace.
+"""
+input UnregisterStorageNamespaceInput @join__type(graph: STRAWBERRY) {
   storageId: UUID!
   namespace: String!
 }
@@ -15240,45 +19921,47 @@ input UnregisterStorageNamespaceInput
 """
 Added in 25.15.0. Payload returned after storage namespace unregistration.
 """
-type UnregisterStorageNamespacePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the unregistered storage namespace"""
+type UnregisterStorageNamespacePayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the unregistered storage namespace
+  """
   id: UUID!
 }
 
-type UnsetQuotaScope
-  @join__type(graph: GRAPHENE)
-{
+type UnsetQuotaScope @join__type(graph: GRAPHENE) {
   quota_scope: QuotaScope
 }
 
 """
 Deprecated since 25.10.0. Use `purge_image_by_id` with `remove_from_registry` option instead.
 """
-type UntagImageFromRegistry
-  @join__type(graph: GRAPHENE)
-{
+type UntagImageFromRegistry @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 
-  """Added since 24.03.1."""
+  """
+  Added since 24.03.1.
+  """
   image: ImageNode
 }
 
 """
 Added in UNRELEASED. Input for updating allowed domains for a resource group.
 """
-input UpdateAllowedDomainsForResourceGroupInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group name."""
+input UpdateAllowedDomainsForResourceGroupInput @join__type(graph: STRAWBERRY) {
+  """
+  Resource group name.
+  """
   resourceGroupName: String!
 
-  """Domain names to allow."""
+  """
+  Domain names to allow.
+  """
   add: [String!] = null
 
-  """Domain names to disallow."""
+  """
+  Domain names to disallow.
+  """
   remove: [String!] = null
 }
 
@@ -15286,31 +19969,40 @@ input UpdateAllowedDomainsForResourceGroupInput
 Added in UNRELEASED. Input for updating allowed projects for a resource group.
 """
 input UpdateAllowedProjectsForResourceGroupInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group name."""
+  @join__type(graph: STRAWBERRY) {
+  """
+  Resource group name.
+  """
   resourceGroupName: String!
 
-  """Project IDs to allow."""
+  """
+  Project IDs to allow.
+  """
   add: [UUID!] = null
 
-  """Project IDs to disallow."""
+  """
+  Project IDs to disallow.
+  """
   remove: [UUID!] = null
 }
 
 """
 Added in UNRELEASED. Input for updating allowed resource groups for a domain.
 """
-input UpdateAllowedResourceGroupsForDomainInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Domain name."""
+input UpdateAllowedResourceGroupsForDomainInput @join__type(graph: STRAWBERRY) {
+  """
+  Domain name.
+  """
   domainName: String!
 
-  """Resource group names to allow."""
+  """
+  Resource group names to allow.
+  """
   add: [String!] = null
 
-  """Resource group names to disallow."""
+  """
+  Resource group names to disallow.
+  """
   remove: [String!] = null
 }
 
@@ -15318,15 +20010,20 @@ input UpdateAllowedResourceGroupsForDomainInput
 Added in UNRELEASED. Input for updating allowed resource groups for a project.
 """
 input UpdateAllowedResourceGroupsForProjectInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Project ID."""
+  @join__type(graph: STRAWBERRY) {
+  """
+  Project ID.
+  """
   projectId: UUID!
 
-  """Resource group names to allow."""
+  """
+  Resource group names to allow.
+  """
   add: [String!] = null
 
-  """Resource group names to disallow."""
+  """
+  Resource group names to disallow.
+  """
   remove: [String!] = null
 }
 
@@ -15336,9 +20033,7 @@ Added in 24.09.0. Input for updating artifact metadata properties.
 Modifies artifact metadata such as readonly status and description.
 This operation does not affect the actual artifact files or revisions.
 """
-input UpdateArtifactInput
-  @join__type(graph: STRAWBERRY)
-{
+input UpdateArtifactInput @join__type(graph: STRAWBERRY) {
   artifactId: ID!
   readonly: Boolean
   description: String
@@ -15347,17 +20042,17 @@ input UpdateArtifactInput
 """
 Added in 25.14.0. Response payload for artifact update operations. Returns the updated artifact with modified metadata properties.
 """
-type UpdateArtifactPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated artifact."""
+type UpdateArtifactPayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated artifact.
+  """
   artifact: Artifact!
 }
 
-"""Added in 25.19.0. Input for updating an auto-scaling rule."""
-input UpdateAutoScalingRuleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0. Input for updating an auto-scaling rule.
+"""
+input UpdateAutoScalingRuleInput @join__type(graph: STRAWBERRY) {
   id: ID!
   metricSource: AutoScalingMetricSource
   metricName: String
@@ -15369,71 +20064,93 @@ input UpdateAutoScalingRuleInput
   maxReplicas: Int
 }
 
-"""Added in 25.19.0. Payload for updating an auto-scaling rule."""
-type UpdateAutoScalingRulePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated auto-scaling rule"""
+"""
+Added in 25.19.0. Payload for updating an auto-scaling rule.
+"""
+type UpdateAutoScalingRulePayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated auto-scaling rule
+  """
   rule: AutoScalingRule!
 }
 
 """
 Added in UNRELEASED. Input for updating a container registry. All fields optional except id.
 """
-input UpdateContainerRegistryInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the registry to update."""
+input UpdateContainerRegistryInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  ID of the registry to update.
+  """
   id: String!
 
-  """Updated URL."""
+  """
+  Updated URL.
+  """
   url: String = null
 
-  """Updated registry name."""
+  """
+  Updated registry name.
+  """
   registryName: String = null
 
-  """Updated type."""
+  """
+  Updated type.
+  """
   type: ContainerRegistryType = null
 
-  """Updated project."""
+  """
+  Updated project.
+  """
   project: String = null
 
-  """Updated username."""
+  """
+  Updated username.
+  """
   username: String = null
 
-  """Updated password."""
+  """
+  Updated password.
+  """
   password: String = null
 
-  """Updated SSL verification."""
+  """
+  Updated SSL verification.
+  """
   sslVerify: Boolean = null
 
-  """Updated global accessibility."""
+  """
+  Updated global accessibility.
+  """
   isGlobal: Boolean = null
 
-  """Updated extra metadata."""
+  """
+  Updated extra metadata.
+  """
   extra: JSON = null
 }
 
-"""Added in UNRELEASED. Payload for container registry update mutation."""
-type UpdateContainerRegistryPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated container registry."""
+"""
+Added in UNRELEASED. Payload for container registry update mutation.
+"""
+type UpdateContainerRegistryPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Updated container registry.
+  """
   registry: ContainerRegistryV2!
 }
 
-"""Added in 25.3.0."""
-type UpdateContainerRegistryQuota
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.3.0.
+"""
+type UpdateContainerRegistryQuota @join__type(graph: GRAPHENE) {
   ok: Boolean
   msg: String
 }
 
-"""Added in 25.19.0. """
-input UpdateDeploymentInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.19.0.
+"""
+input UpdateDeploymentInput @join__type(graph: STRAWBERRY) {
   id: ID!
   openToPublic: Boolean
   tags: [String!]
@@ -15444,11 +20161,13 @@ input UpdateDeploymentInput
   preferredDomainName: String
 }
 
-"""Added in 25.19.0. Payload for updating a model deployment."""
-type UpdateDeploymentPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated deployment"""
+"""
+Added in 25.19.0. Payload for updating a model deployment.
+"""
+type UpdateDeploymentPayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated deployment
+  """
   deployment: ModelDeployment!
 }
 
@@ -15459,9 +20178,7 @@ Exactly one of rolling_update or blue_green must be provided,
 matching the chosen strategy type.
 If a policy already exists for the deployment, it is replaced entirely.
 """
-input UpdateDeploymentPolicyInput
-  @join__type(graph: STRAWBERRY)
-{
+input UpdateDeploymentPolicyInput @join__type(graph: STRAWBERRY) {
   deploymentId: ID!
   strategy: DeploymentStrategyType!
   rollingUpdate: RollingUpdateConfigInput = null
@@ -15471,153 +20188,197 @@ input UpdateDeploymentPolicyInput
 """
 Added in UNRELEASED. Result payload returned after creating or updating a deployment policy. Contains the full deployment_policy object reflecting the applied configuration.
 """
-type UpdateDeploymentPolicyPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The updated deployment policy"""
+type UpdateDeploymentPolicyPayload @join__type(graph: STRAWBERRY) {
+  """
+  The updated deployment policy
+  """
   deploymentPolicy: DeploymentPolicy!
 }
 
-"""Added in UNRELEASED. Update deployment revision preset input."""
-input UpdateDeploymentRevisionPresetInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Preset ID."""
+"""
+Added in UNRELEASED. Update deployment revision preset input.
+"""
+input UpdateDeploymentRevisionPresetInput @join__type(graph: STRAWBERRY) {
+  """
+  Preset ID.
+  """
   id: UUID!
 
-  """New name."""
+  """
+  New name.
+  """
   name: String = null
 
-  """New description."""
+  """
+  New description.
+  """
   description: String = null
 
-  """New rank."""
+  """
+  New rank.
+  """
   rank: Int = null
 }
 
-"""Added in UNRELEASED. Update deployment revision preset payload."""
-type UpdateDeploymentRevisionPresetPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """The updated preset."""
+"""
+Added in UNRELEASED. Update deployment revision preset payload.
+"""
+type UpdateDeploymentRevisionPresetPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  The updated preset.
+  """
   preset: DeploymentRevisionPreset!
 }
 
 """
 Added in UNRELEASED. Input for updating domain information. All fields optional.
 """
-input UpdateDomainInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """New domain name."""
+input UpdateDomainInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  New domain name.
+  """
   name: String = null
 
-  """New description."""
+  """
+  New description.
+  """
   description: String = null
 
-  """Updated active status."""
+  """
+  Updated active status.
+  """
   isActive: Boolean = null
 
-  """New allowed Docker registry URLs."""
+  """
+  New allowed Docker registry URLs.
+  """
   allowedDockerRegistries: [String!] = null
 
-  """New external integration identifier."""
+  """
+  New external integration identifier.
+  """
   integrationId: String = null
 }
 
-"""Added in 25.14.0. """
-input UpdateHuggingFaceRegistryInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.14.0.
+"""
+input UpdateHuggingFaceRegistryInput @join__type(graph: STRAWBERRY) {
   id: ID!
   url: String
   name: String
   token: String
 }
 
-"""Added in 25.14.0. Payload for updating a HuggingFace registry."""
-type UpdateHuggingFaceRegistryPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated HuggingFace registry"""
+"""
+Added in 25.14.0. Payload for updating a HuggingFace registry.
+"""
+type UpdateHuggingFaceRegistryPayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated HuggingFace registry
+  """
   huggingfaceRegistry: HuggingFaceRegistry!
 }
 
 """
 Added in UNRELEASED. Input for updating a keypair resource policy. All fields optional.
 """
-input UpdateKeypairResourcePolicyInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated default for unspecified."""
+input UpdateKeypairResourcePolicyInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  Updated default for unspecified.
+  """
   defaultForUnspecified: String = null
 
-  """Updated resource slot limits."""
+  """
+  Updated resource slot limits.
+  """
   totalResourceSlots: [ResourceSlotEntryInput!] = null
 
-  """Updated max session lifetime."""
+  """
+  Updated max session lifetime.
+  """
   maxSessionLifetime: Int = null
 
-  """Updated max concurrent sessions."""
+  """
+  Updated max concurrent sessions.
+  """
   maxConcurrentSessions: Int = null
 
-  """Updated max pending sessions."""
+  """
+  Updated max pending sessions.
+  """
   maxPendingSessionCount: Int = null
 
-  """Updated max pending session resource slots."""
+  """
+  Updated max pending session resource slots.
+  """
   maxPendingSessionResourceSlots: [ResourceSlotEntryInput!] = null
 
-  """Updated max concurrent SFTP sessions."""
+  """
+  Updated max concurrent SFTP sessions.
+  """
   maxConcurrentSftpSessions: Int = null
 
-  """Updated max containers per session."""
+  """
+  Updated max containers per session.
+  """
   maxContainersPerSession: Int = null
 
-  """Updated idle timeout."""
+  """
+  Updated idle timeout.
+  """
   idleTimeout: Int = null
 
-  """Updated vfolder host permissions."""
+  """
+  Updated vfolder host permissions.
+  """
   allowedVfolderHosts: [VFolderHostPermissionEntryInput!] = null
 }
 
 """
 Added in UNRELEASED. Payload for keypair resource policy update mutation.
 """
-type UpdateKeypairResourcePolicyPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated keypair resource policy."""
+type UpdateKeypairResourcePolicyPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Updated keypair resource policy.
+  """
   keypairResourcePolicy: KeypairResourcePolicyV2!
 }
 
-"""Added in UNRELEASED. Update model card payload."""
-type UpdateModelCardPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """The updated model card."""
+"""
+Added in UNRELEASED. Update model card payload.
+"""
+type UpdateModelCardPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  The updated model card.
+  """
   modelCard: ModelCardV2!
 }
 
-"""Added in UNRELEASED. Update model card input."""
-input UpdateModelCardV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """Model card ID."""
+"""
+Added in UNRELEASED. Update model card input.
+"""
+input UpdateModelCardV2Input @join__type(graph: STRAWBERRY) {
+  """
+  Model card ID.
+  """
   id: UUID!
 
-  """New name."""
+  """
+  New name.
+  """
   name: String = null
 
-  """New description."""
+  """
+  New description.
+  """
   description: String = null
 }
 
 """
 Added in 26.4.0. Input for updating the current user's allowed client IP list. Set allowed_client_ip to null to remove all restrictions. Use force=true to bypass the lockout safety check.
 """
-input UpdateMyAllowedClientIPInput
-  @join__type(graph: STRAWBERRY)
-{
+input UpdateMyAllowedClientIPInput @join__type(graph: STRAWBERRY) {
   """
   New allowed client IP addresses or CIDR ranges. Set to null to remove all IP restrictions.
   """
@@ -15632,40 +20393,42 @@ input UpdateMyAllowedClientIPInput
 """
 Added in 26.4.0. Payload for updating the current user's allowed client IP list.
 """
-type UpdateMyAllowedClientIPPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Whether the update was successful."""
+type UpdateMyAllowedClientIPPayload @join__type(graph: STRAWBERRY) {
+  """
+  Whether the update was successful.
+  """
   success: Boolean!
 }
 
 """
 Added in 24.09.0. Input for updating a keypair owned by the current user.
 """
-input UpdateMyKeypairInput
-  @join__type(graph: STRAWBERRY)
-{
+input UpdateMyKeypairInput @join__type(graph: STRAWBERRY) {
   """
   Access key of the keypair to update. Must be owned by the current user.
   """
   accessKey: String!
 
-  """Target active state for the keypair."""
+  """
+  Target active state for the keypair.
+  """
   isActive: Boolean!
 }
 
-"""Added in 26.2.0. Payload returned after updating a keypair."""
-type UpdateMyKeypairPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The updated keypair."""
+"""
+Added in 26.2.0. Payload returned after updating a keypair.
+"""
+type UpdateMyKeypairPayload @join__type(graph: STRAWBERRY) {
+  """
+  The updated keypair.
+  """
   keypair: KeyPairGQL!
 }
 
-"""Added in 24.09.0. Input for updating a notification channel"""
-input UpdateNotificationChannelInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for updating a notification channel
+"""
+input UpdateNotificationChannelInput @join__type(graph: STRAWBERRY) {
   id: ID!
   name: String
   description: String
@@ -15673,18 +20436,20 @@ input UpdateNotificationChannelInput
   enabled: Boolean
 }
 
-"""Added in 26.3.0. Payload for update notification channel mutation."""
-type UpdateNotificationChannelPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated notification channel"""
+"""
+Added in 26.3.0. Payload for update notification channel mutation.
+"""
+type UpdateNotificationChannelPayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated notification channel
+  """
   channel: NotificationChannel!
 }
 
-"""Added in 24.09.0. Input for updating a notification rule"""
-input UpdateNotificationRuleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for updating a notification rule
+"""
+input UpdateNotificationRuleInput @join__type(graph: STRAWBERRY) {
   id: ID!
   name: String
   description: String
@@ -15692,18 +20457,20 @@ input UpdateNotificationRuleInput
   enabled: Boolean
 }
 
-"""Added in 26.3.0. Payload for update notification rule mutation."""
-type UpdateNotificationRulePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated notification rule"""
+"""
+Added in 26.3.0. Payload for update notification rule mutation.
+"""
+type UpdateNotificationRulePayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated notification rule
+  """
   rule: NotificationRule!
 }
 
-"""Added in 25.14.0. """
-input UpdateObjectStorageInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.14.0.
+"""
+input UpdateObjectStorageInput @join__type(graph: STRAWBERRY) {
   id: ID!
   name: String
   host: String
@@ -15713,18 +20480,20 @@ input UpdateObjectStorageInput
   region: String
 }
 
-"""Added in 25.14.0. Payload for updating an object storage."""
-type UpdateObjectStoragePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated object storage"""
+"""
+Added in 25.14.0. Payload for updating an object storage.
+"""
+type UpdateObjectStoragePayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated object storage
+  """
   objectStorage: ObjectStorage!
 }
 
-"""Added in 26.3.0. Input for updating a scoped permission"""
-input UpdatePermissionInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Input for updating a scoped permission
+"""
+input UpdatePermissionInput @join__type(graph: STRAWBERRY) {
   id: UUID!
   scopeType: RBACElementType = null
   scopeId: String = null
@@ -15735,55 +20504,67 @@ input UpdatePermissionInput
 """
 Added in UNRELEASED. Input for updating project information. All fields optional.
 """
-input UpdateProjectInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """New project name."""
+input UpdateProjectInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  New project name.
+  """
   name: String = null
 
-  """New description."""
+  """
+  New description.
+  """
   description: String = null
 
-  """Updated active status."""
+  """
+  Updated active status.
+  """
   isActive: Boolean = null
 
-  """New external integration identifier."""
+  """
+  New external integration identifier.
+  """
   integrationId: String = null
 
-  """New resource policy name."""
+  """
+  New resource policy name.
+  """
   resourcePolicy: String = null
 }
 
 """
 Added in UNRELEASED. Input for updating a project resource policy. All fields optional.
 """
-input UpdateProjectResourcePolicyInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated max vfolder count."""
+input UpdateProjectResourcePolicyInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  Updated max vfolder count.
+  """
   maxVfolderCount: Int = null
 
-  """Updated max quota scope size."""
+  """
+  Updated max quota scope size.
+  """
   maxQuotaScopeSize: BinarySizeInput = null
 
-  """Updated max network count."""
+  """
+  Updated max network count.
+  """
   maxNetworkCount: Int = null
 }
 
 """
 Added in UNRELEASED. Payload for project resource policy update mutation.
 """
-type UpdateProjectResourcePolicyPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated project resource policy."""
+type UpdateProjectResourcePolicyPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Updated project resource policy.
+  """
   projectResourcePolicy: ProjectResourcePolicyV2!
 }
 
-"""Added in 25.14.0. """
-input UpdateReservoirRegistryInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.14.0.
+"""
+input UpdateReservoirRegistryInput @join__type(graph: STRAWBERRY) {
   id: ID!
   name: String
   endpoint: String
@@ -15792,21 +20573,23 @@ input UpdateReservoirRegistryInput
   apiVersion: String
 }
 
-"""Added in 25.14.0. Payload for updating a reservoir registry."""
-type UpdateReservoirRegistryPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated Reservoir registry"""
+"""
+Added in 25.14.0. Payload for updating a reservoir registry.
+"""
+type UpdateReservoirRegistryPayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated Reservoir registry
+  """
   reservoir: ReservoirRegistry!
 }
 
 """
 Added in 26.1.0. Input for updating resource group fair share configuration. All fields are optional - only provided fields will be updated, others retain existing values.
 """
-input UpdateResourceGroupFairShareSpecInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the resource group to update."""
+input UpdateResourceGroupFairShareSpecInput @join__type(graph: STRAWBERRY) {
+  """
+  Name of the resource group to update.
+  """
   resourceGroupName: String!
 
   """
@@ -15814,7 +20597,9 @@ input UpdateResourceGroupFairShareSpecInput
   """
   halfLifeDays: Int = null
 
-  """Total lookback period in days. Leave null to keep existing value."""
+  """
+  Total lookback period in days. Leave null to keep existing value.
+  """
   lookbackDays: Int = null
 
   """
@@ -15822,7 +20607,9 @@ input UpdateResourceGroupFairShareSpecInput
   """
   decayUnitDays: Int = null
 
-  """Default weight for entities. Leave null to keep existing value."""
+  """
+  Default weight for entities. Leave null to keep existing value.
+  """
   defaultWeight: Decimal = null
 
   """
@@ -15834,20 +20621,20 @@ input UpdateResourceGroupFairShareSpecInput
 """
 Added in 26.1.0. Payload for resource group fair share spec update mutation.
 """
-type UpdateResourceGroupFairShareSpecPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The updated resource group with new fair share configuration."""
+type UpdateResourceGroupFairShareSpecPayload @join__type(graph: STRAWBERRY) {
+  """
+  The updated resource group with new fair share configuration.
+  """
   resourceGroup: ResourceGroup!
 }
 
 """
 Added in 26.2.0. Resource group configuration update input. All fields are optional - only provided fields will be updated. Supports all ScalingGroupUpdaterSpec fields (except fair_share, use separate mutation).
 """
-input UpdateResourceGroupInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the resource group to update."""
+input UpdateResourceGroupInput @join__type(graph: STRAWBERRY) {
+  """
+  Name of the resource group to update.
+  """
   resourceGroupName: String!
 
   """
@@ -15860,16 +20647,24 @@ input UpdateResourceGroupInput
   """
   isPublic: Boolean = null
 
-  """Human-readable description. Leave null to keep existing value."""
+  """
+  Human-readable description. Leave null to keep existing value.
+  """
   description: String = null
 
-  """App proxy address. Leave null to keep existing value."""
+  """
+  App proxy address. Leave null to keep existing value.
+  """
   appProxyAddr: String = null
 
-  """App proxy API token. Leave null to keep existing value."""
+  """
+  App proxy API token. Leave null to keep existing value.
+  """
   appproxyApiToken: String = null
 
-  """Whether to use host network mode. Leave null to keep existing value."""
+  """
+  Whether to use host network mode. Leave null to keep existing value.
+  """
   useHostNetwork: Boolean = null
 
   """
@@ -15883,237 +20678,323 @@ input UpdateResourceGroupInput
   preemption: PreemptionConfigInput = null
 }
 
-"""Added in 26.2.0. Payload for resource group update mutation."""
-type UpdateResourceGroupPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The updated resource group with new configuration."""
+"""
+Added in 26.2.0. Payload for resource group update mutation.
+"""
+type UpdateResourceGroupPayload @join__type(graph: STRAWBERRY) {
+  """
+  The updated resource group with new configuration.
+  """
   resourceGroup: ResourceGroup!
 }
 
-"""Added in UNRELEASED. Payload for resource preset update."""
-type UpdateResourcePresetPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated resource preset."""
+"""
+Added in UNRELEASED. Payload for resource preset update.
+"""
+type UpdateResourcePresetPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Updated resource preset.
+  """
   resourcePreset: ResourcePresetV2!
 }
 
 """
 Added in UNRELEASED. Input for updating a resource preset. All fields optional for partial update.
 """
-input UpdateResourcePresetV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the resource preset to update."""
+input UpdateResourcePresetV2Input @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the resource preset to update.
+  """
   id: UUID!
 
-  """Updated name."""
+  """
+  Updated name.
+  """
   name: String = null
 
-  """Updated resource slot allocations."""
+  """
+  Updated resource slot allocations.
+  """
   resourceSlots: [ResourceSlotEntryInput!] = null
 
-  """Updated shared memory. Use null to clear."""
+  """
+  Updated shared memory. Use null to clear.
+  """
   sharedMemory: BinarySizeInput = null
 
-  """Updated resource group name. Use null to make global."""
+  """
+  Updated resource group name. Use null to make global.
+  """
   resourceGroupName: String = null
 }
 
-"""Added in 26.3.0. Input for updating a role"""
-input UpdateRoleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.3.0. Input for updating a role
+"""
+input UpdateRoleInput @join__type(graph: STRAWBERRY) {
   id: UUID!
   name: String
   description: String
   status: RoleStatus
 }
 
-"""Added in 25.19.0. Input for updating route traffic status."""
-input UpdateRouteTrafficStatusInput
-  @join__type(graph: STRAWBERRY)
-{
-  """The ID of the route to update."""
+"""
+Added in 25.19.0. Input for updating route traffic status.
+"""
+input UpdateRouteTrafficStatusInput @join__type(graph: STRAWBERRY) {
+  """
+  The ID of the route to update.
+  """
   routeId: ID!
 
-  """The new traffic status (ACTIVE/INACTIVE)."""
+  """
+  The new traffic status (ACTIVE/INACTIVE).
+  """
   trafficStatus: RouteTrafficStatus!
 }
 
-"""Added in 25.19.0. Result of updating route traffic status."""
-type UpdateRouteTrafficStatusPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The updated route"""
+"""
+Added in 25.19.0. Result of updating route traffic status.
+"""
+type UpdateRouteTrafficStatusPayload @join__type(graph: STRAWBERRY) {
+  """
+  The updated route
+  """
   route: Route!
 }
 
-"""Added in UNRELEASED. Input for updating a runtime variant."""
-input UpdateRuntimeVariantInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Runtime variant ID."""
+"""
+Added in UNRELEASED. Input for updating a runtime variant.
+"""
+input UpdateRuntimeVariantInput @join__type(graph: STRAWBERRY) {
+  """
+  Runtime variant ID.
+  """
   id: UUID!
 
-  """New name."""
+  """
+  New name.
+  """
   name: String = null
 
-  """New description."""
+  """
+  New description.
+  """
   description: String = null
 }
 
-"""Added in UNRELEASED. Payload for runtime variant update."""
-type UpdateRuntimeVariantPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """The updated runtime variant."""
+"""
+Added in UNRELEASED. Payload for runtime variant update.
+"""
+type UpdateRuntimeVariantPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  The updated runtime variant.
+  """
   runtimeVariant: RuntimeVariant!
 }
 
-"""Added in UNRELEASED. Update preset input."""
-input UpdateRuntimeVariantPresetInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Preset ID."""
+"""
+Added in UNRELEASED. Update preset input.
+"""
+input UpdateRuntimeVariantPresetInput @join__type(graph: STRAWBERRY) {
+  """
+  Preset ID.
+  """
   id: UUID!
 
-  """New name."""
+  """
+  New name.
+  """
   name: String = null
 
-  """New description."""
+  """
+  New description.
+  """
   description: String = null
 
-  """New rank."""
+  """
+  New rank.
+  """
   rank: Int = null
 
-  """New target."""
+  """
+  New target.
+  """
   presetTarget: String = null
 
-  """New value type."""
+  """
+  New value type.
+  """
   valueType: String = null
 
-  """New default value."""
+  """
+  New default value.
+  """
   defaultValue: String = null
 
-  """New key."""
+  """
+  New key.
+  """
   key: String = null
 }
 
-"""Added in UNRELEASED. Update preset payload."""
-type UpdateRuntimeVariantPresetPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """The updated preset."""
+"""
+Added in UNRELEASED. Update preset payload.
+"""
+type UpdateRuntimeVariantPresetPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  The updated preset.
+  """
   preset: RuntimeVariantPreset!
 }
 
 """
 Added in UNRELEASED. Input for updating a user resource policy. All fields optional.
 """
-input UpdateUserResourcePolicyInputGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated max vfolder count."""
+input UpdateUserResourcePolicyInputGQL @join__type(graph: STRAWBERRY) {
+  """
+  Updated max vfolder count.
+  """
   maxVfolderCount: Int = null
 
-  """Updated max quota scope size."""
+  """
+  Updated max quota scope size.
+  """
   maxQuotaScopeSize: BinarySizeInput = null
 
-  """Updated max sessions per model session."""
+  """
+  Updated max sessions per model session.
+  """
   maxSessionCountPerModelSession: Int = null
 
-  """Updated max customized image count."""
+  """
+  Updated max customized image count.
+  """
   maxCustomizedImageCount: Int = null
 }
 
-"""Added in UNRELEASED. Payload for user resource policy update mutation."""
-type UpdateUserResourcePolicyPayloadGQL
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated user resource policy."""
+"""
+Added in UNRELEASED. Payload for user resource policy update mutation.
+"""
+type UpdateUserResourcePolicyPayloadGQL @join__type(graph: STRAWBERRY) {
+  """
+  Updated user resource policy.
+  """
   userResourcePolicy: UserResourcePolicyV2!
 }
 
 """
 Added in 26.3.0. Input for updating user information. All fields are optional - only provided fields will be updated.
 """
-input UpdateUserV2Input
-  @join__type(graph: STRAWBERRY)
-{
-  """New username."""
+input UpdateUserV2Input @join__type(graph: STRAWBERRY) {
+  """
+  New username.
+  """
   username: String
 
-  """New password."""
+  """
+  New password.
+  """
   password: String
 
-  """New full display name."""
+  """
+  New full display name.
+  """
   fullName: String
 
-  """New description."""
+  """
+  New description.
+  """
   description: String
 
-  """New account status."""
+  """
+  New account status.
+  """
   status: UserStatusV2
 
-  """New user role."""
+  """
+  New user role.
+  """
   role: UserRoleV2
 
-  """New domain assignment."""
+  """
+  New domain assignment.
+  """
   domainName: String
 
-  """New project (group) assignments. Replaces existing assignments."""
+  """
+  New project (group) assignments. Replaces existing assignments.
+  """
   groupIds: [UUID!]
 
-  """New allowed client IP addresses or CIDR ranges."""
+  """
+  New allowed client IP addresses or CIDR ranges.
+  """
   allowedClientIp: [String!]
 
-  """Set password change requirement."""
+  """
+  Set password change requirement.
+  """
   needPasswordChange: Boolean
 
-  """New user resource policy name."""
+  """
+  New user resource policy name.
+  """
   resourcePolicy: String
 
-  """Enable or disable sudo session capability."""
+  """
+  Enable or disable sudo session capability.
+  """
   sudoSessionEnabled: Boolean
 
-  """Set the primary API access key."""
+  """
+  Set the primary API access key.
+  """
   mainAccessKey: String
 
-  """New container user ID."""
+  """
+  New container user ID.
+  """
   containerUid: Int
 
-  """New container primary group ID."""
+  """
+  New container primary group ID.
+  """
   containerMainGid: Int
 
-  """New container supplementary group IDs."""
+  """
+  New container supplementary group IDs.
+  """
   containerGids: [Int!]
 }
 
-"""Added in 26.3.0. Payload for user update mutation."""
-type UpdateUserV2Payload
-  @join__type(graph: STRAWBERRY)
-{
-  """The updated user."""
+"""
+Added in 26.3.0. Payload for user update mutation.
+"""
+type UpdateUserV2Payload @join__type(graph: STRAWBERRY) {
+  """
+  The updated user.
+  """
   user: UserV2!
 }
 
-"""Added in 25.16.0. Input for updating VFS storage"""
-input UpdateVFSStorageInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 25.16.0. Input for updating VFS storage
+"""
+input UpdateVFSStorageInput @join__type(graph: STRAWBERRY) {
   id: ID!
   name: String
   host: String
   basePath: String
 }
 
-"""Added in 25.16.0. Payload for updating VFS storage."""
-type UpdateVFSStoragePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated VFS storage"""
+"""
+Added in 25.16.0. Payload for updating VFS storage.
+"""
+type UpdateVFSStoragePayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated VFS storage
+  """
   vfsStorage: VFSStorage!
 }
 
@@ -16123,9 +21004,7 @@ The provided extra_config object will completely replace the existing configurat
 existing keys not present in the new extra_config will be removed.
 All users in this domain will be affected by these settings when their configurations are merged.
 """
-input UpsertDomainConfigInput
-  @join__type(graph: STRAWBERRY)
-{
+input UpsertDomainConfigInput @join__type(graph: STRAWBERRY) {
   domainName: String!
   extraConfig: JSON!
 }
@@ -16133,23 +21012,25 @@ input UpsertDomainConfigInput
 """
 Added in 25.16.0. Payload returned after upserting domain-level app configuration. Contains the resulting configuration that was stored.
 """
-type UpsertDomainConfigPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The resulting app configuration"""
+type UpsertDomainConfigPayload @join__type(graph: STRAWBERRY) {
+  """
+  The resulting app configuration
+  """
   appConfig: AppConfig!
 }
 
 """
 Added in 26.1.0. Input for upserting domain fair share weight. The weight parameter affects scheduling priority - higher weight = higher priority. Set weight to null to use resource group's default_weight.
 """
-input UpsertDomainFairShareWeightInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the scaling group (resource group) for this fair share."""
+input UpsertDomainFairShareWeightInput @join__type(graph: STRAWBERRY) {
+  """
+  Name of the scaling group (resource group) for this fair share.
+  """
   resourceGroupName: String!
 
-  """Name of the domain to update weight for."""
+  """
+  Name of the domain to update weight for.
+  """
   domainName: String!
 
   """
@@ -16158,27 +21039,33 @@ input UpsertDomainFairShareWeightInput
   weight: Decimal = null
 }
 
-"""Added in 26.1.0. Payload for domain fair share weight upsert mutation."""
-type UpsertDomainFairShareWeightPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated domain fair share data"""
+"""
+Added in 26.1.0. Payload for domain fair share weight upsert mutation.
+"""
+type UpsertDomainFairShareWeightPayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated domain fair share data
+  """
   domainFairShare: DomainFairShare!
 }
 
 """
 Added in 26.1.0. Input for upserting project fair share weight. The weight parameter affects scheduling priority - higher weight = higher priority. Set weight to null to use resource group's default_weight.
 """
-input UpsertProjectFairShareWeightInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the scaling group (resource group) for this fair share."""
+input UpsertProjectFairShareWeightInput @join__type(graph: STRAWBERRY) {
+  """
+  Name of the scaling group (resource group) for this fair share.
+  """
   resourceGroupName: String!
 
-  """UUID of the project to update weight for."""
+  """
+  UUID of the project to update weight for.
+  """
   projectId: UUID!
 
-  """Name of the domain the project belongs to."""
+  """
+  Name of the domain the project belongs to.
+  """
   domainName: String!
 
   """
@@ -16190,10 +21077,10 @@ input UpsertProjectFairShareWeightInput
 """
 Added in 26.1.0. Payload for project fair share weight upsert mutation.
 """
-type UpsertProjectFairShareWeightPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated project fair share data"""
+type UpsertProjectFairShareWeightPayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated project fair share data
+  """
   projectFairShare: ProjectFairShare!
 }
 
@@ -16204,9 +21091,7 @@ existing keys not present in the new extra_config will be removed.
 These settings will override domain-level settings when configurations are merged for this user.
 If user_id is not provided, the current user's configuration will be updated.
 """
-input UpsertUserConfigInput
-  @join__type(graph: STRAWBERRY)
-{
+input UpsertUserConfigInput @join__type(graph: STRAWBERRY) {
   extraConfig: JSON!
   userId: ID = null
 }
@@ -16214,29 +21099,35 @@ input UpsertUserConfigInput
 """
 Added in 25.16.0. Payload returned after upserting user-level app configuration. Contains the resulting configuration that was stored.
 """
-type UpsertUserConfigPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The resulting app configuration"""
+type UpsertUserConfigPayload @join__type(graph: STRAWBERRY) {
+  """
+  The resulting app configuration
+  """
   appConfig: AppConfig!
 }
 
 """
 Added in 26.1.0. Input for upserting user fair share weight. The weight parameter affects scheduling priority - higher weight = higher priority. Set weight to null to use resource group's default_weight.
 """
-input UpsertUserFairShareWeightInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the scaling group (resource group) for this fair share."""
+input UpsertUserFairShareWeightInput @join__type(graph: STRAWBERRY) {
+  """
+  Name of the scaling group (resource group) for this fair share.
+  """
   resourceGroupName: String!
 
-  """UUID of the project the user belongs to."""
+  """
+  UUID of the project the user belongs to.
+  """
   projectId: UUID!
 
-  """UUID of the user to update weight for."""
+  """
+  UUID of the user to update weight for.
+  """
   userUuid: UUID!
 
-  """Name of the domain the user belongs to."""
+  """
+  Name of the domain the user belongs to.
+  """
   domainName: String!
 
   """
@@ -16245,49 +21136,56 @@ input UpsertUserFairShareWeightInput
   weight: Decimal = null
 }
 
-"""Added in 26.1.0. Payload for user fair share weight upsert mutation."""
-type UpsertUserFairShareWeightPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """Updated user fair share data"""
+"""
+Added in 26.1.0. Payload for user fair share weight upsert mutation.
+"""
+type UpsertUserFairShareWeightPayload @join__type(graph: STRAWBERRY) {
+  """
+  Updated user fair share data
+  """
   userFairShare: UserFairShare!
 }
 
 """
 Added in 26.1.0. Common metadata for usage bucket records including the measurement period and timestamps.
 """
-type UsageBucketMetadata
-  @join__type(graph: STRAWBERRY)
-{
-  """Start date of the usage measurement period (inclusive)."""
+type UsageBucketMetadata @join__type(graph: STRAWBERRY) {
+  """
+  Start date of the usage measurement period (inclusive).
+  """
   periodStart: Date!
 
-  """End date of the usage measurement period (exclusive)."""
+  """
+  End date of the usage measurement period (exclusive).
+  """
   periodEnd: Date!
 
-  """Number of days in each decay unit for this bucket."""
+  """
+  Number of days in each decay unit for this bucket.
+  """
   decayUnitDays: Int!
 
-  """Timestamp when this record was created."""
+  """
+  Timestamp when this record was created.
+  """
   createdAt: DateTime!
 
-  """Timestamp when this record was last updated."""
+  """
+  Timestamp when this record was last updated.
+  """
   updatedAt: DateTime!
 }
 
 """
 Added in 26.1.0. Fields available for ordering usage bucket query results. PERIOD_START: Order by the start date of the usage measurement period. Use DESC to get most recent buckets first, ASC for chronological order.
 """
-enum UsageBucketOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum UsageBucketOrderField @join__type(graph: STRAWBERRY) {
   PERIOD_START @join__enumValue(graph: STRAWBERRY)
 }
 
 type User implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   uuid: UUID
   username: String
@@ -16330,38 +21228,46 @@ type User implements Item
   groups: [UserGroup]
 }
 
-"""Added in 24.03.0"""
-type UserConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 24.03.0
+"""
+type UserConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [UserEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
 """
 Added in 26.2.0. Nested filter for the domain a user belongs to. Filters users whose domain matches all specified conditions.
 """
-input UserDomainNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
+input UserDomainNestedFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   isActive: Boolean = null
 }
 
-"""Added in 24.03.0 A Relay edge containing a `User` and its cursor."""
-type UserEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+"""
+Added in 24.03.0 A Relay edge containing a `User` and its cursor.
+"""
+type UserEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: UserNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
@@ -16370,33 +21276,50 @@ Added in 26.1.0. User-level fair share data representing scheduling priority for
 """
 type UserFairShare implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Name of the scaling group this fair share belongs to."""
+  """
+  Name of the scaling group this fair share belongs to.
+  """
   resourceGroupName: String!
 
-  """UUID of the user this fair share is calculated for."""
+  """
+  UUID of the user this fair share is calculated for.
+  """
   userUuid: UUID!
 
-  """UUID of the project the user belongs to."""
+  """
+  UUID of the project the user belongs to.
+  """
   projectId: UUID!
 
-  """Name of the domain the user belongs to."""
+  """
+  Name of the domain the user belongs to.
+  """
   domainName: String!
 
-  """Fair share specification parameters used for calculation."""
+  """
+  Fair share specification parameters used for calculation.
+  """
   spec: FairShareSpec!
 
-  """Snapshot of the most recent fair share calculation results."""
+  """
+  Snapshot of the most recent fair share calculation results.
+  """
   calculationSnapshot: FairShareCalculationSnapshot!
 
-  """Timestamp when this record was created."""
+  """
+  Timestamp when this record was created.
+  """
   createdAt: DateTime!
 
-  """Timestamp when this record was last updated."""
+  """
+  Timestamp when this record was last updated.
+  """
   updatedAt: DateTime!
 
   """
@@ -16423,36 +21346,42 @@ type UserFairShare implements Node
 """
 Added in 26.1.0. Paginated connection for user fair share records. Provides relay-style cursor-based pagination for efficient traversal of user fair share data. Use 'edges' to access individual records with cursor information, or 'nodes' for direct data access.
 """
-type UserFairShareConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type UserFairShareConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [UserFairShareEdge!]!
 
-  """Total number of user fair share records matching the query criteria."""
+  """
+  Total number of user fair share records matching the query criteria.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type UserFairShareEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type UserFairShareEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: UserFairShare!
 }
 
 """
 Added in 26.1.0. Filter input for querying user fair shares. Supports filtering by scaling group, user UUID, project ID, and domain name. This is the most granular level of fair share filtering. Multiple filters can be combined using AND, OR, and NOT logical operators.
 """
-input UserFairShareFilter
-  @join__type(graph: STRAWBERRY)
-{
+input UserFairShareFilter @join__type(graph: STRAWBERRY) {
   """
   Filter by scaling group name. Scaling groups define resource pool boundaries where users compete for resources within their project. Supports equals, contains, startsWith, and endsWith operations.
   """
@@ -16478,7 +21407,9 @@ input UserFairShareFilter
   """
   user: UserFairShareUserNestedFilter = null
 
-  """Combine multiple filters with AND logic. All conditions must match."""
+  """
+  Combine multiple filters with AND logic. All conditions must match.
+  """
   AND: [UserFairShareFilter!] = null
 
   """
@@ -16495,9 +21426,7 @@ input UserFairShareFilter
 """
 Added in 26.1.0. Specifies ordering for user fair share query results. Combine field selection with direction to sort results. Default direction is DESC (descending).
 """
-input UserFairShareOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input UserFairShareOrderBy @join__type(graph: STRAWBERRY) {
   """
   The field to order by. See UserFairShareOrderField for available options.
   """
@@ -16512,20 +21441,20 @@ input UserFairShareOrderBy
 """
 Added in 26.1.0. Fields available for ordering user fair share query results. FAIR_SHARE_FACTOR: Order by the calculated fair share factor (0-1 range, lower = higher priority). CREATED_AT: Order by record creation timestamp. USER_USERNAME: Order alphabetically by username. USER_EMAIL: Order alphabetically by email.
 """
-enum UserFairShareOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum UserFairShareOrderField @join__type(graph: STRAWBERRY) {
   FAIR_SHARE_FACTOR @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   USER_USERNAME @join__enumValue(graph: STRAWBERRY)
   USER_EMAIL @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in 24.09.0. Scope parameters for filtering user fair shares."""
-input UserFairShareScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group to filter fair shares by."""
+"""
+Added in 24.09.0. Scope parameters for filtering user fair shares.
+"""
+input UserFairShareScope @join__type(graph: STRAWBERRY) {
+  """
+  Resource group to filter fair shares by.
+  """
   resourceGroupName: String!
 
   """
@@ -16537,38 +21466,34 @@ input UserFairShareScope
 """
 Added in 26.2.0. Nested filter for user entity fields in user fair share queries. Allows filtering by user properties such as username, email, and active status.
 """
-input UserFairShareUserNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
+input UserFairShareUserNestedFilter @join__type(graph: STRAWBERRY) {
   """
   Filter by username. Supports equals, contains, startsWith, and endsWith.
   """
   username: StringFilter = null
 
-  """Filter by email. Supports equals, contains, startsWith, and endsWith."""
+  """
+  Filter by email. Supports equals, contains, startsWith, and endsWith.
+  """
   email: StringFilter = null
 
-  """Filter by user active status (based on user status field)."""
+  """
+  Filter by user active status (based on user status field).
+  """
   isActive: Boolean = null
 }
 
-type UserGroup
-  @join__type(graph: GRAPHENE)
-{
+type UserGroup @join__type(graph: GRAPHENE) {
   id: UUID
   name: String
 }
 
-type UserInfo
-  @join__type(graph: GRAPHENE)
-{
+type UserInfo @join__type(graph: GRAPHENE) {
   email: String
   full_name: String
 }
 
-input UserInput
-  @join__type(graph: GRAPHENE)
-{
+input UserInput @join__type(graph: GRAPHENE) {
   username: String!
   password: String!
   need_password_change: Boolean!
@@ -16602,8 +21527,7 @@ input UserInput
 
 type UserList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [User]!
   total_count: Int!
 }
@@ -16611,33 +21535,46 @@ type UserList implements PaginatedList
 type UserNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
   @join__type(graph: GRAPHENE, key: "id")
-  @join__type(graph: STRAWBERRY, key: "id", extension: true)
-{
-  """The ID of the object"""
+  @join__type(graph: STRAWBERRY, key: "id", extension: true) {
+  """
+  The ID of the object
+  """
   id: ID!
 
-  """Unique username of the user."""
+  """
+  Unique username of the user.
+  """
   username: String @join__field(graph: GRAPHENE)
 
-  """Unique email of the user."""
+  """
+  Unique email of the user.
+  """
   email: String @join__field(graph: GRAPHENE)
   need_password_change: Boolean @join__field(graph: GRAPHENE)
   full_name: String @join__field(graph: GRAPHENE)
   description: String @join__field(graph: GRAPHENE)
-  is_active: Boolean @join__field(graph: GRAPHENE) @deprecated(reason: "Deprecated since 24.03.0. Recommend to use `status` field.")
+  is_active: Boolean
+    @join__field(graph: GRAPHENE)
+    @deprecated(
+      reason: "Deprecated since 24.03.0. Recommend to use `status` field."
+    )
 
   """
   The status is one of `active`, `inactive`, `deleted` or `before-verification`.
   """
   status: String @join__field(graph: GRAPHENE)
 
-  """Additional information of user status."""
+  """
+  Additional information of user status.
+  """
   status_info: String @join__field(graph: GRAPHENE)
   created_at: DateTime @join__field(graph: GRAPHENE)
   modified_at: DateTime @join__field(graph: GRAPHENE)
   domain_name: String @join__field(graph: GRAPHENE)
 
-  """The role is one of `user`, `admin`, `superadmin` or `monitor`."""
+  """
+  The role is one of `user`, `admin`, `superadmin` or `monitor`.
+  """
   role: String @join__field(graph: GRAPHENE)
   resource_policy: String @join__field(graph: GRAPHENE)
   allowed_client_ip: [String] @join__field(graph: GRAPHENE)
@@ -16660,23 +21597,29 @@ type UserNode implements Node
   """
   container_gids: [Int] @join__field(graph: GRAPHENE)
 
-  """Added in 25.5.0."""
-  project_nodes(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): GroupConnection @join__field(graph: GRAPHENE)
+  """
+  Added in 25.5.0.
+  """
+  project_nodes(
+    filter: String
+    order: String
+    offset: Int
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): GroupConnection @join__field(graph: GRAPHENE)
 }
 
 """
 Added in 26.2.0. Nested filter for projects a user belongs to. Filters users that belong to at least one project matching all specified conditions.
 """
-input UserProjectNestedFilter
-  @join__type(graph: STRAWBERRY)
-{
+input UserProjectNestedFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   isActive: Boolean = null
 }
 
-type UserResourcePolicy
-  @join__type(graph: GRAPHENE)
-{
+type UserResourcePolicy @join__type(graph: GRAPHENE) {
   id: ID!
   name: String!
   created_at: DateTime!
@@ -16708,59 +21651,82 @@ Added in UNRELEASED. User resource policy defining vfolder and quota limits per 
 """
 type UserResourcePolicyV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Policy name."""
+  """
+  Policy name.
+  """
   name: String!
 
-  """Timestamp when the policy was created."""
+  """
+  Timestamp when the policy was created.
+  """
   createdAt: DateTime
 
-  """Maximum vfolders a user can create."""
+  """
+  Maximum vfolders a user can create.
+  """
   maxVfolderCount: Int!
 
-  """Maximum quota scope size."""
+  """
+  Maximum quota scope size.
+  """
   maxQuotaScopeSize: BinarySizeInfo!
 
-  """Maximum sessions per model session."""
+  """
+  Maximum sessions per model session.
+  """
   maxSessionCountPerModelSession: Int!
 
-  """Maximum customized images a user can create."""
+  """
+  Maximum customized images a user can create.
+  """
   maxCustomizedImageCount: Int!
 }
 
-"""Added in UNRELEASED. Paginated connection for user resource policies."""
-type UserResourcePolicyV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in UNRELEASED. Paginated connection for user resource policies.
+"""
+type UserResourcePolicyV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [UserResourcePolicyV2Edge!]!
 
-  """Total number of matching policies."""
+  """
+  Total number of matching policies.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type UserResourcePolicyV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type UserResourcePolicyV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: UserResourcePolicyV2!
 }
 
-"""Added in UNRELEASED. Filter for user resource policies."""
-input UserResourcePolicyV2Filter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Filter for user resource policies.
+"""
+input UserResourcePolicyV2Filter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   createdAt: DateTimeFilter = null
   maxVfolderCount: IntFilter = null
@@ -16772,22 +21738,22 @@ input UserResourcePolicyV2Filter
 """
 Added in UNRELEASED. Ordering specification for user resource policies.
 """
-input UserResourcePolicyV2OrderBy
-  @join__type(graph: STRAWBERRY)
-{
-  """Field to order by."""
+input UserResourcePolicyV2OrderBy @join__type(graph: STRAWBERRY) {
+  """
+  Field to order by.
+  """
   field: UserResourcePolicyV2OrderField! = CREATED_AT
 
-  """Sort direction."""
+  """
+  Sort direction.
+  """
   direction: OrderDirection! = DESC
 }
 
 """
 Added in UNRELEASED. Fields available for ordering user resource policies.
 """
-enum UserResourcePolicyV2OrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum UserResourcePolicyV2OrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   MAX_VFOLDER_COUNT @join__enumValue(graph: STRAWBERRY)
@@ -16799,9 +21765,7 @@ enum UserResourcePolicyV2OrderField
 """
 Added in 26.2.0. User role determining access permissions. USER: Standard user with basic permissions. ADMIN: Domain administrator with elevated permissions. SUPERADMIN: System-wide administrator with full access. MONITOR: Read-only access for monitoring purposes.
 """
-enum UserRoleV2
-  @join__type(graph: STRAWBERRY)
-{
+enum UserRoleV2 @join__type(graph: STRAWBERRY) {
   USER @join__enumValue(graph: STRAWBERRY)
   ADMIN @join__enumValue(graph: STRAWBERRY)
   SUPERADMIN @join__enumValue(graph: STRAWBERRY)
@@ -16811,12 +21775,12 @@ enum UserRoleV2
 """
 Added in 26.2.0. Filter for UserRoleV2 enum fields. Supports equals, in, not_equals, and not_in operations.
 """
-input UserRoleV2EnumFilter
-  @join__type(graph: STRAWBERRY)
-{
+input UserRoleV2EnumFilter @join__type(graph: STRAWBERRY) {
   equals: UserRoleV2 = null
 
-  """The in  field."""
+  """
+  The in  field.
+  """
   in: [UserRoleV2!] = null
   notEquals: UserRoleV2 = null
   notIn: [UserRoleV2!] = null
@@ -16825,9 +21789,7 @@ input UserRoleV2EnumFilter
 """
 Added in 26.2.0. User account status. ACTIVE: User can log in and use the system. INACTIVE: User account is disabled but preserved. DELETED: User has been soft-deleted. BEFORE_VERIFICATION: User account is pending email verification.
 """
-enum UserStatusV2
-  @join__type(graph: STRAWBERRY)
-{
+enum UserStatusV2 @join__type(graph: STRAWBERRY) {
   ACTIVE @join__enumValue(graph: STRAWBERRY)
   INACTIVE @join__enumValue(graph: STRAWBERRY)
   DELETED @join__enumValue(graph: STRAWBERRY)
@@ -16837,12 +21799,12 @@ enum UserStatusV2
 """
 Added in 26.2.0. Filter for UserStatusV2 enum fields. Supports equals, in, not_equals, and not_in operations.
 """
-input UserStatusV2EnumFilter
-  @join__type(graph: STRAWBERRY)
-{
+input UserStatusV2EnumFilter @join__type(graph: STRAWBERRY) {
   equals: UserStatusV2 = null
 
-  """The in  field."""
+  """
+  The in  field.
+  """
   in: [UserStatusV2!] = null
   notEquals: UserStatusV2 = null
   notIn: [UserStatusV2!] = null
@@ -16853,24 +21815,35 @@ Added in 26.1.0. User-level usage bucket representing aggregated resource consum
 """
 type UserUsageBucket implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """UUID of the user this usage bucket belongs to."""
+  """
+  UUID of the user this usage bucket belongs to.
+  """
   userUuid: UUID!
 
-  """UUID of the project the user belongs to."""
+  """
+  UUID of the project the user belongs to.
+  """
   projectId: UUID!
 
-  """Name of the domain the user belongs to."""
+  """
+  Name of the domain the user belongs to.
+  """
   domainName: String!
 
-  """Name of the scaling group this usage was recorded in."""
+  """
+  Name of the scaling group this usage was recorded in.
+  """
   resourceGroupName: String!
 
-  """Metadata about the usage measurement period and timestamps."""
+  """
+  Metadata about the usage measurement period and timestamps.
+  """
   metadata: UsageBucketMetadata!
 
   """
@@ -16897,36 +21870,42 @@ type UserUsageBucket implements Node
 """
 Added in 26.1.0. Paginated connection for user usage bucket records. Provides relay-style cursor-based pagination for browsing historical usage data by time period. Use 'edges' to access individual records with cursor information, or 'nodes' for direct data access.
 """
-type UserUsageBucketConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type UserUsageBucketConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [UserUsageBucketEdge!]!
 
-  """Total number of user usage bucket records matching the query criteria."""
+  """
+  Total number of user usage bucket records matching the query criteria.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type UserUsageBucketEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type UserUsageBucketEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: UserUsageBucket!
 }
 
 """
 Added in 26.1.0. Filter input for querying user usage bucket records. Usage buckets contain historical resource consumption data aggregated by time period for users. This is the most granular level of usage bucket filtering. Multiple filters can be combined using AND, OR, and NOT logical operators.
 """
-input UserUsageBucketFilter
-  @join__type(graph: STRAWBERRY)
-{
+input UserUsageBucketFilter @join__type(graph: STRAWBERRY) {
   """
   Filter by scaling group name. Scaling groups define where usage was recorded. Supports equals, contains, startsWith, and endsWith operations.
   """
@@ -16947,13 +21926,19 @@ input UserUsageBucketFilter
   """
   domainName: StringFilter = null
 
-  """Filter by usage measurement period start date."""
+  """
+  Filter by usage measurement period start date.
+  """
   periodStart: DateFilter = null
 
-  """Filter by usage measurement period end date."""
+  """
+  Filter by usage measurement period end date.
+  """
   periodEnd: DateFilter = null
 
-  """Combine multiple filters with AND logic. All conditions must match."""
+  """
+  Combine multiple filters with AND logic. All conditions must match.
+  """
   AND: [UserUsageBucketFilter!] = null
 
   """
@@ -16970,9 +21955,7 @@ input UserUsageBucketFilter
 """
 Added in 26.1.0. Specifies ordering for user usage bucket query results. Combine field selection with direction to sort results. Default direction is DESC (most recent first).
 """
-input UserUsageBucketOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input UserUsageBucketOrderBy @join__type(graph: STRAWBERRY) {
   """
   The field to order by. See UsageBucketOrderField for available options.
   """
@@ -16984,39 +21967,51 @@ input UserUsageBucketOrderBy
   direction: OrderDirection! = DESC
 }
 
-"""Added in 24.09.0. Scope parameters for filtering user usage buckets."""
-input UserUsageScope
-  @join__type(graph: STRAWBERRY)
-{
-  """Resource group to filter usage buckets by."""
+"""
+Added in 24.09.0. Scope parameters for filtering user usage buckets.
+"""
+input UserUsageScope @join__type(graph: STRAWBERRY) {
+  """
+  Resource group to filter usage buckets by.
+  """
   resourceGroupName: String!
 
-  """Project ID that the user belongs to (required for user-level usage)."""
+  """
+  Project ID that the user belongs to (required for user-level usage).
+  """
   projectId: UUID!
 }
 
-"""Added in 25.6.0."""
-type UserUtilizationMetric
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.6.0.
+"""
+type UserUtilizationMetric @join__type(graph: GRAPHENE) {
   user_id: UUID
   metrics: [ContainerUtilizationMetric]
 }
 
-"""Added in 25.6.0."""
-input UserUtilizationMetricQueryInput
-  @join__type(graph: GRAPHENE)
-{
-  """One of 'current', 'capacity'. Default value is 'current'."""
+"""
+Added in 25.6.0.
+"""
+input UserUtilizationMetricQueryInput @join__type(graph: GRAPHENE) {
+  """
+  One of 'current', 'capacity'. Default value is 'current'.
+  """
   value_type: String = "current"
 
-  """metric name of container utilization. For example, 'cpu_util', 'mem'."""
+  """
+  metric name of container utilization. For example, 'cpu_util', 'mem'.
+  """
   metric_name: String!
 
-  """rfc3339 or unix_timestamp."""
+  """
+  rfc3339 or unix_timestamp.
+  """
   start: String!
 
-  """rfc3339 or unix_timestamp."""
+  """
+  rfc3339 or unix_timestamp.
+  """
   end: String!
 
   """
@@ -17030,27 +22025,40 @@ Added in 26.2.0. User entity with structured field groups. Provides comprehensiv
 """
 type UserV2 implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY, key: "id")
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY, key: "id") {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
-  """Basic profile information including username, email, and display name."""
+  """
+  Basic profile information including username, email, and display name.
+  """
   basicInfo: UserV2BasicInfo!
 
-  """Account status and password-related flags."""
+  """
+  Account status and password-related flags.
+  """
   status: UserV2StatusInfo!
 
-  """Organizational context including domain, role, and resource policy."""
+  """
+  Organizational context including domain, role, and resource policy.
+  """
   organization: UserV2OrganizationInfo!
 
-  """Security settings including IP restrictions and TOTP configuration."""
+  """
+  Security settings including IP restrictions and TOTP configuration.
+  """
   security: UserV2SecurityInfo!
 
-  """Container execution settings including UID/GID mappings."""
+  """
+  Container execution settings including UID/GID mappings.
+  """
   container: UserV2ContainerSettings!
 
-  """Creation and modification timestamps."""
+  """
+  Creation and modification timestamps.
+  """
   timestamps: EntityTimestamps!
 
   """
@@ -17061,58 +22069,87 @@ type UserV2 implements Node
   """
   Usage buckets for this user, filtered by resource group and project. Returns aggregated resource usage statistics over time.
   """
-  usageBuckets(scope: UserUsageScope!, filter: UserUsageBucketFilter = null, orderBy: [UserUsageBucketOrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): UserUsageBucketConnection!
+  usageBuckets(
+    scope: UserUsageScope!
+    filter: UserUsageBucketFilter = null
+    orderBy: [UserUsageBucketOrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): UserUsageBucketConnection!
 
-  """The domain this user belongs to."""
+  """
+  The domain this user belongs to.
+  """
   domain: DomainV2
 
-  """Projects this user is a member of."""
-  projects(filter: ProjectV2Filter = null, orderBy: [ProjectV2OrderBy!] = null, before: String = null, after: String = null, first: Int = null, last: Int = null, limit: Int = null, offset: Int = null): ProjectV2Connection!
+  """
+  Projects this user is a member of.
+  """
+  projects(
+    filter: ProjectV2Filter = null
+    orderBy: [ProjectV2OrderBy!] = null
+    before: String = null
+    after: String = null
+    first: Int = null
+    last: Int = null
+    limit: Int = null
+    offset: Int = null
+  ): ProjectV2Connection!
 }
 
 """
 Added in 26.2.0. Basic user profile information. Contains identity and descriptive fields for the user account.
 """
-type UserV2BasicInfo
-  @join__type(graph: STRAWBERRY)
-{
+type UserV2BasicInfo @join__type(graph: STRAWBERRY) {
   """
   Unique username for login. May be null if only email-based login is used.
   """
   username: String
 
-  """User's email address. Used for login and notifications."""
+  """
+  User's email address. Used for login and notifications.
+  """
   email: String!
 
-  """User's full display name."""
+  """
+  User's full display name.
+  """
   fullName: String
 
-  """Optional description or notes about the user."""
+  """
+  Optional description or notes about the user.
+  """
   description: String
 }
 
 """
 Added in 26.2.0. Paginated connection for user records. Provides relay-style cursor-based pagination for efficient traversal of user data. Use 'edges' to access individual records with cursor information, or 'nodes' for direct data access.
 """
-type UserV2Connection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type UserV2Connection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [UserV2Edge!]!
 
-  """Total number of user records matching the query criteria."""
+  """
+  Total number of user records matching the query criteria.
+  """
   count: Int!
 }
 
 """
 Added in 26.2.0. Container execution settings for the user. Defines UID/GID mappings for containers created by this user.
 """
-type UserV2ContainerSettings
-  @join__type(graph: STRAWBERRY)
-{
+type UserV2ContainerSettings @join__type(graph: STRAWBERRY) {
   """
   User ID (UID) to use inside containers. If null, system default is used.
   """
@@ -17123,27 +22160,31 @@ type UserV2ContainerSettings
   """
   containerMainGid: Int
 
-  """Additional supplementary group IDs for container processes."""
+  """
+  Additional supplementary group IDs for container processes.
+  """
   containerGids: [Int!]
 }
 
-"""An edge in a connection."""
-type UserV2Edge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type UserV2Edge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: UserV2!
 }
 
 """
 Added in 26.2.0. Filter input for querying users. Supports filtering by UUID, username, email, status, domain, role, creation time, and nested domain/project filters. Multiple filters can be combined using AND, OR, and NOT logical operators.
 """
-input UserV2Filter
-  @join__type(graph: STRAWBERRY)
-{
+input UserV2Filter @join__type(graph: STRAWBERRY) {
   uuid: UUIDFilter = null
   username: StringFilter = null
   email: StringFilter = null
@@ -17161,9 +22202,7 @@ input UserV2Filter
 """
 Added in 26.2.0. Specifies ordering for user query results. Combine field selection with direction to sort results. Default direction is DESC (descending).
 """
-input UserV2OrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input UserV2OrderBy @join__type(graph: STRAWBERRY) {
   field: UserV2OrderField! = CREATED_AT
   direction: OrderDirection! = DESC
 }
@@ -17171,9 +22210,7 @@ input UserV2OrderBy
 """
 Added in 26.2.0. Fields available for ordering user query results. CREATED_AT: Order by creation timestamp. MODIFIED_AT: Order by last modification timestamp. USERNAME: Order by username alphabetically. EMAIL: Order by email address alphabetically. STATUS: Order by account status. DOMAIN_NAME: Order by domain name (scalar subquery). PROJECT_NAME: Order by project name (MIN aggregation).
 """
-enum UserV2OrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum UserV2OrderField @join__type(graph: STRAWBERRY) {
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   MODIFIED_AT @join__enumValue(graph: STRAWBERRY)
   USERNAME @join__enumValue(graph: STRAWBERRY)
@@ -17186,28 +22223,32 @@ enum UserV2OrderField
 """
 Added in 26.2.0. User's organizational context and permissions. Contains domain membership, role, and resource policy information.
 """
-type UserV2OrganizationInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """Name of the domain this user belongs to."""
+type UserV2OrganizationInfo @join__type(graph: STRAWBERRY) {
+  """
+  Name of the domain this user belongs to.
+  """
   domainName: String
 
-  """User's role determining access permissions. See UserRole enum."""
+  """
+  User's role determining access permissions. See UserRole enum.
+  """
   role: UserRoleV2
 
-  """Name of the user resource policy applied to this user."""
+  """
+  Name of the user resource policy applied to this user.
+  """
   resourcePolicy: String!
 
-  """Primary API access key for this user."""
+  """
+  Primary API access key for this user.
+  """
   mainAccessKey: String
 }
 
 """
 Added in 26.2.0. User security settings and authentication configuration. Contains IP restrictions, TOTP settings, and privilege flags.
 """
-type UserV2SecurityInfo
-  @join__type(graph: STRAWBERRY)
-{
+type UserV2SecurityInfo @join__type(graph: STRAWBERRY) {
   """
   List of allowed client IP addresses or CIDR ranges. If set, login is restricted to these IP addresses. Supports both IPv4 and IPv6 formats (e.g., '192.168.1.0/24', '::1').
   """
@@ -17218,19 +22259,21 @@ type UserV2SecurityInfo
   """
   totpActivated: Boolean
 
-  """Timestamp when TOTP was activated."""
+  """
+  Timestamp when TOTP was activated.
+  """
   totpActivatedAt: DateTime
 
-  """Whether this user can create sudo (privileged) sessions."""
+  """
+  Whether this user can create sudo (privileged) sessions.
+  """
   sudoSessionEnabled: Boolean!
 }
 
 """
 Added in 26.2.0. User account status information. Contains current status and password-related flags.
 """
-type UserV2StatusInfo
-  @join__type(graph: STRAWBERRY)
-{
+type UserV2StatusInfo @join__type(graph: STRAWBERRY) {
   """
   Current account status. See UserStatus enum for possible values. Replaces the deprecated is_active field.
   """
@@ -17241,23 +22284,29 @@ type UserV2StatusInfo
   """
   statusInfo: String
 
-  """If true, user must change password on next login."""
+  """
+  If true, user must change password on next login.
+  """
   needPasswordChange: Boolean
 }
 
 """
 Added in 26.1.0. Input item for a single user weight in bulk upsert. Represents one user's weight configuration within a project.
 """
-input UserWeightInputItem
-  @join__type(graph: STRAWBERRY)
-{
-  """UUID of the user to update weight for."""
+input UserWeightInputItem @join__type(graph: STRAWBERRY) {
+  """
+  UUID of the user to update weight for.
+  """
   userUuid: UUID!
 
-  """ID of the project this user's fair share belongs to."""
+  """
+  ID of the project this user's fair share belongs to.
+  """
   projectId: UUID!
 
-  """Name of the domain this project belongs to."""
+  """
+  Name of the domain this project belongs to.
+  """
   domainName: String!
 
   """
@@ -17270,17 +22319,17 @@ input UserWeightInputItem
 Leverages the internal Python implementation of UUID (uuid.UUID) to provide native UUID objects
 in fields, resolvers and input.
 """
-scalar UUID
-  @join__type(graph: GRAPHENE)
-  @join__type(graph: STRAWBERRY)
+scalar UUID @join__type(graph: GRAPHENE) @join__type(graph: STRAWBERRY)
 
-"""Added in 26.1.0. Filter for UUID fields."""
-input UUIDFilter
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 26.1.0. Filter for UUID fields.
+"""
+input UUIDFilter @join__type(graph: STRAWBERRY) {
   equals: UUID = null
 
-  """The in  field."""
+  """
+  The in  field.
+  """
   in: [UUID!] = null
   notEquals: UUID = null
   notIn: [UUID!] = null
@@ -17290,38 +22339,41 @@ input UUIDFilter
 Added in 25.4.0.
 Verifies that the key is a UUID (represented as a string) and the value is a float.
 """
-scalar UUIDFloatMap
-  @join__type(graph: GRAPHENE)
+scalar UUIDFloatMap @join__type(graph: GRAPHENE)
 
-"""Added in 24.09.0. Input for validate notification channel mutation"""
-input ValidateNotificationChannelInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for validate notification channel mutation
+"""
+input ValidateNotificationChannelInput @join__type(graph: STRAWBERRY) {
   id: ID!
   testMessage: String!
 }
 
-"""Added in 26.3.0. Payload for validate notification channel mutation."""
-type ValidateNotificationChannelPayload
-  @join__type(graph: STRAWBERRY)
-{
-  """ID of the validated notification channel"""
+"""
+Added in 26.3.0. Payload for validate notification channel mutation.
+"""
+type ValidateNotificationChannelPayload @join__type(graph: STRAWBERRY) {
+  """
+  ID of the validated notification channel
+  """
   id: UUID!
 }
 
-"""Added in 24.09.0. Input for validate notification rule mutation"""
-input ValidateNotificationRuleInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for validate notification rule mutation
+"""
+input ValidateNotificationRuleInput @join__type(graph: STRAWBERRY) {
   id: ID!
   notificationData: JSON
 }
 
-"""Added in 26.3.0. Payload for validate notification rule mutation."""
-type ValidateNotificationRulePayload
-  @join__type(graph: STRAWBERRY)
-{
-  """The rendered message from the template"""
+"""
+Added in 26.3.0. Payload for validate notification rule mutation.
+"""
+type ValidateNotificationRulePayload @join__type(graph: STRAWBERRY) {
+  """
+  The rendered message from the template
+  """
   message: String!
 }
 
@@ -17330,9 +22382,10 @@ Added in UNRELEASED. Virtual folder entity with structured field groups. Provide
 """
 type VFolder implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
 
   """
@@ -17340,7 +22393,9 @@ type VFolder implements Node
   """
   status: VFolderOperationStatus!
 
-  """Storage host where the virtual folder is physically located."""
+  """
+  Storage host where the virtual folder is physically located.
+  """
   host: String!
 
   """
@@ -17348,7 +22403,9 @@ type VFolder implements Node
   """
   metadata: VFolderMetadataInfo!
 
-  """Access control including permission level and ownership type."""
+  """
+  Access control including permission level and ownership type.
+  """
   accessControl: VFolderAccessControlInfo!
 
   """
@@ -17356,16 +22413,16 @@ type VFolder implements Node
   """
   ownership: VFolderOwnershipInfo!
 
-  """Path for unmanaged virtual folders."""
+  """
+  Path for unmanaged virtual folders.
+  """
   unmanagedPath: String
 }
 
 """
 Added in UNRELEASED. Access control information for a virtual folder. Includes the mount permission level (read-only, read-write, read-write-delete) and ownership type (user or project).
 """
-type VFolderAccessControlInfo
-  @join__type(graph: STRAWBERRY)
-{
+type VFolderAccessControlInfo @join__type(graph: STRAWBERRY) {
   permission: VFolderMountPermission!
   ownershipType: VFolderOwnershipType!
 }
@@ -17373,36 +22430,42 @@ type VFolderAccessControlInfo
 """
 Added in UNRELEASED. Paginated connection for virtual folder records. Provides relay-style cursor-based pagination for efficient traversal of vfolder data. Use 'edges' to access individual records with cursor information, or 'nodes' for direct data access.
 """
-type VFolderConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+type VFolderConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [VFolderEdge!]!
 
-  """Total number of virtual folder records matching the query criteria."""
+  """
+  Total number of virtual folder records matching the query criteria.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type VFolderEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type VFolderEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: VFolder!
 }
 
 """
 Added in UNRELEASED. Filter input for querying virtual folders. Supports filtering by name, host, status, usage mode, and creation time. Multiple filters can be combined using AND, OR, and NOT logical operators.
 """
-input VFolderFilter
-  @join__type(graph: STRAWBERRY)
-{
+input VFolderFilter @join__type(graph: STRAWBERRY) {
   name: StringFilter = null
   host: StringFilter = null
   status: VFolderOperationStatusFilter = null
@@ -17417,33 +22480,37 @@ input VFolderFilter
 """
 Added in 26.2.0. Storage host permission configuration. Defines what operations are allowed for a specific storage host.
 """
-type VFolderHostPermissionEntry
-  @join__type(graph: STRAWBERRY)
-{
-  """Virtual folder host name (e.g., 'default', 'nfs-vol1')."""
+type VFolderHostPermissionEntry @join__type(graph: STRAWBERRY) {
+  """
+  Virtual folder host name (e.g., 'default', 'nfs-vol1').
+  """
   host: String!
 
-  """List of permission values (e.g., 'mount-in-session', 'upload-file')."""
+  """
+  List of permission values (e.g., 'mount-in-session', 'upload-file').
+  """
   permissions: [VFolderHostPermissionV2!]!
 }
 
-"""Added in UNRELEASED. Input for a vfolder host with its permissions."""
-input VFolderHostPermissionEntryInput
-  @join__type(graph: STRAWBERRY)
-{
-  """Virtual folder host name."""
+"""
+Added in UNRELEASED. Input for a vfolder host with its permissions.
+"""
+input VFolderHostPermissionEntryInput @join__type(graph: STRAWBERRY) {
+  """
+  Virtual folder host name.
+  """
   host: String!
 
-  """List of permission values."""
+  """
+  List of permission values.
+  """
   permissions: [String!]!
 }
 
 """
 Added in 26.2.0. Atomic permissions for virtual folders on a storage host.
 """
-enum VFolderHostPermissionV2
-  @join__type(graph: STRAWBERRY)
-{
+enum VFolderHostPermissionV2 @join__type(graph: STRAWBERRY) {
   CREATE_VFOLDER @join__enumValue(graph: STRAWBERRY)
   MODIFY_VFOLDER @join__enumValue(graph: STRAWBERRY)
   DELETE_VFOLDER @join__enumValue(graph: STRAWBERRY)
@@ -17457,9 +22524,7 @@ enum VFolderHostPermissionV2
 """
 Added in UNRELEASED. Descriptive metadata for a virtual folder. Includes the folder name, usage mode, quota scope, timestamps, and clone eligibility.
 """
-type VFolderMetadataInfo
-  @join__type(graph: STRAWBERRY)
-{
+type VFolderMetadataInfo @join__type(graph: STRAWBERRY) {
   name: String!
   usageMode: VFolderUsageMode!
   quotaScopeId: String
@@ -17468,19 +22533,19 @@ type VFolderMetadataInfo
   cloneable: Boolean!
 }
 
-"""Added in UNRELEASED. Mount permission level for a virtual folder."""
-enum VFolderMountPermission
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Mount permission level for a virtual folder.
+"""
+enum VFolderMountPermission @join__type(graph: STRAWBERRY) {
   READ_ONLY @join__enumValue(graph: STRAWBERRY)
   READ_WRITE @join__enumValue(graph: STRAWBERRY)
   RW_DELETE @join__enumValue(graph: STRAWBERRY)
 }
 
-"""Added in UNRELEASED. Operation status of a virtual folder."""
-enum VFolderOperationStatus
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in UNRELEASED. Operation status of a virtual folder.
+"""
+enum VFolderOperationStatus @join__type(graph: STRAWBERRY) {
   READY @join__enumValue(graph: STRAWBERRY)
   CLONING @join__enumValue(graph: STRAWBERRY)
   DELETE_PENDING @join__enumValue(graph: STRAWBERRY)
@@ -17492,22 +22557,22 @@ enum VFolderOperationStatus
 """
 Added in UNRELEASED. Filter for VFolder operation status enum fields. Supports in and not_in operations.
 """
-input VFolderOperationStatusFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """The in field."""
+input VFolderOperationStatusFilter @join__type(graph: STRAWBERRY) {
+  """
+  The in field.
+  """
   in: [VFolderOperationStatus!] = null
 
-  """Exclude statuses not in this list."""
+  """
+  Exclude statuses not in this list.
+  """
   notIn: [VFolderOperationStatus!] = null
 }
 
 """
 Added in UNRELEASED. Specifies ordering for virtual folder query results. Combine field selection with direction to sort results. Default direction is DESC (descending).
 """
-input VFolderOrderBy
-  @join__type(graph: STRAWBERRY)
-{
+input VFolderOrderBy @join__type(graph: STRAWBERRY) {
   field: VFolderOrderField! = CREATED_AT
   direction: OrderDirection! = DESC
 }
@@ -17515,9 +22580,7 @@ input VFolderOrderBy
 """
 Added in UNRELEASED. Fields available for ordering virtual folder query results. NAME: Order by folder name alphabetically. CREATED_AT: Order by creation timestamp. STATUS: Order by operation status. USAGE_MODE: Order by usage mode. HOST: Order by storage host.
 """
-enum VFolderOrderField
-  @join__type(graph: STRAWBERRY)
-{
+enum VFolderOrderField @join__type(graph: STRAWBERRY) {
   NAME @join__enumValue(graph: STRAWBERRY)
   CREATED_AT @join__enumValue(graph: STRAWBERRY)
   STATUS @join__enumValue(graph: STRAWBERRY)
@@ -17528,10 +22591,10 @@ enum VFolderOrderField
 """
 Added in UNRELEASED. Ownership context for a virtual folder. Provides both scalar IDs (userId, projectId, creatorEmail) for lightweight access and full node resolvers (user, project, creator) for detailed entity information.
 """
-type VFolderOwnershipInfo
-  @join__type(graph: STRAWBERRY)
-{
-  """The user who owns this virtual folder. Null for project-owned folders."""
+type VFolderOwnershipInfo @join__type(graph: STRAWBERRY) {
+  """
+  The user who owns this virtual folder. Null for project-owned folders.
+  """
   user: UserV2
 
   """
@@ -17539,7 +22602,9 @@ type VFolderOwnershipInfo
   """
   project: ProjectV2
 
-  """The user who originally created this virtual folder."""
+  """
+  The user who originally created this virtual folder.
+  """
   creator: UserV2
   userId: UUID
   projectId: UUID
@@ -17549,9 +22614,7 @@ type VFolderOwnershipInfo
 """
 Added in UNRELEASED. Ownership type of a virtual folder (USER or GROUP).
 """
-enum VFolderOwnershipType
-  @join__type(graph: STRAWBERRY)
-{
+enum VFolderOwnershipType @join__type(graph: STRAWBERRY) {
   USER @join__enumValue(graph: STRAWBERRY)
   GROUP @join__enumValue(graph: STRAWBERRY)
 }
@@ -17559,15 +22622,12 @@ enum VFolderOwnershipType
 """
 Added in 24.09.0. One of ['clone', 'assign_permission_to_others', 'read_attribute', 'update_attribute', 'delete_vfolder', 'read_content', 'write_content', 'delete_content', 'mount_ro', 'mount_rw', 'mount_wd'].
 """
-scalar VFolderPermissionValueField
-  @join__type(graph: GRAPHENE)
+scalar VFolderPermissionValueField @join__type(graph: GRAPHENE)
 
 """
 Added in UNRELEASED. Usage mode of a virtual folder (GENERAL, MODEL, DATA).
 """
-enum VFolderUsageMode
-  @join__type(graph: STRAWBERRY)
-{
+enum VFolderUsageMode @join__type(graph: STRAWBERRY) {
   GENERAL @join__enumValue(graph: STRAWBERRY)
   MODEL @join__enumValue(graph: STRAWBERRY)
   DATA @join__enumValue(graph: STRAWBERRY)
@@ -17576,57 +22636,72 @@ enum VFolderUsageMode
 """
 Added in UNRELEASED. Filter for VFolder usage mode enum fields. Supports in and not_in operations.
 """
-input VFolderUsageModeFilter
-  @join__type(graph: STRAWBERRY)
-{
-  """The in field."""
+input VFolderUsageModeFilter @join__type(graph: STRAWBERRY) {
+  """
+  The in field.
+  """
   in: [VFolderUsageMode!] = null
 
-  """Exclude usage modes not in this list."""
+  """
+  Exclude usage modes not in this list.
+  """
   notIn: [VFolderUsageMode!] = null
 }
 
-"""Added in 25.16.0. VFS Storage configuration."""
+"""
+Added in 25.16.0. VFS Storage configuration.
+"""
 type VFSStorage implements Node
   @join__implements(graph: STRAWBERRY, interface: "Node")
-  @join__type(graph: STRAWBERRY)
-{
-  """The Globally Unique ID of this object"""
+  @join__type(graph: STRAWBERRY) {
+  """
+  The Globally Unique ID of this object
+  """
   id: ID!
   name: String!
   host: String!
   basePath: String!
 }
 
-"""Added in 25.16.0. VFS Storage connection."""
-type VFSStorageConnection
-  @join__type(graph: STRAWBERRY)
-{
-  """Pagination data for this connection"""
+"""
+Added in 25.16.0. VFS Storage connection.
+"""
+type VFSStorageConnection @join__type(graph: STRAWBERRY) {
+  """
+  Pagination data for this connection
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection"""
+  """
+  Contains the nodes in this connection
+  """
   edges: [VFSStorageEdge!]!
 
-  """The count of this entity."""
+  """
+  The count of this entity.
+  """
   count: Int!
 }
 
-"""An edge in a connection."""
-type VFSStorageEdge
-  @join__type(graph: STRAWBERRY)
-{
-  """A cursor for use in pagination"""
+"""
+An edge in a connection.
+"""
+type VFSStorageEdge @join__type(graph: STRAWBERRY) {
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 
-  """The item at the end of the edge"""
+  """
+  The item at the end of the edge
+  """
   node: VFSStorage!
 }
 
-"""Added in 25.14.2."""
-type Viewer
-  @join__type(graph: GRAPHENE)
-{
+"""
+Added in 25.14.2.
+"""
+type Viewer @join__type(graph: GRAPHENE) {
   user: UserNode
   user_id: UUID
   encoded_user_role: String
@@ -17634,8 +22709,7 @@ type Viewer
 
 type VirtualFolder implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   host: String
   quota_scope_id: String
@@ -17646,7 +22720,9 @@ type VirtualFolder implements Item
   group_name: String
   creator: String
 
-  """Added in 24.09.0."""
+  """
+  Added in 24.09.0.
+  """
   domain_name: String
   unmanaged_path: String
   usage_mode: String
@@ -17662,51 +22738,63 @@ type VirtualFolder implements Item
   status: String
 }
 
-"""Added in 24.03.4"""
-type VirtualFolderConnection
-  @join__type(graph: GRAPHENE)
-{
-  """Pagination data for this connection."""
+"""
+Added in 24.03.4
+"""
+type VirtualFolderConnection @join__type(graph: GRAPHENE) {
+  """
+  Pagination data for this connection.
+  """
   pageInfo: PageInfo!
 
-  """Contains the nodes in this connection."""
+  """
+  Contains the nodes in this connection.
+  """
   edges: [VirtualFolderEdge]!
 
-  """Total count of the GQL nodes of the query."""
+  """
+  Total count of the GQL nodes of the query.
+  """
   count: Int
 }
 
 """
 Added in 24.03.4 A Relay edge containing a `VirtualFolder` and its cursor.
 """
-type VirtualFolderEdge
-  @join__type(graph: GRAPHENE)
-{
-  """The item at the end of the edge"""
+type VirtualFolderEdge @join__type(graph: GRAPHENE) {
+  """
+  The item at the end of the edge
+  """
   node: VirtualFolderNode
 
-  """A cursor for use in pagination"""
+  """
+  A cursor for use in pagination
+  """
   cursor: String!
 }
 
 type VirtualFolderList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [VirtualFolder]!
   total_count: Int!
 }
 
-"""Added in 24.03.4"""
+"""
+Added in 24.03.4
+"""
 type VirtualFolderNode implements Node
   @join__implements(graph: GRAPHENE, interface: "Node")
   @join__type(graph: GRAPHENE, key: "id")
-  @join__type(graph: STRAWBERRY, key: "id", extension: true)
-{
-  """The ID of the object"""
+  @join__type(graph: STRAWBERRY, key: "id", extension: true) {
+  """
+  The ID of the object
+  """
   id: ID!
 
-  """Added in 24.03.4. ID of VFolder."""
+  """
+  Added in 24.03.4. ID of VFolder.
+  """
   row_id: UUID @join__field(graph: GRAPHENE)
   host: String @join__field(graph: GRAPHENE)
   quota_scope_id: String @join__field(graph: GRAPHENE)
@@ -17740,8 +22828,7 @@ Legacy VirtualFolderPermission GraphQL type (renamed to avoid conflict with VFol
 """
 type VirtualFolderPermission implements Item
   @join__implements(graph: GRAPHENE, interface: "Item")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   id: ID
   permission: String
   vfolder: UUID
@@ -17752,15 +22839,14 @@ type VirtualFolderPermission implements Item
 
 type VirtualFolderPermissionList implements PaginatedList
   @join__implements(graph: GRAPHENE, interface: "PaginatedList")
-  @join__type(graph: GRAPHENE)
-{
+  @join__type(graph: GRAPHENE) {
   items: [VirtualFolderPermission]!
   total_count: Int!
 }
 
-"""Added in 24.09.0. Input for webhook configuration"""
-input WebhookSpecInput
-  @join__type(graph: STRAWBERRY)
-{
+"""
+Added in 24.09.0. Input for webhook configuration
+"""
+input WebhookSpecInput @join__type(graph: STRAWBERRY) {
   url: String!
 }

--- a/react/src/components/CreatePermissionModal.tsx
+++ b/react/src/components/CreatePermissionModal.tsx
@@ -2,13 +2,13 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { CreatePermissionModalCombinationsQuery } from '../__generated__/CreatePermissionModalCombinationsQuery.graphql';
 import {
   CreatePermissionModalCreateMutation,
   type OperationType,
   type RBACElementType,
 } from '../__generated__/CreatePermissionModalCreateMutation.graphql';
 import { CreatePermissionModalDomainQuery } from '../__generated__/CreatePermissionModalDomainQuery.graphql';
+import { CreatePermissionModalPermissionMatrixQuery } from '../__generated__/CreatePermissionModalPermissionMatrixQuery.graphql';
 import { CreatePermissionModalResourceGroupQuery } from '../__generated__/CreatePermissionModalResourceGroupQuery.graphql';
 import { CreatePermissionModalUpdateMutation } from '../__generated__/CreatePermissionModalUpdateMutation.graphql';
 import { App, Form, type SelectProps } from 'antd';
@@ -242,18 +242,17 @@ const CreatePermissionModal: React.FC<CreatePermissionModalProps> = ({
   const watchedScopeId = Form.useWatch('scopeId', form);
   const watchedEntityType = Form.useWatch('entityType', form);
 
-  const { rbacScopeEntityCombinations, rbacEntityOperationCombinations } =
-    useLazyLoadQuery<CreatePermissionModalCombinationsQuery>(
+  const { rbacPermissionMatrix } =
+    useLazyLoadQuery<CreatePermissionModalPermissionMatrixQuery>(
       graphql`
-        query CreatePermissionModalCombinationsQuery {
-          rbacScopeEntityCombinations {
+        query CreatePermissionModalPermissionMatrixQuery {
+          rbacPermissionMatrix {
             scopeType
-            validEntityTypes
-          }
-          rbacEntityOperationCombinations {
-            entityType
-            operations {
-              requiredPermission
+            entities {
+              entityType
+              actions {
+                requiredPermission
+              }
             }
           }
         }
@@ -262,37 +261,33 @@ const CreatePermissionModal: React.FC<CreatePermissionModalProps> = ({
       { fetchPolicy: 'store-and-network' },
     );
 
-  // Valid operations per entity type
-  const entityOperationMap = new Map(
-    rbacEntityOperationCombinations?.map((c) => [
-      c.entityType,
-      c.operations.map((op) => op.requiredPermission),
-    ]) ?? [],
-  );
-
   // Scope types available: intersection of UI-supported types and backend-reported types
   const availableScopeTypes = RBAC_ELEMENT_TYPES.filter((type) => {
-    const combination = rbacScopeEntityCombinations?.find(
-      (c) => c.scopeType === type,
-    );
-    if (!combination) return false;
-    return combination.validEntityTypes.some(
-      (et) => (entityOperationMap.get(et)?.length ?? 0) > 0,
-    );
+    const entry = rbacPermissionMatrix?.find((c) => c.scopeType === type);
+    if (!entry) return false;
+    return entry.entities.some((e) => e.actions.length > 0);
   });
 
   // Entity types valid for the currently selected scope type
-  const validEntityTypes = watchedScopeType
-    ? (rbacScopeEntityCombinations
-        ?.find((c) => c.scopeType === watchedScopeType)
-        ?.validEntityTypes.filter(
-          (et) => (entityOperationMap.get(et)?.length ?? 0) > 0,
-        ) ?? [])
+  const selectedScopeEntry = watchedScopeType
+    ? rbacPermissionMatrix?.find((c) => c.scopeType === watchedScopeType)
+    : undefined;
+
+  const validEntityTypes = selectedScopeEntry
+    ? selectedScopeEntry.entities
+        .filter((e) => e.actions.length > 0)
+        .map((e) => e.entityType)
     : [];
 
-  const validOperations = watchedEntityType
-    ? new Set(entityOperationMap.get(watchedEntityType) ?? [])
-    : new Set<OperationType>();
+  // Valid operations for the selected (scope, entity) pair
+  const validOperations =
+    watchedEntityType && selectedScopeEntry
+      ? new Set(
+          selectedScopeEntry.entities
+            .find((e) => e.entityType === watchedEntityType)
+            ?.actions.map((a) => a.requiredPermission) ?? [],
+        )
+      : new Set<OperationType>();
 
   const [commitCreatePermission, isCreateInFlight] =
     useMutation<CreatePermissionModalCreateMutation>(graphql`


### PR DESCRIPTION
Resolves #6324(FR-2435)

## Summary

- Replace the two separate RBAC combination queries (`rbacScopeEntityCombinations` + `rbacEntityOperationCombinations`) with the unified `rbacPermissionMatrix` API
- Valid operations are now correctly scoped to both the selected scope type **and** entity type, preventing invalid (scope, entity, operation) combinations
- No UI/UX changes — the permission creation modal behaves the same but with more accurate data

## Related

- Backend core PR: https://github.com/lablup/backend.ai/pull/10719

## Test plan

- [ ] Open RBAC management → Create Permission modal
- [ ] Verify scope type dropdown shows valid scope types
- [ ] Select a scope type → verify entity type dropdown shows only valid entities for that scope
- [ ] Select an entity type → verify operation dropdown shows only valid operations for the (scope, entity) pair
- [ ] Confirm that previously invalid combinations (e.g., `model_deployment/session/grant`) are no longer selectable
- [ ] Edit an existing permission and verify form pre-fills correctly

## Verification

```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)