### PR TITLE
feat(FR-2440): add CLI command parser utility for Paste Your Command

### DIFF
--- a/.specs/paste-your-command/.context/findings.md
+++ b/.specs/paste-your-command/.context/findings.md
@@ -1,0 +1,11 @@
+# Paste Your Command Findings
+
+## Decisions
+| Date | Decision | Rationale | Issue |
+|------|----------|-----------|-------|
+
+## Discoveries
+
+## Issues Encountered
+| Date | Problem | Root Cause | Resolution | Issue |
+|------|---------|-----------|------------|-------|

--- a/.specs/paste-your-command/.context/progress.md
+++ b/.specs/paste-your-command/.context/progress.md
@@ -1,0 +1,20 @@
+# Paste Your Command Progress
+
+## Last Session: 2026-04-02 12:00
+
+### 1. Current Phase
+Planning complete. Ready for Wave 1 implementation.
+
+### 2. Next Action
+Run /batch-implement .specs/paste-your-command/dev-plan.md to start Wave 1.
+
+### 3. Current Goal
+Begin implementation of CLI command parser utility (FR-2440).
+
+### 4. Lessons Learned
+(none yet)
+
+### 5. Completed Work
+- Spec created: .specs/paste-your-command/spec.md
+- Dev plan created: .specs/paste-your-command/dev-plan.md
+- 3 issues created with dependency links (FR-2440, FR-2441, FR-2442)

--- a/.specs/paste-your-command/.context/tasks.md
+++ b/.specs/paste-your-command/.context/tasks.md
@@ -1,0 +1,15 @@
+# Paste Your Command Tasks
+
+> Last synced: 2026-04-02 12:00
+> Source: Jira (FR project)
+
+## Progress: 0/3 complete
+
+### Wave 1
+- [ ] FR-2440: CLI command parser utility for extracting port, runtime, GPU hints, and docker flags -- created
+
+### Wave 2
+- [ ] FR-2441: UI: Segmented control and form fields for Enter Command / Use Config File modes -- blocked by FR-2440
+
+### Wave 3
+- [ ] FR-2442: YAML generation, vfolder upload, and service creation integration for Enter Command mode -- blocked by FR-2440, FR-2441

