### PR TITLE
refactor(FR-2444): extract ClusterModeFormItems and add hideClusterFormItems option

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -48,6 +48,7 @@ import InputNumberWithSlider from './InputNumberWithSlider';
 import RuntimeParameterFormSection, {
   RuntimeParameterValues,
 } from './RuntimeParameterFormSection';
+import ClusterModeFormItems from './SessionFormItems/ClusterModeFormItems';
 import ResourceAllocationFormItems, {
   AUTOMATIC_DEFAULT_SHMEM,
   RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
@@ -630,7 +631,13 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         group: baiClient.current_group, // current Project Group,
         domain: currentDomain, // current Domain Group,
         cluster_size: values.cluster_size,
-        cluster_mode: values.cluster_mode,
+        // Convert multi-node x1 to single-node x1 since they are functionally
+        // equivalent but multi-node requires overlay network which may not be
+        // configured in all-in-one environments (FR-2381)
+        cluster_mode:
+          values.cluster_mode === 'multi-node' && values.cluster_size === 1
+            ? 'single-node'
+            : values.cluster_mode,
         open_to_public: values.openToPublic,
         config: {
           model: values.vFolderID,
@@ -863,8 +870,11 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                     })
                   : endpoint.resource_opts,
                 // FIXME: temporarily convert cluster mode string according to server-side type
+                // Also convert multi-node x1 to single-node x1 (FR-2381)
                 cluster_mode:
-                  'single-node' === values.cluster_mode
+                  values.cluster_mode === 'single-node' ||
+                  (values.cluster_mode === 'multi-node' &&
+                    values.cluster_size === 1)
                     ? 'SINGLE_NODE'
                     : 'MULTI_NODE',
                 cluster_size: values.cluster_size,
@@ -1674,6 +1684,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                         ) : (
                           <ResourceAllocationFormItems
                             enableResourcePresets
+                            hideClusterFormItems
                             extraAcceleratorRules={
                               gpuHint
                                 ? [
@@ -1855,9 +1866,13 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                         );
                       }}
                     </Form.Item>
-                    {/* TODO(FR-2444): Extract cluster mode from ResourceAllocationFormItems
-                        into a standalone component so it can be placed in the Advanced Card
-                        with all original logic (disable conditions, max limit, onChange, remaining warnings). */}
+                    <ClusterModeFormItems
+                      remaining={{
+                        cpu: undefined,
+                        mem: undefined,
+                        accelerators: {},
+                      }}
+                    />
                   </Card>
                   <BAIFlex
                     direction="row"

