### PR TITLE
fix(FR-2520): use currentProject instead of model-store project in Model Card deploy

### DIFF
--- a/packages/backend.ai-ui/src/components/BAIProjectResourceGroupSelect.tsx
+++ b/packages/backend.ai-ui/src/components/BAIProjectResourceGroupSelect.tsx
@@ -1,28 +1,14 @@
-import { useSuspenseTanQuery } from '../helper/reactQueryAlias';
-import { useBAISignedRequestWithPromise, useUpdatableState } from '../hooks';
+import { useProjectResourceGroups } from '../hooks';
 import BAISelect, { BAISelectProps } from './BAISelect';
 import BAITextHighlighter from './BAITextHighlighter';
 import { useControllableValue } from 'ahooks';
 import _ from 'lodash';
 import React, { useEffect, useState, useTransition } from 'react';
 
-interface ScalingGroupItem {
-  name: string;
-}
-
-interface VolumeInfo {
-  backend: string;
-  capabilities: string[];
-  usage: {
-    percentage: number;
-  };
-  sftp_scaling_groups?: string[];
-}
-
 interface BAIProjectResourceGroupSelectProps extends BAISelectProps {
   projectName: string;
   autoSelectDefault?: boolean;
-  filter?: (projectName: string) => boolean;
+  filter?: (resourceGroupName: string) => boolean;
 }
 
 const BAIProjectResourceGroupSelect: React.FC<
