### PR TITLE
feat(FR-2458): add Open/Create/Refresh buttons to VFolderSelect (#6394)

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1260,8 +1260,9 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                 !model && !formValuesFromQueryParams.vFolderID
                               }
                               disabled={!!endpoint}
-                              allowFolderExplorer
-                              allowCreateFolder
+                              showOpenButton
+                              showCreateButton
+                              showRefreshButton
                             />
                           </Form.Item>
                         ) : (

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -8,10 +8,10 @@ import useControllableState_deprecated from '../hooks/useControllableState';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import FolderCreateModal from './FolderCreateModal';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
-import { Button, Select, type SelectProps, Tooltip } from 'antd';
-import { useUpdatableState, BAIFlex, BAILink } from 'backend.ai-ui';
+import { Button, Select, type SelectProps, Space, Tooltip } from 'antd';
+import { useUpdatableState, BAIFlex } from 'backend.ai-ui';
 import _ from 'lodash';
-import { PlusIcon } from 'lucide-react';
+import { FolderOpenIcon, PlusIcon, RefreshCwIcon } from 'lucide-react';
 import React, { startTransition, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -40,23 +40,25 @@ export type VFolder = {
 
 interface VFolderSelectProps extends SelectProps {
   autoSelectDefault?: boolean;
-  allowFolderExplorer?: boolean;
-  allowCreateFolder?: boolean;
+  showOpenButton?: boolean;
+  showCreateButton?: boolean;
+  showRefreshButton?: boolean;
   valuePropName?: 'id' | 'name';
   filter?: (vFolder: VFolder) => boolean;
 }
 
 const VFolderSelect: React.FC<VFolderSelectProps> = ({
   autoSelectDefault,
-  allowFolderExplorer,
-  allowCreateFolder,
+  showOpenButton,
+  showCreateButton,
+  showRefreshButton,
   valuePropName = 'name',
   filter,
   ...selectProps
 }) => {
   const currentProject = useCurrentProjectValue();
   const baiRequestWithPromise = useBaiSignedRequestWithPromise();
-  const { generateFolderPath } = useFolderExplorerOpener();
+  const { open: openFolderExplorer } = useFolderExplorerOpener();
   const { t } = useTranslation();
   const [value, setValue] = useControllableState_deprecated(selectProps);
   const [key, checkUpdate] = useUpdatableState('first');
@@ -124,32 +126,13 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
   }, [autoSelectDefault]);
 
   return (
-    <BAIFlex gap="xs">
+    <BAIFlex direction="row" gap={'xxs'}>
       <Select
         showSearch={{
           optionFilterProp: 'label',
         }}
         {...selectProps}
         value={value}
-        labelRender={({ label, value }) =>
-          allowFolderExplorer ? (
-            <BAILink
-              type="hover"
-              to={generateFolderPath(_.toString(value))}
-              onClick={(e: React.MouseEvent<HTMLSpanElement>) => {
-                e.stopPropagation();
-              }}
-              onMouseDown={(e: React.MouseEvent<HTMLSpanElement>) => {
-                e.preventDefault();
-                e.stopPropagation();
-              }}
-            >
-              {label}
-            </BAILink>
-          ) : (
-            label
-          )
-        }
         onChange={setValue}
         onOpenChange={(open) => {
           if (open) {
@@ -165,18 +148,43 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
           };
         })}
       />
-      {allowCreateFolder ? (
-        <Tooltip title={t('data.CreateANewStorageFolder')}>
-          <Button
-            icon={<PlusIcon />}
-            type="primary"
-            ghost
-            onClick={() => {
-              setIsOpenCreateModal(true);
-            }}
-          />
-        </Tooltip>
-      ) : null}
+      <Space.Compact>
+        {showOpenButton ? (
+          <Tooltip title={t('modelService.OpenFolder')}>
+            <Button
+              icon={<FolderOpenIcon />}
+              disabled={!value}
+              onClick={() => {
+                openFolderExplorer(_.toString(value));
+              }}
+            />
+          </Tooltip>
+        ) : null}
+        {showCreateButton ? (
+          <Tooltip title={t('data.CreateANewStorageFolder')}>
+            <Button
+              icon={<PlusIcon />}
+              variant="text"
+              onClick={() => {
+                setIsOpenCreateModal(true);
+              }}
+            />
+          </Tooltip>
+        ) : null}
+        {showRefreshButton ? (
+          <Tooltip title={t('button.Refresh')}>
+            <Button
+              icon={<RefreshCwIcon />}
+              variant="text"
+              onClick={() => {
+                startTransition(() => {
+                  checkUpdate();
+                });
+              }}
+            />
+          </Tooltip>
+        ) : null}
+      </Space.Compact>
       <FolderCreateModal
         open={isOpenCreateModal}
         initialValues={{ usage_mode: 'model' }}


### PR DESCRIPTION
Resolves #6394(FR-2458)

## Summary
- Replace `allowFolderExplorer` / `allowCreateFolder` props with `showOpenButton` / `showCreateButton` / `showRefreshButton` in `VFolderSelect`
- Remove the inline BAILink `labelRender` — folder name now renders as plain text
- Add Open button (folder explorer via `useFolderExplorerOpener().open()`), Create button, and Refresh button as separate icon buttons with tooltips
- Update `ServiceLauncherPageContent` to use the new prop API with all three buttons enabled
- Fix pre-existing lint error: comment out undefined `ClusterModeFormItems` reference

## Test plan
- [ ] Verify VFolderSelect renders Open, Create, and Refresh buttons when props are enabled
- [ ] Verify Open button is disabled when no folder is selected
- [ ] Verify Open button opens the folder explorer modal for the selected folder
- [ ] Verify Create button opens the folder creation modal
- [ ] Verify Refresh button triggers a data refresh of the folder list
- [ ] Verify folder name displays as plain text (no link styling)
- [ ] Verify service launcher model storage section shows all three buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

### Service Creation Page (Start New Service)
![service-launcher-create](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6397/20260404-124009-service-launcher-create.png)

**Changes visible:**
- Open/Create/Refresh buttons next to Model Storage to mount select
- Folder name renders as plain text (no BAILink)
