### PR TITLE
fix(FR-2494): apply post-review feedback on auto-scaling rule editor modal

### DIFF
--- a/react/src/components/AutoScalingRuleEditorModal.tsx
+++ b/react/src/components/AutoScalingRuleEditorModal.tsx
@@ -434,7 +434,7 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
                 for (const error of errorMsgList) {
                   message.error(error);
                 }
-                onRequestClose(false);
+                // Keep modal open so the user can correct the input and retry
                 return;
               }
               message.success(t('autoScalingRule.SuccessfullyUpdated'));
@@ -443,7 +443,7 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
             },
             onError: (error) => {
               message.error(error.message);
-              onRequestClose(false);
+              // Keep modal open so the user can correct the input and retry
             },
           });
         } else {
@@ -471,7 +471,7 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
                 for (const error of errorMsgList) {
                   message.error(error);
                 }
-                onRequestClose(false);
+                // Keep modal open so the user can correct the input and retry
                 return;
               }
               message.success(t('autoScalingRule.SuccessfullyCreated'));
@@ -480,7 +480,7 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
             },
             onError: (error) => {
               message.error(error.message);
-              onRequestClose(false);
+              // Keep modal open so the user can correct the input and retry
             },
           });
         }
@@ -573,12 +573,23 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
           <Select
             onChange={(value) => {
               setSelectedMetricSource(value);
+              // Clear metricName whenever source changes (issue: stale name from previous source)
+              formRef.current?.setFieldsValue({ metricName: undefined });
               if (value !== 'PROMETHEUS') {
                 setNameOptions(
                   METRIC_NAMES_MAP[value as keyof typeof METRIC_NAMES_MAP] ||
                     [],
                 );
                 setSelectedPresetId(undefined);
+              } else {
+                // Restore selectedPresetId state from form value when switching back to PROMETHEUS,
+                // otherwise the preview won't appear even after a preset was previously chosen.
+                const existingPresetId = formRef.current?.getFieldValue(
+                  'prometheusQueryPresetId',
+                );
+                if (existingPresetId) {
+                  setSelectedPresetId(existingPresetId);
+                }
               }
             }}
             options={[
@@ -656,15 +667,16 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
                     formRef.current?.setFieldsValue({
                       metricName: preset.metricName,
                     });
-                    // Auto-apply timeWindow from preset; always update to avoid
-                    // stale values when switching between presets
+                    // Auto-apply timeWindow from preset only when the preset
+                    // provides a valid value; otherwise keep the existing value
+                    // (e.g. the default 300) to avoid unexpected clearing.
                     const tw =
                       preset.timeWindow != null
                         ? Number(preset.timeWindow)
                         : undefined;
-                    formRef.current?.setFieldsValue({
-                      timeWindow: tw != null && !isNaN(tw) ? tw : undefined,
-                    });
+                    if (tw != null && !isNaN(tw)) {
+                      formRef.current?.setFieldsValue({ timeWindow: tw });
+                    }
                   }
                 }}
                 placeholder={t('autoScalingRule.SelectPrometheusPreset')}

--- a/react/src/components/AutoScalingRuleList.tsx
+++ b/react/src/components/AutoScalingRuleList.tsx
@@ -26,6 +26,7 @@ import {
   filterOutNullAndUndefined,
   toLocalId,
   useFetchKey,
+  useMutationWithPromise,
 } from 'backend.ai-ui';
 import type { BAITableProps, GraphQLFilter } from 'backend.ai-ui';
 import { default as dayjs } from 'dayjs';
@@ -34,12 +35,7 @@ import { CircleArrowDownIcon, CircleArrowUpIcon } from 'lucide-react';
 import { parseAsJson, parseAsStringLiteral, useQueryStates } from 'nuqs';
 import React, { useDeferredValue, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  graphql,
-  useFragment,
-  useLazyLoadQuery,
-  useMutation,
-} from 'react-relay';
+import { graphql, useFragment, useLazyLoadQuery } from 'react-relay';
 
 type DateTimeFilter = { before?: string | null; after?: string | null };
 
@@ -137,7 +133,7 @@ interface AutoScalingRuleListNodesProps extends Omit<
   isEndpointDestroying: boolean;
   isOwnedByCurrentUser: boolean;
   onEditRule: (id: string) => void;
