### PR TITLE
fix(FR-2494): replace deprecated addonAfter with suffix, set form validateMessages from locale globally

### DIFF
--- a/react/src/components/AutoScalingRuleEditorModal.tsx
+++ b/react/src/components/AutoScalingRuleEditorModal.tsx
@@ -901,7 +901,7 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
             min={1}
             step={1}
             style={{ width: '100%' }}
-            addonAfter={t('autoScalingRule.Seconds')}
+            suffix={t('autoScalingRule.Seconds')}
           />
         </Form.Item>
 

--- a/react/src/components/DefaultProviders.tsx
+++ b/react/src/components/DefaultProviders.tsx
@@ -220,6 +220,9 @@ export const DefaultProvidersForReactRoot: React.FC<{
 
   const themeConfig = useCustomThemeConfig();
 
+  const currentLocale =
+    buiLanguages[lang as keyof typeof buiLanguages] ?? buiLanguages['en'];
+
   return (
     <>
       <style>{indexCss}</style>
@@ -227,10 +230,7 @@ export const DefaultProvidersForReactRoot: React.FC<{
         <RelayEnvironmentProvider environment={RelayEnvironment}>
           <QueryClientProvider client={queryClient}>
             <BAIConfigProvider
-              locale={
-                buiLanguages[lang as keyof typeof buiLanguages] ??
-                buiLanguages['en']
-              }
+              locale={currentLocale}
               theme={{
                 ...(isDarkMode
                   ? { ...themeConfig?.dark }
@@ -254,6 +254,11 @@ export const DefaultProvidersForReactRoot: React.FC<{
                 },
               }}
               form={{
+                // Explicitly set validateMessages from the antd locale so form
+                // validation errors always appear in the user's selected language
+                // (antd's built-in default falls back to English otherwise).
+                validateMessages:
+                  currentLocale.antdLocale?.Form?.defaultValidateMessages,
                 requiredMark: (label, { required }) => (
                   <>
                     {label}


### PR DESCRIPTION
resolves #NNN (FR-MMM)
<!-- replace NNN, MMM with the GitHub issue number and the corresponding Jira issue number. -->

<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

**Checklist:** (if applicable)

- [ ] Documentation
- [ ] Minium required manager version
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
