### PR TITLE
refactor(FR-2494): improve auto-scaling rule list with URL state, sorting, filtering, and column settings

### DIFF
--- a/react/src/components/AutoScalingRuleEditorModal.tsx
+++ b/react/src/components/AutoScalingRuleEditorModal.tsx
@@ -26,6 +26,7 @@ import {
 } from 'antd';
 import {
   BAIButton,
+  BAIFlex,
   BAIModal,
   BAIModalProps,
   toLocalId,
@@ -257,6 +258,9 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
               node {
                 id
                 name
+                description
+                rank
+                categoryId
                 metricName
                 queryTemplate
                 timeWindow
@@ -299,6 +303,24 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
     () => presetNodes.find((p) => p.id === selectedPresetId),
     [presetNodes, selectedPresetId],
   );
+
+  type PresetOption = {
+    label: string;
+    value: string;
+    description?: string | null;
+  };
+
+  // TODO(needs-backend): group by categoryId with human-readable category names
+  // once the backend exposes a QueryDefinitionCategory type/query.
+  const presetOptions: PresetOption[] = _.orderBy(
+    presetNodes,
+    ['rank'],
+    ['asc'],
+  ).map((preset) => ({
+    label: preset.name,
+    value: preset.id,
+    description: preset.description,
+  }));
 
   const formRef = useRef<FormInstance<AutoScalingRuleFormValues>>(null);
 
@@ -635,10 +657,21 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
                   }
                 }}
                 placeholder={t('autoScalingRule.SelectPrometheusPreset')}
-                options={_.map(presetNodes, (preset) => ({
-                  label: preset.name,
-                  value: preset.id,
-                }))}
+                options={presetOptions}
+                optionRender={(option) => (
+                  <BAIFlex direction="column" align="start">
+                    {option.label}
+                    {option.data.description && (
+                      <Typography.Text
+                        type="secondary"
+                        style={{ fontSize: token.fontSizeSM }}
+                        ellipsis
+                      >
+                        {option.data.description}
+                      </Typography.Text>
+                    )}
+                  </BAIFlex>
+                )}
                 allowClear
                 onClear={() => setSelectedPresetId(undefined)}
               />

--- a/react/src/components/AutoScalingRuleList.tsx
+++ b/react/src/components/AutoScalingRuleList.tsx
@@ -3,43 +3,49 @@
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
 import { AutoScalingRuleListDeleteMutation } from '../__generated__/AutoScalingRuleListDeleteMutation.graphql';
+import {
+  AutoScalingRuleListNodesFragment$data,
+  AutoScalingRuleListNodesFragment$key,
+} from '../__generated__/AutoScalingRuleListNodesFragment.graphql';
 import { AutoScalingRuleListPresetsQuery } from '../__generated__/AutoScalingRuleListPresetsQuery.graphql';
 import { AutoScalingRuleListQuery } from '../__generated__/AutoScalingRuleListQuery.graphql';
-import { useBAIPaginationOptionState } from '../hooks/reactPaginationQueryOptions';
+import { useBAIPaginationOptionStateOnSearchParam } from '../hooks/reactPaginationQueryOptions';
+import { useBAISettingUserState } from '../hooks/useBAISetting';
 import AutoScalingRuleEditorModal from './AutoScalingRuleEditorModal';
 import {
   DeleteOutlined,
   PlusOutlined,
   SettingOutlined,
 } from '@ant-design/icons';
-import { App, Button, Card, Tag, Tooltip, Typography } from 'antd';
+import { App, Button, Card, Tag, Tooltip, Typography, theme } from 'antd';
 import {
   BAIFlex,
+  BAIGraphQLPropertyFilter,
   BAINameActionCell,
   BAITable,
+  filterOutNullAndUndefined,
   toLocalId,
   useFetchKey,
 } from 'backend.ai-ui';
+import type { BAITableProps, GraphQLFilter } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
 import * as _ from 'lodash-es';
 import { CircleArrowDownIcon, CircleArrowUpIcon } from 'lucide-react';
