### PR TITLE
fix(FR-2581): preserve resource values when clicking Change in edit mode

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1834,7 +1834,10 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                                   type="link"
                                   action={async () => {
                                     form.setFieldsValue({
-                                      allocationPreset: 'auto-select',
+                                      allocationPreset: baiClient._config
+                                        .allowCustomResourceAllocation
+                                        ? 'custom'
+                                        : 'auto-select',
                                     });
                                     setWantToChangeResource(true);
                                   }}

--- a/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
+++ b/react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx
@@ -225,7 +225,10 @@ const ResourceAllocationFormItems: React.FC<
   }, [currentImage, acceleratorSlotsInRG, currentEnvironmentManual]);
 
   useEffect(() => {
-    if (!currentResourceValue) {
+    if (
+      !currentResourceValue &&
+      form.getFieldValue('allocationPreset') !== 'custom'
+    ) {
       form.setFieldsValue({
         allocationPreset: 'auto-select',
       });


### PR DESCRIPTION
Resolves #5804 ([FR-2581](https://lablup.atlassian.net/browse/FR-2581))

## Summary
- Fix resource allocation values (CPU, memory) being overwritten when clicking "Change" button on the endpoint edit page
- The root cause was an effect in `ResourceAllocationFormItems` that reset `allocationPreset` to `auto-select` when `Form.useWatch(['resource'])` returned `undefined` on first mount — before the resource Form.Items had registered. This triggered the auto-select cascade which picked the first available preset, overwriting the endpoint's actual values.
- Guard the reset effect so it does not override an explicitly set `custom` preset
- Also fix `react-hooks/exhaustive-deps` lint warning in `RuntimeParameterFormSection` by wrapping the cleanup callback in `useEffectEvent`

## Changed files
- `react/src/components/SessionFormItems/ResourceAllocationFormItems.tsx` — Guard `allocationPreset` reset effect to skip when preset is already `custom`
- `react/src/components/RuntimeParameterFormSection.tsx` — Wrap `onGroupsLoaded` cleanup in `useEffectEvent` to fix lint warning

[FR-2581]: https://lablup.atlassian.net/browse/FR-2581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