### PR TITLE
feat(FR-1939): add column sorting to kernel table in session detail panel

### DIFF
--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -2,13 +2,12 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
+import { ConnectedKernelListRefetchQuery } from '../../__generated__/ConnectedKernelListRefetchQuery.graphql';
 import {
-  ConnectedKernelListFragment$data,
-  ConnectedKernelListFragment$key,
-} from '../../__generated__/ConnectedKernelListFragment.graphql';
+  ConnectedKernelListSessionFragment$data,
+  ConnectedKernelListSessionFragment$key,
+} from '../../__generated__/ConnectedKernelListSessionFragment.graphql';
 import { ContainerLogModalFragment$key } from '../../__generated__/ContainerLogModalFragment.graphql';
-// import BAIPropertyFilter from '../BAIPropertyFilter';
-import { localeCompare } from '../../helper';
 import ContainerLogModal from './ContainerLogModal';
 import { Button, Tag, theme, Tooltip, Typography } from 'antd';
 import type { ColumnType } from 'antd/lib/table';
@@ -21,18 +20,21 @@ import {
 } from 'backend.ai-ui';
 import _ from 'lodash';
 import { ScrollTextIcon } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useFragment } from 'react-relay';
+import { graphql, useRefetchableFragment } from 'react-relay';
 
