### PR TITLE
fix(FR-2477): auto-refresh model service table after creation

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1005,7 +1005,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
               message.success(
                 t('modelService.ServiceCreated', { name: values.serviceName }),
               );
-              webuiNavigate('/serving');
+              webuiNavigate('/serving', { state: { refreshTable: true } });
             },
             onError: (error) => {
               // Ignore user-initiated cancellation (e.g., overwrite confirmation dismissed)

--- a/react/src/pages/ServingPage.tsx
+++ b/react/src/pages/ServingPage.tsx
@@ -20,9 +20,10 @@ import {
   useUpdatableState,
 } from 'backend.ai-ui';
 import _ from 'lodash';
-import React, { Suspense, useDeferredValue, useMemo } from 'react';
+import React, { Suspense, useDeferredValue, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useLazyLoadQuery } from 'react-relay';
+import { useLocation } from 'react-router-dom';
 import { StringParam, useQueryParams, withDefault } from 'use-query-params';
 
 const ServingPage: React.FC = () => {
@@ -47,6 +48,29 @@ const ServingPage: React.FC = () => {
   });
 
   const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
+
+  const location = useLocation();
+  const locationState = location.state as
+    | { refreshTable?: boolean }
+    | undefined;
+
+  useEffect(() => {
+    if (locationState?.refreshTable) {
+      updateFetchKey();
+      // Clear the state to prevent re-triggering on back navigation
+      webuiNavigate(`${location.pathname}${location.search}${location.hash}`, {
+        replace: true,
+        state: null,
+      });
+    }
+  }, [
+    location.hash,
+    location.pathname,
+    location.search,
+    locationState?.refreshTable,
+    updateFetchKey,
+    webuiNavigate,
+  ]);
 
   const lifecycleStageFilter =
     queryParams.lifecycleStage === 'active'


### PR DESCRIPTION
Resolves #6445 (FR-2477)

## Summary
- Pass `refreshTable` state when navigating back to serving page after service creation
- Add `useEffect` in `ServingPage` to detect location state and trigger fetch key update
- Clear location state after refresh to prevent re-triggering on back navigation

## Test plan
- [ ] Create a new model service and verify the serving table refreshes automatically
- [ ] Verify back navigation does not cause unnecessary re-fetch
- [ ] Verify delete still triggers refresh as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)