### PR TITLE
feat(FR-2478): add action buttons to session name column using BAINameActionCell

### DIFF
--- a/react/src/components/SessionNodes.tsx
+++ b/react/src/components/SessionNodes.tsx
@@ -7,10 +7,12 @@ import {
   SessionNodesFragment$key,
 } from '../__generated__/SessionNodesFragment.graphql';
 import { useSuspendedBackendaiClient } from '../hooks';
-import { useCurrentUserRole } from '../hooks/backendai';
+import { useCurrentUserInfo, useCurrentUserRole } from '../hooks/backendai';
+import AppLauncherModal from './ComputeSessionNodeItems/AppLauncherModal';
 import SessionReservation from './ComputeSessionNodeItems/SessionReservation';
 import SessionSlotCell from './ComputeSessionNodeItems/SessionSlotCell';
 import SessionStatusTag from './ComputeSessionNodeItems/SessionStatusTag';
+import TerminateSessionModal from './ComputeSessionNodeItems/TerminateSessionModal';
 import ImageNodeSimpleTag from './ImageNodeSimpleTag';
 import { Tooltip } from 'antd';
 import {
@@ -21,14 +23,17 @@ import {
   BAITable,
   BAITableProps,
   BAISessionAgentIds,
-  BAILink,
+  BAIAppIcon,
+  BAINameActionCell,
   BAISessionTypeTag,
   BAISessionClusterMode,
   BAITag,
+  BAIUnmountAfterClose,
 } from 'backend.ai-ui';
 import dayjs from 'dayjs';
 import _ from 'lodash';
-import React from 'react';
+import { PowerOffIcon } from 'lucide-react';
+import React, { Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment } from 'react-relay';
 
@@ -75,6 +80,11 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
   const { t } = useTranslation();
   const userRole = useCurrentUserRole();
   const baiClient = useSuspendedBackendaiClient();
+  const [userInfo] = useCurrentUserInfo();
+  const [terminateTarget, setTerminateTarget] =
+    useState<SessionNodeInList | null>(null);
+  const [appLauncherTarget, setAppLauncherTarget] =
+    useState<SessionNodeInList | null>(null);
 
   const sessions = useFragment(
     graphql`
@@ -84,6 +94,8 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
         name
         status
         type
+        service_ports
+        user_id
         agent_ids
         ...SessionStatusTagFragment
         ...SessionReservationFragment
@@ -93,6 +105,8 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
         ...BAISessionAgentIdsFragment
         ...BAISessionTypeTagFragment
         ...BAISessionClusterModeFragment
+        ...AppLauncherModalFragment
+        ...TerminateSessionModalFragment
         kernel_nodes {
           edges {
             node {
@@ -140,17 +154,44 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
         title: t('session.SessionName'),
         dataIndex: 'name',
         render: (name: string, session) => {
-          return onClickSessionName ? (
-            <BAILink
-              type="hover"
-              onClick={() => {
-                onClickSessionName(session);
-              }}
-            >
-              {name}
-            </BAILink>
-          ) : (
-            name
+          const isActive =
+            session.type === 'system'
+              ? session.status === 'RUNNING'
+              : !['TERMINATED', 'CANCELLED', 'TERMINATING'].includes(
+                  session.status || '',
+                );
+          const isAppSupported =
+            ['batch', 'interactive', 'inference', 'system', 'running'].includes(
+              session.type || '',
+            ) && !_.isEmpty(JSON.parse(session.service_ports ?? '{}'));
+          const isOwner = userInfo?.uuid === session.user_id;
+          return (
+            <BAINameActionCell
+              title={name}
+              showActions="always"
+              onTitleClick={
+                onClickSessionName
+                  ? () => onClickSessionName(session)
+                  : undefined
+              }
+              actions={filterOutEmpty([
+                session.type !== 'system' && {
+                  key: 'appLauncher',
+                  title: t('session.SeeAppDialog'),
+                  icon: <BAIAppIcon />,
+                  disabled: !isAppSupported || !isActive || !isOwner,
+                  onClick: () => setAppLauncherTarget(session),
+                },
+                {
+                  key: 'terminate',
+                  title: t('session.TerminateSession'),
+                  icon: <PowerOffIcon />,
+                  type: 'danger' as const,
+                  disabled: !isActive,
+                  onClick: () => setTerminateTarget(session),
+                },
+              ])}
+            />
           );
         },
         sorter: isEnableSorter('name'),
@@ -352,6 +393,20 @@ const SessionNodes: React.FC<SessionNodesProps> = ({
           );
         }}
         {...tableProps}
+      />
+      <Suspense fallback={null}>
+        <BAIUnmountAfterClose>
+          <AppLauncherModal
+            sessionFrgmt={appLauncherTarget}
+            open={!!appLauncherTarget}
+            onRequestClose={() => setAppLauncherTarget(null)}
+          />
+        </BAIUnmountAfterClose>
+      </Suspense>
+      <TerminateSessionModal
+        sessionFrgmts={terminateTarget ? [terminateTarget] : []}
+        open={!!terminateTarget}
+        onRequestClose={() => setTerminateTarget(null)}
       />
     </>
   );


### PR DESCRIPTION
Resolves #6436 (FR-2478)

## Summary
- Use `BAINameActionCell` in the session table's name column to display action buttons (app launcher, terminate) next to the session name
- App launcher button opens `AppLauncherModal` directly from the table (hidden for system sessions, disabled when app is unsupported or session is inactive)
- Terminate button opens `TerminateSessionModal` (disabled when session is inactive)
- Both buttons are always visible (`showActions="always"`) and disabled for terminated/cancelled sessions
- Add `...AppLauncherModalFragment` and `...TerminateSessionModalFragment` to `SessionNodesFragment`

## Test plan
- [ ] Session name column shows app launcher and terminate action buttons
- [ ] Clicking app launcher button opens the app launcher modal
- [ ] Clicking terminate button opens the terminate session modal
- [ ] Buttons are disabled for terminated/cancelled sessions
- [ ] App launcher button is hidden for system sessions
- [ ] App launcher button is disabled when session has no supported apps or user is not the owner
- [ ] Actions work correctly on both admin and user session pages

## Verification
```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)