### PR TITLE
feat(FR-2494): extract Legacy auto-scaling rule components and add version gating

### DIFF
--- a/.specs/draft-auto-scaling-rule-ux/.context/findings.md
+++ b/.specs/draft-auto-scaling-rule-ux/.context/findings.md
@@ -1,0 +1,19 @@
+# Auto Scaling Rule UX Improvements Findings
+
+## Decisions
+| Date | Decision | Rationale | Issue |
+|------|----------|-----------|-------|
+
+## Discoveries
+
+- `toLocalId` utility is exported from `packages/backend.ai-ui/src/helper/index.ts` -- used to convert Relay global IDs to raw UUIDs
+- `baiClient.supports('auto-scaling-rule')` gates on `>=25.1.0` in `backend.ai-client-esm.ts:842-844`
+- `COMPARATOR_LABELS` currently includes all 4 comparators (LT, LTE, GT, GTE) -- spec says only expose LT and GT in Legacy editor
+- `EndpointDetailPage` auto-scaling rules table spans lines 765-996 with delete mutation at lines 447-457
+- `ServiceLauncherPageContent.tsx` also queries `endpoint_auto_scaling_rule_nodes` to check rule existence -- will need Strawberry path too eventually
+- `ModelDeployment.autoScalingRules` is a nested connection on the Strawberry type -- no separate top-level query needed
+- `prometheusQueryPresetId` in `UpdateAutoScalingRuleInput` uses `null` as UNSET (no change), not as explicit null
+
+## Issues Encountered
+| Date | Problem | Root Cause | Resolution | Issue |
+|------|---------|-----------|------------|-------|

--- a/.specs/draft-auto-scaling-rule-ux/.context/progress.md
+++ b/.specs/draft-auto-scaling-rule-ux/.context/progress.md
@@ -1,0 +1,20 @@
+# Auto Scaling Rule UX Improvements Progress
+
+## Last Session: 2026-04-13
+
+### 1. Current Phase
+Planning complete. Ready for Wave 1 implementation.
+
+### 2. Next Action
+Begin Sub-task 1: Rename existing editor modal to Legacy, extract Legacy rule list from EndpointDetailPage, add version gating.
+
+### 3. Current Goal
+Begin implementation of auto-scaling rule UX improvements with Strawberry API migration.
+
+### 4. Lessons Learned
+(none yet)
+
+### 5. Completed Work
+- Spec reviewed: .specs/draft-auto-scaling-rule-ux/spec.md
+- Dev plan created: .specs/draft-auto-scaling-rule-ux/dev-plan.md
+- Codebase analyzed: identified all affected files, GraphQL types, version gating patterns

--- a/.specs/draft-auto-scaling-rule-ux/.context/tasks.md
+++ b/.specs/draft-auto-scaling-rule-ux/.context/tasks.md
@@ -1,0 +1,18 @@
+# Auto Scaling Rule UX Improvements Tasks
+
+> Last synced: 2026-04-13 (no issue tracker, local dev plan only)
+> Source: Local dev-plan.md
+
+## Progress: 0/4 complete
+
+### Wave 1
+- [ ] Sub-task 1: Rename existing editor modal to Legacy + extract Legacy rule list + version gating
+
+### Wave 2
+- [ ] Sub-task 2: Create new Strawberry AutoScalingRuleList component -- blocked by Sub-task 1
+
+### Wave 3
+- [ ] Sub-task 3: Create new Strawberry AutoScalingRuleEditorModal with single/range mode and Prometheus preset -- blocked by Sub-task 1, Sub-task 2
+
+### Wave 4 (optional)
+- [ ] Sub-task 4: Add Prometheus query result preview in editor modal -- blocked by Sub-task 3

