### PR TITLE
fix(FR-2587): guard myRoles fetch policy for older Manager versions

### DIFF
--- a/react/src/hooks/useCurrentUserProjectRoles.ts
+++ b/react/src/hooks/useCurrentUserProjectRoles.ts
@@ -65,7 +65,9 @@ export const useCurrentUserProjectRoles = (): CurrentUserProjectRolesResult => {
     {},
     {
       // store-or-network keeps the result cached across pages for the session.
-      fetchPolicy: 'store-or-network',
+      fetchPolicy: baiClient.supports('my-roles')
+        ? 'store-or-network'
+        : 'store-only',
     },
   );
 

--- a/src/lib/backend.ai-client-esm.ts
+++ b/src/lib/backend.ai-client-esm.ts
@@ -899,6 +899,7 @@ class Client {
       this._features['bulk-purge-users'] = true;
       this._features['route-health-status'] = true;
       this._features['model-card-v2'] = true;
+      this._features['my-roles'] = true;
     }
   }
 


### PR DESCRIPTION
Resolves #6737 ([FR-2587](https://lablup.atlassian.net/browse/FR-2587))

## Summary
- Add a `my-roles` feature flag in `backend.ai-client-esm.ts` so the client can detect Manager versions that support the `myRoles` GraphQL field.
- In `useCurrentUserProjectRoles`, switch the Relay `fetchPolicy` to `store-only` when the feature is unsupported, preventing failed network requests against older Managers.
- Newer Managers continue to use `store-or-network` and benefit from session-wide caching as before.

## Test plan
- [ ] Run against an older Manager (without `my-roles` support) and verify the hook does not surface a network error.
- [ ] Run against a newer Manager and verify project roles still load via `store-or-network` and stay cached across pages.

[FR-2587]: https://lablup.atlassian.net/browse/FR-2587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