### PR TITLE
feat(FR-2446): add runtime extra args parser utility

### DIFF
--- a/react/src/helper/runtimeExtraArgsParser.test.ts
+++ b/react/src/helper/runtimeExtraArgsParser.test.ts
@@ -1,0 +1,235 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  parseExtraArgs,
+  serializeExtraArgs,
+  mergeExtraArgs,
+  reverseMapExtraArgs,
+} from './runtimeExtraArgsParser';
+
+describe('parseExtraArgs', () => {
+  it('should parse --flag value pairs', () => {
+    const result = parseExtraArgs('--temperature 0.7 --top-p 0.9');
+    expect(result.knownArgs).toEqual({
+      '--temperature': '0.7',
+      '--top-p': '0.9',
+    });
+    expect(result.unknownTokens).toEqual([]);
+  });
+
+  it('should parse --flag=value pairs', () => {
+    const result = parseExtraArgs('--temperature=0.7 --dtype=float16');
+    expect(result.knownArgs).toEqual({
+      '--temperature': '0.7',
+      '--dtype': 'float16',
+    });
+  });
+
+  it('should parse bool flags (--flag alone)', () => {
+    const result = parseExtraArgs('--enforce-eager --trust-remote-code');
+    expect(result.knownArgs).toEqual({
+      '--enforce-eager': 'true',
+      '--trust-remote-code': 'true',
+    });
+  });
+
+  it('should parse --no-flag as false', () => {
+    const result = parseExtraArgs('--no-enforce-eager');
+    expect(result.knownArgs).toEqual({
+      '--enforce-eager': 'false',
+    });
+  });
+
+  it('should handle last-wins for duplicate keys', () => {
+    const result = parseExtraArgs('--temperature 0.5 --temperature 0.8');
+    expect(result.knownArgs['--temperature']).toBe('0.8');
+  });
+
+  it('should handle last-wins for --flag and --no-flag', () => {
+    const result = parseExtraArgs('--enforce-eager --no-enforce-eager');
+    expect(result.knownArgs['--enforce-eager']).toBe('false');
+  });
+
+  it('should preserve short options as unknown tokens', () => {
+    const result = parseExtraArgs('-f -abc --temperature 0.7');
+    expect(result.knownArgs).toEqual({ '--temperature': '0.7' });
+    expect(result.unknownTokens).toEqual(['-f', '-abc']);
+  });
+
+  it('should handle quoted values', () => {
+    const result = parseExtraArgs(
+      '--chat-template "path with spaces/template.jinja"',
+    );
+    expect(result.knownArgs['--chat-template']).toBe(
+      'path with spaces/template.jinja',
+    );
+  });
+
+  it('should handle mixed syntax', () => {
+    const result = parseExtraArgs(
+      '--temperature=0.7 --max-model-len 4096 --enforce-eager --no-trust-remote-code -v',
+    );
+    expect(result.knownArgs).toEqual({
+      '--temperature': '0.7',
+      '--max-model-len': '4096',
+      '--enforce-eager': 'true',
+      '--trust-remote-code': 'false',
+    });
+    expect(result.unknownTokens).toEqual(['-v']);
+  });
+
+  it('should handle empty input', () => {
+    const result = parseExtraArgs('');
+    expect(result.knownArgs).toEqual({});
+    expect(result.unknownTokens).toEqual([]);
+  });
+
+  it('should handle whitespace-only input', () => {
+    const result = parseExtraArgs('   ');
+    expect(result.knownArgs).toEqual({});
+    expect(result.unknownTokens).toEqual([]);
+  });
+
+  it('should handle orphaned values as unknown tokens', () => {
+    const result = parseExtraArgs('orphan --temperature 0.7');
+    expect(result.knownArgs).toEqual({ '--temperature': '0.7' });
+    expect(result.unknownTokens).toEqual(['orphan']);
+  });
+
+  it('should handle --flag=value with spaces in value', () => {
+    const result = parseExtraArgs('--chat-template="my template"');
+    expect(result.knownArgs['--chat-template']).toBe('my template');
+  });
+});
+
+describe('serializeExtraArgs', () => {
+  it('should serialize key-value pairs', () => {
+    const result = serializeExtraArgs({
+      '--temperature': '0.7',
+      '--top-p': '0.9',
+    });
+    expect(result).toBe('--temperature 0.7 --top-p 0.9');
+  });
+
+  it('should serialize bool true as flag-only', () => {
+    const result = serializeExtraArgs({ '--enforce-eager': 'true' });
+    expect(result).toBe('--enforce-eager');
+  });
+
+  it('should omit bool false flags', () => {
+    const result = serializeExtraArgs({
+      '--enforce-eager': 'false',
+      '--temperature': '0.7',
+    });
+    expect(result).toBe('--temperature 0.7');
+  });
+
+  it('should quote values with spaces', () => {
+    const result = serializeExtraArgs({
+      '--chat-template': 'path with spaces',
+    });
+    expect(result).toBe('--chat-template "path with spaces"');
+  });
+
+  it('should append unknown tokens', () => {
+    const result = serializeExtraArgs({ '--temperature': '0.7' }, ['-v', '-f']);
+    expect(result).toBe('--temperature 0.7 -v -f');
+  });
+
+  it('should handle empty args', () => {
+    expect(serializeExtraArgs({})).toBe('');
+  });
+});
+
+describe('mergeExtraArgs', () => {
+  it('should merge UI and manual args (manual wins on conflict)', () => {
+    const uiArgs = { '--temperature': '0.7', '--top-p': '0.9' };
+    const manualInput = '--temperature 0.5 --max-model-len 4096';
+    const result = mergeExtraArgs(uiArgs, manualInput);
+    expect(result).toContain('--temperature 0.5');
+    expect(result).toContain('--top-p 0.9');
+    expect(result).toContain('--max-model-len 4096');
+  });
+
+  it('should exclude values matching defaults', () => {
+    const uiArgs = { '--temperature': '1.0', '--top-p': '0.9' };
+    const manualInput = '';
+    const defaults = { '--temperature': '1.0' };
+    const result = mergeExtraArgs(uiArgs, manualInput, defaults);
+    expect(result).not.toContain('--temperature');
+    expect(result).toContain('--top-p 0.9');
+  });
+
+  it('should preserve unknown tokens from manual input', () => {
+    const uiArgs = { '--temperature': '0.7' };
+    const manualInput = '-v --dtype float16';
+    const result = mergeExtraArgs(uiArgs, manualInput);
+    expect(result).toContain('--temperature 0.7');
+    expect(result).toContain('--dtype float16');
+    expect(result).toContain('-v');
+  });
+
+  it('should handle empty manual input', () => {
+    const uiArgs = { '--temperature': '0.7' };
+    const result = mergeExtraArgs(uiArgs, '');
+    expect(result).toBe('--temperature 0.7');
+  });
+
+  it('should handle empty UI args', () => {
+    const result = mergeExtraArgs({}, '--temperature 0.7');
+    expect(result).toBe('--temperature 0.7');
+  });
+
+  it('should handle both empty', () => {
+    const result = mergeExtraArgs({}, '');
+    expect(result).toBe('');
+  });
+});
+
+describe('reverseMapExtraArgs', () => {
+  it('should split args into mapped and unmapped', () => {
+    const schemaKeys = new Set(['--temperature', '--top-p']);
+    const result = reverseMapExtraArgs(
+      '--temperature 0.7 --max-model-len 4096 --top-p 0.9',
+      schemaKeys,
+    );
+    expect(result.mappedArgs).toEqual({
+      '--temperature': '0.7',
+      '--top-p': '0.9',
+    });
+    expect(result.unmappedText).toContain('--max-model-len 4096');
+  });
+
+  it('should handle all args mapped', () => {
+    const schemaKeys = new Set(['--temperature']);
+    const result = reverseMapExtraArgs('--temperature 0.7', schemaKeys);
+    expect(result.mappedArgs).toEqual({ '--temperature': '0.7' });
+    expect(result.unmappedText).toBe('');
+  });
+
+  it('should handle no args mapped', () => {
+    const schemaKeys = new Set(['--temperature']);
+    const result = reverseMapExtraArgs('--max-model-len 4096', schemaKeys);
+    expect(result.mappedArgs).toEqual({});
+    expect(result.unmappedText).toContain('--max-model-len 4096');
+  });
+
+  it('should preserve unknown tokens in unmapped text', () => {
+    const schemaKeys = new Set(['--temperature']);
+    const result = reverseMapExtraArgs(
+      '--temperature 0.7 -v orphan',
+      schemaKeys,
+    );
+    expect(result.mappedArgs).toEqual({ '--temperature': '0.7' });
+    expect(result.unmappedText).toContain('-v');
+    expect(result.unmappedText).toContain('orphan');
+  });
+
+  it('should handle empty input', () => {
+    const result = reverseMapExtraArgs('', new Set());
+    expect(result.mappedArgs).toEqual({});
+    expect(result.unmappedText).toBe('');
+  });
+});

