### PR TITLE
feat(FR-2462): improve runtime variant UX with search prefill and ordering

### DIFF
--- a/packages/backend.ai-ui/src/components/BAISelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAISelect.tsx
@@ -51,6 +51,7 @@ const useStyles = createStyles(({ css, token }) => ({
     .ant-select-content-has-search-value img,
     .ant-select-content-has-search-value .ant-divider,
     .ant-select-content-has-search-value .ant-badge,
+    .ant-select-content-has-search-value span.text-high-lighter,
     .ant-select-content-has-search-value span.ant-tag {
       opacity: 0 !important;
       transition: none;

--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -65,6 +65,7 @@ export type ImageEnvironmentFormInput = {
 interface ImageEnvironmentSelectFormItemsProps {
   filter?: (image: Image) => boolean;
   showPrivate?: boolean;
+  searchPrefill?: string;
 }
 
 function compareVersions(version1: string, version2: string): number {
@@ -96,7 +97,7 @@ const isPrivateImage = (image: Image) => {
 
 const ImageEnvironmentSelectFormItems: React.FC<
   ImageEnvironmentSelectFormItemsProps
-> = ({ filter, showPrivate }) => {
+> = ({ filter, showPrivate, searchPrefill }) => {
   const form = Form.useFormInstance<ImageEnvironmentFormInput>();
   const environments = Form.useWatch('environments', { form, preserve: true });
   const baiClient = useSuspendedBackendaiClient();
@@ -112,6 +113,25 @@ const ImageEnvironmentSelectFormItems: React.FC<
 
   const envSelectRef = useRef<RefSelectProps>(null);
   const versionSelectRef = useRef<RefSelectProps>(null);
+  const [envSelectOpen, setEnvSelectOpen] = useState<boolean | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    if (!searchPrefill) {
+      setEnvironmentSearch('');
+      setEnvSelectOpen(undefined);
+      return;
+    }
+
+    setEnvironmentSearch(searchPrefill);
+    // Force open the dropdown and focus the select
+    setEnvSelectOpen(true);
+    queueMicrotask(() => {
+      envSelectRef.current?.focus();
+    });
+  }, [searchPrefill]);
+
   const imageEnvironmentSelectFormItemsVariables = baiClient?._config
     ?.showNonInstalledImages
     ? {}
@@ -421,6 +441,13 @@ const ImageEnvironmentSelectFormItems: React.FC<
       >
         <BAISelect
           ref={envSelectRef}
+          open={envSelectOpen}
+          onDropdownVisibleChange={(visible) => {
+            // Return to uncontrolled mode once the user interacts
+            if (!visible) {
+              setEnvSelectOpen(undefined);
+            }
+          }}
           showSearch={{
             searchValue: environmentSearch,
             onSearch: setEnvironmentSearch,

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -249,6 +249,15 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
     return result;
   }, []);
 
+  // Environment search prefill keyword driven by runtime variant selection
+  const RUNTIME_SEARCH_KEYWORD_MAP: Partial<Record<string, string>> = {
+    vllm: 'vllm',
+    sglang: 'sglang',
+    'modular-max': 'max',
+    nim: 'nim',
+  };
+  const [envSearchPrefill, setEnvSearchPrefill] = useState<string>();
+
   // "Paste Your Command" — GPU hint from parsed CLI command
   const [gpuHint, setGpuHint] = useState<number | null>(null);
 
@@ -1301,7 +1310,11 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                 };
                               },
                             )}
-                            onChange={() => {
+                            onChange={(value) => {
+                              // Prefill the environment search with the runtime variant keyword
+                              const keyword = RUNTIME_SEARCH_KEYWORD_MAP[value];
+                              setEnvSearchPrefill(keyword);
+
                               // Force re-validation of all environment variable fields after form state updates
                               queueMicrotask(() => {
                                 const envvars =
@@ -1321,15 +1334,16 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                           />
                         </Form.Item>
                         <ImageEnvironmentSelectFormItems
-                        // //TODO: test with real inference images
-                        // filter={(image) => {
-                        //   return !!_.find(image?.labels, (label) => {
-                        //     return (
-                        //       label?.key === "ai.backend.role" &&
-                        //       label.value === "INFERENCE" //['COMPUTE', 'INFERENCE', 'SYSTEM']
-                        //     );
-                        //   });
-                        // }}
+                          searchPrefill={envSearchPrefill}
+                          // //TODO: test with real inference images
+                          // filter={(image) => {
+                          //   return !!_.find(image?.labels, (label) => {
+                          //     return (
+                          //       label?.key === "ai.backend.role" &&
+                          //       label.value === "INFERENCE" //['COMPUTE', 'INFERENCE', 'SYSTEM']
+                          //     );
+                          //   });
+                          // }}
                         />
                         <Form.Item dependencies={['runtimeVariant']} noStyle>
                           {({ getFieldValue }) => {

--- a/react/src/components/TextHighlighter.tsx
+++ b/react/src/components/TextHighlighter.tsx
@@ -34,6 +34,7 @@ const TextHighlighter: React.FC<TextHighlighterProps> = ({
             <span
               key={i}
               style={{ backgroundColor: token.colorWarningHover, ...style }}
+              className="text-high-lighter"
             >
               {part}
             </span>


### PR DESCRIPTION
Resolves #(FR-2462)

## Summary
- Remove redundant "(default)" label from runtime variant options since vLLM is already pre-selected
- Reorder runtime variants to show vLLM → SGLang first, then others
- Add runtime-to-keyword mapping for environment image search prefill (vLLM→vllm, SGLang→sglang, Modular MAX→max, NIM→nim)
- Auto-open and prefill environment image dropdown when runtime variant is selected
- Add CSS class to TextHighlighter spans for proper hiding during BAISelect search

## Test plan
- [ ] Open model service launcher, verify runtime variant dropdown shows vLLM first, then SGLang
- [ ] Verify no "(default)" label appears on any runtime variant option
- [ ] Select vLLM → environment image dropdown auto-opens with "vllm" search prefill
- [ ] Select SGLang → prefill changes to "sglang"
- [ ] Select Modular MAX → prefill changes to "max"
- [ ] Select NIM → prefill changes to "nim"
- [ ] Select Custom → no search prefill applied
- [ ] Verify TextHighlighter highlights are hidden during search in BAISelect