### PR TITLE
feat(FR-2452): add missing schema fields to VFolderNodes table as hidden columns

### DIFF
--- a/react/src/components/VFolderNodes.tsx
+++ b/react/src/components/VFolderNodes.tsx
@@ -30,13 +30,16 @@ import {
   BAITableProps,
   BAIFlex,
   BAINameActionCell,
+  BAIText,
   toLocalId,
   useErrorMessageResolver,
   BAILink,
   BAIConfirmModalWithInput,
   BAITag,
+  bytesToGB,
 } from 'backend.ai-ui';
 import type { BAINameActionCellAction } from 'backend.ai-ui';
+import dayjs from 'dayjs';
 import _ from 'lodash';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -58,6 +61,25 @@ export const statusTagColor = {
 };
 
 export type VFolderNodeInList = NonNullable<VFolderNodesFragment$data[number]>;
+
+const availableVFolderSorterKeys = [
+  'name',
+  'host',
+  'quota_scope_id',
+  'usage_mode',
+  'ownership_type',
+  'max_files',
+  'max_size',
+  'created_at',
+  'last_used',
+  'cloneable',
+  'status',
+  'cur_size',
+] as const;
+
+const isEnableSorter = (key: string) => {
+  return _.includes(availableVFolderSorterKeys, key);
+};
 
 interface VFolderNameCellProps {
   vfolder: VFolderNodeInList;
@@ -207,12 +229,20 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
         status
         name
         host
+        quota_scope_id
         ownership_type
         user
         user_email
         group
         group_name
         usage_mode
+        max_files
+        max_size
+        created_at
+        last_used
+        num_files
+        cur_size
+        cloneable
         permissions @since(version: "24.09.0")
         ...VFolderPermissionCellFragment
         ...VFolderNodeIdenticonFragment
@@ -357,7 +387,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
                 />
               );
             },
-            sorter: true,
+            sorter: isEnableSorter('name'),
           },
           {
             key: 'status',
@@ -376,13 +406,13 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
                 </BAITag>
               );
             },
-            sorter: true,
+            sorter: isEnableSorter('status'),
           },
           {
             key: 'host',
             title: t('data.folders.Location'),
             dataIndex: 'host',
-            sorter: true,
+            sorter: isEnableSorter('host'),
           },
           {
             key: 'permissions',
@@ -410,7 +440,7 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
                 </BAIFlex>
               );
             },
-            sorter: true,
+            sorter: isEnableSorter('ownership_type'),
           },
 
           {
@@ -420,6 +450,99 @@ const VFolderNodes: React.FC<VFolderNodesProps> = ({
               vfolder.ownership_type === 'user'
                 ? vfolder?.user_email
                 : vfolder?.group_name,
+          },
+          {
+            key: 'usage_mode',
+            title: t('data.UsageMode'),
+            dataIndex: 'usage_mode',
+            defaultHidden: true,
+            sorter: isEnableSorter('usage_mode'),
+            render: (mode: string) => {
+              switch (mode) {
+                case 'general':
+                  return t('data.General');
+                case 'data':
+                  return t('webui.menu.Data');
+                case 'model':
+                  return t('data.Models');
+                default:
+                  return mode;
+              }
+            },
+          },
+          {
+            key: 'num_files',
+            title: t('data.folders.NumberOfFiles'),
+            dataIndex: 'num_files',
+            defaultHidden: true,
+            sorter: isEnableSorter('num_files'),
+            render: (value: number) =>
+              value != null ? value.toLocaleString() : '-',
+          },
+          {
+            key: 'cur_size',
+            title: t('data.folders.FolderUsage'),
+            dataIndex: 'cur_size',
+            defaultHidden: true,
+            sorter: isEnableSorter('cur_size'),
+            render: (value: string) =>
+              value != null ? `${bytesToGB(Number(value))} GB` : '-',
+          },
+          {
+            key: 'max_files',
+            title: t('data.folders.MaxFolderQuota'),
+            dataIndex: 'max_files',
+            defaultHidden: true,
+            sorter: isEnableSorter('max_files'),
+            render: (value: number) =>
+              value != null && value > 0 ? value.toLocaleString() : '-',
+          },
+          {
+            key: 'max_size',
+            title: t('data.folders.MaxSize'),
+            dataIndex: 'max_size',
+            defaultHidden: true,
+            sorter: isEnableSorter('max_size'),
+            render: (value: string) =>
+              value != null && Number(value) > 0
+                ? `${bytesToGB(Number(value))} GB`
+                : '-',
+          },
+          {
+            key: 'cloneable',
+            title: t('data.folders.Cloneable'),
+            dataIndex: 'cloneable',
+            defaultHidden: true,
+            sorter: isEnableSorter('cloneable'),
+            render: (value: boolean) =>
+              value ? t('button.Yes') : t('button.No'),
+          },
+          {
+            key: 'quota_scope_id',
+            title: t('data.QuotaScopeId'),
+            dataIndex: 'quota_scope_id',
+            defaultHidden: true,
+            sorter: isEnableSorter('quota_scope_id'),
+            render: (value: string) =>
+              value ? <BAIText copyable>{value}</BAIText> : '-',
+          },
+          {
+            key: 'last_used',
+            title: t('credential.LastUsed'),
+            dataIndex: 'last_used',
+            defaultHidden: true,
+            sorter: isEnableSorter('last_used'),
+            render: (value: string) =>
+              value ? dayjs(value).format('ll LT') : '-',
+          },
+          {
+            key: 'created_at',
+            title: t('data.folders.CreatedAt'),
+            dataIndex: 'created_at',
+            defaultHidden: true,
+            sorter: isEnableSorter('created_at'),
+            render: (value: string) =>
+              value ? dayjs(value).format('ll LT') : '-',
           },
         ]}
         {...tableProps}

