### PR TITLE
feat(FR-2599): group prometheus query presets by category in AutoScaling rule editor

### DIFF
--- a/react/src/components/AutoScalingRuleEditorModal.tsx
+++ b/react/src/components/AutoScalingRuleEditorModal.tsx
@@ -26,6 +26,7 @@ import {
   Typography,
   theme,
 } from 'antd';
+import type { DefaultOptionType } from 'antd/es/select';
 import {
   BAIButton,
   BAIFlex,
@@ -276,6 +277,10 @@ const AutoScalingRuleEditorModalContent: React.FC<{
                 metricName
                 queryTemplate
                 timeWindow
+                category @since(version: "26.4.3") {
+                  id
+                  name
+                }
               }
             }
           }
@@ -324,17 +329,29 @@ const AutoScalingRuleEditorModalContent: React.FC<{
     description?: string | null;
   };
 
-  // TODO(needs-backend): group by categoryId with human-readable category names
-  // once the backend exposes a QueryDefinitionCategory type/query.
-  const presetOptions: PresetOption[] = _.orderBy(
-    presetNodes,
-    ['rank'],
-    ['asc'],
-  ).map((preset) => ({
-    label: preset.name,
-    value: preset.id,
-    description: preset.description,
-  }));
+  // Group presets by category name for optgroup display.
+  // Presets without a category are shown in a flat list at the end.
+  const presetOptions: DefaultOptionType[] = React.useMemo(() => {
+    const sorted = _.orderBy(presetNodes, ['rank'], ['asc']);
+    const withCategory = sorted.filter((p) => p.category?.name);
+    const withoutCategory = sorted.filter((p) => !p.category?.name);
+
+    const toOption = (preset: (typeof sorted)[number]): PresetOption => ({
+      label: preset.name,
+      value: preset.id,
+      description: preset.description,
+    });
+
+    const grouped = _.groupBy(withCategory, (p) => p.category!.name);
+    const groupOptions = Object.entries(grouped).map(([catName, presets]) => ({
+      label: catName,
+      options: presets.map(toOption),
+    }));
+
+    return withoutCategory.length > 0
+      ? [...groupOptions, ...withoutCategory.map(toOption)]
+      : groupOptions;
+  }, [presetNodes]);
 
   // Build initial form values from existing rule data
   const getInitialValues = (): Partial<AutoScalingRuleFormValues> => {


### PR DESCRIPTION
Relates to FR-2599

## Summary

Groups Prometheus query presets by category (via the new `QueryPresetCategory` type) in the AutoScaling rule editor modal's preset selector, so users can distinguish presets by domain (e.g. GPU, CPU, Memory) instead of scrolling a flat list.

- Fetches `category { id name }` on each preset node, gated with `@since(version: "26.4.3")` so older Managers fall back gracefully.
- Uses antd `Select` `optgroup` to render a grouped list, with uncategorized presets (or all presets on pre-26.4.3 Managers) shown as a flat list at the end.
- Retains `categoryId` on the node selection as a pre-26.4.3 fallback — when `category` is null on older Managers, `categoryId` is still resolvable and preserves the existing rank ordering.

## Requirements

- **Minimum Manager version:** 26.4.3 (for the `QueryPresetCategory` type). UI degrades to a flat list on older Managers.

**Checklist:** (if applicable)

- [ ] Documentation
- [x] Minimum required manager version — 26.4.3 (graceful fallback on older versions)
- [ ] Specific setting for review (eg., KB link, endpoint or how to setup)
- [ ] Minimum requirements to check during review
- [ ] Test case(s) to demonstrate the difference of before/after
