### PR TITLE
feat(FR-2547): add RuntimeVariantPresets query and refactor parameter schema hook

### DIFF
--- a/react/src/components/RuntimeParameterFormSection.tsx
+++ b/react/src/components/RuntimeParameterFormSection.tsx
@@ -2,12 +2,9 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import {
-  RuntimeParameterDef,
-  RuntimeParameterCategory,
-} from '../constants/runtimeParameterFallbacks';
 import { reverseMapExtraArgs } from '../helper/runtimeExtraArgsParser';
 import {
+  RuntimeVariantPresetDef,
   RuntimeParameterGroup,
   useRuntimeParameterSchema,
   buildDefaultsMap,
@@ -19,17 +16,14 @@ import { BAICard, BAIFlex } from 'backend.ai-ui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-const CATEGORY_LABELS: Record<RuntimeParameterCategory, string> = {
-  sampling: 'modelService.RuntimeParamCategorySampling',
-  context: 'modelService.RuntimeParamCategoryContext',
-  advanced: 'modelService.RuntimeParamCategoryAdvanced',
-};
-
-const ALL_CATEGORIES: RuntimeParameterCategory[] = [
-  'sampling',
-  'context',
-  'advanced',
-];
+/** Convert category slug to a display-friendly label. */
+function formatCategoryLabel(category: string): string {
+  // Convert snake_case to Title Case (e.g., 'model_loading' → 'Model Loading')
+  return category
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
 
 export interface RuntimeParameterValues {
   [key: string]: string;
@@ -45,8 +39,8 @@ interface RuntimeParameterFormSectionProps {
 }
 
 /**
- * Dynamic form section for runtime parameters (vLLM/SGLang).
- * Renders slider/input/select/checkbox controls based on parameter schema.
+ * Dynamic form section for runtime parameters.
+ * Renders slider/input/select/checkbox controls based on API-provided preset schema.
  */
 const RuntimeParameterFormSection: React.FC<
   RuntimeParameterFormSectionProps
@@ -65,8 +59,7 @@ const RuntimeParameterFormSection: React.FC<
   // In edit mode, keys already present in the endpoint's env vars are pre-marked.
   const [touchedKeys, setTouchedKeys] = useState<Set<string>>(new Set());
 
-  const [activeTab, setActiveTab] =
-    useState<RuntimeParameterCategory>('sampling');
+  const [activeTab, setActiveTab] = useState<string>('');
 
   const setValues = useCallback(
     (newValues: RuntimeParameterValues) => {
@@ -120,19 +113,17 @@ const RuntimeParameterFormSection: React.FC<
 
   if (!groups) return null;
 
-  // Build tab list from available categories
-  const availableCategories = ALL_CATEGORIES.filter((cat) =>
-    groups.some((g) => g.category === cat),
-  );
+  // Build tab list from available categories (dynamically from API)
+  const availableCategories = groups.map((g) => g.category);
   const tabList = availableCategories.map((cat) => ({
     key: cat,
-    label: t(CATEGORY_LABELS[cat]),
+    label: formatCategoryLabel(cat),
   }));
 
   // Fall back to first available tab if current tab doesn't exist for this variant
   const effectiveActiveTab = availableCategories.includes(activeTab)
     ? activeTab
-    : (availableCategories[0] ?? 'sampling');
+    : (availableCategories[0] ?? '');
   const activeGroup = groups.find((g) => g.category === effectiveActiveTab);
 
   return (
@@ -141,7 +132,7 @@ const RuntimeParameterFormSection: React.FC<
         size="small"
         tabList={tabList}
         activeTabKey={effectiveActiveTab}
-        onTabChange={(key) => setActiveTab(key as RuntimeParameterCategory)}
+        onTabChange={(key) => setActiveTab(key)}
       >
         <Alert
           type="warning"
@@ -181,7 +172,7 @@ const ParameterGroupContent: React.FC<ParameterGroupContentProps> = ({
         <ParameterControl
           key={param.key}
           param={param}
-          value={values[param.key] ?? param.defaultValue}
+          value={values[param.key] ?? param.defaultValue ?? ''}
           touched={touchedKeys.has(param.key)}
           onChange={(val) => onParamChange(param.key, val)}
         />
@@ -191,7 +182,7 @@ const ParameterGroupContent: React.FC<ParameterGroupContentProps> = ({
 };
 
 interface ParameterControlProps {
-  param: RuntimeParameterDef;
+  param: RuntimeVariantPresetDef;
   value: string;
   touched: boolean;
   onChange: (value: string) => void;
@@ -207,16 +198,21 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
   const { t } = useTranslation();
   const { token } = theme.useToken();
 
-  const label = t(param.name);
-  const tooltip = t(param.description);
+  const label = param.displayName ?? param.name;
+  const tooltip = param.description ?? undefined;
   const formItemStyle = {
     marginBottom: token.marginXS,
   };
   const controlOpacity = touched ? undefined : 0.45;
   const controlTransition = 'opacity 0.2s';
 
-  switch (param.uiType) {
-    case 'slider':
+  const uiType = param.uiType;
+
+  switch (uiType) {
+    case 'slider': {
+      const min = param.slider?.min ?? 0;
+      const max = param.slider?.max ?? 100;
+      const step = param.slider?.step ?? 1;
       return (
         <Form.Item
           label={label}
@@ -225,31 +221,31 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
           required
         >
           <InputNumberWithSlider
-            min={param.min}
-            max={param.max}
-            step={param.step}
-            value={parseFloat(value)}
+            min={min}
+            max={max}
+            step={step}
+            value={value ? parseFloat(value) : min}
             onChange={(v) => onChange(String(v))}
             inputContainerMinWidth={190}
             style={{ opacity: controlOpacity, transition: controlTransition }}
             sliderProps={{
               marks: {
-                ...(param.min !== undefined ? { [param.min]: param.min } : {}),
-                ...(param.max !== undefined
-                  ? {
-                      [param.max]: {
-                        style: { color: token.colorTextSecondary },
-                        label: param.max,
-                      },
-                    }
-                  : {}),
+                [min]: min,
+                [max]: {
+                  style: { color: token.colorTextSecondary },
+                  label: max,
+                },
               },
             }}
           />
         </Form.Item>
       );
+    }
 
-    case 'number_input':
+    case 'number_input': {
+      const min = param.number?.min ?? undefined;
+      const max = param.number?.max ?? undefined;
+      const isInt = param.valueType === 'INT';
       return (
         <Form.Item
           label={label}
@@ -258,13 +254,15 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
           required
         >
           <InputNumber
-            min={param.min}
-            max={param.max}
-            step={param.step}
+            min={min}
+            max={max}
+            step={1}
             value={
-              param.valueType === 'int'
-                ? parseInt(value, 10)
-                : parseFloat(value)
+              value
+                ? isInt
+                  ? parseInt(value, 10)
+                  : parseFloat(value)
+                : undefined
             }
             onChange={(v) => {
               if (v !== null) onChange(String(v));
@@ -277,6 +275,7 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
           />
         </Form.Item>
       );
+    }
 
     case 'select':
       return (
@@ -290,7 +289,7 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
             value={value}
             onChange={onChange}
             style={{ opacity: controlOpacity, transition: controlTransition }}
-            options={param.options?.map((opt) => ({
+            options={param.choices?.items.map((opt) => ({
               value: opt.value,
               label: opt.label,
             }))}
@@ -329,6 +328,7 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
           <Input
             value={value}
             onChange={(e) => onChange(e.target.value)}
+            placeholder={param.text?.placeholder ?? undefined}
             style={{ opacity: controlOpacity, transition: controlTransition }}
           />
         </Form.Item>

--- a/react/src/hooks/useRuntimeParameterSchema.ts
+++ b/react/src/hooks/useRuntimeParameterSchema.ts
@@ -2,65 +2,240 @@
  @license
  Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
  */
-import {
-  RuntimeParameterDef,
-  RuntimeParameterCategory,
-  RUNTIME_PARAMETER_FALLBACKS,
-} from '../constants/runtimeParameterFallbacks';
+import { useRuntimeParameterSchemaPresetsQuery } from '../__generated__/useRuntimeParameterSchemaPresetsQuery.graphql';
+import { useRuntimeParameterSchemaVariantsQuery } from '../__generated__/useRuntimeParameterSchemaVariantsQuery.graphql';
 import { useMemo } from 'react';
+import { graphql, useLazyLoadQuery } from 'react-relay';
 
+/** Target for how the preset value is applied to the inference container. */
+export type PresetTarget = 'ENV' | 'ARGS';
+
+/** Data type for preset value validation. */
+export type PresetValueType = 'STR' | 'INT' | 'FLOAT' | 'BOOL' | 'FLAG';
+
+/** UI rendering type for the preset control. */
+export type PresetUIType =
+  | 'slider'
+  | 'number_input'
+  | 'select'
+  | 'checkbox'
+  | 'text_input';
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+/** A single runtime variant preset from the API. */
+export interface RuntimeVariantPresetDef {
+  /** Preset name (unique identifier within the variant). */
+  name: string;
+  /** Human-readable description of the parameter. */
+  description: string | null;
+  /** Display ordering (lower = shown first). */
+  rank: number;
+  /** UI category group (e.g., 'model_loading', 'resource_memory'). */
+  category: string | null;
+  /** Human-readable display label for the UI. */
+  displayName: string | null;
+  /** How the value is applied: ENV or ARGS. */
+  presetTarget: PresetTarget;
+  /** Data type for parsing/serialization. */
+  valueType: PresetValueType;
+  /** Default value (as string). */
+  defaultValue: string | null;
+  /** Env key or CLI flag key (e.g., '--dtype' or 'HF_TOKEN'). */
+  key: string;
+  /** UI rendering type. */
+  uiType: PresetUIType | null;
+  /** Slider config (min/max/step). */
+  slider: { min: number; max: number; step: number } | null;
+  /** Number input config (min/max). */
+  number: { min: number | null; max: number | null } | null;
+  /** Select/radio options. */
+  choices: { items: ReadonlyArray<SelectOption> } | null;
+  /** Text input placeholder. */
+  text: { placeholder: string | null } | null;
+}
+
+/** Group of presets within the same category. */
 export interface RuntimeParameterGroup {
-  category: RuntimeParameterCategory;
-  params: RuntimeParameterDef[];
+  category: string;
+  params: RuntimeVariantPresetDef[];
 }
 
 /**
- * Hook that returns runtime parameter definitions grouped by category.
+ * Hook that fetches runtime variant presets from the API and returns them
+ * grouped by category and sorted by rank.
  *
- * Currently uses fallback metadata only. When the server extends
- * RuntimeVariantPreset.target_spec with ui_type/category/min/max/step fields,
- * this hook should fetch via GraphQL and merge with fallback data.
+ * Uses two Relay queries:
+ * 1. Resolves the runtime variant name to a UUID via `runtimeVariants`
+ * 2. Fetches presets for that variant via `runtimeVariantPresets`
  *
  * @param runtimeVariant - The selected runtime variant name (e.g., "vllm", "sglang")
- * @returns Grouped parameter definitions, or null if the variant has no parameter schema
+ * @returns Grouped preset definitions, or null if the variant has no presets
  */
-// TODO(needs-backend): FR-2446 — Add GraphQL fetch and merge with server schema
 export function useRuntimeParameterSchema(
   runtimeVariant: string | undefined,
 ): RuntimeParameterGroup[] | null {
+  // Step 1: Resolve variant name → UUID
+  const variantData = useLazyLoadQuery<useRuntimeParameterSchemaVariantsQuery>(
+    graphql`
+      query useRuntimeParameterSchemaVariantsQuery(
+        $filter: RuntimeVariantFilter
+      ) {
+        runtimeVariantsResult: runtimeVariants(filter: $filter, first: 1)
+          @catch(to: RESULT) {
+          edges {
+            node {
+              rowId
+              name
+            }
+          }
+        }
+      }
+    `,
+    {
+      filter: runtimeVariant
+        ? { name: { equals: runtimeVariant } }
+        : { name: { equals: '__none__' } },
+    },
+    { fetchPolicy: 'store-or-network' },
+  );
+
+  const variantRowId =
+    variantData.runtimeVariantsResult?.ok === true
+      ? (variantData.runtimeVariantsResult.value?.edges?.[0]?.node?.rowId ??
+        null)
+      : null;
+
+  // Step 2: Fetch presets for the resolved variant
+  const presetsData = useLazyLoadQuery<useRuntimeParameterSchemaPresetsQuery>(
+    graphql`
+      query useRuntimeParameterSchemaPresetsQuery(
+        $filter: RuntimeVariantPresetFilter
+        $orderBy: [RuntimeVariantPresetOrderBy!]
+      ) {
+        runtimeVariantPresetsResult: runtimeVariantPresets(
+          filter: $filter
+          orderBy: $orderBy
+          first: 100
+        ) @catch(to: RESULT) {
+          edges {
+            node {
+              name
+              description
+              rank
+              category
+              displayName
+              targetSpec {
+                presetTarget
+                valueType
+                defaultValue
+                key
+              }
+              uiOption {
+                uiType
+                slider {
+                  min
+                  max
+                  step
+                }
+                number {
+                  min
+                  max
+                }
+                choices {
+                  items {
+                    value
+                    label
+                  }
+                }
+                text {
+                  placeholder
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      filter: variantRowId
+        ? { runtimeVariantId: variantRowId }
+        : // When no variant UUID, use an impossible filter to get 0 results
+          { name: { equals: '__none__' } },
+      orderBy: [{ field: 'RANK', direction: 'ASC' }],
+    },
+    { fetchPolicy: 'store-or-network' },
+  );
+
   return useMemo(() => {
-    if (!runtimeVariant) return null;
+    if (!runtimeVariant || !variantRowId) return null;
 
-    const params = RUNTIME_PARAMETER_FALLBACKS[runtimeVariant];
-    if (!params || params.length === 0) return null;
+    const edges =
+      presetsData.runtimeVariantPresetsResult?.ok === true
+        ? (presetsData.runtimeVariantPresetsResult.value?.edges ?? [])
+        : [];
 
-    // Group by category and sort by rank within each group
-    const grouped = new Map<RuntimeParameterCategory, RuntimeParameterDef[]>();
-    for (const param of params) {
-      const group = grouped.get(param.category) ?? [];
-      group.push(param);
-      grouped.set(param.category, group);
-    }
+    if (edges.length === 0) return null;
 
-    // Sort params within each group by rank
-    for (const group of grouped.values()) {
-      group.sort((a, b) => a.rank - b.rank);
-    }
-
-    // Return in display order: sampling → context → advanced
-    const categoryOrder: RuntimeParameterCategory[] = [
-      'sampling',
-      'context',
-      'advanced',
-    ];
-
-    return categoryOrder
-      .filter((cat) => grouped.has(cat))
-      .map((cat) => ({
-        category: cat,
-        params: grouped.get(cat)!,
+    // Map edges to preset definitions
+    const presets: RuntimeVariantPresetDef[] = edges
+      .map((edge) => edge?.node)
+      .filter(Boolean)
+      .map((node) => ({
+        name: node.name,
+        description: node.description ?? null,
+        rank: node.rank,
+        category: node.category ?? null,
+        displayName: node.displayName ?? null,
+        presetTarget: node.targetSpec.presetTarget as PresetTarget,
+        valueType: node.targetSpec.valueType as PresetValueType,
+        defaultValue: node.targetSpec.defaultValue ?? null,
+        key: node.targetSpec.key,
+        uiType: (node.uiOption?.uiType as PresetUIType) ?? null,
+        slider: node.uiOption?.slider
+          ? {
+              min: node.uiOption.slider.min,
+              max: node.uiOption.slider.max,
+              step: node.uiOption.slider.step,
+            }
+          : null,
+        number: node.uiOption?.number
+          ? {
+              min: node.uiOption.number.min ?? null,
+              max: node.uiOption.number.max ?? null,
+            }
+          : null,
+        choices: node.uiOption?.choices
+          ? {
+              items: node.uiOption.choices.items.map((item) => ({
+                value: item.value,
+                label: item.label,
+              })),
+            }
+          : null,
+        text: node.uiOption?.text
+          ? { placeholder: node.uiOption.text.placeholder ?? null }
+          : null,
       }));
-  }, [runtimeVariant]);
+
+    // Group by category, maintaining rank order (already sorted by API)
+    const grouped = new Map<string, RuntimeVariantPresetDef[]>();
+    for (const preset of presets) {
+      const cat = preset.category ?? 'general';
+      const group = grouped.get(cat) ?? [];
+      group.push(preset);
+      grouped.set(cat, group);
+    }
+
+    // Convert to array preserving insertion order (which follows rank due to API ordering)
+    return Array.from(grouped.entries()).map(([category, params]) => ({
+      category,
+      params,
+    }));
+  }, [runtimeVariant, variantRowId, presetsData]);
 }
 
 /**
@@ -73,7 +248,9 @@ export function buildDefaultsMap(
   const defaults: Record<string, string> = {};
   for (const group of groups) {
     for (const param of group.params) {
-      defaults[param.key] = param.defaultValue;
+      if (param.defaultValue !== null) {
+        defaults[param.key] = param.defaultValue;
+      }
     }
   }
   return defaults;


### PR DESCRIPTION
Resolves #6710 (FR-2547)

## Summary
- Add Relay GraphQL queries for `runtimeVariants` (name→UUID resolution) and `runtimeVariantPresets` (preset fetching)
- Rewrite `useRuntimeParameterSchema` hook to fetch presets from API instead of hardcoded fallbacks
- Refactor `RuntimeParameterFormSection` to render dynamic categories from API with rank ordering
- Support all `uiOption.uiType` controls: slider, number_input, select, checkbox, text_input
- Use `useEffectEvent` for effect-internal callbacks per project conventions
- Add `'use memo'` directive to all components