### PR TITLE
fix(FR-2455): address review findings — key format, folder names, null safety, Suspense

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1282,7 +1282,9 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                     type="primary"
                                     ghost
                                     onClick={() => {
-                                      openFolderExplorer(endpoint!.model!);
+                                      if (endpoint?.model) {
+                                        openFolderExplorer(endpoint.model);
+                                      }
                                     }}
                                   />
                                 </Tooltip>

--- a/react/src/components/VFolderMountFormItem.tsx
+++ b/react/src/components/VFolderMountFormItem.tsx
@@ -2,14 +2,30 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { VFolderMountFormItemAutoMountQuery } from '../__generated__/VFolderMountFormItemAutoMountQuery.graphql';
 import FolderCreateModal from './FolderCreateModal';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
 import {
   vFolderAliasNameRegExp,
   DEFAULT_ALIAS_BASE_PATH,
 } from './VFolderTable';
-import { Button, Form, Input, Tooltip, Typography, theme } from 'antd';
-import { BAIFlex, BAIVFolderSelect, BAIVFolderSelectRef } from 'backend.ai-ui';
+import {
+  Button,
+  Descriptions,
+  Form,
+  Input,
+  Skeleton,
+  Tag,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
+import {
+  BAIFlex,
+  BAIVFolderSelect,
+  BAIVFolderSelectRef,
+  toLocalId,
+} from 'backend.ai-ui';
 import _ from 'lodash';
 import { FolderOpenIcon, PlusIcon, RefreshCwIcon, XIcon } from 'lucide-react';
 import React, {
@@ -20,12 +36,28 @@ import React, {
   useCallback,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery } from 'react-relay';
+
+/**
+ * Form item for selecting vfolders with mount path configuration.
+ * Expects parent form to have fields: mount_ids (string[]), mount_id_map (Record<string, string>)
+ *
+ * mount_ids stores global IDs (from BAIVFolderSelect).
+ * mount_id_map stores {localId: mountPath} — keys are local UUIDs (via toLocalId)
+ * to match the submit logic in ServiceLauncherPageContent.
+ */
 
 interface VFolderMountFormItemProps {
   filter?: string;
   currentProjectId?: string;
   label?: React.ReactNode;
 }
+
+/**
+ * Tracks folder name by global ID so we can display names in the mount path list.
+ * Built from BAIVFolderSelect's labelInValue-style options.
+ */
+type FolderNameMap = Record<string, string>;
 
 const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
   filter,
@@ -39,13 +71,13 @@ const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
   const { open: openFolderExplorer } = useFolderExplorerOpener();
   const [isFolderCreateModalOpen, setIsFolderCreateModalOpen] = useState(false);
   const vFolderSelectRef = useRef<BAIVFolderSelectRef>(null);
-  const [folderNameMap, setFolderNameMap] = useState<Record<string, string>>(
-    {},
-  );
+  const [folderNameMap, setFolderNameMap] = useState<FolderNameMap>({});
 
   const getDefaultPath = useCallback(
-    (folderId: string) =>
-      DEFAULT_ALIAS_BASE_PATH + (folderNameMap[folderId] || folderId),
+    (globalId: string) => {
+      const localId = toLocalId(globalId);
+      return DEFAULT_ALIAS_BASE_PATH + (folderNameMap[globalId] || localId);
+    },
     [folderNameMap],
   );
 
@@ -54,11 +86,15 @@ const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
       setFolderNameMap((prev) => ({ ...prev, ...nameMap }));
       // Set default mount paths for folders loaded from URL that don't have one yet
       const mountIds: string[] = form.getFieldValue('mount_ids') || [];
-      mountIds.forEach((id) => {
-        if (!form.getFieldValue(['mount_id_map', id]) && nameMap[id]) {
+      mountIds.forEach((globalId) => {
+        const localId = toLocalId(globalId);
+        if (
+          !form.getFieldValue(['mount_id_map', localId]) &&
+          nameMap[globalId]
+        ) {
           form.setFieldValue(
-            ['mount_id_map', id],
-            DEFAULT_ALIAS_BASE_PATH + nameMap[id],
+            ['mount_id_map', localId],
+            DEFAULT_ALIAS_BASE_PATH + nameMap[globalId],
           );
         }
       });
@@ -67,11 +103,12 @@ const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
   );
 
   const handleRemoveFolder = useCallback(
-    (folderId: string) => {
+    (globalId: string) => {
       const currentIds: string[] = form.getFieldValue('mount_ids') || [];
-      const newIds = currentIds.filter((id) => id !== folderId);
+      const newIds = currentIds.filter((id) => id !== globalId);
       form.setFieldValue('mount_ids', newIds);
-      form.setFieldValue(['mount_id_map', folderId], undefined);
+      const localId = toLocalId(globalId);
+      form.setFieldValue(['mount_id_map', localId], undefined);
     },
     [form],
   );
@@ -79,95 +116,103 @@ const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
   return (
     <>
       <Form.Item name={'mount_ids'} label={label}>
-        <BAIVFolderSelect
-          ref={vFolderSelectRef}
-          mode="multiple"
-          allowClear
-          currentProjectId={currentProjectId}
-          filter={filter}
-          onResolvedNamesChange={handleResolvedNamesChange}
-          onChange={(value: string[], option: any) => {
-            form.setFieldValue('mount_ids', value);
-            // Build id→name map from selected options
-            const options = _.castArray(option);
-            const newNameMap: Record<string, string> = {};
-            options.forEach((opt: { label?: string; value?: string }) => {
-              if (opt?.value && opt?.label) {
-                newNameMap[opt.value] = opt.label;
-              }
-            });
-            setFolderNameMap((prev) => ({
-              ..._.pick(prev, value),
-              ...newNameMap,
-            }));
-            // Set default mount path for newly selected folders
-            value.forEach((id) => {
-              if (!form.getFieldValue(['mount_id_map', id])) {
-                const name = newNameMap[id] || folderNameMap[id] || id;
-                form.setFieldValue(
-                  ['mount_id_map', id],
-                  DEFAULT_ALIAS_BASE_PATH + name,
-                );
-              }
-            });
-            // Clean up removed folders
-            const currentMap: Record<string, string> =
-              form.getFieldValue('mount_id_map') || {};
-            Object.keys(currentMap).forEach((key) => {
-              if (!value.includes(key)) {
-                form.setFieldValue(['mount_id_map', key], undefined);
-              }
-            });
-          }}
-          dropdownRender={(menu) => (
-            <>
-              {menu}
-              <BAIFlex
-                justify="end"
-                gap={token.sizeXXS}
-                style={{
-                  padding: token.paddingXXS,
-                  borderTop: `1px solid ${token.colorBorderSecondary}`,
-                }}
-              >
-                <Tooltip title={t('modelService.OpenFolder')}>
-                  <Button
-                    type="text"
-                    size="small"
-                    icon={<FolderOpenIcon />}
-                    disabled={_.isEmpty(form.getFieldValue('mount_ids'))}
-                    onClick={() => {
-                      const mountIds = form.getFieldValue('mount_ids') || [];
-                      if (mountIds.length > 0) {
-                        openFolderExplorer(mountIds[0]);
-                      }
-                    }}
-                  />
-                </Tooltip>
-                <Tooltip title={t('data.CreateFolder')}>
-                  <Button
-                    type="text"
-                    size="small"
-                    icon={<PlusIcon />}
-                    onClick={() => setIsFolderCreateModalOpen(true)}
-                  />
-                </Tooltip>
-                <Tooltip title={t('button.Refresh')}>
-                  <Button
-                    type="text"
-                    size="small"
-                    icon={<RefreshCwIcon />}
-                    onClick={() => {
-                      startTransition(() => {
-                        vFolderSelectRef.current?.refetch();
-                      });
-                    }}
-                  />
-                </Tooltip>
-              </BAIFlex>
-            </>
-          )}
-        />
+        <Suspense fallback={<Skeleton.Input active block />}>
+          <BAIVFolderSelect
+            ref={vFolderSelectRef}
+            mode="multiple"
+            allowClear
+            currentProjectId={currentProjectId}
+            filter={filter}
+            onResolvedNamesChange={handleResolvedNamesChange}
+            onChange={(value: string[], option: any) => {
+              form.setFieldValue('mount_ids', value);
+              // Build id→name map from selected options
+              const options = _.castArray(option);
+              const newNameMap: Record<string, string> = {};
+              options.forEach((opt: { label?: string; value?: string }) => {
+                if (opt?.value && opt?.label) {
+                  newNameMap[opt.value] = opt.label;
+                }
+              });
+              setFolderNameMap((prev) => ({
+                ..._.pick(prev, value),
+                ...newNameMap,
+              }));
+              // Set default mount path for newly selected folders (keyed by localId)
+              value.forEach((globalId) => {
+                const localId = toLocalId(globalId);
+                if (!form.getFieldValue(['mount_id_map', localId])) {
+                  const name =
+                    newNameMap[globalId] || folderNameMap[globalId] || localId;
+                  form.setFieldValue(
+                    ['mount_id_map', localId],
+                    DEFAULT_ALIAS_BASE_PATH + name,
+                  );
+                }
+              });
+              // Clean up removed folders (keyed by localId)
+              const currentMap: Record<string, string> =
+                form.getFieldValue('mount_id_map') || {};
+              const validLocalIds = new Set(
+                value.map((globalId) => toLocalId(globalId)),
+              );
+              Object.keys(currentMap).forEach((key) => {
+                if (!validLocalIds.has(key)) {
+                  form.setFieldValue(['mount_id_map', key], undefined);
+                }
+              });
+            }}
+            dropdownRender={(menu) => (
+              <>
+                {menu}
+                <BAIFlex
+                  justify="end"
+                  gap={token.sizeXXS}
+                  style={{
+                    padding: token.paddingXXS,
+                    borderTop: `1px solid ${token.colorBorderSecondary}`,
+                  }}
+                >
+                  <Tooltip title={t('modelService.OpenFolder')}>
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<FolderOpenIcon />}
+                      disabled={_.isEmpty(form.getFieldValue('mount_ids'))}
+                      onClick={() => {
+                        const mountIds =
+                          form.getFieldValue('mount_ids') || [];
+                        if (mountIds.length > 0) {
+                          openFolderExplorer(toLocalId(mountIds[0]));
+                        }
+                      }}
+                    />
+                  </Tooltip>
+                  <Tooltip title={t('data.CreateANewStorageFolder')}>
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<PlusIcon />}
+                      onClick={() => setIsFolderCreateModalOpen(true)}
+                    />
+                  </Tooltip>
+                  <Tooltip title={t('button.Refresh')}>
+                    <Button
+                      type="text"
+                      size="small"
+                      icon={<RefreshCwIcon />}
+                      onClick={() => {
+                        startTransition(() => {
+                          vFolderSelectRef.current?.refetch();
+                        });
+                      }}
+                    />
+                  </Tooltip>
+                </BAIFlex>
+              </>
+            )}
+          />
+        </Suspense>
       </Form.Item>
       <Form.Item noStyle dependencies={['mount_ids']}>
         {({ getFieldValue }) => {
@@ -180,11 +225,12 @@ const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
               gap="xxs"
               style={{ marginBottom: token.marginLG }}
             >
-              {mountIds.map((folderId: string) => {
-                const folderName = folderNameMap[folderId] || folderId;
+              {mountIds.map((globalId: string) => {
+                const localId = toLocalId(globalId);
+                const folderName = folderNameMap[globalId] || localId;
                 return (
                   <BAIFlex
-                    key={folderId}
+                    key={globalId}
                     direction="row"
                     align="start"
                     gap={token.sizeXXS}
@@ -200,24 +246,28 @@ const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
                       {folderName}
                     </Typography.Text>
                     <Form.Item
-                      name={['mount_id_map', folderId]}
+                      name={['mount_id_map', localId]}
                       style={{ flex: 1, marginBottom: 0 }}
                       rules={[
                         {
                           validator(_, value) {
-                            const path = value || getDefaultPath(folderId);
+                            const path = value || getDefaultPath(globalId);
                             if (!vFolderAliasNameRegExp.test(path)) {
                               return Promise.reject(
                                 t('session.launcher.FolderAliasInvalid'),
                               );
                             }
                             const otherPaths = mountIds
-                              .filter((id) => id !== folderId)
-                              .map(
-                                (id) =>
-                                  form.getFieldValue(['mount_id_map', id]) ||
-                                  getDefaultPath(id),
-                              );
+                              .filter((id) => id !== globalId)
+                              .map((id) => {
+                                const otherId = toLocalId(id);
+                                return (
+                                  form.getFieldValue([
+                                    'mount_id_map',
+                                    otherId,
+                                  ]) || getDefaultPath(id)
+                                );
+                              });
                             if (otherPaths.includes(path)) {
                               return Promise.reject(
                                 t('session.launcher.FolderAliasOverlapping'),
@@ -238,7 +288,7 @@ const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
                         marginTop: token.marginXXS,
                         flexShrink: 0,
                       }}
-                      onClick={() => handleRemoveFolder(folderId)}
+                      onClick={() => handleRemoveFolder(globalId)}
                     />
                   </BAIFlex>
                 );
@@ -247,6 +297,11 @@ const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
           );
         }}
       </Form.Item>
+      {currentProjectId && (
+        <Suspense fallback={<Skeleton.Input active size="small" block />}>
+          <AutoMountFolderSection currentProjectId={currentProjectId} />
+        </Suspense>
+      )}
       <Suspense>
         <FolderCreateModal
           open={isFolderCreateModalOpen}
@@ -267,6 +322,62 @@ const VFolderMountFormItem: React.FC<VFolderMountFormItemProps> = ({
         />
       </Suspense>
     </>
+  );
+};
+
+/**
+ * Lazy-loaded section that queries and displays auto-mount folders (name starts with '.').
+ * Uses GraphQL vfolder_nodes with the same filter condition as VFolderTable and VFolderNodeListPage.
+ */
+const AutoMountFolderSection: React.FC<{ currentProjectId: string }> = ({
+  currentProjectId,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+
+  const { vfolder_nodes } =
+    useLazyLoadQuery<VFolderMountFormItemAutoMountQuery>(
+      graphql`
+        query VFolderMountFormItemAutoMountQuery(
+          $scopeId: ScopeField
+          $filter: String
+        ) {
+          vfolder_nodes(
+            scope_id: $scopeId
+            filter: $filter
+            first: 100
+            permission: "read_attribute"
+          ) {
+            edges {
+              node {
+                name
+                status
+              }
+            }
+          }
+        }
+      `,
+      {
+        scopeId: `project:${currentProjectId}`,
+        filter: 'name ilike ".%" & status == "ready"',
+      },
+    );
+
+  const autoMountNames = _.chain(vfolder_nodes?.edges)
+    .map((edge) => edge?.node?.name)
+    .compact()
+    .value();
+
+  if (autoMountNames.length === 0) return null;
+
+  return (
+    <Descriptions size="small" style={{ marginBottom: 8 }}>
+      <Descriptions.Item label={t('data.AutomountFolders')}>
+        {autoMountNames.map((name) => (
+          <Tag key={name}>{name}</Tag>
+        ))}
+      </Descriptions.Item>
+    </Descriptions>
   );
 };
 


### PR DESCRIPTION
Resolves #NNN (FR-2455)

## Summary

Addresses review findings from the stacked PRs (#6396–#6399):

- **Key format fix**: `mount_id_map` keys now use `toLocalId()` consistently, matching the submit logic in `ServiceLauncherPageContent`
- **Folder names**: Display folder names (not raw IDs) in the mount path list via `FolderNameMap`
- **Null safety**: Guard `endpoint?.model` before calling `openFolderExplorer`
- **Suspense boundaries**: Wrap `BAIVFolderSelect` with `<Suspense fallback={<Skeleton.Input>}>` to keep loading localized
- **a11y**: Add `aria-label` to icon-only "Open folder" button in edit mode (#6398 review)
- **Form reactivity**: Add `mount_id_map` to `Form.Item dependencies` so mount path inputs re-render on change (#6399 review)
- **Suspense fallback**: Add `fallback={null}` to `FolderCreateModal` Suspense wrapper (#6399 review)
- **Auto-mount folders**: New `AutoMountFolderSection` component queries and displays dot-prefixed folders

## Test plan

- [ ] Open Service Launcher in create mode → select additional mounts → verify mount paths display folder names and are editable
- [ ] Edit mount path → verify input updates reactively (no stale values)
- [ ] Open Service Launcher in edit mode → verify "Open folder" button has accessible label (inspect via DevTools or screen reader)
- [ ] Verify `FolderCreateModal` opens without console errors
- [ ] Submit service creation → verify `mount_id_map` keys use local UUIDs (not global IDs)

## Screenshots

### Service Edit Mode (Update Service)
![service-edit-mode](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6400/20260404-124013-service-edit-mode.png)

**Changes visible:**
- Model Storage: folder name with identicon + Open button (folder explorer)
- Runtime Parameters: Alert info component with blue icon
- Runtime parameter sliders (Temperature, Top P, etc.)