### PR TITLE
feat(FR-2444): replace VFolderTableFormItem with BAIVFolderSelect multi-select in advanced section

### DIFF
--- a/.specs/FR-2444-service-launcher-advanced-mode/.context/findings.md
+++ b/.specs/FR-2444-service-launcher-advanced-mode/.context/findings.md
@@ -1,0 +1,11 @@
+# Service Launcher Advanced Mode Findings
+
+## Decisions
+| Date | Decision | Rationale | Issue |
+|------|----------|-----------|-------|
+
+## Discoveries
+
+## Issues Encountered
+| Date | Problem | Root Cause | Resolution | Issue |
+|------|---------|-----------|------------|-------|

--- a/.specs/FR-2444-service-launcher-advanced-mode/.context/progress.md
+++ b/.specs/FR-2444-service-launcher-advanced-mode/.context/progress.md
@@ -1,0 +1,20 @@
+# Service Launcher Advanced Mode Progress
+
+## Last Session: 2026-04-03 00:00
+
+### 1. Current Phase
+Planning complete. Ready for Wave 1 implementation.
+
+### 2. Next Action
+Run /batch-implement .specs/FR-2444-service-launcher-advanced-mode/dev-plan.md to start Wave 1.
+
+### 3. Current Goal
+Begin implementation of service launcher Advanced mode.
+
+### 4. Lessons Learned
+(none yet)
+
+### 5. Completed Work
+- Spec created: .specs/FR-2444-service-launcher-advanced-mode/spec.md
+- Dev plan created: .specs/FR-2444-service-launcher-advanced-mode/dev-plan.md
+- 2 issues created with dependency links

--- a/.specs/FR-2444-service-launcher-advanced-mode/.context/tasks.md
+++ b/.specs/FR-2444-service-launcher-advanced-mode/.context/tasks.md
@@ -1,0 +1,12 @@
+# Service Launcher Advanced Mode Tasks
+
+> Last synced: 2026-04-03 14:00
+> Source: GitHub Issues
+
+## Progress: 2/2 complete
+
+### Wave 1
+- [x] #6368: Add Advanced collapsible Card with toggle, URL sync, and move env vars / cluster mode — PR #6374
+
+### Wave 2
+- [x] #6369: Replace VFolderTableFormItem with BAIVFolderSelect multi-select — PR #6375

