### PR TITLE
fix(FR-2604): correct inverted direction semantics in AutoScaling rule condition

### DIFF
--- a/react/src/components/AutoScalingRuleEditorModal.tsx
+++ b/react/src/components/AutoScalingRuleEditorModal.tsx
@@ -20,7 +20,7 @@ import {
   Form,
   FormInstance,
   InputNumber,
-  Segmented,
+  Radio,
   Select,
   Skeleton,
   Typography,
@@ -54,8 +54,7 @@ import {
   useMutation,
 } from 'react-relay';
 
-type ConditionMode = 'single' | 'range';
-type ThresholdDirection = 'upper' | 'lower';
+type ConditionMode = 'scale_in' | 'scale_out' | 'scale_in_out';
 
 interface AutoScalingRuleEditorModalProps extends Omit<
   BAIModalProps,
@@ -72,7 +71,6 @@ type AutoScalingRuleFormValues = {
   metricName: string;
   prometheusQueryPresetId?: string;
   conditionMode: ConditionMode;
-  direction: ThresholdDirection;
   threshold?: number;
   minThreshold?: number;
   maxThreshold?: number;
@@ -220,29 +218,25 @@ const PrometheusPresetPreview: React.FC<{
 };
 
 /**
- * Determines initial condition mode and direction from existing rule data.
+ * Determines the initial condition mode from existing rule data.
  *
- * Direction semantics match the list's "normal range" display:
- *   'lower' ('<'): Metric < maxThreshold — metric should stay BELOW the upper bound.
- *   'upper' ('>'): Metric > minThreshold — metric should stay ABOVE the lower bound.
- *
- * So maxThreshold → 'lower', minThreshold → 'upper' (mirrors the list column).
+ *   maxThreshold only set → 'scale_out' (trigger when maxThreshold < metric)
+ *   minThreshold only set → 'scale_in'  (trigger when metric < minThreshold)
+ *   both set              → 'scale_in_out'
  */
-const getInitialConditionState = (
+const getInitialConditionMode = (
   rule: AutoScalingRuleEditorModalFragment$data | null | undefined,
-): { mode: ConditionMode; direction: ThresholdDirection } => {
+): ConditionMode => {
   if (!rule) {
-    return { mode: 'single', direction: 'lower' };
+    return 'scale_out';
   }
   if (rule.minThreshold != null && rule.maxThreshold != null) {
-    return { mode: 'range', direction: 'upper' };
+    return 'scale_in_out';
   }
-  // minThreshold set → Metric > minThreshold → direction='upper'
-  if (rule.minThreshold != null) {
-    return { mode: 'single', direction: 'upper' };
+  if (rule.maxThreshold != null) {
+    return 'scale_out';
   }
-  // maxThreshold set (or neither) → Metric < maxThreshold → direction='lower'
-  return { mode: 'single', direction: 'lower' };
+  return 'scale_in';
 };
 
 /**
@@ -294,12 +288,8 @@ const AutoScalingRuleEditorModalContent: React.FC<{
     [prometheusQueryPresets],
   );
 
-  const initialCondition = getInitialConditionState(autoScalingRule);
   const [conditionMode, setConditionMode] = useState<ConditionMode>(
-    initialCondition.mode,
-  );
-  const [direction, setDirection] = useState<ThresholdDirection>(
-    initialCondition.direction,
+    getInitialConditionMode(autoScalingRule),
   );
   const [selectedMetricSource, setSelectedMetricSource] = useState<string>(
     autoScalingRule?.metricSource || 'KERNEL',
@@ -356,26 +346,21 @@ const AutoScalingRuleEditorModalContent: React.FC<{
   // Build initial form values from existing rule data
   const getInitialValues = (): Partial<AutoScalingRuleFormValues> => {
     if (autoScalingRule) {
-      const condition = getInitialConditionState(autoScalingRule);
+      const mode = getInitialConditionMode(autoScalingRule);
+      // In scale_in/scale_out modes, the single `threshold` field is bound to the
+      // corresponding min/max threshold from the rule.
       let threshold: number | undefined;
-      if (condition.mode === 'single') {
-        // 'lower' ('<') → maxThreshold; 'upper' ('>') → minThreshold
-        threshold =
-          condition.direction === 'lower'
-            ? autoScalingRule.maxThreshold != null
-              ? Number(autoScalingRule.maxThreshold)
-              : undefined
-            : autoScalingRule.minThreshold != null
-              ? Number(autoScalingRule.minThreshold)
-              : undefined;
+      if (mode === 'scale_in' && autoScalingRule.minThreshold != null) {
+        threshold = Number(autoScalingRule.minThreshold);
+      } else if (mode === 'scale_out' && autoScalingRule.maxThreshold != null) {
+        threshold = Number(autoScalingRule.maxThreshold);
       }
       return {
         metricSource:
           autoScalingRule.metricSource as AutoScalingRuleFormValues['metricSource'],
         metricName: autoScalingRule.metricName,
         prometheusQueryPresetId: selectedPresetId,
-        conditionMode: condition.mode,
-        direction: condition.direction,
+        conditionMode: mode,
         threshold,
         minThreshold:
           autoScalingRule.minThreshold != null
@@ -393,8 +378,7 @@ const AutoScalingRuleEditorModalContent: React.FC<{
     }
     return {
       metricSource: 'KERNEL',
-      conditionMode: 'single',
-      direction: 'lower',
+      conditionMode: 'scale_out',
       stepSize: 1,
       timeWindow: 300,
       minReplicas: 0,
@@ -554,58 +538,41 @@ const AutoScalingRuleEditorModalContent: React.FC<{
         </>
       )}
 
-      {/* Condition Mode (Single / Range) */}
+      {/* Condition Mode (Scale In / Scale Out / Scale In & Out) */}
       <Form.Item
         label={t('autoScalingRule.Condition')}
         required
         tooltip={t('autoScalingRule.ConditionTooltip')}
       >
         <Form.Item name={'conditionMode'} noStyle>
-          <Segmented
-            options={[
-              {
-                label: t('autoScalingRule.Single'),
-                value: 'single',
-              },
-              {
-                label: t('autoScalingRule.Range'),
-                value: 'range',
-              },
-            ]}
-            onChange={(value) => {
-              setConditionMode(value as ConditionMode);
+          <Radio.Group
+            optionType="button"
+            onChange={(e) => {
+              setConditionMode(e.target.value as ConditionMode);
             }}
             style={{ marginBottom: token.marginSM }}
+            options={[
+              {
+                label: t('autoScalingRule.ScaleIn'),
+                value: 'scale_in',
+              },
+              {
+                label: t('autoScalingRule.ScaleOut'),
+                value: 'scale_out',
+              },
+              {
+                label: t('autoScalingRule.ScaleInAndOut'),
+                value: 'scale_in_out',
+              },
+            ]}
           />
         </Form.Item>
 
-        {conditionMode === 'single' ? (
-          <div
-            style={{
-              display: 'flex',
-              gap: token.marginXS,
-              alignItems: 'center',
-            }}
-          >
+        {conditionMode === 'scale_in' && (
+          <BAIFlex align="center" gap="xs">
             <Typography.Text style={{ flexShrink: 0 }}>
-              {t('autoScalingRule.Metric')}
+              {t('autoScalingRule.Metric')} {'<'}
             </Typography.Text>
-            <Form.Item name={'direction'} noStyle rules={[{ required: true }]}>
-              <Select
-                style={{ width: 60 }}
-                onChange={(value) => setDirection(value as ThresholdDirection)}
-                options={[
-                  {
-                    label: '>',
-                    value: 'upper',
-                  },
-                  {
-                    label: '<',
-                    value: 'lower',
-                  },
-                ]}
-              />
-            </Form.Item>
             <Form.Item
               name={'threshold'}
               noStyle
@@ -622,69 +589,29 @@ const AutoScalingRuleEditorModalContent: React.FC<{
               ]}
             >
               <InputNumber
-                placeholder={t('autoScalingRule.Threshold')}
-                style={{ flex: 1, width: '100%' }}
-                min={0}
-              />
-            </Form.Item>
-          </div>
-        ) : (
-          <div
-            style={{
-              display: 'flex',
-              gap: token.marginXS,
-              alignItems: 'center',
-            }}
-          >
-            <Form.Item
-              name={'minThreshold'}
-              noStyle
-              rules={[
-                {
-                  required: true,
-                  message: t('autoScalingRule.MinThresholdRequired'),
-                },
-                {
-                  type: 'number',
-                  min: 0,
-                  message: t('autoScalingRule.ThresholdMustBeNonNegative'),
-                },
-              ]}
-            >
-              <InputNumber
                 placeholder={t('autoScalingRule.MinThreshold')}
                 style={{ flex: 1, width: '100%' }}
                 min={0}
               />
             </Form.Item>
-            <Typography.Text style={{ flexShrink: 0 }}>
-              {'<'} {t('autoScalingRule.Metric')} {'<'}
-            </Typography.Text>
+          </BAIFlex>
+        )}
+
+        {conditionMode === 'scale_out' && (
+          <BAIFlex align="center" gap="xs">
             <Form.Item
-              name={'maxThreshold'}
+              name={'threshold'}
               noStyle
-              dependencies={['minThreshold']}
               rules={[
                 {
                   required: true,
-                  message: t('autoScalingRule.MaxThresholdRequired'),
+                  message: t('autoScalingRule.ThresholdRequired'),
                 },
                 {
                   type: 'number',
                   min: 0,
                   message: t('autoScalingRule.ThresholdMustBeNonNegative'),
                 },
-                ({ getFieldValue }) => ({
-                  validator(_, value) {
-                    const min = getFieldValue('minThreshold');
-                    if (min != null && value != null && min >= value) {
-                      return Promise.reject(
-                        new Error(t('autoScalingRule.MinMustBeLessThanMax')),
-                      );
-                    }
-                    return Promise.resolve();
-                  },
-                }),
               ]}
             >
               <InputNumber
@@ -693,7 +620,79 @@ const AutoScalingRuleEditorModalContent: React.FC<{
                 min={0}
               />
             </Form.Item>
-          </div>
+            <Typography.Text style={{ flexShrink: 0 }}>
+              {'<'} {t('autoScalingRule.Metric')}
+            </Typography.Text>
+          </BAIFlex>
+        )}
+
+        {conditionMode === 'scale_in_out' && (
+          <BAIFlex direction="column" gap={'xs'} align="stretch">
+            <BAIFlex align="center" gap="xs">
+              <Typography.Text style={{ flexShrink: 0 }}>
+                {t('autoScalingRule.Metric')} {'<'}
+              </Typography.Text>
+              <Form.Item
+                name={'minThreshold'}
+                noStyle
+                rules={[
+                  {
+                    required: true,
+                    message: t('autoScalingRule.MinThresholdRequired'),
+                  },
+                  {
+                    type: 'number',
+                    min: 0,
+                    message: t('autoScalingRule.ThresholdMustBeNonNegative'),
+                  },
+                ]}
+              >
+                <InputNumber
+                  placeholder={t('autoScalingRule.MinThreshold')}
+                  style={{ flex: 1, width: '100%' }}
+                  min={0}
+                />
+              </Form.Item>
+            </BAIFlex>
+            <BAIFlex align="center" gap="xs">
+              <Form.Item
+                name={'maxThreshold'}
+                noStyle
+                dependencies={['minThreshold']}
+                rules={[
+                  {
+                    required: true,
+                    message: t('autoScalingRule.MaxThresholdRequired'),
+                  },
+                  {
+                    type: 'number',
+                    min: 0,
+                    message: t('autoScalingRule.ThresholdMustBeNonNegative'),
+                  },
+                  ({ getFieldValue }) => ({
+                    validator(_, value) {
+                      const min = getFieldValue('minThreshold');
+                      if (min != null && value != null && min >= value) {
+                        return Promise.reject(
+                          new Error(t('autoScalingRule.MinMustBeLessThanMax')),
+                        );
+                      }
+                      return Promise.resolve();
+                    },
+                  }),
+                ]}
+              >
+                <InputNumber
+                  placeholder={t('autoScalingRule.MaxThreshold')}
+                  style={{ flex: 1, width: '100%' }}
+                  min={0}
+                />
+              </Form.Item>
+              <Typography.Text style={{ flexShrink: 0 }}>
+                {'<'} {t('autoScalingRule.Metric')}
+              </Typography.Text>
+            </BAIFlex>
+          </BAIFlex>
         )}
       </Form.Item>
 
@@ -727,9 +726,9 @@ const AutoScalingRuleEditorModalContent: React.FC<{
           style={{ width: '100%' }}
           prefix={
             <Typography.Text type="secondary">
-              {conditionMode === 'range'
+              {conditionMode === 'scale_in_out'
                 ? '±'
-                : direction === 'upper'
+                : conditionMode === 'scale_out'
                   ? '+'
                   : '−'}
             </Typography.Text>
@@ -919,16 +918,15 @@ const AutoScalingRuleEditorModal: React.FC<AutoScalingRuleEditorModalProps> = ({
         let minThreshold: number | null = null;
         let maxThreshold: number | null = null;
 
-        if (values.conditionMode === 'range') {
+        if (values.conditionMode === 'scale_in_out') {
           minThreshold = values.minThreshold ?? null;
           maxThreshold = values.maxThreshold ?? null;
+        } else if (values.conditionMode === 'scale_in') {
+          // Metric < minThreshold
+          minThreshold = values.threshold ?? null;
         } else {
-          // Single mode: 'lower' ('<') → maxThreshold; 'upper' ('>') → minThreshold
-          if (values.direction === 'lower') {
-            maxThreshold = values.threshold ?? null;
-          } else {
-            minThreshold = values.threshold ?? null;
-          }
+          // 'scale_out': maxThreshold < Metric
+          maxThreshold = values.threshold ?? null;
         }
 
         // metricName is always set in the form (auto-filled for PROMETHEUS presets)

--- a/react/src/components/AutoScalingRuleList.tsx
+++ b/react/src/components/AutoScalingRuleList.tsx
@@ -44,10 +44,11 @@ type AutoScalingRuleNode = NonNullable<
 >;
 
 /**
- * Renders the condition column with normalized `<` direction:
- * - maxThreshold only → `[metric_name] < [maxThreshold]`
- * - minThreshold only → `[minThreshold] < [metric_name]`
- * - Both set → `[minThreshold] < [metric_name] < [maxThreshold]`
+ * Renders the condition column showing when scaling triggers.
+ * Comparator is always `<` — orientation of the metric tag indicates the direction.
+ * - maxThreshold only → `[maxThreshold] < [metric_name]` (scale out)
+ * - minThreshold only → `[metric_name] < [minThreshold]` (scale in)
+ * - Both set → stacked rows, one for scale in and one for scale out
  *
  * For PROMETHEUS rules, the tag shows the preset name (from presetMap) instead of
  * the raw metricName, since users select a preset — not the metric directly.
@@ -66,12 +67,17 @@ const renderCondition = (
 
   if (minThreshold != null && maxThreshold != null) {
     return (
-      <BAIFlex gap={'xs'}>
-        {minThreshold}
-        <Tooltip title={t('autoScalingRule.MinThreshold')}>{'<'}</Tooltip>
-        <Tag>{tagLabel}</Tag>
-        <Tooltip title={t('autoScalingRule.MaxThreshold')}>{'<'}</Tooltip>
-        {maxThreshold}
+      <BAIFlex direction="column" gap={'xxs'}>
+        <BAIFlex gap={'xs'}>
+          <Tag>{tagLabel}</Tag>
+          {' < '}
+          {minThreshold}
+        </BAIFlex>
+        <BAIFlex gap={'xs'}>
+          {maxThreshold}
+          {' < '}
+          <Tag>{tagLabel}</Tag>
+        </BAIFlex>
       </BAIFlex>
     );
   }
@@ -79,9 +85,9 @@ const renderCondition = (
   if (maxThreshold != null) {
     return (
       <BAIFlex gap={'xs'}>
-        <Tag>{tagLabel}</Tag>
-        <Tooltip title={t('autoScalingRule.MaxThreshold')}>{'<'}</Tooltip>
         {maxThreshold}
+        <Tooltip title={t('autoScalingRule.MaxThreshold')}>{'<'}</Tooltip>
+        <Tag>{tagLabel}</Tag>
       </BAIFlex>
     );
   }
@@ -89,9 +95,9 @@ const renderCondition = (
   if (minThreshold != null) {
     return (
       <BAIFlex gap={'xs'}>
-        {minThreshold}
-        <Tooltip title={t('autoScalingRule.MinThreshold')}>{'<'}</Tooltip>
         <Tag>{tagLabel}</Tag>
+        <Tooltip title={t('autoScalingRule.MinThreshold')}>{'<'}</Tooltip>
+        {minThreshold}
       </BAIFlex>
     );
   }

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Aktuellen Wert aktualisieren",
     "RefreshPreview": "Vorschau aktualisieren",
     "ScaleIn": "Herunterskalieren",
+    "ScaleInAndOut": "Hoch- und Herunterskalieren",
     "ScaleOut": "Horizontal skalieren",
     "ScalingType": "Typ",
     "Seconds": "s",

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Ανανέωση τρέχουσας τιμής",
     "RefreshPreview": "Ανανέωση προεπισκόπησης",
     "ScaleIn": "Μείωση κλίμακας",
+    "ScaleInAndOut": "Αύξηση και μείωση κλίμακας",
     "ScaleOut": "Οριζόντια κλιμάκωση",
     "ScalingType": "Τύπος",
     "Seconds": "δλ",

--- a/resources/i18n/en.json
+++ b/resources/i18n/en.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Refresh current value",
     "RefreshPreview": "Refresh preview",
     "ScaleIn": "Scale In",
+    "ScaleInAndOut": "Scale In & Out",
     "ScaleOut": "Scale Out",
     "ScalingType": "Type",
     "Seconds": "s",

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Actualizar valor actual",
     "RefreshPreview": "Actualizar vista previa",
     "ScaleIn": "Escalar hacia adentro",
+    "ScaleInAndOut": "Escalar hacia adentro y hacia afuera",
     "ScaleOut": "Escalar horizontalmente",
     "ScalingType": "Tipo",
     "Seconds": "s",

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Päivitä nykyinen arvo",
     "RefreshPreview": "Päivitä esikatselu",
     "ScaleIn": "Skaalaa alas",
+    "ScaleInAndOut": "Skaalaa ylös ja alas",
     "ScaleOut": "Horisontaalinen skaalaus",
     "ScalingType": "Tyyppi",
     "Seconds": "s",

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Actualiser la valeur actuelle",
     "RefreshPreview": "Actualiser l'aperçu",
     "ScaleIn": "Réduire l'échelle",
+    "ScaleInAndOut": "Mise à l'échelle entrante et sortante",
     "ScaleOut": "Mise à l'échelle horizontale",
     "ScalingType": "Type",
     "Seconds": "s",

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Segarkan nilai saat ini",
     "RefreshPreview": "Segarkan pratinjau",
     "ScaleIn": "Perkecil skala",
+    "ScaleInAndOut": "Perbesar dan perkecil skala",
     "ScaleOut": "Skalakan secara horizontal",
     "ScalingType": "Jenis",
     "Seconds": "dtk",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Aggiorna valore attuale",
     "RefreshPreview": "Aggiorna anteprima",
     "ScaleIn": "Riduci capacità",
+    "ScaleInAndOut": "Aumenta e riduci capacità",
     "ScaleOut": "Scalare orizzontalmente",
     "ScalingType": "Tipo",
     "Seconds": "s",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "現在の値を更新",
     "RefreshPreview": "プレビューを更新",
     "ScaleIn": "スケールイン",
+    "ScaleInAndOut": "スケールイン＆アウト",
     "ScaleOut": "スケールアウト",
     "ScalingType": "タイプ",
     "Seconds": "秒",

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "현재 값 새로 고침",
     "RefreshPreview": "미리보기 새로 고침",
     "ScaleIn": "스케일 인",
+    "ScaleInAndOut": "스케일 인 & 아웃",
     "ScaleOut": "스케일 아웃",
     "ScalingType": "타입",
     "Seconds": "초",

--- a/resources/i18n/mn.json
+++ b/resources/i18n/mn.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Одоогийн утгыг шинэчлэх",
     "RefreshPreview": "Урьдчилан харахыг шинэчлэх",
     "ScaleIn": "Хэмжээг бууруулах",
+    "ScaleInAndOut": "Хэмжээг нэмэх ба бууруулах",
     "ScaleOut": "Хэвтээ өргөтгөх",
     "ScalingType": "Маяг",
     "Seconds": "с",

--- a/resources/i18n/ms.json
+++ b/resources/i18n/ms.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Muat semula nilai semasa",
     "RefreshPreview": "Muat semula pratonton",
     "ScaleIn": "Kurangkan Skala",
+    "ScaleInAndOut": "Tambah dan Kurangkan Skala",
     "ScaleOut": "Skala Mendatar",
     "ScalingType": "Jenis",
     "Seconds": "s",

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Odśwież bieżącą wartość",
     "RefreshPreview": "Odśwież podgląd",
     "ScaleIn": "Skaluj w dół",
+    "ScaleInAndOut": "Skaluj w górę i w dół",
     "ScaleOut": "Skalowanie poziome",
     "ScalingType": "Typ",
     "Seconds": "s",

--- a/resources/i18n/pt-BR.json
+++ b/resources/i18n/pt-BR.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Atualizar valor atual",
     "RefreshPreview": "Atualizar visualização",
     "ScaleIn": "Reduzir escala",
+    "ScaleInAndOut": "Ampliar e reduzir escala",
     "ScaleOut": "Escalar horizontalmente",
     "ScalingType": "Tipo",
     "Seconds": "s",

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Atualizar valor atual",
     "RefreshPreview": "Atualizar pré-visualização",
     "ScaleIn": "Reduzir escala",
+    "ScaleInAndOut": "Ampliar e reduzir escala",
     "ScaleOut": "Escalar horizontalmente",
     "ScalingType": "Tipo",
     "Seconds": "s",

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Обновить текущее значение",
     "RefreshPreview": "Обновить предпросмотр",
     "ScaleIn": "Уменьшить масштаб",
+    "ScaleInAndOut": "Увеличить и уменьшить масштаб",
     "ScaleOut": "Горизонтальное масштабирование",
     "ScalingType": "Тип",
     "Seconds": "с",

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "รีเฟรชค่าปัจจุบัน",
     "RefreshPreview": "รีเฟรชตัวอย่าง",
     "ScaleIn": "ย่อขนาด",
+    "ScaleInAndOut": "ขยายและย่อขนาด",
     "ScaleOut": "ขยายแนวนอน",
     "ScalingType": "พิมพ์",
     "Seconds": "วินาที",

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Geçerli değeri yenile",
     "RefreshPreview": "Önizlemeyi yenile",
     "ScaleIn": "Küçült",
+    "ScaleInAndOut": "Büyüt ve Küçült",
     "ScaleOut": "Yatay Ölçeklendirme",
     "ScalingType": "Tip",
     "Seconds": "sn",

--- a/resources/i18n/vi.json
+++ b/resources/i18n/vi.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "Làm mới giá trị hiện tại",
     "RefreshPreview": "Làm mới bản xem trước",
     "ScaleIn": "Giảm quy mô",
+    "ScaleInAndOut": "Tăng và giảm quy mô",
     "ScaleOut": "Mở rộng theo chiều ngang",
     "ScalingType": "Kiểu",
     "Seconds": "giây",

--- a/resources/i18n/zh-CN.json
+++ b/resources/i18n/zh-CN.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "刷新当前值",
     "RefreshPreview": "刷新预览",
     "ScaleIn": "缩容",
+    "ScaleInAndOut": "缩扩容",
     "ScaleOut": "横向扩展",
     "ScalingType": "类型",
     "Seconds": "秒",

--- a/resources/i18n/zh-TW.json
+++ b/resources/i18n/zh-TW.json
@@ -191,6 +191,7 @@
     "RefreshCurrentValue": "重新整理目前值",
     "RefreshPreview": "重新整理預覽",
     "ScaleIn": "縮容",
+    "ScaleInAndOut": "縮擴容",
     "ScaleOut": "水平擴充",
     "ScalingType": "类型",
     "Seconds": "秒",


### PR DESCRIPTION
Resolves #6805 ([FR-2604](https://lablup.atlassian.net/browse/FR-2604))

## Summary
- Fix inverted direction semantics in the AutoScaling rule single-threshold editor:
  - `Metric > threshold` now saves to `maxThreshold` (scale-out trigger, `+` step size)
  - `Metric < threshold` now saves to `minThreshold` (scale-in trigger, `−` step size)
- Update `getInitialConditionState`, `getInitialValues`, `handleOk`, and default direction in `AutoScalingRuleEditorModal.tsx` accordingly
- Update the condition column in `AutoScalingRuleList.tsx` to show the trigger condition for single thresholds:
  - `metric > maxThreshold` (scale out)
  - `metric < minThreshold` (scale in)
  - Range display (`min < metric < max`) unchanged

## Test plan
- [ ] Create a new rule with `Metric > 80` → verify `maxThreshold=80` is saved and step size prefix shows `+`
- [ ] Create a new rule with `Metric < 20` → verify `minThreshold=20` is saved and step size prefix shows `−`
- [ ] Create a range rule and confirm `±` step size and `min < metric < max` display
- [ ] Edit existing rules and verify the correct direction is preselected
- [ ] Verify the list column shows `metric > maxThreshold` / `metric < minThreshold` for single-threshold rules

<img width="239" height="144" alt="image" src="https://github.com/user-attachments/assets/87b3c268-7853-4d11-b129-119c2aa02004" />
<img width="689" height="89" alt="image" src="https://github.com/user-attachments/assets/5bd33f02-958b-4581-ad09-e6b5382efe9d" />

---

<img width="257" height="219" alt="image" src="https://github.com/user-attachments/assets/f01f4426-6074-4d8b-9c41-68d3d304abfb" />
<img width="700" height="96" alt="image" src="https://github.com/user-attachments/assets/9dd81ca9-ad78-4903-91a8-44a5f599e2ae" />



[FR-2604]: https://lablup.atlassian.net/browse/FR-2604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