### PR TITLE
fix(FR-2480): use resourceGroup instead of project for scaling_group in session delegation

### DIFF
--- a/react/src/hooks/useStartSession.tsx
+++ b/react/src/hooks/useStartSession.tsx
@@ -248,7 +248,7 @@ export const useStartSession = () => {
             },
           }),
           scaling_group: values.owner?.enabled
-            ? values.owner.project
+            ? values.owner.resourceGroup
             : values.resourceGroup,
           ...(values?.resource && {
             resource_opts: {


### PR DESCRIPTION
Resolves #6464 (FR-2480)

## Summary

- Fix `scaling_group` parameter in session delegation: use `values.owner.resourceGroup` instead of `values.owner.project`
- When a superadmin delegates session creation via Session Owner Setter, the wrong field was sent as `scaling_group`, causing API errors

## Changes

- `react/src/hooks/useStartSession.tsx` (L251): `values.owner.project` → `values.owner.resourceGroup`

## Verification

```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```

## Test plan

- [ ] Log in as superadmin
- [ ] Open Session Launcher → enable "Set Session Owner"
- [ ] Enter a regular user's email, select access key, project, and resource group
- [ ] Create session → verify no "Scaling group not accessible" error
- [ ] Verify session is created in the correct resource group