### PR TITLE
fix(FR-2581): change initial delay default from 5s to 60s

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -666,7 +666,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
           port: values.commandPort ?? 8000,
           healthCheckPath: values.commandHealthCheck ?? '/health',
           modelMountDestination: values.commandModelMount ?? '/models',
-          initialDelay: values.commandInitialDelay ?? 5.0,
+          initialDelay: values.commandInitialDelay ?? 60,
           maxRetries: values.commandMaxRetries ?? 10,
         });
 
@@ -1215,7 +1215,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         commandModelMount: '/models',
         commandPort: 8000,
         commandHealthCheck: '/health',
-        commandInitialDelay: 5.0,
+        commandInitialDelay: 60,
         commandMaxRetries: 10,
         ...RESOURCE_ALLOCATION_INITIAL_FORM_VALUES,
         ...(baiClient._config?.default_session_environment && {

--- a/react/src/helper/generateModelDefinitionYaml.ts
+++ b/react/src/helper/generateModelDefinitionYaml.ts
@@ -36,7 +36,7 @@ export interface ModelDefinitionInput {
  *       port: 8000
  *       health_check:
  *         path: /health
- *         initial_delay: 5.0
+ *         initial_delay: 60
  *         max_retries: 10
  * ```
  */
@@ -78,7 +78,7 @@ ${startCommandLines}
       port: ${input.port}
       health_check:
         path: "${escapeYamlString(input.healthCheckPath)}"
-        initial_delay: ${input.initialDelay ?? 5.0}
+        initial_delay: ${input.initialDelay ?? 60}
         max_retries: ${input.maxRetries ?? 10}
 `;
 }


### PR DESCRIPTION
Resolves #6716 (FR-2581)

## Summary
- Change health check initial delay default from 5s to 60s in all locations
- `ServiceLauncherPageContent.tsx`: form initial value and fallback
- `generateModelDefinitionYaml.ts`: YAML generation fallback and JSDoc example
- Large model loading (70B+) takes 1-3 minutes; 5s caused premature ROUTE_TERMINATION