### PR TITLE
feat(FR-2581): add model service UI fixes spec

### DIFF
--- a/.specs/FR-2581-model-service-ui-fixes/spec.md
+++ b/.specs/FR-2581-model-service-ui-fixes/spec.md
@@ -1,0 +1,89 @@
+# 모델 서비스 UI 운영 개선
+
+## 개요
+
+모델 서비스 운영 중 발견된 UI 이슈들을 수정한다. Custom 런타임 편집 모드에서 model definition 필드 전체가 누락되는 문제, runtime variant 정보 미표시 문제, health check initial delay 기본값이 너무 짧은 문제를 해결한다.
+
+## 문제 정의
+
+1. **Custom 런타임 편집 시 model definition 필드 전체 누락**: 모델 서비스 생성 시에만 model definition 관련 필드들(startCommand, port, healthCheck, initialDelay, maxRetries 등)이 표시되고, 기존 모델 서비스 편집(수정) 시에는 `modelMountDestination`(disabled)과 `modelDefinitionPath`만 표시된다. initial delay는 처음부터 정확한 값을 알 수 없고 트라이/실패를 반복하며 찾아야 하는 값이므로 편집 화면에서도 반드시 노출되어야 한다.
+
+2. **Runtime variant 미표시**: 특정 모델 서비스가 어떤 runtime variant(vLLM, SGLang, Custom 등)를 사용하는지 서비스 목록(EndpointList)과 상세 페이지(EndpointDetailPage) 어디에도 표시되어 있지 않다.
+
+3. **Initial delay 기본값 부적절**: health check initial delay의 기본값이 5초로 설정되어 있으나, 대형 모델(70B+) 로딩에 1~3분이 소요되므로 너무 짧다. 서버 프로세스가 아직 준비되지 않은 상태에서 health check가 시작되어 ROUTE_TERMINATION으로 세션이 종료되고 반복적으로 재시작되는 문제가 발생한다.
+
+## 현재 상태 (As-Is)
+
+### Custom 런타임 편집 모드
+- 파일: `react/src/components/ServiceLauncherPageContent.tsx`
+- 편집 모드(`endpoint` 존재 시)에서는 `modelMountDestination`(disabled)과 `modelDefinitionPath`만 표시
+- 생성 모드에서만 Segmented UI(Enter Command / Use Config File)를 통해 startCommand, port, healthCheck, initialDelay, maxRetries 등 전체 model definition 필드를 제공
+
+### Initial Delay 기본값
+- 현재 기본값: **5.0초**
+- 설정 위치:
+  - `react/src/components/ServiceLauncherPageContent.tsx` (line 1172): `commandInitialDelay: 5.0`
+  - `react/src/helper/generateModelDefinitionYaml.ts` (line 81): `initial_delay: ${input.initialDelay ?? 5.0}`
+- Initial delay는 Backend.AI 자체 health check 시작 전 대기 시간으로, 컨테이너 안에서 모델이 로드되어 serving을 시작할 때까지 기다리는 시간이다. vLLM/SGLang 공식 문서의 설정값이 아닌 Backend.AI 고유 설정이다.
+
+### Runtime Variant 표시 현황
+- **EndpointDetailPage**: GraphQL 쿼리에 `runtime_variant { human_readable_name }`이 포함되어 있으나 (line 242), UI에 렌더링하는 코드가 없음
+- **EndpointList**: runtime_variant 필드가 GraphQL fragment에 포함되어 있지 않아 표시 불가
+
+## 요구사항
+
+### 필수 (Must Have)
+
+#### 1. Custom 런타임 편집 모드 - Model Definition 편집
+- [ ] Custom 런타임의 편집(수정) 모드에서 model definition 관련 필드 전체를 수정할 수 있는 UI 제공
+- [ ] 생성 모드와 동일한 필드 구성: startCommand, port, healthCheck path, initialDelay, maxRetries 등
+- [ ] 기존 서비스의 model definition 값을 편집 폼에 올바르게 로드 (vfolder의 model-definition.yaml을 읽어 command 필드로 역매핑)
+
+#### 2. Runtime Variant 표시
+- [ ] 서비스 목록(EndpointList)에 runtime variant 정보 표시
+- [ ] 서비스 상세 페이지(EndpointDetailPage)에 runtime variant 정보 표시
+- [ ] EndpointList의 GraphQL fragment에 `runtime_variant` 필드 추가
+- [ ] `human_readable_name`으로 사람이 읽을 수 있는 이름 표시
+
+#### 3. Initial Delay 기본값 변경
+- [ ] health check initial delay 기본값을 **5초에서 60초로 변경**
+- [ ] `ServiceLauncherPageContent.tsx`의 초기값 변경: `commandInitialDelay: 5.0` → `60` (line 1172)
+- [ ] `ServiceLauncherPageContent.tsx`의 fallback값 변경: `values.commandInitialDelay ?? 5.0` → `?? 60` (line 558)
+- [ ] `generateModelDefinitionYaml.ts`의 fallback값 변경: `input.initialDelay ?? 5.0` → `input.initialDelay ?? 60` (line 81)
+
+## 인수 조건
+
+### Model Definition 편집
+- [ ] Custom 런타임의 편집 모드에서 model definition 필드 전체가 표시된다
+- [ ] 기존 서비스의 설정값이 편집 폼에 올바르게 채워진다
+- [ ] 편집 후 저장 시 변경된 model definition이 반영된다
+- [ ] vLLM/SGLang 런타임의 편집 모드는 기존 동작을 유지한다
+
+### Runtime Variant 표시
+- [ ] EndpointList에서 각 서비스의 runtime variant가 표시된다
+- [ ] EndpointDetailPage에서 runtime variant가 표시된다
+- [ ] runtime variant가 `human_readable_name`으로 표시된다
+
+### Initial Delay
+- [ ] 서비스 생성 시 initial delay 입력 필드의 기본값이 60이다
+- [ ] model-definition.yaml 생성 시 initial_delay 미지정 시 fallback이 60이다
+- [ ] 기존 서비스 편집 시에는 해당 서비스에 설정된 initial delay 값이 올바르게 표시된다 (요구사항 1의 model definition 편집 UI에 의존)
+
+## 범위 밖 (Out of Scope)
+
+- vLLM/SGLang 런타임의 model definition 편집 모드 개선 (custom 런타임만 해당)
+- Runtime variant 기반 필터링이나 정렬 기능
+- LLM Playground TPS 표시 개선 (FR-2582에서 별도 처리)
+- 런타임 파라미터 재분류 및 CLI 플래그 수정 (FR-2547에서 처리)
+
+## 관련 파일
+
+- `react/src/components/ServiceLauncherPageContent.tsx` - 런타임 선택 UI, model definition 편집, initial delay 기본값
+- `react/src/helper/generateModelDefinitionYaml.ts` - model-definition.yaml 생성, initial delay fallback
+- `react/src/components/EndpointList.tsx` - 서비스 목록 (runtime variant 표시 추가 필요)
+- `react/src/pages/EndpointDetailPage.tsx` - 서비스 상세 페이지 (runtime variant 표시 추가 필요)
+
+## 관련 이슈
+
+- FR-2581: 모델 서비스 수정 시 model definition 필드 누락
+- FR-2547: 런타임 UI 개선 (상위 스펙, `.specs/runtime-ui-improvement/spec.md`)

