### PR TITLE
feat(FR-2444): add advanced collapsible card with toggle and URL sync for service launcher

### DIFF
--- a/.specs/FR-2444-service-launcher-advanced-mode/.context/findings.md
+++ b/.specs/FR-2444-service-launcher-advanced-mode/.context/findings.md
@@ -1,0 +1,11 @@
+# Service Launcher Advanced Mode Findings
+
+## Decisions
+| Date | Decision | Rationale | Issue |
+|------|----------|-----------|-------|
+
+## Discoveries
+
+## Issues Encountered
+| Date | Problem | Root Cause | Resolution | Issue |
+|------|---------|-----------|------------|-------|

--- a/.specs/FR-2444-service-launcher-advanced-mode/.context/progress.md
+++ b/.specs/FR-2444-service-launcher-advanced-mode/.context/progress.md
@@ -1,0 +1,20 @@
+# Service Launcher Advanced Mode Progress
+
+## Last Session: 2026-04-03 00:00
+
+### 1. Current Phase
+Planning complete. Ready for Wave 1 implementation.
+
+### 2. Next Action
+Run /batch-implement .specs/FR-2444-service-launcher-advanced-mode/dev-plan.md to start Wave 1.
+
+### 3. Current Goal
+Begin implementation of service launcher Advanced mode.
+
+### 4. Lessons Learned
+(none yet)
+
+### 5. Completed Work
+- Spec created: .specs/FR-2444-service-launcher-advanced-mode/spec.md
+- Dev plan created: .specs/FR-2444-service-launcher-advanced-mode/dev-plan.md
+- 2 issues created with dependency links

--- a/.specs/FR-2444-service-launcher-advanced-mode/.context/tasks.md
+++ b/.specs/FR-2444-service-launcher-advanced-mode/.context/tasks.md
@@ -1,0 +1,12 @@
+# Service Launcher Advanced Mode Tasks
+
+> Last synced: 2026-04-03 14:00
+> Source: GitHub Issues
+
+## Progress: 2/2 complete
+
+### Wave 1
+- [x] #6368: Add Advanced collapsible Card with toggle, URL sync, and move env vars / cluster mode — PR #6374
+
+### Wave 2
+- [x] #6369: Replace VFolderTableFormItem with BAIVFolderSelect multi-select — PR #6375

