### PR TITLE
style(FR-2481): replace storage node permission badge with lock icons

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIAllowedVfolderHostsWithPermission.tsx
@@ -2,7 +2,6 @@ import { BAIAllowedVfolderHostsWithPermissionFromGroupFragment$key } from '../..
 import { BAIAllowedVfolderHostsWithPermissionFromKeyPairResourcePolicyFragment$key } from '../../__generated__/BAIAllowedVfolderHostsWithPermissionFromKeyPairResourcePolicyFragment.graphql';
 import { BAIAllowedVfolderHostsWithPermissionQuery } from '../../__generated__/BAIAllowedVfolderHostsWithPermissionQuery.graphql';
 import { SemanticColor } from '../../helper';
-import BAIBadge from '../BAIBadge';
 import BAIFlex from '../BAIFlex';
 import BAILink from '../BAILink';
 import BAIModal from '../BAIModal';
@@ -10,6 +9,7 @@ import { BAITable } from '../Table';
 import { CheckCircleFilled, StopFilled } from '@ant-design/icons';
 import { theme } from 'antd';
 import _ from 'lodash';
+import { LockIcon, LockOpenIcon } from 'lucide-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
@@ -90,17 +90,42 @@ const BAIAllowedVfolderHostsWithPermission: React.FC<
   return (
     <>
       <BAIFlex gap="xs" wrap="wrap">
-        {_.map(_.keys(allowedVfolderHosts), (storageHost) => (
-          <BAILink
-            key={storageHost}
-            onClick={() => {
-              setStorageHost(storageHost);
-            }}
-            type="hover"
-          >
-            <BAIBadge color={getColor(storageHost)} text={storageHost} />
-          </BAILink>
-        ))}
+        {_.map(_.keys(allowedVfolderHosts), (storageHost) => {
+          const color = getColor(storageHost);
+          return (
+            <BAILink
+              key={storageHost}
+              onClick={() => {
+                setStorageHost(storageHost);
+              }}
+              type="hover"
+            >
+              <BAIFlex gap="xxs" align="center">
+                {color === 'error' ? (
+                  <LockIcon
+                    size={14}
+                    aria-hidden="true"
+                    focusable={false}
+                    style={{ color: token.colorError }}
+                  />
+                ) : (
+                  <LockOpenIcon
+                    size={14}
+                    aria-hidden="true"
+                    focusable={false}
+                    style={{
+                      color:
+                        color === 'success'
+                          ? token.colorSuccess
+                          : token.colorWarning,
+                    }}
+                  />
+                )}
+                {storageHost}
+              </BAIFlex>
+            </BAILink>
+          );
+        })}
       </BAIFlex>
       <BAIModal
         centered


### PR DESCRIPTION
Resolves #6424(FR-2481)

## Summary
- Replace `BAIBadge` with Lucide lock icons (`LockIcon`/`LockOpenIcon`) in the admin Project page's Storage Nodes column
- All permissions allowed: `lock-open` icon in **success** (green) color
- Some permissions allowed: `lock-open` icon in **warning** (orange) color
- All permissions blocked: `lock` icon in **error** (red) color

## Verification
```
=== ALL PASS ===
```

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6441/20260406-234624-before-storage-nodes.png) | ![after](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6441/20260406-234627-after-storage-nodes.png) |

## Test plan
- [ ] Navigate to Admin Settings > Projects
- [ ] Scroll right to the "Storage Nodes" column
- [ ] Verify lock-open icons appear in green for storage nodes with all permissions
- [ ] Verify lock-open icons appear in orange for storage nodes with partial permissions
- [ ] Verify lock icons appear in red for storage nodes with no permissions
- [ ] Click on a storage node to verify the permission detail modal still works