--- a/.specs/draft-auto-scaling-rule-ux/dev-plan.md
+++ b/.specs/draft-auto-scaling-rule-ux/dev-plan.md
@@ -1,0 +1,88 @@
+# Auto Scaling Rule UX Improvements Dev Plan
+
+## Spec Reference
+`.specs/draft-auto-scaling-rule-ux/spec.md`
+
+## Sub-tasks (Implementation Order)
+
+### 1. Rename existing editor modal to Legacy + extract Legacy rule list from EndpointDetailPage
+
+Rename the existing Graphene-based `AutoScalingRuleEditorModal.tsx` to `AutoScalingRuleEditorModalLegacy.tsx` and extract the auto-scaling rules table (lines 765-996 of `EndpointDetailPage.tsx`) into a new `AutoScalingRuleListLegacy.tsx` component. Apply comparator display normalization in the Legacy list (flip `GREATER_THAN` to show `[threshold] < [metric]`). Limit the comparator dropdown in the Legacy editor to only `LESS_THAN` and `GREATER_THAN`. Add version-gating support key `prometheus-auto-scaling-rule` for `>=26.4.0` in `backend.ai-client-esm.ts`. Update `EndpointDetailPage.tsx` to conditionally render Legacy components when `<26.4.0`.
+
+- **Changed files**:
+  - `react/src/components/AutoScalingRuleEditorModal.tsx` -> renamed to `react/src/components/AutoScalingRuleEditorModalLegacy.tsx`
+  - `react/src/components/AutoScalingRuleListLegacy.tsx` (new, extracted from EndpointDetailPage)
+  - `react/src/pages/EndpointDetailPage.tsx` (remove inline table, import Legacy components conditionally)
+  - `src/lib/backend.ai-client-esm.ts` (add `prometheus-auto-scaling-rule` feature key for `>=26.4.0`)
+- **Dependencies**: None
+- **Review complexity**: Medium (file restructuring, mostly moving existing code)
+
+### 2. Create new Strawberry AutoScalingRuleList component
+
+Build `AutoScalingRuleList.tsx` for `>=26.4.0` that queries `ModelDeployment.autoScalingRules` nested connection (Strawberry API). Display conditions using `minThreshold`/`maxThreshold` with normalized `<` direction. Show Prometheus preset name for `PROMETHEUS` metric source rules (load presets via `prometheusQueryPresets` query and match by `prometheusQueryPresetId` using `toLocalId`). Wire up delete mutation (`deleteAutoScalingRule`). Update `EndpointDetailPage.tsx` to render the new list when `>=26.4.0`.
+
+- **Changed files**:
+  - `react/src/components/AutoScalingRuleList.tsx` (new)
+  - `react/src/pages/EndpointDetailPage.tsx` (add conditional import for new list, adjust query for Strawberry path)
+  - `resources/i18n/en.json` (add i18n keys: `TimeWindow`, `Range`, `Single`, `Upper`, `Lower`, `PrometheusPreset`, etc.)
+- **Dependencies**: Sub-task 1 (version gating and Legacy extraction must exist first)
+- **Review complexity**: High (new Relay queries against Strawberry schema, threshold display logic, preset matching)
+
+### 3. Create new Strawberry AutoScalingRuleEditorModal with single/range mode and Prometheus preset
+
+Build `AutoScalingRuleEditorModal.tsx` for `>=26.4.0` with:
+- Segmented component for "Single" / "Range" condition mode toggle
+- Single mode: direction selector (upper=`maxThreshold` only, lower=`minThreshold` only)
+- Range mode: `minThreshold` + `maxThreshold` inputs with validation (min >= max = error)
+- Metric source dropdown including `PROMETHEUS` option
+- When `PROMETHEUS` selected: show Prometheus Query Preset Select (loaded via `prometheusQueryPresets`), auto-fill `metricName` from preset, show `queryTemplate` read-only, auto-apply `timeWindow`
+- When `KERNEL`/`INFERENCE_FRAMEWORK` selected: hide preset UI, show AutoComplete for metric name
+- `prometheusQueryPresetId` stored as raw UUID via `toLocalId(globalId)`
+- Strawberry mutations: `createAutoScalingRule`, `updateAutoScalingRule`
+- Wire into `EndpointDetailPage.tsx` for `>=26.4.0` path
+
+- **Changed files**:
+  - `react/src/components/AutoScalingRuleEditorModal.tsx` (new, Strawberry version)
+  - `react/src/pages/EndpointDetailPage.tsx` (conditional import for new editor modal)
+  - `resources/i18n/en.json` (add i18n keys for range mode, Prometheus preset UI)
+- **Dependencies**: Sub-task 1 (version gating), Sub-task 2 (list component to display created/edited rules)
+- **Review complexity**: High (new form logic with mode switching, Prometheus preset integration, Relay mutations)
+
+### 4. (Nice to Have) Add Prometheus query result preview in editor modal
+
+In the Strawberry editor modal (`>=26.4.0`), add a metric preview in the form item `extra` area when a Prometheus preset is selected. Call `prometheusQueryPresetResult` as an instant query (no `timeRange`). Display loading spinner, result value, and a refresh button. Pass `options` with `groupLabels: []` (required). Pass `filterLabels` from preset's `options.filterLabels` definition.
+
+- **Changed files**:
+  - `react/src/components/AutoScalingRuleEditorModal.tsx` (add preview section)
+  - `resources/i18n/en.json` (add i18n keys for preview UI)
+- **Dependencies**: Sub-task 3 (Prometheus preset selection must exist)
+- **Review complexity**: Medium (single API call with display, straightforward)
+
+## PR Stack Strategy
+- Sequential: 1 -> 2 -> 3 -> 4
+- Sub-tasks 2 and 3 both depend on 1 but could theoretically be parallel; however, Sub-task 3 (editor modal) benefits from Sub-task 2 (list) being in place to test the full create/edit flow, so sequential is preferred.
+
+## Dependency Graph
+```
+Sub-task 1 (Legacy extraction + version gating)
+    |
+    +---> Sub-task 2 (Strawberry list)
+              |
+              +---> Sub-task 3 (Strawberry editor modal)
+                        |
+                        +---> Sub-task 4 (Prometheus preview, Nice to Have)
+```
+
+## Execution Waves
+
+### Wave 1
+- Sub-task 1: Legacy rename + extraction + version gating
+
+### Wave 2
+- Sub-task 2: Strawberry rule list
+
+### Wave 3
+- Sub-task 3: Strawberry editor modal with single/range + Prometheus preset
+
+### Wave 4 (optional)
+- Sub-task 4: Prometheus query result preview