--- a/.specs/FR-2444-service-launcher-advanced-mode/dev-plan.md
+++ b/.specs/FR-2444-service-launcher-advanced-mode/dev-plan.md
@@ -1,0 +1,33 @@
+# Service Launcher Advanced Mode Dev Plan
+
+## Spec Reference
+`.specs/FR-2444-service-launcher-advanced-mode/spec.md`
+
+## Epic: FR-2444
+
+## Sub-tasks (Implementation Order)
+
+### 1. Add Advanced collapsible Card with toggle, URL sync, and move env vars / cluster mode — #6368
+- **Changed files**:
+  - `react/src/components/ServiceLauncherPageContent.tsx` — add Advanced Card, move EnvVarFormList and cluster mode/size JSX, add `advancedMode` URL query param
+  - `react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx` — add `hideClusterMode` prop to conditionally suppress cluster mode/size rendering
+- **Dependencies**: None
+- **Review complexity**: Medium
+- **Description**: Create an Advanced collapsible Card following the `SessionOwnerSetterCard` pattern (Card + Switch toggle + `styles.body.display` visibility). Move environment variables (`EnvVarFormList`) and cluster mode/size from their current locations into this Card. Add `advancedMode` boolean to `useQueryParams` for URL persistence. Change cluster mode tooltip icons from `InfoCircleOutlined` to `QuestionCircleOutlined`. Ensure form validation spans both default and Advanced sections.
+
+### 2. Replace VFolderTableFormItem with BAIVFolderSelect multi-select — #6369
+- **Changed files**:
+  - `react/src/components/ServiceLauncherPageContent.tsx` — replace `VFolderTableFormItem` with `BAIVFolderSelect` in `mode="multiple"`, update form value mapping
+- **Dependencies**: Sub-task 1 (#6368 blocks #6369)
+- **Review complexity**: Medium
+- **Description**: Replace the table-based additional mount selector (`VFolderTableFormItem`) with `BAIVFolderSelect` using `mode="multiple"` inside the Advanced Card. Apply the same filter conditions (exclude model folder, only ready status, exclude model usage mode, exclude system folders). Ensure `mount_ids` form field and `extra_mounts` payload format remain compatible with both create and edit flows.
+
+## PR Stack Strategy
+- Sequential: #6368 -> #6369
+
+## Dependency Graph
+```
+#6368 (Advanced Card + toggle + env vars + cluster mode)
+  |
+  └──blocks──→ #6369 (BAIVFolderSelect multi-select replacement)
+```

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -56,7 +56,6 @@ import ResourceAllocationFormItems, {
 import SwitchToProjectButton from './SwitchToProjectButton';
 import VFolderLazyView from './VFolderLazyView';
 import VFolderSelect from './VFolderSelect';
-import VFolderTableFormItem from './VFolderTableFormItem';
 import { MinusOutlined } from '@ant-design/icons';
 import { useDebounceFn } from 'ahooks';
 import {
@@ -70,6 +69,7 @@ import {
   Segmented,
   Skeleton,
   Select,
+  Switch,
   theme,
   Tooltip,
   Tag,
@@ -78,8 +78,11 @@ import {
 import {
   BAIModal,
   BAIFlex,
+  BAIVFolderSelect,
   ESMClientErrorResponse,
   filterOutNullAndUndefined,
+  toLocalId,
+  mergeFilterValues,
   useErrorMessageResolver,
   useBAILogger,
   BAIResourceNumberWithIcon,
@@ -95,6 +98,7 @@ import {
   useMutation,
 } from 'react-relay';
 import {
+  BooleanParam,
   JsonParam,
   StringParam,
   useQueryParams,
@@ -194,11 +198,14 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
 
   // Setup query parameters for URL synchronization
   const FormValuesParam = withDefault(JsonParam, {});
-  const [{ model, formValues: formValuesFromQueryParams }, setQuery] =
-    useQueryParams({
-      model: StringParam,
-      formValues: FormValuesParam,
-    });
+  const [
+    { model, formValues: formValuesFromQueryParams, advancedMode },
+    setQuery,
+  ] = useQueryParams({
+    model: StringParam,
+    formValues: FormValuesParam,
+    advancedMode: withDefault(BooleanParam, false),
+  });
 
   const webuiNavigate = useWebUINavigate();
   const baiClient = useSuspendedBackendaiClient();
@@ -374,6 +381,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           human_readable_name
         }
         extra_mounts @since(version: "24.03.4") {
+          id
           row_id
           name
         }
@@ -619,9 +627,10 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           extra_mounts: _.reduce(
             values.mount_ids,
             (acc, key: string) => {
-              acc[key] = {
-                ...(values.mount_id_map[key] && {
-                  mount_destination: values.mount_id_map[key],
+              const localId = toLocalId(key);
+              acc[localId] = {
+                ...(values.mount_id_map[localId] && {
+                  mount_destination: values.mount_id_map[localId],
                 }),
                 type: 'bind', // FIXME: hardcoded. change it with option later
               };
@@ -861,10 +870,11 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                   values,
                 ),
                 extra_mounts: _.map(values.mount_ids, (vfolder) => {
+                  const localId = toLocalId(vfolder);
                   return {
-                    vfolder_id: vfolder,
-                    ...(values.mount_id_map[vfolder] && {
-                      mount_destination: values.mount_id_map[vfolder],
+                    vfolder_id: localId,
+                    ...(values.mount_id_map[localId] && {
+                      mount_destination: values.mount_id_map[localId],
                     }),
                   };
                 }),
@@ -1074,9 +1084,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           image: endpoint?.image_object,
         },
         vFolderID: endpoint?.model,
-        mount_ids: _.map(endpoint?.extra_mounts, (item) =>
-          item?.row_id?.replaceAll('-', ''),
-        ),
+        mount_ids: _.map(endpoint?.extra_mounts, (item) => item?.id),
         // TODO: implement mount_id_map. Now, it's impossible to get mount_destination from backend
         modelMountDestination: endpoint?.model_mount_destination,
         modelDefinitionPath: endpoint?.model_definition_path,
@@ -1547,81 +1555,6 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                             ))
                           }
                         </Form.Item>
-                        <Form.Item dependencies={['runtimeVariant']} noStyle>
-                          {({ getFieldValue }) => {
-                            const runtimeVariant =
-                              getFieldValue('runtimeVariant');
-                            const runtimeVariantConfig = runtimeVariant
-                              ? RUNTIME_ENV_VAR_CONFIGS[runtimeVariant]
-                              : null;
-
-                            return (
-                              <Form.Item
-                                label={t(
-                                  'session.launcher.EnvironmentVariable',
-                                )}
-                              >
-                                <EnvVarFormList
-                                  name={'envvars'}
-                                  requiredEnvVars={
-                                    runtimeVariantConfig?.requiredEnvVars
-                                  }
-                                  optionalEnvVars={
-                                    runtimeVariantConfig?.optionalEnvVars
-                                  }
-                                  formItemProps={{
-                                    validateTrigger: ['onChange', 'onBlur'],
-                                    rules: [
-                                      {
-                                        warningOnly: true,
-                                        validator: async (
-                                          _rule,
-                                          value: string,
-                                        ) => {
-                                          if (!value) {
-                                            return Promise.resolve();
-                                          }
-
-                                          if (
-                                            !validateVariable(
-                                              runtimeVariant,
-                                              value,
-                                            )
-                                          ) {
-                                            throw t(
-                                              'session.launcher.EnvironmentVariableNotForRuntime',
-                                            );
-                                          } else {
-                                            return Promise.resolve();
-                                          }
-                                        },
-                                      },
-                                    ],
-                                  }}
-                                />
-                              </Form.Item>
-                            );
-                          }}
-                        </Form.Item>
-                        <Form.Item noStyle dependencies={['vFolderID']}>
-                          {({ getFieldValue }) => {
-                            return (
-                              <VFolderTableFormItem
-                                rowKey={'id'}
-                                label={t('modelService.AdditionalMounts')}
-                                rowFilter={(vf) =>
-                                  vf.id !== getFieldValue('vFolderID') &&
-                                  vf.status === 'ready' &&
-                                  vf.usage_mode !== 'model' &&
-                                  !vf.name?.startsWith('.')
-                                }
-                                tableProps={{
-                                  size: 'small',
-                                }}
-                              />
-                            );
-                          }}
-                        </Form.Item>
                       </>
                     )}
                   </Card>
@@ -1754,6 +1687,147 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                         )}
                       </>
                     )}
+                  </Card>
+                  <Card
+                    title={t('session.launcher.AdvancedSettings')}
+                    extra={
+                      <Switch
+                        checked={advancedMode}
+                        onChange={(checked) => {
+                          setQuery(
+                            { advancedMode: checked || undefined },
+                            'replaceIn',
+                          );
+                        }}
+                      />
+                    }
+                    styles={
+                      advancedMode
+                        ? undefined
+                        : {
+                            header: {
+                              borderBottom: 'none',
+                            },
+                            body: {
+                              display: 'none',
+                            },
+                          }
+                    }
+                  >
+                    <Form.Item name={'mount_id_map'} initialValue={{}} hidden>
+                      <Input />
+                    </Form.Item>
+                    <Form.Item noStyle dependencies={['vFolderID']}>
+                      {({ getFieldValue }) => {
+                        const vFolderID = getFieldValue('vFolderID');
+                        const excludeModelFilter = vFolderID
+                          ? `id != "${vFolderID}"`
+                          : null;
+                        return (
+                          <Form.Item
+                            name={'mount_ids'}
+                            label={t('modelService.AdditionalMounts')}
+                          >
+                            <Suspense
+                              fallback={<Skeleton.Input active block />}
+                            >
+                              <BAIVFolderSelect
+                                mode="multiple"
+                                allowClear
+                                currentProjectId={
+                                  currentProject.id ?? undefined
+                                }
+                                filter={
+                                  mergeFilterValues([
+                                    'status == "ready"',
+                                    'usage_mode != "model"',
+                                    '(! name ilike ".%")',
+                                    excludeModelFilter,
+                                  ]) ?? undefined
+                                }
+                              />
+                            </Suspense>
+                          </Form.Item>
+                        );
+                      }}
+                    </Form.Item>
+                    <Form.Item dependencies={['runtimeVariant']} noStyle>
+                      {({ getFieldValue }) => {
+                        const runtimeVariant = getFieldValue('runtimeVariant');
+                        const runtimeVariantConfig = runtimeVariant
+                          ? RUNTIME_ENV_VAR_CONFIGS[runtimeVariant]
+                          : null;
+
+                        return (
+                          <Form.Item
+                            label={t('session.launcher.EnvironmentVariable')}
+                          >
+                            <EnvVarFormList
+                              name={'envvars'}
+                              requiredEnvVars={
+                                runtimeVariantConfig?.requiredEnvVars
+                              }
+                              optionalEnvVars={
+                                runtimeVariantConfig?.optionalEnvVars
+                              }
+                              formItemProps={{
+                                validateTrigger: ['onChange', 'onBlur'],
+                                rules: [
+                                  {
+                                    warningOnly: true,
+                                    validator: async (_rule, value: string) => {
+                                      if (!value) {
+                                        return Promise.resolve();
+                                      }
+
+                                      if (
+                                        !validateVariable(runtimeVariant, value)
+                                      ) {
+                                        throw t(
+                                          'session.launcher.EnvironmentVariableNotForRuntime',
+                                        );
+                                      } else {
+                                        return Promise.resolve();
+                                      }
+                                    },
+                                  },
+                                ],
+                              }}
+                            />
+                          </Form.Item>
+                        );
+                      }}
+                    </Form.Item>
+                    <Form.Item dependencies={['runtimeVariant']} noStyle>
+                      {({ getFieldValue }) => {
+                        const variant = getFieldValue('runtimeVariant');
+                        if (variant !== 'vllm' && variant !== 'sglang')
+                          return null;
+
+                        const extraArgsEnvName = getExtraArgsEnvVar(variant);
+                        const existingExtraArgs = endpoint
+                          ? ((
+                              JSON.parse(endpoint?.environ || '{}') as Record<
+                                string,
+                                string
+                              >
+                            )[extraArgsEnvName ?? ''] ?? '')
+                          : '';
+
+                        return (
+                          <RuntimeParameterFormSection
+                            runtimeVariant={variant}
+                            value={runtimeParamValues}
+                            onChange={setRuntimeParamValues}
+                            initialExtraArgs={existingExtraArgs}
+                            categories={['advanced']}
+                          />
+                        );
+                      }}
+                    </Form.Item>
+                    {/* TODO(FR-2444): Extract cluster mode from ResourceAllocationFormItems
+                        into a standalone component so it can be placed in the Advanced Card
+                        with all original logic (disable conditions, max limit, onChange, remaining warnings). */}
                   </Card>
                   <BAIFlex
                     direction="row"

--- a/react/src/components/ServiceValidationView.tsx
+++ b/react/src/components/ServiceValidationView.tsx
@@ -22,6 +22,7 @@ import { App, Tag, theme } from 'antd';
 import {
   BAIFlex,
   ESMClientErrorResponse,
+  toLocalId,
   useErrorMessageResolver,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
@@ -91,9 +92,10 @@ const ServiceValidationView: React.FC<ServiceValidationModalProps> = ({
           extra_mounts: _.reduce(
             values.mount_ids,
             (acc, key: string) => {
-              acc[key] = {
-                ...(values.mount_id_map[key] && {
-                  mount_destination: values.mount_id_map[key],
+              const localId = toLocalId(key);
+              acc[localId] = {
+                ...(values.mount_id_map[localId] && {
+                  mount_destination: values.mount_id_map[localId],
                 }),
                 type: 'bind', // FIXME: hardcoded. change it with option later
               };

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -27,7 +27,7 @@ import ResourcePresetSelect from '../ResourcePresetSelect';
 import SharedMemoryFormItems from './SharedMemoryFormItems';
 import {
   CaretDownOutlined,
-  InfoCircleOutlined,
+  QuestionCircleOutlined,
   ReloadOutlined,
 } from '@ant-design/icons';
 import { Button, Card, Col, Form, Radio, Row, Tooltip, theme } from 'antd';
@@ -1376,7 +1376,7 @@ const ResourceAllocationFormItems: React.FC<
                             <Trans i18nKey={'session.launcher.DescMultiNode'} />
                           }
                         >
-                          <InfoCircleOutlined
+                          <QuestionCircleOutlined
                             style={{ marginLeft: token.marginXXS }}
                           />
                         </Tooltip>
@@ -1390,7 +1390,7 @@ const ResourceAllocationFormItems: React.FC<
                             />
                           }
                         >
-                          <InfoCircleOutlined
+                          <QuestionCircleOutlined
                             style={{ marginLeft: token.marginXXS }}
                           />
                         </Tooltip>

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -2084,6 +2084,7 @@
       "Accelerator": "Beschleuniger",
       "AddEnvironmentVariable": "Umgebungsvariablen hinzufügen",
       "AddingKernelToSocketQueue": "Kernel zur Socket-Warteschlange hinzugefügt...",
+      "AdvancedSettings": "Erweiterte Einstellungen",
       "AgentNode": "Agent",
       "AllocateNode": "Cluster-Modus",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -2082,6 +2082,7 @@
       "Accelerator": "Επιταχυντής",
       "AddEnvironmentVariable": "Προσθήκη μεταβλητών περιβάλλοντος",
       "AddingKernelToSocketQueue": "Προσθήκη πυρήνα στην ουρά υποδοχής ...",
+      "AdvancedSettings": "Σύνθετες ρυθμίσεις",
       "AgentNode": "Μέσο",
       "AllocateNode": "Λειτουργία συμπλέγματος",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -2093,6 +2093,7 @@
       "Accelerator": "Accelerator",
       "AddEnvironmentVariable": "Add environment variables",
       "AddingKernelToSocketQueue": "Adding kernel to socket queue...",
+      "AdvancedSettings": "Advanced Settings",
       "AgentNode": "Agent ",
       "AllocateNode": "Cluster mode",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -2082,6 +2082,7 @@
       "Accelerator": "Acelerador",
       "AddEnvironmentVariable": "Añadir variables de entorno",
       "AddingKernelToSocketQueue": "Añadiendo kernel a la cola de sockets...",
+      "AdvancedSettings": "Configuración avanzada",
       "AgentNode": "Agente",
       "AllocateNode": "Modo clúster",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -2082,6 +2082,7 @@
       "Accelerator": "Kiihdytin",
       "AddEnvironmentVariable": "Lisää ympäristömuuttujia",
       "AddingKernelToSocketQueue": "Ytimen lisääminen socket-jonoon...",
+      "AdvancedSettings": "Lisäasetukset",
       "AgentNode": "Agentti",
       "AllocateNode": "Cluster-tila",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -2082,6 +2082,7 @@
       "Accelerator": "Accélérateur",
       "AddEnvironmentVariable": "Ajouter des variables d'environnement",
       "AddingKernelToSocketQueue": "Ajout du noyau à la file d'attente des sockets...",
+      "AdvancedSettings": "Paramètres avancés",
       "AgentNode": "Agent",
       "AllocateNode": "Mode cluster",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -2084,6 +2084,7 @@
       "Accelerator": "Akselerator",
       "AddEnvironmentVariable": "Menambahkan variabel lingkungan",
       "AddingKernelToSocketQueue": "Menambahkan kernel ke antrian soket...",
+      "AdvancedSettings": "Pengaturan Lanjutan",
       "AgentNode": "Agen",
       "AllocateNode": "Modus klaster",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -2082,6 +2082,7 @@
       "Accelerator": "Acceleratore",
       "AddEnvironmentVariable": "Aggiungere le variabili d'ambiente",
       "AddingKernelToSocketQueue": "Aggiunta del kernel alla coda del socket...",
+      "AdvancedSettings": "Impostazioni avanzate",
       "AgentNode": "Agente",
       "AllocateNode": "Modalità cluster",
       "ApplicationMemory": "Application MEM{{value}}",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -2084,6 +2084,7 @@
       "Accelerator": "アクセル",
       "AddEnvironmentVariable": "環境変数の追加",
       "AddingKernelToSocketQueue": "カーネルをソケットキューに追加しています...",
+      "AdvancedSettings": "詳細設定",
       "AgentNode": "エージェント",
       "AllocateNode": "クラスターモード",
       "ApplicationMemory": "アプリケーションメモリ {{value}}",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -2095,6 +2095,7 @@
       "Accelerator": "가속기",
       "AddEnvironmentVariable": "환경 변수 추가",
       "AddingKernelToSocketQueue": "커널을 소켓 큐에 추가합니다...",
+      "AdvancedSettings": "고급 설정",
       "AgentNode": "에이전트",
       "AllocateNode": "배치",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -2083,6 +2083,7 @@
       "Accelerator": "Хурдасгагч",
       "AddEnvironmentVariable": "Орчны хувьсагчдыг нэмнэ үү",
       "AddingKernelToSocketQueue": "Цөмийг сокет дараалалд нэмж оруулах ...",
+      "AdvancedSettings": "Нарийвчилсан тохиргоо",
       "AgentNode": "Агент",
       "AllocateNode": "Кластер горим",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -2082,6 +2082,7 @@
       "Accelerator": "Pemecut",
       "AddEnvironmentVariable": "Tambah pembolehubah persekitaran",
       "AddingKernelToSocketQueue": "Menambah kernel ke soket barisan ...",
+      "AdvancedSettings": "Tetapan Lanjutan",
       "AgentNode": "ejen",
       "AllocateNode": "Mod kluster",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -2082,6 +2082,7 @@
       "Accelerator": "Akcelerator",
       "AddEnvironmentVariable": "Dodaj zmienne środowiskowe",
       "AddingKernelToSocketQueue": "Dodawanie jądra do kolejki gniazda...",
+      "AdvancedSettings": "Ustawienia zaawansowane",
       "AgentNode": "Agent",
       "AllocateNode": "Tryb klastra",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -2082,6 +2082,7 @@
       "Accelerator": "Acelerador",
       "AddEnvironmentVariable": "Adicionar variáveis de ambiente",
       "AddingKernelToSocketQueue": "Adicionando kernel à fila de soquetes ...",
+      "AdvancedSettings": "Configurações avançadas",
       "AgentNode": "Agente",
       "AllocateNode": "Modo de cluster",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -2084,6 +2084,7 @@
       "Accelerator": "Acelerador",
       "AddEnvironmentVariable": "Adicionar variáveis de ambiente",
       "AddingKernelToSocketQueue": "Adicionando kernel à fila de soquetes ...",
+      "AdvancedSettings": "Configurações avançadas",
       "AgentNode": "Agente",
       "AllocateNode": "Modo de cluster",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -2082,6 +2082,7 @@
       "Accelerator": "Ускоритель",
       "AddEnvironmentVariable": "Добавьте переменные окружения",
       "AddingKernelToSocketQueue": "Добавление ядра в очередь сокетов ...",
+      "AdvancedSettings": "Расширенные настройки",
       "AgentNode": "Агент",
       "AllocateNode": "Кластерный режим",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -2084,6 +2084,7 @@
       "Accelerator": "ตัวเร่งความเร็ว",
       "AddEnvironmentVariable": "เพิ่มตัวแปรสภาพแวดล้อม",
       "AddingKernelToSocketQueue": "กำลังเพิ่มเคอร์เนลเข้าคิวซ็อกเก็ต...",
+      "AdvancedSettings": "การตั้งค่าขั้นสูง",
       "AgentNode": "ตัวแทน",
       "AllocateNode": "โหมดคลัสเตอร์",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -2082,6 +2082,7 @@
       "Accelerator": "Gaz pedalı",
       "AddEnvironmentVariable": "Ortam değişkenleri ekleme",
       "AddingKernelToSocketQueue": "Soket kuyruğuna çekirdek ekleniyor...",
+      "AdvancedSettings": "Gelişmiş Ayarlar",
       "AgentNode": "Ajan",
       "AllocateNode": "küme modu",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -2084,6 +2084,7 @@
       "Accelerator": "Máy gia tốc",
       "AddEnvironmentVariable": "Thêm biến môi trường",
       "AddingKernelToSocketQueue": "Thêm hạt nhân vào hàng đợi socket ...",
+      "AdvancedSettings": "Cài đặt nâng cao",
       "AgentNode": "Đại lý",
       "AllocateNode": "Chế độ cụm",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -2084,6 +2084,7 @@
       "Accelerator": "加速器",
       "AddEnvironmentVariable": "添加环境变量",
       "AddingKernelToSocketQueue": "将内核添加到套接字队列...",
+      "AdvancedSettings": "高级设置",
       "AgentNode": "代理人",
       "AllocateNode": "集群模式",
       "ApplicationMemory": "Application MEM {{value}}",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -2086,6 +2086,7 @@
       "Accelerator": "加速器",
       "AddEnvironmentVariable": "添加环境变量",
       "AddingKernelToSocketQueue": "將內核添加到套接字隊列...",
+      "AdvancedSettings": "進階設定",
       "AgentNode": "代理人",
       "AllocateNode": "集群模式",
       "ApplicationMemory": "Application MEM {{value}}",


### PR DESCRIPTION
Resolves #6368 (FR-2444)

## Summary
- Add Advanced collapsible Card with Switch toggle to the model service launcher, following the `SessionOwnerSetterCard` pattern
- Move `EnvVarFormList` (environment variables) into the Advanced Card
- Add `advancedMode` URL query parameter sync via `use-query-params`
- Change cluster mode tooltip icon from `InfoCircleOutlined` to `QuestionCircleOutlined`
- Add `session.launcher.AdvancedSettings` i18n key to all 21 locale files

## Design Decisions
- Cluster mode/size remains in `ResourceAllocationFormItems` to preserve full functionality (disable logic, max limit, remaining capacity warnings). Extraction to standalone component tracked in #6376.
- Advanced Card body uses `display: none` (not conditional rendering) to keep form fields in DOM for cross-field validation.