--- a/react/src/components/SessionFormItems/ClusterModeFormItems.tsx
+++ b/react/src/components/SessionFormItems/ClusterModeFormItems.tsx
@@ -1,0 +1,300 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { convertToBinaryUnit } from '../../helper';
+import { useSuspendedBackendaiClient } from '../../hooks';
+import { useCurrentKeyPairResourcePolicyLazyLoadQuery } from '../../hooks/hooksUsingRelay';
+import { RemainingSlots } from '../../hooks/useResourceLimitAndRemaining';
+import InputNumberWithSlider from '../InputNumberWithSlider';
+import { CaretDownOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+import { Card, Col, Form, Radio, Row, Tooltip, theme } from 'antd';
+import { BAIFlex } from 'backend.ai-ui';
+import _ from 'lodash';
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+interface ClusterModeFormItemsProps {
+  remaining: RemainingSlots;
+  showRemainingWarning?: boolean;
+}
+
+const ClusterModeFormItems: React.FC<ClusterModeFormItemsProps> = ({
+  remaining,
+  showRemainingWarning = false,
+}) => {
+  'use memo';
+  const form = Form.useFormInstance();
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+
+  const baiClient = useSuspendedBackendaiClient();
+  const supportMultiAgents = baiClient.supports('multi-agents');
+
+  const [{ keypairResourcePolicy }] =
+    useCurrentKeyPairResourcePolicyLazyLoadQuery();
+
+  return (
+    <Form.Item
+      label={t('session.launcher.ClusterMode')}
+      required
+      dependencies={['agent']}
+    >
+      {({ getFieldValue }) => {
+        return (
+          <Card
+            style={{
+              marginBottom: token.margin,
+            }}
+          >
+            <Row gutter={token.marginMD}>
+              <Col xs={24}>
+                <Form.Item name={'cluster_mode'} required>
+                  <Radio.Group
+                    onChange={() => {
+                      form.validateFields().catch(() => {});
+                    }}
+                    disabled={
+                      !supportMultiAgents &&
+                      !_.isEqual(_.castArray(getFieldValue('agent')), ['auto'])
+                    }
+                  >
+                    <Radio.Button value="multi-node">
+                      {t('session.launcher.MultiNode')}
+                      <Tooltip
+                        title={
+                          <Trans i18nKey={'session.launcher.DescMultiNode'} />
+                        }
+                      >
+                        <QuestionCircleOutlined
+                          style={{ marginLeft: token.marginXXS }}
+                        />
+                      </Tooltip>
+                    </Radio.Button>
+                    <Radio.Button value="single-node">
+                      {t('session.launcher.SingleNode')}
+                      <Tooltip
+                        title={
+                          <Trans i18nKey={'session.launcher.DescSingleNode'} />
+                        }
+                      >
+                        <QuestionCircleOutlined
+                          style={{ marginLeft: token.marginXXS }}
+                        />
+                      </Tooltip>
+                    </Radio.Button>
+                  </Radio.Group>
+                </Form.Item>
+              </Col>
+              <Col xs={24}>
+                <Form.Item
+                  noStyle
+                  shouldUpdate={(prev, next) =>
+                    prev.cluster_mode !== next.cluster_mode ||
+                    prev.cluster_size !== next.cluster_size ||
+                    prev.resource?.cpu !== next.resource?.cpu ||
+                    prev.resource?.mem !== next.resource?.mem ||
+                    prev.resource?.accelerator !== next.resource?.accelerator ||
+                    prev.resource?.acceleratorType !==
+                      next.resource?.acceleratorType
+                  }
+                >
+                  {() => {
+                    const derivedClusterSizeMaxLimit =
+                      keypairResourcePolicy.max_containers_per_session;
+
+                    const clusterUnit =
+                      form.getFieldValue('cluster_mode') === 'single-node'
+                        ? t('session.launcher.Container')
+                        : t('session.launcher.Node');
+
+                    // Calculate max cluster size that can start immediately
+                    // based on current resource allocation and remaining resources
+                    const currentResource = form.getFieldValue('resource');
+                    const maxClusterCandidates: number[] = [];
+                    if (
+                      Number.isFinite(remaining.cpu) &&
+                      currentResource?.cpu > 0
+                    ) {
+                      maxClusterCandidates.push(
+                        Math.floor(remaining.cpu! / currentResource.cpu),
+                      );
+                    }
+                    if (
+                      Number.isFinite(remaining.mem) &&
+                      currentResource?.mem
+                    ) {
+                      const memBytes =
+                        convertToBinaryUnit(currentResource.mem, '')?.number ||
+                        0;
+                      if (memBytes > 0) {
+                        maxClusterCandidates.push(
+                          Math.floor(remaining.mem! / memBytes),
+                        );
+                      }
+                    }
+                    const accelType = currentResource?.acceleratorType;
+                    const accelValue = currentResource?.accelerator || 0;
+                    if (
+                      accelType &&
+                      accelValue > 0 &&
+                      Number.isFinite(remaining.accelerators[accelType])
+                    ) {
+                      maxClusterCandidates.push(
+                        Math.floor(
+                          remaining.accelerators[accelType]! / accelValue,
+                        ),
+                      );
+                    }
+                    const maxImmediateClusterSize =
+                      maxClusterCandidates.length > 0
+                        ? _.min(maxClusterCandidates)
+                        : undefined;
+
+                    // Use resource-aware remaining mark instead of raw remaining.cpu
+                    // Clamp to slider max so the mark doesn't render outside the range
+                    const remainingMarkValue =
+                      _.isNumber(maxImmediateClusterSize) &&
+                      maxImmediateClusterSize >= 1
+                        ? _.isNumber(derivedClusterSizeMaxLimit)
+                          ? Math.min(
+                              maxImmediateClusterSize,
+                              derivedClusterSizeMaxLimit,
+                            )
+                          : maxImmediateClusterSize
+                        : undefined;
+
+                    return (
+                      <Form.Item
+                        name={'cluster_size'}
+                        label={t('session.launcher.ClusterSize')}
+                        required
+                        dependencies={[
+                          ['resource', 'cpu'],
+                          ['resource', 'mem'],
+                          ['resource', 'accelerator'],
+                          ['resource', 'acceleratorType'],
+                        ]}
+                        rules={[
+                          {
+                            warningOnly: true,
+                            validator: async (_rule, value: number) => {
+                              if (
+                                form.getFieldValue('cluster_mode') ===
+                                  'multi-node' &&
+                                value === 1
+                              ) {
+                                return Promise.reject(
+                                  t(
+                                    'session.launcher.ClusterSizeOneMultiNodeConvertInfo',
+                                  ),
+                                );
+                              }
+                              return Promise.resolve();
+                            },
+                          },
+                          {
+                            warningOnly: true,
+                            validator: async (_rule, value: number) => {
+                              if (showRemainingWarning && value > 1) {
+                                if (
+                                  _.isNumber(maxImmediateClusterSize) &&
+                                  maxImmediateClusterSize >= 1 &&
+                                  value > maxImmediateClusterSize
+                                ) {
+                                  return Promise.reject(
+                                    t(
+                                      'session.launcher.ClusterSizeExceedsImmediateCapacity',
+                                      {
+                                        maxClusterSize: maxImmediateClusterSize,
+                                        unit: clusterUnit,
+                                      },
+                                    ),
+                                  );
+                                }
+                              }
+                              return Promise.resolve();
+                            },
+                          },
+                        ]}
+                      >
+                        <InputNumberWithSlider
+                          inputContainerMinWidth={190}
+                          min={1}
+                          step={1}
+                          max={
+                            _.isNumber(derivedClusterSizeMaxLimit)
+                              ? derivedClusterSizeMaxLimit
+                              : undefined
+                          }
+                          disabled={
+                            derivedClusterSizeMaxLimit === 1 ||
+                            (!supportMultiAgents &&
+                              !_.isEqual(_.castArray(getFieldValue('agent')), [
+                                'auto',
+                              ]))
+                          }
+                          sliderProps={{
+                            marks: {
+                              1: '1',
+                              // remaining mark code should be located before max mark code to prevent overlapping when it is same value
+                              ...(remainingMarkValue
+                                ? {
+                                    [remainingMarkValue]: {
+                                      label: <RemainingMark />,
+                                    },
+                                  }
+                                : {}),
+                              ...(_.isNumber(derivedClusterSizeMaxLimit)
+                                ? {
+                                    [derivedClusterSizeMaxLimit]:
+                                      derivedClusterSizeMaxLimit,
+                                  }
+                                : {}),
+                            },
+                            tooltip: {
+                              formatter: (value = 0) => {
+                                return `${value} ${clusterUnit}`;
+                              },
+                            },
+                          }}
+                          inputNumberProps={{
+                            suffix: clusterUnit,
+                          }}
+                          onChange={(value) => {
+                            if (value > 1) {
+                              form.setFieldValue('num_of_sessions', 1);
+                            }
+                          }}
+                        />
+                      </Form.Item>
+                    );
+                  }}
+                </Form.Item>
+              </Col>
+            </Row>
+          </Card>
+        );
+      }}
+    </Form.Item>
+  );
+};
+
+const RemainingMark: React.FC = () => {
+  const { token } = theme.useToken();
+  return (
+    <BAIFlex
+      style={{
+        position: 'absolute',
+        top: -24,
+        transform: 'translateX(-50%)',
+        color: token.colorSuccess,
+        opacity: 0.5,
+      }}
+    >
+      <CaretDownOutlined />
+    </BAIFlex>
+  );
+};
+
+export default ClusterModeFormItems;

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -24,13 +24,10 @@ import {
 } from '../ImageEnvironmentSelectFormItems';
 import InputNumberWithSlider from '../InputNumberWithSlider';
 import ResourcePresetSelect from '../ResourcePresetSelect';
+import ClusterModeFormItems from './ClusterModeFormItems';
 import SharedMemoryFormItems from './SharedMemoryFormItems';
-import {
-  CaretDownOutlined,
-  QuestionCircleOutlined,
-  ReloadOutlined,
-} from '@ant-design/icons';
-import { Button, Card, Col, Form, Radio, Row, Tooltip, theme } from 'antd';
+import { CaretDownOutlined, ReloadOutlined } from '@ant-design/icons';
+import { Button, Card, Form, theme } from 'antd';
 import {
   useResourceSlotsDetails,
   BAIFlex,
@@ -91,6 +88,7 @@ interface ResourceAllocationFormItemsProps {
   enableResourcePresets?: boolean;
   showRemainingWarning?: boolean;
   forceImageMinValues?: boolean;
+  hideClusterFormItems?: boolean;
   extraAcceleratorRules?: Array<{
     warningOnly?: boolean;
     validator: (rule: unknown, value: number) => Promise<void>;
@@ -105,6 +103,7 @@ const ResourceAllocationFormItems: React.FC<
   enableResourcePresets,
   forceImageMinValues = false,
   showRemainingWarning = false,
+  hideClusterFormItems = false,
   extraAcceleratorRules,
 }) => {
   const form = Form.useFormInstance<MergedResourceAllocationFormValue>();
@@ -114,7 +113,7 @@ const ResourceAllocationFormItems: React.FC<
   const baiClient = useSuspendedBackendaiClient();
   const supportMultiAgents = baiClient.supports('multi-agents');
 
-  const [{ keypairResourcePolicy, sessionLimitAndRemaining }] =
+  const [{ sessionLimitAndRemaining }] =
     useCurrentKeyPairResourcePolicyLazyLoadQuery();
 
   const [agentFetchKey, updateAgentFetchKey] = useUpdatableState('first');
@@ -1342,257 +1341,12 @@ const ResourceAllocationFormItems: React.FC<
           </BAIFlex>
         </Form.Item>
       )}
-      <Form.Item
-        label={t('session.launcher.ClusterMode')}
-        required
-        dependencies={['agent']}
-      >
-        {({ getFieldValue }) => {
-          return (
-            <Card
-              style={{
-                marginBottom: token.margin,
-              }}
-            >
-              <Row gutter={token.marginMD}>
-                <Col xs={24}>
-                  {/* <Col xs={24} lg={12}> */}
-                  <Form.Item name={'cluster_mode'} required>
-                    <Radio.Group
-                      onChange={() => {
-                        form.validateFields().catch(() => {});
-                      }}
-                      disabled={
-                        !supportMultiAgents &&
-                        !_.isEqual(_.castArray(getFieldValue('agent')), [
-                          'auto',
-                        ])
-                      }
-                    >
-                      <Radio.Button value="multi-node">
-                        {t('session.launcher.MultiNode')}
-                        <Tooltip
-                          title={
-                            <Trans i18nKey={'session.launcher.DescMultiNode'} />
-                          }
-                        >
-                          <QuestionCircleOutlined
-                            style={{ marginLeft: token.marginXXS }}
-                          />
-                        </Tooltip>
-                      </Radio.Button>
-                      <Radio.Button value="single-node">
-                        {t('session.launcher.SingleNode')}
-                        <Tooltip
-                          title={
-                            <Trans
-                              i18nKey={'session.launcher.DescSingleNode'}
-                            />
-                          }
-                        >
-                          <QuestionCircleOutlined
-                            style={{ marginLeft: token.marginXXS }}
-                          />
-                        </Tooltip>
-                      </Radio.Button>
-                    </Radio.Group>
-                  </Form.Item>
-                </Col>
-                <Col xs={24}>
-                  <Form.Item
-                    noStyle
-                    shouldUpdate={(prev, next) =>
-                      prev.cluster_mode !== next.cluster_mode ||
-                      prev.cluster_size !== next.cluster_size ||
-                      prev.resource?.cpu !== next.resource?.cpu ||
-                      prev.resource?.mem !== next.resource?.mem ||
-                      prev.resource?.accelerator !==
-                        next.resource?.accelerator ||
-                      prev.resource?.acceleratorType !==
-                        next.resource?.acceleratorType
-                    }
-                  >
-                    {() => {
-                      const derivedClusterSizeMaxLimit =
-                        keypairResourcePolicy.max_containers_per_session;
-
-                      const clusterUnit =
-                        form.getFieldValue('cluster_mode') === 'single-node'
-                          ? t('session.launcher.Container')
-                          : t('session.launcher.Node');
-
-                      // Calculate max cluster size that can start immediately
-                      // based on current resource allocation and remaining resources
-                      const currentResource = form.getFieldValue('resource');
-                      const maxClusterCandidates: number[] = [];
-                      if (
-                        Number.isFinite(remaining.cpu) &&
-                        currentResource?.cpu > 0
-                      ) {
-                        maxClusterCandidates.push(
-                          Math.floor(remaining.cpu! / currentResource.cpu),
-                        );
-                      }
-                      if (
-                        Number.isFinite(remaining.mem) &&
-                        currentResource?.mem
-                      ) {
-                        const memBytes =
-                          convertToBinaryUnit(currentResource.mem, '')
-                            ?.number || 0;
-                        if (memBytes > 0) {
-                          maxClusterCandidates.push(
-                            Math.floor(remaining.mem! / memBytes),
-                          );
-                        }
-                      }
-                      const accelType = currentResource?.acceleratorType;
-                      const accelValue = currentResource?.accelerator || 0;
-                      if (
-                        accelType &&
-                        accelValue > 0 &&
-                        Number.isFinite(remaining.accelerators[accelType])
-                      ) {
-                        maxClusterCandidates.push(
-                          Math.floor(
-                            remaining.accelerators[accelType]! / accelValue,
-                          ),
-                        );
-                      }
-                      const maxImmediateClusterSize =
-                        maxClusterCandidates.length > 0
-                          ? _.min(maxClusterCandidates)
-                          : undefined;
-
-                      // Use resource-aware remaining mark instead of raw remaining.cpu
-                      // Clamp to slider max so the mark doesn't render outside the range
-                      const remainingMarkValue =
-                        _.isNumber(maxImmediateClusterSize) &&
-                        maxImmediateClusterSize >= 1
-                          ? _.isNumber(derivedClusterSizeMaxLimit)
-                            ? Math.min(
-                                maxImmediateClusterSize,
-                                derivedClusterSizeMaxLimit,
-                              )
-                            : maxImmediateClusterSize
-                          : undefined;
-
-                      return (
-                        <Form.Item
-                          name={'cluster_size'}
-                          label={t('session.launcher.ClusterSize')}
-                          required
-                          dependencies={[
-                            ['resource', 'cpu'],
-                            ['resource', 'mem'],
-                            ['resource', 'accelerator'],
-                            ['resource', 'acceleratorType'],
-                          ]}
-                          rules={[
-                            {
-                              warningOnly: true,
-                              validator: async (_rule, value: number) => {
-                                if (
-                                  form.getFieldValue('cluster_mode') ===
-                                    'multi-node' &&
-                                  value === 1
-                                ) {
-                                  return Promise.reject(
-                                    t(
-                                      'session.launcher.ClusterSizeOneMultiNodeConvertInfo',
-                                    ),
-                                  );
-                                }
-                                return Promise.resolve();
-                              },
-                            },
-                            {
-                              warningOnly: true,
-                              validator: async (_rule, value: number) => {
-                                if (showRemainingWarning && value > 1) {
-                                  if (
-                                    _.isNumber(maxImmediateClusterSize) &&
-                                    maxImmediateClusterSize >= 1 &&
-                                    value > maxImmediateClusterSize
-                                  ) {
-                                    return Promise.reject(
-                                      t(
-                                        'session.launcher.ClusterSizeExceedsImmediateCapacity',
-                                        {
-                                          maxClusterSize:
-                                            maxImmediateClusterSize,
-                                          unit: clusterUnit,
-                                        },
-                                      ),
-                                    );
-                                  }
-                                }
-                                return Promise.resolve();
-                              },
-                            },
-                          ]}
-                        >
-                          <InputNumberWithSlider
-                            inputContainerMinWidth={190}
-                            min={1}
-                            step={1}
-                            // TODO: max cluster size
-                            max={
-                              _.isNumber(derivedClusterSizeMaxLimit)
-                                ? derivedClusterSizeMaxLimit
-                                : undefined
-                            }
-                            disabled={
-                              derivedClusterSizeMaxLimit === 1 ||
-                              (!supportMultiAgents &&
-                                !_.isEqual(
-                                  _.castArray(getFieldValue('agent')),
-                                  ['auto'],
-                                ))
-                            }
-                            sliderProps={{
-                              marks: {
-                                1: '1',
-                                // remaining mark code should be located before max mark code to prevent overlapping when it is same value
-                                ...(remainingMarkValue
-                                  ? {
-                                      [remainingMarkValue]: {
-                                        label: <RemainingMark />,
-                                      },
-                                    }
-                                  : {}),
-                                ...(_.isNumber(derivedClusterSizeMaxLimit)
-                                  ? {
-                                      [derivedClusterSizeMaxLimit]:
-                                        derivedClusterSizeMaxLimit,
-                                    }
-                                  : {}),
-                              },
-                              tooltip: {
-                                formatter: (value = 0) => {
-                                  return `${value} ${clusterUnit}`;
-                                },
-                              },
-                            }}
-                            inputNumberProps={{
-                              suffix: clusterUnit,
-                            }}
-                            onChange={(value) => {
-                              if (value > 1) {
-                                form.setFieldValue('num_of_sessions', 1);
-                              }
-                            }}
-                          />
-                        </Form.Item>
-                      );
-                    }}
-                  </Form.Item>
-                </Col>
-              </Row>
-            </Card>
-          );
-        }}
-      </Form.Item>
+      {!hideClusterFormItems && (
+        <ClusterModeFormItems
+          remaining={remaining}
+          showRemainingWarning={showRemainingWarning}
+        />
+      )}
     </>
   );
 };

