### PR TITLE
feat(FR-2437): rename integration_id to integration_name

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2854,7 +2854,7 @@ input CreateDomainNodeInput
   total_resource_slots: JSONString = "{}"
   allowed_vfolder_hosts: JSONString = "{}"
   allowed_docker_registries: [String] = []
-  integration_id: String = null
+  integration_name: String = null
   dotfiles: Bytes = "90"
   scaling_groups: [String]
 }
@@ -4521,7 +4521,7 @@ type Domain
   total_resource_slots: JSONString
   allowed_vfolder_hosts: JSONString
   allowed_docker_registries: [String]
-  integration_id: String
+  integration_name: String
   scaling_groups: [String]
 }
 
@@ -4722,7 +4722,7 @@ input DomainInput
   total_resource_slots: JSONString = "{}"
   allowed_vfolder_hosts: JSONString = "{}"
   allowed_docker_registries: [String] = []
-  integration_id: String = null
+  integration_name: String = null
 }
 
 """
@@ -4760,7 +4760,7 @@ type DomainNode implements Node
   allowed_vfolder_hosts: JSONString @join__field(graph: GRAPHENE)
   allowed_docker_registries: [String] @join__field(graph: GRAPHENE)
   dotfiles: Bytes @join__field(graph: GRAPHENE)
-  integration_id: String @join__field(graph: GRAPHENE)
+  integration_name: String @join__field(graph: GRAPHENE)
   scaling_groups(filter: String, order: String, offset: Int, before: String, after: String, first: Int, last: Int): ScalingGroupConnection @join__field(graph: GRAPHENE)
 }
 
@@ -5696,7 +5696,7 @@ type Group
   domain_name: String
   total_resource_slots: JSONString
   allowed_vfolder_hosts: JSONString
-  integration_id: String
+  integration_name: String
   resource_policy: String
 
   """Added in 24.03.0."""
@@ -5742,7 +5742,7 @@ input GroupInput
   domain_name: String!
   total_resource_slots: JSONString = "{}"
   allowed_vfolder_hosts: JSONString = "{}"
-  integration_id: String = ""
+  integration_name: String = ""
   resource_policy: String = "default"
 
   """Added in 24.03.0"""
@@ -5767,7 +5767,7 @@ type GroupNode implements Node
   domain_name: String @join__field(graph: GRAPHENE)
   total_resource_slots: JSONString @join__field(graph: GRAPHENE)
   allowed_vfolder_hosts: JSONString @join__field(graph: GRAPHENE)
-  integration_id: String @join__field(graph: GRAPHENE)
+  integration_name: String @join__field(graph: GRAPHENE)
   resource_policy: String @join__field(graph: GRAPHENE)
 
   """Added in 24.03.7. One of ['GENERAL', 'MODEL_STORE']."""
@@ -8353,7 +8353,7 @@ input ModifyDomainInput
   total_resource_slots: JSONString
   allowed_vfolder_hosts: JSONString
   allowed_docker_registries: [String]
-  integration_id: String
+  integration_name: String
 }
 
 """Added in 24.12.0."""
@@ -8374,7 +8374,7 @@ input ModifyDomainNodeInput
   total_resource_slots: JSONString
   allowed_vfolder_hosts: JSONString
   allowed_docker_registries: [String]
-  integration_id: String
+  integration_name: String
   dotfiles: Bytes
   sgroups_to_add: [String]
   sgroups_to_remove: [String]
@@ -8466,7 +8466,7 @@ input ModifyGroupInput
   user_update_mode: String
   user_uuids: [String]
   allowed_vfolder_hosts: JSONString
-  integration_id: String
+  integration_name: String
   resource_policy: String
 
   """Added in 24.03.0"""

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectSettingModal.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectSettingModal.tsx
@@ -50,7 +50,7 @@ interface FormValues {
   domain_name: string;
   total_resource_slots?: string;
   allowed_vfolder_hosts?: string;
-  integration_id?: string;
+  integration_name?: string;
   resource_policy?: string;
   container_registry?: string;
   scaling_groups?: string[];
@@ -85,7 +85,7 @@ const BAIProjectSettingModal = ({
         domain_name
         total_resource_slots
         allowed_vfolder_hosts
-        integration_id
+        integration_name
         resource_policy
         type
         container_registry

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.stories.tsx
@@ -62,7 +62,7 @@ const meta: Meta<typeof BAIProjectTable> = {
 - **Scaling Groups**: Associated scaling groups
 - **Container Registry**: Registry and project details
 - **Project ID**: Global ID (sortable, copyable)
-- **Integration ID**: External integration ID
+- **Integration Name**: External integration name
 
 For other props (loading, pagination, etc.), refer to [BAITable](?path=/docs/table-baitable--docs).
         `,
@@ -199,7 +199,7 @@ const generateMockProject = (id: number, overrides = {}) => ({
     mem: `${(id + 1) * 8}g`,
     'cuda.device': `${id % 3}`,
   }),
-  integration_id: id % 2 === 0 ? `integration-${id}` : null,
+  integration_name: id % 2 === 0 ? `integration-${id}` : null,
   resource_policy: `user-policy-${id}`,
   type: id % 5 === 0 ? 'MODEL_STORE' : 'GENERAL',
   container_registry: JSON.stringify({

--- a/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIProjectTable.tsx
@@ -76,7 +76,7 @@ const BAIProjectTable = ({
         is_active
         created_at
         total_resource_slots
-        integration_id
+        integration_name
         resource_policy
         type
         container_registry
@@ -379,9 +379,9 @@ const BAIProjectTable = ({
       sorter: isEnableSorter('id'),
     },
     {
-      key: 'integration_id',
-      title: t('comp:BAIProjectTable.IntegrationID'),
-      dataIndex: 'integration_id',
+      key: 'integration_name',
+      title: t('comp:BAIProjectTable.IntegrationName'),
+      dataIndex: 'integration_name',
       render: (value) => value || '-',
     },
   ];

--- a/packages/backend.ai-ui/src/locale/de.json
+++ b/packages/backend.ai-ui/src/locale/de.json
@@ -187,7 +187,7 @@
     "Domain": "Domäne",
     "FailedToDeactivateProject": "Fehler beim Deaktivieren des Projekts.",
     "FailedToPurgeProject": "Fehler beim Bereinigen des Projekts.",
-    "IntegrationID": "Integrations‑ID",
+    "IntegrationName": "Integrationsname",
     "IsActive": "Aktiv",
     "Name": "Name",
     "Project": "Projekt",

--- a/packages/backend.ai-ui/src/locale/el.json
+++ b/packages/backend.ai-ui/src/locale/el.json
@@ -187,7 +187,7 @@
     "Domain": "Τομέας",
     "FailedToDeactivateProject": "Η απενεργοποίηση του έργου απέτυχε.",
     "FailedToPurgeProject": "Αποτυχία εκκαθάρισης του έργου.",
-    "IntegrationID": "ID ενσωμάτωσης",
+    "IntegrationName": "Όνομα ενσωμάτωσης",
     "IsActive": "Ενεργό",
     "Name": "Όνομα",
     "Project": "Έργο",

--- a/packages/backend.ai-ui/src/locale/en.json
+++ b/packages/backend.ai-ui/src/locale/en.json
@@ -190,7 +190,7 @@
     "Domain": "Domain",
     "FailedToDeactivateProject": "Failed to deactivate the project.",
     "FailedToPurgeProject": "Failed to purge the project.",
-    "IntegrationID": "Integration ID",
+    "IntegrationName": "Integration Name",
     "IsActive": "Active",
     "Name": "Name",
     "Project": "Project",

--- a/packages/backend.ai-ui/src/locale/es.json
+++ b/packages/backend.ai-ui/src/locale/es.json
@@ -187,7 +187,7 @@
     "Domain": "Dominio",
     "FailedToDeactivateProject": "No se pudo desactivar el proyecto.",
     "FailedToPurgeProject": "No se pudo purgar el proyecto.",
-    "IntegrationID": "ID de integración",
+    "IntegrationName": "Nombre de integración",
     "IsActive": "Activo",
     "Name": "Nombre",
     "Project": "Proyecto",

--- a/packages/backend.ai-ui/src/locale/fi.json
+++ b/packages/backend.ai-ui/src/locale/fi.json
@@ -187,7 +187,7 @@
     "Domain": "Toimialue",
     "FailedToDeactivateProject": "Projektin poistaminen käytöstä epäonnistui.",
     "FailedToPurgeProject": "Projektin tyhjennys epäonnistui.",
-    "IntegrationID": "Integraation tunnus",
+    "IntegrationName": "Integraation nimi",
     "IsActive": "Aktiivinen",
     "Name": "Nimi",
     "Project": "Projekti",

--- a/packages/backend.ai-ui/src/locale/fr.json
+++ b/packages/backend.ai-ui/src/locale/fr.json
@@ -187,7 +187,7 @@
     "Domain": "Domaine",
     "FailedToDeactivateProject": "Impossible de désactiver le projet.",
     "FailedToPurgeProject": "Échec de la purge du projet.",
-    "IntegrationID": "ID d'intégration",
+    "IntegrationName": "Nom d'intégration",
     "IsActive": "Actif",
     "Name": "Nom",
     "Project": "Projet",

--- a/packages/backend.ai-ui/src/locale/id.json
+++ b/packages/backend.ai-ui/src/locale/id.json
@@ -187,7 +187,7 @@
     "Domain": "Domain",
     "FailedToDeactivateProject": "Gagal menonaktifkan proyek.",
     "FailedToPurgeProject": "Gagal menghapus proyek secara permanen.",
-    "IntegrationID": "ID Integrasi",
+    "IntegrationName": "Nama Integrasi",
     "IsActive": "Aktif",
     "Name": "Nama",
     "Project": "Proyek",

--- a/packages/backend.ai-ui/src/locale/it.json
+++ b/packages/backend.ai-ui/src/locale/it.json
@@ -187,7 +187,7 @@
     "Domain": "Dominio",
     "FailedToDeactivateProject": "Impossibile disattivare il progetto.",
     "FailedToPurgeProject": "Impossibile eliminare definitivamente il progetto.",
-    "IntegrationID": "ID integrazione",
+    "IntegrationName": "Nome integrazione",
     "IsActive": "Attivo",
     "Name": "Nome",
     "Project": "Progetto",

--- a/packages/backend.ai-ui/src/locale/ja.json
+++ b/packages/backend.ai-ui/src/locale/ja.json
@@ -187,7 +187,7 @@
     "Domain": "ドメイン",
     "FailedToDeactivateProject": "プロジェクトの無効化に失敗しました。",
     "FailedToPurgeProject": "プロジェクトの完全削除に失敗しました。",
-    "IntegrationID": "連携ID",
+    "IntegrationName": "連携名",
     "IsActive": "アクティブ",
     "Name": "名前",
     "Project": "プロジェクト",

--- a/packages/backend.ai-ui/src/locale/ko.json
+++ b/packages/backend.ai-ui/src/locale/ko.json
@@ -190,7 +190,7 @@
     "Domain": "도메인",
     "FailedToDeactivateProject": "프로젝트 비활성화에 실패했습니다.",
     "FailedToPurgeProject": "프로젝트 삭제에 실패했습니다.",
-    "IntegrationID": "통합 ID",
+    "IntegrationName": "통합 이름",
     "IsActive": "활성",
     "Name": "이름",
     "Project": "프로젝트",

--- a/packages/backend.ai-ui/src/locale/mn.json
+++ b/packages/backend.ai-ui/src/locale/mn.json
@@ -187,7 +187,7 @@
     "Domain": "Домен",
     "FailedToDeactivateProject": "Төслийг идэвхгүй болгоход амжилтгүй боллоо.",
     "FailedToPurgeProject": "Төслийг бүрмөсөн устгахад амжилтгүй боллоо.",
-    "IntegrationID": "Интеграцийн ID",
+    "IntegrationName": "Интеграцийн нэр",
     "IsActive": "Идэвхтэй",
     "Name": "Нэр",
     "Project": "Төсөл",

--- a/packages/backend.ai-ui/src/locale/ms.json
+++ b/packages/backend.ai-ui/src/locale/ms.json
@@ -187,7 +187,7 @@
     "Domain": "Domain",
     "FailedToDeactivateProject": "Gagal menyahaktifkan projek.",
     "FailedToPurgeProject": "Gagal memadam projek.",
-    "IntegrationID": "ID Integrasi",
+    "IntegrationName": "Nama Integrasi",
     "IsActive": "Aktif",
     "Name": "Nama",
     "Project": "Projek",

--- a/packages/backend.ai-ui/src/locale/pl.json
+++ b/packages/backend.ai-ui/src/locale/pl.json
@@ -187,7 +187,7 @@
     "Domain": "Domena",
     "FailedToDeactivateProject": "Nie udało się dezaktywować projektu.",
     "FailedToPurgeProject": "Nie udało się trwale usunąć projektu.",
-    "IntegrationID": "ID integracji",
+    "IntegrationName": "Nazwa integracji",
     "IsActive": "Aktywny",
     "Name": "Nazwa",
     "Project": "Projekt",

--- a/packages/backend.ai-ui/src/locale/pt-BR.json
+++ b/packages/backend.ai-ui/src/locale/pt-BR.json
@@ -186,7 +186,7 @@
     "Domain": "Domínio",
     "FailedToDeactivateProject": "Falha ao desativar o projeto.",
     "FailedToPurgeProject": "Não foi possível purgar o projeto.",
-    "IntegrationID": "ID da Integração",
+    "IntegrationName": "Nome da Integração",
     "IsActive": "Ativo",
     "Name": "Nome",
     "Project": "Projeto",

--- a/packages/backend.ai-ui/src/locale/pt.json
+++ b/packages/backend.ai-ui/src/locale/pt.json
@@ -187,7 +187,7 @@
     "Domain": "Domínio",
     "FailedToDeactivateProject": "Falha ao desativar o projeto.",
     "FailedToPurgeProject": "Não foi possível purgar o projeto.",
-    "IntegrationID": "ID da Integração",
+    "IntegrationName": "Nome da Integração",
     "IsActive": "Ativo",
     "Name": "Nome",
     "Project": "Projeto",

--- a/packages/backend.ai-ui/src/locale/ru.json
+++ b/packages/backend.ai-ui/src/locale/ru.json
@@ -187,7 +187,7 @@
     "Domain": "Домен",
     "FailedToDeactivateProject": "Не удалось деактивировать проект.",
     "FailedToPurgeProject": "Не удалось очистить проект.",
-    "IntegrationID": "ID интеграции",
+    "IntegrationName": "Имя интеграции",
     "IsActive": "Активный",
     "Name": "Имя",
     "Project": "Проект",

--- a/packages/backend.ai-ui/src/locale/th.json
+++ b/packages/backend.ai-ui/src/locale/th.json
@@ -187,7 +187,7 @@
     "Domain": "โดเมน",
     "FailedToDeactivateProject": "ไม่สามารถปิดใช้งานโปรเจ็กต์ได้",
     "FailedToPurgeProject": "ไม่สามารถล้างโปรเจกต์ได้",
-    "IntegrationID": "รหัสการผสานระบบ",
+    "IntegrationName": "ชื่อการผสานระบบ",
     "IsActive": "ใช้งาน",
     "Name": "ชื่อ",
     "Project": "โปรเจ็กต์",

--- a/packages/backend.ai-ui/src/locale/tr.json
+++ b/packages/backend.ai-ui/src/locale/tr.json
@@ -187,7 +187,7 @@
     "Domain": "Etki Alanı",
     "FailedToDeactivateProject": "Proje devre dışı bırakılamadı.",
     "FailedToPurgeProject": "Proje temizlenemedi.",
-    "IntegrationID": "Entegrasyon Kimliği",
+    "IntegrationName": "Entegrasyon Adı",
     "IsActive": "Aktif",
     "Name": "Ad",
     "Project": "Proje",

--- a/packages/backend.ai-ui/src/locale/vi.json
+++ b/packages/backend.ai-ui/src/locale/vi.json
@@ -187,7 +187,7 @@
     "Domain": "Miền",
     "FailedToDeactivateProject": "Không thể vô hiệu hóa dự án.",
     "FailedToPurgeProject": "Không thể xóa hoàn toàn dự án.",
-    "IntegrationID": "ID tích hợp",
+    "IntegrationName": "Tên tích hợp",
     "IsActive": "Hoạt động",
     "Name": "Tên",
     "Project": "Dự án",

--- a/packages/backend.ai-ui/src/locale/zh-CN.json
+++ b/packages/backend.ai-ui/src/locale/zh-CN.json
@@ -187,7 +187,7 @@
     "Domain": "域",
     "FailedToDeactivateProject": "无法停用该项目。",
     "FailedToPurgeProject": "无法清除该项目。",
-    "IntegrationID": "集成 ID",
+    "IntegrationName": "集成名称",
     "IsActive": "活跃",
     "Name": "名称",
     "Project": "项目",

--- a/packages/backend.ai-ui/src/locale/zh-TW.json
+++ b/packages/backend.ai-ui/src/locale/zh-TW.json
@@ -187,7 +187,7 @@
     "Domain": "網域",
     "FailedToDeactivateProject": "無法停用專案。",
     "FailedToPurgeProject": "無法清除專案。",
-    "IntegrationID": "整合識別碼",
+    "IntegrationName": "整合名稱",
     "IsActive": "啟用",
     "Name": "名稱",
     "Project": "專案",

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -4363,7 +4363,7 @@ class Domain {
    * Get domain information.
    * @param {string} domain_name - domain name of group
    * @param {array} fields - fields to query.  Default fields are: ['name', 'description', 'is_active', 'created_at', 'modified_at', 'total_resource_slots', 'allowed_vfolder_hosts',
-   'allowed_docker_registries', 'integration_id', 'scaling_groups']
+   'allowed_docker_registries', 'integration_name', 'scaling_groups']
    * {
    *   'name': String,          // Group name.
    *   'description': String,   // Description for group.
@@ -4373,7 +4373,7 @@ class Domain {
    *   'total_resource_slots': JSONString,   // Total resource slots
    *   'allowed_vfolder_hosts': [String],   // Allowed virtual folder hosts
    *   'allowed_docker_registries': [String],   // Allowed docker registry lists
-   *   'integration_id': [String],   // Integration ids
+   *   'integration_name': [String],   // Integration ids
    *   'scaling_groups': [String],   // Scaling groups
    * };
    */
@@ -4388,7 +4388,7 @@ class Domain {
       'total_resource_slots',
       'allowed_vfolder_hosts',
       'allowed_docker_registries',
-      'integration_id',
+      'integration_name',
       'scaling_groups',
     ],
   ): Promise<any> {
@@ -4412,7 +4412,7 @@ class Domain {
       'total_resource_slots',
       'allowed_vfolder_hosts',
       'allowed_docker_registries',
-      'integration_id',
+      'integration_name',
     ],
   ): Promise<any> {
     let q = `query {` + ` domains { ${fields.join(' ')} }` + `}`;
@@ -4436,13 +4436,13 @@ class Domain {
    *   'total_resource_slots': JSOONString,   // Total resource slots
    *   'allowed_vfolder_hosts': [String],   // Allowed virtual folder hosts
    *   'allowed_docker_registries': [String],   // Allowed docker registry lists
-   *   'integration_id': [String],   // Integration ids
+   *   'integration_name': [String],   // Integration ids
    *   'scaling_groups': [String],   // Scaling groups
    * };
    */
   async update(domain_name = false, input): Promise<any> {
     //let fields = ['name', 'description', 'is_active', 'created_at', 'modified_at', 'total_resource_slots', 'allowed_vfolder_hosts',
-    //  'allowed_docker_registries', 'integration_id', 'scaling_groups'];
+    //  'allowed_docker_registries', 'integration_name', 'scaling_groups'];
     if (this.client.is_superadmin === true) {
       let q =
         `mutation($name: String!, $input: ModifyDomainInput!) {` +

--- a/src/lib/backend.ai-client-node.ts
+++ b/src/lib/backend.ai-client-node.ts
@@ -3604,7 +3604,7 @@ class Domain {
    * Get domain information.
    * @param {string} domain_name - domain name of group
    * @param {array} fields - fields to query.  Default fields are: ['name', 'description', 'is_active', 'created_at', 'modified_at', 'total_resource_slots', 'allowed_vfolder_hosts',
-   'allowed_docker_registries', 'integration_id', 'scaling_groups']
+   'allowed_docker_registries', 'integration_name', 'scaling_groups']
    * {
    *   'name': String,          // Group name.
    *   'description': String,   // Description for group.
@@ -3614,7 +3614,7 @@ class Domain {
    *   'total_resource_slots': JSOONString,   // Total resource slots
    *   'allowed_vfolder_hosts': [String],   // Allowed virtual folder hosts
    *   'allowed_docker_registries': [String],   // Allowed docker registry lists
-   *   'integration_id': [String],   // Integration ids
+   *   'integration_name': [String],   // Integration ids
    *   'scaling_groups': [String],   // Scaling groups
    * };
    */
@@ -3629,7 +3629,7 @@ class Domain {
       'total_resource_slots',
       'allowed_vfolder_hosts',
       'allowed_docker_registries',
-      'integration_id',
+      'integration_name',
       'scaling_groups',
     ],
   ) {
@@ -3653,7 +3653,7 @@ class Domain {
       'total_resource_slots',
       'allowed_vfolder_hosts',
       'allowed_docker_registries',
-      'integration_id',
+      'integration_name',
     ],
   ) {
     let q = `query {` + ` domains { ${fields.join(' ')} }` + `}`;
@@ -3677,13 +3677,13 @@ class Domain {
    *   'total_resource_slots': JSONString,   // Total resource slots
    *   'allowed_vfolder_hosts': [String],   // Allowed virtual folder hosts
    *   'allowed_docker_registries': [String],   // Allowed docker registry lists
-   *   'integration_id': [String],   // Integration ids
+   *   'integration_name': [String],   // Integration ids
    *   'scaling_groups': [String],   // Scaling groups
    * };
    */
   async update(domain_name = false, input) {
     //let fields = ['name', 'description', 'is_active', 'created_at', 'modified_at', 'total_resource_slots', 'allowed_vfolder_hosts',
-    //  'allowed_docker_registries', 'integration_id', 'scaling_groups'];
+    //  'allowed_docker_registries', 'integration_name', 'scaling_groups'];
     if (this.client.is_superadmin === true) {
       let q =
         `mutation($name: String!, $input: ModifyDomainInput!) {` +


### PR DESCRIPTION
resolves #6331 (FR-2437)

## Summary
- Rename `integration_id` field to `integration_name` across the frontend to match backend schema change
- Update GraphQL schema, Relay fragments, and regenerated types
- Update client SDK field arrays and JSDoc comments
- Update i18n keys and translations across all 21 locale files
- Update storybook mock data and docs

## Verification
```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```

## Test plan
- [ ] Verify project table displays integration name column correctly
- [ ] Verify project settings modal handles integration_name field
- [ ] Verify translations render correctly for all supported languages