### PR TITLE
feat(FR-2547): change default runtime variant from vllm to custom

### DIFF
--- a/react/src/components/LegacyModelTryContentButton.tsx
+++ b/react/src/components/LegacyModelTryContentButton.tsx
@@ -75,7 +75,7 @@ function createServiceInput(
   return {
     serviceName: `${modelName}-${generateRandomString(4)}`,
     replicas: 1,
-    runtimeVariant: 'vllm',
+    runtimeVariant: 'custom',
     cluster_size: 1,
     cluster_mode: 'single-node',
     openToPublic: true,
@@ -653,7 +653,7 @@ const LegacyModelTryContentButton: React.FC<
           mutationToCreateService.isPending
         }
         loading={mutationToClone.isPending || mutationToCreateService.isPending}
-        onClick={() => cloneOrCreateModelService('vllm')}
+        onClick={() => cloneOrCreateModelService('custom')}
         style={{
           width: 'auto',
           display:

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1165,7 +1165,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
       }
     : {
         replicas: 1,
-        runtimeVariant: 'vllm',
+        runtimeVariant: 'custom',
         commandModelMount: '/models',
         commandPort: 8000,
         commandHealthCheck: '/health',

--- a/react/src/hooks/useModelServiceLauncher.ts
+++ b/react/src/hooks/useModelServiceLauncher.ts
@@ -66,7 +66,7 @@ export function createServiceInput(
   return {
     serviceName: `${modelName}-${generateRandomString(4)}`,
     replicas: 1,
-    runtimeVariant: 'vllm',
+    runtimeVariant: 'custom',
     cluster_size: 1,
     cluster_mode: 'single-node',
     openToPublic: true,


### PR DESCRIPTION
Resolves #6709 (FR-2547)

## Summary
- Change default runtime variant from `vllm` to `custom` in all 3 default value locations
- `ServiceLauncherPageContent.tsx`, `useModelServiceLauncher.ts`, `LegacyModelTryContentButton.tsx`
- Custom runtime now shows metrics normally, making it the more universal default choice