--- a/react/src/helper/runtimeExtraArgsParser.ts
+++ b/react/src/helper/runtimeExtraArgsParser.ts
@@ -1,0 +1,183 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { tokenizeShellCommand } from './parseCliCommand';
+
+/**
+ * Parsed representation of a runtime extra args string.
+ * `knownArgs` maps CLI flag keys (e.g., "--temperature") to their string values.
+ * `unknownTokens` preserves tokens that couldn't be parsed (short opts, orphaned values).
+ */
+export interface ParsedExtraArgs {
+  knownArgs: Record<string, string>;
+  unknownTokens: string[];
+}
+
+/**
+ * Parse a runtime extra args string (e.g., VLLM_EXTRA_ARGS value) into a structured map.
+ *
+ * Supported syntax:
+ * - `--flag value` (space-separated)
+ * - `--flag=value` (equals-separated)
+ * - Quoted values: `--flag "value with space"` or `--flag='value'`
+ * - Bool flags: `--flag` alone → "true", `--no-flag` → mapped as `--flag` = "false"
+ * - Last-wins for duplicate keys
+ *
+ * Unsupported (preserved in unknownTokens):
+ * - Short options: `-f`, `-abc`
+ * - Orphaned values (no preceding flag)
+ */
+export function parseExtraArgs(input: string): ParsedExtraArgs {
+  const tokens = tokenizeShellCommand(input.trim());
+  const knownArgs: Record<string, string> = {};
+  const unknownTokens: string[] = [];
+
+  let i = 0;
+  while (i < tokens.length) {
+    const tok = tokens[i];
+
+    // Long option with = (--flag=value)
+    if (tok.startsWith('--') && tok.includes('=')) {
+      const eqIdx = tok.indexOf('=');
+      const key = tok.slice(0, eqIdx);
+      const value = tok.slice(eqIdx + 1);
+      knownArgs[key] = value;
+      i++;
+      continue;
+    }
+
+    // --no-flag (bool negation)
+    if (tok.startsWith('--no-')) {
+      const positiveKey = '--' + tok.slice(5);
+      knownArgs[positiveKey] = 'false';
+      i++;
+      continue;
+    }
+
+    // Long option without = (--flag [value])
+    if (tok.startsWith('--')) {
+      const nextTok = i + 1 < tokens.length ? tokens[i + 1] : undefined;
+      if (nextTok !== undefined && !nextTok.startsWith('-')) {
+        // --flag value
+        knownArgs[tok] = nextTok;
+        i += 2;
+      } else {
+        // --flag (bool, no value)
+        knownArgs[tok] = 'true';
+        i++;
+      }
+      continue;
+    }
+
+    // Short option or orphaned value → unknown
+    unknownTokens.push(tok);
+    i++;
+  }
+
+  return { knownArgs, unknownTokens };
+}
+
+/**
+ * Serialize a {key: value} map back to a CLI argument string.
+ *
+ * - Bool "true" → `--flag` (flag only)
+ * - Bool "false" → omitted (the absence of the flag means false)
+ * - Values with spaces → quoted with double quotes
+ * - Other values → `--flag value`
+ */
+export function serializeExtraArgs(
+  args: Record<string, string>,
+  unknownTokens: string[] = [],
+): string {
+  const parts: string[] = [];
+
+  for (const [key, value] of Object.entries(args)) {
+    if (value === 'true') {
+      parts.push(key);
+    } else if (value === 'false') {
+      // Omit false bool flags
+      continue;
+    } else if (value.includes(' ') || value.includes('\t')) {
+      parts.push(`${key} "${value}"`);
+    } else {
+      parts.push(`${key} ${value}`);
+    }
+  }
+
+  if (unknownTokens.length > 0) {
+    parts.push(unknownTokens.join(' '));
+  }
+
+  return parts.join(' ');
+}
+
+/**
+ * Merge UI-generated parameter args with manually entered extra args.
+ *
+ * Rules:
+ * - Same key in both → manual input wins (overrides UI value)
+ * - Keys only in UI → included
+ * - Keys only in manual → included
+ * - Unknown tokens from manual input are preserved
+ * - Values equal to defaultValue are excluded from the result
+ *
+ * @param uiArgs - Args from UI sliders/inputs: { "--temperature": "0.7", ... }
+ * @param manualInput - Raw text from the EXTRA_ARGS text field
+ * @param defaults - Optional default values: { "--temperature": "1.0", ... }
+ *                    Args matching their default are excluded from the output.
+ * @returns Merged CLI argument string
+ */
+export function mergeExtraArgs(
+  uiArgs: Record<string, string>,
+  manualInput: string,
+  defaults: Record<string, string> = {},
+): string {
+  const parsed = parseExtraArgs(manualInput);
+
+  // Merge: manual overrides UI
+  const merged: Record<string, string> = { ...uiArgs, ...parsed.knownArgs };
+
+  // Remove entries that match their default value
+  const filtered: Record<string, string> = {};
+  for (const [key, value] of Object.entries(merged)) {
+    if (defaults[key] !== undefined && defaults[key] === value) {
+      continue;
+    }
+    filtered[key] = value;
+  }
+
+  return serializeExtraArgs(filtered, parsed.unknownTokens);
+}
+
+/**
+ * Reverse-map an existing EXTRA_ARGS string to UI parameter values.
+ *
+ * Given a set of known schema keys, splits the parsed args into:
+ * - `mappedArgs`: args that match a schema key → suitable for UI controls
+ * - `unmappedText`: remaining args serialized back to text → shown in "additional args" field
+ *
+ * @param input - Raw EXTRA_ARGS string
+ * @param schemaKeys - Set of known CLI flag keys from the parameter schema (e.g., "--temperature")
+ */
+export function reverseMapExtraArgs(
+  input: string,
+  schemaKeys: Set<string>,
+): { mappedArgs: Record<string, string>; unmappedText: string } {
+  const { knownArgs, unknownTokens } = parseExtraArgs(input);
+
+  const mappedArgs: Record<string, string> = {};
+  const unmappedArgs: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(knownArgs)) {
+    if (schemaKeys.has(key)) {
+      mappedArgs[key] = value;
+    } else {
+      unmappedArgs[key] = value;
+    }
+  }
+
+  const unmappedText = serializeExtraArgs(unmappedArgs, unknownTokens);
+
+  return { mappedArgs, unmappedText };
+}


### PR DESCRIPTION
Resolves #6370(FR-2446)

## Summary

- Add `runtimeExtraArgsParser.ts` utility for parsing, serializing, and merging CLI arg strings (e.g., `VLLM_EXTRA_ARGS`, `SGLANG_EXTRA_ARGS`)
- Supports `--flag value`, `--flag=value`, `--no-flag`, boolean flags; preserves short opts and unknown tokens
- Key functions:
  - `parseExtraArgs()` — tokenize and parse CLI arg strings into structured map
  - `serializeExtraArgs()` — convert map back to CLI string (bool true → flag only, false → omit)
  - `mergeExtraArgs()` — merge UI slider values + manual input, manual wins on conflict, excludes defaults
  - `reverseMapExtraArgs()` — split parsed args into UI-mapped and unmapped text (for edit mode)
- Add 30 unit tests covering all parsing edge cases

## Changed Files

- `react/src/helper/runtimeExtraArgsParser.ts` — new
- `react/src/helper/runtimeExtraArgsParser.test.ts` — new