### PR TITLE
fix(FR-2444): address review findings — state bug, optional remaining, checkbox tooltip

### DIFF
--- a/react/src/components/RuntimeParameterFormSection.tsx
+++ b/react/src/components/RuntimeParameterFormSection.tsx
@@ -50,10 +50,7 @@ export interface RuntimeParameterValues {
 
 interface RuntimeParameterFormSectionProps {
   runtimeVariant: string;
-  value?: RuntimeParameterValues;
   onChange?: (values: RuntimeParameterValues) => void;
-  /** Extra args text from manual input field (for merge preview) */
-  manualExtraArgs?: string;
   /** Existing extra args string for edit mode reverse-mapping */
   initialExtraArgs?: string;
 }
@@ -64,32 +61,23 @@ interface RuntimeParameterFormSectionProps {
  */
 const RuntimeParameterFormSection: React.FC<
   RuntimeParameterFormSectionProps
-> = ({
-  runtimeVariant,
-  value: controlledValue,
-  onChange,
-  initialExtraArgs,
-}) => {
+> = ({ runtimeVariant, onChange, initialExtraArgs }) => {
   'use memo';
   const { t } = useTranslation();
   const { token } = theme.useToken();
   const groups = useRuntimeParameterSchema(runtimeVariant);
 
-  // Internal state for uncontrolled usage
   const [internalValues, setInternalValues] = useState<RuntimeParameterValues>(
     {},
   );
-  const values = controlledValue ?? internalValues;
+  const values = internalValues;
 
   const [activeTab, setActiveTab] = useState<string>('sampling');
 
   const setValues = useCallback(
     (newValues: RuntimeParameterValues) => {
-      if (onChange) {
-        onChange(newValues);
-      } else {
-        setInternalValues(newValues);
-      }
+      setInternalValues(newValues);
+      onChange?.(newValues);
     },
     [onChange],
   );
@@ -109,7 +97,7 @@ const RuntimeParameterFormSection: React.FC<
       setValues(defaults);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runtimeVariant]);
+  }, [runtimeVariant, initialExtraArgs]);
 
   const handleParamChange = useCallback(
     (key: string, newValue: string) => {
@@ -130,14 +118,20 @@ const RuntimeParameterFormSection: React.FC<
     label: t(CATEGORY_LABELS[cat]),
   }));
 