--- a/react/src/pages/VFolderNodeListPage.tsx
+++ b/react/src/pages/VFolderNodeListPage.tsx
@@ -567,6 +567,16 @@ const VFolderNodeListPage: React.FC<VFolderNodeListPageProps> = ({
                       },
                     ],
                   },
+                  {
+                    key: 'cloneable',
+                    propertyLabel: t('data.folders.Cloneable'),
+                    type: 'boolean',
+                  },
+                  {
+                    key: 'quota_scope_id',
+                    propertyLabel: t('data.QuotaScopeId'),
+                    type: 'string',
+                  },
                 ]}
                 value={queryParams.filter || undefined}
                 onChange={(value) => {

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Projekt-Ordner",
     "ProjectFolders": "Projektordner",
     "QuotaPerStorageVolume": "Kontingent pro Speichervolumen",
+    "QuotaScopeId": "ID des Kontingentsbereichs",
     "ReadOnly": "Nur lesen",
     "ReadWrite": "Lesen und schreiben",
     "SearchByName": "Suche mit Name",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Φάκελος έργου",
     "ProjectFolders": "Φακέλοι έργου",
     "QuotaPerStorageVolume": "Ποσοστό ανά τόμο αποθήκευσης",
+    "QuotaScopeId": "Αναγνωριστικό πεδίου ποσόστωσης",
     "ReadOnly": "Μόνο διαβάστε",
     "ReadWrite": "Διαβάστε και γράψτε",
     "SearchByName": "Αναζήτηση με όνομα",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -476,6 +476,7 @@
     "ProjectFolder": "Project Folder",
     "ProjectFolders": "Project Folders",
     "QuotaPerStorageVolume": "Quota per storage volume",
+    "QuotaScopeId": "Quota Scope ID",
     "ReadOnly": "Read only",
     "ReadWrite": "Read & Write",
     "SearchByName": "Search by name",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Carpeta de proyectos",
     "ProjectFolders": "Carpetas de proyectos",
     "QuotaPerStorageVolume": "Cuota por volumen de almacenamiento",
+    "QuotaScopeId": "ID del ámbito de cuotas",
     "ReadOnly": "Solo lectura",
     "ReadWrite": "Leer y escribir",
     "SearchByName": "Buscar por nombre",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Projektikansio",
     "ProjectFolders": "Projektikansiot",
     "QuotaPerStorageVolume": "Kiintiö tallennustilavuutta kohti",
+    "QuotaScopeId": "Kiintiön laajuuden ID",
     "ReadOnly": "Vain lue",
     "ReadWrite": "Lue ja kirjoita",
     "SearchByName": "Hae nimellä",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Dossier de projet",
     "ProjectFolders": "Dossiers de projet",
     "QuotaPerStorageVolume": "Quota par volume de stockage",
+    "QuotaScopeId": "ID de l'étendue du quota",
     "ReadOnly": "Lire uniquement",
     "ReadWrite": "Lire et écrire",
     "SearchByName": "Rechercher par nom",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Folder Proyek",
     "ProjectFolders": "Folder Proyek",
     "QuotaPerStorageVolume": "Kuota per volume penyimpanan",
+    "QuotaScopeId": "ID Cakupan Kuota",
     "ReadOnly": "Baca saja",
     "ReadWrite": "Baca dan tulis",
     "SearchByName": "Cari berdasarkan nama",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Cartella del progetto",
     "ProjectFolders": "Cartelle di progetto",
     "QuotaPerStorageVolume": "Quota per volume di archiviazione",
+    "QuotaScopeId": "ID ambito quota",
     "ReadOnly": "Solo lettura",
     "ReadWrite": "Leggi e scrivi",
     "SearchByName": "Ricerca per nome",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "プロジェクトフォルダ",
     "ProjectFolders": "プロジェクトフォルダー",
     "QuotaPerStorageVolume": "ストレージボリュームごとの利用可能量",
+    "QuotaScopeId": "可用量範囲ID",
     "ReadOnly": "読み取り専用",
     "ReadWrite": "読み書き可能",
     "SearchByName": "名前で検索",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -476,6 +476,7 @@
     "ProjectFolder": "프로젝트 폴더",
     "ProjectFolders": "프로젝트 폴더",
     "QuotaPerStorageVolume": "스토리지 볼륨별 가용량",
+    "QuotaScopeId": "가용량 범위 ID",
     "ReadOnly": "읽기 전용",
     "ReadWrite": "읽기 및 쓰기",
     "SearchByName": "이름으로 검색",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Төслийн хавтас",
     "ProjectFolders": "Төслийн хавтас",
     "QuotaPerStorageVolume": "Хадгалах хэмжээ тус бүрийн квот",
+    "QuotaScopeId": "Квотын хамрах хүрээ ID",
     "ReadOnly": "Зөвхөн унших",
     "ReadWrite": "Уншаад бичнэ үү",
     "SearchByName": "Нэрээр нь хайх",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Folder Projek",
     "ProjectFolders": "Folder Projek",
     "QuotaPerStorageVolume": "Kuota setiap volum storan",
+    "QuotaScopeId": "ID Skop Kuota",
     "ReadOnly": "Baca sahaja",
     "ReadWrite": "Baca dan tulis",
     "SearchByName": "Cari mengikut nama",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Folder projektu",
     "ProjectFolders": "Foldery projektu",
     "QuotaPerStorageVolume": "Limit na wolumin pamięci masowej",
+    "QuotaScopeId": "Identyfikator zakresu kwot",
     "ReadOnly": "Czytaj tylko",
     "ReadWrite": "Przeczytaj i napisz",
     "SearchByName": "Szukaj według nazwy",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Pasta de projeto",
     "ProjectFolders": "Pastas de projeto",
     "QuotaPerStorageVolume": "Quota por volume de armazenamento",
+    "QuotaScopeId": "ID do âmbito do contingente",
     "ReadOnly": "Somente leitura",
     "ReadWrite": "Leia e escreva",
     "SearchByName": "Procura por nome",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Pasta de projeto",
     "ProjectFolders": "Pastas de projeto",
     "QuotaPerStorageVolume": "Quota por volume de armazenamento",
+    "QuotaScopeId": "ID do âmbito do contingente",
     "ReadOnly": "Somente leitura",
     "ReadWrite": "Leia e escreva",
     "SearchByName": "Procura por nome",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Папка проекта",
     "ProjectFolders": "Проектные папки",
     "QuotaPerStorageVolume": "Квота на один том хранения",
+    "QuotaScopeId": "Идентификатор области квотирования",
     "ReadOnly": "Читать только",
     "ReadWrite": "Читать и написать",
     "SearchByName": "Поиск по имени",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "โฟลเดอร์โครงการ",
     "ProjectFolders": "โฟลเดอร์โครงการ",
     "QuotaPerStorageVolume": "โควตาต่อปริมาณการจัดเก็บ",
+    "QuotaScopeId": "รหัสขอบเขตโควตา",
     "ReadOnly": "อ่านเท่านั้น",
     "ReadWrite": "อ่านและเขียน",
     "SearchByName": "ค้นหาตามชื่อ",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Proje Klasörü",
     "ProjectFolders": "Proje Klasörleri",
     "QuotaPerStorageVolume": "Depolama birimi başına kota",
+    "QuotaScopeId": "Kota Kapsam Kimliği",
     "ReadOnly": "Sadece oku",
     "ReadWrite": "Oku ve Yaz",
     "SearchByName": "Ada göre ara",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "Thư mục dự án",
     "ProjectFolders": "Thư mục dự án",
     "QuotaPerStorageVolume": "Hạn ngạch cho mỗi dung lượng lưu trữ",
+    "QuotaScopeId": "ID phạm vi hạn ngạch",
     "ReadOnly": "Chỉ đọc",
     "ReadWrite": "Đọc và viết",
     "SearchByName": "Tìm kiếm theo tên",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "项目文件夹",
     "ProjectFolders": "项目文件夹",
     "QuotaPerStorageVolume": "每个存储容量的配额",
+    "QuotaScopeId": "配额范围 ID",
     "ReadOnly": "只读",
     "ReadWrite": "读写",
     "SearchByName": "按名称搜索",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -475,6 +475,7 @@
     "ProjectFolder": "项目文件夹",
     "ProjectFolders": "項目文件夾",
     "QuotaPerStorageVolume": "每个存储容量的配额",
+    "QuotaScopeId": "配额范围 ID",
     "ReadOnly": "只讀",
     "ReadWrite": "讀寫",
     "SearchByName": "按名稱搜尋",


### PR DESCRIPTION
Resolves #6361 (FR-2452)

## Summary

- Add all available but missing VirtualFolderNode schema fields to the VFolderNodes table as default-hidden columns
- New columns: usage_mode, creator, created_at, last_used, num_files, cur_size, max_files, max_size, cloneable, quota_scope_id
- All new columns support sorting; usage_mode and cloneable also support filtering
- Add `data.folders.Creator` i18n key to all 21 language files