### PR TITLE
fix: remove (default) suffix from runtime variant display label

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1379,7 +1379,11 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                               (runtime) => {
                                 return {
                                   value: runtime.name,
-                                  label: runtime.human_readable_name,
+                                  label:
+                                    runtime.human_readable_name?.replace(
+                                      /\s*\(default\)\s*/i,
+                                      '',
+                                    ) || runtime.name,
                                 };
                               },
                             )}


### PR DESCRIPTION
## Summary
- Strip the backend-provided "(default)" suffix from runtime variant `human_readable_name` in the selector
- Shows just "Custom" instead of "Custom (default)"