### PR TITLE
feat(FR-2444): display runtime parameters in BAICard with category tabs

### DIFF
--- a/react/src/components/RuntimeParameterFormSection.tsx
+++ b/react/src/components/RuntimeParameterFormSection.tsx
@@ -26,7 +26,7 @@ import {
   Typography,
   theme,
 } from 'antd';
-import { BAIFlex } from 'backend.ai-ui';
+import { BAICard, BAIFlex } from 'backend.ai-ui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -37,6 +37,12 @@ const CATEGORY_LABELS: Record<RuntimeParameterCategory, string> = {
   context: 'modelService.RuntimeParamCategoryContext',
   advanced: 'modelService.RuntimeParamCategoryAdvanced',
 };
+
+const ALL_CATEGORIES: RuntimeParameterCategory[] = [
+  'sampling',
+  'context',
+  'advanced',
+];
 
 export interface RuntimeParameterValues {
   [key: string]: string;
@@ -50,8 +56,6 @@ interface RuntimeParameterFormSectionProps {
   manualExtraArgs?: string;
   /** Existing extra args string for edit mode reverse-mapping */
   initialExtraArgs?: string;
-  /** Filter to only render specific categories. If omitted, renders sampling + context (excludes advanced). */
-  categories?: RuntimeParameterCategory[];
 }
 
 /**
@@ -65,7 +69,6 @@ const RuntimeParameterFormSection: React.FC<
   value: controlledValue,
   onChange,
   initialExtraArgs,
-  categories,
 }) => {
   'use memo';
   const { t } = useTranslation();
@@ -77,6 +80,8 @@ const RuntimeParameterFormSection: React.FC<
     {},
   );
   const values = controlledValue ?? internalValues;
+
+  const [activeTab, setActiveTab] = useState<string>('sampling');
 
   const setValues = useCallback(
     (newValues: RuntimeParameterValues) => {
@@ -116,50 +121,44 @@ const RuntimeParameterFormSection: React.FC<
 
   if (!groups) return null;
 
-  const defaultCategories: RuntimeParameterCategory[] = ['sampling', 'context'];
-  const visibleCategories = categories ?? defaultCategories;
-  const isDefaultView = !categories;
+  // Build tab list from available categories
+  const availableCategories = ALL_CATEGORIES.filter((cat) =>
+    groups.some((g) => g.category === cat),
+  );
+  const tabList = availableCategories.map((cat) => ({
+    key: cat,
+    label: t(CATEGORY_LABELS[cat]),
+  }));
+
+  const activeGroup = groups.find((g) => g.category === activeTab);
 
   return (
-    <BAIFlex direction="column" gap="xs" align="stretch">
-      {isDefaultView && (
-        <>
-          <Text strong style={{ marginBottom: token.marginXS }}>
-            {t('modelService.RuntimeParamTitle')}
-          </Text>
-          <Text
-            type="secondary"
-            style={{
-              fontSize: token.fontSizeSM,
-              marginBottom: token.marginXS,
-            }}
-          >
-            {t('modelService.RuntimeParamUnchangedHint')}
-          </Text>
-        </>
-      )}
-      {groups
-        .filter((group) => visibleCategories.includes(group.category))
-        .map((group) => (
-          <BAIFlex
-            key={group.category}
-            direction="column"
-            gap="xxs"
-            align="stretch"
-          >
-            <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
-              {isDefaultView
-                ? t(CATEGORY_LABELS[group.category])
-                : t('modelService.RuntimeParamTitle')}
-            </Text>
-            <ParameterGroupContent
-              group={group}
-              values={values}
-              onParamChange={handleParamChange}
-            />
-          </BAIFlex>
-        ))}
-    </BAIFlex>
+    <Form.Item label={t('modelService.RuntimeParamTitle')}>
+      <BAICard
+        size="small"
+        tabList={tabList}
+        activeTabKey={activeTab}
+        onTabChange={setActiveTab}
+      >
+        <Text
+          type="secondary"
+          style={{
+            display: 'block',
+            fontSize: token.fontSizeSM,
+            marginBottom: token.marginSM,
+          }}
+        >
+          {t('modelService.RuntimeParamUnchangedHint')}
+        </Text>
+        {activeGroup && (
+          <ParameterGroupContent
+            group={activeGroup}
+            values={values}
+            onParamChange={handleParamChange}
+          />
+        )}
+      </BAICard>
+    </Form.Item>
   );
 };
 

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1829,35 +1829,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                         );
                       }}
                     </Form.Item>
-                    <Form.Item dependencies={['runtimeVariant']} noStyle>
-                      {({ getFieldValue }) => {
-                        const variant = getFieldValue('runtimeVariant');
-                        if (variant !== 'vllm' && variant !== 'sglang')
-                          return null;
-
-                        const extraArgsEnvName = getExtraArgsEnvVar(variant);
-                        const existingExtraArgs = endpoint
-                          ? ((
-                              JSON.parse(endpoint?.environ || '{}') as Record<
-                                string,
-                                string
-                              >
-                            )[extraArgsEnvName ?? ''] ?? '')
-                          : '';
-
-                        return (
-                          <RuntimeParameterFormSection
-                            runtimeVariant={variant}
-                            onChange={handleRuntimeParamChange}
-                            initialExtraArgs={existingExtraArgs}
-                            categories={['advanced']}
-                          />
-                        );
-                      }}
-                    </Form.Item>
-                    {/* TODO(FR-2444): Extract cluster mode from ResourceAllocationFormItems
-                        into a standalone component so it can be placed in the Advanced Card
-                        with all original logic (disable conditions, max limit, onChange, remaining warnings). */}
+                    <ClusterModeFormItems />
                   </Card>
                   <BAIFlex
                     direction="row"

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1403,7 +1403,7 @@
     "RunThisModel": "Run this model",
     "RuntimeParamAdditionalArgs": "Additional Arguments",
     "RuntimeParamAdditionalArgsPlaceholder": "Additional CLI arguments not covered by the controls above",
-    "RuntimeParamCategoryAdvanced": "Advanced",
+    "RuntimeParamCategoryAdvanced": "Other",
     "RuntimeParamCategoryContext": "Context / Engine",
     "RuntimeParamCategorySampling": "Sampling",
     "RuntimeParamContextLength": "Context Length",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1405,7 +1405,7 @@
     "RunThisModel": "이 모델로 서비스 만들기",
     "RuntimeParamAdditionalArgs": "추가 인자",
     "RuntimeParamAdditionalArgsPlaceholder": "위 컨트롤에서 다루지 않는 추가 CLI 인자",
-    "RuntimeParamCategoryAdvanced": "고급",
+    "RuntimeParamCategoryAdvanced": "기타",
     "RuntimeParamCategoryContext": "컨텍스트 / 엔진",
     "RuntimeParamCategorySampling": "샘플링",
     "RuntimeParamContextLength": "컨텍스트 길이",


### PR DESCRIPTION
Resolves FR-2444

## Summary
- Replace flat group layout in `RuntimeParameterFormSection` with `BAICard` containing tabs for **Sampling**, **Context / Engine**, and **Other** categories
- Render all runtime parameter categories in a single tabbed card instead of splitting advanced params into the advanced settings section
- Remove `categories` prop — all categories are now displayed together via tabs
- Rename "Advanced" category label to "Other" (en) / "기타" (ko)

## Test plan
- [ ] Verify runtime parameters show in a tabbed card with 3 tabs (Sampling, Context/Engine, Other)
- [ ] Verify switching tabs shows the correct parameter controls
- [ ] Verify advanced settings card no longer contains runtime parameter controls
- [ ] Verify form submission still correctly merges all parameter values