### PR TITLE
feat(FR-2482): display env vars as code block on serving detail page

### DIFF
--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -123,6 +123,7 @@ const SessionLauncherPreview: React.FC<{
                   },
                   content: {
                     overflow: 'auto',
+                    display: 'flex',
                   },
                 }}
               >
@@ -385,17 +386,20 @@ const SessionLauncherPreview: React.FC<{
           {form.getFieldValue('envvars')?.length > 0 && (
             <Descriptions.Item
               label={t('session.launcher.EnvironmentVariable')}
+              styles={{
+                content: {
+                  display: 'flex',
+                },
+              }}
             >
               {form.getFieldValue('envvars')?.length ? (
-                <BAIFlex align="stretch" direction="column">
-                  <SourceCodeView language={'shell'}>
-                    {_.map(
-                      form.getFieldValue('envvars'),
-                      (v: { variable: string; value: string }) =>
-                        `${v?.variable || ''}="${v?.value || ''}"`,
-                    ).join('\n')}
-                  </SourceCodeView>
-                </BAIFlex>
+                <SourceCodeView language={'shell'}>
+                  {_.map(
+                    form.getFieldValue('envvars'),
+                    (v: { variable: string; value: string }) =>
+                      `${v?.variable || ''}="${v?.value || ''}"`,
+                  ).join('\n')}
+                </SourceCodeView>
               ) : (
                 <Typography.Text type="secondary">-</Typography.Text>
               )}

--- a/react/src/components/SourceCodeView.tsx
+++ b/react/src/components/SourceCodeView.tsx
@@ -11,6 +11,7 @@ import { BAIFlex, BAIText } from 'backend.ai-ui';
 interface SourceCodeViewProps {
   children: string;
   language: string;
+  style?: React.CSSProperties;
 }
 
 const useStyles = createStyles(({ token }) => ({
@@ -23,9 +24,9 @@ const useStyles = createStyles(({ token }) => ({
       margin: '0 !important',
       padding: `${token.paddingSM}px !important`,
     },
-    '& div[dir="ltr"]': {
-      display: 'table',
-      minWidth: '100%',
+    '& pre': {
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-all',
     },
   },
 }));
@@ -71,21 +72,23 @@ const CodeHead = ({
 const SourceCodeView: React.FC<SourceCodeViewProps> = ({
   children,
   language,
+  style,
 }) => {
   'use memo';
   const { styles } = useStyles();
   const { token } = theme.useToken();
 
   return (
-    <BAIFlex
-      direction="column"
+    <div
       style={{
         border: `1px solid ${token.colorBorderSecondary}`,
         margin: 0,
         padding: 0,
         borderRadius: token.borderRadiusLG,
         overflow: 'hidden',
-        width: '100%',
+        flex: 1,
+        minWidth: 0,
+        ...style,
       }}
     >
       <CodeHead
@@ -100,18 +103,17 @@ const SourceCodeView: React.FC<SourceCodeViewProps> = ({
           />
         }
       />
-      <BAIFlex
+      <div
         className={styles.codeBlock}
         style={{
-          width: '100%',
           paddingTop: 0,
           borderRadius: `0 0 ${token.borderRadiusLG}px ${token.borderRadiusLG}px`,
           overflow: 'auto',
         }}
       >
         <SyntaxHighlighter language={language}>{children}</SyntaxHighlighter>
-      </BAIFlex>
-    </BAIFlex>
+      </div>
+    </div>
   );
 };
 

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -41,7 +41,6 @@ import {
   CloseOutlined,
   DeleteOutlined,
   ExclamationCircleOutlined,
-  FolderOutlined,
   LoadingOutlined,
   PlusOutlined,
   SettingOutlined,
@@ -96,6 +95,7 @@ import React, {
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
 import { useParams } from 'react-router-dom';
+import VFolderNodeIdenticon from 'src/components/VFolderNodeIdenticon';
 
 interface RoutingInfo {
   route_id: string;
@@ -243,6 +243,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           extra_mounts {
             row_id
             name
+            ...VFolderNodeIdenticonFragment
           }
           environ
           resource_group
@@ -561,15 +562,16 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
         <BAIFlex direction="column" align="start">
           {_.map(endpoint?.extra_mounts, (vfolder) => {
             return (
-              <BAIFlex direction="row" gap={'xxs'} key={vfolder?.row_id}>
-                <Typography.Link
-                  onClick={() => {
-                    vfolder?.row_id && open(vfolder?.row_id);
-                  }}
-                >
-                  <FolderOutlined /> {vfolder?.name}
-                </Typography.Link>
-              </BAIFlex>
+              <Typography.Link
+                onClick={() => {
+                  vfolder?.row_id && open(vfolder?.row_id);
+                }}
+              >
+                <BAIFlex direction="row" gap={'xs'} key={vfolder?.row_id}>
+                  <VFolderNodeIdenticon vfolderNodeIdenticonFrgmt={vfolder} />{' '}
+                  {vfolder?.name}
+                </BAIFlex>
+              </Typography.Link>
             );
           })}
         </BAIFlex>
@@ -578,7 +580,12 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
     {
       label: t('session.launcher.EnvironmentVariable'),
       children: (() => {
-        const envObj = JSON.parse(endpoint?.environ || '{}');
+        let envObj: Record<string, string> = {};
+        try {
+          envObj = JSON.parse(endpoint?.environ || '{}');
+        } catch {
+          return '-';
+        }
         if (_.isEmpty(envObj)) return '-';
         const envText = _.map(envObj, (value, key) => `${key}="${value}"`).join(
           '\n',
@@ -687,7 +694,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
       >
         <Descriptions
           bordered
-          column={{ xxl: 3, xl: 3, lg: 2, md: 1, sm: 1, xs: 1 }}
+          column={{ xxl: 3, xl: 2, lg: 2, md: 1, sm: 1, xs: 1 }}
           style={{
             backgroundColor: token.colorBgBase,
           }}


### PR DESCRIPTION
Resolves #6425(FR-2482)

## Summary
- Replace plain monospace `Typography.Text` with `SourceCodeView` component for environment variables on the endpoint detail page
- Adds syntax highlighting (shell language) and a copy button
- Matches the style used in the session start page's final preview step
- Formats env vars as `KEY="VALUE"` pairs (shell-style)

## Verification
```
=== ALL PASS ===
```

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://raw.githubusercontent.com/lablup/backend.ai-webui/assets/images/screenshots/pr-6442/20260406-234636-before-envvars.png) | <img width="985" height="313" alt="image" src="https://github.com/user-attachments/assets/ec64526f-8742-4e9f-b439-9f761851e95c" />
 |



## Test plan
- [ ] Navigate to Serving > click on an endpoint with environment variables
- [ ] Verify env vars are displayed in a code block with syntax highlighting
- [ ] Verify the copy button works to copy env vars text
- [ ] Verify endpoints without env vars still show `-`