### PR TITLE
fix(FR-2519): replace hardcoded 'model-definition.yaml' with undefined in ServingLauncherPage

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -630,9 +630,11 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         const trimmed = value?.trim();
         return trimmed && trimmed.length > 0 ? trimmed : fallback;
       };
+      // If user leaves modelDefinitionPath empty, send undefined instead of
+      // hardcoding 'model-definition.yaml' so the server can infer the value.
       const modelDefinitionPath = isCommandMode
         ? 'model-definition.yaml'
-        : normalizePath(values.modelDefinitionPath, 'model-definition.yaml');
+        : values.modelDefinitionPath?.trim() || undefined;
       const modelMountDestination = isCommandMode
         ? normalizePath(values.commandModelMount, '/models')
         : normalizePath(values.modelMountDestination, '/models');
@@ -920,7 +922,9 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                 }),
                 name: values.serviceName,
                 resource_group: values.resourceGroup,
-                model_definition_path: values.modelDefinitionPath,
+                // If empty, let the server infer the value instead of hardcoding
+                model_definition_path:
+                  values.modelDefinitionPath?.trim() || undefined,
                 runtime_variant: values.runtimeVariant,
               },
             };


### PR DESCRIPTION
resolves #6589 (FR-2519)

**Changes:**

Modified the Service Launcher to send `undefined` for `modelDefinitionPath` when the field is left empty, instead of hardcoding the default value `'model-definition.yaml'`. This allows the server to infer the appropriate model definition path rather than forcing a specific filename.

**Rationale:**

Previously, empty `modelDefinitionPath` values were automatically converted to `'model-definition.yaml'` on the client side. By sending `undefined` instead, the server can now determine the most appropriate model definition file based on its own logic and the specific context of the service being launched.

**Impact:**

Users can now leave the model definition path field blank and rely on server-side inference for determining the correct model definition file, providing more flexibility in service configuration.

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after