-  const activeGroup = groups.find((g) => g.category === activeTab);
+  // Fall back to first available tab if current tab doesn't exist for this variant
+  const effectiveActiveTab = availableCategories.includes(
+    activeTab as RuntimeParameterCategory,
+  )
+    ? activeTab
+    : (availableCategories[0] ?? 'sampling');
+  const activeGroup = groups.find((g) => g.category === effectiveActiveTab);
 
   return (
     <Form.Item label={t('modelService.RuntimeParamTitle')}>
       <BAICard
         size="small"
         tabList={tabList}
-        activeTabKey={activeTab}
+        activeTabKey={effectiveActiveTab}
         onTabChange={setActiveTab}
       >
         <Text
@@ -281,13 +275,15 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
 
     case 'checkbox':
       return (
-        <Form.Item tooltip={tooltip} style={{ marginBottom: token.marginXS }}>
+        <Form.Item
+          label={label}
+          tooltip={tooltip}
+          style={{ marginBottom: token.marginXS }}
+        >
           <Checkbox
             checked={value === 'true'}
             onChange={(e) => onChange(e.target.checked ? 'true' : 'false')}
-          >
-            {label}
-          </Checkbox>
+          />
         </Form.Item>
       );
 

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -57,13 +57,14 @@ import ResourceAllocationFormItems, {
 import SwitchToProjectButton from './SwitchToProjectButton';
 import VFolderLazyView from './VFolderLazyView';
 import VFolderSelect from './VFolderSelect';
-import { MinusOutlined, RightOutlined } from '@ant-design/icons';
+import { MinusOutlined } from '@ant-design/icons';
 import { useDebounceFn } from 'ahooks';
 import {
   App,
   Button,
   Card,
   Checkbox,
+  Collapse,
   Form,
   Input,
   InputNumber,
@@ -1716,138 +1717,125 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                       </>
                     )}
                   </Card>
-                  <Card
-                    title={
-                      <BAIFlex
-                        direction="row"
-                        align="center"
-                        justify="between"
-                        style={{ cursor: 'pointer' }}
-                        onClick={() => {
-                          setQuery(
-                            { advancedMode: !advancedMode || undefined },
-                            'replaceIn',
-                          );
-                        }}
-                      >
-                        {t('session.launcher.AdvancedSettings')}
-                        <RightOutlined
-                          style={{
-                            fontSize: token.fontSizeSM,
-                            transition: `transform ${token.motionDurationMid}`,
-                            transform: advancedMode
-                              ? 'rotate(90deg)'
-                              : 'rotate(0deg)',
-                          }}
-                        />
-                      </BAIFlex>
-                    }
-                    styles={
-                      advancedMode
-                        ? { header: { paddingInlineEnd: 0 } }
-                        : {
-                            header: {
-                              borderBottom: 'none',
-                              paddingInlineEnd: 0,
-                            },
-                            body: {
-                              display: 'none',
-                            },
-                          }
-                    }
-                  >
-                    <Form.Item name={'mount_id_map'} initialValue={{}} hidden>
-                      <Input />
-                    </Form.Item>
-                    <Form.Item noStyle dependencies={['vFolderID']}>
-                      {({ getFieldValue }) => {
-                        const vFolderID = getFieldValue('vFolderID');
-                        const excludeModelFilter = vFolderID
-                          ? `id != "${vFolderID}"`
-                          : null;
-                        return (
-                          <Form.Item
-                            name={'mount_ids'}
-                            label={t('modelService.AdditionalMounts')}
-                          >
-                            <Suspense
-                              fallback={<Skeleton.Input active block />}
-                            >
-                              <BAIVFolderSelect
-                                mode="multiple"
-                                allowClear
-                                currentProjectId={
-                                  currentProject.id ?? undefined
-                                }
-                                filter={
-                                  mergeFilterValues([
-                                    'status == "ready"',
-                                    'usage_mode != "model"',
-                                    '(! name ilike ".%")',
-                                    excludeModelFilter,
-                                  ]) ?? undefined
-                                }
-                              />
-                            </Suspense>
-                          </Form.Item>
-                        );
-                      }}
-                    </Form.Item>
-                    <Form.Item dependencies={['runtimeVariant']} noStyle>
-                      {({ getFieldValue }) => {
-                        const runtimeVariant = getFieldValue('runtimeVariant');
-                        const runtimeVariantConfig = runtimeVariant
-                          ? RUNTIME_ENV_VAR_CONFIGS[runtimeVariant]
-                          : null;
-
-                        return (
-                          <Form.Item
-                            label={t('session.launcher.EnvironmentVariable')}
-                          >
-                            <EnvVarFormList
-                              name={'envvars'}
-                              requiredEnvVars={
-                                runtimeVariantConfig?.requiredEnvVars
-                              }
-                              optionalEnvVars={
-                                runtimeVariantConfig?.optionalEnvVars
-                              }
-                              formItemProps={{
-                                validateTrigger: ['onChange', 'onBlur'],
-                                rules: [
-                                  {
-                                    warningOnly: true,
-                                    validator: async (_rule, value: string) => {
-                                      if (!value) {
-                                        return Promise.resolve();
-                                      }
-
-                                      if (
-                                        !validateVariable(runtimeVariant, value)
-                                      ) {
-                                        throw t(
-                                          'session.launcher.EnvironmentVariableNotForRuntime',
-                                        );
-                                      } else {
-                                        return Promise.resolve();
-                                      }
-                                    },
-                                  },
-                                ],
+                  <Form.Item name={'mount_id_map'} initialValue={{}} hidden>
+                    <Input />
+                  </Form.Item>
+                  <Collapse
+                    activeKey={advancedMode ? ['advanced'] : []}
+                    onChange={(keys) => {
+                      setQuery(
+                        {
+                          advancedMode: keys.includes('advanced') || undefined,
+                        },
+                        'replaceIn',
+                      );
+                    }}
+                    items={[
+                      {
+                        key: 'advanced',
+                        label: t('session.launcher.AdvancedSettings'),
+                        forceRender: true,
+                        children: (
+                          <>
+                            <Form.Item noStyle dependencies={['vFolderID']}>
+                              {({ getFieldValue }) => {
+                                const vFolderID = getFieldValue('vFolderID');
+                                const excludeModelFilter = vFolderID
+                                  ? `id != "${vFolderID}"`
+                                  : null;
+                                return (
+                                  <Form.Item
+                                    name={'mount_ids'}
+                                    label={t('modelService.AdditionalMounts')}
+                                  >
+                                    <Suspense
+                                      fallback={<Skeleton.Input active block />}
+                                    >
+                                      <BAIVFolderSelect
+                                        mode="multiple"
+                                        allowClear
+                                        currentProjectId={
+                                          currentProject.id ?? undefined
+                                        }
+                                        filter={
+                                          mergeFilterValues([
+                                            'status == "ready"',
+                                            'usage_mode != "model"',
+                                            '(! name ilike ".%")',
+                                            excludeModelFilter,
+                                          ]) ?? undefined
+                                        }
+                                      />
+                                    </Suspense>
+                                  </Form.Item>
+                                );
                               }}
-                            />
-                          </Form.Item>
-                        );
-                      }}
-                    </Form.Item>
-                    <ClusterModeFormItems
-                      remaining={{
-                        cpu: undefined,
-                        mem: undefined,
-                        accelerators: {},
-                      }}
-                    />
-                  </Card>
+                            </Form.Item>
+                            <Form.Item
+                              dependencies={['runtimeVariant']}
+                              noStyle
+                            >
+                              {({ getFieldValue }) => {
+                                const runtimeVariant =
+                                  getFieldValue('runtimeVariant');
+                                const runtimeVariantConfig = runtimeVariant
+                                  ? RUNTIME_ENV_VAR_CONFIGS[runtimeVariant]
+                                  : null;
+
+                                return (
+                                  <Form.Item
+                                    label={t(
+                                      'session.launcher.EnvironmentVariable',
+                                    )}
+                                  >
+                                    <EnvVarFormList
+                                      name={'envvars'}
+                                      requiredEnvVars={
+                                        runtimeVariantConfig?.requiredEnvVars
+                                      }
+                                      optionalEnvVars={
+                                        runtimeVariantConfig?.optionalEnvVars
+                                      }
+                                      formItemProps={{
+                                        validateTrigger: ['onChange', 'onBlur'],
+                                        rules: [
+                                          {
+                                            warningOnly: true,
+                                            validator: async (
+                                              _rule,
+                                              value: string,
+                                            ) => {
+                                              if (!value) {
+                                                return Promise.resolve();
+                                              }
+
+                                              if (
+                                                !validateVariable(
+                                                  runtimeVariant,
+                                                  value,
+                                                )
+                                              ) {
+                                                throw t(
+                                                  'session.launcher.EnvironmentVariableNotForRuntime',
+                                                );
+                                              } else {
+                                                return Promise.resolve();
+                                              }
+                                            },
+                                          },
+                                        ],
+                                      }}
+                                    />
+                                  </Form.Item>
+                                );
+                              }}
+                            </Form.Item>
+                            <ClusterModeFormItems />
+                          </>
+                        ),
+                      },
+                    ]}
+                  />
                   <BAIFlex
                     direction="row"
                     justify="between"

--- a/react/src/components/SessionFormItems/ClusterModeFormItems.tsx
+++ b/react/src/components/SessionFormItems/ClusterModeFormItems.tsx
@@ -15,12 +15,18 @@ import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 interface ClusterModeFormItemsProps {
-  remaining: RemainingSlots;
+  remaining?: RemainingSlots;
   showRemainingWarning?: boolean;
 }
 
+const DEFAULT_REMAINING: RemainingSlots = {
+  cpu: undefined,
+  mem: undefined,
+  accelerators: {},
+};
+
 const ClusterModeFormItems: React.FC<ClusterModeFormItemsProps> = ({
-  remaining,
+  remaining = DEFAULT_REMAINING,
   showRemainingWarning = false,
 }) => {
   'use memo';


### PR DESCRIPTION
Resolves FR-2444

## Summary
Addresses code review findings from PRs #6382, #6383, #6384:

- **[CRITICAL]** Fix state bug in `RuntimeParameterFormSection`: `setValues` now always updates `internalValues` regardless of `onChange` presence. Previously, when `onChange` was provided, internal state was never updated, causing all parameter values to be lost on every slider change.
- **[HIGH]** Add `initialExtraArgs` to useEffect dependency array — fixes edit mode where existing EXTRA_ARGS could be ignored if data loads asynchronously.
- **[HIGH]** Add `effectiveActiveTab` fallback — if current tab does not exist for the variant, falls back to first available tab instead of showing empty card.
- **[MEDIUM]** Remove dead `value` and `manualExtraArgs` props from `RuntimeParameterFormSectionProps`.
- **[LOW]** Fix checkbox tooltip: add `label` prop so `Form.Item` `tooltip` renders correctly.
- **[MEDIUM]** Make `remaining` prop optional in `ClusterModeFormItems` with safe default.

## Test plan
- [ ] Verify slider changes preserve all other parameter values (critical regression test)
- [ ] Verify switching runtime variant resets tab to first available category
- [ ] Verify edit mode correctly initializes parameter values from existing EXTRA_ARGS
- [ ] Verify checkbox parameters display tooltip icon next to label
- [ ] Verify ClusterModeFormItems renders correctly without remaining prop