### PR TITLE
fix(FR-2476): add missing permission argument to admin vfolder queries

### DIFF
--- a/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButton.stories.tsx
+++ b/packages/backend.ai-ui/src/components/fragments/BAIVFolderDeleteButton.stories.tsx
@@ -89,8 +89,10 @@ const QueryResolver = ({ disabled = false, onClick }: QueryResolverProps) => {
   const { vfolder_nodes } =
     useLazyLoadQuery<BAIVFolderDeleteButtonStoriesQuery>(
       graphql`
-        query BAIVFolderDeleteButtonStoriesQuery {
-          vfolder_nodes(offset: 0, first: 10) {
+        query BAIVFolderDeleteButtonStoriesQuery(
+          $permission: VFolderPermissionValueField
+        ) {
+          vfolder_nodes(offset: 0, first: 10, permission: $permission) {
             edges {
               node {
                 ...BAIVFolderDeleteButtonFragment
@@ -99,7 +101,7 @@ const QueryResolver = ({ disabled = false, onClick }: QueryResolverProps) => {
           }
         }
       `,
-      {},
+      { permission: 'read_attribute' },
     );
 
   const vfolders = vfolder_nodes?.edges?.map((edge: any) => edge.node);

--- a/react/src/pages/AdminVFolderNodeListPage.tsx
+++ b/react/src/pages/AdminVFolderNodeListPage.tsx
@@ -136,6 +136,7 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
       usageModeFilter,
     ]),
     order: queryParams.order,
+    permission: 'read_attribute',
     filterForActiveCount: FILTER_BY_STATUS_CATEGORY['active'],
     filterForDeletedCount: FILTER_BY_STATUS_CATEGORY['deleted'],
     scope_id: `domain:${domainName}`,
@@ -151,6 +152,7 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
           $first: Int
           $filter: String
           $order: String
+          $permission: VFolderPermissionValueField
           $filterForActiveCount: String
           $filterForDeletedCount: String
           $scope_id: ScopeField
@@ -160,6 +162,7 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
             first: $first
             filter: $filter
             order: $order
+            permission: $permission
             scope_id: $scope_id
           ) {
             edges @required(action: THROW) {
@@ -182,6 +185,8 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
             first: 0
             offset: 0
             filter: $filterForActiveCount
+            permission: $permission
+            scope_id: $scope_id
           ) {
             count
           }
@@ -189,6 +194,8 @@ const AdminVFolderNodeListPage: React.FC = (props) => {
             first: 0
             offset: 0
             filter: $filterForDeletedCount
+            permission: $permission
+            scope_id: $scope_id
           ) {
             count
           }


### PR DESCRIPTION
Resolves #6434 (FR-2476)

## Summary
- Add required `permission` argument to `vfolder_nodes` queries in `AdminVFolderNodeListPage` (all 3 calls: main list, active count, deleted count)
- Use `read_attribute` as the default permission value, consistent with `VFolderNodeListPage`
- Fix `BAIVFolderDeleteButton.stories.tsx` query to pass `permission` as a variable

## Test plan
- [ ] Admin data page loads without GraphQL errors
- [ ] VFolder list displays correctly on admin page
- [ ] Active and deleted folder counts load correctly

## Verification
```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```