### PR TITLE
feat(FR-2459): restore mount path specification for additional mounts (#6395)

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderSelect.tsx
@@ -14,6 +14,7 @@ import { GetRef, Skeleton } from 'antd';
 import _ from 'lodash';
 import {
   useDeferredValue,
+  useEffect,
   useImperativeHandle,
   useOptimistic,
   useRef,
@@ -42,6 +43,7 @@ export interface BAIVFolderSelectProps extends Omit<
   filter?: string;
   valuePropName?: 'id' | 'row_id';
   excludeDeleted?: boolean;
+  onResolvedNamesChange?: (nameMap: Record<string, string>) => void;
   ref?: React.Ref<BAIVFolderSelectRef>;
 }
 
@@ -56,6 +58,7 @@ const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
   filter,
   excludeDeleted,
   valuePropName = 'id',
+  onResolvedNamesChange,
   ref,
   ...selectProps
 }) => {
@@ -207,6 +210,22 @@ const BAIVFolderSelect: React.FC<BAIVFolderSelectProps> = ({
     }),
     [updateFetchKey, startRefetchTransition],
   );
+
+  // Notify parent of resolved id→name mapping when selected nodes are loaded
+  useEffect(() => {
+    if (onResolvedNamesChange && selectedVFolderNodes?.edges) {
+      const nameMap: Record<string, string> = {};
+      selectedVFolderNodes.edges.forEach((edge) => {
+        const key = edge?.node?.[valuePropName];
+        const name = edge?.node?.name;
+        if (key && name) {
+          nameMap[key] = name;
+        }
+      });
+      onResolvedNamesChange(nameMap);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedVFolderNodes]);
 
   const availableOptions = _.map(paginationData, (item) => ({
     label: item?.name,

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -58,6 +58,7 @@ import ResourceAllocationFormItems, {
 import SwitchToProjectButton from './SwitchToProjectButton';
 import VFolderLazyView from './VFolderLazyView';
 import VFolderSelect from './VFolderSelect';
+import VFolderTableFormItem from './VFolderTableFormItem';
 import { MinusOutlined } from '@ant-design/icons';
 import { useDebounceFn } from 'ahooks';
 import {
@@ -80,11 +81,8 @@ import {
 import {
   BAIModal,
   BAIFlex,
-  BAIVFolderSelect,
   ESMClientErrorResponse,
   filterOutNullAndUndefined,
-  toLocalId,
-  mergeFilterValues,
   useErrorMessageResolver,
   useBAILogger,
   BAIResourceNumberWithIcon,
@@ -649,10 +647,9 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           extra_mounts: _.reduce(
             values.mount_ids,
             (acc, key: string) => {
-              const localId = toLocalId(key);
-              acc[localId] = {
-                ...(values.mount_id_map[localId] && {
-                  mount_destination: values.mount_id_map[localId],
+              acc[key] = {
+                ...(values.mount_id_map?.[key] && {
+                  mount_destination: values.mount_id_map[key],
                 }),
                 type: 'bind', // FIXME: hardcoded. change it with option later
               };
@@ -895,11 +892,10 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                   values,
                 ),
                 extra_mounts: _.map(values.mount_ids, (vfolder) => {
-                  const localId = toLocalId(vfolder);
                   return {
-                    vfolder_id: localId,
-                    ...(values.mount_id_map[localId] && {
-                      mount_destination: values.mount_id_map[localId],
+                    vfolder_id: vfolder,
+                    ...(values.mount_id_map?.[vfolder] && {
+                      mount_destination: values.mount_id_map[vfolder],
                     }),
                   };
                 }),
@@ -1163,6 +1159,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           : _.get(formValuesFromQueryParams, 'vFolderID') || undefined,
         resourceGroup: currentGlobalResourceGroup,
         allocationPreset: 'auto-select',
+        customDefinitionMode: 'command' as CustomDefinitionMode,
         // Initialize empty mount configuration for new services
         mount_ids: [],
         mount_id_map: {},
@@ -1329,6 +1326,17 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                             }}
                           />
                         </Form.Item>
+                        <ImageEnvironmentSelectFormItems
+                        // //TODO: test with real inference images
+                        // filter={(image) => {
+                        //   return !!_.find(image?.labels, (label) => {
+                        //     return (
+                        //       label?.key === "ai.backend.role" &&
+                        //       label.value === "INFERENCE" //['COMPUTE', 'INFERENCE', 'SYSTEM']
+                        //     );
+                        //   });
+                        // }}
+                        />
                         <Form.Item dependencies={['runtimeVariant']} noStyle>
                           {({ getFieldValue }) => {
                             const variant = getFieldValue('runtimeVariant');
@@ -1415,11 +1423,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                   marginBottom: token.marginMD,
                                 }}
                               >
-                                <Form.Item
-                                  name="customDefinitionMode"
-                                  initialValue="command"
-                                  noStyle
-                                >
+                                <Form.Item name="customDefinitionMode" noStyle>
                                   <Segmented
                                     options={[
                                       {
@@ -1646,17 +1650,6 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                             disabled={hasAutoScalingRules}
                           />
                         </Form.Item>
-                        <ImageEnvironmentSelectFormItems
-                        // //TODO: test with real inference images
-                        // filter={(image) => {
-                        //   return !!_.find(image?.labels, (label) => {
-                        //     return (
-                        //       label?.key === "ai.backend.role" &&
-                        //       label.value === "INFERENCE" //['COMPUTE', 'INFERENCE', 'SYSTEM']
-                        //     );
-                        //   });
-                        // }}
-                        />
                         {endpoint && !wantToChangeResource ? (
                           <Form.Item
                             label={
@@ -1733,16 +1726,12 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                       </>
                     )}
                   </Card>
-                  <Form.Item name={'mount_id_map'} initialValue={{}} hidden>
-                    <Input />
-                  </Form.Item>
                   <Collapse
                     activeKey={advancedMode ? ['advanced'] : []}
                     onChange={(keys) => {
                       setQuery(
                         {
-                          advancedMode:
-                            keys.includes('advanced') || undefined,
+                          advancedMode: keys.includes('advanced') || undefined,
                         },
                         'replaceIn',
                       );
@@ -1753,48 +1742,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                         label: t('session.launcher.AdvancedSettings'),
                         children: (
                           <>
-                            <Form.Item
-                              noStyle
-                              dependencies={['vFolderID']}
-                            >
-                              {({ getFieldValue }) => {
-                                const vFolderID =
-                                  getFieldValue('vFolderID');
-                                const excludeModelFilter = vFolderID
-                                  ? `id != "${vFolderID}"`
-                                  : null;
-                                return (
-                                  <Form.Item
-                                    name={'mount_ids'}
-                                    label={t(
-                                      'modelService.AdditionalMounts',
-                                    )}
-                                  >
-                                    <Suspense
-                                      fallback={
-                                        <Skeleton.Input active block />
-                                      }
-                                    >
-                                      <BAIVFolderSelect
-                                        mode="multiple"
-                                        allowClear
-                                        currentProjectId={
-                                          currentProject.id ?? undefined
-                                        }
-                                        filter={
-                                          mergeFilterValues([
-                                            'status == "ready"',
-                                            'usage_mode != "model"',
-                                            '(! name ilike ".%")',
-                                            excludeModelFilter,
-                                          ]) ?? undefined
-                                        }
-                                      />
-                                    </Suspense>
-                                  </Form.Item>
-                                );
-                              }}
-                            </Form.Item>
+                            <ClusterModeFormItems />
                             <Form.Item
                               dependencies={['runtimeVariant']}
                               noStyle
@@ -1802,12 +1750,9 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                               {({ getFieldValue }) => {
                                 const runtimeVariant =
                                   getFieldValue('runtimeVariant');
-                                const runtimeVariantConfig =
-                                  runtimeVariant
-                                    ? RUNTIME_ENV_VAR_CONFIGS[
-                                        runtimeVariant
-                                      ]
-                                    : null;
+                                const runtimeVariantConfig = runtimeVariant
+                                  ? RUNTIME_ENV_VAR_CONFIGS[runtimeVariant]
+                                  : null;
 
                                 return (
                                   <Form.Item
@@ -1824,10 +1769,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                         runtimeVariantConfig?.optionalEnvVars
                                       }
                                       formItemProps={{
-                                        validateTrigger: [
-                                          'onChange',
-                                          'onBlur',
-                                        ],
+                                        validateTrigger: ['onChange', 'onBlur'],
                                         rules: [
                                           {
                                             warningOnly: true,
@@ -1860,7 +1802,26 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                 );
                               }}
                             </Form.Item>
-                            <ClusterModeFormItems />
+                            <Form.Item noStyle dependencies={['vFolderID']}>
+                              {({ getFieldValue }) => {
+                                const vFolderID = getFieldValue('vFolderID');
+                                return (
+                                  <VFolderTableFormItem
+                                    label={t('modelService.AdditionalMounts')}
+                                    rowKey="id"
+                                    tableProps={{
+                                      scroll: { x: 'max-content', y: 300 },
+                                    }}
+                                    rowFilter={(vfolder) =>
+                                      vfolder.usage_mode !== 'model' &&
+                                      vfolder.status === 'ready' &&
+                                      !vfolder.name?.startsWith('.') &&
+                                      vfolder.id !== vFolderID
+                                    }
+                                  />
+                                );
+                              }}
+                            </Form.Item>
                           </>
                         ),
                       },

--- a/react/src/components/VFolderMountFormItem.tsx
+++ b/react/src/components/VFolderMountFormItem.tsx
@@ -1,0 +1,273 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import FolderCreateModal from './FolderCreateModal';
+import { useFolderExplorerOpener } from './FolderExplorerOpener';
+import {
+  vFolderAliasNameRegExp,
+  DEFAULT_ALIAS_BASE_PATH,
+} from './VFolderTable';
+import { Button, Form, Input, Tooltip, Typography, theme } from 'antd';
+import { BAIFlex, BAIVFolderSelect, BAIVFolderSelectRef } from 'backend.ai-ui';
+import _ from 'lodash';
+import { FolderOpenIcon, PlusIcon, RefreshCwIcon, XIcon } from 'lucide-react';
+import React, {
+  Suspense,
+  useState,
+  startTransition,
+  useRef,
+  useCallback,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface VFolderMountFormItemProps {
+  filter?: string;
+  currentProjectId?: string;
+  label?: React.ReactNode;
+}
+
+const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
+  filter,
+  currentProjectId,
+  label,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const form = Form.useFormInstance();
+  const { open: openFolderExplorer } = useFolderExplorerOpener();
+  const [isFolderCreateModalOpen, setIsFolderCreateModalOpen] = useState(false);
+  const vFolderSelectRef = useRef<BAIVFolderSelectRef>(null);
+  const [folderNameMap, setFolderNameMap] = useState<Record<string, string>>(
+    {},
+  );
+
+  const getDefaultPath = useCallback(
+    (folderId: string) =>
+      DEFAULT_ALIAS_BASE_PATH + (folderNameMap[folderId] || folderId),
+    [folderNameMap],
+  );
+
+  const handleResolvedNamesChange = useCallback(
+    (nameMap: Record<string, string>) => {
+      setFolderNameMap((prev) => ({ ...prev, ...nameMap }));
+      // Set default mount paths for folders loaded from URL that don't have one yet
+      const mountIds: string[] = form.getFieldValue('mount_ids') || [];
+      mountIds.forEach((id) => {
+        if (!form.getFieldValue(['mount_id_map', id]) && nameMap[id]) {
+          form.setFieldValue(
+            ['mount_id_map', id],
+            DEFAULT_ALIAS_BASE_PATH + nameMap[id],
+          );
+        }
+      });
+    },
+    [form],
+  );
+
+  const handleRemoveFolder = useCallback(
+    (folderId: string) => {
+      const currentIds: string[] = form.getFieldValue('mount_ids') || [];
+      const newIds = currentIds.filter((id) => id !== folderId);
+      form.setFieldValue('mount_ids', newIds);
+      form.setFieldValue(['mount_id_map', folderId], undefined);
+    },
+    [form],
+  );
+
+  return (
+    <>
+      <Form.Item name={'mount_ids'} label={label}>
+        <BAIVFolderSelect
+          ref={vFolderSelectRef}
+          mode="multiple"
+          allowClear
+          currentProjectId={currentProjectId}
+          filter={filter}
+          onResolvedNamesChange={handleResolvedNamesChange}
+          onChange={(value: string[], option: any) => {
+            form.setFieldValue('mount_ids', value);
+            // Build id→name map from selected options
+            const options = _.castArray(option);
+            const newNameMap: Record<string, string> = {};
+            options.forEach((opt: { label?: string; value?: string }) => {
+              if (opt?.value && opt?.label) {
+                newNameMap[opt.value] = opt.label;
+              }
+            });
+            setFolderNameMap((prev) => ({
+              ..._.pick(prev, value),
+              ...newNameMap,
+            }));
+            // Set default mount path for newly selected folders
+            value.forEach((id) => {
+              if (!form.getFieldValue(['mount_id_map', id])) {
+                const name = newNameMap[id] || folderNameMap[id] || id;
+                form.setFieldValue(
+                  ['mount_id_map', id],
+                  DEFAULT_ALIAS_BASE_PATH + name,
+                );
+              }
+            });
+            // Clean up removed folders
+            const currentMap: Record<string, string> =
+              form.getFieldValue('mount_id_map') || {};
+            Object.keys(currentMap).forEach((key) => {
+              if (!value.includes(key)) {
+                form.setFieldValue(['mount_id_map', key], undefined);
+              }
+            });
+          }}
+          dropdownRender={(menu) => (
+            <>
+              {menu}
+              <BAIFlex
+                justify="end"
+                gap={token.sizeXXS}
+                style={{
+                  padding: token.paddingXXS,
+                  borderTop: `1px solid ${token.colorBorderSecondary}`,
+                }}
+              >
+                <Tooltip title={t('modelService.OpenFolder')}>
+                  <Button
+                    type="text"
+                    size="small"
+                    icon={<FolderOpenIcon />}
+                    disabled={_.isEmpty(form.getFieldValue('mount_ids'))}
+                    onClick={() => {
+                      const mountIds = form.getFieldValue('mount_ids') || [];
+                      if (mountIds.length > 0) {
+                        openFolderExplorer(mountIds[0]);
+                      }
+                    }}
+                  />
+                </Tooltip>
+                <Tooltip title={t('data.CreateFolder')}>
+                  <Button
+                    type="text"
+                    size="small"
+                    icon={<PlusIcon />}
+                    onClick={() => setIsFolderCreateModalOpen(true)}
+                  />
+                </Tooltip>
+                <Tooltip title={t('button.Refresh')}>
+                  <Button
+                    type="text"
+                    size="small"
+                    icon={<RefreshCwIcon />}
+                    onClick={() => {
+                      startTransition(() => {
+                        vFolderSelectRef.current?.refetch();
+                      });
+                    }}
+                  />
+                </Tooltip>
+              </BAIFlex>
+            </>
+          )}
+        />
+      </Form.Item>
+      <Form.Item noStyle dependencies={['mount_ids']}>
+        {({ getFieldValue }) => {
+          const mountIds: string[] = getFieldValue('mount_ids') || [];
+          if (mountIds.length === 0) return null;
+
+          return (
+            <BAIFlex
+              direction="column"
+              gap="xxs"
+              style={{ marginBottom: token.marginLG }}
+            >
+              {mountIds.map((folderId: string) => {
+                const folderName = folderNameMap[folderId] || folderId;
+                return (
+                  <BAIFlex
+                    key={folderId}
+                    direction="row"
+                    align="start"
+                    gap={token.sizeXXS}
+                  >
+                    <Typography.Text
+                      ellipsis={{ tooltip: true }}
+                      style={{
+                        width: 150,
+                        flexShrink: 0,
+                        lineHeight: '24px',
+                      }}
+                    >
+                      {folderName}
+                    </Typography.Text>
+                    <Form.Item
+                      name={['mount_id_map', folderId]}
+                      style={{ flex: 1, marginBottom: 0 }}
+                      rules={[
+                        {
+                          validator(_, value) {
+                            const path = value || getDefaultPath(folderId);
+                            if (!vFolderAliasNameRegExp.test(path)) {
+                              return Promise.reject(
+                                t('session.launcher.FolderAliasInvalid'),
+                              );
+                            }
+                            const otherPaths = mountIds
+                              .filter((id) => id !== folderId)
+                              .map(
+                                (id) =>
+                                  form.getFieldValue(['mount_id_map', id]) ||
+                                  getDefaultPath(id),
+                              );
+                            if (otherPaths.includes(path)) {
+                              return Promise.reject(
+                                t('session.launcher.FolderAliasOverlapping'),
+                              );
+                            }
+                            return Promise.resolve();
+                          },
+                        },
+                      ]}
+                    >
+                      <Input size="small" />
+                    </Form.Item>
+                    <XIcon
+                      size={16}
+                      style={{
+                        cursor: 'pointer',
+                        color: token.colorTextQuaternary,
+                        marginTop: token.marginXXS,
+                        flexShrink: 0,
+                      }}
+                      onClick={() => handleRemoveFolder(folderId)}
+                    />
+                  </BAIFlex>
+                );
+              })}
+            </BAIFlex>
+          );
+        }}
+      </Form.Item>
+      <Suspense>
+        <FolderCreateModal
+          open={isFolderCreateModalOpen}
+          hiddenFormItems={[
+            'usage_mode',
+            'usage_mode_model',
+            'usage_mode_automount',
+          ]}
+          initialValues={{ usage_mode: 'general' }}
+          onRequestClose={(response) => {
+            setIsFolderCreateModalOpen(false);
+            if (response) {
+              startTransition(() => {
+                vFolderSelectRef.current?.refetch();
+              });
+            }
+          }}
+        />
+      </Suspense>
+    </>
+  );
+};
+
+export default VFolderMountFormItem;


### PR DESCRIPTION
Resolves #6395 (FR-2459)

## Summary
- Restore mount path (alias) specification for additional mounts in the service launcher using `VFolderTableFormItem` with `showAliasInput` support
- Move `ImageEnvironmentSelectFormItems` below RuntimeVariant selector for better UX flow
- Fix `customDefinitionMode` initialValue conflict with Form's `initialValues`
- Add `onResolvedNamesChange` callback to `BAIVFolderSelect` for resolving folder names from IDs
- Fix `mount_id_map` key lookup to use correct ID format (`rowKey="id"`) in API requests
- Add scroll height limit (300px) for the additional mounts table to prevent excessive page length

## Test plan
- [ ] Create a new service with additional mounts selected and verify mount paths can be specified
- [ ] Verify mount path values are correctly sent in the API request
- [ ] Edit an existing service and confirm additional mount paths are displayed correctly
- [ ] Verify the additional mounts table scrolls when many folders are available
- [ ] Verify no `customDefinitionMode` initialValue warning in console
- [ ] Verify `ImageEnvironmentSelectFormItems` appears below RuntimeVariant selector