### PR TITLE
feat(FR-2581): display runtime variant in endpoint list and detail page

### DIFF
--- a/react/src/components/EndpointList.tsx
+++ b/react/src/components/EndpointList.tsx
@@ -95,6 +95,9 @@ const EndpointList: React.FC<EndpointListProps> = ({
         desired_session_count
         project
         created_user_email
+        runtime_variant {
+          human_readable_name
+        }
         ...EndpointOwnerInfoFragment
         ...EndpointStatusTagFragment
       }
@@ -227,6 +230,14 @@ const EndpointList: React.FC<EndpointListProps> = ({
       title: t('modelService.Status'),
       key: 'status',
       render: (_text, row) => <EndpointStatusTag endpointFrgmt={row} />,
+    },
+    {
+      title: t('modelService.RuntimeVariant'),
+      key: 'runtime_variant',
+      render: (_text, row) =>
+        row.runtime_variant?.human_readable_name
+          ? row.runtime_variant.human_readable_name
+          : '-',
     },
     baiClient.is_admin && {
       title: t('modelService.Owner'),

--- a/react/src/components/RuntimeParameterFormSection.tsx
+++ b/react/src/components/RuntimeParameterFormSection.tsx
@@ -14,7 +14,7 @@ import {
 import InputNumberWithSlider from './InputNumberWithSlider';
 import { Checkbox, Form, InputNumber, Select, Input, theme, Alert } from 'antd';
 import { BAICard, BAIFlex } from 'backend.ai-ui';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useEffectEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 /** Convert category slug to a display-friendly label. */
@@ -64,12 +64,19 @@ const RuntimeParameterFormSection: React.FC<
 
   // Notify parent when groups change (for serialization at submit time)
   // Cleanup on unmount to prevent parent from using stale groups
-  useEffect(() => {
+  const onGroupsChanged = useEffectEvent(() => {
     onGroupsLoaded?.(groups);
+  });
+  const onGroupsCleanup = useEffectEvent(() => {
+    onGroupsLoaded?.(null);
+  });
+
+  useEffect(() => {
+    onGroupsChanged();
     return () => {
-      onGroupsLoaded?.(null);
+      onGroupsCleanup();
     };
-  }, [groups, onGroupsLoaded]);
+  }, [groups]);
 
   const [internalValues, setInternalValues] = useState<RuntimeParameterValues>(
     {},
@@ -91,7 +98,7 @@ const RuntimeParameterFormSection: React.FC<
   );
 
   // Initialize from defaults or reverse-map from existing extra args / env vars
-  useEffect(() => {
+  const initializeValues = useEffectEvent(() => {
     if (!groups) return;
 
     const defaults = buildDefaultsMap(groups);
@@ -132,8 +139,11 @@ const RuntimeParameterFormSection: React.FC<
       setTouchedKeys(new Set());
       onTouchedKeysChange?.(new Set());
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runtimeVariant, initialExtraArgs, initialEnvVars]);
+  });
+
+  useEffect(() => {
+    initializeValues();
+  }, [runtimeVariant, initialExtraArgs, initialEnvVars, groups]);
 
   const handleParamChange = useCallback(
     (key: string, newValue: string) => {
@@ -210,6 +220,7 @@ const ParameterGroupContent: React.FC<ParameterGroupContentProps> = ({
   touchedKeys,
   onParamChange,
 }) => {
+  'use memo';
   return (
     <BAIFlex direction="column" gap="xxs" align="stretch">
       {group.params.map((param) => (
@@ -300,7 +311,7 @@ const ParameterControl: React.FC<ParameterControlProps> = ({
           <InputNumber
             min={min}
             max={max}
-            step={1}
+            step={isInt ? 1 : 0.1}
             value={
               value
                 ? isInt

--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -356,7 +356,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
 
       // Set ENV-type values as individual env vars
       for (const [key, val] of Object.entries(envValues)) {
-        // Skip default values
+        // Skip if value matches default
         const preset = presetMap.get(key);
         if (preset?.defaultValue !== null && preset?.defaultValue === val) {
           continue;

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -460,6 +460,12 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
       children: <EndpointStatusTag endpointFrgmt={endpoint} />,
     },
     {
+      label: t('modelService.RuntimeVariant'),
+      children: endpoint?.runtime_variant?.human_readable_name || (
+        <Typography.Text type="secondary">-</Typography.Text>
+      ),
+    },
+    {
       label: t('modelService.EndpointId'),
       children: endpoint?.endpoint_id,
     },


### PR DESCRIPTION
Resolves #6717 (FR-2581)

## Summary
- Add `runtime_variant { human_readable_name }` to EndpointList GraphQL fragment
- Add runtime variant column to EndpointList table
- Add runtime variant Descriptions.Item to EndpointDetailPage (query already fetched but never rendered)
- Uses existing i18n key `modelService.RuntimeVariant` (available in all 22 languages)