### PR TITLE
refactor(FR-2550): remove lodash-es _.chain sideEffects workaround from craco.config.cjs

### DIFF
--- a/packages/eslint-config-bai/base.js
+++ b/packages/eslint-config-bai/base.js
@@ -18,6 +18,15 @@ export const base = [
   {
     rules: {
       "no-console": "warn",
+      "no-restricted-properties": [
+        "error",
+        {
+          object: "_",
+          property: "chain",
+          message:
+            "_.chain() is incompatible with lodash-es tree-shaking. Use native array methods instead.",
+        },
+      ],
 
       "@typescript-eslint/no-unused-vars": [
         "warn",

--- a/react/craco.config.cjs
+++ b/react/craco.config.cjs
@@ -173,20 +173,6 @@ module.exports = {
     // When you change the this value, you might need to clear cache restart the dev server.
     // you can use `rm -rf node_modules/.cache` to clear cache.
     configure: (webpackConfig, { env, paths }) => {
-      // Override lodash-es's `sideEffects: false` package.json flag.
-      // lodash-es/lodash.default.js attaches chain sequence methods (groupBy,
-      // map, flatten, ...) onto the `lodash` wrapper prototype at module init.
-      // With sideEffects: false, webpack tree-shakes this file away when only
-      // named exports are used (e.g. `import * as _ from 'lodash-es'` +
-      // `_.chain(x).groupBy(...)`), which breaks chain sequences at runtime
-      // with `...default(...).groupBy is not a function`. Marking these two
-      // files as having side effects forces webpack to evaluate them so the
-      // mixin runs.
-      webpackConfig.module.rules.unshift({
-        test: /[\\/]node_modules[\\/]lodash-es[\\/]lodash(\.default)?\.js$/,
-        sideEffects: true,
-      });
-
       // `some.file?raw` will be treated as `asset/source`
       const { isFound, match } = getAssetModule(webpackConfig, (rule) => {
         return rule.oneOf;


### PR DESCRIPTION
Resolves #6637 (FR-2550)

## Summary

- Remove the `sideEffects: true` Webpack rule override for `lodash-es/lodash.default.js` from `react/craco.config.cjs`
- This workaround was added in FR-2525 as a safety net for any remaining `_.chain()` call sites, but all active `_.chain()` usages have since been removed. The workaround defeats lodash-es tree-shaking and doesn't apply to Vite builds (e.g., Storybook in `packages/backend.ai-ui/`)
- Add ESLint `no-restricted-properties` rule in shared `eslint-config-bai` to ban `_.chain()` usage across `react/` and `packages/backend.ai-ui/`

## Files changed

- `react/craco.config.cjs` — remove lodash-es sideEffects override (14 lines deleted)
- `packages/eslint-config-bai/base.js` — add `no-restricted-properties` rule banning `_.chain()`

## Test plan

- [ ] `bash scripts/verify.sh` passes (Relay, Lint, Format, TypeScript)
- [ ] `pnpm run dev` starts without lodash-related runtime errors
- [ ] Verify that adding `_.chain()` in any `.ts`/`.tsx` file triggers an ESLint error

## Verification

```
=== ALL PASS ===
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)