### PR TITLE
fix(FR-2474): fix cluster_size validation, extra mount selection, and VFolderSelect UI in service launcher

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -88,7 +88,14 @@ import {
   BAIButton,
 } from 'backend.ai-ui';
 import _ from 'lodash';
-import React, { Suspense, useCallback, useRef, useState } from 'react';
+import React, {
+  Suspense,
+  useCallback,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   graphql,
@@ -1117,7 +1124,9 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           image: endpoint?.image_object,
         },
         vFolderID: endpoint?.model,
-        mount_ids: _.map(endpoint?.extra_mounts, (item) => item?.id),
+        mount_ids: _.map(endpoint?.extra_mounts, (item) =>
+          item?.row_id?.replaceAll('-', ''),
+        ),
         // TODO: implement mount_id_map. Now, it's impossible to get mount_destination from backend
         modelMountDestination: endpoint?.model_mount_destination,
         modelDefinitionPath: endpoint?.model_definition_path,
@@ -1180,6 +1189,30 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
     INITIAL_FORM_VALUES,
     formValuesFromQueryParams,
   );
+
+  const validateEffectEvent = useEffectEvent(() => {
+    form.validateFields(['cluster_size']).catch(() => {});
+  });
+  useEffect(() => {
+    validateEffectEvent();
+  }, []);
+
+  // Sync mount_ids from endpoint data to form.
+  // initialValues is only applied on first Form mount, but with
+  // fetchPolicy: 'store-and-network', the endpoint data may arrive after the
+  // Form has already mounted with empty mount_ids.
+  useEffect(() => {
+    if (endpoint?.extra_mounts) {
+      const mountIds = _.compact(
+        _.map(endpoint.extra_mounts, (item) =>
+          item?.row_id?.replaceAll('-', ''),
+        ),
+      );
+      if (mountIds.length > 0) {
+        form.setFieldsValue({ mount_ids: mountIds });
+      }
+    }
+  }, [endpoint?.extra_mounts, form]);
 
   return (
     <>
@@ -1744,6 +1777,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                       {
                         key: 'advanced',
                         label: t('session.launcher.AdvancedSettings'),
+                        forceRender: true,
                         children: (
                           <>
                             <ClusterModeFormItems />
@@ -1806,26 +1840,28 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                 );
                               }}
                             </Form.Item>
-                            <Form.Item noStyle dependencies={['vFolderID']}>
-                              {({ getFieldValue }) => {
-                                const vFolderID = getFieldValue('vFolderID');
-                                return (
-                                  <VFolderTableFormItem
-                                    label={t('modelService.AdditionalMounts')}
-                                    rowKey="id"
-                                    tableProps={{
-                                      scroll: { x: 'max-content', y: 300 },
-                                    }}
-                                    rowFilter={(vfolder) =>
-                                      vfolder.usage_mode !== 'model' &&
-                                      vfolder.status === 'ready' &&
-                                      !vfolder.name?.startsWith('.') &&
-                                      vfolder.id !== vFolderID
-                                    }
-                                  />
-                                );
-                              }}
-                            </Form.Item>
+                            <Suspense fallback={<Skeleton active />}>
+                              <Form.Item noStyle dependencies={['vFolderID']}>
+                                {({ getFieldValue }) => {
+                                  const vFolderID = getFieldValue('vFolderID');
+                                  return (
+                                    <VFolderTableFormItem
+                                      label={t('modelService.AdditionalMounts')}
+                                      rowKey="id"
+                                      tableProps={{
+                                        scroll: { x: 'max-content', y: 300 },
+                                      }}
+                                      rowFilter={(vfolder) =>
+                                        vfolder.usage_mode !== 'model' &&
+                                        vfolder.status === 'ready' &&
+                                        !vfolder.name?.startsWith('.') &&
+                                        vfolder.id !== vFolderID
+                                      }
+                                    />
+                                  );
+                                }}
+                              </Form.Item>
+                            </Suspense>
                           </>
                         ),
                       },

--- a/react/src/components/VFolderSelect.tsx
+++ b/react/src/components/VFolderSelect.tsx
@@ -8,10 +8,11 @@ import useControllableState_deprecated from '../hooks/useControllableState';
 import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import FolderCreateModal from './FolderCreateModal';
 import { useFolderExplorerOpener } from './FolderExplorerOpener';
+import { ReloadOutlined } from '@ant-design/icons';
 import { Button, Select, type SelectProps, Space, Tooltip } from 'antd';
 import { useUpdatableState, BAIFlex } from 'backend.ai-ui';
 import _ from 'lodash';
-import { FolderOpenIcon, PlusIcon, RefreshCwIcon } from 'lucide-react';
+import { FolderOpenIcon, PlusIcon } from 'lucide-react';
 import React, { startTransition, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -126,7 +127,7 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
   }, [autoSelectDefault]);
 
   return (
-    <BAIFlex direction="row" gap={'xxs'}>
+    <BAIFlex direction="row" gap={'xs'}>
       <Select
         showSearch={{
           optionFilterProp: 'label',
@@ -174,7 +175,7 @@ const VFolderSelect: React.FC<VFolderSelectProps> = ({
         {showRefreshButton ? (
           <Tooltip title={t('button.Refresh')}>
             <Button
-              icon={<RefreshCwIcon />}
+              icon={<ReloadOutlined />}
               variant="text"
               onClick={() => {
                 startTransition(() => {


### PR DESCRIPTION
Resolves ([FR-2474](https://lablup.atlassian.net/browse/FR-2474))

## Summary
- Validate `cluster_size` field on mount using `useEffect` + `useEffectEvent` with `.catch()` to prevent unhandled rejection
- Add `forceRender: true` to advanced settings tab so validation fields are available before tab is opened
- Wrap `VFolderTableFormItem` in `Suspense` with `Skeleton` fallback to avoid blocking page load from `forceRender`
- Fix extra mount folder selection not persisting in service edit mode:
  - Use `row_id` (UUID) instead of Relay global `id` for `mount_ids` initialization
  - Strip hyphens from `row_id` to match REST API folder ID format
  - Add `useEffect` to sync `mount_ids` via `form.setFieldsValue` to handle `store-and-network` fetch policy timing
- Replace lucide `RefreshCwIcon` with antd `ReloadOutlined` in VFolderSelect for icon consistency
- Adjust VFolderSelect button gap from `xxs` to `xs` for better spacing

## Test plan
- [ ] Open service launcher page and verify cluster_size validation error shows if applicable
- [ ] Edit an existing service with extra mounts and verify folders are shown as selected
- [ ] Confirm advanced settings tab fields are validated without opening the tab
- [ ] Verify VFolderSelect refresh button renders correctly with antd icon

[FR-2474]: https://lablup.atlassian.net/browse/FR-2474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