### PR TITLE
feat(FR-2576): add Project Admin Sessions page using projectSessionsV2

### DIFF
--- a/react/src/components/ProjectSessionV2Nodes.tsx
+++ b/react/src/components/ProjectSessionV2Nodes.tsx
@@ -14,6 +14,7 @@ import {
   filterOutNullAndUndefined,
   BAIColumnType,
   BAIFlex,
+  BAIIntervalView,
   BAINameActionCell,
   BAITable,
   BAITableProps,
@@ -197,8 +198,7 @@ const ProjectSessionV2Nodes: React.FC<ProjectSessionV2NodesProps> = ({
           const name = session.metadata?.name ?? '-';
           const status = session.lifecycle?.status;
           const isTerminated =
-            !!status &&
-            _.includes(TERMINATED_STATUSES, status as SessionV2Status);
+            !!status && _.includes(TERMINATED_STATUSES, status);
           return (
             <BAINameActionCell
               title={name}
@@ -283,11 +283,22 @@ const ProjectSessionV2Nodes: React.FC<ProjectSessionV2NodesProps> = ({
       {
         key: 'elapsedTime',
         title: t('session.ElapsedTime'),
-        render: (__, session) =>
-          formatElapsedTime(
-            session.lifecycle?.createdAt,
-            session.lifecycle?.terminatedAt,
-          ),
+        render: (__, session) => {
+          const createdAt = session.lifecycle?.createdAt;
+          const terminatedAt = session.lifecycle?.terminatedAt;
+          // If the session has already terminated, the elapsed time is fixed
+          // and there is no point in re-running the timer every second.
+          if (terminatedAt) {
+            return formatElapsedTime(createdAt, terminatedAt);
+          }
+          return (
+            <BAIIntervalView
+              key={session.id}
+              callback={() => formatElapsedTime(createdAt, terminatedAt)}
+              delay={1000}
+            />
+          );
+        },
       },
       {
         key: 'environment',

--- a/react/src/components/ProjectSessionV2Nodes.tsx
+++ b/react/src/components/ProjectSessionV2Nodes.tsx
@@ -1,0 +1,366 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import type {
+  ProjectSessionV2NodesFragment$data,
+  ProjectSessionV2NodesFragment$key,
+  SessionV2Status,
+} from '../__generated__/ProjectSessionV2NodesFragment.graphql';
+import { convertToBinaryUnit } from '../helper';
+import { useCurrentUserRole } from '../hooks/backendai';
+import {
+  filterOutEmpty,
+  filterOutNullAndUndefined,
+  BAIColumnType,
+  BAIFlex,
+  BAINameActionCell,
+  BAITable,
+  BAITableProps,
+  BAITag,
+} from 'backend.ai-ui';
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
+import * as _ from 'lodash-es';
+import { PowerOffIcon } from 'lucide-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useFragment } from 'react-relay';
+
+dayjs.extend(duration);
+
+export type ProjectSessionV2InList = NonNullable<
+  ProjectSessionV2NodesFragment$data[number]
+>;
+
+const availableProjectSessionV2SorterKeys = [
+  'name',
+  'status',
+  'createdAt',
+  'terminatedAt',
+  'id',
+] as const;
+
+export const availableProjectSessionV2SorterValues = [
+  ...availableProjectSessionV2SorterKeys,
+  ...availableProjectSessionV2SorterKeys.map((key) => `-${key}` as const),
+] as const;
+
+const isEnableSorter = (key: string) => {
+  return _.includes(availableProjectSessionV2SorterKeys, key);
+};
+
+const TERMINATED_STATUSES: ReadonlyArray<SessionV2Status> = [
+  'TERMINATED',
+  'CANCELLED',
+  'TERMINATING',
+];
+
+const STATUS_COLOR_MAP: Partial<Record<SessionV2Status, string>> = {
+  PENDING: 'default',
+  SCHEDULED: 'blue',
+  PREPARING: 'blue',
+  PREPARED: 'blue',
+  CREATING: 'blue',
+  RUNNING: 'green',
+  DEPRIORITIZING: 'orange',
+  TERMINATING: 'orange',
+  TERMINATED: 'default',
+  CANCELLED: 'red',
+};
+
+type ResourceEntry = { resourceType: string; quantity: string };
+
+const findEntry = (entries: ReadonlyArray<ResourceEntry>, type: string) =>
+  entries.find((entry) => entry.resourceType === type);
+
+const formatElapsedTime = (
+  createdAt?: string | null,
+  endedAt?: string | null,
+) => {
+  if (!createdAt) return '-';
+  const start = dayjs(createdAt);
+  const end = endedAt ? dayjs(endedAt) : dayjs();
+  const diffSeconds = Math.max(0, end.diff(start, 'second'));
+  return dayjs.duration(diffSeconds, 'seconds').format('HH:mm:ss');
+};
+
+const formatCpu = (entry?: ResourceEntry) => {
+  if (!entry) return '-';
+  return entry.quantity;
+};
+
+const formatMemory = (entry?: ResourceEntry) => {
+  if (!entry) return '-';
+  return (
+    convertToBinaryUnit(entry.quantity, 'auto')?.displayValue ?? entry.quantity
+  );
+};
+
+const formatAccelerator = (entries: ReadonlyArray<ResourceEntry>) => {
+  const acceleratorEntries = entries.filter(
+    (entry) => entry.resourceType !== 'cpu' && entry.resourceType !== 'mem',
+  );
+  if (acceleratorEntries.length === 0) return '-';
+  return acceleratorEntries
+    .map((entry) => `${entry.quantity} ${entry.resourceType}`)
+    .join(', ');
+};
+
+interface ProjectSessionV2NodesProps extends Omit<
+  BAITableProps<ProjectSessionV2InList>,
+  'dataSource' | 'columns' | 'onChangeOrder'
+> {
+  sessionsFrgmt: ProjectSessionV2NodesFragment$key;
+  onClickSessionName?: (session: ProjectSessionV2InList) => void;
+  onClickTerminate?: (session: ProjectSessionV2InList) => void;
+  disableSorter?: boolean;
+  onChangeOrder?: (
+    order: (typeof availableProjectSessionV2SorterValues)[number] | null,
+  ) => void;
+}
+
+const ProjectSessionV2Nodes: React.FC<ProjectSessionV2NodesProps> = ({
+  sessionsFrgmt,
+  onClickSessionName,
+  onClickTerminate,
+  disableSorter,
+  onChangeOrder,
+  ...tableProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+  const userRole = useCurrentUserRole();
+
+  const sessions = useFragment(
+    graphql`
+      fragment ProjectSessionV2NodesFragment on SessionV2 @relay(plural: true) {
+        id @required(action: NONE)
+        metadata {
+          name
+          sessionType
+          clusterMode
+        }
+        lifecycle {
+          status
+          createdAt
+          terminatedAt
+        }
+        resource {
+          resourceGroupName
+          allocation {
+            requested {
+              entries {
+                resourceType
+                quantity
+              }
+            }
+            used {
+              entries {
+                resourceType
+                quantity
+              }
+            }
+          }
+        }
+        images {
+          edges {
+            node {
+              id
+              identity {
+                canonicalName
+                namespace
+              }
+            }
+          }
+        }
+        user {
+          id
+          basicInfo {
+            email
+          }
+        }
+      }
+    `,
+    sessionsFrgmt,
+  );
+
+  const filteredSessions = filterOutNullAndUndefined(sessions);
+
+  const columns = _.map(
+    filterOutEmpty<BAIColumnType<ProjectSessionV2InList>>([
+      {
+        key: 'name',
+        title: t('session.SessionName'),
+        dataIndex: ['metadata', 'name'],
+        render: (__, session) => {
+          const name = session.metadata?.name ?? '-';
+          const status = session.lifecycle?.status;
+          const isTerminated =
+            !!status &&
+            _.includes(TERMINATED_STATUSES, status as SessionV2Status);
+          return (
+            <BAINameActionCell
+              title={name}
+              showActions="always"
+              onTitleClick={
+                onClickSessionName
+                  ? () => onClickSessionName(session)
+                  : undefined
+              }
+              actions={filterOutEmpty([
+                {
+                  key: 'terminate',
+                  title: t('session.TerminateSession'),
+                  icon: <PowerOffIcon />,
+                  type: 'danger' as const,
+                  disabled: isTerminated,
+                  onClick: () => onClickTerminate?.(session),
+                },
+              ])}
+            />
+          );
+        },
+        sorter: isEnableSorter('name'),
+        required: true,
+        fixed: 'left',
+      },
+      {
+        key: 'status',
+        title: t('session.Status'),
+        sorter: isEnableSorter('status'),
+        render: (__, session) => {
+          const status = session.lifecycle?.status;
+          if (!status) return '-';
+          return (
+            <BAITag
+              color={STATUS_COLOR_MAP[status as SessionV2Status] ?? 'default'}
+            >
+              {status}
+            </BAITag>
+          );
+        },
+      },
+      {
+        key: 'accelerator',
+        title: t('session.launcher.AIAccelerator'),
+        render: (__, session) => {
+          const requested =
+            session.resource?.allocation?.requested?.entries ?? [];
+          const used = session.resource?.allocation?.used?.entries;
+          const requestedStr = formatAccelerator(requested);
+          if (!used) return requestedStr;
+          const usedStr = formatAccelerator(used);
+          return `${usedStr} / ${requestedStr}`;
+        },
+      },
+      {
+        key: 'cpu',
+        title: t('session.launcher.CPU'),
+        render: (__, session) => {
+          const requested =
+            session.resource?.allocation?.requested?.entries ?? [];
+          const used = session.resource?.allocation?.used?.entries;
+          const requestedCpu = formatCpu(findEntry(requested, 'cpu'));
+          if (!used) return requestedCpu;
+          const usedCpu = formatCpu(findEntry(used, 'cpu'));
+          return `${usedCpu} / ${requestedCpu}`;
+        },
+      },
+      {
+        key: 'mem',
+        title: t('session.launcher.Memory'),
+        render: (__, session) => {
+          const requested =
+            session.resource?.allocation?.requested?.entries ?? [];
+          const used = session.resource?.allocation?.used?.entries;
+          const requestedMem = formatMemory(findEntry(requested, 'mem'));
+          if (!used) return requestedMem;
+          const usedMem = formatMemory(findEntry(used, 'mem'));
+          return `${usedMem} / ${requestedMem}`;
+        },
+      },
+      {
+        key: 'elapsedTime',
+        title: t('session.ElapsedTime'),
+        render: (__, session) =>
+          formatElapsedTime(
+            session.lifecycle?.createdAt,
+            session.lifecycle?.terminatedAt,
+          ),
+      },
+      {
+        key: 'environment',
+        title: t('session.launcher.Environments'),
+        defaultHidden: true,
+        render: (__, session) => {
+          const firstImage = session.images?.edges?.[0]?.node;
+          if (!firstImage) return '-';
+          const displayName =
+            firstImage.identity?.canonicalName ||
+            firstImage.identity?.namespace ||
+            '-';
+          return <BAITag>{displayName}</BAITag>;
+        },
+      },
+      {
+        key: 'resourceGroup',
+        title: t('session.ResourceGroup'),
+        defaultHidden: true,
+        render: (__, session) => session.resource?.resourceGroupName || '-',
+      },
+      {
+        key: 'sessionType',
+        title: t('session.SessionType'),
+        defaultHidden: true,
+        render: (__, session) => session.metadata?.sessionType || '-',
+      },
+      {
+        key: 'clusterMode',
+        title: t('session.ClusterMode'),
+        defaultHidden: true,
+        render: (__, session) => session.metadata?.clusterMode || '-',
+      },
+      {
+        key: 'createdAt',
+        title: t('session.CreatedAt'),
+        defaultHidden: true,
+        sorter: isEnableSorter('createdAt'),
+        render: (__, session) =>
+          session.lifecycle?.createdAt
+            ? dayjs(session.lifecycle.createdAt).format('LLL')
+            : '-',
+      },
+      userRole === 'superadmin' && {
+        key: 'owner',
+        title: t('session.launcher.OwnerEmail'),
+        render: (__, session) => session.user?.basicInfo?.email || '-',
+      },
+    ]),
+    (column) => {
+      return disableSorter ? _.omit(column, 'sorter') : column;
+    },
+  );
+
+  return (
+    <BAIFlex direction="column" align="stretch">
+      <BAITable
+        resizable
+        rowKey="id"
+        size="small"
+        dataSource={filteredSessions}
+        columns={columns}
+        scroll={{ x: 'max-content' }}
+        onChangeOrder={(order) => {
+          onChangeOrder?.(
+            (order as (typeof availableProjectSessionV2SorterValues)[number]) ||
+              null,
+          );
+        }}
+        {...tableProps}
+      />
+    </BAIFlex>
+  );
+};
+
+export default ProjectSessionV2Nodes;

--- a/react/src/hooks/useWebUIMenuItems.tsx
+++ b/react/src/hooks/useWebUIMenuItems.tsx
@@ -105,6 +105,7 @@ export const VALID_MENU_KEYS = [
   'admin-dashboard',
   'admin-data',
   'project-admin-users',
+  'project-admin-sessions',
   'agent',
   'project',
   'settings',
@@ -130,6 +131,7 @@ const ALL_ADMIN_PAGE_KEYS: ReadonlySet<string> = new Set([
   'admin-dashboard',
   'admin-data',
   'project-admin-users',
+  'project-admin-sessions',
   'agent',
   'project',
   'settings',
@@ -150,6 +152,7 @@ export const PROJECT_ADMIN_PAGE_KEYS = [
   // 'admin-serving',
   // 'admin-data',
   'project-admin-users',
+  'project-admin-sessions',
 ] as const;
 
 const PROJECT_ADMIN_PAGE_KEY_SET: ReadonlySet<string> = new Set(
@@ -375,6 +378,16 @@ export const useWebUIMenuItems = (props?: UseWebUIMenuItemsProps) => {
       ),
       icon: <BAISessionsIcon style={{ color: token.colorInfo }} />,
       key: 'admin-session' as MenuKeys,
+      group: 'admin-operations' as AdminMenuGroupName,
+    },
+    {
+      label: (
+        <WebUILink to="/project-admin-sessions">
+          {t('webui.menu.ProjectSessions')}
+        </WebUILink>
+      ),
+      icon: <BAISessionsIcon style={{ color: token.colorInfo }} />,
+      key: 'project-admin-sessions' as MenuKeys,
       group: 'admin-operations' as AdminMenuGroupName,
     },
     isSuperAdmin && {

--- a/react/src/pages/ProjectAdminSessionsPage.tsx
+++ b/react/src/pages/ProjectAdminSessionsPage.tsx
@@ -26,6 +26,7 @@ import {
   BAIGraphQLPropertyFilter,
   GraphQLFilter,
   INITIAL_FETCH_KEY,
+  toLocalId,
   useFetchKey,
 } from 'backend.ai-ui';
 import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
@@ -185,7 +186,7 @@ const ProjectAdminSessionsContent: React.FC<
           commitTerminate({
             variables: {
               scope: { projectId },
-              sessionIds: [session.id],
+              sessionIds: [toLocalId(session.id)],
               forced: false,
             },
             onCompleted: () => {
@@ -266,12 +267,11 @@ const ProjectAdminSessionsContent: React.FC<
           setQueryParams({ order });
         }}
         onClickSessionName={(session) => {
-          // SessionDetailDrawer currently consumes the v1 (ComputeSessionNode)
-          // fragment. We still navigate via sessionDetail search param here for
-          // parity; fully wiring the drawer to v2 sessions is out of scope
-          // for FR-2576.
+          // SessionDetailDrawer consumes the v1 (ComputeSessionNode) fragment
+          // which keys off the row UUID, so convert the v2 global ID here.
+          // Fully wiring the drawer to v2 sessions is out of scope for FR-2576.
           const newSearchParams = new URLSearchParams(location.search);
-          newSearchParams.set('sessionDetail', session.id);
+          newSearchParams.set('sessionDetail', toLocalId(session.id));
           webUINavigate({
             pathname: location.pathname,
             hash: location.hash,

--- a/react/src/pages/ProjectAdminSessionsPage.tsx
+++ b/react/src/pages/ProjectAdminSessionsPage.tsx
@@ -1,0 +1,322 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import type {
+  ProjectAdminSessionsPageQuery,
+  SessionV2OrderBy,
+  SessionV2Status,
+} from '../__generated__/ProjectAdminSessionsPageQuery.graphql';
+import type { ProjectAdminSessionsPageTerminateMutation } from '../__generated__/ProjectAdminSessionsPageTerminateMutation.graphql';
+import BAIErrorBoundary from '../components/BAIErrorBoundary';
+import BAIRadioGroup from '../components/BAIRadioGroup';
+import ProjectSessionV2Nodes, {
+  availableProjectSessionV2SorterValues,
+  ProjectSessionV2InList,
+} from '../components/ProjectSessionV2Nodes';
+import { convertToOrderBy } from '../helper';
+import { useWebUINavigate } from '../hooks';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { useCurrentProjectValue } from '../hooks/useCurrentProject';
+import { App, Skeleton } from 'antd';
+import {
+  BAICard,
+  BAIFetchKeyButton,
+  BAIFlex,
+  BAIGraphQLPropertyFilter,
+  GraphQLFilter,
+  INITIAL_FETCH_KEY,
+  useFetchKey,
+} from 'backend.ai-ui';
+import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
+import React, { Suspense, useDeferredValue } from 'react';
+import { useTranslation } from 'react-i18next';
+import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import { useLocation } from 'react-router-dom';
+
+const statusCategoryValues = ['running', 'finished'] as const;
+
+const RUNNING_STATUSES: ReadonlyArray<SessionV2Status> = [
+  'PENDING',
+  'SCHEDULED',
+  'PREPARING',
+  'PREPARED',
+  'CREATING',
+  'RUNNING',
+  'DEPRIORITIZING',
+  'TERMINATING',
+];
+
+const FINISHED_STATUSES: ReadonlyArray<SessionV2Status> = [
+  'TERMINATED',
+  'CANCELLED',
+];
+
+interface ProjectAdminSessionsContentProps {
+  projectId: string;
+}
+
+const ProjectAdminSessionsContent: React.FC<
+  ProjectAdminSessionsContentProps
+> = ({ projectId }) => {
+  'use memo';
+  const { t } = useTranslation();
+  const { message, modal } = App.useApp();
+  const webUINavigate = useWebUINavigate();
+  const location = useLocation();
+
+  const {
+    baiPaginationOption,
+    tablePaginationOption,
+    setTablePaginationOption,
+  } = useBAIPaginationOptionStateOnSearchParam({
+    current: 1,
+    pageSize: 10,
+  });
+
+  const [queryParams, setQueryParams] = useQueryStates(
+    {
+      statusCategory:
+        parseAsStringLiteral(statusCategoryValues).withDefault('running'),
+      order: parseAsStringLiteral(availableProjectSessionV2SorterValues),
+      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+    },
+    {
+      history: 'replace',
+    },
+  );
+
+  const [fetchKey, updateFetchKey] = useFetchKey();
+
+  const statusFilter =
+    queryParams.statusCategory === 'running'
+      ? { in: RUNNING_STATUSES as readonly SessionV2Status[] }
+      : { in: FINISHED_STATUSES as readonly SessionV2Status[] };
+
+  const queryVariables = {
+    projectId,
+    filter: {
+      ...(queryParams.filter ?? {}),
+      status: statusFilter,
+    },
+    orderBy: convertToOrderBy<Required<SessionV2OrderBy>>(
+      queryParams.order,
+    ) ?? [
+      { field: 'CREATED_AT', direction: 'DESC' } as Required<SessionV2OrderBy>,
+    ],
+    limit: baiPaginationOption.limit,
+    offset: baiPaginationOption.offset,
+  };
+
+  const deferredQueryVariables = useDeferredValue(queryVariables);
+  const deferredFetchKey = useDeferredValue(fetchKey);
+
+  const data = useLazyLoadQuery<ProjectAdminSessionsPageQuery>(
+    graphql`
+      query ProjectAdminSessionsPageQuery(
+        $projectId: UUID!
+        $filter: SessionV2Filter
+        $orderBy: [SessionV2OrderBy!]
+        $limit: Int
+        $offset: Int
+      ) {
+        projectSessionsV2(
+          scope: { projectId: $projectId }
+          filter: $filter
+          orderBy: $orderBy
+          limit: $limit
+          offset: $offset
+        ) {
+          count
+          edges {
+            node {
+              id
+              metadata {
+                name
+              }
+              ...ProjectSessionV2NodesFragment
+            }
+          }
+        }
+      }
+    `,
+    deferredQueryVariables,
+    {
+      fetchKey: deferredFetchKey,
+      fetchPolicy:
+        deferredFetchKey === INITIAL_FETCH_KEY
+          ? 'store-and-network'
+          : 'network-only',
+    },
+  );
+
+  const sessionNodes =
+    data.projectSessionsV2?.edges?.map((edge) => edge?.node) ?? [];
+  const total = data.projectSessionsV2?.count ?? 0;
+
+  const [commitTerminate, isTerminating] =
+    useMutation<ProjectAdminSessionsPageTerminateMutation>(graphql`
+      mutation ProjectAdminSessionsPageTerminateMutation(
+        $scope: ProjectSessionV2Scope!
+        $sessionIds: [ID!]!
+        $forced: Boolean!
+      ) {
+        terminateProjectSessionsV2(
+          scope: $scope
+          sessionIds: $sessionIds
+          forced: $forced
+        ) {
+          cancelled
+          terminating
+          forceTerminated
+          skipped
+        }
+      }
+    `);
+
+  const handleTerminate = (session: ProjectSessionV2InList) => {
+    modal.confirm({
+      title: t('session.TerminateSession'),
+      content: session.metadata?.name ?? '',
+      okText: t('button.Confirm'),
+      okButtonProps: { danger: true },
+      onOk: () =>
+        new Promise<void>((resolve) => {
+          commitTerminate({
+            variables: {
+              scope: { projectId },
+              sessionIds: [session.id],
+              forced: false,
+            },
+            onCompleted: () => {
+              message.success(t('session.SessionTerminated'));
+              updateFetchKey();
+              resolve();
+            },
+            onError: (error) => {
+              message.error(error.message);
+              resolve();
+            },
+          });
+        }),
+    });
+  };
+
+  const isLoading =
+    deferredQueryVariables !== queryVariables || deferredFetchKey !== fetchKey;
+
+  return (
+    <BAIFlex direction="column" align="stretch" gap="sm">
+      <BAIFlex direction="row" justify="between" wrap="wrap" gap="sm">
+        <BAIFlex gap="sm" align="start" wrap="wrap" style={{ flexShrink: 1 }}>
+          <BAIRadioGroup
+            optionType="button"
+            value={queryParams.statusCategory}
+            onChange={(e) => {
+              setQueryParams({ statusCategory: e.target.value });
+              setTablePaginationOption({ current: 1 });
+            }}
+            options={[
+              { label: t('session.Running'), value: 'running' },
+              { label: t('session.Finished'), value: 'finished' },
+            ]}
+          />
+          <BAIGraphQLPropertyFilter
+            filterProperties={[
+              {
+                key: 'id',
+                propertyLabel: 'ID',
+                type: 'uuid',
+              },
+              {
+                key: 'name',
+                propertyLabel: t('session.SessionName'),
+                type: 'string',
+              },
+              {
+                key: 'userUuid',
+                propertyLabel: t('session.launcher.OwnerEmail'),
+                type: 'uuid',
+              },
+              {
+                key: 'domainName',
+                propertyLabel: t('credential.Domain'),
+                type: 'string',
+              },
+            ]}
+            value={queryParams.filter ?? undefined}
+            onChange={(value) => {
+              setQueryParams({ filter: value ?? null });
+              setTablePaginationOption({ current: 1 });
+            }}
+          />
+        </BAIFlex>
+        <BAIFetchKeyButton
+          loading={isLoading || isTerminating}
+          value={fetchKey}
+          onChange={(next) => updateFetchKey(next)}
+          autoUpdateDelay={15_000}
+        />
+      </BAIFlex>
+      <ProjectSessionV2Nodes
+        sessionsFrgmt={sessionNodes}
+        loading={isLoading}
+        order={queryParams.order}
+        onChangeOrder={(order) => {
+          setQueryParams({ order });
+        }}
+        onClickSessionName={(session) => {
+          // SessionDetailDrawer currently consumes the v1 (ComputeSessionNode)
+          // fragment. We still navigate via sessionDetail search param here for
+          // parity; fully wiring the drawer to v2 sessions is out of scope
+          // for FR-2576.
+          const newSearchParams = new URLSearchParams(location.search);
+          newSearchParams.set('sessionDetail', session.id);
+          webUINavigate({
+            pathname: location.pathname,
+            hash: location.hash,
+            search: newSearchParams.toString(),
+          });
+        }}
+        onClickTerminate={handleTerminate}
+        pagination={{
+          current: tablePaginationOption.current,
+          pageSize: tablePaginationOption.pageSize,
+          total,
+          onChange: (current, pageSize) => {
+            setTablePaginationOption({ current, pageSize });
+          },
+        }}
+      />
+    </BAIFlex>
+  );
+};
+
+const ProjectAdminSessionsPage: React.FC = () => {
+  'use memo';
+  const { t } = useTranslation();
+  const currentProject = useCurrentProjectValue();
+
+  return (
+    <BAICard
+      variant="borderless"
+      title={t('webui.menu.ProjectSessions')}
+      styles={{
+        header: { borderBottom: 'none' },
+        body: { paddingTop: 0 },
+      }}
+    >
+      <BAIErrorBoundary>
+        <Suspense fallback={<Skeleton active />}>
+          {currentProject.id ? (
+            <ProjectAdminSessionsContent projectId={currentProject.id} />
+          ) : (
+            <Skeleton active />
+          )}
+        </Suspense>
+      </BAIErrorBoundary>
+    </BAICard>
+  );
+};
+
+export default ProjectAdminSessionsPage;

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -112,6 +112,9 @@ const AdminVFolderNodeListPage = React.lazy(
 const ProjectAdminUsersPage = React.lazy(
   () => import('./pages/ProjectAdminUsersPage'),
 );
+const ProjectAdminSessionsPage = React.lazy(
+  () => import('./pages/ProjectAdminSessionsPage'),
+);
 const EmailVerificationPage = React.lazy(
   () => import('./pages/EmailVerificationPage'),
 );
@@ -452,6 +455,18 @@ export const mainLayoutChildRoutes: RouteObject[] = [
       return (
         <Suspense fallback={<Skeleton active />}>
           <ProjectAdminUsersPage />
+        </Suspense>
+      );
+    },
+  },
+  {
+    path: '/project-admin-sessions',
+    handle: { labelKey: 'webui.menu.ProjectSessions' },
+    Component: () => {
+      useSuspendedBackendaiClient();
+      return (
+        <Suspense fallback={<Skeleton active />}>
+          <ProjectAdminSessionsPage />
         </Suspense>
       );
     },

--- a/react/src/routes.tsx
+++ b/react/src/routes.tsx
@@ -467,6 +467,7 @@ export const mainLayoutChildRoutes: RouteObject[] = [
       return (
         <Suspense fallback={<Skeleton active />}>
           <ProjectAdminSessionsPage />
+          <SessionDetailAndContainerLogOpenerLegacy />
         </Suspense>
       );
     },

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -3027,6 +3027,7 @@
       "ProfileUpdated": "Profile has been successfully updated.",
       "Project": "Project",
       "ProjectMembers": "Users",
+      "ProjectSessions": "Project Sessions",
       "Projects": "Projects",
       "RBACManagement": "RBAC Management",
       "Remaining": "Remaining",


### PR DESCRIPTION
Resolves #6695(FR-2576)

## Summary

Adds a new Project Admin Sessions page at `/project-admin-sessions` that lets project admins view and manage compute sessions within their current project, backed by the new `projectSessionsV2` GraphQL query and `terminateProjectSessionsV2` mutation.

- New page shell `react/src/pages/ProjectAdminSessionsPage.tsx` mirroring `ProjectAdminUsersPage` (BAICard + BAIErrorBoundary + Suspense + gated on `currentProject.id`).
- New table component `react/src/components/ProjectSessionV2Nodes.tsx` rendering a Relay plural fragment on `SessionV2`. Does not modify the existing v1 `SessionNodes`.
- Menu registration in `useWebUIMenuItems.tsx` under the `admin-operations` group with `BAISessionsIcon` and the `webui.menu.ProjectSessions` i18n label. Added to `VALID_MENU_KEYS`, `ALL_ADMIN_PAGE_KEYS`, and `PROJECT_ADMIN_PAGE_KEYS`.
- Lazy route in `routes.tsx` and English i18n key `webui.menu.ProjectSessions` added to `resources/i18n/en.json` (translations follow `/i18n`).
- Filtering: `BAIGraphQLPropertyFilter` with `id`, `name`, `userUuid`, `domainName` + a Running/Finished `BAIRadioGroup` that maps to `SessionV2Status` buckets.
- Sorting: `SessionV2OrderBy` with fields `CREATED_AT`, `TERMINATED_AT`, `STATUS`, `ID`, `NAME`. Default `CREATED_AT DESC`.
- Pagination/refresh: `useBAIPaginationOptionStateOnSearchParam` + `BAIFetchKeyButton` with 15s auto-refresh.
- Terminate action: `Modal.confirm` → `terminateProjectSessionsV2` with `{ scope: { projectId }, sessionIds: [id], forced: false }` → toast + fetch key bump. Disabled for `TERMINATED` / `TERMINATING` / `CANCELLED` sessions.
- Session name click navigates with the `sessionDetail` search param (v1 drawer compatibility caveat inline-commented — full v2 drawer wiring is out of scope).

## Column mapping

| Column | Source on `SessionV2` |
|---|---|
| Name (click → session detail) | `metadata.name` |
| Status | `lifecycle.status` |
| AI Accelerator | `resource.allocation.{used,requested}.entries` (non-cpu/mem) |
| CPU | `resource.allocation.{used,requested}.entries` (cpu) |
| Memory | `resource.allocation.{used,requested}.entries` (mem, formatted) |
| Elapsed Time | `lifecycle.createdAt` → `lifecycle.terminatedAt ?? now` |
| Environment | `images.edges[0].node.identity` |
| Resource Group | `resource.resourceGroupName` |
| Session Type | `metadata.sessionType` |
| Cluster Mode | `metadata.clusterMode` |
| Created At | `lifecycle.createdAt` |
| Owner (superadmin only) | `user.basicInfo.email` |

Default-visible: name, status, cpu, mem, accelerator, elapsedTime, owner (superadmin only). Default-hidden: environment, resourceGroup, sessionType, clusterMode, createdAt.

**Intentionally omitted**: `dependencies` and `agent_ids` columns — these fields do not exist on the v2 `SessionV2` schema.

## Verification

`bash scripts/verify.sh` output tail:

```
=== Relay ===
--- Relay: PASS ---
=== Lint ===
--- Lint: PASS ---
=== Format ===
--- Format: PASS ---
=== TypeScript ===
--- TypeScript: PASS ---
=== ALL PASS ===
```

## Checklist

- [x] Documentation — none required for internal admin page; label added to source locale only
- [ ] Minimum required manager version — depends on `projectSessionsV2` / `terminateProjectSessionsV2` availability
- [x] Specific setting for review — log in as a project admin, switch current project, open `/project-admin-sessions`
- [x] Minimum requirements to check during review — menu visibility for project admins, list scoped to current project, switching project refreshes list, terminate action works on a running session
- [ ] Test case(s) to demonstrate the difference of before/after


## Screenshots

_Skipped._ The running local dev server belongs to another worktree and the `projectSessionsV2` / `terminateProjectSessionsV2` APIs this page depends on may not be deployed to the shared test server yet. Capture manually after backend v2 support is available in the target environment.