### PR TITLE
fix(FR-2461): fix BAISelect CSS selectors for antd 6 compatibility

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -45,33 +45,30 @@ const useStyles = createStyles(({ css, token }) => ({
     }
   `,
   customStyle: css`
+    /* Hide selected value content (except search input) when the user is typing a search query.
+       Matches antd's approach of using color: transparent instead of display: none.
+       Uses opacity: 0 with transition: none to avoid delay from antd Tag's default transition. */
+    .ant-select-content-has-search-value img,
+    .ant-select-content-has-search-value .ant-divider,
+    .ant-select-content-has-search-value .ant-badge,
+    .ant-select-content-has-search-value span.ant-tag {
+      opacity: 0 !important;
+      transition: none;
+    }
+
     /* Change the opacity of images and tags in the select option when the dropdown is open */
-    &.ant-select-open .ant-select-content .ant-select-content-value .ant-badge,
-    &.ant-select-open .ant-select-content .ant-select-content-value img,
-    &.ant-select-open
-      .ant-select-content
-      .ant-select-content-value
-      span.ant-tag {
+    &.ant-select-open .ant-select-content .ant-badge,
+    &.ant-select-open .ant-select-content img,
+    &.ant-select-open .ant-select-content .ant-divider,
+    &.ant-select-open .ant-select-content span.ant-tag {
       opacity: 0.5;
     }
 
     /* Change the color of secondary/success/warning/danger text to placeholder color when the dropdown is open */
-    &.ant-select-open
-      .ant-select-content
-      .ant-select-content-value
-      .ant-typography-secondary,
-    &.ant-select-open
-      .ant-select-content
-      .ant-select-content-value
-      .ant-typography-success,
-    &.ant-select-open
-      .ant-select-content
-      .ant-select-content-value
-      .ant-typography-warning,
-    &.ant-select-open
-      .ant-select-content
-      .ant-select-content-value
-      .ant-typography-danger {
+    &.ant-select-open .ant-select-content .ant-typography-secondary,
+    &.ant-select-open .ant-select-content .ant-typography-success,
+    &.ant-select-open .ant-select-content .ant-typography-warning,
+    &.ant-select-open .ant-select-content .ant-typography-danger {
       color: ${token.colorTextPlaceholder};
     }
 


### PR DESCRIPTION
Resolves #6409 ([FR-2461](https://lablup.atlassian.net/browse/FR-2461))

## Summary
- Remove obsolete `.ant-select-content-value` CSS selectors that no longer exist in antd 6
- Add `.ant-divider` to opacity rules when dropdown is open
- Hide non-text elements (img, divider, badge, tag) when search value is present using `opacity: 0` with `transition: none`, matching antd's `color: transparent` approach without delay from Tag's default transition

## Test plan
- [ ] Open environment/version select in session launcher
- [ ] Verify badge, image, divider, tag become semi-transparent (opacity 0.5) when dropdown opens
- [ ] Type in search field and verify all non-text elements disappear immediately (no delay)
- [ ] Verify typography color changes to placeholder when dropdown is open

[FR-2461]: https://lablup.atlassian.net/browse/FR-2461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