--- a/.specs/runtime-ui-improvement/.context/findings.md
+++ b/.specs/runtime-ui-improvement/.context/findings.md
@@ -1,0 +1,11 @@
+# Runtime UI Improvement Findings
+
+## Decisions
+| Date | Decision | Rationale | Issue |
+|------|----------|-----------|-------|
+
+## Discoveries
+
+## Issues Encountered
+| Date | Problem | Root Cause | Resolution | Issue |
+|------|---------|-----------|------------|-------|

--- a/.specs/runtime-ui-improvement/.context/progress.md
+++ b/.specs/runtime-ui-improvement/.context/progress.md
@@ -1,0 +1,20 @@
+# Runtime UI Improvement Progress
+
+## Last Session: 2026-04-15 00:00
+
+### 1. Current Phase
+Planning complete. Ready for Wave 1 implementation.
+
+### 2. Next Action
+Run /batch-implement .specs/runtime-ui-improvement/dev-plan.md to start Wave 1.
+
+### 3. Current Goal
+Begin implementation of runtime UI improvement — change default runtime, replace hardcoded parameters with API-driven dynamic rendering.
+
+### 4. Lessons Learned
+(none yet)
+
+### 5. Completed Work
+- Spec created: .specs/runtime-ui-improvement/spec.md
+- Dev plan created: .specs/runtime-ui-improvement/dev-plan.md
+- 3 GitHub issues created with dependency links (#6709, #6710, #6711)

--- a/.specs/runtime-ui-improvement/.context/tasks.md
+++ b/.specs/runtime-ui-improvement/.context/tasks.md
@@ -1,0 +1,15 @@
+# Runtime UI Improvement Tasks
+
+> Last synced: 2026-04-15 00:00
+> Source: GitHub Issues
+
+## Progress: 0/3 complete
+
+### Wave 1
+- [ ] #6709: Change default runtime variant from vllm to custom — created
+
+### Wave 2
+- [ ] #6710: Add RuntimeVariantPresets GraphQL query and refactor parameter schema hook — blocked by #6709
+
+### Wave 3
+- [ ] #6711: Refactor service launcher serialization to use API targetSpec and remove hardcoded fallbacks — blocked by #6710

--- a/.specs/runtime-ui-improvement/dev-plan.md
+++ b/.specs/runtime-ui-improvement/dev-plan.md
@@ -1,0 +1,56 @@
+# Runtime UI Improvement Dev Plan
+
+## Spec Reference
+`.specs/runtime-ui-improvement/spec.md`
+
+## Jira Epic: [FR-2547](https://lablup.atlassian.net/browse/FR-2547)
+
+## Sub-tasks (Implementation Order)
+
+### 1. Change default runtime variant from vllm to custom — [#6709](https://github.com/lablup/backend.ai-webui/issues/6709)
+- **Changed files**: `react/src/components/ServiceLauncherPageContent.tsx`, `react/src/hooks/useModelServiceLauncher.ts`, `react/src/components/LegacyModelTryContentButton.tsx`
+- **Dependencies**: None
+- **Review complexity**: Low
+- **Description**: Replace hardcoded `runtimeVariant: 'vllm'` with `runtimeVariant: 'custom'` in all three default value locations. Consider extracting to a shared constant. Simple string replacement with no logic changes.
+
+### 2. Add RuntimeVariantPresets GraphQL query and refactor parameter schema hook — [#6710](https://github.com/lablup/backend.ai-webui/issues/6710)
+- **Changed files**: `react/src/hooks/useRuntimeParameterSchema.ts`, `react/src/components/RuntimeParameterFormSection.tsx`, `react/src/hooks/useVariantConfigs.ts`, new Relay query file(s)
+- **Dependencies**: Sub-task 1 (#6709 blocks #6710)
+- **Review complexity**: High
+- **Description**: Create Relay query for `runtimeVariantPresets` API with full field selection (targetSpec, uiOption, category, rank, displayName). Rewrite `useRuntimeParameterSchema` to fetch from API instead of hardcoded `RUNTIME_PARAMETER_FALLBACKS`. Need to resolve `runtimeVariantId` UUID from variant name (query `runtimeVariants` or use the variant's `rowId`). Update `RuntimeParameterFormSection` to render dynamic categories from API (backend provides 9 categories like `model_loading`, `resource_memory`, etc.) instead of hardcoded `sampling`/`context`/`advanced`. Update `ParameterControl` to use `uiOption` config (slider min/max/step from `uiOption.slider`, select options from `uiOption.choices`). Add error handling for API failures.
+
+### 3. Refactor service launcher serialization to use API targetSpec and remove hardcoded fallbacks — [#6711](https://github.com/lablup/backend.ai-webui/issues/6711)
+- **Changed files**: `react/src/components/ServiceLauncherPageContent.tsx` (6 call sites), `react/src/helper/runtimeExtraArgsParser.ts`, `react/src/helper/runtimeExtraArgsParser.test.ts`, `react/src/hooks/useVariantConfigs.test.ts`, **delete** `react/src/constants/runtimeParameterFallbacks.ts`
+- **Dependencies**: Sub-task 2 (#6710 blocks #6711)
+- **Review complexity**: High
+- **Description**: Refactor the 6 serialization call sites in `ServiceLauncherPageContent.tsx` that use `getExtraArgsEnvVar`/`getAllExtraArgsEnvVars`/`RUNTIME_PARAMETER_FALLBACKS` to use the API's `targetSpec.presetTarget` for ENV vs ARGS determination. Parameters with `presetTarget=ENV` become individual env vars; parameters with `presetTarget=ARGS` are serialized into the runtime's EXTRA_ARGS. Replace hardcoded `EXTRA_ARGS_ENV_MAP` with dynamic derivation from API presets. Delete `runtimeParameterFallbacks.ts` entirely. Update tests.
+
+## PR Stack Strategy
+- Sequential: 1 -> 2 -> 3
+- Stack name: `feat/runtime-ui-improvement`
+
+## Dependency Graph
+```
+#6709 (default runtime) ──blocks──> #6710 (GraphQL + hook) ──blocks──> #6711 (serialization + cleanup)
+```
+
+## Key Implementation Notes
+
+### RuntimeVariantId Resolution
+The `runtimeVariantPresets` API filters by `runtimeVariantId` (UUID), but the frontend currently works with variant names (e.g., `'vllm'`, `'sglang'`). Need to either:
+- Query `runtimeVariants` to get name-to-UUID mapping, or
+- Use the `rowId` from the endpoint's `runtime_variant` in edit mode
+
+### ENV vs ARGS Serialization
+Backend presets define `targetSpec.presetTarget` as `ENV` or `ARGS`:
+- `ENV`: Set as individual environment variable using `targetSpec.key` as the var name
+- `ARGS`: Serialize into `{RUNTIME}_EXTRA_ARGS` env var as CLI flags using `targetSpec.key`
+
+### Category Mapping
+Backend provides categories like `model_loading`, `resource_memory`, `serving_performance` (9 total). Frontend currently uses `sampling`/`context`/`advanced` (3 total). The new implementation should render whatever categories the API returns, with `displayName` used as section headers.
+
+### Removed Parameters
+Per spec, these frontend-only parameters are removed (not in backend presets):
+- Seed (`--seed`) - debugging/reproducibility
+- Enforce Eager (`--enforce-eager`) - debugging only
+- 7 sampling parameters (temperature, top_p, etc.) - request-time params, not server-start params

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1413,9 +1413,6 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                           {({ getFieldValue }) =>
                             getFieldValue('runtimeVariant') === 'custom' &&
                             (endpoint ? (
-                              // TODO(FR-2440): Support "Enter Command" Segmented UI in edit mode.
-                              // - Read existing model-definition.yaml from vfolder and reverse-map to command fields
-                              // - Show overwrite confirmation modal only when user actually modifies the command
                               // Edit mode: keep existing UI (no Segmented)
                               <BAIFlex
                                 direction="row"


### PR DESCRIPTION
Resolves FR-2581

## Summary
- Add spec for model service UI operational fixes
- Custom runtime edit mode: expose full model definition fields
- Display runtime variant in endpoint list and detail page
- Change initial delay default from 5s to 60s
- Includes dev plan with 3 sub-tasks