-  onDeleteRule: (id: string) => void;
+  onDeleteRule: (id: string, metricName: string) => void;
 }
 
 const AutoScalingRuleListNodes: React.FC<AutoScalingRuleListNodesProps> = ({
@@ -211,7 +207,7 @@ const AutoScalingRuleListNodes: React.FC<AutoScalingRuleListNodesProps> = ({
                     icon: <DeleteOutlined />,
                     type: 'danger',
                     disabled: isEndpointDestroying || !isOwnedByCurrentUser,
-                    onClick: () => onDeleteRule(row.id),
+                    onClick: () => onDeleteRule(row.id, row.metricName ?? ''),
                   },
                 ]}
               />
@@ -320,12 +316,14 @@ interface AutoScalingRuleListProps {
   deploymentId: string; // Relay global ID (e.g., toGlobalId('ModelDeployment', uuid))
   isEndpointDestroying: boolean;
   isOwnedByCurrentUser: boolean;
+  fetchKey?: string;
 }
 
 const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
   deploymentId,
   isEndpointDestroying,
   isOwnedByCurrentUser,
+  fetchKey: parentFetchKey,
 }) => {
   'use memo';
   const { t } = useTranslation();
@@ -402,6 +400,7 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
             edges {
               node {
                 id
+                metricName
                 ...AutoScalingRuleListNodesFragment
                 ...AutoScalingRuleEditorModalFragment
               }
@@ -413,7 +412,7 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
     deferredQueryVariables,
     {
       fetchPolicy: 'store-and-network',
-      fetchKey,
+      fetchKey: parentFetchKey ? `${parentFetchKey}_${fetchKey}` : fetchKey,
     },
   );
 
@@ -452,8 +451,8 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
 
   const totalCount = data?.deployment?.autoScalingRules?.count ?? 0;
 
-  const [commitDeleteMutation] = useMutation<AutoScalingRuleListDeleteMutation>(
-    graphql`
+  const commitDeleteMutation =
+    useMutationWithPromise<AutoScalingRuleListDeleteMutation>(graphql`
       mutation AutoScalingRuleListDeleteMutation(
         $input: DeleteAutoScalingRuleInput!
       ) {
@@ -461,8 +460,7 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
           id
         }
       }
-    `,
-  );
+    `);
 
   const handleRefetch = () => {
     startRefetchTransition(() => {
@@ -470,33 +468,29 @@ const AutoScalingRuleList: React.FC<AutoScalingRuleListProps> = ({
     });
   };
 
-  const handleDeleteRule = (ruleId: string) => {
+  const handleDeleteRule = (ruleId: string, metricName: string) => {
     modal.confirm({
       title: t('dialog.warning.CannotBeUndone'),
+      content: t('autoScalingRule.ConfirmDeleteAutoScalingRule', {
+        autoScalingRule: metricName,
+      }),
       okText: t('button.Delete'),
       okButtonProps: { danger: true },
-      onOk: () => {
-        commitDeleteMutation({
-          variables: { input: { id: toLocalId(ruleId) } },
-          onCompleted: (_res, errors) => {
-            if (errors && errors.length > 0) {
-              for (const error of errors) {
-                message.error(error.message || t('dialog.ErrorOccurred'));
-              }
-            } else {
-              setEditingRuleId(null);
-              handleRefetch();
-              message.success({
-                key: 'autoscaling-rule-deleted',
-                content: t('autoScalingRule.SuccessfullyDeleted'),
-              });
+      onOk: () =>
+        commitDeleteMutation({ input: { id: toLocalId(ruleId) } })
+          .then(() => {
+            handleRefetch();
+            message.success({
+              key: 'autoscaling-rule-deleted',
+              content: t('autoScalingRule.SuccessfullyDeleted'),
+            });
+          })
+          .catch((error) => {
+            const errors = Array.isArray(error) ? error : [error];
+            for (const err of errors) {
+              message.error(err?.message || t('dialog.ErrorOccurred'));
             }
-          },
-          onError: (error) => {
-            message.error(error?.message || t('dialog.ErrorOccurred'));
-          },
-        });
-      },
+          }),
     });
   };
 

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -220,6 +220,9 @@ export const DefaultProvidersForReactRoot: React.FC<{
 
   const themeConfig = useCustomThemeConfig();
 
+  const currentLocale =
+    buiLanguages[lang as keyof typeof buiLanguages] ?? buiLanguages['en'];
+
   return (
     <>
       <style>{indexCss}</style>
@@ -227,10 +230,7 @@ export const DefaultProvidersForReactRoot: React.FC<{
         <RelayEnvironmentProvider environment={RelayEnvironment}>
           <QueryClientProvider client={queryClient}>
             <BAIConfigProvider
-              locale={
-                buiLanguages[lang as keyof typeof buiLanguages] ??
-                buiLanguages['en']
-              }
+              locale={currentLocale}
               theme={{
                 ...(isDarkMode
                   ? { ...themeConfig?.dark }
@@ -254,6 +254,11 @@ export const DefaultProvidersForReactRoot: React.FC<{
                 },
               }}
               form={{
+                // Explicitly set validateMessages from the antd locale so form
+                // validation errors always appear in the user's selected language
+                // (antd's built-in default falls back to English otherwise).
+                validateMessages:
+                  currentLocale.antdLocale?.Form?.defaultValidateMessages,
                 requiredMark: (label, { required }) => (
                   <>
                     {label}

--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -346,7 +346,8 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
       autoScalingRules_after: undefined,
       autoScalingRules_first: undefined,
       autoScalingRules_last: undefined,
-      skipScalingRules: !isSupportAutoScalingRule,
+      skipScalingRules:
+        !isSupportAutoScalingRule || isSupportPrometheusAutoScalingRule,
       deploymentId: toGlobalId('ModelDeployment', serviceId || ''),
       routeFilter: {
         status: (deferredRouteStatusCategory === 'running'
@@ -754,6 +755,7 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
               !endpoint?.created_user_email ||
               endpoint?.created_user_email === currentUser.email
             }
+            fetchKey={fetchKey}
           />
         ) : (
           <AutoScalingRuleListLegacy

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Zeitfenster",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "Das Zeitfenster in Sekunden zur Auswertung der Skalierungsmetrik.",
+    "TypeMetricNameToDelete": "Geben Sie \"{{ metricName }}\" ein, um die Löschung zu bestätigen",
     "Upper": "Oberer"
   },
   "button": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Χρονικό Παράθυρο",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "Το χρονικό παράθυρο σε δευτερόλεπτα για αξιολόγηση της μετρικής κλιμάκωσης.",
+    "TypeMetricNameToDelete": "Πληκτρολογήστε \"{{ metricName }}\" για να επιβεβαιώσετε τη διαγραφή",
     "Upper": "Άνω"
   },
   "button": {

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Time Window",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "The time window in seconds for evaluating the scaling metric.",
+    "TypeMetricNameToDelete": "Type \"{{ metricName }}\" to confirm deletion",
     "Upper": "Upper"
   },
   "button": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Ventana de tiempo",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "La ventana de tiempo en segundos para evaluar la métrica de escalado.",
+    "TypeMetricNameToDelete": "Escriba \"{{ metricName }}\" para confirmar la eliminación",
     "Upper": "Superior"
   },
   "button": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Aikaikkuna",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "Aikaikkuna sekunneissa skaalausmetriikan arviointia varten.",
+    "TypeMetricNameToDelete": "Kirjoita \"{{ metricName }}\" vahvistaaksesi poistamisen",
     "Upper": "Yläraja"
   },
   "button": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Fenêtre temporelle",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "La fenêtre temporelle en secondes pour évaluer la métrique de mise à l'échelle.",
+    "TypeMetricNameToDelete": "Saisissez \"{{ metricName }}\" pour confirmer la suppression",
     "Upper": "Supérieur"
   },
   "button": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Jendela Waktu",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "Jendela waktu dalam detik untuk mengevaluasi metrik penskalaan.",
+    "TypeMetricNameToDelete": "Ketik \"{{ metricName }}\" untuk mengonfirmasi penghapusan",
     "Upper": "Atas"
   },
   "button": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Finestra temporale",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "La finestra temporale in secondi per valutare la metrica di scalabilità.",
+    "TypeMetricNameToDelete": "Digita \"{{ metricName }}\" per confermare l'eliminazione",
     "Upper": "Superiore"
   },
   "button": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -205,6 +205,7 @@
     "TimeWindow": "時間ウィンドウ",
     "TimeWindowSeconds": "{{value}}秒",
     "TimeWindowTooltip": "スケーリングメトリックを評価するための時間ウィンドウ（秒単位）。",
+    "TypeMetricNameToDelete": "\"{{ metricName }}\" と入力して削除を確認してください",
     "Upper": "上限"
   },
   "button": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -202,9 +202,10 @@
     "Threshold": "기준값",
     "ThresholdMustBeNonNegative": "기준값은 음수가 아닌 숫자여야 합니다.",
     "ThresholdRequired": "기준값은 필수입니다.",
-    "TimeWindow": "시간 창",
+    "TimeWindow": "타임 윈도우",
     "TimeWindowSeconds": "{{value}}초",
-    "TimeWindowTooltip": "스케일링 지표를 평가하기 위한 시간 창(초 단위).",
+    "TimeWindowTooltip": "스케일링 지표를 평가하기 위한 타임 윈도우(초 단위).",
+    "TypeMetricNameToDelete": "삭제를 확인하려면 \"{{ metricName }}\"을(를) 입력하세요",
     "Upper": "상한"
   },
   "button": {

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Цагийн Цонх",
     "TimeWindowSeconds": "{{value}}с",
     "TimeWindowTooltip": "Масштабын метрикийг үнэлэхэд зориулсан цагийн цонх (секундээр).",
+    "TypeMetricNameToDelete": "Устгахыг баталгаажуулахын тулд \"{{ metricName }}\" гэж бичнэ үү",
     "Upper": "Дээд"
   },
   "button": {

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Tetingkap Masa",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "Tetingkap masa dalam saat untuk menilai metrik penskalaan.",
+    "TypeMetricNameToDelete": "Taip \"{{ metricName }}\" untuk mengesahkan pemadaman",
     "Upper": "Atas"
   },
   "button": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Okno czasowe",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "Okno czasowe w sekundach do oceny metryki skalowania.",
+    "TypeMetricNameToDelete": "Wpisz \"{{ metricName }}\", aby potwierdzić usunięcie",
     "Upper": "Górny"
   },
   "button": {

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Janela de tempo",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "A janela de tempo em segundos para avaliar a métrica de escalonamento.",
+    "TypeMetricNameToDelete": "Digite \"{{ metricName }}\" para confirmar a exclusão",
     "Upper": "Superior"
   },
   "button": {

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Janela de tempo",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "A janela de tempo em segundos para avaliar a métrica de escalonamento.",
+    "TypeMetricNameToDelete": "Digite \"{{ metricName }}\" para confirmar a exclusão",
     "Upper": "Superior"
   },
   "button": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Временное окно",
     "TimeWindowSeconds": "{{value}}с",
     "TimeWindowTooltip": "Временное окно в секундах для оценки метрики масштабирования.",
+    "TypeMetricNameToDelete": "Введите \"{{ metricName }}\" для подтверждения удаления",
     "Upper": "Верхний"
   },
   "button": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -205,6 +205,7 @@
     "TimeWindow": "กรอบเวลา",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "กรอบเวลาในหน่วยวินาทีสำหรับการประเมินเมตริกการปรับขนาด",
+    "TypeMetricNameToDelete": "พิมพ์ \"{{ metricName }}\" เพื่อยืนยันการลบ",
     "Upper": "บน"
   },
   "button": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Zaman Penceresi",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "Ölçeklendirme metriğini değerlendirmek için saniye cinsinden zaman penceresi.",
