### PR TITLE
fix: migrate deprecated Ant Design v5 props to v6 equivalents

### DIFF
--- a/react/src/components/ImageEnvironmentSelectFormItems.tsx
+++ b/react/src/components/ImageEnvironmentSelectFormItems.tsx
@@ -443,7 +443,7 @@ const ImageEnvironmentSelectFormItems: React.FC<
         <BAISelect
           ref={envSelectRef}
           open={envSelectOpen}
-          onDropdownVisibleChange={(visible) => {
+          onOpenChange={(visible) => {
             // Return to uncontrolled mode once the user interacts
             if (!visible) {
               setEnvSelectOpen(undefined);

--- a/react/src/components/ImageNodeSimpleTag.tsx
+++ b/react/src/components/ImageNodeSimpleTag.tsx
@@ -64,14 +64,14 @@ const ImageNodeSimpleTag: React.FC<ImageNodeSimpleTagProps> = ({
       <ImageMetaIcon image={fullName} />
       <Typography.Text>{tagAlias(image.base_image_name || '')}</Typography.Text>
       <Divider
-        type="vertical"
+        orientation="vertical"
         style={{
           marginInline: 0,
         }}
       />
       <Typography.Text>{image.version}</Typography.Text>
       <Divider
-        type="vertical"
+        orientation="vertical"
         style={{
           marginInline: 0,
         }}
@@ -80,7 +80,7 @@ const ImageNodeSimpleTag: React.FC<ImageNodeSimpleTagProps> = ({
       {withoutTag ? null : (
         <>
           <Divider
-            type="vertical"
+            orientation="vertical"
             style={{
               marginInline: 0,
             }}


### PR DESCRIPTION
Resolves #6725 (FR-2584)

## Summary
- Migrate deprecated Ant Design v5 props to v6 equivalents
- `ImageEnvironmentSelectFormItems`: `onDropdownVisibleChange` → `onOpenChange`
- `ImageNodeSimpleTag`: Divider `type="vertical"` → `orientation="vertical"`