### PR TITLE
feat(FR-2597): add --chapters option to docs-toolkit pdf for selective chapter export

### DIFF
--- a/packages/backend.ai-docs-toolkit/src/cli.ts
+++ b/packages/backend.ai-docs-toolkit/src/cli.ts
@@ -41,6 +41,8 @@ Options:
   pdf:
     --lang <all|en|ko|...>    Language(s) to generate (default: all)
     --theme <name>            Theme name (default: default)
+    --chapters <list>         Comma-separated chapter names to include (default: all)
+    --note <text>             Note displayed on the cover page (e.g. "Draft — internal review")
 
   preview:
     --mode <sample|catalog|document>  Preview mode (default: sample)
@@ -66,6 +68,7 @@ Options:
 Examples:
   docs-toolkit pdf --lang all
   docs-toolkit pdf --lang en
+  docs-toolkit pdf --lang ko --chapters "quickstart,session_page,model_serving"
   docs-toolkit preview
   docs-toolkit preview --mode document --lang ko
   docs-toolkit preview:html --lang en
@@ -89,6 +92,17 @@ function getCommand(argv: string[]): Command | null {
 
 function hasFlag(argv: string[], flag: string): boolean {
   return argv.includes(flag);
+}
+
+function getFlagValue(argv: string[], flag: string): string | undefined {
+  const idx = argv.indexOf(flag);
+  if (idx < 0) return undefined;
+  const value = argv[idx + 1];
+  if (!value || value.startsWith('--')) {
+    console.error(`Error: ${flag} requires a value.`);
+    process.exit(1);
+  }
+  return value;
 }
 
 // ── Init Command ────────────────────────────────────────────────
@@ -343,11 +357,18 @@ async function main(): Promise<void> {
   switch (command) {
     case 'pdf': {
       const { generatePdf } = await import('./generate-pdf.js');
-      const langIdx = argv.indexOf('--lang');
-      const themeIdx = argv.indexOf('--theme');
+      const langArg = getFlagValue(argv, '--lang') ?? 'all';
+      const themeArg = getFlagValue(argv, '--theme') ?? 'default';
+      const chaptersRaw = getFlagValue(argv, '--chapters');
+      const chaptersArg = chaptersRaw
+        ? chaptersRaw.split(',').map((c) => c.trim())
+        : undefined;
+      const noteArg = getFlagValue(argv, '--note');
       await generatePdf(config, {
-        lang: langIdx >= 0 ? argv[langIdx + 1] : 'all',
-        theme: themeIdx >= 0 ? argv[themeIdx + 1] : 'default',
+        lang: langArg,
+        theme: themeArg,
+        chapters: chaptersArg,
+        note: noteArg,
       });
       break;
     }

--- a/packages/backend.ai-docs-toolkit/src/generate-pdf.ts
+++ b/packages/backend.ai-docs-toolkit/src/generate-pdf.ts
@@ -18,6 +18,8 @@ interface BookConfig {
 export interface GeneratePdfOptions {
   lang: string;
   theme: string;
+  chapters?: string[];
+  note?: string;
 }
 
 function parseArgs(argv: string[]): GeneratePdfOptions {
@@ -95,10 +97,44 @@ export async function generatePdf(
     const startTime = Date.now();
     console.log(`[${lang}] Generating PDF...`);
 
-    const navigation = bookConfig.navigation[lang];
+    let navigation = bookConfig.navigation[lang];
     if (!navigation) {
       console.warn(`[${lang}] No navigation found, skipping`);
       continue;
+    }
+
+    // Filter chapters if --chapters option is specified
+    const chapterFilter = args.chapters?.filter((c) => c.length > 0);
+    if (chapterFilter && chapterFilter.length > 0) {
+      const filterSet = new Set(chapterFilter);
+      const filtered = navigation.filter((nav) => {
+        const noExt = nav.path.replace(/\.md$/, '');
+        const segments = noExt.split('/');
+        const pathStem = segments[segments.length - 1];
+        const dirName = segments.length > 1 ? segments[segments.length - 2] : '';
+        return (
+          filterSet.has(nav.path) ||
+          filterSet.has(pathStem) ||
+          (dirName !== '' && filterSet.has(dirName))
+        );
+      });
+      if (filtered.length === 0) {
+        const available = navigation
+          .map((n) => n.path.replace(/\.md$/, '').split('/').pop())
+          .join(', ');
+        console.error(
+          `[${lang}] No chapters matched filter: ${chapterFilter.join(', ')}`,
+        );
+        console.error(
+          `[${lang}] Chapter identifiers can be a full path (e.g. overview/overview.md), directory name, or filename.`,
+        );
+        console.error(`[${lang}] Available chapters: ${available}`);
+        process.exit(1);
+      }
+      navigation = filtered;
+      console.log(
+        `[${lang}] Filtered to ${navigation.length} chapter(s): ${navigation.map((n) => n.title).join(', ')}`,
+      );
     }
 
     // Process markdown files
@@ -115,7 +151,7 @@ export async function generatePdf(
     console.log(`[${lang}] Building HTML...`);
     const html = buildFullDocument(
       chapters,
-      { title, version, lang },
+      { title, version, lang, note: args.note },
       config,
       theme,
     );

--- a/packages/backend.ai-docs-toolkit/src/html-builder.ts
+++ b/packages/backend.ai-docs-toolkit/src/html-builder.ts
@@ -9,6 +9,16 @@ export interface DocMetadata {
   title: string;
   version: string;
   lang: string;
+  note?: string;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/\n/g, '<br>');
 }
 
 function getFormattedDate(lang: string): string {
@@ -52,7 +62,7 @@ function buildCoverHtml(
     <p class="company">${config.company}</p>
     <p class="date">${date}</p>
     <p class="lang">${langLabel}</p>
-  </div>
+  </div>${metadata.note ? `\n  <div class="cover-note">${escapeHtml(metadata.note)}</div>` : ''}
 </section>
 `;
 }

--- a/packages/backend.ai-docs-toolkit/src/styles.ts
+++ b/packages/backend.ai-docs-toolkit/src/styles.ts
@@ -105,6 +105,19 @@ body {
   border: none;
 }
 
+.cover-note {
+  margin-top: 32px;
+  padding: 12px 20px;
+  border: 1.5px solid ${theme.brandColor};
+  border-radius: 6px;
+  background: #fafafa;
+  color: #444;
+  font-size: 11pt;
+  line-height: 1.5;
+  max-width: 420px;
+  text-align: center;
+}
+
 /* ==========================================================================
    Table of Contents
    ========================================================================== */


### PR DESCRIPTION
Resolves #6773 (FR-2597)

## Summary

Adds two new CLI options to `docs-toolkit pdf`:

1. **`--chapters`** — comma-separated list of chapter identifiers to include (filters navigation before HTML assembly)
2. **`--note`** — custom text displayed on the PDF cover page (e.g. "Draft — internal review")

## Motivation

`docs-toolkit pdf` previously generated a single monolithic PDF containing all chapters defined in `book.config.yaml`. There was no way to export only a subset of chapters or mark a document as a draft/preview version on the cover.

## Usage

```bash
# Select specific chapters + add cover note
docs-toolkit pdf --lang ko --chapters "quickstart,login,session_page" \
  --note "Internal Review Draft — Session & Login only"

# Cover note only (full document)
docs-toolkit pdf --lang en --note "Pre-release v26.5 — Not for distribution"

# Full PDF (existing behavior, unchanged)
docs-toolkit pdf --lang en
```

## --chapters Matching

Each identifier is matched against navigation entries by:
- Full path: `overview/overview.md`
- Directory name: `overview`
- File stem: `overview`

Invalid identifiers print available chapters with a hint and exit with code 1.

## --note Rendering

The note is rendered as a styled box on the cover page, below the version/company/date metadata. Uses the theme brand color for the border.

## Files Changed

- `packages/backend.ai-docs-toolkit/src/generate-pdf.ts` — `chapters` and `note` options, navigation filtering
- `packages/backend.ai-docs-toolkit/src/cli.ts` — CLI parsing for `--chapters` and `--note`, help text
- `packages/backend.ai-docs-toolkit/src/html-builder.ts` — `note` field in DocMetadata, cover page rendering
- `packages/backend.ai-docs-toolkit/src/styles.ts` — `.cover-note` styling

## Test Plan

- [x] `--chapters "quickstart,login"` produces a 2-chapter PDF (0.4 MB)
- [x] `--note` text renders on cover page (verified via compiled output)
- [x] Omitting both options preserves existing full-PDF behavior
- [x] TOC and chapter numbering recompute correctly for filtered subset
- [x] `scripts/verify.sh` → ALL PASS (Relay, Lint, Format, TypeScript)