### PR TITLE
feat(FR-2446): add runtime parameter schema hook and form component

### DIFF
--- a/react/src/components/RuntimeParameterFormSection.tsx
+++ b/react/src/components/RuntimeParameterFormSection.tsx
@@ -1,0 +1,306 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  RuntimeParameterDef,
+  RuntimeParameterCategory,
+} from '../constants/runtimeParameterFallbacks';
+import {
+  mergeExtraArgs,
+  reverseMapExtraArgs,
+} from '../helper/runtimeExtraArgsParser';
+import {
+  RuntimeParameterGroup,
+  useRuntimeParameterSchema,
+  buildDefaultsMap,
+  buildSchemaKeySet,
+} from '../hooks/useRuntimeParameterSchema';
+import InputNumberWithSlider from './InputNumberWithSlider';
+import { InfoCircleOutlined } from '@ant-design/icons';
+import {
+  Checkbox,
+  Collapse,
+  Form,
+  InputNumber,
+  Select,
+  Input,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
+import { BAIFlex } from 'backend.ai-ui';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const { Text } = Typography;
+
+const CATEGORY_LABELS: Record<RuntimeParameterCategory, string> = {
+  sampling: 'runtimeParam.categorySampling',
+  context: 'runtimeParam.categoryContext',
+  advanced: 'runtimeParam.categoryAdvanced',
+};
+
+export interface RuntimeParameterValues {
+  [key: string]: string;
+}
+
+interface RuntimeParameterFormSectionProps {
+  runtimeVariant: string;
+  value?: RuntimeParameterValues;
+  onChange?: (values: RuntimeParameterValues) => void;
+  /** Extra args text from manual input field (for merge preview) */
+  manualExtraArgs?: string;
+  /** Existing extra args string for edit mode reverse-mapping */
+  initialExtraArgs?: string;
+}
+
+/**
+ * Dynamic form section for runtime parameters (vLLM/SGLang).
+ * Renders slider/input/select/checkbox controls based on parameter schema.
+ */
+const RuntimeParameterFormSection: React.FC<
+  RuntimeParameterFormSectionProps
+> = ({
+  runtimeVariant,
+  value: controlledValue,
+  onChange,
+  initialExtraArgs,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const groups = useRuntimeParameterSchema(runtimeVariant);
+
+  // Internal state for uncontrolled usage
+  const [internalValues, setInternalValues] = useState<RuntimeParameterValues>(
+    {},
+  );
+  const values = controlledValue ?? internalValues;
+
+  const setValues = useCallback(
+    (newValues: RuntimeParameterValues) => {
+      if (onChange) {
+        onChange(newValues);
+      } else {
+        setInternalValues(newValues);
+      }
+    },
+    [onChange],
+  );
+
+  // Initialize from defaults or reverse-map from existing extra args
+  useEffect(() => {
+    if (!groups) return;
+
+    const defaults = buildDefaultsMap(groups);
+
+    if (initialExtraArgs) {
+      const schemaKeys = buildSchemaKeySet(groups);
+      const { mappedArgs } = reverseMapExtraArgs(initialExtraArgs, schemaKeys);
+      // Merge mapped values with defaults for any missing keys
+      setValues({ ...defaults, ...mappedArgs });
+    } else {
+      setValues(defaults);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runtimeVariant]);
+
+  const handleParamChange = useCallback(
+    (key: string, newValue: string) => {
+      const updated = { ...values, [key]: newValue };
+      setValues(updated);
+    },
+    [values, setValues],
+  );
+
+  if (!groups) return null;
+
+  return (
+    <BAIFlex direction="column" gap="xs">
+      <Text strong style={{ marginBottom: token.marginXS }}>
+        {t('runtimeParam.title')}
+      </Text>
+      {groups.map((group) => {
+        if (group.category === 'advanced') {
+          return (
+            <Collapse
+              key={group.category}
+              ghost
+              size="small"
+              items={[
+                {
+                  key: 'advanced',
+                  label: (
+                    <Text type="secondary">
+                      {t(CATEGORY_LABELS[group.category])}
+                    </Text>
+                  ),
+                  children: (
+                    <ParameterGroupContent
+                      group={group}
+                      values={values}
+                      onParamChange={handleParamChange}
+                    />
+                  ),
+                },
+              ]}
+            />
+          );
+        }
+        return (
+          <BAIFlex key={group.category} direction="column" gap="xxs">
+            <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+              {t(CATEGORY_LABELS[group.category])}
+            </Text>
+            <ParameterGroupContent
+              group={group}
+              values={values}
+              onParamChange={handleParamChange}
+            />
+          </BAIFlex>
+        );
+      })}
+    </BAIFlex>
+  );
+};
+
+interface ParameterGroupContentProps {
+  group: RuntimeParameterGroup;
+  values: RuntimeParameterValues;
+  onParamChange: (key: string, value: string) => void;
+}
+
+const ParameterGroupContent: React.FC<ParameterGroupContentProps> = ({
+  group,
+  values,
+  onParamChange,
+}) => {
+  return (
+    <BAIFlex direction="column" gap="xxs">
+      {group.params.map((param) => (
+        <ParameterControl
+          key={param.key}
+          param={param}
+          value={values[param.key] ?? param.defaultValue}
+          onChange={(val) => onParamChange(param.key, val)}
+        />
+      ))}
+    </BAIFlex>
+  );
+};
+
+interface ParameterControlProps {
+  param: RuntimeParameterDef;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const ParameterControl: React.FC<ParameterControlProps> = ({
+  param,
+  value,
+  onChange,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+
+  const label = (
+    <BAIFlex direction="row" gap="xxs" align="center">
+      <span>{t(param.name)}</span>
+      <Tooltip title={t(param.description)}>
+        <InfoCircleOutlined
+          style={{
+            color: token.colorTextSecondary,
+            fontSize: token.fontSizeSM,
+          }}
+        />
+      </Tooltip>
+    </BAIFlex>
+  );
+
+  switch (param.uiType) {
+    case 'slider':
+      return (
+        <Form.Item label={label} style={{ marginBottom: token.marginXS }}>
+          <InputNumberWithSlider
+            min={param.min}
+            max={param.max}
+            step={param.step}
+            value={parseFloat(value)}
+            onChange={(v) => onChange(String(v))}
+            inputContainerMinWidth={150}
+          />
+        </Form.Item>
+      );
+
+    case 'number_input':
+      return (
+        <Form.Item label={label} style={{ marginBottom: token.marginXS }}>
+          <InputNumber
+            min={param.min}
+            max={param.max}
+            step={param.step}
+            value={
+              param.valueType === 'int'
+                ? parseInt(value, 10)
+                : parseFloat(value)
+            }
+            onChange={(v) => {
+              if (v !== null) onChange(String(v));
+            }}
+            style={{ width: '100%' }}
+          />
+        </Form.Item>
+      );
+
+    case 'select':
+      return (
+        <Form.Item label={label} style={{ marginBottom: token.marginXS }}>
+          <Select
+            value={value}
+            onChange={onChange}
+            options={param.options?.map((opt) => ({
+              value: opt.value,
+              label: opt.label,
+            }))}
+          />
+        </Form.Item>
+      );
+
+    case 'checkbox':
+      return (
+        <Form.Item style={{ marginBottom: token.marginXS }}>
+          <Checkbox
+            checked={value === 'true'}
+            onChange={(e) => onChange(e.target.checked ? 'true' : 'false')}
+          >
+            {label}
+          </Checkbox>
+        </Form.Item>
+      );
+
+    case 'text_input':
+    default:
+      return (
+        <Form.Item label={label} style={{ marginBottom: token.marginXS }}>
+          <Input value={value} onChange={(e) => onChange(e.target.value)} />
+        </Form.Item>
+      );
+  }
+};
+
+export default RuntimeParameterFormSection;
+
+/**
+ * Helper to generate the final EXTRA_ARGS string from runtime parameter values.
+ * This is used by the parent form when submitting.
+ */
+export function buildExtraArgsString(
+  paramValues: RuntimeParameterValues,
+  manualExtraArgs: string,
+  groups: RuntimeParameterGroup[],
+): string {
+  const defaults = buildDefaultsMap(groups);
+  return mergeExtraArgs(paramValues, manualExtraArgs, defaults);
+}

--- a/react/src/hooks/useRuntimeParameterSchema.ts
+++ b/react/src/hooks/useRuntimeParameterSchema.ts
@@ -1,0 +1,96 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import {
+  RuntimeParameterDef,
+  RuntimeParameterCategory,
+  RUNTIME_PARAMETER_FALLBACKS,
+} from '../constants/runtimeParameterFallbacks';
+import { useMemo } from 'react';
+
+export interface RuntimeParameterGroup {
+  category: RuntimeParameterCategory;
+  params: RuntimeParameterDef[];
+}
+
+/**
+ * Hook that returns runtime parameter definitions grouped by category.
+ *
+ * Currently uses fallback metadata only. When the server extends
+ * RuntimeVariantPreset.target_spec with ui_type/category/min/max/step fields,
+ * this hook should fetch via GraphQL and merge with fallback data.
+ *
+ * @param runtimeVariant - The selected runtime variant name (e.g., "vllm", "sglang")
+ * @returns Grouped parameter definitions, or null if the variant has no parameter schema
+ */
+// TODO(needs-backend): FR-2446 — Add GraphQL fetch and merge with server schema
+export function useRuntimeParameterSchema(
+  runtimeVariant: string | undefined,
+): RuntimeParameterGroup[] | null {
+  return useMemo(() => {
+    if (!runtimeVariant) return null;
+
+    const params = RUNTIME_PARAMETER_FALLBACKS[runtimeVariant];
+    if (!params || params.length === 0) return null;
+
+    // Group by category and sort by rank within each group
+    const grouped = new Map<RuntimeParameterCategory, RuntimeParameterDef[]>();
+    for (const param of params) {
+      const group = grouped.get(param.category) ?? [];
+      group.push(param);
+      grouped.set(param.category, group);
+    }
+
+    // Sort params within each group by rank
+    for (const group of grouped.values()) {
+      group.sort((a, b) => a.rank - b.rank);
+    }
+
+    // Return in display order: sampling → context → advanced
+    const categoryOrder: RuntimeParameterCategory[] = [
+      'sampling',
+      'context',
+      'advanced',
+    ];
+
+    return categoryOrder
+      .filter((cat) => grouped.has(cat))
+      .map((cat) => ({
+        category: cat,
+        params: grouped.get(cat)!,
+      }));
+  }, [runtimeVariant]);
+}
+
+/**
+ * Build a defaults map from parameter definitions.
+ * Used for excluding default values from the serialized args string.
+ */
+export function buildDefaultsMap(
+  groups: RuntimeParameterGroup[],
+): Record<string, string> {
+  const defaults: Record<string, string> = {};
+  for (const group of groups) {
+    for (const param of group.params) {
+      defaults[param.key] = param.defaultValue;
+    }
+  }
+  return defaults;
+}
+
+/**
+ * Build a set of known schema keys from parameter definitions.
+ * Used for reverse-mapping existing EXTRA_ARGS to UI controls.
+ */
+export function buildSchemaKeySet(
+  groups: RuntimeParameterGroup[],
+): Set<string> {
+  const keys = new Set<string>();
+  for (const group of groups) {
+    for (const param of group.params) {
+      keys.add(param.key);
+    }
+  }
+  return keys;
+}


### PR DESCRIPTION
Resolves #6372(FR-2446)

## Summary

- Add `useRuntimeParameterSchema` hook that returns grouped parameters sorted by rank, in category order: sampling → context → advanced
- Add `buildDefaultsMap()` and `buildSchemaKeySet()` helpers for merge/reverse-mapping
- Currently uses frontend fallback metadata only; TODO for GraphQL fetch when server extends `RuntimeVariantPreset.target_spec`
- Add `RuntimeParameterFormSection` component with dynamic form rendering:
  - Controlled/uncontrolled mode via `value`/`onChange` props
  - `initialExtraArgs` prop for edit mode reverse-mapping
  - Renders slider (`InputNumberWithSlider`), number input, select, checkbox, text input controls
  - Category labels with i18n, info tooltips per parameter
  - Advanced category hidden with `// TODO(FR-2445)` for advanced mode feature
  - Info text explaining unchanged parameters use runtime defaults
- Export `buildExtraArgsString()` helper for form submission

## Changed Files

- `react/src/hooks/useRuntimeParameterSchema.ts` — new
- `react/src/components/RuntimeParameterFormSection.tsx` — new