### PR TITLE
fix(FR-2522): trim whitespace from login email/username field

### DIFF
--- a/react/src/components/LoginView.tsx
+++ b/react/src/components/LoginView.tsx
@@ -366,7 +366,7 @@ const LoginView: React.FC = () => {
         return;
       }
 
-      const userId = form.getFieldValue('user_id') || '';
+      const userId = (form.getFieldValue('user_id') || '').trim();
       const password = form.getFieldValue('password') || '';
       const otp = form.getFieldValue('otp') || '';
 


### PR DESCRIPTION
Resolves #6597 (FR-2522)

## Summary

- Add `.trim()` to the `user_id` field value in `connectUsingSession` to strip leading/trailing whitespace before login
- This matches the existing `.trim()` behavior in `connectUsingAPI`
- Regression was introduced during the Lit component removal migration (originally fixed in FR-556)

## Verification

```
=== ALL PASS ===
```

## Test plan

- [ ] Type email with leading/trailing spaces in login form → login succeeds
- [ ] Paste email with extra whitespace → login succeeds
- [ ] Normal login without spaces → still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)