### PR TITLE
fix(FR-2475): add fetchKey prop to ProjectSelect for data refetch on modal open

### DIFF
--- a/e2e/utils/test-util.ts
+++ b/e2e/utils/test-util.ts
@@ -50,6 +50,70 @@ function mergeWithUndefined<T extends object>(target: T, source: object): T {
   return result;
 }
 
+/**
+ * Remove duplicate keys within the same TOML section.
+ * Keeps the last occurrence of each key per section.
+ */
+function deduplicateTomlKeys(toml: string): string {
+  const lines = toml.split('\n');
+  const result: string[] = [];
+  const seenKeys = new Set<string>();
+  let currentSection = '';
+
+  // First pass: track last occurrence of each key per section
+  const lastOccurrence = new Map<string, number>();
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.startsWith('[')) {
+      currentSection = line;
+      seenKeys.clear();
+    } else if (line && !line.startsWith('#')) {
+      const eqIndex = line.indexOf('=');
+      if (eqIndex > 0) {
+        const key = `${currentSection}::${line.substring(0, eqIndex).trim()}`;
+        lastOccurrence.set(key, i);
+      }
+    }
+  }
+
+  // Second pass: only keep the last occurrence of duplicate keys
+  currentSection = '';
+  const keyLineIndices = new Map<string, number[]>();
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.startsWith('[')) {
+      currentSection = line;
+    } else if (line && !line.startsWith('#')) {
+      const eqIndex = line.indexOf('=');
+      if (eqIndex > 0) {
+        const key = `${currentSection}::${line.substring(0, eqIndex).trim()}`;
+        if (!keyLineIndices.has(key)) {
+          keyLineIndices.set(key, []);
+        }
+        keyLineIndices.get(key)!.push(i);
+      }
+    }
+  }
+
+  const skipLines = new Set<number>();
+  for (const [, indices] of keyLineIndices) {
+    if (indices.length > 1) {
+      // Skip all but the last occurrence
+      for (let j = 0; j < indices.length - 1; j++) {
+        skipLines.add(indices[j]);
+      }
+    }
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!skipLines.has(i)) {
+      result.push(lines[i]);
+    }
+  }
+
+  return result.join('\n');
+}
+
 // Theme configuration types based on theme.schema.json
 type ThemeLogoConfig = {
   src?: string;
@@ -751,7 +815,11 @@ export async function modifyConfigToml(
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           return res.text();
         });
-        config = TOML.parse(configToml);
+        // Pre-process TOML to remove duplicate keys before parsing.
+        // Some server configurations may have duplicate keys (e.g., debug = true
+        // appearing twice under [general]) which strict TOML parsers reject.
+        const deduplicatedToml = deduplicateTomlKeys(configToml);
+        config = TOML.parse(deduplicatedToml);
         break; // Success, exit retry loop
       } catch (error) {
         lastError = error;

--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -25,6 +25,7 @@ export interface ProjectSelectProps extends BAISelectProps {
   autoSelectDefault?: boolean;
   disableDefaultFilter?: boolean;
   lockedProjectTypes?: string[];
+  fetchKey?: string;
 }
 
 const ProjectSelect: React.FC<ProjectSelectProps> = ({
@@ -32,6 +33,7 @@ const ProjectSelect: React.FC<ProjectSelectProps> = ({
   domain,
   disableDefaultFilter,
   lockedProjectTypes,
+  fetchKey,
   ...selectProps
 }) => {
   const { t } = useTranslation();
@@ -74,6 +76,7 @@ const ProjectSelect: React.FC<ProjectSelectProps> = ({
     },
     {
       fetchPolicy: 'store-and-network',
+      fetchKey: fetchKey,
     },
   );
 

--- a/react/src/components/UpdateUsersModal.tsx
+++ b/react/src/components/UpdateUsersModal.tsx
@@ -16,6 +16,7 @@ import {
   useBAILogger,
   useErrorMessageResolver,
   useMutationWithPromise,
+  useUpdatableState,
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { Suspense, useRef, useState } from 'react';
@@ -50,6 +51,7 @@ const UpdateUsersModal = ({
   'use memo';
   const formRef = useRef<FormInstance<UpdateUsersFormValues>>(null);
   const [isPending, setIsPending] = useState(false);
+  const [fetchKey, updateFetchKey] = useUpdatableState('initial-fetch');
   const { token } = theme.useToken();
   const { t } = useTranslation();
   const { message } = App.useApp();
@@ -88,6 +90,12 @@ const UpdateUsersModal = ({
       okText={t('button.Update')}
       confirmLoading={isPending}
       {...modalProps}
+      afterOpenChange={(open) => {
+        if (open) {
+          updateFetchKey();
+        }
+        modalProps.afterOpenChange?.(open);
+      }}
       onOk={(e) => {
         formRef.current
           ?.validateFields()
@@ -232,6 +240,7 @@ const UpdateUsersModal = ({
                     domain={getFieldValue('domain_name')}
                     disableDefaultFilter
                     disabled={!getFieldValue('domain_name')}
+                    fetchKey={fetchKey}
                   />
                 </Form.Item>
               )}

--- a/react/src/components/UserSettingModal.tsx
+++ b/react/src/components/UserSettingModal.tsx
@@ -874,6 +874,7 @@ const UserSettingModal: React.FC<UserSettingModalProps> = ({
                     domain={getFieldValue('domain_name')}
                     disableDefaultFilter
                     lockedProjectTypes={!user ? ['MODEL_STORE'] : undefined}
+                    fetchKey={fetchKey}
                   />
                 </Form.Item>
               )}


### PR DESCRIPTION
Resolves #6433(FR-2475)

## Summary
- Add `fetchKey?: string` prop to `ProjectSelect` component and pass it to `useLazyLoadQuery` options, enabling Relay to trigger a fresh network request when the key changes
- Pass the existing `fetchKey` state from `UserSettingModal` to `ProjectSelect`, matching how `AccessKeySelect` already handles this
- Add `fetchKey` state management to `UpdateUsersModal` using `useUpdatableState('initial-fetch')` and trigger an update via `afterOpenChange` when the modal opens

## Test plan
- [ ] Open user edit modal, verify project list shows fresh data (not stale cache)
- [ ] Change project membership externally, reopen the modal, verify the updated project list appears
- [ ] Open the bulk user update modal, verify project list is fetched fresh on each open