### PR TITLE
fix(FR-2475): force fresh project list fetch in ProjectSelect

### DIFF
--- a/react/src/components/ProjectSelect.tsx
+++ b/react/src/components/ProjectSelect.tsx
@@ -78,7 +78,7 @@ const ProjectSelect: React.FC<ProjectSelectProps> = ({
           : ['GENERAL', 'MODEL_STORE'],
     },
     {
-      fetchPolicy: 'store-and-network',
+      fetchPolicy: 'network-only',
     },
   );
 


### PR DESCRIPTION
Resolves #6433 (FR-2475)

## Problem

`ProjectSelect` uses `useLazyLoadQuery` with `fetchPolicy: 'store-and-network'`. When a modal containing `ProjectSelect` is reopened (e.g., `UserSettingModal`), the project list does **not** reliably refetch from the server — so newly created projects don't show up until the page is reloaded.

Empirically, opening the user edit modal 6 times produces an alternating **call / no-call** network pattern (3 requests for 6 opens), even when the modal content is fully unmounted between opens via `BAIUnmountAfterClose`.

## Fix

```diff
-      fetchPolicy: 'store-and-network',
+      fetchPolicy: 'network-only',
```

A one-line change in `react/src/components/ProjectSelect.tsx`. With `network-only`, every mount of `ProjectSelect` forces a network request and suspends until the response arrives, guaranteeing fresh data on every open.

## Call-site safety review

`ProjectSelect` has 5 call sites (counting `ProjectSelectForAdminPage` as a thin wrapper). Every one already sits under a `<Suspense>` boundary, so the additional suspension from `network-only` is handled:

| Call site | Suspense boundary |
|---|---|
| `UserSettingModal.tsx:872` | Local `<Suspense>` with `<Select loading />` fallback |
| `UpdateUsersModal.tsx:230` | Local `<Suspense>` with `<BAISelect loading />` fallback |
| `MainLayout/WebUIHeader.tsx:102` | Local `<Suspense>` (mounts once per session — no UX regression) |
| `StorageHostSettingsPanel.tsx:128` (via `ProjectSelectForAdminPage`) | Ancestor `<Suspense fallback={<Skeleton active />}>` in `StorageHostSettingPage.tsx:68` |
| `ContainerRegistryEditorModal.tsx:496` (via `ProjectSelectForAdminPage`) | Ancestor `<Suspense>` in `EnvironmentPage.tsx:58` |

### Expected side effects

- **More network requests**: every mount fires one `ProjectSelectorQuery`. In practice that's once per modal open and once per page load — the same rate the feature is expected to produce correct data for.
- **More visible Suspense fallbacks**: users may briefly see a loading state on modal open. Existing loading fallbacks are already in place at every call site.
- **No public API change**: `fetchPolicy` is internal to the component; no consumer code needs to change.

## Suspicious / uncertain parts

I want to flag that **this fix is empirically verified but the exact root cause of the original alternating pattern is not fully understood**. Reviewers should be aware of the theoretical gap.

### The original theory doesn't fully explain the result

I investigated Relay's `QueryResource` (react-relay@20.1.1):

- `cacheIdentifier = ${fetchPolicy}-${renderPolicy}-${operation.request.identifier}${-cacheBreaker}`
- `QueryResource` holds an LRU of 1000 entries; cache entries are retained via `retain()` and disposed when retain count drops to 0 (with a 5-minute `TEMPORARY_RETAIN_DURATION_MS` grace timer from `SuspenseResource`).
- `RelayModernStore` has a separate `DEFAULT_RELEASE_BUFFER_SIZE = 10`, but that only affects `store-or-network`.

Under the LRU-cache-hit theory, **both** `store-and-network` and `network-only` should hit the QueryResource cache equally on the second mount (cacheIdentifier is stable across opens because the input variables don't change). So in principle, switching the fetchPolicy shouldn't matter — yet it clearly does.

### Leading hypotheses (unverified)

1. **`shouldAllowRender` path difference** — `store-and-network` takes `shouldAllowRender = canPartialRender` and creates a snapshot-based cache entry (QueryResource.js:210-214). `network-only` takes `shouldAllowRender = false` and creates a promise-wrapped entry (QueryResource.js:273-281). The resulting suspend-vs-immediate-render difference may interact differently with React 19 StrictMode's double effect invocation and `useLazyLoadQueryNode`'s `maybeHiddenOrFastRefresh` ref, causing `forceUpdateKey` to change only on every other mount for `store-and-network`.
2. **Store release buffer + `canPartialRender` interaction** — if the Store still holds partial records from the previous mount (within the release buffer window), `canPartialRender` may flip on/off across mounts, suppressing the network request half the time.
3. **`fetchQueryDeduped` requestCache interaction** — the per-environment in-flight dedup cache keyed by `operation.request.identifier` may interact with `networkCacheConfig.force` differently between the two policies.

None of these have been definitively confirmed with runtime logging; I'd be happy to add a `__log` hook in a follow-up if a reviewer wants to pin down the exact mechanism. For now, this PR is the pragmatic one-line fix that resolves the user-visible bug.

### Alternative fix considered and rejected

The originally-suggested fix in #6433 was to add a `fetchKey` prop to `ProjectSelect` and bump it from the parent on modal open (mirroring the existing `useFetchKey` / `BAIFetchKeyButton` / `INITIAL_FETCH_KEY` pattern in `UserManagement`). That's a larger change touching every call site and only gains us "we can control when to refetch" — a capability we don't actually need here, since the semantic requirement is **always refetch on mount**. `network-only` expresses that directly with one line.

## Verification

```
bash scripts/verify.sh
# === Relay === PASS
# === Lint === PASS
# === Format === PASS
# === TypeScript === PASS
# === ALL PASS ===
```

## Test plan

- [ ] Open user edit modal in Users page; verify `ProjectSelectorQuery` fires in Network tab every time the modal opens.
- [ ] Create a new project in another tab → reopen user edit modal → verify new project appears immediately.
- [ ] `WebUIHeader` project switcher still loads and functions on initial page load.
- [ ] `StorageHostSettingsPanel` and `ContainerRegistryEditorModal` still render their project selectors without errors.