--- a/react/src/components/AutoScalingRuleEditorModalLegacy.tsx
+++ b/react/src/components/AutoScalingRuleEditorModalLegacy.tsx
@@ -5,11 +5,11 @@
 import {
   AutoScalingMetricComparator,
   AutoScalingMetricSource,
-  AutoScalingRuleEditorModalCreateMutation,
+  AutoScalingRuleEditorModalLegacyCreateMutation,
   EndpointAutoScalingRuleInput,
-} from '../__generated__/AutoScalingRuleEditorModalCreateMutation.graphql';
-import { AutoScalingRuleEditorModalFragment$key } from '../__generated__/AutoScalingRuleEditorModalFragment.graphql';
-import { AutoScalingRuleEditorModalModifyMutation } from '../__generated__/AutoScalingRuleEditorModalModifyMutation.graphql';
+} from '../__generated__/AutoScalingRuleEditorModalLegacyCreateMutation.graphql';
+import { AutoScalingRuleEditorModalLegacyFragment$key } from '../__generated__/AutoScalingRuleEditorModalLegacyFragment.graphql';
+import { AutoScalingRuleEditorModalLegacyModifyMutation } from '../__generated__/AutoScalingRuleEditorModalLegacyModifyMutation.graphql';
 import { SIGNED_32BIT_MAX_INT } from '../helper/const-vars';
 import {
   App,
@@ -29,12 +29,12 @@ import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { graphql, useFragment, useMutation } from 'react-relay';
 
-interface AutoScalingRuleEditorModalProps extends Omit<
+interface AutoScalingRuleEditorModalLegacyProps extends Omit<
   BAIModalProps,
   'onOk' | 'onClose' | 'onCancel'
 > {
   endpoint_id: string;
-  autoScalingRuleFrgmt?: AutoScalingRuleEditorModalFragment$key | null;
+  autoScalingRuleFrgmt?: AutoScalingRuleEditorModalLegacyFragment$key | null;
   onRequestClose: (success?: boolean) => void;
 }
 
@@ -50,11 +50,9 @@ type AutoScalingRuleInput = {
   max_replicas: number;
 };
 
-export const COMPARATOR_LABELS = {
+export const COMPARATOR_LABELS: Record<string, string> = {
   LESS_THAN: '<',
-  LESS_THAN_OR_EQUAL: '≤',
   GREATER_THAN: '>',
-  GREATER_THAN_OR_EQUAL: '≥',
 };
 
 const METRIC_NAMES_MAP: Partial<{
@@ -64,12 +62,15 @@ const METRIC_NAMES_MAP: Partial<{
   INFERENCE_FRAMEWORK: [],
 };
 
-const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
+const AutoScalingRuleEditorModalLegacy: React.FC<
+  AutoScalingRuleEditorModalLegacyProps
+> = ({
   onRequestClose,
   endpoint_id,
   autoScalingRuleFrgmt,
   ...baiModalProps
 }) => {
+  'use memo';
   const { t } = useTranslation();
   const { message } = App.useApp();
   const { logger } = useBAILogger();
@@ -80,7 +81,7 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
 
   const autoScalingRule = useFragment(
     graphql`
-      fragment AutoScalingRuleEditorModalFragment on EndpointAutoScalingRuleNode {
+      fragment AutoScalingRuleEditorModalLegacyFragment on EndpointAutoScalingRuleNode {
         id
         endpoint
         metric_name
@@ -99,8 +100,8 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
   const formRef = useRef<FormInstance<AutoScalingRuleInput>>(null);
 
   const [commitAddAutoScalingRule, isInflightAddAutoScalingRule] =
-    useMutation<AutoScalingRuleEditorModalCreateMutation>(graphql`
-      mutation AutoScalingRuleEditorModalCreateMutation(
+    useMutation<AutoScalingRuleEditorModalLegacyCreateMutation>(graphql`
+      mutation AutoScalingRuleEditorModalLegacyCreateMutation(
         $endpoint: String!
         $props: EndpointAutoScalingRuleInput!
       ) {
@@ -125,8 +126,8 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
     `);
 
   const [commitModifyAutoScalingRule, isInflightModifyAutoScalingRule] =
-    useMutation<AutoScalingRuleEditorModalModifyMutation>(graphql`
-      mutation AutoScalingRuleEditorModalModifyMutation(
+    useMutation<AutoScalingRuleEditorModalLegacyModifyMutation>(graphql`
+      mutation AutoScalingRuleEditorModalLegacyModifyMutation(
         $id: String!
         $props: ModifyEndpointAutoScalingRuleInput!
       ) {
@@ -525,4 +526,4 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
   );
 };
 
-export default AutoScalingRuleEditorModal;
+export default AutoScalingRuleEditorModalLegacy;

--- a/react/src/components/AutoScalingRuleListLegacy.tsx
+++ b/react/src/components/AutoScalingRuleListLegacy.tsx
@@ -1,0 +1,349 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { AutoScalingRuleEditorModalLegacyFragment$key } from '../__generated__/AutoScalingRuleEditorModalLegacyFragment.graphql';
+import { AutoScalingRuleListLegacyDeleteMutation } from '../__generated__/AutoScalingRuleListLegacyDeleteMutation.graphql';
+import AutoScalingRuleEditorModalLegacy, {
+  COMPARATOR_LABELS,
+} from './AutoScalingRuleEditorModalLegacy';
+import {
+  DeleteOutlined,
+  PlusOutlined,
+  SettingOutlined,
+} from '@ant-design/icons';
+import {
+  App,
+  Button,
+  Card,
+  Popconfirm,
+  Tag,
+  Tooltip,
+  Typography,
+  theme,
+} from 'antd';
+import { BAIFlex, BAITable, BAIUnmountAfterClose } from 'backend.ai-ui';
+import { default as dayjs } from 'dayjs';
+import * as _ from 'lodash-es';
+import { CircleArrowDownIcon, CircleArrowUpIcon } from 'lucide-react';
+import React, { useState, useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useMutation } from 'react-relay';
+
+interface AutoScalingRuleListLegacyProps {
+  endpoint_id: string;
+  autoScalingRules: ReadonlyArray<
+    | (AutoScalingRuleEditorModalLegacyFragment$key & Record<string, any>)
+    | null
+    | undefined
+  >;
+  isEndpointDestroying: boolean;
+  isOwnedByCurrentUser: boolean;
+  onRefetch: () => void;
+}
+
+const dayDiff = (a: any, b: any) => {
+  const date1 = dayjs(a.created_at);
+  const date2 = dayjs(b.created_at);
+  return date1.diff(date2);
+};
+
+/**
+ * Renders the condition column with normalized `<` direction:
+ * - LESS_THAN: `[metric_name] < [threshold]`
+ * - GREATER_THAN: `[threshold] < [metric_name]` (flipped)
+ */
+const renderCondition = (row: any) => {
+  const metricName = row?.metric_name;
+  const threshold = row?.threshold;
+  const comparator = row?.comparator;
+  const suffix = row?.metric_source === 'KERNEL' ? '%' : '';
+
+  if (comparator === 'GREATER_THAN') {
+    // Flip: threshold < metric_name
+    return (
+      <BAIFlex gap={'xs'}>
+        {threshold}
+        {suffix}
+        {comparator ? <Tooltip title={comparator}>{'<'}</Tooltip> : '-'}
+        <Tag>{metricName}</Tag>
+      </BAIFlex>
+    );
+  }
+
+  // LESS_THAN or default: metric_name < threshold
+  return (
+    <BAIFlex gap={'xs'}>
+      <Tag>{metricName}</Tag>
+      {comparator ? (
+        <Tooltip title={comparator}>
+          {COMPARATOR_LABELS[comparator] || comparator}
+        </Tooltip>
+      ) : (
+        '-'
+      )}
+      {threshold}
+      {suffix}
+    </BAIFlex>
+  );
+};
+
+const AutoScalingRuleListLegacy: React.FC<AutoScalingRuleListLegacyProps> = ({
+  endpoint_id,
+  autoScalingRules,
+  isEndpointDestroying,
+  isOwnedByCurrentUser,
+  onRefetch,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { token } = theme.useToken();
+  const { message } = App.useApp();
+  const [_isPendingRefetch, startRefetchTransition] = useTransition();
+
+  const [editingAutoScalingRule, setEditingAutoScalingRule] =
+    useState<AutoScalingRuleEditorModalLegacyFragment$key | null>(null);
+  const [isOpenAutoScalingRuleModal, setIsOpenAutoScalingRuleModal] =
+    useState(false);
+
+  const [
+    commitDeleteAutoScalingRuleMutation,
+    isInFlightDeleteAutoScalingRuleMutation,
+  ] = useMutation<AutoScalingRuleListLegacyDeleteMutation>(graphql`
+    mutation AutoScalingRuleListLegacyDeleteMutation($id: String!) {
+      delete_endpoint_auto_scaling_rule_node(id: $id) {
+        ok
+        msg
+      }
+    }
+  `);
+
+  return (
+    <>
+      <Card
+        title={t('modelService.AutoScalingRules')}
+        extra={
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            disabled={isEndpointDestroying}
+            onClick={() => {
+              setIsOpenAutoScalingRuleModal(true);
+            }}
+          >
+            {t('modelService.AddRules')}
+          </Button>
+        }
+      >
+        <BAITable
+          scroll={{ x: 'max-content' }}
+          rowKey={'id'}
+          columns={[
+            {
+              title: t('autoScalingRule.ScalingType'),
+              fixed: 'left',
+              render: (_text, row) =>
+                (row?.step_size || 0) > 0
+                  ? t('autoScalingRule.ScaleOut')
+                  : t('autoScalingRule.ScaleIn'),
+            },
+            {
+              title: t('autoScalingRule.MetricSource'),
+              dataIndex: 'metric_source',
+            },
+            {
+              title: t('autoScalingRule.Condition'),
+              dataIndex: 'metric_name',
+              fixed: 'left',
+              render: (_text, row) => renderCondition(row),
+            },
+            {
+              title: t('modelService.Controls'),
+              dataIndex: 'controls',
+              key: 'controls',
+              render: (_text, row) => (
+                <BAIFlex direction="row" align="stretch">
+                  <Button
+                    type="text"
+                    icon={<SettingOutlined />}
+                    style={
+                      isEndpointDestroying || !isOwnedByCurrentUser
+                        ? {
+                            color: token.colorTextDisabled,
+                          }
+                        : {
+                            color: token.colorInfo,
+                          }
+                    }
+                    disabled={isEndpointDestroying || !isOwnedByCurrentUser}
+                    onClick={() => {
+                      if (row) {
+                        setEditingAutoScalingRule(row);
+                        setIsOpenAutoScalingRuleModal(true);
+                      }
+                    }}
+                  />
+                  <Popconfirm
+                    title={t('dialog.warning.CannotBeUndone')}
+                    okText={t('button.Delete')}
+                    okButtonProps={{
+                      danger: true,
+                    }}
+                    disabled={isInFlightDeleteAutoScalingRuleMutation}
+                    onConfirm={() => {
+                      if (autoScalingRules) {
+                        commitDeleteAutoScalingRuleMutation({
+                          variables: {
+                            id: row?.id as string,
+                          },
+                          onCompleted: (res, errors) => {
+                            if (
+                              !res?.delete_endpoint_auto_scaling_rule_node?.ok
+                            ) {
+                              message.error(
+                                res?.delete_endpoint_auto_scaling_rule_node
+                                  ?.msg,
+                              );
+                            } else if (errors && errors.length > 0) {
+                              const errorMsgList = _.map(
+                                errors,
+                                (error) =>
+                                  error.message || t('dialog.ErrorOccurred'),
+                              );
+                              for (const error of errorMsgList) {
+                                message.error(error);
+                              }
+                            } else {
+                              setEditingAutoScalingRule(null);
+                              startRefetchTransition(() => {
+                                onRefetch();
+                              });
+                              message.success({
+                                key: 'autoscaling-rule-deleted',
+                                content: t(
+                                  'autoScalingRule.SuccessfullyDeleted',
+                                ),
+                              });
+                            }
+                          },
+                          onError: (error) => {
+                            message.error(
+                              error?.message || t('dialog.ErrorOccurred'),
+                            );
+                          },
+                        });
+                      }
+                    }}
+                  >
+                    <Button
+                      type="text"
+                      icon={
+                        <DeleteOutlined
+                          style={
+                            isEndpointDestroying
+                              ? undefined
+                              : {
+                                  color: token.colorError,
+                                }
+                          }
+                        />
+                      }
+                      disabled={false}
+                      onClick={() => {
+                        if (row) {
+                          setEditingAutoScalingRule(row);
+                        }
+                      }}
+                    />
+                  </Popconfirm>
+                </BAIFlex>
+              ),
+            },
+            {
+              title: t('autoScalingRule.StepSize'),
+              dataIndex: 'step_size',
+              render: (_text, row) => {
+                if (row?.step_size) {
+                  return (
+                    <BAIFlex gap={'xs'}>
+                      <Typography.Text>
+                        {row?.step_size > 0 ? (
+                          <CircleArrowUpIcon />
+                        ) : (
+                          <CircleArrowDownIcon />
+                        )}
+                      </Typography.Text>
+                      <Typography.Text>
+                        {Math.abs(row?.step_size)}
+                      </Typography.Text>
+                    </BAIFlex>
+                  );
+                } else {
+                  return '-';
+                }
+              },
+            },
+            {
+              title: t('autoScalingRule.MIN/MAXReplicas'),
+              render: (_text, row) => (
+                <span>
+                  {row?.step_size
+                    ? row?.step_size > 0
+                      ? `Max: ${row?.max_replicas}`
+                      : `Min: ${row?.min_replicas}`
+                    : '-'}
+                </span>
+              ),
+            },
+            {
+              title: t('autoScalingRule.CoolDownSeconds'),
+              dataIndex: 'cooldown_seconds',
+            },
+            {
+              title: t('autoScalingRule.LastTriggered'),
+              render: (_text, row) => {
+                return (
+                  <span>
+                    {row?.last_triggered_at
+                      ? dayjs.utc(row?.last_triggered_at).tz().format('ll LTS')
+                      : `-`}
+                  </span>
+                );
+              },
+              sorter: dayDiff,
+            },
+            {
+              title: t('autoScalingRule.CreatedAt'),
+              dataIndex: 'created_at',
+              render: (_text, row) => (
+                <span>{dayjs(row?.created_at).format('ll LT')}</span>
+              ),
+              sorter: dayDiff,
+            },
+          ]}
+          pagination={false}
+          showSorterTooltip={false}
+          dataSource={autoScalingRules}
+        ></BAITable>
+      </Card>
+      <BAIUnmountAfterClose>
+        <AutoScalingRuleEditorModalLegacy
+          open={isOpenAutoScalingRuleModal}
+          endpoint_id={endpoint_id}
+          autoScalingRuleFrgmt={editingAutoScalingRule}
+          onRequestClose={(success) => {
+            setIsOpenAutoScalingRuleModal(false);
+            setEditingAutoScalingRule(null);
+            if (success) {
+              startRefetchTransition(() => {
+                onRefetch();
+              });
+            }
+          }}
+        />
+      </BAIUnmountAfterClose>
+    </>
+  );
+};
+
+export default AutoScalingRuleListLegacy;

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -2,8 +2,6 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import { AutoScalingRuleEditorModalFragment$key } from '../__generated__/AutoScalingRuleEditorModalFragment.graphql';
-import { EndpointDetailPageAutoScalingRuleDeleteMutation } from '../__generated__/EndpointDetailPageAutoScalingRuleDeleteMutation.graphql';
 import {
   EndpointDetailPageQuery,
   EndpointDetailPageQuery$data,
@@ -13,9 +11,7 @@ import {
   RouteTrafficStatus,
 } from '../__generated__/EndpointDetailPageQuery.graphql';
 import { InferenceSessionErrorModalFragment$key } from '../__generated__/InferenceSessionErrorModalFragment.graphql';
-import AutoScalingRuleEditorModal, {
-  COMPARATOR_LABELS,
-} from '../components/AutoScalingRuleEditorModal';
+import AutoScalingRuleListLegacy from '../components/AutoScalingRuleListLegacy';
 import BAIJSONViewerModal from '../components/BAIJSONViewerModal';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import { isEndpointInDestroyingCategory } from '../components/EndpointList';
@@ -39,7 +35,6 @@ import {
   ArrowRightOutlined,
   CheckOutlined,
   CloseOutlined,
-  DeleteOutlined,
   ExclamationCircleOutlined,
   LoadingOutlined,
   PlusOutlined,
@@ -53,7 +48,6 @@ import {
   Button,
   Card,
   Descriptions,
-  Popconfirm,
   Spin,
   Table,
   Tag,
@@ -81,11 +75,7 @@ import {
 } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
 import * as _ from 'lodash-es';
-import {
-  BotMessageSquareIcon,
-  CircleArrowDownIcon,
-  CircleArrowUpIcon,
-} from 'lucide-react';
+import { BotMessageSquareIcon } from 'lucide-react';
 import React, {
   Suspense,
   useDeferredValue,
@@ -93,7 +83,7 @@ import React, {
   useTransition,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import { graphql, useLazyLoadQuery } from 'react-relay';
 import { useParams } from 'react-router-dom';
 import VFolderNodeIdenticon from 'src/components/VFolderNodeIdenticon';
 
@@ -155,11 +145,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
   const [selectedSessionErrorForModal, setSelectedSessionErrorForModal] =
     useState<InferenceSessionErrorModalFragment$key | null>(null);
 
-  const [editingAutoScalingRule, setEditingAutoScalingRule] =
-    useState<AutoScalingRuleEditorModalFragment$key | null>(null);
   const [isOpenTokenGenerationModal, setIsOpenTokenGenerationModal] =
-    useState(false);
-  const [isOpenAutoScalingRuleModal, setIsOpenAutoScalingRuleModal] =
     useState(false);
   const [currentUser] = useCurrentUserInfo();
   const currentProject = useCurrentProjectValue();
@@ -169,6 +155,9 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
   const { open } = useFolderExplorerOpener();
   const [selectedSessionId, setSelectedSessionId] = useState<string>();
   const isSupportAutoScalingRule = baiClient.supports('auto-scaling-rule');
+  const isSupportPrometheusAutoScalingRule = baiClient.supports(
+    'prometheus-auto-scaling-rule',
+  );
   const isSupportRouteHealthStatus = baiClient.supports('route-health-status');
   const [errorDataForJSONModal, setErrorDataForJSONModal] = useState<string>();
   const {
@@ -312,7 +301,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               max_replicas
               created_at
               last_triggered_at
-              ...AutoScalingRuleEditorModalFragment
+              ...AutoScalingRuleEditorModalLegacyFragment
             }
           }
         }
@@ -444,18 +433,6 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
     },
   });
 
-  const [
-    commitDeleteAutoScalingRuleMutation,
-    isInFlightDeleteAutoScalingRuleMutation,
-  ] = useMutation<EndpointDetailPageAutoScalingRuleDeleteMutation>(graphql`
-    mutation EndpointDetailPageAutoScalingRuleDeleteMutation($id: String!) {
-      delete_endpoint_auto_scaling_rule_node(id: $id) {
-        ok
-        msg
-      }
-    }
-  `);
-
   const legacyRouteStatusSemanticMap: Record<string, SemanticColor> = {
     HEALTHY: 'success',
     PROVISIONING: 'info',
@@ -465,9 +442,10 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
   };
   const semanticColorMap = useSemanticColorMap();
 
-  const autoScalingRules = _.map(endpoint_auto_scaling_rules?.edges, (edge) => {
-    return edge?.node;
-  });
+  const autoScalingRules = _.map(
+    endpoint_auto_scaling_rules?.edges,
+    (edge) => edge?.node,
+  );
 
   const resource_opts = JSON.parse(endpoint?.resource_opts || '{}');
 
@@ -762,239 +740,24 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           items={items}
         ></Descriptions>
       </Card>
-      {isSupportAutoScalingRule && (
-        <Card
-          title={t('modelService.AutoScalingRules')}
-          extra={
-            <Button
-              type="primary"
-              icon={<PlusOutlined />}
-              disabled={isEndpointInDestroyingCategory(endpoint)}
-              onClick={() => {
-                setIsOpenAutoScalingRuleModal(true);
-              }}
-            >
-              {t('modelService.AddRules')}
-            </Button>
-          }
-        >
-          <BAITable
-            scroll={{ x: 'max-content' }}
-            rowKey={'id'}
-            columns={[
-              {
-                title: t('autoScalingRule.ScalingType'),
-                fixed: 'left',
-                render: (_text, row) =>
-                  (row?.step_size || 0) > 0
-                    ? t('autoScalingRule.ScaleOut')
-                    : t('autoScalingRule.ScaleIn'),
-              },
-              {
-                title: t('autoScalingRule.MetricSource'),
-                dataIndex: 'metric_source',
-                // render: (text, row) => <Tag>{row?.metric_source}</Tag>,
-              },
-              {
-                title: t('autoScalingRule.Condition'),
-                dataIndex: 'metric_name',
-                fixed: 'left',
-                render: (_text, row) => (
-                  <BAIFlex gap={'xs'}>
-                    <Tag>{row?.metric_name}</Tag>
-                    {row?.comparator ? (
-                      <Tooltip title={row.comparator}>
-                        {/* @ts-ignore */}
-                        {COMPARATOR_LABELS[row.comparator]}
-                      </Tooltip>
-                    ) : (
-                      '-'
-                    )}
-                    {row?.threshold}
-                    {row?.metric_source === 'KERNEL' ? '%' : ''}
-                  </BAIFlex>
-                ),
-              },
-              {
-                title: t('modelService.Controls'),
-                dataIndex: 'controls',
-                key: 'controls',
-                render: (_text, row) => (
-                  <BAIFlex direction="row" align="stretch">
-                    <Button
-                      type="text"
-                      icon={<SettingOutlined />}
-                      style={
-                        isEndpointInDestroyingCategory(endpoint) ||
-                        (!!endpoint?.created_user_email &&
-                          endpoint?.created_user_email !== currentUser.email)
-                          ? {
-                              color: token.colorTextDisabled,
-                            }
-                          : {
-                              color: token.colorInfo,
-                            }
-                      }
-                      disabled={
-                        isEndpointInDestroyingCategory(endpoint) ||
-                        (!!endpoint?.created_user_email &&
-                          endpoint?.created_user_email !== currentUser.email)
-                      }
-                      onClick={() => {
-                        if (row) {
-                          setEditingAutoScalingRule(row);
-                          setIsOpenAutoScalingRuleModal(true);
-                        }
-                      }}
-                    />
-                    <Popconfirm
-                      title={t('dialog.warning.CannotBeUndone')}
-                      okText={t('button.Delete')}
-                      okButtonProps={{
-                        danger: true,
-                      }}
-                      disabled={isInFlightDeleteAutoScalingRuleMutation}
-                      onConfirm={() => {
-                        if (autoScalingRules) {
-                          commitDeleteAutoScalingRuleMutation({
-                            variables: {
-                              id: row?.id as string,
-                            },
-                            onCompleted: (res, errors) => {
-                              if (
-                                !res?.delete_endpoint_auto_scaling_rule_node?.ok
-                              ) {
-                                message.error(
-                                  res?.delete_endpoint_auto_scaling_rule_node
-                                    ?.msg,
-                                );
-                              } else if (errors && errors.length > 0) {
-                                const errorMsgList = _.map(
-                                  errors,
-                                  (error) =>
-                                    error.message || t('dialog.ErrorOccurred'),
-                                );
-                                for (const error of errorMsgList) {
-                                  message.error(error);
-                                }
-                              } else {
-                                setEditingAutoScalingRule(null);
-                                startRefetchTransition(() => {
-                                  updateFetchKey();
-                                });
-                                message.success({
-                                  key: 'autoscaling-rule-deleted',
-                                  content: t(
-                                    'autoScalingRule.SuccessfullyDeleted',
-                                  ),
-                                });
-                              }
-                            },
-                            onError: (error) => {
-                              message.error(
-                                error?.message || t('dialog.ErrorOccurred'),
-                              );
-                            },
-                          });
-                        }
-                      }}
-                    >
-                      <Button
-                        type="text"
-                        icon={
-                          <DeleteOutlined
-                            style={
-                              isEndpointInDestroyingCategory(endpoint)
-                                ? undefined
-                                : {
-                                    color: token.colorError,
-                                  }
-                            }
-                          />
-                        }
-                        disabled={false}
-                        onClick={() => {
-                          if (row) {
-                            setEditingAutoScalingRule(row);
-                          }
-                        }}
-                      />
-                    </Popconfirm>
-                  </BAIFlex>
-                ),
-              },
-              {
-                title: t('autoScalingRule.StepSize'),
-                dataIndex: 'step_size',
-                render: (_text, row) => {
-                  if (row?.step_size) {
-                    return (
-                      <BAIFlex gap={'xs'}>
-                        <Typography.Text>
-                          {row?.step_size > 0 ? (
-                            <CircleArrowUpIcon />
-                          ) : (
-                            <CircleArrowDownIcon />
-                          )}
-                        </Typography.Text>
-                        <Typography.Text>
-                          {Math.abs(row?.step_size)}
-                        </Typography.Text>
-                      </BAIFlex>
-                    );
-                  } else {
-                    return '-';
-                  }
-                },
-              },
-              {
-                title: t('autoScalingRule.MIN/MAXReplicas'),
-                render: (_text, row) => (
-                  <span>
-                    {row?.step_size
-                      ? row?.step_size > 0
-                        ? `Max: ${row?.max_replicas}`
-                        : `Min: ${row?.min_replicas}`
-                      : '-'}
-                  </span>
-                ),
-              },
-              {
-                title: t('autoScalingRule.CoolDownSeconds'),
-                dataIndex: 'cooldown_seconds',
-                // render: (text, row) => <span>{row?.cooldown_seconds}</span>,
-              },
-              {
-                title: t('autoScalingRule.LastTriggered'),
-                render: (_text, row) => {
-                  return (
-                    <span>
-                      {row?.last_triggered_at
-                        ? dayjs
-                            .utc(row?.last_triggered_at)
-                            .tz()
-                            .format('ll LTS')
-                        : `-`}
-                    </span>
-                  );
-                },
-                sorter: dayDiff,
-              },
-              {
-                title: t('autoScalingRule.CreatedAt'),
-                dataIndex: 'created_at',
-                render: (_text, row) => (
-                  <span>{dayjs(row?.created_at).format('ll LT')}</span>
-                ),
-                sorter: dayDiff,
-              },
-            ]}
-            pagination={false}
-            showSorterTooltip={false}
-            dataSource={autoScalingRules}
-          ></BAITable>
-        </Card>
-      )}
+      {isSupportAutoScalingRule &&
+        (isSupportPrometheusAutoScalingRule ? // TODO(FR-2494): Render Strawberry-based AutoScalingRuleList when >=26.4.0
+        null : (
+          <AutoScalingRuleListLegacy
+            endpoint_id={endpoint?.endpoint_id as string}
+            autoScalingRules={autoScalingRules}
+            isEndpointDestroying={isEndpointInDestroyingCategory(endpoint)}
+            isOwnedByCurrentUser={
+              !endpoint?.created_user_email ||
+              endpoint?.created_user_email === currentUser.email
+            }
+            onRefetch={() => {
+              startRefetchTransition(() => {
+                updateFetchKey();
+              });
+            }}
+          />
+        ))}
       <Card
         title={t('modelService.GeneratedTokens')}
         extra={
@@ -1309,24 +1072,6 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
         }}
         endpoint_id={endpoint?.endpoint_id || ''}
       ></EndpointTokenGenerationModal>
-      {isSupportAutoScalingRule && (
-        <BAIUnmountAfterClose>
-          <AutoScalingRuleEditorModal
-            open={isOpenAutoScalingRuleModal}
-            endpoint_id={endpoint?.endpoint_id as string}
-            autoScalingRuleFrgmt={editingAutoScalingRule}
-            onRequestClose={(success) => {
-              setIsOpenAutoScalingRuleModal(!isOpenAutoScalingRuleModal);
-              setEditingAutoScalingRule(null);
-              if (success) {
-                startRefetchTransition(() => {
-                  updateFetchKey();
-                });
-              }
-            }}
-          />
-        </BAIUnmountAfterClose>
-      )}
       <BAIUnmountAfterClose>
         <SessionDetailDrawer
           open={!!selectedSessionId}

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -900,6 +900,7 @@ class Client {
       this._features['route-health-status'] = true;
       this._features['model-card-v2'] = true;
       this._features['my-roles'] = true;
+      this._features['prometheus-auto-scaling-rule'] = true;
     }
   }
 


### PR DESCRIPTION
Resolves #6485(FR-2494) — Sub-task 1: Legacy extraction + version gating

## Summary

- Rename `AutoScalingRuleEditorModal` to `AutoScalingRuleEditorModalLegacy` with updated GraphQL operation names
- Extract the auto-scaling rules table from `EndpointDetailPage` into a new `AutoScalingRuleListLegacy` component
- Add `prometheus-auto-scaling-rule` feature key gated to `>=26.4.0` for future Strawberry API path
- Apply comparator display normalization in Legacy list: `GREATER_THAN` is flipped to show `[threshold] < [metric_name]`
- Limit Legacy editor comparator dropdown to only `LESS_THAN` and `GREATER_THAN` (removed `≤` and `≥` options)
- Set up version gating conditional in `EndpointDetailPage` with placeholder for Strawberry path (`>=26.4.0`)

## Changed files

- `react/src/components/AutoScalingRuleEditorModal.tsx` → renamed to `AutoScalingRuleEditorModalLegacy.tsx`
- `react/src/components/AutoScalingRuleListLegacy.tsx` (new)
- `react/src/pages/EndpointDetailPage.tsx` (simplified, uses extracted components)
- `src/lib/backend.ai-client-esm.ts` (added `prometheus-auto-scaling-rule` key)

## Verification

```
=== Relay: PASS ===
=== Lint: PASS ===
=== Format: PASS ===
=== TypeScript: PASS ===
=== ALL PASS ===
```