### PR TITLE
chore(FR-2602): enable openToPublic modification when updating service

### DIFF
--- a/react/src/components/ServiceLauncherPageContent.tsx
+++ b/react/src/components/ServiceLauncherPageContent.tsx
@@ -1111,6 +1111,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                 resource_group: values.resourceGroup,
                 model_definition_path: modelDefinitionPath,
                 runtime_variant: values.runtimeVariant,
+                open_to_public: values.openToPublic,
               },
             };
           const newEnvirons: { [key: string]: string } = {};
@@ -1587,9 +1588,7 @@ const ServiceLauncherPageContent: React.FC<ServiceLauncherPageContentProps> = ({
                           <Input disabled={!!endpoint} />
                         </Form.Item>
                         <Form.Item name="openToPublic" valuePropName="checked">
-                          <Checkbox disabled={!!endpoint}>
-                            {t('modelService.OpenToPublic')}
-                          </Checkbox>
+                          <Checkbox>{t('modelService.OpenToPublic')}</Checkbox>
                         </Form.Item>
                         {!endpoint ? (
                           <Form.Item


### PR DESCRIPTION
> [!CAUTION]
> This is pr is closed due to it is not supported by core side yet.



Resolves #6801 ([FR-2602](https://lablup.atlassian.net/browse/FR-2602))

## Summary

- Remove the `disabled={!!endpoint}` state from the `openToPublic` checkbox in the service update form.
- Backend now supports modifying `openToPublic` when updating an existing model service endpoint, so the frontend no longer needs to lock the field in update mode.

## Test plan

- [ ] Create a new model service and confirm the `Open to public` checkbox is toggleable.
- [ ] Update an existing model service and confirm the `Open to public` checkbox is now toggleable (previously disabled).
- [ ] Confirm the updated value is persisted after saving.

[FR-2602]: https://lablup.atlassian.net/browse/FR-2602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