### PR TITLE
fix: render AutoScalingRuleList when prometheus auto-scaling rule is supported

### DIFF
--- a/react/src/pages/EndpointDetailPage.tsx
+++ b/react/src/pages/EndpointDetailPage.tsx
@@ -19,6 +19,7 @@ import { InferenceSessionErrorModalFragment$key } from '../__generated__/Inferen
 import AutoScalingRuleEditorModalLegacy, {
   COMPARATOR_LABELS,
 } from '../components/AutoScalingRuleEditorModalLegacy';
+import AutoScalingRuleList from '../components/AutoScalingRuleList';
 import BAIJSONViewerModal from '../components/BAIJSONViewerModal';
 import BAIRadioGroup from '../components/BAIRadioGroup';
 import { isEndpointInDestroyingCategory } from '../components/EndpointList';
@@ -1015,6 +1016,17 @@ const EndpointDetailPage: React.FC<EndpointDetailPageProps> = () => {
           ]}
         ></Descriptions>
       </BAIModal>
+      {isSupportPrometheusAutoScalingRule && (
+        <AutoScalingRuleList
+          deploymentId={toGlobalId('ModelDeployment', serviceId || '')}
+          isEndpointDestroying={!!isEndpointInDestroyingCategory(endpoint)}
+          isOwnedByCurrentUser={
+            !endpoint?.created_user_email ||
+            endpoint?.created_user_email === currentUser.email
+          }
+          fetchKey={fetchKey}
+        />
+      )}
       {isSupportAutoScalingRule && (
         <Card
           title={t('modelService.AutoScalingRules')}


### PR DESCRIPTION
Resolves #6762

## Summary
- Render `AutoScalingRuleList` (v2) component on `EndpointDetailPage` when `isSupportPrometheusAutoScalingRule` is true
- Keep legacy auto scaling rules table for environments that only support `auto-scaling-rule` (not prometheus)
- Previously, `isSupportPrometheusAutoScalingRule` was only used to skip the legacy query but had no v2 UI wired in, resulting in no auto scaling rules section being visible

## Test plan
- [ ] Verify with a backend that supports `prometheus-auto-scaling-rule`: the new `AutoScalingRuleList` component renders with full functionality (create, edit, delete rules)
- [ ] Verify with a backend that only supports `auto-scaling-rule`: the legacy table renders as before
- [ ] Verify with a backend that supports neither: no auto scaling section is shown