-import React, { useState, useTransition } from 'react';
+import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
+import React, { useDeferredValue, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import { graphql, useLazyLoadQuery, useMutation } from 'react-relay';
+import {
+  graphql,
+  useFragment,
+  useLazyLoadQuery,
+  useMutation,
+} from 'react-relay';
 
-interface AutoScalingRuleListProps {
-  deploymentId: string; // Relay global ID (e.g., toGlobalId('ModelDeployment', uuid))
-  isEndpointDestroying: boolean;
-  isOwnedByCurrentUser: boolean;
-}
+type DateTimeFilter = { before?: string | null; after?: string | null };
 
 type AutoScalingRuleNode = NonNullable<
-  NonNullable<
-    NonNullable<
-      NonNullable<AutoScalingRuleListQuery['response']>['deployment']
-    >['autoScalingRules']
-  >['edges']
->[number]['node'];
+  AutoScalingRuleListNodesFragment$data[number]
+>;
 
 /**
  * Renders the condition column with normalized `<` direction:
@@ -95,6 +101,227 @@ const renderCondition = (
   return '-';
 };
 
+type AutoScalingRuleFilterInput = {
+  createdAt?: DateTimeFilter | null;
+  lastTriggeredAt?: DateTimeFilter | null;
+  AND?: AutoScalingRuleFilterInput[];
+  OR?: AutoScalingRuleFilterInput[];
+  NOT?: AutoScalingRuleFilterInput[];
+};
+
+/** Maps BAIGraphQLPropertyFilter output → AutoScalingRuleFilter, preserving AND/OR/NOT. */
+const toAutoScalingRuleFilter = (
+  filter: GraphQLFilter,
+): AutoScalingRuleFilterInput => {
+  const result: AutoScalingRuleFilterInput = {};
+  if (filter.createdAt) result.createdAt = filter.createdAt as DateTimeFilter;
+  if (filter.lastTriggeredAt)
+    result.lastTriggeredAt = filter.lastTriggeredAt as DateTimeFilter;
+  if (Array.isArray(filter.AND))
+    result.AND = filter.AND.map(toAutoScalingRuleFilter);
+  if (Array.isArray(filter.OR))
+    result.OR = filter.OR.map(toAutoScalingRuleFilter);
+  if (Array.isArray(filter.NOT))
+    result.NOT = filter.NOT.map(toAutoScalingRuleFilter);
+  return result;
+};
+
+// --- Nodes component (fragment-based table rendering) ---
+
+interface AutoScalingRuleListNodesProps extends Omit<
+  BAITableProps<AutoScalingRuleNode>,
+  'dataSource' | 'columns'
+> {
+  autoScalingRulesFrgmt: AutoScalingRuleListNodesFragment$key;
+  presetMap: Map<string, string>;
+  isEndpointDestroying: boolean;
+  isOwnedByCurrentUser: boolean;
+  onEditRule: (id: string) => void;
+  onDeleteRule: (id: string) => void;
+}
+
+const AutoScalingRuleListNodes: React.FC<AutoScalingRuleListNodesProps> = ({
+  autoScalingRulesFrgmt,
+  presetMap,
+  isEndpointDestroying,
+  isOwnedByCurrentUser,
+  onEditRule,
+  onDeleteRule,
+  ...tableProps
+}) => {
+  'use memo';
+  const { t } = useTranslation();
+
+  const autoScalingRules = filterOutNullAndUndefined(
+    useFragment(
+      graphql`
+        fragment AutoScalingRuleListNodesFragment on AutoScalingRule
+        @relay(plural: true) {
+          id @required(action: NONE)
+          metricSource
+          metricName
+          minThreshold
+          maxThreshold
+          stepSize
+          timeWindow
+          minReplicas
+          maxReplicas
+          prometheusQueryPresetId
+          createdAt
+          lastTriggeredAt
+          ...AutoScalingRuleEditorModalFragment
+        }
+      `,
+      autoScalingRulesFrgmt,
+    ),
+  );
+
+  return (
+    <BAITable<AutoScalingRuleNode>
+      scroll={{ x: 'max-content' }}
+      rowKey="id"
+      columns={[
+        {
+          key: 'metricSource',
+          title: t('autoScalingRule.MetricSource'),
+          dataIndex: 'metricSource',
+          fixed: 'left',
+        },
+        {
+          key: 'condition',
+          title: t('autoScalingRule.Condition'),
+          fixed: 'left',
+          render: (_text, row) => {
+            if (!row) return '-';
+            return (
+              <BAINameActionCell
+                title={renderCondition(row, t)}
+                showActions="always"
+                actions={[
+                  {
+                    key: 'edit',
+                    title: t('button.Edit'),
+                    icon: <SettingOutlined />,
+                    disabled: isEndpointDestroying || !isOwnedByCurrentUser,
+                    onClick: () => onEditRule(row.id),
+                  },
+                  {
+                    key: 'delete',
+                    title: t('button.Delete'),
+                    icon: <DeleteOutlined />,
+                    type: 'danger',
+                    disabled: isEndpointDestroying || !isOwnedByCurrentUser,
+                    onClick: () => onDeleteRule(row.id),
+                  },
+                ]}
+              />
+            );
+          },
+        },
+        {
+          key: 'prometheusPreset',
+          title: t('autoScalingRule.PrometheusPreset'),
+          render: (_text, row) => {
+            if (
+              row?.metricSource !== 'PROMETHEUS' ||
+              !row?.prometheusQueryPresetId
+            ) {
+              return '-';
+            }
+            return (
+              presetMap.get(row.prometheusQueryPresetId) ||
+              row.prometheusQueryPresetId
+            );
+          },
+        },
+        {
+          key: 'timeWindow',
+          title: t('autoScalingRule.TimeWindow'),
+          dataIndex: 'timeWindow',
+          render: (value: number) =>
+            value != null
+              ? t('autoScalingRule.TimeWindowSeconds', { value })
+              : '-',
+        },
+        {
+          key: 'stepSize',
+          title: t('autoScalingRule.StepSize'),
+          dataIndex: 'stepSize',
+          render: (_text, row) => {
+            if (row?.stepSize) {
+              return (
+                <BAIFlex gap={'xs'}>
+                  <Typography.Text>
+                    {row.stepSize > 0 ? (
+                      <CircleArrowUpIcon />
+                    ) : (
+                      <CircleArrowDownIcon />
+                    )}
+                  </Typography.Text>
+                  <Typography.Text>{Math.abs(row.stepSize)}</Typography.Text>
+                </BAIFlex>
+              );
+            } else {
+              return '-';
+            }
+          },
+        },
+        {
+          key: 'minMaxReplicas',
+          title: t('autoScalingRule.MIN/MAXReplicas'),
+          render: (_text, row) => (
+            <span>
+              {row?.stepSize
+                ? row.stepSize > 0
+                  ? t('autoScalingRule.MaxReplicasValue', {
+                      value: row?.maxReplicas,
+                    })
+                  : t('autoScalingRule.MinReplicasValue', {
+                      value: row?.minReplicas,
+                    })
+                : '-'}
+            </span>
+          ),
+        },
+        {
+          key: 'createdAt',
+          title: t('autoScalingRule.CreatedAt'),
+          dataIndex: 'createdAt',
+          sorter: true,
+          sortDirections: ['descend', 'ascend'],
+          render: (_text, row) => (
+            <span>
+              {row?.createdAt ? dayjs(row.createdAt).format('ll LT') : '-'}
+            </span>
+          ),
+        },
+        {
+          key: 'lastTriggeredAt',
+          title: t('autoScalingRule.LastTriggered'),
+          render: (_text, row) => (
+            <span>
+              {row?.lastTriggeredAt
+                ? dayjs.utc(row.lastTriggeredAt).tz().format('ll LTS')
+                : '-'}
+            </span>
+          ),
+        },
+      ]}
+      showSorterTooltip={false}
+      dataSource={autoScalingRules}
+      {...tableProps}
+    />
+  );
+};
+
+// --- List orchestrator component ---
+
+interface AutoScalingRuleListProps {
+  deploymentId: string; // Relay global ID (e.g., toGlobalId('ModelDeployment', uuid))
+  isEndpointDestroying: boolean;
+  isOwnedByCurrentUser: boolean;
+}
+
 const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
   deploymentId,
   isEndpointDestroying,
@@ -102,18 +329,58 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
 }) => {
   'use memo';
   const { t } = useTranslation();
+  const { token } = theme.useToken();
   const { message, modal } = App.useApp();
-  const [_isPendingRefetch, startRefetchTransition] = useTransition();
+  const [isPendingRefetch, startRefetchTransition] = useTransition();
   const [fetchKey, updateFetchKey] = useFetchKey();
 
   const [editingRuleId, setEditingRuleId] = useState<string | null>(null);
   const [isOpenEditorModal, setIsOpenEditorModal] = useState(false);
 
+  const [columnOverrides, setColumnOverrides] = useBAISettingUserState(
+    'table_column_overrides.AutoScalingRuleList',
+  );
+
+  // BAITable order string: "createdAt" (ASC) | "-createdAt" (DESC)
+  const [queryParams, setQueryParams] = useQueryStates(
+    {
+      order: parseAsStringLiteral([
+        'createdAt',
+        '-createdAt',
+      ] as const).withDefault('-createdAt'),
+      filter: parseAsJson<GraphQLFilter>((value) => value as GraphQLFilter),
+    },
+    { history: 'replace' },
+  );
+
+  const orderString = queryParams.order;
+  const graphQLFilter = queryParams.filter ?? undefined;
+
   const {
     baiPaginationOption,
     tablePaginationOption,
     setTablePaginationOption,
-  } = useBAIPaginationOptionState({ current: 1, pageSize: 10 });
+  } = useBAIPaginationOptionStateOnSearchParam({ current: 1, pageSize: 10 });
+
+  const filterInput = graphQLFilter
+    ? toAutoScalingRuleFilter(graphQLFilter)
+    : null;
+
+  const queryVariables = {
+    deploymentId,
+    offset: baiPaginationOption.offset,
+    limit: baiPaginationOption.limit,
+    orderBy: [
+      {
+        field: 'CREATED_AT' as const,
+        direction: (orderString.startsWith('-') ? 'DESC' : 'ASC') as
+          | 'ASC'
+          | 'DESC',
+      },
+    ],
+    filter: filterInput,
+  };
+  const deferredQueryVariables = useDeferredValue(queryVariables);
 
   const data = useLazyLoadQuery<AutoScalingRuleListQuery>(
     graphql`
@@ -121,24 +388,21 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
         $deploymentId: ID!
         $offset: Int
         $limit: Int
+        $orderBy: [AutoScalingRuleOrderBy!]
+        $filter: AutoScalingRuleFilter
       ) {
         deployment(id: $deploymentId) {
-          autoScalingRules(offset: $offset, limit: $limit) {
+          autoScalingRules(
+            offset: $offset
+            limit: $limit
+            orderBy: $orderBy
+            filter: $filter
+          ) {
             count
             edges {
               node {
                 id
-                metricSource
-                metricName
-                minThreshold
-                maxThreshold
-                stepSize
-                timeWindow
-                minReplicas
-                maxReplicas
-                prometheusQueryPresetId
-                createdAt
-                lastTriggeredAt
+                ...AutoScalingRuleListNodesFragment
                 ...AutoScalingRuleEditorModalFragment
               }
             }
@@ -146,11 +410,7 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
         }
       }
     `,
-    {
-      deploymentId,
-      offset: baiPaginationOption.offset,
-      limit: baiPaginationOption.limit,
-    },
+    deferredQueryVariables,
     {
       fetchPolicy: 'store-and-network',
       fetchKey,
@@ -174,7 +434,7 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
       {},
     );
 
-  const presetMap = React.useMemo(() => {
+  const presetMap = (() => {
     const map = new Map<string, string>();
     if (prometheusQueryPresets?.edges) {
       for (const edge of prometheusQueryPresets.edges) {
@@ -184,17 +444,16 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
       }
     }
     return map;
-  }, [prometheusQueryPresets]);
+  })();
 
-  const autoScalingRules = React.useMemo(
-    () => _.map(data?.deployment?.autoScalingRules?.edges, (edge) => edge.node),
-    [data?.deployment?.autoScalingRules?.edges],
+  const autoScalingRuleNodes = filterOutNullAndUndefined(
+    _.map(data?.deployment?.autoScalingRules?.edges, 'node'),
   );
 
   const totalCount = data?.deployment?.autoScalingRules?.count ?? 0;
 
-  const [commitDeleteMutation, isInFlightDeleteMutation] =
-    useMutation<AutoScalingRuleListDeleteMutation>(graphql`
+  const [commitDeleteMutation] = useMutation<AutoScalingRuleListDeleteMutation>(
+    graphql`
       mutation AutoScalingRuleListDeleteMutation(
         $input: DeleteAutoScalingRuleInput!
       ) {
@@ -202,11 +461,42 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
           id
         }
       }
-    `);
+    `,
+  );
 
   const handleRefetch = () => {
     startRefetchTransition(() => {
       updateFetchKey();
+    });
+  };
+
+  const handleDeleteRule = (ruleId: string) => {
+    modal.confirm({
+      title: t('dialog.warning.CannotBeUndone'),
+      okText: t('button.Delete'),
+      okButtonProps: { danger: true },
+      onOk: () => {
+        commitDeleteMutation({
+          variables: { input: { id: toLocalId(ruleId) } },
+          onCompleted: (_res, errors) => {
+            if (errors && errors.length > 0) {
+              for (const error of errors) {
+                message.error(error.message || t('dialog.ErrorOccurred'));
+              }
+            } else {
+              setEditingRuleId(null);
+              handleRefetch();
+              message.success({
+                key: 'autoscaling-rule-deleted',
+                content: t('autoScalingRule.SuccessfullyDeleted'),
+              });
+            }
+          },
+          onError: (error) => {
+            message.error(error?.message || t('dialog.ErrorOccurred'));
+          },
+        });
+      },
     });
   };
 
@@ -228,169 +518,50 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
           </Button>
         }
       >
