### PR TITLE
fix: update e2e tests for renamed resource policy modal titles

### DIFF
--- a/e2e/resource-policy/resource-policy.spec.ts
+++ b/e2e/resource-policy/resource-policy.spec.ts
@@ -61,9 +61,9 @@ test.describe(
         // Click Create button
         await page.getByRole('button', { name: 'Create' }).click();
 
-        // Verify Create Resource Policy dialog appears
+        // Verify Create Keypair Resource Policy dialog appears
         const modal = page.getByRole('dialog', {
-          name: 'Create Resource Policy',
+          name: 'Create Keypair Resource Policy',
         });
         await expect(modal).toBeVisible();
 
@@ -186,7 +186,7 @@ test.describe(
 
         // Verify dialog appears
         const modal = page.getByRole('dialog', {
-          name: 'Create Resource Policy',
+          name: 'Create User Resource Policy',
         });
         await expect(modal).toBeVisible();
 


### PR DESCRIPTION
Stacked on #6315

## Summary
- Update e2e test locators for resource-policy modal titles renamed in #6315
- `Create Resource Policy` -> `Create Keypair Resource Policy` (keypair tab)
- `Create Resource Policy` -> `Create User Resource Policy` (user tab)

## Test plan
- [ ] `npx playwright test e2e/resource-policy/resource-policy.spec.ts` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)