--- a/react/src/hooks/useModelServiceLauncher.ts
+++ b/react/src/hooks/useModelServiceLauncher.ts
@@ -120,7 +120,13 @@ export function useModelServiceLauncher() {
         group: baiClient.current_group,
         domain: currentDomain,
         cluster_size: values.cluster_size,
-        cluster_mode: values.cluster_mode,
+        // Convert multi-node x1 to single-node x1 since they are functionally
+        // equivalent but multi-node requires overlay network which may not be
+        // configured in all-in-one environments (FR-2381)
+        cluster_mode:
+          values.cluster_mode === 'multi-node' && values.cluster_size === 1
+            ? 'single-node'
+            : values.cluster_mode,
         open_to_public: values.openToPublic,
         config: {
           model: values.vFolderID,


### PR DESCRIPTION
Resolves FR-2444

## Summary
- Extract `ClusterModeFormItems` as a standalone component from `ResourceAllocationFormItems`
- Add `hideClusterFormItems` prop to `ResourceAllocationFormItems` to optionally hide cluster settings
- In Service Launcher, hide cluster in `ResourceAllocationFormItems` and render `ClusterModeFormItems` in the advanced settings card

## Test plan
- [ ] Verify cluster mode/size form items still work in session launcher (where `hideClusterFormItems` is not set)
- [ ] Verify cluster settings appear in advanced settings card in service launcher
- [ ] Verify remaining warnings and disable conditions work correctly
- [ ] Verify cluster_size>1 still forces num_of_sessions=1