### PR TITLE
feat(FR-2494): add Strawberry AutoScalingRuleList component

### DIFF
--- a/react/src/components/AutoScalingRuleList.tsx
+++ b/react/src/components/AutoScalingRuleList.tsx
@@ -1,0 +1,409 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { AutoScalingRuleListDeleteMutation } from '../__generated__/AutoScalingRuleListDeleteMutation.graphql';
+import { AutoScalingRuleListPresetsQuery } from '../__generated__/AutoScalingRuleListPresetsQuery.graphql';
+import { AutoScalingRuleListQuery } from '../__generated__/AutoScalingRuleListQuery.graphql';
+import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
+import {
+  DeleteOutlined,
+  PlusOutlined,
+  SettingOutlined,
+} from '@ant-design/icons';
+import { App, Button, Card, Tag, Tooltip, Typography } from 'antd';
+import {
+  BAIFlex,
+  BAINameActionCell,
+  BAITable,
+  toLocalId,
+  useFetchKey,
+} from 'backend.ai-ui';
+import { default as dayjs } from 'dayjs';
+import * as _ from 'lodash-es';
+import { CircleArrowDownIcon, CircleArrowUpIcon } from 'lucide-react';
+import React, { useState, useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+
+interface AutoScalingRuleListProps {
+  deploymentId: string; // Relay global ID (e.g., toGlobalId('ModelDeployment', uuid))
+  isEndpointDestroying: boolean;
+  isOwnedByCurrentUser: boolean;
+}
+
+type AutoScalingRuleNode = NonNullable<
+  NonNullable<
+    NonNullable<
+      NonNullable<AutoScalingRuleListQuery['response']>['deployment']
+    >['autoScalingRules']
+  >['edges']
+>[number]['node'];
+
+/**
+ * Renders the condition column with normalized `<` direction:
+ * - maxThreshold only → `[metric_name] < [maxThreshold]`
+ * - minThreshold only → `[minThreshold] < [metric_name]`
+ * - Both set → `[minThreshold] < [metric_name] < [maxThreshold]`
+ */
+const renderCondition = (
+  rule: AutoScalingRuleNode,
+  t: (key: string) => string,
+) => {
+  const metricName = rule.metricName;
+  const minThreshold = rule.minThreshold;
+  const maxThreshold = rule.maxThreshold;
+  const suffix = rule.metricSource === 'KERNEL' ? '%' : '';
+
+  if (minThreshold != null && maxThreshold != null) {
+    return (
+      <BAIFlex gap={'xs'}>
+        {minThreshold}
+        {suffix}
+        <Tooltip title={t('autoScalingRule.MinThreshold')}>{'<'}</Tooltip>
+        <Tag>{metricName}</Tag>
+        <Tooltip title={t('autoScalingRule.MaxThreshold')}>{'<'}</Tooltip>
+        {maxThreshold}
+        {suffix}
+      </BAIFlex>
+    );
+  }
+
+  if (maxThreshold != null) {
+    return (
+      <BAIFlex gap={'xs'}>
+        <Tag>{metricName}</Tag>
+        <Tooltip title={t('autoScalingRule.MaxThreshold')}>{'<'}</Tooltip>
+        {maxThreshold}
+        {suffix}
+      </BAIFlex>
+    );
+  }
+
+  if (minThreshold != null) {
+    return (
+      <BAIFlex gap={'xs'}>
+        {minThreshold}
+        {suffix}
+        <Tooltip title={t('autoScalingRule.MinThreshold')}>{'<'}</Tooltip>
+        <Tag>{metricName}</Tag>
+      </BAIFlex>
+    );
+  }
+
+  return '-';
+};
+
+const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
+  deploymentId,
+  isEndpointDestroying,
+  isOwnedByCurrentUser,
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { message, modal } = App.useApp();
+  const [_isPendingRefetch, startRefetchTransition] = useTransition();
+  const [fetchKey, updateFetchKey] = useFetchKey();
+
+  const [_editingRuleId, setEditingRuleId] = useState<string | null>(null);
+  const [_isOpenEditorModal, setIsOpenEditorModal] = useState(false);
+
+  const {
+    baiPaginationOption,
+    tablePaginationOption,
+    setTablePaginationOption,
+  } = useBAIPaginationOptionState({ current: 1, pageSize: 10 });
+
+  const data = useLazyLoadQuery<AutoScalingRuleListQuery>(
+    graphql`
+      query AutoScalingRuleListQuery(
+        $deploymentId: ID!
+        $offset: Int
+        $limit: Int
+      ) {
+        deployment(id: $deploymentId) {
+          autoScalingRules(offset: $offset, limit: $limit) {
+            count
+            edges {
+              node {
+                id
+                metricSource
+                metricName
+                minThreshold
+                maxThreshold
+                stepSize
+                timeWindow
+                minReplicas
+                maxReplicas
+                prometheusQueryPresetId
+                createdAt
+                lastTriggeredAt
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      deploymentId,
+      offset: baiPaginationOption.offset,
+      limit: baiPaginationOption.limit,
+    },
+    {
+      fetchPolicy: 'store-and-network',
+      fetchKey,
+    },
+  );
+
+  const { prometheusQueryPresets } =
+    useLazyLoadQuery<AutoScalingRuleListPresetsQuery>(
+      graphql`
+        query AutoScalingRuleListPresetsQuery {
+          prometheusQueryPresets {
+            edges {
+              node {
+                id
+                name
+              }
+            }
+          }
+        }
+      `,
+      {},
+    );
+
+  const presetMap = React.useMemo(() => {
+    const map = new Map<string, string>();
+    if (prometheusQueryPresets?.edges) {
+      for (const edge of prometheusQueryPresets.edges) {
+        if (edge?.node) {
+          map.set(toLocalId(edge.node.id), edge.node.name);
+        }
+      }
+    }
+    return map;
+  }, [prometheusQueryPresets]);
+
+  const autoScalingRules = React.useMemo(
+    () => _.map(data?.deployment?.autoScalingRules?.edges, (edge) => edge.node),
+    [data?.deployment?.autoScalingRules?.edges],
+  );
+
+  const totalCount = data?.deployment?.autoScalingRules?.count ?? 0;
+
+  const [commitDeleteMutation, isInFlightDeleteMutation] =
+    useMutation<AutoScalingRuleListDeleteMutation>(graphql`
+      mutation AutoScalingRuleListDeleteMutation(
+        $input: DeleteAutoScalingRuleInput!
+      ) {
+        deleteAutoScalingRule(input: $input) {
+          id
+        }
+      }
+    `);
+
+  const handleRefetch = () => {
+    startRefetchTransition(() => {
+      updateFetchKey();
+    });
+  };
+
+  return (
+    <>
+      <Card
+        title={t('modelService.AutoScalingRules')}
+        extra={
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            disabled={isEndpointDestroying || !isOwnedByCurrentUser}
+            onClick={() => {
+              setEditingRuleId(null);
+              setIsOpenEditorModal(true);
+            }}
+          >
+            {t('modelService.AddRules')}
+          </Button>
+        }
+      >
+        <BAITable<AutoScalingRuleNode>
+          scroll={{ x: 'max-content' }}
+          rowKey={'id'}
+          columns={[
+            {
+              title: t('autoScalingRule.MetricSource'),
+              dataIndex: 'metricSource',
+              fixed: 'left',
+            },
+            {
+              title: t('autoScalingRule.Condition'),
+              fixed: 'left',
+              render: (_text, row) => {
+                if (!row) return '-';
+                return (
+                  <BAINameActionCell
+                    title={renderCondition(row, t)}
+                    showActions="always"
+                    actions={[
+                      {
+                        key: 'edit',
+                        title: t('button.Edit'),
+                        icon: <SettingOutlined />,
+                        disabled: isEndpointDestroying || !isOwnedByCurrentUser,
+                        onClick: () => {
+                          setEditingRuleId(row.id);
+                          setIsOpenEditorModal(true);
+                        },
+                      },
+                      {
+                        key: 'delete',
+                        title: t('button.Delete'),
+                        icon: <DeleteOutlined />,
+                        type: 'danger',
+                        disabled:
+                          isInFlightDeleteMutation ||
+                          isEndpointDestroying ||
+                          !isOwnedByCurrentUser,
+                        onClick: () => {
+                          modal.confirm({
+                            title: t('dialog.warning.CannotBeUndone'),
+                            okText: t('button.Delete'),
+                            okButtonProps: { danger: true },
+                            onOk: () => {
+                              commitDeleteMutation({
+                                variables: { input: { id: toLocalId(row.id) } },
+                                onCompleted: (_res, errors) => {
+                                  if (errors && errors.length > 0) {
+                                    for (const error of errors) {
+                                      message.error(
+                                        error.message ||
+                                          t('dialog.ErrorOccurred'),
+                                      );
+                                    }
+                                  } else {
+                                    setEditingRuleId(null);
+                                    handleRefetch();
+                                    message.success({
+                                      key: 'autoscaling-rule-deleted',
+                                      content: t(
+                                        'autoScalingRule.SuccessfullyDeleted',
+                                      ),
+                                    });
+                                  }
+                                },
+                                onError: (error) => {
+                                  message.error(
+                                    error?.message || t('dialog.ErrorOccurred'),
+                                  );
+                                },
+                              });
+                            },
+                          });
+                        },
+                      },
+                    ]}
+                  />
+                );
+              },
+            },
+            {
+              title: t('autoScalingRule.PrometheusPreset'),
+              render: (_text, row) => {
+                if (
+                  row?.metricSource !== 'PROMETHEUS' ||
+                  !row?.prometheusQueryPresetId
+                ) {
+                  return '-';
+                }
+                return (
+                  presetMap.get(row.prometheusQueryPresetId) ||
+                  row.prometheusQueryPresetId
+                );
+              },
+            },
+            {
+              title: t('autoScalingRule.TimeWindow'),
+              dataIndex: 'timeWindow',
+              render: (value: number) =>
+                value != null
+                  ? t('autoScalingRule.TimeWindowSeconds', { value })
+                  : '-',
+            },
+            {
+              title: t('autoScalingRule.StepSize'),
+              dataIndex: 'stepSize',
+              render: (_text, row) => {
+                if (row?.stepSize) {
+                  return (
+                    <BAIFlex gap={'xs'}>
+                      <Typography.Text>
+                        {row.stepSize > 0 ? (
+                          <CircleArrowUpIcon />
+                        ) : (
+                          <CircleArrowDownIcon />
+                        )}
+                      </Typography.Text>
+                      <Typography.Text>
+                        {Math.abs(row.stepSize)}
+                      </Typography.Text>
+                    </BAIFlex>
+                  );
+                } else {
+                  return '-';
+                }
+              },
+            },
+            {
+              title: t('autoScalingRule.MIN/MAXReplicas'),
+              render: (_text, row) => (
+                <span>
+                  {row?.stepSize
+                    ? row.stepSize > 0
+                      ? t('autoScalingRule.MaxReplicasValue', {
+                          value: row?.maxReplicas,
+                        })
+                      : t('autoScalingRule.MinReplicasValue', {
+                          value: row?.minReplicas,
+                        })
+                    : '-'}
+                </span>
+              ),
+            },
+            {
+              title: t('autoScalingRule.CreatedAt'),
+              dataIndex: 'createdAt',
+              render: (_text, row) => (
+                <span>
+                  {row?.createdAt ? dayjs(row.createdAt).format('ll LT') : '-'}
+                </span>
+              ),
+            },
+            {
+              title: t('autoScalingRule.LastTriggered'),
+              render: (_text, row) => (
+                <span>
+                  {row?.lastTriggeredAt
+                    ? dayjs.utc(row.lastTriggeredAt).tz().format('ll LTS')
+                    : '-'}
+                </span>
+              ),
+            },
+          ]}
+          pagination={{
+            pageSize: tablePaginationOption.pageSize,
+            current: tablePaginationOption.current,
+            total: totalCount,
+            onChange: (current, pageSize) => {
+              setTablePaginationOption({ current, pageSize });
+            },
+          }}
+          showSorterTooltip={false}
+          dataSource={autoScalingRules}
+        />
+      </Card>
+      {/* TODO(FR-2494): AutoScalingRuleEditorModal (Strawberry) integrated in Sub-task 3 */}
+    </>
+  );
+};
+
+export default AutoScalingRuleList;

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -11,6 +11,7 @@ import {
   RouteTrafficStatus,
 } from '../__generated__/EndpointDetailPageQuery.graphql';
 import { InferenceSessionErrorModalFragment$key } from '../__generated__/InferenceSessionErrorModalFragment.graphql';
+import AutoScalingRuleList from '../components/AutoScalingRuleList';
 import AutoScalingRuleListLegacy from '../components/AutoScalingRuleListLegacy';
 import BAIJSONViewerModal from '../components/BAIJSONViewerModal';
 import BAIRadioGroup from '../components/BAIRadioGroup';
@@ -741,8 +742,19 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
         ></Descriptions>
       </Card>
       {isSupportAutoScalingRule &&
-        (isSupportPrometheusAutoScalingRule ? // TODO(FR-2494): Render Strawberry-based AutoScalingRuleList when >=26.4.0
-        null : (
+        (isSupportPrometheusAutoScalingRule ? (
+          <AutoScalingRuleList
+            deploymentId={toGlobalId(
+              'ModelDeployment',
+              endpoint?.endpoint_id || '',
+            )}
+            isEndpointDestroying={isEndpointInDestroyingCategory(endpoint)}
+            isOwnedByCurrentUser={
+              !endpoint?.created_user_email ||
+              endpoint?.created_user_email === currentUser.email
+            }
+          />
+        ) : (
           <AutoScalingRuleListLegacy
             endpoint_id={endpoint?.endpoint_id as string}
             autoScalingRules={autoScalingRules}

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -164,6 +164,7 @@
     "MetricName": "Metric Name",
     "MetricSource": "Metric Source",
     "MinReplicas": "Min Replicas",
+    "PrometheusPreset": "Prometheus Preset",
     "ScaleIn": "Scale In",
     "ScaleOut": "Scale Out",
     "ScalingType": "Type",
@@ -171,7 +172,8 @@
     "SuccessfullyCreated": "Auto scaling rule has been successfully created.",
     "SuccessfullyDeleted": "Auto scaling rule has been successfuly deleted.",
     "SuccessfullyUpdated": "Auto scaling rule has been successfully updated.",
-    "Threshold": "Threshold"
+    "Threshold": "Threshold",
+    "TimeWindow": "Time Window"
   },
   "button": {
     "Add": "Add",


### PR DESCRIPTION
Resolves #6485 (FR-2494) - Sub-task 2

> [!NOTE]
> Translation is handled in #6642 

## Summary

- Create new `AutoScalingRuleList.tsx` component that uses the Strawberry API (`ModelDeployment.autoScalingRules` nested connection) for `>=26.4.0` backends
- Display conditions using `minThreshold`/`maxThreshold` with normalized `<` direction:
    - `maxThreshold` only: `[metric_name] < [maxThreshold]`
    - `minThreshold` only: `[minThreshold] < [metric_name]`
    - Both set: `[minThreshold] < [metric_name] < [maxThreshold]`
- Show Prometheus preset name for `PROMETHEUS` metric source rules by matching `prometheusQueryPresetId` (raw UUID) with `toLocalId(presetGlobalId)`
- Wire up `deleteAutoScalingRule` Strawberry mutation
- Update `EndpointDetailPage.tsx` to render the new list when `isSupportPrometheusAutoScalingRule` is true
- Add i18n keys: `TimeWindow`, `PrometheusPreset`

## Changed files

- `react/src/components/AutoScalingRuleList.tsx` (new)
- `react/src/pages/EndpointDetailPage.tsx` (conditional rendering for Strawberry path)
- `resources/i18n/en.json` (new i18n keys)

## Verification

```
=== ALL PASS ===
```