--- a/.specs/FR-2444-service-launcher-advanced-mode/dev-plan.md
+++ b/.specs/FR-2444-service-launcher-advanced-mode/dev-plan.md
@@ -1,0 +1,33 @@
+# Service Launcher Advanced Mode Dev Plan
+
+## Spec Reference
+`.specs/FR-2444-service-launcher-advanced-mode/spec.md`
+
+## Epic: FR-2444
+
+## Sub-tasks (Implementation Order)
+
+### 1. Add Advanced collapsible Card with toggle, URL sync, and move env vars / cluster mode — #6368
+- **Changed files**:
+  - `react/src/components/ServiceLauncherPageContent.tsx` — add Advanced Card, move EnvVarFormList and cluster mode/size JSX, add `advancedMode` URL query param
+  - `react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx` — add `hideClusterMode` prop to conditionally suppress cluster mode/size rendering
+- **Dependencies**: None
+- **Review complexity**: Medium
+- **Description**: Create an Advanced collapsible Card following the `SessionOwnerSetterCard` pattern (Card + Switch toggle + `styles.body.display` visibility). Move environment variables (`EnvVarFormList`) and cluster mode/size from their current locations into this Card. Add `advancedMode` boolean to `useQueryParams` for URL persistence. Change cluster mode tooltip icons from `InfoCircleOutlined` to `QuestionCircleOutlined`. Ensure form validation spans both default and Advanced sections.
+
+### 2. Replace VFolderTableFormItem with BAIVFolderSelect multi-select — #6369
+- **Changed files**:
+  - `react/src/components/ServiceLauncherPageContent.tsx` — replace `VFolderTableFormItem` with `BAIVFolderSelect` in `mode="multiple"`, update form value mapping
+- **Dependencies**: Sub-task 1 (#6368 blocks #6369)
+- **Review complexity**: Medium
+- **Description**: Replace the table-based additional mount selector (`VFolderTableFormItem`) with `BAIVFolderSelect` using `mode="multiple"` inside the Advanced Card. Apply the same filter conditions (exclude model folder, only ready status, exclude model usage mode, exclude system folders). Ensure `mount_ids` form field and `extra_mounts` payload format remain compatible with both create and edit flows.
+
+## PR Stack Strategy
+- Sequential: #6368 -> #6369
+
+## Dependency Graph
+```
+#6368 (Advanced Card + toggle + env vars + cluster mode)
+  |
+  └──blocks──→ #6369 (BAIVFolderSelect multi-select replacement)
+```

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -81,7 +81,7 @@ import {
   BAIVFolderSelect,
   ESMClientErrorResponse,
   filterOutNullAndUndefined,
-  convertToUUID,
+  toLocalId,
   mergeFilterValues,
   useErrorMessageResolver,
   useBAILogger,
@@ -381,6 +381,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           human_readable_name
         }
         extra_mounts @since(version: "24.03.4") {
+          id
           row_id
           name
         }
@@ -626,9 +627,10 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           extra_mounts: _.reduce(
             values.mount_ids,
             (acc, key: string) => {
-              acc[key] = {
-                ...(values.mount_id_map[key] && {
-                  mount_destination: values.mount_id_map[key],
+              const localId = toLocalId(key);
+              acc[localId] = {
+                ...(values.mount_id_map[localId] && {
+                  mount_destination: values.mount_id_map[localId],
                 }),
                 type: 'bind', // FIXME: hardcoded. change it with option later
               };
@@ -868,10 +870,11 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                   values,
                 ),
                 extra_mounts: _.map(values.mount_ids, (vfolder) => {
+                  const localId = toLocalId(vfolder);
                   return {
-                    vfolder_id: vfolder,
-                    ...(values.mount_id_map[vfolder] && {
-                      mount_destination: values.mount_id_map[vfolder],
+                    vfolder_id: localId,
+                    ...(values.mount_id_map[localId] && {
+                      mount_destination: values.mount_id_map[localId],
                     }),
                   };
                 }),
@@ -1081,7 +1084,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           image: endpoint?.image_object,
         },
         vFolderID: endpoint?.model,
-        mount_ids: _.map(endpoint?.extra_mounts, (item) => item?.row_id),
+        mount_ids: _.map(endpoint?.extra_mounts, (item) => item?.id),
         // TODO: implement mount_id_map. Now, it's impossible to get mount_destination from backend
         modelMountDestination: endpoint?.model_mount_destination,
         modelDefinitionPath: endpoint?.model_definition_path,
@@ -1711,30 +1714,39 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                           }
                     }
                   >
+                    <Form.Item name={'mount_id_map'} initialValue={{}} hidden>
+                      <Input />
+                    </Form.Item>
                     <Form.Item noStyle dependencies={['vFolderID']}>
                       {({ getFieldValue }) => {
                         const vFolderID = getFieldValue('vFolderID');
                         const excludeModelFilter = vFolderID
-                          ? `row_id != "${convertToUUID(vFolderID)}"`
+                          ? `id != "${vFolderID}"`
                           : null;
                         return (
                           <Form.Item
                             name={'mount_ids'}
                             label={t('modelService.AdditionalMounts')}
                           >
-                            <BAIVFolderSelect
-                              mode="multiple"
-                              valuePropName="row_id"
-                              currentProjectId={currentProject.id ?? undefined}
-                              filter={
-                                mergeFilterValues([
-                                  'status == "ready"',
-                                  'usage_mode != "model"',
-                                  'name !ilike ".%"',
-                                  excludeModelFilter,
-                                ]) ?? undefined
-                              }
-                            />
+                            <Suspense
+                              fallback={<Skeleton.Input active block />}
+                            >
+                              <BAIVFolderSelect
+                                mode="multiple"
+                                allowClear
+                                currentProjectId={
+                                  currentProject.id ?? undefined
+                                }
+                                filter={
+                                  mergeFilterValues([
+                                    'status == "ready"',
+                                    'usage_mode != "model"',
+                                    '(! name ilike ".%")',
+                                    excludeModelFilter,
+                                  ]) ?? undefined
+                                }
+                              />
+                            </Suspense>
                           </Form.Item>
                         );
                       }}
@@ -1783,6 +1795,33 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                               }}
                             />
                           </Form.Item>
+                        );
+                      }}
+                    </Form.Item>
+                    <Form.Item dependencies={['runtimeVariant']} noStyle>
+                      {({ getFieldValue }) => {
+                        const variant = getFieldValue('runtimeVariant');
+                        if (variant !== 'vllm' && variant !== 'sglang')
+                          return null;
+
+                        const extraArgsEnvName = getExtraArgsEnvVar(variant);
+                        const existingExtraArgs = endpoint
+                          ? ((
+                              JSON.parse(endpoint?.environ || '{}') as Record<
+                                string,
+                                string
+                              >
+                            )[extraArgsEnvName ?? ''] ?? '')
+                          : '';
+
+                        return (
+                          <RuntimeParameterFormSection
+                            runtimeVariant={variant}
+                            value={runtimeParamValues}
+                            onChange={setRuntimeParamValues}
+                            initialExtraArgs={existingExtraArgs}
+                            categories={['advanced']}
+                          />
                         );
                       }}
                     </Form.Item>

--- a/react/src/components/ServiceValidationView.tsx
+++ b/react/src/components/ServiceValidationView.tsx
@@ -22,6 +22,7 @@ import { App, Tag, theme } from 'antd';
 import {
   BAIFlex,
   ESMClientErrorResponse,
+  toLocalId,
   useErrorMessageResolver,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
@@ -91,9 +92,10 @@ const ServiceValidationView: React.FC<ServiceValidationModalProps> = ({
           extra_mounts: _.reduce(
             values.mount_ids,
             (acc, key: string) => {
-              acc[key] = {
-                ...(values.mount_id_map[key] && {
-                  mount_destination: values.mount_id_map[key],
+              const localId = toLocalId(key);
+              acc[localId] = {
+                ...(values.mount_id_map[localId] && {
+                  mount_destination: values.mount_id_map[localId],
                 }),
                 type: 'bind', // FIXME: hardcoded. change it with option later
               };


### PR DESCRIPTION
Resolves #6369(FR-2444)

## Summary
- Replace `VFolderTableFormItem` (table-based multi-select) with `BAIVFolderSelect` (`mode="multiple"`) for additional mounts in the service launcher
- Move additional mounts section into the Advanced collapsible Card body
- Apply equivalent filter conditions via GraphQL filter string: ready status, exclude model usage mode, exclude system folders (`.` prefix), exclude the selected model folder
- Update edit mode initial values to use standard UUID format (with dashes) matching `BAIVFolderSelect`'s `row_id` value format
- Form field `mount_ids` and submission payloads (`extra_mounts`) remain compatible with both create and modify flows