### PR TITLE
fix(FR-2466): show specific warning message for single-node cluster mode in session preview

### DIFF
--- a/react/src/components/SessionLauncherPreview.tsx
+++ b/react/src/components/SessionLauncherPreview.tsx
@@ -424,8 +424,8 @@ const SessionLauncherPreview: React.FC<{
           onClickEditStep('environment');
         }}
       >
-        <BAIFlex direction="column" align="stretch">
-          {(_.some(
+        <BAIFlex direction="column" align="stretch" gap="sm">
+          {_.some(
             form.getFieldValue('resource'),
             (_v, key: keyof SessionLauncherFormValue['resource']) => {
               return (
@@ -433,13 +433,21 @@ const SessionLauncherPreview: React.FC<{
                   .length > 0
               );
             },
-          ) ||
-            (form.getFieldWarning(['cluster_size'] as any) as any[]).length >
-              0) && (
+          ) && (
             <Alert
               type="warning"
               showIcon
               title={t('session.launcher.EnqueueComputeSessionWarning')}
+            />
+          )}
+          {(form.getFieldWarning(['cluster_size'] as any) as any[]).length >
+            0 && (
+            <Alert
+              type="warning"
+              showIcon
+              title={
+                (form.getFieldWarning(['cluster_size'] as any) as string[])[0]
+              }
             />
           )}
 


### PR DESCRIPTION
Resolves #6417 (FR-2466)

## Summary
- Split the single generic Alert into two separate Alerts in `SessionLauncherPreview.tsx`
- Resource field warnings continue to show the generic `EnqueueComputeSessionWarning` message
- `cluster_size` field warnings now show the specific warning message from the form validator (e.g., "multi-node with size 1" or "exceeds immediate capacity") instead of the generic resource warning

## Test plan
- [ ] Set cluster mode to multi-node with cluster size 1, verify the preview step shows the specific cluster_size warning message (not the generic resource warning)
- [ ] Set insufficient resources, verify the preview step shows the generic `EnqueueComputeSessionWarning` message
- [ ] Trigger both warnings simultaneously, verify both alerts are shown independently