### PR TITLE
fix(FR-2467): disable session commit button until session is Running

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
+++ b/react/src/components/ComputeSessionNodeItems/SessionActionButtons.tsx
@@ -329,7 +329,7 @@ const SessionActionButtons: React.FC<SessionActionButtonsProps> = ({
           >
             <Button
               size={size}
-              disabled={!isActive(session) || !isOwner}
+              disabled={session?.status !== 'RUNNING' || !isOwner}
               icon={<BAIContainerCommitIcon />}
               onClick={() => {
                 onAction?.('containerCommit');


### PR DESCRIPTION
Resolves #6443 (FR-2467)

## Summary
- Disable commit button when session status is not RUNNING
- Previously only checked isActive() which allowed non-running states like PREPARING, PENDING, PULLING to enable the button

## Test plan
- [ ] Verify commit button is disabled when session is in PREPARING state
- [ ] Verify commit button is disabled when session is in PENDING state
- [ ] Verify commit button is enabled when session is in RUNNING state
- [ ] Verify commit button remains disabled for non-owners regardless of session status

🤖 Generated with [Claude Code](https://claude.com/claude-code)