-type Kernel = NonNullable<ConnectedKernelListFragment$data[number]>;
+type Kernel = NonNullable<
+  NonNullable<
+    NonNullable<
+      ConnectedKernelListSessionFragment$data['kernel_nodes']
+    >['edges'][number]
+  >['node']
+>;
 
 interface ConnectedKernelListProps {
-  kernelsFrgmt: ConnectedKernelListFragment$key;
+  sessionFrgmt: ConnectedKernelListSessionFragment$key;
   sessionFrgmtForLogModal: ContainerLogModalFragment$key;
-  // fetchKey?: string;
-  // get the project id of the session for <= v24.12.0.
-  // projectId?: string | null;
 }
 
 const kernelStatusTagColor = {
@@ -58,35 +60,53 @@ const kernelStatusTagColor = {
 };
 
 const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
-  kernelsFrgmt,
+  sessionFrgmt,
   sessionFrgmtForLogModal,
 }) => {
+  'use memo';
   const { t } = useTranslation();
   const [kernelIdForLogModal, setKernelIdForLogModal] = useState<string>();
   const { token } = theme.useToken();
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
+  const [order, setOrder] = useState<string>();
 
-  const kernelNodes = useFragment(
+  const [session, refetch] = useRefetchableFragment<
+    ConnectedKernelListRefetchQuery,
+    ConnectedKernelListSessionFragment$key
+  >(
     graphql`
-      fragment ConnectedKernelListFragment on KernelNode @relay(plural: true) {
-        id
-        row_id
-        cluster_hostname
-        cluster_idx
-        cluster_role
-        status
-        status_info
-        agent_id
-        container_id
+      fragment ConnectedKernelListSessionFragment on ComputeSessionNode
+      @argumentDefinitions(order: { type: "String", defaultValue: null })
+      @refetchable(queryName: "ConnectedKernelListRefetchQuery") {
+        kernel_nodes(order: $order) {
+          edges {
+            node {
+              id
+              row_id
+              cluster_hostname
+              cluster_idx
+              cluster_role
+              status
+              status_info
+              agent_id
+              container_id
+            }
+          }
+        }
       }
     `,
-    kernelsFrgmt,
+    sessionFrgmt,
+  );
+
+  const kernelNodes = filterOutNullAndUndefined(
+    session.kernel_nodes?.edges.map((e) => e?.node),
   );
 
   const columns = filterOutEmpty<ColumnType<Kernel>>([
     {
       title: t('kernel.Hostname'),
       dataIndex: 'cluster_hostname',
-      sorter: (a, b) => localeCompare(a?.cluster_hostname, b?.cluster_hostname),
+      sorter: true,
       render: (hostname, record) => {
         return (
           <>
@@ -113,7 +133,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
     {
       title: t('kernel.Status'),
       dataIndex: 'status',
-      sorter: (a, b) => localeCompare(a?.status, b?.status),
+      sorter: true,
       render: (status, record) => {
         return (
           <>
@@ -140,7 +160,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
     {
       title: t('kernel.AgentId'),
       dataIndex: 'agent_id',
-      sorter: (a, b) => localeCompare(a?.agent_id, b?.agent_id),
+      sorter: true,
       render: (id) =>
         _.isEmpty(id) ? '-' : <Typography.Text copyable>{id}</Typography.Text>,
     },
@@ -173,12 +193,6 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
     },
   ]);
 
-  const sortedKernels = useMemo(() => {
-    return _.orderBy(filterOutNullAndUndefined(kernelNodes), [
-      'cluster_role',
-      'cluster_idx',
-    ] as Array<keyof Kernel>);
-  }, [kernelNodes]);
   return (
     <>
       {/* TODO: implement filter when compute_session_node query supports filter */}
@@ -199,17 +213,24 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
       /> */}
       <BAITable
         bordered
-        // loading={isPendingFilter}
+        loading={isPendingRefetch}
         rowKey="id"
         scroll={{ x: 'max-content' }}
         columns={columns}
-        dataSource={sortedKernels} // TODO: implement pagination when compute_session_node query supports pagination
+        dataSource={kernelNodes}
+        order={order}
+        onChangeOrder={(nextOrder) => {
+          setOrder(nextOrder);
+          startRefetchTransition(() => {
+            refetch({ order: nextOrder ?? null });
+          });
+        }}
       />
 
       <BAIUnmountAfterClose>
         <ContainerLogModal
           open={!!kernelIdForLogModal}
-          sessionFrgmt={sessionFrgmtForLogModal || null}
+          sessionFrgmt={sessionFrgmtForLogModal}
           defaultKernelId={kernelIdForLogModal}
           onCancel={() => {
             setKernelIdForLogModal(undefined);

--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -85,6 +85,8 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
     {
       title: t('kernel.Hostname'),
       dataIndex: 'cluster_hostname',
+      sorter: (a, b) =>
+        (a?.cluster_hostname ?? '').localeCompare(b?.cluster_hostname ?? ''),
       render: (hostname, record) => {
         return (
           <>
@@ -111,6 +113,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
     {
       title: t('kernel.Status'),
       dataIndex: 'status',
+      sorter: (a, b) => (a?.status ?? '').localeCompare(b?.status ?? ''),
       render: (status, record) => {
         return (
           <>
@@ -137,6 +140,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
     {
       title: t('kernel.AgentId'),
       dataIndex: 'agent_id',
+      sorter: (a, b) => (a?.agent_id ?? '').localeCompare(b?.agent_id ?? ''),
       render: (id) =>
         _.isEmpty(id) ? '-' : <Typography.Text copyable>{id}</Typography.Text>,
     },

--- a/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
+++ b/react/src/components/ComputeSessionNodeItems/ConnectedKernelList.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../__generated__/ConnectedKernelListFragment.graphql';
 import { ContainerLogModalFragment$key } from '../../__generated__/ContainerLogModalFragment.graphql';
 // import BAIPropertyFilter from '../BAIPropertyFilter';
+import { localeCompare } from '../../helper';
 import ContainerLogModal from './ContainerLogModal';
 import { Button, Tag, theme, Tooltip, Typography } from 'antd';
 import type { ColumnType } from 'antd/lib/table';
@@ -85,8 +86,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
     {
       title: t('kernel.Hostname'),
       dataIndex: 'cluster_hostname',
-      sorter: (a, b) =>
-        (a?.cluster_hostname ?? '').localeCompare(b?.cluster_hostname ?? ''),
+      sorter: (a, b) => localeCompare(a?.cluster_hostname, b?.cluster_hostname),
       render: (hostname, record) => {
         return (
           <>
@@ -113,7 +113,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
     {
       title: t('kernel.Status'),
       dataIndex: 'status',
-      sorter: (a, b) => (a?.status ?? '').localeCompare(b?.status ?? ''),
+      sorter: (a, b) => localeCompare(a?.status, b?.status),
       render: (status, record) => {
         return (
           <>
@@ -140,7 +140,7 @@ const ConnectedKernelList: React.FC<ConnectedKernelListProps> = ({
     {
       title: t('kernel.AgentId'),
       dataIndex: 'agent_id',
-      sorter: (a, b) => (a?.agent_id ?? '').localeCompare(b?.agent_id ?? ''),
+      sorter: (a, b) => localeCompare(a?.agent_id, b?.agent_id),
       render: (id) =>
         _.isEmpty(id) ? '-' : <Typography.Text copyable>{id}</Typography.Text>,
     },

--- a/react/src/components/SessionDetailContent.tsx
+++ b/react/src/components/SessionDetailContent.tsx
@@ -44,7 +44,6 @@ import {
 } from 'antd';
 import Title from 'antd/es/typography/Title';
 import {
-  filterOutNullAndUndefined,
   BAISessionTypeTag,
   toGlobalId,
   UNSAFELazyUserEmailView,
@@ -160,13 +159,14 @@ const SessionDetailContent: React.FC<{
         type
         startup_command
 
+        ...ConnectedKernelListSessionFragment
+        ...ContainerLogModalFragment
         kernel_nodes {
           edges {
             node {
               image {
                 ...ImageNodeSimpleTagFragment
               }
-              ...ConnectedKernelListFragment
             }
           }
         }
@@ -513,9 +513,7 @@ const SessionDetailContent: React.FC<{
             {t('kernel.Kernels')}
           </Typography.Title>
           <ConnectedKernelList
-            kernelsFrgmt={filterOutNullAndUndefined(
-              session.kernel_nodes?.edges.map((e) => e?.node),
-            )}
+            sessionFrgmt={session}
             sessionFrgmtForLogModal={session}
           />
         </BAIFlex>


### PR DESCRIPTION
Resolves #5087 (FR-1939)

test with http://10.82.1.100:8090

## Summary
- Add server-side sorting to the kernel table in the session detail panel using a Relay `@refetchable` fragment
- `ConnectedKernelList` now owns a refetchable fragment on `ComputeSessionNode` with `kernel_nodes(order: $order)`, enabling sorting via the backend without re-fetching the parent session query
- Hostname, Status, and Agent ID columns are sortable via BAITable's built-in `order`/`onChangeOrder` props
- Refetch is wrapped in `useTransition` to show a loading indicator during sort changes
- The `order` argument defaults to `null` to avoid Relay field argument conflicts with other fragments that also query `kernel_nodes` on `ComputeSessionNode`

## Verification
```
=== ALL PASS ===
```

## Test plan
- [ ] Open session detail panel for a session with multiple kernels
- [ ] Click the Hostname column header → kernels sort by hostname (server-side)
- [ ] Click again → descending order
- [ ] Click Status and Agent ID headers → sorting works for those columns too
- [ ] Verify loading indicator appears briefly during sort refetch
- [ ] Verify the parent session detail data is NOT re-fetched (check network tab — only the `ConnectedKernelListRefetchQuery` should fire)
- [ ] Verify container log modal still works correctly