@@ -35,8 +21,6 @@ const BAIProjectResourceGroupSelect: React.FC<
   loading,
   ...selectProps
 }) => {
-  const baiRequestWithPromise = useBAISignedRequestWithPromise();
-  const [fetchKey] = useUpdatableState('first');
   const [controllableSearchValue, setControllableSearchValue] =
     useControllableValue<string>({
       value:
@@ -60,57 +44,7 @@ const BAIProjectResourceGroupSelect: React.FC<
     [startChangeTransition, setControllableValueDoNotUseWithoutTransition],
   );
 
-  const { data: resourceGroupSelectQueryResult } = useSuspenseTanQuery<
-    | [
-        {
-          scaling_groups: ScalingGroupItem[];
-        },
-        {
-          allowed: string[];
-          default: string;
-          volume_info: {
-            [key: string]: VolumeInfo;
-          };
-        },
-      ]
-    | null
-  >({
-    queryKey: ['ResourceGroupSelectQuery', projectName],
-    queryFn: () => {
-      const search = new URLSearchParams();
-      search.set('group', projectName);
-      return Promise.all([
-        baiRequestWithPromise({
-          method: 'GET',
-          url: `/scaling-groups?${search.toString()}`,
-        }),
-        baiRequestWithPromise({
-          method: 'GET',
-          url: `/folders/_/hosts`,
-        }),
-      ]);
-    },
-    staleTime: 1000 * 60 * 5, // Cache for 5 minutes
-    fetchKey: fetchKey,
-  });
-
-  const sftpResourceGroups = _.flatMap(
-    resourceGroupSelectQueryResult?.[1]?.volume_info,
-    (item) => item?.sftp_scaling_groups ?? [],
-  );
-
-  const resourceGroups = _.filter(
-    resourceGroupSelectQueryResult?.[0]?.scaling_groups,
-    (item: ScalingGroupItem) => {
-      if (_.includes(sftpResourceGroups, item.name)) {
-        return false;
-      }
-      if (filter) {
-        return filter(item.name);
-      }
-      return true;
-    },
-  );
+  const { resourceGroups } = useProjectResourceGroups(projectName, { filter });
 
   // If the current selected value is not in the resourceGroups, reset the value to undefined
   useEffect(() => {

--- a/packages/backend.ai-ui/src/hooks/index.ts
+++ b/packages/backend.ai-ui/src/hooks/index.ts
@@ -4,6 +4,7 @@ import {
   useConnectedBAIClient,
 } from '../components';
 import { useSuspenseTanQuery, useTanQuery } from '../helper/reactQueryAlias';
+import { useBAISignedRequestWithPromise } from './useBAISignedRequestWithPromise';
 import { useEventNotStable } from './useEventNotStable';
 import _ from 'lodash';
 import { useMemo, useState } from 'react';
@@ -149,39 +150,10 @@ export function useMutationWithPromise<T extends MutationParameters>(
     });
   };
 }
-export const baiSignedRequestWithPromise = ({
-  method,
-  url,
-  body = null,
-  client,
-}: {
-  method: string;
-  url: string;
-  body?: any;
-  client: any;
-}) => {
-  const request = client?.newSignedRequest(method, url, body, null);
-  return client?._wrapWithPromise(request);
-};
-
-export const useBAISignedRequestWithPromise = () => {
-  const baliClient = useConnectedBAIClient();
-  return ({
-    method,
-    url,
-    body = null,
-  }: {
-    method: string;
-    url: string;
-    body?: any;
-  }) =>
-    baiSignedRequestWithPromise({
-      method,
-      url,
-      body,
-      client: baliClient,
-    });
-};
+export {
+  baiSignedRequestWithPromise,
+  useBAISignedRequestWithPromise,
+} from './useBAISignedRequestWithPromise';
 
 export { default as useErrorMessageResolver } from './useErrorMessageResolver';
 export { default as useViewer } from './useViewer';
@@ -196,3 +168,5 @@ export {
 } from './useBAILogger';
 export type { LoggerPlugin, LogContext, BAILogger } from './useBAILogger';
 export { useEventNotStable } from './useEventNotStable';
+export { useProjectResourceGroups } from './useProjectResourceGroups';
+export type { ScalingGroupItem } from './useProjectResourceGroups';

--- a/packages/backend.ai-ui/src/hooks/useBAISignedRequestWithPromise.ts
+++ b/packages/backend.ai-ui/src/hooks/useBAISignedRequestWithPromise.ts
@@ -1,0 +1,35 @@
+import { useConnectedBAIClient } from '../components';
+
+export const baiSignedRequestWithPromise = ({
+  method,
+  url,
+  body = null,
+  client,
+}: {
+  method: string;
+  url: string;
+  body?: any;
+  client: any;
+}) => {
+  const request = client?.newSignedRequest(method, url, body, null);
+  return client?._wrapWithPromise(request);
+};
+
+export const useBAISignedRequestWithPromise = () => {
+  const baliClient = useConnectedBAIClient();
+  return ({
+    method,
+    url,
+    body = null,
+  }: {
+    method: string;
+    url: string;
+    body?: any;
+  }) =>
+    baiSignedRequestWithPromise({
+      method,
+      url,
+      body,
+      client: baliClient,
+    });
+};

--- a/packages/backend.ai-ui/src/hooks/useProjectResourceGroups.ts
+++ b/packages/backend.ai-ui/src/hooks/useProjectResourceGroups.ts
@@ -1,0 +1,103 @@
+import { useSuspenseTanQuery } from '../helper/reactQueryAlias';
+import { useBAISignedRequestWithPromise } from './useBAISignedRequestWithPromise';
+import _ from 'lodash';
+
+export interface ScalingGroupItem {
+  name: string;
+}
+
+interface VolumeInfo {
+  backend: string;
+  capabilities: string[];
+  usage: {
+    percentage: number;
+  };
+  sftp_scaling_groups?: string[];
+}
+
+type ProjectResourceGroupsQueryResult =
+  | [
+      {
+        scaling_groups: ScalingGroupItem[];
+      },
+      {
+        allowed: string[];
+        default: string;
+        volume_info: {
+          [key: string]: VolumeInfo;
+        };
+      },
+    ]
+  | null;
+
+interface UseProjectResourceGroupsOptions {
+  /**
+   * Optional additional filter applied after SFTP scaling groups are excluded.
+   * Receives the resource group (scaling group) name and should return `true`
+   * to keep it in the result.
+   */
+  filter?: (resourceGroupName: string) => boolean;
+}
+
+/**
+ * Fetches the resource groups accessible to the given project for the current
+ * user, excluding SFTP-only scaling groups. Shared by
+ * `BAIProjectResourceGroupSelect` and any caller that needs to reason about
+ * the available resource groups (e.g. to decide whether to show a selector or
+ * auto-deploy). Both call sites use the same React Query key so a single
+ * network request is made per `projectName`.
+ *
+ * If `projectName` is empty/falsy, the hook short-circuits and returns an
+ * empty list without issuing any network request — callers that haven't yet
+ * resolved the current project can pass `''` safely.
+ */
+export const useProjectResourceGroups = (
+  projectName: string,
+  options?: UseProjectResourceGroupsOptions,
+) => {
+  const baiRequestWithPromise = useBAISignedRequestWithPromise();
+
+  const { data } = useSuspenseTanQuery<ProjectResourceGroupsQueryResult>({
+    queryKey: ['ResourceGroupSelectQuery', projectName],
+    queryFn: () => {
+      // Short-circuit when there is no project context yet — avoids hitting
+      // `/scaling-groups?group=` and `/folders/_/hosts` with an unscoped query.
+      if (!projectName) {
+        return Promise.resolve(null);
+      }
+      const search = new URLSearchParams();
+      search.set('group', projectName);
+      return Promise.all([
+        baiRequestWithPromise({
+          method: 'GET',
+          url: `/scaling-groups?${search.toString()}`,
+        }),
+        baiRequestWithPromise({
+          method: 'GET',
+          url: `/folders/_/hosts`,
+        }),
+      ]);
+    },
+    staleTime: 1000 * 60 * 5, // Cache for 5 minutes
+  });
+
+  const sftpResourceGroups = _.flatMap(
+    data?.[1]?.volume_info,
+    (item) => item?.sftp_scaling_groups ?? [],
+  );
+
+  const resourceGroups = _.filter(
+    data?.[0]?.scaling_groups ?? [],
+    (item: ScalingGroupItem) => {
+      if (_.includes(sftpResourceGroups, item.name)) {
+        return false;
+      }
+      if (options?.filter) {
+        return options.filter(item.name);
+      }
+      return true;
+    },
+  );
+
+  return { resourceGroups };
+};

--- a/react/src/components/ModelCardDeployModal.tsx
+++ b/react/src/components/ModelCardDeployModal.tsx
@@ -5,15 +5,17 @@
 import { ModelCardDeployModalEndpointPollQuery } from '../__generated__/ModelCardDeployModalEndpointPollQuery.graphql';
 import { ModelCardDeployModalMutation } from '../__generated__/ModelCardDeployModalMutation.graphql';
 import { ModelCardDeployModalQuery } from '../__generated__/ModelCardDeployModalQuery.graphql';
-import { useModelStoreProject } from '../hooks/useModelStoreProject';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
 import { App, Form } from 'antd';
 import type { DefaultOptionType } from 'antd/es/select';
 import {
   BAIButton,
   BAIFlex,
   BAIModal,
+  BAIProjectResourceGroupSelect,
   BAISelect,
   toLocalId,
+  useProjectResourceGroups,
 } from 'backend.ai-ui';
 import * as _ from 'lodash-es';
 import React, {
@@ -72,29 +74,31 @@ const ModelCardDeployModalContent: React.FC<
   const { t } = useTranslation();
   const { message } = App.useApp();
   const navigate = useNavigate();
-  const { id: projectId } = useModelStoreProject();
+  const { id: projectId, name: projectName } = useCurrentProjectValue();
   const relayEnvironment = useRelayEnvironment();
 
-  const { runtimeVariants, scaling_groups } =
-    useLazyLoadQuery<ModelCardDeployModalQuery>(
-      graphql`
-        query ModelCardDeployModalQuery {
-          runtimeVariants {
-            edges {
-              node {
-                id
-                name
-              }
+  // Fetch resource groups accessible to the current project. Uses the same
+  // React Query cache as BAIProjectResourceGroupSelect below, so no duplicate
+  // network request is made — we only need the count here to decide whether
+  // to render the selection UI or auto-deploy.
+  const { resourceGroups } = useProjectResourceGroups(projectName ?? '');
+
+  const { runtimeVariants } = useLazyLoadQuery<ModelCardDeployModalQuery>(
+    graphql`
+      query ModelCardDeployModalQuery {
+        runtimeVariants {
+          edges {
+            node {
+              id
+              name
             }
           }
-          scaling_groups {
-            name
-          }
         }
-      `,
-      {},
-      {},
-    );
+      }
+    `,
+    {},
+    {},
+  );
 
   const [commitDeploy] = useMutation<ModelCardDeployModalMutation>(graphql`
     mutation ModelCardDeployModalMutation(
@@ -180,19 +184,6 @@ const ModelCardDeployModalContent: React.FC<
       })),
     }));
   }, [availablePresets, runtimeVariantNameMap]);
-
-  // Get unique resource groups, filtering out null/undefined entries
-  const resourceGroups = useMemo(
-    () =>
-      _.uniqBy(
-        (scaling_groups ?? []).filter(
-          (sg): sg is NonNullable<typeof sg> & { name: string } =>
-            sg != null && !!sg.name,
-        ),
-        'name',
-      ),
-    [scaling_groups],
-  );
 
   // Determine scenario: auto-deploy (scenario 2) vs selection (scenario 3)
   const isAutoDeployScenario =
@@ -303,13 +294,10 @@ const ModelCardDeployModalContent: React.FC<
           />
         </Form.Item>
         <Form.Item label={t('modelStore.ResourceGroup')} required>
-          <BAISelect
+          <BAIProjectResourceGroupSelect
+            projectName={projectName ?? ''}
             value={effectiveResourceGroup}
             onChange={(value: string) => setUserSelectedResourceGroup(value)}
-            options={resourceGroups.map((sg) => ({
-              label: sg.name,
-              value: sg.name,
-            }))}
             style={{ width: '100%' }}
           />
         </Form.Item>


### PR DESCRIPTION
Resolves #6590 (FR-2520)

## Summary

Two related defects in `ModelCardDeployModal` that prevented regular (non-admin) users from deploying from a Model Card:

1. **Wrong project context for deploy** — `useModelStoreProject()` (the MODEL_STORE marketplace project) was being passed as `projectId` to `deployModelCardV2`. The spec requires the user's current working project. Fixed by switching to `useCurrentProjectValue()`.
2. **Empty resource group selector** — the modal queried the admin-only top-level `scaling_groups` GraphQL field with no project filter, so regular users saw an empty list and could not deploy. Fixed by reusing the same project-scoped REST endpoint as `BAIProjectResourceGroupSelect` (`/scaling-groups?group=<projectName>`), which already powers session creation for regular users.

## Changes

- **New** `packages/backend.ai-ui/src/hooks/useProjectResourceGroups.ts` — extracted shared hook that fetches project-scoped resource groups via the REST endpoint `/scaling-groups?group=<projectName>`, filters out SFTP-only scaling groups, and exposes the result. Single source of truth so the modal and the select component cannot disagree about what's available.
- `packages/backend.ai-ui/src/components/BAIProjectResourceGroupSelect.tsx` — refactored to consume `useProjectResourceGroups`. No behavior change for existing call sites (same query key, same filtering, same React Query cache key).
- `packages/backend.ai-ui/src/hooks/index.ts` — export the new hook and its `ScalingGroupItem` type.
- `react/src/components/ModelCardDeployModal.tsx`:
    - Use `useCurrentProjectValue()` for `projectId` in the `deployModelCardV2` mutation (fix #1).
    - Use `useProjectResourceGroups(projectName)` to fetch the resource group list — same React Query key as the select component, so only one network call is made (fix #2).
    - Replace the inline `BAISelect` for the resource group with `BAIProjectResourceGroupSelect`, which already handles SFTP filtering, auto-default selection, and search.
    - Drop `scaling_groups` from `ModelCardDeployModalQuery` (no longer needed).
    - Auto-deploy scenario detection (`availablePresets.length === 1 && resourceGroups.length === 1`) is preserved by reading `resourceGroups` from the shared hook.

## Verification

- `bash scripts/verify.sh` → `=== ALL PASS ===` (Relay, Lint, Format, TypeScript)

## Spec reference

`.specs/model-card-detail-deploy-ux/spec.md:184` — projectId defaults to the user's current working project; no project-selection UI is included in the deploy modal.

## Stack context

This fix is stacked on top of `04-09-test_fr-2503_add_e2e_tests_for_model_card_drawer_and_deploy_ux`, which transitively includes PR #6517 (`feat/FR-2489-deploy-ux`) where both bugs were introduced.