--- a/.specs/paste-your-command/dev-plan.md
+++ b/.specs/paste-your-command/dev-plan.md
@@ -1,0 +1,82 @@
+# Paste Your Command Dev Plan
+
+## Spec Reference
+`.specs/paste-your-command/spec.md`
+
+## Epic: FR-2438
+
+## Sub-tasks (Implementation Order)
+
+### 1. CLI Command Parser Utility - FR-2440
+- **Changed files**: `react/src/helper/parseCliCommand.ts` (NEW), `react/src/helper/parseCliCommand.test.ts` (NEW)
+- **Dependencies**: None
+- **Review complexity**: High
+- **Description**: Pure TypeScript utility for parsing CLI commands. Extracts runtime type (vllm/sglang/tgi), port (`--port N`), GPU hint (`--tp N`), docker env vars (`-e KEY=VALUE`), docker ports (`-p HOST:CONTAINER`). Includes shell-aware tokenizer for generating `start_command` arrays. All client-side, no external API calls. Unit tests cover all spec parsing examples.
+
+### 2. UI: Segmented Control + Form Fields - FR-2441
+- **Changed files**: `react/src/components/ServiceLauncherPageContent.tsx`, `resources/i18n/en.json`, `resources/i18n/ko.json`
+- **Dependencies**: Sub-task 1 (FR-2440 blocks FR-2441)
+- **Review complexity**: Medium
+- **Description**: Add Ant Design Segmented component to Model Definition area when CUSTOM variant is selected. "Enter Command" (default) shows Start Command textarea + Port/Health Check/Model Mount fields with auto-fill from parser (debounced). "Use Config File" shows existing UI unchanged. GPU hint displayed near resource section. Only visible in create mode (not edit). Docker env vars auto-added to envvars form list.
+
+### 3. YAML Generation + vFolder Upload + Service Creation Integration - FR-2442
+- **Changed files**: `react/src/helper/generateModelDefinitionYaml.ts` (NEW), `react/src/components/ServiceLauncherPageContent.tsx`
+- **Dependencies**: Sub-task 1 (FR-2440 blocks FR-2442), Sub-task 2 (FR-2441 blocks FR-2442)
+- **Review complexity**: High
+- **Description**: On [Create Service] click in "Enter Command" mode: generate model-definition.yaml from form values, check vfolder for existing file (confirm overwrite), upload via tus, then call POST /services. Upload failure aborts service creation. `model_definition_path` auto-set to `"model-definition.yaml"`, `runtime_variant` always `"custom"`.
+
+## PR Stack Strategy
+- Sequential: FR-2440 -> FR-2441 -> FR-2442 (each builds on the previous)
+- Branch pattern: `feature/paste-your-command-{subtask-slug}`
+  - `feature/paste-your-command-cli-parser`
+  - `feature/paste-your-command-ui-segmented`
+  - `feature/paste-your-command-yaml-upload`
+
+## Dependency Graph
+```
+FR-2440 (CLI Parser)
+   |
+   +--blocks--> FR-2441 (UI: Segmented + Form Fields)
+   |                |
+   +--blocks--------+--blocks--> FR-2442 (YAML Gen + Upload + Integration)
+```
+
+## Implementation Notes
+
+### Key Design Decisions from Spec
+- **D1**: API `runtime_variant` is always `"custom"` even if vLLM detected (only CUSTOM reads `start_command` from yaml)
+- **D2**: CLI flags stay in `start_command`, no env var mapping (except explicit `docker -e`)
+- **D3**: yaml upload + service creation in 1 step (no separate "Apply" button)
+- **D5**: Minimal parsing only (`--port`, `--tp`, runtime detection from first token)
+- **D6**: Detected runtime name NOT shown in UI (internal hint only)
+- **D7**: Create mode only (not edit mode)
+
+### Existing Code Integration Points
+- `ServiceLauncherPageContent.tsx` lines 1041-1088: current CUSTOM variant UI (replace with Segmented)
+- `ServiceLauncherPageContent.tsx` lines 400-486: `mutationToCreateService` (insert yaml upload before POST)
+- `baiClient.vfolder.list_files('.',vfolderId)`: check existing yaml
+- `baiClient.vfolder.create_upload_session()`: tus upload for yaml file
+- `EnvVarFormList`: receives docker-extracted env vars via `form.setFieldValue('envvars', ...)`
+
+### yaml Schema Target
+```yaml
+models:
+  - name: "model-name"
+    model_path: "/models"
+    service:
+      start_command:
+        - vllm
+        - serve
+        - /models/my-model
+        - --tensor-parallel-size
+        - "2"
+      port: 8000
+      health_check:
+        path: /health
+        initial_delay: 5.0
+        max_retries: 10
+```
+
+### Risks
+- **tus upload for small files**: Existing code in `VFolderTextFileEditorModal.tsx` shows a workaround for 0-byte files with tus; yaml files will be small but non-zero, so standard tus flow should work. Verify during implementation.
+- **js-yaml dependency**: May need to add `js-yaml` package, or use manual string construction to avoid new dependency. Evaluate during FR-2442.