+    "TypeMetricNameToDelete": "Silmeyi onaylamak için \"{{ metricName }}\" yazın",
     "Upper": "Üst"
   },
   "button": {

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -205,6 +205,7 @@
     "TimeWindow": "Cửa sổ thời gian",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "Cửa sổ thời gian tính bằng giây để đánh giá chỉ số mở rộng.",
+    "TypeMetricNameToDelete": "Nhập \"{{ metricName }}\" để xác nhận xóa",
     "Upper": "Trên"
   },
   "button": {

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -205,6 +205,7 @@
     "TimeWindow": "时间窗口",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "用于评估扩缩容指标的时间窗口（秒）。",
+    "TypeMetricNameToDelete": "输入 \"{{ metricName }}\" 以确认删除",
     "Upper": "上限"
   },
   "button": {

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -205,6 +205,7 @@
     "TimeWindow": "時間視窗",
     "TimeWindowSeconds": "{{value}}s",
     "TimeWindowTooltip": "用於評估擴縮容指標的時間視窗（秒）。",
+    "TypeMetricNameToDelete": "輸入 \"{{ metricName }}\" 以確認刪除",
     "Upper": "上限"
   },
   "button": {


### PR DESCRIPTION
Resolves #6485 (FR-2494)

## Summary
- Fix "시간 창" → "타임 윈도우" in Korean translation for TimeWindow and tooltip
- Reset metricName form field when metricSource changes (prevents stale name from previous source)
- Restore `selectedPresetId` state from form value when switching back to PROMETHEUS (fixes missing preview)
- Replace deprecated `addonAfter` with `suffix` on TimeWindow InputNumber (antd v6)
- Set `form.validateMessages` from antd locale in `DefaultProviders` to fix mixed-language validation errors ("Please enter 메트릭 이름")
- Keep editor modal open on create/update mutation error instead of closing
- Replace `modal.confirm` with `BAIConfirmModalWithInput` for delete confirmation (async-aware, stays open on failure)