### PR TITLE
style(FR-2460): clean up cluster mode card wrappers and runtime parameter alert

### DIFF
--- a/react/src/components/RuntimeParameterFormSection.tsx
+++ b/react/src/components/RuntimeParameterFormSection.tsx
@@ -14,8 +14,8 @@ import {
   buildSchemaKeySet,
 } from '../hooks/useRuntimeParameterSchema';
 import InputNumberWithSlider from './InputNumberWithSlider';
-import { Checkbox, Form, InputNumber, Select, Input, theme } from 'antd';
-import { BAIAlert, BAICard, BAIFlex } from 'backend.ai-ui';
+import { Checkbox, Form, InputNumber, Select, Input, theme, Alert } from 'antd';
+import { BAICard, BAIFlex } from 'backend.ai-ui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -143,8 +143,8 @@ const RuntimeParameterFormSection: React.FC<
         activeTabKey={effectiveActiveTab}
         onTabChange={(key) => setActiveTab(key as RuntimeParameterCategory)}
       >
-        <BAIAlert
-          type="info"
+        <Alert
+          type="warning"
           showIcon
           title={t('modelService.RuntimeParamUnchangedHint')}
           style={{ marginBottom: token.marginSM }}

--- a/react/src/components/SessionFormItems/ClusterModeFormItems.tsx
+++ b/react/src/components/SessionFormItems/ClusterModeFormItems.tsx
@@ -9,7 +9,7 @@ import { RemainingSlots } from '../../hooks/useResourceLimitAndRemaining';
 import InputNumberWithSlider from '../InputNumberWithSlider';
 import RemainingMark from './RemainingMark';
 import { QuestionCircleOutlined } from '@ant-design/icons';
-import { Card, Form, Radio, Tooltip, theme } from 'antd';
+import { Form, Radio, Tooltip, theme } from 'antd';
 import { BAIFlex } from 'backend.ai-ui';
 import _ from 'lodash';
 import React from 'react';
@@ -46,21 +46,12 @@ const ClusterModeFormItems: React.FC<ClusterModeFormItemsProps> = ({
       label={t('session.launcher.ClusterMode')}
       required
       dependencies={['agent']}
-      noStyle
     >
       {({ getFieldValue }) => {
         return (
-          <Card
-            style={{
-              marginBottom: token.margin,
-            }}
-          >
+          <>
             <BAIFlex direction="column" align="stretch">
-              <Form.Item
-                name={'cluster_mode'}
-                required
-                style={{ marginBottom: 0 }}
-              >
+              <Form.Item name={'cluster_mode'} required noStyle>
                 <Radio.Group
                   onChange={() => {
                     form.validateFields().catch(() => undefined);
@@ -174,6 +165,7 @@ const ClusterModeFormItems: React.FC<ClusterModeFormItemsProps> = ({
                       name={'cluster_size'}
                       label={t('session.launcher.ClusterSize')}
                       required
+                      noStyle
                       dependencies={[
                         ['resource', 'cpu'],
                         ['resource', 'mem'],
@@ -277,7 +269,7 @@ const ClusterModeFormItems: React.FC<ClusterModeFormItemsProps> = ({
                 }}
               </Form.Item>
             </BAIFlex>
-          </Card>
+          </>
         );
       }}
     </Form.Item>

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -1349,15 +1349,11 @@ const ResourceAllocationFormItems: React.FC<
         >
           {({ getFieldValue }) => {
             return (
-              <Card
-                style={{
-                  marginBottom: token.margin,
-                }}
-              >
+              <>
                 <Row gutter={token.marginMD}>
                   <Col xs={24}>
                     {/* <Col xs={24} lg={12}> */}
-                    <Form.Item name={'cluster_mode'} required>
+                    <Form.Item name={'cluster_mode'} required noStyle>
                       <Radio.Group
                         onChange={() => {
                           form.validateFields().catch(() => {});
@@ -1482,7 +1478,7 @@ const ResourceAllocationFormItems: React.FC<
                         return (
                           <Form.Item
                             name={'cluster_size'}
-                            label={t('session.launcher.ClusterSize')}
+                            noStyle
                             required
                             dependencies={[
                               ['resource', 'cpu'],
@@ -1591,7 +1587,7 @@ const ResourceAllocationFormItems: React.FC<
                     </Form.Item>
                   </Col>
                 </Row>
-              </Card>
+              </>
             );
           }}
         </Form.Item>


### PR DESCRIPTION
Resolves #PENDING (FR-2460)

## Summary
- Remove unnecessary `Card` wrappers from cluster mode sections in `ClusterModeFormItems` and `ResourceAllocationFormItems`
- Apply `noStyle` to nested `Form.Item` components for tighter layout
- Replace `BAIAlert` with standard antd `Alert` (warning type) in `RuntimeParameterFormSection`
- Remove unused `Card` import from `ClusterModeFormItems`

## Test plan
- [ ] Verify session launcher cluster mode section renders correctly without Card wrappers
- [ ] Verify runtime parameter hint alert displays as warning type
- [ ] Verify form validation still works for cluster mode and cluster size fields