--- a/react/src/helper/parseCliCommand.test.ts
+++ b/react/src/helper/parseCliCommand.test.ts
@@ -1,0 +1,318 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { parseCliCommand, tokenizeShellCommand } from './parseCliCommand';
+
+describe('tokenizeShellCommand', () => {
+  it('should split basic whitespace-separated tokens', () => {
+    expect(tokenizeShellCommand('vllm serve /models/my-model')).toEqual([
+      'vllm',
+      'serve',
+      '/models/my-model',
+    ]);
+  });
+
+  it('should handle double-quoted strings', () => {
+    expect(tokenizeShellCommand('echo "hello world"')).toEqual([
+      'echo',
+      'hello world',
+    ]);
+  });
+
+  it('should handle single-quoted strings', () => {
+    expect(tokenizeShellCommand("echo 'hello world'")).toEqual([
+      'echo',
+      'hello world',
+    ]);
+  });
+
+  it('should handle escaped spaces', () => {
+    expect(tokenizeShellCommand('echo hello\\ world')).toEqual([
+      'echo',
+      'hello world',
+    ]);
+  });
+
+  it('should handle multiple spaces and tabs', () => {
+    expect(tokenizeShellCommand('a   b\tc')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should handle empty input', () => {
+    expect(tokenizeShellCommand('')).toEqual([]);
+  });
+
+  it('should handle multiline input', () => {
+    expect(tokenizeShellCommand('vllm serve\n  --tp 2')).toEqual([
+      'vllm',
+      'serve',
+      '--tp',
+      '2',
+    ]);
+  });
+});
+
+describe('parseCliCommand', () => {
+  describe('empty/blank input', () => {
+    it('should return defaults for empty string', () => {
+      const result = parseCliCommand('');
+      expect(result.runtime).toBe('unknown');
+      expect(result.port).toBe(8000);
+      expect(result.healthCheckPath).toBe('/health');
+      expect(result.modelMountDestination).toBe('/models');
+      expect(result.gpuHint).toBeNull();
+      expect(result.envVars).toEqual([]);
+      expect(result.startCommandTokens).toEqual([]);
+    });
+
+    it('should return defaults for whitespace-only string', () => {
+      const result = parseCliCommand('   ');
+      expect(result.startCommandTokens).toEqual([]);
+    });
+  });
+
+  describe('vllm runtime detection', () => {
+    it('should detect vllm serve command', () => {
+      const result = parseCliCommand(
+        'vllm serve /models/my-model --tensor-parallel-size 2 --quantization awq --port 8080',
+      );
+      expect(result.runtime).toBe('vllm');
+      expect(result.port).toBe(8080);
+      expect(result.healthCheckPath).toBe('/health');
+      expect(result.gpuHint).toBe(2);
+    });
+
+    it('should use vllm default port when --port is not specified', () => {
+      const result = parseCliCommand('vllm serve /models/my-model');
+      expect(result.runtime).toBe('vllm');
+      expect(result.port).toBe(8000);
+    });
+
+    it('should detect python -m vllm', () => {
+      const result = parseCliCommand(
+        'python -m vllm.entrypoints.openai.api_server --model /models/my-model',
+      );
+      expect(result.runtime).toBe('vllm');
+    });
+  });
+
+  describe('sglang runtime detection', () => {
+    it('should detect sglang via python -m', () => {
+      const result = parseCliCommand(
+        'python -m sglang.launch_server --model /models/llama --tp 4 --port 9001',
+      );
+      expect(result.runtime).toBe('sglang');
+      expect(result.port).toBe(9001);
+      expect(result.healthCheckPath).toBe('/health');
+      expect(result.gpuHint).toBe(4);
+    });
+
+    it('should use sglang default port', () => {
+      const result = parseCliCommand(
+        'python -m sglang.launch_server --model /models/llama',
+      );
+      expect(result.runtime).toBe('sglang');
+      expect(result.port).toBe(9001);
+    });
+  });
+
+  describe('TGI runtime detection', () => {
+    it('should detect text-generation-launcher', () => {
+      const result = parseCliCommand(
+        'text-generation-launcher --model-id /models/my-model --port 3000',
+      );
+      expect(result.runtime).toBe('tgi');
+      expect(result.port).toBe(3000);
+      expect(result.healthCheckPath).toBe('/info');
+    });
+
+    it('should use tgi default port', () => {
+      const result = parseCliCommand(
+        'text-generation-launcher --model-id /models/my-model',
+      );
+      expect(result.port).toBe(3000);
+    });
+  });
+
+  describe('unknown runtime', () => {
+    it('should use generic defaults for unrecognized commands', () => {
+      const result = parseCliCommand('./run.sh');
+      expect(result.runtime).toBe('unknown');
+      expect(result.port).toBe(8000);
+      expect(result.healthCheckPath).toBe('/health');
+      expect(result.gpuHint).toBeNull();
+    });
+
+    it('should still extract --port from unknown commands', () => {
+      const result = parseCliCommand(
+        'python my_server.py --port 8000 --workers 4',
+      );
+      expect(result.runtime).toBe('unknown');
+      expect(result.port).toBe(8000);
+    });
+  });
+
+  describe('port extraction', () => {
+    it('should extract --port N', () => {
+      const result = parseCliCommand('vllm serve --port 9090');
+      expect(result.port).toBe(9090);
+    });
+
+    it('should extract --port=N', () => {
+      const result = parseCliCommand('vllm serve --port=9090');
+      expect(result.port).toBe(9090);
+    });
+  });
+
+  describe('GPU hint extraction', () => {
+    it('should extract --tp N', () => {
+      const result = parseCliCommand('vllm serve --tp 4');
+      expect(result.gpuHint).toBe(4);
+    });
+
+    it('should extract --tensor-parallel-size N', () => {
+      const result = parseCliCommand('vllm serve --tensor-parallel-size 8');
+      expect(result.gpuHint).toBe(8);
+    });
+
+    it('should extract --tp=N', () => {
+      const result = parseCliCommand('vllm serve --tp=2');
+      expect(result.gpuHint).toBe(2);
+    });
+
+    it('should return null when no GPU flags', () => {
+      const result = parseCliCommand('vllm serve /models/my-model');
+      expect(result.gpuHint).toBeNull();
+    });
+  });
+
+  describe('docker run parsing', () => {
+    it('should extract env vars and container port', () => {
+      const result = parseCliCommand(
+        'docker run -e MY_VAR=hello -p 9090:8080 my-image:latest python serve.py',
+      );
+      expect(result.port).toBe(8080);
+      expect(result.envVars).toEqual([{ variable: 'MY_VAR', value: 'hello' }]);
+      expect(result.effectiveCommand).toBe('python serve.py');
+    });
+
+    it('should handle docker run with --rm and -d flags', () => {
+      const result = parseCliCommand(
+        'docker run --rm -d -e KEY=val -p 8080:3000 myimage cmd arg',
+      );
+      expect(result.port).toBe(3000);
+      expect(result.envVars).toEqual([{ variable: 'KEY', value: 'val' }]);
+      expect(result.effectiveCommand).toBe('cmd arg');
+    });
+
+    it('should handle multiple -e flags', () => {
+      const result = parseCliCommand(
+        'docker run -e A=1 -e B=2 -e C=3 myimage run',
+      );
+      expect(result.envVars).toHaveLength(3);
+      expect(result.envVars[0]).toEqual({ variable: 'A', value: '1' });
+      expect(result.envVars[1]).toEqual({ variable: 'B', value: '2' });
+      expect(result.envVars[2]).toEqual({ variable: 'C', value: '3' });
+    });
+
+    it('should handle docker run with no command after image', () => {
+      const result = parseCliCommand('docker run -p 8080:8000 my-image:latest');
+      expect(result.port).toBe(8000);
+      expect(result.effectiveCommand).toBe('');
+    });
+
+    it('should detect runtime inside docker command', () => {
+      const result = parseCliCommand(
+        'docker run --gpus all -p 8080:8000 vllm/vllm:latest vllm serve /models/my-model --tp 2',
+      );
+      expect(result.runtime).toBe('vllm');
+      expect(result.gpuHint).toBe(2);
+    });
+
+    it('should handle podman as docker alias', () => {
+      const result = parseCliCommand(
+        'podman run -e MY_VAR=val -p 9090:8080 myimage cmd',
+      );
+      expect(result.port).toBe(8080);
+      expect(result.envVars).toEqual([{ variable: 'MY_VAR', value: 'val' }]);
+    });
+  });
+
+  describe('start_command tokenization', () => {
+    it('should tokenize command into array for yaml', () => {
+      const result = parseCliCommand(
+        'vllm serve /models/my-model --tensor-parallel-size 2',
+      );
+      expect(result.startCommandTokens).toEqual([
+        'vllm',
+        'serve',
+        '/models/my-model',
+        '--tensor-parallel-size',
+        '2',
+      ]);
+    });
+
+    it('should use effective command tokens for docker', () => {
+      const result = parseCliCommand(
+        'docker run -p 8080:8000 myimage vllm serve /models/m --tp 2',
+      );
+      expect(result.startCommandTokens).toEqual([
+        'vllm',
+        'serve',
+        '/models/m',
+        '--tp',
+        '2',
+      ]);
+    });
+  });
+
+  describe('spec acceptance criteria examples', () => {
+    it('vllm with port override and TP', () => {
+      const r = parseCliCommand(
+        'vllm serve /models/my-model --tensor-parallel-size 2 --quantization awq --port 8080',
+      );
+      expect(r.port).toBe(8080);
+      expect(r.healthCheckPath).toBe('/health');
+      expect(r.gpuHint).toBe(2);
+    });
+
+    it('sglang with TP and port', () => {
+      const r = parseCliCommand(
+        'python -m sglang.launch_server --model /models/llama --tp 4 --port 9001',
+      );
+      expect(r.port).toBe(9001);
+      expect(r.healthCheckPath).toBe('/health');
+      expect(r.gpuHint).toBe(4);
+    });
+
+    it('TGI with port', () => {
+      const r = parseCliCommand(
+        'text-generation-launcher --model-id /models/my-model --port 3000',
+      );
+      expect(r.port).toBe(3000);
+      expect(r.healthCheckPath).toBe('/info');
+    });
+
+    it('docker with env and port mapping', () => {
+      const r = parseCliCommand(
+        'docker run -e MY_VAR=hello -p 9090:8080 my-image:latest python serve.py',
+      );
+      expect(r.port).toBe(8080);
+      expect(r.envVars).toEqual([{ variable: 'MY_VAR', value: 'hello' }]);
+      expect(r.effectiveCommand).toBe('python serve.py');
+    });
+
+    it('python script with port', () => {
+      const r = parseCliCommand('python my_server.py --port 8000 --workers 4');
+      expect(r.port).toBe(8000);
+      expect(r.healthCheckPath).toBe('/health');
+    });
+
+    it('unrecognized script with defaults', () => {
+      const r = parseCliCommand('./run.sh');
+      expect(r.port).toBe(8000);
+      expect(r.healthCheckPath).toBe('/health');
+      expect(r.gpuHint).toBeNull();
+    });
+  });
+});

--- a/react/src/helper/parseCliCommand.ts
+++ b/react/src/helper/parseCliCommand.ts
@@ -1,0 +1,442 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+/**
+ * CLI command parser for the "Paste Your Command" feature.
+ *
+ * Parses CLI commands (vllm serve, sglang, docker run, etc.) and extracts:
+ * - Runtime type (for port/health-check defaults)
+ * - Port number (from --port flag or docker -p)
+ * - GPU hint (from --tp / --tensor-parallel-size)
+ * - Docker env vars (from -e KEY=VALUE)
+ * - Shell-tokenized start_command array
+ *
+ * All parsing is client-side with no external API calls (closed-network compatible).
+ */
+
+export type DetectedRuntime = 'vllm' | 'sglang' | 'tgi' | 'unknown';
+
+export interface RuntimeDefaults {
+  port: number;
+  healthCheckPath: string;
+}
+
+export interface ParsedCliCommand {
+  /** Detected runtime type (internal hint, not shown in UI) */
+  runtime: DetectedRuntime;
+  /** Port number: from --port flag, docker -p, or runtime default */
+  port: number;
+  /** Health check path based on detected runtime */
+  healthCheckPath: string;
+  /** Model mount destination (always /models for now) */
+  modelMountDestination: string;
+  /** GPU count hint from --tp / --tensor-parallel-size (null if not found) */
+  gpuHint: number | null;
+  /** Environment variables extracted from docker -e flags */
+  envVars: Array<{ variable: string; value: string }>;
+  /** Shell-tokenized command for model-definition.yaml start_command */
+  startCommandTokens: string[];
+  /** The actual command to execute (docker run arguments stripped) */
+  effectiveCommand: string;
+}
+
+const RUNTIME_DEFAULTS: Record<DetectedRuntime, RuntimeDefaults> = {
+  vllm: { port: 8000, healthCheckPath: '/health' },
+  sglang: { port: 9001, healthCheckPath: '/health' },
+  tgi: { port: 3000, healthCheckPath: '/info' },
+  unknown: { port: 8000, healthCheckPath: '/health' },
+};
+
+/**
+ * Tokenize a shell command string into an array of tokens.
+ * Handles single quotes, double quotes, and escaped characters.
+ */
+export function tokenizeShellCommand(input: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  let escaped = false;
+  let wasQuoted = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+
+    if (ch === '\\' && !inSingle) {
+      escaped = true;
+      continue;
+    }
+
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+      wasQuoted = true;
+      continue;
+    }
+
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+      wasQuoted = true;
+      continue;
+    }
+
+    if ((ch === ' ' || ch === '\t' || ch === '\n') && !inSingle && !inDouble) {
+      if (current.length > 0 || wasQuoted) {
+        tokens.push(current);
+        current = '';
+        wasQuoted = false;
+      }
+      continue;
+    }
+
+    current += ch;
+  }
+
+  if (current.length > 0 || wasQuoted) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
+/**
+ * Detect the runtime type from the first meaningful token(s) of a command.
+ */
+function detectRuntime(tokens: string[]): DetectedRuntime {
+  if (tokens.length === 0) return 'unknown';
+
+  const first = tokens[0].toLowerCase();
+
+  // Direct binary match
+  if (first === 'vllm' || first.endsWith('/vllm')) return 'vllm';
+  if (first === 'sglang' || first.endsWith('/sglang')) return 'sglang';
+  if (
+    first === 'text-generation-launcher' ||
+    first.endsWith('/text-generation-launcher')
+  )
+    return 'tgi';
+
+  // python -m module
+  if ((first === 'python' || first === 'python3') && tokens[1] === '-m') {
+    const module = tokens[2]?.toLowerCase() ?? '';
+    if (module === 'vllm' || module.startsWith('vllm.')) return 'vllm';
+    if (module === 'sglang' || module.startsWith('sglang.')) return 'sglang';
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Extract --port N or --port=N value from tokens.
+ * Returns null if not found.
+ */
+function extractPort(tokens: string[]): number | null {
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+
+    // --port=N
+    if (tok.startsWith('--port=')) {
+      const val = parseInt(tok.slice(7), 10);
+      if (!isNaN(val) && val > 0 && val <= 65535) return val;
+    }
+
+    // --port N
+    if (tok === '--port' && i + 1 < tokens.length) {
+      const val = parseInt(tokens[i + 1], 10);
+      if (!isNaN(val) && val > 0 && val <= 65535) return val;
+    }
+
+    // -p N (short form, common in some tools)
+    if (tok === '-p' && i + 1 < tokens.length) {
+      // Only treat as port if NOT in docker context (docker -p is host:container)
+      // This is handled separately in parseDockerCommand
+      const val = parseInt(tokens[i + 1], 10);
+      if (!isNaN(val) && val > 0 && val <= 65535) {
+        // Check if the value contains ':' which indicates docker port mapping
+        if (!tokens[i + 1].includes(':')) return val;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract --tensor-parallel-size N, --tp N (and =N variants) for GPU hint.
+ * Returns null if not found.
+ */
+function extractGpuHint(tokens: string[]): number | null {
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+
+    // --tensor-parallel-size=N or --tp=N
+    if (tok.startsWith('--tensor-parallel-size=') || tok.startsWith('--tp=')) {
+      const eqIdx = tok.indexOf('=');
+      const val = parseInt(tok.slice(eqIdx + 1), 10);
+      if (!isNaN(val) && val > 0) return val;
+    }
+
+    // --tensor-parallel-size N or --tp N
+    if (
+      (tok === '--tensor-parallel-size' || tok === '--tp') &&
+      i + 1 < tokens.length
+    ) {
+      const val = parseInt(tokens[i + 1], 10);
+      if (!isNaN(val) && val > 0) return val;
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse docker-specific flags from a `docker run` command.
+ * Returns env vars, container port, and the actual command (after image name).
+ */
+interface DockerParseResult {
+  envVars: Array<{ variable: string; value: string }>;
+  containerPort: number | null;
+  /** The command tokens after stripping docker run flags and image */
+  commandTokens: string[];
+  /** The effective command string */
+  effectiveCommand: string;
+}
+
+function parseDockerCommand(tokens: string[]): DockerParseResult | null {
+  // Check if this is a docker run command
+  if (tokens.length < 2) return null;
+  const first = tokens[0].toLowerCase();
+  if (first !== 'docker' && first !== 'podman') return null;
+  if (tokens[1] !== 'run') return null;
+
+  const envVars: Array<{ variable: string; value: string }> = [];
+  let containerPort: number | null = null;
+  let i = 2; // Skip "docker run"
+
+  // Known docker flags that consume the next token
+  const flagsWithArg = new Set([
+    '-e',
+    '--env',
+    '-p',
+    '--publish',
+    '-v',
+    '--volume',
+    '-w',
+    '--workdir',
+    '--name',
+    '--network',
+    '--runtime',
+    '--gpus',
+    '--shm-size',
+    '--memory',
+    '-m',
+    '--cpus',
+    '--entrypoint',
+    '--user',
+    '-u',
+    '--platform',
+    '--mount',
+    '-l',
+    '--label',
+    '--restart',
+    '--hostname',
+    '-h',
+    '--cap-add',
+    '--cap-drop',
+    '--device',
+    '--log-driver',
+    '--log-opt',
+    '--ulimit',
+  ]);
+
+  // Boolean flags (no argument)
+  const booleanFlags = new Set([
+    '--init',
+    '-d',
+    '--detach',
+    '-i',
+    '--interactive',
+    '-t',
+    '--tty',
+    '--rm',
+    '--privileged',
+    '--read-only',
+  ]);
+
+  // Parse docker flags until we hit the image name
+  while (i < tokens.length) {
+    const tok = tokens[i];
+
+    // Boolean flags
+    if (booleanFlags.has(tok) || tok === '-it' || tok === '-dt') {
+      i++;
+      continue;
+    }
+
+    // -e KEY=VALUE or --env KEY=VALUE
+    if (tok === '-e' || tok === '--env') {
+      i++;
+      if (i < tokens.length) {
+        const envStr = tokens[i];
+        const eqIdx = envStr.indexOf('=');
+        if (eqIdx > 0) {
+          envVars.push({
+            variable: envStr.slice(0, eqIdx),
+            value: envStr.slice(eqIdx + 1),
+          });
+        }
+      }
+      i++;
+      continue;
+    }
+
+    // -p HOST:CONTAINER or --publish HOST:CONTAINER
+    if (tok === '-p' || tok === '--publish') {
+      i++;
+      if (i < tokens.length) {
+        const portMapping = tokens[i];
+        const parts = portMapping.split(':');
+        if (parts.length >= 2) {
+          // Last part is the container port (may have /tcp, /udp suffix)
+          const containerPortStr = parts[parts.length - 1].split('/')[0];
+          const val = parseInt(containerPortStr, 10);
+          if (!isNaN(val) && val > 0 && val <= 65535) {
+            containerPort = val;
+          }
+        }
+      }
+      i++;
+      continue;
+    }
+
+    // Other flags with arguments
+    if (flagsWithArg.has(tok)) {
+      i += 2;
+      continue;
+    }
+
+    // Flags with = (e.g., --env=KEY=VALUE, --gpus=all)
+    if (tok.startsWith('-') && tok.includes('=')) {
+      if (tok.startsWith('-e=') || tok.startsWith('--env=')) {
+        const envStr = tok.slice(tok.indexOf('=') + 1);
+        const eqIdx = envStr.indexOf('=');
+        if (eqIdx > 0) {
+          envVars.push({
+            variable: envStr.slice(0, eqIdx),
+            value: envStr.slice(eqIdx + 1),
+          });
+        }
+      } else if (tok.startsWith('-p=') || tok.startsWith('--publish=')) {
+        const portMapping = tok.slice(tok.indexOf('=') + 1);
+        const parts = portMapping.split(':');
+        if (parts.length >= 2) {
+          const containerPortStr = parts[parts.length - 1].split('/')[0];
+          const val = parseInt(containerPortStr, 10);
+          if (!isNaN(val) && val > 0 && val <= 65535) {
+            containerPort = val;
+          }
+        }
+      }
+      i++;
+      continue;
+    }
+
+    // Unknown flag with argument
+    if (tok.startsWith('-')) {
+      // Check if next token looks like a value (not a flag)
+      if (i + 1 < tokens.length && !tokens[i + 1].startsWith('-')) {
+        i += 2;
+      } else {
+        i++;
+      }
+      continue;
+    }
+
+    // First non-flag token is the image name, everything after is the command
+    const commandTokens = tokens.slice(i + 1);
+    return {
+      envVars,
+      containerPort,
+      commandTokens,
+      effectiveCommand: commandTokens.join(' '),
+    };
+  }
+
+  // No command found after image
+  return {
+    envVars,
+    containerPort,
+    commandTokens: [],
+    effectiveCommand: '',
+  };
+}
+
+/**
+ * Parse a CLI command string and extract service configuration hints.
+ *
+ * @param command - The raw CLI command string (e.g., "vllm serve /models/my-model --tp 2")
+ * @returns Parsed command with extracted configuration values
+ */
+export function parseCliCommand(command: string): ParsedCliCommand {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    return {
+      runtime: 'unknown',
+      port: RUNTIME_DEFAULTS.unknown.port,
+      healthCheckPath: RUNTIME_DEFAULTS.unknown.healthCheckPath,
+      modelMountDestination: '/models',
+      gpuHint: null,
+      envVars: [],
+      startCommandTokens: [],
+      effectiveCommand: '',
+    };
+  }
+
+  const tokens = tokenizeShellCommand(trimmed);
+
+  // Check if this is a docker command
+  const dockerResult = parseDockerCommand(tokens);
+
+  let effectiveTokens: string[];
+  let envVars: Array<{ variable: string; value: string }> = [];
+  let dockerPort: number | null = null;
+  let effectiveCommand: string;
+
+  if (dockerResult) {
+    effectiveTokens = dockerResult.commandTokens;
+    envVars = dockerResult.envVars;
+    dockerPort = dockerResult.containerPort;
+    effectiveCommand = dockerResult.effectiveCommand;
+  } else {
+    effectiveTokens = tokens;
+    effectiveCommand = trimmed;
+  }
+
+  const runtime = detectRuntime(effectiveTokens);
+  const defaults = RUNTIME_DEFAULTS[runtime];
+
+  // Extract port: explicit --port > docker -p > runtime default
+  const explicitPort = extractPort(effectiveTokens);
+  const port = explicitPort ?? dockerPort ?? defaults.port;
+
+  const gpuHint = extractGpuHint(effectiveTokens);
+
+  // For start_command in yaml: use the effective command tokens (not docker wrapper)
+  const startCommandTokens =
+    effectiveTokens.length > 0 ? effectiveTokens : tokens;
+
+  return {
+    runtime,
+    port,
+    healthCheckPath: defaults.healthCheckPath,
+    modelMountDestination: '/models',
+    gpuHint,
+    envVars,
+    startCommandTokens,
+    effectiveCommand,
+  };
+}


### PR DESCRIPTION
Resolves #6337 (FR-2440)

## Summary
- Add pure TypeScript CLI command parser utility (`parseCliCommand.ts`) that parses CLI commands (vllm serve, sglang, docker run, etc.) and extracts runtime type, port, GPU hints, docker env vars, and shell-tokenized `start_command` arrays
- All client-side parsing for closed-network compatibility — no external API calls
- Includes shell-aware tokenizer (`tokenizeShellCommand`) supporting quoted strings, escape characters, and multi-line commands
- 38 unit tests covering all spec acceptance criteria
- Add spec files and dev plan for the "Paste Your Command" feature (FR-2438)