### PR TITLE
fix: prevent formItemProps spread from overwriting validation rules in EnvVarFormList

### DIFF
--- a/react/src/components/EnvVarFormList.tsx
+++ b/react/src/components/EnvVarFormList.tsx
@@ -34,7 +34,6 @@ export interface EnvVarFormListValue {
   variable: string;
   value: string;
 }
-// TODO: validation rule for duplicate variable name
 const EnvVarFormList: React.FC<EnvVarFormListProps> = ({
   formItemProps,
   requiredEnvVars,
@@ -42,6 +41,7 @@ const EnvVarFormList: React.FC<EnvVarFormListProps> = ({
   ...props
 }) => {
   'use memo';
+  const { rules: externalRules, ...restFormItemProps } = formItemProps || {};
   const inputRef = useRef<InputRef>(null);
   const { t } = useTranslation();
   const form = Form.useFormInstance();
@@ -144,7 +144,7 @@ const EnvVarFormList: React.FC<EnvVarFormListProps> = ({
                   style={{ marginBottom: 0, flex: 1 }}
                   name={[name, 'variable']}
                   rules={[
-                    ...(formItemProps?.rules || []),
+                    ...(externalRules || []),
                     {
                       required: true,
                       message: t('session.launcher.EnterEnvironmentVariable'),
@@ -180,7 +180,7 @@ const EnvVarFormList: React.FC<EnvVarFormListProps> = ({
                       },
                     }),
                   ]}
-                  {...formItemProps}
+                  {...restFormItemProps}
                 >
                   {optionalEnvVars && getAutoCompleteOptions().length > 0 ? (
                     <AutoComplete


### PR DESCRIPTION
## Summary
- The `{...formItemProps}` spread in `EnvVarFormList` was placed after the `rules` prop, causing external `formItemProps.rules` to completely overwrite the built-in validation rules (required, pattern, duplicate key check)
- This broke validation in the service launcher where `formItemProps` includes a custom `warningOnly` validator — the spread replaced all built-in rules with just that one validator
- Fix: destructure `rules` out of `formItemProps` and spread the rest separately, so built-in rules are always preserved

## Test plan
- [ ] Open service creation page (service/start), add environment variables
- [ ] Verify duplicate key validation shows error when entering same variable name twice
- [ ] Verify invalid character validation works (e.g., variable names starting with numbers)
- [ ] Verify the warningOnly runtime variable validator still shows warnings
- [ ] Verify session launcher env var validation still works as before

## Verification
```
=== ALL PASS ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)