### PR TITLE
feat(FR-2581): expose model definition fields in custom runtime edit mode

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -15,6 +15,7 @@ import {
 } from '../helper';
 import { generateModelDefinitionYaml } from '../helper/generateModelDefinitionYaml';
 import { parseCliCommand } from '../helper/parseCliCommand';
+import { parseModelDefinitionYaml } from '../helper/parseModelDefinitionYaml';
 import {
   mergeExtraArgs,
   reverseMapExtraArgs,
@@ -61,7 +62,6 @@ import SwitchToProjectButton from './SwitchToProjectButton';
 import VFolderLazyView from './VFolderLazyView';
 import VFolderSelect from './VFolderSelect';
 import VFolderTableFormItem from './VFolderTableFormItem';
-import { MinusOutlined } from '@ant-design/icons';
 import { useDebounceFn } from 'ahooks';
 import {
   App,
@@ -954,8 +954,75 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
   const handleOk = () => {
     form
       .validateFields()
-      .then((values) => {
+      .then(async (values) => {
         if (endpoint) {
+          // In edit mode with custom runtime command mode, upload
+          // the generated model-definition.yaml before modifying.
+          const isCommandMode =
+            values.runtimeVariant === 'custom' &&
+            values.customDefinitionMode === 'command' &&
+            values.startCommand?.trim();
+
+          // Preserve existing definition path in edit mode, default for new
+          const definitionFilePath =
+            endpoint?.model_definition_path || 'model-definition.yaml';
+
+          if (isCommandMode) {
+            // In edit mode, use the endpoint's model_mount_destination
+            const modelMountDestination = endpoint
+              ? (endpoint.model_mount_destination ??
+                values.commandModelMount ??
+                '/models')
+              : (values.commandModelMount ?? '/models');
+
+            try {
+              const yamlContent = generateModelDefinitionYaml({
+                startCommand: values.startCommand!.trim(),
+                port: values.commandPort ?? 8000,
+                healthCheckPath: values.commandHealthCheck ?? '/health',
+                modelMountDestination,
+                initialDelay: values.commandInitialDelay ?? 60,
+                maxRetries: values.commandMaxRetries ?? 10,
+              });
+
+              const blob = new Blob([yamlContent], { type: 'text/yaml' });
+              const file = new File([blob], definitionFilePath, {
+                type: 'text/yaml',
+              });
+
+              const uploadUrl: string =
+                await baiClient.vfolder.create_upload_session(
+                  definitionFilePath,
+                  file,
+                  values.vFolderID,
+                );
+
+              const response = await fetch(uploadUrl, {
+                method: 'PATCH',
+                headers: {
+                  'Upload-Offset': '0',
+                  'Content-Type': 'application/offset+octet-stream',
+                  'Tus-Resumable': '1.0.0',
+                },
+                body: blob,
+              });
+
+              if (!response.ok) {
+                message.error(t('modelService.YamlUploadFailed'));
+                return;
+              }
+            } catch (e) {
+              logger.error('Failed to upload model-definition.yaml:', e);
+              message.error(t('modelService.YamlUploadFailed'));
+              return;
+            }
+          }
+
+          // In command mode, use the preserved definition path
+          const modelDefinitionPath = isCommandMode
+            ? definitionFilePath
+            : values.modelDefinitionPath?.trim() || undefined;
+
           const mutationVariables: ServiceLauncherPageContentModifyMutation['variables'] =
             {
               endpoint_id: endpoint?.endpoint_id || '',
@@ -1010,9 +1077,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                 }),
                 name: values.serviceName,
                 resource_group: values.resourceGroup,
-                // If empty, let the server infer the value instead of hardcoding
-                model_definition_path:
-                  values.modelDefinitionPath?.trim() || undefined,
+                model_definition_path: modelDefinitionPath,
                 runtime_variant: values.runtimeVariant,
               },
             };
@@ -1199,6 +1264,15 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
         modelMountDestination: endpoint?.model_mount_destination,
         modelDefinitionPath: endpoint?.model_definition_path,
         runtimeVariant: endpoint?.runtime_variant?.name,
+        // For custom runtime edit mode, default to 'command' mode with full definition fields
+        ...(endpoint?.runtime_variant?.name === 'custom' && {
+          customDefinitionMode: 'command' as CustomDefinitionMode,
+          commandModelMount: endpoint?.model_mount_destination || '/models',
+          commandPort: 8000,
+          commandHealthCheck: '/health',
+          commandInitialDelay: 60,
+          commandMaxRetries: 10,
+        }),
         // Pass environ as-is; managed keys are stripped at submit time
         // by serializeRuntimeParamsToEnviron after presets load from API.
         envvars: (() => {
@@ -1263,6 +1337,53 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
       }
     }
   }, [endpoint?.extra_mounts, form]);
+
+  // Load model-definition.yaml from the vfolder in edit mode for custom runtime
+  // to pre-populate the command form fields.
+  const loadModelDefinitionForEdit = useEffectEvent(
+    async (vfolderId: string) => {
+      try {
+        const definitionPath =
+          endpoint?.model_definition_path || 'model-definition.yaml';
+        const tokenResponse = await baiClient.vfolder.request_download_token(
+          definitionPath,
+          vfolderId,
+          false,
+        );
+        const downloadUrl = `${tokenResponse.url}?token=${tokenResponse.token}&archive=false`;
+        const response = await fetch(downloadUrl);
+        if (!response.ok) return;
+        const yamlText = await response.text();
+        const parsed = parseModelDefinitionYaml(yamlText);
+        if (parsed) {
+          form.setFieldsValue({
+            startCommand: parsed.startCommand,
+            commandPort: parsed.port,
+            commandHealthCheck: parsed.healthCheckPath,
+            commandModelMount: parsed.modelMountDestination,
+            commandInitialDelay: parsed.initialDelay,
+            commandMaxRetries: parsed.maxRetries,
+            customDefinitionMode: 'command' as CustomDefinitionMode,
+          });
+        }
+      } catch {
+        // If download fails, keep the default values — user can fill manually
+        logger.debug(
+          'Failed to load model-definition.yaml for edit mode pre-population',
+        );
+      }
+    },
+  );
+
+  const endpointId = endpoint?.endpoint_id;
+  const endpointRuntimeVariant = endpoint?.runtime_variant?.name;
+  const endpointModel = endpoint?.model;
+
+  useEffect(() => {
+    if (endpointRuntimeVariant === 'custom' && endpointModel) {
+      loadModelDefinitionForEdit(endpointModel);
+    }
+  }, [endpointId, endpointRuntimeVariant, endpointModel]);
 
   return (
     <>
@@ -1466,54 +1587,8 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                         </Form.Item>
                         <Form.Item dependencies={['runtimeVariant']} noStyle>
                           {({ getFieldValue }) =>
-                            getFieldValue('runtimeVariant') === 'custom' &&
-                            (endpoint ? (
-                              // Edit mode: keep existing UI (no Segmented)
-                              <BAIFlex
-                                direction="row"
-                                gap={'xxs'}
-                                align="stretch"
-                                justify="between"
-                              >
-                                <Form.Item
-                                  name={'modelMountDestination'}
-                                  label={t(
-                                    'modelService.ModelMountDestination',
-                                  )}
-                                  style={{ width: '50%' }}
-                                  labelCol={{ style: { flex: 1 } }}
-                                >
-                                  <Input
-                                    allowClear
-                                    placeholder={'/models'}
-                                    disabled={!!endpoint}
-                                  />
-                                </Form.Item>
-                                <MinusOutlined
-                                  style={{
-                                    fontSize: token.fontSizeXL,
-                                    color: token.colorTextDisabled,
-                                  }}
-                                  rotate={290}
-                                />
-                                <Form.Item
-                                  name={'modelDefinitionPath'}
-                                  label={t('modelService.ModelDefinitionPath')}
-                                  style={{ width: '50%' }}
-                                  labelCol={{ style: { flex: 1 } }}
-                                >
-                                  <Input
-                                    allowClear
-                                    placeholder={
-                                      endpoint?.model_definition_path
-                                        ? endpoint?.model_definition_path
-                                        : 'model-definition.yaml'
-                                    }
-                                  />
-                                </Form.Item>
-                              </BAIFlex>
-                            ) : (
-                              // Create mode: Segmented "Enter Command" / "Use Config File"
+                            getFieldValue('runtimeVariant') === 'custom' && (
+                              // Both create and edit modes: Segmented "Enter Command" / "Use Config File"
                               <Card
                                 size="small"
                                 title={t('modelService.ModelDefinition')}
@@ -1666,13 +1741,15 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                       <>
                                         <Form.Item
                                           name={'modelMountDestination'}
-                                          label={t(
-                                            'modelService.ModelMountDestination',
+                                          label={t('modelService.ModelMount')}
+                                          tooltip={t(
+                                            'modelService.ModelMountTooltip',
                                           )}
                                         >
                                           <Input
                                             allowClear
                                             placeholder={'/models'}
+                                            disabled={!!endpoint}
                                           />
                                         </Form.Item>
                                         <Form.Item
@@ -1680,11 +1757,16 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                           label={t(
                                             'modelService.ModelDefinitionPath',
                                           )}
+                                          tooltip={t(
+                                            'modelService.ModelDefinitionPathTooltip',
+                                          )}
                                         >
                                           <Input
                                             allowClear
                                             placeholder={
-                                              'model-definition.yaml'
+                                              endpoint?.model_definition_path
+                                                ? endpoint?.model_definition_path
+                                                : 'model-definition.yaml'
                                             }
                                           />
                                         </Form.Item>
@@ -1693,7 +1775,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                   }
                                 </Form.Item>
                               </Card>
-                            ))
+                            )
                           }
                         </Form.Item>
                       </>

--- a/react/src/helper/parseModelDefinitionYaml.test.ts
+++ b/react/src/helper/parseModelDefinitionYaml.test.ts
@@ -1,0 +1,140 @@
+/**
+ @license
+ Copyright (c) 2015-2026 Lablup Inc. All rights reserved.
+ */
+import { parseModelDefinitionYaml } from './parseModelDefinitionYaml';
+
+describe('parseModelDefinitionYaml', () => {
+  it('should parse a standard model-definition.yaml with array start_command', () => {
+    const yaml = `
+models:
+  - name: "model"
+    model_path: "/models"
+    service:
+      start_command:
+        - vllm
+        - serve
+        - /models/my-model
+      port: 8000
+      health_check:
+        path: /health
+        initial_delay: 60
+        max_retries: 10
+`;
+    const result = parseModelDefinitionYaml(yaml);
+    expect(result).toEqual({
+      startCommand: 'vllm serve /models/my-model',
+      port: 8000,
+      healthCheckPath: '/health',
+      modelMountDestination: '/models',
+      initialDelay: 60,
+      maxRetries: 10,
+    });
+  });
+
+  it('should parse a string start_command', () => {
+    const yaml = `
+models:
+  - name: "model"
+    model_path: "/models"
+    service:
+      start_command: "vllm serve /models/my-model"
+      port: 8080
+      health_check:
+        path: /v1/health
+        initial_delay: 30
+        max_retries: 5
+`;
+    const result = parseModelDefinitionYaml(yaml);
+    expect(result).not.toBeNull();
+    expect(result!.startCommand).toBe('vllm serve /models/my-model');
+    expect(result!.port).toBe(8080);
+    expect(result!.healthCheckPath).toBe('/v1/health');
+    expect(result!.initialDelay).toBe(30);
+    expect(result!.maxRetries).toBe(5);
+  });
+
+  it('should shell-escape tokens containing spaces', () => {
+    const yaml = `
+models:
+  - name: "model"
+    model_path: "/models"
+    service:
+      start_command:
+        - echo
+        - "hello world"
+      port: 8000
+`;
+    const result = parseModelDefinitionYaml(yaml);
+    expect(result).not.toBeNull();
+    expect(result!.startCommand).toBe('echo "hello world"');
+  });
+
+  it('should use defaults for missing health_check fields', () => {
+    const yaml = `
+models:
+  - name: "model"
+    model_path: "/data"
+    service:
+      start_command:
+        - python
+        - serve.py
+      port: 3000
+`;
+    const result = parseModelDefinitionYaml(yaml);
+    expect(result).not.toBeNull();
+    expect(result!.healthCheckPath).toBe('/health');
+    expect(result!.initialDelay).toBe(60);
+    expect(result!.maxRetries).toBe(10);
+    expect(result!.modelMountDestination).toBe('/data');
+  });
+
+  it('should return null for invalid YAML', () => {
+    expect(parseModelDefinitionYaml('{{invalid')).toBeNull();
+  });
+
+  it('should return null when models array is missing', () => {
+    const yaml = `
+service:
+  start_command: foo
+`;
+    expect(parseModelDefinitionYaml(yaml)).toBeNull();
+  });
+
+  it('should return null when service is missing', () => {
+    const yaml = `
+models:
+  - name: "model"
+    model_path: "/models"
+`;
+    expect(parseModelDefinitionYaml(yaml)).toBeNull();
+  });
+
+  it('should return null when start_command is empty', () => {
+    const yaml = `
+models:
+  - name: "model"
+    model_path: "/models"
+    service:
+      start_command: []
+      port: 8000
+`;
+    expect(parseModelDefinitionYaml(yaml)).toBeNull();
+  });
+
+  it('should default port to 8000 for non-numeric port', () => {
+    const yaml = `
+models:
+  - name: "model"
+    model_path: "/models"
+    service:
+      start_command:
+        - python
+        - app.py
+      port: invalid
+`;
+    const result = parseModelDefinitionYaml(yaml);
+    expect(result).not.toBeNull();
+    expect(result!.port).toBe(8000);
+  });
+});

--- a/react/src/helper/parseModelDefinitionYaml.ts
+++ b/react/src/helper/parseModelDefinitionYaml.ts
@@ -1,0 +1,87 @@
+/**
+ * Parses a model-definition.yaml string and extracts the fields needed
+ * to pre-populate the "Enter Command" form in the service launcher.
+ *
+ * Uses the `yaml` package (already a project dependency).
+ */
+import { parse as parseYaml } from 'yaml';
+
+export interface ParsedModelDefinition {
+  /** Reconstructed start command string (tokens joined with spaces) */
+  startCommand: string;
+  /** Service port number */
+  port: number;
+  /** Health check endpoint path */
+  healthCheckPath: string;
+  /** Model mount / model_path value */
+  modelMountDestination: string;
+  /** Health check initial delay in seconds */
+  initialDelay: number;
+  /** Health check max retries */
+  maxRetries: number;
+}
+
+/**
+ * Parse a model-definition.yaml string and return form-ready values.
+ * Returns `null` if parsing fails or the structure is unexpected.
+ */
+export function parseModelDefinitionYaml(
+  yamlContent: string,
+): ParsedModelDefinition | null {
+  try {
+    const doc = parseYaml(yamlContent);
+    if (!doc?.models || !Array.isArray(doc.models) || doc.models.length === 0) {
+      return null;
+    }
+
+    const model = doc.models[0];
+    const service = model?.service;
+    if (!service) {
+      return null;
+    }
+
+    // Reconstruct the start command
+    let startCommand: string;
+    if (Array.isArray(service.start_command)) {
+      // Shell-escape tokens that contain spaces or special characters
+      startCommand = service.start_command
+        .map(String)
+        .map((tok: string) =>
+          /[\s"'\\$`!#&|;()<>{}]/.test(tok)
+            ? `"${tok.replace(/["\\$`]/g, '\\$&')}"`
+            : tok,
+        )
+        .join(' ');
+    } else if (typeof service.start_command === 'string') {
+      startCommand = service.start_command;
+    } else {
+      startCommand = '';
+    }
+    if (!startCommand) {
+      return null;
+    }
+
+    const port =
+      typeof service.port === 'number' ? service.port : parseInt(service.port);
+    const healthCheck = service.health_check ?? {};
+
+    return {
+      startCommand,
+      port: isNaN(port) ? 8000 : port,
+      healthCheckPath:
+        typeof healthCheck.path === 'string' ? healthCheck.path : '/health',
+      modelMountDestination:
+        typeof model.model_path === 'string' ? model.model_path : '/models',
+      initialDelay:
+        typeof healthCheck.initial_delay === 'number'
+          ? healthCheck.initial_delay
+          : 60,
+      maxRetries:
+        typeof healthCheck.max_retries === 'number'
+          ? healthCheck.max_retries
+          : 10,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -1492,6 +1492,7 @@
     "ModelAndServingConfiguration": "Modell- & Serving-Konfiguration",
     "ModelDefinition": "Modelldefinition",
     "ModelDefinitionPath": "Pfad der Modelldefinitionsdatei",
+    "ModelDefinitionPathTooltip": "Relativer Pfad zur YAML-Datei der Modelldefinition im Modellordner (z. B. model-definition.yaml). Standardmäßig wird model-definition.yaml verwendet, wenn das Feld leer bleibt.",
     "ModelDefinitionRequired": "Modelldefinition.yaml-Datei ist erforderlich.",
     "ModelMount": "Modell-Mount",
     "ModelMountDestination": "Mount-Ziel für Modellordner",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -1490,6 +1490,7 @@
     "ModelAndServingConfiguration": "Διαμόρφωση μοντέλου & σερβιρίσματος",
     "ModelDefinition": "Ορισμός μοντέλου",
     "ModelDefinitionPath": "Διαδρομή αρχείου ορισμού μοντέλου",
+    "ModelDefinitionPathTooltip": "Σχετική διαδρομή προς το αρχείο YAML ορισμού μοντέλου μέσα στον φάκελο μοντέλου (π.χ. model-definition.yaml). Αν αφεθεί κενό, ορίζεται ως προεπιλογή το model-definition.yaml.",
     "ModelDefinitionRequired": "Απαιτείται αρχείο μοντέλου-definition.yaml.",
     "ModelMount": "Προσάρτηση μοντέλου",
     "ModelMountDestination": "Προσάρτηση προορισμού για φάκελο μοντέλου",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -1491,6 +1491,7 @@
     "ModelAndServingConfiguration": "Model & Serving Configuration",
     "ModelDefinition": "Model Definition",
     "ModelDefinitionPath": "Model Definition File Path",
+    "ModelDefinitionPathTooltip": "Relative path to the model definition YAML file inside the model folder (e.g. model-definition.yaml). Defaults to model-definition.yaml if left empty.",
     "ModelDefinitionRequired": "model-definition.yaml is required to start a model service. Please add it to the model folder.",
     "ModelMount": "Model Mount",
     "ModelMountDestination": "Mount Destination For Model Folder",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -1490,6 +1490,7 @@
     "ModelAndServingConfiguration": "Configuración de modelo y servicio",
     "ModelDefinition": "Definición de modelo",
     "ModelDefinitionPath": "Ruta del archivo de definición del modelo",
+    "ModelDefinitionPathTooltip": "Ruta relativa al archivo YAML de definición del modelo dentro de la carpeta del modelo (p. ej. model-definition.yaml). Si se deja vacío, se usará model-definition.yaml por defecto.",
     "ModelDefinitionRequired": "se necesita modelo-definición.yaml.",
     "ModelMount": "Montaje del modelo",
     "ModelMountDestination": "Destino de montaje para carpeta de modelo",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -1490,6 +1490,7 @@
     "ModelAndServingConfiguration": "Malli- ja palvelukonfiguraatio",
     "ModelDefinition": "Mallin määritelmä",
     "ModelDefinitionPath": "Mallin määritelmän tiedostopolku",
+    "ModelDefinitionPathTooltip": "Suhteellinen polku mallin määritelmän YAML-tiedostoon mallikansiossa (esim. model-definition.yaml). Oletusarvona käytetään model-definition.yaml, jos kenttä jätetään tyhjäksi.",
     "ModelDefinitionRequired": "Malli-definition.yaml-tiedosto tarvitaan.",
     "ModelMount": "Mallin liittäminen",
     "ModelMountDestination": "Kiinnityskohde mallikansioon",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -1491,6 +1491,7 @@
     "ModelAndServingConfiguration": "Configuration du modèle et du service",
     "ModelDefinition": "Définition du modèle",
     "ModelDefinitionPath": "Chemin du fichier de définition du modèle",
+    "ModelDefinitionPathTooltip": "Chemin relatif vers le fichier YAML de définition du modèle dans le dossier du modèle (ex. model-definition.yaml). Par défaut model-definition.yaml si laissé vide.",
     "ModelDefinitionRequired": "Le fichier modèle-définition.yaml est nécessaire.",
     "ModelMount": "Montage du modèle",
     "ModelMountDestination": "Destination de montage pour le dossier modèle",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -1493,6 +1493,7 @@
     "ModelAndServingConfiguration": "Konfigurasi Model & Serving",
     "ModelDefinition": "Definisi Model",
     "ModelDefinitionPath": "Jalur File Definisi Model",
+    "ModelDefinitionPathTooltip": "Jalur relatif ke file YAML definisi model di dalam folder model (mis. model-definition.yaml). Default ke model-definition.yaml jika dikosongkan.",
     "ModelDefinitionRequired": "Model-Definition.yaml diperlukan file.",
     "ModelMount": "Mount Model",
     "ModelMountDestination": "Pasang Tujuan Untuk Folder Model",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -1490,6 +1490,7 @@
     "ModelAndServingConfiguration": "Configurazione modello e serving",
     "ModelDefinition": "Definizione del modello",
     "ModelDefinitionPath": "Percorso del file di definizione del modello",
+    "ModelDefinitionPathTooltip": "Percorso relativo al file YAML di definizione del modello all'interno della cartella del modello (es. model-definition.yaml). Il valore predefinito è model-definition.yaml se lasciato vuoto.",
     "ModelDefinitionRequired": "È necessario il file Model-Definition.yaml.",
     "ModelMount": "Mount del modello",
     "ModelMountDestination": "Destinazione di montaggio per la cartella del modello",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -1492,6 +1492,7 @@
     "ModelAndServingConfiguration": "モデル & サービング設定",
     "ModelDefinition": "モデル定義",
     "ModelDefinitionPath": "モデル定義ファイルのパス",
+    "ModelDefinitionPathTooltip": "モデルフォルダ内にあるモデル定義 YAML ファイルへの相対パスです（例: model-definition.yaml）。空欄のままにするとデフォルトで model-definition.yaml が使用されます。",
     "ModelDefinitionRequired": "model-definition.yamlファイルが必要です。",
     "ModelMount": "モデルマウント",
     "ModelMountDestination": "モデルフォルダーのマウント先",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -1493,6 +1493,7 @@
     "ModelAndServingConfiguration": "모델 & 서빙 구성",
     "ModelDefinition": "모델 정의",
     "ModelDefinitionPath": "모델 정의 파일 경로",
+    "ModelDefinitionPathTooltip": "모델 폴더 내 모델 정의 YAML 파일의 상대 경로입니다 (예: model-definition.yaml). 비워두면 model-definition.yaml이 기본값으로 사용됩니다.",
     "ModelDefinitionRequired": "모델 서비스를 시작하려면 model-definition.yaml이 필요합니다. 모델 폴더에 추가해 주세요.",
     "ModelMount": "모델 마운트",
     "ModelMountDestination": "모델 폴더 마운트할 경로",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -1491,6 +1491,7 @@
     "ModelAndServingConfiguration": "Загвар & Serving тохиргоо",
     "ModelDefinition": "Загварын тодорхойлолт",
     "ModelDefinitionPath": "Загварын тодорхойлолтын файлын зам",
+    "ModelDefinitionPathTooltip": "Загварын хавтас доторх загварын тодорхойлолтын YAML файлын харьцангуй зам (жж. model-definition.yaml). Хоосон үлдвэл анхдагчаар model-definition.yaml ашиглагдана.",
     "ModelDefinitionRequired": "Загвар-тодорхойлолт ..yaml файл шаардлагатай байна.",
     "ModelMount": "Загварын холболт",
     "ModelMountDestination": "Загварын хавтасыг холбох газар",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -1490,6 +1490,7 @@
     "ModelAndServingConfiguration": "Konfigurasi Model & Serving",
     "ModelDefinition": "Definisi Model",
     "ModelDefinitionPath": "Laluan Fail Definisi Model",
+    "ModelDefinitionPathTooltip": "Laluan relatif ke fail YAML definisi model di dalam folder model (cth. model-definition.yaml). Lalai kepada model-definition.yaml jika dibiarkan kosong.",
     "ModelDefinitionRequired": "Fail definisi model.yaml diperlukan.",
     "ModelMount": "Pemasangan Model",
     "ModelMountDestination": "Lekapkan Destinasi Untuk Folder Model",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -1491,6 +1491,7 @@
     "ModelAndServingConfiguration": "Konfiguracja modelu i serwowania",
     "ModelDefinition": "Definicja modelu",
     "ModelDefinitionPath": "Ścieżka pliku definicji modelu",
+    "ModelDefinitionPathTooltip": "Względna ścieżka do pliku YAML definicji modelu w folderze modelu (np. model-definition.yaml). Domyślnie model-definition.yaml, jeśli pole pozostanie puste.",
     "ModelDefinitionRequired": "Potrzebny jest plik model-definition.yaml.",
     "ModelMount": "Montowanie modelu",
     "ModelMountDestination": "Miejsce docelowe montażu dla folderu modelu",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -1490,6 +1490,7 @@
     "ModelAndServingConfiguration": "Configuração de modelo e serviço",
     "ModelDefinition": "Definição do modelo",
     "ModelDefinitionPath": "Caminho do arquivo de definição de modelo",
+    "ModelDefinitionPathTooltip": "Caminho relativo para o arquivo YAML de definição do modelo dentro da pasta do modelo (ex.: model-definition.yaml). O padrão é model-definition.yaml se deixado em branco.",
     "ModelDefinitionRequired": "é necessário o arquivo model-definition.yaml.",
     "ModelMount": "Montagem do modelo",
     "ModelMountDestination": "Montar destino para pasta de modelo",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -1492,6 +1492,7 @@
     "ModelAndServingConfiguration": "Configuração de modelo e serviço",
     "ModelDefinition": "Definição do modelo",
     "ModelDefinitionPath": "Caminho do arquivo de definição de modelo",
+    "ModelDefinitionPathTooltip": "Caminho relativo para o ficheiro YAML de definição do modelo dentro da pasta do modelo (ex.: model-definition.yaml). O predefinido é model-definition.yaml se ficar em branco.",
     "ModelDefinitionRequired": "é necessário o arquivo model-definition.yaml.",
     "ModelMount": "Montagem do modelo",
     "ModelMountDestination": "Montar destino para pasta de modelo",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -1490,6 +1490,7 @@
     "ModelAndServingConfiguration": "Конфигурация модели и обслуживания",
     "ModelDefinition": "Определение модели",
     "ModelDefinitionPath": "Путь к файлу определения модели",
+    "ModelDefinitionPathTooltip": "Относительный путь к YAML-файлу определения модели внутри папки модели (например, model-definition.yaml). По умолчанию используется model-definition.yaml, если поле оставлено пустым.",
     "ModelDefinitionRequired": "Необходим файл модели.",
     "ModelMount": "Монтирование модели",
     "ModelMountDestination": "Место установки папки модели",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -1492,6 +1492,7 @@
     "ModelAndServingConfiguration": "การตั้งค่าโมเดลและการบริการ",
     "ModelDefinition": "คำนิยามโมเดล",
     "ModelDefinitionPath": "เส้นทางไฟล์กำหนดโมเดล",
+    "ModelDefinitionPathTooltip": "เส้นทางสัมพัทธ์ไปยังไฟล์ YAML คำนิยามโมเดลภายในโฟลเดอร์โมเดล (เช่น model-definition.yaml) หากเว้นว่างจะใช้ model-definition.yaml เป็นค่าเริ่มต้น",
     "ModelDefinitionRequired": "จำเป็นต้องใช้ไฟล์ model-definition.yaml",
     "ModelMount": "การเมานต์โมเดล",
     "ModelMountDestination": "ปลายทางการเมาท์สำหรับโฟลเดอร์โมเดล",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -1490,6 +1490,7 @@
     "ModelAndServingConfiguration": "Model & Serving Yapılandırması",
     "ModelDefinition": "Model tanımı",
     "ModelDefinitionPath": "Model Tanımı Dosya Yolu",
+    "ModelDefinitionPathTooltip": "Model klasöründeki model tanımı YAML dosyasının göreli yolu (örn. model-definition.yaml). Boş bırakılırsa varsayılan olarak model-definition.yaml kullanılır.",
     "ModelDefinitionRequired": "Model-Definition.YAML dosyası gereklidir.",
     "ModelMount": "Model bağlama",
     "ModelMountDestination": "Model Klasörü İçin Montaj Hedefi",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -1492,6 +1492,7 @@
     "ModelAndServingConfiguration": "Cấu hình mô hình & phục vụ",
     "ModelDefinition": "Định nghĩa mô hình",
     "ModelDefinitionPath": "Đường dẫn tệp định nghĩa mô hình",
+    "ModelDefinitionPathTooltip": "Đường dẫn tương đối đến file YAML định nghĩa mô hình bên trong thư mục mô hình (ví dụ: model-definition.yaml). Mặc định là model-definition.yaml nếu để trống.",
     "ModelDefinitionRequired": "Cần định nghĩa mô hình.YAML.",
     "ModelMount": "Gắn kết mô hình",
     "ModelMountDestination": "Mount đích cho thư mục mẫu",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -1492,6 +1492,7 @@
     "ModelAndServingConfiguration": "模型与服务配置",
     "ModelDefinition": "模型定义",
     "ModelDefinitionPath": "模型定义文件路径",
+    "ModelDefinitionPathTooltip": "模型文件夹内模型定义 YAML 文件的相对路径（例如 model-definition.yaml）。如果留空，则默认使用 model-definition.yaml。",
     "ModelDefinitionRequired": "需要模型定义。yaml文件。",
     "ModelMount": "模型挂载",
     "ModelMountDestination": "模型文件夹的安装目标",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -1494,6 +1494,7 @@
     "ModelAndServingConfiguration": "模型與服務配置",
     "ModelDefinition": "模型定義",
     "ModelDefinitionPath": "模型定義檔路徑",
+    "ModelDefinitionPathTooltip": "模型資料夾內模型定義 YAML 檔的相對路徑（例如 model-definition.yaml）。若留空，預設使用 model-definition.yaml。",
     "ModelDefinitionRequired": "需要model-definition.yaml文件。",
     "ModelMount": "模型掛載",
     "ModelMountDestination": "模型資料夾的安裝目標",


### PR DESCRIPTION
Resolves #6718 (FR-2581)

## Summary
- Show full Segmented UI (Enter Command / Use Config File) in custom runtime edit mode, not just minimal fields
- Add `parseModelDefinitionYaml` helper to parse existing model-definition.yaml and populate form fields
- Load existing model-definition.yaml from vfolder in edit mode and pre-populate startCommand, port, healthCheck, initialDelay, maxRetries
- Upload updated model-definition.yaml to vfolder on save in edit mode
- vLLM/SGLang edit mode remains unchanged