-        <BAITable<AutoScalingRuleNode>
-          scroll={{ x: 'max-content' }}
-          rowKey={'id'}
-          columns={[
+        <BAIGraphQLPropertyFilter
+          style={{ marginBottom: token.marginMD }}
+          filterProperties={[
             {
-              title: t('autoScalingRule.MetricSource'),
-              dataIndex: 'metricSource',
-              fixed: 'left',
+              key: 'createdAt',
+              propertyLabel: t('autoScalingRule.CreatedAt'),
+              type: 'datetime',
+              operators: ['after', 'before'],
+              defaultOperator: 'after',
             },
             {
-              title: t('autoScalingRule.Condition'),
-              fixed: 'left',
-              render: (_text, row) => {
-                if (!row) return '-';
-                return (
-                  <BAINameActionCell
-                    title={renderCondition(row, t)}
-                    showActions="always"
-                    actions={[
-                      {
-                        key: 'edit',
-                        title: t('button.Edit'),
-                        icon: <SettingOutlined />,
-                        disabled: isEndpointDestroying || !isOwnedByCurrentUser,
-                        onClick: () => {
-                          setEditingRuleId(row.id);
-                          setIsOpenEditorModal(true);
-                        },
-                      },
-                      {
-                        key: 'delete',
-                        title: t('button.Delete'),
-                        icon: <DeleteOutlined />,
-                        type: 'danger',
-                        disabled:
-                          isInFlightDeleteMutation ||
-                          isEndpointDestroying ||
-                          !isOwnedByCurrentUser,
-                        onClick: () => {
-                          modal.confirm({
-                            title: t('dialog.warning.CannotBeUndone'),
-                            okText: t('button.Delete'),
-                            okButtonProps: { danger: true },
-                            onOk: () => {
-                              commitDeleteMutation({
-                                variables: { input: { id: toLocalId(row.id) } },
-                                onCompleted: (_res, errors) => {
-                                  if (errors && errors.length > 0) {
-                                    for (const error of errors) {
-                                      message.error(
-                                        error.message ||
-                                          t('dialog.ErrorOccurred'),
-                                      );
-                                    }
-                                  } else {
-                                    setEditingRuleId(null);
-                                    handleRefetch();
-                                    message.success({
-                                      key: 'autoscaling-rule-deleted',
-                                      content: t(
-                                        'autoScalingRule.SuccessfullyDeleted',
-                                      ),
-                                    });
-                                  }
-                                },
-                                onError: (error) => {
-                                  message.error(
-                                    error?.message || t('dialog.ErrorOccurred'),
-                                  );
-                                },
-                              });
-                            },
-                          });
-                        },
-                      },
-                    ]}
-                  />
-                );
-              },
-            },
-            {
-              title: t('autoScalingRule.PrometheusPreset'),
-              render: (_text, row) => {
-                if (
-                  row?.metricSource !== 'PROMETHEUS' ||
-                  !row?.prometheusQueryPresetId
-                ) {
-                  return '-';
-                }
-                return (
-                  presetMap.get(row.prometheusQueryPresetId) ||
-                  row.prometheusQueryPresetId
-                );
-              },
-            },
-            {
-              title: t('autoScalingRule.TimeWindow'),
-              dataIndex: 'timeWindow',
-              render: (value: number) =>
-                value != null
-                  ? t('autoScalingRule.TimeWindowSeconds', { value })
-                  : '-',
-            },
-            {
-              title: t('autoScalingRule.StepSize'),
-              dataIndex: 'stepSize',
-              render: (_text, row) => {
-                if (row?.stepSize) {
-                  return (
-                    <BAIFlex gap={'xs'}>
-                      <Typography.Text>
-                        {row.stepSize > 0 ? (
-                          <CircleArrowUpIcon />
-                        ) : (
-                          <CircleArrowDownIcon />
-                        )}
-                      </Typography.Text>
-                      <Typography.Text>
-                        {Math.abs(row.stepSize)}
-                      </Typography.Text>
-                    </BAIFlex>
-                  );
-                } else {
-                  return '-';
-                }
-              },
-            },
-            {
-              title: t('autoScalingRule.MIN/MAXReplicas'),
-              render: (_text, row) => (
-                <span>
-                  {row?.stepSize
-                    ? row.stepSize > 0
-                      ? t('autoScalingRule.MaxReplicasValue', {
-                          value: row?.maxReplicas,
-                        })
-                      : t('autoScalingRule.MinReplicasValue', {
-                          value: row?.minReplicas,
-                        })
-                    : '-'}
-                </span>
-              ),
-            },
-            {
-              title: t('autoScalingRule.CreatedAt'),
-              dataIndex: 'createdAt',
-              render: (_text, row) => (
-                <span>
-                  {row?.createdAt ? dayjs(row.createdAt).format('ll LT') : '-'}
-                </span>
-              ),
-            },
-            {
-              title: t('autoScalingRule.LastTriggered'),
-              render: (_text, row) => (
-                <span>
-                  {row?.lastTriggeredAt
-                    ? dayjs.utc(row.lastTriggeredAt).tz().format('ll LTS')
-                    : '-'}
-                </span>
-              ),
+              key: 'lastTriggeredAt',
+              propertyLabel: t('autoScalingRule.LastTriggered'),
+              type: 'datetime',
+              operators: ['after', 'before'],
+              defaultOperator: 'after',
             },
           ]}
+          value={graphQLFilter}
+          onChange={(filter) => {
+            startRefetchTransition(() => {
+              setQueryParams({ filter: filter ?? null });
+              setTablePaginationOption({ current: 1 });
+            });
+          }}
+        />
+        <AutoScalingRuleListNodes
+          autoScalingRulesFrgmt={autoScalingRuleNodes}
+          presetMap={presetMap}
+          order={orderString}
+          loading={
+            isPendingRefetch || deferredQueryVariables !== queryVariables
+          }
+          tableSettings={{
+            columnOverrides: columnOverrides,
+            onColumnOverridesChange: setColumnOverrides,
+          }}
+          onChangeOrder={(order) => {
+            startRefetchTransition(() => {
+              setQueryParams({
+                order: order ? (order as 'createdAt' | '-createdAt') : null,
+              });
+            });
+          }}
           pagination={{
             pageSize: tablePaginationOption.pageSize,
             current: tablePaginationOption.current,
@@ -399,8 +570,13 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
               setTablePaginationOption({ current, pageSize });
             },
           }}
-          showSorterTooltip={false}
-          dataSource={autoScalingRules}
+          isEndpointDestroying={isEndpointDestroying}
+          isOwnedByCurrentUser={isOwnedByCurrentUser}
+          onEditRule={(id) => {
+            setEditingRuleId(id);
+            setIsOpenEditorModal(true);
+          }}
+          onDeleteRule={handleDeleteRule}
         />
       </Card>
       <AutoScalingRuleEditorModal
@@ -409,7 +585,7 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
         modelDeploymentId={toLocalId(deploymentId)}
         autoScalingRuleFrgmt={
           editingRuleId
-            ? (autoScalingRules.find((r) => r.id === editingRuleId) ?? null)
+            ? (autoScalingRuleNodes.find((r) => r.id === editingRuleId) ?? null)
             : null
         }
         onRequestClose={(success) => {


### PR DESCRIPTION
Resolves #6703 ([FR-2494](https://lablup.atlassian.net/browse/FR-2494))

## Summary

- Add `description`, `rank`, `categoryId` fields to Prometheus preset query with `optionRender` showing description below preset name
- Persist filter, sort order, and pagination in URL via `nuqs` (`parseAsStringLiteral`, `parseAsJson`, `useBAIPaginationOptionStateOnSearchParam`)
- Use `useDeferredValue` for query variables to prevent Suspense flash on URL state changes
- Add `BAIGraphQLPropertyFilter` with `createdAt`/`lastTriggeredAt` datetime filters (`defaultOperator: after`)
- Fix sort toggle (change `sortDirections` to `[descend, ascend]`, toggle on null cancel)
- Add `tableSettings` with `useBAISettingUserState` for column visibility controls
- Add unique `key` props to all BAITable columns for proper column override identification
- Replace hardcoded `marginBottom: 16` with `token.marginMD`
- Remove stale `TODO(needs-backend)` comments for resolved BA-5719
- Remove unused i18n keys (`CreatedAtBefore`, `LastTriggeredBefore`)

[FR-2494]: https://lablup.atlassian.net/browse/FR-2494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